### PR TITLE
fix: correct HAVE_TE detection in remaining files

### DIFF
--- a/examples/multimodal/layer_specs.py
+++ b/examples/multimodal/layer_specs.py
@@ -17,6 +17,8 @@ from megatron.core.transformer.transformer_layer import TransformerLayer, Transf
 from megatron.core.typed_torch import not_none
 
 try:
+    import transformer_engine  # noqa: F401
+
     from megatron.core.extensions.transformer_engine import (
         TEColumnParallelLinear,
         TEDotProductAttention,
@@ -27,6 +29,7 @@ try:
 
     HAVE_TE = True
 except ImportError:
+    HAVE_TE = False
     (
         TEColumnParallelLinear,
         TEDotProductAttention,
@@ -34,7 +37,6 @@ except ImportError:
         TENorm,
         TERowParallelLinear,
     ) = (None, None, None, None, None)
-    HAVE_TE = False
 
 try:
     import apex

--- a/examples/multimodal/radio/radio_g.py
+++ b/examples/multimodal/radio/radio_g.py
@@ -18,6 +18,8 @@ from megatron.core.transformer.transformer_layer import TransformerLayer, Transf
 from megatron.core.typed_torch import not_none
 
 try:
+    import transformer_engine  # noqa: F401
+
     from megatron.core.extensions.transformer_engine import (
         TEColumnParallelLinear,
         TEDotProductAttention,
@@ -28,6 +30,7 @@ try:
 
     HAVE_TE = True
 except ImportError:
+    HAVE_TE = False
     (
         TEColumnParallelLinear,
         TEDotProductAttention,
@@ -35,7 +38,6 @@ except ImportError:
         TENorm,
         TERowParallelLinear,
     ) = (None, None, None, None, None)
-    HAVE_TE = False
 
 try:
     import apex

--- a/tests/unit_tests/transformer/moe/test_upcycling.py
+++ b/tests/unit_tests/transformer/moe/test_upcycling.py
@@ -34,6 +34,8 @@ from megatron.training.utils import (
 from tests.unit_tests.test_utilities import Utils
 
 try:
+    import transformer_engine  # noqa: F401
+
     from megatron.core.extensions.transformer_engine import TEColumnParallelGroupedLinear
 
     HAVE_TE = True

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -41,6 +41,8 @@ from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 
 try:
+    import transformer_engine  # noqa: F401
+
     from megatron.core.extensions.transformer_engine import TEColumnParallelGroupedLinear
 
     HAVE_TE = True


### PR DESCRIPTION
# What does this PR do?

PR #3763 fixed incorrect `HAVE_TE` detection in `multi_latent_attention.py`
and `shared_experts.py`. This PR applies the same fix to 4 additional files
that have the identical bug.

## Root Cause

Importing from `megatron.core.extensions.transformer_engine` never raises
`ImportError` because the module falls back to `MagicMock` when
TransformerEngine is unavailable. This causes `HAVE_TE` to be incorrectly
set to `True`.

## Fix

Add `import transformer_engine` before the extension imports to ensure
`ImportError` is properly raised when TE is not installed.

## Files Fixed

| File | Context |
|------|---------|
| `examples/multimodal/layer_specs.py` | Multimodal example layer specs |
| `examples/multimodal/radio/radio_g.py` | RADIO-G vision encoder specs |
| `tests/unit_tests/transformer/test_multi_token_prediction.py` | MTP unit tests |
| `tests/unit_tests/transformer/moe/test_upcycling.py` | MoE upcycling unit tests |

## Methodology

I audited all 45 files containing `HAVE_TE` in the codebase. The 30+
files in `megatron/core/` already use the correct pattern (importing
`transformer_engine` first). Only these 4 files in `examples/` and
`tests/` were missed.

Related to #3764
