### PR TITLE
"Lazy" import symbols from apex to make data preprocess can run without GPUs

### DIFF
--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -18,8 +18,10 @@ try:
 except:
     HAVE_PERSIST_LAYER_NORM = False
 
-from apex.normalization.fused_layer_norm import FusedLayerNormAffineFunction
-
+try:
+    from apex.normalization.fused_layer_norm import FusedLayerNormAffineFunction
+except:
+    FusedLayerNormAffineFunction = None
 
 global fused_layer_norm_cuda
 fused_layer_norm_cuda = None
@@ -77,6 +79,8 @@ class MixedFusedLayerNorm(torch.nn.Module):
     weight = self.weight + 1 if self.apply_layernorm_1p else self.weight
 
     if self.no_persist_layer_norm:
+        assert FusedLayerNormAffineFunction is not None, \
+            "FusedLayerNormAffineFunction is not available, please install apex from https://github.com/NVIDIA/apex"
         return FusedLayerNormAffineFunction.apply(input, weight, self.bias, self.normalized_shape, self.eps)
     else:
         output = FastLayerNormFN.apply(input, weight, self.bias, self.eps)

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -7,8 +7,15 @@ import sys
 import torch
 from torch.nn.parallel import DistributedDataParallel as torchDDP
 
-from apex.multi_tensor_apply import multi_tensor_applier
-import amp_C
+try:
+    from apex.multi_tensor_apply import multi_tensor_applier
+except ImportError:
+    multi_tensor_applier = None
+
+try:
+    import amp_C
+except ImportError:
+    amp_C = None
 
 from megatron import (
     get_args,
@@ -50,6 +57,10 @@ def calc_params_l2_norm(model):
                     params_data.append(param.data.float())
                 else:
                     params_data.append(param.data)
+    # Check the availability of apex
+    assert multi_tensor_applier is not None and amp_C is not None, \
+        "apex is not available, please install it from https://github.com/NVIDIA/apex"
+
     # Calculate norm
     dummy_overflow_buf = torch.cuda.IntTensor([0])
     norm, _ = multi_tensor_applier(


### PR DESCRIPTION
The data preprocessing step doesn't require GPUs, but it requires some utility modules which unnecessarily import `apex` package and then fails where there's only CPU available.

Separately deploying data preprocessing and training on different environments would be a nice feature for developers. This pull request fixes that by lazily import (evaluate the availability) those symbols and suggests installing apex when they are required but not found.