### PR TITLE
Fix #2541: Make nv-grouped-gemm truly optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,21 @@ For a version of Megatron Core with only torch, run:
 pip install megatron-core
 ```
 
+### Optional MoE Dependencies
+
+For Mixture of Experts (MoE) training with Grouped GEMM support:
+
+```bash
+pip install --no-build-isolation megatron-core[moe]
+```
+
+**Note:** The `nv-grouped-gemm` package requires:
+- CUDA toolkit (nvcc) with CUTLASS headers
+- On Ubuntu/Debian: `apt-get install libcutlass-dev`
+- GPU with compute capability >= 8.0
+
+If you encounter build errors, you can skip this optional dependency and use MoE without Grouped GEMM optimization.
+
 ## System Requirements
 
 ### Hardware Requirements

--- a/megatron/core/transformer/moe/grouped_gemm_util.py
+++ b/megatron/core/transformer/moe/grouped_gemm_util.py
@@ -13,10 +13,23 @@ def grouped_gemm_is_available():
 
 def assert_grouped_gemm_is_available():
     """Assert that grouped_gemm is available."""
-    assert grouped_gemm_is_available(), (
-        "Grouped GEMM is not available. Please run "
-        "`pip install git+https://github.com/fanshiqing/grouped_gemm@v1.1.4`."
+    error_msg = (
+        "Grouped GEMM is not available. To use MoE with grouped GEMM, you need to install "
+        "nv-grouped-gemm.\n\n"
+        "Installation options:\n"
+        "1. Install from PyPI (requires CUDA toolkit and CUTLASS headers):\n"
+        "   pip install 'megatron-core[moe]'\n"
+        "   or\n"
+        "   pip install nv-grouped-gemm\n\n"
+        "2. Build from source:\n"
+        "   pip install git+https://github.com/fanshiqing/grouped_gemm@v1.1.4\n\n"
+        "Note: Building from source requires:\n"
+        "- CUDA toolkit (nvcc)\n"
+        "- CUTLASS headers (can be installed via 'apt-get install libcutlass-dev' on Ubuntu)\n"
+        "- Compatible GPU with compute capability >= 8.0\n\n"
+        "If you don't need MoE functionality, you can continue without this package."
     )
+    assert grouped_gemm_is_available(), error_msg
 
 
 ops = grouped_gemm.ops if grouped_gemm_is_available() else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,6 @@ dev = [
     "opentelemetry-api~=1.33.1",
     "mamba-ssm~=2.2",
     "causal-conv1d~=1.5",
-    "nv-grouped-gemm~=1.1",
     "megatron-energon[av_decode]~=6.0",
     "av",
     "flashinfer-python",
@@ -86,6 +85,11 @@ dev = [
     "onnxscript",
     "fastapi~=0.50",                                          # Forcing a little bit more recent version of fastapi to be compatible with pydantic 2.0
     "datasets",
+]
+
+# Optional MoE dependencies that may require building from source with CUTLASS headers
+moe = [
+    "nv-grouped-gemm~=1.1",
 ]
 
 lts = [
@@ -97,7 +101,6 @@ lts = [
     "opentelemetry-api~=1.33.1",
     "mamba-ssm~=2.2",
     "causal-conv1d~=1.5",
-    "nv-grouped-gemm~=1.1",
     "megatron-energon[av_decode]~=6.0",
     "av",
     "flashinfer-python",


### PR DESCRIPTION
- Move nv-grouped-gemm from dev/lts extras to new moe extra
- Users can now install megatron-core[dev] without build failures
- Add comprehensive error messages with installation instructions
- Update README with MoE dependencies documentation

This resolves the installation failure when nv-grouped-gemm cannot build due to missing CUTLASS headers. Users who need MoE with grouped GEMM can now explicitly install it with megatron-core[moe], while others can install dev/lts extras without encountering build errors.

Fixes #2541