### PR TITLE
Fix assertion for MTP layers in pipeline layout

### DIFF
--- a/megatron/core/transformer/pipeline_parallel_layer_layout.py
+++ b/megatron/core/transformer/pipeline_parallel_layer_layout.py
@@ -126,7 +126,7 @@ class PipelineParallelLayerLayout:
                 ), "All of the MTP layers must be in the same stage"
                 assert (
                     pp_rank == self.pipeline_model_parallel_size - 1
-                    and LayerType.loss in self.layout[pp_rank][-1],
+                    and LayerType.loss in self.layout[pp_rank][-1]
                 ), "MTP layers must be in the last stage together with Loss stage."
         # TODO: remove them in the future once they are supported
         if self.flatten_layout.count(LayerType.encoder) > 0:


### PR DESCRIPTION
This assert from the recent commit is broken and will always be True. Detected by static linting