### PR TITLE
Fix text_generation_cli 

### DIFF
--- a/tools/text_generation_cli.py
+++ b/tools/text_generation_cli.py
@@ -1,21 +1,18 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 import json
 import sys
-import urllib2
-class PutRequest(urllib2.Request):
-    '''class to handling putting with urllib2'''
-
-    def get_method(self, *args, **kwargs):
-        return 'PUT'
+import urllib
+from urllib.request import Request
 
 if __name__ == "__main__":
     url = sys.argv[1]
     while True:
-        sentence = raw_input("Enter prompt: ")
+        sentence = input("Enter prompt: ")
         tokens_to_generate = int(input("Enter number of tokens to generate: "))
         data = json.dumps({"prompts": [sentence], "tokens_to_generate":tokens_to_generate})
-        req = PutRequest(url, data, {'Content-Type': 'application/json'})
-        response = urllib2.urlopen(req)
+        data = data.encode('utf-8')
+        req = Request(url, data=data, headers={'Content-Type': 'application/json'}, method='PUT')
+        response = urllib.request.urlopen(req)
         resp_sentences = json.load(response)
         print("Megatron Response: ")
         print(resp_sentences["text"][0])


### PR DESCRIPTION
The old version of the CLI tool used urllib2, which cannot be used on Python3. This commit fixed this issue.