### PR TITLE
Avoid calling set_save_original_input with FP8 delayed scaling

### DIFF
--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -62,9 +62,11 @@ class SharedExpertMLP(MLP):
         else:
             self.gate_weight = None
 
-        if (self.config.fp8 and self.config.fp8_recipe != 'delayed' and is_te_min_version("2.6.0dev0")) or (
-            self.config.fp4 and is_te_min_version("2.7.0.dev0")
-        ):
+        if (
+            self.config.fp8
+            and self.config.fp8_recipe != 'delayed'
+            and is_te_min_version("2.6.0dev0")
+        ) or (self.config.fp4 and is_te_min_version("2.7.0.dev0")):
             # For fp8/fp4 training, the output of pre_mlp_layernorm is saved by router, and
             # the shared expert linear_fc1 also saves the quantized tensor of this output.
             # Here we set the linear_fc1 to save the original input tensors to avoid the extra


### PR DESCRIPTION
This pull request fixes a missing condition in the FP8 delayed scaling check related to set_save_original_input().

When FP8 delayed scaling is enabled (--fp8-recipe 'delayed'), set_save_original_input() function should not be called, but the necessary condition was accidentally omitted in [commit 08814e8](https://github.com/NVIDIA/Megatron-LM/commit/08814e8)
 (ADLR/megatron-lm!4030 - perf(MoE): Support recomputation for FP8 layernorm/moe_act/shared_experts). 

This PR adds the missing condition to ensure the correct behavior, and fixes an "AssertionError: DelayedScaling recipe is not supported with save_original_input" error in core_v0.14.0 released version.