### PR TITLE
transformer.py: do not handle query-key-layer-scaling again in FusedS…

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -240,7 +240,7 @@ class CoreAttention(MegatronModule):
             args.masked_softmax_fusion,
             attention_mask_func,
             self.attention_softmax_in_fp32,
-            coeff)
+            None)
 
         # Dropout. Note that for a single iteration, this layer will generate
         # different outputs on different number of parallel partitions but


### PR DESCRIPTION
…caleMaskSoftmax

In CoreAttention.__init__
        self.norm_factor = math.sqrt(self.hidden_size_per_attention_head)
        if self.apply_query_key_layer_scaling:
            coeff = self.layer_number
            self.norm_factor *= coeff

In CoreAttention.forward
        matmul_result = torch.baddbmm(
            matmul_input_buffer,
            query_layer.transpose(0, 1),   # [b * np, sq, hn]
            key_layer.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
            beta=0.0, alpha=(1.0/self.norm_factor))

query_key_layer_scaling is already handled in torch.baddbmm(alpha), and so don't need to handle again in FusedScaleMaskSoftmax which actually multiples the self.layer_number back, see detail in below code

In CoreAttention.__init__
        self.scale_mask_softmax = FusedScaleMaskSoftmax(
            self.fp16, self.bf16,
            self.attn_mask_type,
            args.masked_softmax_fusion,
            attention_mask_func,
            self.attention_softmax_in_fp32,
            coeff)

In FusedScaleMaskSoftmax.__init__
    def __init__(
        self,
        input_in_fp16,
        input_in_bf16,
        attn_mask_type,
        scaled_masked_softmax_fusion,
        mask_func,
        softmax_in_fp32,
        scale,
    ):
        super(FusedScaleMaskSoftmax, self).__init__()
        ...
        self.scale = scale

In FusedScaleMaskSoftmax.forward_torch_softmax
        if self.scale is not None:
            input = input * self.scale

So, roughly in math, it is qk * 1 /(sqrt(s_per_h) * l_num) * l_num equals qk * 1 / sqrt(s_per_h) besides the dtype change, it means that query-key-layer-scaling contributes little with current implementation.