### PR TITLE
Fix variable access

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -784,8 +784,8 @@ class ParallelTransformerLayer(MegatronModule):
         # Retriever (bi-directional transformer with cross attention)
         if layer_type == LayerType.retro_decoder_with_retriever:
             self.retriever = ParallelTransformer(
-                init_method,
-                output_layer_init_method,
+                config.init_method,
+                config.output_layer_init_method,
                 model_type=ModelType.retro_encoder,
                 self_attn_mask_type=AttnMaskType.padding,
                 pre_process=True,


### PR DESCRIPTION
These were apparently missed when porting over to the usage of `TransformerConfig`.