### PR TITLE
Add Qwen3VL

### DIFF
--- a/megatron/core/datasets/qwen3vl_dataset.py
+++ b/megatron/core/datasets/qwen3vl_dataset.py
@@ -1,0 +1,713 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+# Qwen3-VL multimodal dataset for QAT training.
+"""
+Qwen3-VL multimodal dataset that loads JSONL files with images.
+
+This dataset reads JSONL files containing:
+- text: Conversation text with <image> token markers
+- images: List of relative image paths
+
+And returns:
+- tokens: Tokenized input_ids
+- labels: Target labels for causal LM
+- loss_mask: Mask for loss computation
+- position_ids: Position IDs
+- pixel_values: Preprocessed image tensors
+- image_grid_thw: Grid dimensions for variable resolution
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+try:
+    from transformers import AutoProcessor
+
+    HAS_TRANSFORMERS = True
+except ImportError:
+    HAS_TRANSFORMERS = False
+
+logger = logging.getLogger(__name__)
+
+
+def qwen3vl_collate_fn(batch: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
+    """Custom collate function for Qwen3-VL dataset.
+
+    Handles variable-length pixel_values by concatenating instead of stacking.
+    Pads text tokens to the same length within a batch.
+
+    Args:
+        batch: List of sample dictionaries from __getitem__
+
+    Returns:
+        Collated batch dictionary
+    """
+    if not batch:
+        return {}
+
+    # Find max sequence length in batch
+    max_seq_len = max(sample["tokens"].size(0) for sample in batch)
+
+    # Initialize output tensors
+    batch_size = len(batch)
+    tokens = torch.zeros(batch_size, max_seq_len, dtype=torch.long)
+    labels = torch.full((batch_size, max_seq_len), -100, dtype=torch.long)
+    loss_mask = torch.zeros(batch_size, max_seq_len, dtype=torch.float32)
+    position_ids = torch.zeros(batch_size, max_seq_len, dtype=torch.long)
+
+    # Collect pixel_values and grid_thw (variable length)
+    all_pixel_values = []
+    all_grid_thw = []
+    has_images = False
+
+    for i, sample in enumerate(batch):
+        seq_len = sample["tokens"].size(0)
+
+        # Copy tokens (left-padded or truncated)
+        tokens[i, :seq_len] = sample["tokens"][:max_seq_len]
+        labels[i, :seq_len] = sample["labels"][:max_seq_len]
+        loss_mask[i, :seq_len] = sample["loss_mask"][:max_seq_len]
+        position_ids[i, :seq_len] = sample["position_ids"][:max_seq_len]
+
+        # Collect pixel_values if present
+        if "pixel_values" in sample and sample["pixel_values"] is not None:
+            has_images = True
+            all_pixel_values.append(sample["pixel_values"])
+
+            if "image_grid_thw" in sample and sample["image_grid_thw"] is not None:
+                all_grid_thw.append(sample["image_grid_thw"])
+
+    result = {
+        "tokens": tokens,
+        "labels": labels,
+        "loss_mask": loss_mask,
+        "position_ids": position_ids,
+    }
+
+    # Always include a has_images flag so get_batch can broadcast it
+    # unconditionally (all TP ranks must participate in the NCCL collective).
+    # broadcast_data uses 0 as a sentinel for dimension parsing, so zero-sized
+    # tensors cannot be broadcast — use this flag to gate image broadcasts.
+    if has_images and all_pixel_values:
+        result["has_images"] = torch.tensor([1], dtype=torch.int64)
+        result["pixel_values"] = torch.cat(all_pixel_values, dim=0)
+        result["image_grid_thw"] = (
+            torch.cat(all_grid_thw, dim=0) if all_grid_thw
+            else torch.ones(1, 3, dtype=torch.long)  # dummy; model ignores if no grid info
+        )
+    else:
+        result["has_images"] = torch.tensor([0], dtype=torch.int64)
+
+    return result
+
+
+@dataclass
+class Qwen3VLDatasetConfig:
+    """Configuration for Qwen3-VL multimodal dataset."""
+
+    # JSONL file paths
+    jsonl_paths: List[str] = None
+
+    # Image settings
+    image_base_dir: str = None  # Base directory for relative image paths
+    img_h: int = 384
+    img_w: int = 384
+
+    # Tokenizer/Processor
+    processor_name: str = "Qwen/Qwen3-VL-8B-Instruct"
+
+    # Sequence settings
+    sequence_length: int = 4096
+
+    # Random seed
+    random_seed: int = 42
+
+
+class Qwen3VLDataset(Dataset):
+    """Qwen3-VL multimodal dataset for QAT training.
+
+    Loads JSONL files containing text and image paths, processes images
+    using Qwen3-VL processor, and returns batches suitable for training.
+    """
+
+    def __init__(self, config: Qwen3VLDatasetConfig, split: str = "train"):
+        """Initialize the dataset.
+
+        Args:
+            config: Dataset configuration
+            split: Data split ("train", "valid", or "test")
+        """
+        super().__init__()
+
+        if not HAS_TRANSFORMERS:
+            raise ImportError("transformers is required for Qwen3VLDataset")
+
+        self.config = config
+        self.split = split
+        self.sequence_length = config.sequence_length
+
+        # Load processor
+        self.processor = AutoProcessor.from_pretrained(
+            config.processor_name, trust_remote_code=True
+        )
+        self.tokenizer = self.processor.tokenizer
+
+        # Set image token
+        self.image_token = "<|image_pad|>"
+        self.image_token_id = self.tokenizer.convert_tokens_to_ids(self.image_token)
+
+        # Cache frequently used tokenizer lookups (Fix 1: avoid per-sample calls)
+        self._im_start_id = self.tokenizer.convert_tokens_to_ids("<|im_start|>")
+        self._im_end_id = self.tokenizer.convert_tokens_to_ids("<|im_end|>")
+        self._assistant_tokens = self.tokenizer.encode("assistant", add_special_tokens=False)
+        self._newline_id = self.tokenizer.convert_tokens_to_ids("\n")
+
+        # Set custom collate function for variable-length pixel_values
+        self.collate_fn = qwen3vl_collate_fn
+
+        # HF dataset cache: (hf_name, hf_config, split) -> loaded dataset
+        self._hf_datasets = {}
+
+        # Directory listing cache for image path resolution (Fix 2)
+        self._dir_listing_cache = {}
+
+        # Load all samples from JSONL files
+        self.samples = []
+        if config.jsonl_paths:
+            for jsonl_path in config.jsonl_paths:
+                if os.path.exists(jsonl_path):
+                    self._load_jsonl(jsonl_path)
+
+        # Pre-resolve image paths (Fix 2: avoid per-sample filesystem stat calls)
+        self._resolved_paths = {}
+        self._pre_resolve_image_paths()
+
+        logger.info("Loaded %d samples for %s", len(self.samples), split)
+
+        # Random state
+        self.rng = np.random.RandomState(config.random_seed)
+
+    def _load_jsonl(self, jsonl_path: str):
+        """Load samples from a JSONL file."""
+        with open(jsonl_path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    sample = json.loads(line)
+                    # Store jsonl directory for relative image paths
+                    sample['_jsonl_dir'] = os.path.dirname(jsonl_path)
+                    self.samples.append(sample)
+                except json.JSONDecodeError:
+                    continue
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def _cached_listdir(self, dir_path: str) -> List[str]:
+        """Cached os.listdir to avoid repeated filesystem calls."""
+        if dir_path not in self._dir_listing_cache:
+            try:
+                self._dir_listing_cache[dir_path] = os.listdir(dir_path)
+            except OSError:
+                self._dir_listing_cache[dir_path] = []
+        return self._dir_listing_cache[dir_path]
+
+    def _pre_resolve_image_paths(self):
+        """Pre-resolve all image paths during init to avoid per-sample stat calls."""
+        for sample_idx, sample in enumerate(self.samples):
+            image_paths = sample.get('images', [])
+            jsonl_dir = sample.get('_jsonl_dir', '')
+            for img_path in image_paths:
+                cache_key = (img_path, jsonl_dir)
+                if cache_key not in self._resolved_paths:
+                    self._resolved_paths[cache_key] = self._resolve_image_path_uncached(
+                        img_path, jsonl_dir
+                    )
+
+    def _resolve_image_path_uncached(self, image_path: str, jsonl_dir: str) -> str:
+        """Resolve relative image path to absolute path (uncached implementation).
+
+        Handles multiple directory structures:
+        - Direct relative paths from JSONL directory
+        - source_images/ subdirectory
+        - source_images/extracted/<archive_name>/ subdirectory
+        """
+        if os.path.isabs(image_path):
+            return image_path
+
+        # Try relative to image_base_dir first
+        if self.config.image_base_dir:
+            full_path = os.path.join(self.config.image_base_dir, image_path)
+            if os.path.exists(full_path):
+                return full_path
+
+        # Try relative to JSONL directory
+        full_path = os.path.join(jsonl_dir, image_path)
+        if os.path.exists(full_path):
+            return full_path
+
+        # Try relative to source_images subdirectory
+        full_path = os.path.join(jsonl_dir, "source_images", image_path)
+        if os.path.exists(full_path):
+            return full_path
+
+        # Try relative to source_images/extracted/ directly
+        extracted_dir = os.path.join(jsonl_dir, "source_images", "extracted")
+        if os.path.isdir(extracted_dir):
+            full_path = os.path.join(extracted_dir, image_path)
+            if os.path.exists(full_path):
+                return full_path
+
+            # Try with archive subdirectory prefix (use cached listdir)
+            for subdir in self._cached_listdir(extracted_dir):
+                full_path = os.path.join(extracted_dir, subdir, image_path)
+                if os.path.exists(full_path):
+                    return full_path
+
+        return image_path  # Return as-is, let downstream handle error
+
+    def _resolve_image_path(self, image_path: str, jsonl_dir: str) -> str:
+        """Resolve relative image path to absolute path (cached).
+
+        Returns pre-resolved path from init, falling back to uncached resolution.
+        """
+        cache_key = (image_path, jsonl_dir)
+        resolved = self._resolved_paths.get(cache_key)
+        if resolved is not None:
+            return resolved
+        # Fallback for paths not seen during init
+        resolved = self._resolve_image_path_uncached(image_path, jsonl_dir)
+        self._resolved_paths[cache_key] = resolved
+        return resolved
+
+    def _load_image(self, image_path: str) -> Optional[Image.Image]:
+        """Load an image from path."""
+        try:
+            image = Image.open(image_path).convert('RGB')
+            return image
+        except Exception as e:
+            return None
+
+    def _load_image_from_hf(self, sample: Dict[str, Any], image_path: str) -> Optional[Image.Image]:
+        """Load image from HuggingFace dataset when local file not found.
+
+        Uses hf_image_source metadata saved during download to lazily load
+        images from the source HF dataset. Loaded images are cached to disk.
+
+        Args:
+            sample: The JSONL sample dict containing hf_image_source metadata
+            image_path: The relative image path from the sample
+
+        Returns:
+            PIL Image if found, None otherwise
+        """
+        hf_source = sample.get('hf_image_source')
+        if not hf_source:
+            return None
+
+        hf_name = hf_source['hf_name']
+        hf_config = hf_source.get('hf_config')
+        hf_split = hf_source.get('hf_split', 'train')
+        image_column = hf_source.get('image_column', 'image')
+
+        key = (hf_name, hf_config, hf_split)
+
+        # Lazy-load the HF dataset
+        if key not in self._hf_datasets:
+            try:
+                from datasets import load_dataset
+
+                logger.info(
+                    "Loading HF dataset: %s (config=%s, split=%s)",
+                    hf_name, hf_config, hf_split,
+                )
+                self._hf_datasets[key] = load_dataset(hf_name, hf_config, split=hf_split)
+            except Exception as e:
+                logger.warning("Failed to load HF dataset %s: %s", hf_name, e)
+                self._hf_datasets[key] = None
+                return None
+
+        ds = self._hf_datasets[key]
+        if ds is None:
+            return None
+
+        # Use hf_image_index if available (pre-computed during download)
+        hf_idx = sample.get('hf_image_index')
+        if hf_idx is not None and 0 <= hf_idx < len(ds):
+            return self._extract_hf_image(ds, hf_idx, image_column, image_path)
+
+        # Fallback: try to match by extracting numeric ID from filename
+        basename = os.path.splitext(os.path.basename(image_path))[0]
+        # Try to interpret basename as an integer index
+        try:
+            idx = int(basename)
+            if 0 <= idx < len(ds):
+                return self._extract_hf_image(ds, idx, image_column, image_path)
+        except ValueError:
+            pass
+
+        return None
+
+    def _extract_hf_image(
+        self, ds, idx: int, image_column: str, image_path: str
+    ) -> Optional[Image.Image]:
+        """Extract a PIL image from an HF dataset row.
+
+        Args:
+            ds: The loaded HF dataset
+            idx: Row index
+            image_column: Column name containing the image(s)
+            image_path: Original image path (used for multi-image matching)
+
+        Returns:
+            PIL Image if found, None otherwise
+        """
+        try:
+            row = ds[idx]
+            img_data = row.get(image_column)
+            if img_data is None:
+                return None
+
+            # Handle list of images (e.g., "images" column)
+            if isinstance(img_data, list):
+                if len(img_data) == 0:
+                    return None
+                # Use first image by default; could refine with path-based matching
+                img = img_data[0]
+            else:
+                img = img_data
+
+            # img should be a PIL Image from the HF dataset
+            if isinstance(img, Image.Image):
+                return img.convert('RGB')
+
+            return None
+        except Exception as e:
+            logger.warning("Failed to extract HF image at index %d: %s", idx, e)
+            return None
+
+    def _parse_conversation(self, text: str) -> List[Dict[str, Any]]:
+        """Parse text into conversation format for Qwen3-VL processor.
+
+        Converts "User: <image> ...\n\nAssistant: ..." format to chat messages.
+
+        Args:
+            text: Raw text from JSONL with User/Assistant format
+
+        Returns:
+            List of message dicts with role and content
+        """
+        messages = []
+        current_role = None
+        current_content = []
+
+        lines = text.split('\n')
+        for line in lines:
+            line_stripped = line.strip()
+
+            # Check for role markers
+            if line_stripped.startswith('User:'):
+                if current_role and current_content:
+                    messages.append(
+                        {"role": current_role, "content": '\n'.join(current_content).strip()}
+                    )
+                current_role = "user"
+                current_content = [line_stripped[5:].strip()]  # Remove "User:"
+            elif line_stripped.startswith('Assistant:'):
+                if current_role and current_content:
+                    messages.append(
+                        {"role": current_role, "content": '\n'.join(current_content).strip()}
+                    )
+                current_role = "assistant"
+                current_content = [line_stripped[10:].strip()]  # Remove "Assistant:"
+            elif current_role:
+                current_content.append(line)
+
+        # Add final message
+        if current_role and current_content:
+            messages.append({"role": current_role, "content": '\n'.join(current_content).strip()})
+
+        return messages
+
+    def _process_sample(self, sample: Dict[str, Any]) -> Dict[str, torch.Tensor]:
+        """Process a single sample into model inputs.
+
+        Args:
+            sample: Dictionary containing 'text' and 'images' fields
+
+        Returns:
+            Dictionary with tokens, labels, loss_mask, position_ids,
+            pixel_values, and image_grid_thw
+        """
+        text = sample.get('text', '')
+        image_paths = sample.get('images', [])
+        jsonl_dir = sample.get('_jsonl_dir', '')
+
+        # Load images (with HF dataset fallback and disk caching)
+        images = []
+        for img_path in image_paths:
+            full_path = self._resolve_image_path(img_path, jsonl_dir)
+            img = self._load_image(full_path)
+
+            # Fallback: try loading from HF dataset
+            if img is None and sample.get('hf_image_source'):
+                img = self._load_image_from_hf(sample, img_path)
+                # Cache to disk for subsequent runs
+                if img is not None:
+                    cache_path = os.path.join(jsonl_dir, "source_images", img_path)
+                    try:
+                        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+                        img.save(cache_path)
+                    except Exception:
+                        pass  # Non-fatal: image is still usable in memory
+
+            if img is not None:
+                images.append(img)
+
+        # Parse conversation and build messages for Qwen3-VL
+        messages = self._parse_conversation(text)
+
+        # Convert messages to format expected by Qwen3-VL processor
+        # Replace <image> with actual image content markers
+        conversation = []
+        img_idx = 0
+        for msg in messages:
+            content = msg['content']
+            # Replace <image> markers with proper image content
+            if '<image>' in content and images:
+                parts = content.split('<image>')
+                content_list = []
+                for i, part in enumerate(parts):
+                    if part:
+                        content_list.append({"type": "text", "text": part})
+                    if i < len(parts) - 1 and img_idx < len(images):
+                        content_list.append({"type": "image", "image": images[img_idx]})
+                        img_idx += 1
+                conversation.append({"role": msg['role'], "content": content_list})
+            else:
+                conversation.append({"role": msg['role'], "content": msg['content']})
+
+        # Apply chat template and process
+        try:
+            formatted_text = self.processor.apply_chat_template(
+                conversation, tokenize=False, add_generation_prompt=False
+            )
+
+            # Process with Qwen3-VL processor
+            if images:
+                inputs = self.processor(
+                    text=[formatted_text],
+                    images=images,
+                    return_tensors="pt",
+                    padding="max_length",
+                    max_length=self.sequence_length,
+                    truncation=True,
+                )
+            else:
+                inputs = self.tokenizer(
+                    formatted_text,
+                    return_tensors="pt",
+                    padding="max_length",
+                    max_length=self.sequence_length,
+                    truncation=True,
+                )
+        except Exception as e:
+            # Fallback: process text directly
+            if images:
+                inputs = self.processor(
+                    text=[text],
+                    images=images,
+                    return_tensors="pt",
+                    padding="max_length",
+                    max_length=self.sequence_length,
+                    truncation=True,
+                )
+            else:
+                inputs = self.tokenizer(
+                    text,
+                    return_tensors="pt",
+                    padding="max_length",
+                    max_length=self.sequence_length,
+                    truncation=True,
+                )
+
+        # Extract tensors (remove batch dimension)
+        input_ids = inputs["input_ids"].squeeze(0)
+        attention_mask = inputs.get("attention_mask", torch.ones_like(input_ids)).squeeze(0)
+
+        # Create labels (shift by 1 for causal LM)
+        labels = input_ids.clone()
+        labels[:-1] = input_ids[1:]
+        labels[-1] = -100  # Ignore last position
+
+        # Create loss mask (1 for ASSISTANT tokens only)
+        # For VLM, we only compute loss on assistant responses, not user prompts/system messages
+        # Find assistant response regions by looking for assistant header tokens
+        loss_mask = torch.zeros(len(input_ids), dtype=torch.float32)
+
+        # Qwen3-VL uses <|im_start|>assistant as the header for assistant turns
+        # We need to find these regions and set loss_mask=1 for assistant content
+        input_ids_list = input_ids.tolist()
+
+        # Get special token IDs
+        im_start_id = self.tokenizer.convert_tokens_to_ids("<|im_start|>")
+        im_end_id = self.tokenizer.convert_tokens_to_ids("<|im_end|>")
+        assistant_token_id = self.tokenizer.convert_tokens_to_ids("assistant")
+        newline_id = self.tokenizer.convert_tokens_to_ids("\n")
+
+        # Find assistant regions: <|im_start|>assistant\n ... <|im_end|>
+        i = 0
+        while i < len(input_ids_list) - 2:
+            # Check for <|im_start|>assistant pattern
+            if (
+                input_ids_list[i] == im_start_id
+                and i + 1 < len(input_ids_list)
+                and input_ids_list[i + 1] == assistant_token_id
+            ):
+                # Skip the header: <|im_start|>assistant\n
+                start_idx = i + 2  # Skip <|im_start|> and assistant
+                if start_idx < len(input_ids_list) and input_ids_list[start_idx] == newline_id:
+                    start_idx += 1  # Skip newline
+
+                # Find the end: <|im_end|>
+                end_idx = start_idx
+                while end_idx < len(input_ids_list) and input_ids_list[end_idx] != im_end_id:
+                    end_idx += 1
+
+                # Set loss_mask=1 for predicting assistant content tokens.
+                # labels are left-shifted (labels[p] = input_ids[p+1]), so to
+                # include prediction of the first assistant token at start_idx,
+                # loss_mask must start at start_idx - 1.
+                loss_mask[start_idx - 1:end_idx] = 1.0
+                i = end_idx + 1
+            else:
+                i += 1
+
+        # Mask out padding tokens and -100 labels
+        loss_mask[labels == -100] = 0.0
+        if self.tokenizer.pad_token_id is not None:
+            loss_mask[input_ids == self.tokenizer.pad_token_id] = 0.0
+
+        # Position IDs
+        position_ids = torch.arange(len(input_ids), dtype=torch.long)
+
+        # Build output
+        output = {
+            "tokens": input_ids,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "position_ids": position_ids,
+        }
+
+        # Add image data if present
+        if images and "pixel_values" in inputs:
+            output["pixel_values"] = inputs["pixel_values"].squeeze(0)
+
+            if "image_grid_thw" in inputs:
+                grid_thw = inputs["image_grid_thw"].squeeze(0)
+                # Ensure grid_thw is always 2D [num_images, 3]
+                if grid_thw.dim() == 1:
+                    grid_thw = grid_thw.unsqueeze(0)
+                output["image_grid_thw"] = grid_thw
+
+        return output
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        """Get a single sample.
+
+        Args:
+            idx: Sample index
+
+        Returns:
+            Dictionary with model inputs
+        """
+        sample = self.samples[idx]
+        return self._process_sample(sample)
+
+
+class Qwen3VLDatasetBuilder:
+    """Builder for Qwen3-VL datasets from datablend configuration."""
+
+    def __init__(
+        self, config: Qwen3VLDatasetConfig, blend_path: str, train_val_test_num_samples: List[int]
+    ):
+        """Initialize the builder.
+
+        Args:
+            config: Dataset configuration
+            blend_path: Path to datablend JSON file
+            train_val_test_num_samples: Number of samples for [train, val, test]
+        """
+        self.config = config
+        self.blend_path = blend_path
+        self.train_val_test_num_samples = train_val_test_num_samples
+
+        # Load blend configuration
+        with open(blend_path, 'r') as f:
+            self.blend_config = json.load(f)
+
+    def _get_jsonl_paths(self, split: str) -> List[str]:
+        """Get JSONL paths for a given split.
+
+        The datablend JSON points to preprocessed binary files like:
+        ./mlm_output/.../chartqa_cot_train_text_document
+
+        We convert these to JSONL paths:
+        ./mlm_output/.../chartqa_cot_train.jsonl
+        """
+        split_key = "valid" if split == "valid" else split
+        blend_data = self.blend_config.get(split_key, [])
+
+        jsonl_paths = []
+        # blend_data format: [weight, path, weight, path, ...]
+        for i in range(1, len(blend_data), 2):
+            binary_path = blend_data[i]
+            # Convert binary path to JSONL path
+            # e.g., .../chartqa_cot_train_text_document -> .../chartqa_cot_train.jsonl
+            jsonl_path = binary_path.replace("_text_document", ".jsonl")
+            # Handle path relative to preprocessed -> parent
+            jsonl_path = jsonl_path.replace("/preprocessed/", "/")
+            if os.path.exists(jsonl_path):
+                jsonl_paths.append(jsonl_path)
+            else:
+                logger.warning("JSONL not found: %s", jsonl_path)
+
+        return jsonl_paths
+
+    def build(self) -> tuple:
+        """Build train, validation, and test datasets.
+
+        Returns:
+            Tuple of (train_ds, valid_ds, test_ds)
+        """
+        datasets = []
+
+        for split in ["train", "valid", "test"]:
+            jsonl_paths = self._get_jsonl_paths(split)
+
+            if jsonl_paths:
+                config = Qwen3VLDatasetConfig(
+                    jsonl_paths=jsonl_paths,
+                    image_base_dir=self.config.image_base_dir,
+                    img_h=self.config.img_h,
+                    img_w=self.config.img_w,
+                    processor_name=self.config.processor_name,
+                    sequence_length=self.config.sequence_length,
+                    random_seed=self.config.random_seed,
+                )
+                ds = Qwen3VLDataset(config, split=split)
+            else:
+                ds = None
+
+            datasets.append(ds)
+
+        return tuple(datasets)

--- a/megatron/core/models/multimodal/__init__.py
+++ b/megatron/core/models/multimodal/__init__.py
@@ -1,1 +1,27 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.models.multimodal.llava_model import (
+    DEFAULT_IMAGE_TOKEN_INDEX,
+    IGNORE_INDEX,
+    IMAGE_TOKEN,
+    VIDEO_TOKEN,
+    LLaVAModel,
+)
+from megatron.core.models.multimodal.qwen3_vl_model import (
+    DEFAULT_VIDEO_TOKEN_INDEX,
+    Qwen3VLModel,
+    Qwen3VLTransformerBlock,
+    Qwen3VLVisionEncoder,
+)
+
+__all__ = [
+    'LLaVAModel',
+    'Qwen3VLModel',
+    'Qwen3VLVisionEncoder',
+    'Qwen3VLTransformerBlock',
+    'DEFAULT_IMAGE_TOKEN_INDEX',
+    'DEFAULT_VIDEO_TOKEN_INDEX',
+    'IMAGE_TOKEN',
+    'VIDEO_TOKEN',
+    'IGNORE_INDEX',
+]

--- a/megatron/core/models/multimodal/qwen3_vl_model.py
+++ b/megatron/core/models/multimodal/qwen3_vl_model.py
@@ -1,0 +1,733 @@
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Modified for Qwen3-VL support.
+"""Qwen3-VL multi-modal model implementation for Megatron-LM."""
+
+import logging
+from contextlib import nullcontext
+from typing import List, Optional, Tuple
+
+import torch
+
+from megatron.core import parallel_state, tensor_parallel
+from megatron.core.config_logger import has_config_logger_enabled, log_config_to_disk
+from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.inference.contexts import BaseInferenceContext
+from megatron.core.models.gpt import GPTModel
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer import MegatronModule
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_block import TransformerBlock
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.utils import log_single_rank
+
+try:
+    import transformer_engine  # pylint: disable=unused-import
+
+    HAVE_TE = True
+except ImportError:
+    HAVE_TE = False
+
+
+IGNORE_INDEX = -100
+DEFAULT_IMAGE_TOKEN_INDEX = -200
+DEFAULT_VIDEO_TOKEN_INDEX = -300
+IMAGE_TOKEN = "<image>"
+VIDEO_TOKEN = "<video>"
+
+
+class Qwen3VLVisionEncoder(MegatronModule):
+    """
+    Qwen3-VL Vision Encoder that wraps HuggingFace Qwen3-VL vision components.
+
+    This module loads the vision encoder from a HuggingFace Qwen3-VL model
+    and provides the interface expected by Megatron-LM.
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        hf_model_name: str = "Qwen/Qwen3-VL-8B-Instruct",
+        freeze_vision: bool = False,
+        img_h: int = 384,
+        img_w: int = 384,
+    ):
+        super().__init__(config=config)
+
+        self.config = config
+        self.img_h = img_h
+        self.img_w = img_w
+        self.freeze_vision = freeze_vision
+
+        # Load HuggingFace Qwen3-VL model to extract vision components
+        self._load_hf_vision_model(hf_model_name)
+
+    def _load_hf_vision_model(self, hf_model_name: str):
+        """Load vision encoder from HuggingFace model."""
+        try:
+            from transformers import AutoConfig, AutoModelForVision2Seq, AutoProcessor
+
+            # Load config first to get vision config parameters
+            hf_config = AutoConfig.from_pretrained(hf_model_name, trust_remote_code=True)
+
+            # Load the full model to extract vision components
+            # Use AutoModelForVision2Seq for proper Qwen3-VL loading
+            hf_model = AutoModelForVision2Seq.from_pretrained(
+                hf_model_name,
+                torch_dtype=torch.bfloat16,
+                attn_implementation="flash_attention_2",
+                trust_remote_code=True,
+            )
+
+            # Extract vision encoder (visual module)
+            self.visual = hf_model.visual
+            self.hidden_size = hf_config.vision_config.hidden_size
+
+            # Store vision config for preprocessing
+            self.patch_size = hf_config.vision_config.patch_size
+            self.temporal_patch_size = hf_config.vision_config.temporal_patch_size
+            self.spatial_merge_size = hf_config.vision_config.spatial_merge_size
+
+            # Store config values needed for get_rope_index (M-RoPE position IDs)
+            self.image_token_id = hf_config.image_token_id
+            self.video_token_id = hf_config.video_token_id
+            self.vision_start_token_id = hf_config.vision_start_token_id
+
+            # Clean up the rest of the model to free memory
+            del hf_model.model  # Delete language model
+            del hf_model
+
+            # Replace Conv3d patch_embed with equivalent Linear layer.
+            # When kernel_size == stride, Conv3d produces 1x1x1 output per patch,
+            # making it equivalent to a Linear layer. cuDNN has a pathological
+            # slow path for this configuration (~14s vs 0.04ms for Linear).
+            self._replace_patch_embed_conv3d_with_linear()
+
+            if self.freeze_vision:
+                for param in self.visual.parameters():
+                    param.requires_grad = False
+
+        except ImportError:
+            raise ImportError(
+                "transformers package is required for Qwen3-VL vision encoder. "
+                "Install with: pip install transformers"
+            )
+
+    def _replace_patch_embed_conv3d_with_linear(self):
+        """Override patch_embed forward to use Linear math instead of Conv3d.
+
+        The Conv3d in Qwen3VLVisionPatchEmbed uses kernel_size == stride,
+        so each input patch maps to exactly one output vector. This is
+        mathematically identical to a Linear layer on the flattened input.
+        cuDNN hits a pathological slow path for this Conv3d configuration,
+        making it ~350,000x slower than the equivalent Linear.
+
+        We keep the Conv3d module and its weight shape unchanged for checkpoint
+        compatibility, but override the forward to reshape the weight and
+        use F.linear instead.
+        """
+        patch_embed = self.visual.patch_embed
+        conv3d_proj = patch_embed.proj
+
+        def patched_forward(hidden_states: torch.Tensor) -> torch.Tensor:
+            weight = conv3d_proj.weight  # (out_ch, in_ch, T, H, W)
+            bias = conv3d_proj.bias
+            out_features = weight.shape[0]
+            # Reshape Conv3d weight to Linear weight on the fly
+            return torch.nn.functional.linear(
+                hidden_states.to(dtype=weight.dtype), weight.reshape(out_features, -1), bias
+            )
+
+        patch_embed.forward = patched_forward
+
+    def forward(
+        self, pixel_values: torch.Tensor, grid_thw: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        """
+        Forward pass through vision encoder.
+
+        Aligned with ms-swift's Qwen3VL_Vit approach: pass pixel_values directly to
+        the HuggingFace visual encoder without custom preprocessing. The HF processor
+        should have already preprocessed pixel_values into the correct format.
+
+        Args:
+            pixel_values: Preprocessed image tensor from HuggingFace processor
+                         Shape: [total_patches, C * temporal_patch_size * patch_size * patch_size]
+            grid_thw: Grid dimensions tensor [N, 3] for temporal, height, width
+
+        Returns:
+            image_embeds: Vision embeddings [num_tokens, hidden_size] (2D, no batch dim)
+            deepstack_visual_embeds: List of intermediate visual embeddings for deepstack
+        """
+        # Pass pixel_values directly to HuggingFace visual encoder (like ms-swift does)
+        # The HF processor should have already preprocessed the images correctly
+        image_embeds = self.visual(pixel_values, grid_thw=grid_thw)
+
+        # Handle the output format - HF visual returns (image_embeds, deepstack_visual_embeds)
+        if isinstance(image_embeds, tuple):
+            image_embeds, deepstack_visual_embeds = image_embeds
+        else:
+            deepstack_visual_embeds = []
+
+        return image_embeds, deepstack_visual_embeds
+
+
+class Qwen3VLTransformerBlock(TransformerBlock):
+    """
+    TransformerBlock with DeepStack support for Qwen3-VL.
+
+    This extends the standard TransformerBlock to inject visual features
+    at intermediate layers (DeepStack mechanism).
+    """
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        context: Optional[torch.Tensor] = None,
+        context_mask: Optional[torch.Tensor] = None,
+        rotary_pos_emb: Optional[torch.Tensor] = None,
+        rotary_pos_cos: Optional[torch.Tensor] = None,
+        rotary_pos_sin: Optional[torch.Tensor] = None,
+        attention_bias: Optional[torch.Tensor] = None,
+        inference_context: Optional[BaseInferenceContext] = None,
+        packed_seq_params: Optional[PackedSeqParams] = None,
+        sequence_len_offset: Optional[torch.Tensor] = None,
+        # DeepStack arguments
+        visual_pos_masks: Optional[torch.Tensor] = None,
+        deepstack_visual_embeds: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """
+        Forward with DeepStack visual feature injection.
+
+        Args:
+            visual_pos_masks: Boolean mask [seq, batch] indicating visual token positions
+            deepstack_visual_embeds: Visual embeddings [num_layers, num_visual_tokens, hidden]
+        """
+
+        # Standard forward through layers with DeepStack injection
+        for layer_idx, layer in enumerate(self.layers):
+            # Get FP8 context if needed
+            inner_fp8_context = (
+                get_fp8_context(self.config, layer.layer_number - 1)
+                if self.config.fp8
+                else nullcontext()
+            )
+
+            with inner_fp8_context:
+                hidden_states, context = layer(
+                    hidden_states=hidden_states,
+                    attention_mask=attention_mask,
+                    context=context,
+                    context_mask=context_mask,
+                    rotary_pos_emb=rotary_pos_emb,
+                    rotary_pos_cos=rotary_pos_cos,
+                    rotary_pos_sin=rotary_pos_sin,
+                    attention_bias=attention_bias,
+                    inference_context=inference_context,
+                    packed_seq_params=packed_seq_params,
+                    sequence_len_offset=sequence_len_offset,
+                )
+
+            # DeepStack: Inject visual features at intermediate layers
+            layer_number = layer.layer_number - 1
+            if (
+                deepstack_visual_embeds is not None
+                and visual_pos_masks is not None
+                and layer_number < deepstack_visual_embeds.shape[0]
+            ):
+                hidden_states = self._deepstack_process(
+                    hidden_states, visual_pos_masks, deepstack_visual_embeds[layer_number]
+                )
+
+        return hidden_states, context
+
+    def _deepstack_process(
+        self,
+        hidden_states: torch.Tensor,
+        visual_pos_masks: torch.Tensor,
+        visual_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Add visual features to hidden states at masked positions.
+
+        Args:
+            hidden_states: [seq, batch, hidden]
+            visual_pos_masks: [seq, batch] boolean mask
+            visual_embeds: [num_visual_tokens, hidden]
+        """
+        if visual_pos_masks is None or visual_embeds is None:
+            return hidden_states
+
+        visual_embeds = visual_embeds.to(device=hidden_states.device, dtype=hidden_states.dtype)
+
+        # Add visual embeddings to positions marked by mask
+        # Flatten for indexing
+        flat_hidden = hidden_states.view(-1, hidden_states.shape[-1])
+        flat_mask = visual_pos_masks.view(-1)
+
+        # Add visual features (residual connection)
+        flat_hidden[flat_mask] = flat_hidden[flat_mask] + visual_embeds
+
+        return flat_hidden.view_as(hidden_states)
+
+
+class Qwen3VLModel(MegatronModule):
+    """
+    Qwen3-VL multi-modal model for Megatron-LM.
+
+    This model combines:
+    - Qwen3-VL vision encoder (from HuggingFace)
+    - Megatron-LM GPT language model
+    - DeepStack mechanism for multi-layer visual feature injection
+
+    Args:
+        language_transformer_config: Transformer config for language model
+        language_transformer_layer_spec: Language model layer specification
+        language_vocab_size: Vocabulary size
+        language_max_sequence_length: Maximum sequence length
+        vision_config: Vision encoder configuration
+        hf_model_name: HuggingFace model name for loading vision encoder
+        freeze_vision: Whether to freeze vision encoder weights
+        freeze_language: Whether to freeze language model weights
+        parallel_output: Keep outputs split across tensor parallel ranks
+        share_embeddings_and_output_weights: Share embedding and output weights
+        pre_process: Include embedding layer (pipeline parallel)
+        post_process: Include output layer (pipeline parallel)
+        add_encoder: Construct encoder (pipeline parallel)
+        add_decoder: Construct decoder (pipeline parallel)
+        img_h: Input image height
+        img_w: Input image width
+        image_token_index: Token ID for image token
+        video_token_index: Token ID for video token
+        num_deepstack_layers: Number of layers for DeepStack injection
+    """
+
+    def __init__(
+        self,
+        language_transformer_config: TransformerConfig,
+        language_transformer_layer_spec: ModuleSpec,
+        language_vocab_size: int,
+        language_max_sequence_length: int,
+        vision_transformer_config: Optional[TransformerConfig] = None,
+        hf_model_name: str = "Qwen/Qwen3-VL-8B-Instruct",
+        freeze_vision: bool = False,
+        freeze_language: bool = False,
+        freeze_lm_embedding: bool = False,
+        parallel_output: bool = True,
+        share_embeddings_and_output_weights: bool = False,
+        language_position_embedding_type: str = 'rope',
+        language_rotary_percent: float = 1.0,
+        pre_process: bool = True,
+        post_process: bool = True,
+        add_encoder: bool = True,
+        add_decoder: bool = True,
+        img_h: int = 336,
+        img_w: int = 336,
+        language_rotary_base: int = 10000,
+        image_token_index: int = DEFAULT_IMAGE_TOKEN_INDEX,
+        video_token_index: int = DEFAULT_VIDEO_TOKEN_INDEX,
+        num_deepstack_layers: int = 5,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+        vp_stage: Optional[int] = None,
+    ) -> None:
+        super().__init__(config=language_transformer_config)
+
+        if has_config_logger_enabled(language_transformer_config):
+            log_config_to_disk(language_transformer_config, locals(), prefix=type(self).__name__)
+
+        log_single_rank(
+            logging.getLogger(__name__),
+            logging.WARNING,
+            "Qwen3VLModel is under development. Features may be missing.",
+        )
+
+        self.pre_process = pre_process
+        self.post_process = post_process
+        self.add_encoder = add_encoder
+        self.add_decoder = add_decoder
+        self.vp_stage = vp_stage
+
+        self.image_token_index = image_token_index
+        self.video_token_index = video_token_index
+        self.num_deepstack_layers = num_deepstack_layers
+        self.img_h = img_h
+        self.img_w = img_w
+        self.freeze_vision = freeze_vision
+        self.freeze_language = freeze_language
+        self.freeze_lm_embedding = freeze_lm_embedding
+
+        self.encoder_hidden_state = None
+        self.visual = None
+        self.language_model = None
+
+        # Vision Encoder
+        if add_encoder:
+            vision_config = vision_transformer_config or language_transformer_config
+            self.visual = Qwen3VLVisionEncoder(
+                config=vision_config,
+                hf_model_name=hf_model_name,
+                freeze_vision=freeze_vision,
+                img_h=img_h,
+                img_w=img_w,
+            )
+            # Override default token indices with actual values from HuggingFace config
+            # (stored in vision encoder during _load_hf_vision_model)
+            if hasattr(self.visual, 'image_token_id'):
+                self.image_token_index = self.visual.image_token_id
+                log_single_rank(
+                    logging.getLogger(__name__),
+                    logging.INFO,
+                    f"Using image_token_index from HF config: {self.image_token_index}",
+                )
+            if hasattr(self.visual, 'video_token_id'):
+                self.video_token_index = self.visual.video_token_id
+
+        # Language Model (GPT)
+        if add_decoder:
+            self.language_model = GPTModel(
+                config=language_transformer_config,
+                transformer_layer_spec=language_transformer_layer_spec,
+                vocab_size=language_vocab_size,
+                max_sequence_length=language_max_sequence_length,
+                parallel_output=parallel_output,
+                share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+                position_embedding_type=language_position_embedding_type,
+                rotary_percent=language_rotary_percent,
+                rotary_base=language_rotary_base,
+                pre_process=pre_process,
+                post_process=post_process,
+                pg_collection=pg_collection,
+            )
+
+            if freeze_language:
+                for param in self.language_model.parameters():
+                    param.requires_grad = False
+
+            if freeze_lm_embedding:
+                self.freeze_embedding()
+
+    def set_input_tensor(self, input_tensor: torch.Tensor) -> None:
+        """Set input tensor for pipeline parallelism."""
+        if self.add_decoder:
+            self.language_model.set_input_tensor(input_tensor)
+
+    def freeze(self, freeze_language_model: bool = False, freeze_vision_model: bool = False):
+        """Freeze model components."""
+        if freeze_language_model and self.language_model is not None:
+            for param in self.language_model.parameters():
+                param.requires_grad = False
+
+        if freeze_vision_model and self.visual is not None:
+            for param in self.visual.parameters():
+                param.requires_grad = False
+
+    def freeze_embedding(self):
+        """Freeze language model embedding layer weights.
+
+        The embedding table is not quantized, so freezing it during QAD
+        avoids unnecessary drift and saves memory (no gradient storage).
+        """
+        if self.language_model is not None and hasattr(self.language_model, 'embedding'):
+            for param in self.language_model.embedding.parameters():
+                param.requires_grad = False
+            self.freeze_lm_embedding = True
+
+    def _get_image_embeddings(
+        self, images: torch.Tensor, grid_thw: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        """Get image embeddings from vision encoder."""
+        if self.visual is None:
+            return None, []
+
+        image_embeds, deepstack_embeds = self.visual(images, grid_thw)
+        return image_embeds, deepstack_embeds
+
+    def _preprocess_data(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        image_embeds: Optional[torch.Tensor],
+        deepstack_embeds: Optional[List[torch.Tensor]],
+        labels: Optional[torch.Tensor] = None,
+        loss_mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+    ]:
+        """
+        Preprocess data by inserting image embeddings at image token positions.
+
+        For Qwen3-VL, this uses masked_scatter to replace image placeholder tokens
+        with image embeddings in-place, keeping the sequence length unchanged.
+
+        Args:
+            input_ids: Input token IDs [batch, seq]
+            position_ids: Position IDs [batch, seq]
+            image_embeds: Image embeddings [total_patches, hidden]
+            deepstack_embeds: List of intermediate embeddings for deepstack
+            labels: Target labels [batch, seq] (optional)
+            loss_mask: Loss mask [batch, seq] (optional)
+
+        Returns:
+            combined_embeddings: Text + image embeddings [seq, batch, hidden]
+            position_ids: Position IDs (unchanged) [batch, seq]
+            visual_pos_masks: Mask for visual token positions [seq, batch]
+            deepstack_embeds: Passthrough
+            labels: Labels (unchanged)
+            loss_mask: Loss mask (unchanged)
+        """
+        batch_size, seq_len = input_ids.shape
+        device = input_ids.device
+
+        # Get text embeddings first
+        # Replace image/video tokens with 0 to avoid embedding lookup errors
+        input_ids_text = input_ids.clone()
+        input_ids_text[input_ids_text == self.image_token_index] = 0
+        input_ids_text[input_ids_text == self.video_token_index] = 0
+
+        text_embeds = self.language_model.embedding(
+            input_ids=input_ids_text, position_ids=position_ids
+        )
+        # text_embeds: [seq, batch, hidden] or [seq/tp, batch, hidden] if sequence parallel
+
+        # If no images, just return text embeddings as-is
+        if image_embeds is None:
+            # Debug: commented out
+            # if parallel_state.get_data_parallel_rank() == 0:
+            #     print(f"  [_preprocess_data] image_embeds is None, returning early")
+            return text_embeds, position_ids, None, deepstack_embeds, labels, loss_mask
+
+        # If sequence parallelism is enabled, gather the full sequence first
+        language_config = self.language_model.config
+        tp_size = parallel_state.get_tensor_model_parallel_world_size()
+        if language_config.sequence_parallel and tp_size > 1:
+            text_embeds = tensor_parallel.gather_from_sequence_parallel_region(
+                text_embeds, tensor_parallel_output_grad=True
+            )
+        # text_embeds: [seq, batch, hidden] (full sequence)
+
+        # Transpose to [batch, seq, hidden] for masked_scatter
+        inputs_embeds = text_embeds.transpose(0, 1).contiguous()
+
+        # Create masks for image and video tokens
+        # input_ids: [batch, seq]
+        image_mask = input_ids == self.image_token_index
+        video_mask = input_ids == self.video_token_index
+        visual_mask = image_mask | video_mask
+
+        # Expand mask to match embedding dimensions: [batch, seq, hidden]
+        embed_dim = inputs_embeds.shape[-1]
+        image_mask_expanded = image_mask.unsqueeze(-1).expand_as(inputs_embeds)
+        video_mask_expanded = video_mask.unsqueeze(-1).expand_as(inputs_embeds)
+
+        # image_embeds is [total_embeddings, hidden] or [seq, batch, hidden]
+        # For Qwen3-VL: total_embeddings should equal num_image_tokens (1:1 mapping)
+        if image_embeds.dim() == 2:
+            # [total_embeddings, hidden] -> use directly
+            image_embeds_flat = image_embeds.to(device=device, dtype=inputs_embeds.dtype)
+        else:
+            # [seq, batch, hidden] -> flatten
+            image_embeds_flat = image_embeds.transpose(0, 1).reshape(-1, embed_dim)
+            image_embeds_flat = image_embeds_flat.to(device=device, dtype=inputs_embeds.dtype)
+
+        # Use masked_scatter to replace image token embeddings with image embeddings
+        # masked_scatter replaces True positions with values from the source tensor
+        # Use masked_scatter to replace image token embeddings with image embeddings.
+        # masked_scatter consumes exactly as many values as True positions in the mask,
+        # so no explicit count/slice is needed. We call it unconditionally (no-op when
+        # mask is all-False) to avoid .sum().item() or .any() CPU-GPU sync stalls.
+        inputs_embeds = inputs_embeds.masked_scatter(image_mask_expanded, image_embeds_flat)
+        # Handle video embeddings similarly if present (for future use)
+        # Currently treating all visual tokens as images
+
+        # Transpose back to [seq, batch, hidden]
+        combined_embeds = inputs_embeds.transpose(0, 1).contiguous()
+
+        # Create visual position mask [seq, batch]
+        visual_pos_mask = visual_mask.transpose(0, 1).contiguous()
+
+        # Labels and loss_mask don't change since sequence length is preserved
+        return combined_embeds, position_ids, visual_pos_mask, deepstack_embeds, labels, loss_mask
+
+    def forward(
+        self,
+        images: Optional[torch.Tensor] = None,
+        input_ids: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        labels: Optional[torch.Tensor] = None,
+        loss_mask: Optional[torch.Tensor] = None,
+        grid_thw: Optional[torch.Tensor] = None,
+        inference_context: Optional[BaseInferenceContext] = None,
+        packed_seq_params: Optional[PackedSeqParams] = None,
+        extra_block_kwargs: Optional[dict] = None,
+        runtime_gather_output: Optional[bool] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        Forward pass.
+
+        Args:
+            images: Input images [batch, channels, height, width]
+            input_ids: Input token IDs [batch, seq_length]
+            position_ids: Position IDs [batch, seq_length]
+            attention_mask: Attention mask
+            labels: Target labels for loss computation
+            loss_mask: Mask for loss computation
+            grid_thw: Grid dimensions for dynamic resolution
+            inference_context: Inference context for generation
+            packed_seq_params: Parameters for sequence packing
+            extra_block_kwargs: Extra arguments for transformer blocks
+            runtime_gather_output: Whether to gather output at runtime
+
+        Returns:
+            output: Model output (logits or loss depending on mode)
+        """
+        # Get image embeddings
+        image_embeds = None
+        deepstack_embeds = None
+
+        if self.add_encoder and images is not None:
+            # Skip saving activations when vision encoder is frozen (saves memory)
+            if self.freeze_vision:
+                with torch.no_grad():
+                    image_embeds, deepstack_embeds = self._get_image_embeddings(images, grid_thw)
+            else:
+                image_embeds, deepstack_embeds = self._get_image_embeddings(images, grid_thw)
+
+            # Convert deepstack to tensor if list
+            if deepstack_embeds and isinstance(deepstack_embeds, list):
+                deepstack_embeds = torch.stack(deepstack_embeds, dim=0)
+
+        # Preprocess data: replace image placeholder embeddings with actual
+        # image embeddings. Uses masked_scatter for in-place replacement.
+        # When LM embedding is frozen, skip saving activations.
+        if self.freeze_lm_embedding:
+            with torch.no_grad():
+                (
+                    combined_embeds,
+                    position_ids,
+                    visual_pos_masks,
+                    deepstack_embeds,
+                    new_labels,
+                    new_loss_mask,
+                ) = self._preprocess_data(
+                    input_ids=input_ids,
+                    position_ids=position_ids,
+                    image_embeds=image_embeds,
+                    deepstack_embeds=deepstack_embeds,
+                    labels=labels,
+                    loss_mask=loss_mask,
+                )
+        else:
+            (
+                combined_embeds,
+                position_ids,
+                visual_pos_masks,
+                deepstack_embeds,
+                new_labels,
+                new_loss_mask,
+            ) = self._preprocess_data(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                image_embeds=image_embeds,
+                deepstack_embeds=deepstack_embeds,
+                labels=labels,
+                loss_mask=loss_mask,
+            )
+
+        # If sequence parallelism is enabled AND we had images, scatter
+        # combined_embeds back to SP format for TransformerBlock.
+        language_config = self.language_model.config
+        has_images = self.add_encoder and images is not None
+        tp_size = parallel_state.get_tensor_model_parallel_world_size()
+        if has_images and language_config.sequence_parallel and tp_size > 1:
+            # Sequence length is unchanged (no expansion), should already be divisible by TP
+            # but pad if necessary just in case
+            seq_len = combined_embeds.shape[0]  # [seq, batch, hidden]
+            if seq_len % tp_size != 0:
+                pad_len = tp_size - (seq_len % tp_size)
+                padding = torch.zeros(
+                    pad_len,
+                    combined_embeds.shape[1],
+                    combined_embeds.shape[2],
+                    dtype=combined_embeds.dtype,
+                    device=combined_embeds.device,
+                )
+                combined_embeds = torch.cat([combined_embeds, padding], dim=0)
+            combined_embeds = tensor_parallel.scatter_to_sequence_parallel_region(combined_embeds)
+
+        # Note: DeepStack feature (visual_pos_masks, deepstack_visual_embeds) requires
+        # custom TransformerBlock. Standard GPTModel doesn't support it, so we skip it for now.
+        # TODO: Implement DeepStack with custom Qwen3VLTransformerBlock when needed.
+
+        # Forward through language model
+        # Note: We pass embeddings directly instead of input_ids
+        # Labels and loss_mask are unchanged since sequence length is preserved
+
+        # When LM embedding is frozen, combined_embeds has
+        # requires_grad=False. Activation checkpointing requires the
+        # input to have requires_grad=True to propagate gradients to
+        # decoder layer parameters.
+        if self.freeze_lm_embedding and combined_embeds.requires_grad is False:
+            combined_embeds = combined_embeds.detach().requires_grad_(True)
+
+        output = self.language_model(
+            input_ids=None,  # Use decoder_input instead
+            decoder_input=combined_embeds,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            labels=new_labels,
+            inference_context=inference_context,
+            packed_seq_params=packed_seq_params,
+            extra_block_kwargs=extra_block_kwargs,
+            runtime_gather_output=runtime_gather_output,
+        )
+
+        return output, new_loss_mask
+
+    def sharded_state_dict(
+        self, prefix: str = '', sharded_offsets: tuple = (), metadata: Optional[dict] = None
+    ):
+        """Get sharded state dict for distributed checkpointing.
+
+        This properly wraps vision encoder parameters with ShardedTensor
+        to support torch_dist checkpoint format for TP resharding.
+        """
+        from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
+
+        sharded_state_dict = {}
+
+        if self.visual is not None:
+            vision_prefix = f'{prefix}visual.'
+            # Vision model parameters are replicated (not TP-sharded)
+            # Use make_sharded_tensors_for_checkpoint to properly wrap them
+            # for distributed checkpoint format (torch_dist)
+            vision_state_dict = {}
+            for name, param in self.visual.named_parameters():
+                vision_state_dict[name] = param
+
+            # Wrap vision parameters as replicated sharded tensors
+            # tensor_parallel_layers_axis_map=None means all tensors are replicated
+            vision_sharded_sd = make_sharded_tensors_for_checkpoint(
+                vision_state_dict,
+                vision_prefix,
+                tensor_parallel_layers_axis_map=None,  # No TP sharding for vision
+                sharded_offsets=sharded_offsets,
+            )
+            sharded_state_dict.update(vision_sharded_sd)
+
+        if self.language_model is not None:
+            language_prefix = f'{prefix}language_model.'
+            language_sharded_sd = self.language_model.sharded_state_dict(
+                prefix=language_prefix, sharded_offsets=sharded_offsets, metadata=metadata
+            )
+            sharded_state_dict.update(language_sharded_sd)
+
+        return sharded_state_dict

--- a/megatron/training/datasets/data_samplers.py
+++ b/megatron/training/datasets/data_samplers.py
@@ -79,8 +79,13 @@ def build_pretraining_data_loader(dataset, consumed_samples):
         worker_init_fn if args.exit_signal_handler and args.num_workers > 0 else None
     )
     # Torch dataloader.
+    # Check if dataset provides a custom collate function (e.g., for VLM datasets
+    # with variable-length inputs like pixel_values).
+    collate_fn = getattr(dataset, 'collate_fn', None)
     if args.hybrid_context_parallel:
         extra_kwargs = {"collate_fn": lambda x: x,}
+    elif collate_fn is not None:
+        extra_kwargs = {"collate_fn": collate_fn}
     else:
         extra_kwargs = {}
     return torch.utils.data.DataLoader(

--- a/pretrain_qwenvl.py
+++ b/pretrain_qwenvl.py
@@ -1,0 +1,802 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025, Qwen3-VL pretraining script.
+"""Pretrain Qwen3-VL vision language model.
+
+This script supports training Qwen3-VL models with real multimodal data.
+It uses the Qwen3VLModel from megatron.core.models.multimodal which includes:
+- HuggingFace Qwen3-VL visual encoder
+- DeepStack mechanism for multi-layer visual feature injection
+- Proper sequence expansion for image embeddings
+
+Usage:
+    torchrun --nproc_per_node=8 pretrain_qwenvl.py \
+        --vision-model-type qwen3_vl \
+        --hf-model-name Qwen/Qwen3-VL-8B-Instruct \
+        --img-h 384 --img-w 384 \
+        ...
+
+References:
+    - megatron/core/models/multimodal/qwen3_vl_model.py
+    - Megatron-LM pretrain_vlm.py for LLaVA architecture
+"""
+from copy import deepcopy
+from functools import partial
+
+import torch
+
+from megatron.core import parallel_state, tensor_parallel
+from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
+from megatron.core.datasets.gpt_dataset import GPTDataset, GPTDatasetConfig
+from megatron.core.datasets.multimodal_dataset import MockMultimodalDataset, MultimodalDatasetConfig
+from megatron.core.datasets.qwen3vl_dataset import Qwen3VLDataset, Qwen3VLDatasetConfig, Qwen3VLDatasetBuilder
+from megatron.core.enums import ModelType
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_local_spec,
+    get_gpt_layer_with_transformer_engine_spec,
+)
+# [ModelOpt]: Import modelopt layer spec for QAT training
+try:
+    from megatron.core.post_training.modelopt.gpt.model_specs import get_gpt_modelopt_spec
+    has_modelopt_spec = True
+except ImportError:
+    has_modelopt_spec = False
+from megatron.core.models.multimodal.qwen3_vl_model import (
+    Qwen3VLModel,
+    DEFAULT_IMAGE_TOKEN_INDEX,
+    DEFAULT_VIDEO_TOKEN_INDEX,
+)
+from megatron.core.transformer.spec_utils import import_module
+from megatron.training import get_args, get_timers, get_tokenizer, pretrain, print_rank_0
+from megatron.training.arguments import core_transformer_config_from_args
+from megatron.training.utils import get_blend_and_blend_per_split
+from pretrain_gpt import loss_func
+
+# [ModelOpt]: Import for loading quantization state from PTQ checkpoints
+try:
+    from megatron.post_training.checkpointing import load_modelopt_state, has_modelopt_state
+    has_modelopt_support = True
+except ImportError:
+    has_modelopt_support = False
+
+# [ModelOpt]: Import modelopt arguments for QAT training
+try:
+    from megatron.post_training.arguments import add_modelopt_args
+    has_modelopt_args = True
+except ImportError:
+    has_modelopt_args = False
+
+# [ModelOpt]: Import for knowledge distillation (QAD)
+try:
+    import modelopt.torch.distill as mtd
+    import modelopt.torch.distill.plugins.megatron as mtd_mcore
+    import modelopt.torch.opt as mto
+    from megatron.post_training.model_builder import (
+        _load_teacher_model_config,
+    )
+    has_kd_support = True
+except ImportError:
+    has_kd_support = False
+
+
+class _VLMTeacherWrapper(torch.nn.Module):
+    """Temporary wrapper to load a teacher GPTModel from a VLM checkpoint.
+
+    VLM checkpoints store the language model under the 'language_model.' prefix
+    (e.g., language_model.embedding.word_embeddings.weight). This wrapper places
+    the teacher GPTModel as self.language_model so that sharded_state_dict()
+    generates keys matching the checkpoint structure.
+
+    The visual.* keys in the checkpoint are simply not requested (only language_model.*
+    keys are generated), so they are ignored during loading.
+    """
+
+    def __init__(self, language_model):
+        super().__init__()
+        self.language_model = language_model
+
+    def sharded_state_dict(self, prefix='', sharded_offsets=(), metadata=None):
+        language_prefix = f'{prefix}language_model.'
+        return self.language_model.sharded_state_dict(
+            prefix=language_prefix,
+            sharded_offsets=sharded_offsets,
+            metadata=metadata,
+        )
+
+
+def _load_vlm_teacher_model(config, config_raw, model_kwargs):
+    """Load teacher GPTModel from a VLM checkpoint.
+
+    Unlike _load_teacher_model in model_builder.py (designed for text-only GPT checkpoints),
+    this function handles loading from a VLM checkpoint where the language model weights
+    are stored under the 'language_model.' prefix (e.g., language_model.embedding.word_embeddings.weight).
+
+    The teacher is a bare MCoreGPTModel, but the checkpoint was saved from a Qwen3VLModel
+    which stores GPTModel as self.language_model. We wrap the teacher in a _VLMTeacherWrapper
+    that mirrors the Qwen3VLModel structure, then use Megatron's load_checkpoint which
+    handles all the distributed checkpoint complexity (TP resharding, factory merging, etc.).
+
+    Uses a regular (non-modelopt) layer spec because the VLM checkpoint was saved from
+    a regular ms-swift mcore model, not a PTQ/modelopt checkpoint.
+    """
+    from megatron.core.models.gpt import GPTModel as MCoreGPTModel
+    from megatron.training.checkpointing import load_checkpoint
+
+    args = get_args()
+
+    # Use regular layer spec (NOT modelopt spec) because the VLM teacher checkpoint
+    # was saved from a regular mcore model (ms-swift export), not a PTQ checkpoint.
+    if args.transformer_impl == "transformer_engine":
+        model_kwargs["transformer_layer_spec"] = get_gpt_layer_with_transformer_engine_spec(
+            num_experts=args.num_experts,
+            moe_grouped_gemm=args.moe_grouped_gemm,
+            qk_layernorm=args.qk_layernorm,
+        )
+    else:
+        model_kwargs["transformer_layer_spec"] = get_gpt_layer_local_spec(
+            num_experts=args.num_experts,
+            moe_grouped_gemm=args.moe_grouped_gemm,
+            qk_layernorm=args.qk_layernorm,
+        )
+    teacher = MCoreGPTModel(config=config, **model_kwargs)
+
+    teacher_load_path = args.export_kd_teacher_load
+    print_rank_0(f"Loading VLM teacher as {type(teacher).__name__} from {teacher_load_path} ...")
+
+    # Wrap teacher in _VLMTeacherWrapper so its sharded_state_dict() generates
+    # 'language_model.' prefixed keys matching the VLM checkpoint structure.
+    wrapper = _VLMTeacherWrapper(teacher)
+
+    # Temporarily set finetune=True to avoid checkpoint arg/rng validation
+    original_finetune = args.finetune
+    args.finetune = True
+
+    # Use Megatron's load_checkpoint which handles TP resharding, factory merging,
+    # and all the distributed checkpoint complexity automatically.
+    # The wrapper's sharded_state_dict() only requests language_model.* keys,
+    # so visual.* keys in the checkpoint are silently ignored (strict=False).
+    load_checkpoint([wrapper], None, None, strict=False, load_arg='export_kd_teacher_load')
+
+    args.finetune = original_finetune
+
+    # Reset global checkpoint version set by teacher's load_checkpoint.
+    # Without this, the student's checkpoint loading would fail with
+    # "checkpoint versions do not match" if the versions differ.
+    import megatron.training.checkpointing as _ckpt_module
+    _ckpt_module._CHECKPOINT_VERSION = None
+
+    print_rank_0("...VLM teacher loaded successfully.")
+    return teacher
+
+
+def model_provider(
+    pre_process: bool = True,
+    post_process: bool = True,
+    parallel_output: bool = True,
+    config=None,
+    pg_collection=None,
+    vp_stage: int = None,
+) -> Qwen3VLModel:
+    """Build the Qwen3-VL model.
+
+    This uses the Qwen3VLModel from megatron.core.models.multimodal which
+    combines a Megatron-LM GPT language model with HuggingFace Qwen3-VL
+    visual encoder and supports DeepStack multi-layer visual injection.
+
+    Args:
+        pre_process: Include embedding layer (for pipeline parallelism)
+        post_process: Include output layer (for pipeline parallelism)
+        parallel_output: Enable model parallel output
+        config: TransformerConfig passed by Megatron-LM training
+        pg_collection: Process group collection
+        vp_stage: Virtual pipeline stage
+
+    Returns:
+        Qwen3VLModel instance
+    """
+    args = get_args()
+
+    print_rank_0('building Qwen3-VL model ...')
+
+    # Get transformer config for language model
+    # Use provided config if available, otherwise create from args
+    if config is not None:
+        language_transformer_config = config
+    else:
+        language_transformer_config = core_transformer_config_from_args(args)
+
+    # Configure heterogeneous distributed checkpoint based on checkpoint type
+    # - PTQ checkpoints (from quantize.py) use per-layer format: "layers.0.", "layers.1.", etc.
+    # - ms-swift mcore checkpoints use factory-merged format: "layers.self_attention..." with merged tensors
+    # Only enable hetereogenous_dist_checkpoint for PTQ checkpoints
+    is_ptq_checkpoint = (
+        args.load is not None and
+        has_modelopt_support and
+        has_modelopt_state(args.load)
+    )
+    if is_ptq_checkpoint:
+        language_transformer_config.hetereogenous_dist_checkpoint = True
+        print_rank_0('Loading PTQ checkpoint: using hetereogenous_dist_checkpoint=True (per-layer format)')
+    else:
+        # For ms-swift mcore checkpoints, use factory-merged format
+        language_transformer_config.hetereogenous_dist_checkpoint = False
+        print_rank_0('Loading mcore checkpoint: using hetereogenous_dist_checkpoint=False (factory-merged format)')
+
+    # Override num_layers if decoder_num_layers is specified
+    if hasattr(args, 'decoder_num_layers') and args.decoder_num_layers is not None:
+        language_transformer_config.num_layers = args.decoder_num_layers
+
+    # Get transformer layer spec
+    # [ModelOpt]: Use modelopt spec when loading from PTQ checkpoint for QAT training
+    use_modelopt_spec = getattr(args, 'use_modelopt_spec', False)
+    if args.load is not None and has_modelopt_support and has_modelopt_state(args.load):
+        if has_modelopt_spec:
+            use_modelopt_spec = True
+            print_rank_0('Detected PTQ checkpoint, using modelopt layer spec for QAT training')
+        else:
+            print_rank_0('Warning: PTQ checkpoint detected but modelopt spec not available')
+
+    if args.spec is not None:
+        language_transformer_layer_spec = import_module(args.spec)
+    elif use_modelopt_spec and has_modelopt_spec:
+        # Use modelopt spec for QAT training with quantized checkpoints
+        # remap_te_layernorm=True for compatibility with checkpoints saved with --export-te-mcore-model
+        language_transformer_layer_spec = get_gpt_modelopt_spec(
+            config=language_transformer_config,
+            local_core_attention=getattr(args, 'use_local_attention', False),
+            remap_te_layernorm=True,
+            real_quant_cfg=getattr(args, 'export_real_quant_cfg', 'None'),
+            use_arbitrary_attention_mask=True if language_transformer_config.context_parallel_size == 1 else False,
+        )
+    elif args.transformer_impl == "transformer_engine":
+        language_transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
+            args.num_experts, args.moe_grouped_gemm
+        )
+    else:
+        language_transformer_layer_spec = get_gpt_layer_local_spec(
+            args.num_experts, args.moe_grouped_gemm
+        )
+
+    # Vision transformer config (use same as language but with vision-specific settings)
+    vision_transformer_config = deepcopy(language_transformer_config)
+    if hasattr(args, 'encoder_num_layers') and args.encoder_num_layers is not None:
+        vision_transformer_config.num_layers = args.encoder_num_layers
+    vision_transformer_config.context_parallel_size = 1  # Force CP=1 for vision
+
+    # When no data path is provided, we run in mock-data mode (no real images).
+    # Skip the HuggingFace vision encoder to avoid model downloads.
+    has_data = (getattr(args, 'data_path', None) is not None or
+                getattr(args, 'per_split_data_args_path', None) is not None)
+    add_encoder = parallel_state.is_pipeline_first_stage() and has_data
+
+    # Build the Qwen3-VL model
+    model = Qwen3VLModel(
+        language_transformer_config=language_transformer_config,
+        language_transformer_layer_spec=language_transformer_layer_spec,
+        language_vocab_size=args.padded_vocab_size,
+        language_max_sequence_length=args.max_position_embeddings,
+        vision_transformer_config=vision_transformer_config,
+        hf_model_name=args.hf_model_name,
+        freeze_vision=args.freeze_ViT,
+        freeze_language=args.freeze_LM,
+        freeze_lm_embedding=args.freeze_lm_embedding,
+        parallel_output=parallel_output,
+        share_embeddings_and_output_weights=not args.untie_embeddings_and_output_weights,
+        language_position_embedding_type=args.position_embedding_type,
+        language_rotary_percent=args.rotary_percent,
+        language_rotary_base=args.rotary_base,
+        pre_process=pre_process,
+        post_process=post_process,
+        add_encoder=add_encoder,
+        add_decoder=True,
+        img_h=args.img_h,
+        img_w=args.img_w,
+        image_token_index=args.image_token_index,
+        video_token_index=args.video_token_index,
+        num_deepstack_layers=args.num_deepstack_layers,
+        pg_collection=pg_collection,
+        vp_stage=vp_stage,
+    )
+
+    # [ModelOpt]: Load modelopt state from PTQ checkpoint for QAT training
+    # This converts the model to have quantization-aware modules before weights are loaded.
+    # The quantization config (in modelopt_state) specifies which layers to quantize.
+    # For VLM, only the language_model is quantized (visual encoder is not quantized).
+    #
+    # The main checkpoint has keys like: language_model.decoder.layers.0.*._extra_state
+    # We must NOT use a prefix here because Qwen3VLModel.sharded_state_dict() already
+    # adds "language_model." internally. Using prefix="" ensures the keys match correctly.
+    # (Using prefix="language_model." would create "language_model.language_model.*" keys)
+    if has_modelopt_support and args.load is not None:
+        if has_modelopt_state(args.load):
+            print_rank_0(f'Loading modelopt state from {args.load} for QAT training...')
+            from megatron.post_training.checkpointing import get_sharded_load_dir
+            from modelopt.torch.opt.plugins.mcore_dist_checkpointing import restore_sharded_modelopt_state
+            sharded_load_dir, _ = get_sharded_load_dir(args.load)
+            if sharded_load_dir is not None:
+                # No prefix needed - checkpoint keys already have language_model. prefix
+                # and Qwen3VLModel.sharded_state_dict() generates matching keys
+                restore_sharded_modelopt_state([model], sharded_load_dir, prefix="")
+                print_rank_0('Modelopt state loaded. Model converted to quantization-aware format.')
+            else:
+                print_rank_0('No sharded checkpoint found. Skipping modelopt state loading.')
+
+    # [ModelOpt]: Knowledge Distillation (QAD) setup
+    # For VLM, we wrap model.language_model (not the full Qwen3VLModel) with DistillationModel.
+    # The teacher is a text-only GPTModel that receives the same embeddings (text + image features)
+    # as the student's language_model. The vision encoder is NOT distilled.
+    if has_kd_support and getattr(args, 'export_kd_teacher_load', None):
+        print_rank_0("VLM Distillation: Enabled (wrapping language_model only).")
+
+        assert not getattr(args, 'manual_gc', False), \
+            "ModelOpt Distillation currently incompatible with `--manual-gc` option."
+        assert not getattr(args, 'tp_comm_overlap', False), \
+            "ModelOpt Distillation currently incompatible with `--tp-comm-overlap` option."
+
+        teacher_config_raw = _load_teacher_model_config(args.export_kd_teacher_load)
+        teacher_config = core_transformer_config_from_args(teacher_config_raw)
+
+        distill_cfg = mtd_mcore.setup_distillation_config(
+            getattr(args, 'export_kd_cfg', None),
+            student_cfg=language_transformer_config,
+            teacher_cfg=teacher_config,
+        )
+
+        # Build model_kwargs for teacher (same structure as language_model)
+        teacher_model_kwargs = {
+            "vocab_size": args.padded_vocab_size,
+            "max_sequence_length": args.max_position_embeddings,
+            "parallel_output": parallel_output,
+            "share_embeddings_and_output_weights": not args.untie_embeddings_and_output_weights,
+            "position_embedding_type": args.position_embedding_type,
+            "rotary_percent": args.rotary_percent,
+            "pre_process": pre_process,
+            "post_process": post_process,
+        }
+
+        kd_config = {
+            "teacher_model": _load_vlm_teacher_model(teacher_config, teacher_config_raw, teacher_model_kwargs),
+            "criterion": distill_cfg.criterion,
+            "loss_balancer": distill_cfg.loss_balancer,
+        }
+
+        # Wrap only language_model with DistillationModel
+        model.language_model = mtd.convert(model.language_model, mode=[("kd_loss", kd_config)])
+        mtd_mcore.adjust_distillation_model_for_mcore(model.language_model, distill_cfg)
+
+        # Fix "Model has multiple modelopt states!" during checkpoint saving.
+        # restore_sharded_modelopt_state (above) sets _modelopt_state on the root Qwen3VLModel,
+        # then mtd.convert creates a second _modelopt_state on language_model. Two modules
+        # with state triggers an assertion in save_sharded_modelopt_state. Remove language_model's
+        # state so only the root has it, then pop the quantization state from root to match
+        # text-only QAD behavior (see model_builder.py:338).
+        if hasattr(model.language_model, '_modelopt_state'):
+            mto.ModeloptStateManager.remove_state(model.language_model)
+        mto.ModeloptStateManager(model).state_dict().pop()
+        print_rank_0("VLM Distillation: language_model wrapped with DistillationModel.")
+
+    elif getattr(args, 'export_kd_teacher_load', None) and not has_kd_support:
+        raise RuntimeError(
+            "--export-kd-teacher-load is set but knowledge distillation dependencies are not available. "
+            "Please install modelopt with distillation support: pip install nvidia-modelopt[torch]"
+        )
+
+    # [ModelOpt]: Memory-efficient quantizer (--me-quantizer)
+    # Monkey-patches TensorQuantizer._fake_quantize for inplace NVFP4 fake quantization.
+    # Incompatible with --use-distributed-optimizer / --overlap-param-gather because the
+    # bound method leaks into modelopt's extra_state pickle and hits unpicklable DDP hooks.
+    if getattr(args, 'me_quantizer', False):
+        from patch_tensor_quantizer import inject_memory_efficient_dynamic_block_quant
+        inject_memory_efficient_dynamic_block_quant(model)
+
+    return model
+
+
+def train_valid_test_datasets_provider(train_val_test_num_samples):
+    """Build training, validation, and test datasets.
+
+    This function creates datasets that can load real multimodal data
+    from the specified data blend path. Supports both --data-path and
+    --per-split-data-args-path for specifying data.
+
+    For VLM training with images, use --use-vlm-dataset to load images
+    from JSONL files instead of preprocessed binary files.
+
+    Args:
+        train_val_test_num_samples: List of sample counts [train, val, test]
+
+    Returns:
+        Tuple of (train_ds, val_ds, test_ds)
+    """
+    args = get_args()
+
+    print_rank_0("> building train, validation, and test datasets for Qwen3-VL ...")
+
+    # Determine sequence length for dataloader
+    seq_length = args.dataloader_seq_length if args.dataloader_seq_length else args.seq_length
+
+    # Get blend paths from args (handles both --data-path and --per-split-data-args-path)
+    blend, blend_per_split = get_blend_and_blend_per_split(args)
+
+    # When no data paths are provided, use MockMultimodalDataset (mock mode).
+    if blend is None and blend_per_split is None:
+        print_rank_0(">   No data paths provided. Using MockMultimodalDataset (mock data mode)")
+        config = MultimodalDatasetConfig(
+            random_seed=args.seed,
+            split=args.split,
+            sequence_length=seq_length,
+            tokenizer=get_tokenizer(),
+            reset_position_ids=args.reset_position_ids,
+            reset_attention_mask=args.reset_attention_mask,
+            eod_mask_loss=args.eod_mask_loss,
+            image_h=args.img_h,
+            image_w=args.img_w,
+        )
+
+        train_ds, valid_ds, test_ds = BlendedMegatronDatasetBuilder(
+            MockMultimodalDataset,
+            train_val_test_num_samples,
+            lambda: parallel_state.get_tensor_model_parallel_rank() == 0,
+            config,
+        ).build()
+
+        print_rank_0("> finished creating mock Qwen3-VL datasets ...")
+        return train_ds, valid_ds, test_ds
+
+    print_rank_0(f">   blend: {blend}")
+    print_rank_0(f">   blend_per_split: {blend_per_split}")
+
+    # Check if we should use VLM dataset with images
+    use_vlm_dataset = getattr(args, 'use_vlm_dataset', False)
+
+    if use_vlm_dataset:
+        # Use Qwen3VL multimodal dataset that loads images from JSONL
+        print_rank_0(">   Using Qwen3VL multimodal dataset with images")
+
+        # Get the blend path (for VLM, we expect per-split-data-args-path)
+        blend_path = getattr(args, 'per_split_data_args_path', None)
+        if not blend_path:
+            raise ValueError("--per-split-data-args-path is required for --use-vlm-dataset")
+
+        # Create VLM dataset config
+        vlm_config = Qwen3VLDatasetConfig(
+            image_base_dir=getattr(args, 'image_base_dir', None),
+            img_h=args.img_h,
+            img_w=args.img_w,
+            processor_name=args.hf_model_name,
+            sequence_length=seq_length,
+            random_seed=args.seed,
+        )
+
+        # Build VLM datasets
+        builder = Qwen3VLDatasetBuilder(
+            config=vlm_config,
+            blend_path=blend_path,
+            train_val_test_num_samples=train_val_test_num_samples,
+        )
+        train_ds, valid_ds, test_ds = builder.build()
+
+    else:
+        # Use standard GPTDataset (text-only, no images)
+        print_rank_0(">   Using GPTDataset (text-only, no images)")
+        print_rank_0(">   NOTE: Add --use-vlm-dataset to load images from JSONL files")
+
+        # Create dataset config
+        # Note: split and blend_per_split are incompatible - only use split when blend is provided
+        config = GPTDatasetConfig(
+            random_seed=args.seed,
+            sequence_length=seq_length,
+            blend=blend,
+            blend_per_split=blend_per_split,
+            split=args.split if blend_per_split is None else None,
+            num_dataset_builder_threads=args.num_dataset_builder_threads,
+            path_to_cache=args.data_cache_path,
+            mmap_bin_files=args.mmap_bin_files,
+            tokenizer=get_tokenizer(),
+            reset_position_ids=args.reset_position_ids,
+            reset_attention_mask=args.reset_attention_mask,
+            eod_mask_loss=args.eod_mask_loss,
+            create_attention_mask=args.create_attention_mask_in_dataloader,
+        )
+
+        # Build datasets
+        train_ds, valid_ds, test_ds = BlendedMegatronDatasetBuilder(
+            GPTDataset,
+            train_val_test_num_samples,
+            lambda: parallel_state.get_tensor_model_parallel_rank() == 0,
+            config,
+        ).build()
+
+    print_rank_0("> finished creating Qwen3-VL datasets ...")
+
+    return train_ds, valid_ds, test_ds
+
+
+def get_batch(data_iterator):
+    """Generate a batch for Qwen3-VL training.
+
+    Args:
+        data_iterator: Iterator over the dataset
+
+    Returns:
+        Tuple of batch components for Qwen3VLModel.forward()
+    """
+    args = get_args()
+
+    # Get data from iterator
+    if data_iterator is not None:
+        data = next(data_iterator)
+    else:
+        data = None
+
+    # Broadcast data across tensor parallel ranks
+    data_i = tensor_parallel.broadcast_data(
+        ["tokens", "position_ids", "labels"], data, torch.int64
+    )
+    data_f = tensor_parallel.broadcast_data(
+        ["loss_mask"], data, torch.float32
+    )
+
+    # Extract batch components
+    tokens = data_i["tokens"].long()
+    position_ids = data_i["position_ids"].long()
+    labels = data_i["labels"].long()
+    loss_mask = data_f["loss_mask"].float()
+
+    # Handle image data.
+    # All broadcast_data calls must be unconditional — every TP rank must
+    # participate in the NCCL collective, even when data is None on non-TP0 ranks.
+    images = None
+    grid_thw = None
+
+    has_data_path = (getattr(args, 'data_path', None) is not None or
+                     getattr(args, 'per_split_data_args_path', None) is not None)
+
+    if not has_data_path:
+        # Mock data mode: MockMultimodalDataset always returns "image" key
+        image_data = tensor_parallel.broadcast_data(
+            ["image"], data, torch.float32
+        )
+        images = image_data["image"].to(torch.bfloat16)
+    else:
+        # Real data mode: broadcast a flag first so all TP ranks agree on
+        # whether to enter the image broadcast (avoids NCCL deadlock).
+        # Note: broadcast_data uses 0 as a sentinel for dimension sizes,
+        # so zero-sized tensors cannot be broadcast directly.
+        flag = tensor_parallel.broadcast_data(
+            ["has_images"], data, torch.int64
+        )
+        if flag["has_images"].item() == 1:
+            pixel_data = tensor_parallel.broadcast_data(
+                ["pixel_values"], data, torch.float32
+            )
+            grid_data = tensor_parallel.broadcast_data(
+                ["image_grid_thw"], data, torch.int64
+            )
+            images = pixel_data["pixel_values"].to(torch.bfloat16)
+            grid_thw = grid_data["image_grid_thw"]
+
+    attention_mask = None  # Use mask type from layer spec
+    packed_seq_params = None
+
+    return (
+        images,
+        tokens,
+        position_ids,
+        labels,
+        loss_mask,
+        attention_mask,
+        grid_thw,
+        packed_seq_params,
+    )
+
+
+def forward_step(data_iterator, model: Qwen3VLModel):
+    """Forward training step for Qwen3-VL.
+
+    Args:
+        data_iterator: Iterator over the dataset
+        model: The Qwen3-VL model
+
+    Returns:
+        Tuple of (output_tensor, loss_func)
+    """
+    timers = get_timers()
+
+    # Get batch
+    timers('batch-generator', log_level=2).start()
+    (
+        images,
+        tokens,
+        position_ids,
+        labels,
+        loss_mask,
+        attention_mask,
+        grid_thw,
+        packed_seq_params,
+    ) = get_batch(data_iterator)
+    timers('batch-generator').stop()
+
+    # Forward pass through Qwen3VLModel
+    # The model handles:
+    # - Image embedding extraction via vision encoder
+    # - Sequence expansion to insert image embeddings
+    # - DeepStack visual feature injection
+    # - Labels and loss_mask expansion
+    output_tensor, expanded_loss_mask = model(
+        images=images,
+        input_ids=tokens,
+        position_ids=position_ids,
+        attention_mask=attention_mask,
+        labels=labels,
+        loss_mask=loss_mask,
+        grid_thw=grid_thw,
+        packed_seq_params=packed_seq_params,
+    )
+
+    # For QAD (knowledge distillation): the DistillationModel wraps the inner
+    # language_model (GPTModel), not the outer Qwen3VLModel. Pass language_model
+    # to loss_func so compute_kd_loss() is reachable. For regular QAT (no KD),
+    # pass the full model as-is.
+    args = get_args()
+    if getattr(args, 'export_kd_teacher_load', None):
+        from megatron.training.utils import unwrap_model as _unwrap
+        _unwrapped = _unwrap(model)
+        loss_model = getattr(_unwrapped, 'language_model', model)
+    else:
+        loss_model = model
+    return output_tensor, partial(loss_func, expanded_loss_mask, model=loss_model)
+
+
+def add_qwen3vl_extra_args(parser):
+    """Add Qwen3-VL specific arguments and modelopt arguments for QAT.
+
+    Args:
+        parser: Argument parser
+
+    Returns:
+        Updated parser
+    """
+    # [ModelOpt]: Add modelopt arguments for QAT training (export_kd_teacher_load, etc.)
+    if has_modelopt_args:
+        parser = add_modelopt_args(parser)
+
+    group = parser.add_argument_group(title='Qwen3-VL specific arguments')
+
+    # Visual encoder arguments
+    group.add_argument(
+        '--hf-model-name',
+        type=str,
+        default='Qwen/Qwen3-VL-8B-Instruct',
+        help='HuggingFace model name for loading the visual encoder'
+    )
+    group.add_argument(
+        '--num-deepstack-layers',
+        type=int,
+        default=5,
+        help='Number of deepstack layers for visual feature injection'
+    )
+    group.add_argument(
+        '--image-token-index',
+        type=int,
+        default=DEFAULT_IMAGE_TOKEN_INDEX,
+        help='Token index used to mark image positions (-200 for Qwen3-VL)'
+    )
+    group.add_argument(
+        '--video-token-index',
+        type=int,
+        default=DEFAULT_VIDEO_TOKEN_INDEX,
+        help='Token index used to mark video positions (-300 for Qwen3-VL)'
+    )
+
+    # Note: --img-h, --img-w, --patch-dim, --encoder-num-layers, --decoder-num-layers
+    # are already defined in megatron/training/arguments.py
+
+    # Training arguments
+    group.add_argument(
+        '--freeze-LM',
+        action='store_true',
+        default=False,
+        help='Freeze language model weights during training'
+    )
+    group.add_argument(
+        '--freeze-ViT',
+        action='store_true',
+        default=False,
+        help='Freeze vision encoder weights during training'
+    )
+    group.add_argument(
+        '--freeze-lm-embedding',
+        action='store_true',
+        default=False,
+        help='Freeze language model embedding layer during training '
+             '(not quantized, saves memory and avoids drift)'
+    )
+    group.add_argument(
+        '--dataloader-seq-length',
+        type=int,
+        help='Sequence length for dataloader (text tokens only, before adding image tokens)'
+    )
+
+    # VLM Dataset arguments
+    group.add_argument(
+        '--use-vlm-dataset',
+        action='store_true',
+        default=False,
+        help='Use VLM dataset that loads images from JSONL files instead of preprocessed binary files'
+    )
+    group.add_argument(
+        '--image-base-dir',
+        type=str,
+        default=None,
+        help='Base directory for resolving relative image paths in JSONL files'
+    )
+
+    # Vision model type
+    group.add_argument(
+        '--vision-model-type',
+        type=str,
+        default='qwen3_vl',
+        choices=['qwen3_vl', 'clip'],
+        help='Type of vision model to use'
+    )
+
+    # memory efficient quantizer
+    group.add_argument(
+        "--me-quantizer",
+        action="store_true",
+        default=False,
+        help="Inject custom NVFP4 quantizer into the model.",
+    )
+    return parser
+
+
+def qwen3vl_embedding_ranks(pp_ranks):
+    """Get embedding ranks for Qwen3-VL with pipeline parallelism.
+
+    For Qwen3-VL, embeddings are needed on:
+    - First rank: for input embeddings and visual encoder
+    - Last rank: for output layer
+
+    Args:
+        pp_ranks: List of global ranks in a pipeline group
+
+    Returns:
+        List of ranks that hold embeddings
+    """
+    first_rank = pp_ranks[0]
+    last_rank = pp_ranks[-1]
+
+    if len(pp_ranks) == 1:
+        return [first_rank]
+    return [first_rank, last_rank]
+
+
+def qwen3vl_position_embedding_ranks(pp_ranks):
+    """Get position embedding ranks for Qwen3-VL.
+
+    Position embeddings are only on the first pipeline stage.
+
+    Args:
+        pp_ranks: List of global ranks in a pipeline group
+
+    Returns:
+        List of ranks that hold position embeddings
+    """
+    return [pp_ranks[0]]
+
+
+if __name__ == "__main__":
+    # Mark dataset provider as distributed
+    train_valid_test_datasets_provider.is_distributed = True
+
+    # Run pretraining
+    pretrain(
+        train_valid_test_datasets_provider,
+        model_provider,
+        ModelType.encoder_or_decoder,
+        forward_step,
+        args_defaults={'tokenizer_type': 'HuggingFaceTokenizer'},
+        extra_args_provider=add_qwen3vl_extra_args,
+        get_embedding_ranks=qwen3vl_embedding_ranks,
+        get_position_embedding_ranks=qwen3vl_position_embedding_ranks,
+    )

--- a/tests/unit_tests/data/test_qwen3vl_dataset.py
+++ b/tests/unit_tests/data/test_qwen3vl_dataset.py
@@ -1,0 +1,557 @@
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Test for Qwen3-VL multimodal dataset.
+
+##
+# Compile megatron.core.datasets.helpers_cpp dependencies before BlendedDataset import
+##
+
+import json
+import os
+from typing import Dict
+
+import pytest
+import torch
+
+from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
+from megatron.core.datasets.multimodal_dataset import MockMultimodalDataset, MultimodalDatasetConfig
+from megatron.core.datasets.qwen3vl_dataset import (
+    Qwen3VLDataset,
+    Qwen3VLDatasetBuilder,
+    Qwen3VLDatasetConfig,
+    qwen3vl_collate_fn,
+)
+from megatron.core.datasets.utils import compile_helpers
+from megatron.core.tokenizers import MegatronTokenizer
+from tests.unit_tests.test_utilities import Utils
+
+_MOCK_VOCAB_SIZE = 8192
+
+
+class MockQwen3VLDataset(MockMultimodalDataset):
+    """Mock Qwen3-VL multimodal dataset.
+
+    Extends MockMultimodalDataset to produce Qwen3-VL style samples with
+    pixel_values (preprocessed patches) and image_grid_thw instead of raw
+    image tensors.
+    """
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        # Get base multimodal sample (has "image" key with [C, H, W] tensor).
+        sample = super().__getitem__(idx)
+
+        image = sample.pop("image")
+        _, h, w = image.shape
+
+        # Simulate Qwen3-VL preprocessed pixel_values.
+        # Real processor produces [num_patches, patch_dim] but for mock we use
+        # a small fixed shape.
+        patch_size = 14
+        num_h_patches = h // patch_size
+        num_w_patches = w // patch_size
+        num_patches = num_h_patches * num_w_patches
+        patch_dim = 3 * patch_size * patch_size  # 588
+
+        sample["pixel_values"] = torch.zeros(num_patches, patch_dim, dtype=torch.float32)
+        sample["image_grid_thw"] = torch.tensor([[1, num_h_patches, num_w_patches]])
+
+        return sample
+
+
+class TestQwen3VLCollate:
+    """Tests for the qwen3vl_collate_fn function."""
+
+    def test_empty_batch(self):
+        result = qwen3vl_collate_fn([])
+        assert result == {}
+
+    def test_single_sample_text_only(self):
+        sample = {
+            "tokens": torch.tensor([1, 2, 3, 4, 5]),
+            "labels": torch.tensor([2, 3, 4, 5, -100]),
+            "loss_mask": torch.tensor([1.0, 1.0, 1.0, 1.0, 0.0]),
+            "position_ids": torch.tensor([0, 1, 2, 3, 4]),
+        }
+        result = qwen3vl_collate_fn([sample])
+
+        assert result["tokens"].shape == torch.Size([1, 5])
+        assert result["labels"].shape == torch.Size([1, 5])
+        assert result["loss_mask"].shape == torch.Size([1, 5])
+        assert result["position_ids"].shape == torch.Size([1, 5])
+        assert "pixel_values" not in result
+
+    def test_variable_length_padding(self):
+        """Shorter sequences are zero-padded to the max length in the batch."""
+        sample_short = {
+            "tokens": torch.tensor([1, 2, 3]),
+            "labels": torch.tensor([2, 3, -100]),
+            "loss_mask": torch.tensor([1.0, 1.0, 0.0]),
+            "position_ids": torch.tensor([0, 1, 2]),
+        }
+        sample_long = {
+            "tokens": torch.tensor([10, 20, 30, 40, 50]),
+            "labels": torch.tensor([20, 30, 40, 50, -100]),
+            "loss_mask": torch.tensor([1.0, 1.0, 1.0, 1.0, 0.0]),
+            "position_ids": torch.tensor([0, 1, 2, 3, 4]),
+        }
+        result = qwen3vl_collate_fn([sample_short, sample_long])
+
+        # Padded to max_len=5.
+        assert result["tokens"].shape == torch.Size([2, 5])
+        assert torch.equal(result["tokens"][0], torch.tensor([1, 2, 3, 0, 0]))
+        assert torch.equal(result["tokens"][1], torch.tensor([10, 20, 30, 40, 50]))
+        # Labels padded with -100 (default fill).
+        assert torch.equal(result["labels"][0], torch.tensor([2, 3, -100, -100, -100]))
+
+    def test_with_pixel_values(self):
+        """Pixel values from different samples are concatenated along dim 0."""
+        sample1 = {
+            "tokens": torch.tensor([1, 2, 3]),
+            "labels": torch.tensor([2, 3, -100]),
+            "loss_mask": torch.tensor([1.0, 1.0, 0.0]),
+            "position_ids": torch.tensor([0, 1, 2]),
+            "pixel_values": torch.randn(10, 1176),
+            "image_grid_thw": torch.tensor([[1, 5, 2]]),
+        }
+        sample2 = {
+            "tokens": torch.tensor([4, 5, 6]),
+            "labels": torch.tensor([5, 6, -100]),
+            "loss_mask": torch.tensor([1.0, 1.0, 0.0]),
+            "position_ids": torch.tensor([0, 1, 2]),
+            "pixel_values": torch.randn(20, 1176),
+            "image_grid_thw": torch.tensor([[1, 10, 2]]),
+        }
+        result = qwen3vl_collate_fn([sample1, sample2])
+
+        # 10 + 20 patches concatenated.
+        assert result["pixel_values"].shape == torch.Size([30, 1176])
+        assert result["image_grid_thw"].shape == torch.Size([2, 3])
+
+    def test_mixed_image_and_text_samples(self):
+        """Batch with some image samples and some text-only samples."""
+        sample_img = {
+            "tokens": torch.tensor([1, 2]),
+            "labels": torch.tensor([2, -100]),
+            "loss_mask": torch.tensor([1.0, 0.0]),
+            "position_ids": torch.tensor([0, 1]),
+            "pixel_values": torch.randn(5, 1176),
+            "image_grid_thw": torch.tensor([[1, 5, 1]]),
+        }
+        sample_txt = {
+            "tokens": torch.tensor([3, 4]),
+            "labels": torch.tensor([4, -100]),
+            "loss_mask": torch.tensor([1.0, 0.0]),
+            "position_ids": torch.tensor([0, 1]),
+        }
+        result = qwen3vl_collate_fn([sample_img, sample_txt])
+
+        assert "pixel_values" in result
+        assert result["pixel_values"].shape == torch.Size([5, 1176])
+
+    def test_none_pixel_values_ignored(self):
+        """Samples with pixel_values=None are treated as text-only."""
+        sample = {
+            "tokens": torch.tensor([1, 2]),
+            "labels": torch.tensor([2, -100]),
+            "loss_mask": torch.tensor([1.0, 0.0]),
+            "position_ids": torch.tensor([0, 1]),
+            "pixel_values": None,
+        }
+        result = qwen3vl_collate_fn([sample])
+        assert "pixel_values" not in result
+
+
+class TestQwen3VLDatasetConfig:
+    """Tests for the Qwen3VLDatasetConfig dataclass."""
+
+    def test_defaults(self):
+        config = Qwen3VLDatasetConfig()
+        assert config.jsonl_paths is None
+        assert config.image_base_dir is None
+        assert config.img_h == 384
+        assert config.img_w == 384
+        assert config.processor_name == "Qwen/Qwen3-VL-8B-Instruct"
+        assert config.sequence_length == 4096
+        assert config.random_seed == 42
+
+    def test_custom_values(self):
+        config = Qwen3VLDatasetConfig(
+            jsonl_paths=["/data/train.jsonl"],
+            image_base_dir="/data/images",
+            img_h=224,
+            img_w=224,
+            sequence_length=2048,
+            random_seed=123,
+        )
+        assert config.jsonl_paths == ["/data/train.jsonl"]
+        assert config.image_base_dir == "/data/images"
+        assert config.img_h == 224
+        assert config.img_w == 224
+        assert config.sequence_length == 2048
+
+
+class TestParseConversation:
+    """Tests for Qwen3VLDataset._parse_conversation.
+
+    Uses a stub instance since the method only operates on its text argument.
+    """
+
+    def _make_stub(self):
+        return object.__new__(Qwen3VLDataset)
+
+    def test_single_turn(self):
+        ds = self._make_stub()
+        text = "User: What is this?\n\nAssistant: This is a test."
+        messages = ds._parse_conversation(text)
+
+        assert len(messages) == 2
+        assert messages[0] == {"role": "user", "content": "What is this?"}
+        assert messages[1] == {"role": "assistant", "content": "This is a test."}
+
+    def test_multi_turn(self):
+        ds = self._make_stub()
+        text = (
+            "User: Hello\n\n"
+            "Assistant: Hi there!\n\n"
+            "User: How are you?\n\n"
+            "Assistant: I'm fine."
+        )
+        messages = ds._parse_conversation(text)
+
+        assert len(messages) == 4
+        assert messages[0]["role"] == "user"
+        assert messages[1]["role"] == "assistant"
+        assert messages[2]["role"] == "user"
+        assert messages[3]["role"] == "assistant"
+        assert messages[0]["content"] == "Hello"
+        assert messages[3]["content"] == "I'm fine."
+
+    def test_with_image_token(self):
+        ds = self._make_stub()
+        text = "User: <image> Describe this image.\n\nAssistant: A cat."
+        messages = ds._parse_conversation(text)
+
+        assert len(messages) == 2
+        assert "<image>" in messages[0]["content"]
+        assert messages[1]["content"] == "A cat."
+
+    def test_empty_text(self):
+        ds = self._make_stub()
+        assert ds._parse_conversation("") == []
+
+    def test_no_role_markers(self):
+        ds = self._make_stub()
+        assert ds._parse_conversation("Just plain text without roles.") == []
+
+    def test_multiline_content(self):
+        ds = self._make_stub()
+        text = "User: Line one\nLine two\nLine three\n\nAssistant: Response."
+        messages = ds._parse_conversation(text)
+
+        assert len(messages) == 2
+        assert "Line one\nLine two\nLine three" == messages[0]["content"]
+
+
+class TestLoadJsonl:
+    """Tests for Qwen3VLDataset._load_jsonl."""
+
+    def _make_stub(self):
+        stub = object.__new__(Qwen3VLDataset)
+        stub.samples = []
+        return stub
+
+    def test_load_valid_jsonl(self, tmp_path):
+        jsonl_file = tmp_path / "data.jsonl"
+        samples = [
+            {"text": "User: Hello\nAssistant: Hi", "images": []},
+            {"text": "User: <image> What?\nAssistant: A cat.", "images": ["img.jpg"]},
+        ]
+        jsonl_file.write_text("\n".join(json.dumps(s) for s in samples))
+
+        ds = self._make_stub()
+        ds._load_jsonl(str(jsonl_file))
+
+        assert len(ds.samples) == 2
+        assert ds.samples[0]["text"] == samples[0]["text"]
+        assert ds.samples[1]["images"] == ["img.jpg"]
+        assert ds.samples[0]["_jsonl_dir"] == str(tmp_path)
+
+    def test_skip_empty_lines(self, tmp_path):
+        jsonl_file = tmp_path / "data.jsonl"
+        jsonl_file.write_text('{"text": "line1"}\n\n\n{"text": "line2"}\n')
+
+        ds = self._make_stub()
+        ds._load_jsonl(str(jsonl_file))
+        assert len(ds.samples) == 2
+
+    def test_skip_invalid_json(self, tmp_path):
+        jsonl_file = tmp_path / "data.jsonl"
+        jsonl_file.write_text('{"text": "valid"}\nnot json\n{"text": "also valid"}\n')
+
+        ds = self._make_stub()
+        ds._load_jsonl(str(jsonl_file))
+        assert len(ds.samples) == 2
+
+    def test_empty_file(self, tmp_path):
+        jsonl_file = tmp_path / "empty.jsonl"
+        jsonl_file.write_text("")
+
+        ds = self._make_stub()
+        ds._load_jsonl(str(jsonl_file))
+        assert len(ds.samples) == 0
+
+    def test_len(self, tmp_path):
+        jsonl_file = tmp_path / "data.jsonl"
+        jsonl_file.write_text('{"text":"a"}\n{"text":"b"}\n{"text":"c"}\n')
+
+        ds = self._make_stub()
+        ds._load_jsonl(str(jsonl_file))
+        assert len(ds) == 3
+
+
+class TestResolveImagePath:
+    """Tests for Qwen3VLDataset._resolve_image_path_uncached."""
+
+    def _make_stub(self, image_base_dir=None):
+        stub = object.__new__(Qwen3VLDataset)
+        stub.config = Qwen3VLDatasetConfig(image_base_dir=image_base_dir)
+        stub._dir_listing_cache = {}
+        stub._resolved_paths = {}
+        return stub
+
+    def test_absolute_path(self):
+        ds = self._make_stub()
+        result = ds._resolve_image_path_uncached("/absolute/path/img.jpg", "/some/dir")
+        assert result == "/absolute/path/img.jpg"
+
+    def test_relative_to_image_base_dir(self, tmp_path):
+        img_dir = tmp_path / "images"
+        img_dir.mkdir()
+        (img_dir / "photo.jpg").touch()
+
+        ds = self._make_stub(image_base_dir=str(img_dir))
+        result = ds._resolve_image_path_uncached("photo.jpg", str(tmp_path))
+        assert result == str(img_dir / "photo.jpg")
+
+    def test_relative_to_jsonl_dir(self, tmp_path):
+        (tmp_path / "photo.jpg").touch()
+
+        ds = self._make_stub()
+        result = ds._resolve_image_path_uncached("photo.jpg", str(tmp_path))
+        assert result == str(tmp_path / "photo.jpg")
+
+    def test_source_images_subdir(self, tmp_path):
+        src_dir = tmp_path / "source_images"
+        src_dir.mkdir()
+        (src_dir / "photo.jpg").touch()
+
+        ds = self._make_stub()
+        result = ds._resolve_image_path_uncached("photo.jpg", str(tmp_path))
+        assert result == str(src_dir / "photo.jpg")
+
+    def test_extracted_subdir(self, tmp_path):
+        extracted = tmp_path / "source_images" / "extracted"
+        extracted.mkdir(parents=True)
+        (extracted / "photo.jpg").touch()
+
+        ds = self._make_stub()
+        result = ds._resolve_image_path_uncached("photo.jpg", str(tmp_path))
+        assert result == str(extracted / "photo.jpg")
+
+    def test_extracted_archive_subdir(self, tmp_path):
+        archive_dir = tmp_path / "source_images" / "extracted" / "archive1"
+        archive_dir.mkdir(parents=True)
+        (archive_dir / "photo.jpg").touch()
+
+        ds = self._make_stub()
+        result = ds._resolve_image_path_uncached("photo.jpg", str(tmp_path))
+        assert result == str(archive_dir / "photo.jpg")
+
+    def test_fallback_returns_original(self):
+        ds = self._make_stub()
+        result = ds._resolve_image_path_uncached("nonexistent.jpg", "/no/such/dir")
+        assert result == "nonexistent.jpg"
+
+    def test_cached_resolve_uses_cache(self, tmp_path):
+        (tmp_path / "img.jpg").touch()
+
+        ds = self._make_stub()
+        ds._resolved_paths[("img.jpg", str(tmp_path))] = "/cached/path.jpg"
+
+        result = ds._resolve_image_path("img.jpg", str(tmp_path))
+        assert result == "/cached/path.jpg"
+
+    def test_cached_resolve_fallback(self, tmp_path):
+        """Cache miss falls back to uncached resolution."""
+        (tmp_path / "img.jpg").touch()
+
+        ds = self._make_stub()
+        result = ds._resolve_image_path("img.jpg", str(tmp_path))
+        assert result == str(tmp_path / "img.jpg")
+        # Now cached.
+        assert ("img.jpg", str(tmp_path)) in ds._resolved_paths
+
+
+class TestCachedListdir:
+    """Tests for Qwen3VLDataset._cached_listdir."""
+
+    def _make_stub(self):
+        stub = object.__new__(Qwen3VLDataset)
+        stub._dir_listing_cache = {}
+        return stub
+
+    def test_lists_directory(self, tmp_path):
+        (tmp_path / "a.txt").touch()
+        (tmp_path / "b.txt").touch()
+
+        ds = self._make_stub()
+        result = ds._cached_listdir(str(tmp_path))
+        assert sorted(result) == ["a.txt", "b.txt"]
+
+    def test_returns_cached_result(self, tmp_path):
+        (tmp_path / "file.txt").touch()
+
+        ds = self._make_stub()
+        result1 = ds._cached_listdir(str(tmp_path))
+        result2 = ds._cached_listdir(str(tmp_path))
+        assert result1 is result2  # Same object from cache.
+
+    def test_nonexistent_dir(self):
+        ds = self._make_stub()
+        result = ds._cached_listdir("/nonexistent/dir/path")
+        assert result == []
+
+
+class TestQwen3VLDatasetBuilder:
+    """Tests for Qwen3VLDatasetBuilder._get_jsonl_paths."""
+
+    def test_get_jsonl_paths(self, tmp_path):
+        # Create the JSONL file that the path conversion should find.
+        jsonl_file = tmp_path / "chartqa_train.jsonl"
+        jsonl_file.write_text('{"text": "sample"}\n')
+
+        blend_config = {
+            "train": [0.5, str(tmp_path / "preprocessed" / "chartqa_train_text_document")]
+        }
+        blend_path = tmp_path / "blend.json"
+        blend_path.write_text(json.dumps(blend_config))
+
+        config = Qwen3VLDatasetConfig()
+        builder = Qwen3VLDatasetBuilder(
+            config=config, blend_path=str(blend_path), train_val_test_num_samples=[100, 10, 10]
+        )
+
+        paths = builder._get_jsonl_paths("train")
+        assert str(jsonl_file) in paths
+
+    def test_missing_jsonl_files(self, tmp_path):
+        blend_config = {"train": [1.0, "/nonexistent/path_text_document"]}
+        blend_path = tmp_path / "blend.json"
+        blend_path.write_text(json.dumps(blend_config))
+
+        config = Qwen3VLDatasetConfig()
+        builder = Qwen3VLDatasetBuilder(
+            config=config, blend_path=str(blend_path), train_val_test_num_samples=[100, 10, 10]
+        )
+
+        assert builder._get_jsonl_paths("train") == []
+
+    def test_empty_split(self, tmp_path):
+        blend_config = {"train": []}
+        blend_path = tmp_path / "blend.json"
+        blend_path.write_text(json.dumps(blend_config))
+
+        config = Qwen3VLDatasetConfig()
+        builder = Qwen3VLDatasetBuilder(
+            config=config, blend_path=str(blend_path), train_val_test_num_samples=[100, 10, 10]
+        )
+
+        assert builder._get_jsonl_paths("valid") == []
+
+    def test_multiple_paths(self, tmp_path):
+        # Two JSONL files.
+        (tmp_path / "ds1_train.jsonl").write_text('{"text":"a"}\n')
+        (tmp_path / "ds2_train.jsonl").write_text('{"text":"b"}\n')
+
+        blend_config = {
+            "train": [
+                0.5,
+                str(tmp_path / "preprocessed" / "ds1_train_text_document"),
+                0.5,
+                str(tmp_path / "preprocessed" / "ds2_train_text_document"),
+            ]
+        }
+        blend_path = tmp_path / "blend.json"
+        blend_path.write_text(json.dumps(blend_config))
+
+        config = Qwen3VLDatasetConfig()
+        builder = Qwen3VLDatasetBuilder(
+            config=config, blend_path=str(blend_path), train_val_test_num_samples=[100, 10, 10]
+        )
+
+        paths = builder._get_jsonl_paths("train")
+        assert len(paths) == 2
+
+
+def test_mock_qwen3vl_dataset():
+    """Test MockQwen3VLDataset via BlendedMegatronDatasetBuilder.
+
+    Follows the same pattern as test_multimodal_dataset.py but validates
+    Qwen3-VL specific output fields (pixel_values, image_grid_thw).
+    """
+    if torch.distributed.is_available():
+        Utils.initialize_distributed()
+        if torch.distributed.get_rank() == 0:
+            compile_helpers()
+        torch.distributed.barrier()
+    else:
+        compile_helpers()
+
+    tokenizer = MegatronTokenizer.from_pretrained(
+        metadata_path={"library": "null-text"}, vocab_size=_MOCK_VOCAB_SIZE
+    )
+    config = MultimodalDatasetConfig(
+        random_seed=1234,
+        sequence_length=1024,
+        reset_position_ids=False,
+        reset_attention_mask=False,
+        eod_mask_loss=True,
+        image_h=336,
+        image_w=336,
+        split="990,9,1",
+        tokenizer=tokenizer,
+        mid_level_dataset_surplus=0.005,
+    )
+
+    datasets = BlendedMegatronDatasetBuilder(
+        MockQwen3VLDataset, [100, 100, 100], lambda: True, config
+    ).build()
+
+    patch_size = 14
+    num_h = 336 // patch_size  # 24
+    num_w = 336 // patch_size  # 24
+    expected_patches = num_h * num_w  # 576
+    expected_patch_dim = 3 * patch_size * patch_size  # 588
+
+    for ds in datasets:
+        sample = ds[0]
+
+        # Should have Qwen3-VL keys, not raw "image".
+        assert "image" not in sample
+        assert "tokens" in sample
+        assert "pixel_values" in sample
+        assert "image_grid_thw" in sample
+
+        # Validate shapes.
+        assert sample["pixel_values"].shape == torch.Size([expected_patches, expected_patch_dim])
+        assert sample["image_grid_thw"].shape == torch.Size([1, 3])
+        assert sample["image_grid_thw"][0, 0].item() == 1  # temporal
+        assert sample["image_grid_thw"][0, 1].item() == num_h
+        assert sample["image_grid_thw"][0, 2].item() == num_w
+
+    # Test collation of mock samples.
+    batch = [datasets[0][i] for i in range(3)]
+    collated = qwen3vl_collate_fn(batch)
+
+    assert collated["tokens"].shape[0] == 3  # batch size
+    assert collated["pixel_values"].shape == torch.Size([expected_patches * 3, expected_patch_dim])
+    assert collated["image_grid_thw"].shape == torch.Size([3, 3])

--- a/tests/unit_tests/models/test_qwen3_vl_model.py
+++ b/tests/unit_tests/models/test_qwen3_vl_model.py
@@ -1,0 +1,524 @@
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Test for Qwen3-VL multi-modal model.
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.multimodal.qwen3_vl_model import (
+    DEFAULT_IMAGE_TOKEN_INDEX,
+    DEFAULT_VIDEO_TOKEN_INDEX,
+    Qwen3VLModel,
+    Qwen3VLTransformerBlock,
+    Qwen3VLVisionEncoder,
+)
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+class MockVisionEncoder(torch.nn.Module):
+    """Mock vision encoder that avoids HuggingFace model loading."""
+
+    def __init__(self, input_dim, output_dim):
+        super().__init__()
+        self.hidden_size = output_dim
+        self.proj = torch.nn.Linear(input_dim, output_dim)
+        self.image_token_id = DEFAULT_IMAGE_TOKEN_INDEX
+        self.video_token_id = DEFAULT_VIDEO_TOKEN_INDEX
+
+    def forward(self, pixel_values, grid_thw=None):
+        output = self.proj(pixel_values)
+        return output, []
+
+
+class TestQwen3VLModel:
+
+    @pytest.mark.internal
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+
+        self.language_hidden_size = 64
+        self.language_num_attention_heads = 4
+        self.seq_len = 128
+        self.vocab_size = 8192
+
+        self.language_config = TransformerConfig(
+            num_layers=3,
+            hidden_size=self.language_hidden_size,
+            num_attention_heads=self.language_num_attention_heads,
+            use_cpu_initialization=False,
+        )
+
+        self.language_layer_spec = get_gpt_layer_with_transformer_engine_spec()
+
+        # Create model without vision encoder to avoid HuggingFace dependency.
+        # Vision encoder is mocked in tests that need it.
+        self.model = Qwen3VLModel(
+            language_transformer_config=self.language_config,
+            language_transformer_layer_spec=self.language_layer_spec,
+            language_vocab_size=self.vocab_size,
+            language_max_sequence_length=4096,
+            add_encoder=False,
+            add_decoder=True,
+            image_token_index=DEFAULT_IMAGE_TOKEN_INDEX,
+            video_token_index=DEFAULT_VIDEO_TOKEN_INDEX,
+        )
+
+    @pytest.mark.internal
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.internal
+    def test_constructor(self):
+        assert isinstance(self.model, Qwen3VLModel)
+        assert self.model.language_model is not None
+        assert self.model.visual is None
+        assert self.model.add_decoder is True
+        assert self.model.add_encoder is False
+        assert self.model.image_token_index == DEFAULT_IMAGE_TOKEN_INDEX
+        assert self.model.video_token_index == DEFAULT_VIDEO_TOKEN_INDEX
+
+        num_weights = sum([p.numel() for p in self.model.parameters()])
+        assert num_weights > 0
+
+    @pytest.mark.internal
+    def test_constructor_with_encoder(self):
+        """Test constructor with add_encoder=True using mocked HF loading."""
+        with patch.object(Qwen3VLVisionEncoder, '_load_hf_vision_model'):
+            model = Qwen3VLModel(
+                language_transformer_config=self.language_config,
+                language_transformer_layer_spec=self.language_layer_spec,
+                language_vocab_size=self.vocab_size,
+                language_max_sequence_length=4096,
+                add_encoder=True,
+                add_decoder=True,
+            )
+        assert model.visual is not None
+        assert isinstance(model.visual, Qwen3VLVisionEncoder)
+        assert model.language_model is not None
+        assert model.add_encoder is True
+
+    @pytest.mark.internal
+    def test_set_input_tensor(self):
+        expected_shape = (1, 2, 3, 4)
+        input_tensor = torch.zeros(expected_shape)
+        self.model.set_input_tensor(input_tensor)
+        assert self.model.language_model.decoder.input_tensor.shape == expected_shape
+
+    @pytest.mark.internal
+    def test_preprocess_data_no_images(self):
+        """Test _preprocess_data returns text embeddings when no images are provided."""
+        self.model.cuda()
+
+        batch_size = 2
+        seq_len = self.seq_len
+
+        input_ids = torch.randint(0, 100, (batch_size, seq_len)).cuda()
+        position_ids = torch.arange(seq_len).expand(batch_size, seq_len).cuda()
+        labels = torch.randint(0, 100, (batch_size, seq_len)).cuda()
+        loss_mask = torch.ones((batch_size, seq_len)).cuda()
+
+        combined_embeds, pos_ids, visual_pos_mask, deepstack_embeds, new_labels, new_loss_mask = (
+            self.model._preprocess_data(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                image_embeds=None,
+                deepstack_embeds=None,
+                labels=labels,
+                loss_mask=loss_mask,
+            )
+        )
+
+        # Sequence length unchanged, no visual mask.
+        assert combined_embeds.shape == torch.Size((seq_len, batch_size, self.language_hidden_size))
+        assert visual_pos_mask is None
+        assert torch.equal(new_labels, labels)
+        assert torch.equal(new_loss_mask, loss_mask)
+
+    @pytest.mark.internal
+    def test_preprocess_data_with_images(self):
+        """Test _preprocess_data replaces image token positions via masked_scatter."""
+        self.model.cuda()
+
+        batch_size = 2
+        seq_len = 64
+        hidden_size = self.language_hidden_size
+        num_img_tokens_per_sample = 5
+
+        # Create input_ids with image tokens at known positions.
+        input_ids = torch.randint(0, 100, (batch_size, seq_len)).cuda()
+        # Sample 0: image tokens at positions 10-14
+        for i in range(num_img_tokens_per_sample):
+            input_ids[0, 10 + i] = DEFAULT_IMAGE_TOKEN_INDEX
+        # Sample 1: image tokens at positions 20-24
+        for i in range(num_img_tokens_per_sample):
+            input_ids[1, 20 + i] = DEFAULT_IMAGE_TOKEN_INDEX
+
+        position_ids = torch.arange(seq_len).expand(batch_size, seq_len).cuda()
+        labels = torch.randint(0, 100, (batch_size, seq_len)).cuda()
+        loss_mask = torch.ones((batch_size, seq_len)).cuda()
+
+        total_image_tokens = num_img_tokens_per_sample * batch_size
+        image_embeds = torch.randn(total_image_tokens, hidden_size).cuda()
+
+        combined_embeds, pos_ids, visual_pos_mask, deepstack_embeds, new_labels, new_loss_mask = (
+            self.model._preprocess_data(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                image_embeds=image_embeds,
+                deepstack_embeds=None,
+                labels=labels,
+                loss_mask=loss_mask,
+            )
+        )
+
+        # Sequence length is unchanged (masked_scatter, not expansion like LLaVA).
+        assert combined_embeds.shape == torch.Size((seq_len, batch_size, hidden_size))
+
+        # Visual position mask marks image token positions.
+        assert visual_pos_mask is not None
+        assert visual_pos_mask.shape == torch.Size((seq_len, batch_size))
+
+        # Check mask is True at image positions and False elsewhere.
+        for i in range(num_img_tokens_per_sample):
+            assert visual_pos_mask[10 + i, 0].item() is True
+            assert visual_pos_mask[20 + i, 1].item() is True
+        assert visual_pos_mask[0, 0].item() is False
+        assert visual_pos_mask[0, 1].item() is False
+
+        # Verify image embeddings were scattered into the correct positions.
+        # combined_embeds is [seq, batch, hidden]; transpose to [batch, seq, hidden].
+        result = combined_embeds.transpose(0, 1)
+        assert torch.allclose(result[0, 10:15], image_embeds[0:5].to(result.dtype), atol=1e-5)
+        assert torch.allclose(result[1, 20:25], image_embeds[5:10].to(result.dtype), atol=1e-5)
+
+        # Labels and loss_mask are unchanged.
+        assert torch.equal(new_labels, labels)
+        assert torch.equal(new_loss_mask, loss_mask)
+
+    @pytest.mark.internal
+    def test_preprocess_data_with_video_tokens(self):
+        """Test _preprocess_data handles video tokens in the visual mask."""
+        self.model.cuda()
+
+        batch_size = 1
+        seq_len = 32
+        hidden_size = self.language_hidden_size
+
+        input_ids = torch.randint(0, 100, (batch_size, seq_len)).cuda()
+        # Mix of image and video tokens.
+        input_ids[0, 5] = DEFAULT_IMAGE_TOKEN_INDEX
+        input_ids[0, 6] = DEFAULT_IMAGE_TOKEN_INDEX
+        input_ids[0, 10] = DEFAULT_VIDEO_TOKEN_INDEX
+        input_ids[0, 11] = DEFAULT_VIDEO_TOKEN_INDEX
+
+        position_ids = torch.arange(seq_len).expand(batch_size, seq_len).cuda()
+
+        # 4 total visual tokens (2 image + 2 video).
+        image_embeds = torch.randn(4, hidden_size).cuda()
+
+        combined_embeds, pos_ids, visual_pos_mask, _, _, _ = self.model._preprocess_data(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            image_embeds=image_embeds,
+            deepstack_embeds=None,
+        )
+
+        # Visual mask includes both image and video positions.
+        assert visual_pos_mask[5, 0].item() is True
+        assert visual_pos_mask[6, 0].item() is True
+        assert visual_pos_mask[10, 0].item() is True
+        assert visual_pos_mask[11, 0].item() is True
+        assert visual_pos_mask[0, 0].item() is False
+
+    @pytest.mark.internal
+    def test_forward_text_only(self):
+        """Test forward pass with text-only input (no images)."""
+        self.model.cuda()
+
+        batch_size = 2
+        seq_len = self.seq_len
+
+        input_ids = torch.randint(0, self.vocab_size, (batch_size, seq_len)).cuda()
+        position_ids = torch.arange(seq_len).expand(batch_size, seq_len).cuda()
+        labels = torch.randint(0, self.vocab_size, (batch_size, seq_len)).cuda()
+        loss_mask = torch.ones((batch_size, seq_len)).cuda()
+
+        output, new_loss_mask = self.model.forward(
+            images=None,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=labels,
+            loss_mask=loss_mask,
+        )
+
+        # With labels, output is per-token loss.
+        assert output.shape == torch.Size((batch_size, seq_len))
+        assert new_loss_mask.shape == torch.Size((batch_size, seq_len))
+
+    @pytest.mark.internal
+    def test_forward_text_only_no_labels(self):
+        """Test forward pass without labels returns logits."""
+        self.model.cuda()
+
+        batch_size = 2
+        seq_len = self.seq_len
+
+        input_ids = torch.randint(0, self.vocab_size, (batch_size, seq_len)).cuda()
+        position_ids = torch.arange(seq_len).expand(batch_size, seq_len).cuda()
+
+        output, new_loss_mask = self.model.forward(
+            images=None,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=None,
+            loss_mask=None,
+        )
+
+        # Without labels, output is logits.
+        assert output.shape == torch.Size((batch_size, seq_len, self.vocab_size))
+        assert new_loss_mask is None
+
+    @pytest.mark.internal
+    def test_forward_with_images(self):
+        """Test forward pass with images using a mock vision encoder."""
+        self.model.cuda()
+
+        batch_size = 2
+        seq_len = self.seq_len
+        num_image_tokens = 10
+        mock_input_dim = 16
+
+        # Attach a mock vision encoder.
+        mock_vision = MockVisionEncoder(mock_input_dim, self.language_hidden_size).cuda()
+        self.model.visual = mock_vision
+        self.model.add_encoder = True
+
+        # Place image tokens in input_ids.
+        input_ids = torch.randint(0, 100, (batch_size, seq_len)).cuda()
+        for i in range(num_image_tokens):
+            input_ids[0, 5 + i] = DEFAULT_IMAGE_TOKEN_INDEX
+            input_ids[1, 20 + i] = DEFAULT_IMAGE_TOKEN_INDEX
+
+        position_ids = torch.arange(seq_len).expand(batch_size, seq_len).cuda()
+        labels = torch.randint(0, 100, (batch_size, seq_len)).cuda()
+        loss_mask = torch.ones((batch_size, seq_len)).cuda()
+
+        # Mock vision encoder expects [total_tokens, input_dim].
+        total_image_tokens = num_image_tokens * batch_size
+        images = torch.randn(total_image_tokens, mock_input_dim).cuda()
+
+        output, new_loss_mask = self.model.forward(
+            images=images,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=labels,
+            loss_mask=loss_mask,
+        )
+
+        # Sequence length is unchanged (masked_scatter, not expansion).
+        assert output.shape == torch.Size((batch_size, seq_len))
+        assert new_loss_mask.shape == torch.Size((batch_size, seq_len))
+
+    @pytest.mark.internal
+    def test_forward_with_images_no_labels(self):
+        """Test forward pass with images but no labels returns logits."""
+        self.model.cuda()
+
+        batch_size = 1
+        seq_len = self.seq_len
+        num_image_tokens = 8
+        mock_input_dim = 16
+
+        mock_vision = MockVisionEncoder(mock_input_dim, self.language_hidden_size).cuda()
+        self.model.visual = mock_vision
+        self.model.add_encoder = True
+
+        input_ids = torch.randint(0, 100, (batch_size, seq_len)).cuda()
+        for i in range(num_image_tokens):
+            input_ids[0, 10 + i] = DEFAULT_IMAGE_TOKEN_INDEX
+
+        position_ids = torch.arange(seq_len).expand(batch_size, seq_len).cuda()
+        images = torch.randn(num_image_tokens, mock_input_dim).cuda()
+
+        output, new_loss_mask = self.model.forward(
+            images=images,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=None,
+            loss_mask=None,
+        )
+
+        assert output.shape == torch.Size((batch_size, seq_len, self.vocab_size))
+        assert new_loss_mask is None
+
+    @pytest.mark.internal
+    def test_forward_frozen_vision(self):
+        """Test forward pass with frozen vision encoder runs under torch.no_grad."""
+        self.model.cuda()
+        self.model.freeze_vision = True
+
+        batch_size = 1
+        seq_len = self.seq_len
+        num_image_tokens = 4
+        mock_input_dim = 16
+
+        mock_vision = MockVisionEncoder(mock_input_dim, self.language_hidden_size).cuda()
+        self.model.visual = mock_vision
+        self.model.add_encoder = True
+
+        input_ids = torch.randint(0, 100, (batch_size, seq_len)).cuda()
+        for i in range(num_image_tokens):
+            input_ids[0, i] = DEFAULT_IMAGE_TOKEN_INDEX
+
+        position_ids = torch.arange(seq_len).expand(batch_size, seq_len).cuda()
+        labels = torch.randint(0, 100, (batch_size, seq_len)).cuda()
+        loss_mask = torch.ones((batch_size, seq_len)).cuda()
+        images = torch.randn(num_image_tokens, mock_input_dim).cuda()
+
+        output, new_loss_mask = self.model.forward(
+            images=images,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=labels,
+            loss_mask=loss_mask,
+        )
+
+        assert output.shape == torch.Size((batch_size, seq_len))
+
+    @pytest.mark.internal
+    def test_freeze(self):
+        """Test freezing language and vision model parameters."""
+        self.model.cuda()
+
+        mock_vision = MockVisionEncoder(16, self.language_hidden_size).cuda()
+        self.model.visual = mock_vision
+
+        # Initially all params require grad.
+        for param in self.model.language_model.parameters():
+            assert param.requires_grad
+        for param in self.model.visual.parameters():
+            assert param.requires_grad
+
+        self.model.freeze(freeze_language_model=True, freeze_vision_model=True)
+
+        for param in self.model.language_model.parameters():
+            assert not param.requires_grad
+        for param in self.model.visual.parameters():
+            assert not param.requires_grad
+
+    @pytest.mark.internal
+    def test_freeze_partial(self):
+        """Test freezing only one component."""
+        self.model.cuda()
+
+        mock_vision = MockVisionEncoder(16, self.language_hidden_size).cuda()
+        self.model.visual = mock_vision
+
+        self.model.freeze(freeze_language_model=True, freeze_vision_model=False)
+
+        for param in self.model.language_model.parameters():
+            assert not param.requires_grad
+        for param in self.model.visual.parameters():
+            assert param.requires_grad
+
+    @pytest.mark.internal
+    def test_freeze_embedding(self):
+        """Test freezing only the language model embedding layer."""
+        self.model.cuda()
+
+        for param in self.model.language_model.embedding.parameters():
+            assert param.requires_grad
+
+        self.model.freeze_embedding()
+
+        for param in self.model.language_model.embedding.parameters():
+            assert not param.requires_grad
+        assert self.model.freeze_lm_embedding is True
+
+    @pytest.mark.internal
+    def test_save_load(self, tmp_path):
+        """Test saving and loading model state dict."""
+        path = tmp_path / "model.pt"
+        torch.save(self.model.state_dict(), path)
+        self.model.load_state_dict(torch.load(path))
+
+
+class TestQwen3VLTransformerBlock:
+    """Tests for the DeepStack mechanism in Qwen3VLTransformerBlock."""
+
+    @pytest.mark.internal
+    def test_deepstack_process(self):
+        """Test that _deepstack_process adds visual features at masked positions."""
+        hidden_size = 64
+        seq_len = 32
+        batch_size = 2
+        num_visual_tokens = 5
+
+        # Only need _deepstack_process; skip full TransformerBlock construction.
+        block = Qwen3VLTransformerBlock.__new__(Qwen3VLTransformerBlock)
+
+        hidden_states = torch.zeros(seq_len, batch_size, hidden_size)
+        visual_pos_masks = torch.zeros(seq_len, batch_size, dtype=torch.bool)
+        # Mark positions 5-9 in batch 0 as visual tokens.
+        visual_pos_masks[5:10, 0] = True
+        visual_embeds = torch.ones(num_visual_tokens, hidden_size)
+
+        result = block._deepstack_process(hidden_states, visual_pos_masks, visual_embeds)
+
+        assert result.shape == hidden_states.shape
+        # Visual positions: 0 + 1 = 1
+        assert torch.allclose(result[5:10, 0], torch.ones(num_visual_tokens, hidden_size))
+        # Non-visual positions in batch 0 remain zero.
+        assert torch.allclose(result[0:5, 0], torch.zeros(5, hidden_size))
+        assert torch.allclose(result[10:, 0], torch.zeros(seq_len - 10, hidden_size))
+        # Batch 1 entirely unchanged (no visual tokens marked).
+        assert torch.allclose(result[:, 1], torch.zeros(seq_len, hidden_size))
+
+    @pytest.mark.internal
+    def test_deepstack_process_residual(self):
+        """Test that _deepstack_process adds (not replaces) visual features."""
+        hidden_size = 32
+        seq_len = 16
+        batch_size = 1
+
+        block = Qwen3VLTransformerBlock.__new__(Qwen3VLTransformerBlock)
+
+        hidden_states = torch.full((seq_len, batch_size, hidden_size), 2.0)
+        visual_pos_masks = torch.zeros(seq_len, batch_size, dtype=torch.bool)
+        visual_pos_masks[0:3, 0] = True
+        visual_embeds = torch.full((3, hidden_size), 5.0)
+
+        result = block._deepstack_process(hidden_states, visual_pos_masks, visual_embeds)
+
+        # Visual positions: 2 + 5 = 7
+        assert torch.allclose(result[0:3, 0], torch.full((3, hidden_size), 7.0))
+        # Non-visual positions unchanged at 2.
+        assert torch.allclose(result[3:, 0], torch.full((seq_len - 3, hidden_size), 2.0))
+
+    @pytest.mark.internal
+    def test_deepstack_process_none_mask(self):
+        """Test _deepstack_process returns hidden_states unchanged when mask is None."""
+        block = Qwen3VLTransformerBlock.__new__(Qwen3VLTransformerBlock)
+
+        hidden_states = torch.randn(16, 2, 64)
+        result = block._deepstack_process(hidden_states, None, torch.randn(5, 64))
+        assert torch.equal(result, hidden_states)
+
+    @pytest.mark.internal
+    def test_deepstack_process_none_embeds(self):
+        """Test _deepstack_process returns hidden_states unchanged when embeds is None."""
+        block = Qwen3VLTransformerBlock.__new__(Qwen3VLTransformerBlock)
+
+        hidden_states = torch.randn(16, 2, 64)
+        mask = torch.zeros(16, 2, dtype=torch.bool)
+        result = block._deepstack_process(hidden_states, mask, None)
+        assert torch.equal(result, hidden_states)


### PR DESCRIPTION
# What does this PR do ?

Add Qwen3-VL (Vision-Language) model support to Megatron-LM, including the model          
  architecture, multimodal dataset, pretraining script, and unit tests.

 ## Changes

 ### Model (megatron/core/models/multimodal/qwen3_vl_model.py)

  - Qwen3VLModel: Multimodal model integrating a HuggingFace Qwen3-VL vision encoder with a
  Megatron GPT language backbone
  - Qwen3VLVisionEncoder: Wrapper around the HuggingFace Qwen2_5_VLForConditionalGeneration
  vision tower, supporting frozen/trainable modes
  - Qwen3VLTransformerBlock: Custom transformer block that supports DeepStack multi-layer
  visual feature injection
  - Supports tensor parallelism (TP), pipeline parallelism (PP), and bf16 precision

  ### Dataset (megatron/core/datasets/qwen3vl_dataset.py)

  - Qwen3VLDataset: Multimodal dataset that loads JSONL files with conversation text and
  images, using the HuggingFace AutoProcessor for image preprocessing (variable resolution,
  grid-based patching)
  - Qwen3VLDatasetConfig: Configuration dataclass for dataset parameters
  - Qwen3VLDatasetBuilder: Builder class that constructs train/val/test splits from a blend
  path JSON specification
  - qwen3vl_collate_fn: Custom collate function handling variable-length pixel_values and
  text padding

  ### Pretraining script (pretrain_qwenvl.py)

  - Training entrypoint supporting three data modes:
    - Mock data (no data paths): Auto-detects when no --data-path or
  --per-split-data-args-path is provided; uses MockMultimodalDataset with unconditional
  image broadcast to avoid NCCL deadlocks under TP > 1
    - VLM dataset (--use-vlm-dataset): Loads real images from JSONL via
  Qwen3VLDatasetBuilder
    - Text-only (default with data paths): Standard GPTDataset for text pretraining
  - Handles get_batch broadcasting correctly for all TP configurations
  - Supports ModelOpt layer specs for QAT training

  ### Module exports (megatron/core/models/multimodal/__init__.py)

  - Export Qwen3VLModel, Qwen3VLVisionEncoder, Qwen3VLTransformerBlock,
  DEFAULT_VIDEO_TOKEN_INDEX

  ### Tests

  - Model tests (tests/unit_tests/models/test_qwen3_vl_model.py): 19 unit tests covering
  model construction, forward pass, loss computation, vision encoder, DeepStack,
  freeze/unfreeze, and parallelism configurations
  - Dataset tests (tests/unit_tests/data/test_qwen3vl_dataset.py): 36 unit tests covering
  dataset loading, tokenization, collation, config validation, dataset builder, and
  MockMultimodalDataset integration

 ### Launch script for testing

  - Example script to run mock training with the full Qwen3-VL-8B-Instruct architecture (36
  layers, 4096 hidden, 8 GQA groups) on 8 GPUs (TP=2, PP=1, DP=4)
```
#!/bin/bash
# Launch Qwen3-VL-8B mock training on 8 GPUs with MockMultimodalDataset.
# No data paths provided => auto-uses MockMultimodalDataset, skips HF vision encoder.
#
# Model config matches Qwen/Qwen3-VL-8B-Instruct (HuggingFace config.json):
#   num_hidden_layers=36, hidden_size=4096, intermediate_size=12288,
#   num_attention_heads=32, num_key_value_heads=8, head_dim=128,
#   max_position_embeddings=262144, vocab_size=151936, rope_theta=5000000
#
# Training settings:
#   Optimizer: Adam (default, beta1=0.9, beta2=0.999, eps=1e-8)
#   Parallelism: TP=2, PP=1, DP=4 (8 GPUs total)
#   Precision: bf16

CUDA_DEVICE_MAX_CONNECTIONS=1 torchrun --nproc_per_node=8 pretrain_qwenvl.py \
    --no-masked-softmax-fusion \
    --disable-bias-linear \
    --untie-embeddings-and-output-weights \
    --position-embedding-type rope \
    --no-rope-fusion \
    --normalization RMSNorm \
    --swiglu \
    --no-bias-swiglu-fusion \
    --num-layers 36 \
    --hidden-size 4096 \
    --ffn-hidden-size 12288 \
    --num-attention-heads 32 \
    --group-query-attention \
    --num-query-groups 8 \
    --kv-channels 128 \
    --qk-layernorm \
    --seq-length 4096 \
    --max-position-embeddings 262144 \
    --tokenizer-type HuggingFaceTokenizer \
    --tokenizer-model Qwen/Qwen3-VL-8B-Instruct \
    --make-vocab-size-divisible-by 1187 \
    --use-mcore-models \
    --rotary-percent 1.0 \
    --rotary-base 5000000 \
    --tensor-model-parallel-size 2 \
    --pipeline-model-parallel-size 1 \
    --micro-batch-size 1 \
    --global-batch-size 8 \
    --split 100,0,0 \
    --lr 2e-6 \
    --min-lr 1e-8 \
    --lr-decay-style cosine \
    --train-iters 5 \
    --eval-interval 10 \
    --eval-iters 0 \
    --img-h 384 \
    --img-w 384 \
    --bf16 \
    --no-save-optim \
    --no-save-rng \
    --log-interval 1 \
    --attention-softmax-in-fp32 \
    --no-gradient-accumulation-fusion \
    2>&1

```

## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [x] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

Feel free to message or comment the @mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.
