### PR TITLE
Ensure type-checker understands use of Submodules in unit tests

### DIFF
--- a/tests/functional_tests/test_cases/common/ckpt_converter/__main__.py
+++ b/tests/functional_tests/test_cases/common/ckpt_converter/__main__.py
@@ -8,7 +8,6 @@ import time
 import types
 import typing as T
 from collections import namedtuple
-from copy import deepcopy
 from functools import partial
 
 import numpy as np
@@ -19,14 +18,10 @@ from gpt_builders import gpt_builder
 from megatron.core import parallel_state
 from megatron.core.datasets.gpt_dataset import _get_ltor_masks_and_position_ids
 from megatron.core.enums import ModelType
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
-from megatron.core.models.multimodal.llava_model import DEFAULT_IMAGE_TOKEN_INDEX, LLaVAModel
-from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.models.multimodal.llava_model import DEFAULT_IMAGE_TOKEN_INDEX
 from megatron.core.pipeline_parallel import get_forward_backward_func
 from megatron.core.tensor_parallel.mappings import gather_from_tensor_model_parallel_region
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.core.utils import get_attr_wrapped_model
 from megatron.training import get_args, get_tokenizer
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.checkpointing import load_checkpoint as _load_checkpoint

--- a/tests/functional_tests/test_cases/common/moe_perf/__main__.py
+++ b/tests/functional_tests/test_cases/common/moe_perf/__main__.py
@@ -8,9 +8,8 @@ import json
 import os
 import statistics
 from contextlib import nullcontext
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, cast
+from typing import Any, Dict, Mapping, Sequence, cast
 
 import pytest  # type: ignore[import]
 import torch
@@ -18,8 +17,7 @@ import torch
 from megatron.core.config import set_experimental_flag
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.models.gpt.gpt_layer_specs import (
-    get_gpt_layer_local_spec,
-    get_gpt_layer_with_transformer_engine_spec,
+    get_gpt_layer_with_transformer_engine_submodules,
 )
 from megatron.core.transformer.moe.fused_a2a import HAVE_DEEP_EP, HAVE_HYBRIDEP
 from megatron.core.transformer.moe.moe_layer import MoELayer
@@ -89,10 +87,9 @@ def _build_transformer_config(case: MoEPerformanceCase) -> TransformerConfig:
 
 # NOTE: Only TE backend is covered in this test.
 def _resolve_moe_submodules(case: MoEPerformanceCase):
-    layer_spec = get_gpt_layer_with_transformer_engine_spec(
+    return get_gpt_layer_with_transformer_engine_submodules(
         num_experts=case.model.num_experts, moe_grouped_gemm=True
-    )
-    return layer_spec.submodules.mlp.submodules
+    ).mlp.submodules
 
 
 def _load_baselines() -> Dict[str, Dict[str, float]]:

--- a/tests/unit_tests/dist_checkpointing/models/test_mlp_glu.py
+++ b/tests/unit_tests/dist_checkpointing/models/test_mlp_glu.py
@@ -13,7 +13,9 @@ from megatron.core.dist_checkpointing.optimizer import (
     get_param_id_to_sharded_param_map,
     optim_state_to_sharding_state,
 )
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_submodules,
+)
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.mlp import MLP, apply_swiglu_sharded_factory
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -32,7 +34,7 @@ def initialize_mlp(glu=True):
         gated_linear_unit=glu,
     )
     return MLP(
-        transformer_config, get_gpt_layer_with_transformer_engine_spec().submodules.mlp.submodules
+        transformer_config, get_gpt_layer_with_transformer_engine_submodules().mlp.submodules
     )
 
 

--- a/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py
+++ b/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py
@@ -8,11 +8,12 @@ import torch
 
 from megatron.core import parallel_state
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
-from megatron.core.distributed.param_and_grad_buffer import partition_buckets
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_submodules,
+)
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.moe.moe_layer import MoELayer
-from tests.unit_tests.test_utilities import TestModel, Utils
+from tests.unit_tests.test_utilities import Utils
 
 
 class TestMoEModel(torch.nn.Module):
@@ -41,15 +42,13 @@ class TestMoEModel(torch.nn.Module):
             params_dtype=torch.bfloat16,
             add_bias_linear=False,
         )
-        transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
+        submodules = get_gpt_layer_with_transformer_engine_submodules(
             num_experts=num_moe_experts, moe_grouped_gemm=moe_grouped_gemm
         )
         super().__init__()
         self.layers = torch.nn.ModuleList(
             [
-                MoELayer(
-                    transformer_config, transformer_layer_spec.submodules.mlp.submodules
-                ).cuda()
+                MoELayer(transformer_config, submodules.mlp.submodules).cuda()
                 for _ in range(num_layers)
             ]
         )

--- a/tests/unit_tests/inference/model_inference_wrappers/gpt/test_gpt_inference_wrapper.py
+++ b/tests/unit_tests/inference/model_inference_wrappers/gpt/test_gpt_inference_wrapper.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-from argparse import Namespace
-
 import pytest
 import torch
 
@@ -10,10 +8,7 @@ from megatron.core.inference.contexts import StaticInferenceContext
 from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper import (
     GPTInferenceWrapper,
 )
-from megatron.core.models.gpt.gpt_layer_specs import (
-    get_gpt_layer_local_spec,
-    get_gpt_layer_with_transformer_engine_spec,
-)
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_config import TransformerConfig

--- a/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
@@ -1,13 +1,11 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import copy
-import os
 import random
 import string
 import time
-from argparse import Namespace
 from collections import OrderedDict
-from typing import Dict
+from typing import Dict, List
 from unittest import mock
 
 import pytest
@@ -22,12 +20,13 @@ from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.inference.text_generation_controllers.vlm_text_generation_controller import (
     VLMTextGenerationController,
 )
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.models.multimodal.llava_model import LLaVAModel
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.module import Float16Module
+from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.transformer.transformer_layer import TransformerLayer
 from tests.unit_tests.test_utilities import Utils
 
 
@@ -68,15 +67,19 @@ class TestVLMTextGenerationController:
             bf16=True,
         )
 
-        language_layer_spec = get_gpt_layer_local_spec()
-        vision_layer_spec = copy.deepcopy(language_layer_spec)
-        vision_projection_spec = copy.deepcopy(language_layer_spec.submodules.mlp.submodules)
+        language_layer_submodules = get_gpt_layer_local_submodules()
+        vision_layer_spec = ModuleSpec(
+            module=TransformerLayer, submodules=copy.deepcopy(language_layer_submodules)
+        )
+        vision_projection_spec = copy.deepcopy(language_layer_submodules.mlp.submodules)
 
         language_config.language_model_type = "dummy"
         vision_config.vision_model_type = "clip"
         self.model = LLaVAModel(
             language_transformer_config=language_config,
-            language_transformer_layer_spec=language_layer_spec,
+            language_transformer_layer_spec=ModuleSpec(
+                module=TransformerLayer, submodules=language_layer_submodules
+            ),
             language_vocab_size=self.language_vocab_size,
             language_max_sequence_length=self.language_max_sequence_length,
             vision_transformer_config=vision_config,

--- a/tests/unit_tests/ssm/test_mamba_mixer.py
+++ b/tests/unit_tests/ssm/test_mamba_mixer.py
@@ -6,7 +6,9 @@ import torch
 from megatron.core.inference.contexts.static_context import StaticInferenceContext
 from megatron.core.models.mamba.mamba_layer_specs import mamba_stack_spec
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.ssm.mamba_mixer import MambaMixer
+from megatron.core.ssm.mamba_block import MambaStackSubmodules
+from megatron.core.ssm.mamba_layer import MambaLayerSubmodules
+from megatron.core.ssm.mamba_mixer import MambaMixer, MambaMixerSubmodules
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
@@ -36,11 +38,16 @@ class TestMambaMixer:
             num_attention_heads=1,
             use_cpu_initialization=True,
         )
-        modules = mamba_stack_spec.submodules.mamba_layer.submodules.mixer.submodules
+        assert isinstance(mamba_stack_spec.submodules, MambaStackSubmodules)
+        assert isinstance(mamba_stack_spec.submodules.mamba_layer.submodules, MambaLayerSubmodules)
+        assert isinstance(
+            mamba_stack_spec.submodules.mamba_layer.submodules.mixer.submodules,
+            MambaMixerSubmodules,
+        )
         pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
         mixer = MambaMixer(
             transformer_config,
-            modules,
+            mamba_stack_spec.submodules.mamba_layer.submodules.mixer.submodules,
             transformer_config.hidden_size,
             layer_number=1,
             use_mem_eff_path=use_mem_eff_path,
@@ -119,12 +126,17 @@ class TestMambaMixerErrorChecks:
             use_cpu_initialization=True,
             mamba_num_groups=ngroups,
         )
-        submodules = mamba_stack_spec.submodules.mamba_layer.submodules.mixer.submodules
+        assert isinstance(mamba_stack_spec.submodules, MambaStackSubmodules)
+        assert isinstance(mamba_stack_spec.submodules.mamba_layer.submodules, MambaLayerSubmodules)
+        assert isinstance(
+            mamba_stack_spec.submodules.mamba_layer.submodules.mixer.submodules,
+            MambaMixerSubmodules,
+        )
         pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
         with pytest.raises(AssertionError, match=expected_error_message):
             MambaMixer(
                 transformer_config,
-                submodules,
+                mamba_stack_spec.submodules.mamba_layer.submodules.mixer.submodules,
                 transformer_config.hidden_size,
                 pg_collection=pg_collection,
             )

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -15,7 +15,9 @@ import megatron.core.utils as util
 import megatron.training.utils as training_util
 from megatron.core import config
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_submodules,
+)
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.moe.moe_layer import MoELayer
@@ -313,12 +315,12 @@ def test_param_norm_moe(use_distributed_optimizer: bool):
         add_bias_linear=False,
         bf16=True,
     )
-    transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
-        num_experts=2, moe_grouped_gemm=True
-    )
-    model = MoELayer(transformer_config, transformer_layer_spec.submodules.mlp.submodules).to(
-        device='cuda'
-    )
+    model = MoELayer(
+        transformer_config,
+        get_gpt_layer_with_transformer_engine_submodules(
+            num_experts=2, moe_grouped_gemm=True
+        ).mlp.submodules,
+    ).to(device='cuda')
     model.requires_grad_(True)
     # Initialize the model with all 1.0 for weights.
     for param in model.parameters():

--- a/tests/unit_tests/transformer/moe/test_sequential_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_sequential_mlp.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from megatron.core.extensions.transformer_engine import TEColumnParallelLinear, TERowParallelLinear
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.mlp import MLPSubmodules
@@ -37,12 +37,10 @@ class TestParallelSequentialMLP:
             moe_router_topk=1,
             add_bias_linear=False,
         )
-        transformer_layer_spec = get_gpt_layer_local_spec(
+        submodules = get_gpt_layer_local_submodules(
             num_experts=num_moe_experts, moe_grouped_gemm=False
         )
-        self.sequential_mlp = MoELayer(
-            transformer_config, transformer_layer_spec.submodules.mlp.submodules
-        )
+        self.sequential_mlp = MoELayer(transformer_config, submodules.mlp.submodules)
 
     def teardown_method(self, method):
         Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -3,7 +3,7 @@
 import pytest
 import torch
 
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -41,12 +41,10 @@ class TestSharedExperts:
             add_bias_linear=False,
             moe_shared_expert_gate=shared_expert_gate,
         )
-        transformer_layer_spec = get_gpt_layer_local_spec(
+        submodules = get_gpt_layer_local_submodules(
             num_experts=num_moe_experts, moe_grouped_gemm=False
         )
-        self.moe_layer = MoELayer(
-            transformer_config, transformer_layer_spec.submodules.mlp.submodules
-        )
+        self.moe_layer = MoELayer(transformer_config, submodules.mlp.submodules)
 
         assert isinstance(self.moe_layer, MoELayer)
 
@@ -103,12 +101,10 @@ class TestSharedExpertsOverlap:
             moe_router_topk=1,
             add_bias_linear=False,
         )
-        transformer_layer_spec = get_gpt_layer_local_spec(
+        submodules = get_gpt_layer_local_submodules(
             num_experts=num_moe_experts, moe_grouped_gemm=False
         )
-        self.moe_layer = MoELayer(
-            transformer_config, transformer_layer_spec.submodules.mlp.submodules
-        )
+        self.moe_layer = MoELayer(transformer_config, submodules.mlp.submodules)
 
         assert isinstance(self.moe_layer, MoELayer)
 

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 from megatron.core import config, parallel_state
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.moe.moe_utils import get_capacity
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -99,15 +99,11 @@ class MoEModelTestContainer:
         self.moe_layer = self.new_moe_layer()
 
     def new_moe_layer(self, **kargs):
-        transformer_layer_spec = get_gpt_layer_local_spec(
+        submodules = get_gpt_layer_local_submodules(
             num_experts=self.config.num_moe_experts, moe_grouped_gemm=self.config.moe_grouped_gemm
         )
         new_config = dataclasses.replace(self.config, **kargs)
-        moe_layer = (
-            MoELayer(new_config, transformer_layer_spec.submodules.mlp.submodules)
-            .cuda()
-            .to(dtype=self.test_dtype)
-        )
+        moe_layer = MoELayer(new_config, submodules.mlp.submodules).cuda().to(dtype=self.test_dtype)
         moe_layer.set_layer_number(0)
         return moe_layer
 

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -8,7 +8,9 @@ from packaging import version
 
 import megatron.core.parallel_state as parallel_state
 from megatron.core.hyper_comm_grid import HyperCommGrid
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_submodules,
+)
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
@@ -43,7 +45,7 @@ class TestParallelAttention:
         )
         self.parallel_attention = SelfAttention(
             self.transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
         )
 
@@ -136,7 +138,7 @@ class TestParallelAttention:
         transformer_config.recompute_granularity = 'selective'
         checkpointed_parallel_attention = SelfAttention(
             transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
         )
         config = checkpointed_parallel_attention.config
@@ -186,7 +188,7 @@ class TestClipQK:
         )
         attention = SelfAttention(
             transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
         )
 
@@ -206,7 +208,7 @@ class TestClipQK:
         )
         attention = SelfAttention(
             transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
         )
 
@@ -226,7 +228,7 @@ class TestClipQK:
         )
         attention = SelfAttention(
             transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
         )
         attention.cuda()
@@ -260,7 +262,7 @@ class TestClipQK:
         )
         attention = SelfAttention(
             transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
         )
         attention.cuda()
@@ -295,7 +297,7 @@ class TestClipQK:
         )
         attention = SelfAttention(
             transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
         )
         attention.cuda()
@@ -329,7 +331,7 @@ class TestClipQK:
         )
         attention = SelfAttention(
             transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
         )
         attention.cuda()
@@ -374,7 +376,7 @@ class TestSelfAttention:
         )
         self.self_attention = SelfAttention(
             self.transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
             pg_collection=pg_collection,

--- a/tests/unit_tests/transformer/test_attention_no_rope.py
+++ b/tests/unit_tests/transformer/test_attention_no_rope.py
@@ -3,7 +3,9 @@
 import pytest
 import torch
 
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_submodules,
+)
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.attention import SelfAttention
 from megatron.core.transformer.enums import AttnMaskType
@@ -30,7 +32,7 @@ class TestParallelAttentionWithNoRope:
         )
         self.parallel_attention = SelfAttention(
             self.transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
         )
@@ -176,7 +178,7 @@ class TestParallelAttentionWithNoRope:
 
         checkpointed_parallel_attention = SelfAttention(
             transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
         )

--- a/tests/unit_tests/transformer/test_attention_packed_seq.py
+++ b/tests/unit_tests/transformer/test_attention_packed_seq.py
@@ -3,7 +3,9 @@
 import pytest
 import torch
 
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_submodules,
+)
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.attention import SelfAttention
@@ -62,7 +64,7 @@ class TestParallelAttentionWithPackedSequence:
         )
         self.parallel_attention = SelfAttention(
             self.transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
         )
@@ -138,7 +140,7 @@ class TestParallelAttentionWithPackedSequence:
         transformer_config.recompute_granularity = 'selective'
         checkpointed_parallel_attention = SelfAttention(
             transformer_config,
-            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
         )

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -37,6 +37,7 @@ from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.transformer.moe.fused_a2a import reset_hybrid_ep_buffer
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.transformer.transformer_layer import TransformerLayerSubmodules
 from megatron.core.utils import is_fa_min_version, is_te_min_version
 from megatron.training.arguments import core_transformer_config_from_args, parse_args, validate_args
 from megatron.training.global_vars import (
@@ -327,6 +328,7 @@ class TestLLaVACudaGraph:
         # Get layer specs
         language_layer_spec = get_gpt_layer_with_transformer_engine_spec()
         vision_layer_spec = get_vit_layer_with_transformer_engine_spec()
+        assert isinstance(language_layer_spec.submodules, TransformerLayerSubmodules)
         vision_projection_spec = deepcopy(language_layer_spec.submodules.mlp.submodules)
 
         # Set vision model type

--- a/tests/unit_tests/transformer/test_mlp.py
+++ b/tests/unit_tests/transformer/test_mlp.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 
+
 import pytest
 import torch
 
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.mlp import MLP
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -18,7 +19,7 @@ class TestParallelMLP:
         transformer_config = TransformerConfig(
             num_layers=2, hidden_size=12, num_attention_heads=4, use_cpu_initialization=True
         )
-        self.mlp = MLP(transformer_config, get_gpt_layer_local_spec().submodules.mlp.submodules)
+        self.mlp = MLP(transformer_config, get_gpt_layer_local_submodules().mlp.submodules)
 
     def teardown_method(self, method):
         Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/test_submodule_callables.py
+++ b/tests/unit_tests/transformer/test_submodule_callables.py
@@ -3,7 +3,9 @@ import pytest
 import torch
 
 from megatron.core.models.gpt.fine_grained_callables import build_layer_callables
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_submodules,
+)
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.utils import is_te_min_version
 from tests.unit_tests.a2a_overlap.utils import (
@@ -140,13 +142,13 @@ class TestTransformerLayerSubmoduleCallables:
         config = get_test_config(extra_kwargs=extra_kwargs, moe_grouped_gemm=grouped_gemm)
         microbatches = 4
         with deterministic_mode():
-            transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
+            transformer_layer_submodules = get_gpt_layer_with_transformer_engine_submodules(
                 num_experts=8,
                 moe_grouped_gemm=grouped_gemm,
                 qk_layernorm=True,
                 multi_latent_attention=True,
             )
-            model = TransformerLayer(config, transformer_layer_spec.submodules)
+            model = TransformerLayer(config, transformer_layer_submodules)
 
             params = reset_model(model)
             input_tensors = [build_data() for _ in range(microbatches)]

--- a/tests/unit_tests/transformer/test_transformer_block_custom_pgs.py
+++ b/tests/unit_tests/transformer/test_transformer_block_custom_pgs.py
@@ -68,7 +68,7 @@ class HeterogenousTransformerLayer(TransformerLayer):
         # Temporarily replace attention and MLP with IdentityOp,
         # This is a temporary workaround for the test until we have a better interface
         # will rebuild them with custom process groups after super init
-        def _modify_submodules(submodules):
+        def _modify_submodules(submodules: TransformerLayerSubmodules):
             submodules.self_attention = IdentityOp
             submodules.mlp = IdentityOp
             return submodules

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -7,7 +7,9 @@ import torch
 from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedTensor
 from megatron.core.inference.contexts import StaticInferenceContext
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_submodules,
+)
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import (
@@ -26,7 +28,7 @@ class TestParallelTransformerLayer:
             num_layers=2, hidden_size=12, num_attention_heads=4, use_cpu_initialization=True
         )
         self.parallel_transformer_layer = TransformerLayer(
-            transformer_config, get_gpt_layer_with_transformer_engine_spec().submodules
+            transformer_config, get_gpt_layer_with_transformer_engine_submodules()
         )
 
     def teardown_method(self, method):
@@ -81,7 +83,7 @@ class TestParallelTransformerLayer:
                     use_cpu_initialization=True,
                 )
                 parallel_transformer_layer = TransformerLayer(
-                    transformer_config, get_gpt_layer_with_transformer_engine_spec().submodules
+                    transformer_config, get_gpt_layer_with_transformer_engine_submodules()
                 )
 
                 parallel_transformer_layer.cuda()
@@ -265,7 +267,7 @@ class TestParallelTransformerLayer:
             num_layers=2, hidden_size=128, num_attention_heads=8, use_cpu_initialization=True
         )
         parallel_transformer_layer = TransformerLayer(
-            transformer_config, get_gpt_layer_with_transformer_engine_spec().submodules
+            transformer_config, get_gpt_layer_with_transformer_engine_submodules()
         )
 
         sharded_state_dict = parallel_transformer_layer.sharded_state_dict()


### PR DESCRIPTION
# What does this PR do ?
Went through the unit tests and found cases where we were using untyped accesses into submodules, and made it easier for the type-checker to introspect into them.

In order to safely refactor `Submodules` classes, I want to make sure I can easily find everywhere those classes are being referenced. A lot of callers manipulate `ModuleSpec` objects directly and modify the contained `submodules`, which makes the operations untyped; I went through unit tests looking for cases where we were doing this, and replaced them with typed accesses instead (either by using the helpers from https://github.com/NVIDIA/Megatron-LM/pull/3255 or by casting/asserting). 

Relevant design doc: [Typed ModuleSpec.pdf](https://github.com/user-attachments/files/25191841/Typed.ModuleSpec.pdf)

Also removed unused imports while I was here!

## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [X] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [X] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

Feel free to message or comment the @mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.
