### PR TITLE
fix(moe): the missing argument 'router_dtype' of _DeepepManager.__init__

### DIFF
--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -723,6 +723,7 @@ class _DeepepManager(_DispatchManager):
         capacity_factor: float = None,
         num_experts: int = None,
         num_local_experts: int = None,
+        router_dtype: str = None
     ):
         self.group = group
         self.router_topk = router_topk


### PR DESCRIPTION
This PR fix the error caused by the missing`router_dtype` argument.