### PR TITLE
Replace outdated import path of get_forward_backward_func in eval_utils.py

### DIFF
--- a/tasks/eval_utils.py
+++ b/tasks/eval_utils.py
@@ -11,7 +11,7 @@ import torch
 from megatron import get_args
 from megatron import print_rank_last, is_last_rank
 from megatron.core import mpu
-from megatron.schedules import get_forward_backward_func
+from megatron.core.pipeline_parallel import get_forward_backward_func
 from tasks.finetune_utils import build_data_loader
 from tasks.finetune_utils import process_batch
 


### PR DESCRIPTION
In `eval_utils.py` the current method of importing  `get_forward_backward_func` uses an outdated path ( `from megatron.schedules`). I replaced this import start with the updated correct path: `from megatron.core.pipeline_parallel import get_forward_backward_func`