### PR TITLE
Fix AttributeError in MultiTokenPredictionLayer

### DIFF
--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -462,7 +462,7 @@ class MultiTokenPredictionLayer(MegatronModule):
             fp8_group = None
             if parallel_state.model_parallel_is_initialized():
                 fp8_group = parallel_state.get_amax_reduction_group(
-                    with_context_parallel=True, tp_only_amax_red=self.tp_only_amax_red
+                    with_context_parallel=True, tp_only_amax_red=self.config.tp_only_amax_red
                 )
             fp8_context = transformer_engine.pytorch.fp8_autocast(
                 enabled=True, fp8_recipe=fp8_recipe, fp8_group=fp8_group


### PR DESCRIPTION
Fix the following error:
```
AttributeError: 'MultiTokenPredictionLayer' object has no attribute 'tp_only_amax_red'  
```