### PR TITLE
Refactor: Use safe_get_rank in Logging to Handle Uninitialized Distributed Mode

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -360,7 +360,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
             if checkpointing_context is not None:
                 checkpointing_context['save_strategy'] = save_strategy
             end_ckpt = time()
-            logger.debug(f"rank: {torch.distributed.get_rank()}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
+            logger.debug(f"rank: {maybe_get_current_rank()}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
             async_save_request = dist_checkpointing.save(state_dict, checkpoint_name, save_strategy,
                                                          async_sharded_save=args.async_save)
 
@@ -423,7 +423,8 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
         torch.distributed.barrier()
 
     end_misc = time()
-    logger.debug(f"rank: {torch.distributed.get_rank()}, takes {end_misc - start_misc} to finalize ckpt save ")
+
+    logger.debug(f"rank: {maybe_get_current_rank()}, takes {end_misc - start_misc} to finalize ckpt save ")
 
 def generate_state_dict(args, model, optimizer, opt_param_scheduler,
                         rng_state, use_dist_ckpt=False, iteration=None,

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -19,7 +19,7 @@ from megatron.core.dist_checkpointing.strategies.fully_parallel import \
 from megatron.core.num_microbatches_calculator import update_num_microbatches
 from .async_utils import schedule_async_save
 from .global_vars import get_args, get_one_logger
-from .utils import unwrap_model, print_rank_0, append_to_progress_log, is_last_rank, maybe_get_current_rank
+from .utils import unwrap_model, print_rank_0, append_to_progress_log, is_last_rank, safe_get_rank
 from ..core.dist_checkpointing.serialization import \
     get_default_save_sharded_strategy
 from .one_logger_utils import on_save_checkpoint_start, on_save_checkpoint_success
@@ -360,7 +360,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
             if checkpointing_context is not None:
                 checkpointing_context['save_strategy'] = save_strategy
             end_ckpt = time()
-            logger.debug(f"rank: {maybe_get_current_rank()}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
+            logger.debug(f"rank: {safe_get_rank()}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
             async_save_request = dist_checkpointing.save(state_dict, checkpoint_name, save_strategy,
                                                          async_sharded_save=args.async_save)
 
@@ -424,7 +424,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
 
     end_misc = time()
 
-    logger.debug(f"rank: {maybe_get_current_rank()}, takes {end_misc - start_misc} to finalize ckpt save ")
+    logger.debug(f"rank: {safe_get_rank()}, takes {end_misc - start_misc} to finalize ckpt save ")
 
 def generate_state_dict(args, model, optimizer, opt_param_scheduler,
                         rng_state, use_dist_ckpt=False, iteration=None,

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -423,7 +423,6 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
         torch.distributed.barrier()
 
     end_misc = time()
-
     logger.debug(f"rank: {safe_get_rank()}, takes {end_misc - start_misc} to finalize ckpt save ")
 
 def generate_state_dict(args, model, optimizer, opt_param_scheduler,

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -19,7 +19,7 @@ from megatron.core.dist_checkpointing.strategies.fully_parallel import \
 from megatron.core.num_microbatches_calculator import update_num_microbatches
 from .async_utils import schedule_async_save
 from .global_vars import get_args, get_one_logger
-from .utils import unwrap_model, print_rank_0, append_to_progress_log, is_last_rank
+from .utils import unwrap_model, print_rank_0, append_to_progress_log, is_last_rank, maybe_get_current_rank
 from ..core.dist_checkpointing.serialization import \
     get_default_save_sharded_strategy
 from .one_logger_utils import on_save_checkpoint_start, on_save_checkpoint_success

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -282,6 +282,11 @@ def print_rank_last(message):
     else:
         print(message, flush=True)
 
+def maybe_get_current_rank():
+    if not torch.distributed.is_initialized():
+        return torch.distributed.get_rank()
+    else:
+        return "N/A"
 
 def append_to_progress_log(string, barrier=True):
     """ Append given string to progress log. """

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -283,7 +283,7 @@ def print_rank_last(message):
         print(message, flush=True)
 
 def safe_get_rank():
-    if not torch.distributed.is_initialized():
+    if torch.distributed.is_initialized():
         return torch.distributed.get_rank()
     else:
         return "N/A"

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -282,7 +282,7 @@ def print_rank_last(message):
     else:
         print(message, flush=True)
 
-def maybe_get_current_rank():
+def safe_get_rank():
     if not torch.distributed.is_initialized():
         return torch.distributed.get_rank()
     else:


### PR DESCRIPTION
## Refactor: Use `safe_get_rank` in Logging to Handle Uninitialized Distributed Mode

### Description

This PR introduces changes to improve logging within the `checkpointing.py` module by handling cases where the distributed mode is not initialized. The key change involves replacing direct calls to `torch.distributed.get_rank()` with a new utility function, `safe_get_rank()`, which checks if the distributed mode is initialized before attempting to get the rank.

### Changes

1. **Modified `checkpointing.py`**:
   - Replaced `torch.distributed.get_rank()` with `safe_get_rank()` in logging statements to avoid errors when the distributed mode is not initialized.
   
   ```python
   logger.debug(f"rank: {safe_get_rank()}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
   logger.debug(f"rank: {safe_get_rank()}, takes {end_misc - start_misc} to finalize ckpt save ")
   ```

2. **Added `safe_get_rank` in `utils.py`**:
   - Created a new utility function `safe_get_rank()` which returns the rank if distributed mode is initialized, otherwise returns `"N/A"`.
   
   ```python
   def safe_get_rank():
       if torch.distributed.is_initialized():
           return torch.distributed.get_rank()
       else:
           return "N/A"
   ```

### Motivation

These changes ensure that logging does not raise errors in scenarios where the distributed mode has not been initialized, enhancing robustness and providing clearer logging information during model training and checkpointing.

---

Please review the changes and provide any feedback. Thank you!

---