### PR TITLE
fix bug caused by func get_blend_and_blend_per_split()

### DIFF
--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -337,6 +337,8 @@ def get_blend_and_blend_per_split(args):
 
     blend = None
     blend_per_split = None
+    if args.mock_data:
+        pass
     if use_data_path:
         if args.data_args_path is not None:
             assert args.data_path is None


### PR DESCRIPTION
args.mock_data was not taken into account.

This bug caused by commit 7e9ab5c