### PR TITLE
perf(MoE): Use TE quant/dequant for SwiGLU fp8 input store to improve performance and stability

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1990,6 +1990,8 @@ def _add_training_args(parser):
                        'If None, the default backend will be used.')
     group.add_argument('--high-priority-stream-groups', nargs='*', type=str, default=[],
                        help='The communicator group names to use high priority streams.')
+    group.add_argument('--activation-func-fp8-input-store', action='store_true',
+                       help='Store swiglu inputs in fp8 to save activation memory.')
 
     return parser
 


### PR DESCRIPTION
# Description

Replace native .to(fp8) casting in SwiGLU with Transformer Engine quant/dequant interfaces for storing activation inputs in FP8.

Benefits:
1. Higher performance – For quant+dequant operator performance,  the dynamic quantization and dequantization method in transformer_engineprovides a 1.48x to 1.66x speedup compared to the native method.
2. Better numerical stability – The dynamic quantization and dequantization method in transformer_engine handles extreme values more gracefully. Native .to(fp8) can cause underflow of very small numbers to 0, or overflow of large values to inf, while TE scaling reduces these issues.
