### PR TITLE
Remove unnecessary repeat_interleave to fix performance drop

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -753,14 +753,15 @@ class ParallelAttention(MegatronModule):
         # ==================================
 
         # expand the key_layer and value_layer [sk, b, ng, hn] -> [sk, b, np, hn]
-        key_layer = key_layer.repeat_interleave(
-            self.num_attention_heads_per_partition // self.num_query_groups_per_partition,
-            dim = 2
-        )
-        value_layer = value_layer.repeat_interleave(
-            self.num_attention_heads_per_partition // self.num_query_groups_per_partition,
-            dim = 2
-        )
+        if self.num_attention_heads_per_partition // self.num_query_groups_per_partition > 1:
+            key_layer = key_layer.repeat_interleave(
+                self.num_attention_heads_per_partition // self.num_query_groups_per_partition,
+                dim = 2
+            )
+            value_layer = value_layer.repeat_interleave(
+                self.num_attention_heads_per_partition // self.num_query_groups_per_partition,
+                dim = 2
+            )
 
         # apply relative positional encoding (rotary embedding)
         if rotary_pos_emb is not None:


### PR DESCRIPTION
There are unnecessary repeat_interleave when  `self.num_attention_heads_per_partition == self.num_query_groups_per_partition` in attention.py and transformer.py, which will trigger torch.repeat_interleave even when repeat==1, which hurt the performance when `self.num_attention_heads_per_partition == self.num_query_groups_per_partition`.

![image](https://github.com/NVIDIA/Megatron-LM/assets/10606312/db87042e-d5de-4c41-aa3d-7eff292ec7d1)
