### PR TITLE
Fix error in pipeline-parallel schedules to support context parallel

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -954,10 +954,10 @@ def get_tensor_shapes(
     tensor_shapes = []
 
     if config.sequence_parallel:
-        seq_length = seq_length // (parallel_state.get_tensor_model_parallel_world_size() * parallel_state.get_context_parallel_world_size())
+        seq_length = seq_length // parallel_state.get_tensor_model_parallel_world_size()
         if model_type == ModelType.encoder_and_decoder:
             decoder_seq_length = (
-                decoder_seq_length // (parallel_state.get_tensor_model_parallel_world_size() * parallel_state.get_context_parallel_world_size())
+                decoder_seq_length // parallel_state.get_tensor_model_parallel_world_size()
             )
 
     if model_type == ModelType.encoder_and_decoder:

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -954,10 +954,10 @@ def get_tensor_shapes(
     tensor_shapes = []
 
     if config.sequence_parallel:
-        seq_length = seq_length // parallel_state.get_tensor_model_parallel_world_size()
+        seq_length = seq_length // (parallel_state.get_tensor_model_parallel_world_size() * parallel_state.get_context_parallel_world_size())
         if model_type == ModelType.encoder_and_decoder:
             decoder_seq_length = (
-                decoder_seq_length // parallel_state.get_tensor_model_parallel_world_size()
+                decoder_seq_length // (parallel_state.get_tensor_model_parallel_world_size() * parallel_state.get_context_parallel_world_size())
             )
 
     if model_type == ModelType.encoder_and_decoder:


### PR DESCRIPTION
The original `get_tensor_shapes()` in `megatron/core/pipeline_parallel/schedules.py` doesn't consider context parallel size.