### PR TITLE
Make TE and Apex dependencies optional

### DIFF
--- a/megatron/core/fusions/fused_layer_norm.py
+++ b/megatron/core/fusions/fused_layer_norm.py
@@ -103,7 +103,7 @@ class FusedLayerNorm(torch.nn.Module):
 
         if not persist_layer_norm and not HAVE_FUSED_LAYER_NORM:
             # TODO: Add pytorch only layer norm
-            raise ValueError(f'Apex must currently be installed to use megatron core.')
+            raise ValueError(f'Apex must be installed to use FusedLayerNorm.')
 
         if isinstance(hidden_size, numbers.Integral):
             hidden_size = (hidden_size,)

--- a/megatron/core/models/retro/decoder_spec.py
+++ b/megatron/core/models/retro/decoder_spec.py
@@ -19,18 +19,22 @@ from megatron.core.models.retro.encoder_spec import get_retro_encoder_block_spec
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
 from megatron.core.transformer import ModuleSpec
 from megatron.core.transformer.attention import CrossAttentionSubmodules
-from megatron.core.transformer.custom_layers.transformer_engine import (
-    TEColumnParallelLinear,
-    TEDotProductAttention,
-    TENorm,
-    TERowParallelLinear,
-)
 from megatron.core.transformer.dot_product_attention import DotProductAttention
 from megatron.core.transformer.transformer_block import (
     TransformerBlockSubmodules,
     get_num_layers_to_build,
 )
 
+try:
+    from megatron.core.transformer.custom_layers.transformer_engine import (
+        TEDotProductAttention,
+        TELayerNormColumnParallelLinear,
+        TENorm,
+        TERowParallelLinear,
+    )
+    HAVE_TE = True
+except ImportError:
+    HAVE_TE = False
 
 def get_retro_decoder_layer_te_spec(
     encoder_block_spec: typing.Union[ModuleSpec, TransformerBlockSubmodules, None] = None

--- a/megatron/core/models/retro/encoder_spec.py
+++ b/megatron/core/models/retro/encoder_spec.py
@@ -16,17 +16,21 @@ from megatron.core.models.retro.encoder_attention import (
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
 from megatron.core.transformer import ModuleSpec
 from megatron.core.transformer.attention import CrossAttentionSubmodules
-from megatron.core.transformer.custom_layers.transformer_engine import (
-    TEColumnParallelLinear,
-    TEDotProductAttention,
-    TENorm,
-    TERowParallelLinear,
-)
 from megatron.core.transformer.dot_product_attention import DotProductAttention
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
 
+try:
+    from megatron.core.transformer.custom_layers.transformer_engine import (
+        TEDotProductAttention,
+        TELayerNormColumnParallelLinear,
+        TENorm,
+        TERowParallelLinear,
+    )
+    HAVE_TE = True
+except ImportError:
+    HAVE_TE = False
 
 def get_retro_encoder_layer_te_spec() -> ModuleSpec:
     """Retro encoder TE spec (uses Transformer Engine components).

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -7,7 +7,9 @@ try:
     from apex.optimizers import FusedAdam as Adam
     from apex.optimizers import FusedSGD as SGD
 except ImportError:
-    from torch.optim import Adam, SGD
+    ## apex's FusedAdam is a drop-in replacement for torch's AdamW
+    ## see https://github.com/NVIDIA/apex/blob/7b73b12361068a10b0f44844534613f252a5ea75/apex/optimizers/fused_adam.py#L16
+    from torch.optim import AdamW as Adam, SGD
 
 from megatron.core import mpu
 

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -3,8 +3,11 @@ import logging
 from typing import Callable, Dict, List, Optional
 
 import torch
-from apex.optimizers import FusedAdam as Adam
-from apex.optimizers import FusedSGD as SGD
+try:
+    from apex.optimizers import FusedAdam as Adam
+    from apex.optimizers import FusedSGD as SGD
+except ImportError:
+    from torch.optim import Adam, SGD
 
 from megatron.core import mpu
 

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -192,6 +192,7 @@ def _get_megatron_optimizer_based_on_param_groups(
                     if len(opt.state[p]) == 0:
                         opt.state[p]['exp_avg'] = torch.zeros_like(p.data)
                         opt.state[p]['exp_avg_sq'] = torch.zeros_like(p.data)
+                        opt.state[p]['step'] = torch.zeros((1,))
 
     elif config.optimizer == 'sgd':
         optimizer = SGD(

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -26,7 +26,7 @@ except ImportError:
     )
     multi_tensor_applier = local_multi_tensor_applier
     l2_norm_impl = local_multi_tensor_l2_norm
-    multi_tensor_scale_impl =local_multi_tensor_scale
+    multi_tensor_scale_impl = local_multi_tensor_scale
 
 def get_grad_norm_fp32(
     grads_for_norm: Union[List[torch.Tensor], torch.Tensor],

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -12,7 +12,7 @@ from ..tensor_parallel import param_is_not_tensor_parallel_duplicate
 from ..transformer.module import param_is_not_shared
 
 try:
-    import amp_C ## TODO: handle gradient clipping with no apex
+    import amp_C
     from apex.multi_tensor_apply import multi_tensor_applier
     l2_norm_impl = amp_C.multi_tensor_l2norm
     multi_tensor_scale_impl = amp_C.multi_tensor_scale

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -8,7 +8,10 @@ from logging import getLogger
 from typing import Callable, Dict, List, Optional, Tuple
 
 import torch
-from apex.optimizers import FusedAdam as Adam
+try:
+    from apex.optimizers import FusedAdam as Adam
+except ImportError:
+    from torch.optim import Adam
 
 from .. import parallel_state, tensor_parallel
 from ..dist_checkpointing import ShardedTensor

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -13,7 +13,7 @@ try:
     HAVE_APEX=True
 
 except ImportError:
-    from torch.optim import Adam
+    from torch.optim import AdamW as Adam
     HAVE_APEX=False
 
 from .. import parallel_state, tensor_parallel

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -10,8 +10,11 @@ from typing import Callable, Dict, List, Optional, Tuple
 import torch
 try:
     from apex.optimizers import FusedAdam as Adam
+    HAVE_APEX=True
+
 except ImportError:
     from torch.optim import Adam
+    HAVE_APEX=False
 
 from .. import parallel_state, tensor_parallel
 from ..dist_checkpointing import ShardedTensor
@@ -583,6 +586,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         - state_order : The index of a parameter within the shared parameter
             list.
         """
+
+        if not HAVE_APEX:
+            return super().load_state_dict(state_dict)
+
 
         # Get the Torch optimizer's state dict.
         # - This 'inner' optimizer at this point is unallocated, and only

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -8,9 +8,13 @@ from itertools import chain
 from logging import getLogger
 from typing import Any, Callable, List, Optional, Tuple
 
-import amp_C
+try:
+    import amp_C
+    from apex.multi_tensor_apply import multi_tensor_applier
+except ImportError:
+    pass
+
 import torch
-from apex.multi_tensor_apply import multi_tensor_applier
 
 from .. import parallel_state, tensor_parallel
 from ..dist_checkpointing.mapping import ShardedStateDict

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -17,7 +17,6 @@ from megatron.core.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
-from megatron.core.transformer.custom_layers.transformer_engine import SplitAlongDim
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.identity_op import IdentityFuncOp, IdentityOp
 from megatron.core.transformer.module import MegatronModule
@@ -28,6 +27,16 @@ from megatron.core.utils import divide
 from .enums import AttnMaskType
 from .transformer_config import TransformerConfig
 
+try:
+    import transformer_engine
+    HAVE_TE = True
+except ImportError:
+    HAVE_TE = False
+
+if HAVE_TE:
+    from megatron.core.transformer.custom_layers.transformer_engine import SplitAlongDim
+else:
+    SplitAlongDim = None
 
 @dataclass
 class SelfAttentionSubmodules:

--- a/megatron/core/transformer/torch_layer_norm.py
+++ b/megatron/core/transformer/torch_layer_norm.py
@@ -1,0 +1,19 @@
+import torch
+from megatron.core.transformer import TransformerConfig
+
+class WrappedTorchLayerNorm(torch.nn.LayerNorm):
+    
+    def __init__(
+        self,
+        config: TransformerConfig, ## unused
+        hidden_size: int,
+        eps: float = 1e-5,
+        persist_layer_norm: bool = True,
+        zero_centered_gamma: bool = False,
+        normalization: str = "LayerNorm",  # included to match TE interface
+    ):
+        ## TODO: make sure computation is identical to fused LN version
+        super().__init__(
+            normalized_shape = hidden_size, ## applied to last len(normalized_shape.size) dimensions
+            eps = eps,
+        )

--- a/megatron/core/transformer/torch_layer_norm.py
+++ b/megatron/core/transformer/torch_layer_norm.py
@@ -12,7 +12,6 @@ class WrappedTorchLayerNorm(torch.nn.LayerNorm):
         zero_centered_gamma: bool = False,
         normalization: str = "LayerNorm",  # included to match TE interface
     ):
-        ## TODO: make sure computation is identical to fused LN version
         super().__init__(
             normalized_shape = hidden_size, ## applied to last len(normalized_shape.size) dimensions
             eps = eps,

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -452,15 +452,15 @@ def local_multi_tensor_applier(op, noop_flag_buffer, tensor_lists, *args):
 ## computes l2 norm for a list of contiguous tensors
 ## TODO: check that this gives the same output as amp version!!
 def local_multi_tensor_l2_norm(noop_flag, tensor_lists, per_tensor):
-    l2_sq = [[(torch.norm(tensor))**2 for tensor in tensor_list] for tensor_list in tensor_lists]
-    l2_sq_reduced = torch.norm(torch.tensor(l2_sq))**2
-    l2_sq_cuda = torch.tensor([float(l2_sq_reduced)], dtype=torch.float, device='cuda')
-    return l2_sq_cuda, None
+    l2_sq = [[(torch.norm(tensor)) for tensor in tensor_list] for tensor_list in tensor_lists]
+    l2_reduced = torch.norm(torch.tensor(l2_sq))
+    l2_cuda = torch.tensor([float(l2_reduced)], dtype=torch.float, device='cuda')
+    return l2_cuda, None
 
 def local_multi_tensor_scale(noop_flag, tensor_lists, scale):
     inputs, targets = tensor_lists
     for i in range(len(targets)):
-        targets[i] = inputs[i] / scale
+        targets[i] = inputs[i] * scale
 
 class _ValueWithRank:
     """This is an internal class, not for use outside this module

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -446,6 +446,21 @@ def drain_embedding_wgrad_compute(config, embedding_activation_buffer, grad_outp
     wgrad_compute(all_gathered_input[1], grad_output, weight)
     input, all_gathered_input[1], grad_output = None, None, None
 
+def local_multi_tensor_applier(op, noop_flag_buffer, tensor_lists, *args):
+    return op(noop_flag_buffer, tensor_lists, *args)
+
+## computes l2 norm for a list of contiguous tensors
+## TODO: check that this gives the same output as amp version!!
+def local_multi_tensor_l2_norm(noop_flag, tensor_lists, per_tensor):
+    l2_sq = [[(torch.norm(tensor))**2 for tensor in tensor_list] for tensor_list in tensor_lists]
+    l2_sq_reduced = torch.norm(torch.tensor(l2_sq))**2
+    l2_sq_cuda = torch.tensor([float(l2_sq_reduced)], dtype=torch.float, device='cuda')
+    return l2_sq_cuda, None
+
+def local_multi_tensor_scale(noop_flag, tensor_lists, scale):
+    inputs, targets = tensor_lists
+    for i in range(len(targets)):
+        targets[i] = inputs[i] / scale
 
 class _ValueWithRank:
     """This is an internal class, not for use outside this module


### PR DESCRIPTION
This PR provides a fallback codepath that defaults to pure Pytorch/jit when TE and Apex are not installed.