### PR TITLE
pass the correct dropout prob when using FlashAttention

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -384,12 +384,11 @@ class FlashSelfAttention(torch.nn.Module):
             # only on first autoregressive step q,k,v have same seqlen
             is_causal = seqlen_q == seqlen_k
             cu_seqlens_k = torch.arange(0, (batch_size + 1) * seqlen_k, step=seqlen_k, dtype=torch.int32,
-                        device=q.device)
-            self.dropout_p = 0
+                                        device=q.device)
 
         output = flash_attn_unpadded_func(
             q, k, v, cu_seqlens_q, cu_seqlens_k, seqlen_q, seqlen_k,
-            self.dropout_p,
+            self.dropout_p if self.training else 0.0,
             softmax_scale=self.softmax_scale, causal=is_causal
         )
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -383,8 +383,11 @@ class FlashSelfAttention(torch.nn.Module):
             # turn off FA causal mask after first inference autoregressive iteration
             # only on first autoregressive step q,k,v have same seqlen
             is_causal = seqlen_q == seqlen_k
-            cu_seqlens_k = torch.arange(0, (batch_size + 1) * seqlen_k, step=seqlen_k, dtype=torch.int32,
-                                        device=q.device)
+            if not is_causal:
+                cu_seqlens_k = torch.arange(0, (batch_size + 1) * seqlen_k, step=seqlen_k, dtype=torch.int32,
+                                            device=q.device)
+            else:
+                cu_seqlens_k = cu_seqlens_q
 
         output = flash_attn_unpadded_func(
             q, k, v, cu_seqlens_q, cu_seqlens_k, seqlen_q, seqlen_k,


### PR DESCRIPTION
A recent fix at cdd2afdf22a8d3490b5c9091c957449765519fdc performs stateful modification of the dropout probability of the Attention layer.
This could lead to incorrect behavior after the first evaluation performed during training.