### PR TITLE
Fix a crash with multiple datasets

### DIFF
--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -446,7 +446,7 @@ def build_train_valid_test_datasets(data_prefix, data_impl, splits_string,
             prefixes[i], data_impl, splits_string,
             datasets_train_valid_test_num_samples[i],
             max_seq_length, masked_lm_prob, short_seq_prob,
-            seed, skip_warmup, binary_head, dataset_type=dataset_type)
+            seed, skip_warmup, binary_head, max_seq_length_dec, dataset_type=dataset_type)
         if train_ds:
             train_datasets.append(train_ds)
         if valid_ds:


### PR DESCRIPTION
A call to `_build_train_valid_test_datasets` is missing the `max_seq_length_dec` argument, so training crashes if there is more than one dataset. Fix is straightforward.