### PR TITLE
Skip 'world_size' instead of coping from checkpint args.

### DIFF
--- a/tools/checkpoint_saver_megatron.py
+++ b/tools/checkpoint_saver_megatron.py
@@ -136,7 +136,7 @@ def save_checkpoint(queue, args):
     if hasattr (md, 'checkpoint_args'):
         # These are arguments that we are either changing, or cause problems for validation if they are set
         # Note that some of these deal with T5 so will need to be changed if we support T5.
-        args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'params_dtype',
+        args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'world_size', 'params_dtype',
                         'num_layers_per_virtual_pipeline_stage', 'virtual_pipeline_model_parallel_size',
                         'masked_softmax_fusion', 'bias_gelu_fusion', 'bias_dropout_fusion',
                         'sequence_parallel', 'async_tensor_model_parallel_allreduce',
@@ -159,7 +159,7 @@ def save_checkpoint(queue, args):
             if getattr(margs, arg) != value:
                 print(f"Overwriting default {arg} value {getattr(margs, arg)} with value from checkpoint {value}.")
                 setattr(margs, arg, value)
-
+    
     validate_args(margs)
 
     set_global_variables(margs, build_tokenizer=False)


### PR DESCRIPTION
**Describe**
The `world_size` of `margs` will be overwritten by `checkpoint_args` in `tools/checkpoint_saver_megatron.py`.

**To Reproduce**

1. Produce a ckpt by global_batch_size =24,  micro_batch_size=1, data_parallel_size =2, tensor_model_parallel_size=4, pipeline_model_paralell_size=2
2. Convert the ckpt to target_tensor_parallel_size=1, target_pipeline_paralell_size=1 by using `tools/checkpoint_util.py
`
3. Get assertion error `assert global_batch_size % micro_batch_times_data_parallel == 0` in `megatron/microbatches.py
`
