### PR TITLE
A typing error on variable name in distrib_optimizer.py (param->model…

### DIFF
--- a/megatron/optimizer/distrib_optimizer.py
+++ b/megatron/optimizer/distrib_optimizer.py
@@ -318,7 +318,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                                     'torch.cuda.FloatTensor,  '
                                     'torch.cuda.HalfTensor, or '
                                     'torch.cuda.BFloat16Tensor. '
-                                    'Received {}'.format(param.type()))
+                                    'Received {}'.format(model_param.type()))
 
             # Update optimizer's params.
             group_range["orig_group"]["params"] = [


### PR DESCRIPTION
A typing error on variable name in distrib_optimizer.py (param->model_param), causing undefined variable error.