### PR TITLE
Fix ambiguous tensor truth-value check in train_rl.loss_func (use .it…

### DIFF
--- a/train_rl.py
+++ b/train_rl.py
@@ -101,8 +101,9 @@ def loss_func(
 
     total_tokens = loss_mask_flat.sum()
     # Avoid division by zero for empty bins
-    if total_tokens == 0:
-        total_tokens = torch.tensor(1.0, device=loss_mask_flat.device)
+    # total_tokens is a 0-d tensor; use .item() to compare its scalar value safely in Python
+    if total_tokens.item() == 0:
+        total_tokens = torch.tensor(1.0, device=loss_mask_flat.device, dtype=loss_mask_flat.dtype)
     loss = torch.cat([torch.sum(losses_flat * loss_mask_flat).view(1), total_tokens.view(1)])
 
     # Ensure all tensors are on the same device as losses


### PR DESCRIPTION
Fixes a runtime error in train_rl.py where a 0-d PyTorch tensor (total_tokens) was compared directly to 0 in an if-statement. Comparing a tensor truth value in Python is ambiguous and can raise an exception ("The truth value of a tensor is ambiguous"). The change uses total_tokens.item() for a safe scalar comparison and creates the fallback tensor with a matching dtype/device. Motivation

In some RL training configurations (ex: empty bins / no non-padded tokens), loss_mask.sum() produces a 0-d tensor. The original code used if total_tokens == 0: which tries to evaluate the truth value of a tensor and can crash. This fix makes the check explicit and robust, avoiding failures during forward passes. What I changed

In loss_func in train_rl.py:

Replaced: if total_tokens == 0:
With: if total_tokens.item() == 0: and create the fallback total_tokens with the same device and dtype as loss_mask_flat: total_tokens = torch.tensor(1.0, device=loss_mask_flat.device, dtype=loss_mask_flat.dtype) No functional changes to the loss computation beyond avoiding the exception and ensuring dtype/device consistency for the fallback scalar.

Files modified

train_rl.py
One-line logic change in loss_func to safely compare the 0-d tensor and to create the fallback tensor with matching dtype/device. Behavioral impact

Prevents a runtime exception when total_tokens is zero (empty or fully padded microbatches). Keeps the original behavior of using 1 as the fallback token count to avoid division-by-zero. Backwards compatible with existing training setups.

Notes

Cosmetic typos in comments were observed (ex: "Without out" -> "Without", "determinisic" -> "deterministic"). Those do not affect runtime; I left them untouched in this change but can include a follow-up cleanup commit if preferred.
