### PR TITLE
ci: Fix build-test-publish summary job always passing

### DIFF
--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          SKIPPING_IS_ALLOWED: true
+          SKIPPING_IS_ALLOWED: false
         run: |
           FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
 


### PR DESCRIPTION
## Summary
- `SKIPPING_IS_ALLOWED` was hardcoded to `true` in the summary job, causing it to always exit 0 regardless of actual job outcomes
- This masked failures in matrix jobs (e.g. the arm64 build job in #3858)
- Fixed by setting `SKIPPING_IS_ALLOWED: false` since `build-test-publish-wheels` has no `if` condition that would legitimately skip it

## Test plan
- [ ] Verify the summary job correctly fails when a matrix job (arm64/amd64) fails
- [ ] Verify the summary job passes when all jobs succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)