### PR TITLE
fix router input jitter dtype

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -387,7 +387,7 @@ class TopKRouter(Router):
                     torch.tensor(1.0 - eps, device=input.device),
                     torch.tensor(1.0 + eps, device=input.device),
                 ).rsample
-            return input * self.input_jitter(input.shape)
+            return input * self.input_jitter(input.shape).type_as(input)
         else:
             return input
 


### PR DESCRIPTION
`self.input_jitter` creates a tensor of dtype `torch.FloatTensor`. pytorch auto-casts `input` to the same dtype as jitter tensor. This breaks the downstream router forward pass if router weights are in a different dtype e.g, `torch.BFloat16Tensor`.