### PR TITLE
Modify LayerNorm to support other dtype inputs

### DIFF
--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -18,7 +18,7 @@ try:
 except:
     HAVE_PERSIST_LAYER_NORM = False
 
-from apex.normalization.fused_layer_norm import FusedLayerNormAffineFunction
+from apex.normalization.fused_layer_norm import FusedLayerNormAffineMixedDtypesFunction
 
 
 global fused_layer_norm_cuda
@@ -77,7 +77,7 @@ class MixedFusedLayerNorm(torch.nn.Module):
     weight = self.weight + 1 if self.apply_layernorm_1p else self.weight
 
     if self.no_persist_layer_norm:
-        return FusedLayerNormAffineFunction.apply(input, weight, self.bias, self.normalized_shape, self.eps)
+        return FusedLayerNormAffineMixedDtypesFunction.apply(input, weight, self.bias, self.normalized_shape, self.eps)
     else:
         output = FastLayerNormFN.apply(input, weight, self.bias, self.eps)
 


### PR DESCRIPTION
The Megatron code was recently updated to use apex's layernorm code.
However, in the case of fp32, the Layer Nom code of the previous Megatron was considered, but the Apex code did not consider the Layer Nom, so I made a PR.
In the case of code using `--fp32-residual-connection` in Megatron, fp32 dtype is used for layernorm input, but when learning with bf16 or fp16, there is a problem that layernorm of apex cannot be used.
By using `FusedLayerNormAffineFunction` instead of `FusedLayerNormAffineFunction` within Apex, you can keep the same layernorm functionality previously used in Megatron.
