### PR TITLE
Bugfix: import warnings

### DIFF
--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Callable, ContextManager, Optional
 
 import torch
+import warnings
 
 
 @dataclass


### PR DESCRIPTION
Adds missing `warnings` import used during [sequence parallel check](https://github.com/NVIDIA/Megatron-LM/blob/3cc6faec03e23eb7b55d3d5157c9f70b988a9c06/megatron/core/model_parallel_config.py#L391).