### PR TITLE
Fix incorrect `src` argument in `broadcast_params` function

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -263,13 +263,13 @@ class DistributedDataParallel(MegatronModule):
             if is_expert_parallel:
                 torch.distributed.broadcast(
                     param.data,
-                    src=torch.distributed.get_process_group_ranks(self.expert_data_parallel_group),
+                    src=torch.distributed.get_process_group_ranks(self.expert_data_parallel_group)[0],
                     group=self.expert_data_parallel_group,
                 )
             else:
                 torch.distributed.broadcast(
                     param.data,
-                    src=torch.distributed.get_process_group_ranks(self.data_parallel_group),
+                    src=torch.distributed.get_process_group_ranks(self.data_parallel_group)[0],
                     group=self.data_parallel_group,
                 )
 


### PR DESCRIPTION
Corrects the `broadcast_params` function to use the first rank of the process group as the source for parameter broadcasting. Previously, the function erroneously passed all ranks of the `data_parallel_group` to the `src` parameter, which expects a single integer. This update ensures that only the first rank is used as the source, aligning with expected `torch.distributed.broadcast` usage.