### PR TITLE
[dev] Fix cuda graph scope check in `language_model.py`

### DIFF
--- a/megatron/core/models/common/language_module/language_module.py
+++ b/megatron/core/models/common/language_module/language_module.py
@@ -138,6 +138,7 @@ class LanguageModule(MegatronModule):
                     # Use is_cg_capturable=True for full iteration CUDA graphs to avoid torch.equal checks
                     is_cg_capturable = (
                         hasattr(self.config, 'cuda_graph_scope')
+                        and self.config.cuda_graph_scope
                         and 'full_iteration' in self.config.cuda_graph_scope
                     )
                     if is_cg_capturable and not is_te_min_version("2.7.0"):


### PR DESCRIPTION
main branch PR #1920 

# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

`cuda_graph_scope` by default is `None`: https://github.com/NVIDIA/Megatron-LM/blob/6cc224db3bdd86995f020d2d13cf47d1d0e1f9a5/megatron/core/transformer/transformer_config.py#L693
and `cuda_graph_impl` by default is "none": https://github.com/NVIDIA/Megatron-LM/blob/6cc224db3bdd86995f020d2d13cf47d1d0e1f9a5/megatron/core/transformer/transformer_config.py#L685

the check in language_model doesn't guard against the value being `None`, which leads to errors like this:

```
[rank255]:   File "/opt/megatron-lm/megatron/core/models/common/language_module/language_module.py", line 139, in compute_language_model_loss
[rank255]:     and 'full_iteration' in self.config.cuda_graph_scope
[rank255]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank255]: TypeError: argument of type 'NoneType' is not iterable
```
this PR adds an explicit check. other usages reading into `cuda_graph_scope` either already check against the graph scope being non-empty or that the cuda_graph_impl is not "none" 
 

## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.
