### PR TITLE
Add support for ffn_hidden_size in throughput logging

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -62,17 +62,19 @@ def num_floating_point_operations(args, batch_size):
     if not args.group_query_attention:
         args.num_query_groups = args.num_attention_heads
     return (
-        60
+        6
         * batch_size
         * args.seq_length
-        * args.num_layers
-        * args.hidden_size
         * args.hidden_size
         * (
-            1
-            + (args.num_query_groups / (5 * args.num_attention_heads))
-            + (args.seq_length / (5 * args.hidden_size))
-            + (args.padded_vocab_size / (10 * args.num_layers * args.hidden_size))
+            args.num_layers
+            * (
+            3 * args.hidden_size
+            + (args.hidden_size // args.num_attention_heads) * args.num_query_groups
+            + 2 * args.seq_length
+            + 2 * args.ffn_hidden_size
+            )
+            + args.padded_vocab_size
         )
     )
 


### PR DESCRIPTION
The existing calculation for throughput assumes `ffn_hidden_size` is fixed at `4 * hidden_size` resulting in incorrect TFLOP/s/GPU when using `args.swiglu` or specifying a custom `args.ffn_hidden_size`. Depending on how different the custom `ffn_hidden_size` setting is this can result in reported throughput difference of 30 TFLOP/s/GPU.

This PR adjusts the throughput calculation to account for `ffn_hidden_size`.

### Calculation Details:
The calculation follows the notation and procedure of the FLOPs approximation in the Appendix of the paper "[Efficient Large-Scale Language Model Training on GPU Clusters Using Megatron-LM](https://arxiv.org/abs/2104.04473)".
Beyond the variables described in the appendix, we introduce `f`= ffn hidden size, `a`= # of attention heads, and `g`:= # query groups for GQA where `g == a` is vanilla MHA.

Attention FLOPs:
`6bsh**2` (key, value, output proj) + `2bsh(h//a)g` (query proj) + `4bhs**2` (attn compute)

FFN FLOPs:
`4bshf` (f = 4h is the default Megatron setting)

Output FLOPs:
`6bshV` (unembedding compute)

Total FLOPs:
`6bsh(L(3h + (h//a)g + 2s + 2f) + V)`

