### PR TITLE
provide the alternative to the data preprocessing using pyspark acceleration

### DIFF
--- a/tests/unit_tests/data/test_preprocess_data_spark.py
+++ b/tests/unit_tests/data/test_preprocess_data_spark.py
@@ -15,8 +15,6 @@ from megatron.training.tokenizer.gpt2_tokenization import (
     PRETRAINED_MERGES_ARCHIVE_MAP,
     PRETRAINED_VOCAB_ARCHIVE_MAP,
 )
-import tools
-print(f"Module file path: {tools.__file__}")
 
 from tools.merge_datasets import main as merge_main
 from tools.preprocess_data_spark import Encoder

--- a/tests/unit_tests/data/test_preprocess_data_spark.py
+++ b/tests/unit_tests/data/test_preprocess_data_spark.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+
+import json
+import os
+import sys
+import tempfile
+import time
+
+import nltk
+import pytest
+import requests
+
+from megatron.core.datasets.indexed_dataset import IndexedDataset
+from megatron.training.tokenizer.gpt2_tokenization import (
+    PRETRAINED_MERGES_ARCHIVE_MAP,
+    PRETRAINED_VOCAB_ARCHIVE_MAP,
+)
+from tools.merge_datasets import main as merge_main
+from tools.preprocess_data import Encoder
+from tools.preprocess_data import get_args as build_args
+from tools.preprocess_data import main as build_main
+
+__HUGGINGFACE_BERT_BASE_UNCASED_VOCAB = (
+    "https://huggingface.co/bert-base-uncased/raw/main/vocab.txt"
+)
+
+__LOCAL_BERT_VOCAB = "/home/gitlab-runner/data/bert_data/vocab.txt"
+
+__LOCAL_GPT2_MERGE = "/home/gitlab-runner/data/gpt3_data/gpt2-merges.txt"
+
+__LOCAL_GPT2_VOCAB = "/home/gitlab-runner/data/gpt3_data/gpt2-vocab.json"
+
+
+# def dummy_jsonl(odir):
+#     # numbers
+#     list_numbers = [json.dumps({"text": str(i + 1)}) + "\n" for i in range(100)]
+#     with open(os.path.join(odir, "numbers.jsonl"), "w") as writer:
+#         writer.writelines(list_numbers)
+#     # numbers ascending
+#     list_numbers_ascending = [
+#         json.dumps({"text": " ".join([str(j + 1) for j in range(i + 1)])}) + "\n"
+#         for i in range(100)
+#     ]
+#     with open(os.path.join(odir, "numbers_ascending.jsonl"), "w") as writer:
+#         writer.writelines(list_numbers_ascending)
+#     # test
+#     list_test = []
+#     with open(__file__) as reader:
+#         for line in reader:
+#             list_test.append(json.dumps({"text": line}) + "\n")
+#     with open(os.path.join(odir, "test.jsonl"), "w") as writer:
+#         writer.writelines(list_test)
+
+NUM_SAMPLES = 100000
+SEQ_LEN = 8192
+
+def dummy_long_jsonl(odir):
+    """
+    Creates a jsonl file with NUM_SAMPLES rows, each row containing a sequence of '1' characters
+    with length SEQ_LEN.
+    
+    Args:
+        odir: Output directory where the jsonl file will be saved
+        seq_len: Length of the sequence of '1' characters in each row
+    """
+    # Create a sequence of '1' characters with length SEQ_LEN
+    sequence = '1' * SEQ_LEN
+    
+    # Generate NUM_SAMPLES rows, each containing the sequence
+    list_sequences = [json.dumps({"text": sequence}) + "\n" for _ in range(NUM_SAMPLES)]
+    
+    # Write the rows to a jsonl file
+    with open(os.path.join(odir, "sequences.jsonl"), "w") as writer:
+        writer.writelines(list_sequences)
+
+
+
+def build_datasets(idir, odir, extra_args=[]):
+    for name in os.listdir(idir):
+        sys.argv = [
+            sys.argv[0],
+            "--input",
+            os.path.join(idir, name),
+            "--output-prefix",
+            os.path.join(odir, os.path.splitext(name)[0]),
+        ] + extra_args
+        build_main()
+
+
+def merge_datasets(idir):
+    sys.argv = [sys.argv[0], "--input", idir, "--output-prefix", os.path.join(idir, "merge")]
+    merge_main()
+
+
+def do_test_preprocess_data(temp_dir, extra_args=[]):
+    # set the default nltk data path
+    os.environ["NLTK_DATA"] = os.path.join(temp_dir, "nltk_data")
+    nltk.data.path.append(os.environ["NLTK_DATA"])
+
+    path_to_raws = os.path.join(temp_dir, "sample_raws")
+    path_to_data = os.path.join(temp_dir, "sample_data")
+    os.mkdir(path_to_raws)
+    os.mkdir(path_to_data)
+
+    # create the dummy resources
+    start_time = time.time()
+    # dummy_jsonl(path_to_raws)
+    dummy_long_jsonl(path_to_raws)
+    create_time = time.time() - start_time
+    print(f"{time.strftime('%H:%M:%S', time.localtime())}  Test - Dataset creation completed in {create_time:.2f} seconds")
+
+    # build the datasets
+    start_time = time.time()
+    build_datasets(path_to_raws, path_to_data, extra_args=extra_args)
+    build_time = time.time() - start_time
+    print(f"{time.strftime('%H:%M:%S', time.localtime())}  Test - Dataset building completed in {build_time:.2f} seconds")
+
+    # merge the datasets
+    start_time = time.time()
+    merge_datasets(path_to_data)
+    merge_time = time.time() - start_time
+    print(f"{time.strftime('%H:%M:%S', time.localtime())}  Test - Dataset merging completed in {merge_time:.2f} seconds")
+
+    sys.argv = [sys.argv[0], "--input", None, "--output-prefix", None] + extra_args
+    encoder = Encoder(build_args())
+    encoder.initializer()
+
+    def tokens_to_string(toks):
+        for option in ["decode", "detokenize"]:
+            try:
+                return getattr(encoder.tokenizer, option)(toks)
+            except:
+                continue
+        raise RuntimeError(f"{type(encoder.tokenizer)} tokenizer cannot decode or detokenize")
+
+    merged_index = 0
+    merged_dataset = IndexedDataset(os.path.join(path_to_data, "merge"))
+
+    # sorted to ensure ordering matches merged dataset
+    basenames = sorted(
+        [
+            name
+            for name in os.listdir(path_to_data)
+            if name.endswith(".idx") and not name.startswith("merge")
+        ]
+    )
+
+    # index into the merged document index
+    merged_doc_index_index = 0
+
+    for basename in basenames:
+        realpath_raw = f"{os.path.join(path_to_raws, '_'.join(basename.split('_')[:-2]))}.jsonl"
+        realpath_doc = os.path.join(path_to_data, basename.split(".")[-2])
+
+        dataset_index = 0
+        dataset = IndexedDataset(realpath_doc)
+
+        merged_doc_idx = merged_dataset.document_indices[
+            merged_doc_index_index : merged_doc_index_index + len(dataset.document_indices)
+        ]
+        merged_doc_idx = merged_doc_idx - merged_doc_idx[0]
+
+        assert (
+            dataset.document_indices == merged_doc_idx
+        ).all(), f"ERROR: {basename.split('_')[:-2]}: merged dataset document indices mismatch"
+
+        merged_doc_index_index += len(dataset.document_indices) - 1
+
+        with open(realpath_raw, "rt") as reader:
+            for json_line in reader:
+                toks = encoder.encode(json_line)[0]["text"]
+
+                raw = tokens_to_string(toks)
+
+                processed_toks = []
+                while len(processed_toks) < len(toks):
+                    processed_toks.extend(dataset[dataset_index])
+                    dataset_index += 1
+                processed = tokens_to_string(processed_toks)
+
+                assert (
+                    raw == processed
+                ), f"ERROR: {basename.split('_')[:-2]}: raw and processed documents do not match"
+
+                merged_toks = []
+                while len(merged_toks) < len(toks):
+                    merged_toks.extend(merged_dataset[merged_index])
+                    merged_index += 1
+                merged = tokens_to_string(merged_toks)
+
+                assert (
+                    raw == merged
+                ), f"ERROR: {basename.split('_')[:-2]}: raw and merged documents do not match"
+
+        print(
+            f"INFO: {''.join(basename.split('_')[:-2])}: raw, processed, and merged documents match!"
+        )
+
+    print("INFO: Success!")
+
+
+def gpt2_vocab(odir):
+    if os.path.exists(__LOCAL_GPT2_VOCAB):
+        return __LOCAL_GPT2_VOCAB
+    path = os.path.join(odir, "vocab.json")
+    with open(path, "wb") as writer:
+        writer.write(requests.get(PRETRAINED_VOCAB_ARCHIVE_MAP['gpt2']).content)
+    return path
+
+
+def gpt2_merge(odir):
+    if os.path.exists(__LOCAL_GPT2_MERGE):
+        return __LOCAL_GPT2_MERGE
+    path = os.path.join(odir, "merge.txt")
+    with open(path, "wb") as writer:
+        writer.write(requests.get(PRETRAINED_MERGES_ARCHIVE_MAP['gpt2']).content)
+    return path
+
+
+def test_preprocess_data_gpt():
+    # Set default environment variables if not already set
+    if 'WORLD_SIZE' not in os.environ:
+        os.environ['WORLD_SIZE'] = '1'
+    if 'LOCAL_RANK' not in os.environ:
+        os.environ['LOCAL_RANK'] = '0'
+        
+    test_start = time.time()
+    print(f"{time.strftime('%H:%M:%S', time.localtime())}  Test - Started")
+    
+    with tempfile.TemporaryDirectory() as temp_dir:
+
+        # gpt specific args
+        gpt_args = [
+            "--tokenizer-type",
+            "GPT2BPETokenizer",
+            "--vocab-file",
+            gpt2_vocab(temp_dir),
+            "--merge-file",
+            gpt2_merge(temp_dir),
+            "--append-eod",
+            "--workers",
+            "10",
+            "--log-interval",
+            "1", 
+        ]
+
+        do_test_preprocess_data(temp_dir, extra_args=gpt_args)
+    
+    test_end = time.time()
+    print(f"{time.strftime('%H:%M:%S', time.localtime())}  Test - Total test execution took {test_end - test_start:.2f} seconds")
+
+
+def bert_vocab(odir):
+    if os.path.exists(__LOCAL_BERT_VOCAB):
+        return __LOCAL_BERT_VOCAB
+    path = os.path.join(odir, "vocab.txt")
+    with open(path, "wb") as writer:
+        writer.write(requests.get(__HUGGINGFACE_BERT_BASE_UNCASED_VOCAB).content)
+    return path
+
+
+# @pytest.mark.flaky
+# @pytest.mark.flaky_in_dev
+# def test_preprocess_data_bert():
+#     with tempfile.TemporaryDirectory() as temp_dir:
+
+#         # bert specific args
+#         bert_args = [
+#             "--tokenizer-type",
+#             "BertWordPieceLowerCase",
+#             "--vocab-file",
+#             bert_vocab(temp_dir),
+#             "--split-sentences",
+#             "--workers",
+#             "10",
+#             "--log-interval",
+#             "1",
+#             "--partitions",
+#             "2",
+#             "--keep-sequential-samples",
+#         ]
+
+#         do_test_preprocess_data(temp_dir, extra_args=bert_args)
+
+
+if __name__ == "__main__":
+    test_preprocess_data_gpt()
+    # test_preprocess_data_bert()

--- a/tools/preprocess_data_spark.py
+++ b/tools/preprocess_data_spark.py
@@ -267,6 +267,25 @@ class Partition(object):
             builder.finalize(output_idx_file)
         
         print(f"{time.strftime('%H:%M:%S', time.localtime())} IN - Merging partitions completed.")
+        
+        # ---------------------------
+        # Phase 3: Clean up intermediate files
+        # ---------------------------
+        cleanup_start = time.time()
+        deleted_count = 0
+        
+        # Delete all partition .idx files
+        for idx_file in glob.glob(f"{output_prefix}_*_{level}_*.idx"):
+            os.remove(idx_file)
+            deleted_count += 1
+            
+        # Delete all partition .bin files 
+        for bin_file in glob.glob(f"{output_prefix}_*_{level}_*.bin"):
+            os.remove(bin_file)
+            deleted_count += 1
+        
+        cleanup_end = time.time()
+        print(f"{time.strftime('%H:%M:%S', time.localtime())} IN - Deleted {deleted_count} intermediate files in {cleanup_end - cleanup_start:.2f} seconds")
 
 def get_args():
     parser = argparse.ArgumentParser()

--- a/tools/preprocess_data_spark.py
+++ b/tools/preprocess_data_spark.py
@@ -1,0 +1,447 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+
+"""Processing large data for pretraining."""
+import argparse
+import math
+import json
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             os.path.pardir)))
+import time
+import gzip
+import glob
+import torch
+import numpy as np
+import multiprocessing
+
+# Force 'spawn' method for all multiprocessing
+try:
+    multiprocessing.set_start_method('spawn')
+    print(f"{time.strftime('%H:%M:%S', time.localtime())} Process - Using 'spawn' multiprocessing start method")
+except RuntimeError:
+    print(f"{time.strftime('%H:%M:%S', time.localtime())} Process - Multiprocessing start method already set to: {multiprocessing.get_start_method()}")
+
+import functools
+try:
+    import nltk
+    from nltk.tokenize.punkt import PunktLanguageVars
+    nltk_available = True
+except ImportError:
+    PunktLanguageVars = object  # Fallback to the built-in object class
+    nltk_available = False
+
+from megatron.training.tokenizer import build_tokenizer
+from megatron.training.arguments import _add_tokenizer_args
+from megatron.core.datasets import indexed_dataset
+
+
+def timing_decorator(func):
+    """Decorator to measure and print the execution time of a function."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        start_time = time.time()
+        result = func(*args, **kwargs)
+        elapsed = time.time() - start_time
+        print(f"{time.strftime('%H:%M:%S', time.localtime())} Process - {func.__name__} took {elapsed:.2f} seconds")
+        return result
+    return wrapper
+
+# https://stackoverflow.com/questions/33139531/preserve-empty-lines-with-nltks-punkt-tokenizer
+class CustomLanguageVars(PunktLanguageVars):
+
+    _period_context_fmt = r"""
+        \S*                          # some word material
+        %(SentEndChars)s             # a potential sentence ending
+        \s*                       #  <-- THIS is what I changed
+        (?=(?P<after_tok>
+            %(NonWord)s              # either other punctuation
+            |
+            (?P<next_tok>\S+)     #  <-- Normally you would have \s+ here
+        ))"""
+
+class IdentitySplitter(object):
+    def tokenize(self, *text):
+        return text
+
+
+class Encoder(object):
+    def __init__(self, args):
+        self.args = args
+
+    def initializer(self):
+        # Use Encoder class as a container for global data
+        Encoder.tokenizer = build_tokenizer(self.args)
+        if self.args.split_sentences:
+            if not nltk_available:
+                print("NLTK is not available to split sentences.")
+                exit()
+            if os.environ.get("NLTK_DATA"):
+                library = os.path.join(os.environ.get("NLTK_DATA"), "tokenizers", "punkt", f"{self.args.lang}.pickle")
+                url = f"file:{library}"
+            else:
+                library = os.path.join("tokenizers", "punkt", f"{self.args.lang}.pickle")
+                url = f"nltk:{library}"
+            splitter = nltk.load(url)
+            if self.args.keep_newlines:
+                # this prevents punkt from eating newlines after sentences
+                Encoder.splitter = nltk.tokenize.punkt.PunktSentenceTokenizer(
+                    train_text = splitter._params,
+                    lang_vars = CustomLanguageVars())
+            else:
+                Encoder.splitter = splitter
+
+        else:
+            Encoder.splitter = IdentitySplitter()
+
+    def split(self, json_line):
+        data = json.loads(json_line)
+        output = {}
+        for key in self.args.json_keys:
+            text = data[key]
+            max_len = 1000000
+            tokens_list = [Encoder.splitter.tokenize(text[i:i+max_len]) for i in range(0, len(text), max_len)]
+            output[key] = [tokens for partial in tokens_list for tokens in partial]
+        return json.dumps(output), len(json_line)
+
+    def encode(self, json_line):
+        data = json.loads(json_line)
+        ids = {}
+        lens = {}
+        for key in self.args.json_keys:
+            text = data[key]
+            if isinstance(text, list):
+                sentences = text
+            else:
+                sentences = [text]
+            doc_ids = []
+            sentence_lens = []
+            for sentence in sentences:
+                sentence_ids = Encoder.tokenizer.tokenize(sentence)
+                if len(sentence_ids) > 0:
+                    doc_ids.extend(sentence_ids)
+                    sentence_lens.append(len(sentence_ids))
+            if len(doc_ids) > 0 and self.args.append_eod:
+                doc_ids.append(Encoder.tokenizer.eod)
+                sentence_lens[-1] += 1
+            ids[key] = doc_ids
+            lens[key] = sentence_lens
+        return ids, lens, len(json_line)
+
+
+class Partition(object):
+    @timing_decorator
+    def __init__(self, args, workers):
+        self.args = args
+        self.workers = workers
+
+    def print_processing_stats(self, count, proc_start, total_bytes_processed):
+        if count % self.args.log_interval == 0:
+            current = time.time()
+            elapsed = current - proc_start
+            mbs = total_bytes_processed/elapsed/1024/1024
+            print(f"Processed {count} documents",
+                  f"({count/elapsed} docs/s, {mbs} MB/s).",
+                  file=sys.stderr)
+
+    @timing_decorator
+    def split_sentences(self, file_name):
+        input_file_name, output_file_name = file_name
+        print("Opening", input_file_name)
+        fin = open(input_file_name, 'r', encoding='utf-8')
+        fout = open(output_file_name, 'w')
+
+        encoder = Encoder(self.args)
+        pool = multiprocessing.Pool(self.workers, initializer=encoder.initializer)
+        split_docs = pool.imap(encoder.split, fin, 32)
+
+        proc_start = time.time()
+        total_bytes_processed = 0
+        for i, (doc, bytes_processed) in enumerate(split_docs, start=1):
+            total_bytes_processed += bytes_processed
+            fout.write(doc + "\n")
+            self.print_processing_stats(i, proc_start, total_bytes_processed)
+
+        fin.close()
+        fout.close()
+
+    def process_json_file(self, file_name):
+        input_file_name, output_prefix = file_name
+        print("Opening", input_file_name)
+        
+        file_open_start = time.time()
+        fin = open(input_file_name, 'r', encoding='utf-8')
+        file_open_end = time.time()
+        print(f"{time.strftime('%H:%M:%S', time.localtime())} IN - Opening file took {file_open_end - file_open_start:.2f} seconds")
+
+        startup_start = time.time()
+        encoder = Encoder(self.args)
+        tokenizer = build_tokenizer(self.args)
+        pool = multiprocessing.Pool(self.workers, initializer=encoder.initializer)
+        encoded_docs = pool.imap(encoder.encode, fin, 32)
+
+        level = "document"
+        if self.args.split_sentences:
+            level = "sentence"
+
+        output_bin_files = {}
+        output_idx_files = {}
+        builders = {}
+
+        for key in self.args.json_keys:
+            output_bin_files[key] = "{}_{}_{}.bin".format(output_prefix,
+                                                          key, level)
+            output_idx_files[key] = "{}_{}_{}.idx".format(output_prefix,
+                                                          key, level)
+            builders[key] = indexed_dataset.IndexedDatasetBuilder(
+                output_bin_files[key],
+                dtype=indexed_dataset.DType.optimal_dtype(tokenizer.vocab_size),
+            )
+
+        startup_end = time.time()
+        proc_start = time.time()
+        total_bytes_processed = 0
+        print(f"{time.strftime('%H:%M:%S', time.localtime())}  IN - startup took: {startup_end - startup_start:.2f} seconds")
+        encode_start = time.time()
+        for i, (doc, sentence_lens, bytes_processed) in enumerate(encoded_docs, start=1):
+            total_bytes_processed += bytes_processed
+            for key in doc.keys():
+                builders[key].add_document(doc[key], sentence_lens[key])
+            self.print_processing_stats(i, proc_start, total_bytes_processed)            
+
+        fin.close()
+        encode_end = time.time()
+        print(f"{time.strftime('%H:%M:%S', time.localtime())}  IN - Encoding partitions took {encode_end - encode_start:.2f} seconds")
+
+        finalize_start = time.time()
+        for key in builders:
+            builders[key].finalize(output_idx_files[key])
+        finalize_end = time.time()
+        print(f"{time.strftime('%H:%M:%S', time.localtime())}  IN - Finalizing builders took {finalize_end - finalize_start:.2f} seconds")
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser = _add_tokenizer_args(parser)
+    group = parser.add_argument_group(title='input data')
+    group.add_argument('--input', type=str, required=True,
+                       help='Path to input JSON')
+    group.add_argument('--json-keys', nargs='+', default=['text'],
+                       help='space separate listed of keys to extract from json')
+    group.add_argument('--split-sentences', action='store_true',
+                       help='Split documents into sentences.')
+    group.add_argument('--keep-newlines', action='store_true',
+                       help='Keep newlines between sentences when splitting.')
+    group = parser.add_argument_group(title='tokenization process')
+    group.add_argument('--append-eod', action='store_true',
+                       help='Append an <eod> token to the end of a document.')
+    group.add_argument('--lang', type=str, default='english',
+                       help='Language to use for NLTK-powered sentence splitting.')
+    group = parser.add_argument_group(title='output data')
+    group.add_argument('--output-prefix', type=str, required=True,
+                       help='Path to binary output file without suffix')
+    group = parser.add_argument_group(title='runtime')
+    group.add_argument('--workers', type=int, required=True,
+                       help=('Number of worker processes to launch.'
+                             'A good default for fast pre-processing '
+                             'is: (workers * partitions) = available CPU cores.'))
+    group.add_argument('--partitions', type=int, default=1,
+                        help='Number of file partitions')
+    group.add_argument('--log-interval', type=int, default=1000,
+                       help='Interval between progress updates')
+    group.add_argument('--keep-sequential-samples', action='store_true',
+                       help='Ensure ordering of samples in .jsonl files is '
+                            'preserved when using partitions>1.')
+    args = parser.parse_args()
+    args.keep_empty = False
+
+    if args.tokenizer_type.lower().startswith('bert') and not args.split_sentences:
+        print("Are you sure you don't want to split sentences?")
+
+    # some default/dummy values for the tokenizer
+    args.rank = 1
+    args.make_vocab_size_divisible_by = 128
+    args.tensor_model_parallel_size = 1
+    args.vocab_extra_ids = 0
+
+    return args
+
+
+def get_file_name(args, file_id):
+    file_name, extension = os.path.splitext(args.input)
+    input_file_name = file_name + "_" + str(file_id) + extension
+    sentence_split_file = file_name + "_ss_" + str(file_id) + extension
+    output_prefix = args.output_prefix + "_" + str(file_id)
+    file_names = {
+        'partition': input_file_name,
+        'sentence_split': sentence_split_file,
+        'output_prefix': output_prefix}
+    return file_names
+
+
+@timing_decorator
+def check_files_exist(in_ss_out_names, key, num_partitions):
+    for i in range(num_partitions):
+        if not os.path.exists(in_ss_out_names[i][key]):
+            return False
+    return True
+
+
+def main():
+    args = get_args()
+
+    if args.split_sentences:
+        if nltk_available:
+            nltk.download("punkt", quiet=True, download_dir=os.environ.get("NLTK_DATA"))
+        else:
+            raise Exception(
+                "nltk library required for sentence splitting is not available.")
+
+    in_ss_out_names = []
+
+    print(f"{time.strftime('%H:%M:%S', time.localtime())}  Sentence splitting is {'enabled' if args.split_sentences else 'disabled'}")
+    print(f"{time.strftime('%H:%M:%S', time.localtime())}  Number of partitions: {args.partitions}")
+
+    if args.partitions == 1:
+        file_name, extension = os.path.splitext(args.input)
+        sentence_split_file = file_name + "_ss" + extension
+        file_names = {
+            'partition': args.input,
+            'sentence_split': sentence_split_file,
+            'output_prefix': args.output_prefix}
+        in_ss_out_names.append(file_names)
+    else:
+        in_file_names = glob.glob(args.input)
+
+        # Count total number of lines across .jsonl files
+        if args.keep_sequential_samples:
+            total_sample_count = 0
+            for filename in in_file_names:
+                with open(filename, "r") as fin:
+                    for fc, _ in enumerate(fin):
+                        pass
+                total_sample_count += (fc + 1)
+            partition_size = math.ceil(total_sample_count / args.partitions)
+
+        # create .jsonl parition files
+        for idx in range(args.partitions):
+            in_ss_out_name = get_file_name(args, idx)
+            in_ss_out_names.append(in_ss_out_name)
+
+        # check to see if paritions were already created
+        partitions_present = check_files_exist(in_ss_out_names, 'partition', args.partitions)
+
+        # check to see if paritions with split sentences already created
+        split_sentences_present = check_files_exist(in_ss_out_names, 'sentence_split', args.partitions)
+
+        if not partitions_present and not split_sentences_present:
+            # populate .jsonl partition files from parent files
+            partitioned_input_files = []
+            for idx in range(args.partitions):
+                partitioned_input_file = open(in_ss_out_names[idx]['partition'], 'w')
+                partitioned_input_files.append(partitioned_input_file)
+
+            index = 0
+            if args.keep_sequential_samples: line_count = 0
+            for in_file_name in in_file_names:
+                # support for gzip files
+                if in_file_name.endswith(".gz"):
+                    fin = gzip.open(in_file_name, 'rt')
+                else:
+                    fin = open(in_file_name, 'r', encoding='utf-8')
+
+                for line in fin:
+                    partitioned_input_files[index].write(line)
+                    if args.keep_sequential_samples:
+                        line_count += 1
+                        if line_count % partition_size == 0:
+                            index += 1
+                    else:
+                        index = (index + 1)%args.partitions
+
+                fin.close()
+
+            for idx in range(args.partitions):
+                partitioned_input_files[idx].close()
+
+    assert args.workers % args.partitions == 0
+    partition = Partition(args, args.workers//args.partitions)
+
+    # check to see if paritions with split sentences already created
+    split_sentences_present = check_files_exist(in_ss_out_names, 'sentence_split', args.partitions)
+
+    # split sentences in partition files
+    if args.split_sentences and not split_sentences_present:
+        processes = []
+        for name in in_ss_out_names:
+            p = multiprocessing.Process(target=partition.split_sentences,
+                                        args=((name['partition'], name['sentence_split']),))
+            p.start()
+            processes.append(p)
+
+        for p in processes:
+            p.join()
+
+        if args.partitions == 1:
+            return
+
+
+    # encode partition files in parallel
+    processes = []
+    input_key = 'sentence_split' if args.split_sentences else 'partition'
+    
+    process_json_start = time.time()
+    for name in in_ss_out_names:
+        p = multiprocessing.Process(target=partition.process_json_file,
+                                    args=((name[input_key], name['output_prefix']),))
+        p.start()
+        processes.append(p)
+
+    add_process_end = time.time()
+    print(f"{time.strftime('%H:%M:%S', time.localtime())}  Process - Adding {len(processes)} processes took {add_process_end - process_json_start:.2f} seconds")  
+    for p in processes:
+        p.join()
+    process_json_end = time.time()
+    print(f"{time.strftime('%H:%M:%S', time.localtime())}  Process - Process json took {process_json_end - process_json_start:.2f} seconds")
+
+    if args.partitions == 1:
+        return
+
+    # merge bin/idx partitions
+    level = "document"
+    if args.split_sentences:
+        level = "sentence"
+
+    output_bin_files = {}
+    output_idx_files = {}
+    builders = {}
+    tokenizer_start = time.time()
+    tokenizer = build_tokenizer(args)
+    tokenizer_end = time.time()
+    print(f"{time.strftime('%H:%M:%S', time.localtime())}  Process - Building tokenizer took {tokenizer_end - tokenizer_start:.2f} seconds")
+
+    merge_start = time.time()
+    for key in args.json_keys:
+        output_bin_files[key] = "{}_{}_{}.bin".format(args.output_prefix,
+                                                      key, level)
+        output_idx_files[key] = "{}_{}_{}.idx".format(args.output_prefix,
+                                                      key, level)
+        builders[key] = indexed_dataset.IndexedDatasetBuilder(
+            output_bin_files[key],
+            dtype=indexed_dataset.DType.optimal_dtype(tokenizer.vocab_size),
+        )
+
+        for name in in_ss_out_names:
+            parition_output_prefix = name['output_prefix']
+            full_partition_output_prefix = "{}_{}_{}".format(parition_output_prefix,
+                                                             key, level)
+            builders[key].add_index(full_partition_output_prefix)
+        builders[key].finalize(output_idx_files[key])
+    merge_end = time.time()
+    print(f"{time.strftime('%H:%M:%S', time.localtime())} Process - Merging partitions took {merge_end - merge_start:.2f} seconds")
+
+
+if __name__ == '__main__':
+
+    main()
+

--- a/tools/preprocess_data_spark.py
+++ b/tools/preprocess_data_spark.py
@@ -254,7 +254,10 @@ class Partition(object):
                 dtype=indexed_dataset.DType.optimal_dtype(tokenizer.vocab_size)
             )
             # Find all partitions with the common output prefix and extract unique partition prefixes
-            partitions = glob.glob(f"{output_prefix}_{key}_{level}_*.idx")
+            partitions = sorted(
+                glob.glob(f"{output_prefix}_{key}_{level}_*.idx"),
+                key=lambda x: int(x.split('_')[-1].split('.')[0])  # Sort by numeric partition index
+            )
             print(f"{time.strftime('%H:%M:%S', time.localtime())} IN - Found {len(partitions)} partitions")
             for partition in partitions:
                 # Extract the base name without extension


### PR DESCRIPTION
for large CPU clusters (>100 CPUs, > 200GB RAMs), pyspark can be used in lieu of multiprocessing to further accelerate the preprocessing step.

This PR includes:
1. **tools/preprocess_data.py**: the implementation of pyspark conversion, which:
- defaults to single input file partition
- the args.partitions are ignored, instead the default pyspark auto partitioning will be used (each partition size 128 MB)
- the logic that manually counts the line, and partition the input jsonl file are removed
- the sentence_split logic is also change from multiprocessing to serial.

2. **tests/unit_tests/data/test_preprocess_data_spark.py**:  the test script, which 
- the sentense split test with bert tokenizer as in the original **test_preprocess_data.py** is removed, given nltk loading error in recent python versions, we can add it back after such bug is resolve
- additional throughput test is added, by preprocessing a large dummy file with the following size, given the same hardware _workers=n_cpus=32_, suggests that pyspark is at least 2x faster than multiprocessing.
  ```
  NUM_SAMPLES = 100000
  SEQ_LEN = 81920
  ```
