### PR TITLE
Fix variable type for layernorm1p 

### DIFF
--- a/megatron/core/transformer/custom_layers/transformer_engine.py
+++ b/megatron/core/transformer/custom_layers/transformer_engine.py
@@ -41,7 +41,7 @@ class TENorm:
         normalization="LayerNorm",
         **kwargs
     ):
-        zero_centered_gamma = kwargs.get('zero_centered_gamma', 'False')
+        zero_centered_gamma = kwargs.get('zero_centered_gamma', False)
         if normalization == "LayerNorm":
             instance = te.pytorch.LayerNorm(
                 hidden_size=hidden_size,


### PR DESCRIPTION
False should be a boolean type, not string (see https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/pytorch/module/layernorm_linear.py#L648)
