### PR TITLE
Fix wrong function and module names

### DIFF
--- a/megatron/mpu/layers.py
+++ b/megatron/mpu/layers.py
@@ -109,7 +109,7 @@ def _initialize_affine_weight_cpu(weight, output_size, input_size,
     per_partition_per_stride_size = divide(per_partition_size, stride)
     weight_list = torch.split(master_weight, per_partition_per_stride_size,
                               dim=partition_dim)
-    rank = get_model_parallel_rank()
+    rank = get_tensor_model_parallel_rank()
     world_size = get_tensor_model_parallel_world_size()
     my_weight_list = weight_list[rank::world_size]
 

--- a/tasks/zeroshot_gpt2/evaluate.py
+++ b/tasks/zeroshot_gpt2/evaluate.py
@@ -24,7 +24,7 @@ from megatron import print_rank_0, is_last_rank
 from megatron import get_tokenizer
 from megatron import mpu
 from megatron.checkpointing import load_checkpoint
-from megatron.model import GPT2Model, GPT2ModelFirstStage, GPT2ModelLastStage, GPT2ModelIntermediateStage
+from megatron.model import GPTModel, GPTModelFirstStage, GPTModelLastStage, GPTModelIntermediateStage
 from megatron.training import get_model, communicate
 from megatron.utils import get_ltor_masks_and_position_ids
 from tasks.finetune_utils import build_data_loader
@@ -47,18 +47,18 @@ def get_model_provider(eval_metric):
             raise NotImplementedError('output type for {} evaluation metric '
                                       'is not supported.'.format(eval_metric))
 
-        print_rank_0('building GPT2 model ...')
+        print_rank_0('building GPT model ...')
         if mpu.get_pipeline_model_parallel_world_size() > 1:
             # Determine model based on position of stage in pipeline.
             if mpu.is_pipeline_first_stage():
-                model = GPT2ModelFirstStage(num_tokentypes=0)
+                model = GPTModelFirstStage(num_tokentypes=0)
             elif mpu.is_pipeline_last_stage():
-                model = GPT2ModelLastStage(
+                model = GPTModelLastStage(
                     parallel_output=parallel_output, num_tokentypes=0)
             else:
-                model = GPT2ModelIntermediateStage(num_tokentypes=0)
+                model = GPTModelIntermediateStage(num_tokentypes=0)
         else:
-            model = GPT2Model(num_tokentypes=0, parallel_output=parallel_output)
+            model = GPTModel(num_tokentypes=0, parallel_output=parallel_output)
 
         return model
 


### PR DESCRIPTION
This is a trivial fix. Some function/module names were not changed and several errors happen like `NameError: name 'get_model_parallel_rank' is not defined`.

The change in `megatron/mpu/layers.py` is related to a runtime option, `--use-cpu-initialization`.
Also, to run GPT evaluation (https://github.com/NVIDIA/Megatron-LM#wikitext-perplexity-evaluation), the changes in `tasks/zeroshot_gpt2/evaluate.py` are needed.