### PR TITLE
KV-cache for T5 model

### DIFF
--- a/megatron/core/models/T5/t5_model.py
+++ b/megatron/core/models/T5/t5_model.py
@@ -347,6 +347,10 @@ class T5Model(LanguageModule):
         # Decoder position ids
         decoder_position_ids = t5_position_ids(decoder_input_ids)
 
+        # Add offset to the postion_ids when kv-cache is enabled
+        if inference_params is not None:
+            decoder_position_ids = decoder_position_ids + inference_params.sequence_len_offset
+
         # Decoder embedding.
         if self.pre_process:
             decoder_input = self.embedding(

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -324,11 +324,12 @@ class TransformerLayer(MegatronModule, BaseTransformerLayer):
         pre_cross_attn_layernorm_output = self.pre_cross_attn_layernorm(hidden_states)
 
         # Cross attention.
+        # Cross attention do not need kv_cache, we set the inference_params to None
         attention_output_with_bias = self.cross_attention(
             pre_cross_attn_layernorm_output,
             attention_mask=context_mask,
             key_value_states=context,
-            inference_params=inference_params,
+            inference_params=None,
         )
 
         if isinstance(attention_output_with_bias, dict) and "context" in attention_output_with_bias:


### PR DESCRIPTION
The current Megatron-core only implements the KV-cache mechanism for decoder-only models. I have implemented the KV-cache for seq2seq (T5) model to integrate with NeMo (https://github.com/NVIDIA/NeMo/pull/11881). The main changes include setting the KV-cache input for cross_attention to None, as it doesn't require a KV-cache. Additionally, I added the KV-cache offset to the T5 model's position ID in each forward step.