### PR TITLE
Fix pipeline parallel hang under FP8

### DIFF
--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -228,8 +228,11 @@ class TransformerBlock(MegatronModule):
                 amax_history_len=self.config.fp8_amax_history_len,
                 override_linear_precision=(False, False, not self.config.fp8_wgrad),
             )
+            fp8_group = None
+            if parallel_state.model_parallel_is_initialized():
+                fp8_group = parallel_state.get_amax_reduction_group()
             fp8_context = transformer_engine.pytorch.fp8_autocast(
-                enabled=True, fp8_recipe=fp8_recipe
+                enabled=True, fp8_recipe=fp8_recipe, fp8_group=fp8_group
             )
         else:
             fp8_context = nullcontext()


### PR DESCRIPTION
This PR fixes a program hang issue when using FP8 TE and pipeline parallel. 

As shown in commit 588ef65 and previous commits, correct usage of FP8 context requires a `fp8_group` argument which should be initialized by the `get_amax_reduction_group()` API. Refer to the non-mcore version in Nemo https://github.com/NVIDIA/NeMo/blob/458f630724a77b2dcd928004a6c078a25cc0a627/nemo/collections/nlp/modules/common/megatron/transformer.py#L1455