### PR TITLE
Refactor imports for better IDE integration

### DIFF
--- a/megatron/core/__init__.py
+++ b/megatron/core/__init__.py
@@ -1,6 +1,6 @@
-import megatron.core.parallel_state
-import megatron.core.tensor_parallel
-import megatron.core.utils
+from megatron.core import parallel_state
+from megatron.core import tensor_parallel
+from megatron.core import utils
 
 from .inference_params import InferenceParams
 from .model_parallel_config import ModelParallelConfig


### PR DESCRIPTION
This PR changes the import statements in `megatron.core` submodule for better IDE integration.

In the old implementation, the statement `import megatron.core.xxx` sets submodule object `xxx` to the partially initialized module `megatron.core`. Like:

```python
setattr(megatron.core, 'xxx', <xxx submodule>)
```

Then in the `__init__.py` file's `globals()`, it can access the `xxx` submodule via a variable name `xxx` (which is set in `megatron.core.__dict__`).

The old implementation just works but not follows the Python best practice. It relies on the implementation details of the Python import statement.

In this PR, we use explicitly `from-import` statement to explicitly set the member to the global namespace.

```python
from megatron.core import xxx
```

This benefits better readability and better IDE and linter integration.

-------

Before:

<img width="844" alt="image" src="https://github.com/NVIDIA/Megatron-LM/assets/16078332/97f9a7ab-8913-46a8-b305-f39d0163c3c8">

<img width="521" alt="image" src="https://github.com/NVIDIA/Megatron-LM/assets/16078332/73fc2aa0-42fa-4397-b120-5aae2b59f34f">

After:

<img width="857" alt="image" src="https://github.com/NVIDIA/Megatron-LM/assets/16078332/c44fa3d1-63f8-4e9d-be90-07461420dbe8">

<img width="602" alt="image" src="https://github.com/NVIDIA/Megatron-LM/assets/16078332/c8bb9921-d4a7-423b-a49a-4ef5b79ed4d4">
