### PR TITLE
add omitted prepare command to multimodal README.md

### DIFF
--- a/examples/multimodal/README.md
+++ b/examples/multimodal/README.md
@@ -57,7 +57,7 @@ examples/multimodal/combine_mistral_clip.sh /path/to/mistral/model /path/to/clip
 
     ```
     cd <LLaVA-Pretrain dir>/wds
-    energon ./
+    energon prepare ./
     ```
 
     select the following values for the presented options:


### PR DESCRIPTION
This PR updates the multimodal README.md to include a missing option in the `megatron-energon` section. 