### PR TITLE
Allow random state variables to be synced across TP.

### DIFF
--- a/megatron/data/data_samplers.py
+++ b/megatron/data/data_samplers.py
@@ -56,6 +56,7 @@ def build_pretraining_data_loader(dataset, consumed_samples):
     return torch.utils.data.DataLoader(dataset,
                                        batch_sampler=batch_sampler,
                                        num_workers=args.num_workers,
+				       generator=torch.Generator().manual_seed(args.seed),
                                        pin_memory=True)
 
 class MegatronPretrainingSampler:


### PR DESCRIPTION
Upstream change from https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/276.

Essentially in BigScience, we noticed states going out of sync, in particular `torch.rng_state`. It was mainly due to the data loader using rng_state to generate seeds for workers. This causes the main process to consume a RNG state,  while other TP ranks didn't. This cause a change in RNG state between `tp_rank = 0` and `tp_rank > 0`, which some layers relie on (for example, `nn.Dropout`). More details in https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/276