### PR TITLE
fix several typos in megatron/core/transformer/multi_token_prediction.py

### DIFF
--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -448,7 +448,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         )
 
         # For the linear projection at the (k - 1)-th MTP layer, the input is the concatenation
-        # of the i-th tocken's hidden states and the (i + K)-th tocken's decoder input,
+        # of the i-th token's hidden states and the (i + K)-th token's decoder input,
         # so the input's shape is [s, b, 2*h].
         # The output will be send to the following transformer layer,
         # so the output's shape should be [s, b, h].
@@ -499,7 +499,7 @@ class MultiTokenPredictionLayer(MegatronModule):
             decoder_input (Tensor): Input tensor of shape [s, b, h] where s is the
                 sequence length, b is the batch size, and h is the hidden size.
                 At the (k - 1)-th MTP module, the i-th element of decoder input is
-                the embedding of (i + K)-th tocken.
+                the embedding of (i + K)-th token.
             attention_mask (Tensor): Boolean tensor of shape [1, 1, s, s] for masking
                 self-attention.
             context (Tensor, optional): Context tensor for cross-attention.
@@ -545,8 +545,8 @@ class MultiTokenPredictionLayer(MegatronModule):
             hidden_states = make_viewless_tensor(
                 inp=hidden_states, requires_grad=True, keep_graph=True
             )
-            # At the (k - 1)-th MTP module, concatenates the i-th tocken's hidden_states
-            # and the (i + K)-th tocken's embedding, and combine them with linear projection.
+            # At the (k - 1)-th MTP module, concatenates the i-th token's hidden_states
+            # and the (i + K)-th token's embedding, and combine them with linear projection.
             hidden_states = torch.cat((decoder_input, hidden_states), -1)
             hidden_states, _ = self.eh_proj(hidden_states)
             # For tensor parallel we need to gather the tensor across the model-parallel


### PR DESCRIPTION
As the title describe, when I am learning the MTP code in Megatron-LM.
I find there are several typos about the word "token", so I fixed it.

Thanks for this great repo. Cuz I had few open-source contributing experience, if I make any mistake during the contribution,  please forgive me.
