### PR TITLE
Save vocabulary and merge files in model dir

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -405,9 +405,11 @@ def _add_data_args(parser):
                        '`90,5,5` will use 90% of data for training, 5% for '
                        'validation and 5% for test.')
     group.add_argument('--vocab-file', type=str, default=None,
-                       help='Path to the vocab file.')
+                       help='Path to the vocab file. Will be copied to the model directory. If omitted and a vocab '
+                            'file already exists in the model directory, that file will be used.')
     group.add_argument('--merge-file', type=str, default=None,
-                       help='Path to the BPE merge file.')
+                       help='Path to the BPE merge file. Will be copied to the model directory. If omitted and a merge '
+                            'file already exists in the model directory, that file will be used.')
     group.add_argument('--seq-length', type=int, default=None,
                        help="Maximum sequence length to process.")
     group.add_argument('--mask-prob', type=float, default=0.15,

--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -25,7 +25,7 @@ from .gpt2_tokenization import GPT2Tokenizer
 
 def copy_file_to_model_dir(args, file_from_args, file_name_in_model_dir):
     """Copy a file to the model directory and return the path to the file that should be used."""
-    if args.save and file_from_args and args.rank == 0:
+    if hasattr(args, "save") and args.save and file_from_args and args.rank == 0:
         file_in_model_dir = os.path.join(args.save, file_name_in_model_dir)
         print(f"copying vocab file from {file_from_args} to {file_in_model_dir}")
         os.makedirs(args.save, exist_ok=True)


### PR DESCRIPTION
In most cases, when fine tuning or generating text from an existing model, you will want to use exactly the same vocabulary and merge files that were used to train the original model. Therefore, it is helpful for these files to default to the same ones used for training the original model in these cases. To facilitate this, this pull request automatically copies these files into the model directory when they are specified on the command line. If they are not specified on the command line, it will look for the files in the model directory and use them if they are there.