### PR TITLE
consider when not using distributed file system

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -784,6 +784,11 @@ def _add_distributed_args(parser):
                        'affects the encoder embedding.)')
     group.add_argument('--use-distributed-optimizer', action='store_true',
                        help='Use distributed optimizer.')
+    group.add_argument('--no-distributed-file-system',
+                       action='store_false',
+                       help='Assume there is no shared file system (i.e., each node has an isolated disk).',
+                       dest='distributed_file_system')
+
 
     return parser
 

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -293,7 +293,14 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler):
         iteration, args.save))
 
     # And update the latest iteration
-    if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+    if not torch.distributed.is_initialized():
+        is_iteration_tracker = True
+    else:
+        if args.distributed_file_system:
+            is_iteration_tracker = torch.distributed.get_rank() == 0
+        else:
+            is_iteration_tracker = args.local_rank == 0
+    if is_iteration_tracker:
         tracker_filename = get_checkpoint_tracker_filename(args.save)
         with open(tracker_filename, 'w') as f:
             f.write(str(iteration))

--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -662,8 +662,12 @@ def get_samples_mapping(indexed_dataset,
     indexmap_filename += '.npy'
 
     # Build the indexed mapping if not exist.
-    if torch.distributed.get_rank() == 0 and \
-       not os.path.isfile(indexmap_filename):
+    args = get_args()
+    if args.distributed_file_system:
+        is_index_mapper = torch.distributed.get_rank() == 0
+    else:
+        is_index_mapper = args.local_rank == 0
+    if is_index_mapper and not os.path.isfile(indexmap_filename):
         print(' > WARNING: could not find index map file {}, building '
               'the indices on rank 0 ...'.format(indexmap_filename))
 

--- a/megatron/data/gpt_dataset.py
+++ b/megatron/data/gpt_dataset.py
@@ -21,7 +21,7 @@ import time
 import numpy as np
 import torch
 
-from megatron import mpu, print_rank_0
+from megatron import mpu, get_args, print_rank_0
 from megatron.data.blendable_dataset import BlendableDataset
 from megatron.data.dataset_utils import get_datasets_weights_and_num_samples
 from megatron.data.dataset_utils import get_train_valid_test_split_
@@ -212,7 +212,12 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     shuffle_idx_filename = _filename + '_shuffle_idx.npy'
 
     # Build the indexed mapping if not exist.
-    if torch.distributed.get_rank() == 0:
+    args = get_args()
+    if args.distributed_file_system:
+        is_index_mapper = torch.distributed.get_rank() == 0
+    else:
+        is_index_mapper = args.local_rank == 0
+    if is_index_mapper:
         if (not os.path.isfile(doc_idx_filename)) or \
            (not os.path.isfile(sample_idx_filename)) or \
            (not os.path.isfile(shuffle_idx_filename)):


### PR DESCRIPTION
When running a training job with multi-nodes,
The current version assumes that all nodes can access a single file system.
In other words, when each node uses an isolated file system, the nodes except for master node cannot access compiled fused kernels, data index mapper, etc...

This PR supports running such cluster configuration