### PR TITLE
Allow setting initial warmup LR

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -826,6 +826,9 @@ def _add_learning_rate_args(parser):
     group.add_argument('--lr-warmup-samples', type=int, default=0,
                        help='number of samples to linearly warmup '
                        'learning rate over.')
+    group.add_argument('--lr-warmup-init', type=float, default=0.0,
+                       help='Initial value for learning rate warmup. The '
+                       'scheduler starts warmup from this value.')
     group.add_argument('--warmup', type=int, default=None,
                        help='Old lr warmup argument, do not use. Use one of the'
                        '--lr-warmup-* arguments above')

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -345,6 +345,7 @@ def get_optimizer_param_scheduler(optimizer):
 
     opt_param_scheduler = OptimizerParamScheduler(
         optimizer,
+        init_lr=args.lr_warmup_init,
         max_lr=args.lr,
         min_lr=args.min_lr,
         lr_warmup_steps=lr_warmup_steps,


### PR DESCRIPTION
Allows starting linear warmup from a value other than 0. Backward-compatible due to the default of 0.0, except for the API change. If you'd like, I can also add the new argument in a backward-compatible way; however, I thought the positioning made sense this way. (The order initial LR, max LR, min LR follows the temporal evolution.) :)