### PR TITLE
Replace np.float by float (cont.)

### DIFF
--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -95,7 +95,7 @@ dtypes = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
+    6: float,
     7: np.double,
     8: np.uint16
 }
@@ -268,7 +268,7 @@ class IndexedDatasetBuilder(object):
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
+        float: 4,
         np.double: 8
     }
 


### PR DESCRIPTION
np.float was deprecated in numpy 1.20 (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations), and Megatron-LM fails when enabling --log-validation-ppl-to-tensorboard) and using the latest version of numpy. This commit fixes that runtime error.

Related to https://github.com/NVIDIA/Megatron-LM/pull/347