### PR TITLE
Add support to track consumed samples for each data shard during training

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1079,6 +1079,9 @@ def _add_checkpointing_args(parser):
                        help='Do not save current rng state.')
     group.add_argument('--load', type=str, default=None,
                        help='Directory containing a model checkpoint.')
+    group.add_argument('--override-dataloader-consumed-samples', type=int, default=None,
+                       help='When loading from checkpoint and using a new dataset, override the consumed training '
+                       'samples in the dataloader.')
     group.add_argument('--no-load-optim', action='store_true', default=None,
                        help='Do not load optimizer when loading checkpoint.')
     group.add_argument('--no-load-rng', action='store_true', default=None,
@@ -1099,6 +1102,9 @@ def _add_checkpointing_args(parser):
                        help="If '--load' is set, but checkpoint is not found "
                        "(e.g., path typo), then exit instead of random "
                        "initialization.")
+    group.add_argument('--resume-with-new-dataset', action='store_true', default=False,
+                       help="Reloads the dataset with tracking for consumed samples of "
+                       "each datashard. Used when resuming training with a changed dataset.")
 
     return parser
 

--- a/megatron/core/datasets/blended_dataset.py
+++ b/megatron/core/datasets/blended_dataset.py
@@ -78,7 +78,6 @@ class BlendedDataset(torch.utils.data.Dataset):
         self.dataset_index, self.dataset_sample_index = self._build_indices()
 
         # Check size
-        _ = self[self.size - 1]
         try:
             _ = self[self.size]
             raise RuntimeError(f"{type(self).__name__} size is improperly bounded")

--- a/megatron/core/datasets/megatron_dataset.py
+++ b/megatron/core/datasets/megatron_dataset.py
@@ -41,6 +41,7 @@ class MegatronDataset(ABC, torch.utils.data.Dataset):
         indices: numpy.ndarray,
         num_samples: int,
         index_split: Split,
+        consumed_samples_dict: dict,
         config: BlendedMegatronDatasetConfig,
     ) -> None:
         self.dataset = dataset
@@ -48,6 +49,7 @@ class MegatronDataset(ABC, torch.utils.data.Dataset):
         self.indices = indices
         self.num_samples = num_samples
         self.index_split = index_split
+        self.consumed_samples_dict = consumed_samples_dict
         self.config = config
 
         self.unique_identifiers = OrderedDict()

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -495,6 +495,8 @@ def setup_model_and_optimizer(model_provider_func,
                                        scale_lr_cond, lr_mult)
     opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
 
+    args.consumed_samples_per_dataset = dict()
+
     if args.load is not None:
         timers = get_timers()
         timers('load-checkpoint', log_level=0).start(barrier=True)
@@ -1285,7 +1287,8 @@ def build_train_valid_test_datasets(build_train_valid_test_datasets_provider):
     print_rank_0('    test:       {}'.format(train_val_test_num_samples[2]))
 
     # Build the datasets.
-    return build_train_valid_test_datasets_provider(train_val_test_num_samples)
+    return build_train_valid_test_datasets_provider(train_val_test_num_samples, 
+                                                    args.consumed_samples_per_dataset)
 
 
 def build_train_valid_test_data_loaders(
@@ -1319,7 +1322,8 @@ def build_train_valid_test_data_loaders(
             build_train_valid_test_datasets_provider)
         # Build dataloders.
         train_dataloader = build_pretraining_data_loader(
-            train_ds, args.consumed_train_samples)
+            train_ds, args.consumed_train_samples if args.override_dataloader_consumed_samples is None
+                else  args.override_dataloader_consumed_samples)
         if args.skip_train:
             valid_dataloader = build_pretraining_data_loader(valid_ds, 0)
         else:

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -21,7 +21,8 @@ from megatron.core.transformer.spec_utils import import_module
 from megatron.utils import (
     get_batch_on_this_cp_rank,
     get_batch_on_this_tp_rank,
-    average_losses_across_data_parallel_group
+    average_losses_across_data_parallel_group,
+    get_shard_names
 )
 from megatron.arguments import core_transformer_config_from_args
 from megatron.yaml_arguments import core_transformer_config_from_yaml
@@ -173,10 +174,11 @@ def core_gpt_dataset_config_from_args(args):
         reset_attention_mask=args.reset_attention_mask,
         eod_mask_loss=args.eod_mask_loss,
         vocab_size=get_tokenizer().vocab_size,
+        filter_consumed_samples=args.resume_with_new_dataset
     )
 
 
-def train_valid_test_datasets_provider(train_val_test_num_samples):
+def train_valid_test_datasets_provider(train_val_test_num_samples, consumed_samples_per_dataset):
     """Build the train test and validation datasets.
 
     Args:
@@ -196,6 +198,7 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
     train_ds, valid_ds, test_ds = BlendedMegatronDatasetBuilder(
         dataset_type,
         train_val_test_num_samples,
+        consumed_samples_per_dataset,
         config
     ).build()
 

--- a/tests/unit_tests/data/test_blendable_dataset.py
+++ b/tests/unit_tests/data/test_blendable_dataset.py
@@ -1,0 +1,145 @@
+
+import unittest
+from unittest import mock
+import numpy as np
+import nltk
+import os
+from glob import glob
+import tempfile
+import torch
+from tests.unit_tests.data.test_preprocess_data import dummy_jsonl, build_datasets, gpt2_merge, gpt2_vocab
+from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
+from megatron.core.datasets.gpt_dataset import GPTDataset, GPTDatasetConfig
+import io
+from contextlib import redirect_stdout, redirect_stderr
+
+def build_dummy_data(temp_dir):
+    # set the default nltk data path
+    os.environ["NLTK_DATA"] = os.path.join(temp_dir, "nltk_data")
+    nltk.data.path.append(os.environ["NLTK_DATA"])
+
+    path_to_raws = os.path.join(temp_dir, "sample_raws")
+    path_to_data = os.path.join(temp_dir, "sample_data")
+    os.mkdir(path_to_raws)
+    os.mkdir(path_to_data)
+    # supress output for these calls
+    with io.StringIO() as buf, redirect_stdout(buf), redirect_stderr(buf):
+        # create the dummy resources
+        dummy_jsonl(path_to_raws)
+
+        gpt_args = [
+            "--tokenizer-type",
+            "GPT2BPETokenizer",
+            "--vocab-file",
+            gpt2_vocab(temp_dir),
+            "--merge-file",
+            gpt2_merge(temp_dir),
+            "--append-eod",
+            "--workers",
+            "10",
+            "--log-interval",
+            "1",
+        ]
+
+        # build the datasets
+        build_datasets(
+            path_to_raws, path_to_data, extra_args=gpt_args,
+        )
+    return path_to_data
+
+def init_dist():
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '12357'
+    # Initialize the process group
+    torch.distributed.init_process_group("gloo", rank=0, world_size=1)
+
+def destroy_dist():
+    torch.distributed.destroy_process_group()
+
+class TestGPTDataset(unittest.TestCase):
+    
+    def tearDown(self) -> None:
+        destroy_dist()
+        self.temp_dir.cleanup()
+        return super().tearDown()
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.path_to_data = build_dummy_data(self.temp_dir.name)
+        paths = [path[:-4] for path in glob(self.path_to_data+'/*.bin')]
+        self.data_path = []
+        for path in paths:
+            self.data_path.append('1.0')
+            self.data_path.append(path)
+        init_dist()
+
+    def test_build(self):
+        config = GPTDatasetConfig(lambda: True, 1234, 5, blend=self.data_path, 
+                                  split="1,0,0", path_to_cache=self.temp_dir.name, filter_consumed_samples=False)
+        builder = BlendedMegatronDatasetBuilder(GPTDataset, [2000], dict(), config)
+        train_dataset = builder.build()[0]
+        dataset = train_dataset.datasets[0]
+        num_samples = len(dataset.shuffle_index)
+        n=5
+        for i in range(n): 
+            dataset[i]
+        dataset.shuffle_index = dataset._filter_shuffle_index(dataset.shuffle_index, dataset.sample_index)
+        self.assertEqual(len(dataset.shuffle_index), num_samples-n, 
+                         f"Filtering resulted in {len(dataset.shuffle_index)} but should be {num_samples-n}!")
+
+    def test_build_initial(self):
+        init_dict = {(208, 25): 1, (214, 0): 1, (79, 17): 1, (166, 13): 1, (62, 6): 1}
+        consumed_samples_dict = {os.path.basename(self.data_path[1]): init_dict.copy()}
+        config = GPTDatasetConfig(lambda: True, 1234, 5, blend=self.data_path, 
+                                  split="1,0,0", path_to_cache=self.temp_dir.name, filter_consumed_samples=False)
+        builder = BlendedMegatronDatasetBuilder(GPTDataset, [2000], consumed_samples_dict, config)
+        train_dataset = builder.build()[0]
+        dataset = train_dataset.datasets[0]
+        num_samples = len(dataset.shuffle_index)
+        n=5
+        for i in range(n): 
+            dataset[i]
+        # make sure the first 5 samples have been counted twice
+        for k, v in dataset.consumed_samples_dict.items():
+            self.assertEqual(v, init_dict[k]+1, 
+                             f"Frequency of sample {k} != {init_dict[k]+1} in consumed samples dict")
+        dataset.shuffle_index = dataset._filter_shuffle_index(dataset.shuffle_index, dataset.sample_index)
+        self.assertEqual(len(dataset.shuffle_index), num_samples-n, 
+                         f"Filtering resulted in {len(dataset.shuffle_index)} but should be {num_samples-n}!")
+
+    def test_build_initial_filter(self):
+        init_dict = {(208, 25): 1, (214, 0): 1, (79, 17): 1, (166, 13): 1, (62, 6): 1}
+        consumed_samples_dict = {os.path.basename(self.data_path[1]): init_dict}
+        config = GPTDatasetConfig(lambda: True, 1234, 5, blend=self.data_path, 
+                                  split="1,0,0", path_to_cache=self.temp_dir.name, filter_consumed_samples=True)
+        builder = BlendedMegatronDatasetBuilder(GPTDataset, [2000], consumed_samples_dict, config)
+        train_dataset = builder.build()[0]
+        dataset = train_dataset.datasets[0]
+        num_samples = len(dataset.shuffle_index)
+        n=5
+        for i in range(n): 
+            dataset[i]
+        dataset.shuffle_index = dataset._filter_shuffle_index(dataset.shuffle_index, dataset.sample_index)
+        self.assertEqual(len(dataset.shuffle_index), num_samples-n, 
+                         f"Filtering resulted in {len(dataset.shuffle_index)} but should be {num_samples-n}!")
+
+
+    def test_blendable(self):
+        config = GPTDatasetConfig(lambda: True, 1234, 5, blend=self.data_path, 
+                                  split="1,0,0", path_to_cache=self.temp_dir.name, filter_consumed_samples=False)
+        builder = BlendedMegatronDatasetBuilder(GPTDataset, [2000], dict(), config)
+        train_dataset = builder.build()[0]
+        num_samples = sum(len(dataset.shuffle_index) for dataset in train_dataset.datasets)
+        n = 5
+        for i in range(n):
+            train_dataset[i]
+        
+        for dataset in train_dataset.datasets:
+            dataset.shuffle_index = dataset._filter_shuffle_index(dataset.shuffle_index, dataset.sample_index)
+        num_samples_after_filter = sum(len(dataset.shuffle_index) for dataset in train_dataset.datasets)
+        self.assertEqual(num_samples_after_filter, num_samples-n, 
+                         f"Filtering resulted in {num_samples_after_filter} but should be {num_samples-n}!")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/retro/query/multi_split_gpt_dataset.py
+++ b/tools/retro/query/multi_split_gpt_dataset.py
@@ -79,7 +79,7 @@ class MultiSplitGPTDataset(GPTDataset):
         index_split: Split,
         config: MultiSplitGPTDatasetConfig,
     ) -> None:
-        super().__init__(indexed_dataset, dataset_path, indexed_indices, num_samples, index_split, config)
+        super().__init__(indexed_dataset, dataset_path, indexed_indices, num_samples, index_split, None, config)
 
     def __getitem__(self, idx: int) -> Dict[str, numpy.ndarray]:
         """Abstract method implementation


### PR DESCRIPTION
# Issue:
Pretraining jobs often span multiple weeks or months and it is often desirable to stop training, modify the dataset by adding/removing datashards or reweighting them, and resume training. 
Currently MegatronLM does not support this (safely/without inadvertently repeating data samples) as training jobs are expected to run on a fix set of blended datashards. The current behavior for resuming training tracks the consumed samples by a single index into the array of samples and resumes training safely if the identical dataset is rebuilt in exactly the same way.

# Solution:
This PR introduces functionality to track every sample consumed during training and associates the consumed samples to each data shard.

## Two arguments introduced:

- `--override-dataloader-consumed-samples`: allows setting the consumed samples manually
- `--resume-with-new-dataset`: setting this flag filters the consumed samples from each datashard before building the high level datasets

## Extra state added to checkpoints:

`consumed_samples_per_dataset`: tracks every sample seen during training until this checkpoint for each data shard

A unittest is provided for the new functionality.