### PR TITLE
Escape % in --split help message

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -385,8 +385,8 @@ def _add_data_args(parser):
     group.add_argument('--split', type=str, default='969, 30, 1',
                        help='Comma-separated list of proportions for training,'
                        ' validation, and test split. For example the split '
-                       '`90,5,5` will use 90% of data for training, 5% for '
-                       'validation and 5% for test.')
+                       '`90,5,5` will use 90%% of data for training, 5%% for '
+                       'validation and 5%% for test.')
     group.add_argument('--vocab-file', type=str, default=None,
                        help='Path to the vocab file.')
     group.add_argument('--merge-file', type=str, default=None,


### PR DESCRIPTION
The `--split` help message contains literal `%` which is in conflict with `%`-formatting. Due to this reason, `--help` on a Megatron-LM application fails. The literal `%` should be escaped with `%%`.

```
$ python some_megatron_application.py --help
...
TypeError: %o format: an integer is required, not dict
```