### PR TITLE
fix: MultiLatentAttention cp_comm_type

### DIFF
--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -235,6 +235,7 @@ class MLASelfAttention(MultiLatentAttention):
             layer_number=layer_number,
             attn_mask_type=attn_mask_type,
             attention_type="self",
+            cp_comm_type=cp_comm_type,
         )
 
         if self.config.q_lora_rank is None:


### PR DESCRIPTION
The MultiLatentAttention class does not correctly pass the cp_comm_type variable.