### PR TITLE
fix(mtp logging): Correctly accumulate MTP loss for logging when log_interval > 1

### DIFF
--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -167,7 +167,10 @@ class MTPLossLoggingHelper:
             name = f"mtp_{i+1} loss"
             loss = mtp_losses[i]
             if total_loss_dict is not None:
-                total_loss_dict[name] = loss
+                if name in total_loss_dict:
+                    total_loss_dict[name] += loss
+                else:
+                    total_loss_dict[name] = loss
             if writer is not None:
                 writer.add_scalar(name, loss, iteration)
             if wandb_writer is not None:


### PR DESCRIPTION
In `multi_token_prediction.py`, the MTP loss is not correctly accumulated for logging when the log_interval is greater than 1.

The current implementation overwrites the
`total_loss_dict[f"mtp_{i+1} loss"]` at each step. This means only the loss from the logging step itself (e.g., the 10th step if `log_interval=10`) is stored. This single value is then incorrectly divided by `log_interval`, resulting in a reported MTP loss that is artificially low and does not reflect the true average.

This commit modifies the logic to correctly accumulate the `f"mtp_{i+1} loss"` across all steps within a logging interval by checking for the key's existence and using addition (`+=`) instead of assignment.

This fix ensures the reported MTP loss is accurate.