### PR TITLE
Add activation logging and tokens per expert logging

### DIFF
--- a/megatron/training/activation_logging.py
+++ b/megatron/training/activation_logging.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 
-"""dgrad logging using backward hooks."""
+"""Forward activation logging using forward hooks."""
 
 from collections import defaultdict
 import torch
@@ -14,7 +14,7 @@ from .utils import unwrap_model
 
 
 def _get_linear_types():
-    """Build tuple of linear layer types to capture gradients from."""
+    """Build tuple of linear layer types to capture activations from."""
     types = [nn.Linear, nn.Embedding, ColumnParallelLinear, RowParallelLinear, Router]
 
     # Add Transformer Engine layers if available.
@@ -49,47 +49,57 @@ def _get_linear_types():
 LINEAR_TYPES = _get_linear_types()
 
 
-class DataGradLogger:
-    """Captures and saves gradients from all linear layers using backward hooks.
-    
-    NOTE: Right now, we only save the dgrads for the last microbatch in a batch on DP replica 0.
-    The code below would need to be extended to save dgrads for all microbatches in a batch."""
+class ActivationLogger:
+    """Captures and saves forward activations from all linear layers using forward hooks."""
 
     def __init__(self, save_dir: str):
         self._save_dir = save_dir
-        self._dgrads_state_dict = defaultdict(dict)
+        self._activations_state_dict = defaultdict(dict)
         self._hooks = []
 
     def _make_hook(self, model_chunk_name: str, module_name: str):
-        """Create a backward hook for a named module."""
-        def hook(_, grad_input, grad_output):
-            for idx, grad in enumerate(grad_output):
-                if grad is not None:
+        """Create a forward hook for a named module (with_kwargs=True: args, kwargs, output)."""
+        def hook(_, args, kwargs, output):
+            input_tuple = args if isinstance(args, tuple) else (args,)
+            for idx, inp in enumerate(input_tuple):
+                if inp is None:
+                    continue
+                key = f"{module_name}/input{idx}"
+                if isinstance(inp, torch.Tensor):
+                    self._activations_state_dict[model_chunk_name][key] = inp.detach().cpu()
+                else:
+                    self._activations_state_dict[model_chunk_name][key] = inp
+            output_tuple = output if isinstance(output, tuple) else (output,)
+            for idx, out in enumerate(output_tuple):
+                if out is not None and isinstance(out, torch.Tensor):
                     key = f"{module_name}/output{idx}"
-                    self._dgrads_state_dict[model_chunk_name][key] = grad.detach().cpu()
-            for idx, grad in enumerate(grad_input):
-                if grad is not None:
-                    key = f"{module_name}/input{idx}"
-                    self._dgrads_state_dict[model_chunk_name][key] = grad.detach().cpu()
+                    self._activations_state_dict[model_chunk_name][key] = out.detach().cpu()
+            for kwarg_key, kwarg_value in kwargs.items():
+                key = f"{module_name}/{kwarg_key}"
+                if isinstance(kwarg_value, torch.Tensor):
+                    self._activations_state_dict[model_chunk_name][key] = kwarg_value.detach().cpu()
+                else:
+                    self._activations_state_dict[model_chunk_name][key] = kwarg_value
         return hook
 
     def save(self, iteration: int):
-        """Save captured gradients to disk and clear the buffer."""
-        if not self._dgrads_state_dict:
+        """Save captured activations to disk and clear the buffer."""
+        if not self._activations_state_dict:
             return
-        save_grads(self._save_dir, self._dgrads_state_dict, iteration, "dgrads")
-        self._dgrads_state_dict.clear()
+        save_grads(self._save_dir, self._activations_state_dict, iteration, "activations")
+        self._activations_state_dict.clear()
 
     def register_hooks(self, model: torch.nn.Module):
-        """Find and register hooks on all linear layers."""
+        """Find and register forward hooks on all linear layers."""
         assert len(self._hooks) == 0
         for model_chunk_id, model_chunk in enumerate(model):
             unwrapped_model_chunk = unwrap_model(model_chunk)
             for module_name, module in unwrapped_model_chunk.named_modules():
                 if isinstance(module, LINEAR_TYPES):
                     model_chunk_name = f"model_chunk{model_chunk_id}"
-                    handle = module.register_full_backward_hook(
-                        self._make_hook(model_chunk_name, module_name)
+                    handle = module.register_forward_hook(
+                        self._make_hook(model_chunk_name, module_name),
+                        with_kwargs=True,
                     )
                     self._hooks.append(handle)
 
@@ -103,23 +113,23 @@ class DataGradLogger:
 _LOGGER = None
 
 
-def enable_dgrad_logging(model: torch.nn.Module, save_dir: str):
-    """Enable dgrad logging on a model."""
+def enable_activation_logging(model: torch.nn.Module, save_dir: str):
+    """Enable activation logging on a model."""
     global _LOGGER
     if _LOGGER is None:
-        _LOGGER = DataGradLogger(save_dir)
+        _LOGGER = ActivationLogger(save_dir)
     _LOGGER.register_hooks(model)
 
 
-def disable_dgrad_logging():
-    """Disable dgrad logging on a model."""
+def disable_activation_logging():
+    """Disable activation logging on a model."""
     global _LOGGER
     assert _LOGGER is not None
     _LOGGER.remove_hooks()
 
 
-def save_dgrads(iteration: int):
-    """Save dgrads to disk."""
+def save_activations(iteration: int):
+    """Save activations to disk."""
     global _LOGGER
     assert _LOGGER is not None
     _LOGGER.save(iteration)

--- a/megatron/training/activation_logging.py
+++ b/megatron/training/activation_logging.py
@@ -3,8 +3,16 @@
 """Forward activation logging using forward hooks."""
 
 from collections import defaultdict
+import json
+import logging
+import os
+import re
+from typing import Callable, List, Tuple
+
 import torch
 import torch.nn as nn
+
+logger = logging.getLogger(__name__)
 
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
 from megatron.core.transformer.moe.router import Router
@@ -13,11 +21,15 @@ from .checkpointing import save_grads
 from .utils import unwrap_model
 
 
-def _get_linear_types():
-    """Build tuple of linear layer types to capture activations from."""
-    types = [nn.Linear, nn.Embedding, ColumnParallelLinear, RowParallelLinear, Router]
+def _discover_te_types():
+    """Discover available Transformer Engine layer types.
 
-    # Add Transformer Engine layers if available.
+    Returns (all_types, grouped_types) where grouped_types is the subset of
+    TEGroupedLinear variants used for tokens-per-expert capture.
+    """
+    all_types = []
+    grouped_types = []
+
     try:
         from megatron.core.extensions.transformer_engine import (
             TELinear,
@@ -26,8 +38,8 @@ def _get_linear_types():
             TERowParallelLinear,
             TELayerNormColumnParallelLinear,
         )
-        types.extend([TELinear, TENorm, TEColumnParallelLinear, TERowParallelLinear,
-                      TELayerNormColumnParallelLinear])
+        all_types.extend([TELinear, TENorm, TEColumnParallelLinear, TERowParallelLinear,
+                          TELayerNormColumnParallelLinear])
     except ImportError:
         pass
 
@@ -38,98 +50,211 @@ def _get_linear_types():
             TERowParallelGroupedLinear,
         )
         if TEGroupedLinear is not None:
-            types.extend([TEGroupedLinear, TEColumnParallelGroupedLinear,
-                          TERowParallelGroupedLinear])
+            grouped = [TEGroupedLinear, TEColumnParallelGroupedLinear,
+                       TERowParallelGroupedLinear]
+            all_types.extend(grouped)
+            grouped_types.extend(grouped)
     except ImportError:
         pass
 
-    return tuple(types)
+    return tuple(all_types), tuple(grouped_types)
 
 
-LINEAR_TYPES = _get_linear_types()
+_TE_TYPES, _GROUPED_LINEAR_TYPES = _discover_te_types()
 
+LINEAR_TYPES = (nn.Linear, nn.Embedding, ColumnParallelLinear, RowParallelLinear,
+                Router, *_TE_TYPES)
+
+
+def _register_hooks(model, module_types, hook_factory, *, name_filter=None):
+    """Walk *model* and register a forward hook on every module matching *module_types*.
+
+    Args:
+        model: Iterable of model chunks (possibly wrapped).
+        module_types: Tuple of types to match via ``isinstance``.
+        hook_factory: ``(model_chunk_name, module_name) -> hook_fn``.
+        name_filter: Optional ``str -> bool`` predicate on the module name.
+
+    Returns:
+        List of hook handles.
+    """
+    handles = []
+    for model_chunk_id, model_chunk in enumerate(model):
+        model_chunk_name = f"model_chunk{model_chunk_id}"
+        unwrapped = unwrap_model(model_chunk)
+        for module_name, module in unwrapped.named_modules():
+            if isinstance(module, module_types) and (name_filter is None or name_filter(module_name)):
+                hook_fn = hook_factory(model_chunk_name, module_name)
+                if hook_fn is None:
+                    continue
+                handle = module.register_forward_hook(hook_fn, with_kwargs=True)
+                handles.append(handle)
+    return handles
 
 class ActivationLogger:
-    """Captures and saves forward activations from all linear layers using forward hooks."""
+    """Captures and saves forward activations using forward hooks.
+
+    Manages two independent hook sets:
+
+    - **Full activation hooks** capture all inputs / outputs / kwargs for every
+      ``LINEAR_TYPES`` module.
+    - **Tokens-per-expert (TPE) hooks** are lightweight hooks that only capture
+      the tokens-per-expert routing metadata from MoE.
+    """
 
     def __init__(self, save_dir: str):
         self._save_dir = save_dir
-        self._activations_state_dict = defaultdict(dict)
-        self._hooks = []
 
-    def _make_hook(self, model_chunk_name: str, module_name: str):
-        """Create a forward hook for a named module (with_kwargs=True: args, kwargs, output)."""
+        # Full activation state.
+        self._activations_state_dict: defaultdict = defaultdict(dict)
+        self._activation_hooks: List[torch.utils.hooks.RemovableHook] = []
+
+        # Tokens-per-expert state: layer -> list of per-microbatch token counts.
+        self._tpe_records: dict[str, list] = defaultdict(list)
+        self._tpe_hooks: List[torch.utils.hooks.RemovableHook] = []
+
+    # ------------------------------------------------------------------
+    # Full activation hooks
+    # ------------------------------------------------------------------
+
+    def _make_activation_hook(self, model_chunk_name: str, module_name: str) -> Callable:
+        """Forward hook that captures all inputs, outputs and kwargs."""
+        sd = self._activations_state_dict
+
         def hook(_, args, kwargs, output):
             input_tuple = args if isinstance(args, tuple) else (args,)
             for idx, inp in enumerate(input_tuple):
                 if inp is None:
                     continue
                 key = f"{module_name}/input{idx}"
-                if isinstance(inp, torch.Tensor):
-                    self._activations_state_dict[model_chunk_name][key] = inp.detach().cpu()
-                else:
-                    self._activations_state_dict[model_chunk_name][key] = inp
-            output_tuple = output if isinstance(output, tuple) else (output,)
-            for idx, out in enumerate(output_tuple):
+                sd[model_chunk_name][key] = inp.detach().cpu() if isinstance(inp, torch.Tensor) else inp
+            for idx, out in enumerate(output if isinstance(output, tuple) else (output,)):
                 if out is not None and isinstance(out, torch.Tensor):
-                    key = f"{module_name}/output{idx}"
-                    self._activations_state_dict[model_chunk_name][key] = out.detach().cpu()
+                    sd[model_chunk_name][f"{module_name}/output{idx}"] = out.detach().cpu()
             for kwarg_key, kwarg_value in kwargs.items():
                 key = f"{module_name}/{kwarg_key}"
-                if isinstance(kwarg_value, torch.Tensor):
-                    self._activations_state_dict[model_chunk_name][key] = kwarg_value.detach().cpu()
-                else:
-                    self._activations_state_dict[model_chunk_name][key] = kwarg_value
+                sd[model_chunk_name][key] = (
+                    kwarg_value.detach().cpu() if isinstance(kwarg_value, torch.Tensor) else kwarg_value
+                )
+
         return hook
 
-    def save(self, iteration: int):
-        """Save captured activations to disk and clear the buffer."""
+    def register_activation_hooks(self, model):
+        assert not self._activation_hooks
+        self._activation_hooks = _register_hooks(model, LINEAR_TYPES, self._make_activation_hook)
+
+    def remove_activation_hooks(self):
+        for hook in self._activation_hooks:
+            hook.remove()
+        self._activation_hooks.clear()
+
+    def save_activations(self, iteration: int):
         if not self._activations_state_dict:
             return
         save_grads(self._save_dir, self._activations_state_dict, iteration, "activations")
         self._activations_state_dict.clear()
 
-    def register_hooks(self, model: torch.nn.Module):
-        """Find and register forward hooks on all linear layers."""
-        assert len(self._hooks) == 0
-        for model_chunk_id, model_chunk in enumerate(model):
-            unwrapped_model_chunk = unwrap_model(model_chunk)
-            for module_name, module in unwrapped_model_chunk.named_modules():
-                if isinstance(module, LINEAR_TYPES):
-                    model_chunk_name = f"model_chunk{model_chunk_id}"
-                    handle = module.register_forward_hook(
-                        self._make_hook(model_chunk_name, module_name),
-                        with_kwargs=True,
-                    )
-                    self._hooks.append(handle)
+    # ------------------------------------------------------------------
+    # Tokens-per-expert hooks
+    # ------------------------------------------------------------------
 
-    def remove_hooks(self):
-        """Remove all registered hooks."""
-        for handle in self._hooks:
-            handle.remove()
-        self._hooks.clear()
+    def _make_tpe_hook(self, _model_chunk_name: str, module_name: str) -> Callable:
+        """Forward hook that captures only the non-Tensor ``input1`` (tokens_per_expert).
+
+        The layer number is extracted from *module_name*
+        (e.g. ``decoder.layers.3.mlp.experts.linear_fc1`` → ``3``).
+        """
+        m = re.search(r'\.layers\.(\d+)\.', module_name)
+        if not m:
+            logger.warning(
+                "Cannot extract layer number from module name: %r — "
+                "skipping tokens-per-expert hook for this module", module_name
+            )
+            return None
+        layer = m.group(1)
+
+        def hook(_, args, kwargs, output):
+            input_tuple = args if isinstance(args, tuple) else (args,)
+            if len(input_tuple) > 1 and input_tuple[1] is not None:
+                inp = input_tuple[1]
+                if not isinstance(inp, torch.Tensor):
+                    self._tpe_records[layer].append(list(inp))
+
+        return hook
+
+    def register_tpe_hooks(self, model):
+        assert not self._tpe_hooks
+        self._tpe_hooks = _register_hooks(
+            model, _GROUPED_LINEAR_TYPES, self._make_tpe_hook,
+            name_filter=lambda name: name.endswith("linear_fc1"),
+        )
+
+    def remove_tpe_hooks(self):
+        for hook in self._tpe_hooks:
+            hook.remove()
+        self._tpe_hooks.clear()
+
+    def save_tpe(self, iteration: int):
+        """Append captured tokens-per-expert records as JSON Lines.
+
+        Each rank writes to its own file under ``{save_dir}/tokens_per_expert/``,
+        e.g. ``rank0.jsonl``, ``rank1.jsonl``.  Each line is a JSON object::
+
+            {"iter": 100, "layer": 3, "tpe": [[128, 64], [96, 80]]}
+        """
+        if not self._tpe_records:
+            return
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        tpe_dir = os.path.join(self._save_dir, "tokens_per_expert")
+        os.makedirs(tpe_dir, exist_ok=True)
+        filepath = os.path.join(tpe_dir, f"rank{rank}.jsonl")
+        lines = "".join(
+            json.dumps({"iter": iteration, "layer": int(layer),
+                        "tpe": microbatches}) + "\n"
+            for layer, microbatches in sorted(self._tpe_records.items())
+        )
+        with open(filepath, "a") as f:
+            f.write(lines)
+        self._tpe_records.clear()
+
+_LOGGER: ActivationLogger | None = None
 
 
-_LOGGER = None
-
-
-def enable_activation_logging(model: torch.nn.Module, save_dir: str):
-    """Enable activation logging on a model."""
+def _get_logger(save_dir: str) -> ActivationLogger:
     global _LOGGER
     if _LOGGER is None:
         _LOGGER = ActivationLogger(save_dir)
-    _LOGGER.register_hooks(model)
+    return _LOGGER
+
+
+def _require_logger() -> ActivationLogger:
+    assert _LOGGER is not None, "No ActivationLogger has been initialised"
+    return _LOGGER
+
+
+# -- Full activation logging -------------------------------------------
+
+def enable_activation_logging(model: torch.nn.Module, save_dir: str):
+    _get_logger(save_dir).register_activation_hooks(model)
 
 
 def disable_activation_logging():
-    """Disable activation logging on a model."""
-    global _LOGGER
-    assert _LOGGER is not None
-    _LOGGER.remove_hooks()
+    _require_logger().remove_activation_hooks()
 
 
 def save_activations(iteration: int):
-    """Save activations to disk."""
-    global _LOGGER
-    assert _LOGGER is not None
-    _LOGGER.save(iteration)
+    _require_logger().save_activations(iteration)
+
+
+# -- Tokens-per-expert logging ----------------------------------------
+
+def enable_tokens_per_expert_logging(model: torch.nn.Module, save_dir: str):
+    _get_logger(save_dir).register_tpe_hooks(model)
+
+
+def disable_tokens_per_expert_logging():
+    _require_logger().remove_tpe_hooks()
+
+
+def save_tokens_per_expert(iteration: int):
+    _require_logger().save_tpe(iteration)

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1194,6 +1194,8 @@ def validate_args(args, defaults={}):
         if args.save_retain_interval is not None:
             assert args.save_retain_interval > 0
             assert args.save_retain_interval % args.save_interval == 0
+        if args.save_params_interval is not None:
+            assert not args.overlap_param_gather
     if args.log_memory_interval is not None:
         assert args.log_memory_interval % args.log_interval == 0
     # Mixed precision checks.

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -352,6 +352,12 @@ class CheckpointConfig:
     save_interval: int | None = field(default=None, metadata={"argparse_meta": {"arg_names": ["--save-interval", "--persistent-save-interval"]}})
     """Number of iterations between persistent checkpoint saves."""
 
+    save_params_interval: int | None = None
+    """Number of iterations between param.name->param.data mapping saves."""
+
+    save_activations_interval: int | None = None
+    """Number of iterations between act.name->act.data mapping saves."""
+
     save_wgrads_interval: int | None = None
     """Number of iterations between wgrad (main_grad) saves."""
 

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -358,6 +358,9 @@ class CheckpointConfig:
     save_activations_interval: int | None = None
     """Number of iterations between act.name->act.data mapping saves."""
 
+    save_tokens_per_expert_interval: int | None = None
+    """Number of iterations between tokens-per-expert routing metadata saves."""
+
     save_wgrads_interval: int | None = None
     """Number of iterations between wgrad (main_grad) saves."""
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -252,6 +252,11 @@ from .global_vars import (
     get_energy_monitor,
 )
 from . import one_logger_utils
+from .activation_logging import (
+    enable_activation_logging,
+    disable_activation_logging,
+    save_activations,
+)
 from .dgrad_logging import enable_dgrad_logging, disable_dgrad_logging, save_dgrads
 
 from . import ft_integration
@@ -1782,10 +1787,14 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     timers = get_timers()
 
     rerun_state_machine = get_rerun_state_machine()
-    save_dgrads_in_this_iteration = (args.save_dgrads_interval is not None and
-                                     (iteration + 1) % args.save_dgrads_interval == 0)
+    save_params_in_this_iteration = (args.save_params_interval is not None and
+                                     (iteration + 1) % args.save_params_interval == 0)
+    save_activations_in_this_iteration = (args.save_activations_interval is not None and
+                                          (iteration + 1) % args.save_activations_interval == 0)
     save_wgrads_in_this_iteration = (args.save_wgrads_interval is not None and
                                      (iteration + 1) % args.save_wgrads_interval == 0)
+    save_dgrads_in_this_iteration = (args.save_dgrads_interval is not None and
+                                     (iteration + 1) % args.save_dgrads_interval == 0)
     while rerun_state_machine.should_run_forward_backward(data_iterator):
         # Set grad to zero.
         for model_chunk in model:
@@ -1823,6 +1832,8 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
                         optim_instance._copy_main_params_to_param_buffer()
 
         # Forward pass.
+        if save_activations_in_this_iteration:
+            enable_activation_logging(model, args.save)
         if save_dgrads_in_this_iteration:
             enable_dgrad_logging(model, args.save)
         losses_reduced = forward_backward_func(
@@ -1837,6 +1848,9 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
             adjust_tensor_shapes_fn=adjust_tensor_shapes_fn,
             force_all_reduce=save_wgrads_in_this_iteration,
         )
+        if save_activations_in_this_iteration:
+            save_activations(iteration + 1)
+            disable_activation_logging()
         if save_dgrads_in_this_iteration:
             save_dgrads(iteration + 1)
             disable_dgrad_logging()
@@ -1845,20 +1859,23 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
         for model_chunk in model:
             model_chunk.force_all_reduce = False
 
-    # Checkpoint main_grads.
-    if save_wgrads_in_this_iteration:
+    def _save_state_dict(attr_name, label):
         # Collect state_dict of wgrads (each param's .main_grad field).
         state_dict = defaultdict(dict)
         for model_chunk_id, model_chunk in enumerate(model):
             model_chunk_name = f"model_chunk{model_chunk_id}"
             unwrapped_model_chunk = unwrap_model(model_chunk)
             for param_name, param in unwrapped_model_chunk.named_parameters():
-                if getattr(param, "main_grad", None) is not None:
-                    main_grad_on_cpu = param.main_grad.cpu()
-                    state_dict[model_chunk_name][param_name] = main_grad_on_cpu
+                if getattr(param, attr_name, None) is not None:
+                    tensor_on_cpu = getattr(param, attr_name).cpu()
+                    state_dict[model_chunk_name][param_name] = tensor_on_cpu
 
         # iteration is 0-indexed, move to 1-indexed for checkpoint name and logging.
-        save_grads(args.save, state_dict, iteration + 1, "wgrads")
+        save_grads(args.save, state_dict, iteration + 1, label)
+
+    # Checkpoint wgrads with parameter names.
+    if save_wgrads_in_this_iteration:
+        _save_state_dict(attr_name="main_grad", label="wgrads")
 
     should_checkpoint, should_exit, exit_code = rerun_state_machine.should_checkpoint_and_exit()
     if should_exit:
@@ -1885,6 +1902,10 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
         log_max_attention_logit = clip_qk(model, log_max_only=not args.qk_clip)
 
     timers('optimizer').stop()
+
+    # Checkpoint params with parameter names.
+    if save_params_in_this_iteration:
+        _save_state_dict(attr_name="data", label="params")
 
     # when freezing sub-models we may have a mixture of successful and unsucessful ranks,
     # so we must gather across mp ranks

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -256,6 +256,9 @@ from .activation_logging import (
     enable_activation_logging,
     disable_activation_logging,
     save_activations,
+    enable_tokens_per_expert_logging,
+    disable_tokens_per_expert_logging,
+    save_tokens_per_expert,
 )
 from .dgrad_logging import enable_dgrad_logging, disable_dgrad_logging, save_dgrads
 
@@ -1791,6 +1794,8 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
                                      (iteration + 1) % args.save_params_interval == 0)
     save_activations_in_this_iteration = (args.save_activations_interval is not None and
                                           (iteration + 1) % args.save_activations_interval == 0)
+    save_tpe_in_this_iteration = (args.save_tokens_per_expert_interval is not None and
+                                  (iteration + 1) % args.save_tokens_per_expert_interval == 0)
     save_wgrads_in_this_iteration = (args.save_wgrads_interval is not None and
                                      (iteration + 1) % args.save_wgrads_interval == 0)
     save_dgrads_in_this_iteration = (args.save_dgrads_interval is not None and
@@ -1834,6 +1839,8 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
         # Forward pass.
         if save_activations_in_this_iteration:
             enable_activation_logging(model, args.save)
+        if save_tpe_in_this_iteration:
+            enable_tokens_per_expert_logging(model, args.save)
         if save_dgrads_in_this_iteration:
             enable_dgrad_logging(model, args.save)
         losses_reduced = forward_backward_func(
@@ -1851,6 +1858,9 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
         if save_activations_in_this_iteration:
             save_activations(iteration + 1)
             disable_activation_logging()
+        if save_tpe_in_this_iteration:
+            save_tokens_per_expert(iteration + 1)
+            disable_tokens_per_expert_logging()
         if save_dgrads_in_this_iteration:
             save_dgrads(iteration + 1)
             disable_dgrad_logging()
@@ -1860,7 +1870,7 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
             model_chunk.force_all_reduce = False
 
     def _save_state_dict(attr_name, label):
-        # Collect state_dict of wgrads (each param's .main_grad field).
+        # Collect state_dict of the given attribute for each parameter.
         state_dict = defaultdict(dict)
         for model_chunk_id, model_chunk in enumerate(model):
             model_chunk_name = f"model_chunk{model_chunk_id}"

--- a/tests/unit_tests/test_activation_logging.py
+++ b/tests/unit_tests/test_activation_logging.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import json
+import logging
+
+import pytest
+import torch
+import torch.nn as nn
+
+from megatron.training.activation_logging import ActivationLogger
+
+
+@pytest.fixture()
+def logger(tmp_path):
+    return ActivationLogger(save_dir=str(tmp_path))
+
+
+@pytest.fixture()
+def simple_model():
+    """A minimal model with two nn.Linear layers, wrapped as a single-element model chunk list."""
+    model = nn.Sequential(nn.Linear(16, 32), nn.Linear(32, 8))
+    return [model]
+
+
+class TestMakeTpeHook:
+    """Tests for _make_tpe_hook regex layer extraction."""
+
+    def test_extracts_layer_number(self, logger):
+        hook = logger._make_tpe_hook("chunk0", "decoder.layers.3.mlp.experts.linear_fc1")
+        assert hook is not None
+        fake_tpe = [128, 64, 96, 80]
+        hook(None, (torch.zeros(1), fake_tpe), {}, torch.zeros(1))
+        assert logger._tpe_records["3"] == [fake_tpe]
+
+    def test_returns_none_for_non_matching_name(self, logger, caplog):
+        with caplog.at_level(logging.WARNING):
+            hook = logger._make_tpe_hook("chunk0", "some.module.without.layer.number")
+        assert hook is None
+        assert "Cannot extract layer number" in caplog.text
+
+
+class TestSaveTpe:
+    """Tests for save_tpe JSONL output."""
+
+    def test_creates_jsonl(self, tmp_path, logger):
+        logger._tpe_records["3"].append([128, 64, 96, 80])
+        logger._tpe_records["3"].append([100, 90, 110, 70])
+        logger._tpe_records["7"].append([200, 200])
+
+        logger.save_tpe(iteration=100)
+
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        filepath = tmp_path / "tokens_per_expert" / f"rank{rank}.jsonl"
+        assert filepath.exists()
+
+        records = [json.loads(line) for line in filepath.read_text().strip().split("\n")]
+        assert records == [
+            {"iter": 100, "layer": 3, "tpe": [[128, 64, 96, 80], [100, 90, 110, 70]]},
+            {"iter": 100, "layer": 7, "tpe": [[200, 200]]},
+        ]
+
+    def test_appends_across_calls(self, tmp_path, logger):
+        logger._tpe_records["0"].append([10, 20])
+        logger.save_tpe(iteration=100)
+
+        logger._tpe_records["0"].append([30, 40])
+        logger.save_tpe(iteration=200)
+
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        filepath = tmp_path / "tokens_per_expert" / f"rank{rank}.jsonl"
+        records = [json.loads(line) for line in filepath.read_text().strip().split("\n")]
+        assert len(records) == 2
+        assert records[0]["iter"] == 100
+        assert records[1]["iter"] == 200
+
+
+class TestActivationHookLifecycle:
+    """Tests for activation hook registration and removal."""
+
+    def test_register_and_remove(self, logger, simple_model):
+        logger.register_activation_hooks(simple_model)
+        assert len(logger._activation_hooks) == 2
+
+        logger.remove_activation_hooks()
+        assert len(logger._activation_hooks) == 0
+
+    def test_hooks_capture_activations(self, logger, simple_model):
+        logger.register_activation_hooks(simple_model)
+
+        simple_model[0](torch.randn(2, 16))
+
+        assert len(logger._activations_state_dict) > 0
+        logger.remove_activation_hooks()
+
+    def test_removed_hooks_dont_capture(self, logger, simple_model):
+        logger.register_activation_hooks(simple_model)
+        logger.remove_activation_hooks()
+
+        simple_model[0](torch.randn(2, 16))
+        assert len(logger._activations_state_dict) == 0


### PR DESCRIPTION
Adding activation logging and tokens per expert logging,
activation logging can be enabled through --save-activations-interval,
tokens per expert logging can be enabled through --save-tokens-per-experts-interval,
when enabled, they will be dumped at checkpoint folder. tokens per expert will be logged in args.save/tokens_per_expert/rank3.jsonl.

