### PR TITLE
enable 16bit IO for larger vercab_size

### DIFF
--- a/megatron/core/datasets/indexed_dataset.py
+++ b/megatron/core/datasets/indexed_dataset.py
@@ -93,7 +93,7 @@ class DType(Enum):
         Returns:
             Type[numpy.number]: The dtype to use for the index
         """
-        if cardinality is not None and cardinality < 65500:
+        if cardinality is not None and cardinality < 65535:
             return numpy.uint16
         else:
             return numpy.int32


### PR DESCRIPTION
During bench testing, I found unusual thing :

> the dataset is actually passing data in fp32 bit

The codes was written with multiple process with python generator (e.g.: pool.imap), make this issue hard to uncover.

```
    @staticmethod
    def optimal_dtype(cardinality: Optional[int]) -> Type[numpy.number]:
        """Get the dtype to use for an index of a certain cardinality

        Args:
            cardinality (Optional[int]): The number of elements to be indexed

        Returns:
            Type[numpy.number]: The dtype to use for the index
        """
        if cardinality is not None and cardinality < 65500:
            return numpy.uint16
        else:
            return numpy.int32
```

when vercab_size > 65500 (< 2**16=65536), data is actually dump to 32 bit byte strings, waisting half of disk memory and increase end 2 end data loading overhead in a distributed cloud env.

This issue also exist in previous implementation `megatron/data/indexed_dataset.py`

