### PR TITLE
Allow head_dim to override kv_channel calculation

### DIFF
--- a/tools/checkpoint/loader_llama_mistral.py
+++ b/tools/checkpoint/loader_llama_mistral.py
@@ -299,6 +299,8 @@ def load_args_from_checkpoint(args, model_size):
     args.norm_epsilon = model_args["rms_norm_eps"]
     args.iteration = 1 # '0', 'release' don't work
     args.position_embedding_type = "rope"
+    if "head_dim" in model_args:
+        args.kv_channels = model_args["head_dim"]
     args.swiglu = True
     args.normalization = "RMSNorm"
     args.add_bias_linear = False


### PR DESCRIPTION
As the title says. This will allow conversions of models such as nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1 ([config.json](https://huggingface.co/nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1/blob/main/config.json)).