### PR TITLE
export _move_new_state_to_right_device for offload/load

### DIFF
--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -366,6 +366,9 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                     else:
                         self.state[orig_param][k] = state[k] = v.to("cuda")
 
+    def move_state_to_right_device(self):
+        self._move_new_state_to_right_device()
+
     def _update_fp32_params_by_new_state(self):
         if not self.param_update_in_fp32:
             return


### PR DESCRIPTION
Some RL frameworks offload optimizer parameters to CPU when not in use. For example: https://github.com/volcengine/verl/blob/083da9ab130efa2dc284eeb821a3edd6ce570fe3/verl/utils/megatron_utils.py#L489 . It will load all the parameters of HybridDeviceOptimizer to the GPU. So I think we should expose this method to users for simplicity.