### PR TITLE
Add scripts for merging and splitting checkpoints; fix minor issues when running scripts

### DIFF
--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -75,8 +75,12 @@ class MixedFusedLayerNorm(torch.nn.Module):
         super(MixedFusedLayerNorm, self).__init__()
 
         global fused_mix_prec_layer_norm_cuda
-        fused_mix_prec_layer_norm_cuda = importlib.import_module(
-          "fused_mix_prec_layer_norm_cuda")
+        try:
+          fused_mix_prec_layer_norm_cuda = importlib.import_module(
+            "fused_mix_prec_layer_norm_cuda")
+        except:
+          fused_mix_prec_layer_norm_cuda = importlib.import_module(
+            "fused_layer_norm_cuda")
 
         # List of hiddens sizes supported in the persistent layer norm kernel
         # If the hidden size is not supported, fall back to the non-persistent

--- a/tools/merge_mp_partitions.py
+++ b/tools/merge_mp_partitions.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Merge model parallel partitions."""
+"""Merge model (tensor and pipeline) parallel partitions."""
 
 import os
 import re
@@ -25,31 +25,12 @@ import torch
 
 from megatron import mpu
 from megatron.checkpointing import load_checkpoint, save_checkpoint
-from megatron.checkpointing import ensure_directory_exists
-from megatron.checkpointing import get_checkpoint_name
+from megatron.checkpointing import read_metadata
+from megatron.checkpointing import get_checkpoint_names
 from megatron.checkpointing import get_checkpoint_version
 from megatron.checkpointing import get_checkpoint_tracker_filename
 from megatron.global_vars import set_global_variables, get_args
 from megatron.global_vars import rebuild_tokenizer
-
-
-def split_into_partitions(tensor, num_partitions, partition_dim, stride):
-
-    per_partition_size = mpu.utils.divide(tensor.size(partition_dim),
-                                          num_partitions)
-    per_partition_per_stride_size = mpu.utils.divide(per_partition_size, stride)
-
-    partitions_list = torch.split(tensor,
-                                  per_partition_per_stride_size,
-                                  dim=partition_dim)
-
-    partitions = []
-    for i in range(num_partitions):
-        partition = torch.cat(partitions_list[i::num_partitions],
-                              dim=partition_dim)
-        partitions.append(partition)
-
-    return partitions
 
 
 def merge_partitions(merged, partitions, partition_dim, stride):
@@ -107,7 +88,7 @@ def merge_partitions(merged, partitions, partition_dim, stride):
     return
 
 
-def get_model(model_type):
+def get_model(model_type, pre_process=True, post_process=True):
 
     if model_type == 'BERT':
         from pretrain_bert import model_provider
@@ -120,59 +101,24 @@ def get_model(model_type):
         if model_type == 'MNLI':
             num_classes = 3
         from megatron.model.classification import Classification
-        def model_provider():
+        def model_provider(pre_process, post_process):
             return Classification(num_classes=num_classes, num_tokentypes=2)
     else:
         raise Exception('unrecognized model type: {}'.format(model_type))
 
-    model = model_provider()
+    model = model_provider(pre_process=pre_process, post_process=post_process)
     model = model.half()
 
     return model
 
 
 def get_parallel_checkpoint_name(path):
-
     tracker_filename = get_checkpoint_tracker_filename(path)
-    iteration = 0
-    with open(tracker_filename, 'r') as f:
-        metastring = f.read().strip()
-        iteration = int(metastring)
-    assert iteration > 0
-    checkpoint_name = get_checkpoint_name(path, iteration)
-
+    iteration, release = read_metadata(tracker_filename)
+    checkpoint_name = get_checkpoint_names(path, iteration, use_distributed_optimizer=False, release=release)
+    if release:
+        iteration = "release"
     return checkpoint_name, iteration
-
-
-def test_split_merge():
-
-    print('testing split and merge ...')
-
-    #[QKV.ROW-COL]
-    tensor = torch.FloatTensor([[1.11, 1.12, 1.13, 1.14, 1.15],
-                                [1.21, 1.22, 1.23, 1.24, 1.25],
-                                [1.31, 1.32, 1.33, 1.34, 1.35],
-                                [1.41, 1.42, 1.43, 1.44, 1.45],
-                                [2.11, 2.12, 2.13, 2.14, 2.15],
-                                [2.21, 2.22, 2.23, 2.24, 2.25],
-                                [2.31, 2.32, 2.33, 2.34, 2.35],
-                                [2.41, 2.42, 2.43, 2.44, 2.45],
-                                [3.11, 3.12, 3.13, 3.14, 3.15],
-                                [3.21, 3.22, 3.23, 3.24, 3.25],
-                                [3.31, 3.32, 3.33, 3.34, 3.35],
-                                [3.41, 3.42, 3.43, 3.44, 3.45]])
-
-    num_partitions = 2
-    partition_dim = 0
-    stride = 3
-    partitions = split_into_partitions(tensor, num_partitions,
-                                       partition_dim, stride)
-
-    merged = torch.zeros_like(tensor)
-    merge_partitions(merged, partitions, partition_dim, stride)
-
-    max_error = (merged - tensor).abs().max()
-    print('  > max error (should be zero): {}'.format(max_error))
 
 
 def get_mp_merge_args(parser):
@@ -204,18 +150,13 @@ def main():
                                           'no_save_rng': True,
                                           'save_interval': 1})
     args = get_args()
-
-    if args.pipeline_model_parallel_size > 1:
-        print("Checkpoints with pipeline model parallelism are not currently supported.")
-        exit()
-
     model_type = args.model_type
     orig_tensor_model_parallel_size = args.tensor_model_parallel_size
     args.tensor_model_parallel_size = 1
     tokenizer = rebuild_tokenizer(args)
 
     print('\n merging model parallel partitions ...')
-    print(' > number of partitions: {}'.format(orig_tensor_model_parallel_size))
+    print(' > number of partitions: {}'.format(orig_tensor_model_parallel_size * args.pipeline_model_parallel_size))
     print(' > checkpoint path: {}'.format(args.load))
     print(' > model parameters:')
     print('    number of tokens ................ {} '.format(
@@ -234,115 +175,110 @@ def main():
     mpu.initialize.set_pipeline_model_parallel_world_size(1)
     mpu.initialize.set_pipeline_model_parallel_rank(0)
     merged_model = get_model(model_type)
+    
+    pp_partitions = []
+    for pp_rank in range(args.pipeline_model_parallel_size):
+        mpu.initialize.set_tensor_model_parallel_world_size(1)
+        mpu.initialize.set_tensor_model_parallel_rank(0)
+        mpu.initialize.set_pipeline_model_parallel_world_size(args.pipeline_model_parallel_size)
+        mpu.initialize.set_pipeline_model_parallel_rank(pp_rank)
+        pre_process = mpu.is_pipeline_first_stage()
+        post_process = mpu.is_pipeline_last_stage()
 
-    # Build and load partitions.
-    partitions = []
-    iteration = 0
-    args.tensor_model_parallel_size = orig_tensor_model_parallel_size
-    tokenizer = rebuild_tokenizer(args)
-    mpu.initialize.set_tensor_model_parallel_world_size(args.tensor_model_parallel_size)
-    for rank in range(args.tensor_model_parallel_size):
-        # Reset these since load_checkpoint asserts they are 0, but we are loading
-        # multiple checkpoints in the same process and they get set each time
-        args.consumed_train_samples = 0
-        args.consumed_valid_samples = 0
+        args.tensor_model_parallel_size = 1
+        tokenizer = rebuild_tokenizer(args)
+        tp_merged_model = get_model(model_type, pre_process, post_process)
 
-        mpu.initialize.set_tensor_model_parallel_rank(rank)
-        checkpoint_name, iteration = get_parallel_checkpoint_name(args.load)
-        model_ = get_model(model_type)
-        print(f'> loading {checkpoint_name} ...')
-        load_checkpoint(model_, None, None)
-        print(f'> checkpoint version {get_checkpoint_version()}')
-        partitions.append(model_)
+        # Build and load partitions.
+        partitions = []
+        iteration = 0
+        args.tensor_model_parallel_size = orig_tensor_model_parallel_size
+        tokenizer = rebuild_tokenizer(args)
 
-    # Parameter generators so we can loop through them semiltaneouly.
-    merged_params_gen = merged_model.named_parameters()
-    partitions_params_gen = [partition.named_parameters()
-                             for partition in partitions]
-    while True:
-        try:
+        for tp_rank in range(args.tensor_model_parallel_size):
+            # Reset these since load_checkpoint asserts they are 0, but we are loading
+            # multiple checkpoints in the same process and they get set each time
+            args.consumed_train_samples = 0
+            args.consumed_valid_samples = 0
 
-            # Get the params and check names.
-            name, merged_param = next(merged_params_gen)
-            print(' > working on {} ...'.format(name))
-            print('     merged         type: {}, size: {}'.format(
-                merged_param.dtype, list(merged_param.size())))
-            partitions_param = []
-            for rank, partition_params_gen in enumerate(partitions_params_gen):
-                partition_name, partition_param = next(partition_params_gen)
-                assert partition_name == name
-                partitions_param.append(partition_param)
-                print('     partition {}    type: {}, size: {}'.format(
-                    rank, partition_param.dtype, list(partition_param.size())))
+            mpu.initialize.set_tensor_model_parallel_world_size(orig_tensor_model_parallel_size)
+            mpu.initialize.set_tensor_model_parallel_rank(tp_rank)
+            checkpoint_name, iteration = get_parallel_checkpoint_name(args.load)
+            model_ = get_model(model_type, pre_process, post_process)
+            print(f'> loading {checkpoint_name} ...')
+            load_checkpoint(model_, None, None)
+            print(f'> checkpoint version {get_checkpoint_version()}')
+            partitions.append(model_)
 
-            # For the non-parallel parameters, simply copy the rank 0 values.
-            if not hasattr(merged_param, 'tensor_model_parallel'):
-                print('     none-parallel parameter, simple copy from rank 0')
-                with torch.no_grad():
-                    merged_param.data.copy_(partitions_param[0].data)
-            # For parallel parameters, merge the values
-            else:
-                dim = merged_param.partition_dim
-                stride = merged_param.partition_stride
-                print(f'     parallel parameter merge with stride {stride} along '
-                      f'dimention {dim}')
-                merge_partitions(merged_param,
-                                 partitions_param,
-                                 dim,
-                                 stride)
+        # Parameter generators so we can loop through them semiltaneouly.
+        merged_params_gen = tp_merged_model.named_parameters()
+        partitions_params_gen = [partition.named_parameters()
+                                for partition in partitions]
+        while True:
+            try:
 
-        except StopIteration:
-            break
+                # Get the params and check names.
+                name, merged_param = next(merged_params_gen)
+                print(' > working on {} ...'.format(name))
+                print('     merged         type: {}, size: {}'.format(
+                    merged_param.dtype, list(merged_param.size())))
+                partitions_param = []
+                for rank, partition_params_gen in enumerate(partitions_params_gen):
+                    partition_name, partition_param = next(partition_params_gen)
+                    assert partition_name == name
+                    partitions_param.append(partition_param)
+                    print('     partition {}    type: {}, size: {}'.format(
+                        rank, partition_param.dtype, list(partition_param.size())))
 
-    partitions = []
-    args.tensor_model_parallel_size = 1
-    args.pipeline_model_parallel_size = args.target_pipeline_model_parallel_size
+                # For the non-parallel parameters, simply copy the rank 0 values.
+                if not hasattr(merged_param, 'tensor_model_parallel'):
+                    print('     none-parallel parameter, simple copy from rank 0')
+                    with torch.no_grad():
+                        merged_param.data.copy_(partitions_param[0].data)
+                # For parallel parameters, merge the values
+                else:
+                    dim = merged_param.partition_dim
+                    stride = merged_param.partition_stride
+                    print(f'     parallel parameter merge with stride {stride} along '
+                        f'dimention {dim}')
+                    merge_partitions(
+                        merged_param,
+                        partitions_param,
+                        dim,
+                        stride
+                    )
 
-    assert args.num_layers % args.pipeline_model_parallel_size == 0, \
-        'num_layers must be divisible by target pipeline model parallel size'
-    layers_per_part = args.num_layers // args.pipeline_model_parallel_size
-
-    tokenizer = rebuild_tokenizer(args)
-    mpu.initialize.set_tensor_model_parallel_world_size(args.tensor_model_parallel_size)
-    mpu.initialize.set_tensor_model_parallel_rank(0)
-    mpu.initialize.set_pipeline_model_parallel_world_size(args.pipeline_model_parallel_size)
+            except StopIteration:
+                break
+        pp_partitions.append(tp_merged_model)
 
     # regex to parse out layer number from param name
     layer_re = re.compile('layers\.([0-9]+)')
+    layers_per_part = args.num_layers // args.pipeline_model_parallel_size
 
-    if args.pipeline_model_parallel_size > 1:
-        merged_params = {}
-        for name, merged_param in merged_model.named_parameters():
-            merged_params[name] = merged_param
+    merged_params = {}
+    for pp_rank, partition in enumerate(pp_partitions):
+        def update_layer_num(m):
+            # TODO! This assumes no interleaved pipeline execution
+            layer = int(m.group(1))
+            layer += pp_rank * layers_per_part
+            return f'layers.{layer}'
+        for name, partition_param in partition.named_parameters():
+            name = re.sub(layer_re, update_layer_num, name)
+            merged_params[name] = partition_param
 
-        for rank in range(args.pipeline_model_parallel_size):
-            mpu.initialize.set_pipeline_model_parallel_rank(rank)
-            model = get_model(model_type)
-            def update_layer_num(m):
-                # TODO! This assumes no interleaved pipeline execution
-                layer = int(m.group(1))
-                layer += rank * layers_per_part
-                return f'layers.{layer}'
+    for name, param in merged_model.named_parameters():
+        param.data.copy_(merged_params[name].data)
 
-            for dst_name, partition_param in model.named_parameters():
-                if dst_name == "word_embeddings.weight":
-                    # See comment in MegatronModule.initialize_word_embeddings()
-                    src_name = "language_model.embedding.word_embeddings.weight"
-                else:
-                    # Translate destination layer number (0-N for each partition)
-                    # to source layer number (single-model layer number)
-                    src_name = re.sub(layer_re, update_layer_num, dst_name)
-                print(f" > copying {src_name} to {dst_name} in rank {rank}'s model")
-                partition_param.data.copy_(merged_params[src_name].data)
-
-            partitions.append(model)
-    else:
-        partitions = [merged_model]
-
-    for rank, model in enumerate(partitions):
-        mpu.initialize.set_pipeline_model_parallel_rank(rank)
-        print(f"> saving rank {rank}'s model")
-        save_checkpoint(iteration, model, None, None)
+    args.tensor_model_parallel_size = 1
+    args.pipeline_model_parallel_size = 1
+    tokenizer = rebuild_tokenizer(args)
+    mpu.initialize.set_tensor_model_parallel_world_size(1)
+    mpu.initialize.set_tensor_model_parallel_rank(0)
+    mpu.initialize.set_pipeline_model_parallel_world_size(1)
+    mpu.initialize.set_pipeline_model_parallel_rank(0)
+    
+    save_checkpoint(iteration, merged_model, None, None)
 
     print('done :-)')
 

--- a/tools/split_into_mp_partitions.py
+++ b/tools/split_into_mp_partitions.py
@@ -1,0 +1,219 @@
+# coding=utf-8
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Split model (tensor and pipeline) parallel partitions."""
+
+import os
+import re
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             os.path.pardir)))
+
+import torch
+
+from megatron import mpu
+from megatron.checkpointing import load_checkpoint, save_checkpoint
+from megatron.checkpointing import read_metadata
+from megatron.checkpointing import get_checkpoint_names
+from megatron.checkpointing import get_checkpoint_version
+from megatron.checkpointing import get_checkpoint_tracker_filename
+from megatron.global_vars import set_global_variables, get_args
+from megatron.global_vars import rebuild_tokenizer
+
+
+def split_into_partitions(tensor, num_partitions, partition_dim, stride):
+
+    per_partition_size = mpu.utils.divide(tensor.size(partition_dim),
+                                          num_partitions)
+    per_partition_per_stride_size = mpu.utils.divide(per_partition_size, stride)
+
+    partitions_list = torch.split(tensor,
+                                  per_partition_per_stride_size,
+                                  dim=partition_dim)
+
+    partitions = []
+    for i in range(num_partitions):
+        partition = torch.cat(partitions_list[i::num_partitions],
+                              dim=partition_dim)
+        partitions.append(partition)
+
+    return partitions
+
+
+def get_model(model_type, pre_process=True, post_process=True):
+
+    if model_type == 'BERT':
+        from pretrain_bert import model_provider
+    elif model_type == 'GPT':
+        from pretrain_gpt import model_provider
+    elif model_type == 'RACE':
+        from tasks.race.finetune import model_provider
+    elif model_type == ['MNLI', 'QQP']:
+        num_classes = 2
+        if model_type == 'MNLI':
+            num_classes = 3
+        from megatron.model.classification import Classification
+        def model_provider(pre_process, post_process):
+            return Classification(num_classes=num_classes, num_tokentypes=2)
+    else:
+        raise Exception('unrecognized model type: {}'.format(model_type))
+
+    model = model_provider(pre_process=pre_process, post_process=post_process)
+    model = model.half()
+
+    return model
+
+
+def get_parallel_checkpoint_name(path):
+    tracker_filename = get_checkpoint_tracker_filename(path)
+    iteration, release = read_metadata(tracker_filename)
+    checkpoint_name = get_checkpoint_names(path, iteration, use_distributed_optimizer=False, release=release)
+    if release:
+        iteration = "release"
+    return checkpoint_name, iteration
+
+
+def get_mp_merge_args(parser):
+    """Provide extra arguments required for merging."""
+    group = parser.add_argument_group(title='mp merge')
+
+    group.add_argument('--model-type', type=str, required=True,
+                       choices=['BERT', 'GPT', 'RACE', 'MNLI', 'QQP'],
+                       help='Type of the mdoel.')
+    group.add_argument('--target-pipeline-model-parallel-size', type=int, default=1,
+                       help='Degree of pipeline model parallelism in output model.')
+
+    return parser
+
+
+def main():
+
+    # Arguments do sanity checks on the world size, but we don't care,
+    # so trick it into thinking we are plenty of processes
+    os.environ["WORLD_SIZE"] = f'{2**31}'
+
+    # Args
+    set_global_variables(extra_args_provider=get_mp_merge_args,
+                         args_defaults = {'use_cpu_initialization': True,
+                                          'micro_batch_size': 1,
+                                          'no_load_optim': True,
+                                          'no_load_rng': True,
+                                          'no_save_optim': True,
+                                          'no_save_rng': True,
+                                          'save_interval': 1})
+    args = get_args()
+    model_type = args.model_type
+    num_partitions = args.tensor_model_parallel_size
+    orig_tensor_model_parallel_size = args.tensor_model_parallel_size
+    orig_pipeline_model_parallel_size = args.pipeline_model_parallel_size
+    args.tensor_model_parallel_size = 1
+    args.pipeline_model_parallel_size = 1
+    tokenizer = rebuild_tokenizer(args)
+
+    print('\n splitting model parallel partitions ...')
+    print(' > checkpoint path: {}'.format(args.load))
+    print(' > model parameters:')
+    print('    number of tokens ................ {} '.format(
+        tokenizer.vocab_size))
+    print('    number of layers ................ {}'.format(args.num_layers))
+    print('    hidden size ..................... {}'.format(args.hidden_size))
+    print('    number of attention heads ....... {}'.format(
+        args.num_attention_heads))
+    print('    maximum position embeddings ..... {}'.format(
+        args.max_position_embeddings))
+
+    # Full model.
+    print('> building the full model ...')
+    mpu.initialize.set_tensor_model_parallel_world_size(1)
+    mpu.initialize.set_tensor_model_parallel_rank(0)
+    mpu.initialize.set_pipeline_model_parallel_world_size(1)
+    mpu.initialize.set_pipeline_model_parallel_rank(0)
+
+    cp_model = get_model(model_type)
+    checkpoint_name, iteration = get_parallel_checkpoint_name(args.load)
+    print(f'> loading {checkpoint_name} ...')
+    load_checkpoint(cp_model, None, None)
+    print(f'> checkpoint version {get_checkpoint_version()}')
+
+    args.tensor_model_parallel_size = orig_tensor_model_parallel_size
+    args.pipeline_model_parallel_size = orig_pipeline_model_parallel_size
+    tokenizer = rebuild_tokenizer(args)
+    model = get_model(model_type)
+    
+    cp_params_gen = cp_model.parameters()
+    model_params = model.parameters()
+
+    for param, cp_param in zip(model_params, cp_params_gen):
+        if not hasattr(param, 'tensor_model_parallel'):
+            with torch.no_grad():
+                param.data.copy_(cp_param.data)
+        else:
+            partition_dim = param.partition_dim
+            if param.size(partition_dim) == cp_param.size(partition_dim):
+                param.data.copy_(cp_param.data)
+            else:
+                param[:cp_param.size(partition_dim)].data.copy_(cp_param.data)
+
+    model_params = {}
+    for name, param in model.named_parameters():
+        if not hasattr(param, 'tensor_model_parallel'):
+            params = param
+        else:
+            partition_dim = param.partition_dim
+            stride = param.partition_stride
+            params = split_into_partitions(param, num_partitions, partition_dim, stride)
+        model_params[name] = params
+
+    
+
+    # regex to parse out layer number from param name
+    layer_re = re.compile('layers\.([0-9]+)')
+    layers_per_part = args.num_layers // args.pipeline_model_parallel_size
+
+    mpu.initialize.set_tensor_model_parallel_world_size(args.tensor_model_parallel_size)
+    mpu.initialize.set_pipeline_model_parallel_world_size(args.pipeline_model_parallel_size)
+    for pp_rank in range(args.pipeline_model_parallel_size):
+        mpu.initialize.set_pipeline_model_parallel_rank(pp_rank)
+        def update_layer_num(m):
+            # TODO! This assumes no interleaved pipeline execution
+            layer = int(m.group(1))
+            layer += pp_rank * layers_per_part
+            return f'layers.{layer}'
+        for tp_rank in range(args.tensor_model_parallel_size):
+            mpu.initialize.set_tensor_model_parallel_rank(tp_rank)
+            pre_process = mpu.is_pipeline_first_stage()
+            post_process = mpu.is_pipeline_last_stage()
+            partition_model = get_model(model_type, pre_process, post_process)
+            for dst_name, partition_param in partition_model.named_parameters():
+                if dst_name == "word_embeddings.weight":
+                    # See comment in MegatronModule.initialize_word_embeddings()
+                    src_name = "language_model.embedding.word_embeddings.weight"
+                else:
+                    # Translate destination layer number (0-N for each partition)
+                    # to source layer number (single-model layer number)
+                    src_name = re.sub(layer_re, update_layer_num, dst_name)
+                print(f" > copying {src_name} to {dst_name} in rank tp-{tp_rank} and pp-{pp_rank}'s model")
+                if not hasattr(partition_param, 'tensor_model_parallel'):
+                    partition_param.data.copy_(model_params[src_name].data)
+                else:
+                    partition_param.data.copy_(model_params[src_name][tp_rank].data)
+            save_checkpoint(iteration, partition_model, None, None)
+            
+    print('done :-)')
+
+
+if __name__ == '__main__':
+
+    main()


### PR DESCRIPTION
This PR is related to #232.
I added scripts for merging (and splitting into) model parallelism including tensor and pipeline parallel.
For running the scripts, I also revised `megatron/checkpointing.py` and `megatron/model/fused_layer_norm.py` not compromising generality. 

following shell script is an example with gpt-345m.
```
#!/bin/bash
WORLD_SIZE=$((TENSOR_MODEL_PARALLEL_SIZE * PIPELINE_MODEL_PARALLEL_SIZE)) \
                                python tools/split_into_mp_partitions.py \
                                --model-type GPT \
                                --tensor-model-parallel-size $TENSOR_MODEL_PARALLEL_SIZE \
                                --pipeline-model-parallel-size $PIPELINE_MODEL_PARALLEL_SIZE \
                                --tokenizer-type GPT2BPETokenizer \
                                --vocab-file $VOCAB_FILE \
                                --merge-file $MERGE_FILE \
                                --num-layers 24 \
                                --hidden-size 1024 \
                                --num-attention-heads 16 \
                                --seq-length 1024 \
                                --max-position-embeddings 1024 \
                                --load $LOAD_PATH \
                                --save $SAVE_PATH
```