### PR TITLE
Fix: checkpoint load bug (TE)

### DIFF
--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -585,7 +585,7 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
         print_rank_0('could not find arguments in the checkpoint ...')
 
     # Model.
-    strict = False if args.retro_add_retriever or args.transformer_impl == 'transformer_engine' else strict
+    strict = False if args.retro_add_retriever else strict
     if len(model) == 1:
         model[0].load_state_dict(state_dict['model'], strict=strict)
     else:

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1802,7 +1802,11 @@ class ParallelTransformer(MegatronModule):
         # Handle renaming layernorm -> norm in component names
         state_dict_ = {}
         for key in state_dict.keys():
-            newkey = key.replace("layernorm", "norm")
-            state_dict_[newkey] = state_dict[key]
+            if self.transformer_impl == 'transformer_engine':
+                new_key = key
+            else:
+                new_key = key.replace("layernorm", "norm")
+
+            state_dict_[new_key] = state_dict[key]
 
         super().load_state_dict(state_dict_, strict)


### PR DESCRIPTION
## Issue

When using TransformerEngine with Megatron-LM for training, I encountered an issue where the Loss Curve would significantly change after loading a checkpoint. This problem did not occur when TransformerEngine was not utilized.

With TransformerEngine
![W B Chart 2_26_2024, 3_49_43 PM](https://github.com/NVIDIA/Megatron-LM/assets/68278821/1e78cabf-1a79-4c0d-bb21-91fba7d558ba)

Without TransformerEngine
![W B Chart 2_26_2024, 3_56_54 PM](https://github.com/NVIDIA/Megatron-LM/assets/68278821/6d4c004b-4d7e-407b-8673-88f3aef61323)


## Overview

Upon investigation to resolve this issue, I noticed that during load_state_dict, the strict parameter was set to False. This appears to be a measure to prevent errors during loading due to the name of keys in TransformerEngine `transformer_engine.pytorch.TransformerLayer` being different from those in the Megatron-LM implementation. However, bypassing the error by setting strict=False resulted in checkpoints not being loaded correctly.

To correct this, I made the necessary changes.

## Result

After changes ( With TransformerEngine)

![image](https://github.com/NVIDIA/Megatron-LM/assets/68278821/7532c563-4546-47df-b474-1303dcd78b7e)
![image](https://github.com/NVIDIA/Megatron-LM/assets/68278821/ab2c07f9-464f-4279-9e3b-18af2bec038c)



