### PR TITLE
[Dev] fix(moe): align MoE router loss scale semantics

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -443,9 +443,14 @@ class TopKRouter(Router):
             fused=self.config.moe_router_fusion,
         )
 
+        # `global_aux_loss` uses DP-aggregated tokens_per_expert, while router probs remain
+        # local to each rank. Scale only by DP so the coefficient matches aux_loss semantics.
+        dp_size = self.tp_dp_cp_group.size() // self.tp_cp_group.size()
+        global_aux_loss = global_aux_loss * dp_size
+
         probs = self.attach_and_log_load_balancing_loss(
             probs,
-            global_aux_loss_coeff,
+            global_aux_loss_coeff * dp_size,
             global_aux_loss,
             "global_load_balancing_loss",
             self.tp_dp_cp_group,
@@ -457,7 +462,7 @@ class TopKRouter(Router):
     def attach_and_log_load_balancing_loss(
         self,
         activation: torch.Tensor,
-        aux_loss_coeff: float,
+        normalize_scale: float,
         aux_loss: torch.Tensor,
         aux_loss_name: str,
         reduce_group: torch.distributed.ProcessGroup,
@@ -468,7 +473,8 @@ class TopKRouter(Router):
 
         Args:
             activation (torch.Tensor): Activation tensor to attach the aux loss to.
-            aux_loss_coeff (float): Coefficient for the aux loss.
+            normalize_scale (float): Scale factor to normalize aux_loss for logging.
+                The logged value is `aux_loss / normalize_scale`.
             aux_loss (torch.Tensor): Computed aux loss.
             aux_loss_name (str): Name of the aux loss for logging.
             reduce_group (torch.distributed.ProcessGroup): Process group for reduction.
@@ -502,22 +508,17 @@ class TopKRouter(Router):
 
         get_moe_metrics_tracker().record(
             aux_loss_name,
-            aux_loss / aux_loss_coeff,
+            aux_loss / normalize_scale,
             layer_number,
             num_layers,
             reduce_group=reduce_group,
             needs_dp_avg=needs_dp_avg,
         )
         if self.calculate_per_token_loss:
-            # Scale the aux_loss by the number of tokens.
-            # The expected final scaling for aux_loss gradients is 1/(num_micro_batches * dp_size).
-            # After commit 02648000, Megatron started using the number of total tokens to scale
-            # gradients under the argument of calculate_per_token_loss,
-            # which scales both the main_loss gradient and aux_loss gradient by
-            # 1/(num_local_tokens * dp_size * num_micro_batches) in finalize_model_grads function.
-            # To correct this scaling, we need to scale the aux_loss by num_local_tokens here.
-            # Use valid_token_count (excluding padding) if provided, otherwise use total tokens.
+            # Match the non-per-token aux_loss baseline by converting the local mean-style
+            # aux loss to the TP/CP-wide token sum before final per-token normalization.
             num_tokens = valid_token_count if valid_token_count is not None else activation.shape[0]
+            num_tokens = num_tokens * self.tp_cp_group.size()
             activation = MoEAuxLossAutoScaler.apply(activation, aux_loss * num_tokens)
         else:
             activation = MoEAuxLossAutoScaler.apply(activation, aux_loss)
@@ -541,15 +542,9 @@ class TopKRouter(Router):
             moe_z_loss_coeff = self.config.moe_z_loss_coeff / self.tp_cp_group.size()
             z_loss = z_loss_func(logits, moe_z_loss_coeff, padding_mask=padding_mask)
             if self.calculate_per_token_loss:
-                # The expected final scaling for z_loss gradients is
-                # 1/(num_micro_batches * dp_size).
-                # After commit 02648000, Megatron started using the number of total tokens
-                # to scale gradients under the argument of calculate_per_token_loss,
-                # which scales both the main_loss gradient and z_loss gradient by
-                # 1/(num_local_tokens * dp_size * num_micro_batches) in finalize_model_grads().
-                # To correct this scaling, we need to scale the z_loss by num_local_tokens here.
-                # Count valid tokens: sum of inverted mask (False -> True = valid)
+                # Keep z_loss on the same scale as the non-per-token baseline.
                 num_tokens = (~padding_mask).sum() if padding_mask is not None else logits.shape[0]
+                num_tokens = num_tokens * self.tp_cp_group.size()
                 logits = MoEAuxLossAutoScaler.apply(logits, z_loss * num_tokens)
             else:
                 logits = MoEAuxLossAutoScaler.apply(logits, z_loss)

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -443,8 +443,16 @@ class TopKRouter(Router):
             fused=self.config.moe_router_fusion,
         )
 
-        # `global_aux_loss` uses DP-aggregated tokens_per_expert, while router probs remain
-        # local to each rank. Scale only by DP so the coefficient matches aux_loss semantics.
+        # Compensate for DP dilution so global_aux_loss_coeff produces the same router
+        # gradient as aux_loss_coeff under identical input.
+        # global_aux_loss reduces tokens_per_expert/total_num_tokens over tp_dp_cp_group, but
+        # `probs` in switch_load_balancing_loss_func stays local to each rank (autograd cannot
+        # cross DP). The result is that for the same input, global_aux_loss is dp_size smaller
+        # than aux_loss, and so is its backward gradient. Subsequent DDP gradient averaging
+        # over dp_cp_group does not recover this factor. Multiply by dp_size here so the
+        # gradient strength matches the aux_loss baseline; the same dp_size is propagated to
+        # `normalize_scale` below so the logged value (aux_loss / normalize_scale) is
+        # unchanged and dashboards stay comparable across this fix.
         dp_size = self.tp_dp_cp_group.size() // self.tp_cp_group.size()
         global_aux_loss = global_aux_loss * dp_size
 
@@ -473,8 +481,12 @@ class TopKRouter(Router):
 
         Args:
             activation (torch.Tensor): Activation tensor to attach the aux loss to.
-            normalize_scale (float): Scale factor to normalize aux_loss for logging.
-                The logged value is `aux_loss / normalize_scale`.
+            normalize_scale (float): Divisor applied to aux_loss before logging so that the
+                recorded metric stays on the coefficient-free scale. Callers must pass
+                `aux_loss_coeff` multiplied by any external scaling already applied to
+                `aux_loss` (e.g. the dp_size compensation in `_apply_global_aux_loss`), so
+                that `aux_loss / normalize_scale` reproduces the unit-coefficient loss
+                regardless of how the gradient strength was rescaled.
             aux_loss (torch.Tensor): Computed aux loss.
             aux_loss_name (str): Name of the aux loss for logging.
             reduce_group (torch.distributed.ProcessGroup): Process group for reduction.
@@ -515,8 +527,15 @@ class TopKRouter(Router):
             needs_dp_avg=needs_dp_avg,
         )
         if self.calculate_per_token_loss:
-            # Match the non-per-token aux_loss baseline by converting the local mean-style
-            # aux loss to the TP/CP-wide token sum before final per-token normalization.
+            # Align with the non-per-token baseline gradient scale.
+            # In per-token mode, `MoEAuxLossAutoScaler` is seeded with `loss_scale` only
+            # (schedules.py drops the `cp / num_microbatches` factor), and finalize_model_grads
+            # divides every gradient by the global token count, all-reduced over dp_cp_group.
+            # That global divisor does not include the TP/CP factor that splits the local
+            # sequence (CP slices tokens directly; SP slices via `activation.shape[0]`), so
+            # attaching just `local_num_tokens` leaves the aux gradient 1/tp_cp_size smaller
+            # than the non-per-token baseline. Multiply by tp_cp_group.size() here to cancel
+            # that factor. The same correction applies to z_loss in `apply_z_loss`.
             num_tokens = valid_token_count if valid_token_count is not None else activation.shape[0]
             num_tokens = num_tokens * self.tp_cp_group.size()
             activation = MoEAuxLossAutoScaler.apply(activation, aux_loss * num_tokens)
@@ -542,7 +561,10 @@ class TopKRouter(Router):
             moe_z_loss_coeff = self.config.moe_z_loss_coeff / self.tp_cp_group.size()
             z_loss = z_loss_func(logits, moe_z_loss_coeff, padding_mask=padding_mask)
             if self.calculate_per_token_loss:
-                # Keep z_loss on the same scale as the non-per-token baseline.
+                # Mirror the per-token attach scaling in `attach_and_log_load_balancing_loss`:
+                # finalize_model_grads divides by global token count reduced over dp_cp_group,
+                # which omits the TP/CP factor that splits the local sequence. Multiply by
+                # tp_cp_group.size() so the z_loss gradient stays on the non-per-token baseline.
                 num_tokens = (~padding_mask).sum() if padding_mask is not None else logits.shape[0]
                 num_tokens = num_tokens * self.tp_cp_group.size()
                 logits = MoEAuxLossAutoScaler.apply(logits, z_loss * num_tokens)

--- a/tests/unit_tests/transformer/moe/test_aux_loss.py
+++ b/tests/unit_tests/transformer/moe/test_aux_loss.py
@@ -472,6 +472,73 @@ class TestRouterAuxLoss:
     @pytest.mark.parametrize(
         "tp_size,ep_size,cp_size", [(8, 1, 1), (4, 2, 1), (1, 1, 8), (2, 1, 4), (2, 2, 2)]
     )
+    def test_global_aux_loss_gradient_scale(self, tp_size, ep_size, cp_size):
+        """Test that global_aux_loss produces the same router gradient as aux_loss
+        when all DP ranks receive identical input.
+
+        See: https://github.com/NVIDIA/Megatron-LM/issues/3672
+        """
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=tp_size,
+            expert_tensor_parallel_size=ep_size,
+            context_parallel_size=cp_size,
+        )
+        model_parallel_cuda_manual_seed(42)
+
+        aux_loss_router = self.new_router(
+            moe_router_load_balancing_type="aux_loss",
+            moe_aux_loss_coeff=1.0,
+            moe_router_dtype="fp64",
+            tensor_model_parallel_size=tp_size,
+            expert_tensor_parallel_size=ep_size,
+            context_parallel_size=cp_size,
+        ).cuda()
+        global_aux_loss_router = self.new_router(
+            moe_router_load_balancing_type="global_aux_loss",
+            moe_aux_loss_coeff=1.0,
+            moe_router_dtype="fp64",
+            tensor_model_parallel_size=tp_size,
+            expert_tensor_parallel_size=ep_size,
+            context_parallel_size=cp_size,
+        ).cuda()
+
+        # Set identical weights
+        with torch.no_grad():
+            global_aux_loss_router.weight.copy_(aux_loss_router.weight)
+
+        # Create identical input across all DP ranks using a fixed seed
+        torch.manual_seed(0)
+        hidden_states = torch.randn(
+            (32, 1, aux_loss_router.config.hidden_size),
+            device=torch.device("cuda"),
+            dtype=torch.bfloat16,
+        )
+
+        # Forward + backward for aux_loss router (zero out main grad, isolate aux loss grad)
+        clear_aux_losses_tracker()
+        aux_loss_router.weight.grad = None
+        scores1, _ = aux_loss_router(hidden_states)
+        scores1.backward(torch.zeros_like(scores1))
+        grad1 = aux_loss_router.weight.grad.clone()
+
+        # Forward + backward for global_aux_loss router
+        clear_aux_losses_tracker()
+        global_aux_loss_router.weight.grad = None
+        scores2, _ = global_aux_loss_router(hidden_states)
+        scores2.backward(torch.zeros_like(scores2))
+        grad2 = global_aux_loss_router.weight.grad.clone()
+
+        assert torch.equal(grad1, grad2), (
+            f"global_aux_loss gradient should match aux_loss gradient with identical input. "
+            f"Max diff: {(grad1 - grad2).abs().max().item()}"
+        )
+        clear_aux_losses_tracker()
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize(
+        "tp_size,ep_size,cp_size", [(8, 1, 1), (4, 2, 1), (1, 1, 8), (2, 1, 4), (2, 2, 2)]
+    )
     def test_combined_aux_loss(self, tp_size, ep_size, cp_size):
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=tp_size,


### PR DESCRIPTION
## Summary

This PR aligns the effective scale of MoE router auxiliary losses across aux-loss variants, `--calculate-per-token-loss`, and TP/CP/DP parallel strategies.

The conservative semantic baseline is kept unchanged: `load_balancing_type=aux_loss` with `--calculate-per-token-loss=false`. Other paths are aligned to that baseline.

Fixes #3672.

## Problem Manifestation

Before this fix, equivalent MoE training configurations could apply different effective router regularization strengths even when using the same `moe_aux_loss_coeff`.

The most visible symptoms were:

- `global_aux_loss` did not have the same effective scale as the standard `aux_loss`. In practice, the active load-balancing loss and router gradient strength could drift when switching only the aux-loss type from `aux_loss` to `global_aux_loss`.
- With `aux_loss` and `--calculate-per-token-loss` enabled, changing TP/CP sizes changed the effective aux-loss scale. The same model and data could therefore show different router-loss/router-gradient behavior under different TP/CP parallel strategies.
- The same per-token normalization issue also affected `seq_aux_loss`/`z_loss` style router-loss attachment paths, so aux type, per-token mode, and TP/CP/DP strategy were not cleanly comparable.

The expected behavior is that these configurations should preserve the same coefficient semantics: changing aux-loss type or parallel decomposition should not systematically rescale router gradients, except where the loss definition itself intentionally differs.

## Root Cause

There were two scale mismatches in the router-loss attachment path:

- `global_aux_loss` builds `tokens_per_expert` from a DP-aggregated `tp_dp_cp_group`, while router probabilities remain local. Since the final gradient is averaged across DP ranks, the attached gradient was diluted by `dp_size`.
- Per-token aux/z-loss paths attached loss scaled by the local valid-token count, but `finalize_model_grads` normalizes by the global token count. With TP/CP enabled, this missed the `tp_cp_group.size()` factor.

As a result, otherwise equivalent configurations could show systematic router-loss and router-gradient scale drift when switching aux-loss type, per-token-loss mode, or TP/CP/DP strategy.

## Fix

- Scale `global_aux_loss` by `dp_size = tp_dp_cp_group.size() // tp_cp_group.size()` so its backward strength matches `aux_loss`.
- Keep the logged global aux loss normalized through the same scale factor, so reported metrics stay comparable.
- Scale per-token aux-loss and z-loss attachment by `local_valid_tokens * tp_cp_group.size()` to match global-token-count gradient normalization.
- Preserve the non-per-token `aux_loss` baseline behavior.

## Validation

Public W&B report: https://api.wandb.ai/links/megatron-core-moe-dev/xafmkree

Original W&B report: https://wandb.ai/megatron-core-moe-dev/moe-aux-loss-scale-alignment/reports/MoE-Aux-Loss-Scale-Alignment-E2E-Ablation---2026-05-25--VmlldzoxNzAwODkxMw==

E2E validation uses the same model/config family and compares loss ratios against the baseline instead of forcing load balancing. Horizontal aux-type comparisons use a deterministic `mock_repeat` dataset so each global batch is identical across aux types. Vertical parallel-strategy comparisons use the real SlimPajama data path and load all compared TP/CP/DP jobs from the same one-iteration checkpoint.

Key validation results:

| Comparison | Before fix active LB ratio | After fix active LB ratio | After fix LM ratio |
| --- | ---: | ---: | ---: |
| `aux_loss` vertical | 0.9994 - 1.0455 | 0.9952 - 1.0063 | 0.9985 - 1.0053 |
| `seq_aux_loss` vertical | 0.9929 - 1.0419 | 0.9948 - 1.0053 | 0.9997 - 1.0057 |
| `global_aux_loss` vertical | 0.9483 - 1.0080 | 0.9981 - 1.0086 | 0.9986 - 1.0035 |
| `z_loss` vertical | 0.9844 - 2.6181 | 0.9254 - 1.0281 | 0.9968 - 1.0067 |

Additional checks:

- Horizontal deterministic repeat-data jobs: 12/12 completed.
- `aux_loss + --calculate-per-token-loss=false` is bitwise identical before/after fix, confirming the baseline is unchanged.
- `aux_loss` and `seq_aux_loss` fixed TP1/CP1 horizontal runs are bitwise identical before/after fix where the scale correction should be neutral.
- `global_aux_loss` changes after the first step as expected because the fix intentionally changes its backward scale.
- Added unit coverage for `global_aux_loss` gradient scaling.

Local sanity checks:

```bash
git diff --check
python3 -m py_compile megatron/core/transformer/moe/router.py megatron/core/transformer/moe/moe_utils.py tests/unit_tests/transformer/moe/test_aux_loss.py
```
