### PR TITLE
Support S3 checkpointing for the torch strategy in distributed checkpointing

### DIFF
--- a/megatron/core/dist_checkpointing/core.py
+++ b/megatron/core/dist_checkpointing/core.py
@@ -3,8 +3,9 @@
 """ Module for managing distributed checkpoints metadata. """
 
 import json
+import os
+from cloudpathlib import AnyPath
 from dataclasses import asdict, dataclass
-from pathlib import Path
 from typing import Optional
 
 CONFIG_FNAME = 'metadata.json'
@@ -33,7 +34,7 @@ class CheckpointingConfig:
     common_backend_version: int = 1
 
 
-def check_is_distributed_checkpoint(checkpoint_dir):
+def check_is_distributed_checkpoint(checkpoint_dir: str):
     """ Checks if `metadata.json` exists in the checkpoint and is a valid config.
 
     Args:
@@ -54,7 +55,7 @@ def maybe_load_config(checkpoint_dir: str) -> Optional[CheckpointingConfig]:
     Returns:
         CheckpointingConfig (optional): None if checkpoint is not a valid distributed checkpoint
     """
-    config_path = Path(checkpoint_dir, CONFIG_FNAME)
+    config_path = AnyPath(os.path.join(checkpoint_dir, CONFIG_FNAME))
     if not config_path.exists():
         return None
     with config_path.open() as f:
@@ -72,6 +73,6 @@ def save_config(config: CheckpointingConfig, checkpoint_dir: str):
     Returns:
         None
     """
-    config_path = Path(checkpoint_dir, CONFIG_FNAME)
+    config_path = AnyPath(os.path.join(checkpoint_dir, CONFIG_FNAME))
     with config_path.open('w') as f:
         json.dump(asdict(config), f)

--- a/megatron/core/dist_checkpointing/strategies/base.py
+++ b/megatron/core/dist_checkpointing/strategies/base.py
@@ -5,7 +5,6 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from enum import Enum
-from pathlib import Path
 from typing import Dict, List, Optional
 
 from ..mapping import CheckpointingException, ShardedStateDict, ShardedTensor, StateDict
@@ -77,7 +76,7 @@ class LoadCommonStrategy(LoadStrategyBase):
     """ Load strategy for common (non-sharded) objects """
 
     @abstractmethod
-    def load(self, checkpoint_dir: Path):
+    def load(self, checkpoint_dir: str):
         raise NotImplementedError
 
 
@@ -85,11 +84,11 @@ class LoadShardedStrategy(LoadStrategyBase):
     """ Load strategy for sharded tensors """
 
     @abstractmethod
-    def load(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path):
+    def load(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: str):
         raise NotImplementedError
 
     @abstractmethod
-    def load_tensors_metadata(self, checkpoint_dir: Path):
+    def load_tensors_metadata(self, checkpoint_dir: str):
         """Load tensors metadata from the checkpoint.
 
         Returns a dictionary similar to a sharded state dict, but note that
@@ -108,7 +107,7 @@ class SaveCommonStrategy(SaveStrategyBase):
     """ Save strategy for common (non-sharded) objects """
 
     @abstractmethod
-    def save(self, common_state_dict: StateDict, checkpoint_dir: Path):
+    def save(self, common_state_dict: StateDict, checkpoint_dir: str):
         raise NotImplementedError
 
 
@@ -116,5 +115,5 @@ class SaveShardedStrategy(SaveStrategyBase):
     """ Save strategy for sharded tensors """
 
     @abstractmethod
-    def save(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path):
+    def save(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: str):
         raise NotImplementedError

--- a/megatron/core/dist_checkpointing/strategies/two_stage.py
+++ b/megatron/core/dist_checkpointing/strategies/two_stage.py
@@ -9,7 +9,6 @@ from functools import partial, wraps
 from itertools import chain
 from logging import DEBUG, INFO, StreamHandler, getLogger
 from operator import attrgetter, itemgetter
-from pathlib import Path
 from typing import Iterable, List, NamedTuple, Optional, Tuple, Union
 
 import torch
@@ -103,7 +102,7 @@ class TwoStageDataParallelLoadShardedStrategy(LoadShardedStrategy):
         self.dp_group_rank = torch.distributed.get_rank(self.data_parallel_group_orig)
         self.global_rank = torch.distributed.get_rank()
 
-    def load(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path):
+    def load(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: str):
         self.maybe_init_gloo_group()
         all_tensors_sorted = self._build_load_plan(sharded_state_dict)
         self._exchange_loaded_tensors(all_tensors_sorted, sharded_state_dict, checkpoint_dir)
@@ -247,7 +246,7 @@ class TwoStageDataParallelLoadShardedStrategy(LoadShardedStrategy):
 
         dict_list_map_inplace(_fill_in_data, sharded_state_dict)
 
-    def load_tensors_metadata(self, checkpoint_dir: Path):
+    def load_tensors_metadata(self, checkpoint_dir: str):
         def get_ts_shape_dtype(path):
             arr = open_ts_array(path)
             return arr.shape, arr.dtype.numpy_dtype


### PR DESCRIPTION
This PR adds support for saving checkpoints to cloud storage (e.g., S3) and loading checkpoints from cloud storage for the torch strategy in distributed checkpointing. It does so by replacing pathlib.Path with cloudpathlib.AnyPath, FileSystemReader with FsspecSystemReader, and FileSytemWriter with FsspecSystemWriter. The PR enables cloud checkpointing, but makes little attempt to optimize it.