### PR TITLE
Fix not contiguous error when generation with return_output_log_probs=True

### DIFF
--- a/megatron/text_generation/generation.py
+++ b/megatron/text_generation/generation.py
@@ -269,7 +269,9 @@ def generate_tokens_probs_and_return_on_first_stage(
     tokens = tokens[:, :(context_length + 1)]
     if mpu.is_pipeline_last_stage():
         if return_output_log_probs:
-            output_log_probs = output_log_probs[:, :context_length].contiguous()
+            output_log_probs = output_log_probs[:, :context_length]
+            if args.pipeline_model_parallel_size > 1:
+                output_log_probs = output_log_probs.contiguous()
 
     # ======================================
     # Broadcast to the first pipeline stage.

--- a/megatron/text_generation/generation.py
+++ b/megatron/text_generation/generation.py
@@ -269,7 +269,7 @@ def generate_tokens_probs_and_return_on_first_stage(
     tokens = tokens[:, :(context_length + 1)]
     if mpu.is_pipeline_last_stage():
         if return_output_log_probs:
-            output_log_probs = output_log_probs[:, :context_length]
+            output_log_probs = output_log_probs[:, :context_length].contiguous()
 
     # ======================================
     # Broadcast to the first pipeline stage.


### PR DESCRIPTION
Fix not contiguous error when generation with return_output_log_probs=True and 
pipeline_model_parallel_size>1

In `generation.generate_tokens_probs_and_return_on_first_stage` , when `return_output_log_probs=True`, 
`output_log_probs[:, :context_length]` makes it not contiguous, which raise none-contiguous error in the following `broadcast_from_last_to_first_pipeline_stage`, which requires the tensor to be contiguous.
