### PR TITLE
Fix test data preparation

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -82,7 +82,7 @@ def ensure_test_data():
 
         try:
             # Download assets to /opt/data
-            download_and_extract_asset(assets_dir=str(data_path))
+            download_and_extract_asset(assets_dir=data_path)
 
             print("Test data downloaded successfully.")
 


### PR DESCRIPTION
By passing a `Path` instead of `str`, we fix test data downloading, because a `Path` is what's expected in the `download_and_extract_assets` function.