### PR TITLE
[Dev] fix: skip FSDP DTensor boundary validation under fake process group

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
@@ -175,6 +175,11 @@ def validate_uneven_dtensor(dtensor: DTensor) -> None:
     )
 
     # Check that all boundaries (start and end) are touched.
+    # Skip under fake process group — all_reduce is a no-op so only rank 0's
+    # boundaries are visible, which makes the end-boundary check always fail.
+    if torch.distributed.is_initialized() and torch.distributed.get_backend() == 'fake':
+        return
+
     boundary_checks = torch.tensor(
         [
             [offset == 0, offset + size == dtensor.shape[dim]]


### PR DESCRIPTION
PR to main https://github.com/NVIDIA/Megatron-LM/pull/3669
## Summary
- Skip `validate_uneven_dtensor` boundary check when the distributed backend is `'fake'` (fake process group)
- The validation uses `all_reduce(MAX)` to verify all ranks' shards cover the full tensor, but under fake PG all collectives are no-ops — only rank 0's boundaries are visible, causing the end-boundary assertion to always fail
- Fake process group is only used for single-GPU memory profiling where numerical correctness is irrelevant, so the validation can be safely skipped

## Target branch: `dev`

## Test plan
- Run Megatron-LM with `--fake-process-group --use-megatron-fsdp --data-parallel-sharding-strategy optim_grads_params --init-model-with-meta-device` on a single GPU
- Verify training completes 3 iterations without DTensor assertion error
- Verify memory snapshot is correctly captured