### PR TITLE
Option to disable gradient reduce for ColumnParallelLinear Layer

### DIFF
--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -595,6 +595,7 @@ class ColumnParallelLinear(torch.nn.Module):
         skip_weight_param_allocation: bool = False,
         is_expert: bool = False,
         tp_comm_buffer_name: str = None,  # Not used
+        skip_reduce_in_bprop: bool = False,
     ):
         super(ColumnParallelLinear, self).__init__()
 
@@ -609,6 +610,7 @@ class ColumnParallelLinear(torch.nn.Module):
         self.is_expert = is_expert
         self.expert_parallel = config.expert_model_parallel_size > 1
         self.config = config
+        self.skip_reduce_in_bprop = skip_reduce_in_bprop
 
         # Parameters.
         # Note: torch.nn.functional.linear performs XA^T + b and as a result
@@ -760,6 +762,7 @@ class ColumnParallelLinear(torch.nn.Module):
             self.async_tensor_model_parallel_allreduce
             or self.sequence_parallel
             or self.explicit_expert_comm
+            or self.skip_reduce_in_bprop
         ):
             input_parallel = input_
         else:

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -595,7 +595,7 @@ class ColumnParallelLinear(torch.nn.Module):
         skip_weight_param_allocation: bool = False,
         is_expert: bool = False,
         tp_comm_buffer_name: str = None,  # Not used
-        skip_reduce_in_bprop: bool = False,
+        disable_grad_reduce: bool = False,
     ):
         super(ColumnParallelLinear, self).__init__()
 
@@ -610,7 +610,7 @@ class ColumnParallelLinear(torch.nn.Module):
         self.is_expert = is_expert
         self.expert_parallel = config.expert_model_parallel_size > 1
         self.config = config
-        self.skip_reduce_in_bprop = skip_reduce_in_bprop
+        self.disable_grad_reduce = disable_grad_reduce
 
         # Parameters.
         # Note: torch.nn.functional.linear performs XA^T + b and as a result
@@ -762,7 +762,7 @@ class ColumnParallelLinear(torch.nn.Module):
             self.async_tensor_model_parallel_allreduce
             or self.sequence_parallel
             or self.explicit_expert_comm
-            or self.skip_reduce_in_bprop
+            or self.disable_grad_reduce
         ):
             input_parallel = input_
         else:


### PR DESCRIPTION
The default setting for the param disable_grad_reduce is False. When it is set to True, gradient reduction in the bprop is disabled.