### PR TITLE
Add world_size dict getter method for simple integration with W&B

### DIFF
--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -1846,6 +1846,30 @@ def get_all_ranks():
         get_expert_model_parallel_rank(),
     ]
     return "_".join(map(lambda x: str(x or 0), ranks))
+    
+
+def get_all_world_sizes():
+    """Get world sizes of tensor-model-parallel, data-parallel, context-parallel,
+    pipeline-model-parallel and expert-model-parallel groups."""
+    sizes = [
+        get_tensor_model_parallel_world_size() or 0,
+        get_data_parallel_world_size() or 0,
+        get_context_parallel_world_size() or 0,
+        get_pipeline_model_parallel_world_size() or 0,
+        get_expert_model_parallel_world_size() or 0,
+    ]
+    return "_".join(map(str, sizes))
+
+
+def get_world_sizes_dict():
+    """Return a dict with world sizes for tp/dp/cp/pp/ep."""
+    return {
+        "tp": int(get_tensor_model_parallel_world_size() or 0),
+        "dp": int(get_data_parallel_world_size() or 0),
+        "cp": int(get_context_parallel_world_size() or 0),
+        "pp": int(get_pipeline_model_parallel_world_size() or 0),
+        "ep": int(get_expert_model_parallel_world_size() or 0),
+    }
 
 
 def destroy_model_parallel():


### PR DESCRIPTION
Thanks for this amazing distributed learning tool for users!
I have something to propose for integration with W&B.

### What
This PR adds two getter methods to `megatron.core.parallel_state.py`:
- `get_all_world_sizes()`: returns a string of world sizes for TP, DP, CP, PP, and EP.
- `get_world_sizes_dict()`: returns the same information as a dictionary, e.g. `{"tp": 4, "dp": 8, "cp": 1, "pp": 2, "ep": 1}`.

### Why
When integrating Megatron-LM with logging tools such as Weights & Biases, it is often useful to record the parallelism configuration (world sizes for each parallel group) alongside the training metrics.  
Currently, there is a convenient `get_all_ranks()` method for ranks, but no equivalent for world sizes. 

### Benefits
- Simplifies logging of parallelism configuration for distributed training.

Thanks for your time for reviewing this PR.
Thanks.
