### PR TITLE
Check head dim for flash attention

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -391,7 +391,7 @@ class ParallelAttention(MegatronModule):
                 if rearrange is None:
                     raise ImportError('einops is not installed, please install with pip install einops')
             except (ImportError, AssertionError) as e:
-                print('WARNING: failed to apply FlashAttention, fallback to default, ', str(e))
+                print('WARNING: failed to use FlashAttention, fallback to default, reason: ', str(e))
                 self.use_flash_attn = False
 
         projection_size = args.kv_channels * args.num_attention_heads

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -377,16 +377,22 @@ class ParallelAttention(MegatronModule):
         self.sequence_parallel = args.sequence_parallel
 
         self.use_flash_attn = args.use_flash_attn
+        headdim = args.hidden_size / args.num_attention_heads
         if self.use_flash_attn:
-            if flash_attn_unpadded_func is None:
-                raise ImportError('FlashAttention is not installed, please install with '
-                                  'pip install flash-attn')
-            assert attention_type == AttnType.self_attn, ('FlashAttention code path only supports '
-                                                          'self-attention for now')
-            assert self.attn_mask_type == AttnMaskType.causal, ('FlashAttention code path only '
-                                                                'supports causal mask for now')
-            if rearrange is None:
-                raise ImportError('einops is not installed, please install with pip install einops')
+            try:
+                if flash_attn_unpadded_func is None:
+                    raise ImportError('FlashAttention is not installed, please install with '
+                                      'pip install flash-attn')
+                assert headdim <= 128, 'FlashAttention only supports head dimension at most 128'
+                assert attention_type == AttnType.self_attn, ('FlashAttention code path only supports '
+                                                              'self-attention for now')
+                assert self.attn_mask_type == AttnMaskType.causal, ('FlashAttention code path only '
+                                                                    'supports causal mask for now')
+                if rearrange is None:
+                    raise ImportError('einops is not installed, please install with pip install einops')
+            except (ImportError, AssertionError) as e:
+                print('WARNING: failed to apply FlashAttention, fallback to default, ', str(e))
+                self.use_flash_attn = False
 
         projection_size = args.kv_channels * args.num_attention_heads
 


### PR DESCRIPTION
add a check for head dim when flash attention is used, only supports head dim <=128
Reference:
https://github.com/HazyResearch/flash-attention/issues/108
https://github.com/NVIDIA/Megatron-LM/commit/9200e43aec830ead3950180f1e7a0f82df82d019

Also added fallback logic when flash attention failed 

@tridao @jaredcasper could you help take a look? Thanks!