### PR TITLE
bug fix: when eval, dropout_p turns to 0 forever

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -372,17 +372,18 @@ class FlashSelfAttention(torch.nn.Module):
 
             is_causal = self.causal
             cu_seqlens_k = cu_seqlens_q
+            dropout_p = self.dropout_p
         else:
             # turn off FA causal mask after first inference autoregressive iteration
             # only on first autoregressive step q,k,v have same seqlen
             is_causal = seqlen_q == seqlen_k
             cu_seqlens_k = torch.arange(0, (batch_size + 1) * seqlen_k, step=seqlen_k, dtype=torch.int32,
                         device=q.device)
-            self.dropout_p = 0
+            dropout_p = 0
 
         output = flash_attn_unpadded_func(
             q, k, v, cu_seqlens_q, cu_seqlens_k, seqlen_q, seqlen_k,
-            self.dropout_p,
+            dropout_p,
             softmax_scale=self.softmax_scale, causal=is_causal
         )
 


### PR DESCRIPTION
It's a bug in `FlashSelfAttention` class.

Once you run `forward` in eval mode, `dropout_p` will become 0 forever, even you turn back to training mode.