### PR TITLE
Change Claude behavior

### DIFF
--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -1,18 +1,17 @@
 name: Claude Code Review
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request_target:
+    types: [synchronize, reopened, ready_for_review]
 
 jobs:
-  review-on-comment:
-    name: Claude Review (comment trigger)
-    if: github.event.issue.pull_request
+  review:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false && github.repository == 'NVIDIA/Megatron-LM'
     permissions:
       contents: read
       pull-requests: write
-      issues: write
+      issues: read
       id-token: write
     steps:
       - name: Checkout repository
@@ -24,12 +23,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          trigger_phrase: "/claude review"
-          show_full_output: true
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+
+          # Your custom review instructions
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             You are doing a light code review. Keep it concise and actionable.
+
             Focus ONLY on:
             - Critical bugs or logic errors
             - Typos in code, comments, or strings
@@ -42,4 +43,12 @@ jobs:
             - Architectural opinions or refactoring ideas
             - Performance unless there is a clear, measurable issue
 
-            Always post a comment summarizing your findings. If everything looks good, post a brief LGTM.
+            Provide feedback using inline comments for specific code suggestions.
+            Use top-level comments for general observations.
+
+            It's perfectly acceptable to not have anything to comment on.
+            If you do not have anything to comment on, post "LGTM".
+
+          # Tools for comprehensive PR review
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*)"


### PR DESCRIPTION
# What does this PR do ?

Claude will now use the target branch instead of the origin branch, which was causing Claude to only review PRs after they are merged.

This also changes Claude to review all non-draft PRs.

## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

Feel free to message or comment the @mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.
