### PR TITLE
Update clip_grads.py

### DIFF
--- a/megatron/optimizer/clip_grads.py
+++ b/megatron/optimizer/clip_grads.py
@@ -3,7 +3,7 @@
 """Gradient clipping."""
 
 import torch
-from torch._six import inf
+from torch import inf
 
 from apex.multi_tensor_apply import multi_tensor_applier
 import amp_C


### PR DESCRIPTION
The torch._six module was an internal PyTorch module used to provide compatibility between Python 2 and Python 3. However, since Python 2 reached its end-of-life on January 1, 2020, and PyTorch dropped support for Python 2, the torch._six module was removed.