### PR TITLE
[doc] `--workers` is missing in data preprocessing example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ python tools/preprocess_data.py \
        --vocab-file bert-vocab.txt \
        --tokenizer-type BertWordPieceLowerCase \
        --split-sentences
+       --workers 32
 </pre>
 
 The output will be two files named, in this case, `my-bert_text_sentence.bin` and `my-bert_text_sentence.idx`. The `--data-path` specified in later BERT training is the full path and new filename, but without the file extension.


### PR DESCRIPTION
`--workers` is required as in[ preprocess_data.py](https://github.com/NVIDIA/Megatron-LM/blob/0052bf0de70b266d8648e2655da16f7eb2c9ca56/tools/preprocess_data.py#L223), but it is missing in readme.