### PR TITLE
Automatically add final or expert review label

### DIFF
--- a/.github/workflows/auto-assign-review-labels.yml
+++ b/.github/workflows/auto-assign-review-labels.yml
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+name: Auto Assign Review Labels
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  assign-label:
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.pull_request.draft
+      && github.repository == 'NVIDIA/Megatron-LM'
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install --no-cache-dir PyGithub
+
+      - name: Assign initial review label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python tests/test_utils/python_scripts/swap_pr_labels.py --pr ${{ github.event.pull_request.number }} assign

--- a/.github/workflows/auto-swap-labels.yml
+++ b/.github/workflows/auto-swap-labels.yml
@@ -23,11 +23,9 @@ jobs:
           python-version: "3.10"
 
       - name: Install dependencies
-        run: |
-          pip install --no-cache-dir PyGithub slack-sdk
+        run: pip install --no-cache-dir PyGithub
 
-      - name: Run Auto Reminder Bot
-        run: |
-          export GH_TOKEN=${{ github.token }}
-          export PR_NUMBER=${{ github.event.pull_request.number }}
-          python tests/test_utils/python_scripts/swap_pr_labels.py
+      - name: Swap labels after approval
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python tests/test_utils/python_scripts/swap_pr_labels.py --pr ${{ github.event.pull_request.number }} swap

--- a/tests/test_utils/python_scripts/swap_pr_labels.py
+++ b/tests/test_utils/python_scripts/swap_pr_labels.py
@@ -1,16 +1,25 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #!/usr/bin/env python3
 """
-GitHub PR Review Reminder Automation
-Requirements: pip install PyGithub slack-sdk requests
-Usage: GH_TOKEN=ghp_... SLACK_TOKEN=xoxb-... SLACK_WEBHOOK_URL=https://... REPO=NVIDIA/Megatron-LM python github_pr_reminder.py
+GitHub PR Label Automation
+
+Supports two actions:
+  - swap:   On approval, check if all expert reviewers have approved and
+            swap "Expert Review" -> "Final Review" when appropriate.
+  - assign: On PR opened / ready-for-review, assign the correct initial
+            label ("Expert Review", "Final Review", or none) based on the
+            requested review teams.
+
+Requirements: pip install PyGithub
+Usage:
+  GH_TOKEN=ghp_... python swap_pr_labels.py --pr 42 swap
+  GH_TOKEN=ghp_... python swap_pr_labels.py --pr 42 assign
 """
 
+import argparse
 import logging
 import os
 import sys
-from dataclasses import dataclass
-from typing import List
 
 from github import Github
 
@@ -18,51 +27,129 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class Reminder:
-    id: int
-    pr: str
-    milestone: str
-    author: str
-    priority: str
-    review_stage: str
-    total_review_time: int
-    current_stage_time: int
-    reviewers: List[str]
-    action_message: str
-
-
 class PRReviewTracker:
     EXPERT_REVIEW = "Expert Review"
     FINAL_REVIEW = "Final Review"
+    REVIEW_LABELS = {EXPERT_REVIEW, FINAL_REVIEW}
     EXCLUDED_TEAMS = {"core-adlr", "core-nemo"}
+    NON_REQUIRED_TEAMS = {"mcore-oncall"}
 
-    def __init__(self, token: str, repo_name: str, pr_number: str):
+    def __init__(self, token: str, repo_name: str, pr_number: int):
         self.github = Github(token)
         self.repo = self.github.get_repo(repo_name)
         self.pr = self.repo.get_pull(pr_number)
-        self.stage = self.get_stage(self.pr)
         self.org = self.github.get_organization(self.repo.organization.login)
 
-    def get_stage(self, pr):
-        """Get current review stage."""
-        labels = {l.name for l in pr.labels}
-        return self.FINAL_REVIEW if self.FINAL_REVIEW in labels else self.EXPERT_REVIEW
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
 
-    def swap_labels(self):
-        """Get filtered reviewer emails who haven't approved yet."""
+    def _get_current_label(self):
+        labels = {l.name for l in self.pr.labels}
+        if self.FINAL_REVIEW in labels:
+            return self.FINAL_REVIEW
+        if self.EXPERT_REVIEW in labels:
+            return self.EXPERT_REVIEW
+        return None
+
+    def _get_pending_review_teams(self):
+        try:
+            _, pending_teams_req = self.pr.get_review_requests()
+            return {t.slug for t in pending_teams_req}
+        except Exception as e:
+            logger.warning(f"Could not get review requests for PR #{self.pr.number}: {e}")
+            return set()
+
+    def _set_label(self, desired_label):
+        """Ensure only *desired_label* (or none) from the review-label set is present."""
         pr = self.pr
-        if self.stage == self.FINAL_REVIEW:
-            logger.info(f"PR #{self.pr.number} is in the {self.stage} stage. No reviewers needed.")
+        current_labels = {l.name for l in pr.labels}
+
+        for label in self.REVIEW_LABELS:
+            if label != desired_label and label in current_labels:
+                try:
+                    pr.remove_from_labels(label)
+                    logger.info(f'Removed "{label}" label from PR #{pr.number}')
+                except Exception as e:
+                    logger.warning(f'Failed to remove "{label}" label from PR #{pr.number}: {e}')
+
+        if desired_label and desired_label not in current_labels:
+            try:
+                pr.add_to_labels(desired_label)
+                logger.info(f'Added "{desired_label}" label to PR #{pr.number}')
+            except Exception as e:
+                logger.warning(f'Failed to add "{desired_label}" label to PR #{pr.number}: {e}')
+
+    # ------------------------------------------------------------------
+    # Action: assign  (PR opened / ready-for-review)
+    # ------------------------------------------------------------------
+
+    def assign_initial_label(self):
+        """Determine the correct label for a newly opened / ready-for-review PR.
+
+        Logic (mirrors the PR template):
+          - No review teams requested  → no review label
+          - Only core-adlr / core-nemo / mcore-oncall → "Final Review"
+          - Any *other* expert teams requested          → "Expert Review"
+        """
+        pr = self.pr
+        if pr.draft:
+            logger.info(f"PR #{pr.number} is still a draft — skipping label assignment.")
             return
 
-        # 1. Get the latest review state for everyone who has submitted a review
+        current_label = self._get_current_label()
+        if current_label is not None:
+            logger.info(
+                f'PR #{pr.number} already has "{current_label}" — skipping initial assignment.'
+            )
+            return
+
+        pending_teams = self._get_pending_review_teams()
+        meaningful_teams = pending_teams - self.NON_REQUIRED_TEAMS
+
+        if not meaningful_teams:
+            logger.info(f"PR #{pr.number} has no meaningful review teams — no label assigned.")
+            return
+
+        expert_teams = meaningful_teams - self.EXCLUDED_TEAMS
+        if expert_teams:
+            logger.info(
+                f"PR #{pr.number} has expert review teams {expert_teams} — "
+                f'assigning "{self.EXPERT_REVIEW}".'
+            )
+            self._set_label(self.EXPERT_REVIEW)
+        else:
+            logger.info(
+                f"PR #{pr.number} only has core teams {meaningful_teams} — "
+                f'assigning "{self.FINAL_REVIEW}".'
+            )
+            self._set_label(self.FINAL_REVIEW)
+
+    # ------------------------------------------------------------------
+    # Action: swap  (review submitted)
+    # ------------------------------------------------------------------
+
+    def swap_labels(self):
+        """After an approval, check if all expert reviewers are satisfied.
+
+        If every expert reviewer has approved, swap "Expert Review" → "Final Review".
+        """
+        pr = self.pr
+        stage = self._get_current_label()
+
+        if stage == self.FINAL_REVIEW:
+            logger.info(f"PR #{pr.number} is already in Final Review — nothing to swap.")
+            return
+
+        if stage is None:
+            logger.info(f"PR #{pr.number} has no review label — nothing to swap.")
+            return
+
         latest_reviews = {}
         try:
             for review in pr.get_reviews():
-                if not review.user:  # Handle rare cases of deleted users
+                if not review.user:
                     continue
-                # Only track 'APPROVED' or 'CHANGES_REQUESTED' as definitive states
                 if review.state in ("APPROVED", "CHANGES_REQUESTED"):
                     if (
                         review.user.login not in latest_reviews
@@ -72,13 +159,11 @@ class PRReviewTracker:
         except Exception as e:
             logger.warning(f"Could not get reviews for PR #{pr.number}: {e}")
 
-        # 2. Separate reviewers into approvers (List B) and non-approvers
         approvers = {user for user, review in latest_reviews.items() if review.state == "APPROVED"}
         non_approving_reviewers = {
             user for user, review in latest_reviews.items() if review.state == "CHANGES_REQUESTED"
         }
 
-        # 3. Get all *currently pending* review requests
         try:
             pending_users_req, pending_teams_req = pr.get_review_requests()
             pending_individuals = {r.login for r in pending_users_req}
@@ -88,16 +173,10 @@ class PRReviewTracker:
             pending_individuals = set()
             pending_teams_slugs = set()
 
-        # 4. Filter pending teams based on the current stage
-        teams_to_query = (
-            pending_teams_slugs - self.EXCLUDED_TEAMS
-            if self.stage == self.EXPERT_REVIEW
-            else pending_teams_slugs & self.EXCLUDED_TEAMS
-        )
+        expert_teams = pending_teams_slugs - self.EXCLUDED_TEAMS
 
-        # 5. Get members from the required pending teams
         pending_team_members = set()
-        for slug in teams_to_query:
+        for slug in expert_teams:
             try:
                 pending_team_members.update(
                     m.login for m in self.org.get_team_by_slug(slug).get_members()
@@ -105,42 +184,39 @@ class PRReviewTracker:
             except Exception as e:
                 logger.warning(f"Could not get members for team {slug} on PR #{pr.number}: {e}")
 
-        # 6. "List A": Combine all users who *still need to review*
         all_required_reviewers = (
             pending_individuals | pending_team_members | non_approving_reviewers
         )
-
-        # 7. Final list (List A - List B):
         pending_reviewers = all_required_reviewers - approvers
-        logger.info(f"Pending reviewers: {pending_reviewers}")
-        if len(pending_reviewers) == 0:
-            try:
-                pr.remove_from_labels(self.EXPERT_REVIEW)
-                logger.info(f'Removed "{self.EXPERT_REVIEW}" label from PR #{pr.number}')
-            except Exception as e:
-                logger.warning(
-                    f'Failed to remove "{self.EXPERT_REVIEW}" label from PR #{pr.number}: {e}'
-                )
+        logger.info(f"Pending expert reviewers: {pending_reviewers}")
 
-            try:
-                pr.add_to_labels(self.FINAL_REVIEW)
-                logger.info(f'Added "{self.FINAL_REVIEW}" label to PR #{pr.number}')
-            except Exception as e:
-                logger.warning(f'Failed to add "{self.FINAL_REVIEW}" label to PR #{pr.number}: {e}')
+        if len(pending_reviewers) == 0:
+            logger.info(
+                f'All expert reviewers approved — swapping to "{self.FINAL_REVIEW}" '
+                f"on PR #{pr.number}."
+            )
+            self._set_label(self.FINAL_REVIEW)
 
 
 def main():
-    token = os.environ.get("GH_TOKEN")
-    repo = os.environ.get("REPO", "NVIDIA/Megatron-LM")
-    pr_number = int(os.environ.get("PR_NUMBER"))
+    parser = argparse.ArgumentParser(description="GitHub PR label automation")
+    parser.add_argument("action", choices=["swap", "assign"])
+    parser.add_argument("--pr", type=int, required=True, help="PR number")
+    parser.add_argument("--repo", default="NVIDIA/Megatron-LM", help="GitHub repo (owner/name)")
+    args = parser.parse_args()
 
+    token = os.environ.get("GH_TOKEN")
     if not token:
         logger.error("GH_TOKEN environment variable is required")
         sys.exit(1)
 
-    logger.info(f"Starting PR review reminder for {repo}")
-    tracker = PRReviewTracker(token, repo, pr_number)
-    tracker.swap_labels()
+    logger.info(f"Running action={args.action} for PR #{args.pr} in {args.repo}")
+    tracker = PRReviewTracker(token, args.repo, args.pr)
+
+    if args.action == "assign":
+        tracker.assign_initial_label()
+    else:
+        tracker.swap_labels()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this PR do ?

Automatically add the right label (either expert or final review) when a PR is opened and ready for review.

## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

Feel free to message or comment the @mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.
