### PR TITLE
Update outdated method name passed to get linear_layer function to match intented method that was imported

### DIFF
--- a/megatron/model/classification.py
+++ b/megatron/model/classification.py
@@ -42,7 +42,7 @@ class Classification(MegatronModule):
             self.classification_dropout = torch.nn.Dropout(args.hidden_dropout)
             self.classification_head = get_linear_layer(args.hidden_size,
                                                         self.num_classes,
-                                                        init_method)
+                                                        init_method_normal)
             self._classification_head_key = 'classification_head'
 
     def set_input_tensor(self, input_tensor):


### PR DESCRIPTION
Currently, `model/classification.py` throws an error because line 49 attempts to pass a method that doesn't exist (`init_method`) to `get_linear_layer`. This commit updates `classification.py` to instead pass `init_method_normal` to `get_linear_layer`, which is the correct method specified by the import