### PR TITLE
chore: add kwargs for `_pre/_postprocess` of `GPTModel`

### DIFF
--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -310,6 +310,7 @@ class GPTModel(LanguageModule):
         inference_context: BaseInferenceContext = None,
         packed_seq_params: PackedSeqParams = None,
         padding_mask: Optional[Tensor] = None,
+        **kwargs,
     ):
         """Preprocesses inputs for the transformer decoder.
 
@@ -522,6 +523,7 @@ class GPTModel(LanguageModule):
         padding_mask: Optional[Tensor] = None,
         output_processor: Optional[Callable[..., Tensor]] = None,
         output_processor_context: Optional[Any] = None,
+        **kwargs,
     ) -> Tensor:
         """Forward function of the GPT Model This function passes the input tensors
         through the embedding layer, and then the decoder and finally into the post
@@ -555,6 +557,7 @@ class GPTModel(LanguageModule):
             inference_context=inference_context,
             packed_seq_params=packed_seq_params,
             padding_mask=padding_mask,
+            **kwargs,
         )
 
         (
@@ -604,6 +607,7 @@ class GPTModel(LanguageModule):
             inference_context=inference_context,
             output_processor=output_processor,
             output_processor_context=output_processor_context,
+            **kwargs,
         )
 
     def _postprocess(
@@ -628,6 +632,7 @@ class GPTModel(LanguageModule):
         inference_context=None,
         output_processor=None,
         output_processor_context=None,
+        **kwargs,
     ):
         """Postprocesses decoder hidden states to generate logits or compute loss.
 


### PR DESCRIPTION
So that downstream programs can patch `_pre/_postprocess` methods directly with additional arguments, without the need to override the `forward` function and duplicate the code in the upstream.

A practical application: https://github.com/volcengine/verl/pull/3849#issuecomment-3432115063

https://github.com/volcengine/verl/blob/ab676dc2b6732e8d32c793e15b94121548060220/verl/models/mcore/model_forward_fused.py#L144-L145