### PR TITLE
Fix calling torch.TypedStorage._untyped

### DIFF
--- a/megatron/optimizer/distrib_optimizer.py
+++ b/megatron/optimizer/distrib_optimizer.py
@@ -388,7 +388,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         for model_index, model in enumerate(self.models):
             current_param_buffers = {}
             for dtype, grad_buffer in model._grad_buffers.items():
-                param_buffer = torch.tensor(grad_buffer.data.storage()._untyped(),
+                param_buffer = torch.tensor(grad_buffer.data.storage().untyped(),
                                             dtype = params_dtype,
                                             device = grad_buffer.data.device)
                 param_buffer = param_buffer[:grad_buffer.numel_padded]


### PR DESCRIPTION
I ran the main branch with PyTorch1.13.1, and get this exception:
```
Traceback (most recent call last):
  File "/checkpoint/binary/train_package/pretrain_gpt.py", line 117, in <module>
    pretrain(train_valid_test_datasets_provider, model_provider,
  File "/checkpoint/binary/train_package/megatron/training.py", line 111, in pretrain
    model, optimizer, opt_param_scheduler = setup_model_and_optimizer(
  File "/checkpoint/binary/train_package/megatron/training.py", line 375, in setup_model_and_optimizer
    optimizer = get_megatron_optimizer(model, no_wd_decay_cond,
  File "/checkpoint/binary/train_package/megatron/optimizer/__init__.py", line 128, in get_megatron_optimizer
    return opt_ty(optimizer,
  File "/checkpoint/binary/train_package/megatron/optimizer/distrib_optimizer.py", line 391, in __init__
    param_buffer = torch.tensor(grad_buffer.data.storage()._untyped(),
AttributeError: 'torch.storage.TypedStorage' object has no attribute '_untyped'
```

So, I turn to PyTorch docs. It seems that this interface has become a public interface since 1.13
https://pytorch.org/docs/stable/storage.html#torch.TypedStorage.untyped