### PR TITLE
Expose cp_comm_type in ModelParallelConfig

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -522,6 +522,9 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
         else:
             kv_channels = self.config.kv_channels
 
+        if config.cp_comm_type is not None:
+            extra_kwargs['cp_comm_type'] = config.cp_comm_type
+
         super().__init__(
             num_attention_heads=self.config.num_attention_heads,
             kv_channels=kv_channels,

--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -39,6 +39,10 @@ class ModelParallelConfig:
     context_parallel_size: int = 1
     """Splits network input along sequence dimension across GPU ranks."""
 
+    cp_comm_type: str = 'p2p'
+    """Inter-gpu communication type for context parallelism. Can be "p2p" or "all_gather" or "a2a".
+    """
+
     expert_model_parallel_size: int = 1
     """Distributes Moe Experts across sub data parallel dimension."""
 


### PR DESCRIPTION
The default cp_comm_type 'p2p' does not work with sliding window attention in TransformerEngine. Exposing this parameter will allow us to test context parallel with sliding window attention.

More details about this change can be seen in the previous PRs https://github.com/NVIDIA/TransformerEngine/pull/1060 and https://github.com/NVIDIA/TransformerEngine/pull/1160 