### PR TITLE
fix: replace 52 bare except clauses with except Exception

### DIFF
--- a/examples/multimodal/evaluation/evaluation_datasets.py
+++ b/examples/multimodal/evaluation/evaluation_datasets.py
@@ -154,7 +154,7 @@ class CaptioningDataset(torch.utils.data.Dataset):
         img_file = self._image_files[idx]
         try:
             image_id = int(img_file.split("_")[-1].split(".")[0])  # coco
-        except:
+        except Exception:
             image_id = int(img_file.split("/")[-1].split(".")[0])  # flickr
 
         img = Image.open(img_file)

--- a/examples/rl/environments/countdown/countdown.py
+++ b/examples/rl/environments/countdown/countdown.py
@@ -37,7 +37,7 @@ def validate_equation(equation_str, available_numbers):
 
         # Each number should be used exactly once
         return numbers_in_eq == available_numbers
-    except:
+    except Exception:
         return False
 
 
@@ -105,7 +105,7 @@ def compute_score(solution_str, ground_truth, method='strict', format_score=0.1,
             if do_print:
                 print(f"Wrong result: equation = {result}, target = {target}")
             return format_score
-    except:
+    except Exception:
         if do_print:
             print("Error evaluating equation")
         return format_score

--- a/megatron/core/config_logger.py
+++ b/megatron/core/config_logger.py
@@ -90,7 +90,7 @@ class JSONEncoderWithMcoreTypes(json.JSONEncoder):
             return dataclasses.asdict(o)
         try:
             return super().default(o)
-        except:
+        except Exception:
             return str(o)
 
 

--- a/megatron/core/dist_checkpointing/dict_utils.py
+++ b/megatron/core/dist_checkpointing/dict_utils.py
@@ -156,7 +156,7 @@ def inspect_types(x: Any, prefix: Tuple = (), indent: int = 4):
         else:
             try:
                 x_str = str(x)
-            except:
+            except Exception:
                 x_str = "<no string repr>"
             if len(x_str) > 30:
                 x_str = x_str[:30] + "... (truncated)"

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/mixed_precision.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/mixed_precision.py
@@ -41,7 +41,7 @@ try:
         TE_VERSION = PkgVersion(str(te.__version__))
     else:
         TE_VERSION = PkgVersion(version("transformer-engine"))
-except:
+except Exception:
     TE_VERSION = None
 
 # Detect the quantized_model_init or fp8_model_init context manager.
@@ -50,7 +50,7 @@ if HAVE_TE:
         from transformer_engine.pytorch import quantized_model_init
 
         QUANTIZED_MODEL_INIT_CLASS = quantized_model_init
-    except:
+    except Exception:
         # Fallback to original FP8 model init.
         from transformer_engine.pytorch import fp8_model_init
 
@@ -64,13 +64,13 @@ try:
 
     HAVE_TE_FP8_TENSOR_CLASS = True
     FP8_TENSOR_CLASS = QuantizedTensor
-except:
+except Exception:
     try:
         from transformer_engine.pytorch.float8_tensor import Float8Tensor
 
         HAVE_TE_FP8_TENSOR_CLASS = True
         FP8_TENSOR_CLASS = Float8Tensor
-    except:
+    except Exception:
         HAVE_TE_FP8_TENSOR_CLASS = False
 
 # Detect the MXFP8 tensor class
@@ -78,7 +78,7 @@ try:
     from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Tensor
 
     HAVE_TE_MXFP8TENSOR = True
-except:
+except Exception:
     HAVE_TE_MXFP8TENSOR = False
 
 # Detect the Blockwise FP8 tensor class
@@ -86,7 +86,7 @@ try:
     from transformer_engine.pytorch.tensor.float8_blockwise_tensor import Float8BlockwiseQTensor
 
     HAVE_TE_BLOCKWISE_FP8TENSOR = True
-except:
+except Exception:
     HAVE_TE_BLOCKWISE_FP8TENSOR = False
 
 # Detect the "cast_master_weights_to_fp8" function of Transformer Engine
@@ -94,7 +94,7 @@ try:
     from transformer_engine.pytorch.tensor.utils import cast_master_weights_to_fp8
 
     HAVE_TE_CAST_MASTER_WEIGHTS_TO_FP8 = True
-except:
+except Exception:
     HAVE_TE_CAST_MASTER_WEIGHTS_TO_FP8 = False
 
     # Try to import multi_tensor_apply, used in the fallback of fp8 quantization.
@@ -154,7 +154,7 @@ try:
     from transformer_engine.pytorch.tensor.utils import post_all_gather_processing
 
     HAVE_TE_POST_ALL_GATHER_PROCESSING = True
-except:
+except Exception:
     HAVE_TE_POST_ALL_GATHER_PROCESSING = False
 
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
@@ -285,7 +285,7 @@ def gather_uneven_dtensor_to_full_tensor(
                 # Two Cases: Name is a root dimension, or using the old DeviceMesh
                 # API which allows us to get flattened dimensions.
                 process_group = device_mesh[full_flattened_mesh_dim_name].get_group()
-            except:
+            except Exception:
                 # Name is a flattened dimension that cannot be retrieved from the
                 # DeviceMesh.__getitem__, so fall-back to new DeviceMesh API.
                 process_group = (

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -37,7 +37,7 @@ try:
     else:
         dist_all_gather_func = torch.distributed._all_gather_base
         dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
-except:
+except Exception:
     dist_all_gather_func = torch.distributed._all_gather_base
     dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
 

--- a/megatron/core/export/trtllm/engine_builder/trtllm_engine_builder.py
+++ b/megatron/core/export/trtllm/engine_builder/trtllm_engine_builder.py
@@ -89,7 +89,7 @@ class TRTLLMEngineBuilder:
         )
         try:
             model_cls = getattr(tensorrt_llm.models, architecture)
-        except:
+        except Exception:
             raise AttributeError(f"Could not find TRTLLM model for architecture: {architecture}!")
 
         logger.set_level("info")

--- a/megatron/core/inference/data_parallel_inference_coordinator.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator.py
@@ -18,14 +18,14 @@ try:
     import zmq
 
     HAVE_ZMQ = True
-except:
+except Exception:
     HAVE_ZMQ = False
 
 try:
     import msgpack
 
     HAVE_MSGPACK = True
-except:
+except Exception:
     HAVE_MSGPACK = False
 
 # Register faulthandler to emit stack traces upon process kill.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -63,21 +63,21 @@ try:
     from tqdm import tqdm
 
     HAVE_TQDM = True
-except:
+except Exception:
     HAVE_TQDM = False
 
 try:
     import zmq
 
     HAVE_ZMQ = True
-except:
+except Exception:
     HAVE_ZMQ = False
 
 try:
     import msgpack
 
     HAVE_MSGPACK = True
-except:
+except Exception:
     HAVE_MSGPACK = False
 
 try:

--- a/megatron/core/inference/inference_client.py
+++ b/megatron/core/inference/inference_client.py
@@ -15,14 +15,14 @@ try:
     import zmq
 
     HAVE_ZMQ = True
-except:
+except Exception:
     HAVE_ZMQ = False
 
 try:
     import msgpack
 
     HAVE_MSGPACK = True
-except:
+except Exception:
     HAVE_MSGPACK = False
 
 from .headers import Headers

--- a/megatron/core/models/common/language_module/language_module.py
+++ b/megatron/core/models/common/language_module/language_module.py
@@ -11,7 +11,7 @@ from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 
 try:
     from megatron.core.extensions.transformer_engine import te_parallel_cross_entropy
-except:
+except Exception:
     te_parallel_cross_entropy = None
 from megatron.core.fusions.fused_cross_entropy import fused_vocab_parallel_cross_entropy
 from megatron.core.pipeline_parallel.utils import (

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -34,9 +34,9 @@ try:
         import transformer_engine_torch as tex
 
         HAVE_TEX = True
-    except:
+    except Exception:
         HAVE_TEX = False
-except:
+except Exception:
     HAVE_TE = False
 
 

--- a/megatron/core/models/vision/clip_vit_model.py
+++ b/megatron/core/models/vision/clip_vit_model.py
@@ -18,7 +18,7 @@ try:
     from megatron.core.extensions.transformer_engine import TENorm
 
     NORM_IMPL = TENorm
-except:
+except Exception:
     NORM_IMPL = torch.nn.LayerNorm
 
 

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -90,11 +90,11 @@ def set_ideal_affinity_for_current_gpu():
     try:
         import cuda.bindings.driver as cuda_driver
         import cuda.bindings.runtime as cuda_runtime
-    except:
+    except Exception:
         try:
             import cuda.cuda as cuda_driver
             import cuda.cudart as cuda_runtime
-        except:
+        except Exception:
             raise RuntimeError("Please install cuda-python to enable GPU affinity setting")
     import pynvml
 

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -72,7 +72,7 @@ try:
     else:
         custom_fwd = torch.cuda.amp.custom_fwd
         custom_bwd = torch.cuda.amp.custom_bwd
-except:
+except Exception:
     custom_fwd = torch.cuda.amp.custom_fwd
     custom_bwd = torch.cuda.amp.custom_bwd
 
@@ -83,7 +83,7 @@ try:
     else:
         dist_all_gather_func = torch.distributed._all_gather_base
         dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
-except:
+except Exception:
     dist_all_gather_func = torch.distributed._all_gather_base
     dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
 

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -14,7 +14,7 @@ try:
     else:
         dist_all_gather_func = torch.distributed._all_gather_base
         dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
-except:
+except Exception:
     dist_all_gather_func = torch.distributed._all_gather_base
     dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
 

--- a/megatron/core/timers.py
+++ b/megatron/core/timers.py
@@ -26,7 +26,7 @@ try:
         dist_all_gather_func = torch.distributed.all_gather_into_tensor
     else:
         dist_all_gather_func = torch.distributed._all_gather_base
-except:
+except Exception:
     dist_all_gather_func = torch.distributed._all_gather_base
 
 logger = logging.getLogger(__name__)

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -93,7 +93,7 @@ from megatron.core.transformer.transformer_config import MLATransformerConfig
 
 try:
     from flash_attn import flash_attn_varlen_func, flash_attn_with_kvcache
-except:
+except Exception:
     flash_attn_varlen_func = None
     flash_attn_with_kvcache = None
 

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -54,14 +54,14 @@ try:
     from transformer_engine.pytorch.utils import make_weak_ref
 
     HAVE_TE_GRAPHS = True
-except:
+except Exception:
     HAVE_TE_GRAPHS = False
 
 try:
     from tqdm import tqdm
 
     HAVE_TQDM = True
-except:
+except Exception:
     HAVE_TQDM = False
 
 _IS_GRAPH_CAPTURING = False

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -46,7 +46,7 @@ try:
         fused_apply_mla_rope_for_kv,
         fused_apply_mla_rope_for_q,
     )
-except:
+except Exception:
     fused_apply_mla_rope_for_kv = None
     fused_apply_mla_rope_for_q = None
 

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -772,7 +772,7 @@ def get_nvtx_range():
                     timers(msg, log_level=0).stop()
 
         return nvtx_range
-    except:
+    except Exception:
         @contextmanager
         def dummy_range(msg):
             yield

--- a/tests/unit_tests/data/test_preprocess_data.py
+++ b/tests/unit_tests/data/test_preprocess_data.py
@@ -92,7 +92,7 @@ def do_test_preprocess_data(temp_dir, extra_args=[]):
         for option in ["decode", "detokenize"]:
             try:
                 return getattr(encoder.tokenizer, option)(toks)
-            except:
+            except Exception:
                 continue
         raise RuntimeError(f"{type(encoder.tokenizer)} tokenizer cannot decode or detokenize")
 

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -13,7 +13,7 @@ try:
         fused_apply_mla_rope_for_kv,
         fused_apply_mla_rope_for_q,
     )
-except:
+except Exception:
     fused_apply_mla_rope_for_kv = None
     fused_apply_mla_rope_for_q = None
 

--- a/tests/unit_tests/inference/test_data_parallel_inference_coordinator.py
+++ b/tests/unit_tests/inference/test_data_parallel_inference_coordinator.py
@@ -381,7 +381,7 @@ class TestCoordinator:
                     await asyncio.wait_for(asyncio.gather(*futures), timeout=0.5)
                 except asyncio.TimeoutError:
                     pytest.fail("Resumed requests did not complete in time.")
-        except:
+        except Exception:
             success = False
         finally:
             try:

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -36,12 +36,12 @@ try:
 
     fp8_block_scaling_available, reason_for_no_fp8_block_scaling = check_fp8_block_scaling_support()
     from transformer_engine.common.recipe import DelayedScaling, Float8BlockScaling, Format
-except:
+except Exception:
     fp8_block_scaling_available = False
     reason_for_no_fp8_block_scaling = "FP8 block scaled GEMM requires Hopper and CUDA >= 12.9."
     try:
         from transformer_engine.common.recipe import DelayedScaling
-    except:
+    except Exception:
         delayed_scaling_available = False
 
 

--- a/tests/unit_tests/test_optimizer_cpu_offloading.py
+++ b/tests/unit_tests/test_optimizer_cpu_offloading.py
@@ -11,7 +11,7 @@ from torch.optim import SGD, Adam
 try:
     from transformer_engine.pytorch.optimizers import FusedAdam as GPUAdam
     from transformer_engine.pytorch.optimizers import FusedSGD as GPUSGD
-except:
+except Exception:
     # Handle environment where transformer_engine is not installed
     from torch.optim import SGD as GPUSGD
     from torch.optim import Adam as GPUAdam

--- a/tests/unit_tests/transformer/test_spec_customization.py
+++ b/tests/unit_tests/transformer/test_spec_customization.py
@@ -173,7 +173,7 @@ class TestSpecCustomization:
                 attention_type='self',
                 pg_collection=self.pg_collection,
             )
-        except:
+        except Exception:
             threw = True
         finally:
             assert threw, "Expected TEDotProductAttention to throw for integer window-size"

--- a/tools/checkpoint/checkpoint_inspector.py
+++ b/tools/checkpoint/checkpoint_inspector.py
@@ -115,7 +115,7 @@ def inspect(checkpoint_dir, enable_msc, not_ignore_param_to_group_meta):
             click.echo(
                 f"  {bullet} {click.style(key, fg='green')}: {click.style(str(value), fg='white')}"
             )
-    except:
+    except Exception:
         click.echo(
             click.style("Failed to load checkpoint strategies.", fg="red", bold=True)
         )
@@ -177,7 +177,7 @@ def inspect(checkpoint_dir, enable_msc, not_ignore_param_to_group_meta):
             click.echo(
                 f"  {bullet} {click.style(key, fg='blue')}: {click.style(str(value), fg='white')}"
             )
-    except:
+    except Exception:
         click.echo(
             click.style("No MCore data found in the checkpoint.", fg="red", bold=True)
         )
@@ -633,7 +633,7 @@ def convert_checkpoint(
             ckpt_param_groups = []
             for opt_state_dict in common_state["optimizer"].values():
                 ckpt_param_groups.extend(opt_state_dict["optimizer"]["param_groups"])
-    except:
+    except Exception:
         ckpt_param_groups = None
     common_state = flatten(common_state)
     for key, value in common_state.items():

--- a/tools/checkpoint/hybrid_conversion.py
+++ b/tools/checkpoint/hybrid_conversion.py
@@ -294,7 +294,7 @@ def main(args):
             try:
                 layer_num = int(re.findall(r'\d+', key)[0])
                 new_key = key.replace(str(layer_num), str(layer_num + pp*num_layers_per_pipeline_rank), 1)
-            except:
+            except Exception:
                 new_key = key
             full_model[new_key] = original_tensor
     # print("Combined model: {}".format(full_model.keys()))

--- a/tools/checkpoint/loader_llava.py
+++ b/tools/checkpoint/loader_llava.py
@@ -295,12 +295,12 @@ class MegatronCheckpointLoaderLLaVA(MegatronCheckpointLoaderBase):
         # if hasattr(self.all_models[0][0][0].vision_projection.encoder.linear_fc1.layer_norm_weight, "data"):
         try:
             message["vision projection norm weight"] = self.all_models[0][0][0].vision_projection.encoder.linear_fc1.layer_norm_weight.data
-        except:
+        except Exception:
             pass
         try:
         # if hasattr(self.all_models[0][0][0].vision_projection.encoder.linear_fc1.layer_norm_bias, "data"):
             message["vision projection norm bias"] = self.all_models[0][0][0].vision_projection.encoder.linear_fc1.layer_norm_bias.data
-        except:
+        except Exception:
             pass
         if self.md.vision_projection_linear_bias:
             message["vision projection l0 bias"] = torch.cat([self.all_models[0][0][tp_rank].vision_projection.encoder.linear_fc1.bias.data for tp_rank in range(encoder_tp_size)], dim=0)

--- a/train_rl.py
+++ b/train_rl.py
@@ -271,7 +271,7 @@ def forward_step(data_iterator, model: GPTModel, loss_only: bool = False):
                 module._forward.cache_clear()
             if hasattr(module, 'forward') and hasattr(module.forward, 'cache_clear'):
                 module.forward.cache_clear()
-    except:
+    except Exception:
         pass
 
     # Get current logprobs and calculate loss with straggler detection


### PR DESCRIPTION
## What
Replace 52 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.