### PR TITLE
fix typo in SP/TP config validation error

### DIFF
--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -350,7 +350,7 @@ class ModelParallelConfig:
         """
         if self.sequence_parallel:
             if self.tensor_model_parallel_size <= 1:
-                raise ValueError("Can not use sequence paralllelism without tensor parallelism")
+                raise ValueError("Cannot use sequence parallelism without tensor parallelism")
 
         if self.expert_tensor_parallel_size is None:
             self.expert_tensor_parallel_size = self.tensor_model_parallel_size


### PR DESCRIPTION
Fixing a typo in `parallelism`.

`Can not` -> `Cannot` for consistency with validation inside the current method.