### PR TITLE
Fix runaway Etpt in straggler detector by resetting FLOPs accumulator

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1794,6 +1794,7 @@ def post_training_step_callbacks(
 
     # Straggler detector.
     if iteration % args.log_interval == 0 and args.log_straggler:
+        # Use FLOPs accumulated since last log event and then reset the counter
         stimer.report(num_floating_point_operations_since_last_log_event, args.log_interval)
         num_floating_point_operations_since_last_log_event = 0.0
 
@@ -1834,6 +1835,9 @@ def post_training_step_callbacks(
     if args.manual_gc:
         if args.manual_gc_interval != 0 and iteration % args.manual_gc_interval == 0:
             gc.collect()
+
+    # Return updated FLOPs accumulator so caller can persist the reset
+    return num_floating_point_operations_since_last_log_event
 
 
 def checkpoint_and_decide_exit(
@@ -2444,8 +2448,9 @@ def train(
                 energy_monitor.resume()
 
         # Miscellaneous post-training-step functions (e.g., FT heartbeats, GC).
-        # Some of these only happen at specific iterations.
-        post_training_step_callbacks(
+        # Some of these only happen at specific iterations. Capture updated FLOPs accumulator
+        # (it is reset inside the callback after logging).
+        num_floating_point_operations_since_last_log_event = post_training_step_callbacks(
             model,
             optimizer,
             opt_param_scheduler,


### PR DESCRIPTION
This PR fixes the same issue as #1755 - copying it to run CI against it.

## Problem

The straggler detector's Etpt (estimated throughput) metric was growing linearly with iteration count, reaching unrealistic values like 147,000+ TF/s (indicating impossible 147000%+ MFU).

## Root Cause

In `post_training_step_callbacks()`, the code was setting the FLOPs counter to 0.0 but this reset was local to the function and not persisted back to the main training loop. The caller continued using the growing accumulator.

## Solution

- Modified `post_training_step_callbacks()` to return the updated FLOPs counter
- Updated the call site to capture and use the returned (reset) counter
- Added clear comments explaining the reset behavior

This ensures the straggler detector gets accurate per-interval FLOPs measurements instead of cumulative values.

Co-authored-by: Li Ruixiao <cgruixiao@outlook.com>