### PR TITLE
use a cpu set to cache cuda tensor `finished_request_ids`

### DIFF
--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -173,11 +173,12 @@ class DynamicInferenceEngine(AbstractEngine):
         if result is not None:
             request_ids, finished_request_ids, sample = result
             self.finished_request_count += finished_request_ids.numel()
+            finished_request_id_set = set(finished_request_ids.tolist())
 
             for request_id, token in zip(request_ids.tolist(), sample.tolist()):
                 request: DynamicInferenceRequest = self.requests[request_id]
                 request.generated_tokens.append(token)
-                if request_id in finished_request_ids:
+                if request_id in finished_request_id_set:
                     request.status = Status.COMPLETED
                     finished_request = self.requests.pop(request_id)
                     finished_request.generated_length = len(finished_request.generated_tokens)


### PR DESCRIPTION
`finished_request_ids` is a Tensor on GPU.
In the `for` loop, every `in` op invokes a `__contains__` of a cuda tensor, and makes a D2H event, which hurt the performance.

<img width="889" alt="image" src="https://github.com/user-attachments/assets/609c95e3-2cf1-4606-930b-590491ce0b73" />


This simple change can speedup about 22% in my case (33s -> 27s, 256 prompts).
It's a very easy but efficient improvement.
