### PR TITLE
[BUG] Rank worldsize mismatch prevents tensorboard from being set

### DIFF
--- a/megatron/training/global_vars.py
+++ b/megatron/training/global_vars.py
@@ -144,7 +144,7 @@ def _set_tensorboard_writer(args):
                                    'tensorboard writer')
 
     if hasattr(args, 'tensorboard_dir') and \
-       args.tensorboard_dir and args.rank == (args.world_size - 1):
+       args.tensorboard_dir and args.rank == 0:
         try:
             from torch.utils.tensorboard import SummaryWriter
             print('> setting tensorboard ...')


### PR DESCRIPTION
In the ```global_vars.py``` file, the ```_set_tensorboard_writer``` function only gets set if the ```rank == world size - 1```. However, this can be an issue if ranks are local and world size > number of gpus on one node.

Thus, I propose setting it to the master node.