### PR TITLE
[Dev] Support EP Overlap's Dynamic Computation Stream For Full-Iter CUDA Graph

### DIFF
--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -345,12 +345,6 @@ def set_streams(comm_stream=None):
         _COMM_STREAM = comm_stream
 
 
-def reset_streams():
-    """Reset all stream state. Intended for testing or reinitialisation."""
-    global _COMM_STREAM
-    _COMM_STREAM = None
-
-
 def get_comp_stream():
     """Get the stream for computation"""
     return torch.cuda.current_stream()

--- a/tests/unit_tests/a2a_overlap/test_cuda_graphed_schedule_chunk_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_cuda_graphed_schedule_chunk_1f1b.py
@@ -13,7 +13,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.num_microbatches_calculator import destroy_num_microbatches_calculator
-from megatron.core.pipeline_parallel.utils import reset_streams, set_streams
+from megatron.core.pipeline_parallel.utils import set_streams
 from megatron.core.tensor_parallel.random import HAVE_TE, model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.transformer.module import float16_to_fp32
@@ -68,7 +68,6 @@ class TestPartialCudaGraphedA2AOverlap:
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
-        reset_streams()
         Utils.destroy_model_parallel()
         destroy_global_vars()
         destroy_num_microbatches_calculator()

--- a/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
@@ -10,7 +10,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_mtp_block_spec,
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
-from megatron.core.pipeline_parallel.utils import reset_streams, set_streams
+from megatron.core.pipeline_parallel.utils import set_streams
 from megatron.core.transformer.module import float16_to_fp32
 from megatron.core.utils import is_te_min_version
 from tests.unit_tests.a2a_overlap.utils import (
@@ -80,7 +80,6 @@ class TestA2AOverlap:
         set_streams()
 
     def teardown_method(self, method):
-        reset_streams()
         Utils.destroy_model_parallel()
 
     @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")

--- a/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
@@ -12,12 +12,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_mtp_block_spec,
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
-from megatron.core.pipeline_parallel.utils import (
-    get_comm_stream,
-    get_comp_stream,
-    reset_streams,
-    set_streams,
-)
+from megatron.core.pipeline_parallel.utils import get_comm_stream, get_comp_stream, set_streams
 from megatron.core.utils import is_te_min_version
 from tests.unit_tests.a2a_overlap.utils import (
     DummyState,
@@ -259,7 +254,6 @@ class TestA2AOverlap:
         )
 
     def teardown_method(self, method):
-        reset_streams()
         Utils.destroy_model_parallel()
 
     @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -346,7 +346,7 @@ def test_fine_grained_activation_offload_with_ep_a2a_overlap_compatibility(
     from megatron.core.models.common.model_chunk_schedule_plan import (
         TransformerModelChunkSchedulePlan,
     )
-    from megatron.core.pipeline_parallel.utils import reset_streams, set_streams
+    from megatron.core.pipeline_parallel.utils import set_streams
     from tests.unit_tests.a2a_overlap.utils import deterministic_mode
 
     # EP overlap requires distributed initialization with EP groups.
@@ -570,5 +570,4 @@ def test_fine_grained_activation_offload_with_ep_a2a_overlap_compatibility(
                         f"(rel_err={rel_err:.2f}, abs_err={abs_err:.2f})"
                     )
     finally:
-        reset_streams()
         Utils.destroy_model_parallel()


### PR DESCRIPTION
# What does this PR do ?
### Background
Full-Iteration CUDA Graph requires using `current_stream` during the capture phase, whereas 1f1b uses the `default_stream` which is cached into a global variable and causes issues. This PR removes the caching behavior of compute stream (keep the cached communicate stream) to support Full-Iteration CUDA Graph.

PR for main: https://github.com/NVIDIA/Megatron-LM/pull/3820

### How to Use
This feature is now the default behavior for 1f1b overlap since it doesn't incur any performance degradation.

### Performance: 
Tested with DSv3(MTP) full model with GB300, this PR doesn't influence the throughput of 1f1b overlapping.
<img width="1000" height="295" alt="Screenshot 2026-03-24 at 11 28 52" src="https://github.com/user-attachments/assets/ec59737f-2339-4daf-8d17-1810f1e09432" />

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
