### PR TITLE
Fix a bug in optimizer's mix_lr/max_lr when args.override_opt_param_scheduler==True

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1204,6 +1204,16 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
                     opt_param_scheduler.load_state_dict(state_dict['lr_scheduler'])
                 else:
                     opt_param_scheduler.load_state_dict(state_dict['opt_param_scheduler'])
+
+            if args.override_opt_param_scheduler:
+                from megatron.core.optimizer import _update_min_and_max_lr_in_param_groups
+                _update_min_and_max_lr_in_param_groups(
+                    optimizer.param_groups,
+                    opt_param_scheduler.max_lr,
+                    opt_param_scheduler.min_lr,
+                    args.decoupled_lr,
+                    args.decoupled_min_lr,
+                    )
         except KeyError as e:
             print_rank_0('Unable to load optimizer from checkpoint {}. '
                          'Specify --no-load-optim or --finetune to prevent '


### PR DESCRIPTION
1. In the current setting, OptimizerParamScheduler uses the `max_lr` and `min_lr` from optimizer instead of its own attributes to compute the learning rate at a certain step. 
2. When `--override-opt_param_scheduler` is used, user expects to override the learning rate schedule that is stored in the checkpoint. However, the optimizer still loads the `max_lr`, `min_lr` and the decoupled versions from the checkpoint. 
3. Therefore, when `--override-opt_param_scheduler` is used, the learning rate in training is computed using the old `max_lr` and the new `init_lr`, a mixture of old and new setting. This can be confusing for user to figure out the issue.

Here I propose an fix that during the `load_checkpoint`, when `--override-opt_param_scheduler` is set to `True`, the function `megatron.core.optimizer._update_min_and_max_lr_in_param_groups` is invoked to update the optimizer loaded from the checkpoint with the new learning rate boudaries. Thus the training would be carried out using the updated learning rate setting in situations like CPT, etc.