### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ cd Megatron-LM
 # Optional: checkout specific release
 git checkout core_r0.13.0
 
-bash docker/common/install.sh --environment {dev,lts}
+bash docker/common/install_source_wheels.sh --environment {dev,lts}
 ```
 
 ## System Requirements


### PR DESCRIPTION
I found that the install.sh file no longer exists in the Megatron-LM/docker/common directory; instead, there is install_source_wheels.sh. Therefore, the command for installing from the source code should be updated to:
```
bash docker/common/install_source_wheels.sh --environment {dev,lts}
```