### PR TITLE
fix: name the token indices properly for training with tokens padding

### DIFF
--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -224,7 +224,7 @@ def permute(tokens, routing_map, num_out_tokens: int = None, drop_and_pad: bool 
             :, :capacity
         ].contiguous()
         # flatten from [num_experts, capacity] to 1D
-        token_indices = token_indices.view(-1)
+        sorted_indices = token_indices.view(-1)
     else:
         # mask [num_tokens, num_experts] -> [num_experts, num_tokens]
         routing_map = routing_map.bool().T.contiguous()


### PR DESCRIPTION
I think https://github.com/NVIDIA/Megatron-LM/commit/f27a04f6d64e14ebe18cabd807c29cec449ccdc6 introduced a typo for the case when MoE model trained with padding. Training fails with `NameError: name 'sorted_indices' is not defined`. I think `token_indices.view(-1)` is actually `sorted_indices`.

@guyueh1 @jaredcasper could you please review.