### PR TITLE
fix some bug

### DIFF
--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -147,6 +147,8 @@ def _allreduce_word_embedding_grads(model: List[torch.nn.Module], config: Transf
             grad_attr = _get_main_grad_attr(weight, ddp_config.use_custom_fsdp)
             orig_grad = getattr(weight, grad_attr)
             grad = _unshard_if_dtensor(orig_grad)
+            if grad is None:
+                return
             torch.distributed.all_reduce(grad, group=parallel_state.get_embedding_group())
             setattr(weight, grad_attr, _reshard_if_dtensor(grad, orig_grad))
 

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -587,6 +587,7 @@ class _ParamAndGradBuffer:
                         param_start_index = _pad_end_of_bucket_if_needed(param_start_index)
                 if len(bucket_params) > 0:
                     bucket_end_index = _update_bucket_metadata(param_start_index)
+                    param_start_index = bucket_end_index
 
             param_end_index = param_start_index + this_numel
             self.param_index_map[param] = (param_start_index, param_end_index, bucket_id)

--- a/megatron/training/wandb_utils.py
+++ b/megatron/training/wandb_utils.py
@@ -25,6 +25,7 @@ def on_save_checkpoint_success(checkpoint_path: str, tracker_filename: str, save
         save_dir (str): path of the root save folder for all checkpoints
         iteration (int): iteration of the checkpoint
     """
+    checkpoint_path = str(Path(checkpoint_path).resolve())
 
     wandb_writer = get_wandb_writer()
 


### PR DESCRIPTION
# Bug Fixes Summary

1. **Bug 1**: In the `_allreduce_word_embedding_grads` function, the `embedding` might be frozen, which can cause the code to crash.

2. **Bug 2**: `_ParamAndGradBuffer` fails to update `param_start_index` during initialization, potentially causing a parameter to be placed into multiple buckets. This triggers the assertion error:
    ```python
    assert param not in param_gbuf_map, (
        "Param should not be in param_gbuf_map; each param only belongs "
        "to a single bucket."
    )
    ```
3. **Bug 3**: In `on_save_checkpoint_success`, wandb's `artifact.add_reference` requires absolute paths for `checkpoint_path`. Using relative paths will result in errors.