### PR TITLE
Prefork Dataloader worker before CUDA Init

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2742,6 +2742,11 @@ def _add_data_args(parser):
                        help='Probability of producing a short sequence.')
     group.add_argument('--num-workers', type=int, default=2,
                        help="Dataloader number of workers.")
+    group.add_argument(
+        '--prefork-dataloader-before-cuda',
+        action='store_true',
+        help='Fork dataloader workers before CUDA/distributed initialization.',
+    )
     group.add_argument('--reset-position-ids', action='store_true',
                        help='Reset posistion ids after end-of-document token.')
     group.add_argument('--reset-attention-mask', action='store_true',


### PR DESCRIPTION
Added "--prefork-dataloader-before-cuda" to fork dataloader worker before CUDA context init, so GPU memory reclaim doesn't wait for dataloader worker process to exit.

Details of the changes:
1) Added read_dataloader_state_from_checkpoint. Used early checkpoint
   state to initialize prefork dataloader sampler state.
2) Break initialize_megatron() into two stages. Defer CUDA init in
   prefork mode.
3) Build iterators early (i.e. build_train_valid_test_data_iterators),
   but have dataloader worker wait after training process done on full
   init.
4) Complete CUDA init in finalize_megatron_init
