### PR TITLE
Fix argument-help typo

### DIFF
--- a/tools/checkpoint_util.py
+++ b/tools/checkpoint_util.py
@@ -114,7 +114,7 @@ def main():
     parser.add_argument('--loader', type=str, default='megatron',
                         help='Module name to load checkpoint, should be on python path')
     parser.add_argument('--saver', type=str, default='megatron',
-                        help='Module name to save checkpoint, shdoul be on python path')
+                        help='Module name to save checkpoint, should be on python path')
     parser.add_argument('--load-dir', type=str, required=True,
                         help='Directory to load model checkpoint from')
     parser.add_argument('--save-dir', type=str, required=True,


### PR DESCRIPTION
This PR fixes a typo in --saver argument help.