### PR TITLE
fix: when using moe parallel folding feature and set etp > 1 && ep == 1, the grad sync is incorrect and the loss curve is bad

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -207,7 +207,8 @@ class TELinear(te.pytorch.Linear):
             assert tp_group is not None, "Parallel linear should always have tp_group set"
             tp_size = tp_group.size()
 
-        self.expert_parallel = self.config.expert_model_parallel_size > 1
+        self.moe_parallel_folding = is_expert and (tp_size != config.tensor_model_parallel_size or config.expert_model_parallel_size > 1)
+        explicit_expert_comm = is_expert and (tp_size > 1 or config.expert_model_parallel_size > 1)
         if is_expert:
             rng_tracker_name = get_expert_parallel_rng_tracker_name()
         else:
@@ -223,11 +224,9 @@ class TELinear(te.pytorch.Linear):
             # Handle non-parallel case
             tp_group = None
             tp_size = 1
-            explicit_expert_comm = False
             te_parallel_mode = None
         else:
             # Disable communications in TE when using TP or EP by
-            explicit_expert_comm = is_expert and (tp_size > 1 or self.expert_parallel)
 
             if explicit_expert_comm:
                 if parallel_mode == "column":
@@ -259,7 +258,7 @@ class TELinear(te.pytorch.Linear):
         for param in self.parameters():
             if is_expert:
                 # Reduce the gradient on the expert_data_parallel group for expert linear layers
-                setattr(param, 'allreduce', not self.expert_parallel)
+                setattr(param, 'allreduce', not self.moe_parallel_folding)
             else:
                 # Reduce the gradient on DP group
                 setattr(param, 'allreduce', True)
@@ -920,7 +919,6 @@ if is_te_min_version("1.9.0.dev0"):
             extra_kwargs = _get_extra_te_kwargs(config)
             extra_kwargs["ub_name"] = tp_comm_buffer_name
 
-            self.expert_parallel = self.config.expert_model_parallel_size > 1
             if is_expert:
                 extra_kwargs["rng_tracker_name"] = get_expert_parallel_rng_tracker_name()
 
@@ -929,9 +927,10 @@ if is_te_min_version("1.9.0.dev0"):
             tp_group = get_tensor_model_parallel_group_if_none(tp_group, is_expert=is_expert)
             tp_size = tp_group.size()
 
-            self.explicit_expert_comm = is_expert and (tp_size > 1 or self.expert_parallel)
+            self.moe_parallel_folding = is_expert and (tp_size != config.tensor_model_parallel_size or config.expert_model_parallel_size > 1)
+            explicit_expert_comm = is_expert and (tp_size > 1 or config.expert_model_parallel_size > 1)
 
-            if self.explicit_expert_comm:
+            if explicit_expert_comm:
                 if parallel_mode == "column":
                     output_size = divide(output_size, tp_size)
                 elif parallel_mode == "row":
@@ -959,7 +958,7 @@ if is_te_min_version("1.9.0.dev0"):
             )
 
             for param in self.parameters():
-                setattr(param, 'allreduce', not (is_expert and self.expert_parallel))
+                setattr(param, 'allreduce', not self.moe_parallel_folding)
 
             def merge_extra_states(
                 self,

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -160,7 +160,7 @@ class MoELayer(BaseMoELayer):
                 self.token_dispatcher.set_shared_experts(self.shared_experts)
 
     def forward(self, hidden_states: torch.Tensor):
-        if self.training and self.attn_tp_group.size() > 1 and not self.config.sequence_parallel:
+        if self.training and self.config.tensor_model_parallel_size > 1 and not self.config.sequence_parallel:
             raise ValueError(
                 "During training, performance may degrade if MoE and tensor parallelism"
                 "are enabled without also enabling sequence parallelism."


### PR DESCRIPTION
Phenomenon:

When using moe parallel folding feature and set etp > 1 && ep == 1, the grad sync is incorrect and the loss curve is bad
![图片](https://github.com/user-attachments/assets/24b42514-26f6-40e2-9e92-a3e37351a6ab "loss diff")

parallel config1: tp 1 / ep 4 / etp 1 / pp 1
parallel config2: tp 1 / ep 1 / etp 4 / pp 1

other config:
* nodes: 1
* gpu per nodes: 8
* batch size: gbs 4 / mbs 1
* load ckpt: yes
* number of layers: 2
* number of experts: 8
* gpu: 8*4090D

Problem:

In DDP init function, when ep == 1 and etp != tp, the moe linear_fcs will not be tagged as `moe_param` but `dense_param`, and then in final_grad_sync function, the allreduce process uses incorrect dense dp group and mess the weight grad.

Fix:

In Linear init function and GroupMLP init function, an `moe_parallel_folding` attr is added to correctly tag the weight is `moe_param` or `dense_param`. The attr value is set to(etp > 1 && ep == 1).

Test:

Tested in the case above. The 2 curves are overlapped.
![图片](https://github.com/user-attachments/assets/0b6e3d2f-9613-4484-9d53-05360205a4f5 "loss diff")

And also tested with transformer_impl of `te` and `local` and with grouped_gemm, te grouped_gemm and seq mlp. 
![图片](https://github.com/user-attachments/assets/ba6ab468-0035-4726-9a20-26a4af2d3990 "loss diff")
