### PR TITLE
indexed_dataset: define size of uint16

### DIFF
--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -265,6 +265,7 @@ class IndexedDatasetBuilder(object):
     element_sizes = {
         np.uint8: 1,
         np.int8: 1,
+        np.uint16: 2,
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,


### PR DESCRIPTION
The ``np.uint16`` type is a valid dtype used in ``indexed_dataset.py``.  This PR adds the type to the ``element_sizes`` dictionary.