### PR TITLE
Add seq-length argument to distribued BERT example

### DIFF
--- a/examples/pretrain_bert_distributed_with_mp.sh
+++ b/examples/pretrain_bert_distributed_with_mp.sh
@@ -23,6 +23,7 @@ python -m torch.distributed.launch $DISTRIBUTED_ARGS \
        --num-attention-heads 16 \
        --micro-batch-size 2 \
        --global-batch-size 16 \
+       --seq-length 512 \
        --max-position-embeddings 512 \
        --train-iters 1000000 \
        --save $CHECKPOINT_PATH \


### PR DESCRIPTION
The `--seq-length` argument was missing from the example distributed BERT pre-training script which throws an error while attempting to parse the arguments as the code expects all arguments to be specified and have a non-`None` value. By updating the example variables at the top of the script and running it, the application will quickly error out with the following stack unless the `--seq-length` argument is specified:

```
AssertionError
Traceback (most recent call last):
  File "pretrain_bert.py", line 146, in <module>
    pretrain(train_valid_test_datasets_provider, model_provider, forward_step,
  File "/workspace/megatron-lm/megatron/training.py", line 94, in pretrain
    initialize_megatron(extra_args_provider=extra_args_provider,
  File "/workspace/megatron-lm/megatron/initialize.py", line 51, in initialize_megatron
    set_global_variables(extra_args_provider=extra_args_provider,
  File "/workspace/megatron-lm/megatron/global_vars.py", line 82, in set_global_variables
    args = _parse_args(extra_args_provider=extra_args_provider,
  File "/workspace/megatron-lm/megatron/global_vars.py", line 98, in _parse_args
    _GLOBAL_ARGS = parse_args(extra_args_provider=extra_args_provider,
  File "/workspace/megatron-lm/megatron/arguments.py", line 213, in parse_args
    assert args.encoder_seq_length is not None
```

Signed-Off-By: Robert Clark <roclark@nvidia.com>