### PR TITLE
Support frozen tensor parallel layers when gradient accumulation fusion is enabled

### DIFF
--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -395,7 +395,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
             # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
             # reduce scatter is scheduled before the weight gradient computation
 
-        if ctx.gradient_accumulation_fusion:
+        if ctx.gradient_accumulation_fusion and weight.requires_grad:
             if weight.main_grad.dtype == torch.float32:
                 fused_weight_gradient_mlp_cuda.wgrad_gemm_accum_fp32(
                     total_input, grad_output, weight.main_grad


### PR DESCRIPTION
I found that when setting `.requires_grad = False` for some TP layers during training (with grad accumulation fusion on) that the backward assumes the layer has a gradient. This patch fixes this by avoiding gradient accumulation fusion when the layer is frozen.