### PR TITLE
Align import to existing module

### DIFF
--- a/megatron/core/datasets/utils_s3.py
+++ b/megatron/core/datasets/utils_s3.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
-from megatron.core.datasets.object_storage_utils import (  # pylint: disable=unused-import
+from megatron.core.datasets.utils_object_storage import (  # pylint: disable=unused-import
     S3_PREFIX,
     S3Client,
 )


### PR DESCRIPTION
This module file [does exist](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/datasets/utils_object_storage.py)

Whereas the previous one [does not exist](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/datasets/object_storage_utils.py)

I checked to ensure the two imports are in `utils_object_storage`