### PR TITLE
Reduce-scatter implementation with FP32 accumulation

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -49,6 +49,11 @@ class DistributedDataParallelConfig:
        message size (which for ring algorithms is bucket_size / dp_size) apparently needs
        to be divisible by a power of 2 for high busbw."""
 
+    reduce_scatter_with_fp32_accumulation: bool = False
+    """If true, use a reduce-scatter implementation which sends lower-precision values
+       over the wire (using an all-to-all to keep total communication overhead in line
+       with the standard ring implementation) but performs accumulation locally in FP32."""
+
     average_in_collective: bool = False
     """If true, compute average in collective directly, as opposed to dividing by the
        dp_size first and then computing sum in the collective."""

--- a/megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py
+++ b/megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+
+from typing import Any
+
+import torch
+
+
+class _ReduceScatterWithFP32AccumulationWorkHandle:
+    """Work handle to return to user when using reduce_scatter_with_fp32_accumulation with
+    async_op=True."""
+
+    def __init__(
+        self,
+        all_to_all_handle: Any,
+        all_to_all_output_tensor: torch.Tensor,
+        output_tensor: torch.Tensor,
+        world_size: int,
+    ):
+        """Initialize WorkHandle object."""
+        self.all_to_all_handle = all_to_all_handle
+        self.all_to_all_output_tensor = all_to_all_output_tensor
+        self.output_tensor = output_tensor
+        self.world_size = world_size
+
+    def wait(self):
+        """Wait until communication (and associated computation) is completed."""
+        # Wait for communication to complete if needed.
+        if self.all_to_all_handle is not None:
+            self.all_to_all_handle.wait()
+
+        # Accumulate into a fp32 sum.
+        output_tensor_in_fp32 = torch.sum(
+            self.all_to_all_output_tensor.view((self.world_size, -1)), dim=0, dtype=torch.float32
+        )
+        assert output_tensor_in_fp32.dtype == torch.float32
+
+        # Copy downcasted sum into output_tensor.
+        self.output_tensor.copy_(output_tensor_in_fp32)
+
+
+def reduce_scatter_with_fp32_accumulation(
+    output_tensor: torch.Tensor,
+    input_tensor: torch.Tensor,
+    op: torch.distributed.ReduceOp,
+    group: torch.distributed.ProcessGroup,
+    async_op: bool,
+):
+    """Reduce-scatter with FP32 accumulation.
+
+    Collects input_tensor in lower precision using an all-to-all, then locally accumulates in FP32
+    precision, then downcasts final sum back into right location in input_tensor.
+
+
+    Args:
+        output_tensor (torch.Tensor): Output tensor with reduce-scattered output (only the shard).
+        input_tensor (torch.Tensor): Input tensor that needs to be reduce-scattered.
+        op (torch.distributed.ReduceOp): Only torch.distributed.ReduceOp.SUM is supported.
+        group (torch.distributed.ProcessGroup): Process group to use for reduce-scatter.
+        async_op (bool): Only False is supported right now.
+    """
+    # Make sure arguments conform to the implementation.
+    assert op == torch.distributed.ReduceOp.SUM
+
+    # Get world_size.
+    if group is None:
+        world_size = torch.distributed.get_world_size()
+    else:
+        world_size = group.size()
+
+    # Make sure input_tensor size is divisible by world size.
+    assert input_tensor.numel() % world_size == 0
+
+    # Call all_to_all (every rank should have their respective gradient shards collected from
+    # all ranks). We also create a tensor for the all-to-all output (the all-to-all collective
+    # cannot be performed in-place).
+    all_to_all_output_tensor = torch.empty_like(input_tensor)
+    all_to_all_handle = torch.distributed.all_to_all_single(
+        output=all_to_all_output_tensor, input=input_tensor, group=group, async_op=async_op
+    )
+
+    # Create a work handle to finish communication and reduction.
+    reduce_scatter_handle = _ReduceScatterWithFP32AccumulationWorkHandle(
+        all_to_all_handle, all_to_all_output_tensor, output_tensor, world_size
+    )
+    if async_op:
+        # Return work handle; consumers can call .wait() to ensure communication and associated
+        # reduction complete.
+        return reduce_scatter_handle
+    else:
+        # Wait on work handle.
+        reduce_scatter_handle.wait()

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2636,6 +2636,10 @@ def _add_distributed_args(parser):
                        'of 2 (2^16) to ensure NCCL collectives have high bus bandwidth at large DP counts, '
                        'since NCCL message size (which for ring algorithms is bucket_size / dp_size) '
                        'apparently needs to be divisible by a power of 2 for high busbw.')
+    group.add_argument('--ddp-reduce-scatter-with-fp32-accumulation', action='store_true',
+                       default=False, help='If set, use a reduce-scatter implementation which sends lower-precision '
+                       'values over the wire (using an all-to-all to keep total communication overhead in line '
+                       'with the standard ring implementation) but performs accumulation locally in FP32.')
     group.add_argument('--ddp-average-in-collective', action='store_true',
                        default=False, help='If set, average directly in data-parallel communication collective.')
     group.add_argument('--overlap-param-gather', action='store_true',

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -971,6 +971,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             else:
                 kwargs['bucket_size'] = args.ddp_bucket_size
             kwargs['pad_buckets_for_high_nccl_busbw'] = args.ddp_pad_buckets_for_high_nccl_busbw
+            kwargs['reduce_scatter_with_fp32_accumulation'] = args.ddp_reduce_scatter_with_fp32_accumulation
             kwargs['average_in_collective'] = args.ddp_average_in_collective
             if args.use_megatron_fsdp and args.use_precision_aware_optimizer:
                 kwargs["preserve_fp32_weights"] = False

--- a/tests/unit_tests/distributed/test_reduce_scatter_with_fp32_accumulation.py
+++ b/tests/unit_tests/distributed/test_reduce_scatter_with_fp32_accumulation.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+
+import pytest
+import torch
+
+# Import our reduce_scatter implementation and shard_buffer (used for
+# checks in the test).
+from megatron.core.distributed.param_and_grad_buffer import (
+    reduce_scatter_with_fp32_accumulation,
+    shard_buffer,
+)
+from tests.unit_tests.test_utilities import Utils
+
+
+def get_non_matching_values(tensor1_shard, tensor2_shard):
+    mask = torch.isclose(tensor1_shard, tensor2_shard)
+    indices = (~mask).nonzero()
+    return indices, tensor1_shard[indices], tensor2_shard[indices]
+
+
+class TestReduceScatterWithFP32Accumulation:
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel()
+
+    @classmethod
+    def teardown_class(cls):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("async_op", [True, False])
+    @pytest.mark.parametrize("baseline_reduce_scatter_in_fp32", [True, False])
+    def test_reduce_scatter_with_fp32_accumulation(
+        self, async_op: bool, baseline_reduce_scatter_in_fp32: bool
+    ):
+        num_tests = 20
+        rank = Utils.rank
+        world_size = Utils.world_size
+        for _ in range(num_tests):
+            # Initialize input tensors.
+            tensor1 = torch.rand(100000, device='cuda', dtype=torch.bfloat16)
+            tensor2 = tensor1.clone()
+
+            # Make sure the two APIs are *identical*.
+            kwargs = {"op": torch.distributed.ReduceOp.SUM, "group": None, "async_op": async_op}
+
+            # Reduce-scatter with all-to-alls.
+            args = [
+                shard_buffer(tensor1, world_size)[rank],
+                tensor1,
+            ]  # Output tensor is view into original input.
+            handle = reduce_scatter_with_fp32_accumulation(*args, **kwargs)
+            if async_op:
+                assert handle is not None
+                handle.wait()
+            tensor1_shard = shard_buffer(tensor1, world_size)[rank]
+
+            if baseline_reduce_scatter_in_fp32:
+                tensor2 = tensor2.float()
+
+            # Reduce-scatter with reduce-scatter API.
+            args = [
+                shard_buffer(tensor2, world_size)[rank],
+                tensor2,
+            ]  # Output tensor is view into original input.
+            handle = torch.distributed.reduce_scatter_tensor(*args, **kwargs)
+            if async_op:
+                assert handle is not None
+                handle.wait()
+            tensor2_shard = shard_buffer(tensor2, world_size)[rank]
+            if baseline_reduce_scatter_in_fp32:  # Cast result back to bfloat16.
+                tensor2_shard = tensor2_shard.bfloat16()
+
+            # Compare results: results should match when doing FP32 reduction and not match when
+            # doing direct BF16 reduction. We only look at relevant shard of tensor1 and tensor2.
+            assert (
+                torch.allclose(tensor1_shard, tensor2_shard) == baseline_reduce_scatter_in_fp32
+            ), f"{get_non_matching_values(tensor1_shard, tensor2_shard)}"


### PR DESCRIPTION
- Include plumbing to use this implementation for actual model training
- Add async_op=True option for reduce_scatter_with_fp32_accumulation
- Add unit test