### PR TITLE
Bug fix: Use amax_reduction_group instead of data_parallel_group as fp8_group

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -211,6 +211,7 @@ def _initialize_distributed():
                 args.pipeline_model_parallel_size,
                 args.virtual_pipeline_model_parallel_size,
                 args.pipeline_model_parallel_split_rank,
+                args.fp8_e4m3 or args.fp8_hybrid
             )
             if args.rank == 0:
                 print(

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1335,7 +1335,7 @@ class ParallelTransformer(MegatronModule):
         self.fp8_recipe = None
         self.fp8_group = None
         if self.use_fp8:
-            self.fp8_group = mpu.get_data_parallel_group()
+            self.fp8_group = mpu.get_amax_reduction_group()
             if args.fp8_e4m3:
                 fp8_format = transformer_engine.common.recipe.Format.E4M3
             elif args.fp8_hybrid:


### PR DESCRIPTION
All our FP8 trainings of a 40B gpt3 model with tensor_model_parallel_size=8 have been diverging after around 1000 iterations. Comparing our code with NeMo, we figured out that the major difference is the reduction group for the amax history (see https://github.com/NVIDIA/NeMo/blob/7f4e8a50e80c5582e551ab98a60fccd4cc21fa7a/nemo/collections/nlp/modules/common/megatron/transformer.py#L1466). Fixing this did the job for us: everything stable now.