### PR TITLE
[Dev] Fix backward dw dependency

### DIFF
--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -329,9 +329,11 @@ class TransformerLayerNode(ScheduleNode):
         """Computes the weight gradients for the transformer layer node."""
         if not self.delay_wgrad_compute:
             return
-        with self.stream_acquire_context(f"{self.name} wgrad", wait_event=False):
+        with torch.cuda.stream(self.stream):
+            torch.cuda.nvtx.range_push(f"{self.name} wgrad")
             for module in self.bwd_dw_callables:
                 module.backward_dw()
+            torch.cuda.nvtx.range_pop()
 
         # the output grad memory is last used in wgrad compute, should be safe to release.
         assert self.delay_grads_release, "output grad memory should be valid before wgrad."

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -271,7 +271,7 @@ class ScheduleNode:
         return grad
 
     @contextmanager
-    def stream_acquire_context(self, name=None, wait_event=True):
+    def stream_acquire_context(self, name=None):
         """Stream acquire context that handles event synchronization,
             NVTX profiling, and stream context.
 
@@ -282,10 +282,8 @@ class ScheduleNode:
 
         Args:
             name: Optional name for NVTX range profiling
-            wait_event: Whether to wait for the previous event
         """
-        if wait_event:
-            self.event.wait(self.stream)
+        self.event.wait(self.stream)
         if name:
             torch.cuda.nvtx.range_push(name)
         try:
@@ -294,8 +292,7 @@ class ScheduleNode:
         finally:
             if name:
                 torch.cuda.nvtx.range_pop()
-            if wait_event:
-                self.event.record(self.stream)
+            self.event.record(self.stream)
 
     def _release_state(self):
         """Clear the state of the node"""


### PR DESCRIPTION
# What does this PR do ?
#3163 adds stream context to `backward_dw`, but also accidentally adds event synchronization as well, which leads to perf regression.
main PR: #3164 
## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

Feel free to message or comment the @mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.
