### PR TITLE
fix for group_limited_topk: K_r is moe_router_topk instead of moe_router_num_groups

### DIFF
--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -415,10 +415,10 @@ def group_limited_topk(
         Tuple[torch.Tensor, torch.Tensor]: Probs and indices tensor.
     """
     # Organize the experts into groups
-    # Select groups based on sum of top-(num_groups/group_topk) routing scores within each group
+    # Select groups based on sum of top-(topk/group_topk) routing scores within each group
     group_scores = (
         scores.view(num_tokens, num_groups, -1)
-        .topk(num_groups // group_topk, dim=-1)[0]
+        .topk(topk // group_topk, dim=-1)[0]
         .sum(dim=-1)
     )
     group_idx = torch.topk(group_scores, k=group_topk, dim=-1, sorted=False)[1]

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -325,7 +325,7 @@ class TransformerConfig(ModelParallelConfig):
     When using group-limited routing:
     1. Experts are divided into 'moe_router_num_groups' equal-sized groups
     2. For each token, 'moe_router_group_topk' groups are selected based on sum of
-    top-('moe_router_num_groups'/'moe_router_group_topk') routing scores within each group
+    top-('moe_router_topk'/'moe_router_group_topk') routing scores within each group
     3. From these selected groups, 'moe_router_topk' individual experts are chosen
     Two common use cases:
     - Device-limited routing: Set 'moe_router_num_groups' equal to expert parallel size (EP)


### PR DESCRIPTION
fix for group_limited_topk: K_r is moe_router_topk instead of moe_router_num_groups

discussed in issue: https://github.com/NVIDIA/Megatron-LM/issues/1441
related commit: https://github.com/NVIDIA/Megatron-LM/commit/e85385a761e09f1f08ea309c6b6858bf1961a56f