### PR TITLE
Support Mixtral 8*7B MOE 

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -666,7 +666,7 @@ def _add_network_size_args(parser):
                             ' to use for each input token in the Switch Transformer model')
     group.add_argument('--moe-type', type=str, default=None,
                        help='Extra type of MOE network to use, default None means switch transformers, Optional: mixtral')
-    group.add_argument('--moe-load-balancing-mode', type=str, default="sinkhorn",
+    group.add_argument('--moe-load-balancing-mode', default=None,
                        help="Balancing the probability of each expert's vote suppored in mixtral moe."
                             "Only sinkhorn and None supported now.")
     group.add_argument('--untie-embeddings-and-output-weights', action='store_true',

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -661,6 +661,14 @@ def _add_network_size_args(parser):
                        'launch to improve the utilization and performance by '
                        'leveraging the Grouped GEMM feature introduced since '
                        'CUTLASS 2.8 (https://github.com/fanshiqing/grouped_gemm).')
+    group.add_argument('--num-experts-per-tok', type=int, default=2,
+                       help='The num-experts-per-tok parameter specifies the number of MLP experts'
+                            ' to use for each input token in the Switch Transformer model')
+    group.add_argument('--moe-type', type=str, default=None,
+                       help='Extra type of MOE network to use, default None means switch transformers, Optional: mixtral')
+    group.add_argument('--moe-load-balancing-mode', type=str, default="sinkhorn",
+                       help="Balancing the probability of each expert's vote suppored in mixtral moe."
+                            "Only sinkhorn and None supported now.")
     group.add_argument('--untie-embeddings-and-output-weights', action='store_true',
                        help='Untie embeddings and output weights.'),
     return parser

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -361,7 +361,7 @@ class MixtralSparseMoeBlock(MegatronModule):
         self.hidden_dim = args.hidden_size
         self.ffn_dim = args.ffn_hidden_size
         self.num_experts = getattr(args, "num_experts", 8)
-        self.top_k = getattr(args, "top_k", 2)
+        self.top_k = getattr(args, "num_experts_per_tok", 2)
         self.moe_load_balancing_mode = getattr(args, "moe_load_balancing_mode", None)
 
         # gating

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1015,7 +1015,10 @@ class ParallelTransformerLayer(MegatronModule):
 
         # MLP
         if args.num_experts is not None:
-            self.mlp = SwitchMLP(config)
+            if args.moe_type == "mixtral":
+                self.mlp = MixtralSparseMoeBlock(config)
+            else:
+                self.mlp = SwitchMLP(config)
         else:
             self.mlp = ParallelMLP(config)
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -294,6 +294,122 @@ class SwitchMLP(MegatronModule):
         return output_total, output_bias_total
 
 
+class MixtralParallelMLP(torch.nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.ffn_dim = config.ffn_hidden_size
+        self.hidden_dim = config.hidden_size
+
+        self.w1 = tensor_parallel.ColumnParallelLinear(
+            config.hidden_size,
+            config.ffn_hidden_size,
+            config=config,
+            init_method=config.init_method,
+            bias=False,
+            gather_output=False,
+            skip_bias_add=True,
+            is_expert=False,
+        )
+
+        self.w3 = tensor_parallel.ColumnParallelLinear(
+            config.hidden_size,
+            config.ffn_hidden_size,
+            config=config,
+            init_method=config.init_method,
+            bias=False,
+            gather_output=False,
+            skip_bias_add=True,
+            is_expert=False,
+        )
+
+        self.w2 = tensor_parallel.RowParallelLinear(
+            config.ffn_hidden_size,
+            config.hidden_size,
+            config=config,
+            init_method=config.output_layer_init_method,
+            bias=False,
+            skip_bias_add=True,
+            input_is_parallel=True,
+            is_expert=False,
+        )
+
+        self.act_fn = F.silu
+
+    def forward(self, hidden_states):
+        selects, h = hidden_states.shape
+        hidden_states = hidden_states.view(selects, 1, h)
+        current_hidden_states = self.act_fn(self.w1(hidden_states)[0]) * self.w3(hidden_states)[0]
+        current_hidden_states = self.w2(current_hidden_states)[0].view(selects, h)
+        return current_hidden_states
+
+
+class MixtralSparseMoeBlock(MegatronModule):
+    """
+    This is a megatron implementation refer to HuggingFace Mixtral Model.
+    Which strictly equivalent to standard MoE with full capacity (no
+    dropped tokens). It's faster since it formulates MoE operations
+    in terms of block-sparse operations to accomodate imbalanced
+    assignments of tokens to experts, whereas standard MoE either
+    (1) drop tokens at the cost of reduced performance or (2) set
+    capacity factor to number of experts and thus waste computation
+    and memory on padding.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        args = get_args()
+        self.hidden_dim = args.hidden_size
+        self.ffn_dim = args.ffn_hidden_size
+        self.num_experts = getattr(args, "num_experts", 8)
+        self.top_k = getattr(args, "top_k", 2)
+        self.moe_load_balancing_mode = getattr(args, "moe_load_balancing_mode", None)
+
+        # gating
+        self.gate = torch.nn.Linear(self.hidden_dim, self.num_experts, bias=False)
+
+        self.experts = torch.nn.ModuleList(
+            [MixtralParallelMLP(config) for _ in range(self.num_experts)]
+        )
+
+    def forward(self, hidden_states: torch.Tensor):
+        b, s, h = hidden_states.shape
+        hidden_states = hidden_states.view(-1, h)
+
+        # route: (batch * sequence_length, n_experts)
+        router_logits = self.gate(hidden_states)
+        if self.moe_load_balancing_mode == "sinkhorn":
+            router_logits = sinkhorn(router_logits)
+
+        routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        output_total = torch.zeros_like(hidden_states)
+
+        # One hot encode the selected experts to create an expert mask
+        # this will be used to easily index which expert is going to be solicited
+        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+
+        # Loop over all available experts in the model and perform the computation on each expert
+        for expert_idx in range(self.num_experts):
+            expert_layer = self.experts[expert_idx]
+            row, column = torch.where(expert_mask[expert_idx])
+
+            if column.shape[0] == 0:
+                continue
+
+            # Index the correct hidden states and compute the expert hidden state for
+            # the current expert. We need to make sure to multiply the output hidden
+            # states by `routing_weights` on the corresponding tokens (top-1 and top-2)
+            current_hidden_states = expert_layer(hidden_states[column]) * routing_weights[column, row, None]
+            output_total[column] = output_total[column] + current_hidden_states.to(hidden_states.dtype)
+
+        output_total = output_total.reshape(b, s, h)
+
+        return output_total, None
+
+
 class CoreAttention(MegatronModule):
 
     def __init__(self, layer_number, config,

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -372,7 +372,7 @@ class MixtralSparseMoeBlock(MegatronModule):
         )
 
     def forward(self, hidden_states: torch.Tensor):
-        b, s, h = hidden_states.shape
+        s, b, h = hidden_states.shape
         hidden_states = hidden_states.view(-1, h)
 
         # route: (batch * sequence_length, n_experts)
@@ -405,7 +405,7 @@ class MixtralSparseMoeBlock(MegatronModule):
             current_hidden_states = expert_layer(hidden_states[column]) * routing_weights[column, row, None]
             output_total[column] = output_total[column] + current_hidden_states.to(hidden_states.dtype)
 
-        output_total = output_total.reshape(b, s, h)
+        output_total = output_total.view(s, b, h).contiguous()
 
         return output_total, None
 

--- a/tools/checkpoint/loader_mixtral_hf.py
+++ b/tools/checkpoint/loader_mixtral_hf.py
@@ -1,0 +1,390 @@
+# coding=utf-8
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+
+import json
+import os
+import sys
+import types
+import torch
+import torch_npu
+import transformers
+from tqdm import tqdm
+
+
+def add_arguments(parser):
+    group = parser.add_argument_group(title='Mixtral 8x7B HF loader.')
+
+    group.add_argument('--true-vocab-size', type=int, default=None,
+                       help='original size of vocab, if specified will trim padding from embedding table.')
+    group.add_argument('--vocab-file', type=str, default=None,
+                       help='Path to the vocab file. If specified will use this to get vocab size and '
+                       'trim padding from the embedding table.')
+    group.add_argument('--tokenizer-model', required=True,
+                       help='Sentencepiece tokenizer model.')
+    group.add_argument('--megatron-path', type=str, default=None,
+                       help='Base directory of deepspeed repository')
+
+
+def verify_transformers_version():
+    major, minor, patch = map(int, transformers.__version__.split('.'))
+    if major < 4 or minor < 31:
+        raise ValueError("the version transformers should greater or equal 4.31")
+
+
+def load_args_from_checkpoint(args):
+
+    # Read Mixtral args.
+    args_path = os.path.join(args.load, "config.json")
+    with open(args_path) as f:
+        mixtral_args = json.load(f)
+
+    # Update Megatron args.
+    args.seq_length = 4096
+    args.max_position_embeddings = mixtral_args.get("max_position_embeddings", 32768)
+    args.num_experts = mixtral_args.get("num_local_experts", None)
+    args.num_experts_per_tok = mixtral_args.get("num_experts_per_tok", 2)
+    args.moe_type = "mixtral"
+    args.hidden_size = mixtral_args["hidden_size"]
+    args.num_attention_heads = mixtral_args["num_attention_heads"]
+    args.num_layers = mixtral_args["num_hidden_layers"]
+    args.global_batch_size = 1
+    args.norm_epsilon = mixtral_args["rms_norm_eps"]
+    args.iteration = 1
+    args.position_embedding_type = "rope"
+    args.swiglu = True
+    args.tokenizer_type = "Llama2Tokenizer"
+    args.fp16 = True
+    args.normalization = "RMSNorm"
+    args.add_bias_linear = False
+    args.untie_embeddings_and_output_weights = True
+    args.vocab_size = mixtral_args["vocab_size"]
+    args.padded_vocab_size = mixtral_args["vocab_size"]
+    args.mixtral = mixtral_args
+    args.ffn_hidden_size = mixtral_args["intermediate_size"]
+    args.gradient_accumulation_fusion = False
+
+    if "num_key_value_heads" in mixtral_args:
+        args.group_query_attention = True
+        args.num_query_groups = mixtral_args["num_key_value_heads"]
+
+
+def set_preprocess_state(args, model, hf_model):
+    """Set embedding params."""
+    model.language_model.embedding.word_embeddings.weight.data.copy_(
+        hf_model.model.embed_tokens.weight)
+
+
+def set_postprocess_state(args, model, hf_model):
+    """Set output layer & norm params."""
+    model.language_model.encoder.final_norm.weight.data.copy_(hf_model.model.norm.weight)
+    model.language_model.output_layer.weight.data.copy_(hf_model.lm_head.weight)
+
+
+def set_attn_state(args, layer, hf_layer):
+    """Set self-attention params."""
+
+    # Get attention layer & state.
+    attn = layer.self_attention
+    hf_attn = hf_layer.self_attn
+
+    # Reshape loaded weights.
+    tp = args.tensor_model_parallel_size
+    nh = args.num_attention_heads // tp
+    ng = (args.num_query_groups if args.group_query_attention else args.num_attention_heads) // tp
+    dim = args.kv_channels
+    if not nh % ng == 0:
+        raise ValueError("nh % ng should equal 0")
+
+    # Copy weights (re-order dimensions for Megatron).
+    attn.query_key_value.weight.data.copy_(torch.cat([
+        hf_attn.q_proj.weight.reshape((ng, dim * nh // ng, -1)),
+        hf_attn.k_proj.weight.reshape((ng, dim, -1)),
+        hf_attn.v_proj.weight.reshape((ng, dim, -1)),
+    ], dim=1).reshape((-1, args.hidden_size)))
+    attn.dense.weight.data.copy_(hf_attn.o_proj.weight)
+
+
+def set_mlp_state(args, layer, hf_layer):
+    """Set Mixtral SMOE params."""
+
+    mlp = layer.mlp
+    hf_mlp = hf_layer.block_sparse_moe
+
+    gate = mlp.gate.weight.data.copy_
+    hf_gate_weight = hf_mlp.gate.weight
+    gate(hf_gate_weight)
+
+    for idx in range(args.num_experts):
+        w1 = getattr(mlp.experts, f"{idx}").w1.weight.data.copy_
+        w2 = getattr(mlp.experts, f"{idx}").w2.weight.data.copy_
+        w3 = getattr(mlp.experts, f"{idx}").w3.weight.data.copy_
+
+        hf_w1_weight = getattr(hf_mlp.experts, f"{idx}").w1.weight
+        hf_w2_weight = getattr(hf_mlp.experts, f"{idx}").w2.weight
+        hf_w3_weight = getattr(hf_mlp.experts, f"{idx}").w3.weight
+
+        w1(hf_w1_weight)
+        w2(hf_w2_weight)
+        w3(hf_w3_weight)
+
+
+def set_layer_state(args, model, hf_model, layer_idx):
+    """Set transformer layer params."""
+
+    layer = model.language_model.encoder.layers[layer_idx]
+    hf_layer = hf_model.model.layers[layer_idx]
+
+    set_attn_state(args, layer, hf_layer)
+    set_mlp_state(args, layer, hf_layer)
+    layer.input_norm.weight.data.copy_(hf_layer.input_layernorm.weight)
+    layer.post_attention_norm.weight.data.copy_(hf_layer.post_attention_layernorm.weight)
+
+
+def load_checkpoint_to_model(args):
+    """Set model params."""
+    from pretrain_gpt import model_provider
+    from transformers import AutoModelForCausalLM
+
+    # Load Huggingface model.
+    hf_model = AutoModelForCausalLM.from_pretrained(args.load, device_map="cpu")
+
+    # Init Megatron model.
+    model = model_provider(True, True).to(args.params_dtype)
+
+    # Set model state.
+    set_preprocess_state(args, model, hf_model)
+    set_postprocess_state(args, model, hf_model)
+    for layer_idx in tqdm(range(args.num_layers), "set layer states"):
+        set_layer_state(args, model, hf_model, layer_idx)
+
+    return model
+
+
+def _load_checkpoint(queue, args):
+
+    # Mixtral requires HF transformers >=4.36.0.
+    verify_transformers_version()
+
+    # Search in directory above this.
+    sys.path.append(os.path.abspath(
+        os.path.join(os.path.dirname(__file__),
+                     os.path.pardir,
+                     os.path.pardir)))
+    if args.megatron_path is not None:
+        sys.path.insert(0, args.megatron_path)
+    try:
+        from ascendspeed import megatron_adaptor
+        from megatron.arguments import parse_args, validate_args
+        from megatron.global_vars import set_args, set_global_variables
+        from megatron.model import module
+        from megatron.core import mpu
+        from megatron.core.enums import ModelType
+        from megatron import fused_kernels
+    except ModuleNotFoundError:
+        print("Unable to import Megatron, please specify the path to Megatron using --megatron-path.")
+        queue.put("exit")
+        exit(1)
+
+    # We want all arguments to come from us.
+    sys.argv = ['script.py',
+                '--no-masked-softmax-fusion',
+                '--no-bias-gelu-fusion',
+                '--no-bias-dropout-fusion',
+                '--no-async-tensor-model-parallel-allreduce',
+                '--use-cpu-initialization',
+                '--micro-batch-size', '1',
+                '--no-load-optim',
+                '--no-load-rng',
+                '--no-save-optim',
+                '--no-save-rng',
+                '--no-initialization',
+                '--load', args.load_dir
+                ]
+
+    margs = parse_args()
+    margs.tokenizer_model = args.tokenizer_model
+    load_args_from_checkpoint(margs)
+
+    # Arguments do sanity checks on the world size, but we don't care,
+    # so trick it into thinking we are plenty of processes.
+    margs.world_size = margs.tensor_model_parallel_size * margs.pipeline_model_parallel_size
+
+    margs = validate_args(margs)
+
+    def check_for_arg(arg_name, default=None):
+        if getattr(margs, arg_name, None) is None:
+            if default is not None:
+                setattr(margs, arg_name, default)
+            else:
+                print(f"Checkpoint does not specify the argument {arg_name}. Exiting.")
+                print(f"Arguments: {margs}")
+                queue.put("exit")
+                exit(1)
+
+    check_for_arg('tensor_model_parallel_size')
+    check_for_arg('pipeline_model_parallel_size')
+    check_for_arg('num_layers')
+    check_for_arg('hidden_size')
+    check_for_arg('seq_length')
+    check_for_arg('num_attention_heads')
+    check_for_arg('max_position_embeddings')
+    check_for_arg('position_embedding_type')
+    check_for_arg('tokenizer_type')
+    check_for_arg('iteration')
+    check_for_arg('bert_binary_head')
+    check_for_arg('disable_bias_linear', False)
+    check_for_arg('params_dtype')
+    check_for_arg('swiglu', False)
+
+    # Determine how to make our models.
+    if not args.model_type == 'GPT':
+        raise ValueError("Mixtral is a GPT model.")
+    margs.model_type = ModelType.encoder_or_decoder
+
+    # Suppress warning about torch.distributed not being initialized.
+    module.MegatronModule.embedding_warning_printed = True
+
+    set_global_variables(margs, build_tokenizer=False)
+    mpu.set_tensor_model_parallel_world_size(margs.tensor_model_parallel_size)
+    mpu.set_pipeline_model_parallel_world_size(margs.pipeline_model_parallel_size)
+    mpu.set_virtual_pipeline_model_parallel_world_size(margs.virtual_pipeline_model_parallel_size)
+
+    # Short aliases.
+    tp_size = margs.tensor_model_parallel_size
+    pp_size = margs.pipeline_model_parallel_size
+    vp_size = margs.virtual_pipeline_model_parallel_size
+    if vp_size is None:
+        vp_size = 1
+
+    # Metadata.
+    md = types.SimpleNamespace()
+    md.model_type = args.model_type
+    md.moe_type = margs.moe_type
+    md.num_experts = margs.num_experts
+    md.num_experts_per_tok = margs.num_experts_per_tok
+    md.num_layers = margs.num_layers
+    md.hidden_size = margs.hidden_size
+    md.seq_length = margs.seq_length
+    md.num_attention_heads = margs.num_attention_heads
+    md.max_position_embeddings = margs.max_position_embeddings
+    md.tokenizer_type = margs.tokenizer_type
+    md.iteration = margs.iteration
+    md.params_dtype = margs.params_dtype
+    md.bert_binary_head = margs.bert_binary_head
+    md.output_layer = margs.untie_embeddings_and_output_weights
+    md.position_embedding_type = margs.position_embedding_type
+    md.linear_bias = margs.add_bias_linear
+    md.norm_has_bias = False
+    md.swiglu = margs.swiglu
+    md.previous_tensor_parallel_size = margs.tensor_model_parallel_size
+    md.previous_pipeline_parallel_size = margs.pipeline_model_parallel_size
+    md.true_vocab_size = None
+    md.make_vocab_size_divisible_by = None
+    md.checkpoint_args = margs
+    md.consumed_train_samples = 0
+    md.consumed_valid_samples = 0
+
+    # Get first pipe stage.
+    mpu.set_tensor_model_parallel_rank(0)
+    mpu.set_pipeline_model_parallel_rank(0)
+    model = load_checkpoint_to_model(margs)
+
+    queue.put(md)
+
+    def queue_put(name, msg):
+        print(f"sending {name}")
+        msg["name"] = name
+        queue.put(msg)
+
+    # Send embeddings.
+    message = {
+        "word embeddings": model.language_model.embedding.word_embeddings.weight.data
+    }
+    if md.position_embedding_type == 'learned_absolute':
+        message["position embeddings"] = model.language_model.embedding.position_embeddings.weight.data
+    else:
+        if hasattr(model.language_model.embedding, 'position_embeddings'):
+            raise ValueError("model should have position_embeddings")
+
+    queue_put("embeddings", message)
+
+    for layer_num in range(margs.num_layers):
+        message = {}
+
+        # Get non-parallel tensors from tp_rank 0.
+        layer = model.language_model.encoder.layers[layer_num]
+        message["input norm weight"] = layer.input_norm.weight.data
+        message["post norm weight"] = layer.post_attention_norm.weight.data
+        if md.linear_bias:
+            message["dense bias"] = layer.self_attention.dense.bias.data
+
+        # Grab all parallel tensors for this layer.
+        qkv_weight = []
+        qkv_bias = []
+        dense_weight = []
+        mlp_gate_weight = []
+        mlp_gate_bias = []
+
+        layer = model.language_model.encoder.layers[layer_num]
+        qkv_weight.append(layer.self_attention.query_key_value.weight.data)
+        dense_weight.append(layer.self_attention.dense.weight.data)
+        mlp_gate_weight.append(layer.mlp.gate.weight.data)
+
+        if md.linear_bias:
+            qkv_bias.append(layer.self_attention.query_key_value.bias.data)
+            mlp_gate_bias.append(layer.mlp.gate.bias.data)
+
+        for expert_idx in range(margs.num_experts):
+            message[f"mlp {expert_idx} w1 weight"] = getattr(layer.mlp.experts, f"{expert_idx}").w1.weight.data
+            message[f"mlp {expert_idx} w2 weight"] = getattr(layer.mlp.experts, f"{expert_idx}").w2.weight.data
+            message[f"mlp {expert_idx} w3 weight"] = getattr(layer.mlp.experts, f"{expert_idx}").w3.weight.data
+            if md.linear_bias:
+                message[f"mlp {expert_idx} w1 bias"] = getattr(layer.mlp.experts, f"{expert_idx}").w1.bias.data
+                message[f"mlp {expert_idx} w2 bias"] = getattr(layer.mlp.experts, f"{expert_idx}").w2.bias.data
+                message[f"mlp {expert_idx} w3 bias"] = getattr(layer.mlp.experts, f"{expert_idx}").w3.bias.data
+
+        # Simple concat of the rest.
+        message["qkv weight"] = torch.cat(qkv_weight, dim=0)
+        message["dense weight"] = torch.cat(dense_weight, dim=1)
+        message["mlp gate weight"] = torch.cat(mlp_gate_weight, dim=1)
+
+        if md.linear_bias:
+            message["qkv bias"] = torch.cat(qkv_bias, dim=0)
+            message["mlp gate bias"] = torch.cat(mlp_gate_bias, dim=0)
+
+        queue_put(f"transformer layer {layer_num}", message)
+
+    # Send final norm from tp_rank 0.
+    message = {
+        "weight": model.language_model.encoder.final_norm.weight.data,
+    }
+    queue_put("final norm", message)
+
+    if md.output_layer:
+        message = {
+            "weight": model.language_model.output_layer.weight.dataloader_mixtral_hf
+        }
+        queue_put("output layer", message)
+
+    queue.put("done")
+
+
+def load_checkpoint(queue, args):
+    try:
+        _load_checkpoint(queue, args)
+    except:
+        queue.put("exit")
+        raise

--- a/tools/checkpoint/saver_mixtral.py
+++ b/tools/checkpoint/saver_mixtral.py
@@ -18,8 +18,6 @@ import os
 import sys
 
 import torch
-# TODO delete in megatron repository
-import torch_npu
 
 
 def add_arguments(parser):
@@ -46,8 +44,6 @@ def save_model_checkpoint(queue, args):
         sys.path.insert(0, args.megatron_path)
 
     try:
-        # TODO delete in megatron repository
-        from ascendspeed import megatron_adaptor
         from megatron.arguments import (parse_args, validate_args)
         from megatron.checkpointing import save_checkpoint
         from megatron.global_vars import set_global_variables, get_args

--- a/tools/checkpoint/saver_mixtral.py
+++ b/tools/checkpoint/saver_mixtral.py
@@ -1,0 +1,439 @@
+# coding=utf-8
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+
+import os
+import sys
+
+import torch
+# TODO delete in megatron repository
+import torch_npu
+
+
+def add_arguments(parser):
+    group = parser.add_argument_group(title='Megatron saver')
+
+    group.add_argument('--megatron-path', type=str, default=None,
+                       help='Base directory of Megatron repository')
+
+    group.add_argument('--target-tensor-parallel-size', type=int,
+                       help='Target tensor model parallel size, defaults to the tensor parallel size '
+                       'in the input checkpoint if provided by the loader, otherwise to 1')
+    group.add_argument('--target-pipeline-parallel-size', type=int,
+                       help='Target tensor model parallel size, default to the pipeline parall size '
+                       'in the input checkpoint if provided by the loader, otherwise to 1')
+
+
+def save_model_checkpoint(queue, args):
+    # Search in directory above this
+    sys.path.append(os.path.abspath(
+        os.path.join(os.path.dirname(__file__),
+                     os.path.pardir,
+                     os.path.pardir)))
+    if args.megatron_path is not None:
+        sys.path.insert(0, args.megatron_path)
+
+    try:
+        # TODO delete in megatron repository
+        from ascendspeed import megatron_adaptor
+        from megatron.arguments import (parse_args, validate_args)
+        from megatron.checkpointing import save_checkpoint
+        from megatron.global_vars import set_global_variables, get_args
+        from megatron.core.enums import ModelType
+        from megatron.tokenizer.tokenizer import _vocab_size_with_padding
+        from megatron import fused_kernels
+        from megatron.core import mpu
+    except ModuleNotFoundError:
+        print("Unable to import Megatron, please specify the path to Megatron using --megatron-path.")
+        exit(1)
+
+    def queue_get(name=None):
+        val = queue.get()
+        if val == "exit":
+            print("Loader exited, exiting saver")
+            exit(1)
+        if name is not None and args.checking and val["name"] != name:
+            val_name = val["name"]
+            print(f'Unexpected message. Expecting "{name}" but got "{val_name}". Exiting saver.')
+            exit(1)
+        if name is not None:
+            print(f"received {name}")
+        return val
+
+    def check_message(msg):
+        if not args.checking:
+            return
+        msg_name = msg.pop("name")
+        if len(msg.keys()) > 0:
+            print(f"Unexpected values in {msg_name}:")
+            for key in msg.keys():
+                print(f"   {key}")
+            print(f"Exiting. If you want to ignore this, use the argument --no-checking.")
+            exit(1)
+
+
+    md = queue_get()
+
+    if args.target_tensor_parallel_size is None:
+        if hasattr(md, 'previous_tensor_parallel_size'):
+            args.target_tensor_parallel_size = md.previous_tensor_parallel_size
+        else:
+            print("loader did not provide a tensor parallel size and --target-tensor-parallel-size not provided on command line. "
+                  "Default to 1.")
+            args.target_tensor_parallel_size = 1
+
+    if args.target_pipeline_parallel_size is None:
+        if hasattr(md, 'previous_pipeline_parallel_size'):
+            args.target_pipeline_parallel_size = md.previous_pipeline_parallel_size
+        else:
+            print("loader did not provide a pipeline parallel size and --target-pipeline-parallel-size not provided on command line. "
+                  "Default to 1.")
+            args.target_pipeline_parallel_size = 1
+
+    # Arguments do sanity checks on the world size, but we don't care,
+    # so trick it into thinking we are plenty of processes
+    if args.target_tensor_parallel_size is not None and args.target_pipeline_parallel_size is not None:
+        os.environ["WORLD_SIZE"] = f'{args.target_tensor_parallel_size * args.target_pipeline_parallel_size}'
+
+    # We want all arguments to come from us
+    sys.argv = ['script.py',
+                '--num-layers', str(md.num_layers),
+                '--hidden-size', str(md.hidden_size),
+                '--seq-length', str(md.seq_length),
+                '--num-attention-heads', str(md.num_attention_heads),
+                '--max-position-embeddings', str(md.max_position_embeddings),
+                '--position-embedding-type', str(md.position_embedding_type),
+                '--tokenizer-type', str(md.tokenizer_type),
+                '--tensor-model-parallel-size', str(args.target_tensor_parallel_size),
+                '--pipeline-model-parallel-size', str(args.target_pipeline_parallel_size),
+                '--no-masked-softmax-fusion',
+                '--no-bias-gelu-fusion',
+                '--no-bias-dropout-fusion',
+                '--no-async-tensor-model-parallel-allreduce',
+                '--use-cpu-initialization',
+                '--micro-batch-size', '1',
+                '--no-load-optim',
+                '--no-load-rng',
+                '--no-save-optim',
+                '--no-save-rng',
+                '--no-initialization',
+                '--save-interval', '1',
+                '--save', args.save_dir
+                ]
+
+    if md.make_vocab_size_divisible_by is not None:
+        sys.argv.extend(['--make-vocab-size-divisible-by', str(md.make_vocab_size_divisible_by)])
+    if md.params_dtype == torch.float16:
+        sys.argv.append('--fp16')
+    elif md.params_dtype == torch.bfloat16:
+        sys.argv.append('--bf16')
+
+    if md.output_layer:
+        sys.argv.append('--untie-embeddings-and-output-weights')
+    if not md.linear_bias:
+        sys.argv.append('--disable-bias-linear')
+
+    if md.model_type == 'BERT' and not md.bert_binary_head:
+        sys.argv.append('--bert-no-binary-head')
+
+    margs = parse_args()
+
+    if hasattr(md, 'checkpoint_args'):
+        # These are arguments that we are either changing, or cause problems for validation if they are set
+        # Note that some of these deal with T5 so will need to be changed if we support T5.
+        args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'world_size', 'params_dtype',
+                        'num_layers_per_virtual_pipeline_stage', 'virtual_pipeline_model_parallel_size',
+                        'masked_softmax_fusion', 'bias_gelu_fusion', 'bias_dropout_fusion',
+                        'sequence_parallel', 'async_tensor_model_parallel_allreduce',
+                        'no_load_optim', 'no_load_rng', 'no_save_optim', 'no_save_rng',
+                        'vocab_file', 'tokenizer_model',
+                        'save_interval', 'save',
+                        'perform_initialization', 'use_cpu_initialization',
+                        'recompute_granularity', 'recompute_num_layers', 'recompute_method',
+                        'encoder_num_layers', 'encoder_seq_length',
+                        'distribute_saved_activations',
+                        'train_iters', 'lr_decay_iters', 'lr_warmup_iters', 'lr_warmup_fraction',
+                        'start_weight_decay', 'end_weight_decay']
+
+        for arg, value in vars(md.checkpoint_args).items():
+            if arg in args_to_keep:
+                continue
+            if not hasattr(margs, arg):
+                print(f"Checkpoint had argument {arg} but new arguments does not have this.")
+                continue
+            if getattr(margs, arg) != value:
+                print(f"Overwriting default {arg} value {getattr(margs, arg)} with value from checkpoint {value}.")
+                setattr(margs, arg, value)
+
+    margs.moe_type = md.moe_type
+    margs.num_experts = md.num_experts
+    margs.num_experts_per_tok = md.num_experts_per_tok
+
+    validate_args(margs)
+
+    set_global_variables(margs, build_tokenizer=False)
+
+    # margs = megatron args
+    margs = get_args()
+
+    if hasattr(md, 'consumed_train_samples'):
+        margs.consumed_train_samples = md.consumed_train_samples
+        margs.consumed_valid_samples = md.consumed_valid_samples
+        print(f"Setting consumed_train_samples to {margs.consumed_train_samples}"
+              f" and consumed_valid_samples to {margs.consumed_valid_samples}")
+    else:
+        print("consumed_train_samples not provided.")
+
+    # Determine how to make our models
+    if md.model_type == 'GPT':
+        from pretrain_gpt import model_provider
+        margs.model_type = ModelType.encoder_or_decoder
+    elif md.model_type == 'BERT':
+        from pretrain_bert import model_provider
+        margs.model_type = ModelType.encoder_or_decoder
+    else:
+        raise Exception(f'unrecognized model type: {args.model_type}')
+
+    def get_models(count, dtype, pre_process, post_process):
+        models = [model_provider(pre_process, post_process).to(dtype) for _ in range(count)]
+        return models
+
+    # fake initializing distributed
+    mpu.set_tensor_model_parallel_world_size(args.target_tensor_parallel_size)
+    mpu.set_pipeline_model_parallel_world_size(args.target_pipeline_parallel_size)
+    mpu.set_tensor_model_parallel_rank(0)
+    mpu.set_pipeline_model_parallel_rank(0)
+
+    # Embeddings
+    #-----------
+    embeddings_msg = queue_get("embeddings")
+
+    pos_embed = None
+    if md.position_embedding_type == 'learned_absolute':
+        pos_embed = embeddings_msg.pop("position embeddings")
+    orig_word_embed = embeddings_msg.pop("word embeddings")
+    check_message(embeddings_msg)
+
+    # Deal with padding
+    if md.true_vocab_size is not None:
+        # figure out what our padded vocab size is
+        orig_vocab_size = orig_word_embed.shape[0]
+        margs.padded_vocab_size = _vocab_size_with_padding(md.true_vocab_size, margs)
+
+        # Cut out extra padding we don't need
+        if orig_vocab_size > margs.padded_vocab_size:
+            full_word_embed = orig_word_embed[0:margs.padded_vocab_size, :]
+
+        # Expanding embedding to larger size by replicating final entry
+        elif orig_vocab_size < margs.padded_vocab_size:
+            padding_size = margs.padded_vocab_size - orig_vocab_size
+
+            full_word_embed = torch.cat((
+                orig_word_embed,
+                orig_word_embed[-1].unsqueeze(0).expand(padding_size, -1)))
+
+        # Same size!
+        else:
+            full_word_embed = orig_word_embed
+    else:
+        print("Original vocab size not specified, leaving embedding table as-is. "
+              "If you've changed the tensor parallel size this could cause problems.")
+        margs.padded_vocab_size = orig_word_embed.shape[0]
+        full_word_embed = orig_word_embed
+
+    # Split into new tensor model parallel sizes
+    out_word_embed = torch.chunk(full_word_embed, args.target_tensor_parallel_size, dim=0)
+
+    # Make models for first pipeline stage and fill in embeddings
+    mpu.set_pipeline_model_parallel_rank(0)
+    post_process = args.target_pipeline_parallel_size == 1
+    models = get_models(args.target_tensor_parallel_size, md.params_dtype, True, post_process)
+    for tp_rank, model in enumerate(models):
+        model.language_model.embedding.word_embeddings.weight.data.copy_(out_word_embed[tp_rank])
+        if pos_embed is not None:
+            model.language_model.embedding.position_embeddings.weight.data.copy_(pos_embed)
+        else:
+            if hasattr(model.language_model.embedding, 'position_embeddings'):
+                raise ValueError("model should have position_embeddings")
+
+    # Transformer layers
+    #-------------------
+    total_layer_num = 0
+    for pp_rank in range(args.target_pipeline_parallel_size):
+        # For later pipeline parallel ranks, make the new models
+        if pp_rank > 0:
+            mpu.set_pipeline_model_parallel_rank(pp_rank)
+            post_process = pp_rank == args.target_pipeline_parallel_size - 1
+            models = get_models(args.target_tensor_parallel_size, md.params_dtype, False, post_process)
+
+        for layer in range(len(models[0].language_model.encoder.layers)):
+            msg = queue_get(f"transformer layer {total_layer_num}")
+
+            # duplicated tensors
+            input_norm_weight = msg.pop("input norm weight")
+            if md.norm_has_bias:
+                input_norm_bias = msg.pop("input norm bias")
+            post_norm_weight = msg.pop("post norm weight")
+            if md.norm_has_bias:
+                post_norm_bias = msg.pop("post norm bias")
+            if md.linear_bias:
+                dense_bias = msg.pop("dense bias")
+
+            # Split up the parallel tensors
+            qkv_weight = torch.chunk(msg.pop("qkv weight"), args.target_tensor_parallel_size, dim=0)
+            dense_weight = torch.chunk(msg.pop("dense weight"), args.target_tensor_parallel_size, dim=1)
+            mlp_gate_weight = msg.pop("mlp gate weight")
+
+            if md.linear_bias:
+                qkv_bias = torch.chunk(msg.pop("qkv bias"), args.target_tensor_parallel_size, dim=0)
+                mlp_gate_bias = msg.pop("mlp gate bias")
+
+            for expert_idx in range(md.num_experts):
+                mlp_w1_weight = torch.chunk(
+                    msg.pop(f"mlp {expert_idx} w1 weight"), args.target_tensor_parallel_size, dim=0)
+                mlp_w2_weight = torch.chunk(
+                    msg.pop(f"mlp {expert_idx} w2 weight"), args.target_tensor_parallel_size, dim=1)
+                mlp_w3_weight = torch.chunk(
+                    msg.pop(f"mlp {expert_idx} w3 weight"), args.target_tensor_parallel_size, dim=0)
+
+                if md.linear_bias:
+                    mlp_w1_bias = msg.pop(f"mlp {expert_idx} w1 bias")
+                    mlp_w2_bias = msg.pop(f"mlp {expert_idx} w2 bias")
+                    mlp_w3_bias = msg.pop(f"mlp {expert_idx} w3 bias")
+
+                for tp_rank in range(args.target_tensor_parallel_size):
+                    layer_chunk = models[tp_rank].language_model.encoder.layers[layer]
+                    w1_weight = getattr(layer_chunk.mlp.experts, f"{expert_idx}").w1.weight.data.copy_
+                    w2_weight = getattr(layer_chunk.mlp.experts, f"{expert_idx}").w2.weight.data.copy_
+                    w3_weight = getattr(layer_chunk.mlp.experts, f"{expert_idx}").w3.weight.data.copy_
+
+                    w1_weight(mlp_w1_weight[tp_rank])
+                    w2_weight(mlp_w2_weight[tp_rank])
+                    w3_weight(mlp_w3_weight[tp_rank])
+
+                    if md.linear_bias:
+                        w1_bias = getattr(layer_chunk.mlp.experts, f"{expert_idx}").w1.bias.data.copy_
+                        w2_bias = getattr(layer_chunk.mlp.experts, f"{expert_idx}").w2.bias.data.copy_
+                        w3_bias = getattr(layer_chunk.mlp.experts, f"{expert_idx}").w3.bias.data.copy_
+
+                        w1_bias(mlp_w1_bias)
+                        w2_bias(mlp_w2_bias)
+                        w3_bias(mlp_w3_bias)
+
+            # Save them to the model
+            for tp_rank in range(args.target_tensor_parallel_size):
+                layer_chunk = models[tp_rank].language_model.encoder.layers[layer]
+                layer_chunk.input_norm.weight.data.copy_(input_norm_weight)
+                if md.norm_has_bias:
+                    layer_chunk.input_norm.bias.data.copy_(input_norm_bias)
+                layer_chunk.self_attention.query_key_value.weight.data.copy_(qkv_weight[tp_rank])
+                layer_chunk.self_attention.dense.weight.data.copy_(dense_weight[tp_rank])
+                layer_chunk.post_attention_norm.weight.data.copy_(post_norm_weight)
+                layer_chunk.mlp.gate.weight.data.copy_(mlp_gate_weight)
+
+                if md.norm_has_bias:
+                    layer_chunk.post_attention_norm.bias.data.copy_(post_norm_bias)
+
+                if md.linear_bias:
+                    layer_chunk.self_attention.query_key_value.bias.data.copy_(qkv_bias[tp_rank])
+                    layer_chunk.self_attention.dense.bias.data.copy_(dense_bias)
+                    layer_chunk.mlp.gate.bias.data.copy_(mlp_gate_bias)
+
+            total_layer_num = total_layer_num + 1
+            check_message(msg)
+
+        if post_process:
+            msg = queue_get("final norm")
+            final_norm_weight = msg.pop("weight")
+            if md.norm_has_bias:
+                final_norm_bias = msg.pop("bias")
+            for tp_rank in range(args.target_tensor_parallel_size):
+                models[tp_rank].language_model.encoder.final_norm.weight.data.copy_(final_norm_weight)
+                if md.norm_has_bias:
+                    models[tp_rank].language_model.encoder.final_norm.bias.data.copy_(final_norm_bias)
+                if pp_rank != 0 and not md.output_layer:
+                    # Copy word embeddings to final pipeline rank
+                    models[tp_rank].word_embeddings.weight.data.copy_(out_word_embed[tp_rank])
+            del final_norm_weight
+            if md.norm_has_bias:
+                del final_norm_bias
+            check_message(msg)
+
+            if md.output_layer:
+                msg = queue_get("output layer")
+                if not hasattr(models[0].language_model, 'output_layer'):
+                    print("ERROR: got an output layer, but model does not have one")
+                    exit(1)
+                output_layer_weight = torch.chunk(msg.pop("weight"), args.target_tensor_parallel_size, dim=0)
+                for tp_rank in range(args.target_tensor_parallel_size):
+                    models[tp_rank].language_model.output_layer.weight.data.copy_(output_layer_weight[tp_rank])
+                del output_layer_weight
+                check_message(msg)
+
+            msg = queue_get()
+            if msg != "done" and msg["name"] == "pooler":
+                if not hasattr(models[0].language_model, 'pooler'):
+                    print("ERROR: got a pooler, but model does not have one")
+                    exit(1)
+                print("received pooler")
+                pooler_weight = msg.pop("weight")
+                pooler_bias = msg.pop("bias")
+                for tp_rank in range(args.target_tensor_parallel_size):
+                    models[tp_rank].language_model.pooler.dense.weight.data.copy_(pooler_weight)
+                    models[tp_rank].language_model.pooler.dense.bias.data.copy_(pooler_bias)
+                del pooler_weight
+                del pooler_bias
+                check_message(msg)
+                msg = queue_get()
+
+            if msg != "done" and msg["name"] == "lm head":
+                if not hasattr(models[0], 'lm_head'):
+                    print("ERROR: got an lm head, but model does not have one")
+                    exit(1)
+                print("received lm head")
+                lm_head_dense_weight = msg.pop("dense weight")
+                lm_head_dense_bias = msg.pop("dense bias")
+                lm_head_norm_weight = msg.pop("norm weight")
+                if md.norm_has_bias:
+                    lm_head_norm_bias = msg.pop("norm bias")
+                for tp_rank in range(args.target_tensor_parallel_size):
+                    models[tp_rank].lm_head.dense.weight.data.copy_(lm_head_dense_weight)
+                    models[tp_rank].lm_head.dense.bias.data.copy_(lm_head_dense_bias)
+                    models[tp_rank].lm_head.norm.weight.data.copy_(lm_head_norm_weight)
+                    if md.norm_has_bias:
+                        models[tp_rank].lm_head.norm.bias.data.copy_(lm_head_norm_bias)
+                check_message(msg)
+                msg = queue_get()
+
+            if msg != "done" and msg["name"] == "binary head":
+                if not hasattr(models[0], 'binary_head'):
+                    print("ERROR: got a binary head, but model does not have one")
+                    exit(1)
+                print("received binary head")
+                binary_head_weight = msg.pop("weight")
+                binary_head_bias = msg.pop("bias")
+                for tp_rank in range(args.target_tensor_parallel_size):
+                    models[tp_rank].binary_head.weight.data.copy_(binary_head_weight)
+                    models[tp_rank].binary_head.bias.data.copy_(binary_head_bias)
+                check_message(msg)
+                msg = queue_get()
+
+            if msg != "done":
+                print("ERROR: got some more data but was expecting to be done")
+
+        for tp_rank in range(args.target_tensor_parallel_size):
+            mpu.set_tensor_model_parallel_rank(tp_rank)
+            save_checkpoint(md.iteration, [models[tp_rank]], None, None)
+    print("Done!")


### PR DESCRIPTION
 Support Mixtral 8*7B MOE  model structure and weight converter from huggingface.

You can refer to this script to convert the huggingface weight to megatron:
```shell
python tools/checkpoint/util.py --model-type GPT
--loader mixtral_hf
--saver mixtral
--load-dir ../models/Mixtral-8x7B-Instruct-v0.1
--save-dir ../models/Mixtral-8x7B-Instruct-v0.1-tp2-pp4
--tokenizer-model ../models/Mixtral-8x7B-Instruct-v0.1/tokenizer.model
--target-tensor-parallel-size 2
--target-pipeline-parallel-size 4
```

To activate mixtral moe in training:
```shell
--num-experts 8 \
--moe-type mixtral \
```

Note that:
To implement the load balancing loss of huggingface equivalently on megatron requires a lot of modifications for returning router  logits. Therefore, in order to simplify the work, I choose to use the original sinkhorn algorithm to balance the voting probability of each expert instead of using the load_balancing_loss_func in huggingface.