### PR TITLE
Fix UnboundLocalError in initialize.py due to uninitialized 'seed' variable

### DIFF
--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -320,7 +320,7 @@ def _set_random_seed(seed_, data_parallel_random_init=False):
         if torch.cuda.device_count() > 0:
             tensor_parallel.model_parallel_cuda_manual_seed(seed)
     else:
-        raise ValueError("Seed ({}) should be a positive integer.".format(seed))
+        raise ValueError("Seed ({}) should be a positive integer.".format(seed_))
 
 
 def write_args_to_tensorboard():


### PR DESCRIPTION
Fixes an `UnboundLocalError` in `initialize.py` where the `seed` variable was referenced before being initialized.
