### PR TITLE
Fix packages error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,10 @@ setuptools.setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
     ],
-    packages=setuptools.find_namespace_packages(include=["megatron.core", "megatron.core.*"]),
+    packages=setuptools.find_namespace_packages(
+        include=["megatron.core", "megatron.core.*"],
+        exclude=["images", "images.*"]
+    ),
     ext_modules=[
         Extension(
             "megatron.core.datasets.helpers_cpp",


### PR DESCRIPTION
Fix the following error during pre-training of BERT.

```
error: Multiple top-level packages discovered in a flat-layout: ['images', 'megatron'].
```