### PR TITLE
Add RMSNorm

### DIFF
--- a/megatron/fused_kernels/tests/rmsnorm.py
+++ b/megatron/fused_kernels/tests/rmsnorm.py
@@ -1,0 +1,16 @@
+import torch
+import torch.nn as nn
+
+
+class RMSNorm(torch.nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x):
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight

--- a/megatron/fused_kernels/tests/test_rmsnorm.py
+++ b/megatron/fused_kernels/tests/test_rmsnorm.py
@@ -1,0 +1,66 @@
+from megatron.model.fused_layer_norm import MixedFusedRMSNorm
+from .rmsnorm import RMSNorm
+
+
+def test_load_fused_kernels():
+    try:
+        import fused_layer_norm_cuda
+
+        print("[Success] load_fused_kernels")
+    except ImportError as e:
+        print("[Fail] load_fused_kernels")
+        raise e
+
+
+def test_rms_norm():
+    from transformers import BertTokenizer
+    from transformers.models.bert.modeling_bert import BertModel
+
+    bert = BertModel.from_pretrained("bert-base-cased").cuda().half()
+    tokenizer = BertTokenizer.from_pretrained("bert-base-cased")
+    test_text = (
+        "Hello. How are you? I am fine thank you and you? yes Good. "
+        "hi hi hi hi hi hi hi hi hi hi hi hi hi"  # 32
+    )
+
+    tokens = tokenizer(
+        [test_text] * 4,
+        return_tensors="pt",
+    )
+
+    # [bsz, seq_len, d_model]
+    embedding_output = (
+        bert.embeddings(
+            input_ids=tokens["input_ids"].cuda(),
+            position_ids=None,
+            token_type_ids=tokens["token_type_ids"].cuda(),
+            inputs_embeds=None,
+            past_key_values_length=0,
+        )
+        .cuda()
+        .half()
+    )
+
+    fused_rmsnorm_layer = (
+        MixedFusedRMSNorm(normalized_shape=embedding_output.size(-1)).cuda().half()
+    )
+
+    rmsnorm_layer = (
+        RMSNorm(dim=embedding_output.size(-1)).cuda().half()
+    )
+
+    fused_output = fused_rmsnorm_layer(embedding_output)
+    torch_output = rmsnorm_layer(embedding_output)
+    test_result = (fused_output - torch_output).abs()
+
+    while test_result.dim() != 1:
+        test_result = test_result.mean(dim=-1)
+
+    diff = test_result.mean(dim=-1)
+
+    report = f'''
+        > mean_difference={diff}
+        > fused_values={fused_output[-1][-1][:5].tolist()}
+        > torch_values={torch_output[-1][-1][:5].tolist()}
+    '''
+    assert diff <= 1e-3, report

--- a/megatron/model/__init__.py
+++ b/megatron/model/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 
+from .fused_layer_norm import MixedFusedNorm
 from .fused_layer_norm import MixedFusedLayerNorm as LayerNorm
 
 from .distributed import DistributedDataParallel

--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -19,10 +19,39 @@ except:
     HAVE_PERSIST_LAYER_NORM = False
 
 from apex.normalization.fused_layer_norm import FusedLayerNormAffineFunction
+from apex.normalization.fused_layer_norm import FusedRMSNormAffineFunction, FusedRMSNormFunction
 
 
 global fused_layer_norm_cuda
 fused_layer_norm_cuda = None
+
+
+class MixedFusedNorm:
+    """
+    A conditional wrapper to initialize an instance of
+    `MixedFusedLayerNorm` or `MixedFusedRMSNorm` based on input
+    """
+    def __new__(
+        cls,
+        normalization: str,  # LayerNorm or RMSNorm
+        hidden_size: int,
+        eps: float = 1e-5,
+        **kwargs
+    ):
+        if normalization == "LayerNorm":
+            instance = MixedFusedLayerNorm(
+                normalized_shape=hidden_size,
+                eps=eps,
+                **kwargs)
+        elif normalization == "RMSNorm":
+            instance = MixedFusedRMSNorm(
+                normalized_shape=hidden_size,
+                eps=eps,
+                **kwargs)
+        else:
+            raise Exception('Only LayerNorm and RMSNorm are curently supported')
+
+        return instance
 
 
 class MixedFusedLayerNorm(torch.nn.Module):
@@ -90,3 +119,97 @@ class MixedFusedLayerNorm(torch.nn.Module):
                                       keep_graph = True)
 
         return output
+
+
+class MixedFusedRMSNorm(torch.nn.Module):
+    r"""Applies RMS Normalization over a mini-batch of inputs
+
+    Currently only runs on cuda() tensors.
+
+    .. math::
+        y = \frac{x}{\mathrm{RMS}[x]} * \gamma
+
+    The root-mean-square is calculated separately over the last
+    certain number dimensions which have to be of the shape specified by
+    :attr:`normalized_shape`.
+    :math:`\gamma` is a learnable affine transform parameter of
+    :attr:`normalized_shape` if :attr:`elementwise_affine` is ``True``.
+    `epsilon` is added to the mean-square, then the root of the sum is taken.
+
+    .. note::
+        Unlike Batch Normalization and Instance Normalization, which applies
+        scalar scale and bias for each entire channel/plane with the
+        :attr:`affine` option, RMS Normalization applies per-element scale
+        with :attr:`elementwise_affine`.
+
+    This layer uses statistics computed from input data in both training and
+    evaluation modes.
+
+    Args:
+        normalized_shape (int or list or torch.Size): input shape from an expected input
+            of size
+
+            .. math::
+                [* \times \text{normalized}\_\text{shape}[0] \times \text{normalized}\_\text{shape}[1]
+                    \times \ldots \times \text{normalized}\_\text{shape}[-1]]
+
+            If a single integer is used, it is treated as a singleton list, and this module will
+            normalize over the last dimension which is expected to be of that specific size.
+        eps: a value added to the denominator for numerical stability. Default: 1e-5
+        elementwise_affine: a boolean value that when set to ``True``, this module
+            has learnable per-element affine parameters initialized to ones (for weights)
+            and zeros (for biases). Default: ``True``.
+
+    Shape:
+        - Input: :math:`(N, *)`
+        - Output: :math:`(N, *)` (same shape as input)
+
+    Examples::
+
+        >>> input = torch.randn(20, 5, 10, 10)
+        >>> # With Learnable Parameters
+        >>> m = FusedRMSNorm(input.size()[1:])
+        >>> # Without Learnable Parameters
+        >>> m = FusedRMSNorm(input.size()[1:], elementwise_affine=False)
+        >>> # Normalize over last two dimensions
+        >>> m = FusedRMSNorm([10, 10])
+        >>> # Normalize over last dimension of size 10
+        >>> m = FusedRMSNorm(10)
+        >>> # Activating the module
+        >>> output = m(input)
+
+    .. _`Root Mean Square Layer Normalization`: https://arxiv.org/pdf/1910.07467.pdf
+    """
+    def __init__(self, normalized_shape, eps=1e-5,
+                 elementwise_affine=True,
+                 sequence_parallel=False,
+                 **kwargs):
+        super(MixedFusedRMSNorm, self).__init__()
+
+        global fused_layer_norm_cuda
+        fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
+
+        if isinstance(normalized_shape, numbers.Integral):
+            normalized_shape = (normalized_shape,)
+        self.normalized_shape = torch.Size(normalized_shape)
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
+        if self.elementwise_affine:
+            self.weight = Parameter(torch.Tensor(*normalized_shape))
+        else:
+            self.register_parameter("weight", None)
+        self.reset_parameters()
+        self.sequence_parallel = sequence_parallel
+
+        # set sequence parallelism flag on weight parameters
+        setattr(self.weight, "sequence_parallel", self.sequence_parallel)
+
+    def reset_parameters(self):
+        if self.elementwise_affine:
+            init.ones_(self.weight)
+
+    def forward(self, input):
+        if self.elementwise_affine:
+            return FusedRMSNormAffineFunction.apply(input, self.weight, self.normalized_shape, self.eps)
+        else:
+            return FusedRMSNormFunction.apply(input, self.normalized_shape, self.eps)


### PR DESCRIPTION
This is a different version from PR #459. Since the submission of PR #459, RMSNorm has been added to Megatron-LM. However, it currently requires transformer_engine. This version adds support for RMSNorm without transformer_engine. 

Therefore, it can be used with the following configuration:
```bash
--transformer-impl local --normalization RMSNorm
```