### PR TITLE
Fix document regarding GQA (`--group-query-attention`) argument

### DIFF
--- a/docs/llama_mistral.md
+++ b/docs/llama_mistral.md
@@ -293,7 +293,8 @@ If loading for either inference or finetuning, use the following arguments for L
 --attention-softmax-in-fp32 \
 --disable-bias-linear \
 --transformer-impl transformer_engine \
---group-query-attention 8 \
+--group-query-attention \
+--num-query-groups 8 \
 --attention-dropout 0.0 \
 --hidden-dropout 0.0 \
 --rotary-base 500000 \


### PR DESCRIPTION
Fix argument in [llama_mistral document](https://github.com/NVIDIA/Megatron-LM/blob/main/docs/llama_mistral.md#launch-model-1)

path: `docs/llama_mistral.md`

```bash
  --attention-softmax-in-fp32 \
  --disable-bias-linear \
  --transformer-impl transformer_engine \
- --group-query-attention 8 \
+ --group-query-attention \
+ --num-query-groups 8 \
  --attention-dropout 0.0 \
  --hidden-dropout 0.0 \
  --rotary-base 500000 \
```

@jon-barker Could you take a look this?