### PR TITLE
[Dev] Cherry-pick: M-FSDP: Cancel erroneous grad accumulation check (#3629)

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -86,12 +86,6 @@ class FullyShardedDataParallel(_BaseDataParallel):
         self.megatron_fsdp_dist_index = self._init_dist_index(pg_collection)
 
         if config.gradient_accumulation_fusion:
-            assert (
-                self.megatron_fsdp_dist_index.get_dp_group(is_expert_parallel=True).size() == 1
-            ), (
-                "Megatron-FSDP with gradient_accumulation_fusion does not support "
-                "data parallelism when expert parallelism is enabled."
-            )
             assert is_te_min_version("2.10"), (
                 "Megatron-FSDP with gradient_accumulation_fusion requires "
                 "Transformer Engine version 2.10 or higher."


### PR DESCRIPTION
## Summary

Cherry-pick of https://github.com/NVIDIA/Megatron-LM/pull/3629 from `main` into `dev`.

- Removes the incorrect assert that blocked EP + `gradient_accumulation_fusion` in Megatron-FSDP. Since Transformer Engine v2.10, these features are compatible, so the restriction is no longer needed.

**Original PR**: #3629
**Original Author**: @shjwudp


Made with [Cursor](https://cursor.com)