### PR TITLE
Change distributed argument group title to appropriate one.

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -341,7 +341,7 @@ def _add_mixed_precision_args(parser):
 
 
 def _add_distributed_args(parser):
-    group = parser.add_argument_group(title='mixed precision')
+    group = parser.add_argument_group(title='distributed')
 
     group.add_argument('--model-parallel-size', type=int, default=1,
                        help='Size of the model parallel.')


### PR DESCRIPTION
This is a very trivial change. A help message for distributed args is wrong. `title` parameter is changed from `mixed precision` to `distributed`.