### PR TITLE
MoE Overlap: Add 2 CUDA Events to Synchronize Computation & Communication Operations for Forward and Backward Respectively

### DIFF
--- a/megatron/core/pipeline_parallel/combined_1f1b.py
+++ b/megatron/core/pipeline_parallel/combined_1f1b.py
@@ -405,7 +405,7 @@ def combined_forward_backward_step(
         from megatron.core.pipeline_parallel.schedules import forward_step_calc_loss
 
         loss_node = ScheduleNode(
-            loss_func, torch.cuda.current_stream(), f_schedule_plan.event, name="loss_func"
+            loss_func, torch.cuda.current_stream(), f_schedule_plan.event_fwd, f_schedule_plan.event_back, name="loss_func"
         )
         loss_func = loss_node.forward
         output_tensor, num_tokens = forward_step_calc_loss(


### PR DESCRIPTION
# Problem Description

Please refer to issue [#2180](https://github.com/NVIDIA/Megatron-LM/issues/2180). MoE communication & computation cannot overlap completely.  

# Root Cause Analysis

Basically, forward computation of a micro-batch overlaps with backward communication of a different micro-batch and vice versa during interleaving phase. Therefore, the forward or backward process with respect to a transformer layer is split into a couple of  communication and computation modules which are managed by TransformerLayerSchedulePlan (megatron/core/model/common/mode_trunk_schedule_plan.py). Additionally, based on TransformerLayerSchedulePlan, the schedule plan of a model trunk is generated by TransformerModelChunkSchedulePlan (megatron/core/model/common/mode_trunk_schedule_plan.py). 

Roughly, in the interleaving phase, a forward process of a micro-batch over a transformer layer moves forward side by side with a backward process of a different micro-batch over a different transformer layer within a model trunk. For example, backward combine (communication) is scheduled to go in parallel with forward attention (computation) on different CUDA streams, forward dispatch (communication) is conducted wth backward mlp.

To synchronize the operations on communication stream and computation stream, one CUDA event is used to manage the dependencies of the sub modules in forward pass or backward pass. The computation and communication in forward pass are independent of the computation and communication in backward pass and vice versa. With only one CUDA event for synchronization, a computation operation in forward pass may wait for a communication operation in backward pass mistakenly.

# Solution

Add 2 CUDA events for communication & computation synchronization with regard to forward pass and backward pass respectively. A CUDA event is used for forward synchronization and a different CUDA is used for backward synchronization. 

# Test

As shown by below screen shot, forward attention overlaps with moe_combine backward.

![5e060f2c-324f-4c87-addc-3418d7099226](https://github.com/user-attachments/assets/701c3444-d6c6-464a-bc4e-975fa0c50eb8)

