### PR TITLE
[bugfix] Fix the incorrect with-statement

### DIFF
--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -397,7 +397,7 @@ class TransformerBlock(MegatronModule):
         else:
             fp8_context = nullcontext()
 
-        with rng_context and fp8_context:
+        with rng_context, fp8_context:
             # Forward pass.
             if self.config.recompute_granularity == 'full' and self.training:
                 hidden_states = self._checkpointed_forward(


### PR DESCRIPTION
You may want to enter multiple context managers in one with-statement.
However, `with rng_context and fp8_context` is equivalent to `with fp8_context`, because `rng_context` doesn't rewrite `__and__` method.
The correct way is `with rng_context, fp8_context:` .

Ref: https://docs.python.org/3/reference/compound_stmts.html#the-with-statement