### PR TITLE
fix a bug on missing error message when loading checkpoints

### DIFF
--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -438,7 +438,7 @@ def _load_base_checkpoint(load_dir, no_load_optim, use_distributed_optimizer,
         from megatron.fp16_deprecated import loss_scaler
         # For backward compatibility.
         if not rank0:
-            print_rank_0(' > deserializing using the old code structure ...')
+            print_with_rank(' > deserializing using the old code structure ...')
         sys.modules['fp16.loss_scaler'] = sys.modules[
             'megatron.fp16_deprecated.loss_scaler']
         sys.modules['megatron.fp16.loss_scaler'] = sys.modules[
@@ -448,8 +448,8 @@ def _load_base_checkpoint(load_dir, no_load_optim, use_distributed_optimizer,
         sys.modules.pop('fp16.loss_scaler', None)
         sys.modules.pop('megatron.fp16.loss_scaler', None)
     except BaseException as e:
-        print_rank_0('could not load the checkpoint')
-        print_rank_0(e)
+        print_with_rank('could not load the checkpoint')
+        print_with_rank(e)
         sys.exit()
 
     return model_state_dict, optim_state_dict, release

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -200,6 +200,13 @@ def print_rank_0(message):
     else:
         print(message, flush=True)
 
+def print_with_rank(message):
+    """If distributed is initialized, print only on rank 0."""
+    if torch.distributed.is_initialized():
+        print(f"rank {torch.distributed.get_rank()}: {message}", flush=True)
+    else:
+        print(message, flush=True)
+
 def is_last_rank():
     return torch.distributed.get_rank() == (
         torch.distributed.get_world_size() - 1)


### PR DESCRIPTION
To support to print error message for each rank, not only rank-0, when loading checkpoints.  

The errors on non-zero ranks can cause a hang since the torch.distributed.barrier() is invoked and there is no any information on terminal.