### PR TITLE
Enabling UCC backend for PP communication

### DIFF
--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -22,6 +22,9 @@ class ModelParallelConfig:
     pipeline_model_parallel_size: int = 1
     """Inter-layer model parallelism. Splits transformer layers across GPU ranks."""
 
+    pipeline_model_parallel_comm_backend: str = "nccl"
+    """Configuring backend option of pipeline parallel communication (e.g., nccl, ucc, mpi)"""
+
     virtual_pipeline_model_parallel_size: Optional[int] = None
     """Interleaved pipeline parallelism is used to improve performance by reducing the pipeline
        bubble.  Considers a transformer block as a list of smaller transformer (virtual) blocks.

--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -169,7 +169,7 @@ def _p2p_ops(
     reqs = []
     rank = get_pipeline_model_parallel_rank()
     even_send_odd_recv_group = group
-    if get_pipeline_model_parallel_world_size() == 2:
+    if get_pipeline_model_parallel_world_size() == 2 and torch.distributed.get_backend(group) is not 'ucc':
         # Use the global process group for one of the two p2p communications
         # to allow the overlap of the independent communications.
         # Using the global process group is compatible because the pipeline-parallel


### PR DESCRIPTION
This MR provides an interface to enable the UCC backend for PP communication.
To enable the UCC backend, set the following argument:

`training.model.pipeline_model_parallel_comm_backend=ucc`

Requires a related NeMo PR ([link](https://github.com/NVIDIA/NeMo/pull/10531)).