### PR TITLE
Minor change in tensor_parallel to align with apex implementation

### DIFF
--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -537,6 +537,8 @@ class ColumnParallelLinear(torch.nn.Module):
                 "cannot be enabled at the same time."
             )
 
+        self._forward_impl = linear_with_grad_accumulation_and_async_allreduce
+
 
     def forward(self, input_):
         """Forward of ColumnParallelLinear
@@ -556,7 +558,7 @@ class ColumnParallelLinear(torch.nn.Module):
         else:
             input_parallel = copy_to_tensor_model_parallel_region(input_)
         # Matrix multiply.
-        output_parallel = linear_with_grad_accumulation_and_async_allreduce(
+        output_parallel = self._forward_impl(
             input=input_parallel,
             weight=self.weight,
             bias=bias,
@@ -674,6 +676,7 @@ class RowParallelLinear(torch.nn.Module):
         else:
             self.register_parameter('bias', None)
 
+        self._forward_impl = linear_with_grad_accumulation_and_async_allreduce
 
 
     def forward(self, input_):
@@ -693,7 +696,7 @@ class RowParallelLinear(torch.nn.Module):
             assert not self.sequence_parallel_enabled
             input_parallel = scatter_to_tensor_model_parallel_region(input_)
         # Matrix multiply.
-        output_parallel = linear_with_grad_accumulation_and_async_allreduce(
+        output_parallel = self._forward_impl(
             input=input_parallel,
             weight=self.weight,
             bias=None,


### PR DESCRIPTION
### Context

1. NeMo previously depended on `apex.transformer.tensor_parallel`, and now depends on `megatron.core.tensor_parallel`. 
2. NeMo plans to add quantization support to megatron models, the [apex version](https://github.com/NVIDIA/apex/blob/0c8400aa04f4279b1384ae0633e73d6daf9fead7/apex/transformer/tensor_parallel/layers.py#L638) of `RowParallelLinear` and `ColumnParallelLinear` is easier to add quantization hook, while the current megatron version requires code copy of the entire forward function.

This PR changes the implementation of megatron.core with apex.