### PR TITLE
[Fix] Fix router sync bug when moe and sequence parallelism are enable

### DIFF
--- a/examples/pretrain_gpt_moe_1B.sh
+++ b/examples/pretrain_gpt_moe_1B.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+GPUS_PER_NODE=8
+# Change for multinode config
+MASTER_ADDR=localhost
+MASTER_PORT=6000
+NNODES=1
+NODE_RANK=0
+WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
+CHECKPOINT_PATH=checkpoint
+VOCAB_FILE=../megatron-lm-data/gpt2-vocab.json
+MERGE_FILE=../megatron-lm-data/gpt2-merges.txt
+DATA_PATH=../megatron-lm-data/my-gpt2_text_document
+
+DISTRIBUTED_ARGS="
+    --nproc_per_node $GPUS_PER_NODE \
+    --nnodes $NNODES \
+    --node_rank $NODE_RANK \
+    --master_addr $MASTER_ADDR \
+    --master_port $MASTER_PORT \
+"
+
+LLAMA_ARGS="
+    --tensor-model-parallel-size 2 \
+    --pipeline-model-parallel-size 2 \
+    --sequence-parallel \
+    --use-flash-attn \
+    --untie-embeddings-and-output-weights \
+    --use-rotary-position-embeddings \
+    --num-layers 18 \
+    --hidden-size 2560 \
+    --num-attention-heads 20 \
+    --seq-length 2048 \
+    --max-position-embeddings 2048 \
+    --bf16
+    --micro-batch-size 1 \
+    --global-batch-size 2 \
+    --lr 0.00015 \
+    --train-iters 500000 \
+    --lr-decay-iters 320000 \
+    --lr-decay-style cosine \
+    --min-lr 1.0e-5 \
+    --weight-decay 1e-2 \
+    --lr-warmup-fraction .01 \
+    --clip-grad 1.0 \
+    --num-experts 4 \
+"
+DATA_ARGS="
+    --data-path $DATA_PATH \
+    --vocab-file $VOCAB_FILE \
+    --merge-file $MERGE_FILE \
+    --split 949,50,1
+"
+
+OUTPUT_ARGS="
+    --log-interval 1 \
+    --save-interval 10000 \
+    --eval-interval 1000 \
+    --eval-iters 10  \
+    --save $CHECKPOINT_PATH \
+    --load $CHECKPOINT_PATH \
+"
+torchrun $DISTRIBUTED_ARGS pretrain_gpt.py \
+    $LLAMA_ARGS \
+    $DATA_ARGS \
+    $OUTPUT_ARGS \
+    --distributed-backend nccl

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -189,6 +189,9 @@ class SwitchMLP(MegatronModule):
         super(SwitchMLP, self).__init__()
         args = get_args()
         self.router = get_router_linear_layer(config)
+        if config.sequence_parallel:
+            setattr(self.router.weight, 'sequence_parallel', True)
+
         self.expert_parallel_size = mpu.get_expert_model_parallel_world_size()
         self.sequence_parallel = config.sequence_parallel
         self.add_bias = config.add_bias_linear


### PR DESCRIPTION
This PR addresses the issue of unsynchronized router weights in switchmlp when using sequence parallelism with moe enabled, as detailed in the related issue https://github.com/NVIDIA/Megatron-LM/issues/599.

**Description**
We discovered that this problem occurs when sequence parallelism, tensor parallelism, and moe are all enabled simultaneously. Within the same tensor parallel group, different tp rank workers' routers receive input that has been partitioned by sequence parallelism. When the router calculates and updates its weights, there is no synchronization within the tp groups, leading to differences in the router's weights as training progresses.

**Fix**
To fix this issue, it is relatively simple: just add the sequence parallel attribute to the router's weights, allowing them to be synchronized during parameter updates.
```
if config.sequence_parallel:
    setattr(self.router.weight, 'sequence_parallel', True)
```

**Test script**
We tested the fix using the `examples/pretrain_gpt_moe_1B.sh`