### PR TITLE
Escape `%` in help message for `--rotary-percent`.

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -575,7 +575,7 @@ def _add_network_size_args(parser):
                        help='Use rotary positional embeddings or not. '
                        'Deprecated: use --position-embedding-type')
     group.add_argument('--rotary-percent', type=float, default=1.0,
-                       help='Percent of rotary dimension to use, default 100%')
+                       help='Percent of rotary dimension to use, default 100%%')
     group.add_argument('--rotary-seq-len-interpolation-factor', type=int, default=None,
                        help='Sequence length interpolation factor for rotary embeddings.')
     group.add_argument('--no-position-embedding',


### PR DESCRIPTION
Fix for https://github.com/NVIDIA/Megatron-LM/issues/472.