### PR TITLE
Updating the logic for reducing the load_balancing_loss during logging, such that the correct value is logged while using CUDA Graphs

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -247,7 +247,6 @@ class TopKRouter(Router):
             aux_loss / moe_aux_loss_coeff,
             self.layer_number,
             self.config.num_layers,
-            reduce_group=sequence_partition_group,
         )
         activation = MoEAuxLossAutoScaler.apply(activation, aux_loss)
         return activation

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1037,7 +1037,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_r
             )
     if args.num_experts is not None:
         moe_loss_scale = 1 / get_num_microbatches()
-        track_moe_metrics(moe_loss_scale, iteration, writer, wandb_writer, total_loss_dict, args.moe_per_layer_logging)
+        track_moe_metrics(moe_loss_scale, iteration, writer, wandb_writer, total_loss_dict, args.moe_per_layer_logging, args.moe_token_dispatcher_type)
 
     if iteration % args.log_interval == 0:
         elapsed_time = timers('interval-time').elapsed(barrier=True)


### PR DESCRIPTION
The CUDA graphs can only register tensor operations. As such, caching the PG during graph capture doesn't work when we want to reduce the values later on. This CR fixes that. 