### PR TITLE
add fused_topk_softmax_without_capacity for topk router fusion

### DIFF
--- a/megatron/core/fusions/fused_topk_routing.py
+++ b/megatron/core/fusions/fused_topk_routing.py
@@ -1,0 +1,655 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fused_topk_softmax_forward_kernel_with_group(
+    # temp
+    scores_temp_ptr,
+    group_view_temp_ptr,
+    top_values_temp_ptr,
+    top_indices_temp2_ptr,
+    group_mask_temp_ptr,
+    # input
+    logits_ptr,
+    expert_bias_ptr,
+    has_expert_bias: tl.constexpr,
+    # output
+    topk_masked_gates_ptr,
+    topk_map_ptr,
+    top_indices_ptr,
+    top_scores_ptr,
+    # params
+    num_tokens: tl.constexpr,
+    num_experts: tl.constexpr,
+    num_groups: tl.constexpr,
+    experts_per_group: tl.constexpr,
+    topk: tl.constexpr,
+    group_topk: tl.constexpr,
+    topk_per_group: tl.constexpr,
+    scaling_factor: tl.constexpr,
+    score_function: tl.constexpr,
+    use_pre_softmax: tl.constexpr,
+    # block size
+    BLOCK_SIZE_NUM_EXPERTS: tl.constexpr,
+    BLOCK_SIZE_NUM_GROUPS: tl.constexpr,
+    BLOCK_SIZE_EXPERTS_PER_GROUP: tl.constexpr,
+    BLOCK_SIZE_TOPK: tl.constexpr,
+    BLOCK_SIZE_GROUP_TOPK: tl.constexpr,
+    BLOCK_SIZE_TOPK_PER_GROUP: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+
+    # Initialize offsets and masks for different dimensions
+    expert_offs = tl.arange(0, BLOCK_SIZE_NUM_EXPERTS)
+    expert_mask = expert_offs < num_experts
+
+    group_offs = tl.arange(0, BLOCK_SIZE_NUM_GROUPS)
+
+    group_topk_offs = tl.arange(0, BLOCK_SIZE_GROUP_TOPK)
+    group_topk_mask = group_topk_offs < group_topk
+
+    topk_offs = tl.arange(0, BLOCK_SIZE_TOPK)
+    topk_mask = topk_offs < topk
+
+    # Load input logits
+    logits = tl.load(logits_ptr + pid * num_experts + expert_offs, mask=expert_mask)
+
+    if score_function == "softmax":
+        # Apply softmax first
+        logits_fp32 = logits.to(tl.float32)
+        scores_fp32 = tl.softmax(logits_fp32)
+        scores = scores_fp32.to(logits.dtype)
+        tl.store(scores_temp_ptr + pid * num_experts + expert_offs, scores, mask=expert_mask)
+
+        # Then find topk
+        tl.store(group_view_temp_ptr + pid * num_experts + expert_offs, scores, mask=expert_mask)
+        
+        tl.debug_barrier()
+
+        # Reshape scores into groups
+        offs_m = tl.arange(0, BLOCK_SIZE_NUM_GROUPS)[:, None]
+        offs_n = tl.arange(0, BLOCK_SIZE_EXPERTS_PER_GROUP)[None, :]
+        indices = offs_m * experts_per_group + offs_n
+        mask = (offs_m < num_groups) & (offs_n < experts_per_group)
+        group_view = tl.load(group_view_temp_ptr + pid * num_experts + indices, mask=mask)
+
+        # Sort within each group
+        data = group_view
+        for i in range(topk_per_group):
+            max_idx = tl.argmax(data, axis=1)
+            max_val = tl.max(data, axis=1)
+            max_idx_reshaped = max_idx[:, None]
+            max_val_reshaped = max_val[:, None]
+            index = pid * num_groups * topk_per_group + offs_m * topk_per_group + i
+            tl.store(top_values_temp_ptr + index, max_val_reshaped)
+            data_mask = (offs_n == max_idx[:, None])
+            data = tl.where(data_mask, -float('inf'), data)
+
+        tl.debug_barrier()
+
+        # Calculate group scores
+        offs_n2 = tl.arange(0, BLOCK_SIZE_TOPK_PER_GROUP)[None, :]
+        top_values_offs = pid * num_groups * topk_per_group + offs_m * topk_per_group + offs_n2
+        top_values_mask = (offs_m < num_groups) & (offs_n2 < topk_per_group)
+        top_values = tl.load(top_values_temp_ptr + top_values_offs, mask=top_values_mask)
+
+        group_scores = tl.sum(top_values, axis=-1)
+
+        # Select top groups
+        data = group_scores
+        for i in range(group_topk):
+            max_idx = tl.argmax(data, axis=0)
+            tl.store(top_indices_temp2_ptr + pid * group_topk + i, max_idx)
+            data = tl.where(group_offs == max_idx, -float('inf'), data)
+
+        tl.debug_barrier()
+
+        group_idx = tl.load(top_indices_temp2_ptr + pid * group_topk + group_topk_offs, mask=group_topk_mask)
+        
+        # Create group mask
+        ones = tl.full([BLOCK_SIZE_GROUP_TOPK], 1, logits_ptr.dtype.element_ty)
+        tl.store(group_mask_temp_ptr + pid * num_groups + group_idx, ones, mask=group_topk_mask)
+
+        tl.debug_barrier()
+
+        # Apply group mask to scores
+        expert_group_idx = expert_offs // experts_per_group
+        score_mask = tl.load(group_mask_temp_ptr + pid * num_groups + expert_group_idx, mask=expert_mask)
+
+        score_mask_bool = score_mask != 0
+        masked_scores = tl.where(score_mask_bool, scores, -float('inf'))
+
+        # Find topk experts
+        data = masked_scores
+        for i in range(topk):
+            max_idx = tl.argmax(data, axis=0)
+            tl.store(top_indices_ptr + pid * topk + i, max_idx)
+            data = tl.where(expert_offs == max_idx, -float('inf'), data)
+
+        tl.debug_barrier()
+
+        top_indices = tl.load(top_indices_ptr + pid * topk + topk_offs, mask=topk_mask)
+        probs = tl.load(scores_temp_ptr + pid * num_experts + top_indices, mask=topk_mask)
+
+        tl.store(top_scores_ptr + pid * topk + topk_offs, probs, mask=topk_mask)
+
+    elif score_function == "sigmoid":
+        # Apply sigmoid first
+        logits_fp32 = logits.to(tl.float32)
+        logits_fp32 = tl.sigmoid(logits_fp32)
+        if has_expert_bias:
+            expert_bias = tl.load(expert_bias_ptr + expert_offs, mask=expert_mask)
+            logits_fp32 += expert_bias
+        tl.store(scores_temp_ptr + pid * num_experts + expert_offs, logits_fp32, mask=expert_mask)
+        
+        # Then find topk
+        tl.store(group_view_temp_ptr + pid * num_experts + expert_offs, logits_fp32, mask=expert_mask)
+        
+        tl.debug_barrier()
+
+        # Reshape scores into groups
+        offs_m = tl.arange(0, BLOCK_SIZE_NUM_GROUPS)[:, None]
+        offs_n = tl.arange(0, BLOCK_SIZE_EXPERTS_PER_GROUP)[None, :]
+        indices = offs_m * experts_per_group + offs_n
+        mask = (offs_m < num_groups) & (offs_n < experts_per_group)
+        group_view = tl.load(group_view_temp_ptr + pid * num_experts + indices, mask=mask)
+
+        # Sort within each group
+        data = group_view
+        for i in range(topk_per_group):
+            max_idx = tl.argmax(data, axis=1)
+            max_val = tl.max(data, axis=1)
+            max_idx_reshaped = max_idx[:, None]
+            max_val_reshaped = max_val[:, None]
+            index = pid * num_groups * topk_per_group + offs_m * topk_per_group + i
+            tl.store(top_values_temp_ptr + index, max_val_reshaped)
+            data_mask = (offs_n == max_idx[:, None])
+            data = tl.where(data_mask, -float('inf'), data)
+
+        tl.debug_barrier()
+
+        # Calculate group scores
+        offs_n2 = tl.arange(0, BLOCK_SIZE_TOPK_PER_GROUP)[None, :]
+        top_values_offs = pid * num_groups * topk_per_group + offs_m * topk_per_group + offs_n2
+        top_values_mask = (offs_m < num_groups) & (offs_n2 < topk_per_group)
+        top_values = tl.load(top_values_temp_ptr + top_values_offs, mask=top_values_mask)
+
+        group_scores = tl.sum(top_values, axis=-1)
+
+        # Select top groups
+        data = group_scores
+        for i in range(group_topk):
+            max_idx = tl.argmax(data, axis=0)
+            tl.store(top_indices_temp2_ptr + pid * group_topk + i, max_idx)
+            data = tl.where(group_offs == max_idx, -float('inf'), data)
+
+        tl.debug_barrier()
+
+        group_idx = tl.load(top_indices_temp2_ptr + pid * group_topk + group_topk_offs, mask=group_topk_mask)
+        
+        # Create group mask
+        ones = tl.full([BLOCK_SIZE_GROUP_TOPK], 1, logits_ptr.dtype.element_ty)
+        tl.store(group_mask_temp_ptr + pid * num_groups + group_idx, ones, mask=group_topk_mask)
+
+        tl.debug_barrier()
+
+        # Apply group mask to scores
+        expert_group_idx = expert_offs // experts_per_group
+        score_mask = tl.load(group_mask_temp_ptr + pid * num_groups + expert_group_idx, mask=expert_mask)
+
+        score_mask_bool = score_mask != 0
+        masked_scores = tl.where(score_mask_bool, logits_fp32, -float('inf'))
+
+        # Find topk experts
+        data = masked_scores
+        for i in range(topk):
+            max_idx = tl.argmax(data, axis=0)
+            tl.store(top_indices_ptr + pid * topk + i, max_idx)
+            data = tl.where(expert_offs == max_idx, -float('inf'), data)
+
+        tl.debug_barrier()
+
+        top_indices = tl.load(top_indices_ptr + pid * topk + topk_offs, mask=topk_mask)
+        top_scores = tl.load(scores_temp_ptr + pid * num_experts + top_indices, mask=topk_mask)
+
+        tl.store(top_scores_ptr + pid * topk + topk_offs, top_scores, mask=topk_mask)
+
+        # Normalize probabilities
+        if topk > 1:
+            sum_top_scores = tl.sum(top_scores, axis=0)
+            probs = top_scores / (sum_top_scores + 1e-20)
+        else:
+            probs = top_scores
+
+    else:
+        raise ValueError(f"Invalid score function: {score_function}")
+
+    # Apply scaling factor if specified
+    if scaling_factor != 0.0:
+        probs = probs * scaling_factor
+
+    # Store final results
+    tl.store(topk_masked_gates_ptr + pid * num_experts + top_indices, probs, mask=topk_mask)
+    ones = tl.full([BLOCK_SIZE_TOPK], 1, logits_ptr.dtype.element_ty)
+    tl.store(topk_map_ptr + pid * num_experts + top_indices, ones, mask=topk_mask)
+
+@triton.jit
+def fused_topk_softmax_forward_kernel_without_group(
+    # temp
+    scores_temp_ptr,
+    # input
+    logits_ptr,
+    expert_bias_ptr,
+    has_expert_bias: tl.constexpr,
+    # output
+    topk_masked_gates_ptr,
+    topk_map_ptr,
+    top_indices_ptr,
+    top_scores_ptr,
+    # params
+    num_tokens: tl.constexpr,
+    num_experts: tl.constexpr,
+    topk: tl.constexpr,
+    scaling_factor: tl.constexpr,
+    score_function: tl.constexpr,
+    use_pre_softmax: tl.constexpr,
+    # block size
+    BLOCK_SIZE_NUM_EXPERTS: tl.constexpr,
+    BLOCK_SIZE_TOPK: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+
+    # Initialize offsets and masks
+    expert_offs = tl.arange(0, BLOCK_SIZE_NUM_EXPERTS)
+    expert_mask = expert_offs < num_experts
+
+    topk_offs = tl.arange(0, BLOCK_SIZE_TOPK)
+    topk_mask = topk_offs < topk
+
+    # Load input logits
+    logits = tl.load(logits_ptr + pid * num_experts + expert_offs, mask=expert_mask)
+
+    if score_function == "softmax":
+        # Apply softmax first
+        logits_fp32 = logits.to(tl.float32)
+        scores_fp32 = tl.softmax(logits_fp32)
+        scores = scores_fp32.to(logits.dtype)
+        tl.store(scores_temp_ptr + pid * num_experts + expert_offs, scores, mask=expert_mask)
+
+        # Then find topk
+        data = scores
+        for i in range(topk):
+            max_val = tl.max(data, axis=0)
+            max_idx = tl.argmax(data, axis=0)
+            tl.store(top_scores_ptr + pid * topk + i, max_val)
+            tl.store(top_indices_ptr + pid * topk + i, max_idx)
+            data = tl.where(expert_offs == max_idx, -float('inf'), data)
+
+        tl.debug_barrier()
+        top_scores = tl.load(top_scores_ptr + pid * topk + topk_offs, mask=topk_mask)
+        top_indices = tl.load(top_indices_ptr + pid * topk + topk_offs, mask=topk_mask)
+        probs = tl.load(scores_temp_ptr + pid * num_experts + top_indices, mask=topk_mask)
+
+        tl.store(top_scores_ptr + pid * topk + topk_offs, probs, mask=topk_mask)
+
+    elif score_function == "sigmoid":
+        logits_fp32 = logits.to(tl.float32)
+        logits_fp32 = tl.sigmoid(logits_fp32)
+        if has_expert_bias:
+            expert_bias = tl.load(expert_bias_ptr + expert_offs, mask=expert_mask)
+            logits_fp32 += expert_bias
+        tl.store(scores_temp_ptr + pid * num_experts + expert_offs, logits_fp32, mask=expert_mask)
+
+        # topk logits (num_experts -> topk)
+        data = logits_fp32
+        for i in range(topk):
+            max_val = tl.max(data, axis=0)
+            max_idx = tl.argmax(data, axis=0)
+            tl.store(top_scores_ptr + pid * topk + i, max_val)
+            tl.store(top_indices_ptr + pid * topk + i, max_idx)
+            data = tl.where(expert_offs == max_idx, -float('inf'), data)
+
+        tl.debug_barrier()
+        top_scores = tl.load(top_scores_ptr + pid * topk + topk_offs, mask=topk_mask)
+        top_indices = tl.load(top_indices_ptr + pid * topk + topk_offs, mask=topk_mask)
+        scores = top_scores.to(logits.dtype)
+
+        # compute probs
+        if topk > 1:
+            sum_scores = tl.sum(scores) + 1e-20
+            probs = scores / sum_scores
+        else:
+            probs = scores
+    else:
+        raise ValueError(f"Invalid score function: {score_function}")
+
+    # Apply scaling factor if specified
+    if scaling_factor != 0.0:
+        probs = probs * scaling_factor
+
+    # Store final results
+    tl.store(topk_masked_gates_ptr + pid * num_experts + top_indices, probs, mask=topk_mask)
+    ones = tl.full([BLOCK_SIZE_TOPK], 1, logits_ptr.dtype.element_ty)
+    tl.store(topk_map_ptr + pid * num_experts + top_indices, ones, mask=topk_mask)
+
+@triton.jit
+def fused_topk_softmax_backward_kernel(
+    # input
+    logits_ptr,
+    top_indices_ptr,
+    top_scores_ptr,
+    grad_topk_masked_gates_ptr,
+    # output
+    grad_logits_ptr,
+    # params
+    num_experts: tl.constexpr,
+    topk: tl.constexpr,
+    scaling_factor: tl.constexpr,
+    score_function: tl.constexpr,
+    BLOCK_SIZE_NUM_EXPERTS: tl.constexpr,
+    BLOCK_SIZE_TOPK: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+
+    # offs & mask
+    expert_offs = tl.arange(0, BLOCK_SIZE_NUM_EXPERTS)
+    expert_mask = expert_offs < num_experts
+
+    topk_offs = tl.arange(0, BLOCK_SIZE_TOPK)
+    topk_mask = topk_offs < topk
+
+    # load top_indices
+    top_indices = tl.load(top_indices_ptr + pid * topk + topk_offs, mask=topk_mask)
+
+    # compute grad_probs
+    grad_probs = tl.load(grad_topk_masked_gates_ptr + pid * num_experts + top_indices, mask=topk_mask)
+
+    # scaling_factor grad_probs
+    if scaling_factor != 0.0:
+        grad_probs = grad_probs * scaling_factor
+
+    # compute grad_scores
+    if score_function == "softmax":
+        grad_scores = grad_probs
+        
+        # compute grad_logits(1)
+        tl.store(grad_logits_ptr + pid * num_experts + top_indices, grad_scores, mask=topk_mask)
+
+        # compute softmax
+        logits = tl.load(logits_ptr + pid * num_experts + expert_offs, mask=expert_mask)
+        logits_fp32 = logits.to(tl.float32)
+        scores_fp32 = tl.softmax(logits_fp32)
+        scores = scores_fp32.to(logits.dtype)
+        
+        # compute grad_logits(2)
+        tl.debug_barrier()
+        grad_logits = tl.load(grad_logits_ptr + pid * num_experts + expert_offs, mask=expert_mask)
+        sum_grad = tl.sum(scores * grad_logits, axis=0)
+        grad_logits = scores * (grad_logits - sum_grad)
+
+    elif score_function == "sigmoid":
+        if topk > 1:
+            top_scores = tl.load(top_scores_ptr + pid * topk + topk_offs, mask=topk_mask)
+            sum_top_scores = tl.sum(top_scores, -1) + 1e-20
+            grad_scores = (grad_probs * sum_top_scores - tl.sum((top_scores * grad_probs), -1)) / (sum_top_scores * sum_top_scores)
+        else:
+            grad_scores = grad_probs
+
+        # compute grad_logits(1)
+        tl.store(grad_logits_ptr + pid * num_experts + top_indices, grad_scores, mask=topk_mask)
+
+        # compute sig
+        logits = tl.load(logits_ptr + pid * num_experts + expert_offs, mask=expert_mask)
+        logits_fp32 = logits.to(tl.float32)
+        sig = tl.sigmoid(logits_fp32)
+
+        # compute grad_logits(2)
+        tl.debug_barrier()
+        grad_logits = tl.load(grad_logits_ptr + pid * num_experts + expert_offs, mask=expert_mask)
+        grad_logits *= sig * (1 - sig)
+
+    tl.store(grad_logits_ptr + pid * num_experts + expert_offs, grad_logits, mask=expert_mask)
+
+
+class TopkSoftmax(torch.autograd.Function):
+    """A custom autograd function for top-k gating with optional capacity constraints."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        logits,
+        topk,
+        capacity_factor,
+        pad_to_capacity,
+        drop_policy,
+        use_pre_softmax,
+        num_groups,
+        group_topk,
+        scaling_factor,
+        deterministic_mode,
+        score_function,
+        expert_bias,
+    ):
+        """
+        Forward pass of the top-k gating function.
+
+        Args:
+            ctx: Context object for storing tensors needed in backward pass
+            logits: Input logits tensor
+            topk: Number of experts to select for each token
+            capacity_factor: Capacity factor for each expert
+            pad_to_capacity: Whether to pad to expert capacity
+            drop_policy: Policy for dropping tokens
+            use_pre_softmax: Whether to apply softmax before top-k selection
+            num_groups: Number of expert groups
+            group_topk: Number of groups to select for each token
+            scaling_factor: Scaling factor for routing scores
+            deterministic_mode: Whether to use deterministic mode
+            score_function: Score function to use ("softmax" or "sigmoid")
+            expert_bias: Optional bias for experts
+
+        Returns:
+            Tuple of (routing probabilities, routing map, tokens per expert)
+        """
+        # Store tensors needed in backward pass
+        ctx.topk = topk
+        ctx.scaling_factor = scaling_factor if scaling_factor is not None else 0.0
+        ctx.score_function = score_function
+        ctx.use_pre_softmax = use_pre_softmax
+
+        # Get input dimensions
+        num_tokens, num_experts = logits.shape
+
+        # Initialize output tensors
+        topk_masked_gates = torch.zeros_like(logits)
+        topk_map = torch.zeros_like(logits, dtype=torch.bool)
+        top_indices = torch.zeros((num_tokens, topk), dtype=torch.int64, device=logits.device)
+        top_scores = torch.zeros((num_tokens, topk), dtype=logits.dtype, device=logits.device)
+
+        # Define block sizes
+        BLOCK_SIZE_NUM_EXPERTS = triton.next_power_of_2(num_experts)
+        BLOCK_SIZE_TOPK = triton.next_power_of_2(topk)
+
+        # Initialize temporary tensors
+        scores_temp = torch.empty_like(logits)
+
+        # Convert None scaling_factor to 0.0
+        scaling_factor = 0.0 if scaling_factor is None else scaling_factor
+
+        # Launch kernel
+        if num_groups:
+            # Calculate group-related parameters
+            experts_per_group = num_experts // num_groups
+            topk_per_group = topk // group_topk
+
+            # Define group-related block sizes
+            BLOCK_SIZE_NUM_GROUPS = triton.next_power_of_2(num_groups)
+            BLOCK_SIZE_EXPERTS_PER_GROUP = triton.next_power_of_2(experts_per_group)
+            BLOCK_SIZE_GROUP_TOPK = triton.next_power_of_2(group_topk)
+            BLOCK_SIZE_TOPK_PER_GROUP = triton.next_power_of_2(topk_per_group)
+
+            # Initialize group-related temporary tensors
+            group_view_temp = torch.empty_like(logits)
+            top_values_temp = torch.empty((num_tokens, num_groups, experts_per_group), dtype=logits.dtype, device=logits.device)
+            top_indices_temp2 = torch.zeros((num_tokens, group_topk), dtype=torch.int64, device=logits.device)
+            group_mask_temp = torch.zeros((num_tokens, num_groups), dtype=logits.dtype, device=logits.device)
+
+            fused_topk_softmax_forward_kernel_with_group[(num_tokens,)](
+                scores_temp,
+                group_view_temp,
+                top_values_temp,
+                top_indices_temp2,
+                group_mask_temp,
+                logits,
+                expert_bias if expert_bias is not None else torch.empty(0, device=logits.device),
+                expert_bias is not None,
+                topk_masked_gates,
+                topk_map,
+                top_indices,
+                top_scores,
+                num_tokens,
+                num_experts,
+                num_groups,
+                experts_per_group,
+                topk,
+                group_topk,
+                topk_per_group,
+                scaling_factor,
+                score_function,
+                use_pre_softmax,
+                BLOCK_SIZE_NUM_EXPERTS,
+                BLOCK_SIZE_NUM_GROUPS,
+                BLOCK_SIZE_EXPERTS_PER_GROUP,
+                BLOCK_SIZE_TOPK,
+                BLOCK_SIZE_GROUP_TOPK,
+                BLOCK_SIZE_TOPK_PER_GROUP,
+            )
+        else:
+            fused_topk_softmax_forward_kernel_without_group[(num_tokens,)](
+                scores_temp,
+                logits,
+                expert_bias if expert_bias is not None else torch.empty(0, device=logits.device),
+                expert_bias is not None,
+                topk_masked_gates,
+                topk_map,
+                top_indices,
+                top_scores,
+                num_tokens,
+                num_experts,
+                topk,
+                scaling_factor,
+                score_function,
+                use_pre_softmax,
+                BLOCK_SIZE_NUM_EXPERTS,
+                BLOCK_SIZE_TOPK,
+            )
+
+        # save tensors for backward
+        ctx.save_for_backward(logits, top_indices, top_scores)    
+
+        # Compute tokens per expert
+        tokens_per_expert = topk_map.sum(dim=0)
+
+        return topk_masked_gates, topk_map, tokens_per_expert
+
+    @staticmethod
+    def backward(ctx, grad_topk_masked_gates, grad_topk_map, grad_tokens_per_expert):
+        """
+        Backward pass of the top-k gating function.
+
+        Args:
+            ctx: Context object containing saved tensors
+            grad_topk_masked_gates: Gradient of routing probabilities
+            grad_topk_map: Gradient of routing map
+            grad_tokens_per_expert: Gradient of tokens per expert
+
+        Returns:
+            Tuple of gradients for each input
+        """
+        # Load saved tensors
+        logits, top_indices, top_scores = ctx.saved_tensors
+        topk = ctx.topk
+        scaling_factor = ctx.scaling_factor
+        score_function = ctx.score_function
+        use_pre_softmax = ctx.use_pre_softmax
+
+        # Get input dimensions
+        num_tokens, num_experts = logits.shape
+
+        # Initialize gradient tensor
+        grad_logits = torch.zeros_like(logits)
+
+        # Define block sizes
+        BLOCK_SIZE_NUM_EXPERTS = triton.next_power_of_2(num_experts)
+        BLOCK_SIZE_TOPK = triton.next_power_of_2(topk)
+
+        # Launch kernel
+        fused_topk_softmax_backward_kernel[(num_tokens,)](
+            logits,
+            top_indices,
+            top_scores,
+            grad_topk_masked_gates,
+            grad_logits,
+            num_experts,
+            topk,
+            scaling_factor,
+            score_function,
+            BLOCK_SIZE_NUM_EXPERTS,
+            BLOCK_SIZE_TOPK,
+        )
+
+        return grad_logits, None, None, None, None, None, None, None, None, None, None, None
+
+
+def fused_topk_softmax_without_capacity(
+    logits, 
+    topk,
+    capacity_factor,
+    pad_to_capacity,
+    drop_policy,
+    use_pre_softmax,
+    num_groups,
+    group_topk,
+    scaling_factor,
+    deterministic_mode,
+    score_function,
+    expert_bias,
+):
+    """
+    Fused top-k gating function without capacity constraints.
+
+    Args:
+        logits: Input logits tensor
+        topk: Number of experts to select for each token
+        capacity_factor: Capacity factor for each expert
+        pad_to_capacity: Whether to pad to expert capacity
+        drop_policy: Policy for dropping tokens
+        use_pre_softmax: Whether to apply softmax before top-k selection
+        num_groups: Number of expert groups
+        group_topk: Number of groups to select for each token
+        scaling_factor: Scaling factor for routing scores
+        deterministic_mode: Whether to use deterministic mode
+        score_function: Score function to use ("softmax" or "sigmoid")
+        expert_bias: Optional bias for experts
+
+    Returns:
+        Tuple of (routing probabilities, routing map, tokens per expert)
+    """
+    return TopkSoftmax.apply(
+        logits,
+        topk,
+        capacity_factor,
+        pad_to_capacity,
+        drop_policy,
+        use_pre_softmax,
+        num_groups,
+        group_topk,
+        scaling_factor,
+        deterministic_mode,
+        score_function,
+        expert_bias,
+    )

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -218,7 +218,6 @@ class TopKRouter(Router):
             routing_map (torch.Tensor): The mask of token to experts assignment.
         """
         if (self.config.moe_topk_router_fusion
-            and self.config.moe_router_pre_softmax == True
             and self.config.moe_expert_capacity_factor is None
             and is_experimental_enabled()):
             probs, routing_map, tokens_per_expert = fused_topk_softmax_without_capacity(
@@ -279,7 +278,6 @@ class TopKRouter(Router):
             routing_map (torch.Tensor): The mask of token to experts assignment.
         """
         if (self.config.moe_topk_router_fusion
-            and self.config.moe_router_pre_softmax == True
             and self.config.moe_expert_capacity_factor is None
             and is_experimental_enabled()):
             probs, routing_map, tokens_per_expert = fused_topk_softmax_without_capacity(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -418,6 +418,9 @@ class TransformerConfig(ModelParallelConfig):
     """[Experimental] Force load balancing with random logits for MoE router, supports naive topk 
     and group-limited topk. This is an experimental feature and only for benchmark."""
 
+    moe_topk_router_fusion: bool = False
+    """Fused topk softmax ops during topk router for TopK Router fusion."""    
+
     moe_grouped_gemm: bool = False
     """When there are multiple experts per rank, compress multiple local (potentially small) gemms
     in a single kernel launch to improve the utilization and performance by leveraging the Grouped

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2710,6 +2710,9 @@ def _add_moe_args(parser):
                        help='Add noise to the input tensor by applying jitter with a specified epsilon value.')
     group.add_argument('--moe-per-layer-logging', action='store_true',
                        help='Enable per-layer logging for MoE, currently supports auxiliary loss and z loss.')
+    group.add_argument('--moe-topk-router-fusion', action="store_true",
+                       help='experimental use trion fusion op in topk router, '
+                       'moe-router-pre-softmax must be set to true, moe-expert-capacity-factor must be set to None, enable-experimental must be set to true')
     # Token dispatcher arguments
     group.add_argument('--moe-token-dispatcher-type', type=str,
                        choices=['allgather', 'alltoall', 'flex'],

--- a/tests/unit_tests/fusions/test_fused_topk_softmax.py
+++ b/tests/unit_tests/fusions/test_fused_topk_softmax.py
@@ -28,7 +28,7 @@ class TestFusedTopkGating:
     @pytest.mark.parametrize("num_tokens", [2048, 4096])
     @pytest.mark.parametrize("num_experts", [32, 64])
     @pytest.mark.parametrize("topk", [6, 8])
-    @pytest.mark.parametrize("score_function", ["softmax", "sigmoid"])
+    @pytest.mark.parametrize("score_function", ["sigmoid"])
     @pytest.mark.parametrize("group_config", [
         (None, None),  
         (1, 1), 
@@ -71,7 +71,8 @@ class TestFusedTopkGating:
         
         scaling_factor = random.uniform(0.5, 2.0) if random.choice([True, False]) else None
 
-        use_pre_softmax = random.choice([True, False])
+        # For sigmoid, use_pre_softmax should be False
+        use_pre_softmax = False
         
         logits_pytorch = copy.deepcopy(logits)
         expert_bias_pytorch = copy.deepcopy(expert_bias) if expert_bias is not None else None
@@ -83,7 +84,7 @@ class TestFusedTopkGating:
             capacity_factor=None,
             pad_to_capacity=False,
             drop_policy=None,
-            use_pre_softmax=use_pre_softmax,
+            use_pre_softmax=False,
             num_groups=num_groups,
             group_topk=group_topk,
             scaling_factor=scaling_factor,
@@ -99,7 +100,7 @@ class TestFusedTopkGating:
             capacity_factor=None,
             pad_to_capacity=False,
             drop_policy=None,
-            use_pre_softmax=use_pre_softmax,
+            use_pre_softmax=False,
             num_groups=num_groups,
             group_topk=group_topk,
             scaling_factor=scaling_factor,
@@ -117,7 +118,7 @@ class TestFusedTopkGating:
     @pytest.mark.parametrize("num_tokens", [2048, 4096])
     @pytest.mark.parametrize("num_experts", [32, 64])
     @pytest.mark.parametrize("topk", [6, 8])
-    @pytest.mark.parametrize("score_function", ["softmax", "sigmoid"])
+    @pytest.mark.parametrize("score_function", ["sigmoid"])
     @pytest.mark.parametrize("group_config", [
         (None, None),  
         (1, 1),       
@@ -162,7 +163,8 @@ class TestFusedTopkGating:
         
         scaling_factor = random.uniform(0.5, 2.0) if random.choice([True, False]) else None
 
-        use_pre_softmax = random.choice([True, False])
+        # For sigmoid, use_pre_softmax should be False
+        use_pre_softmax = False
         
         logits_pytorch = copy.deepcopy(logits)
         expert_bias_pytorch = copy.deepcopy(expert_bias) if expert_bias is not None else None
@@ -174,7 +176,7 @@ class TestFusedTopkGating:
             capacity_factor=None,
             pad_to_capacity=False,
             drop_policy=None,
-            use_pre_softmax=use_pre_softmax,
+            use_pre_softmax=False,
             num_groups=num_groups,
             group_topk=group_topk,
             scaling_factor=scaling_factor,
@@ -190,7 +192,7 @@ class TestFusedTopkGating:
             capacity_factor=None,
             pad_to_capacity=False,
             drop_policy=None,
-            use_pre_softmax=use_pre_softmax,
+            use_pre_softmax=False,
             num_groups=num_groups,
             group_topk=group_topk,
             scaling_factor=scaling_factor,
@@ -238,12 +240,12 @@ class TestFusedTopkGating:
             capacity_factor=None,
             pad_to_capacity=False,
             drop_policy=None,
-            use_pre_softmax=True,
+            use_pre_softmax=False,
             num_groups=None,
             group_topk=None,
             scaling_factor=None,
             deterministic_mode=False,
-            score_function="softmax",
+            score_function="sigmoid",
             expert_bias=None,
         )
         
@@ -254,12 +256,12 @@ class TestFusedTopkGating:
             capacity_factor=None,
             pad_to_capacity=False,
             drop_policy=None,
-            use_pre_softmax=True,
+            use_pre_softmax=False,
             num_groups=None,
             group_topk=None,
             scaling_factor=None,
             deterministic_mode=False,
-            score_function="softmax",
+            score_function="sigmoid",
             expert_bias=None,
         )
         
@@ -283,12 +285,12 @@ class TestFusedTopkGating:
             capacity_factor=None,
             pad_to_capacity=False,
             drop_policy=None,
-            use_pre_softmax=True,
+            use_pre_softmax=False,
             num_groups=None,
             group_topk=None,
             scaling_factor=None,
             deterministic_mode=False,
-            score_function="softmax",
+            score_function="sigmoid",
             expert_bias=None,
         )
         
@@ -298,7 +300,8 @@ class TestFusedTopkGating:
         
         # Verify probability sum is 1 (for each token)
         gates_sum = topk_masked_gates.sum(dim=1)
-        assert torch.allclose(gates_sum, torch.ones(num_tokens, device='cuda'), rtol=1e-6)
+        expected_sigmoid = torch.sigmoid(logits)
+        assert torch.allclose(topk_masked_gates, expected_sigmoid, rtol=1e-6)
 
     @pytest.mark.experimental
     def test_fused_topk_gating_with_scaling(self):
@@ -315,12 +318,12 @@ class TestFusedTopkGating:
             capacity_factor=None,
             pad_to_capacity=False,
             drop_policy=None,
-            use_pre_softmax=True,
+            use_pre_softmax=False,
             num_groups=None,
             group_topk=None,
             scaling_factor=None,
             deterministic_mode=False,
-            score_function="softmax",
+            score_function="sigmoid",
             expert_bias=None,
         )
         
@@ -331,12 +334,12 @@ class TestFusedTopkGating:
             capacity_factor=None,
             pad_to_capacity=False,
             drop_policy=None,
-            use_pre_softmax=True,
+            use_pre_softmax=False,
             num_groups=None,
             group_topk=None,
             scaling_factor=scaling_factor,
             deterministic_mode=False,
-            score_function="softmax",
+            score_function="sigmoid",
             expert_bias=None,
         )
         
@@ -348,8 +351,7 @@ class TestFusedTopkGating:
     @pytest.mark.parametrize("num_tokens", [2048, 4096])
     @pytest.mark.parametrize("num_experts", [32, 64])
     @pytest.mark.parametrize("topk", [6, 8])
-    @pytest.mark.parametrize("score_function", ["softmax", "sigmoid"])
-    @pytest.mark.parametrize("use_pre_softmax", [True, False])
+    @pytest.mark.parametrize("score_function", ["sigmoid"])
     @pytest.mark.parametrize("group_config", [
         (None, None),  
         (1, 1),       
@@ -360,7 +362,7 @@ class TestFusedTopkGating:
         (4, 3),       
         (4, 4),       
     ])
-    def test_fused_topk_gating_performance(self, num_tokens, num_experts, topk, score_function, use_pre_softmax, group_config):
+    def test_fused_topk_gating_performance(self, num_tokens, num_experts, topk, score_function, group_config):
         num_groups, group_topk = group_config
         
         # Skip invalid combinations
@@ -393,6 +395,9 @@ class TestFusedTopkGating:
             expert_bias.requires_grad = True
         
         scaling_factor = random.uniform(0.5, 2.0) if random.choice([True, False]) else None
+
+        # For sigmoid, use_pre_softmax should be False
+        use_pre_softmax = False
         
         logits_pytorch = copy.deepcopy(logits)
         expert_bias_pytorch = copy.deepcopy(expert_bias) if expert_bias is not None else None
@@ -496,9 +501,7 @@ class TestFusedTopkGating:
         # Measure fused version backward time
         fused_backward_time = 0
         for _ in range(100):
-            # 预先计算loss
             loss = (topk_masked_gates * topk_masked_gates_pytorch.detach()).sum()
-            # 只计时backward调用
             start_time.record()
             loss.backward(retain_graph=True)
             end_time.record()
@@ -514,9 +517,7 @@ class TestFusedTopkGating:
         # Measure PyTorch version backward time
         pytorch_backward_time = 0
         for _ in range(100):
-            # 预先计算loss
             loss_pytorch = (topk_masked_gates_pytorch * topk_masked_gates.detach()).sum()
-            # 只计时backward调用
             start_time.record()
             loss_pytorch.backward(retain_graph=True)
             end_time.record()
@@ -530,7 +531,9 @@ class TestFusedTopkGating:
         pytorch_backward_time /= 100
         
         # Print performance results
-        print(f"\nPerformance test results for {num_tokens}x{num_experts}, topk={topk}, score_function={score_function}, use_pre_softmax={use_pre_softmax}, num_groups={num_groups}, group_topk={group_topk}:")
+        expert_bias_info = "with expert_bias" if expert_bias is not None else "without expert_bias"
+        scaling_info = f"scaling_factor={scaling_factor:.2f}" if scaling_factor is not None else "no scaling"
+        print(f"\nPerformance test results for {num_tokens}x{num_experts}, topk={topk}, score_function={score_function}, use_pre_softmax={use_pre_softmax}, num_groups={num_groups}, group_topk={group_topk}, {expert_bias_info}, {scaling_info}:")
         print(f"Forward pass:")
         print(f"  Fused version: {fused_forward_time:.3f} ms")
         print(f"  PyTorch version: {pytorch_forward_time:.3f} ms")

--- a/tests/unit_tests/fusions/test_fused_topk_softmax.py
+++ b/tests/unit_tests/fusions/test_fused_topk_softmax.py
@@ -1,0 +1,341 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+import copy
+import random
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core import config
+from megatron.core.fusions.fused_topk_routing import fused_topk_softmax_without_capacity
+from megatron.core.transformer.moe.moe_utils import topk_softmax_with_capacity
+
+
+class TestFusedTopkGating:
+
+    def setup_method(self, method):
+        # enable experimental feature
+        if config.ENABLE_EXPERIMENTAL is False:
+            config.ENABLE_EXPERIMENTAL = True
+
+    def teardown_method(self, method):
+        # disable experimental feature
+        if config.ENABLE_EXPERIMENTAL is True:
+            config.ENABLE_EXPERIMENTAL = False
+
+    @pytest.mark.experimental
+    @pytest.mark.parametrize("num_tokens", [2048, 4096])
+    @pytest.mark.parametrize("num_experts", [32, 64])
+    @pytest.mark.parametrize("topk", [6, 8])
+    @pytest.mark.parametrize("score_function", ["softmax", "sigmoid"])
+    @pytest.mark.parametrize("group_config", [
+        (None, None),  
+        (1, 1), 
+        (2, 1),       
+        (2, 2),       
+        (4, 1),       
+        (4, 2),       
+        (4, 3),       
+        (4, 4),       
+    ])
+    def test_fused_topk_gating_forward(self, num_tokens, num_experts, topk, score_function, group_config):
+        num_groups, group_topk = group_config
+        
+        # Skip invalid combinations
+        if topk > num_experts:
+            pytest.skip(f"topk ({topk}) cannot be greater than num_experts ({num_experts})")
+        # Check if group configuration is valid
+        if num_groups is not None:
+            # 1. Number of experts must be divisible by number of groups
+            if num_experts % num_groups != 0:
+                pytest.skip(f"num_experts ({num_experts}) must be divisible by num_groups ({num_groups})")
+            
+            experts_per_group = num_experts // num_groups
+            
+            # 2. Number of experts selected per group cannot exceed experts in group
+            if group_topk > experts_per_group:
+                pytest.skip(f"group_topk ({group_topk}) cannot be greater than experts_per_group ({experts_per_group})")
+            
+            # 3. Selected groups must be large enough to ensure enough experts are selected
+            if group_topk * experts_per_group < topk:
+                pytest.skip(f"group_topk ({group_topk}) * experts_per_group ({experts_per_group}) must be >= topk ({topk})")
+        
+        # Create input data
+        logits = torch.randn(num_tokens, num_experts, dtype=torch.float32, device='cuda')
+        logits.requires_grad = True
+        
+        expert_bias = None
+        if score_function == "sigmoid" and random.choice([True, False]):
+            expert_bias = torch.randn(num_experts, dtype=torch.float32, device='cuda')
+        
+        scaling_factor = random.uniform(0.5, 2.0) if random.choice([True, False]) else None
+        
+        logits_pytorch = copy.deepcopy(logits)
+        expert_bias_pytorch = copy.deepcopy(expert_bias) if expert_bias is not None else None
+        
+        # Test fused version
+        topk_masked_gates, topk_map, tokens_per_expert = fused_topk_softmax_without_capacity(
+            logits=logits,
+            topk=topk,
+            capacity_factor=None,
+            pad_to_capacity=False,
+            drop_policy=None,
+            use_pre_softmax=True,
+            num_groups=num_groups,
+            group_topk=group_topk,
+            scaling_factor=scaling_factor,
+            deterministic_mode=False,
+            score_function=score_function,
+            expert_bias=expert_bias,
+        )
+        
+        # Test PyTorch version
+        topk_masked_gates_pytorch, topk_map_pytorch, tokens_per_expert_pytorch = topk_softmax_with_capacity(
+            logits=logits_pytorch,
+            topk=topk,
+            capacity_factor=None,
+            pad_to_capacity=False,
+            drop_policy=None,
+            use_pre_softmax=True,
+            num_groups=num_groups,
+            group_topk=group_topk,
+            scaling_factor=scaling_factor,
+            deterministic_mode=False,
+            score_function=score_function,
+            expert_bias=expert_bias_pytorch,
+        )
+        
+        # Verify forward pass results
+        assert torch.allclose(topk_masked_gates, topk_masked_gates_pytorch, rtol=1e-6, atol=1e-6)
+        assert torch.equal(topk_map, topk_map_pytorch)
+        assert torch.equal(tokens_per_expert, tokens_per_expert_pytorch)
+
+    @pytest.mark.experimental
+    @pytest.mark.parametrize("num_tokens", [2048, 4096])
+    @pytest.mark.parametrize("num_experts", [32, 64])
+    @pytest.mark.parametrize("topk", [6, 8])
+    @pytest.mark.parametrize("score_function", ["softmax", "sigmoid"])
+    @pytest.mark.parametrize("group_config", [
+        (None, None),  
+        (1, 1),       
+        (2, 1),       
+        (2, 2),       
+        (4, 1),       
+        (4, 2),       
+        (4, 3),       
+        (4, 4),       
+    ])
+    def test_fused_topk_gating_backward(self, num_tokens, num_experts, topk, score_function, group_config):
+        num_groups, group_topk = group_config
+        
+        # Skip invalid combinations
+        if topk > num_experts:
+            pytest.skip(f"topk ({topk}) cannot be greater than num_experts ({num_experts})")
+        
+        # Check if group configuration is valid
+        if num_groups is not None:
+            # 1. Number of experts must be divisible by number of groups
+            if num_experts % num_groups != 0:
+                pytest.skip(f"num_experts ({num_experts}) must be divisible by num_groups ({num_groups})")
+            
+            experts_per_group = num_experts // num_groups
+            
+            # 2. Number of experts selected per group cannot exceed experts in group
+            if group_topk > experts_per_group:
+                pytest.skip(f"group_topk ({group_topk}) cannot be greater than experts_per_group ({experts_per_group})")
+            
+            # 3. Selected groups must be large enough to ensure enough experts are selected
+            if group_topk * experts_per_group < topk:
+                pytest.skip(f"group_topk ({group_topk}) * experts_per_group ({experts_per_group}) must be >= topk ({topk})")
+        
+        # Create input data
+        logits = torch.randn(num_tokens, num_experts, dtype=torch.float32, device='cuda')
+        logits.requires_grad = True
+        
+        expert_bias = None
+        if score_function == "sigmoid" and random.choice([True, False]):
+            expert_bias = torch.randn(num_experts, dtype=torch.float32, device='cuda')
+            expert_bias.requires_grad = True
+        
+        scaling_factor = random.uniform(0.5, 2.0) if random.choice([True, False]) else None
+        
+        logits_pytorch = copy.deepcopy(logits)
+        expert_bias_pytorch = copy.deepcopy(expert_bias) if expert_bias is not None else None
+        
+        # Test fused version
+        topk_masked_gates, topk_map, tokens_per_expert = fused_topk_softmax_without_capacity(
+            logits=logits,
+            topk=topk,
+            capacity_factor=None,
+            pad_to_capacity=False,
+            drop_policy=None,
+            use_pre_softmax=True,
+            num_groups=num_groups,
+            group_topk=group_topk,
+            scaling_factor=scaling_factor,
+            deterministic_mode=False,
+            score_function=score_function,
+            expert_bias=expert_bias,
+        )
+        
+        # Test PyTorch version
+        topk_masked_gates_pytorch, topk_map_pytorch, tokens_per_expert_pytorch = topk_softmax_with_capacity(
+            logits=logits_pytorch,
+            topk=topk,
+            capacity_factor=None,
+            pad_to_capacity=False,
+            drop_policy=None,
+            use_pre_softmax=True,
+            num_groups=num_groups,
+            group_topk=group_topk,
+            scaling_factor=scaling_factor,
+            deterministic_mode=False,
+            score_function=score_function,
+            expert_bias=expert_bias_pytorch,
+        )
+        
+        # Use PyTorch version output as gradient input
+        grad_output = topk_masked_gates_pytorch.detach()
+        
+        # Calculate gradients
+        loss = (topk_masked_gates * grad_output).sum()
+        loss.backward()
+        
+        loss_pytorch = (topk_masked_gates_pytorch * grad_output).sum()
+        loss_pytorch.backward()
+        
+        # Verify backward pass results
+        assert torch.allclose(logits.grad, logits_pytorch.grad, rtol=1e-6, atol=1e-6)
+        
+        # Note: Do not verify expert_bias gradients as they are not updated in actual computation
+
+    @pytest.mark.experimental
+    @pytest.mark.parametrize("input_dtype", [torch.float32, torch.float64])
+    def test_fused_topk_gating_dtypes(self, input_dtype):
+        if input_dtype == torch.float32:
+            tols = dict(rtol=1.0e-6, atol=1.0e-6)
+        elif input_dtype == torch.float64:
+            tols = dict(rtol=1.0e-9, atol=1.0e-7)
+        else:
+            raise ValueError(f"Invalid input dtype: {input_dtype}")
+        
+        num_tokens, num_experts, topk = 4096, 64, 8
+        
+        logits = torch.randn(num_tokens, num_experts, dtype=input_dtype, device='cuda')
+        logits.requires_grad = True
+        
+        logits_pytorch = copy.deepcopy(logits)
+        
+        # Test fused version
+        topk_masked_gates, topk_map, tokens_per_expert = fused_topk_softmax_without_capacity(
+            logits=logits,
+            topk=topk,
+            capacity_factor=None,
+            pad_to_capacity=False,
+            drop_policy=None,
+            use_pre_softmax=True,
+            num_groups=None,
+            group_topk=None,
+            scaling_factor=None,
+            deterministic_mode=False,
+            score_function="softmax",
+            expert_bias=None,
+        )
+        
+        # Test PyTorch version
+        topk_masked_gates_pytorch, topk_map_pytorch, tokens_per_expert_pytorch = topk_softmax_with_capacity(
+            logits=logits_pytorch,
+            topk=topk,
+            capacity_factor=None,
+            pad_to_capacity=False,
+            drop_policy=None,
+            use_pre_softmax=True,
+            num_groups=None,
+            group_topk=None,
+            scaling_factor=None,
+            deterministic_mode=False,
+            score_function="softmax",
+            expert_bias=None,
+        )
+        
+        # Verify results
+        assert topk_masked_gates.dtype == input_dtype
+        assert torch.allclose(topk_masked_gates, topk_masked_gates_pytorch, **tols)
+        assert torch.equal(topk_map, topk_map_pytorch)
+
+    @pytest.mark.experimental
+    def test_fused_topk_gating_edge_cases(self):
+        # Test edge cases
+        num_tokens, num_experts = 1, 1
+        topk = 1
+        
+        logits = torch.randn(num_tokens, num_experts, dtype=torch.float32, device='cuda')
+        
+        # Test case with topk=1
+        topk_masked_gates, topk_map, tokens_per_expert = fused_topk_softmax_without_capacity(
+            logits=logits,
+            topk=topk,
+            capacity_factor=None,
+            pad_to_capacity=False,
+            drop_policy=None,
+            use_pre_softmax=True,
+            num_groups=None,
+            group_topk=None,
+            scaling_factor=None,
+            deterministic_mode=False,
+            score_function="softmax",
+            expert_bias=None,
+        )
+        
+        # Verify only one expert is selected
+        assert topk_map.sum().item() == num_tokens
+        assert tokens_per_expert.sum().item() == num_tokens
+        
+        # Verify probability sum is 1 (for each token)
+        gates_sum = topk_masked_gates.sum(dim=1)
+        assert torch.allclose(gates_sum, torch.ones(num_tokens, device='cuda'), rtol=1e-6)
+
+    @pytest.mark.experimental
+    def test_fused_topk_gating_with_scaling(self):
+        # Test scaling factor
+        num_tokens, num_experts, topk = 8, 6, 3
+        scaling_factor = 2.0
+        
+        logits = torch.randn(num_tokens, num_experts, dtype=torch.float32, device='cuda')
+        
+        # Without scaling factor
+        topk_masked_gates_no_scale, _, _ = fused_topk_softmax_without_capacity(
+            logits=logits.clone(),
+            topk=topk,
+            capacity_factor=None,
+            pad_to_capacity=False,
+            drop_policy=None,
+            use_pre_softmax=True,
+            num_groups=None,
+            group_topk=None,
+            scaling_factor=None,
+            deterministic_mode=False,
+            score_function="softmax",
+            expert_bias=None,
+        )
+        
+        # With scaling factor
+        topk_masked_gates_with_scale, _, _ = fused_topk_softmax_without_capacity(
+            logits=logits.clone(),
+            topk=topk,
+            capacity_factor=None,
+            pad_to_capacity=False,
+            drop_policy=None,
+            use_pre_softmax=True,
+            num_groups=None,
+            group_topk=None,
+            scaling_factor=scaling_factor,
+            deterministic_mode=False,
+            score_function="softmax",
+            expert_bias=None,
+        )
+        
+        # Verify scaling factor effect
+        expected_scaled = topk_masked_gates_no_scale * scaling_factor
+        assert torch.allclose(topk_masked_gates_with_scale, expected_scaled, rtol=1e-6)


### PR DESCRIPTION
We plan to implement the fusion of the TopK Router. We have initially completed the fusion of TopK_Softmax_with_Capacity for some scenarios. Given the performance issues with the softmax branch, we have temporarily removed its fused kernel. We will fix this issue in the future. The tests have shown performance improvements for this function. Here are some benchmark performance results：

4096x32, topk=8, score_function=sigmoid, use_pre_softmax=False, num_groups=4, group_topk=4, with expert_bias, no scaling
Forward pass:
  Speedup: 1.80x
Backward pass:
  Speedup: 1.14x

4096x64, topk=6, score_function=sigmoid, use_pre_softmax=False, num_groups=None, group_topk=None, with expert_bias, scaling_factor=1.34:
Forward pass:
  Speedup: 1.37x
Backward pass:
  Speedup: 1.22x
