### PR TITLE
cp: `ci: Skip cleanup-taint-node jobs during deployments (3612)` into `core_r0.16.0`

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -705,6 +705,7 @@ jobs:
       always()
       && !cancelled()
       && contains(needs.is-not-external-contributor.outputs.selected_runner, 'ephemeral')
+      && !needs.pre-flight.outputs.is_deployment_workflow == 'true'
     steps:
       - name: Taint node for cleanup
         shell: bash


### PR DESCRIPTION
beep boop [🤖]: Hi @ko3n1g 👋,

    we've cherry picked #3612 into  for you! 🚀

    Please review and approve this cherry pick by your convenience!