### PR TITLE
Add NaN check asserts before scalar all-reduce operations.  This is i…

### DIFF
--- a/megatron/optimizer/clip_grads.py
+++ b/megatron/optimizer/clip_grads.py
@@ -88,6 +88,10 @@ def clip_grad_norm_fp32(parameters, grads_for_norm,
                 grad_norm = torch.norm(grad, norm_type)
                 total_norm += grad_norm ** norm_type
 
+        global_rank = torch.distributed.get_rank()
+        # print(f'Testing backward gradient norm on {global_rank}!', flush=True)
+        assert not total_norm.isnan(),f'Rank {global_rank}: found NaN in local grad norm in backwards pass'
+
         # Sum across all model-parallel GPUs.
         torch.distributed.all_reduce(total_norm,
                                      op=torch.distributed.ReduceOp.SUM,

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -68,6 +68,10 @@ def loss_func(loss_mask, output_tensor):
     loss_mask = loss_mask.view(-1).float()
     loss = torch.sum(losses.view(-1) * loss_mask) / loss_mask.sum()
 
+    global_rank = torch.distributed.get_rank()
+    # print(f'Testing forward loss on {global_rank}!', flush=True)
+    assert not loss.isnan(),f'Rank {global_rank}: found NaN in local forward loss calculation'
+
     # Reduce loss for logging.
     averaged_loss = average_losses_across_data_parallel_group([loss])
 


### PR DESCRIPTION
…nexpensive but gives much finer-grain info when training diverges.