### PR TITLE
fix bug that must have transformer_engine

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -13,7 +13,6 @@ import torch.nn.functional as F
 from megatron.global_vars import set_retro_args, get_retro_args
 from tools.retro.utils import get_args_path as get_retro_args_path
 
-from megatron.core.models.retro import RetroConfig
 from megatron.core.transformer import TransformerConfig
 
 
@@ -493,6 +492,7 @@ def core_transformer_config_from_args(args):
     # If using Retro, return Retro config.
     retro_args = get_retro_args()
     if retro_args:
+        from megatron.core.models.retro import RetroConfig
         kw_args['retro_preprocess'] = retro_args
         return RetroConfig(**kw_args)
 

--- a/megatron/yaml_arguments.py
+++ b/megatron/yaml_arguments.py
@@ -18,7 +18,6 @@ import torch.nn.functional as F
 from megatron.global_vars import set_retro_args, get_retro_args
 from tools.retro.utils import get_args_path as get_retro_args_path
 
-from megatron.core.models.retro import RetroConfig
 from megatron.core.transformer import TransformerConfig
 
 # Taken from https://stackoverflow.com/questions/65414773/parse-environment-variable-from-yaml-with-pyyaml
@@ -458,6 +457,7 @@ def core_transformer_config_from_yaml(args, transfomer_key = "language_model"):
     # If using Retro, return Retro config.
     retro_args = get_retro_args()
     if retro_args:
+        from megatron.core.models.retro import RetroConfig
         kw_args['retro_preprocess'] = retro_args
         return RetroConfig(**kw_args)
 


### PR DESCRIPTION
#713 
When I use megatron but don't have transformer_engine, it will report error:
```
  File "/home/z00454081/Megatron-LM-main/megatron/__init__.py", line 16, in <module>
    from .initialize  import initialize_megatron
  File "/home/z00454081/Megatron-LM-main/megatron/initialize.py", line 18, in <module>
    from megatron.arguments import parse_args, validate_args
  File "/home/z00454081/Megatron-LM-main/megatron/arguments.py", line 16, in <module>
    from megatron.core.models.retro import RetroConfig
  File "/home/z00454081/Megatron-LM-main/megatron/core/models/retro/__init__.py", line 4, in <module>
    from .decoder_spec import get_retro_decoder_block_spec
  File "/home/z00454081/Megatron-LM-main/megatron/core/models/retro/decoder_spec.py", line 5, in <module>
    from megatron.core.models.gpt.gpt_layer_specs import (
  File "/home/z00454081/Megatron-LM-main/megatron/core/models/gpt/__init__.py", line 1, in <module>
    from .gpt_model import GPTModel
  File "/home/z00454081/Megatron-LM-main/megatron/core/models/gpt/gpt_model.py", line 17, in <module>
    from megatron.core.transformer.transformer_block import TransformerBlock
  File "/home/z00454081/Megatron-LM-main/megatron/core/transformer/transformer_block.py", line 16, in <module>
    from megatron.core.transformer.custom_layers.transformer_engine import (
  File "/home/z00454081/Megatron-LM-main/megatron/core/transformer/custom_layers/transformer_engine.py", line 7, in <module>
    import transformer_engine as te
ModuleNotFoundError: No module named 'transformer_engine'
```

This is a bug I think, because I don't want to use transformer_engine, and when I remove the RetroConfig code, I can use megatron normally.