### PR TITLE
Trigger memory log based on skipped_iter

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -640,7 +640,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         total_loss_dict[skipped_iters_key] = 0
         total_loss_dict[nan_iters_key] = 0
         print_rank_last(log_string)
-        if report_memory_flag and learning_rate > 0.:
+        if report_memory_flag and not skipped_iter:
             # Report memory after optimizer state has been initialized.
             report_memory('(after {} iterations)'.format(iteration))
             report_memory_flag = False


### PR DESCRIPTION
reporting memory status is commented as
`# Report memory after optimization state has been initialized.`
However, I think optimizer states might not be initialized even though the learning rate is not zero when `grad_scaler` is used.
