### PR TITLE
Fix wrong key for output_layer_init_method

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -470,7 +470,7 @@ def core_transformer_config_from_args(args):
         kw_args['activation_func'] = squared_relu
     if args.init_method_xavier_uniform:
         kw_args['init_method'] = torch.nn.init.xavier_uniform_
-        kw_args['scaled_init_method'] = torch.nn.init.xavier_uniform_
+        kw_args['output_layer_init_method'] = torch.nn.init.xavier_uniform_
     if args.group_query_attention:
         kw_args['num_query_groups'] = args.num_query_groups
     else:


### PR DESCRIPTION
Given that we aim  to use mcore to do the training, we have a function to parse the args from Megatron-LM to mcore.

Howover, the key of `output_layer_init_method ` is incorrect. [1]

This PR fix this.

[1] https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/transformer_config.py#L95