### PR TITLE
Update indexed_dataset.py

### DIFF
--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -268,7 +268,7 @@ class IndexedDatasetBuilder(object):
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
+        np.float32: 4,
         np.double: 8
     }
 


### PR DESCRIPTION
np.float deprecated in NumPy 1.20