### PR TITLE
[Dev] feat(fsdp): use TE general_gemm for mixed-precision wgrad in FSDP path

### DIFF
--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -561,7 +561,23 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
                 # In case of Megatron-FSDP, need to create main grad buffers in-place
                 if hasattr(weight, "__fsdp_param__"):
                     weight.main_grad = weight.get_main_grad()
-                    torch.matmul(grad_output.t(), total_input, out=weight.main_grad)
+                    # Import here to avoid circular import
+                    from megatron.core.extensions.transformer_engine import te_general_gemm
+
+                    if te_general_gemm is not None:
+                        # Use TE general_gemm to support mixed-precision output
+                        # (e.g. bf16 input -> fp32 main_grad) which torch.matmul
+                        # does not support via the out= parameter.
+                        te_general_gemm(
+                            total_input,
+                            grad_output,
+                            out_dtype=weight.main_grad.dtype,
+                            layout="NT",
+                            out=weight.main_grad,
+                            grad=True,
+                        )
+                    else:
+                        torch.matmul(grad_output.t(), total_input, out=weight.main_grad)
                 else:
                     if weight.main_grad.dtype == torch.float32:
                         fused_weight_gradient_mlp_cuda.wgrad_gemm_accum_fp32(


### PR DESCRIPTION
## Summary

PR to main https://github.com/NVIDIA/Megatron-LM/pull/3822
- Replace `torch.matmul` with TE `general_gemm` in the FSDP gradient accumulation fusion path to support mixed-precision output (e.g. bf16 input → fp32 `main_grad` buffer)
- `torch.matmul` requires the `out` tensor dtype to match the compute dtype, which forces FSDP to use `grad_reduce_in_bf16` when `gradient_accumulation_fusion` is enabled
- TE's `general_gemm` supports arbitrary `out_dtype` via cuBLAS, removing this hard dependency
- Uses inline lazy import to avoid circular dependency with `megatron.core.extensions.transformer_engine`

## Test plan

- [x] Verified on DeepSeek-V3-proxy (MLA+MoE+MTP) with FSDP (`fsdp_double_buffer=True`, `gradient_accumulation_fusion=True`, fp32 grad buffer, TP1/PP1/EP4/DP2, 8×H100)
- [ ] Unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)