### PR TITLE
Fix bug

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -422,7 +422,8 @@ def forward_backward_pipelining_with_interleaving(*,
         raise RuntimeError("Interleaving is not supported with a different decoder sequence length.")
 
     if config.sequence_parallel:
-        tensor_shape[0] = tensor_shape[0] // parallel_state.get_tensor_model_parallel_world_size()
+        sharded_seq_length = tensor_shape[0] // parallel_state.get_tensor_model_parallel_world_size()
+        tensor_shape = (sharded_seq_length, micro_batch_size, config.hidden_size)
 
     # Compute number of warmup and remaining microbatches.
     num_model_chunks = len(model)


### PR DESCRIPTION
Hi all,

With sequence parallel and 1f1b-interleave schedule, this line triggers the following error. I created a simple fix for this. 
```
File "Megatron/megatron/core/pipeline_parallel/schedules.py", line 425, in forward_backward_pipelining_with_interleaving
    tensor_shape[0] = tensor_shape[0] // parallel_state.get_tensor_model_parallel_world_size()
TypeError: 'tuple' object does not support item assignment
```

~Weiqi