### PR TITLE
Optimizer State and Master Weight Offloading

### DIFF
--- a/megatron/core/optimizer/cpu_offloading/README.md
+++ b/megatron/core/optimizer/cpu_offloading/README.md
@@ -1,6 +1,10 @@
-## How to use ?
+# Optimizer CPU Offloading
 
-Add these flags to enable optimizer cpu offload in MCore.
+MCore provides two mutually exclusive options for reducing optimizer GPU memory usage by leveraging CPU memory. They cannot be combined.
+
+## Option 1: `--optimizer-cpu-offload`
+
+Runs the entire optimizer step on CPU. Gradients are copied to CPU, the optimizer updates parameters there, and the updated parameters are copied back to GPU.
 
 ```bash
 --optimizer-cpu-offload
@@ -8,6 +12,13 @@ Add these flags to enable optimizer cpu offload in MCore.
 --use-precision-aware-optimizer
 ```
 
-## Configuration Recommendations
+Gradient copy, CPU optimizer step, and parameter copy can be time-consuming. Use `--overlap-cpu-optimizer-d2h-h2d` to overlap these transfers with computation.
 
-Gradient copy from GPU to CPU, CPU optimizer step, and subsequent parameter copy from CPU to GPU can be time-consuming operations, and it is recommended to use the flag `--overlap-cpu-optimizer-d2h-h2d` to execute them concurrently.
+## Option 2: `--offload-optimizer-states`
+
+A lighter-weight alternative that keeps the optimizer step on GPU but moves optimizer states to CPU between steps to save GPU memory. Requires the distributed optimizer and Adam (TE FusedAdam).
+
+```bash
+--use-distributed-optimizer
+--offload-optimizer-states
+```

--- a/megatron/core/optimizer/cpu_offloading/optimizer_state_offloader.py
+++ b/megatron/core/optimizer/cpu_offloading/optimizer_state_offloader.py
@@ -25,7 +25,6 @@ class OptimizerStateOffloader:
     OPTIMIZER_STATE_KEYS = ('exp_avg', 'exp_avg_sq')
     MASTER_WEIGHT_KEY = 'master_param'
 
-
     def __init__(self, distrib_optimizer: "DistributedOptimizer"):
         """
         Args:

--- a/megatron/core/optimizer/cpu_offloading/optimizer_state_offloader.py
+++ b/megatron/core/optimizer/cpu_offloading/optimizer_state_offloader.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Optimizer state offloading class."""
+
+from typing import TYPE_CHECKING, Dict, List, Tuple
+
+import torch
+
+if TYPE_CHECKING:
+    from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+
+
+class OptimizerStateOffloader:
+    """
+    Manages offloading of optimizer states and master weights to CPU.
+    Used with DistributedOptimizer to reduce GPU memory usage.
+
+    Supports overlapped D2H/H2D transfers using CUDA streams.
+
+    Master weights can be stored in two locations:
+    - In adam optimizer state (when use_precision_aware_optimizer_no_fp8_or_ds_fp8 is True)
+    - In mcore's shard_fp32_from_float16_groups
+    """
+
+    OPTIMIZER_STATE_KEYS = ('exp_avg', 'exp_avg_sq')
+    MASTER_WEIGHT_KEY = 'master_param'
+
+
+    def __init__(
+        self,
+        distrib_optimizer: "DistributedOptimizer",
+    ):
+        """
+        Args:
+            distrib_optimizer: The DistributedOptimizer to offload states and master weights from.
+        """
+        self.dist_optimizer = distrib_optimizer
+        self.adam_optimizer = distrib_optimizer.optimizer
+
+        # Only support TE FusedAdam optimizer for now.
+        try:
+            from transformer_engine.pytorch.optimizers import FusedAdam
+
+            assert isinstance(self.adam_optimizer, FusedAdam), (
+                f"OptimizerStateOffloader requires TE FusedAdam optimizer, "
+                f"but got {type(self.adam_optimizer).__name__}"
+            )
+        except ImportError:
+            raise ImportError(
+                "OptimizerStateOffloader requires transformer_engine.pytorch.optimizers.FusedAdam"
+            )
+
+        # Check if master weights are stored in adam optimizer state
+        self.optimizer_contains_master_weights = self.adam_optimizer.master_weights
+
+        # CUDA streams for async transfers
+        self._d2h_stream = torch.cuda.Stream()
+        self._h2d_stream = torch.cuda.Stream()
+
+        # CPU buffers for optimizer states: {param: {key: cpu_tensor}}
+        self._opt_state_cpu_buffers: Dict[torch.Tensor, Dict[str, torch.Tensor]] = {}
+
+        # CPU buffers for mcore master weights, matching the structure of source groups
+        # List[List[cpu_tensor]]
+        self._shard_fp32_from_float16_cpu_buffers: List[List[torch.Tensor]] = []
+
+        # State tracking
+        self._offloaded = False
+        self._offloaded_state_keys: Tuple[str, ...] = ()
+        self._offloaded_mcore_master_weights = False
+
+    def _get_state_keys_to_offload(
+        self, offload_optimizer_states: bool, offload_master_weights: bool
+    ) -> Tuple[str, ...]:
+        """Get the state keys in FusedAdam to offload based on configuration."""
+        keys = []
+        if offload_optimizer_states:
+            keys.extend(self.OPTIMIZER_STATE_KEYS)
+        if offload_master_weights and self.optimizer_contains_master_weights:
+            keys.append(self.MASTER_WEIGHT_KEY)
+        return tuple(keys)
+
+    def _ensure_state_cpu_buffer(
+        self,
+        param: torch.Tensor,
+        state_key: str,
+        gpu_tensor: torch.Tensor,
+        pin_memory: bool = True,
+    ) -> torch.Tensor:
+        """Get or create a CPU buffer for a state tensor."""
+        if param not in self._opt_state_cpu_buffers:
+            self._opt_state_cpu_buffers[param] = {}
+
+        if state_key not in self._opt_state_cpu_buffers[param]:
+            cpu_buffer = torch.empty(
+                gpu_tensor.size(),
+                dtype=gpu_tensor.dtype,
+                layout=gpu_tensor.layout,
+                device='cpu',
+                pin_memory=pin_memory,
+            )
+            self._opt_state_cpu_buffers[param][state_key] = cpu_buffer
+
+        return self._opt_state_cpu_buffers[param][state_key]
+
+    def _offload_shard_groups(
+        self,
+        shard_groups: List[List[torch.Tensor]],
+        cpu_buffers: List[List[torch.Tensor]],
+        pin_memory: bool = True,
+    ):
+        """Offload a shard group to CPU buffers."""
+        # Initialize CPU buffers on first call
+        if len(cpu_buffers) == 0:
+            for group in shard_groups:
+                group_buffers = []
+                for gpu_tensor in group:
+                    cpu_buffer = torch.empty(
+                        gpu_tensor.size(),
+                        dtype=gpu_tensor.dtype,
+                        layout=gpu_tensor.layout,
+                        device='cpu',
+                        pin_memory=pin_memory,
+                    )
+                    group_buffers.append(cpu_buffer)
+                cpu_buffers.append(group_buffers)
+
+        # Copy D2H
+        for group_idx, group in enumerate(shard_groups):
+            for param_idx, gpu_tensor in enumerate(group):
+                cpu_buffer = cpu_buffers[group_idx][param_idx]
+                cpu_buffer.copy_(gpu_tensor, non_blocking=pin_memory)
+                gpu_tensor.record_stream(self._d2h_stream)
+
+    def _offload_states(
+        self,
+        offload_optimizer_states: bool,
+        offload_master_weights: bool,
+        use_pin_memory: bool = True,
+    ):
+        """Offload optimizer states and/or master weights to CPU."""
+        # Offload states from adam optimizer
+        self._offloaded_state_keys = self._get_state_keys_to_offload(
+            offload_optimizer_states, offload_master_weights
+        )
+        states = self.adam_optimizer.state
+
+        for param, param_state in states.items():
+            for state_key in self._offloaded_state_keys:
+                if state_key not in param_state:
+                    continue
+
+                gpu_tensor = param_state[state_key]
+                if not isinstance(gpu_tensor, torch.Tensor) or not gpu_tensor.is_cuda:
+                    continue
+
+                cpu_buffer = self._ensure_state_cpu_buffer(
+                    param,
+                    state_key,
+                    gpu_tensor,
+                    use_pin_memory,
+                )
+                cpu_buffer.copy_(gpu_tensor, non_blocking=use_pin_memory)
+                gpu_tensor.record_stream(self._d2h_stream)
+
+        # Offload mcore master weights if not in optimizer state
+        if offload_master_weights and not self.optimizer_contains_master_weights:
+            self._offload_shard_groups(
+                self.dist_optimizer.shard_fp32_from_float16_groups,
+                self._shard_fp32_from_float16_cpu_buffers,
+                use_pin_memory,
+            )
+            self._offloaded_mcore_master_weights = True
+
+    def _release_states(self):
+        """Replace optimizer state GPU tensors with CPU tensors to free GPU memory."""
+        states = self.adam_optimizer.state
+
+        for param, param_state in states.items():
+            if param not in self._opt_state_cpu_buffers:
+                continue
+
+            for state_key in self._offloaded_state_keys:
+                if state_key not in self._opt_state_cpu_buffers[param]:
+                    continue
+
+                param_state[state_key].untyped_storage().resize_(0)
+
+        if self._offloaded_mcore_master_weights:
+            for group in self.dist_optimizer.shard_fp32_from_float16_groups:
+                for gpu_tensor in group:
+                    gpu_tensor.untyped_storage().resize_(0)
+
+    def _reload_shard_groups(
+        self,
+        shard_groups: List[List[torch.Tensor]],
+        cpu_buffers: List[List[torch.Tensor]],
+        is_allocate_stage: bool,
+    ):
+        """Reload shard groups from CPU to GPU."""
+        for group_idx, group in enumerate(shard_groups):
+            for param_idx, _ in enumerate(group):
+                cpu_buffer = cpu_buffers[group_idx][param_idx]
+                if is_allocate_stage:
+                    shard_groups[group_idx][param_idx].untyped_storage().resize_(
+                        cpu_buffer.untyped_storage().size()
+                    )
+                else:
+                    shard_groups[group_idx][param_idx].copy_(
+                        cpu_buffer, non_blocking=cpu_buffer.is_pinned()
+                    )
+
+    def _reload_states(self, is_allocate_stage: bool):
+        """
+        Reload optimizer states and/or master weights from CPU to GPU.
+
+        If is_allocate_stage is True, only allocate GPU memory for the states and master weights,
+        but do not copy the data from CPU to GPU. Otherwise, copy the data from CPU to GPU.
+        The two processes are separated to make sure that the GPU memory is allocated on the
+        default stream to avoid fragmentation.
+        """
+        # Reload states to adam optimizer
+        states = self.adam_optimizer.state
+
+        for param, param_state in states.items():
+            if param not in self._opt_state_cpu_buffers:
+                continue
+
+            for state_key in self._offloaded_state_keys:
+                if state_key not in self._opt_state_cpu_buffers[param]:
+                    continue
+
+                cpu_buffer = self._opt_state_cpu_buffers[param][state_key]
+                if is_allocate_stage:
+                    param_state[state_key].untyped_storage().resize_(
+                        cpu_buffer.untyped_storage().size()
+                    )
+                else:
+                    param_state[state_key].copy_(cpu_buffer, non_blocking=cpu_buffer.is_pinned())
+
+        # Reload mcore master weights if not in optimizer state
+        if self._offloaded_mcore_master_weights:
+            self._reload_shard_groups(
+                self.dist_optimizer.shard_fp32_from_float16_groups,
+                self._shard_fp32_from_float16_cpu_buffers,
+                is_allocate_stage,
+            )
+
+    def offload(
+        self, offload_optimizer_states: bool = True, offload_master_weights: bool = True
+    ):
+        """
+        Offload optimizer states and/or master weights to CPU.
+        Starts async D2H transfer that can overlap with other operations.
+
+        Args:
+            offload_optimizer_states: Whether to offload exp_avg, exp_avg_sq.
+            offload_master_weights: Whether to offload master weights.
+        """
+        if not offload_optimizer_states and not offload_master_weights:
+            return
+
+        # Wait for current stream finishing updating the optimizer states.
+        self._d2h_stream.wait_stream(torch.cuda.current_stream())
+
+        with torch.cuda.stream(self._d2h_stream):
+            self._offload_states(offload_optimizer_states, offload_master_weights)
+
+        self._offloaded = True
+
+    def release_gpu_memory(self):
+        """
+        Release GPU memory for optimizer states and master weights after D2H copy completes.
+
+        This is separated from offload() to allow delayed GPU memory release,
+        which is needed for mxfp8 + overlap_param_gather case where master weights
+        must remain on GPU until after _copy_main_params_to_param_buffer() is called.
+        """
+        if not self._offloaded:
+            return
+
+        self._release_states()
+
+    def reload(self):
+        """
+        Reload optimizer states and/or master weights from CPU to GPU.
+        Call before optimizer.step() to ensure states are on GPU.
+        """
+        if not self._offloaded:
+            return
+
+        # Allocate GPU memory on the current stream to avoid fragmentation.
+        self._reload_states(is_allocate_stage=True)
+
+        self._h2d_stream.wait_stream(self._d2h_stream)
+        self._h2d_stream.wait_stream(torch.cuda.current_stream())
+
+        # Reload states on the h2d stream to overlap with other operations.
+        with torch.cuda.stream(self._h2d_stream):
+            self._reload_states(is_allocate_stage=False)
+
+        self._offloaded_state_keys = ()
+        self._offloaded_mcore_master_weights = False
+        self._offloaded = False
+
+    def sync_before_step(self):
+        """
+        Wait for H2D reload to complete before optimizer.step().
+        Must be called to ensure states are on GPU before optimizer uses them.
+
+        This is separated from reload() to make it possible to move the reload ahead of time.
+        """
+        torch.cuda.current_stream().wait_stream(self._h2d_stream)

--- a/megatron/core/optimizer/cpu_offloading/optimizer_state_offloader.py
+++ b/megatron/core/optimizer/cpu_offloading/optimizer_state_offloader.py
@@ -12,23 +12,23 @@ if TYPE_CHECKING:
 
 class OptimizerStateOffloader:
     """
-    Manages offloading of optimizer states and master weights to CPU.
+    Manages offloading of optimizer states and primary weights to CPU.
     Used with DistributedOptimizer to reduce GPU memory usage.
 
     Supports overlapped D2H/H2D transfers using CUDA streams.
 
-    Master weights can be stored in two locations:
+    Primary weights can be stored in two locations:
     - In adam optimizer state (when use_precision_aware_optimizer_no_fp8_or_ds_fp8 is True)
     - In mcore's shard_fp32_from_float16_groups
     """
 
     OPTIMIZER_STATE_KEYS = ('exp_avg', 'exp_avg_sq')
-    MASTER_WEIGHT_KEY = 'master_param'
+    PRIMARY_WEIGHT_KEY = 'master_param'
 
     def __init__(self, distrib_optimizer: "DistributedOptimizer"):
         """
         Args:
-            distrib_optimizer: The DistributedOptimizer to offload states and master weights from.
+            distrib_optimizer: The DistributedOptimizer to offload states and primary weights from.
         """
         self.dist_optimizer = distrib_optimizer
         self.adam_optimizer = distrib_optimizer.optimizer
@@ -46,8 +46,8 @@ class OptimizerStateOffloader:
                 "OptimizerStateOffloader requires transformer_engine.pytorch.optimizers.FusedAdam"
             )
 
-        # Check if master weights are stored in adam optimizer state
-        self.optimizer_contains_master_weights = self.adam_optimizer.master_weights
+        # Check if primary weights are stored in adam optimizer state
+        self.optimizer_contains_primary_weights = self.adam_optimizer.master_weights
 
         # CUDA streams for async transfers
         self._d2h_stream = torch.cuda.Stream()
@@ -56,18 +56,18 @@ class OptimizerStateOffloader:
         # CPU buffers for optimizer states: {param: {key: cpu_tensor}}
         self._opt_state_cpu_buffers: Dict[torch.Tensor, Dict[str, torch.Tensor]] = {}
 
-        # CPU buffers for mcore master weights, matching the structure of source groups
+        # CPU buffers for mcore primary weights, matching the structure of source groups
         # List[List[cpu_tensor]]
         self._shard_fp32_from_float16_cpu_buffers: List[List[torch.Tensor]] = []
 
         # State tracking
         self._offloaded = False
         self._offloaded_state_keys: Tuple[str, ...] = ()
-        self._offloaded_mcore_master_weights = False
+        self._offloaded_mcore_primary_weights = False
 
         # Track whether optimizer states (exp_avg, exp_avg_sq) have been initialized.
         # These are lazily initialized by FusedAdam during the first optimizer.step().
-        # Master weights (shard_fp32_from_float16_groups) are available from the start.
+        # Primary weights (shard_fp32_from_float16_groups) are available from the start.
         self._optimizer_states_initialized = False
 
     def mark_optimizer_states_initialized(self):
@@ -78,7 +78,7 @@ class OptimizerStateOffloader:
         self._optimizer_states_initialized = True
 
     def _get_state_keys_to_offload(
-        self, offload_optimizer_states: bool, offload_master_weights: bool
+        self, offload_optimizer_states: bool, offload_primary_weights: bool
     ) -> Tuple[str, ...]:
         """Get the state keys in FusedAdam to offload based on configuration."""
         keys = []
@@ -87,8 +87,8 @@ class OptimizerStateOffloader:
         if self._optimizer_states_initialized:
             if offload_optimizer_states:
                 keys.extend(self.OPTIMIZER_STATE_KEYS)
-            if offload_master_weights and self.optimizer_contains_master_weights:
-                keys.append(self.MASTER_WEIGHT_KEY)
+            if offload_primary_weights and self.optimizer_contains_primary_weights:
+                keys.append(self.PRIMARY_WEIGHT_KEY)
         return tuple(keys)
 
     def _ensure_state_cpu_buffer(
@@ -142,13 +142,13 @@ class OptimizerStateOffloader:
     def _offload_states(
         self,
         offload_optimizer_states: bool,
-        offload_master_weights: bool,
+        offload_primary_weights: bool,
         use_pin_memory: bool = True,
     ):
-        """Offload optimizer states and/or master weights to CPU."""
+        """Offload optimizer states and/or primary weights to CPU."""
         # Offload states from adam optimizer
         self._offloaded_state_keys = self._get_state_keys_to_offload(
-            offload_optimizer_states, offload_master_weights
+            offload_optimizer_states, offload_primary_weights
         )
         states = self.adam_optimizer.state
 
@@ -167,14 +167,14 @@ class OptimizerStateOffloader:
                 cpu_buffer.copy_(gpu_tensor, non_blocking=use_pin_memory)
                 gpu_tensor.record_stream(self._d2h_stream)
 
-        # Offload mcore master weights if not in optimizer state
-        if offload_master_weights and not self.optimizer_contains_master_weights:
+        # Offload mcore primary weights if not in optimizer state
+        if offload_primary_weights and not self.optimizer_contains_primary_weights:
             self._offload_shard_groups(
                 self.dist_optimizer.shard_fp32_from_float16_groups,
                 self._shard_fp32_from_float16_cpu_buffers,
                 use_pin_memory,
             )
-            self._offloaded_mcore_master_weights = True
+            self._offloaded_mcore_primary_weights = True
 
     def _release_states(self):
         """Replace optimizer state GPU tensors with CPU tensors to free GPU memory."""
@@ -190,7 +190,7 @@ class OptimizerStateOffloader:
 
                 param_state[state_key].untyped_storage().resize_(0)
 
-        if self._offloaded_mcore_master_weights:
+        if self._offloaded_mcore_primary_weights:
             for group in self.dist_optimizer.shard_fp32_from_float16_groups:
                 for gpu_tensor in group:
                     gpu_tensor.untyped_storage().resize_(0)
@@ -216,9 +216,9 @@ class OptimizerStateOffloader:
 
     def _reload_states(self, is_allocate_stage: bool):
         """
-        Reload optimizer states and/or master weights from CPU to GPU.
+        Reload optimizer states and/or primary weights from CPU to GPU.
 
-        If is_allocate_stage is True, only allocate GPU memory for the states and master weights,
+        If is_allocate_stage is True, only allocate GPU memory for the states and primary weights,
         but do not copy the data from CPU to GPU. Otherwise, copy the data from CPU to GPU.
         The two processes are separated to make sure that the GPU memory is allocated on the
         default stream to avoid fragmentation.
@@ -242,40 +242,40 @@ class OptimizerStateOffloader:
                 else:
                     param_state[state_key].copy_(cpu_buffer, non_blocking=cpu_buffer.is_pinned())
 
-        # Reload mcore master weights if not in optimizer state
-        if self._offloaded_mcore_master_weights:
+        # Reload mcore primary weights if not in optimizer state
+        if self._offloaded_mcore_primary_weights:
             self._reload_shard_groups(
                 self.dist_optimizer.shard_fp32_from_float16_groups,
                 self._shard_fp32_from_float16_cpu_buffers,
                 is_allocate_stage,
             )
 
-    def offload(self, offload_optimizer_states: bool = True, offload_master_weights: bool = True):
+    def offload(self, offload_optimizer_states: bool = True, offload_primary_weights: bool = True):
         """
-        Offload optimizer states and/or master weights to CPU.
+        Offload optimizer states and/or primary weights to CPU.
         Starts async D2H transfer that can overlap with other operations.
 
         Args:
             offload_optimizer_states: Whether to offload exp_avg, exp_avg_sq.
-            offload_master_weights: Whether to offload master weights.
+            offload_primary_weights: Whether to offload primary weights.
         """
-        if not offload_optimizer_states and not offload_master_weights:
+        if not offload_optimizer_states and not offload_primary_weights:
             return
 
         # Wait for current stream finishing updating the optimizer states.
         self._d2h_stream.wait_stream(torch.cuda.current_stream())
 
         with torch.cuda.stream(self._d2h_stream):
-            self._offload_states(offload_optimizer_states, offload_master_weights)
+            self._offload_states(offload_optimizer_states, offload_primary_weights)
 
         self._offloaded = True
 
     def release_gpu_memory(self):
         """
-        Release GPU memory for optimizer states and master weights after D2H copy completes.
+        Release GPU memory for optimizer states and primary weights after D2H copy completes.
 
         This is separated from offload() to allow delayed GPU memory release,
-        which is needed for mxfp8 + overlap_param_gather case where master weights
+        which is needed for mxfp8 + overlap_param_gather case where primary weights
         must remain on GPU until after _copy_main_params_to_param_buffer() is called.
         """
         if not self._offloaded:
@@ -285,7 +285,7 @@ class OptimizerStateOffloader:
 
     def reload(self):
         """
-        Reload optimizer states and/or master weights from CPU to GPU.
+        Reload optimizer states and/or primary weights from CPU to GPU.
         Call before optimizer.step() to ensure states are on GPU.
         """
         if not self._offloaded:
@@ -302,7 +302,7 @@ class OptimizerStateOffloader:
             self._reload_states(is_allocate_stage=False)
 
         self._offloaded_state_keys = ()
-        self._offloaded_mcore_master_weights = False
+        self._offloaded_mcore_primary_weights = False
         self._offloaded = False
 
     def sync_before_step(self):

--- a/megatron/core/optimizer/cpu_offloading/optimizer_state_offloader.py
+++ b/megatron/core/optimizer/cpu_offloading/optimizer_state_offloader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 """Optimizer state offloading class."""
 

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -531,6 +531,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             "due to checkpointing requirements."
         )
 
+        self._state_offloader: Optional[OptimizerStateOffloader] = None
+
         # when freezing sub-models we have no real optimizer
         # but still need a stub DistributedOptimizer class
         if optimizer is None:
@@ -620,7 +622,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             self.optimizer.param_groups = [g["orig_group"] for g in self.opt_group_ranges]
             self.optimizer.load_state_dict(self.optimizer.state_dict())
 
-        self._state_offloader: Optional[OptimizerStateOffloader] = None
         if self.config.offload_optimizer_states:
             self._state_offloader = OptimizerStateOffloader(self)
 

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -51,6 +51,7 @@ from ..distributed.param_and_grad_buffer import _ParamAndGradBuffer, partition_b
 from ..fp8_utils import dequantize_fp8_tensor, is_float8tensor, quantize_param_shard
 from ..transformer.fsdp_dtensor_checkpoint import handle_experts_in_state_dict
 from ..transformer.module import MegatronModule
+from .cpu_offloading.optimizer_state_offloader import OptimizerStateOffloader
 from .grad_scaler import MegatronGradScaler
 from .optimizer import MixedPrecisionOptimizer, _zero_grad_group_helper, param_group_identifier_keys
 from .optimizer_config import OptimizerConfig
@@ -618,6 +619,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         else:
             self.optimizer.param_groups = [g["orig_group"] for g in self.opt_group_ranges]
             self.optimizer.load_state_dict(self.optimizer.state_dict())
+
+        self._state_offloader: Optional[OptimizerStateOffloader] = None
 
     def _get_model_param_range_map(self, param: torch.nn.Parameter):
         """
@@ -2640,6 +2643,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         Under the hood, either launch synchronous param all-gathers or get ready to launch
         asynchorous all-gathers that get overlapped with the next forward pass.
         """
+        if self._state_offloader is not None:
+            self._state_offloader.sync_before_step()
         update_successful = super().step_with_ready_grads()
 
         timers = self.config.timers
@@ -2662,4 +2667,24 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         if timers is not None:
             timers('params-all-gather').stop()
 
+        # The states are initialized after the first optimizer.step() call.
+        # So we initialize the offloader here to make sure the states are initialized.
+        if self.config.offload_optimizer_states and self._state_offloader is None:
+            self._state_offloader = OptimizerStateOffloader(self)
+
         return update_successful
+
+    def offload_states(self):
+        """Offload states to CPU."""
+        if self._state_offloader is not None:
+            self._state_offloader.offload()
+
+    def reload_offloaded_states(self):
+        """Start async reload of offloaded states."""
+        if self._state_offloader is not None:
+            self._state_offloader.reload()
+
+    def release_offloaded_gpu_states(self):
+        """Release GPU memory after D2H completes. For delayed release case."""
+        if self._state_offloader is not None:
+            self._state_offloader.release_gpu_memory()

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -621,6 +621,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             self.optimizer.load_state_dict(self.optimizer.state_dict())
 
         self._state_offloader: Optional[OptimizerStateOffloader] = None
+        if self.config.offload_optimizer_states or self.config.offload_master_weights:
+            self._state_offloader = OptimizerStateOffloader(self)
 
     def _get_model_param_range_map(self, param: torch.nn.Parameter):
         """
@@ -2667,10 +2669,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         if timers is not None:
             timers('params-all-gather').stop()
 
-        # The states are initialized after the first optimizer.step() call.
-        # So we initialize the offloader here to make sure the states are initialized.
-        if self.config.offload_optimizer_states and self._state_offloader is None:
-            self._state_offloader = OptimizerStateOffloader(self)
+        if self._state_offloader is not None:
+            self._state_offloader.mark_optimizer_states_initialized()
 
         return update_successful
 

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -621,7 +621,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             self.optimizer.load_state_dict(self.optimizer.state_dict())
 
         self._state_offloader: Optional[OptimizerStateOffloader] = None
-        if self.config.offload_optimizer_states or self.config.offload_master_weights:
+        if self.config.offload_optimizer_states:
             self._state_offloader = OptimizerStateOffloader(self)
 
     def _get_model_param_range_map(self, param: torch.nn.Parameter):

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -365,6 +365,12 @@ class OptimizerConfig:
     pin_cpu_params: bool = True
     """If True, pin the optimizer parameters to CPU memory."""
 
+    offload_optimizer_states: bool = False
+    """
+    If True, offload optimizer states to CPU after each optimizer step and
+    reload them before the next optimizer step.
+    """
+
     ################
     # Miscellaneous
     ################

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1519,6 +1519,11 @@ def validate_args(args, defaults={}):
             "must be used in conjunction with `--fp8-recipe delayed`."
         )
 
+    if args.offload_optimizer_states:
+        assert args.use_distributed_optimizer, "offload_optimizer_states is only supported with distributed optimizer"
+        assert args.optimizer == 'adam', "offload_optimizer_states is only supported with adam optimizer"
+        assert not args.use_megatron_fsdp, "offload_optimizer_states does not support Megatron-FSDP for now."
+
     if args.non_persistent_ckpt_type == "local":
         assert args.non_persistent_local_ckpt_dir is not None, "Tried to use local checkpointing without specifying --local-ckpt-dir!"
     if args.replication:
@@ -2522,6 +2527,13 @@ def _add_training_args(parser):
                        help='Disable pinning of CPU memory for gradients.')
     group.add_argument('--no-pin-cpu-params', action='store_false', dest='pin_cpu_params',
                        help='Disable pinning of CPU memory for parameters.')
+    group.add_argument('--offload-optimizer-states',
+                       action='store_true',
+                       dest='offload_optimizer_states',
+                       help='Offload optimizer states to CPU after each optimizer step and '
+                       'reload them before the next optimizer step. '
+                       'Note that this still uses pure GPU optimizer instead of '
+                       'HybridDeviceOptimizer for --optimizer-cpu-offload.')
     group.add_argument('--dataloader-type', type=str, default=None,
                        choices=['single', 'cyclic', 'external'],
                        help='Single pass vs multiple pass data loader')

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2532,6 +2532,7 @@ def _add_training_args(parser):
                        dest='offload_optimizer_states',
                        help='Offload optimizer states to CPU after each optimizer step and '
                        'reload them before the next optimizer step. '
+                       'Only support TE FusedAdam optimizer.'
                        'Note that this still uses pure GPU optimizer instead of '
                        'HybridDeviceOptimizer for --optimizer-cpu-offload.')
     group.add_argument('--dataloader-type', type=str, default=None,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1523,6 +1523,7 @@ def validate_args(args, defaults={}):
         assert args.use_distributed_optimizer, "offload_optimizer_states is only supported with distributed optimizer"
         assert args.optimizer == 'adam', "offload_optimizer_states is only supported with adam optimizer"
         assert not args.use_megatron_fsdp, "offload_optimizer_states does not support Megatron-FSDP for now."
+        assert not args.optimizer_cpu_offload, "offload_optimizer_states can not be used with optimizer_cpu_offload."
 
     if args.non_persistent_ckpt_type == "local":
         assert args.non_persistent_local_ckpt_dir is not None, "Tried to use local checkpointing without specifying --local-ckpt-dir!"

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1790,6 +1790,12 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     save_wgrads_in_this_iteration = (args.save_wgrads_interval is not None and
                                      (iteration + 1) % args.save_wgrads_interval == 0)
     while rerun_state_machine.should_run_forward_backward(data_iterator):
+        # Offload optimizer states to CPU if enabled.
+        if args.offload_optimizer_states:
+            for optim_instance in optimizer.chained_optimizers:
+                if isinstance(optim_instance, DistributedOptimizer):
+                    optim_instance.offload_states()
+
         # Set grad to zero.
         for model_chunk in model:
             model_chunk.zero_grad_buffer()
@@ -1824,6 +1830,14 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
                 for optim_instance in optimizer.chained_optimizers:
                     if isinstance(optim_instance, DistributedOptimizer):
                         optim_instance._copy_main_params_to_param_buffer()
+
+        # Release GPU memory for offloaded optimizer states.
+        # This needs to be done after _copy_main_params_to_param_buffer().
+        # Separate offload and release to allow early D2H transfer to overlap with other operations.
+        if args.offload_optimizer_states:
+            for optim_instance in optimizer.chained_optimizers:
+                if isinstance(optim_instance, DistributedOptimizer):
+                    optim_instance.release_offloaded_gpu_states()
 
         # Forward pass.
         if save_dgrads_in_this_iteration:
@@ -2759,7 +2773,21 @@ def train(
         config.param_sync_func = [model_chunk.start_param_sync for model_chunk in model]
         if len(model) == 1:
             config.param_sync_func = config.param_sync_func[0]
-    config.finalize_model_grads_func = finalize_model_grads
+
+    # Wrap finalize_model_grads to reload offloaded optimizer states before grad finalization.
+    # This allows H2D transfer to overlap with grad all-reduce.
+    if args.offload_optimizer_states:
+
+        def finalize_model_grads_with_state_reload(*fmg_args, **fmg_kwargs):
+            # Reload offloaded states for all DistributedOptimizer instances
+            for optim_instance in optimizer.chained_optimizers:
+                if isinstance(optim_instance, DistributedOptimizer):
+                    optim_instance.reload_offloaded_states()
+            return finalize_model_grads(*fmg_args, **fmg_kwargs)
+
+        config.finalize_model_grads_func = finalize_model_grads_with_state_reload
+    else:
+        config.finalize_model_grads_func = finalize_model_grads
 
     if args.log_energy:
         energy_monitor.setup()

--- a/tests/unit_tests/test_optimizer_state_offloading.py
+++ b/tests/unit_tests/test_optimizer_state_offloading.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for OptimizerStateOffloader."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+from megatron.core.transformer import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+try:
+    from transformer_engine.pytorch.optimizers import FusedAdam  # noqa: F401
+
+    TE_FUSED_ADAM_AVAILABLE = True
+except ImportError:
+    TE_FUSED_ADAM_AVAILABLE = False
+
+
+class SimpleModel(nn.Module):
+    """Simple model for testing."""
+
+    def __init__(self, hidden_size=256):
+        super().__init__()
+        self.fc1 = nn.Linear(hidden_size, hidden_size)
+        self.fc2 = nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, x):
+        return self.fc2(torch.relu(self.fc1(x)))
+
+
+def create_model_and_optimizer(hidden_size=256, offload_optimizer_states=True, **optimizer_kwargs):
+    """Helper to create model and optimizer for tests."""
+    model = SimpleModel(hidden_size=hidden_size).bfloat16().cuda()
+    ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=True)
+    model = DistributedDataParallel(
+        TransformerConfig(num_attention_heads=1, num_layers=1), ddp_config, model
+    )
+
+    default_config = dict(
+        optimizer='adam',
+        bf16=True,
+        use_distributed_optimizer=True,
+        offload_optimizer_states=offload_optimizer_states,
+    )
+    default_config.update(optimizer_kwargs)
+
+    optimizer_config = OptimizerConfig(**default_config)
+    optim = get_megatron_optimizer(optimizer_config, [model])
+    return model, optim
+
+
+def run_forward_backward_step(model, optim, hidden_size=256):
+    """Run a single forward-backward-step cycle."""
+    input_tensor = torch.randn(8, hidden_size, dtype=torch.bfloat16, device='cuda')
+    output = model(input_tensor)
+    output.sum().backward()
+    optim.step()
+    optim.zero_grad()
+
+
+# =============================================================================
+# Test 1: Basic OptimizerStateOffloader Initialization
+# =============================================================================
+@pytest.mark.skipif(not TE_FUSED_ADAM_AVAILABLE, reason="Requires TE FusedAdam")
+def test_offloader_initialization():
+    """Test that OptimizerStateOffloader initializes correctly."""
+    Utils.initialize_model_parallel()
+    model, optim = create_model_and_optimizer()
+    dist_optim = optim.chained_optimizers[0]
+
+    # Before first step, offloader should be None
+    assert dist_optim._state_offloader is None
+
+    # Run one step to initialize optimizer states
+    run_forward_backward_step(model, optim)
+
+    # After first step, offloader should be initialized
+    assert dist_optim._state_offloader is not None
+    offloader = dist_optim._state_offloader
+
+    # Verify offloader properties
+    assert offloader.adam_optimizer is not None
+    assert offloader._d2h_stream is not None
+    assert offloader._h2d_stream is not None
+    assert offloader._offloaded is False
+    Utils.destroy_model_parallel()
+
+
+# =============================================================================
+# Test 2: Offload and Reload Correctness
+# =============================================================================
+@pytest.mark.skipif(not TE_FUSED_ADAM_AVAILABLE, reason="Requires TE FusedAdam")
+@pytest.mark.parametrize("offload_optimizer_states", [True, False])
+@pytest.mark.parametrize("offload_master_weights", [True, False])
+def test_offload_reload_correctness(offload_optimizer_states, offload_master_weights):
+    """Test that offload/reload preserves optimizer state values."""
+    if not offload_optimizer_states and not offload_master_weights:
+        pytest.skip("At least one offload type required")
+
+    Utils.initialize_model_parallel()
+    model, optim = create_model_and_optimizer()
+    dist_optim = optim.chained_optimizers[0]
+
+    # Run steps to build up optimizer state
+    for _ in range(3):
+        run_forward_backward_step(model, optim)
+
+    offloader = dist_optim._state_offloader
+
+    # Capture original states before offload
+    original_states = {}
+    for param, state in offloader.adam_optimizer.state.items():
+        original_states[param] = {
+            k: v.clone() for k, v in state.items() if isinstance(v, torch.Tensor)
+        }
+
+    # Offload
+    offloader.offload(
+        offload_optimizer_states=offload_optimizer_states,
+        offload_master_weights=offload_master_weights,
+    )
+
+    # Release GPU memory
+    offloader.release_gpu_memory()
+    torch.cuda.synchronize()
+
+    # Reload
+    offloader.reload()
+    offloader.sync_before_step()
+
+    # Verify states match after reload
+    for param, state in offloader.adam_optimizer.state.items():
+        if param in original_states:
+            for key, original_tensor in original_states[param].items():
+                if key in state and isinstance(state[key], torch.Tensor):
+                    reloaded_tensor = state[key]
+                    assert reloaded_tensor.device.type == 'cuda', f"State {key} should be on GPU"
+                    torch.testing.assert_close(
+                        reloaded_tensor, original_tensor, msg=f"State {key} mismatch after offload/reload"
+                    )
+    Utils.destroy_model_parallel()
+
+
+# =============================================================================
+# Test 3: GPU Memory Release Verification
+# =============================================================================
+@pytest.mark.skipif(not TE_FUSED_ADAM_AVAILABLE, reason="Requires TE FusedAdam")
+def test_gpu_memory_release():
+    """Test that GPU memory is actually freed after release_gpu_memory()."""
+    Utils.initialize_model_parallel()
+    # Use larger model for measurable memory impact
+    model, optim = create_model_and_optimizer(hidden_size=1024)
+    dist_optim = optim.chained_optimizers[0]
+
+    # Initialize optimizer states
+    run_forward_backward_step(model, optim, hidden_size=1024)
+
+    offloader = dist_optim._state_offloader
+
+    # Measure memory before offload
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    memory_before = torch.cuda.memory_allocated()
+
+    # Offload and release
+    offloader.offload()
+    offloader.release_gpu_memory()
+
+    # Wait for async operations
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    memory_after = torch.cuda.memory_allocated()
+
+    # Memory should decrease
+    memory_freed = memory_before - memory_after
+    assert memory_freed > 0, f"Expected memory to be freed, but got {memory_freed} bytes difference"
+    Utils.destroy_model_parallel()
+
+
+# =============================================================================
+# Test 4: Multiple Offload/Reload Cycles
+# =============================================================================
+@pytest.mark.skipif(not TE_FUSED_ADAM_AVAILABLE, reason="Requires TE FusedAdam")
+def test_multiple_offload_reload_cycles():
+    """Test that multiple offload/reload cycles work correctly."""
+    Utils.initialize_model_parallel()
+    model, optim = create_model_and_optimizer()
+    dist_optim = optim.chained_optimizers[0]
+
+    # Initialize
+    run_forward_backward_step(model, optim)
+
+    offloader = dist_optim._state_offloader
+
+    # Run multiple cycles
+    for cycle in range(5):
+        # Offload
+        offloader.offload()
+        offloader.release_gpu_memory()
+
+        # Reload
+        offloader.reload()
+        offloader.sync_before_step()
+
+        # Run optimizer step
+        run_forward_backward_step(model, optim)
+
+    # Verify model can still produce valid outputs
+    input_tensor = torch.randn(8, 256, dtype=torch.bfloat16, device='cuda')
+    output = model(input_tensor)
+    assert not output.isnan().any(), "Model output contains NaN after multiple cycles"
+    Utils.destroy_model_parallel()
+
+
+# =============================================================================
+# Test 5: Training Correctness with Offloading
+# =============================================================================
+@pytest.mark.skipif(not TE_FUSED_ADAM_AVAILABLE, reason="Requires TE FusedAdam")
+def test_training_correctness_with_offloading():
+    """Test that training with offloading produces same results as without."""
+    Utils.initialize_model_parallel()
+    torch.manual_seed(42)
+
+    # Model 1: with offloading
+    model1, optim1 = create_model_and_optimizer(offload_optimizer_states=True, lr=0.01)
+
+    # Model 2: without offloading (reference)
+    torch.manual_seed(42)
+    model2, optim2 = create_model_and_optimizer(offload_optimizer_states=False, lr=0.01)
+
+    # Train both models
+    n_steps = 10
+    torch.manual_seed(123)
+    for step in range(n_steps):
+        input_tensor = torch.randn(8, 256, dtype=torch.bfloat16, device='cuda')
+
+        # Model 1 with offloading
+        dist_optim1 = optim1.chained_optimizers[0]
+        if dist_optim1._state_offloader is not None:
+            dist_optim1._state_offloader.offload()
+            dist_optim1._state_offloader.release_gpu_memory()
+
+        output1 = model1(input_tensor)
+        loss1 = output1.sum()
+        loss1.backward()
+
+        if dist_optim1._state_offloader is not None:
+            dist_optim1._state_offloader.reload()
+            dist_optim1._state_offloader.sync_before_step()
+        optim1.step()
+        optim1.zero_grad()
+
+        # Model 2 without offloading
+        output2 = model2(input_tensor)
+        loss2 = output2.sum()
+        loss2.backward()
+        optim2.step()
+        optim2.zero_grad()
+
+    # Compare final model weights
+    for (n1, p1), (n2, p2) in zip(model1.named_parameters(), model2.named_parameters()):
+        torch.testing.assert_close(
+            p1.data,
+            p2.data,
+            atol=1e-5,
+            rtol=1e-4,
+            msg=f"Parameter {n1} mismatch between offloaded and non-offloaded training",
+        )
+    Utils.destroy_model_parallel()

--- a/tests/unit_tests/test_optimizer_state_offloading.py
+++ b/tests/unit_tests/test_optimizer_state_offloading.py
@@ -42,6 +42,7 @@ def create_model_and_optimizer(hidden_size=256, offload_optimizer_states=True, *
     default_config = dict(
         optimizer='adam',
         bf16=True,
+        lr=0.001,
         use_distributed_optimizer=True,
         offload_optimizer_states=offload_optimizer_states,
     )

--- a/tests/unit_tests/test_optimizer_state_offloading.py
+++ b/tests/unit_tests/test_optimizer_state_offloading.py
@@ -94,11 +94,11 @@ def test_offloader_initialization():
 
 
 # =============================================================================
-# Test 2: Early Master Weight Offloading Before First Step
+# Test 2: Early Primary Weight Offloading Before First Step
 # =============================================================================
 @pytest.mark.skipif(not TE_FUSED_ADAM_AVAILABLE, reason="Requires TE FusedAdam")
-def test_early_master_weight_offloading():
-    """Test that master weights can be offloaded before the first optimizer step."""
+def test_early_primary_weight_offloading():
+    """Test that primary weights can be offloaded before the first optimizer step."""
     Utils.initialize_model_parallel()
     model, optim = create_model_and_optimizer()
     dist_optim = optim.chained_optimizers[0]
@@ -110,34 +110,34 @@ def test_early_master_weight_offloading():
     # Before first step, optimizer states are not initialized
     assert offloader._optimizer_states_initialized is False
 
-    # Capture original master weights before offload
-    original_master_weights = []
+    # Capture original primary weights before offload
+    original_primary_weights = []
     for group in dist_optim.shard_fp32_from_float16_groups:
         group_weights = [tensor.clone() for tensor in group]
-        original_master_weights.append(group_weights)
+        original_primary_weights.append(group_weights)
 
-    # Offload before first step - should only offload master weights
+    # Offload before first step - should only offload primary weights
     offloader.offload()
     offloader.release_gpu_memory()
     torch.cuda.synchronize()
 
-    # Verify master weights were offloaded (storage resized to 0)
+    # Verify primary weights were offloaded (storage resized to 0)
     for group in dist_optim.shard_fp32_from_float16_groups:
         for tensor in group:
-            assert tensor.untyped_storage().size() == 0, "Master weight should be offloaded"
+            assert tensor.untyped_storage().size() == 0, "Primary weight should be offloaded"
 
-    # Reload master weights
+    # Reload primary weights
     offloader.reload()
     offloader.sync_before_step()
 
-    # Verify master weights match after reload
+    # Verify primary weights match after reload
     for group_idx, group in enumerate(dist_optim.shard_fp32_from_float16_groups):
         for param_idx, tensor in enumerate(group):
-            original = original_master_weights[group_idx][param_idx]
+            original = original_primary_weights[group_idx][param_idx]
             torch.testing.assert_close(
                 tensor,
                 original,
-                msg=f"Master weight [{group_idx}][{param_idx}] mismatch after offload/reload",
+                msg=f"Primary weight [{group_idx}][{param_idx}] mismatch after offload/reload",
             )
 
     # Now run a step and verify optimizer states can be offloaded after
@@ -152,10 +152,10 @@ def test_early_master_weight_offloading():
 # =============================================================================
 @pytest.mark.skipif(not TE_FUSED_ADAM_AVAILABLE, reason="Requires TE FusedAdam")
 @pytest.mark.parametrize("offload_optimizer_states", [True, False])
-@pytest.mark.parametrize("offload_master_weights", [True, False])
-def test_offload_reload_correctness(offload_optimizer_states, offload_master_weights):
+@pytest.mark.parametrize("offload_primary_weights", [True, False])
+def test_offload_reload_correctness(offload_optimizer_states, offload_primary_weights):
     """Test that offload/reload preserves optimizer state values."""
-    if not offload_optimizer_states and not offload_master_weights:
+    if not offload_optimizer_states and not offload_primary_weights:
         pytest.skip("At least one offload type required")
 
     Utils.initialize_model_parallel()
@@ -178,7 +178,7 @@ def test_offload_reload_correctness(offload_optimizer_states, offload_master_wei
     # Offload
     offloader.offload(
         offload_optimizer_states=offload_optimizer_states,
-        offload_master_weights=offload_master_weights,
+        offload_primary_weights=offload_primary_weights,
     )
 
     # Release GPU memory
@@ -304,7 +304,7 @@ def test_training_correctness_with_offloading():
         input_tensor = torch.randn(8, 256, dtype=torch.bfloat16, device='cuda')
 
         # Model 1 with offloading
-        # Offload states (master weights can be offloaded from the start,
+        # Offload states (primary weights can be offloaded from the start,
         # optimizer states will be skipped until after first step)
         offloader.offload()
         offloader.release_gpu_memory()

--- a/tests/unit_tests/test_optimizer_state_offloading.py
+++ b/tests/unit_tests/test_optimizer_state_offloading.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 """Unit tests for OptimizerStateOffloader."""
 


### PR DESCRIPTION
# What does this PR do ?
dev branch: #2760 

## PR Description: Optimizer State Offloading for DistributedOptimizer

### Summary

This PR introduces optimizer state offloading to CPU for the `DistributedOptimizer`, enabling significant GPU memory savings during training by temporarily moving optimizer states (exp_avg, exp_avg_sq) and master weights to CPU memory when not in use.

### Motivation

During the forward and backward passes, optimizer states occupy GPU memory but are not actively used. For large models, these states can consume a substantial portion of GPU memory. By offloading optimizer states to CPU after `optimizer.step()` and reloading them before the next step, we can reclaim this GPU memory for other operations like activation checkpointing or larger batch sizes.

### Performance & Memory Savings

**Memory Savings:**
- On **DeepSeek-V3**, this feature saves **15-20GB** of GPU memory (with 0.1-0.2s/iter overhead on GB200)

**Comparison with Optimizer CPU Offloading:**

| Aspect | CPU Offloading (ZeRO-Offload style) | State Offloading (This PR) |
|--------|-------------------------------------|----------------------------|
| **Where optimizer runs** | CPU | GPU |
| **D2H/H2D frequency** | Every step (gradients + params) | Every step (states only) |
| **Compute location** | Adam step on CPU | Adam step on GPU |
| **Best for** | Memory-constrained, bandwidth-limited | High-bandwidth interconnects (NVLink, GB200) |

More details:
- With higher H2D/D2H bandwidth such as **GB200**, the state offloading has significantly less overhead
- Async transfer overlapping
- Optimizer step still runs on GPU, avoiding CPU compute bottleneck
- Pinned memory enables maximum PCIe/NVLink bandwidth utilization
- Currently requires TE FusedAdam optimizer

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @megatron-oncall.

## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

Feel free to message or comment the @megatron-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.
