### PR TITLE
fix bug in uniform activation recompute

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1035,9 +1035,10 @@ class ParallelTransformer(MegatronModule):
         """Forward method with activation checkpointing."""
         def custom(start, end, is_transformer_engine=False):
             def custom_forward(*args, **kwargs):
+                x_, *args = args
                 for index in range(start, end):
                     layer = self._get_layer(index)
-                    x_ = layer(*args, **kwargs)
+                    x_ = layer(x_, *args, **kwargs)
                 return x_
             def custom_forward_transformer_engine(*args, **kwargs):
                 return custom_forward(*args, is_first_microbatch=is_first_microbatch, **kwargs)


### PR DESCRIPTION
When running with uniform activation checkpointing and `--recompute-num-layers` > 1, the original hidden states are passed to all layers from `start` to `end` instead of the updated activations.