### PR TITLE
Fix issue with preprocessing empty first document

### DIFF
--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -85,7 +85,7 @@ class Encoder(object):
                 sentence_ids = Encoder.tokenizer.tokenize(sentence)
                 if len(sentence_ids) > 0:
                     doc_ids.append(sentence_ids)
-            if self.args.append_eod:
+            if self.args.append_eod and len(doc_ids) > 0:
                 doc_ids[-1].append(Encoder.tokenizer.eod)
             ids[key] = doc_ids
         return ids, len(json_line)


### PR DESCRIPTION
This is a bug fix for issue #62 

When running the [preprocess_data.py](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/preprocess_data.py) script as described on the [documentation](https://github.com/NVIDIA/Megatron-LM#data-preprocessing), if the first processed entry has an empty text [this line](https://github.com/NVIDIA/Megatron-LM/blob/ac837a4e77aa976ce3b5ab0b6ec5ef2b06dfa896/tools/preprocess_data.py#L89) fails with an `IndexError: list index out of range` because `len(doc_ids)==0`

The bug fix implements a check for the length of `doc_ids`.