### PR TITLE
ci: Skip more tests in test_vision_cuda_graphs for LTS

### DIFF
--- a/tests/unit_tests/transformer/test_vision_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_vision_cuda_graphs.py
@@ -345,6 +345,7 @@ class TestVisionTECudaGraphHelper:
         assert sample_kwargs_list == []
 
     # -- create_cudagraphs / delete_cuda_graphs lifecycle --
+    @pytest.mark.flaky
     @pytest.mark.flaky_in_dev
     @pytest.mark.skipif(
         not (HAVE_TE_GRAPHS and is_te_min_version("2.7.0")),
@@ -382,6 +383,7 @@ class TestVisionTECudaGraphHelper:
         not (HAVE_TE_GRAPHS and is_te_min_version("2.7.0")),
         reason="TE CUDA graph capture requires TransformerEngine >= 2.7.0",
     )
+    @pytest.mark.flaky
     @pytest.mark.flaky_in_dev
     def test_create_cudagraphs_multi_microbatch(self):
         """Verify that graphs are created per-microbatch per-layer."""
@@ -572,6 +574,7 @@ class TestVisionTECudaGraphHelperPP2:
         not (HAVE_TE_GRAPHS and is_te_min_version("2.7.0")),
         reason="TE CUDA graph capture requires TransformerEngine >= 2.7.0",
     )
+    @pytest.mark.flaky
     @pytest.mark.flaky_in_dev
     def test_pp2_create_cudagraphs_first_stage(self):
         """On stage 0, CUDA graphs should be captured with the full pipeline order."""


### PR DESCRIPTION
# What does this PR do ?
ci: Skip more tests in test_vision_cuda_graphs for LTS

We missed some additional unit tests to skip. We had previously skipped some tests in the dev CI run. But these same tests should also be skipped in the LTS CI run. The tests never passed as part of CI because they only activated for TE 2.13, which we only just bumped to in the past few days.

Issue for following-up to fix these tests:
https://github.com/NVIDIA/Megatron-LM/issues/3804

PR to bump to TE 2.13:
https://github.com/NVIDIA/Megatron-LM/pull/3800

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
