### PR TITLE
Fix the typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ pip install megatron-core[lts]
 For a version of Megatron-Core with minimal dependencies (only torch), run:
 
 ```bash
-pip install mnegatron-core
+pip install megatron-core
 ```
 
 For dependencies required by Megatron-LM, please run:


### PR DESCRIPTION
There is a typo in the pip install command. The original command gives error
```
ERROR: Could not find a version that satisfies the requirement mnegatron-core (from versions: none)
ERROR: No matching distribution found for mnegatron-core
```