### PR TITLE
Fix torch_dist checkpointing ETP replica_id

### DIFF
--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -327,7 +327,7 @@ class GroupedMLP(MegatronModule):
         local_expert_indices_offset = ep_rank * self.num_local_experts
 
         prepend_axis_num = len(sharded_offsets)
-        replica_id = (0, 0, dp_rank)
+        replica_id = (0, tp_rank, dp_rank)
 
         local_ffn_dim_size = (
             self.weight2.numel() // self.num_local_experts // self.config.hidden_size


### PR DESCRIPTION
The replica_id is not correct; expert-tensor-parallelism (ETP) would only save the model weights in 1 tensor replica. After this change, the file size of FSDP ETP models, and pipeline parallelism non-ETP models match.