### PR TITLE
Fix incorrect HAVE_TE detection when transformer_engine is not installed

### DIFF
--- a/examples/multimodal/layer_specs.py
+++ b/examples/multimodal/layer_specs.py
@@ -17,6 +17,8 @@ from megatron.core.transformer.transformer_layer import TransformerLayer, Transf
 from megatron.core.typed_torch import not_none
 
 try:
+    import transformer_engine  # pylint: disable=unused-import
+
     from megatron.core.extensions.transformer_engine import (
         TEColumnParallelLinear,
         TEDotProductAttention,

--- a/examples/multimodal/radio/radio_g.py
+++ b/examples/multimodal/radio/radio_g.py
@@ -18,6 +18,8 @@ from megatron.core.transformer.transformer_layer import TransformerLayer, Transf
 from megatron.core.typed_torch import not_none
 
 try:
+    import transformer_engine  # pylint: disable=unused-import
+
     from megatron.core.extensions.transformer_engine import (
         TEColumnParallelLinear,
         TEDotProductAttention,

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -78,11 +78,14 @@ class SharedExpertMLP(MLP):
             )
             if not shared_experts_recompute:
                 try:
-                    HAVE_TE = True
+                    import transformer_engine  # pylint: disable=unused-import
+
                     from megatron.core.extensions.transformer_engine import (
                         TELinear,
                         set_save_original_input,
                     )
+
+                    HAVE_TE = True
                 except ImportError:
                     HAVE_TE = False
                     TELinear, set_save_original_input = None, None

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -52,6 +52,8 @@ except:
 
 
 try:
+    import transformer_engine  # pylint: disable=unused-import
+
     from megatron.core.extensions.transformer_engine import (
         TEColumnParallelLinear,
         TELinear,

--- a/tests/unit_tests/transformer/moe/test_upcycling.py
+++ b/tests/unit_tests/transformer/moe/test_upcycling.py
@@ -34,6 +34,8 @@ from megatron.training.utils import (
 from tests.unit_tests.test_utilities import Utils
 
 try:
+    import transformer_engine  # pylint: disable=unused-import
+
     from megatron.core.extensions.transformer_engine import TEColumnParallelGroupedLinear
 
     HAVE_TE = True

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -41,6 +41,8 @@ from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 
 try:
+    import transformer_engine  # pylint: disable=unused-import
+
     from megatron.core.extensions.transformer_engine import TEColumnParallelGroupedLinear
 
     HAVE_TE = True


### PR DESCRIPTION
## Summary

- Add explicit `import transformer_engine` check before importing from the extensions module in all affected files, ensuring `HAVE_TE` is only set to `True` when the package is genuinely installed
- The `megatron.core.extensions.transformer_engine` module falls back to `MagicMock` when TE is absent, so imports from it never raise `ImportError` — this meant `HAVE_TE` was incorrectly recognised as `True` in no-TE environments
- Also fixes the same detection pattern in two related test files that recieved the same bug

### Affected files

**Core modules:**
- `megatron/core/transformer/multi_latent_attention.py`
- `megatron/core/transformer/moe/shared_experts.py`
- `examples/multimodal/layer_specs.py`
- `examples/multimodal/radio/radio_g.py`

**Tests:**
- `tests/unit_tests/transformer/test_multi_token_prediction.py`
- `tests/unit_tests/transformer/moe/test_upcycling.py`

### Approach

The fix follows the established pattern already used in other modules such as `attention.py`, `mlp.py`, and `multi_token_prediction.py`:

```python
try:
    import transformer_engine  # pylint: disable=unused-import

    from megatron.core.extensions.transformer_engine import (...)

    HAVE_TE = True
except ImportError:
    HAVE_TE = False
```

By importing `transformer_engine` first, the `ImportError` is correctly raised when the package is not installed, and the `except` branch properly sets `HAVE_TE = False`.

For `shared_experts.py`, the `HAVE_TE = True` assignment was also moved to after teh extension imports (it was previously set before them, which would leave it as `True` even if a subsequent import failed).

## Test plan

- [ ] Verify `HAVE_TE` is `False` in an environment without `transformer_engine` installed
- [ ] Verify `HAVE_TE` is `True` in an environment with `transformer_engine` installed
- [ ] Existing unit tests continue to pass

Fixes #3764