### PR TITLE
Fix(memory optimization): inplace subtract vocab_parallel_logits

### DIFF
--- a/megatron/core/tensor_parallel/cross_entropy.py
+++ b/megatron/core/tensor_parallel/cross_entropy.py
@@ -21,7 +21,7 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
             logits_max, op=torch.distributed.ReduceOp.MAX, group=get_tensor_model_parallel_group()
         )
         # Subtract the maximum value.
-        vocab_parallel_logits = vocab_parallel_logits - logits_max.unsqueeze(dim=-1)
+        vocab_parallel_logits.sub_(logits_max.unsqueeze(dim=-1))
 
         # Get the partition's vocab indecies
         get_vocab_range = VocabUtility.vocab_range_from_per_partition_vocab_size


### PR DESCRIPTION
vocab_parallel_logits's shape is [seq_len, batch_size, vocab_size / tp].
if vocab_size is very large like Llama3, use inplace subtract to reduce memory usage.