### PR TITLE
fix param overwrite problem in saver_mcore

### DIFF
--- a/tools/checkpoint/saver_mcore.py
+++ b/tools/checkpoint/saver_mcore.py
@@ -170,7 +170,8 @@ def save_checkpoint(queue, args):
                         'distribute_saved_activations',
                         'train_iters', 'lr_decay_iters', 'lr_warmup_iters', 'lr_warmup_fraction',
                         'start_weight_decay', 'end_weight_decay',
-                        'ckpt_format',
+                        'ckpt_format', 
+                        'main_params_dtype', 'main_grads_dtype', 'exp_avg_dtype', 'exp_avg_sq_dtype'
         ]
 
         for arg, value in vars(md.checkpoint_args).items():


### PR DESCRIPTION
As shown in the images below, I found that the following four arguments are being wrongly overwritten in tools.checkpoint.saver_mcore.save_checkpoint:
-	main_params_dtype
-	main_grads_dtype
-	exp_avg_dtype
-	exp_avg_sq_dtype

This issue prevents these arguments from passing the validation performed by the validate_args function. To resolve this, I added them to the args_to_keep list within the save_checkpoint function.

Supporting Images:
<img width="1139" alt="image" src="https://github.com/user-attachments/assets/344324bf-af10-4495-ad80-8bdf0dcfe9d4" />
<img width="1103" alt="image" src="https://github.com/user-attachments/assets/f97b38df-0e11-472f-98fb-71b066d16d14" />

If any additional details or discussions are required, feel free to reach out.

Thank you for your time and feedback!