### PR TITLE
Add ALiBi positional embedding

### DIFF
--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -471,7 +471,7 @@ def load_args_from_checkpoint(args, load_arg='load'):
     _set_arg('kv_channels')
     _set_arg('max_position_embeddings')
     _set_arg('add_position_embedding', force=True)
-    _set_arg('use_rotary_position_embeddings', force=True)
+    _set_arg('position_embedding_type', force=True)
     _set_arg('rotary_percent', force=True)
     _set_arg('add_bias_linear', force=True)
     _set_arg('swiglu', force=True)

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -11,6 +11,7 @@ import torch
 
 from megatron import update_num_microbatches
 from megatron.core import mpu, tensor_parallel
+from megatron.model.enums import PositionEmbeddingType
 from .global_vars import get_args
 from .utils import (unwrap_model,
                     print_rank_0)
@@ -56,8 +57,10 @@ def check_checkpoint_args(checkpoint_args):
     _compare('hidden_size')
     _compare('num_attention_heads')
     _compare('add_position_embedding', default=True)
-    if args.vocab_file:
+    # With ALiBi, `max_position_embeddings` can be changed.
+    if args.position_embedding_type != PositionEmbeddingType.alibi:
         _compare('max_position_embeddings')
+    if args.vocab_file:
         _compare('make_vocab_size_divisible_by')
         _compare('padded_vocab_size')
         _compare('tokenizer_type')

--- a/megatron/model/enums.py
+++ b/megatron/model/enums.py
@@ -17,5 +17,10 @@ class AttnMaskType(enum.Enum):
     padding = 1
     causal = 2
 
+class PositionEmbeddingType(enum.Enum):
+    none = 1
+    alibi = 2
+    rotary = 3
+
 # For backward compatibility with old model checkpoints
 from megatron.core.enums import ModelType

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -9,7 +9,7 @@ from megatron import get_args
 from megatron.core import mpu, tensor_parallel
 from megatron.core.enums import ModelType
 
-from .enums import AttnMaskType, LayerType
+from .enums import AttnMaskType, LayerType, PositionEmbeddingType
 from .module import MegatronModule
 from .rotary_pos_embedding import apply_rotary_pos_emb, RotaryEmbedding
 from .transformer import ParallelTransformer
@@ -371,9 +371,8 @@ class TransformerLanguageModel(MegatronModule):
             self._embedding_key = 'embedding'
 
         # Rotary positional embeddings
-        self.use_rotary_position_embeddings = \
-            args.use_rotary_position_embeddings
-        if args.use_rotary_position_embeddings:
+        self.position_embedding_type = args.position_embedding_type
+        if args.position_embedding_type is PositionEmbeddingType.rotary:
             self.seq_length = args.seq_length
             rotary_dim = args.hidden_size // args.num_attention_heads \
                 if args.kv_channels is None else args.kv_channels
@@ -485,7 +484,7 @@ class TransformerLanguageModel(MegatronModule):
 
         # Rotary positional embeddings
         rotary_pos_emb = None
-        if self.use_rotary_position_embeddings:
+        if self.position_embedding_type is PositionEmbeddingType.rotary:
             if inference_params is not None:
                 rotary_pos_emb = \
                     self.rotary_pos_emb(inference_params.max_sequence_len)

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -13,7 +13,12 @@ from .module import MegatronModule
 from megatron.core import mpu, tensor_parallel
 from megatron.core.enums import ModelType
 from megatron.model import LayerNorm
-from megatron.model.enums import AttnMaskType, LayerType, AttnType
+from megatron.model.enums import (
+    AttnMaskType,
+    AttnType,
+    LayerType,
+    PositionEmbeddingType,
+)
 from megatron.model.fused_softmax import FusedScaleMaskSoftmax
 from megatron.model.fused_bias_gelu import bias_gelu_impl
 from megatron.model.rotary_pos_embedding import apply_rotary_pos_emb
@@ -241,7 +246,7 @@ class CoreAttention(MegatronModule):
         self.attention_dropout = torch.nn.Dropout(config.attention_dropout)
 
     def forward(self, query_layer, key_layer,
-                value_layer, attention_mask):
+                value_layer, attention_mask, alibi=None):
 
         # ===================================
         # Raw attention scores. [b, np, s, s]
@@ -266,11 +271,26 @@ class CoreAttention(MegatronModule):
             query_layer.dtype, "mpu")
 
         # Raw attention scores. [b * np, sq, sk]
-        matmul_result = torch.baddbmm(
-            matmul_input_buffer,
-            query_layer.transpose(0, 1),   # [b * np, sq, hn]
-            key_layer.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
-            beta=0.0, alpha=(1.0/self.norm_factor))
+        if alibi is None:
+            matmul_result = torch.baddbmm(
+                matmul_input_buffer,
+                query_layer.transpose(0, 1),   # [b * np, sq, hn]
+                key_layer.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
+                beta=0.0, alpha=(1.0/self.norm_factor))
+        else:
+            matmul_result = alibi[
+                :output_size[0]*output_size[1], :, :output_size[3]]
+
+            if self.apply_query_key_layer_scaling:
+                beta = 1.0 / self.layer_number
+            else:
+                beta = 1.0
+
+            matmul_result = torch.baddbmm(
+                matmul_result,
+                query_layer.transpose(0, 1),  # [b * np, sq, hn]
+                key_layer.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
+                beta=beta, alpha=(1.0 / self.norm_factor))
 
         # change view to [b, np, sq, sk]
         attention_scores = matmul_result.view(*output_size)
@@ -480,7 +500,8 @@ class ParallelAttention(MegatronModule):
 
     def _checkpointed_attention_forward(self, query_layer, key_layer,
                                         value_layer, attention_mask,
-                                        rotary_pos_emb=None):
+                                        rotary_pos_emb=None,
+                                        alibi=None):
         """Forward method with activation checkpointing."""
         def custom_forward(*inputs):
             query_layer = inputs[0]
@@ -512,7 +533,7 @@ class ParallelAttention(MegatronModule):
 
     def forward(self, hidden_states, attention_mask,
                 encoder_output=None, inference_params=None,
-                rotary_pos_emb=None):
+                rotary_pos_emb=None, alibi=None):
         # hidden_states: [sq, b, h]
 
         # =================================================
@@ -644,7 +665,8 @@ class ParallelAttention(MegatronModule):
                     query_layer, key_layer, value_layer, attention_mask)
             else:
                 context_layer = self.core_attention(
-                    query_layer, key_layer, value_layer, attention_mask)
+                    query_layer, key_layer, value_layer, attention_mask,
+                    alibi=alibi)
         else:
             q, k, v = [rearrange(x, 's b ... -> b s ...').contiguous()
                        for x in (query_layer, key_layer, value_layer)]
@@ -767,6 +789,22 @@ class ParallelTransformerLayer(MegatronModule):
             self.mlp = SwitchMLP(config)
         else:
             self.mlp = ParallelMLP(config)
+
+        # ALiBi
+        if args.position_embedding_type == PositionEmbeddingType.alibi:
+            assert not args.use_flash_attn, \
+                'ALiBi does not work with FlashAttention currently'
+            self.alibi = self._build_alibi_tensor(
+                args.seq_length,
+                args.num_attention_heads,
+                args.micro_batch_size,
+            ).to(torch.cuda.current_device())
+            if args.params_dtype is torch.float16:
+                self.alibi = self.alibi.to(torch.float16)
+            elif args.params_dtype is torch.bfloat16:
+                self.alibi = self.alibi.to(torch.bfloat16)
+        else:
+            self.alibi = None
 
         # Set bias+dropout+add fusion grad_enable execution handler.
         TORCH_MAJOR = int(torch.__version__.split('.')[0])
@@ -1021,7 +1059,8 @@ class ParallelTransformerLayer(MegatronModule):
                 layernorm_output,
                 attention_mask,
                 inference_params=inference_params,
-                rotary_pos_emb=rotary_pos_emb)
+                rotary_pos_emb=rotary_pos_emb,
+                alibi=self.alibi)
 
         # Residual connection.
         if self.apply_residual_connection_post_layernorm:
@@ -1133,6 +1172,47 @@ class ParallelTransformerLayer(MegatronModule):
             return output, retriever_output
         else:
             return output
+
+    @staticmethod
+    def _build_alibi_tensor(max_seq_len, num_attention_heads, batch_size):
+        # Copied from bigscience-workshop/Megatron-DeepSpeed
+        # Based on https://github.com/ofirpress/attention_with_linear_biases/blob/a35aaca144e0eb6b789dfcb46784c4b8e31b7983/fairseq/models/transformer.py#L742
+        """Returns tensor shaped
+        (batch_size * num_attention_heads, 1, max_seq_len).
+        """
+
+        def get_slopes(n):
+            def get_slopes_power_of_2(n):
+                start = (2 ** (-2 ** -(math.log2(n) - 3)))
+                ratio = start
+                return [start * ratio ** i for i in range(n)]
+
+            if math.log2(n).is_integer():
+                return get_slopes_power_of_2(n)
+            else:
+                closest_power_of_2 = 2 ** math.floor(math.log2(n))
+                return (
+                    get_slopes_power_of_2(closest_power_of_2)
+                    + get_slopes(
+                        2 * closest_power_of_2,
+                    )[0::2][:n - closest_power_of_2]
+                )
+
+        slopes = torch.Tensor(get_slopes(num_attention_heads))
+        alibi = (
+            slopes.unsqueeze(1).unsqueeze(1)
+            * torch.arange(max_seq_len).unsqueeze(0).unsqueeze(0).expand(
+                num_attention_heads, -1, -1)
+        )
+
+        # Select the part of the tensor that corresponds to our tensor
+        # parallel index.
+        tp_world_size = mpu.get_tensor_model_parallel_world_size()
+        tp_index = mpu.get_tensor_model_parallel_rank()
+        alibi = alibi.reshape((tp_world_size, -1, *alibi.shape[1:]))[tp_index]
+
+        alibi = alibi.repeat(batch_size, 1, 1)
+        return alibi
 
 
 class NoopTransformerLayer(MegatronModule):

--- a/tools/checkpoint_loader_megatron.py
+++ b/tools/checkpoint_loader_megatron.py
@@ -30,6 +30,7 @@ def _load_checkpoint(queue, args):
         from megatron.global_vars import set_args, set_global_variables
         from megatron.checkpointing import load_args_from_checkpoint, load_checkpoint
         from megatron.model import module
+        from megatron.model.enums import PositionEmbeddingType
         from megatron.core import mpu
         from megatron.core.enums import ModelType
         from megatron import fused_kernels
@@ -81,7 +82,7 @@ def _load_checkpoint(queue, args):
     check_for_arg('num_attention_heads')
     check_for_arg('max_position_embeddings')
     check_for_arg('add_position_embedding', True)
-    check_for_arg('use_rotary_position_embeddings', False)
+    check_for_arg('position_embedding_type', PositionEmbeddingType.absolute)
     check_for_arg('tokenizer_type')
     check_for_arg('iteration')
     check_for_arg('bert_binary_head')


### PR DESCRIPTION
This adds the [ALiBi](https://arxiv.org/abs/2108.12409) method for positional information by simply porting over the implementation from [BigScience/Megatron-DeepSpeed](https://github.com/bigscience-workshop/Megatron-DeepSpeed).

In addition, I changed the selection of position embedding:
`--use-rotary-position-embeddings` is now replaced by `--position-embedding-type rotary`. If you want, I can keep the old flag for backward-compatibility. The current state doesn't worry about backward-compatibility.

I'd also suggest replacing `--no-position-embedding` by adding it as the `learned` or `absolute` position embedding type, but I did not go that far. This would prevent mistakes by making sure absolute position embeddings are turned off when a different positional embedding is used.