### PR TITLE
Enabling Alternative Path ABC implementations

### DIFF
--- a/megatron/core/dist_checkpointing/core.py
+++ b/megatron/core/dist_checkpointing/core.py
@@ -5,6 +5,7 @@
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from pathlib_abc import PathBase
 from typing import Optional
 
 CONFIG_FNAME = 'metadata.json'
@@ -45,7 +46,7 @@ def check_is_distributed_checkpoint(checkpoint_dir):
     return maybe_load_config(checkpoint_dir) is not None
 
 
-def maybe_load_config(checkpoint_dir: str) -> Optional[CheckpointingConfig]:
+def maybe_load_config(checkpoint_dir: str | PathBase) -> Optional[CheckpointingConfig]:
     """Returns checkpoint config if `checkpoint_dir` is a distributed checkpoint and None otherwise
 
     Args:
@@ -54,7 +55,9 @@ def maybe_load_config(checkpoint_dir: str) -> Optional[CheckpointingConfig]:
     Returns:
         CheckpointingConfig (optional): None if checkpoint is not a valid distributed checkpoint
     """
-    config_path = Path(checkpoint_dir, CONFIG_FNAME)
+    if isinstance(checkpoint_dir, str):
+        config_path = Path(checkpoint_dir)
+    config_path = config_path / CONFIG_FNAME
     if not config_path.exists():
         return None
     with config_path.open() as f:
@@ -62,7 +65,7 @@ def maybe_load_config(checkpoint_dir: str) -> Optional[CheckpointingConfig]:
     return CheckpointingConfig(**config_dict)
 
 
-def save_config(config: CheckpointingConfig, checkpoint_dir: str):
+def save_config(config: CheckpointingConfig, checkpoint_dir: str | PathBase):
     """Save given config to checkpoint directory.
 
     Args:
@@ -72,6 +75,8 @@ def save_config(config: CheckpointingConfig, checkpoint_dir: str):
     Returns:
         None
     """
-    config_path = Path(checkpoint_dir, CONFIG_FNAME)
+    if isinstance(checkpoint_dir, str):
+        config_path = Path(checkpoint_dir)
+    config_path = config_path / CONFIG_FNAME
     with config_path.open('w') as f:
         json.dump(asdict(config), f)

--- a/megatron/core/dist_checkpointing/validation.py
+++ b/megatron/core/dist_checkpointing/validation.py
@@ -3,6 +3,7 @@ import logging
 from collections import Counter, defaultdict
 from enum import Enum
 from pathlib import Path
+from pathlib_abc import PathBase
 from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -202,7 +203,7 @@ def validate_integrity_and_strict_load(
 
 
 def verify_checkpoint_and_load_strategy(
-    checkpoint_dir: str,
+    checkpoint_dir: str | PathBase,
     sharded_strategy: Union[LoadShardedStrategy, Tuple[str, int], None] = None,
     common_strategy: Union[LoadCommonStrategy, Tuple[str, int], None] = None,
 ) -> Tuple[LoadShardedStrategy, LoadCommonStrategy]:
@@ -219,7 +220,9 @@ def verify_checkpoint_and_load_strategy(
             if compatible with the checkpoint content. If None, the default common load strategy
             for the checkpoint backend will be returned.
     """
-    if not Path(checkpoint_dir).exists():
+    if isinstance(checkpoint_dir, str):
+        checkpoint_dir = Path(checkpoint_dir)
+    if not checkpoint_dir.exists():
         raise CheckpointingException(f'Checkpoint directory {checkpoint_dir} does not exist')
 
     saved_config = maybe_load_config(checkpoint_dir)


### PR DESCRIPTION
Different Implementation of Path like objects are useful for various different filesystems/cloud paths. Unifying them around PathLib ABC 