### PR TITLE
[bug] fix xavier uniform init for output layers

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -582,7 +582,7 @@ def core_transformer_config_from_args(args, config_class=None):
         kw_args['activation_func'] = squared_relu
     if args.init_method_xavier_uniform:
         kw_args['init_method'] = torch.nn.init.xavier_uniform_
-        kw_args['scaled_init_method'] = torch.nn.init.xavier_uniform_
+        kw_args['output_layer_init_method'] = torch.nn.init.xavier_uniform_
     if args.group_query_attention:
         kw_args['num_query_groups'] = args.num_query_groups
     else:


### PR DESCRIPTION
In `TransformerConfig`, initializations for the output layers should be specified as `output_layer_init_method`. 

https://github.com/NVIDIA/Megatron-LM/blob/db3a3f79d1cda60ea4b3db0ceffcf20c5760e11d/megatron/core/transformer/transformer_config.py#L110-L113

But Xavier uniform initialization with `--init-method-xavier-uniform` utilizes `scaled_init_method` instead. This PR addresses the bugs encountered when utilizing Xavier uniform initialization.