### PR TITLE
[BUG] Suppress initialization for moe router if not necessary

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -46,8 +46,9 @@ class Router(ABC, MegatronModule):
         self.weight = torch.nn.Parameter(
             torch.empty((self.config.num_moe_experts, self.config.hidden_size))
         )
-        with get_cuda_rng_tracker().fork(get_data_parallel_rng_tracker_name()):
-            config.init_method(self.weight)
+        if config.perform_initialization:
+            with get_cuda_rng_tracker().fork(get_data_parallel_rng_tracker_name()):
+                config.init_method(self.weight)
         setattr(self.weight, 'sequence_parallel', config.sequence_parallel)
 
     def gating(self, input: torch.Tensor):


### PR DESCRIPTION
In [megatron/core/transformer/moe/router.py](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/moe/router.py), the class `Router`, as well as `TopKRouter`, will always perform weight initialization. However, there exists cases that initialization is unnecessary, such as converting checkpoints.

I found that most of other modules in megatron-core have included the `if config.perform_initialization` clause.(e.g. `GroupedMLP` in [megatron/core/transformer/moe/experts.py](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/moe/experts.py)). Thus, I add the clause here for suppressing unnecessary initializations.

Please find the details in the attached files:)