### PR TITLE
Only regard decoder sequence length when using an encoder-decoder

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -882,7 +882,11 @@ def get_tensor_shapes(*,
 
     if config.sequence_parallel:
         seq_length = seq_length // parallel_state.get_tensor_model_parallel_world_size()
-        decoder_seq_length = decoder_seq_length // parallel_state.get_tensor_model_parallel_world_size()
+        if model_type == ModelType.encoder_and_decoder:
+            decoder_seq_length = (
+                decoder_seq_length
+                // parallel_state.get_tensor_model_parallel_world_size()
+            )
 
     if model_type == ModelType.encoder_and_decoder:
         if parallel_state.is_pipeline_stage_before_split(rank):


### PR DESCRIPTION
`decoder_seq_len` was unconditionally divided before. When using a decoder-only model, this variable may not be set and just `seq_len` may be given (`seq_len` is also what's used a few lines below the modified code in the decoder-only case).