### PR TITLE
Add a nicer exception for missing model keys in the checkpoint

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -493,6 +493,10 @@ class MCoreLoadPlanner(DefaultLoadPlanner):
 
     def _validate_global_shapes(self, metadata, sharded_tensors):
         for sh_ten in sharded_tensors:
+            if sh_ten.key not in self.metadata.state_dict_metadata:
+                raise KeyError(
+                    f"{sh_ten.key} from model not in state dict: {sorted(self.metadata.state_dict_metadata.keys())}"
+                )
             loaded_shape = metadata.state_dict_metadata[sh_ten.key].size
             if not is_nd_flattened_tensor(sh_ten):
                 expected_shape = sh_ten.global_shape


### PR DESCRIPTION
When debugging a failing checkpoint load in test, I was just confronted with a missing Key exception with no indication of what the target options were. This improved exception message allowed me to identify/fix the problem on my end.