### PR TITLE
Fix `UnboundLocalError` during validation

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2771,8 +2771,11 @@ def evaluate_and_print_results(
         torch.distributed.broadcast(eval_iters, 0)
         eval_iters = eval_iters.tolist()
         args.eval_iters = eval_iters[0] if not args.multiple_validation_sets else eval_iters
-    
-    for index, (iterator, iterations) in enumerate(zip(data_iterators, eval_iters)):
+
+    if not args.multiple_validation_sets:
+        args.eval_iters = [args.eval_iters]
+
+    for index, (iterator, iterations) in enumerate(zip(data_iterators, args.eval_iters)): 
         suffix = ""
         if args.multiple_validation_sets:
             suffix = f"-{index}"


### PR DESCRIPTION
Error log:

```
[rank1]: Traceback (most recent call last):
[rank1]:   File "/workspace/gpt3/pretrain_gpt.py", line 396, in <module>
[rank1]:     pretrain(
[rank1]:   File "/workspace/gpt3/megatron/training/training.py", line 1010, in pretrain
[rank1]:     evaluate_and_print_results(
[rank1]:   File "/workspace/gpt3/megatron/training/training.py", line 2775, in evaluate_and_print_results
[rank1]:     for index, (iterator, iterations) in enumerate(zip(data_iterators, eval_iters)):
[rank1]:                                                                        ^^^^^^^^^^
[rank1]: UnboundLocalError: cannot access local variable 'eval_iters' where it is not associated with a value
[rank0]: Traceback (most recent call last):
[rank0]:   File "/workspace/gpt3/pretrain_gpt.py", line 396, in <module>
[rank0]:     pretrain(
[rank0]:   File "/workspace/gpt3/megatron/training/training.py", line 1010, in pretrain
[rank0]:     evaluate_and_print_results(
[rank0]:   File "/workspace/gpt3/megatron/training/training.py", line 2775, in evaluate_and_print_results
[rank0]:     for index, (iterator, iterations) in enumerate(zip(data_iterators, eval_iters)):
[rank0]:                                                                        ^^^^^^^^^^
[rank0]: UnboundLocalError: cannot access local variable 'eval_iters' where it is not associated with a value
[rank1]:[W820 21:39:35.128643664 ProcessGroupNCCL.cpp:1534] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```