### PR TITLE
Fix type annotation and checkpoint conversion script

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1108,7 +1108,7 @@ class TEDelayedScaling(te.common.recipe.DelayedScaling):
 
     def __init__(
         self,
-        config: ModelParallelConfig,
+        config: TransformerConfig,
         fp8_format: int,
         override_linear_precision: tuple = (False, False, False),
     ):

--- a/tools/checkpoint/convert.py
+++ b/tools/checkpoint/convert.py
@@ -2,6 +2,7 @@
 
 import argparse
 import importlib
+import torch
 import torch.multiprocessing as mp
 import sys
 
@@ -107,6 +108,9 @@ def load_plugin(plugin_type, name):
     return plugin
 
 def main():
+    if not torch.cuda.is_initialized():
+        torch.cuda.init()
+
     import argparse
     parser = argparse.ArgumentParser(description="Megatron Checkpoint Converter Arguments",
                                      allow_abbrev=False, conflict_handler='resolve')
@@ -151,4 +155,5 @@ def main():
 
 
 if __name__ == '__main__':
+    mp.set_start_method(method='spawn')
     main()


### PR DESCRIPTION
## What is the issue

I have found that if you are using TransformerEngine v1.10 or later, `CUDA error: initialization error` will occur in the following location in saver_mcore.py.

https://github.com/NVIDIA/Megatron-LM/blob/076972e37420b5325c5fe06e7131be7d96f05b53/tools/checkpoint/saver_mcore.py#L299

If the version of TransformerEngine is 1.10 or later, `torch.cuda.Stream()` is called in the following places. This causes an initialization error.

https://github.com/NVIDIA/Megatron-LM/blob/076972e37420b5325c5fe06e7131be7d96f05b53/megatron/core/extensions/transformer_engine.py#L1218-L1221

https://github.com/NVIDIA/TransformerEngine/blob/c9ea6be92948e1ec553037f1a04900617b9f7f6b/transformer_engine/pytorch/cpu_offload.py#L314-L315

## How to solve the issue

Add `mp.set_start_method(method='spawn')` and `torch.cuda.init()`