### PR TITLE
Update theoretical memory footprint formula

### DIFF
--- a/megatron/training/theoretical_memory_usage.py
+++ b/megatron/training/theoretical_memory_usage.py
@@ -32,10 +32,11 @@ def compute_weight_and_optimizer_memory(args, verbose=False):
             # MLP.
             + ((args.ffn_hidden_size / args.hidden_size) * num_experts * gated_linear_multiplier)
             # Transformer layernorms.
-            + (2 / args.hidden_size)
-            # Final layernorm.
-            + (1 / (args.num_layers * args.hidden_size))
+            + (1 / args.hidden_size)
         )
+    ) + (
+        # final layernorm
+        args.hidden_size
     )
     embedding_size = args.hidden_size * args.padded_vocab_size
     if args.untie_embeddings_and_output_weights:

--- a/megatron/training/theoretical_memory_usage.py
+++ b/megatron/training/theoretical_memory_usage.py
@@ -175,8 +175,10 @@ def report_theoretical_memory(args, num_microbatches=None, verbose=False):
         compute_weight_and_optimizer_memory(args, verbose=verbose) / NUM_BYTES_IN_GIGABYTE
     )
 
-    # Formulae here assume sequence parallelism and selective activation recomputation.
-    if not args.sequence_parallel or args.recompute_granularity != 'selective':
+    # Formulae here assume sequence parallelism and selective activation recomputation or flash-attention.
+    if not args.sequence_parallel or not (
+        args.recompute_granularity == 'selective' or args.use_flash_attn is True
+    ):
         print(
             f"Theoretical memory footprints: weight and optimizer={weight_and_optimizer_memory:.2f} GB"
         )

--- a/megatron/training/theoretical_memory_usage.py
+++ b/megatron/training/theoretical_memory_usage.py
@@ -5,7 +5,7 @@
 
 import math
 
-NUM_BYTES_IN_MEGABYTE = 1024 * 1024
+NUM_BYTES_IN_GIGABYTE = 1024 * 1024 * 1024
 
 
 def compute_weight_and_optimizer_memory(args, verbose=False):
@@ -111,7 +111,7 @@ def compute_activation_memory(args, num_microbatches, verbose=False):
     if verbose:
         print(
             f"Activation memory footprint per transformer layer: "
-            f"{activation_memory / NUM_BYTES_IN_MEGABYTE / args.tensor_model_parallel_size:.1f} MB"
+            f"{activation_memory / NUM_BYTES_IN_GIGABYTE / args.tensor_model_parallel_size:.1f} GB"
         )
     activation_memory *= args.num_layers
 
@@ -172,23 +172,23 @@ def compute_activation_memory(args, num_microbatches, verbose=False):
 
 def report_theoretical_memory(args, num_microbatches=None, verbose=False):
     weight_and_optimizer_memory = (
-        compute_weight_and_optimizer_memory(args, verbose=verbose) / NUM_BYTES_IN_MEGABYTE
+        compute_weight_and_optimizer_memory(args, verbose=verbose) / NUM_BYTES_IN_GIGABYTE
     )
 
     # Formulae here assume sequence parallelism and selective activation recomputation.
     if not args.sequence_parallel or args.recompute_granularity != 'selective':
         print(
-            f"Theoretical memory footprints: weight and optimizer={weight_and_optimizer_memory:.2f} MB"
+            f"Theoretical memory footprints: weight and optimizer={weight_and_optimizer_memory:.2f} GB"
         )
         return
 
     activation_memory = (
         compute_activation_memory(args, num_microbatches=num_microbatches, verbose=verbose)
-        / NUM_BYTES_IN_MEGABYTE
+        / NUM_BYTES_IN_GIGABYTE
     )
     total_memory = weight_and_optimizer_memory + activation_memory
 
     print(
-        f"Theoretical memory footprints: weight and optimizer={weight_and_optimizer_memory:.2f} MB, "
-        f"activation={activation_memory:.2f} MB, total={total_memory:.2f} MB\n"
+        f"Theoretical memory footprints: weight and optimizer={weight_and_optimizer_memory:.2f} GB, "
+        f"activation={activation_memory:.2f} GB, total={total_memory:.2f} GB\n"
     )


### PR DESCRIPTION
## number of parameters

```diff
- + (2 / args.hidden_size)
+ + (1 / args.hidden_size)
```

 Because there is `2 * args.num_layers * args.hidden_size * args.hidden_size`, the coefficient of layernorms should be 1, not 2.

## final layernorm

```diff
- (num_parameters_in_transformer_layers / args.pipeline_model_parallel_size)
+ (num_parameters_in_transformer_layers - args.hidden_size) / args.pipeline_model_parallel_size
```

Since the final layernorm is not relevant for stages other than the last pipeline stage, it is necessary to subtract the number of parameters for the final layernorm using `- args.hidden_size`.

## gradients' type

```diff
- 6 + (12 / args.data_parallel_size)
+ (2 + gradient_accumulation_factor) + (12 / args.data_parallel_size
```

When `args.accumulate_allreduce_grads_in_fp32` is True, the coefficient can be set to 6 from parameters(bf16) + gradients(fp32), but when it is False, it becomes 4, so case separation is necessary.


## flash attention

```diff
- if not args.sequence_parallel or args.recompute_granularity != 'selective':
+ if not args.sequence_parallel or not (
+      args.recompute_granularity == 'selective' or args.use_flash_attn is True
+  ):
```

Since it is possible to calculate not only when `args.recompute_granularity` is selective, but also when `args.use_flash_attn` is True, it is added to the conditions.

## SwiGLU

```python
            (
                # SwiGLU
                2 * b * s * h  # input
                + 2 * b * s * args.ffn_hidden_size  # up_proj
                + 2 * b * s * args.ffn_hidden_size  # gate_proj
                + 2 * b * s * args.ffn_hidden_size  # act_fn
                + 2 * b * s * args.ffn_hidden_size  # down_proj
            ) if args.swiglu else (
                2 * b * s * h  # h -> ffn_h
                + 2 * b * s * args.ffn_hidden_size  # act
                + 2 * b * s * args.ffn_hidden_size  # ffn_h  -> h
            )
```

Added conditional branching to support both GPT and Llama architectures

## other changes

- Theoritical memory footprint is easier to read in GB units, so I changed it from MB to GB.
- Change so that the theoretical memory footprint per GPU when CP (Context Parallelism) is enabled can be correctly calculated.
-  Support GQA(Grouped Query Attention).