### PR TITLE
fix torch.py when saving checkpoints using pytorch2.4

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -444,7 +444,8 @@ class MCoreSavePlanner(DefaultSavePlanner):
 
     def create_local_plan(self) -> SavePlan:
         plan = create_default_local_save_plan(self.state_dict, self.is_coordinator)
-        self._add_non_coordinator_iobytes_request(plan)
+        if packaging.version.Version(torch.__version__) <= packaging.version.Version("2.3"):
+            self._add_non_coordinator_iobytes_request(plan)
         if self.flatten_state_dict:
             plan = dataclasses.replace(plan, planner_data=self.mappings)
         plan = MCoreSavePlan(


### PR DESCRIPTION
issue #1003 
this bug is due to the calling of function _add_non_coordinator_iobytes_request() in create_local_plan()
https://github.com/NVIDIA/Megatron-LM/blob/6bf8448ba065a0a37b2b874f49fd65ca9547b5c0/megatron/core/dist_checkpointing/strategies/torch.py#L445-L447
https://github.com/NVIDIA/Megatron-LM/blob/6bf8448ba065a0a37b2b874f49fd65ca9547b5c0/megatron/core/dist_checkpointing/strategies/torch.py#L469-L474
function create_default_local_save_plan() is different between Pytorch 2.3 and 2.4 
PyTorch 2.3
https://github.com/pytorch/pytorch/blob/63d5e9221bedd1546b7d364b5ce4171547db12a9/torch/distributed/checkpoint/default_planner.py#L259
```python
def create_default_local_save_plan(
    state_dict: Dict[str, Any], is_coordinator: bool
) -> SavePlan:
    """
    Create the ``SavePlan`` used by DefaultSavePlanner.

    On non-coordinator ranks, this function ignores tensors and non-tensor objects,
    only producing writes for ShardedTensor objects.

    On the coordinator rank, produce writes for all values.
    """
    requests = []
    for fqn, obj in state_dict.items():
        # Since DTensor supports submesh, adding extra check to ensure _create_write_items()
        # gets called only when the current rank is part of the mesh for the corresponding DTensor.
        if isinstance(obj, DTensor):
            if obj.device_mesh.get_coordinate() is not None:
                requests += _create_write_items(fqn, obj)
        elif isinstance(obj, (torch.Tensor)) or is_coordinator:
            requests += _create_write_items(fqn, obj)

    return SavePlan(requests)

``` 
Pytorch 2.4
https://github.com/pytorch/pytorch/blob/f6fb80b0f906ebc89e4bfcfe4e322585cbbcecb8/torch/distributed/checkpoint/default_planner.py#L344
```python
def create_default_local_save_plan(
    state_dict: Dict[str, Any], is_coordinator: bool
) -> SavePlan:
    """
    Create the ``SavePlan`` used by DefaultSavePlanner.

    On non-coordinator ranks, this function ignores tensors and non-tensor objects,
    only producing writes for ShardedTensor objects.

    On the coordinator rank, produce writes for all values.
    """
    requests = []
    for fqn, obj in state_dict.items():
        # Since DTensor supports submesh, adding extra check to ensure _create_write_items()
        # gets called only when the current rank is part of the mesh for the corresponding DTensor.
        if isinstance(obj, DTensor):
            if obj.device_mesh.get_coordinate() is not None:
                requests += _create_write_items(fqn, obj)
        else:
            # For the plain tensor and non-tensor values, add the request for all
            # the ranks. Coordinator will decides whether to deduplicate the
            # values based on the keys.
            requests += _create_write_items(fqn, obj)

    return SavePlan(requests)
``` 

This bug happens when using pytorch2.4. Because in pytorch 2.4, `is_coordinator` condition check is removed. `non_coordinator` requests haved been added in "plan" by PyTorch. So it's no need to call `_add_non_coordinator_iobytes_request` in Megatron core.