### PR TITLE
fix new bucket when param require new bucket

### DIFF
--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -284,8 +284,6 @@ class ParamAndGradBuffer:
             # and skip parameters that don't require gradients.
             if not param.requires_grad:
                 continue
-            this_numel = param.data.nelement()
-            data_end_index = data_start_index + this_numel
 
             def _does_param_require_new_bucket(param):
                 """
@@ -301,11 +299,13 @@ class ParamAndGradBuffer:
             if _does_param_require_new_bucket(param) and len(bucket_params) > 0:
                 # We are creating a bucket for the already accumulated parameters, whose params
                 # end at the current data_start_index.
+                data_start_index = _create_new_bucket(data_start_index)
                 if use_distributed_optimizer:
                     # data_start_index should already be padded.
                     assert data_start_index % self.data_parallel_world_size == 0
-                _create_new_bucket(data_start_index)
 
+            this_numel = param.data.nelement()
+            data_end_index = data_start_index + this_numel
             self.param_index_map[param] = (
                 data_start_index,
                 data_end_index,


### PR DESCRIPTION
## Problem description
Suppose we have three parameters a, b, c of size 10, 4, 8, and the last parameter is `shared_embedding`, dp = 4. According to the previous implementation, the result will be (while False will be judged by `assert data_start_index % self.data_parallel_world_size == 0` during `c` param iter):
| param | data_start_index | data_end_index |
| - | - | - |
| a | 0 | 10 |
| b | 10 | 14 |
| c(emb) | 14 | 22 |
## After fix
| param | data_start_index | data_end_index |
| - | - | - |
| a | 0 | 10 |
| b | 10 | 14 |
| c(emb) | 16 | 24 |

