### PR TITLE
fix: ckpt loading failed because of padding metadata in dist optimizer

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1780,8 +1780,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     for src_tensors, (model_param, param_range_map) in zip(
                         bucket_state, gbuf_range_map["param_map"].items()
                     ):
+                        # Strip metadata fields like 'padding' before loading the state tensors.
+                        param_state_tensors = {
+                            k: v for k, v in src_tensors.items() if k != "padding"
+                        }
                         # Main param & optimizer states.
-                        self._set_main_param_and_optimizer_states(model_param, src_tensors)
+                        self._set_main_param_and_optimizer_states(model_param, param_state_tensors)
 
     @torch.no_grad()
     def load_parameter_state_from_fs_model_space(self, state_dict):


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

DP-reshardable checkpoint entries still carried the metadata flag padding, so _set_main_param_and_optimizer_states tried to push a boolean into Transformer Engine’s fused optimizer, which then expected a tensor with .dtype. Dropping metadata before the load keeps only the real tensors.

"""
(MegatronPolicyWorker pid=2943741)   File "/opt/nemo-rl/nemo_rl/models/policy/megatron_policy_worker.py", line 757, in __init__
(MegatronPolicyWorker pid=2943741)     ) = setup_megatron_model(
(MegatronPolicyWorker pid=2943741)         ^^^^^^^^^^^^^^^^^^^^^
(MegatronPolicyWorker pid=2943741)   File "/opt/nemo-rl/nemo_rl/models/policy/megatron_policy_worker.py", line 313, in setup_megatron_model
(MegatronPolicyWorker pid=2943741)     load_checkpoint(
(MegatronPolicyWorker pid=2943741)   File "/opt/nemo-rl/3rdparty/Megatron-Bridge-workspace/Megatron-Bridge/src/megatron/bridge/training/checkpointing.py", line 1251, in load_checkpoint
(MegatronPolicyWorker pid=2943741)     return _load_checkpoint_from_path(
(MegatronPolicyWorker pid=2943741)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(MegatronPolicyWorker pid=2943741)   File "/opt/nemo-rl/3rdparty/Megatron-Bridge-workspace/Megatron-Bridge/src/megatron/bridge/training/checkpointing.py", line 1577, in _load_checkpoint_from_path
(MegatronPolicyWorker pid=2943741)     optimizer.load_state_dict(state_dict["optimizer"])
(MegatronPolicyWorker pid=2943741)   File "/opt/nemo-rl/3rdparty/Megatron-LM-workspace/Megatron-LM/megatron/core/optimizer/optimizer.py", line 1215, in load_state_dict
(MegatronPolicyWorker pid=2943741)     self.chained_optimizers[0].load_state_dict(state_dict)
(MegatronPolicyWorker pid=2943741)   File "/opt/nemo-rl/3rdparty/Megatron-LM-workspace/Megatron-LM/megatron/core/optimizer/distrib_optimizer.py", line 866, in load_state_dict
(MegatronPolicyWorker pid=2943741)     self.load_parameter_state_from_dp_reshardable(param_state)
(MegatronPolicyWorker pid=2943741)   File "/opt/nemo-rl/3rdparty/Megatron-LM-workspace/Megatron-LM/megatron/core/optimizer/distrib_optimizer.py", line 1784, in load_parameter_state_from_dp_reshardable
(MegatronPolicyWorker pid=2943741)     self._set_main_param_and_optimizer_states(model_param, src_tensors)
(MegatronPolicyWorker pid=2943741)   File "/opt/nemo-rl/3rdparty/Megatron-LM-workspace/Megatron-LM/megatron/core/optimizer/distrib_optimizer.py", line 923, in _set_main_param_and_optimizer_states
(MegatronPolicyWorker pid=2943741)     self.optimizer.set_scaled_state(sharded_model_param, k, v)
(MegatronPolicyWorker pid=2943741)   File "/opt/ray_venvs/nemo_rl.models.policy.megatron_policy_worker.MegatronPolicyWorker/lib/python3.12/site-packages/transformer_engine/pytorch/optimizers/fused_adam.py", line 349, in set_scaled_state
(MegatronPolicyWorker pid=2943741)     assert unscaled_state.dtype == torch.float32
(MegatronPolicyWorker pid=2943741)            ^^^^^^^^^^^^^^^^^^^^
(MegatronPolicyWorker pid=2943741) AttributeError: 'bool' object has no attribute 'dtype'
"""


## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.
