### PR TITLE
Squeeze zero-size group ranges for the distributed optimizer

### DIFF
--- a/megatron/optimizer/distrib_optimizer.py
+++ b/megatron/optimizer/distrib_optimizer.py
@@ -237,11 +237,13 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     local_param_group_map[param] = \
                         (group_index, len(group_range["params"]) - 1)
 
-        # Squeeze zero-size group ranges.
         for group_index, group_range in enumerate(group_ranges):
             group_range["orig_group"] = param_groups[group_index]
-            group_range["orig_group_idx"] = param_groups[group_index]
-
+            group_range["orig_group_idx"] = group_index
+            
+        # Squeeze zero-size group ranges.    
+        group_ranges = [ g for g in group_ranges if len(g["params"]) > 0 ]
+        
         return local_param_group_map, group_ranges
 
 


### PR DESCRIPTION
**Describe the bug**
- Considering the following case: 
   - The model has two parameter which are `param0` with `10` elements and `param1` with `2` elements. There are also two parameter groups where `group0` has `param0` and `group1` has `param1`.
   - The used data parallel degree is `2`, so the size of the contiguous gradient buffer is `10 + 2 =12`, and each rank owns a local gradient buffer with `12 / 2 = 6` elements. So after applying the distributed optimizer, we got 
     - Rank 0: `group0 = {'params': param0[0:6]}`, `group1 = {'params': []}`
     - Rank 1:  `group1 = {'params': param0[6:10]}`, ` group1 = {'params': param1[0:2]}`
- The potential problem is the `group1 `of Rank 0 has nothing and the underlying optimizer implementation should take care of the parameter group of zero length.
   - The new Apex Adam implementation can check for empty params in group now: https://github.com/NVIDIA/apex/pull/1596.
   - But the Apex Adam in the NGC  23.03 docker image doesn't have been updated. So the code of Apex Adam `device = group['params'][0].device` will trigger `IndexError list index out of range` when given the empty params.
  
**Proposed fix**
The original code has the comment `Squeeze zero-size group ranges` but without no implementation now. This pr add back the zero group filtering. Besides, fix the assignment of `group_range["orig_group_idx"]`.
