### PR TITLE
fix compute check for hopper arch

### DIFF
--- a/megatron/fused_kernels/__init__.py
+++ b/megatron/fused_kernels/__init__.py
@@ -23,7 +23,7 @@ def load(args):
     if int(bare_metal_major) >= 11:
         cc_flag.append('-gencode')
         cc_flag.append('arch=compute_80,code=sm_80')
-        if int(bare_metal_minor) >= 7:
+        if int(bare_metal_minor) >= 8:
             cc_flag.append('-gencode')
             cc_flag.append('arch=compute_90,code=sm_90')
 


### PR DESCRIPTION
"compute_90" (Hopper arch) is supported since CUDA 11.8, not 11.7, so I fixed the code very slightly.
Please check https://docs.nvidia.com/cuda/hopper-compatibility-guide/#building-applications-using-cuda-toolkit-11-7-or-earlier