### PR TITLE
Speed up the creation of attention mask

### DIFF
--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -674,9 +674,9 @@ def _get_ltor_masks_and_position_ids(
     seq_length = data.numel()
 
     if create_attention_mask:
-        attention_mask = torch.tril(
+        attention_mask = (
             torch.ones((seq_length, seq_length), device=data.device)
-        ).unsqueeze(0)
+        ).tril_().unsqueeze(0)
     else:
         attention_mask = None
 

--- a/megatron/core/transformer/utils.py
+++ b/megatron/core/transformer/utils.py
@@ -29,7 +29,7 @@ def get_linear_layer(rows, columns, init_method, perform_initialization=True):
 @lru_cache(maxsize=32)
 def get_default_causal_mask(sq: int) -> torch.Tensor:
     """Return the causal upper triangular mask for softmax input."""
-    return torch.triu(torch.ones(sq, sq, device="cuda"), diagonal=1).bool()
+    return torch.ones(sq, sq, dtype=torch.bool, device="cuda").triu_(diagonal=1)
 
 
 def attention_mask_func(attention_scores, attention_mask):

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -174,8 +174,8 @@ def get_ltor_masks_and_position_ids(data,
         att_mask_batch = micro_batch_size
     else:
         att_mask_batch = 1
-    attention_mask = torch.tril(torch.ones(
-        (att_mask_batch, seq_length, seq_length), device=data.device)).view(
+    attention_mask = torch.ones(
+        (att_mask_batch, seq_length, seq_length), device=data.device).tril_().view(
             att_mask_batch, 1, seq_length, seq_length)
 
     # Loss mask.


### PR DESCRIPTION
Prefer to use the inplace variant of triu_/tril_ because they are faster than the out-of-place variants since torch 2.3.0 (https://github.com/pytorch/pytorch/pull/115013).