### PR TITLE
Updated `fused_kernels` import path

### DIFF
--- a/tools/checkpoint/loader_mcore.py
+++ b/tools/checkpoint/loader_mcore.py
@@ -42,7 +42,7 @@ def _load_checkpoint(queue, args):
         from megatron.legacy.model import module
         from megatron.core import mpu
         from megatron.core.enums import ModelType
-        from megatron.training import fused_kernels
+        from megatron.legacy import fused_kernels
     except ModuleNotFoundError:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
         queue.put("exit")

--- a/tools/checkpoint/loader_megatron.py
+++ b/tools/checkpoint/loader_megatron.py
@@ -40,7 +40,7 @@ def _load_checkpoint(queue, args):
         from megatron.legacy.model import module
         from megatron.core import mpu
         from megatron.core.enums import ModelType
-        from megatron.training import fused_kernels
+        from megatron.legacy import fused_kernels
     except ModuleNotFoundError:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
         queue.put("exit")

--- a/tools/checkpoint/saver_mcore.py
+++ b/tools/checkpoint/saver_mcore.py
@@ -233,7 +233,7 @@ def save_checkpoint(queue, args):
         from megatron.training.global_vars import set_global_variables, get_args
         from megatron.core.enums import ModelType
         from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
-        from megatron.training import fused_kernels
+        from megatron.legacy import fused_kernels
         from megatron.core import mpu
     except ModuleNotFoundError:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")

--- a/tools/checkpoint/saver_megatron.py
+++ b/tools/checkpoint/saver_megatron.py
@@ -34,7 +34,7 @@ def save_checkpoint(queue, args):
         from megatron.training.global_vars import set_global_variables, get_args
         from megatron.core.enums import ModelType
         from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
-        from megatron.training import fused_kernels
+        from megatron.legacy import fused_kernels
         from megatron.core import mpu
     except ModuleNotFoundError:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")


### PR DESCRIPTION
Model conversion scripts in `tools/checkpoint` fail after the refactor with the following error:
```
Traceback (most recent call last):
  File "Megatron-LM/tools/checkpoint/convert.py", line 155, in <module>
    main()
  File "Megatron-LM/tools/checkpoint/convert.py", line 148, in main
    loader.load_checkpoint(queue, args)
  File "Megatron-LM/tools/checkpoint/loader_llama2_hf.py", line 361, in load_checkpoint
    _load_checkpoint(queue, args)
  File "Megatron-LM/tools/checkpoint/loader_llama2_hf.py", line 166, in _load_checkpoint
    from megatron.training import fused_kernels
ImportError: cannot import name 'fused_kernels' from 'megatron.training' (Megatron-LM/megatron/training/__init__.py)
```
I updated the import paths to `fused_kernels`, which solved this issue.