### PR TITLE
Ignore padding tokens when generating text

### DIFF
--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -381,6 +381,8 @@ def sample_sequence_batch(model, context_tokens, context_lengths,
                                            forward_method_parallel_output=False)
                 logits = logits[:, -1].view(batch_size, -1).contiguous()
 
+            # Ignore padding tokens
+            logits = logits[:, :tokenizer.vocab_size]
             if args.greedy:
                 prev = torch.argmax(logits, dim=-1).view(-1)
             else:


### PR DESCRIPTION
The current version of `text_generation_utils.py` considers all tokens when generating text. However, some of these tokens may be padding tokens. If they somehow get selected for generation, this causes an exception. This pull request excludes padding tokens from consideration when generating text.