### PR TITLE
Fix KV block allocation for chunked prefill

### DIFF
--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1615,12 +1615,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         finished = req.finished_chunk_token_count
         already_allocated_blocks = (finished + self.block_size_tokens - 1) // self.block_size_tokens
-        # +1 accounts for the decode token that follows this chunk: after the
-        # chunk is processed, the bookkeeping produces a decode token at
-        # position (finished + chunk_length).  When chunk tokens exactly fill
-        # the last block, that decode token lands in the *next* block.  The
-        # chunked-prefill request is excluded from the normal new-block-pause
-        # path (to keep it schedulable), so we must pre-allocate that block here.
+        # +1 reserves space for the decode token produced after this chunk.
+        # The chunked-prefill request is excluded from the normal
+        # pause-and-allocate path, so we must ensure the block is available.
         overall_required_blocks = (
             finished + chunk_length + 1 + self.block_size_tokens - 1
         ) // self.block_size_tokens
@@ -2333,10 +2330,19 @@ class DynamicInferenceContext(BaseInferenceContext):
             ).byte()
 
             if self.chunked_prefill_request_id != -1:
-                # find the id in request_ids that is the chunked_prefill_request_id. Only one request should be chunked.
-                active_requests_requiring_new_block[
-                    self.get_index_of_chunked_prefill_request() - self.paused_request_count
-                ] = 0  # chunked prefill should not be paused
+                chunked_idx = self.get_index_of_chunked_prefill_request()
+                chunked_active_idx = chunked_idx - self.paused_request_count
+                if active_requests_requiring_new_block[chunked_active_idx]:
+                    # The chunked request needs a new block but must not be
+                    # paused (pausing breaks the chunked-prefill scheduling
+                    # invariants). Allocate the block directly instead.
+                    new_block = self.block_allocator.allocate_memory_blocks(1)
+                    if new_block is not None and len(new_block) == 1:
+                        col = self.request_kv_block_counts[chunked_idx]
+                        self.request_to_kv_block_ids[chunked_idx, col] = new_block[0]
+                        self.request_kv_block_counts[chunked_idx] += 1
+                        self.request_last_kv_block_id[chunked_idx] = new_block[0]
+                active_requests_requiring_new_block[chunked_active_idx] = 0
 
             active_requests_requiring_new_block_count = (
                 (active_requests_requiring_new_block == 1).sum().item()


### PR DESCRIPTION
# What does this PR do ?
Fixes a corner case in KV cache block allocation that occurs under very specific conditions when using chunked-prefill.

The conditions for the IMA are the following:
1. a partial chunk is scheduled, i.e. the remaining prompt doesn’t fully fit in the remaining token budget (max_tokens), so only part of it is prefilled
2. `(finished_chunk_token_count + chunk_length) % block_size_tokens == 0` - the total tokens prefilled so far exactly fills the last KV cache block, so the subsequent (dummy/unused) decode token needs a new block
3. The chunked request is still pending (`chunked_prefill_request_id != -1`) on the next step - meaning the next chunk couldn’t be scheduled immediately, e.g. because the token budget is full of other requests’ decode tokens)

When these conditions are all met, the block for the decode token position is -1 in the block table so whatever step reads from that position is accesses invalid memory. That latter point is true whether it’s a cuda graph or eager step.

The fix itself is a one-liner. We just pre-allocate an extra block for the decode token that follows every partial chunk just in case you hit this boundary condition. The existing logic fails because new block allocation is usually handled by pausing the request, allocating the new block and then resuming but chunked-prefill requests are explicitly excluded from that process.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
