### PR TITLE
fix: Fix crash in validation when no main replicas on rank

### DIFF
--- a/megatron/core/dist_checkpointing/validation.py
+++ b/megatron/core/dist_checkpointing/validation.py
@@ -518,6 +518,9 @@ def _validate_sharding_for_key_flattened(tensors_by_shard):
 
         all_slices.append((sharding.flattened_range.start, sharding.flattened_range.stop))
 
+    if not all_slices:
+        return
+
     starts, stops = map(np.asarray, zip(*sorted(all_slices)))
     expected_size = np.prod(local_shape)
     if starts[0] != 0 or stops[-1] != expected_size or not np.all(starts[1:] == stops[:-1]):


### PR DESCRIPTION
## Description
Fixes a crash in `validation.py` when resharding checkpoints with different tensor parallelism sizes.

## Problem
When `_validate_sharding_for_key_flattened()` runs on a rank that doesn't hold any main replicas, `all_slices` remains empty, causing `zip(*unique_slices)` to crash with `ValueError`.

## Solution
Add early return when `all_slices` is empty, allowing validation to safely skip on ranks without main replicas.

## Reproduction
1. Train model with TP=2 and save checkpoint
2. Load checkpoint with TP=4
3. Observe crash: `ValueError: zip() argument after * must be a sequence`

## Testing
Tested with various TP size changes during checkpoint resharding.