### PR TITLE
[ENHANCEMENT] Add an option to scale the values of embedding matrix by sqrt(hidden_size)

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -229,6 +229,12 @@ class TransformerConfig(ModelParallelConfig):
     training of very large models. This feature is only works when megatron fsdp is turned on.
     """
 
+    scaled_embedding: bool = False
+    """
+    If True, scale the embedding matrix by math.sqrt(hidden_size) to stablize the training.
+    This feature is meant to be used along the tying of the embedding and output matrices.
+    """
+
     ####################
     # mixed-precision
     ####################

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1533,6 +1533,8 @@ def _add_network_size_args(parser):
                        dest='bert_binary_head')
     group.add_argument('--untie-embeddings-and-output-weights', action='store_true',
                        help='Untie embeddings and output weights.')
+    group.add_argument('--scaled-embedding', action="store_true",
+                       help='Scale the embedding matrix by sqrt(hidden_size).')
     group.add_argument('--multi-latent-attention', action='store_true',
                        help='Use multi-latent attention for model.')
     group.add_argument('--mtp-num-layers', type=int, default=None,


### PR DESCRIPTION
### What's this PR do?
This PR adds an option to scale the values of the embedding matrix by sqrt(hidden_size). 

### Why do we want to scale the values of the embedding matrix?
It is a well known practice to multiply the embedding matrix by constant `sqrt(hidden_size)` when tying the embedding and lm output matrices. The technique was used initially by the original transformer models proposed in the ["Attention is all you need"](https://arxiv.org/abs/1706.03762) paper, and following transformer models developed by Google such as [PaLM](https://arxiv.org/abs/2204.02311). There seems to be no fixed technical terms for this trick yet. I constantly use this technique to train models, and believes that this technique likely contributes to the stability of the training runs (some [reference](https://arxiv.org/abs/2312.16903) supports the claim, disclaimer: the paper is of my colleagues).

### Comments
Although I frequently train models with this option enabled, and maintain a fork that incorporates this option, I'm not sure whether this technique is widely used by other people in the community. If this feature seems to provide good to the community of the Megatron-LM users, I would appreciate if the maintainers have a look and review this PR.