### PR TITLE
Fix Bug: Configuring Datasets with train-data-path, valid-data-path, test-data-path

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -216,6 +216,10 @@ def validate_args(args, defaults={}):
         args.recompute_granularity = 'selective'
     del args.recompute_activations
 
+    # train-data-path and split cannot be set simultaneously
+    if args.train_data_path is not None and args.split is not None:
+        args.split = None
+
     # Set input defaults.
     for key in defaults:
         # For default to be valid, it should not be provided in the


### PR DESCRIPTION
Fixed the bug that prevents configuring datasets using train-data-path, valid-data-path, and test-data-path.

When the --split parameter is not configured, the --split parameter will be set to the default value 969, 30, 1. In the blended_megatron_dataset_config.py file, within the __post_init__ function, the following code will raise an error when configuring datasets using train-data-path, valid-data-path, and test-data-path because the split parameter is not None:

if self.blend_per_split is not None and any(self.blend_per_split):
    assert self.blend is None, "blend and blend_per_split are incompatible"
    assert self.split is None, "split and blend_per_split are incompatible"

