### PR TITLE
fix no_shard training convergency and add unittest for no_shard

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -1242,6 +1242,9 @@ class MegatronFSDP(torch.nn.Module):
         """
         self._replace_param_with_raw_if_needed()
 
+        if self.data_parallel_sharding_strategy == "no_shard":
+            return
+
         if not force_sync and self.ddp_config.overlap_param_gather:
             # All-gather the first bucket before the forward pass.
             if self.ddp_config.fsdp_all_gather_in_start_param_sync:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -3246,7 +3246,7 @@ class ParamAndGradBuffer:
         all_reduce_ops = []
         for g in self.parameter_groups:
             gbuf = g.main_grad_buffer
-            if gbuf is not None:
+            if gbuf is None:
                 continue
             scaling_factor = gbuf.gradient_scaling_factor
             if self.ddp_config.check_for_nan_in_grad:

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -675,7 +675,18 @@ def _get_megatron_optimizer_based_on_param_groups(
             # This is needed for case where num_distributed_optimizer_instances > 1. In this case,
             # weight gradients are all-reduced across optimizer instances, so each instance has
             # the duplicated weight gradients, need to reduce gradient stats inside each instance.
-            setattr(optimizer, 'grad_stats_parallel_group', intra_dist_opt_group)
+            # Besides, for Megatron-FSDP with no_shard, gradients are replicated across DP ranks (after
+            # all-reduce), so grad stats should only be reduced across model-parallel ranks
+            # (TP*PP) to avoid inflating the grad norm by sqrt(DP_world_size).
+            ddp_config = getattr(model_chunks[0], 'ddp_config', None)
+            if (
+                ddp_config is not None
+                and getattr(ddp_config, 'use_megatron_fsdp', False)
+                and ddp_config.data_parallel_sharding_strategy == 'no_shard'
+            ):
+                setattr(optimizer, 'grad_stats_parallel_group', model_parallel_group)
+            else:
+                setattr(optimizer, 'grad_stats_parallel_group', intra_dist_opt_group)
         else:
             optimizer = Float16OptimizerWithFloat16Params(*optimizer_args)
             setattr(optimizer, 'grad_stats_parallel_group', model_parallel_group)

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -675,18 +675,7 @@ def _get_megatron_optimizer_based_on_param_groups(
             # This is needed for case where num_distributed_optimizer_instances > 1. In this case,
             # weight gradients are all-reduced across optimizer instances, so each instance has
             # the duplicated weight gradients, need to reduce gradient stats inside each instance.
-            # Besides, for Megatron-FSDP with no_shard, gradients are replicated across DP ranks (after
-            # all-reduce), so grad stats should only be reduced across model-parallel ranks
-            # (TP*PP) to avoid inflating the grad norm by sqrt(DP_world_size).
-            ddp_config = getattr(model_chunks[0], 'ddp_config', None)
-            if (
-                ddp_config is not None
-                and getattr(ddp_config, 'use_megatron_fsdp', False)
-                and ddp_config.data_parallel_sharding_strategy == 'no_shard'
-            ):
-                setattr(optimizer, 'grad_stats_parallel_group', model_parallel_group)
-            else:
-                setattr(optimizer, 'grad_stats_parallel_group', intra_dist_opt_group)
+            setattr(optimizer, 'grad_stats_parallel_group', intra_dist_opt_group)
         else:
             optimizer = Float16OptimizerWithFloat16Params(*optimizer_args)
             setattr(optimizer, 'grad_stats_parallel_group', model_parallel_group)
@@ -950,6 +939,13 @@ def get_megatron_optimizer(
     model_chunk_offset = 0
     ddp_config = model_chunks[0].ddp_config  # Use the first model chunk's DDP config
     if ddp_config.use_megatron_fsdp:
+        # For no_shard, gradients are replicated across DP ranks after all-reduce, so grad stats
+        # should only be reduced over TP/PP (model_parallel_group) to avoid inflating the norm.
+        effective_intra_dist_opt_group = (
+            mp_group
+            if ddp_config.data_parallel_sharding_strategy == 'no_shard'
+            else intra_dist_opt_group
+        )
         for model_chunk, overlap_param_gather_with_optimizer_step in zip(
             all_dense_model_chunks, overlap_param_gather_with_optimizer_step_flags
         ):
@@ -971,7 +967,7 @@ def get_megatron_optimizer(
                 data_parallel_group=dp_cp_group,
                 data_parallel_group_gloo=intra_dp_cp_group_gloo,
                 data_parallel_group_idx=model_parallel_rank,
-                intra_dist_opt_group=intra_dist_opt_group,
+                intra_dist_opt_group=effective_intra_dist_opt_group,
                 distributed_optimizer_instance_id=distributed_optimizer_instance_id,
                 pg_collection=pg_collection,
             )

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1141,7 +1141,13 @@ def validate_args(args, defaults={}):
 
         assert args.ckpt_format == "fsdp_dtensor", \
             "Megatron-FSDP requires the `fsdp_dtensor` checkpointing format."
-    
+
+        if args.init_model_with_meta_device and args.data_parallel_sharding_strategy == "no_shard":
+            raise ValueError(
+                "Meta device initialization (init_model_with_meta_device=True) is not "
+                "supported or necessary for the 'no_shard' / 0 sharding strategy."
+            )
+
     if args.nccl_ub and args.use_megatron_fsdp:
         # In Megatron-LM, required implementation for manual registration is already provided.
         # So we enable the manual registration by default when nccl-ub and use_megatron_fsdp is set.

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 import copy
+import gc
 import random
 
 import numpy as np
@@ -323,6 +324,10 @@ class TestFullyShardedDataParallel:
                 msg=f"Parameters for {name1} don't match",
             )
 
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+
     def test_fsdp_expt_device_mesh(self):
         """Test that expt_device_mesh is None for dense models and not None for MoE models."""
         if not is_torch_min_version("2.4.0"):
@@ -533,6 +538,10 @@ class TestFullyShardedDataParallel:
                 atol=0,
                 msg=f"Parameters for {name1} don't match",
             )
+
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
 
     @classmethod
     def hsdp_one_step_test(cls, num_fsdp_group):
@@ -856,6 +865,10 @@ class TestMegatronFSDPE2E:
                 dict(data_parallel_sharding_strategy="optim", fsdp_double_buffer=False),
                 id="optim_double_buffer",
             ),
+            pytest.param(
+                dict(data_parallel_sharding_strategy="no_shard", fsdp_double_buffer=False),
+                id="no_shard",
+            ),
         ],
     )
     def test_compatible_with_nd_parallel(self, ref_cache, nd_topology, spec_configs):
@@ -872,9 +885,13 @@ class TestMegatronFSDPE2E:
                 use_distributed_optimizer=True, **distopt_spec_configs
             )
 
+        fsdp_sharding_strategy = spec_configs["data_parallel_sharding_strategy"]
+        # no_shard is incompatible with meta device initialization. See fully_shard.py:326.
+        init_model_with_meta_device = fsdp_sharding_strategy != "no_shard"
+
         outputs = TestMegatronFSDPE2E._training_loop(
             use_megatron_fsdp=True,
-            init_model_with_meta_device=True,
+            init_model_with_meta_device=init_model_with_meta_device,
             ckpt_format="fsdp_dtensor",
             gradient_accumulation_fusion=False,
             **spec_configs,
@@ -896,6 +913,10 @@ class TestMegatronFSDPE2E:
                         f", Compare = {compare_losses(loss.item(), ref_loss.item())}"
                     ),
                 )
+
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
 
 
 def compare_losses(loss_a: float, loss_b: float, reference: str = "b"):


### PR DESCRIPTION
# What does this PR do ?
Fixes no_shard convergence by correcting grad_norm and all_reduce logic.

1.  fix no_shard grad_norm calculation 
2. fix no_shard all_reduce grad continue bug
3. Make no_shard to be compatiable without overlap_param_gather and overlap_grad_reduce
4. add  unittest for no_shard
5. add assert False for no_shard and `init_model_with_meta_device` follow [fully_shard.py:326](https://github.com/NVIDIA/Megatron-LM/blob/597721a17891669c6ebcb098beb74cd83087205d/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py#L326)

Grad_norm and loss convergency and unittest result is below.

<img width="2470" height="574" alt="image" src="https://github.com/user-attachments/assets/ef8c453d-6b0a-42ec-aae3-66a0e9340a63" />
<img width="2132" height="1362" alt="image" src="https://github.com/user-attachments/assets/bf88e413-a20e-4f52-972e-29c00cb05636" />
<img width="2132" height="1388" alt="image" src="https://github.com/user-attachments/assets/e108d3c4-5251-47b7-bd54-53272ec196b0" />


<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
6. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
