### PR TITLE
feat: implement Cross-Layer Attention (CLA) for KV cache reduction

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -221,12 +221,20 @@ class TransformerConfig(ModelParallelConfig):
     multi_latent_attention: bool = False
     """Whether to use multi-latent attention."""
 
+    cross_layer_attention_interval: int = 1
+    """Interval for Cross-Layer Attention (CLA) KV sharing.
+    1: Standard attention (no sharing, every layer computes its own KV).
+    2: CLA2 - Share KV every 2 layers (Layer i generates KV, Layer i+1 reuses it).
+    N: Share KV every N layers. Layers where (layer_number - 1) % N == 0 compute fresh KV.
+    See arXiv:2405.12981 for details."""
+
     no_rope_freq: Optional[Union[int, List[int]]] = None
     """Controls which layers perform Rotary Position Embedding (RoPE). Accepts either:
     An integer N: Creates a pattern where RoPE is skipped every N-1 layers. For example,
     no_rope=4 means RoPE is applied for 3 layers, then skipped for 1 layer, repeating this pattern.
     A list of integers: Defines a custom pattern where 1 means skip RoPE and 0 means apply RoPE.
     For example, [0,1,1,0] means: apply RoPE, skip RoPE, skip RoPE, apply RoPE."""
+
 
     ####################
     # attention variant

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -81,7 +81,7 @@ class TestParallelAttention:
 
         attention_mask = torch.ones((micro_batch_size, 1, 1, sequence_length), dtype=bool).cuda()
 
-        output, bias = self.parallel_attention(hidden_states, attention_mask)
+        output, bias, _ = self.parallel_attention(hidden_states, attention_mask)
 
         assert config.recompute_granularity is None
         assert output.shape[0] == sequence_length
@@ -119,7 +119,7 @@ class TestParallelAttention:
         rotary_pos_emb = torch.ones(
             sequence_length, 1, 1, self.parallel_attention.config.kv_channels
         ).cuda()
-        output, bias = self.parallel_attention(
+        output, bias, _ = self.parallel_attention(
             hidden_states, attention_mask, rotary_pos_emb=rotary_pos_emb
         )
 
@@ -155,7 +155,7 @@ class TestParallelAttention:
 
         attention_mask = torch.ones((micro_batch_size, 1, 1, sequence_length), dtype=bool).cuda()
 
-        output, bias = checkpointed_parallel_attention(hidden_states, attention_mask)
+        output, bias, _ = checkpointed_parallel_attention(hidden_states, attention_mask)
 
         assert config.recompute_granularity == 'selective'
         assert "core_attn" in config.recompute_modules
@@ -393,7 +393,7 @@ class TestSelfAttention:
         )
         hidden_states_ref = copy.deepcopy(hidden_states)
 
-        output, bias = self.self_attention(hidden_states, None)
+        output, bias, _ = self.self_attention(hidden_states, None)
         assert config.recompute_granularity is None
         # Check if output and bias have the correct shape
         assert output.shape[0] == sequence_length

--- a/tests/unit_tests/transformer/test_cross_layer_attention.py
+++ b/tests/unit_tests/transformer/test_cross_layer_attention.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""
+Unit tests for Cross-Layer Attention (CLA).
+
+CLA is a technique to reduce KV cache memory by sharing Key-Value tensors
+across multiple transformer layers. See arXiv:2405.12981 for details.
+"""
+
+import pytest
+import torch
+
+import megatron.core.parallel_state as parallel_state
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.transformer_block import TransformerBlock
+from tests.unit_tests.test_utilities import Utils
+
+
+class TestCrossLayerAttention:
+    """Tests for Cross-Layer Attention (CLA) feature."""
+
+    def setup_method(self):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self):
+        Utils.destroy_model_parallel()
+
+    def test_cla_config_default(self):
+        """Test that CLA is disabled by default (interval=1)."""
+        config = TransformerConfig(
+            num_layers=4,
+            hidden_size=64,
+            num_attention_heads=2,
+            use_cpu_initialization=True,
+        )
+        assert config.cross_layer_attention_interval == 1
+
+    def test_cla_config_interval_2(self):
+        """Test CLA config with interval=2 (CLA2)."""
+        config = TransformerConfig(
+            num_layers=4,
+            hidden_size=64,
+            num_attention_heads=2,
+            cross_layer_attention_interval=2,
+            use_cpu_initialization=True,
+        )
+        assert config.cross_layer_attention_interval == 2
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_cla_forward_no_error(self):
+        """Test that CLA forward pass runs without error."""
+        config = TransformerConfig(
+            num_layers=4,
+            hidden_size=64,
+            num_attention_heads=2,
+            cross_layer_attention_interval=2,
+            use_cpu_initialization=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+        )
+        layer_spec = get_gpt_layer_with_transformer_engine_spec()
+        block = TransformerBlock(config=config, spec=layer_spec)
+        block.cuda()
+
+        sequence_length = 16
+        micro_batch_size = 2
+
+        hidden_states = torch.randn(
+            sequence_length, micro_batch_size, config.hidden_size,
+            device='cuda', dtype=torch.bfloat16
+        )
+        attention_mask = torch.ones(
+            (micro_batch_size, 1, 1, sequence_length), dtype=bool, device='cuda'
+        )
+
+        # Forward pass should work without error
+        output = block(hidden_states, attention_mask)
+
+        assert output.shape == hidden_states.shape
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_cla_output_shape_consistency(self):
+        """Test that CLA output shape matches standard attention output shape."""
+        # Config without CLA
+        config_standard = TransformerConfig(
+            num_layers=4,
+            hidden_size=64,
+            num_attention_heads=2,
+            cross_layer_attention_interval=1,  # Standard attention
+            use_cpu_initialization=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+        )
+        # Config with CLA
+        config_cla = TransformerConfig(
+            num_layers=4,
+            hidden_size=64,
+            num_attention_heads=2,
+            cross_layer_attention_interval=2,  # CLA2
+            use_cpu_initialization=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+        )
+
+        layer_spec = get_gpt_layer_with_transformer_engine_spec()
+        block_standard = TransformerBlock(config=config_standard, spec=layer_spec)
+        block_cla = TransformerBlock(config=config_cla, spec=layer_spec)
+
+        block_standard.cuda()
+        block_cla.cuda()
+
+        sequence_length = 16
+        micro_batch_size = 2
+
+        hidden_states = torch.randn(
+            sequence_length, micro_batch_size, config_standard.hidden_size,
+            device='cuda', dtype=torch.bfloat16
+        )
+        attention_mask = torch.ones(
+            (micro_batch_size, 1, 1, sequence_length), dtype=bool, device='cuda'
+        )
+
+        output_standard = block_standard(hidden_states, attention_mask)
+        output_cla = block_cla(hidden_states.clone(), attention_mask)
+
+        # Shapes should match
+        assert output_standard.shape == output_cla.shape
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_cla_layer_numbering(self):
+        """Test that Master/Slave layer assignment follows expected pattern."""
+        config = TransformerConfig(
+            num_layers=4,
+            hidden_size=64,
+            num_attention_heads=2,
+            cross_layer_attention_interval=2,
+            use_cpu_initialization=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+        )
+        layer_spec = get_gpt_layer_with_transformer_engine_spec()
+        block = TransformerBlock(config=config, spec=layer_spec)
+
+        # With interval=2, layers 1, 3 are Masters (compute fresh KV)
+        # Layers 2, 4 are Slaves (reuse KV from previous layer)
+        cla_interval = config.cross_layer_attention_interval
+        for layer in block.layers:
+            is_master = (layer.layer_number - 1) % cla_interval == 0
+            if layer.layer_number in [1, 3]:
+                assert is_master, f"Layer {layer.layer_number} should be a Master layer"
+            elif layer.layer_number in [2, 4]:
+                assert not is_master, f"Layer {layer.layer_number} should be a Slave layer"
+
+
+class TestCrossLayerAttentionIntervals:
+    """Tests for different CLA interval configurations."""
+
+    def setup_method(self):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("interval", [1, 2, 3, 4])
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_cla_various_intervals(self, interval):
+        """Test CLA with various interval values."""
+        config = TransformerConfig(
+            num_layers=8,
+            hidden_size=64,
+            num_attention_heads=2,
+            cross_layer_attention_interval=interval,
+            use_cpu_initialization=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+        )
+        layer_spec = get_gpt_layer_with_transformer_engine_spec()
+        block = TransformerBlock(config=config, spec=layer_spec)
+        block.cuda()
+
+        sequence_length = 16
+        micro_batch_size = 2
+
+        hidden_states = torch.randn(
+            sequence_length, micro_batch_size, config.hidden_size,
+            device='cuda', dtype=torch.bfloat16
+        )
+        attention_mask = torch.ones(
+            (micro_batch_size, 1, 1, sequence_length), dtype=bool, device='cuda'
+        )
+
+        # Should not raise an error
+        output = block(hidden_states, attention_mask)
+        assert output.shape == hidden_states.shape


### PR DESCRIPTION
## Summary
Implements Cross-Layer Attention (CLA) as described in [arXiv:2405.12981](https://arxiv.org/abs/2405.12981).

CLA reduces KV cache memory by sharing Key-Value tensors across transformer layers. "Master" layers compute fresh KV, while "Slave" layers reuse the shared KV from the preceding Master.

## Changes
- Add `cross_layer_attention_interval` config parameter to `TransformerConfig`
- Modify `Attention.forward` to accept `cross_layer_kv` and return `kv_for_sharing`
- Add Master/Slave layer logic in `TransformerBlock` forward loop
- Update existing tests for new 3-tuple return signature
- Add unit tests in `test_cross_layer_attention.py`

## Usage
```python
config = TransformerConfig(
    num_layers=32,
    hidden_size=4096,
    num_attention_heads=32,
    cross_layer_attention_interval=2,  # Enable CLA2
)
```

## Testing
```bash
pytest tests/unit_tests/transformer/test_cross_layer_attention.py -v
```