### PR TITLE
Fix bug in distopt allgathers with interleaved pipeline parallelism for old MCore

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -557,7 +557,7 @@ def forward_backward_pipelining_with_interleaving(*,
         # pipeline-parallel group.
         if param_sync_func is not None:
             param_sync_microbatch_id = microbatch_id + pipeline_parallel_rank
-            if param_sync_microbatch_id < num_microbatches and is_first_microbatch_for_model_chunk(param_sync_microbatch_id):
+            if param_sync_microbatch_id < total_num_microbatches and is_first_microbatch_for_model_chunk(param_sync_microbatch_id):
                 param_sync_chunk_id = get_model_chunk_id(param_sync_microbatch_id, forward=True) + 1
                 if 1 < param_sync_chunk_id < num_model_chunks:
                     param_sync_func(model[param_sync_chunk_id].parameters())


### PR DESCRIPTION
This is an equivalent of [this commit](https://github.com/NVIDIA/Megatron-LM/commit/32bbb76d5767fdbf8dc60d4ef07d103cef8aca02), but applied to old MCore