### PR TITLE
bugfix: raise error if eos_token is not set in tokenizer

### DIFF
--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -73,6 +73,9 @@ class Encoder(object):
 
         else:
             Encoder.splitter = IdentitySplitter()
+          
+        if Encoder.tokenizer.eod is None:
+            raise ValueError("EOD token is not set.")
 
     def split(self, json_line):
         data = json.loads(json_line)


### PR DESCRIPTION
Fixes tools/preprocess_data when tokenizer does not have eod_token. Otherwise the error raised by preprocess_data.py is not clear to debug.