### PR TITLE
initialize torch distributed using ranks and world size from MPI

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -192,13 +192,13 @@ def _initialize_distributed():
             else:
                 args.local_rank = device
             torch.cuda.set_device(device)
-    # Call the init process
-    torch.distributed.init_process_group(
-        backend=args.distributed_backend,
-        world_size=args.world_size,
-        rank=args.rank,
-        timeout=timedelta(minutes=args.distributed_timeout_minutes),
-    )
+        # Call the init process
+        torch.distributed.init_process_group(
+            backend=args.distributed_backend,
+            world_size=args.world_size,
+            rank=args.rank,
+            timeout=timedelta(minutes=args.distributed_timeout_minutes),
+        )
 
     # Set the tensor model-parallel, pipeline model-parallel, and
     # data-parallel communicators.


### PR DESCRIPTION
This initialization scheme is easier to adapt to other clusters compared to using torchrun, since most clusters have some version of MPI. 

The changes here only use rank and world-size data from MPI for initializing the torch process group. All communication still happens via NCCL.