### PR TITLE
Set `weights_only=False` in optimizer

### DIFF
--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1391,7 +1391,7 @@ class ChainedOptimizer(MegatronOptimizer):
 
             # Lazy loading checkpoint, state dict is needed only when DP rank = 0.
             if optimizer.data_parallel_group.rank() == 0 and states is None:
-                states = torch.load(filename,  weights_only=False)
+                states = torch.load(filename, weights_only=False)
 
             state_dict = states[idx] if states else None
             optimizer.load_parameter_state_from_dp_zero(


### PR DESCRIPTION
This PR sets `weights_only=False` when loading optimizer states to avoid failure since PyTorch has changed the default value to `True`.