### PR TITLE
Indented torch.init_distributed()

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -192,13 +192,13 @@ def _initialize_distributed():
             else:
                 args.local_rank = device
             torch.cuda.set_device(device)
-    # Call the init process
-    torch.distributed.init_process_group(
-        backend=args.distributed_backend,
-        world_size=args.world_size,
-        rank=args.rank,
-        timeout=timedelta(minutes=args.distributed_timeout_minutes),
-    )
+        # Call the init process
+        torch.distributed.init_process_group(
+            backend=args.distributed_backend,
+            world_size=args.world_size,
+            rank=args.rank,
+            timeout=timedelta(minutes=args.distributed_timeout_minutes),
+        )
 
     # Set the tensor model-parallel, pipeline model-parallel, and
     # data-parallel communicators.


### PR DESCRIPTION
Indented the init_distributed in initialize.py, to the else path of `if torch.distributed.is_initialized(),` such that it's only executed if torch distributed is really not initialized.

When initializing the process group manually, it will be executed a second time due to the missing indent.
This Leads to a `RuntimeError: trying to initialize the default process group twice!`