### PR TITLE
Add log index map files

### DIFF
--- a/megatron/data/gpt_dataset.py
+++ b/megatron/data/gpt_dataset.py
@@ -308,8 +308,8 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
            (not os.path.isfile(sample_idx_filename)) or \
            (not os.path.isfile(shuffle_idx_filename)):
 
-            print_rank_0(' > WARNING: could not find index map files, building '
-                         'the indices on rank 0 ...')
+            print_rank_0(' > WARNING: could not find index map files for {}, building '
+                         'the indices on rank 0 ...'.format(_filename))
 
             # For the last epoch, decide whether include the entire epoch
             # in the global shuffle or not.


### PR DESCRIPTION
Add log about index map files

## old log

```
> WARNING: could not find index map files, building the indices on rank 0 ...
 > elasped time to build and save doc-idx mapping (seconds): 0.008020
    using:
     number of documents:       2662
     number of epochs:          1
     tokens_per_epoch:          109490076893
     sequence length:           2048
     total number of samples:   53461951
 > elapsed time to build and save sample-idx mapping (seconds): 1.838097
 > elapsed time to build and save shuffle-idx mapping (seconds): 4.836150
```

## new log

```
> WARNING: could not find index map files for data/wiki_text_document_train_0_indexmap_5145600ns_2048sl_1234s, building the indices on rank 0 ...
 > elasped time to build and save doc-idx mapping (seconds): 0.008020
    using:
     number of documents:       2662
     number of epochs:          1
     tokens_per_epoch:          109490076893
     sequence length:           2048
     total number of samples:   53461951
 > elapsed time to build and save sample-idx mapping (seconds): 1.838097
 > elapsed time to build and save shuffle-idx mapping (seconds): 4.836150
```
