### PR TITLE
fix bugs for multi_latent_attention

### DIFF
--- a/megatron/core/transformer/dot_product_attention.py
+++ b/megatron/core/transformer/dot_product_attention.py
@@ -41,6 +41,8 @@ class DotProductAttention(MegatronModule):
         attention_type: str,
         attention_dropout: float = None,
         softmax_scale: float = None,
+        k_channels: int = None,
+        v_channels: int = None,
     ):
         super().__init__(config=config)
 

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -366,6 +366,7 @@ class MLASelfAttention(MultiLatentAttention):
         query = torch.cat([q_no_pe, q_pos_emb], dim=-1)
 
         # key: [s, b, n, 192]
+        k_pos_emb = k_pos_emb.repeat_interleave(self.num_attention_heads_per_partition, dim=2)
         key = torch.cat([k_no_pe, k_pos_emb], dim=-1)
 
         query = query.contiguous()


### PR DESCRIPTION
1. The initialization parameters for `DotProductAttention` and `TEDotProductAttention` are different. Using DotProductAttention to construct MultiLatentAttention will result in an error.
2. In the `MLASelfAttention` module, the dimensions of `k_pos_emb` and `k_no_pe` differ in terms of num_attention_heads.`torch.cat` will result in an error.
