### PR TITLE
Fix inference_params bug when using transformer engine

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1675,6 +1675,9 @@ class ParallelTransformer(MegatronModule):
                         forward_kwargs['checkpoint_core_attention'] = self.checkpoint_core_attention
                         if self.transformer_engine_v_0_10:
                             forward_kwargs['rotary_pos_emb'] = rotary_pos_emb
+
+                        # Backward compatibility for legacy name
+                        forward_kwargs['inference_params'].max_sequence_len = inference_params.max_sequence_length
                     else:
                         forward_kwargs['rotary_pos_emb'] = rotary_pos_emb
                         forward_kwargs['retriever_input'] = retriever_input


### PR DESCRIPTION
During inference, the current version of TransformerEngine will try to get property `max_sequence_len` of `inference_params`, which will result in an error. https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/pytorch/attention.py#L1580

We should add backward compatibility for this legacy name.