### PR TITLE
Feat/pre dp grad clip

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -714,6 +714,10 @@ class TransformerConfig(ModelParallelConfig):
     config_logger_dir: str = ""
     """When non-empty, dumps entry-point configs to config_logger_dir"""
 
+    pre_dp_grad_clip_norm: float = 0.0
+    """If > 0.0, clip local gradients by L2 norm on each rank before any DP sync.
+    """
+
     flash_decode: bool = False
     """ Use the optimized flash decoding kernel during inference. """
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1929,6 +1929,8 @@ def _add_regularization_args(parser):
                        'apply weight decay to qk layernorm as a special case.')
     group.add_argument('--clip-grad', type=float, default=1.0,
                        help='Gradient clipping based on global L2 norm.')
+    group.add_argument('--pre-dp-grad-clip-norm', type=float, default=0.0,
+                       help='If > 0, clip local gradients by L2 norm on each rank before DP sync')
     group.add_argument('--adam-beta1', type=float, default=0.9,
                        help='First coefficient for computing running averages '
                        'of gradient and its square')


### PR DESCRIPTION
# apply grad clip on each rank before sync avg across dp
clipping local grad outliers then do grad average, instead of existing methods(avg-then-clip, which might introduce outliers noises to cover the positive grad signals of other sample)

For modern LLM training,  micro-bsz usually set to 1; for large scale training, grad accumulation is very expensive. So, if you set micro-bsz=1, grad acc =1, per dp clip become per sample clip approximately


