### PR TITLE
[Main][feat] Support overlapping A2A Combine backprop with wgrad GEMM

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -696,7 +696,8 @@ class MegatronFSDP(torch.nn.Module):
             # is set but the delayed hook was never installed, process the parameter
             # immediately as a safety fallback to avoid silently dropping gradients.
             param_list = [
-                p for p in param_list
+                p
+                for p in param_list
                 if not getattr(p, 'skip_backward_post_hook', False)
                 or not hasattr(p, 'post_wgrad_grad_acc_hook')
             ]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -76,7 +76,7 @@ class TrainingState(Enum):
 def setup_delayed_wgrad_acc_hook(module, grad_acc_func):
     """Configure delayed wgrad gradient processing for MoE expert parameters.
 
-    When ``delay_wgrad_compute_for_te_grouped_gemm`` is enabled on a TransformerLayer,
+    When ``overlap_dispatch_backward_with_experts_wgrad`` is enabled on a TransformerLayer,
     this function:
       1. Marks expert parameters so the normal post-accumulate-grad hook is skipped.
       2. Registers a callback on the MoE layer that invokes FSDP's gradient
@@ -698,8 +698,10 @@ class MegatronFSDP(torch.nn.Module):
             param_list = [
                 p
                 for p in param_list
-                if not getattr(p, 'skip_backward_post_hook', False)
-                or not hasattr(p, 'post_wgrad_grad_acc_hook')
+                if not (
+                    getattr(p, 'skip_backward_post_hook', False)
+                    and hasattr(p, 'post_wgrad_grad_acc_hook')
+                )
             ]
 
             if not param_list:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -73,6 +73,34 @@ class TrainingState(Enum):
     IDLE = auto()
 
 
+def setup_delayed_wgrad_acc_hook(module, grad_acc_func):
+    """Configure delayed wgrad gradient processing for MoE expert parameters.
+
+    When ``delay_wgrad_compute_for_te_grouped_gemm`` is enabled on a TransformerLayer,
+    this function:
+      1. Marks expert parameters so the normal post-accumulate-grad hook is skipped.
+      2. Registers a callback on the MoE layer that invokes FSDP's gradient
+         reduce-scatter after the delayed wgrad computation completes.
+
+    Args:
+        module: The module being processed in the forward pre-hook. Only
+            ``TransformerLayer`` instances with the delayed wgrad config flag
+            enabled are affected; all other modules are no-ops.
+        process_post_backward_gradients_fn: The FSDP gradient processing function
+            (``_process_post_backward_gradients``) to be called after the delayed
+            wgrad computation finishes.
+    """
+    from functools import partial
+
+    need_backward_dw = getattr(module, "need_backward_dw", lambda: False)
+    if not need_backward_dw():
+        return
+
+    for param in module.parameters():
+        if getattr(param, 'skip_backward_post_hook', False):
+            param.post_wgrad_grad_acc_hook = partial(grad_acc_func, [param])
+
+
 class MegatronFSDP(torch.nn.Module):
     """Fully Sharded Data Parallel training.
 
@@ -728,6 +756,7 @@ class MegatronFSDP(torch.nn.Module):
                 prefetch=fsdp_forward_prefetch,
                 prefetch_order=PrefetchOrder.FORWARD_PASS_ORDER,
             )
+
             return args, kwargs
 
         @torch.compiler.disable
@@ -983,6 +1012,8 @@ class MegatronFSDP(torch.nn.Module):
 
         fsdp_modules = []
         for name, module in root_module.named_modules():
+            # Set post backward hook for TE grouped gemm if enabled comm overlap
+            setup_delayed_wgrad_acc_hook(module, _process_post_backward_gradients)
             if self.enable_fine_grained_param_gather_hook:
                 _register_pre_forward_param_unshard_hook(module)
                 _register_pre_backward_param_unshard_hook(module)
@@ -1038,7 +1069,11 @@ class MegatronFSDP(torch.nn.Module):
             for param in grad_acc_param_list:
                 self.grad_acc_hooks[f"grad_acc and reduce for {self.param_to_name[param]}"] = (
                     param.register_post_accumulate_grad_hook(
-                        lambda p: _process_post_backward_gradients([p])
+                        lambda p: (
+                            None
+                            if getattr(p, 'skip_backward_post_hook', False)
+                            else _process_post_backward_gradients([p])
+                        )
                     )
                 )
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -690,6 +690,20 @@ class MegatronFSDP(torch.nn.Module):
             """
             # Filter out shared parameters whose gradients are handled by the root hook.
             param_list = [p for p in param_list if not getattr(p, "_is_shared", False)]
+
+            # Filter out parameters whose gradient processing is deferred to a delayed
+            # wgrad accumulation hook (post_wgrad_grad_acc_hook).  If skip_backward_post_hook
+            # is set but the delayed hook was never installed, process the parameter
+            # immediately as a safety fallback to avoid silently dropping gradients.
+            param_list = [
+                p for p in param_list
+                if not getattr(p, 'skip_backward_post_hook', False)
+                or not hasattr(p, 'post_wgrad_grad_acc_hook')
+            ]
+
+            if not param_list:
+                return
+
             for param in param_list:
                 _grad_acc(param)
 
@@ -1069,11 +1083,7 @@ class MegatronFSDP(torch.nn.Module):
             for param in grad_acc_param_list:
                 self.grad_acc_hooks[f"grad_acc and reduce for {self.param_to_name[param]}"] = (
                     param.register_post_accumulate_grad_hook(
-                        lambda p: (
-                            None
-                            if getattr(p, 'skip_backward_post_hook', False)
-                            else _process_post_backward_gradients([p])
-                        )
+                        lambda p: _process_post_backward_gradients([p])
                     )
                 )
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -2632,6 +2632,13 @@ class ParamAndGradBuffer:
                 if getattr(old_param, tp_attr, None) is not None:
                     setattr(new_param, tp_attr, getattr(old_param, tp_attr))
 
+            # For FSDP with delayed_wgrad_compute, `skip_backward_post_hook` needs
+            # to be reset on new param for correct grad accumulation of wgrad computation.
+            setattr(
+                new_param,
+                'skip_backward_post_hook',
+                getattr(old_param, 'skip_backward_post_hook', False),
+            )
         for item_id, p in enumerate(self.params):
             if p in param_map:
                 new_p = param_map[p]

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1709,7 +1709,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
             extra_kwargs = _get_extra_te_kwargs(config)
             self.delay_wgrad_compute = (
                 self.config.delay_wgrad_compute
-                or self.config.delay_wgrad_compute_for_te_grouped_gemm
+                or self.config.overlap_dispatch_backward_with_experts_wgrad
             )
 
             if self.delay_wgrad_compute:

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1707,10 +1707,14 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
             self.disable_parameter_transpose_cache = self.config.disable_parameter_transpose_cache
 
             extra_kwargs = _get_extra_te_kwargs(config)
+            self.delay_wgrad_compute = (
+                self.config.delay_wgrad_compute
+                or self.config.delay_wgrad_compute_for_te_grouped_gemm
+            )
 
-            if self.config.delay_wgrad_compute:
+            if self.delay_wgrad_compute:
                 if is_te_min_version("2.3.0"):
-                    extra_kwargs["delay_wgrad_compute"] = self.config.delay_wgrad_compute
+                    extra_kwargs["delay_wgrad_compute"] = True
                 else:
                     raise RuntimeError(
                         "Only TE with version >=2.3.0 supports delay_wgrad_compute now."
@@ -2040,7 +2044,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
             Compute weight gradients during the backward pass
             if delay_wgrad_compute is enabled.
             """
-            if self.config.delay_wgrad_compute:
+            if self.delay_wgrad_compute:
                 super().backward_dw()
 
     class TEColumnParallelGroupedLinear(TEGroupedLinear):

--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -261,7 +261,7 @@ class ModelParallelConfig:
     delay_wgrad_compute: bool = False
     """Delay the weight gradient computation to improve batch-level communication overlapping"""
 
-    delay_wgrad_compute_for_te_grouped_gemm: bool = False
+    overlap_dispatch_backward_with_experts_wgrad: bool = False
     """Delay the weight gradient computation for TE Grouped GEMM MoE experts.
     When enabled with FSDP, the expert weight gradients are computed on a separate
     CUDA stream after the data gradients finish, allowing overlap of wgrad compute

--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -261,6 +261,15 @@ class ModelParallelConfig:
     delay_wgrad_compute: bool = False
     """Delay the weight gradient computation to improve batch-level communication overlapping"""
 
+    delay_wgrad_compute_for_te_grouped_gemm: bool = False
+    """Delay the weight gradient computation for TE Grouped GEMM MoE experts.
+    When enabled with FSDP, the expert weight gradients are computed on a separate
+    CUDA stream after the data gradients finish, allowing overlap of wgrad compute
+    with EP A2A communication. The FSDP gradient reduce-scatter for
+    expert parameters is deferred until the delayed wgrad computation completes.
+    This requires transformer_engine with GroupedLinear support (TE >= 2.3.0).
+    """
+
     ep_overlap_early_attn_memory_release: bool = False
     """Enable early memory release of attention activations during EP overlap.
     EP overlap can increase peak memory usage when the overlapped forward module allocates 

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -374,7 +374,7 @@ class MoELayer(BaseMoELayer):
         """
         self._delayed_wgrad_event: Optional[torch.cuda.Event] = None
         self._delayed_wgrad_stream: Optional[torch.cuda.Stream] = None
-        if self.config.delay_wgrad_compute_for_te_grouped_gemm:
+        if self.config.overlap_dispatch_backward_with_experts_wgrad:
             self._delayed_wgrad_event = torch.cuda.Event()
             self._delayed_wgrad_stream = torch.cuda.Stream(device="cuda")
 
@@ -448,7 +448,7 @@ class MoELayer(BaseMoELayer):
         tokens and their associated probabilities to the devices hosting their assigned
         experts.
         """
-        if self.config.delay_wgrad_compute_for_te_grouped_gemm:
+        if self.config.overlap_dispatch_backward_with_experts_wgrad:
             hidden_states = _RegisterDelayedWgradForExperts.apply(self, hidden_states)
         return self.token_dispatcher.token_dispatch(hidden_states, probs)
 
@@ -488,7 +488,7 @@ class MoELayer(BaseMoELayer):
         for each expert. It then passes the tokens through the local experts.
         The output from the experts is preprocessed for the combine step.
         """
-        if self.config.delay_wgrad_compute_for_te_grouped_gemm:
+        if self.config.overlap_dispatch_backward_with_experts_wgrad:
             hidden_states = _RecordExpertDgradCompletion.apply(
                 self._delayed_wgrad_event, hidden_states
             )

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -637,24 +637,24 @@ class MoELayer(BaseMoELayer):
 
     def backward_dw(self, routed_experts: bool = True, shared_experts: bool = False):
         """Compute weight gradients for experts and shared experts."""
+        from megatron.core.pipeline_parallel.utils import get_comm_stream
+
         # TODO(Wohox): replace the "routed_experts" and "shared_experts" arguments with better
         # naming to better explain that they are actually from different fine-grained callables,
         # or use scanning to decide which backward_dw should be called.
         if routed_experts:
             self.experts.backward_dw()
-            if self.config.moe_latent_size:
+            if self.config.moe_latent_size and self.config.overlap_moe_expert_parallel_comm:
                 # TODO(Wohox): fc2_latent_proj forward and backward are executed in comm stream,
                 # so we execute its backward_dw in the comm stream too. But this may harm the
                 # EP overlap performance. Better to check if there is a better way to handle this.
-                from megatron.core.pipeline_parallel.utils import get_comm_stream
-
                 comm_stream = get_comm_stream()
                 with torch.cuda.stream(comm_stream):
                     self.fc2_latent_proj.backward_dw()
         if shared_experts:
             if self.use_shared_expert and not self.shared_expert_overlap:
                 self.shared_experts.backward_dw()
-            if self.config.moe_latent_size:
+            if self.config.moe_latent_size and self.config.overlap_moe_expert_parallel_comm:
                 self.fc1_latent_proj.backward_dw()
 
     def set_for_recompute_pre_mlp_layernorm(self):

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -345,6 +345,9 @@ class MoELayer(BaseMoELayer):
         self.cudagraph_tensor_store = MoECudaGraphTensorStore()
         self.fwd_execution_map = ["route", "expert_compute", "postprocess"]
 
+        # Setup events and streams for delayed wgrad computation.
+        self.setup_delayed_wgrad_for_dispatch_backward_overlap()
+
     def _setup_inference_mode(self, pg_collection):
         """Set up inference-optimized token dispatcher and state.
 
@@ -364,6 +367,17 @@ class MoELayer(BaseMoELayer):
             config=self.config,
             pg_collection=pg_collection,
         )
+
+    def setup_delayed_wgrad_for_dispatch_backward_overlap(self):
+        """Initializes CUDA events and streams for overlapping expert
+        weight gradient computation with dispatch backward.
+        """
+        self._delayed_wgrad_event: Optional[torch.cuda.Event] = None
+        self._delayed_wgrad_stream: Optional[torch.cuda.Stream] = None
+        self._process_expert_grads_fn = None
+        if self.config.delay_wgrad_compute_for_te_grouped_gemm:
+            self._delayed_wgrad_event = torch.cuda.Event()
+            self._delayed_wgrad_stream = torch.cuda.Stream(device="cuda")
 
     def set_inference_cuda_graphed_iteration(self):
         """Enable CUDA-graphed iteration mode on this layer, its router, and its experts.
@@ -435,6 +449,8 @@ class MoELayer(BaseMoELayer):
         tokens and their associated probabilities to the devices hosting their assigned
         experts.
         """
+        if self.config.delay_wgrad_compute_for_te_grouped_gemm:
+            hidden_states = _RegisterDelayedWgradForExperts.apply(self, hidden_states)
         return self.token_dispatcher.token_dispatch(hidden_states, probs)
 
     @maybe_skip_or_early_return_by_cudagraph("shared_experts_compute")
@@ -473,6 +489,10 @@ class MoELayer(BaseMoELayer):
         for each expert. It then passes the tokens through the local experts.
         The output from the experts is preprocessed for the combine step.
         """
+        if self.config.delay_wgrad_compute_for_te_grouped_gemm:
+            hidden_states = _RecordExpertDgradCompletion.apply(
+                self._delayed_wgrad_event, hidden_states
+            )
         dispatched_input, tokens_per_expert, permuted_probs = (
             self.token_dispatcher.dispatch_postprocess(hidden_states, probs)
         )
@@ -646,3 +666,66 @@ class MoELayer(BaseMoELayer):
             from megatron.core.extensions.transformer_engine import set_save_original_input
 
             set_save_original_input(self.shared_experts.linear_fc1)
+
+
+class _RecordExpertDgradCompletion(torch.autograd.Function):
+    """Autograd function that records a CUDA event when expert data gradients finish.
+
+    Placed in the forward graph just before the expert computation so that during
+    the backward pass, when the expert dgrad completes, we record an event. The
+    subsequent ``_RegisterDelayedWgradForExperts`` waits on this event before
+    launching the delayed wgrad computation on a separate CUDA stream.
+    """
+
+    @staticmethod
+    def forward(ctx, event: torch.cuda.Event, *inputs):
+        """Forward pass that stores the event and passes through inputs unchanged."""
+        ctx.event = event
+        return inputs[0] if len(inputs) == 1 else inputs
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        """Backward pass that records the event when expert dgrad completes."""
+        ctx.event.record(torch.cuda.current_stream())
+        ctx.event = None
+        return (None,) + grad_outputs
+
+
+class _RegisterDelayedWgradForExperts(torch.autograd.Function):
+    """Autograd function that orchestrates delayed wgrad computation for MoE experts.
+
+    Placed in the forward graph at the dispatch boundary. During the backward pass,
+    this function:
+      1. Records an event on the current (backward) stream to signal the dgrad is done.
+      2. Executes the delayed wgrad computation on a dedicated CUDA stream.
+      3. Waits for the wgrad computation to complete.
+      4. Invokes the registered gradient processing callback (e.g., FSDP reduce-scatter).
+    """
+
+    @staticmethod
+    def forward(ctx, module: MoELayer, *inputs):
+        """Forward pass that stores the MoE module and passes through inputs unchanged."""
+        ctx.module = module
+        return inputs[0] if len(inputs) == 1 else inputs
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        """Backward pass that executes delayed wgrad computation on a separate stream."""
+        module = ctx.module
+        event = module._delayed_wgrad_event
+        wgrad_stream = module._delayed_wgrad_stream
+
+        wgrad_stream.wait_event(event)
+        with torch.cuda.stream(wgrad_stream):
+            with torch.cuda.nvtx.range("delayed_expert_wgrad"):
+                module.backward_dw(routed_experts=True, shared_experts=False)
+            event.record(wgrad_stream)
+
+        torch.cuda.current_stream().wait_event(event)
+
+        for param in module.parameters():
+            if getattr(param, "post_wgrad_grad_acc_hook", None) is not None:
+                param.post_wgrad_grad_acc_hook()
+
+        ctx.module = None
+        return (None,) + grad_outputs

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -374,7 +374,6 @@ class MoELayer(BaseMoELayer):
         """
         self._delayed_wgrad_event: Optional[torch.cuda.Event] = None
         self._delayed_wgrad_stream: Optional[torch.cuda.Stream] = None
-        self._process_expert_grads_fn = None
         if self.config.delay_wgrad_compute_for_te_grouped_gemm:
             self._delayed_wgrad_event = torch.cuda.Event()
             self._delayed_wgrad_stream = torch.cuda.Stream(device="cuda")

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2149,10 +2149,6 @@ class TransformerConfig(ModelParallelConfig):
                 )
 
         if self.delay_wgrad_compute_for_te_grouped_gemm:
-            assert self.moe_latent_size is None, (
-                'moe_latent_size must be disabled when enabling '
-                'delay_wgrad_compute_for_te_grouped_gemm.'
-            )
             assert not self.overlap_moe_expert_parallel_comm, (
                 'overlap_moe_expert_parallel_comm must be disabled when enabling '
                 'delay_wgrad_compute_for_te_grouped_gemm.'

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2157,10 +2157,6 @@ class TransformerConfig(ModelParallelConfig):
                 'overlap_moe_expert_parallel_comm must be disabled when enabling '
                 'delay_wgrad_compute_for_te_grouped_gemm.'
             )
-            assert not self.moe_use_legacy_grouped_gemm, (
-                'delay_wgrad_compute_for_te_grouped_gemm is not supported with '
-                'legacy grouped gemm implementation'
-            )
             assert is_te_min_version(
                 "2.3.0"
             ), 'TE version >= 2.3.0 is required for delay_wgrad_compute_for_te_grouped_gemm'

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2148,16 +2148,16 @@ class TransformerConfig(ModelParallelConfig):
                     'partial cuda graph'
                 )
 
-        if self.delay_wgrad_compute_for_te_grouped_gemm:
+        if self.overlap_dispatch_backward_with_experts_wgrad:
             assert not self.overlap_moe_expert_parallel_comm, (
                 'overlap_moe_expert_parallel_comm must be disabled when enabling '
-                'delay_wgrad_compute_for_te_grouped_gemm.'
+                'overlap_dispatch_backward_with_experts_wgrad.'
             )
             assert is_te_min_version(
                 "2.3.0"
-            ), 'TE version >= 2.3.0 is required for delay_wgrad_compute_for_te_grouped_gemm'
+            ), 'TE version >= 2.3.0 is required for overlap_dispatch_backward_with_experts_wgrad'
             assert not self.delay_wgrad_compute, (
-                'delay_wgrad_compute and delay_wgrad_compute_for_te_grouped_gemm '
+                'delay_wgrad_compute and overlap_dispatch_backward_with_experts_wgrad '
                 'are mutually exclusive; use only one'
             )
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2148,6 +2148,27 @@ class TransformerConfig(ModelParallelConfig):
                     'partial cuda graph'
                 )
 
+        if self.delay_wgrad_compute_for_te_grouped_gemm:
+            assert self.moe_latent_size is None, (
+                'moe_latent_size must be disabled when enabling '
+                'delay_wgrad_compute_for_te_grouped_gemm.'
+            )
+            assert not self.overlap_moe_expert_parallel_comm, (
+                'overlap_moe_expert_parallel_comm must be disabled when enabling '
+                'delay_wgrad_compute_for_te_grouped_gemm.'
+            )
+            assert not self.moe_use_legacy_grouped_gemm, (
+                'delay_wgrad_compute_for_te_grouped_gemm is not supported with '
+                'legacy grouped gemm implementation'
+            )
+            assert is_te_min_version(
+                "2.3.0"
+            ), 'TE version >= 2.3.0 is required for delay_wgrad_compute_for_te_grouped_gemm'
+            assert not self.delay_wgrad_compute, (
+                'delay_wgrad_compute and delay_wgrad_compute_for_te_grouped_gemm '
+                'are mutually exclusive; use only one'
+            )
+
         if self.ep_overlap_early_attn_memory_release:
             assert self.overlap_moe_expert_parallel_comm, (
                 'overlap_moe_expert_parallel_comm must be enabled when enabling '

--- a/tests/unit_tests/a2a_overlap/test_cuda_graphed_schedule_chunk_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_cuda_graphed_schedule_chunk_1f1b.py
@@ -347,7 +347,6 @@ class TestPartialCudaGraphedA2AOverlap:
                 pytest.skip("Deep EP is not available")
             extra_kwargs["moe_token_dispatcher_type"] = "flex"
             extra_kwargs["moe_flex_dispatcher_backend"] = "deepep"
-            extra_kwargs["moe_router_dtype"] = "fp32"
         elif moe_dispatcher_type == "hybridep":
             if not is_hybrid_ep_available():
                 pytest.skip("Hybrid EP is not available")

--- a/tests/unit_tests/a2a_overlap/test_cuda_graphed_schedule_chunk_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_cuda_graphed_schedule_chunk_1f1b.py
@@ -347,6 +347,7 @@ class TestPartialCudaGraphedA2AOverlap:
                 pytest.skip("Deep EP is not available")
             extra_kwargs["moe_token_dispatcher_type"] = "flex"
             extra_kwargs["moe_flex_dispatcher_backend"] = "deepep"
+            extra_kwargs["moe_router_dtype"] = "fp32"
         elif moe_dispatcher_type == "hybridep":
             if not is_hybrid_ep_available():
                 pytest.skip("Hybrid EP is not available")

--- a/tests/unit_tests/a2a_overlap/test_delay_wgrad_compute.py
+++ b/tests/unit_tests/a2a_overlap/test_delay_wgrad_compute.py
@@ -153,9 +153,19 @@ class TestDelayWgradCompute:
         This test checks that the deferred reduce-scatter produces identical
         per-step loss and final weights as the non-delayed FSDP baseline.
         """
+        from torch.distributed import DeviceMesh
+
+        from megatron.core import parallel_state
         from megatron.core.distributed.fsdp.src.megatron_fsdp.fully_shard import (
             fully_shard_model,
             fully_shard_optimizer,
+        )
+
+        # Build expert device mesh required by MegatronFSDP for expert parallelism.
+        expt_dp_group = parallel_state.get_expert_data_parallel_group()
+        expt_dp_ranks = torch.distributed.get_process_group_ranks(expt_dp_group)
+        expt_device_mesh = DeviceMesh.from_group(
+            expt_dp_group, device_type="cuda", mesh=expt_dp_ranks, mesh_dim_names=("fsdp",)
         )
 
         num_layers = 4
@@ -171,7 +181,11 @@ class TestDelayWgradCompute:
             ref_model = _build_gpt_model(ref_config)
             init_params = reset_model(ref_model)
 
-            ref_fsdp = fully_shard_model(module=ref_model, fsdp_unit_modules=[TransformerLayer])
+            ref_fsdp = fully_shard_model(
+                module=ref_model,
+                fsdp_unit_modules=[TransformerLayer],
+                expt_device_mesh=expt_device_mesh,
+            )
             ref_opt = torch.optim.SGD(ref_fsdp.parameters(), lr=LR)
             ref_opt = fully_shard_optimizer(optimizer=ref_opt)
 
@@ -181,7 +195,11 @@ class TestDelayWgradCompute:
             test_model = _build_gpt_model(test_config)
             reset_model(test_model, init_params)
 
-            test_fsdp = fully_shard_model(module=test_model, fsdp_unit_modules=[TransformerLayer])
+            test_fsdp = fully_shard_model(
+                module=test_model,
+                fsdp_unit_modules=[TransformerLayer],
+                expt_device_mesh=expt_device_mesh,
+            )
             test_opt = torch.optim.SGD(test_fsdp.parameters(), lr=LR)
             test_opt = fully_shard_optimizer(optimizer=test_opt)
 

--- a/tests/unit_tests/a2a_overlap/test_delay_wgrad_compute.py
+++ b/tests/unit_tests/a2a_overlap/test_delay_wgrad_compute.py
@@ -72,7 +72,7 @@ def _assert_models_equal(ref_model, test_model):
 
 
 class TestDelayWgradCompute:
-    """Verify that delay_wgrad_compute_for_te_grouped_gemm produces identical
+    """Verify that overlap_dispatch_backward_with_experts_wgrad produces identical
     training behaviour (per-step loss and final weights) as the non-delayed baseline
     across multiple forward-backward-optimizer steps on the full GPTModel.
     """
@@ -91,10 +91,10 @@ class TestDelayWgradCompute:
     @pytest.mark.parametrize("shared_expert_intermediate_size", [None, 512])
     @pytest.mark.parametrize("dispatcher_type", get_valid_token_dispatcher_types())
     @pytest.mark.parametrize("fp8_flag", get_valid_fp8_flags())
-    def test_delay_wgrad_compute_for_te_grouped_gemm(
+    def test_overlap_dispatch_backward_with_experts_wgrad(
         self, shared_expert_intermediate_size, dispatcher_type, fp8_flag
     ):
-        """Verify that delay_wgrad_compute_for_te_grouped_gemm produces identical
+        """Verify that overlap_dispatch_backward_with_experts_wgrad produces identical
         per-step loss and final weights as the non-delayed baseline across multiple
         forward-backward-optimizer steps on the full GPTModel.
 
@@ -116,7 +116,7 @@ class TestDelayWgradCompute:
             ref_model = _build_gpt_model(ref_config)
             init_params = reset_model(ref_model)
 
-            delay_kwargs = {**extra_kwargs, "delay_wgrad_compute_for_te_grouped_gemm": True}
+            delay_kwargs = {**extra_kwargs, "overlap_dispatch_backward_with_experts_wgrad": True}
             test_config = get_test_config(num_layers=num_layers, extra_kwargs=delay_kwargs)
             test_model = _build_gpt_model(test_config)
             reset_model(test_model, init_params)
@@ -143,7 +143,7 @@ class TestDelayWgradCompute:
     @pytest.mark.skipif(not is_te_min_version("2.3.0"), reason="Requires TE >= 2.3.0")
     @pytest.mark.parametrize("shared_expert_intermediate_size", [None, 512])
     @pytest.mark.parametrize("dispatcher_type", get_valid_token_dispatcher_types())
-    def test_delay_wgrad_compute_for_te_grouped_gemm_with_fsdp(
+    def test_overlap_dispatch_backward_with_experts_wgrad_with_fsdp(
         self, shared_expert_intermediate_size, dispatcher_type
     ):
         """Verify delayed wgrad with MegatronFSDP wrapping.
@@ -176,7 +176,7 @@ class TestDelayWgradCompute:
             ref_opt = fully_shard_optimizer(optimizer=ref_opt)
 
             # Build test model (with delay) and wrap with FSDP
-            delay_kwargs = {**extra_kwargs, "delay_wgrad_compute_for_te_grouped_gemm": True}
+            delay_kwargs = {**extra_kwargs, "overlap_dispatch_backward_with_experts_wgrad": True}
             test_config = get_test_config(num_layers=num_layers, extra_kwargs=delay_kwargs)
             test_model = _build_gpt_model(test_config)
             reset_model(test_model, init_params)

--- a/tests/unit_tests/a2a_overlap/test_delay_wgrad_compute.py
+++ b/tests/unit_tests/a2a_overlap/test_delay_wgrad_compute.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+import gc
+
+import pytest
+import torch
+
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.transformer import TransformerLayer
+from megatron.core.transformer.module import float16_to_fp32
+from megatron.core.utils import is_te_min_version
+from tests.unit_tests.a2a_overlap.utils import (
+    deterministic_mode,
+    get_test_config,
+    get_valid_flex_dispatcher_backend,
+    get_valid_fp8_flags,
+    get_valid_token_dispatcher_types,
+    reset_model,
+)
+from tests.unit_tests.test_utilities import Utils
+
+NUM_STEPS = 3
+SEQ_LEN = 128
+VOCAB_SIZE = 512
+LR = 0.01
+
+
+def _build_gpt_model(config):
+    """Build and return a GPTModel on CUDA from the given config."""
+    layer_spec = get_gpt_decoder_block_spec(config=config, use_transformer_engine=True)
+    model = GPTModel(
+        config=config,
+        transformer_layer_spec=layer_spec,
+        vocab_size=VOCAB_SIZE,
+        pre_process=True,
+        post_process=True,
+        max_sequence_length=300,
+    )
+    model.cuda()
+    return model
+
+
+def _build_input_data():
+    """Build fixed input data for the model."""
+    return {
+        "input_ids": torch.randint(0, VOCAB_SIZE, (1, SEQ_LEN), dtype=torch.int64).cuda(),
+        "labels": torch.randint(0, VOCAB_SIZE, (1, SEQ_LEN), dtype=torch.int64).cuda(),
+        "position_ids": torch.arange(SEQ_LEN, dtype=torch.int64).unsqueeze(0).cuda(),
+        "attention_mask": torch.ones((1, 1, SEQ_LEN, SEQ_LEN), dtype=bool).cuda(),
+    }
+
+
+def _train_step(model, optimizer, data):
+    """Run one forward-backward-optimizer step. Return the detached loss."""
+    optimizer.zero_grad()
+    loss = model.forward(**data)
+    loss = float16_to_fp32(loss)
+    loss.backward(torch.ones_like(loss))
+    optimizer.step()
+    return loss.detach().clone()
+
+
+def _assert_models_equal(ref_model, test_model):
+    """Assert that all parameters of two models are bit-identical."""
+    rank = torch.distributed.get_rank()
+    for (name_r, param_r), (_, param_t) in zip(
+        ref_model.named_parameters(), test_model.named_parameters()
+    ):
+        assert torch.equal(
+            param_r.data, param_t.data
+        ), f"[rank {rank}] Parameter mismatch after training: {name_r}"
+
+
+class TestDelayWgradCompute:
+    """Verify that delay_wgrad_compute_for_te_grouped_gemm produces identical
+    training behaviour (per-step loss and final weights) as the non-delayed baseline
+    across multiple forward-backward-optimizer steps on the full GPTModel.
+    """
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=4,
+        )
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(not is_te_min_version("2.3.0"), reason="Requires TE >= 2.3.0")
+    @pytest.mark.parametrize("shared_expert_intermediate_size", [None, 512])
+    @pytest.mark.parametrize("dispatcher_type", get_valid_token_dispatcher_types())
+    @pytest.mark.parametrize("fp8_flag", get_valid_fp8_flags())
+    def test_delay_wgrad_compute_for_te_grouped_gemm(
+        self, shared_expert_intermediate_size, dispatcher_type, fp8_flag
+    ):
+        """Verify that delay_wgrad_compute_for_te_grouped_gemm produces identical
+        per-step loss and final weights as the non-delayed baseline across multiple
+        forward-backward-optimizer steps on the full GPTModel.
+
+        Covers single/multi-layer, with/without shared experts, dispatcher types,
+        and FP8 modes.
+        """
+        num_layers = 4
+        extra_kwargs = {"moe_token_dispatcher_type": dispatcher_type}
+        if dispatcher_type == "flex":
+            extra_kwargs["moe_flex_dispatcher_backend"] = get_valid_flex_dispatcher_backend()
+        if fp8_flag is not None:
+            extra_kwargs["fp8"] = fp8_flag[0]
+            extra_kwargs["fp8_recipe"] = fp8_flag[1]
+        if shared_expert_intermediate_size is not None:
+            extra_kwargs["moe_shared_expert_intermediate_size"] = shared_expert_intermediate_size
+
+        with deterministic_mode():
+            ref_config = get_test_config(num_layers=num_layers, extra_kwargs=extra_kwargs)
+            ref_model = _build_gpt_model(ref_config)
+            init_params = reset_model(ref_model)
+
+            delay_kwargs = {**extra_kwargs, "delay_wgrad_compute_for_te_grouped_gemm": True}
+            test_config = get_test_config(num_layers=num_layers, extra_kwargs=delay_kwargs)
+            test_model = _build_gpt_model(test_config)
+            reset_model(test_model, init_params)
+
+            data = _build_input_data()
+            ref_opt = torch.optim.SGD(ref_model.parameters(), lr=LR)
+            test_opt = torch.optim.SGD(test_model.parameters(), lr=LR)
+
+            rank = torch.distributed.get_rank()
+            for step in range(NUM_STEPS):
+                ref_loss = _train_step(ref_model, ref_opt, data)
+                test_loss = _train_step(test_model, test_opt, data)
+                assert torch.equal(ref_loss, test_loss), (
+                    f"[rank {rank}] Loss mismatch at step {step}: "
+                    f"ref={ref_loss.item()}, test={test_loss.item()}"
+                )
+
+            _assert_models_equal(ref_model, test_model)
+
+            del ref_model, test_model
+            gc.collect()
+            torch.cuda.empty_cache()
+
+    @pytest.mark.skipif(not is_te_min_version("2.3.0"), reason="Requires TE >= 2.3.0")
+    @pytest.mark.parametrize("shared_expert_intermediate_size", [None, 512])
+    @pytest.mark.parametrize("dispatcher_type", get_valid_token_dispatcher_types())
+    def test_delay_wgrad_compute_for_te_grouped_gemm_with_fsdp(
+        self, shared_expert_intermediate_size, dispatcher_type
+    ):
+        """Verify delayed wgrad with MegatronFSDP wrapping.
+
+        The delayed wgrad path defers the FSDP reduce-scatter for expert
+        parameters until the wgrad computation completes on a separate stream.
+        This test checks that the deferred reduce-scatter produces identical
+        per-step loss and final weights as the non-delayed FSDP baseline.
+        """
+        from megatron.core.distributed.fsdp.src.megatron_fsdp.fully_shard import (
+            fully_shard_model,
+            fully_shard_optimizer,
+        )
+
+        num_layers = 4
+        extra_kwargs = {"moe_token_dispatcher_type": dispatcher_type}
+        if dispatcher_type == "flex":
+            extra_kwargs["moe_flex_dispatcher_backend"] = get_valid_flex_dispatcher_backend()
+        if shared_expert_intermediate_size is not None:
+            extra_kwargs["moe_shared_expert_intermediate_size"] = shared_expert_intermediate_size
+
+        with deterministic_mode():
+            # Build reference model (no delay) and wrap with FSDP
+            ref_config = get_test_config(num_layers=num_layers, extra_kwargs=extra_kwargs)
+            ref_model = _build_gpt_model(ref_config)
+            init_params = reset_model(ref_model)
+
+            ref_fsdp = fully_shard_model(module=ref_model, fsdp_unit_modules=[TransformerLayer])
+            ref_opt = torch.optim.SGD(ref_fsdp.parameters(), lr=LR)
+            ref_opt = fully_shard_optimizer(optimizer=ref_opt)
+
+            # Build test model (with delay) and wrap with FSDP
+            delay_kwargs = {**extra_kwargs, "delay_wgrad_compute_for_te_grouped_gemm": True}
+            test_config = get_test_config(num_layers=num_layers, extra_kwargs=delay_kwargs)
+            test_model = _build_gpt_model(test_config)
+            reset_model(test_model, init_params)
+
+            test_fsdp = fully_shard_model(module=test_model, fsdp_unit_modules=[TransformerLayer])
+            test_opt = torch.optim.SGD(test_fsdp.parameters(), lr=LR)
+            test_opt = fully_shard_optimizer(optimizer=test_opt)
+
+            data = _build_input_data()
+            rank = torch.distributed.get_rank()
+            for step in range(NUM_STEPS):
+                ref_loss = _train_step(ref_fsdp, ref_opt, data)
+                test_loss = _train_step(test_fsdp, test_opt, data)
+                assert torch.equal(ref_loss, test_loss), (
+                    f"[rank {rank}] Loss mismatch at step {step}: "
+                    f"ref={ref_loss.item()}, test={test_loss.item()}"
+                )
+
+            _assert_models_equal(ref_fsdp, test_fsdp)
+
+            del ref_fsdp, test_fsdp, ref_opt, test_opt
+            gc.collect()
+            torch.cuda.empty_cache()

--- a/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
@@ -103,7 +103,6 @@ class TestA2AOverlap:
         extra_kwargs = {"moe_token_dispatcher_type": dispatcher_type}
         if dispatcher_type == "flex":
             extra_kwargs["moe_flex_dispatcher_backend"] = "deepep"
-            extra_kwargs["moe_router_dtype"] = "fp32"
         if fp8_flag is not None:
             extra_kwargs["fp8"] = fp8_flag[0]
             extra_kwargs["fp8_recipe"] = fp8_flag[1]
@@ -215,7 +214,6 @@ class TestA2AOverlap:
         }
         if dispatcher_type == "flex":
             extra_kwargs["moe_flex_dispatcher_backend"] = "deepep"
-            extra_kwargs["moe_router_dtype"] = "fp32"
         with deterministic_mode():
             for layer_num in layers:
                 output_tensors = []

--- a/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
@@ -410,7 +410,6 @@ class TestA2AOverlap:
         extra_kwargs = {"moe_token_dispatcher_type": dispatcher_type}
         if dispatcher_type == "flex":
             extra_kwargs["moe_flex_dispatcher_backend"] = "deepep"
-            extra_kwargs["moe_router_dtype"] = "fp32"
         if fp8_flag is not None:
             extra_kwargs["fp8"] = fp8_flag[0]
             extra_kwargs["fp8_recipe"] = fp8_flag[1]
@@ -460,7 +459,6 @@ class TestA2AOverlap:
         }
         if dispatcher_type == "flex":
             extra_kwargs["moe_flex_dispatcher_backend"] = "deepep"
-            extra_kwargs["moe_router_dtype"] = "fp32"
         if fp8_flag is not None:
             extra_kwargs["fp8_recipe"] = fp8_flag[1]
             extra_kwargs["fp8"] = fp8_flag[0]

--- a/tests/unit_tests/a2a_overlap/utils.py
+++ b/tests/unit_tests/a2a_overlap/utils.py
@@ -216,33 +216,54 @@ def get_test_config(num_layers=1, num_moe_experts=8, extra_kwargs={}, moe_groupe
         multi_latent_attention=True,
         num_moe_experts=num_moe_experts,
         moe_grouped_gemm=moe_grouped_gemm,
+        moe_router_dtype="fp32",
         **extra_kwargs,
     )
     return config
 
 
 def get_valid_token_dispatcher_types():
-    try:
-        from deep_ep import Buffer
-        from deep_ep.utils import EventHandle, EventOverlap
+    from megatron.core.transformer.moe.fused_a2a import HAVE_DEEP_EP, HAVE_HYBRIDEP
 
+    if HAVE_HYBRIDEP or HAVE_DEEP_EP:
         return ["alltoall", "flex"]
-    except ImportError:
+    else:
         return ["alltoall"]
+
+
+def get_valid_flex_dispatcher_backend():
+    from megatron.core.transformer.moe.fused_a2a import HAVE_DEEP_EP, HAVE_HYBRIDEP
+
+    if HAVE_HYBRIDEP:
+        return "hybridep"
+    elif HAVE_DEEP_EP:
+        return "deepep"
+    else:
+        return None
 
 
 def get_valid_fp8_flags():
     from megatron.core.enums import Fp8Recipe
+    from megatron.training.utils import get_device_arch_version
 
     fp8_types = ["e4m3", "hybrid"]
     recipes = []
-    valid_flags = []
-    if is_te_min_version("2.3.0.dev0"):
-        recipes.append(Fp8Recipe.blockwise)
-        recipes.append(Fp8Recipe.tensorwise)
+    arch = get_device_arch_version()
 
+    if is_te_min_version("2.3.0.dev0"):
+        recipes.append(Fp8Recipe.tensorwise)  # Hopper + Blackwell
+
+    if is_te_min_version("2.4.0.dev0") and arch == 9:
+        recipes.append(Fp8Recipe.blockwise)  # Hopper only
+
+    if is_te_min_version("2.3.0.dev0") and arch >= 10:
+        recipes.append(Fp8Recipe.mxfp8)  # Blackwell only
+
+    valid_flags = []
     for fp8_type in fp8_types:
         for recipe in recipes:
+            if fp8_type == "hybrid" and recipe == Fp8Recipe.mxfp8:
+                continue
             valid_flags.append((fp8_type, recipe))
     valid_flags.append(None)
 

--- a/tests/unit_tests/models/test_mamba_moe_model.py
+++ b/tests/unit_tests/models/test_mamba_moe_model.py
@@ -75,7 +75,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "deallocate_pipeline_outputs": True,
     "defer_embedding_wgrad_compute": False,
     "delay_wgrad_compute": False,
-    "delay_wgrad_compute_for_te_grouped_gemm": False,
+    "overlap_dispatch_backward_with_experts_wgrad": False,
     "deterministic_mode": False,
     "disable_bf16_reduced_precision_matmul": False,
     "disable_parameter_transpose_cache": False,

--- a/tests/unit_tests/models/test_mamba_moe_model.py
+++ b/tests/unit_tests/models/test_mamba_moe_model.py
@@ -75,6 +75,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "deallocate_pipeline_outputs": True,
     "defer_embedding_wgrad_compute": False,
     "delay_wgrad_compute": False,
+    "delay_wgrad_compute_for_te_grouped_gemm": False,
     "deterministic_mode": False,
     "disable_bf16_reduced_precision_matmul": False,
     "disable_parameter_transpose_cache": False,

--- a/tests/unit_tests/transformer/test_submodule_callables.py
+++ b/tests/unit_tests/transformer/test_submodule_callables.py
@@ -138,7 +138,6 @@ class TestTransformerLayerSubmoduleCallables:
         }
         if dispatcher_type == "flex":
             extra_kwargs["moe_flex_dispatcher_backend"] = "deepep"
-            extra_kwargs["moe_router_dtype"] = "fp32"
         config = get_test_config(extra_kwargs=extra_kwargs, moe_grouped_gemm=grouped_gemm)
         microbatches = 4
         with deterministic_mode():


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->
PR for dev: https://github.com/NVIDIA/Megatron-LM/pull/3766
### Problem

In MoE models, the expert weight gradient (wgrad) computation during backward is serialized on the main CUDA stream. This blocks the data gradient (dgrad) from flowing to earlier layers until the expert wgrad finishes, even though there is no data dependency between them. The result is wasted GPU cycles — earlier layers' backward pass sits idle waiting for expert wgrad to complete.

With FSDP, this is further compounded because the gradient reduce-scatter for expert parameters is also blocked on the same critical path.

### Solution

This PR introduces a new flag `--delay-wgrad-compute-for-te-grouped-gemm` that separates the expert wgrad computation from the main backward stream:

1. **Two autograd functions** are inserted into the MoE layer's forward graph:
   - `_RecordExpertDgradCompletion` — placed before the expert computation; during backward, it records a CUDA event once the expert dgrad is done.
   - `_RegisterDelayedWgradForExperts` — placed at the dispatch boundary; during backward, it waits on the dgrad event, then launches `backward_dw()` on a **dedicated CUDA stream**, and synchronizes back to the main stream before proceeding.

2. **FSDP integration** — When used with MegatronFSDP, expert parameters are marked with `_fsdp_delay_grad_reduce = True` so the normal post-accumulate-grad hook skips them. A callback is registered via `register_process_expert_grads_fn()` that triggers the FSDP reduce-scatter for expert parameters only after the delayed wgrad computation completes.

3. **TE GroupedLinear** is configured with `delay_wgrad_compute=True`, which tells Transformer Engine to skip wgrad during the normal autograd backward and instead wait for an explicit `backward_dw()` call.

### How to enable

```bash
--delay-wgrad-compute-for-te-grouped-gemm
```

**Requirements:**
- Transformer Engine >= 2.3.0
- `moe_grouped_gemm` enabled (not legacy grouped gemm)
- Mutually exclusive with `--delay-wgrad-compute` (the existing A2A-overlap-based delay)
- Mutually exclusive with `--overlap-moe-expert-parallel-comm`

Works with both **FSDP** and **3-D parallelism** (TP/EP/PP).

### What is achieved

The expert wgrad computation runs on a separate CUDA stream, overlapping with the EP communication within the same transformer layer. This reduces the wall-clock time of the backward pass without changing numerical results — the feature is **bit-exact** with the non-delayed baseline (verified by unit tests comparing per-step losses and final weights over multiple optimizer steps).

### Changes

| File | Description |
|------|-------------|
| `megatron/core/model_parallel_config.py` | New config flag `delay_wgrad_compute_for_te_grouped_gemm` |
| `megatron/core/transformer/transformer_config.py` | Validation assertions for the new flag |
| `megatron/core/transformer/moe/moe_layer.py` | Autograd functions for delayed wgrad + dedicated CUDA stream/event + `register_process_expert_grads_fn` callback |
| `megatron/core/extensions/transformer_engine.py` | Pass `delay_wgrad_compute=True` to TE GroupedLinear when the new flag is set |
| `megatron/core/distributed/fsdp/.../megatron_fsdp.py` | FSDP hook to defer reduce-scatter for expert params and trigger it after delayed wgrad |
| `tests/unit_tests/a2a_overlap/test_delay_wgrad_compute.py` | Unit tests covering basic, shared-expert, multi-layer, and FSDP scenarios |

### Test plan

- [x] Unit test: `test_delay_wgrad_compute_for_te_grouped_gemm` — full-model training loop (forward → backward → optimizer) comparing delayed vs. non-delayed across `num_layers × shared_experts × dispatcher_type × fp8_flag`
- [x] Unit test: `test_delay_wgrad_compute_for_te_grouped_gemm_with_fsdp` — same comparison with MegatronFSDP wrapping (`fully_shard_model` + `fully_shard_optimizer`), verifying the deferred reduce-scatter path

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
