### PR TITLE
Fix parameter error in text_generation_server.py file

### DIFF
--- a/megatron/inference/text_generation_server.py
+++ b/megatron/inference/text_generation_server.py
@@ -180,7 +180,7 @@ class MegatronGenerate(Resource):
                 if beam_width is not None:
                     send_do_beam_search()  # Tell other ranks we're doing beam_search
                     response, response_seg, response_scores = beam_search_and_post_process(
-                        self.model,
+                        self.engine,
                         prompts=prompts,
                         tokens_to_generate=tokens_to_generate,
                         beam_size=beam_width,


### PR DESCRIPTION
The parameter required here should be self.engine.