### PR TITLE
Fix dataset helper compilation

### DIFF
--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -125,7 +125,7 @@ def _compile_dependencies():
     # Compile dataset C++ code.
     # =========================
     # TODO: move this to ninja
-    if torch.distributed.get_rank() == 0:
+    if args.local_rank == 0:
         start_time = time.time()
         print("> compiling dataset index builder ...")
         from megatron.core.datasets.utils import compile_helpers


### PR DESCRIPTION
When using mock data in multi-node run, current logic will only build dataset helpers in node 0. This commit makes it compiled on all nodes.