### PR TITLE
Fix bug in create_masked_lm_predictions in data/dataset_utils.py

### DIFF
--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -256,10 +256,14 @@ def create_masked_lm_predictions(tokens,
             continue
         # Note(mingdachen):
         # Skip current piece if they are covered in lm masking or previous ngrams.
+        skip = False
         for index_set in cand_index_set[0]:
             for index in index_set:
                 if index in covered_indexes:
-                    continue
+                    skip = True
+
+        if skip:
+            continue
 
         if not geometric_dist:
             n = np_rng.choice(ngrams[:len(cand_index_set)],
@@ -330,10 +334,15 @@ def create_masked_lm_predictions(tokens,
                 continue
             # Note(mingdachen):
             # Skip current piece if they are covered in lm masking or previous ngrams.
+
+            skip = False
             for index_set in cand_index_set[0]:
                 for index in index_set:
                     if index in covered_indexes or index in select_indexes:
-                        continue
+                        skip = True
+
+            if skip:
+                continue
 
             n = np.random.choice(ngrams[:len(cand_index_set)],
                                  p=pvals[:len(cand_index_set)] /


### PR DESCRIPTION
There is a bug in https://github.com/NVIDIA/Megatron-LM/blob/e156d2fea7fc5c98e645f7742eb86b643956d840/megatron/data/dataset_utils.py#L259-L262
and
https://github.com/NVIDIA/Megatron-LM/blob/e156d2fea7fc5c98e645f7742eb86b643956d840/megatron/data/dataset_utils.py#L333-L336

Actually, the conditional judgement and the continue keyword do nothing, and do not skip processing `index` which is in `covered_indexes` and `select_indexes`.