### PR TITLE
Safe assertion for interleaved pipeline

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -141,7 +141,7 @@ def validate_args(args, defaults={}):
         assert args.pipeline_model_parallel_size > 2, \
             'pipeline-model-parallel size should be greater than 2 with ' \
             'interleaved schedule'
-        assert args.num_layers % args.num_layers_per_virtual_pipeline_stage == 0, \
+        assert args.num_layers % (args.num_layers_per_virtual_pipeline_stage * args.transformer_pipeline_model_parallel_size) == 0, \
             'number of layers is not divisible by number of layers per virtual ' \
             'pipeline stage'
         args.virtual_pipeline_model_parallel_size = \


### PR DESCRIPTION
Simple edge case of the current implementation:

When training GPT-13B model that has 40 Transformer layers with
- `pipeline_model_parallel_size`: 8
- `num_layers_per_virtual_pipeline_stage`: 2

It does not fail although `40 % (8 * 2) != 0`.
Consequently, each model chunk has two layers (missing 1 layer per each device).