### PR TITLE
Fix two small problems

### DIFF
--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -262,10 +262,16 @@ def create_masked_lm_predictions(tokens,
             continue
         # Note(mingdachen):
         # Skip current piece if they are covered in lm masking or previous ngrams.
+        is_covered = False
         for index_set in cand_index_set[0]:
             for index in index_set:
                 if index in covered_indexes:
-                    continue
+                    is_covered = True
+                    break
+            if is_covered:
+                break
+        if is_covered:
+            continue
 
         if not geometric_dist:
             n = np_rng.choice(ngrams[:len(cand_index_set)],

--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -262,7 +262,7 @@ class _GPT2BPETokenizer(AbstractTokenizer):
 
     @property
     def vocab_size(self):
-        return len(self.tokenizer.encoder)
+        return len(self.tokenizer)
 
     @property
     def vocab(self):


### PR DESCRIPTION
Problems:
- BERT/T5 dataset handles already corrupted indices incorrectly.
- GPT tokenizer vocab size does not include special tokens.

This PR fixes these issues. Since the changes are so small, I didn't bother creating separate PRs but please tell me if you need it separate.