### PR TITLE
[Bugfix] [MoE] Fix typo in token drop policy's default value

### DIFF
--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -269,7 +269,7 @@ def topk_softmax_with_capacity(
     topk: int,
     capacity_factor: float = None,
     pad_to_capacity: bool = False,
-    drop_policy: str = "probs",
+    drop_policy: str = "prob",
 ):
     """Apply capacity and padding to the top-k selection.
         Args:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1634,7 +1634,7 @@ def _add_moe_args(parser):
                        help='The capacity factor for each expert, None means no token will be dropped.')
     group.add_argument('--moe-pad-expert-input-to-capacity', action='store_true',
                        help='Pads the input for each expert to match the expert capacity length, effective only after the --moe-expert-capacity-factor is set.')
-    group.add_argument('--moe-token-drop-policy', type=str, default='probs', choices=['probs', 'position'],
+    group.add_argument('--moe-token-drop-policy', type=str, default='prob', choices=['prob', 'position'],
                        help='The policy to drop tokens. Can be either "prob" or "position". If "prob", the tokens with the lowest probabilities will be dropped. If "position", tokens at the end of each batch will be dropped.')
     group.add_argument('--moe-layer-recompute', action='store_true',
                        help='Enable checkpointing for moe_layer, should be used when memory is not sufficient.')


### PR DESCRIPTION
In the new MoE Token Drop code, the code and documentation expect `drop_policy` to be either `prob` or `position`, but the current default argument is `probs`. This fixes that typo.

@yanring

