### PR TITLE
Add NormHead for Baichuan

### DIFF
--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -675,6 +675,8 @@ class ColumnParallelLinear(torch.nn.Module):
                         dtype=config.params_dtype,
                     )
                 )
+                if config.use_normhead:
+                    init.kaiming_uniform_(self.weight, a=math.sqrt(5))
                 if config.perform_initialization:
                     _initialize_affine_weight_gpu(
                         self.weight,
@@ -773,6 +775,8 @@ class ColumnParallelLinear(torch.nn.Module):
                     "and skip_weight_param_allocation is True."
                 )
             weight = self.weight
+            if self.config.use_normhead:
+                weight = F.normalize(weight) 
         else:
             # Check the weight passed in is the correct shape
             expected_shape = (self.output_size_per_partition, self.input_size)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -98,6 +98,9 @@ class TransformerConfig(ModelParallelConfig):
     test_mode: bool = False
     """Whether to run real-time tests."""
 
+    use_normhead: bool = False
+    """Whether to use normalization for the output layer."""
+
     ####################
     # initialization
     ####################


### PR DESCRIPTION
Add NormHead implementation for Baichuan model. NormHead is a training technic proposed in Chinese LLM Baichuan2. This PR adds a normalization to the output embeddings. If we want to enable NormHead in a model architecture, just set use_normhead=True in model config yaml file. 