### PR TITLE
Fix incorrect activation function comparison in TEActivationOp for ReGLU and ReLU

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -408,12 +408,12 @@ if HAVE_TE and is_te_min_version("1.13.0"):
                     layer_type = te.pytorch.ops.SwiGLU
                 elif config.activation_func == F.gelu:
                     layer_type = te.pytorch.ops.GEGLU
-                elif config.activation_func == F.silu:
+                elif config.activation_func == F.relu:
                     layer_type = te.pytorch.ops.ReGLU
             else:
                 if config.activation_func == F.gelu:
                     layer_type = te.pytorch.ops.GELU
-                elif config.activation_func == F.silu:
+                elif config.activation_func == F.relu:
                     layer_type = te.pytorch.ops.ReLU
             if layer_type is None:
                 raise Exception(


### PR DESCRIPTION
# What does this PR do ?

Fix a bug in `TEActivationOp.__new__` where `F.silu` was incorrectly used instead of `F.relu`
for the ReGLU and ReLU activation branches, making them unreachable dead code.

## Problem

In `megatron/core/extensions/transformer_engine.py`, the `TEActivationOp` class maps
`(activation_func, gated_linear_unit)` combinations to Transformer Engine activation ops.
However, two branches compared against `F.silu` instead of `F.relu`:

- **Line 411**: `config.activation_func == F.silu` → `te.pytorch.ops.ReGLU`
- **Line 416**: `config.activation_func == F.silu` → `te.pytorch.ops.ReLU`

Since `F.silu` was already matched earlier (line 407 for SwiGLU), these branches could
never be reached. As a result, any user setting `activation_func=F.relu` with
`use_te_activation_func=True` would get an exception instead of the expected ReGLU/ReLU op.

## Fix

Changed the comparisons from `F.silu` to `F.relu`, consistent with the correct implementation
in `TEFusedMLP._make_activation_op` (line 1998-2001) which already handles this mapping properly.

## How to test

- Verify that `TEActivationOp` correctly returns `te.pytorch.ops.ReGLU` when
  `activation_func=F.relu` and `gated_linear_unit=True`
- Verify that `TEActivationOp` correctly returns `te.pytorch.ops.ReLU` when
  `activation_func=F.relu` and `gated_linear_unit=False`
- Existing SwiGLU / GEGLU / GELU paths are unaffected

## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

Feel free to message or comment the @mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.
