### PR TITLE
Add support for MegaBlocks MoEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 build
 .coverage_*
 *.egg-info
+*~

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following table shows both model (MFU) and hardware (HFU) FLOPs utilization 
       * [Distributed Pretraining](#distributed-pretraining)
       * [Activation Checkpointing and Recomputation](#activation-checkpointing-and-recomputation)
       * [Distributed Optimizer](#distributed-optimizer)
+      * [Mixture-of-Experts](#mixture-of-experts)
       * [GPT-3 Example](#gpt-3-example)
    * [Evaluation and Tasks](#evaluation-and-tasks)
       * [GPT Text Generation](#gpt-text-generation)
@@ -344,6 +345,17 @@ training and reduces memory requirement.
 To install FlashAttention:
 ```sh
 pip install flash-attn
+```
+
+## Mixture-of-Experts
+
+Usage: `--moe-num-experts <number_of_experts>`. See command line arguments prefixed with `moe-` for additional mixture-of-experts (MoE) arguments. Compatible with GPT models.
+
+MoEs are supported through [MegaBlocks](https://github.com/stanford-futuredata/megablocks), a light-weight library for MoE training. The core of the system is efficient "dropless-MoE" ([paper](https://arxiv.org/abs/2211.15841)) and standard MoE layers.
+
+To install MegaBlocks:
+```sh
+pip install megablocks
 ```
 
 ## GPT-3 Example

--- a/megatron/model/megablocks_utils.py
+++ b/megatron/model/megablocks_utils.py
@@ -1,0 +1,16 @@
+"""Adapter to expose MegaBlocks package, if available."""
+try:
+    import megablocks
+except ImportError:
+    megablocks = None
+
+def megablocks_is_available():
+    return megablocks is not None
+
+def assert_megablocks_is_available():
+    assert megablocks_is_available(), (
+        'MegaBlocks not available. Please run `pip install megablocks`.')
+
+moe = megablocks.layers.moe if megablocks_is_available() else None
+dmoe = megablocks.layers.dmoe if megablocks_is_available() else None
+arguments = megablocks.layers.arguments if megablocks_is_available() else None

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -10,7 +10,7 @@ from megatron import get_timers, get_args, core, get_num_microbatches
 from .module import MegatronModule
 from megatron.core import mpu, tensor_parallel
 from megatron.model.enums import AttnMaskType, ModelType, LayerType, AttnType
-from megatron.model import LayerNorm
+from megatron.model import LayerNorm, megablocks_utils
 from megatron.model.fused_softmax import FusedScaleMaskSoftmax
 from megatron.model.fused_bias_gelu import bias_gelu_impl
 from megatron.model.utils import attention_mask_func, openai_gelu, erf_gelu
@@ -136,9 +136,9 @@ class SwitchMLP(MegatronModule):
     def __init__(self, init_method, output_layer_init_method):
         super(SwitchMLP, self).__init__()
         args = get_args()
-        self.router = torch.nn.Linear(args.hidden_size, args.num_experts)
+        self.router = torch.nn.Linear(args.hidden_size, args.moe_num_experts)
         self.experts = torch.nn.ModuleList()
-        for i in range(args.num_experts):
+        for i in range(args.moe_num_experts):
             self.experts.append(ParallelMLP(init_method, output_layer_init_method))
 
     def forward(self, hidden_states):
@@ -177,6 +177,33 @@ class SwitchMLP(MegatronModule):
 
         return output_total, output_bias_total
 
+class _MegablocksAdapter(MegatronModule):
+
+    def __init__(self, layer_cls, init_method, output_layer_init_method):
+        super().__init__()
+        megablocks_utils.assert_megablocks_is_available()
+        args = megablocks_utils.arguments.from_megatron(get_args())
+        args.device = torch.cuda.current_device()
+        args.init_method = init_method
+        args.output_layer_init_method = output_layer_init_method
+        self.moe = layer_cls(args)
+
+    def forward(self, x):
+        return self.moe.forward(x)
+
+class MoE(_MegablocksAdapter):
+
+    def __init__(self, init_method, output_layer_init_method):
+        megablocks_utils.assert_megablocks_is_available()
+        super().__init__(
+            megablocks_utils.moe.MoE, init_method, output_layer_init_method)
+
+class dMoE(_MegablocksAdapter):
+
+    def __init__(self, init_method, output_layer_init_method):
+        megablocks_utils.assert_megablocks_is_available()
+        super().__init__(
+            megablocks_utils.dmoe.dMoE, init_method, output_layer_init_method)
 
 class CoreAttention(MegatronModule):
 
@@ -673,10 +700,15 @@ class ParallelTransformerLayer(MegatronModule):
                 sequence_parallel=args.sequence_parallel)
 
         # MLP
-        if args.num_experts is not None:
-            self.mlp = SwitchMLP(init_method, output_layer_init_method)
-        else:
-            self.mlp = ParallelMLP(init_method, output_layer_init_method)
+        mlp_cls = ParallelMLP
+        if args.moe_num_experts is not None:
+            if args.moe_use_megatron_switch:
+                mlp_cls = SwitchMLP
+            elif args.moe_capacity_factor > 0:
+                mlp_cls = MoE
+            else:
+                mlp_cls = dMoE
+        self.mlp = mlp_cls(init_method, output_layer_init_method)
 
         # Set bias+dropout+add fusion grad_enable execution handler.
         TORCH_MAJOR = int(torch.__version__.split('.')[0])

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -4,13 +4,15 @@
 
 import torch
 from functools import partial
+
 from megatron import get_args
 from megatron import print_rank_0
 from megatron import get_timers
 from megatron import get_tokenizer
 from megatron.core import tensor_parallel
 from megatron.data.gpt_dataset import build_train_valid_test_datasets
-from megatron.model import GPTModel, ModelType
+from megatron.model import GPTModel, ModelType, megablocks_utils
+from megatron.model.megablocks_utils import moe
 from megatron.training import pretrain
 from megatron.utils import get_ltor_masks_and_position_ids
 from megatron.utils import average_losses_across_data_parallel_group
@@ -69,6 +71,37 @@ def loss_func(loss_mask, output_tensor):
 
     return loss, {'lm loss': averaged_loss[0]}
 
+def moe_loss_func(loss_mask, output_tensor):
+    loss, loss_dict = loss_func(loss_mask, output_tensor)
+    assert loss.numel() == 1
+
+    # NOTE: If recompute is enabled we will collect duplicate load
+    # balancing loss contributions. Prune these before calculating
+    # the load balancing loss.
+    args = get_args()
+    if args.recompute_granularity is not None:
+        # Ignore load balancing loss contributions compute during
+        # the forward pass if recompute is turned on.
+        load_balancing_loss_data = moe.get_load_balancing_loss()
+        if args.num_layers * 2 == len(load_balancing_loss_data):
+            load_balancing_loss_data = (
+                load_balancing_loss_data[args.num_layers:])
+            moe.clear_load_balancing_loss()
+            moe.save_load_balancing_loss(load_balancing_loss_data)
+
+    # Compute the load balancing loss for all MoE layers.
+    megablocks_args = megablocks_utils.arguments.from_megatron(args)
+    lbl = moe.batched_load_balancing_loss(megablocks_args)
+    moe.clear_load_balancing_loss()
+
+    # Average the load balancing loss across data parallel
+    # replicas and save for logging.
+    averaged_lbl = average_losses_across_data_parallel_group([lbl])
+    loss_dict['load balancing loss'] = averaged_lbl[0]
+
+    # Compute the total loss, if necessary.
+    total_loss = loss + lbl if loss is not None else lbl
+    return total_loss, loss_dict
 
 def forward_step(data_iterator, model):
     """Forward step."""
@@ -84,8 +117,9 @@ def forward_step(data_iterator, model):
     output_tensor = model(tokens, position_ids, attention_mask,
                           labels=labels)
 
-    return output_tensor, partial(loss_func, loss_mask)
-
+    loss_fn = (
+        moe_loss_func if args.moe_num_experts is not None else loss_func)
+    return output_tensor, partial(loss_fn, loss_mask)
 
 def train_valid_test_datasets_provider(train_val_test_num_samples):
     """Build train, valid, and test datasets."""
@@ -110,7 +144,6 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
 
 
 if __name__ == "__main__":
-
     pretrain(train_valid_test_datasets_provider, model_provider,
              ModelType.encoder_or_decoder,
              forward_step,


### PR DESCRIPTION
These changes add support for using MegaBlocks dMoE and MoE layers in Megatron. MegaBlocks is exposed through an [adapter](https://github.com/NVIDIA/Megatron-LM/compare/main...stanford-futuredata:Megatron-LM:basic-megablocks-integration#diff-aa9d60b130b2ce6bd6810f247a0e1770fe0d0279d01cf8b491cd03df2c72be7a) which isolates the `megablocks` package dependency so that it does not need to be installed if users are not training MoEs. 

Changes Description:
- Add wrappers for MegaBlocks layers in [megatron/model/transformer.py](https://github.com/NVIDIA/Megatron-LM/compare/main...stanford-futuredata:Megatron-LM:basic-megablocks-integration#diff-46c4c76deb18adf1de8e0be6d4229baed5f1f0308e141479f5a993b3d83dd445)
- Add load balancing loss support in [pretrain_gpt.py](https://github.com/NVIDIA/Megatron-LM/compare/main...stanford-futuredata:Megatron-LM:basic-megablocks-integration#diff-8f7acbd2608d54e2faf8653c0d144c718cd78bcb6a53430c35e81199c6c6651a)
- Add MoE arguments in [megatron/arguments.py](https://github.com/NVIDIA/Megatron-LM/compare/main...stanford-futuredata:Megatron-LM:basic-megablocks-integration#diff-5f7d1ddfb0666cb6bb4ec0f07fd2fd7b1cd0354f421df5560489091db2ff5a55)
- Document MoE support in [README.md](https://github.com/NVIDIA/Megatron-LM/compare/main...stanford-futuredata:Megatron-LM:basic-megablocks-integration#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)

Note that this pull request does not include the changes to Megatron to support expert model parallelism, pipeline parallelism and tensor model parallelism for MoEs.
