### PR TITLE
Add fallbacks for c++ extension + jit_fuser

### DIFF
--- a/megatron/core/jit.py
+++ b/megatron/core/jit.py
@@ -1,11 +1,48 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
+import os
+import warnings
+from typing import Callable, Any
+
 import torch
+
 
 TORCH_MAJOR = int(torch.__version__.split(".")[0])
 TORCH_MINOR = int(torch.__version__.split(".")[1])
+STRICT_JIT_FUSION = os.environ.get('STRICT_JIT_FUSION', 'false').lower() == 'true'
 
-jit_fuser = torch.jit.script
-# nvFuser is deprecated in PyTorch JIT starting from 2.2
-if (TORCH_MAJOR > 2) or (TORCH_MAJOR == 2 and TORCH_MINOR >= 2):
-    jit_fuser = torch.compile
+
+def safe_jit_fuser(func: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    Safely apply JIT fusion to a function, with fallback for newer PyTorch versions.
+
+    This function attempts to apply JIT fusion to the input function. For PyTorch
+    versions 2.2 and above, it uses `torch.compile`. If compilation fails, it
+    either falls back to the original function and logs a warning, or raises an
+    exception if STRICT_JIT_FUSION is set to True. For older PyTorch versions,
+    it uses `torch.jit.script`.
+
+    Args:
+        func (Callable[..., Any]): The function to be JIT fused.
+
+    Returns:
+        Callable[..., Any]: A wrapped function that applies JIT fusion when possible,
+        or falls back to the original function if compilation fails (unless in strict mode).
+
+    Raises:
+        RuntimeError: If compilation fails and STRICT_JIT_FUSION is set to True.
+    """
+    if (TORCH_MAJOR > 2) or (TORCH_MAJOR == 2 and TORCH_MINOR >= 2):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return torch.compile(func)(*args, **kwargs)
+            except RuntimeError as e:
+                if STRICT_JIT_FUSION:
+                    raise RuntimeError(f"torch.compile failed in strict mode: {str(e)}")
+                warnings.warn(f"torch.compile failed: {str(e)}. Falling back to original function.")
+                return func(*args, **kwargs)
+        return wrapper
+    else:
+        return torch.jit.script(func)
+
+jit_fuser = safe_jit_fuser


### PR DESCRIPTION
In [NeMo-Run](https://github.com/NVIDIA/NeMo-Run) we offer to configure an experiment locally but execute it remotely through a wide variety of different executors. For the best UX we require mcore to be able to be installed locally (eventhough we don't intend to train models locally). Currently there are some issues to make a pip-install fail.

1. The C++ extension, I propose to log a warning when this fails but don't fail the entire installation.
2. The `jit_fuser` can fail on newer python installs. I propose to make it a no-op when it fails. Current error is:

```
  from megatron.core.transformer.utils import (
  File "/Users/mromeijn/base/code/.venv/lib/python3.12/site-packages/megatron/core/transformer/utils.py", line 40, in <module>
    @jit_fuser
     ^^^^^^^^^
  File "/Users/mromeijn/base/code/.venv/lib/python3.12/site-packages/lightning_fabric/wrappers.py", line 411, in _capture
    return compile_fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mromeijn/base/code/.venv/lib/python3.12/site-packages/torch/__init__.py", line 1868, in compile
    raise RuntimeError("Dynamo is not supported on Python 3.12+")
RuntimeError: Dynamo is not supported on Python 3.12+
```