### PR TITLE
Add RMSNorm

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -375,10 +375,6 @@ def validate_args(args, defaults={}):
                 retro_args.retro_gpt_chunk_length
             set_retro_args(retro_args)
 
-    # Normalization args
-    if args.normalization == "RMSNorm":
-        assert args.transformer_impl == "transformer_engine", "TransformerEngine is required for RMSNorm."
-
     # Legacy RoPE arguments
     if args.use_rotary_position_embeddings:
         args.position_embedding_type = 'rope'

--- a/megatron/core/fusions/fused_rms_norm.py
+++ b/megatron/core/fusions/fused_rms_norm.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+
+import numbers
+import torch
+from torch.nn.parameter import Parameter
+from torch.nn import init
+
+try:
+    from apex.normalization.fused_layer_norm import FusedRMSNormAffineFunction
+    HAVE_FUSED_RMS_NORM = True
+except Exception:
+    HAVE_FUSED_RMS_NORM = False
+
+
+class FusedRMSNorm(torch.nn.Module):
+    def __init__(self, hidden_size, eps=1e-5,
+                 sequence_parallel=False,
+                 zero_centered_gamma=False):
+        super().__init__()
+
+        self.zero_centered_gamma = zero_centered_gamma
+
+        if not HAVE_FUSED_RMS_NORM:
+            # TODO: Add pytorch only RMS norm
+            raise ValueError(
+                'Apex must currently be installed to use megatron core.')
+
+        if isinstance(hidden_size, numbers.Integral):
+            hidden_size = (hidden_size,)
+        self.hidden_size = torch.Size(hidden_size)
+        self.eps = eps
+        self.weight = Parameter(torch.Tensor(*hidden_size))
+        self.reset_parameters()
+        self.sequence_parallel = sequence_parallel
+
+        # Set sequence parallelism flag on weight parameter.
+        setattr(self.weight, 'sequence_parallel', self.sequence_parallel)
+
+    def reset_parameters(self):
+        if self.zero_centered_gamma:
+            init.zeros_(self.weight)
+        else:
+            init.ones_(self.weight)
+
+    def forward(self, input):
+        weight = self.weight + 1 if self.zero_centered_gamma else self.weight
+        return FusedRMSNormAffineFunction.apply(
+            input, weight, self.hidden_size, self.eps)

--- a/megatron/core/transformer/custom_layers/transformer_engine.py
+++ b/megatron/core/transformer/custom_layers/transformer_engine.py
@@ -20,6 +20,17 @@ class TELayerNorm(te.pytorch.LayerNorm):
         super().__init__(hidden_size=hidden_size, eps=eps, sequence_parallel=sequence_parallel)
 
 
+class TERMSNorm(te.pytorch.RMSNorm):
+    """
+    Wrapper for the Transformer-Engine's `RMSNorm`.
+    """
+
+    def __init__(
+        self, hidden_size: int, eps: float = 1e-5, sequence_parallel: bool = False, **kwargs
+    ):
+        super().__init__(hidden_size=hidden_size, eps=eps, sequence_parallel=sequence_parallel)
+
+
 class TELinear(te.pytorch.Linear):
     """
     Wrapper for the Transformer-Engine's `Linear` layer.

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -6,6 +6,7 @@ import torch
 
 from megatron.core import parallel_state, tensor_parallel
 from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
+from megatron.core.fusions.fused_rms_norm import FusedRMSNorm
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -32,6 +32,7 @@ class TransformerConfig(ModelParallelConfig):
         fp32_residual_connection (bool): If true, move residual connections to fp32.
         apply_residual_connection_post_layernorm (bool): If true, uses the original BERT residule connection ordering.
                                                          Defaults to False.
+        normalization (str): Normalization function to use. Defaults to "LayerNorm".
         layernorm_epsilon (float): Layernorm epsilon. Defaults to 1e-5.
 
         layernorm_zero_centered_gamma (bool): if set to 'True', the LayerNorm is adjusted to center the gamma values
@@ -131,6 +132,7 @@ class TransformerConfig(ModelParallelConfig):
     fp32_residual_connection: bool = False
     # @jcasper should we keep this option?
     apply_residual_connection_post_layernorm: bool = False
+    normalization: str = "LayerNorm"
     layernorm_epsilon: float = 1e-5
     layernorm_zero_centered_gamma: bool = False
     add_bias_linear: bool = True

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -4,12 +4,25 @@ import torch
 
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
 from megatron.core.transformer.attention import SelfAttention
-from megatron.core.transformer.custom_layers.transformer_engine import TELayerNorm
+from megatron.core.transformer.custom_layers.transformer_engine import \
+    TELayerNorm, TERMSNorm
 from megatron.core.transformer.enums import AttnMaskType, AttnType
 from megatron.core.transformer.mlp import MLP
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import make_viewless_tensor
+
+
+def _get_layernorm(config: TransformerConfig):
+    extra_kwargs = {}
+    if config.normalization == 'LayerNorm':
+        layernorm_cls = TELayerNorm
+        extra_kwargs['persist_layer_norm'] = config.persist_layer_norm
+    elif config.normalization == 'RMSNorm':
+        layernorm_cls = TERMSNorm
+    else:
+        raise ValueError(f'unknown normalization "{config.normalization}"')
+    return layernorm_cls, extra_kwargs
 
 
 class TransformerLayer(MegatronModule):
@@ -31,14 +44,15 @@ class TransformerLayer(MegatronModule):
         self.layer_number = layer_number
         self.self_attn_mask_type = self_attn_mask_type
 
+        layernorm_cls, layernorm_extra_kwargs = _get_layernorm(self.config)
         # Layernorm on the input data.
         # TODO: add pytorch only layernorm
-        self.input_layernorm = TELayerNorm(
+        self.input_layernorm = layernorm_cls(
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
-            persist_layer_norm=self.config.persist_layer_norm,
             sequence_parallel=self.config.sequence_parallel,
             zero_centered_gamma=self.config.layernorm_zero_centered_gamma,
+            **layernorm_extra_kwargs,
         )
 
         # Self attention.
@@ -47,12 +61,12 @@ class TransformerLayer(MegatronModule):
         )
 
         # Layernorm on the attention output
-        self.post_self_attn_layernorm = TELayerNorm(
+        self.post_self_attn_layernorm = layernorm_cls(
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
-            persist_layer_norm=self.config.persist_layer_norm,
             sequence_parallel=self.config.sequence_parallel,
             zero_centered_gamma=self.config.layernorm_zero_centered_gamma,
+            **layernorm_extra_kwargs,
         )
 
         # MLP

--- a/megatron/model/__init__.py
+++ b/megatron/model/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 
 from .fused_layer_norm import MixedFusedLayerNorm as LayerNorm
+from .fused_rms_norm import MixedFusedRMSNorm as RMSNorm
 
 from .distributed import DistributedDataParallel
 from .bert_model import BertModel

--- a/megatron/model/fused_rms_norm.py
+++ b/megatron/model/fused_rms_norm.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+
+"""This code is copied fron NVIDIA apex:
+      https://github.com/NVIDIA/apex
+   with some changes. """
+
+import numbers
+
+from apex.normalization.fused_layer_norm import FusedRMSNormAffineFunction
+import torch
+from torch.nn import init
+from torch.nn.parameter import Parameter
+
+
+class MixedFusedRMSNorm(torch.nn.Module):
+    def __init__(self, normalized_shape, eps=1e-5,
+                 sequence_parallel=False,
+                 apply_layernorm_1p=False):
+        super(MixedFusedRMSNorm, self).__init__()
+
+        self.apply_layernorm_1p = apply_layernorm_1p
+
+        if isinstance(normalized_shape, numbers.Integral):
+            normalized_shape = (normalized_shape,)
+        self.normalized_shape = torch.Size(normalized_shape)
+        self.eps = eps
+        self.weight = Parameter(torch.Tensor(*normalized_shape))
+        self.reset_parameters()
+        self.sequence_parallel = sequence_parallel
+
+        # Set sequence parallelism flag on weight parameter.
+        setattr(self.weight, 'sequence_parallel', self.sequence_parallel)
+
+    def reset_parameters(self):
+        if self.apply_layernorm_1p:
+            init.zeros_(self.weight)
+        else:
+            init.ones_(self.weight)
+
+    def forward(self, input):
+        weight = self.weight + 1 if self.apply_layernorm_1p else self.weight
+        return FusedRMSNormAffineFunction.apply(
+            input, weight, self.normalized_shape, self.eps)


### PR DESCRIPTION
This adds support for RMSNorm even without TransformerEngine by using the existing fused implementation in Apex.