### PR TITLE
Add warning for cp_size > 1 and no per token loss

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -246,8 +246,9 @@ class TransformerConfig(ModelParallelConfig):
     """Whether to run real-time tests."""
 
     calculate_per_token_loss: bool = False
-    """Whether cross entropy loss is calculated over the actual number of non-padded tokens in the
-    global batch, versus the default behavior of assuming all tokens are non-padded."""
+    """Whether cross entropy loss is calculated over the actual number of non-padded and non-masked
+    tokens in the global batch, versus the default behavior of assuming all tokens are non-padded 
+    and non-masked."""
 
     multi_latent_attention: bool = False
     """Whether to use multi-latent attention."""

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1053,6 +1053,13 @@ def validate_args(args, defaults={}):
         assert args.seq_length % (args.context_parallel_size * 2) == 0, \
             'seq-length should be a multiple of 2 * context-parallel-size ' \
             'if context-parallel-size > 1.'
+    
+    if args.context_parallel_size > 1 and not args.calculate_per_token_loss:
+        warn_rank_0(
+            'Using Context Parallelism (CP) without per-token loss. Please ensure that'\
+            'the number of tokens is identical across different CP ranks, '\
+            'and verify that data has not been padded or masked differently across ranks.'
+        )
 
     if args.seq_length is not None:
         assert args.encoder_seq_length is None


### PR DESCRIPTION
# What does this PR do ?

When using padding or loss mask, it's better to train model with `per-token-loss`.
And it's crucial to use `--calculate-per-token-loss` with (padding or loss mask) and CP_size > 1.  

This PR add a warning for this case.

