### PR TITLE
add mark_dirty for in-place operation

### DIFF
--- a/megatron/mpu/mappings.py
+++ b/megatron/mpu/mappings.py
@@ -98,6 +98,8 @@ class _ReduceFromModelParallelRegion(torch.autograd.Function):
     
     @staticmethod
     def forward(ctx, input_):
+        if get_tensor_model_parallel_world_size() > 1:
+            ctx.mark_dirty(input_)
         return _reduce(input_)
 
     @staticmethod


### PR DESCRIPTION
Hi Team,

According to the PyTorch code explanation here:
  https://github.com/pytorch/pytorch/blob/75024e228ca441290b6a1c2e564300ad507d7af6/torch/autograd/function.py#L35, 

torch.distributed.all_reduce operates in-place for its inputs according to
https://pytorch.org/docs/stable/_modules/torch/distributed/distributed_c10d.html#all_reduce

So I propose this change as PR. Hope this makes sense.