### PR TITLE
Remove cross-rank synchronization during checkpoint load & deprecate torch.distributed.checkpoint.state_dict_loader.load_state_dict

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -859,7 +859,7 @@ class TorchDistLoadShardedStrategy:
         fsr = _get_filesystem_reader(
             checkpoint_dir, cache_metadata=self.cache_metadata, async_strategy=async_strategy
         )
-        checkpoint.load_state_dict(
+        checkpoint.load(
             pyt_state_dict,
             fsr,
             planner=MCoreLoadPlanner(

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -993,10 +993,10 @@ class TestOptimizerResharding:
     ):
         Utils.initialize_model_parallel(*src_tp_pp)
         with TempNamedDir(
-            tmp_path_dist_ckpt / 'test_fp32_optimizer_state_dict_A', sync=False
+            tmp_path_dist_ckpt / 'test_fp32_optimizer_state_dict_A', sync=True
         ) as ckpt_dir_A:
             with TempNamedDir(
-                tmp_path_dist_ckpt / 'test_fp32_optimizer_state_dict_B', sync=False
+                tmp_path_dist_ckpt / 'test_fp32_optimizer_state_dict_B', sync=True
             ) as ckpt_dir_B:
                 model_A, optimizer_A = setup_model_and_optimizer(
                     seed=2,
@@ -1073,10 +1073,10 @@ class TestOptimizerResharding:
         src_tp, src_pp, src_exp = src_tp_pp_exp
         dest_tp, dest_pp, dest_exp = dest_tp_pp_exp
         with TempNamedDir(
-            tmp_path_dist_ckpt / 'test_fp32_optimizer_state_dict_A', sync=False
+            tmp_path_dist_ckpt / 'test_fp32_optimizer_state_dict_A', sync=True
         ) as ckpt_dir_A:
             with TempNamedDir(
-                tmp_path_dist_ckpt / 'test_fp32_optimizer_state_dict_B', sync=False
+                tmp_path_dist_ckpt / 'test_fp32_optimizer_state_dict_B', sync=True
             ) as ckpt_dir_B:
                 Utils.initialize_model_parallel(src_tp, src_pp, expert_model_parallel_size=src_exp)
                 model_A, optimizer_A = setup_moe_model_and_optimizer(


### PR DESCRIPTION
  - Set `no_dist=True` during checkpoint load to remove cross-rank synchronization during checkpoint load.
  - Use `torch.distributed.checkpoint.state_dict_loader.load` instead of `torch.distributed.checkpoint.state_dict_loader.load_state_dict`
