### PR TITLE
fix param_buffer peak memory may be OOM

### DIFF
--- a/megatron/optimizer/distrib_optimizer.py
+++ b/megatron/optimizer/distrib_optimizer.py
@@ -421,35 +421,11 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             current_param_buffers = {}
             for dtype, grad_buffer in model.grad_buffers.items():
                 size_ratio = torch.finfo(dtype).bits // torch.finfo(params_dtype).bits
+                assert size_ratio >= 1, "param dtype size should <= grad dtype size"
                 current_param_buffers[dtype] = []
                 for bucket in grad_buffer.buckets:
-
-                    # Handle older/newer method for getting untyped storage.
-                    try:
-                        storage = bucket.data.untyped_storage()
-                    except:
-                        try:
-                            storage = bucket.data.storage()._untyped()
-                        except:
-                            storage = bucket.data.storage().untyped()
-
-                    # Typed param buffer.
-                    param_buffer = torch.tensor(
-                        storage,
-                        dtype = params_dtype,
-                        device = bucket.data.device)
-
-                    # .storage() ignores views / slices, so param_buffer now points to the start
-                    # of the grad_buffer instead of to the start of each bucket. As a result,
-                    # add bucket.offset to make sure param_buffers point to the right region of
-                    # memory.
-                    # Since we want the start of each bucket's param_buffer to coincide with the
-                    # start of the same bucket's grad_buffer (this ensures that zeroing the grad
-                    # buffer does not zero out params in the param_buffer before they are copied
-                    # into the model_params), multiply the offset by the size ratio of grads and
-                    # params.
-                    offset = bucket.offset * size_ratio
-                    param_buffer = param_buffer[offset:offset+bucket.data.numel()]
+                    param_buffer = bucket.data.view(dtype=params_dtype)
+                    param_buffer = param_buffer[:bucket.data.numel()]
                     assert param_buffer.data_ptr() == bucket.data.data_ptr(), \
                         "param_buffer and grad_buffer for same bucket should start at the same byte address"
                     assert param_buffer.numel() == bucket.data.numel(), \


### PR DESCRIPTION
## Problem description
As shown in Figure 2, using `torch.tensor(storage)` will increase the peak memory. `torch.tensor(storage)` may create a new tensor first, and then replace the storage of the new tensor with the incoming storage, resulting in a problem of high peak memory, and may cause OOM. (For example, if we have 16GB param and 32GB grad, and when obtaining the param_buffer 32GB storage is needed, 16+32+32 = 80GB, it may cause OOM)
## Solution
As shown in Figure 1, we can use `tensor.view(dtype)` to share tensor, there will be no problem with high peak memory. In addition, as shown in Figure 3, `.view()` does not ignore views/slices, so there is no need to calculate offset.

![ubFd36nrJe](https://github.com/NVIDIA/Megatron-LM/assets/10208305/403a1fba-cfa9-4eca-8389-fa10224a414d)
