### PR TITLE
[Fix] moe router layer missing dtype argument

### DIFF
--- a/megatron/core/transformer/moe/base_moe_layer.py
+++ b/megatron/core/transformer/moe/base_moe_layer.py
@@ -29,7 +29,7 @@ def sinkhorn(cost, tol=0.0001):
 
 
 def get_router_linear_layer(config):
-    router = torch.nn.Linear(config.hidden_size, config.num_moe_experts, bias=False)
+    router = torch.nn.Linear(config.hidden_size, config.num_moe_experts, bias=False, dtype=config.params_dtype)
     with get_cuda_rng_tracker().fork(get_data_parallel_rng_tracker_name()):
         config.init_method(router.weight)
     setattr(router.weight, 'sequence_parallel', config.sequence_parallel)


### PR DESCRIPTION
**Description**

I build a moe model, and construct input for it like below, 
``` 
 from megatron.core.models.gpt import GPTModel

 model = GPTModel(
        config=config,
        transformer_layer_spec=transformer_layer_spec,
        vocab_size=args.padded_vocab_size,
        max_sequence_length=args.max_position_embeddings,
        pre_process=pre_process,
        post_process=post_process,
        fp16_lm_cross_entropy=args.fp16_lm_cross_entropy,
        parallel_output=True,
        share_embeddings_and_output_weights=not args.untie_embeddings_and_output_weights,
        position_embedding_type=args.position_embedding_type,
        rotary_percent=args.rotary_percent,
        rotary_base=args.rotary_base,
    )
...
model(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids)
```
then when enable bf16, the model forward will encounter an param dtype RunTimeError. This PR will fix it 

>   File "/megatron/core/transformer/switch_mlp.py", line 94, in forward
    route = self.router(hidden_states)
  File "/usr/local/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/torch/nn/modules/linear.py", line 114, in forward
    return F.linear(input, self.weight, self.bias)
RuntimeError: expected scalar type BFloat16 but found Float
