### PR TITLE
[bugfix] fix the bug that loss: 0 will not be printed

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1678,7 +1678,7 @@ def training_log(
                 avg = total_loss_dict[key].item() / float(
                     max(1, total_loss_dict[advanced_iters_key])
                 )
-                if avg > 0.0:
+                if avg >= 0.0:
                     log_string += ' {}: {:.6E} |'.format(key, avg)
                 total_loss_dict[key] = torch.tensor([0.0], dtype=torch.float, device='cuda')
         log_string += f' loss scale: {loss_scale:.1f} |'


### PR DESCRIPTION
Right now the log will not provide information when loss is equal to 0.0, will just skip it.