### PR TITLE
Fix PersistentAsyncCaller.__del__ crash during shutdown

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/async_utils.py
+++ b/megatron/core/dist_checkpointing/strategies/async_utils.py
@@ -493,16 +493,21 @@ class PersistentAsyncCaller(AsyncCaller):
             abort (bool, optional): Default to False. Needs to be manually set to true when
                 the checkpoint async process needs to be aborted.
         """
-        logger.debug(
-            f"PersistentAsyncCaller: {torch.distributed.get_rank()}, Destroying Async Caller"
-        )
+        if torch.distributed.is_initialized():
+            logger.debug(
+                f"PersistentAsyncCaller: {torch.distributed.get_rank()}, Destroying Async Caller"
+            )
         if self.process:
             if abort:
-                log_single_rank(
-                    logger,
-                    logging.WARNING,
-                    f"Persistent worker aborted in rank {torch.distributed.get_rank()}",
-                )
+                if torch.distributed.is_initialized():
+                    log_single_rank(
+                        logger,
+                        logging.WARNING,
+                        f"Persistent worker aborted in rank {torch.distributed.get_rank()}",
+                    )
+                else:
+                    logger.warning("Persistent worker aborted (rank unavailable)")
+
                 self.process.kill()
             else:
                 self._persistent_queue.put('DONE')


### PR DESCRIPTION
## Summary

- Guard `torch.distributed.get_rank()` calls in `PersistentAsyncCaller.close()` with `torch.distributed.is_initialized()` to prevent `ValueError` when `close()` is invoked from `__del__` during Python garbage collection, after the distributed process group has already been destroyed.

Fixes #3775

## Test plan

- [ ] Enable async checkpointing (`config.checkpoint.async_save = True`) and run a training job to completion — verify no `ValueError` traceback on shutdown
- [ ] Verify that debug log messages still appear during normal (non-shutdown) `close()` calls
- [ ] Test abort path (`close(abort=True)`) both with and without initialized process group