### PR TITLE
Bug Fixed when using activation checkpoints and rotary position embedding

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1169,13 +1169,13 @@ class ParallelTransformer(MegatronModule):
                         tensor_parallel.get_cuda_rng_tracker,
                         mpu.get_tensor_model_parallel_group(),
                         hidden_states, attention_mask, encoder_output,
-                        enc_dec_attn_mask, rotary_pos_emb)
+                        enc_dec_attn_mask, None, rotary_pos_emb)
                 else:
                     hidden_states = tensor_parallel.checkpoint(
                         custom(l, l + self.recompute_num_layers),
                         self.distribute_saved_activations,
                         hidden_states, attention_mask, encoder_output,
-                        enc_dec_attn_mask, rotary_pos_emb)
+                        enc_dec_attn_mask, None, rotary_pos_emb)
 
                 l += self.recompute_num_layers
 
@@ -1192,22 +1192,22 @@ class ParallelTransformer(MegatronModule):
                             tensor_parallel.get_cuda_rng_tracker,
                             mpu.get_tensor_model_parallel_group(),
                             hidden_states, attention_mask, encoder_output,
-                            enc_dec_attn_mask, rotary_pos_emb)
+                            enc_dec_attn_mask, None, rotary_pos_emb)
                     else:
                         hidden_states = tensor_parallel.checkpoint(
                             custom(l, l + 1),
                             self.distribute_saved_activations,
                             hidden_states, attention_mask, encoder_output,
-                            enc_dec_attn_mask, rotary_pos_emb)
+                            enc_dec_attn_mask, None, rotary_pos_emb)
                 else:
                     if self.transformer_impl == 'transformer_engine':
                         hidden_states = custom(l, l + 1, is_transformer_engine=True)(
                             hidden_states, attention_mask, encoder_output,
-                            enc_dec_attn_mask, rotary_pos_emb)
+                            enc_dec_attn_mask, None, rotary_pos_emb)
                     else:
                         hidden_states = custom(l, l + 1)(
                             hidden_states, attention_mask, encoder_output,
-                            enc_dec_attn_mask, rotary_pos_emb)
+                            enc_dec_attn_mask, None, rotary_pos_emb)
         else:
             raise ValueError("Invalid activation recompute method.")
 


### PR DESCRIPTION
Hi there,

In `megatron/model/transformer.py`, the signature of the function [`ParallelAttention.forward`](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/transformer.py#L522-L524) is
```python
# In class ParallelAttention
    def forward(self, hidden_states, attention_mask,
                encoder_output=None, enc_dec_attn_mask=None,
                inference_params=None, rotary_pos_emb=None):
```

When using activation checkpoints and rotary position embedding, this function is called as the following
https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/transformer.py#L1174-L1178
```python
                    hidden_states = tensor_parallel.checkpoint(
                        custom(l, l + self.recompute_num_layers),
                        self.distribute_saved_activations,
                        hidden_states, attention_mask, encoder_output,
                        enc_dec_attn_mask, rotary_pos_emb)
```

The variable `rotary_pos_emb` is passed as `inference_params` by mistake.

In this PR, I correct the order of arguments.