### PR TITLE
Fix multimodal model_provider missing config and pg_collection kwargs

### DIFF
--- a/examples/multimodal/model.py
+++ b/examples/multimodal/model.py
@@ -16,7 +16,8 @@ from megatron.core.utils import log_single_rank
 
 
 def model_provider(
-    pre_process=True, post_process=True, add_encoder=True, add_decoder=True, parallel_output=True
+    pre_process=True, post_process=True, add_encoder=True, add_decoder=True, parallel_output=True,
+    config=None, pg_collection=None,
 ) -> LLaVAModel:
     """Builds the model.
 


### PR DESCRIPTION
Fixes #3468

`get_model()` now passes `config` and `pg_collection` to all model providers. The multimodal `model_provider` in `examples/multimodal/model.py` was missing these keyword arguments, causing a `TypeError` when running `pretrain_mistral_clip.sh`.

Added `config=None` and `pg_collection=None` to the function signature, matching `pretrain_vlm.py` and other model providers.