### PR TITLE
replace outdated import in eval_utils.py 

### DIFF
--- a/tasks/eval_utils.py
+++ b/tasks/eval_utils.py
@@ -11,7 +11,7 @@ import torch
 from megatron import get_args
 from megatron import print_rank_last, is_last_rank
 from megatron.core import mpu
-from megatron.schedules import get_forward_backward_func
+from megatron.core.pipeline_parallel import get_forward_backward_func
 from tasks.finetune_utils import build_data_loader
 from tasks.finetune_utils import process_batch
 

--- a/tasks/main.py
+++ b/tasks/main.py
@@ -71,6 +71,9 @@ def get_tasks_args(parser):
                         help='Av.rank validation: how many other negatives to'
                         ' take from each question pool')
 
+    # local-rank param for torch.distributed.launch
+    group.add_argument("--local-rank", type=int, default=None)
+
 
     return parser
 


### PR DESCRIPTION
`eval_utils.py` currently imports `get_forward_backward_func` from `megatron.schedules`. This is outdated; instead, `get_forward_backward_func` should be imported from `megatron.core.pipeline_parallel`