### PR TITLE
Fix duplicate init for self.module in DistributedDataParallel

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -46,8 +46,6 @@ class DistributedDataParallel(MegatronModule):
         if has_config_logger_enabled(config):
             log_config_to_disk(config, locals(), prefix=type(self).__name__)
 
-        self.module = module
-
         # If bucket_size is not provided as an input, use sane default.
         # If using very large dp_sizes, make buckets larger to ensure that chunks used in NCCL
         # ring-reduce implementations are large enough to remain bandwidth-bound rather than
@@ -72,9 +70,7 @@ class DistributedDataParallel(MegatronModule):
         # disable_bucketing is True (e.g., we might not want to break up model parameters
         # into buckets for model chunks after the first in the interleaved schedule).
         self.bucket_size = self.ddp_config.bucket_size
-        if parallel_state.get_pipeline_model_parallel_rank() > 0:
-            self.bucket_size = None
-        if disable_bucketing:
+        if disable_bucketing or parallel_state.get_pipeline_model_parallel_rank() > 0:
             self.bucket_size = None
 
         self.module = module

--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -142,7 +142,6 @@ def finalize_model_grads(model: List[torch.nn.Module], num_tokens: Optional[torc
         pp_group = parallel_state.get_pipeline_model_parallel_group()
 
         if not isinstance(last_rank, list):
-            assert not isinstance(last_rank, list)
             last_rank = [last_rank]
             assert not isinstance(pp_group, list)
             pp_group = [pp_group]


### PR DESCRIPTION
When I learning source code in Megatron-LLM, I found it seems no need to assign `self.module` twice.