### PR TITLE
[Dev] Fix precision issues when resuming training from a checkpoint with BF16 and optimizer offload enabled

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -914,6 +914,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 if isinstance(self.optimizer, HybridDeviceOptimizer):
                     if k == "param":
                         k = "master_param"
+                        sharded_model_param.copy_(v)
                     self.optimizer.state[sharded_model_param][k] = v
                     continue
 


### PR DESCRIPTION
### Problem Description
When training with BF16, enabling CPU offload and loading a checkpoint together with the optimizer state can introduce a small accuracy discrepancy at the first training step.
parameter settings:

```shell
--bf16
--use-precision-aware-optimizer
--optimizer-cpu-offload
--optimizer-offload-fraction 1.0

--load $CHECKPOINT_PATH
#--no-load-optim
#--no-load-rng
```

### Our Solution
We found that this accuracy discrepancy is caused by errors in the model parameters when loading the checkpoint. To address this, we restore the original model parameters using the parameter values stored in the optimizer when loading the optimizer state.


### Experiment
<img width="1192" height="354" alt="bf16-opt" src="https://github.com/user-attachments/assets/6b807e03-781c-49e9-9514-ed3cd7d00ea4" />
Under BF16 training, optimizer offload exhibits an accuracy issue during resumed training. When loading the checkpoint from the 10th iteration together with the optimizer state, before the fix the loss at the 11th iteration (i.e., the first iteration after loading) shows a noticeable discrepancy, whereas after the fix the discrepancy is reduced to the order of 1e-4.

### Summary
Overall, we identified and fixed the accuracy issue that occurs when loading checkpoints and optimizer states with CPU offload enabled during BF16 training.