### PR TITLE
[Draft] Fix excess CUDA memory reservation on resume of training

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -12,6 +12,7 @@ import types
 from argparse import Namespace
 from datetime import datetime
 from enum import Enum, auto
+import gc
 from logging import getLogger
 from pathlib import Path
 from time import time
@@ -1719,6 +1720,11 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
         load_dir, args, rank0=False, checkpointing_context=checkpointing_context,
         **load_kwargs
     )
+    del load_kwargs
+
+    # collect the freed reference to load_kwargs so that CUDA can let go of load_kwargs["sharded_state_dict"] 
+    gc.collect()
+    torch.cuda.empty_cache()
 
     # Checkpoint not loaded.
     if state_dict is None:
@@ -1775,6 +1781,7 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
     if not skip_load_to_model_and_opt:
         if len(ddp_model) == 1:
             load_model_state_dict(ddp_model[0], state_dict['model'], strict)
+            del state_dict['model']
         else:
             for i in range(len(ddp_model)):
                 # If there is no corresponding model in the state_dict, it will be ignored.
@@ -1782,6 +1789,7 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                 if 'model%d' % i not in state_dict:
                     continue
                 load_model_state_dict(ddp_model[i], state_dict['model%d' % i], strict)
+                del state_dict['model%d' % i]
     # Fix up query/key/value matrix ordering if needed.
     checkpoint_version = get_checkpoint_version()
     print_rank_0(f' checkpoint version {checkpoint_version}')
@@ -1798,6 +1806,7 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                 optimizer.load_state_dict_from_file(optim_checkpoint_name)
             elif not skip_load_to_model_and_opt and optimizer is not None and not optimizer.is_stub_optimizer:
                 optimizer.load_state_dict(state_dict['optimizer'])
+                del state_dict['optimizer']
 
             # Load distributed optimizer's custom parameter state.
             # For distributed checkpoint it's already loaded in load_state_dict above
@@ -1914,6 +1923,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
        or is_last_rank():
         wandb_utils.on_load_checkpoint_success(checkpoint_name, load_dir)
 
+    # collect freed references to state_dict['model'] and state_dict['optimizer'] so CUDA can let go of the memory
+    gc.collect()
     torch.cuda.empty_cache()
 
     if iteration > 0:


### PR DESCRIPTION
# What does this PR do ?

Fixes excess CUDA reserved memory when resuming training from a torch_dist checkpoint with optim states (https://github.com/NVIDIA/Megatron-LM/issues/2339, https://github.com/NVIDIA/Megatron-LM/issues/1380, https://github.com/NVIDIA/Megatron-LM/issues/1746)

I will not able to test this on main Megatron; we have forked pretty heavily. But thought I'd at least show an (untested) draft of what this patch would look like on main, in case anybody else is struggling with this and wants a lead on how to fix it.

### The problem

If I train Qwen3 8B on 2 GPUs, my CUDA memory usage is different depending on whether I start training anew (via `--pretrained-checkpoint`) or resume training via `--load` (with optimizer weights).

If I add this logging in `train()`:

```diff
  while iteration < args.train_iters:
+     print_rank_0(f"Beginning iteration {iteration}... Memory: {torch.cuda.memory_reserved()/1024**3:.1f}GiB")
```

Training anew, I get:

```
Beginning iteration 0... Memory: 30.0GiB
Beginning iteration 1... Memory: 43.0GiB
Beginning iteration 2... Memory: 43.7GiB
Beginning iteration 3... Memory: 43.7GiB
```

Resuming from a torch_dist checkpoint saved (with optimizer weights) on step 100, I get more memory usage:

```
Beginning iteration 100... Memory: 63.3GiB
Beginning iteration 101... Memory: 64.1GiB
Beginning iteration 102... Memory: 64.1GiB
Beginning iteration 103... Memory: 64.1GiB
```

The main allocations are:

get_model(): 0->30.0GiB  
_load_base_checkpoint: 30.0 -> 60.0GiB (we can get this down to 41.2GiB if we empty_cache()
optimizer.load_state_dict(state_dict['optimizer']): 60.0 -> 63.3GiB

I believe the problem is that `load_kwargs["sharded_state_dict"]`, `state_dict['optimizer']`, and possibly (I didn't check this one) `state_dict['model']` retain python references to CUDA tensors. we need to not only free the references, but also GC collect them, and then we can empty_cache() to get our CUDA memory back.

For me, this improved my situation on resumes to:

```
Beginning iteration 101... Memory: 43.7GiB
Beginning iteration 102... Memory: 43.7GiB
Beginning iteration 103... Memory: 43.7GiB
```

which is parity with training anew.

The optimizer I'm using is `--use-distributed-optimizer --use-precision-aware-optimizer`.  
I don't offload to CPU (i.e. I don't use `--optimizer-cpu-offload`). I am not sure if GPU AdamW works on main, I know in my fork I had to make this additional patch to allow FusedAdamW construction to succeed:

```diff
                  if is_te_min_version("2.1.0.dev0"):
                      kwargs.update({"store_param_remainders": config.store_param_remainders})
+                     init_state_kwargs["store_param_remainders"] = config.store_param_remainders
```

https://github.com/NVIDIA/Megatron-LM/blob/23dd639cf3de30f3b9d8d0fae71ee31180be9ddd/megatron/core/optimizer/__init__.py#L386C1-L387C93

<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

Feel free to message or comment the @mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.
