### PR TITLE
[Logging] Surface up loader module import error

### DIFF
--- a/tools/checkpoint/util.py
+++ b/tools/checkpoint/util.py
@@ -96,7 +96,8 @@ def load_plugin(plugin_type, name):
         module_name = name
         try:
             plugin = importlib.import_module(module_name)
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as e:
+            print(f"Exception: {e}")
             sys.exit(f"Unable to load {plugin_type} plugin {name}. Exiting.")
 
     if not hasattr(plugin, 'add_arguments'):


### PR DESCRIPTION
## Why?
The loader import errors is swallowed if the root cause is not loader_X.py not found. For example, if i don't have `transformers` installed, it also printed loader_X not found, but the actual error is `transformers` not found.
