### PR TITLE
Bias-Dropout-Add fusion fix / Avoided an unwanted interleave operation / Added support for UB/TP communication overlap

### DIFF
--- a/megatron/core/fusions/fused_bias_dropout.py
+++ b/megatron/core/fusions/fused_bias_dropout.py
@@ -22,9 +22,13 @@ def _bias_dropout_add_func(x_with_bias, residual, prob, training):
     residual = residual if residual.dtype == x.dtype else residual.to(x.dtype)
     if bias is not None:
         x = x + bias
-    out = torch.nn.functional.dropout(x, p=prob, training=training)
-    out = residual + out
-    return out
+        out = torch.nn.functional.dropout(x, p=prob, training=training)
+        out = residual + out
+        return out
+    else:
+        out = torch.nn.functional.dropout(x, p=prob, training=training)
+        out = residual + out
+        return out
 
 
 def bias_dropout_add_unfused(training):

--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -139,6 +139,7 @@ class ModelParallelConfig:
     # Optimizations
     gradient_accumulation_fusion: bool = False
     async_tensor_model_parallel_allreduce: bool = False
+    ub_tp_comm_overlap: bool = False
 
     # Pipeline Parallel
     pipeline_dtype: torch.dtype = None

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -244,12 +244,13 @@ class Attention(MegatronModule, ABC):
         # This is a noop for normal attention where ng == np. When using group query attention this
         # creates a view that has the keys and values virtually repeated along their dimension to
         # match the number of queries.
-        key = key.repeat_interleave(
-            self.num_attention_heads_per_partition // self.num_query_groups_per_partition, dim=2
-        )
-        value = value.repeat_interleave(
-            self.num_attention_heads_per_partition // self.num_query_groups_per_partition, dim=2
-        )
+        if (self.num_attention_heads_per_partition // self.num_query_groups_per_partition) > 1:
+           key = key.repeat_interleave(
+               self.num_attention_heads_per_partition // self.num_query_groups_per_partition, dim=2
+           )
+           value = value.repeat_interleave(
+               self.num_attention_heads_per_partition // self.num_query_groups_per_partition, dim=2
+           )
 
         if self.checkpoint_dot_product_attention:
             core_attn_out = self._checkpointed_attention_forward(query, key, value, attention_mask)

--- a/megatron/core/transformer/custom_layers/transformer_engine.py
+++ b/megatron/core/transformer/custom_layers/transformer_engine.py
@@ -2,6 +2,7 @@ from importlib.metadata import version
 from typing import Callable
 
 import torch
+import os
 import transformer_engine as te
 from pkg_resources import packaging
 
@@ -107,6 +108,8 @@ class TELinear(te.pytorch.Linear):
             parallel_mode=parallel_mode,
             bias=bias,
             return_bias=self.te_return_bias,
+            ub_split_rs=self.config.ub_tp_comm_overlap and bool(int(os.getenv("NVTE_UB_OVERLAP", "1"))) and bool(int(os.getenv("NVTE_UB_SPLIT_RS", "1"))),
+            ub_split_ag=self.config.ub_tp_comm_overlap and bool(int(os.getenv("NVTE_UB_OVERLAP", "1"))) and bool(int(os.getenv("NVTE_UB_SPLIT_AG", "1"))),
             **_get_extra_te_kwargs(config),
         )
 
@@ -163,6 +166,9 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
             params_dtype=self.config.params_dtype,
             parallel_mode="column",
             return_bias=self.te_return_bias,
+            ub_bulk_wgrad= self.config.ub_tp_comm_overlap and bool(int(os.getenv("NVTE_UB_OVERLAP", "1"))) and bool(int(os.getenv("NVTE_UB_BULK_WGRAD", "1"))),
+            ub_bulk_dgrad= self.config.ub_tp_comm_overlap and bool(int(os.getenv("NVTE_UB_OVERLAP", "1"))) and bool(int(os.getenv("NVTE_UB_BULK_DGRAD", "1"))),
+            ub_split_ag= self.config.ub_tp_comm_overlap and bool(int(os.getenv("NVTE_UB_OVERLAP", "1"))) and bool(int(os.getenv("NVTE_UB_SPLIT_AG", "1"))),
             **_get_extra_te_kwargs(config),
         )
 


### PR DESCRIPTION
Bias-Dropout-Add fusion: The if statement to check for presence of Bias does the Bias addition, while the Dropout-Add is done generically outside the if block. This causes Torch to not fuse these operations. Patched the code to make Torch fuse the operations for better performance.

Attention's torch.interleave operation: The Attention block uses a torch.interleave operation before Flash Attention. This inserts unwanted kernels even when the interleaving factor is 1 for GPT based models. An idempotent operation is inserting kernels hurting some performance. So, did this interleaving based on the interleaving factor.

Added support for user buffer/tensor parallel communication overlap to improve performance of these models.