### PR TITLE
docs: fix wrong documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Megatron-LM and Megatron Core
 
 <h4>GPU-optimized library for training transformer models at scale</h4>
 
-[![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](https://docs.nvidia.com/Megatron-Core/developer-guide/latest/index.html)
+[![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](https://docs.nvidia.com/megatron-core/developer-guide/latest/get-started/quickstart.html)
 [![version](https://img.shields.io/badge/release-0.12.0-green)](./CHANGELOG.md)
 [![license](https://img.shields.io/badge/license-Apache-blue)](./LICENSE)
 


### PR DESCRIPTION
Hi team, I submitted this PR to correct a broken link to the documentation in the README.md file. The original URL was outdated and returned a "Page Not Found" error; it has been updated to point to the current, valid documentation page.

Example of the fix:
```markdown
<!-- Before -->
[Documentation](https://docs.nvidia.com/Megatron-Core/developer-guide/latest/index.html) ❌

<!-- After -->
[Documentation](https://docs.nvidia.com/megatron-core/developer-guide/latest/get-started/quickstart.html) ✅
```

This small but important fix helps maintain the project's professionalism and usability.