### PR TITLE
[Fix] compile dependencies in local rank 0

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -93,7 +93,7 @@ def _compile_dependencies():
     # Compile dataset C++ code.
     # =========================
     # TODO: move this to ninja
-    if torch.distributed.get_rank() == 0:
+    if args.local_rank == 0:
         start_time = time.time()
         print('> compiling dataset index builder ...')
         from megatron.data.dataset_utils import compile_helper
@@ -123,8 +123,8 @@ def _compile_dependencies():
                   ' fused softmax kernel are not met. We default'
                   ' back to unfused kernel invocations.', flush=True)
     
-    # Always build on rank zero first.
-    if torch.distributed.get_rank() == 0:
+    # Always build on local rank zero first.
+    if args.local_rank == 0:
         start_time = time.time()
         print('> compiling and loading fused kernels ...', flush=True)
         fused_kernels.load(args)
@@ -137,7 +137,7 @@ def _compile_dependencies():
     # rest of the program. We think this might ensure that
     # the lock is released.
     torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    if args.local_rank == 0:
         print('>>> done with compiling and loading fused kernels. '
               'Compilation time: {:.3f} seconds'.format(
                   time.time() - start_time), flush=True)


### PR DESCRIPTION
Hi there,
when using Megatron-LM on multiple nodes, the dependencies are built in only rank 0 of Node 0. Other nodes do not build the dependencies, e.g. `megatron.data.helpers`. It causes that other nodes raise the following error:
```
    File "./megatron/data/blendable_dataset.py", line 52, in __init__
      from megatron.data import helpers
  ImportError: cannot import name 'helpers' from 'megatron.data' (./megatron/data/__init__.py)
```

To address the issue, I replaced `torch.distributed.get_rank()` with `args.local_rank` in the function `megatron.initialize._compile_dependencies`. The dependencies will be compiled if local_rank is 0.