### PR TITLE
fix packaging import bug when using setuptools v70

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 
 import numpy as np
 import torch
-from pkg_resources import packaging
+from pkg_resources.extern import packaging
 from torch.distributed import checkpoint
 from torch.distributed._shard._utils import narrow_tensor_by_index
 from torch.distributed._shard.metadata import ShardMetadata

--- a/megatron/core/models/retro/config.py
+++ b/megatron/core/models/retro/config.py
@@ -7,7 +7,7 @@ import types
 from dataclasses import dataclass
 from importlib.metadata import version
 
-from pkg_resources import packaging
+from pkg_resources.extern import packaging
 
 from megatron.core.transformer import TransformerConfig
 

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -8,7 +8,7 @@ import logging
 from importlib.metadata import version
 
 import torch
-from pkg_resources import packaging
+from pkg_resources.extern import packaging
 from torch import _C
 from torch.cuda import _lazy_call
 from torch.cuda import device as device_ctx_manager


### PR DESCRIPTION
From `v70.0.0` to `v70.3.0` of `setuptools`, `packaging` can't be imported by 
```python
from pkg_resources import packaging
``` 
It should be modified to:
```python
from pkg_resources.extern import packaging
``` 
And this writing is also applicable in versions before `v70.0.0`

[The history of the commit associated with it in `setuptools`](https://github.com/pypa/setuptools/commit/e9995828311c5e0c843622ca2be85e7f09f1ff0d)
