### PR TITLE
Fix wrong config check

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -164,7 +164,7 @@ class TransformerConfig(ModelParallelConfig):
             if self.recompute_method is not None:
                 if not self.recompute_method in ['block', 'uniform']:
                     raise ValueError(f'recompute_method: {self.recompute_method} must be "block" or "uniform".')
-            else:
+            elif self.recompute_granularity != 'selective':
                 raise ValueError(
                     f'Using recompute_granularity: {self.recompute_granularity} so recompute_method must be "block" or "uniform"'
                 )


### PR DESCRIPTION
In the new `TransformerConfig`, when `--recompute-granularity` is set, it is checked whether `--recompute-method` is in allowed the values and not `None`. However, when `--recompute-granularity selective` is used, `--recompute-method` _must not_ be set (i.e. it must be `None`) according to `megatron/arguments.py`.