### PR TITLE
[Bug Fix] fix p2p communication order error and stuck problems when pp 2 and vpp 2 with remove pad

### DIFF
--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -68,34 +68,64 @@ def _communicate_shapes(tensor_send_next, tensor_send_prev, recv_prev, recv_next
         )
     else:
         ops = []
-        if send_prev_shape_tensor is not None:
-            send_prev_op = torch.distributed.P2POp(
-                torch.distributed.isend,
-                send_prev_shape_tensor,
-                get_pipeline_model_parallel_prev_rank(),
-            )
-            ops.append(send_prev_op)
-        if recv_prev_shape_tensor is not None:
-            recv_prev_op = torch.distributed.P2POp(
-                torch.distributed.irecv,
-                recv_prev_shape_tensor,
-                get_pipeline_model_parallel_prev_rank(),
-            )
-            ops.append(recv_prev_op)
-        if send_next_shape_tensor is not None:
-            send_next_op = torch.distributed.P2POp(
-                torch.distributed.isend,
-                send_next_shape_tensor,
-                get_pipeline_model_parallel_next_rank(),
-            )
-            ops.append(send_next_op)
-        if recv_next_shape_tensor is not None:
-            recv_next_op = torch.distributed.P2POp(
-                torch.distributed.irecv,
-                recv_next_shape_tensor,
-                get_pipeline_model_parallel_next_rank(),
-            )
-            ops.append(recv_next_op)
+        if get_pipeline_model_parallel_world_size() % 2 == 0:
+            if send_prev_shape_tensor is not None:
+                send_prev_op = torch.distributed.P2POp(
+                    torch.distributed.isend,
+                    send_prev_shape_tensor,
+                    get_pipeline_model_parallel_prev_rank(),
+                )
+                ops.append(send_prev_op)
+            if recv_next_shape_tensor is not None:
+                recv_next_op = torch.distributed.P2POp(
+                    torch.distributed.irecv,
+                    recv_next_shape_tensor,
+                    get_pipeline_model_parallel_next_rank(),
+                )
+                ops.append(recv_next_op)
+            if send_next_shape_tensor is not None:
+                send_next_op = torch.distributed.P2POp(
+                    torch.distributed.isend,
+                    send_next_shape_tensor,
+                    get_pipeline_model_parallel_next_rank(),
+                )
+                ops.append(send_next_op)
+            if recv_prev_shape_tensor is not None:
+                recv_prev_op = torch.distributed.P2POp(
+                    torch.distributed.irecv,
+                    recv_prev_shape_tensor,
+                    get_pipeline_model_parallel_prev_rank(),
+                )
+                ops.append(recv_prev_op)
+        else:
+            if send_prev_shape_tensor is not None:
+                send_prev_op = torch.distributed.P2POp(
+                    torch.distributed.isend,
+                    send_prev_shape_tensor,
+                    get_pipeline_model_parallel_prev_rank(),
+                )
+                ops.append(send_prev_op)
+            if recv_prev_shape_tensor is not None:
+                recv_prev_op = torch.distributed.P2POp(
+                    torch.distributed.irecv,
+                    recv_prev_shape_tensor,
+                    get_pipeline_model_parallel_prev_rank(),
+                )
+                ops.append(recv_prev_op)
+            if send_next_shape_tensor is not None:
+                send_next_op = torch.distributed.P2POp(
+                    torch.distributed.isend,
+                    send_next_shape_tensor,
+                    get_pipeline_model_parallel_next_rank(),
+                )
+                ops.append(send_next_op)
+            if recv_next_shape_tensor is not None:
+                recv_next_op = torch.distributed.P2POp(
+                    torch.distributed.irecv,
+                    recv_next_shape_tensor,
+                    get_pipeline_model_parallel_next_rank(),
+                )
+                ops.append(recv_next_op)
         if len(ops) > 0:
             reqs = torch.distributed.batch_isend_irecv(ops)
             for req in reqs:
@@ -127,26 +157,48 @@ def _batched_p2p_ops(
     next_pipeline_rank: int,
 ):
     ops = []
-    if tensor_send_prev is not None:
-        send_prev_op = torch.distributed.P2POp(
-            torch.distributed.isend, tensor_send_prev, prev_pipeline_rank, group
-        )
-        ops.append(send_prev_op)
-    if tensor_recv_prev is not None:
-        recv_prev_op = torch.distributed.P2POp(
-            torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank, group
-        )
-        ops.append(recv_prev_op)
-    if tensor_send_next is not None:
-        send_next_op = torch.distributed.P2POp(
-            torch.distributed.isend, tensor_send_next, next_pipeline_rank, group
-        )
-        ops.append(send_next_op)
-    if tensor_recv_next is not None:
-        recv_next_op = torch.distributed.P2POp(
-            torch.distributed.irecv, tensor_recv_next, next_pipeline_rank, group
-        )
-        ops.append(recv_next_op)
+    if torch.distributed.get_world_size(group) % 2 == 0:
+        if tensor_send_prev is not None:
+            send_prev_op = torch.distributed.P2POp(
+                torch.distributed.isend, tensor_send_prev, prev_pipeline_rank, group
+            )
+            ops.append(send_prev_op)
+        if tensor_recv_next is not None:
+            recv_next_op = torch.distributed.P2POp(
+                torch.distributed.irecv, tensor_recv_next, next_pipeline_rank, group
+            )
+            ops.append(recv_next_op)
+        if tensor_send_next is not None:
+            send_next_op = torch.distributed.P2POp(
+                torch.distributed.isend, tensor_send_next, next_pipeline_rank, group
+            )
+            ops.append(send_next_op)
+        if tensor_recv_prev is not None:
+            recv_prev_op = torch.distributed.P2POp(
+                torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank, group
+            )
+            ops.append(recv_prev_op)
+    else:
+        if tensor_send_prev is not None:
+            send_prev_op = torch.distributed.P2POp(
+                torch.distributed.isend, tensor_send_prev, prev_pipeline_rank, group
+            )
+            ops.append(send_prev_op)
+        if tensor_recv_prev is not None:
+            recv_prev_op = torch.distributed.P2POp(
+                torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank, group
+            )
+            ops.append(recv_prev_op)
+        if tensor_send_next is not None:
+            send_next_op = torch.distributed.P2POp(
+                torch.distributed.isend, tensor_send_next, next_pipeline_rank, group
+            )
+            ops.append(send_next_op)
+        if tensor_recv_next is not None:
+            recv_next_op = torch.distributed.P2POp(
+                torch.distributed.irecv, tensor_recv_next, next_pipeline_rank, group
+            )
+            ops.append(recv_next_op)
     if len(ops) > 0:
         reqs = torch.distributed.batch_isend_irecv(ops)
     else:

--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -17,135 +17,6 @@ from megatron.core.parallel_state import (
 # Types
 Shape = Union[List[int], torch.Size]
 
-
-def _communicate_shapes(tensor_send_next, tensor_send_prev, recv_prev, recv_next, config):
-    """Communicate tensor shapes between stages. Used to communicate
-    tensor shapes before the actual tensor communication happens.
-    This is required when the sequence lengths across micro batches
-    are not uniform.
-
-    Args:
-        tensor_send_next: tensor to send to next rank (no tensor sent if
-                          set to None).
-        tensor_send_prev: tensor to send to prev rank (no tensor sent if
-                          set to None).
-        recv_prev: boolean for whether tensor should be received from
-                   previous rank.
-        recv_next: boolean for whether tensor should be received from
-                   next rank.
-    Returns:
-        (recv_prev_shape, recv_next_shape)
-    """
-
-    recv_prev_shape_tensor = None
-    recv_next_shape_tensor = None
-    send_prev_shape_tensor = None
-    send_next_shape_tensor = None
-    if recv_prev:
-        recv_prev_shape_tensor = torch.empty(
-            (3), device=torch.cuda.current_device(), dtype=torch.int64
-        )
-    if recv_next:
-        recv_next_shape_tensor = torch.empty(
-            (3), device=torch.cuda.current_device(), dtype=torch.int64
-        )
-    if tensor_send_prev is not None:
-        send_prev_shape_tensor = torch.tensor(
-            tensor_send_prev.size(), device=torch.cuda.current_device(), dtype=torch.int64
-        )
-    if tensor_send_next is not None:
-        send_next_shape_tensor = torch.tensor(
-            tensor_send_next.size(), device=torch.cuda.current_device(), dtype=torch.int64
-        )
-
-    if config.use_ring_exchange_p2p:
-        torch.distributed.ring_exchange(
-            tensor_send_prev=send_prev_shape_tensor,
-            tensor_recv_prev=recv_prev_shape_tensor,
-            tensor_send_next=send_next_shape_tensor,
-            tensor_recv_next=recv_next_shape_tensor,
-            group=get_pipeline_model_parallel_group(),
-        )
-    else:
-        ops = []
-        if get_pipeline_model_parallel_world_size() % 2 == 0:
-            if send_prev_shape_tensor is not None:
-                send_prev_op = torch.distributed.P2POp(
-                    torch.distributed.isend,
-                    send_prev_shape_tensor,
-                    get_pipeline_model_parallel_prev_rank(),
-                )
-                ops.append(send_prev_op)
-            if recv_next_shape_tensor is not None:
-                recv_next_op = torch.distributed.P2POp(
-                    torch.distributed.irecv,
-                    recv_next_shape_tensor,
-                    get_pipeline_model_parallel_next_rank(),
-                )
-                ops.append(recv_next_op)
-            if send_next_shape_tensor is not None:
-                send_next_op = torch.distributed.P2POp(
-                    torch.distributed.isend,
-                    send_next_shape_tensor,
-                    get_pipeline_model_parallel_next_rank(),
-                )
-                ops.append(send_next_op)
-            if recv_prev_shape_tensor is not None:
-                recv_prev_op = torch.distributed.P2POp(
-                    torch.distributed.irecv,
-                    recv_prev_shape_tensor,
-                    get_pipeline_model_parallel_prev_rank(),
-                )
-                ops.append(recv_prev_op)
-        else:
-            if send_prev_shape_tensor is not None:
-                send_prev_op = torch.distributed.P2POp(
-                    torch.distributed.isend,
-                    send_prev_shape_tensor,
-                    get_pipeline_model_parallel_prev_rank(),
-                )
-                ops.append(send_prev_op)
-            if recv_prev_shape_tensor is not None:
-                recv_prev_op = torch.distributed.P2POp(
-                    torch.distributed.irecv,
-                    recv_prev_shape_tensor,
-                    get_pipeline_model_parallel_prev_rank(),
-                )
-                ops.append(recv_prev_op)
-            if send_next_shape_tensor is not None:
-                send_next_op = torch.distributed.P2POp(
-                    torch.distributed.isend,
-                    send_next_shape_tensor,
-                    get_pipeline_model_parallel_next_rank(),
-                )
-                ops.append(send_next_op)
-            if recv_next_shape_tensor is not None:
-                recv_next_op = torch.distributed.P2POp(
-                    torch.distributed.irecv,
-                    recv_next_shape_tensor,
-                    get_pipeline_model_parallel_next_rank(),
-                )
-                ops.append(recv_next_op)
-        if len(ops) > 0:
-            reqs = torch.distributed.batch_isend_irecv(ops)
-            for req in reqs:
-                req.wait()
-
-        # To protect against race condition when using batch_isend_irecv().
-        # should take this out once the bug with batch_isend_irecv is resolved.
-        torch.cuda.synchronize()
-
-    recv_prev_shape = [0, 0, 0]
-    if recv_prev_shape_tensor is not None:
-        recv_prev_shape = recv_prev_shape_tensor.tolist()
-
-    recv_next_shape = [0, 0, 0]
-    if recv_next_shape_tensor is not None:
-        recv_next_shape = recv_next_shape_tensor.tolist()
-
-    return recv_prev_shape, recv_next_shape
-
-
 def _batched_p2p_ops(
     *,
     tensor_send_prev: Optional[torch.Tensor],
@@ -277,6 +148,96 @@ def _p2p_ops(
             )
             reqs["send_prev"] = send_prev_req
     return reqs
+
+
+def _communicate_shapes(tensor_send_next, tensor_send_prev, recv_prev, recv_next, config):
+    """Communicate tensor shapes between stages. Used to communicate
+    tensor shapes before the actual tensor communication happens.
+    This is required when the sequence lengths across micro batches
+    are not uniform.
+
+    Args:
+        tensor_send_next: tensor to send to next rank (no tensor sent if
+                          set to None).
+        tensor_send_prev: tensor to send to prev rank (no tensor sent if
+                          set to None).
+        recv_prev: boolean for whether tensor should be received from
+                   previous rank.
+        recv_next: boolean for whether tensor should be received from
+                   next rank.
+    Returns:
+        (recv_prev_shape, recv_next_shape)
+    """
+
+    recv_prev_shape_tensor = None
+    recv_next_shape_tensor = None
+    send_prev_shape_tensor = None
+    send_next_shape_tensor = None
+    if recv_prev:
+        recv_prev_shape_tensor = torch.empty(
+            (3), device=torch.cuda.current_device(), dtype=torch.int64
+        )
+    if recv_next:
+        recv_next_shape_tensor = torch.empty(
+            (3), device=torch.cuda.current_device(), dtype=torch.int64
+        )
+    if tensor_send_prev is not None:
+        send_prev_shape_tensor = torch.tensor(
+            tensor_send_prev.size(), device=torch.cuda.current_device(), dtype=torch.int64
+        )
+    if tensor_send_next is not None:
+        send_next_shape_tensor = torch.tensor(
+            tensor_send_next.size(), device=torch.cuda.current_device(), dtype=torch.int64
+        )
+
+    if config.use_ring_exchange_p2p:
+        torch.distributed.ring_exchange(
+            tensor_send_prev=send_prev_shape_tensor,
+            tensor_recv_prev=recv_prev_shape_tensor,
+            tensor_send_next=send_next_shape_tensor,
+            tensor_recv_next=recv_next_shape_tensor,
+            group=get_pipeline_model_parallel_group(),
+        )
+    elif config.batch_p2p_comm:
+        reqs = _batched_p2p_ops(
+            tensor_send_prev=send_prev_shape_tensor,
+            tensor_recv_prev=recv_prev_shape_tensor,
+            tensor_send_next=send_next_shape_tensor,
+            tensor_recv_next=recv_next_shape_tensor,
+            group=get_pipeline_model_parallel_group(),
+            prev_pipeline_rank=get_pipeline_model_parallel_prev_rank(),
+            next_pipeline_rank=get_pipeline_model_parallel_next_rank(),
+        )
+        if len(reqs) > 0:
+            for req in reqs:
+                req.wait()
+    else:
+        reqs = _p2p_ops(
+            tensor_send_prev=send_prev_shape_tensor,
+            tensor_recv_prev=recv_prev_shape_tensor,
+            tensor_send_next=send_next_shape_tensor,
+            tensor_recv_next=recv_next_shape_tensor,
+            group=get_pipeline_model_parallel_group(),
+            prev_pipeline_rank=get_pipeline_model_parallel_prev_rank(),
+            next_pipeline_rank=get_pipeline_model_parallel_next_rank(),
+        )
+        if len(reqs) > 0:
+            for req in reqs.values():
+                req.wait()
+
+        # To protect against race condition when using batch_isend_irecv().
+        # should take this out once the bug with batch_isend_irecv is resolved.
+        torch.cuda.synchronize()
+
+    recv_prev_shape = [0, 0, 0]
+    if recv_prev_shape_tensor is not None:
+        recv_prev_shape = recv_prev_shape_tensor.tolist()
+
+    recv_next_shape = [0, 0, 0]
+    if recv_next_shape_tensor is not None:
+        recv_next_shape = recv_next_shape_tensor.tolist()
+
+    return recv_prev_shape, recv_next_shape
 
 
 def _communicate(

--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -17,6 +17,98 @@ from megatron.core.parallel_state import (
 # Types
 Shape = Union[List[int], torch.Size]
 
+
+
+def _communicate_shapes(tensor_send_next, tensor_send_prev, recv_prev, recv_next, config):
+    """Communicate tensor shapes between stages. Used to communicate
+    tensor shapes before the actual tensor communication happens.
+    This is required when the sequence lengths across micro batches
+    are not uniform.
+
+    Args:
+        tensor_send_next: tensor to send to next rank (no tensor sent if
+                          set to None).
+        tensor_send_prev: tensor to send to prev rank (no tensor sent if
+                          set to None).
+        recv_prev: boolean for whether tensor should be received from
+                   previous rank.
+        recv_next: boolean for whether tensor should be received from
+                   next rank.
+    Returns:
+        (recv_prev_shape, recv_next_shape)
+    """
+
+    recv_prev_shape_tensor = None
+    recv_next_shape_tensor = None
+    send_prev_shape_tensor = None
+    send_next_shape_tensor = None
+    if recv_prev:
+        recv_prev_shape_tensor = torch.empty(
+            (3), device=torch.cuda.current_device(), dtype=torch.int64
+        )
+    if recv_next:
+        recv_next_shape_tensor = torch.empty(
+            (3), device=torch.cuda.current_device(), dtype=torch.int64
+        )
+    if tensor_send_prev is not None:
+        send_prev_shape_tensor = torch.tensor(
+            tensor_send_prev.size(), device=torch.cuda.current_device(), dtype=torch.int64
+        )
+    if tensor_send_next is not None:
+        send_next_shape_tensor = torch.tensor(
+            tensor_send_next.size(), device=torch.cuda.current_device(), dtype=torch.int64
+        )
+
+
+    if config.use_ring_exchange_p2p:
+
+        def _ring_exchange_wrapper(**kwargs):
+            torch.distributed.ring_exchange(**kwargs)
+            return []
+
+        p2p_func = _ring_exchange_wrapper
+    elif config.batch_p2p_comm:
+        p2p_func = _batched_p2p_ops
+    else:
+        p2p_func = _p2p_ops
+        
+    if config.use_ring_exchange_p2p:
+        torch.distributed.ring_exchange(
+            tensor_send_prev=send_prev_shape_tensor,
+            tensor_recv_prev=recv_prev_shape_tensor,
+            tensor_send_next=send_next_shape_tensor,
+            tensor_recv_next=recv_next_shape_tensor,
+            group=get_pipeline_model_parallel_group(),
+        )
+    else:
+        reqs = p2p_func(
+            tensor_send_prev=send_prev_shape_tensor,
+            tensor_recv_prev=recv_prev_shape_tensor,
+            tensor_send_next=send_next_shape_tensor,
+            tensor_recv_next=recv_next_shape_tensor,
+            group=get_pipeline_model_parallel_group(),
+            prev_pipeline_rank=get_pipeline_model_parallel_prev_rank(),
+            next_pipeline_rank=get_pipeline_model_parallel_next_rank(),
+        )
+        if len(reqs) > 0:
+            for req in reqs:
+                req.wait()
+
+        # To protect against race condition when using batch_isend_irecv().
+        # should take this out once the bug with batch_isend_irecv is resolved.
+        torch.cuda.synchronize()
+
+    recv_prev_shape = [0, 0, 0]
+    if recv_prev_shape_tensor is not None:
+        recv_prev_shape = recv_prev_shape_tensor.tolist()
+
+    recv_next_shape = [0, 0, 0]
+    if recv_next_shape_tensor is not None:
+        recv_next_shape = recv_next_shape_tensor.tolist()
+
+    return recv_prev_shape, recv_next_shape
+
+
 def _batched_p2p_ops(
     *,
     tensor_send_prev: Optional[torch.Tensor],
@@ -148,96 +240,6 @@ def _p2p_ops(
             )
             reqs["send_prev"] = send_prev_req
     return reqs
-
-
-def _communicate_shapes(tensor_send_next, tensor_send_prev, recv_prev, recv_next, config):
-    """Communicate tensor shapes between stages. Used to communicate
-    tensor shapes before the actual tensor communication happens.
-    This is required when the sequence lengths across micro batches
-    are not uniform.
-
-    Args:
-        tensor_send_next: tensor to send to next rank (no tensor sent if
-                          set to None).
-        tensor_send_prev: tensor to send to prev rank (no tensor sent if
-                          set to None).
-        recv_prev: boolean for whether tensor should be received from
-                   previous rank.
-        recv_next: boolean for whether tensor should be received from
-                   next rank.
-    Returns:
-        (recv_prev_shape, recv_next_shape)
-    """
-
-    recv_prev_shape_tensor = None
-    recv_next_shape_tensor = None
-    send_prev_shape_tensor = None
-    send_next_shape_tensor = None
-    if recv_prev:
-        recv_prev_shape_tensor = torch.empty(
-            (3), device=torch.cuda.current_device(), dtype=torch.int64
-        )
-    if recv_next:
-        recv_next_shape_tensor = torch.empty(
-            (3), device=torch.cuda.current_device(), dtype=torch.int64
-        )
-    if tensor_send_prev is not None:
-        send_prev_shape_tensor = torch.tensor(
-            tensor_send_prev.size(), device=torch.cuda.current_device(), dtype=torch.int64
-        )
-    if tensor_send_next is not None:
-        send_next_shape_tensor = torch.tensor(
-            tensor_send_next.size(), device=torch.cuda.current_device(), dtype=torch.int64
-        )
-
-
-    if config.use_ring_exchange_p2p:
-
-        def _ring_exchange_wrapper(**kwargs):
-            torch.distributed.ring_exchange(**kwargs)
-            return []
-
-        p2p_func = _ring_exchange_wrapper
-    elif config.batch_p2p_comm:
-        p2p_func = _batched_p2p_ops
-    else:
-        p2p_func = _p2p_ops
-        
-    if config.use_ring_exchange_p2p:
-        torch.distributed.ring_exchange(
-            tensor_send_prev=send_prev_shape_tensor,
-            tensor_recv_prev=recv_prev_shape_tensor,
-            tensor_send_next=send_next_shape_tensor,
-            tensor_recv_next=recv_next_shape_tensor,
-            group=get_pipeline_model_parallel_group(),
-        )
-    else:
-        reqs = p2p_func(
-            tensor_send_prev=send_prev_shape_tensor,
-            tensor_recv_prev=recv_prev_shape_tensor,
-            tensor_send_next=send_next_shape_tensor,
-            tensor_recv_next=recv_next_shape_tensor,
-            group=get_pipeline_model_parallel_group(),
-            prev_pipeline_rank=get_pipeline_model_parallel_prev_rank(),
-            next_pipeline_rank=get_pipeline_model_parallel_next_rank(),
-        )
-        if len(reqs) > 0:
-            for req in reqs:
-                req.wait()
-
-        # To protect against race condition when using batch_isend_irecv().
-        # should take this out once the bug with batch_isend_irecv is resolved.
-        torch.cuda.synchronize()
-
-    recv_prev_shape = [0, 0, 0]
-    if recv_prev_shape_tensor is not None:
-        recv_prev_shape = recv_prev_shape_tensor.tolist()
-
-    recv_next_shape = [0, 0, 0]
-    if recv_next_shape_tensor is not None:
-        recv_next_shape = recv_next_shape_tensor.tolist()
-
-    return recv_prev_shape, recv_next_shape
 
 
 def _communicate(


### PR DESCRIPTION
Bug issue connects to #1450 , re-open #1451 PR

# Environent and Configuration

When use `PP=2` and `VPP=2` with `config.variable_seq_lengths=True`, `config.batch_p2p_comm=True` and `config.overlap_p2p_comm=False`, current implementation of p2p_communication.py will cause incorrect behavior.

If we set `config.overlap_p2p_comm=True` and `config.batch_p2p_comm=False`, bug disappear.

# Bug 1: Communication Misorder

## Description and Analysis

Like this image below:

![vpp](https://github.com/user-attachments/assets/5150685a-a7e9-4632-a8ca-49ad82490fad)

After 2 devices finish at the dashed time, Device 1 should pass `output_tensor` and `input_tensor_grad` to Device 2, and because world size is 2, both devices have the same `next_rank` and `prev_rank`, the original ring communication becomes intercommunication, thus cause conflicts in p2p_communication. In detail, Device 1 passes `output_tensor` to `next_rank` and `input_tensor_grad` to `prev_rank`, and Device 2 receives `output_tensor_grad` from `next_rank` and `input_tensor` from `prev_rank`.

if we use the original implementation of `_communicate_shapes`:

```py
if send_prev_shape_tensor is not None:
    send_prev_op = torch.distributed.P2POp(
        torch.distributed.isend,
        send_prev_shape_tensor,
        get_pipeline_model_parallel_prev_rank(),
    )
    ops.append(send_prev_op)
if recv_prev_shape_tensor is not None:
    recv_prev_op = torch.distributed.P2POp(
        torch.distributed.irecv,
        recv_prev_shape_tensor,
        get_pipeline_model_parallel_prev_rank(),
    )
    ops.append(recv_prev_op)
if send_next_shape_tensor is not None:
    send_next_op = torch.distributed.P2POp(
        torch.distributed.isend,
        send_next_shape_tensor,
        get_pipeline_model_parallel_next_rank(),
    )
    ops.append(send_next_op)
if recv_next_shape_tensor is not None:
    recv_next_op = torch.distributed.P2POp(
        torch.distributed.irecv,
        recv_next_shape_tensor,
        get_pipeline_model_parallel_next_rank(),
    )
    ops.append(recv_next_op)
```

If we assume that the send-and-send, or recv-and-recv operation are in order when using `torch.distributed.batch_isend_irecv` with the same destination rank, Device 0 will send `input_tensor_grad.shape` to first Device 1, then send `output_tensor.shape` to 1. Meanwhile Device 1 receives `input_tensor.shape` first from Device 0, then `output_tensor_grad.shape` from 0. That is to say,

```py
input_tensor_gpu1 = input_tensor_grad_gpu0
output_tensor_grad_gpu1 = output_tensor_gpu0
```

This cause backward tensor shape mismatch: `Mismatch in shape: grad_output[0] has a shape of torch.Size([3131, 1, 3584]) and output[0] has a shape of torch.Size([3204, 1, 3584])`

Here is more log:

```txt
# Device 0
send_prev_shape_tensor: torch.Tensor([1673, 1, 3840], device='cuda:0'), send_next_shape_tensor: torch.Tensor([1702, 1, 3840], device='cuda:0')
recv_prev_shape_tensor: torch.Tensor([], device='cuda:0'), recv_next_shape_tensor: torch.Tensor([1664, 1, 3840], device='cuda:0')

# Device 1
send_prev_shape_tensor: torch.Tensor([1664, 1, 3840], device='cuda:0'), send_next_shape_tensor: torch.Tensor([1653, 1, 3840], device='cuda:0')
recv_prev_shape_tensor: torch.Tensor([1673, 1, 3840], device='cuda:0'), recv_next_shape_tensor: torch.Tensor([1702, 1, 3840], device='cuda:0') # Reverse Error
```

## Solution

We notice that the `_p2p_op` has the logic for cases where `world size % 2 == 0`, so we use this for shape communication. The solution is change order of recv tensors: `send_prev`, `recv_next`, `send_next`, `recv_prev`

# Bug 2: P2P hangs

After we fix Bug 1, because we use `config.batch_p2p_comm=True`, so `_batched_p2p_ops` is called and hangs. No clear reason about why it hangs, but if we refactor its logic like above, we successfully fix this.

# Refactor

We can reuse `_batch_p2p_ops` and `_p2p_ops` here to support `communicate_shapes`, codes are more clean.

This solution is just a proposal.