### PR TITLE
Use enum for position embedding type

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -386,7 +386,7 @@ def validate_args(args, defaults={}):
 
     # Would just need to add 'NoPE' as a position_embedding_type to support this, but for now
     # don't allow it to keep things simple
-    if not args.add_position_embedding and args.position_embedding_type != 'rope':
+    if not args.add_position_embedding and args.position_embedding_type == 'learned_absolute':
         raise RuntimeError('--no-position-embedding is deprecated, use --position-embedding-type')
 
     # Print arguments.

--- a/megatron/model/enums.py
+++ b/megatron/model/enums.py
@@ -17,5 +17,9 @@ class AttnMaskType(enum.Enum):
     padding = 1
     causal = 2
 
+class PositionEmbeddingType(enum.Enum):
+    learned_absolute = 1
+    rope = 2
+
 # For backward compatibility with old model checkpoints
 from megatron.core.enums import ModelType

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -10,7 +10,7 @@ from megatron.core import mpu, tensor_parallel
 from megatron.core.enums import ModelType
 from megatron.core.models.common.rotary_pos_embedding import RotaryEmbedding
 
-from .enums import AttnMaskType, LayerType
+from .enums import AttnMaskType, LayerType, PositionEmbeddingType
 from .module import MegatronModule
 from .transformer import ParallelTransformer
 from .utils import get_linear_layer
@@ -159,7 +159,8 @@ class Embedding(MegatronModule):
         self._word_embeddings_key = 'word_embeddings'
 
         # Position embedding (serial).
-        self.add_position_embedding = args.position_embedding_type == 'learned_absolute'
+        self.add_position_embedding = \
+            args.position_embedding_type is PositionEmbeddingType.learned_absolute
         if self.add_position_embedding:
             self.position_embeddings = torch.nn.Embedding(
                 max_sequence_length, self.hidden_size)
@@ -372,7 +373,7 @@ class TransformerLanguageModel(MegatronModule):
 
         # Rotary positional embeddings
         self.use_rotary_position_embeddings = \
-            args.position_embedding_type == 'rope'
+            args.position_embedding_type is PositionEmbeddingType.rope
         if self.use_rotary_position_embeddings:
             self.seq_length = args.seq_length
             rotary_dim = args.hidden_size // args.num_attention_heads \


### PR DESCRIPTION
Improve maintainability and extensibility. I couldn't figure out how to make this backward-compatible without slightly convoluted workarounds (such as `x if isinstance(x, str) else x.value`). Since you haven't tagged a release with the string-based version, breaking BC may be fine (?).