### PR TITLE
Optimize communication in interleaved pipeline parallelism

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -529,7 +529,7 @@ def forward_backward_pipelining_with_interleaving(*,
             if param_sync_microbatch_id < num_microbatches and is_first_microbatch_for_model_chunk(param_sync_microbatch_id):
                 param_sync_chunk_id = get_model_chunk_id(param_sync_microbatch_id, forward=True) + 1
                 if 1 < param_sync_chunk_id < num_model_chunks:
-                    custom_param_sync_func(model[param_sync_chunk_id].parameters())
+                    param_sync_func(model[param_sync_chunk_id].parameters())
 
         # forward step
         if parallel_state.is_pipeline_first_stage():


### PR DESCRIPTION
This is work toward restoring NeMo-Megatron support for interleaved pipeline parallelism after https://github.com/NVIDIA/NeMo/pull/6393. In particular, it ports some changes from the [Apex fork of Megatron](https://github.com/NVIDIA/apex/tree/master/apex/transformer/pipeline_parallel/schedules):

- Adds support for custom communication (e.g. for the [Apex distributed optimizer](https://github.com/NVIDIA/apex/blob/master/apex/contrib/optimizers/distributed_fused_adam.py)). This is for the non-pipeline, non-interleaved pipeline, and interleaved pipeline cases.
- Optimizes performance for interleaved pipeline parallelism by aligning communication over the pipeline parallel group to avoid GPU idling. See https://github.com/NVIDIA/apex/pull/1611.

This is intended to have minimal effect on existing downstream code. Pinging @aklife97.