### PR TITLE
Add T5 SwiGLU

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -41,6 +41,8 @@ class TransformerConfig(ModelParallelConfig):
                                 in MLP layer). Default is True.
 
         gated_linear_unit (bool): Use a gated linear unit for the first linear layer in the MLP. Defaults to False.
+        t5_gated_linear_unit (bool): Use a correctly implemented gated linear unit for the
+                                     first linear layer in the MLP. Defaults to False.
 
         activation_func (Callable): Activation function to use for the non-linearity in the MLP. Defaults to F.gelu.
 
@@ -135,6 +137,7 @@ class TransformerConfig(ModelParallelConfig):
     layernorm_zero_centered_gamma: bool = False
     add_bias_linear: bool = True
     gated_linear_unit: bool = False
+    t5_gated_linear_unit: bool = False
     activation_func: Callable = F.gelu
 
     # initialization

--- a/megatron/model/t5_glu.py
+++ b/megatron/model/t5_glu.py
@@ -1,0 +1,62 @@
+import torch
+
+from megatron.core import tensor_parallel
+from megatron.model.module import MegatronModule
+
+
+class T5GLU(MegatronModule):
+    def __init__(
+            self,
+            in_features,
+            out_features,
+            *,
+            config,
+            init_method,
+            activation_fn=torch.sigmoid,
+            bias=False,
+            gather_output=False,
+    ):
+        super().__init__()
+        self.linear = tensor_parallel.ColumnParallelLinear(
+            in_features,
+            out_features,
+            config=config,
+            bias=bias,
+            gather_output=gather_output,
+            init_method=init_method,
+        )
+        self.nonlinear = tensor_parallel.ColumnParallelLinear(
+            in_features,
+            out_features,
+            config=config,
+            bias=bias,
+            gather_output=gather_output,
+            init_method=init_method,
+        )
+        self.activation_fn = activation_fn
+
+    def forward(self, x):
+        output = self.linear(x)[0] * self.activation_fn(self.nonlinear(x)[0])
+        return output, None
+
+
+class T5SwiGLU(T5GLU):
+    def __init__(
+            self,
+            in_features,
+            out_features,
+            *,
+            config,
+            init_method,
+            bias=False,
+            gather_output=False,
+    ):
+        super().__init__(
+            in_features,
+            out_features,
+            config=config,
+            init_method=init_method,
+            activation_fn=torch.nn.functional.silu,
+            bias=bias,
+            gather_output=gather_output,
+        )


### PR DESCRIPTION
The standard SwiGLU is incorrectly implemented, making the same mistake as PyTorch's GLU activation function.

This keeps backward compatibility by activating the fixed SwiGLU via `--t5-swiglu`, while disallowing having it enabled together with `--swiglu`.