### PR TITLE
Add timeout parameter for `new_group`

### DIFF
--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -103,6 +103,7 @@ def initialize_model_parallel(
     context_parallel_size: int = 1,
     expert_model_parallel_size: int = 1,
     nccl_communicator_config_path: Optional[str] = None,
+    timeout = None,
 ) -> None:
     """Initialize model data parallel groups.
 
@@ -272,9 +273,9 @@ def initialize_model_parallel(
                 start_rank + j, end_rank, context_parallel_size * tensor_model_parallel_size
             )
             group = torch.distributed.new_group(
-                ranks, pg_options=get_nccl_options('dp', nccl_comm_cfgs)
+                ranks, pg_options=get_nccl_options('dp', nccl_comm_cfgs), timeout=timeout
             )
-            group_gloo = torch.distributed.new_group(ranks, backend="gloo")
+            group_gloo = torch.distributed.new_group(ranks, backend="gloo", timeout=timeout)
             if rank in ranks:
                 _DATA_PARALLEL_GROUP = group
                 _DATA_PARALLEL_GROUP_GLOO = group_gloo
@@ -283,9 +284,9 @@ def initialize_model_parallel(
             ranks_with_cp = range(start_rank + j, end_rank, tensor_model_parallel_size)
             all_data_parallel_group_ranks_with_cp.append(list(ranks_with_cp))
             group_with_cp = torch.distributed.new_group(
-                ranks_with_cp, pg_options=get_nccl_options('dp_cp', nccl_comm_cfgs)
+                ranks_with_cp, pg_options=get_nccl_options('dp_cp', nccl_comm_cfgs), timeout=timeout
             )
-            group_with_cp_gloo = torch.distributed.new_group(ranks_with_cp, backend="gloo")
+            group_with_cp_gloo = torch.distributed.new_group(ranks_with_cp, backend="gloo", timeout=timeout)
             if rank in ranks_with_cp:
                 _DATA_PARALLEL_GROUP_WITH_CP = group_with_cp
                 _DATA_PARALLEL_GROUP_WITH_CP_GLOO = group_with_cp_gloo
@@ -328,7 +329,7 @@ def initialize_model_parallel(
             for k in range(tensor_model_parallel_size):
                 ranks = range(start_rank + k, end_rank, tensor_model_parallel_size)
                 group = torch.distributed.new_group(
-                    ranks, pg_options=get_nccl_options('cp', nccl_comm_cfgs)
+                    ranks, pg_options=get_nccl_options('cp', nccl_comm_cfgs), timeout=timeout
                 )
                 if rank in ranks:
                     _CONTEXT_PARALLEL_GROUP = group
@@ -343,7 +344,7 @@ def initialize_model_parallel(
             for data_parallel_group_ranks_with_cp in all_data_parallel_group_ranks_with_cp
         ]
         group = torch.distributed.new_group(
-            ranks, pg_options=get_nccl_options('mp', nccl_comm_cfgs)
+            ranks, pg_options=get_nccl_options('mp', nccl_comm_cfgs), timeout=timeout
         )
         if rank in ranks:
             _MODEL_PARALLEL_GROUP = group
@@ -356,7 +357,7 @@ def initialize_model_parallel(
     for i in range(num_tensor_model_parallel_groups):
         ranks = range(i * tensor_model_parallel_size, (i + 1) * tensor_model_parallel_size)
         group = torch.distributed.new_group(
-            ranks, pg_options=get_nccl_options('tp', nccl_comm_cfgs)
+            ranks, pg_options=get_nccl_options('tp', nccl_comm_cfgs), timeout=timeout
         )
         if rank in ranks:
             _TENSOR_MODEL_PARALLEL_GROUP = group
@@ -377,7 +378,7 @@ def initialize_model_parallel(
     for i in range(num_pipeline_model_parallel_groups):
         ranks = range(i, world_size, num_pipeline_model_parallel_groups)
         group = torch.distributed.new_group(
-            ranks, pg_options=get_nccl_options('pp', nccl_comm_cfgs)
+            ranks, pg_options=get_nccl_options('pp', nccl_comm_cfgs), timeout=timeout
         )
         if rank in ranks:
             _PIPELINE_MODEL_PARALLEL_GROUP = group
@@ -401,7 +402,7 @@ def initialize_model_parallel(
             position_embedding_ranks = ranks
 
         group = torch.distributed.new_group(
-            embedding_ranks, pg_options=get_nccl_options('embd', nccl_comm_cfgs)
+            embedding_ranks, pg_options=get_nccl_options('embd', nccl_comm_cfgs), timeout=timeout
         )
         if rank in embedding_ranks:
             _EMBEDDING_GROUP = group
@@ -409,7 +410,7 @@ def initialize_model_parallel(
             _EMBEDDING_GLOBAL_RANKS = embedding_ranks
 
         group = torch.distributed.new_group(
-            position_embedding_ranks, pg_options=get_nccl_options('embd', nccl_comm_cfgs)
+            position_embedding_ranks, pg_options=get_nccl_options('embd', nccl_comm_cfgs), timeout=timeout
         )
         if rank in position_embedding_ranks:
             _POSITION_EMBEDDING_GROUP = group
@@ -429,7 +430,7 @@ def initialize_model_parallel(
         end_rank = start_rank + tensor_and_data_group_size_with_cp
         ranks = range(start_rank, end_rank)
         group = torch.distributed.new_group(
-            ranks, pg_options=get_nccl_options('tp_dp_cp', nccl_comm_cfgs)
+            ranks, pg_options=get_nccl_options('tp_dp_cp', nccl_comm_cfgs), timeout=timeout
         )
         if rank in ranks:
             _TENSOR_AND_DATA_PARALLEL_GROUP_WITH_CP = group
@@ -445,7 +446,7 @@ def initialize_model_parallel(
                 end_rank = start_rank + tensor_model_parallel_size
                 ranks = ranks + list(range(start_rank, end_rank))
             group = torch.distributed.new_group(
-                ranks, pg_options=get_nccl_options('tp_dp', nccl_comm_cfgs)
+                ranks, pg_options=get_nccl_options('tp_dp', nccl_comm_cfgs), timeout=timeout
             )
             if rank in ranks:
                 _TENSOR_AND_DATA_PARALLEL_GROUP = group
@@ -470,7 +471,7 @@ def initialize_model_parallel(
             end_rank = i * tensor_and_data_group_size + (j + 1) * tensor_and_expert_group_size
             ranks = range(start_rank, end_rank)
             group = torch.distributed.new_group(
-                ranks, pg_options=get_nccl_options('tp_exp', nccl_comm_cfgs)
+                ranks, pg_options=get_nccl_options('tp_exp', nccl_comm_cfgs), timeout=timeout
             )
             if rank in ranks:
                 _TENSOR_AND_EXPERT_PARALLEL_GROUP = group
@@ -481,9 +482,9 @@ def initialize_model_parallel(
         for j in range(tensor_and_expert_group_size):
             ranks = range(start_rank + j, end_rank, tensor_and_expert_group_size)
             group = torch.distributed.new_group(
-                ranks, pg_options=get_nccl_options('dp_modulo_exp', nccl_comm_cfgs)
+                ranks, pg_options=get_nccl_options('dp_modulo_exp', nccl_comm_cfgs), timeout=timeout
             )
-            group_gloo = torch.distributed.new_group(ranks, backend="gloo")
+            group_gloo = torch.distributed.new_group(ranks, backend="gloo", timeout=timeout)
             if rank in ranks:
                 _DATA_MODULO_EXPERT_PARALLEL_GROUP = group
                 _DATA_MODULO_EXPERT_PARALLEL_GROUP_GLOO = group_gloo

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -250,6 +250,7 @@ def _initialize_distributed():
                 context_parallel_size=args.context_parallel_size,
                 expert_model_parallel_size=args.expert_model_parallel_size,
                 nccl_communicator_config_path=args.nccl_communicator_config_path,
+                timeout=timedelta(minutes=args.distributed_timeout_minutes),
             )
             if args.rank == 0:
                 print(


### PR DESCRIPTION
This PR aims to pass `timeout` parameters to `new_group` function. 

Previously, the ProcessGroups created by `new_group` does not set `timeout` parameters, which would make the communications under these ProcessGroup uses the default timeout threshold instead of what users want to set. It is crucial for failure detection.