### PR TITLE
[DOC] Fix wrong llama2 pretrain url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ python tasks/main.py \
 
 The Llama-2 [family of models](https://ai.meta.com/llama/) are an open-source set of pretrained & finetuned (for chat) models that have achieved strong results across a wide set of benchmarks. At the time of release, Llama-2 models achieved among the best results for open-source models, and were competitive with the closed-source GPT-3.5 model (see https://arxiv.org/pdf/2307.09288.pdf).
 
-The Llama-2 checkpoints can be loaded into Megatron for inference and finetuning. See documentation [here](docs/llama2.md).
+The Llama-2 checkpoints can be loaded into Megatron for inference and finetuning. See documentation [here](docs/llama_mistral.md).
 
 # Model Optimization and Deployment
 Megatron-Core (MCore) `GPTModel` family supports advanced quantization algorithms and high-performance inference through TensorRT-LLM.


### PR DESCRIPTION
The url link in [this section](https://github.com/NVIDIA/Megatron-LM?tab=readme-ov-file#llama-2-inference-and-finetuning) is out-dated and invalid, I think it should be updated