### PR TITLE
Add --step-batch-size-schedule for step-wise batch size control

### DIFF
--- a/megatron/core/num_microbatches_calculator.py
+++ b/megatron/core/num_microbatches_calculator.py
@@ -262,6 +262,10 @@ def _build_num_microbatches_calculator(
         raise ValueError(
             'Cannot specify both --step-batch-size-schedule and --rampup-batch-size'
         )
+    if step_batch_size_schedule is not None and decrease_batch_size_if_needed:
+        raise ValueError(
+            'Cannot specify both --step-batch-size-schedule and --decrease-batch-size-if-needed'
+        )
 
     # Step batch size schedule
     if step_batch_size_schedule is not None:
@@ -272,7 +276,6 @@ def _build_num_microbatches_calculator(
         num_microbatches_calculator = StepBatchsizeNumMicroBatchesCalculator(
             micro_batch_size=micro_batch_size,
             data_parallel_size=data_parallel_size,
-            decrease_batch_size_if_needed=decrease_batch_size_if_needed,
             rank=rank,
             schedule=step_batch_size_schedule,
             seq_length=seq_length,
@@ -584,7 +587,6 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
     Args:
         micro_batch_size (int): Micro batch size.
         data_parallel_size (int): Data parallel size.
-        decrease_batch_size_if_needed (bool): Decrease batch size for divisibility.
         rank (int): Rank for logging.
         schedule (str): Schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
             Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
@@ -600,7 +602,6 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
         self,
         micro_batch_size: int,
         data_parallel_size: int,
-        decrease_batch_size_if_needed: bool,
         rank: int,
         schedule: str,
         seq_length: Optional[int] = None,
@@ -609,7 +610,6 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
 
         self.micro_batch_size = micro_batch_size
         self.data_parallel_size = data_parallel_size
-        self.decrease_batch_size_if_needed = decrease_batch_size_if_needed
         self.rank = rank
         self.seq_length = seq_length
 
@@ -631,7 +631,6 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
             logger.info(f'  seq_length: {seq_length} (thresholds interpreted as {"tokens" if seq_length else "samples"})')
             logger.info(f'  micro_batch_size: {micro_batch_size}')
             logger.info(f'  data_parallel_size: {data_parallel_size}')
-            logger.info(f'  decrease_batch_size_if_needed: {decrease_batch_size_if_needed}')
             logger.info(f'step batch size schedule ({len(self.schedule)} steps):')
             for threshold, batch_size in self.schedule:
                 num_microbatches = batch_size // self.micro_batch_times_data_parallel_size
@@ -733,11 +732,6 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
                 break
         return batch_size
 
-    @staticmethod
-    def _round(batch_size: int, divisor: int) -> int:
-        """Round batch_size down to nearest value divisible by divisor."""
-        return (batch_size // divisor) * divisor
-
     def update(self, consumed_samples: int, consistency_check: bool, verbose: bool = False) -> None:
         """Update number of microbatches based on consumed samples.
 
@@ -761,28 +755,14 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
                 )
 
         # Consistency check
-        if consistency_check and not self.decrease_batch_size_if_needed:
+        if consistency_check:
             assert self.current_global_batch_size % self.micro_batch_times_data_parallel_size == 0, (
                 f'current global batch size ({self.current_global_batch_size}) is not divisible by '
                 f'micro_batch_size ({self.micro_batch_size}) * '
                 f'data_parallel_size ({self.data_parallel_size})'
             )
 
-        # Handle decrease_batch_size_if_needed
-        if (
-            self.decrease_batch_size_if_needed
-            and self.current_global_batch_size % self.micro_batch_times_data_parallel_size != 0
-        ):
-            self.current_running_global_batch_size = self._round(
-                self.current_global_batch_size, self.micro_batch_times_data_parallel_size
-            )
-            if self.rank == 0 and global_batch_size_changed and verbose:
-                logger.info(
-                    f'adjusted running batch size to {self.current_running_global_batch_size} '
-                    f'for divisibility'
-                )
-        else:
-            self.current_running_global_batch_size = self.current_global_batch_size
+        self.current_running_global_batch_size = self.current_global_batch_size
 
         self.num_micro_batches = (
             self.current_running_global_batch_size // self.micro_batch_times_data_parallel_size

--- a/megatron/core/num_microbatches_calculator.py
+++ b/megatron/core/num_microbatches_calculator.py
@@ -257,16 +257,6 @@ def _build_num_microbatches_calculator(
             If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
     """
 
-    # Validate mutually exclusive options
-    if step_batch_size_schedule is not None and rampup_batch_size is not None:
-        raise ValueError(
-            'Cannot specify both --step-batch-size-schedule and --rampup-batch-size'
-        )
-    if step_batch_size_schedule is not None and decrease_batch_size_if_needed:
-        raise ValueError(
-            'Cannot specify both --step-batch-size-schedule and --decrease-batch-size-if-needed'
-        )
-
     # Step batch size schedule
     if step_batch_size_schedule is not None:
         if global_batch_size is not None and rank == 0:

--- a/megatron/core/num_microbatches_calculator.py
+++ b/megatron/core/num_microbatches_calculator.py
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 
 # TODO: global_var merge into mcore?
 _GLOBAL_NUM_MICROBATCHES_CALCULATOR: Union[
-    'ConstantNumMicroBatchesCalculator', 'RampupBatchsizeNumMicroBatchesCalculator', 'StepBatchsizeNumMicroBatchesCalculator'
+    'ConstantNumMicroBatchesCalculator',
+    'RampupBatchsizeNumMicroBatchesCalculator',
+    'StepBatchsizeNumMicroBatchesCalculator',
 ] = None
 
 
@@ -230,7 +232,11 @@ def _build_num_microbatches_calculator(
     decrease_batch_size_if_needed: bool,
     step_batch_size_schedule: Optional[str] = None,
     seq_length: Optional[int] = None,
-) -> Union['ConstantNumMicroBatchesCalculator', 'RampupBatchsizeNumMicroBatchesCalculator', 'StepBatchsizeNumMicroBatchesCalculator']:
+) -> Union[
+    'ConstantNumMicroBatchesCalculator',
+    'RampupBatchsizeNumMicroBatchesCalculator',
+    'StepBatchsizeNumMicroBatchesCalculator',
+]:
     """Build number of microbatches calculator. Internal helper method.
 
     Args:
@@ -260,9 +266,7 @@ def _build_num_microbatches_calculator(
     # Step batch size schedule
     if step_batch_size_schedule is not None:
         if global_batch_size is not None and rank == 0:
-            logger.warning(
-                '--global-batch-size is ignored when using --step-batch-size-schedule'
-            )
+            logger.warning('--global-batch-size is ignored when using --step-batch-size-schedule')
         num_microbatches_calculator = StepBatchsizeNumMicroBatchesCalculator(
             micro_batch_size=micro_batch_size,
             data_parallel_size=data_parallel_size,
@@ -273,9 +277,9 @@ def _build_num_microbatches_calculator(
 
     # Batch size ramp up
     elif rampup_batch_size is not None:
-        assert global_batch_size is not None, (
-            '--global-batch-size is required when using --rampup-batch-size'
-        )
+        assert (
+            global_batch_size is not None
+        ), '--global-batch-size is required when using --rampup-batch-size'
         assert len(rampup_batch_size) == 3, (
             'expected the following '
             'format: --rampup-batch-size <start batch size> '
@@ -303,9 +307,9 @@ def _build_num_microbatches_calculator(
 
     # Constant batch size
     else:
-        assert global_batch_size is not None, (
-            '--global-batch-size is required when not using --step-batch-size-schedule'
-        )
+        assert (
+            global_batch_size is not None
+        ), '--global-batch-size is required when not using --step-batch-size-schedule'
         num_microbatches_calculator = ConstantNumMicroBatchesCalculator(
             global_batch_size,
             micro_batch_size,
@@ -618,7 +622,9 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
         if rank == 0:
             logger.info(f'> initializing step batch size schedule')
             logger.info(f'  raw schedule string: "{schedule}"')
-            logger.info(f'  seq_length: {seq_length} (thresholds interpreted as {"tokens" if seq_length else "samples"})')
+            logger.info(
+                f'  seq_length: {seq_length} (thresholds interpreted as {"tokens" if seq_length else "samples"})'
+            )
             logger.info(f'  micro_batch_size: {micro_batch_size}')
             logger.info(f'  data_parallel_size: {data_parallel_size}')
             logger.info(f'step batch size schedule ({len(self.schedule)} steps):')
@@ -626,9 +632,13 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
                 num_microbatches = batch_size // self.micro_batch_times_data_parallel_size
                 if seq_length:
                     tokens = threshold * seq_length
-                    logger.info(f'  >= {tokens:,} tokens ({threshold:,} samples) -> batch_size={batch_size}, num_microbatches={num_microbatches}')
+                    logger.info(
+                        f'  >= {tokens:,} tokens ({threshold:,} samples) -> batch_size={batch_size}, num_microbatches={num_microbatches}'
+                    )
                 else:
-                    logger.info(f'  >= {threshold:,} samples -> batch_size={batch_size}, num_microbatches={num_microbatches}')
+                    logger.info(
+                        f'  >= {threshold:,} samples -> batch_size={batch_size}, num_microbatches={num_microbatches}'
+                    )
         # Initialize
         self.update(0, consistency_check=False, verbose=True)
 
@@ -654,9 +664,7 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
         return int(float(value_str) * multiplier)
 
     @classmethod
-    def _parse_schedule(
-        cls, schedule_str: str, seq_length: Optional[int]
-    ) -> List[Tuple[int, int]]:
+    def _parse_schedule(cls, schedule_str: str, seq_length: Optional[int]) -> List[Tuple[int, int]]:
         """Parse schedule string into list of (threshold_samples, batch_size) tuples.
 
         Args:
@@ -693,9 +701,9 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
     def _validate_schedule(self) -> None:
         """Validate the parsed schedule."""
         assert len(self.schedule) > 0, 'schedule must have at least one entry'
-        assert self.schedule[0][0] == 0, (
-            f'first schedule entry must have threshold 0, got {self.schedule[0][0]}'
-        )
+        assert (
+            self.schedule[0][0] == 0
+        ), f'first schedule entry must have threshold 0, got {self.schedule[0][0]}'
 
         # Check strictly increasing thresholds
         for i in range(1, len(self.schedule)):
@@ -746,7 +754,9 @@ class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
 
         # Consistency check
         if consistency_check:
-            assert self.current_global_batch_size % self.micro_batch_times_data_parallel_size == 0, (
+            assert (
+                self.current_global_batch_size % self.micro_batch_times_data_parallel_size == 0
+            ), (
                 f'current global batch size ({self.current_global_batch_size}) is not divisible by '
                 f'micro_batch_size ({self.micro_batch_size}) * '
                 f'data_parallel_size ({self.data_parallel_size})'

--- a/megatron/core/num_microbatches_calculator.py
+++ b/megatron/core/num_microbatches_calculator.py
@@ -4,13 +4,13 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
 # TODO: global_var merge into mcore?
 _GLOBAL_NUM_MICROBATCHES_CALCULATOR: Union[
-    'ConstantNumMicroBatchesCalculator', 'RampupBatchsizeNumMicroBatchesCalculator'
+    'ConstantNumMicroBatchesCalculator', 'RampupBatchsizeNumMicroBatchesCalculator', 'StepBatchsizeNumMicroBatchesCalculator'
 ] = None
 
 
@@ -67,6 +67,8 @@ def init_num_microbatches_calculator(
     global_batch_size: int,
     micro_batch_size: int,
     data_parallel_size: int,
+    step_batch_size_schedule: Optional[str] = None,
+    seq_length: Optional[int] = None,
     decrease_batch_size_if_needed: bool = False,
 ) -> None:
     """Initialize number of microbatches calculator. Supporting backward compatibility.
@@ -83,6 +85,13 @@ def init_num_microbatches_calculator(
             Micro batch size at initialization.
         data_parallel_size (int):
             Data parallel size.
+        step_batch_size_schedule (Optional[str]):
+            Step batch size schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
+            Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+            Example: "0:768 250B:1536 500B:3072 750B:6144"
+        seq_length (Optional[int]):
+            Sequence length for token-to-sample conversion when using step_batch_size_schedule.
+            If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
         decrease_batch_size_if_needed (bool, optional):
             If true, scale down batch size to ensure divisibility by DP size * microbatch size.
             Defaults to False.
@@ -93,6 +102,8 @@ def init_num_microbatches_calculator(
         global_batch_size,
         micro_batch_size,
         data_parallel_size,
+        step_batch_size_schedule,
+        seq_length,
         decrease_batch_size_if_needed,
         init=True,
     )
@@ -110,6 +121,8 @@ def reconfigure_num_microbatches_calculator(
     global_batch_size: int,
     micro_batch_size: int,
     data_parallel_size: int,
+    step_batch_size_schedule: Optional[str] = None,
+    seq_length: Optional[int] = None,
     decrease_batch_size_if_needed: bool = False,
 ) -> None:
     """Reconfigure number of microbatches calculator. Supporting backward compatibility.
@@ -126,6 +139,13 @@ def reconfigure_num_microbatches_calculator(
             Micro batch size at initialization.
         data_parallel_size (int):
             Data parallel size.
+        step_batch_size_schedule (Optional[str]):
+            Step batch size schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
+            Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+            Example: "0:768 250B:1536 500B:3072 750B:6144"
+        seq_length (Optional[int]):
+            Sequence length for token-to-sample conversion when using step_batch_size_schedule.
+            If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
         decrease_batch_size_if_needed (bool, optional):
             If true, scale down batch size to ensure divisibility by DP size * microbatch size.
             Defaults to False.
@@ -136,6 +156,8 @@ def reconfigure_num_microbatches_calculator(
         global_batch_size,
         micro_batch_size,
         data_parallel_size,
+        step_batch_size_schedule,
+        seq_length,
         decrease_batch_size_if_needed,
         init=False,
     )
@@ -147,6 +169,8 @@ def _configure_global_num_microbatches_calculator(
     global_batch_size: int,
     micro_batch_size: int,
     data_parallel_size: int,
+    step_batch_size_schedule: Optional[str] = None,
+    seq_length: Optional[int] = None,
     decrease_batch_size_if_needed: bool = False,
     init: bool = False,
 ) -> None:
@@ -165,6 +189,13 @@ def _configure_global_num_microbatches_calculator(
             Micro batch size at initialization.
         data_parallel_size (int):
             Data parallel size.
+        step_batch_size_schedule (Optional[str]):
+            Step batch size schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
+            Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+            Example: "0:768 250B:1536 500B:3072 750B:6144"
+        seq_length (Optional[int]):
+            Sequence length for token-to-sample conversion when using step_batch_size_schedule.
+            If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
         decrease_batch_size_if_needed (bool, optional):
             If true, scale down batch size to ensure divisibility by DP size * microbatch size.
             Defaults to False.
@@ -185,17 +216,21 @@ def _configure_global_num_microbatches_calculator(
         micro_batch_size,
         data_parallel_size,
         decrease_batch_size_if_needed,
+        step_batch_size_schedule,
+        seq_length,
     )
 
 
 def _build_num_microbatches_calculator(
     rank: int,
     rampup_batch_size: Optional[List[int]],
-    global_batch_size: int,
+    global_batch_size: Optional[int],
     micro_batch_size: int,
     data_parallel_size: int,
     decrease_batch_size_if_needed: bool,
-) -> Union['ConstantNumMicroBatchesCalculator', 'RampupBatchsizeNumMicroBatchesCalculator']:
+    step_batch_size_schedule: Optional[str] = None,
+    seq_length: Optional[int] = None,
+) -> Union['ConstantNumMicroBatchesCalculator', 'RampupBatchsizeNumMicroBatchesCalculator', 'StepBatchsizeNumMicroBatchesCalculator']:
     """Build number of microbatches calculator. Internal helper method.
 
     Args:
@@ -204,32 +239,50 @@ def _build_num_microbatches_calculator(
         rampup_batch_size (Optional[List[int]]):
             Rampup batch size, should be in format of
             [start_global_batch_size, batch_size_increment, ramup_samples].
-        global_batch_size (int):
-            Global batch size for the model.
+        global_batch_size (Optional[int]):
+            Global batch size for the model. Required for constant and rampup modes.
+            Ignored when step_batch_size_schedule is provided.
         micro_batch_size (int):
             Micro batch size at initialization.
         data_parallel_size (int):
             Data parallel size.
         decrease_batch_size_if_needed (bool):
             If true, scale down batch size to ensure divisibility by DP size * microbatch size.
-
+        step_batch_size_schedule (Optional[str]):
+            Step batch size schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
+            Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+            Example: "0:768 250B:1536 500B:3072 750B:6144"
+        seq_length (Optional[int]):
+            Sequence length for token-to-sample conversion when using step_batch_size_schedule.
+            If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
     """
 
-    # Constant batch size.
-    if rampup_batch_size is None:
-        num_microbatches_calculator = ConstantNumMicroBatchesCalculator(
-            global_batch_size,
-            micro_batch_size,
-            data_parallel_size,
-            decrease_batch_size_if_needed,
-            rank,
+    # Validate mutually exclusive options
+    if step_batch_size_schedule is not None and rampup_batch_size is not None:
+        raise ValueError(
+            'Cannot specify both --step-batch-size-schedule and --rampup-batch-size'
         )
-        if rank == 0:
-            logger.info(
-                f'setting number of microbatches to constant {num_microbatches_calculator.get()}'
+
+    # Step batch size schedule
+    if step_batch_size_schedule is not None:
+        if global_batch_size is not None and rank == 0:
+            logger.warning(
+                '--global-batch-size is ignored when using --step-batch-size-schedule'
             )
-    # Batch size ramp up.
-    else:
+        num_microbatches_calculator = StepBatchsizeNumMicroBatchesCalculator(
+            micro_batch_size=micro_batch_size,
+            data_parallel_size=data_parallel_size,
+            decrease_batch_size_if_needed=decrease_batch_size_if_needed,
+            rank=rank,
+            schedule=step_batch_size_schedule,
+            seq_length=seq_length,
+        )
+
+    # Batch size ramp up
+    elif rampup_batch_size is not None:
+        assert global_batch_size is not None, (
+            '--global-batch-size is required when using --rampup-batch-size'
+        )
         assert len(rampup_batch_size) == 3, (
             'expected the following '
             'format: --rampup-batch-size <start batch size> '
@@ -254,6 +307,23 @@ def _build_num_microbatches_calculator(
             batch_size_increment,
             ramup_samples,
         )
+
+    # Constant batch size
+    else:
+        assert global_batch_size is not None, (
+            '--global-batch-size is required when not using --step-batch-size-schedule'
+        )
+        num_microbatches_calculator = ConstantNumMicroBatchesCalculator(
+            global_batch_size,
+            micro_batch_size,
+            data_parallel_size,
+            decrease_batch_size_if_needed,
+            rank,
+        )
+        if rank == 0:
+            logger.info(
+                f'setting number of microbatches to constant {num_microbatches_calculator.get()}'
+            )
 
     return num_microbatches_calculator
 
@@ -500,6 +570,217 @@ class RampupBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
                 self.current_running_global_batch_size % self.micro_batch_times_data_parallel_size
                 == 0
             )
+        else:
+            self.current_running_global_batch_size = self.current_global_batch_size
+
+        self.num_micro_batches = (
+            self.current_running_global_batch_size // self.micro_batch_times_data_parallel_size
+        )
+
+
+class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
+    """Calculator of number of microbatches with arbitrary step-wise batch size schedule.
+
+    Args:
+        micro_batch_size (int): Micro batch size.
+        data_parallel_size (int): Data parallel size.
+        decrease_batch_size_if_needed (bool): Decrease batch size for divisibility.
+        rank (int): Rank for logging.
+        schedule (str): Schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
+            Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+            Examples:
+                "0:768 250B:1536 500B:3072 750B:6144" (thresholds in tokens)
+                "0:768 61035156250:1536" (thresholds in samples)
+        seq_length (int, optional): Sequence length for token-to-sample conversion.
+            If provided, thresholds are interpreted as tokens and converted to samples.
+            If None, thresholds are interpreted as samples directly.
+    """
+
+    def __init__(
+        self,
+        micro_batch_size: int,
+        data_parallel_size: int,
+        decrease_batch_size_if_needed: bool,
+        rank: int,
+        schedule: str,
+        seq_length: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+
+        self.micro_batch_size = micro_batch_size
+        self.data_parallel_size = data_parallel_size
+        self.decrease_batch_size_if_needed = decrease_batch_size_if_needed
+        self.rank = rank
+        self.seq_length = seq_length
+
+        self.micro_batch_times_data_parallel_size = micro_batch_size * data_parallel_size
+        assert self.micro_batch_times_data_parallel_size > 0
+
+        # Parse schedule string
+        self.schedule = self._parse_schedule(schedule, seq_length)
+
+        # Validate schedule
+        self._validate_schedule()
+
+        self.global_batch_size = self.schedule[-1][1]
+        self.current_global_batch_size = None
+
+        if rank == 0:
+            logger.info(f'> initializing step batch size schedule')
+            logger.info(f'  raw schedule string: "{schedule}"')
+            logger.info(f'  seq_length: {seq_length} (thresholds interpreted as {"tokens" if seq_length else "samples"})')
+            logger.info(f'  micro_batch_size: {micro_batch_size}')
+            logger.info(f'  data_parallel_size: {data_parallel_size}')
+            logger.info(f'  decrease_batch_size_if_needed: {decrease_batch_size_if_needed}')
+            logger.info(f'step batch size schedule ({len(self.schedule)} steps):')
+            for threshold, batch_size in self.schedule:
+                num_microbatches = batch_size // self.micro_batch_times_data_parallel_size
+                if seq_length:
+                    tokens = threshold * seq_length
+                    logger.info(f'  >= {tokens:,} tokens ({threshold:,} samples) -> batch_size={batch_size}, num_microbatches={num_microbatches}')
+                else:
+                    logger.info(f'  >= {threshold:,} samples -> batch_size={batch_size}, num_microbatches={num_microbatches}')
+        # Initialize
+        self.update(0, consistency_check=False, verbose=True)
+
+    @staticmethod
+    def _parse_numeric_value(value_str: str) -> int:
+        """Parse numeric value with optional suffix (K, M, B, T)."""
+        value_str = value_str.strip().upper()
+
+        multiplier = 1
+        if value_str.endswith('T'):
+            multiplier = 1_000_000_000_000
+            value_str = value_str[:-1]
+        elif value_str.endswith('B'):
+            multiplier = 1_000_000_000
+            value_str = value_str[:-1]
+        elif value_str.endswith('M'):
+            multiplier = 1_000_000
+            value_str = value_str[:-1]
+        elif value_str.endswith('K'):
+            multiplier = 1_000
+            value_str = value_str[:-1]
+
+        return int(float(value_str) * multiplier)
+
+    @classmethod
+    def _parse_schedule(
+        cls, schedule_str: str, seq_length: Optional[int]
+    ) -> List[Tuple[int, int]]:
+        """Parse schedule string into list of (threshold_samples, batch_size) tuples.
+
+        Args:
+            schedule_str: Space-separated "THRESHOLD:BATCH_SIZE" pairs.
+            seq_length: If provided, convert thresholds from tokens to samples.
+
+        Returns:
+            List of (threshold_samples, batch_size) tuples, sorted by threshold.
+        """
+        schedule = []
+        entries = schedule_str.strip().replace(',', ' ').split()
+
+        for entry in entries:
+            if ':' not in entry:
+                raise ValueError(
+                    f'Invalid schedule entry "{entry}". Expected format: "THRESHOLD:BATCH_SIZE"'
+                )
+
+            threshold_str, batch_size_str = entry.split(':', 1)
+            threshold = cls._parse_numeric_value(threshold_str)
+            batch_size = cls._parse_numeric_value(batch_size_str)
+
+            # Convert tokens to samples if seq_length provided
+            if seq_length is not None:
+                threshold = threshold // seq_length
+
+            schedule.append((threshold, batch_size))
+
+        # Sort by threshold ascending
+        schedule.sort(key=lambda x: x[0])
+
+        return schedule
+
+    def _validate_schedule(self) -> None:
+        """Validate the parsed schedule."""
+        assert len(self.schedule) > 0, 'schedule must have at least one entry'
+        assert self.schedule[0][0] == 0, (
+            f'first schedule entry must have threshold 0, got {self.schedule[0][0]}'
+        )
+
+        # Check strictly increasing thresholds
+        for i in range(1, len(self.schedule)):
+            assert self.schedule[i][0] > self.schedule[i - 1][0], (
+                f'schedule thresholds must be strictly increasing, '
+                f'got {self.schedule[i - 1][0]} before {self.schedule[i][0]}'
+            )
+
+        # Validate batch sizes are positive.
+        # NOTE: divisibility by micro_batch_size * data_parallel_size is NOT checked here
+        # because early schedule entries may be smaller than the current GPU configuration
+        # (e.g., after scaling up GPUs mid-training). Divisibility of the CURRENT batch size
+        # is checked at runtime in update() when consistency_check=True (after checkpoint loading).
+        for threshold, batch_size in self.schedule:
+            assert batch_size > 0, f'batch size must be positive, got {batch_size}'
+
+    def _get_batch_size_for_samples(self, consumed_samples: int) -> int:
+        """Get the batch size for the given number of consumed samples."""
+        batch_size = self.schedule[0][1]
+        for threshold, bs in self.schedule:
+            if consumed_samples >= threshold:
+                batch_size = bs
+            else:
+                break
+        return batch_size
+
+    @staticmethod
+    def _round(batch_size: int, divisor: int) -> int:
+        """Round batch_size down to nearest value divisible by divisor."""
+        return (batch_size // divisor) * divisor
+
+    def update(self, consumed_samples: int, consistency_check: bool, verbose: bool = False) -> None:
+        """Update number of microbatches based on consumed samples.
+
+        Args:
+            consumed_samples (int): Number of samples consumed.
+            consistency_check (bool): Check divisibility constraints.
+            verbose (bool): Enable logging.
+        """
+        old_current_global_batch_size = self.current_global_batch_size
+        self.current_global_batch_size = self._get_batch_size_for_samples(consumed_samples)
+
+        global_batch_size_changed = old_current_global_batch_size != self.current_global_batch_size
+
+        if self.rank == 0 and global_batch_size_changed and verbose:
+            if old_current_global_batch_size is None:
+                logger.info(f'setting initial batch size to {self.current_global_batch_size}')
+            else:
+                logger.info(
+                    f'stepping batch size from {old_current_global_batch_size} to '
+                    f'{self.current_global_batch_size} at {consumed_samples:,} samples'
+                )
+
+        # Consistency check
+        if consistency_check and not self.decrease_batch_size_if_needed:
+            assert self.current_global_batch_size % self.micro_batch_times_data_parallel_size == 0, (
+                f'current global batch size ({self.current_global_batch_size}) is not divisible by '
+                f'micro_batch_size ({self.micro_batch_size}) * '
+                f'data_parallel_size ({self.data_parallel_size})'
+            )
+
+        # Handle decrease_batch_size_if_needed
+        if (
+            self.decrease_batch_size_if_needed
+            and self.current_global_batch_size % self.micro_batch_times_data_parallel_size != 0
+        ):
+            self.current_running_global_batch_size = self._round(
+                self.current_global_batch_size, self.micro_batch_times_data_parallel_size
+            )
+            if self.rank == 0 and global_batch_size_changed and verbose:
+                logger.info(
+                    f'adjusted running batch size to {self.current_running_global_batch_size} '
+                    f'for divisibility'
+                )
         else:
             self.current_running_global_batch_size = self.current_global_batch_size
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -524,6 +524,15 @@ def validate_args(args, defaults={}):
         print_rank_0('setting global batch size to {}'.format(args.global_batch_size))
     assert args.global_batch_size > 0
 
+    # Step batch size schedule validations.
+    if args.step_batch_size_schedule is not None:
+        assert args.rampup_batch_size is None, (
+            'Cannot specify both --step-batch-size-schedule and --rampup-batch-size'
+        )
+        assert not args.decrease_batch_size_if_needed, (
+            'Cannot specify both --step-batch-size-schedule and --decrease-batch-size-if-needed'
+        )
+
     if args.perform_rl_step:
         num_generated_samples_per_inference_iteration = (
             args.grpo_samples_per_iteration * args.grpo_iterations)

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 import signal
 from typing import Literal, Optional
 
+
 @dataclass(kw_only=True)
 class TrainingConfig:
     """Configuration settings related to the training loop."""
@@ -16,7 +17,9 @@ class TrainingConfig:
     data-parallel-size. If this value is None, then use micro-batch-size * data-parallel-size
     as the global batch size. This choice will result in 1 for number of micro-batches."""
 
-    rampup_batch_size: list[int] | None = field(default=None, metadata={"argparse_meta": {"nargs": 3}})
+    rampup_batch_size: list[int] | None = field(
+        default=None, metadata={"argparse_meta": {"nargs": 3}}
+    )
     """Batch size ramp up with the following values: <start batch size>, <batch size increment>,
     <ramp-up samples>
     For example:
@@ -168,13 +171,30 @@ class SchedulerConfig:
     """number of samples to warmup learning rate over. Calculated at runtime from
     lr_warmup_fraction, lr_warmup_iters, or lr_warmup_samples.
     """
-    
-    override_opt_param_scheduler: bool = field(default=False, metadata={"argparse_meta": {"arg_names": ["--override-opt_param-scheduler", "--override-opt-param-scheduler"]}})
+
+    override_opt_param_scheduler: bool = field(
+        default=False,
+        metadata={
+            "argparse_meta": {
+                "arg_names": ["--override-opt_param-scheduler", "--override-opt-param-scheduler"]
+            }
+        },
+    )
     """Reset the values of the scheduler (learning rate, warmup iterations, minimum learning rate,
     maximum number of iterations, and decay style) from input arguments and ignore values from
     checkpoints. Note that all the above values will be reset."""
 
-    use_checkpoint_opt_param_scheduler: bool = field(default=False, metadata={"argparse_meta": {"arg_names": ["--use-checkpoint-opt_param-scheduler", "--use-checkpoint-opt-param-scheduler"]}})
+    use_checkpoint_opt_param_scheduler: bool = field(
+        default=False,
+        metadata={
+            "argparse_meta": {
+                "arg_names": [
+                    "--use-checkpoint-opt_param-scheduler",
+                    "--use-checkpoint-opt-param-scheduler",
+                ]
+            }
+        },
+    )
     """Use checkpoint to set the values of the scheduler (learning rate, warmup iterations,
     minimum learning rate, maximum number of iterations, and decay style) from checkpoint
     and ignore input arguments."""
@@ -290,7 +310,10 @@ class LoggerConfig:
     runtime_time_unit: str = "hours"
     """Time unit to use for time logging. """
 
-    barrier_with_L1_time: bool = field(default=True, metadata={"argparse_meta": {"arg_names": ["--no-barrier-with-level-1-timing"]}})
+    barrier_with_L1_time: bool = field(
+        default=True,
+        metadata={"argparse_meta": {"arg_names": ["--no-barrier-with-level-1-timing"]}},
+    )
     """If not disabled, use barrier with level 1 time measurements. Note that this is up to the user to
     make sure calling barrier with their timers will not result in hangs. This can happen if for
     example the user adds a level 1 timer that is not called by all ranks.
@@ -337,7 +360,12 @@ class CheckpointConfig:
     save: str | None = None
     """Output directory to save checkpoints to."""
 
-    save_interval: int | None = field(default=None, metadata={"argparse_meta": {"arg_names": ["--save-interval", "--persistent-save-interval"]}})
+    save_interval: int | None = field(
+        default=None,
+        metadata={
+            "argparse_meta": {"arg_names": ["--save-interval", "--persistent-save-interval"]}
+        },
+    )
     """Number of iterations between persistent checkpoint saves."""
 
     save_wgrads_interval: int | None = None
@@ -465,7 +493,9 @@ class CheckpointConfig:
     ckpt_fully_parallel_load: bool = False
     """Apply full load parallelization across DP for distributed checkpoints."""
 
-    ckpt_fully_parallel_load_exchange_algo: Literal["broadcast", "gather_rounds", "gather_object"] = "broadcast"
+    ckpt_fully_parallel_load_exchange_algo: Literal[
+        "broadcast", "gather_rounds", "gather_object"
+    ] = "broadcast"
     """Algorithm for fully parallel load of distributed checkpoints.
     "broadcast"(default): Broadcast the checkpoint from rank 0 to all other ranks.
     "gather_rounds": Gather the checkpoint from all ranks in rounds.

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -27,9 +27,17 @@ class TrainingConfig:
     300000 / 126 = 2380 samples.
     """
 
+    step_batch_size_schedule: str | None = None
+    """Step-wise batch size schedule in format "THRESHOLD:BS THRESHOLD:BS ...".
+    Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+    If --seq-length is provided, thresholds are interpreted as tokens;
+    otherwise as samples.
+    Example: --step-batch-size-schedule "0:768 250B:1536 500B:3072 750B:6144"
+    Cannot be used together with --rampup-batch-size."""
+
     decrease_batch_size_if_needed: bool = False
-    """If set, decrease batch size if microbatch_size * dp_size does not 
-    divide batch_size. Old batch_size will be restored if training is re-started 
+    """If set, decrease batch size if microbatch_size * dp_size does not
+    divide batch_size. Old batch_size will be restored if training is re-started
     with dp_size that divides batch_size // microbatch_size."""
 
     empty_unused_memory_level: Literal[0, 1, 2] = 0

--- a/megatron/training/global_vars.py
+++ b/megatron/training/global_vars.py
@@ -10,7 +10,10 @@ from megatron.core import Timers
 from megatron.core.config import set_experimental_flag
 from megatron.core.energy_monitor import EnergyMonitor
 from megatron.core.jit import disable_jit_fuser
-from megatron.core.num_microbatches_calculator import init_num_microbatches_calculator, unset_num_microbatches_calculator
+from megatron.core.num_microbatches_calculator import (
+    init_num_microbatches_calculator,
+    unset_num_microbatches_calculator,
+)
 from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer
 from megatron.training.dist_signal_handler import DistributedSignalHandler
 
@@ -23,6 +26,7 @@ _GLOBAL_ADLR_AUTORESUME = None
 _GLOBAL_TIMERS = None
 _GLOBAL_ENERGY_MONITOR = None
 _GLOBAL_SIGNAL_HANDLER = None
+
 
 def get_args():
     """Return arguments."""
@@ -53,6 +57,7 @@ def get_one_logger():
     to check if it is initialized."""
     return _GLOBAL_ONE_LOGGER
 
+
 def get_adlr_autoresume():
     """ADLR autoresume object. It can be None so no need
     to check if it is initialized."""
@@ -64,10 +69,12 @@ def get_timers():
     _ensure_var_is_initialized(_GLOBAL_TIMERS, 'timers')
     return _GLOBAL_TIMERS
 
+
 def get_energy_monitor():
     """Return energy monitor."""
     _ensure_var_is_initialized(_GLOBAL_ENERGY_MONITOR, 'energy monitor')
     return _GLOBAL_ENERGY_MONITOR
+
 
 def get_signal_handler():
     _ensure_var_is_initialized(_GLOBAL_SIGNAL_HANDLER, 'signal handler')
@@ -79,7 +86,6 @@ def _set_signal_handler(exit_signal):
     global _GLOBAL_SIGNAL_HANDLER
     _ensure_var_is_not_initialized(_GLOBAL_SIGNAL_HANDLER, 'signal handler')
     _GLOBAL_SIGNAL_HANDLER = DistributedSignalHandler(exit_signal).__enter__()
-
 
 
 def set_global_variables(args, build_tokenizer=True):
@@ -172,39 +178,48 @@ def rebuild_tokenizer(args):
 def _set_tensorboard_writer(args):
     """Set tensorboard writer."""
     global _GLOBAL_TENSORBOARD_WRITER
-    _ensure_var_is_not_initialized(_GLOBAL_TENSORBOARD_WRITER,
-                                   'tensorboard writer')
+    _ensure_var_is_not_initialized(_GLOBAL_TENSORBOARD_WRITER, 'tensorboard writer')
 
-    if hasattr(args, 'tensorboard_dir') and \
-       args.tensorboard_dir and args.rank == (args.world_size - 1):
+    if (
+        hasattr(args, 'tensorboard_dir')
+        and args.tensorboard_dir
+        and args.rank == (args.world_size - 1)
+    ):
         try:
             from torch.utils.tensorboard import SummaryWriter
+
             print('> setting tensorboard ...')
             _GLOBAL_TENSORBOARD_WRITER = SummaryWriter(
-                log_dir=args.tensorboard_dir,
-                max_queue=args.tensorboard_queue_size)
+                log_dir=args.tensorboard_dir, max_queue=args.tensorboard_queue_size
+            )
         except ModuleNotFoundError:
-            print('WARNING: TensorBoard writing requested but is not '
-                  'available (are you using PyTorch 1.1.0 or later?), '
-                  'no TensorBoard logs will be written.', flush=True)
+            print(
+                'WARNING: TensorBoard writing requested but is not '
+                'available (are you using PyTorch 1.1.0 or later?), '
+                'no TensorBoard logs will be written.',
+                flush=True,
+            )
 
 
 def _set_wandb_writer(args):
     global _GLOBAL_WANDB_WRITER
-    _ensure_var_is_not_initialized(_GLOBAL_WANDB_WRITER,
-                                   'wandb writer')
+    _ensure_var_is_not_initialized(_GLOBAL_WANDB_WRITER, 'wandb writer')
     if getattr(args, 'wandb_project', '') and args.rank == (args.world_size - 1):
         if args.wandb_exp_name == '':
             raise ValueError("Please specify the wandb experiment name!")
 
         import wandb
+
         if args.wandb_save_dir:
             save_dir = args.wandb_save_dir
         else:
             # Defaults to the save dir.
             save_dir = os.path.join(args.save, 'wandb')
         wandb_config = vars(args)
-        if 'kitchen_config_file' in wandb_config and wandb_config['kitchen_config_file'] is not None:
+        if (
+            'kitchen_config_file' in wandb_config
+            and wandb_config['kitchen_config_file'] is not None
+        ):
             # Log the contents of the config for discovery of what the quantization
             # settings were.
             with open(wandb_config['kitchen_config_file'], "r") as f:
@@ -213,7 +228,8 @@ def _set_wandb_writer(args):
             'dir': save_dir,
             'name': args.wandb_exp_name,
             'project': args.wandb_project,
-            'config': wandb_config}
+            'config': wandb_config,
+        }
         if args.wandb_entity:
             wandb_kwargs['entity'] = args.wandb_entity
         os.makedirs(wandb_kwargs['dir'], exist_ok=True)
@@ -232,18 +248,22 @@ def _set_one_logger(args):
             one_logger_async = False
         try:
             from one_logger import OneLogger
+
             config = {
-               'project': args.one_logger_project,
-               'name': args.one_logger_run_name,
-               'async': one_logger_async,
+                'project': args.one_logger_project,
+                'name': args.one_logger_run_name,
+                'async': one_logger_async,
             }
             one_logger = OneLogger(config=config)
             _GLOBAL_ONE_LOGGER = one_logger
         except Exception:
-            print('WARNING: one_logger package is required to enable e2e metrics '
-                  'tracking. please go to '
-                  'https://confluence.nvidia.com/display/MLWFO/Package+Repositories'
-                  ' for details to install it')
+            print(
+                'WARNING: one_logger package is required to enable e2e metrics '
+                'tracking. please go to '
+                'https://confluence.nvidia.com/display/MLWFO/Package+Repositories'
+                ' for details to install it'
+            )
+
 
 def _set_adlr_autoresume(args):
     """Initialize ADLR autoresume."""
@@ -252,6 +272,7 @@ def _set_adlr_autoresume(args):
 
     if args.adlr_autoresume:
         from megatron.training.utils import print_rank_0
+
         print_rank_0('enabling autoresume ...')
         sys.path.append(os.environ.get('SUBMIT_SCRIPTS', '.'))
         try:
@@ -269,6 +290,7 @@ def _set_timers(args):
     _ensure_var_is_not_initialized(_GLOBAL_TIMERS, 'timers')
     _GLOBAL_TIMERS = Timers(args.timing_log_level, args.timing_log_option)
 
+
 def _set_energy_monitor(args):
     """Initialize energy monitor."""
     global _GLOBAL_ENERGY_MONITOR
@@ -284,6 +306,7 @@ def _ensure_var_is_initialized(var, name):
 def _ensure_var_is_not_initialized(var, name):
     """Make sure the input variable is not None."""
     assert var is None, '{} is already initialized.'.format(name)
+
 
 def destroy_global_vars():
     global _GLOBAL_ARGS

--- a/megatron/training/global_vars.py
+++ b/megatron/training/global_vars.py
@@ -96,6 +96,8 @@ def set_global_variables(args, build_tokenizer=True):
         args.global_batch_size,
         args.micro_batch_size,
         args.data_parallel_size,
+        args.step_batch_size_schedule,
+        args.seq_length,
         args.decrease_batch_size_if_needed,
     )
     if build_tokenizer:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2,15 +2,14 @@
 
 """Pretrain utilities."""
 import time
-
 # The earliest we can measure the start time.
 _TRAIN_START_TIME = time.time()
 
 # Startup timestamps for tracking program initialization phases
 _STARTUP_TIMESTAMPS = {
     'program_start': None,  # Set by entry script before imports
-    'main_entry': None,  # Set by entry script at start of __main__
-    'pretrain_entry': None,  # Set at top of pretrain()
+    'main_entry': None,     # Set by entry script at start of __main__
+    'pretrain_entry': None, # Set at top of pretrain()
 }
 
 
@@ -57,20 +56,20 @@ from .log_handler import CustomHandler
 logging.basicConfig(handlers=[CustomHandler()], level=logging.INFO)
 from .theoretical_memory_usage import report_theoretical_memory
 
-_LEGACY_TRAIN_START_TIME = time.time()  # NOTE(asolergi-nv): Legacy timestamp
+_LEGACY_TRAIN_START_TIME = time.time() # NOTE(asolergi-nv): Legacy timestamp
 
 import torch
 
 try:
     from megatron.rl import rl_utils
-
     has_rl_utils = True
 except ImportError:
     has_rl_utils = False
 from megatron.rl.parallel_utils import build_inference_pg_collection
-
 try:
-    from modelopt.torch.distill.plugins.megatron import get_tensor_shapes_adjust_fn_for_distillation
+    from modelopt.torch.distill.plugins.megatron import (
+        get_tensor_shapes_adjust_fn_for_distillation,
+    )
 
     has_nvidia_modelopt = True
 except ImportError:
@@ -111,14 +110,9 @@ from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
 from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.transformer.module import Float16Module
-from megatron.core.distributed import (
-    DistributedDataParallelConfig,
-    TorchFullyShardedDataParallelConfig,
-)
+from megatron.core.distributed import DistributedDataParallelConfig, TorchFullyShardedDataParallelConfig
 from megatron.core.distributed import DistributedDataParallel as DDP
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
-    FullyShardedDataParallel as megatron_FSDP,
-)
+from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
 from megatron.core.optimizer.optimizer import param_group_identifier_keys
 
 from megatron.core.optimizer.qk_clip import clip_qk
@@ -132,13 +126,7 @@ except ImportError:
 
 from megatron.core.distributed import finalize_model_grads
 from megatron.core.enums import ModelType
-from megatron.core.optimizer import (
-    get_megatron_optimizer,
-    AdamOptimizerConfig,
-    SGDOptimizerConfig,
-    OptimizerConfig,
-    ParamKey,
-)
+from megatron.core.optimizer import get_megatron_optimizer, AdamOptimizerConfig, SGDOptimizerConfig, OptimizerConfig, ParamKey
 from megatron.core.optimizer.muon import get_megatron_muon_optimizer
 from megatron.core.rerun_state_machine import (
     get_rerun_state_machine,
@@ -149,11 +137,7 @@ from megatron.core.rerun_state_machine import (
 from megatron.training.initialize import initialize_megatron
 from megatron.training.initialize import write_args_to_tensorboard
 from megatron.training.initialize import set_jit_fusion_options
-from megatron.training.utils import (
-    get_batch_on_this_cp_rank,
-    get_batch_on_this_tp_rank,
-    is_hybrid_model,
-)
+from megatron.training.utils import get_batch_on_this_cp_rank, get_batch_on_this_tp_rank, is_hybrid_model
 from megatron.training.datasets.data_samplers import build_pretraining_data_loader
 from megatron.core.datasets.data_schedule import HybridCPDataLoaderWrapper
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
@@ -164,7 +148,7 @@ from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelpe
 from megatron.core.parallel_state import (
     destroy_global_memory_buffer,
     destroy_model_parallel,
-    update_pg_timeout,
+    update_pg_timeout
 )
 from megatron.core.inference.symmetric_memory import SymmetricMemoryManager
 from megatron.core.inference.unified_memory import create_unified_mempool
@@ -172,7 +156,6 @@ from megatron.core.resharding.refit import swap_model_weights
 
 try:
     from torch_memory_saver import torch_memory_saver
-
     torch_memory_saver.hook_mode = "torch"
     HAVE_TORCH_MEMORY_SAVER = True
 except ImportError:
@@ -184,7 +167,7 @@ from megatron.core.num_microbatches_calculator import (
     get_current_global_batch_size,
     get_current_running_global_batch_size,
     get_num_microbatches,
-    update_num_microbatches,
+    update_num_microbatches
 )
 
 from .async_utils import maybe_finalize_async_save
@@ -234,7 +217,7 @@ def destroy_global_state():
 
 def print_datetime(string, override_timestamp=None):
     """Note that this call will sync across all ranks. Use override_timestamp if provided;
-    otherwise use current timestamp."""
+       otherwise use current timestamp."""
     torch.distributed.barrier()
     if override_timestamp is None:
         time_str = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
@@ -242,51 +225,27 @@ def print_datetime(string, override_timestamp=None):
         time_str = datetime.fromtimestamp(override_timestamp).strftime('%Y-%m-%d %H:%M:%S.%f')
     print_rank_0(f'[{string}] datetime: {time_str} ')
 
-
 def num_floating_point_operations(args, batch_size):
     def mlp_layer_flops(batch_size, seq_len, hidden_size, expansion=4.0, swiglu=False):
         """Calculate FLOPs for an MLP layer."""
         scale_factor = 3.0 / 2.0 if swiglu else 1.0
         return 4 * expansion * scale_factor * batch_size * seq_len * hidden_size**2
 
-    def moe_layer_flops(
-        batch_size,
-        seq_len,
-        hidden_size,
-        moe_ffn_hidden_size,
-        shared_expert_ffn_hidden_size,
-        num_experts_routed_to,
-        moe_latent_size=None,
-        swiglu=False,
-    ):
+    def moe_layer_flops(batch_size, seq_len, hidden_size, moe_ffn_hidden_size,
+                        shared_expert_ffn_hidden_size, num_experts_routed_to,
+                        moe_latent_size=None, swiglu=False):
         """Calculate FLOPs for an MoE layer."""
         scale_factor = 3.0 / 2.0 if swiglu else 1.0
         if moe_latent_size is None:
-            routed_flops = (
-                4
-                * batch_size
-                * seq_len
-                * hidden_size
-                * moe_ffn_hidden_size
-                * num_experts_routed_to
-                * scale_factor
-            )
+            routed_flops = (4 * batch_size * seq_len * hidden_size *
+                            moe_ffn_hidden_size * num_experts_routed_to * scale_factor)
         else:
             # Routed experts run on moe_latent_size.
-            routed_flops = (
-                4
-                * batch_size
-                * seq_len
-                * moe_latent_size
-                * moe_ffn_hidden_size
-                * num_experts_routed_to
-                * scale_factor
-            )
+            routed_flops = (4 * batch_size * seq_len * moe_latent_size *
+                            moe_ffn_hidden_size * num_experts_routed_to * scale_factor)
             # Up proj and down proj.
-            routed_flops += 4 * batch_size * seq_len * hidden_size * moe_latent_size
-        shared_flops = (
-            4 * batch_size * seq_len * hidden_size * shared_expert_ffn_hidden_size * scale_factor
-        )
+            routed_flops += (4 * batch_size * seq_len * hidden_size * moe_latent_size)
+        shared_flops = 4 * batch_size * seq_len * hidden_size * shared_expert_ffn_hidden_size * scale_factor
         return routed_flops + shared_flops
 
     def attn_layer_flops(
@@ -304,9 +263,8 @@ def num_floating_point_operations(args, batch_size):
             * (hidden_size + (hidden_size * (g / num_heads)) + (seq_len / 2))
         )
 
-    def mamba_layer_flops(
-        batch_size, seq_len, hidden_size, state_dim=16, head_dim=64, num_groups=1, num_heads=128
-    ):
+    def mamba_layer_flops(batch_size, seq_len, hidden_size, state_dim=16,
+                          head_dim=64, num_groups=1, num_heads=128):
         """Calculate FLOPs for a Mamba layer."""
         # Note (rwaleffe): flops estimate for scan should be updated based on new SSD kernels,
         # but small percent of overall layer flops
@@ -327,63 +285,29 @@ def num_floating_point_operations(args, batch_size):
             + (2 * batch_size * seq_len * d_in * hidden_size)  # out_proj
         )
 
-    def hybrid_flops(
-        batch_size,
-        seq_len,
-        hidden_size,
-        num_attn_layers,
-        num_mamba_layers,
-        num_mlp_layers,
-        num_moe_layers,
-        mamba_state_dim=128,
-        mamba_head_dim=64,
-        mamba_num_groups=8,
-        mamba_num_heads=128,
-        num_attn_heads=32,
-        gqa=True,
-        gqa_groups=8,
-        kv_channels=None,
-        mlp_expansion=4.0,
-        swiglu=False,
-        moe_latent_size=None,
-        moe_ffn_hidden_size=2048,
-        shared_expert_ffn_hidden_size=2048,
-        num_experts_routed_to=1,
-        vocab_size=256000,
-        mtp_num_layers=0,
-    ):
+    def hybrid_flops(batch_size, seq_len, hidden_size,
+                     num_attn_layers, num_mamba_layers, num_mlp_layers, num_moe_layers,
+                     mamba_state_dim=128, mamba_head_dim=64,
+                     mamba_num_groups=8, mamba_num_heads=128,
+                     num_attn_heads=32, gqa=True,
+                     gqa_groups=8, kv_channels=None,
+                     mlp_expansion=4.0, swiglu=False,
+                     moe_latent_size=None,
+                     moe_ffn_hidden_size=2048, shared_expert_ffn_hidden_size=2048, num_experts_routed_to=1,
+                     vocab_size=256000, mtp_num_layers=0):
         """Calculate total FLOPs for the hybrid model."""
         flops_fwd = (
-            num_attn_layers
-            * attn_layer_flops(
-                batch_size, seq_len, hidden_size, num_attn_heads, gqa, gqa_groups, kv_channels
-            )
-            + num_mlp_layers
-            * mlp_layer_flops(batch_size, seq_len, hidden_size, mlp_expansion, swiglu)
-            + num_mamba_layers
-            * mamba_layer_flops(
-                batch_size,
-                seq_len,
-                hidden_size,
-                mamba_state_dim,
-                mamba_head_dim,
-                mamba_num_groups,
-                mamba_num_heads,
-            )
-            + num_moe_layers
-            * moe_layer_flops(
-                batch_size,
-                seq_len,
-                hidden_size,
-                moe_ffn_hidden_size,
-                shared_expert_ffn_hidden_size,
-                num_experts_routed_to,
-                moe_latent_size,
-                swiglu,
-            )
-            + (
-                2 * batch_size * seq_len * hidden_size * vocab_size * (1 + mtp_num_layers)
-            )  # logits computation
+                num_attn_layers * attn_layer_flops(batch_size, seq_len, hidden_size,
+                                                   num_attn_heads, gqa, gqa_groups, kv_channels) +
+                num_mlp_layers * mlp_layer_flops(batch_size, seq_len, hidden_size,
+                                                 mlp_expansion, swiglu) +
+                num_mamba_layers * mamba_layer_flops(batch_size, seq_len, hidden_size,
+                                                     mamba_state_dim, mamba_head_dim,
+                                                     mamba_num_groups, mamba_num_heads) +
+                num_moe_layers * moe_layer_flops(batch_size, seq_len, hidden_size, moe_ffn_hidden_size,
+                                                 shared_expert_ffn_hidden_size, num_experts_routed_to,
+                                                 moe_latent_size, swiglu) +
+                (2 * batch_size * seq_len * hidden_size * vocab_size * (1 + mtp_num_layers))  # logits computation
         )
         return flops_fwd * 3
 
@@ -526,7 +450,8 @@ def num_floating_point_operations(args, batch_size):
                     / 2  # causal mask (only half of the mask is non-zero)
                     * 2  # QK^T and (QK^T)V
                     ## out proj
-                    + query_projection_size * args.hidden_size
+                    + query_projection_size
+                    * args.hidden_size
                 )
             )
 
@@ -535,8 +460,8 @@ def num_floating_point_operations(args, batch_size):
             if isinstance(args.linear_attention_freq, int):
                 linear_attention_pattern = [
                     # [1,1,...,1,0,1,1,...,1,0,...]
-                    0 if ((i + 1) % args.linear_attention_freq == 0) else 1
-                    for i in range(num_layers)
+                    0 if ((i + 1) % args.linear_attention_freq == 0)
+                    else 1 for i in range(num_layers)
                 ]
             elif isinstance(args.linear_attention_freq, list):
                 linear_attention_pattern = args.linear_attention_freq
@@ -573,13 +498,18 @@ def num_floating_point_operations(args, batch_size):
                     * fma_expansion_factor
                     * (
                         ## in proj
-                        args.hidden_size * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
+                        args.hidden_size
+                        * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
                         ## conv1d
-                        + args.linear_conv_kernel_dim * (2 * qk_dim + v_dim)
+                        + args.linear_conv_kernel_dim
+                        * (2 * qk_dim + v_dim)
                         ## gated delta rule
-                        + num_v_heads * (v_head_dim**2) * 4  # KK^T, VK^T, S(a(I-bKK^T)), and SQ
+                        + num_v_heads
+                        * (v_head_dim ** 2)
+                        * 4  # KK^T, VK^T, S(a(I-bKK^T)), and SQ
                         ## out proj
-                        + args.hidden_size * v_dim
+                        + args.hidden_size
+                        * v_dim
                     )
                 )
             else:
@@ -607,7 +537,8 @@ def num_floating_point_operations(args, batch_size):
                 * args.hidden_size
                 * (
                     # dense layer (deepseek v2, v3 style)
-                    (args.ffn_hidden_size * ffn_expansion_factor) * num_dense_layers
+                    (args.ffn_hidden_size * ffn_expansion_factor)
+                    * num_dense_layers
                     # routed experts
                     + (
                         (moe_ffn_hidden_size * num_experts_routed_to * ffn_expansion_factor)
@@ -625,7 +556,8 @@ def num_floating_point_operations(args, batch_size):
                     )
                     * num_moe_layers
                     # Shared Experts.
-                    + (shared_expert_ffn_hidden_size * ffn_expansion_factor) * num_moe_layers
+                    + (shared_expert_ffn_hidden_size * ffn_expansion_factor)
+                    * num_moe_layers
                 )
                 # Self Attention
                 + self_attn_term
@@ -655,7 +587,6 @@ def num_floating_point_operations(args, batch_size):
         from operator import itemgetter
 
         from megatron.core.ssm.mamba_hybrid_layer_allocation import Symbols, get_hybrid_layer_counts
-
         num_attn_layers, num_mamba_layers, num_mlp_layers, num_moe_layers = itemgetter(
             Symbols.ATTENTION, Symbols.MAMBA, Symbols.MLP, Symbols.MOE
         )(get_hybrid_layer_counts(args.hybrid_layer_pattern))
@@ -683,16 +614,10 @@ def num_floating_point_operations(args, batch_size):
             mlp_expansion=args.ffn_hidden_size / args.hidden_size,
             swiglu=args.swiglu,
             moe_latent_size=args.moe_latent_size,
-            moe_ffn_hidden_size=(
-                args.moe_ffn_hidden_size
-                if args.moe_ffn_hidden_size is not None
-                else args.ffn_hidden_size
-            ),
-            shared_expert_ffn_hidden_size=(
-                0
-                if args.moe_shared_expert_intermediate_size is None
-                else args.moe_shared_expert_intermediate_size
-            ),
+            moe_ffn_hidden_size=(args.moe_ffn_hidden_size if args.moe_ffn_hidden_size is not None
+                                 else args.ffn_hidden_size),
+            shared_expert_ffn_hidden_size=(0 if args.moe_shared_expert_intermediate_size is None
+                                           else args.moe_shared_expert_intermediate_size),
             num_experts_routed_to=args.moe_router_topk,
             vocab_size=args.padded_vocab_size,
             mtp_num_layers=mtp_num_layers,
@@ -758,7 +683,6 @@ def preprocess_common_state_dict(common_state_dict):
         preprocessed_common_state_dict['args']['use_distributed_optimizer']
         and "optimizer" in preprocessed_common_state_dict
     ):
-
         def reorder_inner_param_groups(optimizer_state_dict):
             # When distributed optimizer loading, source param groups will be reordered,
             # so we reorder the param groups here to prevent warning.
@@ -877,9 +801,11 @@ def pretrain(
     timers = get_timers()
 
     if args.fine_grained_activation_offloading:
-        from megatron.core.pipeline_parallel.utils import set_ideal_affinity_for_current_gpu
-
+        from megatron.core.pipeline_parallel.utils import (
+            set_ideal_affinity_for_current_gpu
+        )
         set_ideal_affinity_for_current_gpu()
+
 
     if args.log_progress:
         append_to_progress_log("Starting job")
@@ -899,9 +825,7 @@ def pretrain(
     # Initialize program_start_global with a fallback value in case set_startup_timestamps() wasn't called
     program_start_global = _TRAIN_START_TIME
     if _STARTUP_TIMESTAMPS['program_start'] is not None:
-        program_start_global = torch.tensor(
-            [_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda'
-        )
+        program_start_global = torch.tensor([_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda')
         torch.distributed.all_reduce(program_start_global, op=torch.distributed.ReduceOp.MIN)
         program_start_global = program_start_global.item()
     set_startup_timestamps(program_start=program_start_global)
@@ -921,41 +845,26 @@ def pretrain(
     # Print basic megatron init time (using global min start)
     # NOTE(asolergi-nv): This is not entirely accurate, but we keep it for backwards compatibility.
     print_rank_0(
-        'time to initialize megatron (seconds): {:.3f}'.format(
-            megatron_init_end - _LEGACY_TRAIN_START_TIME
-        )
+        'time to initialize megatron (seconds): {:.3f}'.format(megatron_init_end - _LEGACY_TRAIN_START_TIME)
     )
 
     # Note, not entirely accurate as rank 0 might not be the first or last to hit these timestamps
-    print_datetime(
-        'after in-process setup and before initialize_megatron', timestamp_after_inprocess_setup
-    )
-    print_datetime(
-        'after in-job setup and before initialize_megatron', timestamp_after_in_job_setup
-    )
+    print_datetime('after in-process setup and before initialize_megatron', timestamp_after_inprocess_setup)
+    print_datetime('after in-job setup and before initialize_megatron', timestamp_after_in_job_setup)
 
     if program_start is not None and main_entry is not None and pretrain_entry is not None:
         # Inject startup deltas into timers
         startup_timers = {
-            'startup-program-entry-spread': program_start
-            - program_start_global,  # Local program start timestamp vs the global earliest program start timestamp
-            'startup-library-setup': main_entry - program_start,  # Local library imports
-            'startup-program-setup': pretrain_entry
-            - main_entry,  # Local __main__ entry to pretrain entry
-            'startup-in-process-setup': timestamp_after_inprocess_setup
-            - pretrain_entry,  # Local in-process setup
-            'startup-in-job-setup': timestamp_after_in_job_setup
-            - timestamp_after_inprocess_setup,  # Local in-job setup
-            'startup-initialize-megatron': timestamp_after_initialize_megatron
-            - timestamp_after_in_job_setup,  # Local initialize megatron
-            'startup-set-jit-fusion-options': timestamp_after_set_jit_fusion_options
-            - timestamp_after_initialize_megatron,  # Local set JIT fusion options
-            'all-reduce-start-timestamps-tensor': megatron_init_end
-            - timestamp_after_set_jit_fusion_options,  # 2x All-reduce, first collective call
-            'startup-megatron-init-local': megatron_init_end
-            - pretrain_entry,  # Local megatron init
-            'startup-megatron-init-global': megatron_init_end
-            - program_start_global,  # Local megatron init vs the global earliest program start timestamp
+            'startup-program-entry-spread': program_start - program_start_global, # Local program start timestamp vs the global earliest program start timestamp
+            'startup-library-setup': main_entry - program_start, # Local library imports
+            'startup-program-setup': pretrain_entry - main_entry, # Local __main__ entry to pretrain entry
+            'startup-in-process-setup': timestamp_after_inprocess_setup - pretrain_entry, # Local in-process setup
+            'startup-in-job-setup': timestamp_after_in_job_setup - timestamp_after_inprocess_setup, # Local in-job setup
+            'startup-initialize-megatron': timestamp_after_initialize_megatron - timestamp_after_in_job_setup, # Local initialize megatron
+            'startup-set-jit-fusion-options': timestamp_after_set_jit_fusion_options - timestamp_after_initialize_megatron, # Local set JIT fusion options
+            'all-reduce-start-timestamps-tensor': megatron_init_end - timestamp_after_set_jit_fusion_options, # 2x All-reduce, first collective call
+            'startup-megatron-init-local': megatron_init_end - pretrain_entry, # Local megatron init
+            'startup-megatron-init-global': megatron_init_end - program_start_global, # Local megatron init vs the global earliest program start timestamp
         }
         for name, delta in startup_timers.items():
             timers(name, log_level=0).set_elapsed(delta)
@@ -1049,9 +958,7 @@ def pretrain(
             # Build an isolated inference config so training config remains unchanged
             inference_config = copy.deepcopy(config)
             if args.rl_inference_tensor_model_parallel_size is not None:
-                inference_config.tensor_model_parallel_size = (
-                    args.rl_inference_tensor_model_parallel_size
-                )
+                inference_config.tensor_model_parallel_size = args.rl_inference_tensor_model_parallel_size
             if args.rl_inference_pipeline_model_parallel_size is not None:
                 inference_config.pipeline_model_parallel_size = (
                     args.rl_inference_pipeline_model_parallel_size
@@ -1115,15 +1022,11 @@ def pretrain(
         valid_data_iterator = []
         test_data_iterator = []
         for vp_stage in range(len(model)):
-            dataset_provider_parameters = inspect.signature(
-                train_valid_test_dataset_provider
-            ).parameters
-            assert (
-                "vp_stage" in dataset_provider_parameters
-            ), "vp_stage must be a kwarg in train_valid_test_dataset_provider when using virtual pipeline parallelism"
-            vp_stage_train_valid_test_dataset_provider = functools.partial(
-                train_valid_test_dataset_provider, vp_stage=vp_stage
-            )
+            dataset_provider_parameters = inspect.signature(train_valid_test_dataset_provider).parameters
+            assert "vp_stage" in dataset_provider_parameters, \
+                "vp_stage must be a kwarg in train_valid_test_dataset_provider when using virtual pipeline parallelism"
+            vp_stage_train_valid_test_dataset_provider = \
+                functools.partial(train_valid_test_dataset_provider, vp_stage=vp_stage)
             if getattr(train_valid_test_dataset_provider, 'is_distributed', False):
                 vp_stage_train_valid_test_dataset_provider.is_distributed = True
             iterators = build_train_valid_test_data_iterators(
@@ -1187,12 +1090,7 @@ def pretrain(
 
         print_datetime('after training is done')
 
-        if (
-            not args.skip_train
-            and args.save
-            and iteration != 0
-            and iteration % args.save_interval != 0
-        ):
+        if not args.skip_train and args.save and iteration != 0 and iteration % args.save_interval != 0:
             save_checkpoint(
                 iteration,
                 model,
@@ -1236,16 +1134,11 @@ def pretrain(
             )
         else:
             evaluate_and_print_results(
-                prefix,
-                forward_step_func,
-                valid_data_iterator,
-                model,
-                iteration,
-                process_non_loss_data_func,
-                config,
-                verbose=True,
-                write_to_tensorboard=not args.skip_train,
-                non_loss_data_func=non_loss_data_func,
+                prefix, forward_step_func,
+                valid_data_iterator, model,
+                iteration, process_non_loss_data_func, config,
+                verbose=True, write_to_tensorboard=not args.skip_train,
+                non_loss_data_func=non_loss_data_func
             )
 
     if args.do_test:
@@ -1327,13 +1220,7 @@ def update_train_iters(args):
     print_rank_0(f'setting training iterations to {args.train_iters}')
 
 
-def get_model(
-    model_provider_func,
-    model_type=ModelType.encoder_or_decoder,
-    wrap_with_ddp=True,
-    config=None,
-    pg_collection=None,
-):
+def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap_with_ddp=True, config=None, pg_collection=None):
     """Build the model."""
     args = get_args()
     args.model_type = model_type
@@ -1342,7 +1229,6 @@ def get_model(
 
     if has_nvidia_modelopt:
         from megatron.post_training.checkpointing import has_modelopt_state
-
         # [ModelOpt]: Check if the checkpoint is a ModelOpt checkpoint and
         # set a flag to use our model provider if so.
         if args.load is not None and has_modelopt_state(args.load):
@@ -1390,6 +1276,7 @@ def get_model(
             model.model_type = model_type
         return model
 
+
     if args.init_model_with_meta_device:
         with torch.device('meta'):
             model = build_model()
@@ -1415,7 +1302,9 @@ def get_model(
         print(
             ' > number of parameters on (tensor, pipeline) '
             'model parallel rank ({}, {}): {}'.format(
-                get_pg_rank(pg_collection.tp), get_pg_rank(pg_collection.pp), num_parameters
+                get_pg_rank(pg_collection.tp),
+                get_pg_rank(pg_collection.pp),
+                num_parameters,
             ),
             flush=True,
         )
@@ -1437,10 +1326,7 @@ def get_model(
 
     # Materialize tensors on meta device (GPU allocation) if not using FSDP2 and not using Megatron FSDP.
     if args.init_model_with_meta_device and not args.use_torch_fsdp2 and not args.use_megatron_fsdp:
-        model = [
-            to_empty_if_meta_device(model_module, device=torch.device("cuda"))
-            for model_module in model
-        ]
+        model = [to_empty_if_meta_device(model_module, device=torch.device("cuda")) for model_module in model]
 
     # Before TE2.x: The model_module.bfloat16()/model_module.half() above will call the inplace
     #               copy of TE's Float8Tensor, which will write an unwanted value (amax calculated
@@ -1462,9 +1348,7 @@ def get_model(
 
         if getattr(args, "use_torch_fsdp2", False):
             reshard_after_forward = getattr(args, "torch_fsdp2_reshard_after_forward", True)
-            ddp_config = TorchFullyShardedDataParallelConfig(
-                reshard_after_forward=reshard_after_forward
-            )
+            ddp_config = TorchFullyShardedDataParallelConfig(reshard_after_forward=reshard_after_forward)
         else:
             kwargs = {}
             for f in dataclasses.fields(DistributedDataParallelConfig):
@@ -1474,17 +1358,15 @@ def get_model(
             kwargs['check_for_nan_in_grad'] = args.check_for_nan_in_loss_and_grad
             kwargs['check_for_large_grads'] = args.check_for_large_grads
             if args.ddp_num_buckets is not None:
-                assert (
-                    args.ddp_bucket_size is None
-                ), "Cannot specify both --ddp-num-buckets and --ddp-bucket-size"
-                assert args.ddp_num_buckets > 0, "--ddp-num-buckets must be greater than 0"
+                assert args.ddp_bucket_size is None, \
+                    "Cannot specify both --ddp-num-buckets and --ddp-bucket-size"
+                assert args.ddp_num_buckets > 0, \
+                    "--ddp-num-buckets must be greater than 0"
                 kwargs['bucket_size'] = num_parameters // args.ddp_num_buckets
             else:
                 kwargs['bucket_size'] = args.ddp_bucket_size
             kwargs['pad_buckets_for_high_nccl_busbw'] = args.ddp_pad_buckets_for_high_nccl_busbw
-            kwargs['reduce_scatter_with_fp32_accumulation'] = (
-                args.ddp_reduce_scatter_with_fp32_accumulation
-            )
+            kwargs['reduce_scatter_with_fp32_accumulation'] = args.ddp_reduce_scatter_with_fp32_accumulation
             kwargs['average_in_collective'] = args.ddp_average_in_collective
             ddp_config = DistributedDataParallelConfig(**kwargs)
 
@@ -1523,8 +1405,7 @@ def get_model(
                     module=model_chunk,
                     # Turn off bucketing for model_chunk 2 onwards, since communication
                     # for these model chunks is overlapped with compute anyway.
-                    disable_bucketing=(model_chunk_idx > 0)
-                    or args.overlap_param_gather_with_optimizer_step,
+                    disable_bucketing=(model_chunk_idx > 0) or args.overlap_param_gather_with_optimizer_step,
                     **ddp_init_kwargs,
                 )
                 for (model_chunk_idx, model_chunk) in enumerate(model)
@@ -1625,7 +1506,11 @@ def get_megatron_optimizer_config(args: Any) -> OptimizerConfig:
     return config, config_overrides
 
 
-def setup_model_and_optimizer(model_provider_func, model_type, checkpointing_context=None):
+def setup_model_and_optimizer(
+    model_provider_func,
+    model_type,
+    checkpointing_context=None,
+):
     """Setup model and optimizer."""
     args = get_args()
     timers = get_timers()
@@ -1639,9 +1524,7 @@ def setup_model_and_optimizer(model_provider_func, model_type, checkpointing_con
     model = get_model(model_provider_func, model_type, wrap_with_ddp=wrap_with_ddp)
     unwrapped_model = unwrap_model(model)
 
-    one_logger and one_logger.log_metrics(
-        {"app_build_optimzer_start_time": one_logger_utils.get_timestamp_in_ms()}
-    )
+    one_logger and one_logger.log_metrics({"app_build_optimzer_start_time": one_logger_utils.get_timestamp_in_ms()})
     if skip_optimizer:
         optimizer, opt_param_scheduler = None, None
         # In RL inference-only mode, train_iters must still be set despite having no optimizer.
@@ -1684,9 +1567,7 @@ def setup_model_and_optimizer(model_provider_func, model_type, checkpointing_con
             )
         opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
 
-    one_logger and one_logger.log_metrics(
-        {"app_build_optimzer_finish_time": one_logger_utils.get_timestamp_in_ms()}
-    )
+    one_logger and one_logger.log_metrics({"app_build_optimzer_finish_time": one_logger_utils.get_timestamp_in_ms()})
 
     if args.moe_use_upcycling:
         torch.distributed.barrier()
@@ -1824,27 +1705,16 @@ def dummy_train_step(data_iterator):
             batch = get_batch_on_this_cp_rank(batch)
 
 
-def train_step(
-    forward_step_func,
-    data_iterator,
-    model,
-    optimizer,
-    opt_param_scheduler,
-    config,
-    forward_backward_func,
-    iteration=None,
-):
+def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_scheduler, config, forward_backward_func, iteration=None):
     """Single training step."""
     args = get_args()
     timers = get_timers()
 
     rerun_state_machine = get_rerun_state_machine()
-    save_dgrads_in_this_iteration = (
-        args.save_dgrads_interval is not None and (iteration + 1) % args.save_dgrads_interval == 0
-    )
-    save_wgrads_in_this_iteration = (
-        args.save_wgrads_interval is not None and (iteration + 1) % args.save_wgrads_interval == 0
-    )
+    save_dgrads_in_this_iteration = (args.save_dgrads_interval is not None and
+                                     (iteration + 1) % args.save_dgrads_interval == 0)
+    save_wgrads_in_this_iteration = (args.save_wgrads_interval is not None and
+                                     (iteration + 1) % args.save_wgrads_interval == 0)
     while rerun_state_machine.should_run_forward_backward(data_iterator):
         # Set grad to zero.
         for model_chunk in model:
@@ -1982,7 +1852,8 @@ def train_step(
                 # over the total number of tokens across the global batch.
                 val = torch.vstack(val).sum(dim=0)
                 torch.distributed.all_reduce(
-                    val, group=mpu.get_data_parallel_group(with_context_parallel=True)
+                    val,
+                    group=mpu.get_data_parallel_group(with_context_parallel=True)
                 )
                 loss_reduced[key] = val[0] / val[1]
             elif val[0].numel() == 1:
@@ -2001,16 +1872,7 @@ def train_step(
             num_zeros_in_grad,
             log_max_attention_logit,
         )
-    return (
-        {},
-        skipped_iter,
-        should_checkpoint,
-        should_exit,
-        exit_code,
-        grad_norm,
-        num_zeros_in_grad,
-        log_max_attention_logit,
-    )
+    return {}, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad, log_max_attention_logit
 
 
 def training_log(
@@ -2068,68 +1930,45 @@ def training_log(
     # Logging.
     timers_to_log = []
     if args.timing_log_level >= 1:
-        timers_to_log.extend(
-            [
-                'forward-backward',
-                'layernorm-grads-all-reduce',
-                'embedding-grads-all-reduce',
-                'all-grads-sync',
-                'params-all-gather',
-                'optimizer-copy-to-main-grad',
-                'optimizer-unscale-and-check-inf',
-                'optimizer-clip-main-grad',
-                'optimizer-count-zeros',
-                'optimizer-inner-step',
-                'optimizer-copy-main-to-model-params',
-                'optimizer',
-            ]
-        )
+        timers_to_log.extend([
+            'forward-backward',
+            'layernorm-grads-all-reduce',
+            'embedding-grads-all-reduce',
+            'all-grads-sync',
+            'params-all-gather',
+            'optimizer-copy-to-main-grad',
+            'optimizer-unscale-and-check-inf',
+            'optimizer-clip-main-grad',
+            'optimizer-count-zeros',
+            'optimizer-inner-step',
+            'optimizer-copy-main-to-model-params',
+            'optimizer',
+        ])
     if args.timing_log_level >= 2:
-        timers_to_log.extend(
-            [
-                'batch-generator',
-                'forward-compute',
-                'backward-compute',
-                'forward-recv',
-                'forward-send',
-                'backward-recv',
-                'backward-send',
-                'forward-send-forward-recv',
-                'forward-send-backward-recv',
-                'backward-send-forward-recv',
-                'backward-send-backward-recv',
-                'forward-backward-send-forward-backward-recv',
-            ]
-        )
+        timers_to_log.extend([
+            'batch-generator',
+            'forward-compute',
+            'backward-compute',
+            'forward-recv',
+            'forward-send',
+            'backward-recv',
+            'backward-send',
+            'forward-send-forward-recv',
+            'forward-send-backward-recv',
+            'backward-send-forward-recv',
+            'backward-send-backward-recv',
+            'forward-backward-send-forward-backward-recv',
+        ])
     # Add timers from RL loop if needed.
     if args.perform_rl_step:
-        timers_to_log.extend(
-            [
-                'rollout-collection',
-                'inference-setup',
-                'collect-rollouts',
-                'postrollout-gc-collect',
-                'sync-rollouts',
-                'prepare-data-for-update',
-                'compute-group-stats',
-                'prepare-trajectories',
-                'get-ltor-masks-and-position-ids',
-                'create-logprobs-dataloader',
-                'compute-logprobs',
-                'compute-ref-logprobs',
-                'compute-prob-stats',
-                'prepare-advantages',
-                'create-dataloader',
-                'log-wandb-tb',
-                'offload-optimizer-before-inference',
-                'onload-kv-cache-before-inference',
-                'wait-for-decode-only',
-                'build-cuda-graphs',
-                'suspend-engine',
-                'offload-kv-cache-after-inference',
-                'onload-optimizer-after-inference',
-            ]
-        )
+        timers_to_log.extend(['rollout-collection', 'inference-setup', 'collect-rollouts', 'postrollout-gc-collect',
+                              'sync-rollouts', 'prepare-data-for-update', 'compute-group-stats',
+                              'prepare-trajectories', 'get-ltor-masks-and-position-ids', 'create-logprobs-dataloader',
+                              'compute-logprobs', 'compute-ref-logprobs', 'compute-prob-stats',
+                              'prepare-advantages', 'create-dataloader', 'log-wandb-tb',
+                              'offload-optimizer-before-inference', 'onload-kv-cache-before-inference',
+                              'wait-for-decode-only', 'build-cuda-graphs', 'suspend-engine',
+                              'offload-kv-cache-after-inference', 'onload-optimizer-after-inference'])
 
     # Calculate batch size.
     batch_size = args.micro_batch_size * args.data_parallel_size * get_num_microbatches()
@@ -2147,9 +1986,7 @@ def training_log(
             wandb_writer.log({'samples vs steps': args.consumed_train_samples}, iteration)
         if learning_rate is not None:
             writer.add_scalar('learning-rate', learning_rate, iteration)
-            writer.add_scalar(
-                'learning-rate vs samples', learning_rate, args.consumed_train_samples
-            )
+            writer.add_scalar('learning-rate vs samples', learning_rate, args.consumed_train_samples)
             if wandb_writer:
                 wandb_writer.log({'learning-rate': learning_rate}, iteration)
         if args.skipped_train_samples > 0:
@@ -2200,14 +2037,10 @@ def training_log(
             if wandb_writer:
                 wandb_writer.log({'params-norm': params_norm}, iteration)
         if args.perform_rl_step:
-            grpo_collection_iteration = iteration // (
-                args.grpo_iterations * ((args.grpo_samples_per_iteration) // args.global_batch_size)
-            )
+            grpo_collection_iteration = iteration // (args.grpo_iterations * ( ( args.grpo_samples_per_iteration )// args.global_batch_size ))
             writer.add_scalar('grpo_collection_iteration', grpo_collection_iteration, iteration)
             if wandb_writer:
-                wandb_writer.log(
-                    {'grpo_collection_iteration': grpo_collection_iteration}, iteration
-                )
+                wandb_writer.log({'grpo_collection_iteration': grpo_collection_iteration}, iteration)
         if args.log_memory_to_tensorboard:
             mem_stats = torch.cuda.memory_stats()
             writer.add_scalar(
@@ -2242,10 +2075,8 @@ def training_log(
             from operator import itemgetter
 
             from megatron.core.ssm.mamba_hybrid_layer_allocation import (
-                Symbols,
-                get_hybrid_layer_counts,
+                Symbols, get_hybrid_layer_counts,
             )
-
             layers = itemgetter(Symbols.MOE)(get_hybrid_layer_counts(args.hybrid_layer_pattern))
         else:
             layers = args.num_layers
@@ -2285,9 +2116,7 @@ def training_log(
 
     # Dump memory snapshot and print metrics to stdout.
     if iteration % args.log_interval == 0 or is_first_iteration:
-        if args.record_memory_history and (
-            is_last_rank() or torch.distributed.get_backend() == 'fake'
-        ):
+        if args.record_memory_history and (is_last_rank() or torch.distributed.get_backend() == 'fake'):
             snapshot = torch.cuda.memory._snapshot()
             from pickle import dump
 
@@ -2380,20 +2209,13 @@ def training_log(
             if iteration > (loaded_iteration + 1):
                 # Make sure the memory after the second iteration is reported to include optimizer state memory.
                 report_memory_flag = False
-        if (
-            args.log_memory_interval is not None
-            and iteration % args.log_memory_interval == 0
-            and not reported_memory_in_this_iteration
-        ):
+        if args.log_memory_interval is not None and iteration % args.log_memory_interval == 0 and \
+            not reported_memory_in_this_iteration:
             report_memory(f'(after {iteration} iterations)')
         # Write timers to wandb, don't reset the counts.
         if args.log_timers_to_tensorboard:
-            timers.write(
-                timers_to_log, writer, iteration, normalizer=args.log_interval, reset=False
-            )
-            timers.write(
-                timers_to_log, wandb_writer, iteration, normalizer=args.log_interval, reset=False
-            )
+            timers.write(timers_to_log, writer, iteration, normalizer=args.log_interval, reset=False)
+            timers.write(timers_to_log, wandb_writer, iteration, normalizer=args.log_interval, reset=False)
         # Log timers to stdout
         timers.log(timers_to_log, normalizer=args.log_interval, reset=should_reset)
 
@@ -2450,11 +2272,9 @@ def force_param_sync(model_chunks: list[DDP]) -> None:
         assert isinstance(model_chunk, DDP)
         model_chunk.start_param_sync(force_sync=True)
 
-
 # Only report memory for first 3 checkpoint saves.
 num_checkpoints_memory_reported = 0
 MAX_NUM_CHECKPOINTS_MEMORY_REPORTED = 3
-
 
 def save_checkpoint_and_time(
     iteration,
@@ -2545,7 +2365,7 @@ def post_training_step_callbacks(
     iteration,
     prof,
     num_floating_point_operations_since_last_log_event,
-    nsys_nvtx_context=None,
+    nsys_nvtx_context = None,
 ):
     """Run all post-training-step functions (e.g., FT heartbeats, GC)."""
     args = get_args()
@@ -2583,7 +2403,8 @@ def post_training_step_callbacks(
     if (
         args.profile
         and iteration == args.profile_step_end
-        and (len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks)
+        and (len(args.profile_ranks) == 0 or
+             torch.distributed.get_rank() in args.profile_ranks)
     ):
         if args.use_pytorch_profiler:
             assert prof is not None
@@ -2692,8 +2513,12 @@ def checkpoint_and_decide_exit(
             return True
 
     # Exit based on iterations.
-    if (args.exit_interval and iteration % args.exit_interval == 0) or (
-        args.phase_transition_iterations and iteration in args.phase_transition_iterations
+    if (
+        args.exit_interval
+        and iteration % args.exit_interval == 0
+    ) or (
+        args.phase_transition_iterations
+        and iteration in args.phase_transition_iterations
     ):
         if args.save and not saved_checkpoint:
             save_checkpoint_and_time(
@@ -2749,31 +2574,29 @@ def train(
             args.load = None
             args.finetune = True
             load_checkpoint(
-                model,
-                None,  # Don't load optimizer state
-                None,  # Don't load scheduler state
-                checkpointing_context=checkpointing_context,
-                skip_load_to_model_and_opt=HAVE_FSDP2
-                and getattr(args, "use_torch_fsdp2", False)
-                and args.ckpt_format == "torch_dist",
-            )
-            ref_state_dict = {
-                k: (v.cpu() if v is not None else v) for k, v in model[0].state_dict().items()
-            }
+                    model,
+                    None,  # Don't load optimizer state
+                    None,  # Don't load scheduler state
+                    checkpointing_context=checkpointing_context,
+                    skip_load_to_model_and_opt=HAVE_FSDP2
+                    and getattr(args, "use_torch_fsdp2", False)
+                    and args.ckpt_format == "torch_dist",
+                )
+            ref_state_dict = {k: (v.cpu() if v is not None else v) for k, v in model[0].state_dict().items()}
 
             # Reload RL training checkpoint weights
             args.load = load
             args.finetune = finetune
             print_rank_0("> Reloading RL training checkpoint...")
             load_checkpoint(
-                model,
-                None,
-                None,
-                checkpointing_context=checkpointing_context,
-                skip_load_to_model_and_opt=HAVE_FSDP2
-                and getattr(args, "use_torch_fsdp2", False)
-                and args.ckpt_format == "torch_dist",
-            )
+                    model,
+                    None,
+                    None,
+                    checkpointing_context=checkpointing_context,
+                    skip_load_to_model_and_opt=HAVE_FSDP2
+                    and getattr(args, "use_torch_fsdp2", False)
+                    and args.ckpt_format == "torch_dist",
+                )
 
             args.no_load_optim = no_load_optim
 
@@ -2782,9 +2605,8 @@ def train(
         print_rank_0("> Reinitializing microbatch calculator for GRPO training...")
         from megatron.core.num_microbatches_calculator import (
             destroy_num_microbatches_calculator,
-            init_num_microbatches_calculator,
+            init_num_microbatches_calculator
         )
-
         # First destroy the existing calculator
         destroy_num_microbatches_calculator()
         # Then initialize with the correct perform_rl_step=True context
@@ -2834,10 +2656,8 @@ def train(
     # Make sure rerun_state_machine has the right iteration loaded from checkpoint.
     rerun_state_machine = get_rerun_state_machine()
     if rerun_state_machine.current_iteration != iteration:
-        print_rank_0(
-            f"Overwriting rerun_state_machine.current_iteration from "
-            f"{rerun_state_machine.current_iteration} to {iteration}..."
-        )
+        print_rank_0(f"Overwriting rerun_state_machine.current_iteration from "
+                     f"{rerun_state_machine.current_iteration} to {iteration}...")
         rerun_state_machine.current_iteration = iteration
 
     # Track E2E metrics at the start of training.
@@ -2918,9 +2738,7 @@ def train(
     # Wrap forward_backward_func for Full iteration CUDA graph
     forward_backward_func = get_forward_backward_func()
     if args.cuda_graph_impl == "local" and CudaGraphScope.full_iteration in args.cuda_graph_scope:
-        forward_backward_func = FullCudaGraphWrapper(
-            forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps
-        )
+        forward_backward_func = FullCudaGraphWrapper(forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps)
 
     def get_e2e_base_metrics():
         """Get base metrics values for one-logger to calculate E2E tracking metrics."""
@@ -2945,26 +2763,23 @@ def train(
             one_logger.store_set('get_e2e_base_metrics', get_e2e_base_metrics)
 
     prof = None
-    nsys_nvtx_context = None  # reference to context for nsys profiling, so it can be cleaned up
+    nsys_nvtx_context = None # reference to context for nsys profiling, so it can be cleaned up
     if (
         args.profile
-        and (len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks)
+        and (len(args.profile_ranks) == 0 or
+             torch.distributed.get_rank() in args.profile_ranks)
         and args.use_pytorch_profiler
     ):
         if args.pytorch_profiler_collect_chakra:
             et_dir = Path(f"{args.tensorboard_dir}/../chakra")
             et_dir.mkdir(parents=True, exist_ok=True)
-            et = torch.profiler.ExecutionTraceObserver().register_callback(
-                f"{et_dir}/rank-{torch.distributed.get_rank()}.json.gz"
-            )
+            et = torch.profiler.ExecutionTraceObserver().register_callback(f"{et_dir}/rank-{torch.distributed.get_rank()}.json.gz")
         else:
             et = None
-
         def trace_handler(p):
             profile_dir = Path(f"{args.tensorboard_dir}/../torch_profile")
             profile_dir.mkdir(parents=True, exist_ok=True)
             p.export_chrome_trace(f"{profile_dir}/rank-{torch.distributed.get_rank()}.json.gz")
-
         prof = torch.profiler.profile(
             schedule=torch.profiler.schedule(
                 wait=max(args.profile_step_start - 1, 0),
@@ -3011,9 +2826,9 @@ def train(
     # Run training iterations till done.
     buffered_rollouts = None
     while iteration < args.train_iters:
-        if args.profile and (
-            len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks
-        ):
+        if (args.profile 
+            and (len(args.profile_ranks) == 0 or
+                 torch.distributed.get_rank() in args.profile_ranks)):
             if args.use_pytorch_profiler:
                 prof.step()
             elif iteration == args.profile_step_start:
@@ -3027,10 +2842,7 @@ def train(
         # Update the timeout for all process groups after initialization
         # We update the timeout after the first successful iteration,
         # which takes longer than others usually
-        if (
-            args.distributed_timeout_seconds_after_init is not None
-            and iteration == start_iteration + 1
-        ):
+        if args.distributed_timeout_seconds_after_init is not None and iteration == start_iteration+1:
             # TODO: some dynamic timeout setting is required
             # based on the iteration time considering interval-based steps (e.g. eval, checkpoint)
             # e.g. timeout for normal iterations vs timeout for iterations with checkpoint
@@ -3106,11 +2918,7 @@ def train(
                 torch.cuda.empty_cache()
             with torch.no_grad():
                 train_data_iterator = rl_utils.get_grpo_data_iterator(
-                    model,
-                    inference_model,
-                    optimizer,
-                    iteration,
-                    ref_state_dict,
+                    model, inference_model, optimizer, iteration, ref_state_dict,
                     grpo_iterations=args.grpo_iterations,
                     grpo_prompts_per_step=args.grpo_prompts_per_step,
                     grpo_group_size=args.grpo_group_size,
@@ -3145,14 +2953,7 @@ def train(
                 num_zeros_in_grad,
                 max_attention_logit,
             ) = train_step(
-                forward_step_func,
-                train_data_iterator,
-                model,
-                optimizer,
-                opt_param_scheduler,
-                config,
-                forward_backward_func,
-                iteration=iteration,
+                forward_step_func, train_data_iterator, model, optimizer, opt_param_scheduler, config, forward_backward_func, iteration=iteration
             )
             ft_integration.on_training_step_end()
         if should_checkpoint:
@@ -3201,7 +3002,7 @@ def train(
         if (
             getattr(args, "fsdp_manual_registration", False)
             and getattr(args, "use_megatron_fsdp", False)
-            and iteration == start_iteration + 1
+            and iteration ==  start_iteration + 1
         ):
             for model_chunk in model:
                 if isinstance(model_chunk, megatron_FSDP) and getattr(
@@ -3307,23 +3108,14 @@ def train(
                     training_model=rl_training_model,
                 )
             else:
-                evaluate_and_print_results(
-                    prefix,
-                    forward_step_func,
-                    valid_data_iterator,
-                    model,
-                    iteration,
-                    process_non_loss_data_func,
-                    config,
-                    verbose=False,
-                    write_to_tensorboard=True,
-                    non_loss_data_func=non_loss_data_func,
-                )
+                evaluate_and_print_results(prefix, forward_step_func,
+                                       valid_data_iterator, model,
+                                       iteration, process_non_loss_data_func,
+                                       config, verbose=False, write_to_tensorboard=True,
+                                       non_loss_data_func=non_loss_data_func)
 
             eval_duration += timers('eval-time').elapsed()
-            eval_iterations += (
-                sum(args.eval_iters) if isinstance(args.eval_iters, list) else args.eval_iters
-            )
+            eval_iterations += sum(args.eval_iters) if isinstance(args.eval_iters, list) else args.eval_iters
             timers('eval-time').stop()
             one_logger_utils.track_e2e_metrics()
 
@@ -3443,9 +3235,7 @@ def evaluate(
     eval_num_microbatches = eval_batch_size // (args.micro_batch_size * args.data_parallel_size)
     forward_backward_func = get_forward_backward_func()
     if args.cuda_graph_impl == "local" and CudaGraphScope.full_iteration in args.cuda_graph_scope:
-        forward_backward_func = FullCudaGraphWrapper(
-            forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps
-        )
+        forward_backward_func = FullCudaGraphWrapper(forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps)
 
     if has_nvidia_modelopt:
         # [ModelOpt]: Pipeline-parallel Distillation stacks student and teacher tensors
@@ -3495,9 +3285,7 @@ def evaluate(
                 # Reduce across processes.
                 for key in loss_dicts[0].keys():
                     if key not in total_loss_dict:
-                        total_loss_dict[key] = torch.tensor(
-                            [0.0, 0.0], dtype=torch.float, device='cuda'
-                        )
+                        total_loss_dict[key] = torch.tensor([0.0, 0.0], dtype=torch.float, device='cuda')
                     val = [x[key].view(-1) for x in loss_dicts]
 
                     if val[0].numel() == 2:
@@ -3507,17 +3295,19 @@ def evaluate(
                             val = val[:, 0] / val[:, 1].clamp(min=1)
                             val = val.mean()
                             torch.distributed.all_reduce(
-                                val, group=mpu.get_data_parallel_group(with_context_parallel=True)
+                                val,
+                                group=mpu.get_data_parallel_group(with_context_parallel=True)
                             )
                             val /= torch.distributed.get_world_size(
                                 group=mpu.get_data_parallel_group(with_context_parallel=True)
                             )
                             total_loss_dict[key][0] += val
                             total_loss_dict[key][1] += 1
-                        else:
+                        else :
                             val = torch.vstack(val).sum(dim=0)
                             torch.distributed.all_reduce(
-                                val, group=mpu.get_data_parallel_group(with_context_parallel=True)
+                                val,
+                                group=mpu.get_data_parallel_group(with_context_parallel=True)
                             )
                             total_loss_dict[key] += val
                     elif val[0].numel() == 1:
@@ -3640,9 +3430,7 @@ def evaluate_and_print_results(
             ppl = math.exp(min(20, total_loss_dict[key].item()))
             string += '{} PPL: {:.6E} | '.format(key, ppl)
             if writer:
-                writer.add_scalar(
-                    '{} validation{}'.format(key, suffix), total_loss_dict[key].item(), iteration
-                )
+                writer.add_scalar('{} validation{}'.format(key, suffix), total_loss_dict[key].item(), iteration)
                 writer.add_scalar(
                     '{} validation{} vs samples'.format(key, suffix),
                     total_loss_dict[key].item(),
@@ -3651,14 +3439,11 @@ def evaluate_and_print_results(
                 if args.log_validation_ppl_to_tensorboard:
                     writer.add_scalar('{} validation{} ppl'.format(key, suffix), ppl, iteration)
                     writer.add_scalar(
-                        '{} validation{} ppl vs samples'.format(key, suffix),
-                        ppl,
-                        args.consumed_train_samples,
+                        '{} validation{} ppl vs samples'.format(key, suffix), ppl, args.consumed_train_samples
                     )
                 if wandb_writer and is_last_rank():
                     wandb_writer.log(
-                        {'{} validation{}'.format(key, suffix): total_loss_dict[key].item()},
-                        iteration,
+                        {'{} validation{}'.format(key, suffix): total_loss_dict[key].item()}, iteration
                     )
 
         if process_non_loss_data_func is not None and writer and is_last_rank():
@@ -3699,11 +3484,7 @@ def get_train_valid_test_num_samples():
 
     # Get train_samples in current phase.
     if args.phase_transition_iterations:
-        phase_transition_samples = (
-            [0]
-            + [t * args.global_batch_size for t in args.phase_transition_iterations]
-            + [args.train_samples]
-        )
+        phase_transition_samples = [0] + [t * args.global_batch_size for t in args.phase_transition_iterations] + [args.train_samples]
         current_sample = args.iteration * args.global_batch_size
         last_transition_sample = max(s for s in phase_transition_samples if s <= current_sample)
         next_transition_sample = min(s for s in phase_transition_samples if s > current_sample)
@@ -3714,9 +3495,7 @@ def get_train_valid_test_num_samples():
     return (train_samples_in_current_phase, eval_samples, test_samples)
 
 
-def build_train_valid_test_datasets(
-    build_train_valid_test_datasets_provider, train_valid_test_num_samples=None
-):
+def build_train_valid_test_datasets(build_train_valid_test_datasets_provider, train_valid_test_num_samples=None):
     """Build pretraining datasets."""
     if train_valid_test_num_samples is None:
         train_valid_test_num_samples = get_train_valid_test_num_samples()
@@ -3751,14 +3530,8 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
 
     # Get consumed train samples in this phase.
     if args.phase_transition_iterations:
-        last_transition = max(
-            iteration
-            for iteration in (0, *args.phase_transition_iterations)
-            if iteration <= args.iteration
-        )
-        consumed_train_samples_in_current_phase = (
-            args.iteration - last_transition
-        ) * args.global_batch_size
+        last_transition = max(iteration for iteration in (0, *args.phase_transition_iterations) if iteration <= args.iteration)
+        consumed_train_samples_in_current_phase = (args.iteration - last_transition) * args.global_batch_size
     else:
         consumed_train_samples_in_current_phase = args.consumed_train_samples
 
@@ -3775,21 +3548,17 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
             valid_dataloaders = None
             test_dataloader = None
             do_train = (args.train_iters or 0) > 0
-            do_valid = args.full_validation or args.eval_iters > 0
-            do_test = args.full_validation or args.eval_iters > 0
+            do_valid = (args.full_validation or args.eval_iters > 0)
+            do_test = (args.full_validation or args.eval_iters > 0)
 
         else:
             # Build datasets.
-            train_ds, valid_ds, test_ds = build_train_valid_test_datasets(
-                build_train_valid_test_datasets_provider
-            )
+            train_ds, valid_ds, test_ds = build_train_valid_test_datasets(build_train_valid_test_datasets_provider)
             valid_ds = [valid_ds] if not isinstance(valid_ds, list) else valid_ds
             if args.skip_train:
                 train_dataloader = None
             else:
-                train_dataloader = build_pretraining_data_loader(
-                    train_ds, consumed_train_samples_in_current_phase
-                )
+                train_dataloader = build_pretraining_data_loader(train_ds, consumed_train_samples_in_current_phase)
             valid_dataloaders = []
             for valid_d in valid_ds:
                 if args.skip_train or args.full_validation:
@@ -3798,19 +3567,13 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
                     if args.multiple_validation_sets:
                         # TODO(bnorick): for multiple validation sets without full validation, args.consumed_valid_samples is not
                         # correct and needs to be calculated/set per validation set
-                        raise NotImplementedError(
-                            "--multiple-validation-sets currently requires --full-validation"
-                        )
-                    valid_dataloaders.append(
-                        build_pretraining_data_loader(valid_d, args.consumed_valid_samples)
-                    )
+                        raise NotImplementedError("--multiple-validation-sets currently requires --full-validation")
+                    valid_dataloaders.append(build_pretraining_data_loader(valid_d, args.consumed_valid_samples))
             if not args.multiple_validation_sets:
                 assert len(valid_dataloaders) == 1
             test_dataloader = build_pretraining_data_loader(test_ds, 0)
             do_train = train_dataloader is not None and (args.skip_train or args.train_iters > 0)
-            do_valid = valid_dataloaders is not None and (
-                args.full_validation or args.eval_iters > 0
-            )
+            do_valid = valid_dataloaders is not None and (args.full_validation or args.eval_iters > 0)
             do_test = test_dataloader is not None and (args.full_validation or args.eval_iters > 0)
 
         flags = torch.tensor(
@@ -3868,7 +3631,7 @@ def build_train_valid_test_data_iterators(build_train_valid_test_datasets_provid
         if args.full_validation:
             if args.multiple_validation_sets:
                 if valid_dataloaders[0] is None:
-                    args.eval_iters = [None] * len(valid_dataloaders)
+                    args.eval_iters = [None]*len(valid_dataloaders)
                 else:
                     args.eval_iters = [len(dl) for dl in valid_dataloaders]
             else:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2,14 +2,15 @@
 
 """Pretrain utilities."""
 import time
+
 # The earliest we can measure the start time.
 _TRAIN_START_TIME = time.time()
 
 # Startup timestamps for tracking program initialization phases
 _STARTUP_TIMESTAMPS = {
     'program_start': None,  # Set by entry script before imports
-    'main_entry': None,     # Set by entry script at start of __main__
-    'pretrain_entry': None, # Set at top of pretrain()
+    'main_entry': None,  # Set by entry script at start of __main__
+    'pretrain_entry': None,  # Set at top of pretrain()
 }
 
 
@@ -56,20 +57,20 @@ from .log_handler import CustomHandler
 logging.basicConfig(handlers=[CustomHandler()], level=logging.INFO)
 from .theoretical_memory_usage import report_theoretical_memory
 
-_LEGACY_TRAIN_START_TIME = time.time() # NOTE(asolergi-nv): Legacy timestamp
+_LEGACY_TRAIN_START_TIME = time.time()  # NOTE(asolergi-nv): Legacy timestamp
 
 import torch
 
 try:
     from megatron.rl import rl_utils
+
     has_rl_utils = True
 except ImportError:
     has_rl_utils = False
 from megatron.rl.parallel_utils import build_inference_pg_collection
+
 try:
-    from modelopt.torch.distill.plugins.megatron import (
-        get_tensor_shapes_adjust_fn_for_distillation,
-    )
+    from modelopt.torch.distill.plugins.megatron import get_tensor_shapes_adjust_fn_for_distillation
 
     has_nvidia_modelopt = True
 except ImportError:
@@ -110,9 +111,14 @@ from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
 from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.transformer.module import Float16Module
-from megatron.core.distributed import DistributedDataParallelConfig, TorchFullyShardedDataParallelConfig
+from megatron.core.distributed import (
+    DistributedDataParallelConfig,
+    TorchFullyShardedDataParallelConfig,
+)
 from megatron.core.distributed import DistributedDataParallel as DDP
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
+from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+    FullyShardedDataParallel as megatron_FSDP,
+)
 from megatron.core.optimizer.optimizer import param_group_identifier_keys
 
 from megatron.core.optimizer.qk_clip import clip_qk
@@ -126,7 +132,13 @@ except ImportError:
 
 from megatron.core.distributed import finalize_model_grads
 from megatron.core.enums import ModelType
-from megatron.core.optimizer import get_megatron_optimizer, AdamOptimizerConfig, SGDOptimizerConfig, OptimizerConfig, ParamKey
+from megatron.core.optimizer import (
+    get_megatron_optimizer,
+    AdamOptimizerConfig,
+    SGDOptimizerConfig,
+    OptimizerConfig,
+    ParamKey,
+)
 from megatron.core.optimizer.muon import get_megatron_muon_optimizer
 from megatron.core.rerun_state_machine import (
     get_rerun_state_machine,
@@ -137,7 +149,11 @@ from megatron.core.rerun_state_machine import (
 from megatron.training.initialize import initialize_megatron
 from megatron.training.initialize import write_args_to_tensorboard
 from megatron.training.initialize import set_jit_fusion_options
-from megatron.training.utils import get_batch_on_this_cp_rank, get_batch_on_this_tp_rank, is_hybrid_model
+from megatron.training.utils import (
+    get_batch_on_this_cp_rank,
+    get_batch_on_this_tp_rank,
+    is_hybrid_model,
+)
 from megatron.training.datasets.data_samplers import build_pretraining_data_loader
 from megatron.core.datasets.data_schedule import HybridCPDataLoaderWrapper
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
@@ -148,7 +164,7 @@ from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelpe
 from megatron.core.parallel_state import (
     destroy_global_memory_buffer,
     destroy_model_parallel,
-    update_pg_timeout
+    update_pg_timeout,
 )
 from megatron.core.inference.symmetric_memory import SymmetricMemoryManager
 from megatron.core.inference.unified_memory import create_unified_mempool
@@ -156,6 +172,7 @@ from megatron.core.resharding.refit import swap_model_weights
 
 try:
     from torch_memory_saver import torch_memory_saver
+
     torch_memory_saver.hook_mode = "torch"
     HAVE_TORCH_MEMORY_SAVER = True
 except ImportError:
@@ -167,7 +184,7 @@ from megatron.core.num_microbatches_calculator import (
     get_current_global_batch_size,
     get_current_running_global_batch_size,
     get_num_microbatches,
-    update_num_microbatches
+    update_num_microbatches,
 )
 
 from .async_utils import maybe_finalize_async_save
@@ -217,7 +234,7 @@ def destroy_global_state():
 
 def print_datetime(string, override_timestamp=None):
     """Note that this call will sync across all ranks. Use override_timestamp if provided;
-       otherwise use current timestamp."""
+    otherwise use current timestamp."""
     torch.distributed.barrier()
     if override_timestamp is None:
         time_str = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
@@ -225,27 +242,51 @@ def print_datetime(string, override_timestamp=None):
         time_str = datetime.fromtimestamp(override_timestamp).strftime('%Y-%m-%d %H:%M:%S.%f')
     print_rank_0(f'[{string}] datetime: {time_str} ')
 
+
 def num_floating_point_operations(args, batch_size):
     def mlp_layer_flops(batch_size, seq_len, hidden_size, expansion=4.0, swiglu=False):
         """Calculate FLOPs for an MLP layer."""
         scale_factor = 3.0 / 2.0 if swiglu else 1.0
         return 4 * expansion * scale_factor * batch_size * seq_len * hidden_size**2
 
-    def moe_layer_flops(batch_size, seq_len, hidden_size, moe_ffn_hidden_size,
-                        shared_expert_ffn_hidden_size, num_experts_routed_to,
-                        moe_latent_size=None, swiglu=False):
+    def moe_layer_flops(
+        batch_size,
+        seq_len,
+        hidden_size,
+        moe_ffn_hidden_size,
+        shared_expert_ffn_hidden_size,
+        num_experts_routed_to,
+        moe_latent_size=None,
+        swiglu=False,
+    ):
         """Calculate FLOPs for an MoE layer."""
         scale_factor = 3.0 / 2.0 if swiglu else 1.0
         if moe_latent_size is None:
-            routed_flops = (4 * batch_size * seq_len * hidden_size *
-                            moe_ffn_hidden_size * num_experts_routed_to * scale_factor)
+            routed_flops = (
+                4
+                * batch_size
+                * seq_len
+                * hidden_size
+                * moe_ffn_hidden_size
+                * num_experts_routed_to
+                * scale_factor
+            )
         else:
             # Routed experts run on moe_latent_size.
-            routed_flops = (4 * batch_size * seq_len * moe_latent_size *
-                            moe_ffn_hidden_size * num_experts_routed_to * scale_factor)
+            routed_flops = (
+                4
+                * batch_size
+                * seq_len
+                * moe_latent_size
+                * moe_ffn_hidden_size
+                * num_experts_routed_to
+                * scale_factor
+            )
             # Up proj and down proj.
-            routed_flops += (4 * batch_size * seq_len * hidden_size * moe_latent_size)
-        shared_flops = 4 * batch_size * seq_len * hidden_size * shared_expert_ffn_hidden_size * scale_factor
+            routed_flops += 4 * batch_size * seq_len * hidden_size * moe_latent_size
+        shared_flops = (
+            4 * batch_size * seq_len * hidden_size * shared_expert_ffn_hidden_size * scale_factor
+        )
         return routed_flops + shared_flops
 
     def attn_layer_flops(
@@ -263,8 +304,9 @@ def num_floating_point_operations(args, batch_size):
             * (hidden_size + (hidden_size * (g / num_heads)) + (seq_len / 2))
         )
 
-    def mamba_layer_flops(batch_size, seq_len, hidden_size, state_dim=16,
-                          head_dim=64, num_groups=1, num_heads=128):
+    def mamba_layer_flops(
+        batch_size, seq_len, hidden_size, state_dim=16, head_dim=64, num_groups=1, num_heads=128
+    ):
         """Calculate FLOPs for a Mamba layer."""
         # Note (rwaleffe): flops estimate for scan should be updated based on new SSD kernels,
         # but small percent of overall layer flops
@@ -285,29 +327,63 @@ def num_floating_point_operations(args, batch_size):
             + (2 * batch_size * seq_len * d_in * hidden_size)  # out_proj
         )
 
-    def hybrid_flops(batch_size, seq_len, hidden_size,
-                     num_attn_layers, num_mamba_layers, num_mlp_layers, num_moe_layers,
-                     mamba_state_dim=128, mamba_head_dim=64,
-                     mamba_num_groups=8, mamba_num_heads=128,
-                     num_attn_heads=32, gqa=True,
-                     gqa_groups=8, kv_channels=None,
-                     mlp_expansion=4.0, swiglu=False,
-                     moe_latent_size=None,
-                     moe_ffn_hidden_size=2048, shared_expert_ffn_hidden_size=2048, num_experts_routed_to=1,
-                     vocab_size=256000, mtp_num_layers=0):
+    def hybrid_flops(
+        batch_size,
+        seq_len,
+        hidden_size,
+        num_attn_layers,
+        num_mamba_layers,
+        num_mlp_layers,
+        num_moe_layers,
+        mamba_state_dim=128,
+        mamba_head_dim=64,
+        mamba_num_groups=8,
+        mamba_num_heads=128,
+        num_attn_heads=32,
+        gqa=True,
+        gqa_groups=8,
+        kv_channels=None,
+        mlp_expansion=4.0,
+        swiglu=False,
+        moe_latent_size=None,
+        moe_ffn_hidden_size=2048,
+        shared_expert_ffn_hidden_size=2048,
+        num_experts_routed_to=1,
+        vocab_size=256000,
+        mtp_num_layers=0,
+    ):
         """Calculate total FLOPs for the hybrid model."""
         flops_fwd = (
-                num_attn_layers * attn_layer_flops(batch_size, seq_len, hidden_size,
-                                                   num_attn_heads, gqa, gqa_groups, kv_channels) +
-                num_mlp_layers * mlp_layer_flops(batch_size, seq_len, hidden_size,
-                                                 mlp_expansion, swiglu) +
-                num_mamba_layers * mamba_layer_flops(batch_size, seq_len, hidden_size,
-                                                     mamba_state_dim, mamba_head_dim,
-                                                     mamba_num_groups, mamba_num_heads) +
-                num_moe_layers * moe_layer_flops(batch_size, seq_len, hidden_size, moe_ffn_hidden_size,
-                                                 shared_expert_ffn_hidden_size, num_experts_routed_to,
-                                                 moe_latent_size, swiglu) +
-                (2 * batch_size * seq_len * hidden_size * vocab_size * (1 + mtp_num_layers))  # logits computation
+            num_attn_layers
+            * attn_layer_flops(
+                batch_size, seq_len, hidden_size, num_attn_heads, gqa, gqa_groups, kv_channels
+            )
+            + num_mlp_layers
+            * mlp_layer_flops(batch_size, seq_len, hidden_size, mlp_expansion, swiglu)
+            + num_mamba_layers
+            * mamba_layer_flops(
+                batch_size,
+                seq_len,
+                hidden_size,
+                mamba_state_dim,
+                mamba_head_dim,
+                mamba_num_groups,
+                mamba_num_heads,
+            )
+            + num_moe_layers
+            * moe_layer_flops(
+                batch_size,
+                seq_len,
+                hidden_size,
+                moe_ffn_hidden_size,
+                shared_expert_ffn_hidden_size,
+                num_experts_routed_to,
+                moe_latent_size,
+                swiglu,
+            )
+            + (
+                2 * batch_size * seq_len * hidden_size * vocab_size * (1 + mtp_num_layers)
+            )  # logits computation
         )
         return flops_fwd * 3
 
@@ -450,8 +526,7 @@ def num_floating_point_operations(args, batch_size):
                     / 2  # causal mask (only half of the mask is non-zero)
                     * 2  # QK^T and (QK^T)V
                     ## out proj
-                    + query_projection_size
-                    * args.hidden_size
+                    + query_projection_size * args.hidden_size
                 )
             )
 
@@ -460,8 +535,8 @@ def num_floating_point_operations(args, batch_size):
             if isinstance(args.linear_attention_freq, int):
                 linear_attention_pattern = [
                     # [1,1,...,1,0,1,1,...,1,0,...]
-                    0 if ((i + 1) % args.linear_attention_freq == 0)
-                    else 1 for i in range(num_layers)
+                    0 if ((i + 1) % args.linear_attention_freq == 0) else 1
+                    for i in range(num_layers)
                 ]
             elif isinstance(args.linear_attention_freq, list):
                 linear_attention_pattern = args.linear_attention_freq
@@ -498,18 +573,13 @@ def num_floating_point_operations(args, batch_size):
                     * fma_expansion_factor
                     * (
                         ## in proj
-                        args.hidden_size
-                        * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
+                        args.hidden_size * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
                         ## conv1d
-                        + args.linear_conv_kernel_dim
-                        * (2 * qk_dim + v_dim)
+                        + args.linear_conv_kernel_dim * (2 * qk_dim + v_dim)
                         ## gated delta rule
-                        + num_v_heads
-                        * (v_head_dim ** 2)
-                        * 4  # KK^T, VK^T, S(a(I-bKK^T)), and SQ
+                        + num_v_heads * (v_head_dim**2) * 4  # KK^T, VK^T, S(a(I-bKK^T)), and SQ
                         ## out proj
-                        + args.hidden_size
-                        * v_dim
+                        + args.hidden_size * v_dim
                     )
                 )
             else:
@@ -537,8 +607,7 @@ def num_floating_point_operations(args, batch_size):
                 * args.hidden_size
                 * (
                     # dense layer (deepseek v2, v3 style)
-                    (args.ffn_hidden_size * ffn_expansion_factor)
-                    * num_dense_layers
+                    (args.ffn_hidden_size * ffn_expansion_factor) * num_dense_layers
                     # routed experts
                     + (
                         (moe_ffn_hidden_size * num_experts_routed_to * ffn_expansion_factor)
@@ -556,8 +625,7 @@ def num_floating_point_operations(args, batch_size):
                     )
                     * num_moe_layers
                     # Shared Experts.
-                    + (shared_expert_ffn_hidden_size * ffn_expansion_factor)
-                    * num_moe_layers
+                    + (shared_expert_ffn_hidden_size * ffn_expansion_factor) * num_moe_layers
                 )
                 # Self Attention
                 + self_attn_term
@@ -587,6 +655,7 @@ def num_floating_point_operations(args, batch_size):
         from operator import itemgetter
 
         from megatron.core.ssm.mamba_hybrid_layer_allocation import Symbols, get_hybrid_layer_counts
+
         num_attn_layers, num_mamba_layers, num_mlp_layers, num_moe_layers = itemgetter(
             Symbols.ATTENTION, Symbols.MAMBA, Symbols.MLP, Symbols.MOE
         )(get_hybrid_layer_counts(args.hybrid_layer_pattern))
@@ -614,10 +683,16 @@ def num_floating_point_operations(args, batch_size):
             mlp_expansion=args.ffn_hidden_size / args.hidden_size,
             swiglu=args.swiglu,
             moe_latent_size=args.moe_latent_size,
-            moe_ffn_hidden_size=(args.moe_ffn_hidden_size if args.moe_ffn_hidden_size is not None
-                                 else args.ffn_hidden_size),
-            shared_expert_ffn_hidden_size=(0 if args.moe_shared_expert_intermediate_size is None
-                                           else args.moe_shared_expert_intermediate_size),
+            moe_ffn_hidden_size=(
+                args.moe_ffn_hidden_size
+                if args.moe_ffn_hidden_size is not None
+                else args.ffn_hidden_size
+            ),
+            shared_expert_ffn_hidden_size=(
+                0
+                if args.moe_shared_expert_intermediate_size is None
+                else args.moe_shared_expert_intermediate_size
+            ),
             num_experts_routed_to=args.moe_router_topk,
             vocab_size=args.padded_vocab_size,
             mtp_num_layers=mtp_num_layers,
@@ -683,6 +758,7 @@ def preprocess_common_state_dict(common_state_dict):
         preprocessed_common_state_dict['args']['use_distributed_optimizer']
         and "optimizer" in preprocessed_common_state_dict
     ):
+
         def reorder_inner_param_groups(optimizer_state_dict):
             # When distributed optimizer loading, source param groups will be reordered,
             # so we reorder the param groups here to prevent warning.
@@ -801,11 +877,9 @@ def pretrain(
     timers = get_timers()
 
     if args.fine_grained_activation_offloading:
-        from megatron.core.pipeline_parallel.utils import (
-            set_ideal_affinity_for_current_gpu
-        )
-        set_ideal_affinity_for_current_gpu()
+        from megatron.core.pipeline_parallel.utils import set_ideal_affinity_for_current_gpu
 
+        set_ideal_affinity_for_current_gpu()
 
     if args.log_progress:
         append_to_progress_log("Starting job")
@@ -825,7 +899,9 @@ def pretrain(
     # Initialize program_start_global with a fallback value in case set_startup_timestamps() wasn't called
     program_start_global = _TRAIN_START_TIME
     if _STARTUP_TIMESTAMPS['program_start'] is not None:
-        program_start_global = torch.tensor([_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda')
+        program_start_global = torch.tensor(
+            [_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda'
+        )
         torch.distributed.all_reduce(program_start_global, op=torch.distributed.ReduceOp.MIN)
         program_start_global = program_start_global.item()
     set_startup_timestamps(program_start=program_start_global)
@@ -845,26 +921,41 @@ def pretrain(
     # Print basic megatron init time (using global min start)
     # NOTE(asolergi-nv): This is not entirely accurate, but we keep it for backwards compatibility.
     print_rank_0(
-        'time to initialize megatron (seconds): {:.3f}'.format(megatron_init_end - _LEGACY_TRAIN_START_TIME)
+        'time to initialize megatron (seconds): {:.3f}'.format(
+            megatron_init_end - _LEGACY_TRAIN_START_TIME
+        )
     )
 
     # Note, not entirely accurate as rank 0 might not be the first or last to hit these timestamps
-    print_datetime('after in-process setup and before initialize_megatron', timestamp_after_inprocess_setup)
-    print_datetime('after in-job setup and before initialize_megatron', timestamp_after_in_job_setup)
+    print_datetime(
+        'after in-process setup and before initialize_megatron', timestamp_after_inprocess_setup
+    )
+    print_datetime(
+        'after in-job setup and before initialize_megatron', timestamp_after_in_job_setup
+    )
 
     if program_start is not None and main_entry is not None and pretrain_entry is not None:
         # Inject startup deltas into timers
         startup_timers = {
-            'startup-program-entry-spread': program_start - program_start_global, # Local program start timestamp vs the global earliest program start timestamp
-            'startup-library-setup': main_entry - program_start, # Local library imports
-            'startup-program-setup': pretrain_entry - main_entry, # Local __main__ entry to pretrain entry
-            'startup-in-process-setup': timestamp_after_inprocess_setup - pretrain_entry, # Local in-process setup
-            'startup-in-job-setup': timestamp_after_in_job_setup - timestamp_after_inprocess_setup, # Local in-job setup
-            'startup-initialize-megatron': timestamp_after_initialize_megatron - timestamp_after_in_job_setup, # Local initialize megatron
-            'startup-set-jit-fusion-options': timestamp_after_set_jit_fusion_options - timestamp_after_initialize_megatron, # Local set JIT fusion options
-            'all-reduce-start-timestamps-tensor': megatron_init_end - timestamp_after_set_jit_fusion_options, # 2x All-reduce, first collective call
-            'startup-megatron-init-local': megatron_init_end - pretrain_entry, # Local megatron init
-            'startup-megatron-init-global': megatron_init_end - program_start_global, # Local megatron init vs the global earliest program start timestamp
+            'startup-program-entry-spread': program_start
+            - program_start_global,  # Local program start timestamp vs the global earliest program start timestamp
+            'startup-library-setup': main_entry - program_start,  # Local library imports
+            'startup-program-setup': pretrain_entry
+            - main_entry,  # Local __main__ entry to pretrain entry
+            'startup-in-process-setup': timestamp_after_inprocess_setup
+            - pretrain_entry,  # Local in-process setup
+            'startup-in-job-setup': timestamp_after_in_job_setup
+            - timestamp_after_inprocess_setup,  # Local in-job setup
+            'startup-initialize-megatron': timestamp_after_initialize_megatron
+            - timestamp_after_in_job_setup,  # Local initialize megatron
+            'startup-set-jit-fusion-options': timestamp_after_set_jit_fusion_options
+            - timestamp_after_initialize_megatron,  # Local set JIT fusion options
+            'all-reduce-start-timestamps-tensor': megatron_init_end
+            - timestamp_after_set_jit_fusion_options,  # 2x All-reduce, first collective call
+            'startup-megatron-init-local': megatron_init_end
+            - pretrain_entry,  # Local megatron init
+            'startup-megatron-init-global': megatron_init_end
+            - program_start_global,  # Local megatron init vs the global earliest program start timestamp
         }
         for name, delta in startup_timers.items():
             timers(name, log_level=0).set_elapsed(delta)
@@ -958,7 +1049,9 @@ def pretrain(
             # Build an isolated inference config so training config remains unchanged
             inference_config = copy.deepcopy(config)
             if args.rl_inference_tensor_model_parallel_size is not None:
-                inference_config.tensor_model_parallel_size = args.rl_inference_tensor_model_parallel_size
+                inference_config.tensor_model_parallel_size = (
+                    args.rl_inference_tensor_model_parallel_size
+                )
             if args.rl_inference_pipeline_model_parallel_size is not None:
                 inference_config.pipeline_model_parallel_size = (
                     args.rl_inference_pipeline_model_parallel_size
@@ -1022,11 +1115,15 @@ def pretrain(
         valid_data_iterator = []
         test_data_iterator = []
         for vp_stage in range(len(model)):
-            dataset_provider_parameters = inspect.signature(train_valid_test_dataset_provider).parameters
-            assert "vp_stage" in dataset_provider_parameters, \
-                "vp_stage must be a kwarg in train_valid_test_dataset_provider when using virtual pipeline parallelism"
-            vp_stage_train_valid_test_dataset_provider = \
-                functools.partial(train_valid_test_dataset_provider, vp_stage=vp_stage)
+            dataset_provider_parameters = inspect.signature(
+                train_valid_test_dataset_provider
+            ).parameters
+            assert (
+                "vp_stage" in dataset_provider_parameters
+            ), "vp_stage must be a kwarg in train_valid_test_dataset_provider when using virtual pipeline parallelism"
+            vp_stage_train_valid_test_dataset_provider = functools.partial(
+                train_valid_test_dataset_provider, vp_stage=vp_stage
+            )
             if getattr(train_valid_test_dataset_provider, 'is_distributed', False):
                 vp_stage_train_valid_test_dataset_provider.is_distributed = True
             iterators = build_train_valid_test_data_iterators(
@@ -1090,7 +1187,12 @@ def pretrain(
 
         print_datetime('after training is done')
 
-        if not args.skip_train and args.save and iteration != 0 and iteration % args.save_interval != 0:
+        if (
+            not args.skip_train
+            and args.save
+            and iteration != 0
+            and iteration % args.save_interval != 0
+        ):
             save_checkpoint(
                 iteration,
                 model,
@@ -1134,11 +1236,16 @@ def pretrain(
             )
         else:
             evaluate_and_print_results(
-                prefix, forward_step_func,
-                valid_data_iterator, model,
-                iteration, process_non_loss_data_func, config,
-                verbose=True, write_to_tensorboard=not args.skip_train,
-                non_loss_data_func=non_loss_data_func
+                prefix,
+                forward_step_func,
+                valid_data_iterator,
+                model,
+                iteration,
+                process_non_loss_data_func,
+                config,
+                verbose=True,
+                write_to_tensorboard=not args.skip_train,
+                non_loss_data_func=non_loss_data_func,
             )
 
     if args.do_test:
@@ -1220,7 +1327,13 @@ def update_train_iters(args):
     print_rank_0(f'setting training iterations to {args.train_iters}')
 
 
-def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap_with_ddp=True, config=None, pg_collection=None):
+def get_model(
+    model_provider_func,
+    model_type=ModelType.encoder_or_decoder,
+    wrap_with_ddp=True,
+    config=None,
+    pg_collection=None,
+):
     """Build the model."""
     args = get_args()
     args.model_type = model_type
@@ -1229,6 +1342,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
     if has_nvidia_modelopt:
         from megatron.post_training.checkpointing import has_modelopt_state
+
         # [ModelOpt]: Check if the checkpoint is a ModelOpt checkpoint and
         # set a flag to use our model provider if so.
         if args.load is not None and has_modelopt_state(args.load):
@@ -1276,7 +1390,6 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             model.model_type = model_type
         return model
 
-
     if args.init_model_with_meta_device:
         with torch.device('meta'):
             model = build_model()
@@ -1302,9 +1415,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         print(
             ' > number of parameters on (tensor, pipeline) '
             'model parallel rank ({}, {}): {}'.format(
-                get_pg_rank(pg_collection.tp),
-                get_pg_rank(pg_collection.pp),
-                num_parameters,
+                get_pg_rank(pg_collection.tp), get_pg_rank(pg_collection.pp), num_parameters
             ),
             flush=True,
         )
@@ -1326,7 +1437,10 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
     # Materialize tensors on meta device (GPU allocation) if not using FSDP2 and not using Megatron FSDP.
     if args.init_model_with_meta_device and not args.use_torch_fsdp2 and not args.use_megatron_fsdp:
-        model = [to_empty_if_meta_device(model_module, device=torch.device("cuda")) for model_module in model]
+        model = [
+            to_empty_if_meta_device(model_module, device=torch.device("cuda"))
+            for model_module in model
+        ]
 
     # Before TE2.x: The model_module.bfloat16()/model_module.half() above will call the inplace
     #               copy of TE's Float8Tensor, which will write an unwanted value (amax calculated
@@ -1348,7 +1462,9 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
         if getattr(args, "use_torch_fsdp2", False):
             reshard_after_forward = getattr(args, "torch_fsdp2_reshard_after_forward", True)
-            ddp_config = TorchFullyShardedDataParallelConfig(reshard_after_forward=reshard_after_forward)
+            ddp_config = TorchFullyShardedDataParallelConfig(
+                reshard_after_forward=reshard_after_forward
+            )
         else:
             kwargs = {}
             for f in dataclasses.fields(DistributedDataParallelConfig):
@@ -1358,15 +1474,17 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             kwargs['check_for_nan_in_grad'] = args.check_for_nan_in_loss_and_grad
             kwargs['check_for_large_grads'] = args.check_for_large_grads
             if args.ddp_num_buckets is not None:
-                assert args.ddp_bucket_size is None, \
-                    "Cannot specify both --ddp-num-buckets and --ddp-bucket-size"
-                assert args.ddp_num_buckets > 0, \
-                    "--ddp-num-buckets must be greater than 0"
+                assert (
+                    args.ddp_bucket_size is None
+                ), "Cannot specify both --ddp-num-buckets and --ddp-bucket-size"
+                assert args.ddp_num_buckets > 0, "--ddp-num-buckets must be greater than 0"
                 kwargs['bucket_size'] = num_parameters // args.ddp_num_buckets
             else:
                 kwargs['bucket_size'] = args.ddp_bucket_size
             kwargs['pad_buckets_for_high_nccl_busbw'] = args.ddp_pad_buckets_for_high_nccl_busbw
-            kwargs['reduce_scatter_with_fp32_accumulation'] = args.ddp_reduce_scatter_with_fp32_accumulation
+            kwargs['reduce_scatter_with_fp32_accumulation'] = (
+                args.ddp_reduce_scatter_with_fp32_accumulation
+            )
             kwargs['average_in_collective'] = args.ddp_average_in_collective
             ddp_config = DistributedDataParallelConfig(**kwargs)
 
@@ -1405,7 +1523,8 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
                     module=model_chunk,
                     # Turn off bucketing for model_chunk 2 onwards, since communication
                     # for these model chunks is overlapped with compute anyway.
-                    disable_bucketing=(model_chunk_idx > 0) or args.overlap_param_gather_with_optimizer_step,
+                    disable_bucketing=(model_chunk_idx > 0)
+                    or args.overlap_param_gather_with_optimizer_step,
                     **ddp_init_kwargs,
                 )
                 for (model_chunk_idx, model_chunk) in enumerate(model)
@@ -1506,11 +1625,7 @@ def get_megatron_optimizer_config(args: Any) -> OptimizerConfig:
     return config, config_overrides
 
 
-def setup_model_and_optimizer(
-    model_provider_func,
-    model_type,
-    checkpointing_context=None,
-):
+def setup_model_and_optimizer(model_provider_func, model_type, checkpointing_context=None):
     """Setup model and optimizer."""
     args = get_args()
     timers = get_timers()
@@ -1524,7 +1639,9 @@ def setup_model_and_optimizer(
     model = get_model(model_provider_func, model_type, wrap_with_ddp=wrap_with_ddp)
     unwrapped_model = unwrap_model(model)
 
-    one_logger and one_logger.log_metrics({"app_build_optimzer_start_time": one_logger_utils.get_timestamp_in_ms()})
+    one_logger and one_logger.log_metrics(
+        {"app_build_optimzer_start_time": one_logger_utils.get_timestamp_in_ms()}
+    )
     if skip_optimizer:
         optimizer, opt_param_scheduler = None, None
         # In RL inference-only mode, train_iters must still be set despite having no optimizer.
@@ -1567,7 +1684,9 @@ def setup_model_and_optimizer(
             )
         opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
 
-    one_logger and one_logger.log_metrics({"app_build_optimzer_finish_time": one_logger_utils.get_timestamp_in_ms()})
+    one_logger and one_logger.log_metrics(
+        {"app_build_optimzer_finish_time": one_logger_utils.get_timestamp_in_ms()}
+    )
 
     if args.moe_use_upcycling:
         torch.distributed.barrier()
@@ -1705,16 +1824,27 @@ def dummy_train_step(data_iterator):
             batch = get_batch_on_this_cp_rank(batch)
 
 
-def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_scheduler, config, forward_backward_func, iteration=None):
+def train_step(
+    forward_step_func,
+    data_iterator,
+    model,
+    optimizer,
+    opt_param_scheduler,
+    config,
+    forward_backward_func,
+    iteration=None,
+):
     """Single training step."""
     args = get_args()
     timers = get_timers()
 
     rerun_state_machine = get_rerun_state_machine()
-    save_dgrads_in_this_iteration = (args.save_dgrads_interval is not None and
-                                     (iteration + 1) % args.save_dgrads_interval == 0)
-    save_wgrads_in_this_iteration = (args.save_wgrads_interval is not None and
-                                     (iteration + 1) % args.save_wgrads_interval == 0)
+    save_dgrads_in_this_iteration = (
+        args.save_dgrads_interval is not None and (iteration + 1) % args.save_dgrads_interval == 0
+    )
+    save_wgrads_in_this_iteration = (
+        args.save_wgrads_interval is not None and (iteration + 1) % args.save_wgrads_interval == 0
+    )
     while rerun_state_machine.should_run_forward_backward(data_iterator):
         # Set grad to zero.
         for model_chunk in model:
@@ -1852,8 +1982,7 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
                 # over the total number of tokens across the global batch.
                 val = torch.vstack(val).sum(dim=0)
                 torch.distributed.all_reduce(
-                    val,
-                    group=mpu.get_data_parallel_group(with_context_parallel=True)
+                    val, group=mpu.get_data_parallel_group(with_context_parallel=True)
                 )
                 loss_reduced[key] = val[0] / val[1]
             elif val[0].numel() == 1:
@@ -1872,7 +2001,16 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
             num_zeros_in_grad,
             log_max_attention_logit,
         )
-    return {}, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad, log_max_attention_logit
+    return (
+        {},
+        skipped_iter,
+        should_checkpoint,
+        should_exit,
+        exit_code,
+        grad_norm,
+        num_zeros_in_grad,
+        log_max_attention_logit,
+    )
 
 
 def training_log(
@@ -1930,45 +2068,68 @@ def training_log(
     # Logging.
     timers_to_log = []
     if args.timing_log_level >= 1:
-        timers_to_log.extend([
-            'forward-backward',
-            'layernorm-grads-all-reduce',
-            'embedding-grads-all-reduce',
-            'all-grads-sync',
-            'params-all-gather',
-            'optimizer-copy-to-main-grad',
-            'optimizer-unscale-and-check-inf',
-            'optimizer-clip-main-grad',
-            'optimizer-count-zeros',
-            'optimizer-inner-step',
-            'optimizer-copy-main-to-model-params',
-            'optimizer',
-        ])
+        timers_to_log.extend(
+            [
+                'forward-backward',
+                'layernorm-grads-all-reduce',
+                'embedding-grads-all-reduce',
+                'all-grads-sync',
+                'params-all-gather',
+                'optimizer-copy-to-main-grad',
+                'optimizer-unscale-and-check-inf',
+                'optimizer-clip-main-grad',
+                'optimizer-count-zeros',
+                'optimizer-inner-step',
+                'optimizer-copy-main-to-model-params',
+                'optimizer',
+            ]
+        )
     if args.timing_log_level >= 2:
-        timers_to_log.extend([
-            'batch-generator',
-            'forward-compute',
-            'backward-compute',
-            'forward-recv',
-            'forward-send',
-            'backward-recv',
-            'backward-send',
-            'forward-send-forward-recv',
-            'forward-send-backward-recv',
-            'backward-send-forward-recv',
-            'backward-send-backward-recv',
-            'forward-backward-send-forward-backward-recv',
-        ])
+        timers_to_log.extend(
+            [
+                'batch-generator',
+                'forward-compute',
+                'backward-compute',
+                'forward-recv',
+                'forward-send',
+                'backward-recv',
+                'backward-send',
+                'forward-send-forward-recv',
+                'forward-send-backward-recv',
+                'backward-send-forward-recv',
+                'backward-send-backward-recv',
+                'forward-backward-send-forward-backward-recv',
+            ]
+        )
     # Add timers from RL loop if needed.
     if args.perform_rl_step:
-        timers_to_log.extend(['rollout-collection', 'inference-setup', 'collect-rollouts', 'postrollout-gc-collect',
-                              'sync-rollouts', 'prepare-data-for-update', 'compute-group-stats',
-                              'prepare-trajectories', 'get-ltor-masks-and-position-ids', 'create-logprobs-dataloader',
-                              'compute-logprobs', 'compute-ref-logprobs', 'compute-prob-stats',
-                              'prepare-advantages', 'create-dataloader', 'log-wandb-tb',
-                              'offload-optimizer-before-inference', 'onload-kv-cache-before-inference',
-                              'wait-for-decode-only', 'build-cuda-graphs', 'suspend-engine',
-                              'offload-kv-cache-after-inference', 'onload-optimizer-after-inference'])
+        timers_to_log.extend(
+            [
+                'rollout-collection',
+                'inference-setup',
+                'collect-rollouts',
+                'postrollout-gc-collect',
+                'sync-rollouts',
+                'prepare-data-for-update',
+                'compute-group-stats',
+                'prepare-trajectories',
+                'get-ltor-masks-and-position-ids',
+                'create-logprobs-dataloader',
+                'compute-logprobs',
+                'compute-ref-logprobs',
+                'compute-prob-stats',
+                'prepare-advantages',
+                'create-dataloader',
+                'log-wandb-tb',
+                'offload-optimizer-before-inference',
+                'onload-kv-cache-before-inference',
+                'wait-for-decode-only',
+                'build-cuda-graphs',
+                'suspend-engine',
+                'offload-kv-cache-after-inference',
+                'onload-optimizer-after-inference',
+            ]
+        )
 
     # Calculate batch size.
     batch_size = args.micro_batch_size * args.data_parallel_size * get_num_microbatches()
@@ -1986,7 +2147,9 @@ def training_log(
             wandb_writer.log({'samples vs steps': args.consumed_train_samples}, iteration)
         if learning_rate is not None:
             writer.add_scalar('learning-rate', learning_rate, iteration)
-            writer.add_scalar('learning-rate vs samples', learning_rate, args.consumed_train_samples)
+            writer.add_scalar(
+                'learning-rate vs samples', learning_rate, args.consumed_train_samples
+            )
             if wandb_writer:
                 wandb_writer.log({'learning-rate': learning_rate}, iteration)
         if args.skipped_train_samples > 0:
@@ -2037,10 +2200,14 @@ def training_log(
             if wandb_writer:
                 wandb_writer.log({'params-norm': params_norm}, iteration)
         if args.perform_rl_step:
-            grpo_collection_iteration = iteration // (args.grpo_iterations * ( ( args.grpo_samples_per_iteration )// args.global_batch_size ))
+            grpo_collection_iteration = iteration // (
+                args.grpo_iterations * ((args.grpo_samples_per_iteration) // args.global_batch_size)
+            )
             writer.add_scalar('grpo_collection_iteration', grpo_collection_iteration, iteration)
             if wandb_writer:
-                wandb_writer.log({'grpo_collection_iteration': grpo_collection_iteration}, iteration)
+                wandb_writer.log(
+                    {'grpo_collection_iteration': grpo_collection_iteration}, iteration
+                )
         if args.log_memory_to_tensorboard:
             mem_stats = torch.cuda.memory_stats()
             writer.add_scalar(
@@ -2075,8 +2242,10 @@ def training_log(
             from operator import itemgetter
 
             from megatron.core.ssm.mamba_hybrid_layer_allocation import (
-                Symbols, get_hybrid_layer_counts,
+                Symbols,
+                get_hybrid_layer_counts,
             )
+
             layers = itemgetter(Symbols.MOE)(get_hybrid_layer_counts(args.hybrid_layer_pattern))
         else:
             layers = args.num_layers
@@ -2116,7 +2285,9 @@ def training_log(
 
     # Dump memory snapshot and print metrics to stdout.
     if iteration % args.log_interval == 0 or is_first_iteration:
-        if args.record_memory_history and (is_last_rank() or torch.distributed.get_backend() == 'fake'):
+        if args.record_memory_history and (
+            is_last_rank() or torch.distributed.get_backend() == 'fake'
+        ):
             snapshot = torch.cuda.memory._snapshot()
             from pickle import dump
 
@@ -2209,13 +2380,20 @@ def training_log(
             if iteration > (loaded_iteration + 1):
                 # Make sure the memory after the second iteration is reported to include optimizer state memory.
                 report_memory_flag = False
-        if args.log_memory_interval is not None and iteration % args.log_memory_interval == 0 and \
-            not reported_memory_in_this_iteration:
+        if (
+            args.log_memory_interval is not None
+            and iteration % args.log_memory_interval == 0
+            and not reported_memory_in_this_iteration
+        ):
             report_memory(f'(after {iteration} iterations)')
         # Write timers to wandb, don't reset the counts.
         if args.log_timers_to_tensorboard:
-            timers.write(timers_to_log, writer, iteration, normalizer=args.log_interval, reset=False)
-            timers.write(timers_to_log, wandb_writer, iteration, normalizer=args.log_interval, reset=False)
+            timers.write(
+                timers_to_log, writer, iteration, normalizer=args.log_interval, reset=False
+            )
+            timers.write(
+                timers_to_log, wandb_writer, iteration, normalizer=args.log_interval, reset=False
+            )
         # Log timers to stdout
         timers.log(timers_to_log, normalizer=args.log_interval, reset=should_reset)
 
@@ -2272,9 +2450,11 @@ def force_param_sync(model_chunks: list[DDP]) -> None:
         assert isinstance(model_chunk, DDP)
         model_chunk.start_param_sync(force_sync=True)
 
+
 # Only report memory for first 3 checkpoint saves.
 num_checkpoints_memory_reported = 0
 MAX_NUM_CHECKPOINTS_MEMORY_REPORTED = 3
+
 
 def save_checkpoint_and_time(
     iteration,
@@ -2365,7 +2545,7 @@ def post_training_step_callbacks(
     iteration,
     prof,
     num_floating_point_operations_since_last_log_event,
-    nsys_nvtx_context = None,
+    nsys_nvtx_context=None,
 ):
     """Run all post-training-step functions (e.g., FT heartbeats, GC)."""
     args = get_args()
@@ -2403,8 +2583,7 @@ def post_training_step_callbacks(
     if (
         args.profile
         and iteration == args.profile_step_end
-        and (len(args.profile_ranks) == 0 or
-             torch.distributed.get_rank() in args.profile_ranks)
+        and (len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks)
     ):
         if args.use_pytorch_profiler:
             assert prof is not None
@@ -2513,12 +2692,8 @@ def checkpoint_and_decide_exit(
             return True
 
     # Exit based on iterations.
-    if (
-        args.exit_interval
-        and iteration % args.exit_interval == 0
-    ) or (
-        args.phase_transition_iterations
-        and iteration in args.phase_transition_iterations
+    if (args.exit_interval and iteration % args.exit_interval == 0) or (
+        args.phase_transition_iterations and iteration in args.phase_transition_iterations
     ):
         if args.save and not saved_checkpoint:
             save_checkpoint_and_time(
@@ -2574,29 +2749,31 @@ def train(
             args.load = None
             args.finetune = True
             load_checkpoint(
-                    model,
-                    None,  # Don't load optimizer state
-                    None,  # Don't load scheduler state
-                    checkpointing_context=checkpointing_context,
-                    skip_load_to_model_and_opt=HAVE_FSDP2
-                    and getattr(args, "use_torch_fsdp2", False)
-                    and args.ckpt_format == "torch_dist",
-                )
-            ref_state_dict = {k: (v.cpu() if v is not None else v) for k, v in model[0].state_dict().items()}
+                model,
+                None,  # Don't load optimizer state
+                None,  # Don't load scheduler state
+                checkpointing_context=checkpointing_context,
+                skip_load_to_model_and_opt=HAVE_FSDP2
+                and getattr(args, "use_torch_fsdp2", False)
+                and args.ckpt_format == "torch_dist",
+            )
+            ref_state_dict = {
+                k: (v.cpu() if v is not None else v) for k, v in model[0].state_dict().items()
+            }
 
             # Reload RL training checkpoint weights
             args.load = load
             args.finetune = finetune
             print_rank_0("> Reloading RL training checkpoint...")
             load_checkpoint(
-                    model,
-                    None,
-                    None,
-                    checkpointing_context=checkpointing_context,
-                    skip_load_to_model_and_opt=HAVE_FSDP2
-                    and getattr(args, "use_torch_fsdp2", False)
-                    and args.ckpt_format == "torch_dist",
-                )
+                model,
+                None,
+                None,
+                checkpointing_context=checkpointing_context,
+                skip_load_to_model_and_opt=HAVE_FSDP2
+                and getattr(args, "use_torch_fsdp2", False)
+                and args.ckpt_format == "torch_dist",
+            )
 
             args.no_load_optim = no_load_optim
 
@@ -2605,8 +2782,9 @@ def train(
         print_rank_0("> Reinitializing microbatch calculator for GRPO training...")
         from megatron.core.num_microbatches_calculator import (
             destroy_num_microbatches_calculator,
-            init_num_microbatches_calculator
+            init_num_microbatches_calculator,
         )
+
         # First destroy the existing calculator
         destroy_num_microbatches_calculator()
         # Then initialize with the correct perform_rl_step=True context
@@ -2656,8 +2834,10 @@ def train(
     # Make sure rerun_state_machine has the right iteration loaded from checkpoint.
     rerun_state_machine = get_rerun_state_machine()
     if rerun_state_machine.current_iteration != iteration:
-        print_rank_0(f"Overwriting rerun_state_machine.current_iteration from "
-                     f"{rerun_state_machine.current_iteration} to {iteration}...")
+        print_rank_0(
+            f"Overwriting rerun_state_machine.current_iteration from "
+            f"{rerun_state_machine.current_iteration} to {iteration}..."
+        )
         rerun_state_machine.current_iteration = iteration
 
     # Track E2E metrics at the start of training.
@@ -2738,7 +2918,9 @@ def train(
     # Wrap forward_backward_func for Full iteration CUDA graph
     forward_backward_func = get_forward_backward_func()
     if args.cuda_graph_impl == "local" and CudaGraphScope.full_iteration in args.cuda_graph_scope:
-        forward_backward_func = FullCudaGraphWrapper(forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps)
+        forward_backward_func = FullCudaGraphWrapper(
+            forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps
+        )
 
     def get_e2e_base_metrics():
         """Get base metrics values for one-logger to calculate E2E tracking metrics."""
@@ -2763,23 +2945,26 @@ def train(
             one_logger.store_set('get_e2e_base_metrics', get_e2e_base_metrics)
 
     prof = None
-    nsys_nvtx_context = None # reference to context for nsys profiling, so it can be cleaned up
+    nsys_nvtx_context = None  # reference to context for nsys profiling, so it can be cleaned up
     if (
         args.profile
-        and (len(args.profile_ranks) == 0 or
-             torch.distributed.get_rank() in args.profile_ranks)
+        and (len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks)
         and args.use_pytorch_profiler
     ):
         if args.pytorch_profiler_collect_chakra:
             et_dir = Path(f"{args.tensorboard_dir}/../chakra")
             et_dir.mkdir(parents=True, exist_ok=True)
-            et = torch.profiler.ExecutionTraceObserver().register_callback(f"{et_dir}/rank-{torch.distributed.get_rank()}.json.gz")
+            et = torch.profiler.ExecutionTraceObserver().register_callback(
+                f"{et_dir}/rank-{torch.distributed.get_rank()}.json.gz"
+            )
         else:
             et = None
+
         def trace_handler(p):
             profile_dir = Path(f"{args.tensorboard_dir}/../torch_profile")
             profile_dir.mkdir(parents=True, exist_ok=True)
             p.export_chrome_trace(f"{profile_dir}/rank-{torch.distributed.get_rank()}.json.gz")
+
         prof = torch.profiler.profile(
             schedule=torch.profiler.schedule(
                 wait=max(args.profile_step_start - 1, 0),
@@ -2826,9 +3011,9 @@ def train(
     # Run training iterations till done.
     buffered_rollouts = None
     while iteration < args.train_iters:
-        if (args.profile 
-            and (len(args.profile_ranks) == 0 or
-                 torch.distributed.get_rank() in args.profile_ranks)):
+        if args.profile and (
+            len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks
+        ):
             if args.use_pytorch_profiler:
                 prof.step()
             elif iteration == args.profile_step_start:
@@ -2842,7 +3027,10 @@ def train(
         # Update the timeout for all process groups after initialization
         # We update the timeout after the first successful iteration,
         # which takes longer than others usually
-        if args.distributed_timeout_seconds_after_init is not None and iteration == start_iteration+1:
+        if (
+            args.distributed_timeout_seconds_after_init is not None
+            and iteration == start_iteration + 1
+        ):
             # TODO: some dynamic timeout setting is required
             # based on the iteration time considering interval-based steps (e.g. eval, checkpoint)
             # e.g. timeout for normal iterations vs timeout for iterations with checkpoint
@@ -2918,7 +3106,11 @@ def train(
                 torch.cuda.empty_cache()
             with torch.no_grad():
                 train_data_iterator = rl_utils.get_grpo_data_iterator(
-                    model, inference_model, optimizer, iteration, ref_state_dict,
+                    model,
+                    inference_model,
+                    optimizer,
+                    iteration,
+                    ref_state_dict,
                     grpo_iterations=args.grpo_iterations,
                     grpo_prompts_per_step=args.grpo_prompts_per_step,
                     grpo_group_size=args.grpo_group_size,
@@ -2953,7 +3145,14 @@ def train(
                 num_zeros_in_grad,
                 max_attention_logit,
             ) = train_step(
-                forward_step_func, train_data_iterator, model, optimizer, opt_param_scheduler, config, forward_backward_func, iteration=iteration
+                forward_step_func,
+                train_data_iterator,
+                model,
+                optimizer,
+                opt_param_scheduler,
+                config,
+                forward_backward_func,
+                iteration=iteration,
             )
             ft_integration.on_training_step_end()
         if should_checkpoint:
@@ -3002,7 +3201,7 @@ def train(
         if (
             getattr(args, "fsdp_manual_registration", False)
             and getattr(args, "use_megatron_fsdp", False)
-            and iteration ==  start_iteration + 1
+            and iteration == start_iteration + 1
         ):
             for model_chunk in model:
                 if isinstance(model_chunk, megatron_FSDP) and getattr(
@@ -3108,14 +3307,23 @@ def train(
                     training_model=rl_training_model,
                 )
             else:
-                evaluate_and_print_results(prefix, forward_step_func,
-                                       valid_data_iterator, model,
-                                       iteration, process_non_loss_data_func,
-                                       config, verbose=False, write_to_tensorboard=True,
-                                       non_loss_data_func=non_loss_data_func)
+                evaluate_and_print_results(
+                    prefix,
+                    forward_step_func,
+                    valid_data_iterator,
+                    model,
+                    iteration,
+                    process_non_loss_data_func,
+                    config,
+                    verbose=False,
+                    write_to_tensorboard=True,
+                    non_loss_data_func=non_loss_data_func,
+                )
 
             eval_duration += timers('eval-time').elapsed()
-            eval_iterations += sum(args.eval_iters) if isinstance(args.eval_iters, list) else args.eval_iters
+            eval_iterations += (
+                sum(args.eval_iters) if isinstance(args.eval_iters, list) else args.eval_iters
+            )
             timers('eval-time').stop()
             one_logger_utils.track_e2e_metrics()
 
@@ -3235,7 +3443,9 @@ def evaluate(
     eval_num_microbatches = eval_batch_size // (args.micro_batch_size * args.data_parallel_size)
     forward_backward_func = get_forward_backward_func()
     if args.cuda_graph_impl == "local" and CudaGraphScope.full_iteration in args.cuda_graph_scope:
-        forward_backward_func = FullCudaGraphWrapper(forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps)
+        forward_backward_func = FullCudaGraphWrapper(
+            forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps
+        )
 
     if has_nvidia_modelopt:
         # [ModelOpt]: Pipeline-parallel Distillation stacks student and teacher tensors
@@ -3285,7 +3495,9 @@ def evaluate(
                 # Reduce across processes.
                 for key in loss_dicts[0].keys():
                     if key not in total_loss_dict:
-                        total_loss_dict[key] = torch.tensor([0.0, 0.0], dtype=torch.float, device='cuda')
+                        total_loss_dict[key] = torch.tensor(
+                            [0.0, 0.0], dtype=torch.float, device='cuda'
+                        )
                     val = [x[key].view(-1) for x in loss_dicts]
 
                     if val[0].numel() == 2:
@@ -3295,19 +3507,17 @@ def evaluate(
                             val = val[:, 0] / val[:, 1].clamp(min=1)
                             val = val.mean()
                             torch.distributed.all_reduce(
-                                val,
-                                group=mpu.get_data_parallel_group(with_context_parallel=True)
+                                val, group=mpu.get_data_parallel_group(with_context_parallel=True)
                             )
                             val /= torch.distributed.get_world_size(
                                 group=mpu.get_data_parallel_group(with_context_parallel=True)
                             )
                             total_loss_dict[key][0] += val
                             total_loss_dict[key][1] += 1
-                        else :
+                        else:
                             val = torch.vstack(val).sum(dim=0)
                             torch.distributed.all_reduce(
-                                val,
-                                group=mpu.get_data_parallel_group(with_context_parallel=True)
+                                val, group=mpu.get_data_parallel_group(with_context_parallel=True)
                             )
                             total_loss_dict[key] += val
                     elif val[0].numel() == 1:
@@ -3430,7 +3640,9 @@ def evaluate_and_print_results(
             ppl = math.exp(min(20, total_loss_dict[key].item()))
             string += '{} PPL: {:.6E} | '.format(key, ppl)
             if writer:
-                writer.add_scalar('{} validation{}'.format(key, suffix), total_loss_dict[key].item(), iteration)
+                writer.add_scalar(
+                    '{} validation{}'.format(key, suffix), total_loss_dict[key].item(), iteration
+                )
                 writer.add_scalar(
                     '{} validation{} vs samples'.format(key, suffix),
                     total_loss_dict[key].item(),
@@ -3439,11 +3651,14 @@ def evaluate_and_print_results(
                 if args.log_validation_ppl_to_tensorboard:
                     writer.add_scalar('{} validation{} ppl'.format(key, suffix), ppl, iteration)
                     writer.add_scalar(
-                        '{} validation{} ppl vs samples'.format(key, suffix), ppl, args.consumed_train_samples
+                        '{} validation{} ppl vs samples'.format(key, suffix),
+                        ppl,
+                        args.consumed_train_samples,
                     )
                 if wandb_writer and is_last_rank():
                     wandb_writer.log(
-                        {'{} validation{}'.format(key, suffix): total_loss_dict[key].item()}, iteration
+                        {'{} validation{}'.format(key, suffix): total_loss_dict[key].item()},
+                        iteration,
                     )
 
         if process_non_loss_data_func is not None and writer and is_last_rank():
@@ -3484,7 +3699,11 @@ def get_train_valid_test_num_samples():
 
     # Get train_samples in current phase.
     if args.phase_transition_iterations:
-        phase_transition_samples = [0] + [t * args.global_batch_size for t in args.phase_transition_iterations] + [args.train_samples]
+        phase_transition_samples = (
+            [0]
+            + [t * args.global_batch_size for t in args.phase_transition_iterations]
+            + [args.train_samples]
+        )
         current_sample = args.iteration * args.global_batch_size
         last_transition_sample = max(s for s in phase_transition_samples if s <= current_sample)
         next_transition_sample = min(s for s in phase_transition_samples if s > current_sample)
@@ -3495,7 +3714,9 @@ def get_train_valid_test_num_samples():
     return (train_samples_in_current_phase, eval_samples, test_samples)
 
 
-def build_train_valid_test_datasets(build_train_valid_test_datasets_provider, train_valid_test_num_samples=None):
+def build_train_valid_test_datasets(
+    build_train_valid_test_datasets_provider, train_valid_test_num_samples=None
+):
     """Build pretraining datasets."""
     if train_valid_test_num_samples is None:
         train_valid_test_num_samples = get_train_valid_test_num_samples()
@@ -3530,8 +3751,14 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
 
     # Get consumed train samples in this phase.
     if args.phase_transition_iterations:
-        last_transition = max(iteration for iteration in (0, *args.phase_transition_iterations) if iteration <= args.iteration)
-        consumed_train_samples_in_current_phase = (args.iteration - last_transition) * args.global_batch_size
+        last_transition = max(
+            iteration
+            for iteration in (0, *args.phase_transition_iterations)
+            if iteration <= args.iteration
+        )
+        consumed_train_samples_in_current_phase = (
+            args.iteration - last_transition
+        ) * args.global_batch_size
     else:
         consumed_train_samples_in_current_phase = args.consumed_train_samples
 
@@ -3548,17 +3775,21 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
             valid_dataloaders = None
             test_dataloader = None
             do_train = (args.train_iters or 0) > 0
-            do_valid = (args.full_validation or args.eval_iters > 0)
-            do_test = (args.full_validation or args.eval_iters > 0)
+            do_valid = args.full_validation or args.eval_iters > 0
+            do_test = args.full_validation or args.eval_iters > 0
 
         else:
             # Build datasets.
-            train_ds, valid_ds, test_ds = build_train_valid_test_datasets(build_train_valid_test_datasets_provider)
+            train_ds, valid_ds, test_ds = build_train_valid_test_datasets(
+                build_train_valid_test_datasets_provider
+            )
             valid_ds = [valid_ds] if not isinstance(valid_ds, list) else valid_ds
             if args.skip_train:
                 train_dataloader = None
             else:
-                train_dataloader = build_pretraining_data_loader(train_ds, consumed_train_samples_in_current_phase)
+                train_dataloader = build_pretraining_data_loader(
+                    train_ds, consumed_train_samples_in_current_phase
+                )
             valid_dataloaders = []
             for valid_d in valid_ds:
                 if args.skip_train or args.full_validation:
@@ -3567,13 +3798,19 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
                     if args.multiple_validation_sets:
                         # TODO(bnorick): for multiple validation sets without full validation, args.consumed_valid_samples is not
                         # correct and needs to be calculated/set per validation set
-                        raise NotImplementedError("--multiple-validation-sets currently requires --full-validation")
-                    valid_dataloaders.append(build_pretraining_data_loader(valid_d, args.consumed_valid_samples))
+                        raise NotImplementedError(
+                            "--multiple-validation-sets currently requires --full-validation"
+                        )
+                    valid_dataloaders.append(
+                        build_pretraining_data_loader(valid_d, args.consumed_valid_samples)
+                    )
             if not args.multiple_validation_sets:
                 assert len(valid_dataloaders) == 1
             test_dataloader = build_pretraining_data_loader(test_ds, 0)
             do_train = train_dataloader is not None and (args.skip_train or args.train_iters > 0)
-            do_valid = valid_dataloaders is not None and (args.full_validation or args.eval_iters > 0)
+            do_valid = valid_dataloaders is not None and (
+                args.full_validation or args.eval_iters > 0
+            )
             do_test = test_dataloader is not None and (args.full_validation or args.eval_iters > 0)
 
         flags = torch.tensor(
@@ -3631,7 +3868,7 @@ def build_train_valid_test_data_iterators(build_train_valid_test_datasets_provid
         if args.full_validation:
             if args.multiple_validation_sets:
                 if valid_dataloaders[0] is None:
-                    args.eval_iters = [None]*len(valid_dataloaders)
+                    args.eval_iters = [None] * len(valid_dataloaders)
                 else:
                     args.eval_iters = [len(dl) for dl in valid_dataloaders]
             else:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1182,7 +1182,19 @@ def update_train_iters(args):
         return
 
     # Constant batch size with sample-based training.
-    if args.rampup_batch_size is None:
+    if args.step_batch_size_schedule is not None:
+        # Sample based training with step batch size schedule.
+        iterations = 0
+        consumed_samples = 0
+        while consumed_samples < args.train_samples:
+            update_num_microbatches(consumed_samples, consistency_check=False)
+            consumed_samples += get_current_global_batch_size()
+            iterations += 1
+        # Reset
+        update_num_microbatches(0, consistency_check=False)
+        args.train_iters = iterations
+
+    elif args.rampup_batch_size is None:
         args.train_iters = args.train_samples // args.global_batch_size
 
     else:
@@ -1632,6 +1644,21 @@ def setup_model_and_optimizer(
     else:
         args.iteration = 0
         args.num_floating_point_operations_so_far = 0
+
+    # Validate that the world size can accommodate the current batch size.
+    # This catches the case where GPUs were scaled up mid-training but the
+    # current position in the batch size schedule yields a batch size that
+    # is too small for the number of data-parallel replicas.
+    num_microbatches = get_num_microbatches()
+    current_global_batch_size = get_current_global_batch_size()
+    data_parallel_size = mpu.get_data_parallel_world_size()
+    assert num_microbatches is not None and num_microbatches >= 1, (
+        f'current global batch size ({current_global_batch_size}) is too small for '
+        f'micro_batch_size ({args.micro_batch_size}) * data_parallel_size ({data_parallel_size}) = '
+        f'{args.micro_batch_size * data_parallel_size}. The world size cannot accommodate the '
+        f'batch size. This can happen when resuming with more GPUs than the current batch size '
+        f'schedule entry supports.'
+    )
 
     # get model without FP16 and/or DDP wrappers
     if (
@@ -2589,7 +2616,9 @@ def train(
             args.global_batch_size,
             args.micro_batch_size,
             mpu.get_data_parallel_world_size(),
-            args.decrease_batch_size_if_needed
+            args.step_batch_size_schedule,
+            args.seq_length,
+            args.decrease_batch_size_if_needed,
         )
         print_rank_0(f"> GRPO training: num_microbatches set to {get_num_microbatches()}")
 

--- a/tests/unit_tests/test_num_microbatches_calculator.py
+++ b/tests/unit_tests/test_num_microbatches_calculator.py
@@ -7,21 +7,21 @@ import megatron.core.num_microbatches_calculator as mb_calculator
 
 def test_init_num_microbatches_calculator():
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, False)
+    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, None, None, False)
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 32
 
     with pytest.raises(AssertionError):
-        mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, False)
+        mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, None, None, False)
 
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 3, True)
+    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 3, None, None, True)
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 32
     assert mb_calculator.get_current_running_global_batch_size() == 24
 
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 33, 8, 2, True)
+    mb_calculator.init_num_microbatches_calculator(0, None, 33, 8, 2, None, None, True)
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 33
     assert mb_calculator.get_current_running_global_batch_size() == 32
@@ -29,52 +29,52 @@ def test_init_num_microbatches_calculator():
 
 def test_reconfigure_num_microbatches_calculator():
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, False)
+    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, None, None, False)
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 32
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, None, None, False)
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 16
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 16, 96], 32, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 16, 96], 32, 8, 2, None, None, False)
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 16
 
 
 def test_get_num_microbatches():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, None, None, False)
     assert mb_calculator.get_num_microbatches() == 1
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 3, True)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 3, None, None, True)
     assert mb_calculator.get_num_microbatches() == 1
 
 
 def test_get_current_global_batch_size():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 2, None, None, False)
     assert mb_calculator.get_current_global_batch_size() == 16
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 3, True)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 3, None, None, True)
     assert mb_calculator.get_current_global_batch_size() == 16
     assert mb_calculator.get_current_running_global_batch_size() == 12
 
 
 def test_get_micro_batch_size():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, None, None, False)
     assert mb_calculator.get_micro_batch_size() == 8
 
 
 def test_update_num_microbatches():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 8, 96], 32, 4, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 8, 96], 32, 4, 2, None, None, False)
     assert mb_calculator.get_num_microbatches() == 2
     mb_calculator.update_num_microbatches(48, False)
     assert mb_calculator.get_num_microbatches() == 3
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 8, 96], 32, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 8, 96], 32, 8, 2, None, None, False)
     with pytest.raises(AssertionError):
         mb_calculator.update_num_microbatches(49, True)
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 32, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 32, 8, 2, None, None, False)
     mb_calculator.update_num_microbatches(16)
     assert mb_calculator.get_num_microbatches() == 2
 
@@ -135,7 +135,7 @@ class TestRampupBatchsizeNumMicroBatchesCalculator:
 
 
 def test_ramp_up():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 16, 96], 32, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 16, 96], 32, 8, 2, None, None, False)
     consumed_samples = 0
     count = 0
     expected_consumed_samples = [0, 16, 32, 48, 64, 80, 96, 128, 160, 192, 224, 256]
@@ -145,3 +145,108 @@ def test_ramp_up():
         count += 1
         assert consumed_samples == expected_consumed_samples[count]
         mb_calculator.update_num_microbatches(consumed_samples, True)
+
+
+def test_step_batch_size_schedule_allows_past_entries_smaller_than_dp():
+    """Test that step batch size schedule does not crash when early schedule entries
+    are smaller than micro_batch_size * data_parallel_size.
+
+    This happens when scaling to more GPUs mid-training: the initial batch sizes
+    in the schedule are smaller than the new GPU count can support, but training
+    has progressed past those entries. The divisibility check should only apply
+    to the CURRENT batch size (after checkpoint loading), not all schedule entries.
+    """
+    # micro=1, dp=512, micro*dp=512
+    # Schedule starts at 256 which is < 512, but later entries are fine.
+    # This should NOT raise during construction.
+    calc = mb_calculator.StepBatchsizeNumMicroBatchesCalculator(
+        micro_batch_size=1,
+        data_parallel_size=512,
+        decrease_batch_size_if_needed=False,
+        rank=0,
+        schedule="0:256 200000:512 600000:1024 1500000:2048 3000000:4096 6000000:6144",
+    )
+
+    # At init (consumed_samples=0), batch=256 < micro*dp=512.
+    # No consistency_check at init, so no error.
+    assert calc.current_global_batch_size == 256
+
+    # After training past the first entry, batch=512. Consistency check passes.
+    calc.update(200000, consistency_check=True)
+    assert calc.current_global_batch_size == 512
+    assert calc.num_micro_batches == 1
+
+    # Later entries work fine.
+    calc.update(1500000, consistency_check=True)
+    assert calc.current_global_batch_size == 2048
+    assert calc.num_micro_batches == 4
+
+    calc.update(6000000, consistency_check=True)
+    assert calc.current_global_batch_size == 6144
+    assert calc.num_micro_batches == 12
+
+
+def test_step_batch_size_schedule_consistency_check_fails_when_batch_too_small():
+    """Test that consistency_check=True raises when current batch size is smaller
+    than micro_batch_size * data_parallel_size.
+
+    This is the scenario caught by the runtime check in setup_model_and_optimizer:
+    GPUs were scaled up but the current schedule entry yields a batch size too small
+    for the new world size.
+    """
+    calc = mb_calculator.StepBatchsizeNumMicroBatchesCalculator(
+        micro_batch_size=1,
+        data_parallel_size=512,
+        decrease_batch_size_if_needed=False,
+        rank=0,
+        schedule="0:256 200000:512 600000:1024",
+    )
+
+    # At consumed_samples=0, batch=256 < micro*dp=512.
+    # consistency_check=True should fail because 256 % 512 != 0.
+    with pytest.raises(AssertionError):
+        calc.update(0, consistency_check=True)
+
+
+def test_step_batch_size_schedule_decrease_batch_yields_zero_microbatches():
+    """Test that decrease_batch_size_if_needed=True with a batch size smaller
+    than micro_batch_size * data_parallel_size results in num_micro_batches=0.
+
+    This is a silent failure mode: the batch rounds down to 0 and training would
+    fail. The runtime check in setup_model_and_optimizer catches this by asserting
+    num_micro_batches >= 1.
+    """
+    calc = mb_calculator.StepBatchsizeNumMicroBatchesCalculator(
+        micro_batch_size=1,
+        data_parallel_size=512,
+        decrease_batch_size_if_needed=True,
+        rank=0,
+        schedule="0:256 200000:512 600000:1024",
+    )
+
+    # At consumed_samples=0, batch=256, rounds down to 0.
+    calc.update(0, consistency_check=True)
+    assert calc.num_micro_batches == 0
+
+    # After progressing past the threshold, batch=512 works.
+    calc.update(200000, consistency_check=True)
+    assert calc.num_micro_batches == 1
+
+
+def test_rampup_consistency_check_fails_when_batch_too_small():
+    """Test that rampup batch size with consistency_check=True raises when the
+    current ramped-up batch size is smaller than micro_batch_size * data_parallel_size."""
+    calc = mb_calculator.RampupBatchsizeNumMicroBatchesCalculator(
+        global_batch_size=1024,
+        micro_batch_size=1,
+        data_parallel_size=512,
+        decrease_batch_size_if_needed=False,
+        rank=0,
+        start_global_batch_size=256,
+        batch_size_increment=256,
+        ramup_samples=768,
+    )
+
+    # At consumed_samples=0, batch=256 < micro*dp=512.
+    with pytest.raises(AssertionError):
+        calc.update(0, consistency_check=True)

--- a/tests/unit_tests/test_num_microbatches_calculator.py
+++ b/tests/unit_tests/test_num_microbatches_calculator.py
@@ -37,7 +37,9 @@ def test_reconfigure_num_microbatches_calculator():
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 16
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 16, 96], 32, 8, 2, None, None, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(
+        0, [16, 16, 96], 32, 8, 2, None, None, False
+    )
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 16
 
@@ -65,12 +67,16 @@ def test_get_micro_batch_size():
 
 
 def test_update_num_microbatches():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 8, 96], 32, 4, 2, None, None, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(
+        0, [16, 8, 96], 32, 4, 2, None, None, False
+    )
     assert mb_calculator.get_num_microbatches() == 2
     mb_calculator.update_num_microbatches(48, False)
     assert mb_calculator.get_num_microbatches() == 3
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 8, 96], 32, 8, 2, None, None, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(
+        0, [16, 8, 96], 32, 8, 2, None, None, False
+    )
     with pytest.raises(AssertionError):
         mb_calculator.update_num_microbatches(49, True)
 
@@ -135,7 +141,9 @@ class TestRampupBatchsizeNumMicroBatchesCalculator:
 
 
 def test_ramp_up():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 16, 96], 32, 8, 2, None, None, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(
+        0, [16, 16, 96], 32, 8, 2, None, None, False
+    )
     consumed_samples = 0
     count = 0
     expected_consumed_samples = [0, 16, 32, 48, 64, 80, 96, 128, 160, 192, 224, 256]
@@ -194,10 +202,7 @@ def test_step_batch_size_schedule_consistency_check_fails_when_batch_too_small()
     for the new world size.
     """
     calc = mb_calculator.StepBatchsizeNumMicroBatchesCalculator(
-        micro_batch_size=1,
-        data_parallel_size=512,
-        rank=0,
-        schedule="0:256 200000:512 600000:1024",
+        micro_batch_size=1, data_parallel_size=512, rank=0, schedule="0:256 200000:512 600000:1024"
     )
 
     # At consumed_samples=0, batch=256 < micro*dp=512.

--- a/tests/unit_tests/test_num_microbatches_calculator.py
+++ b/tests/unit_tests/test_num_microbatches_calculator.py
@@ -162,7 +162,6 @@ def test_step_batch_size_schedule_allows_past_entries_smaller_than_dp():
     calc = mb_calculator.StepBatchsizeNumMicroBatchesCalculator(
         micro_batch_size=1,
         data_parallel_size=512,
-        decrease_batch_size_if_needed=False,
         rank=0,
         schedule="0:256 200000:512 600000:1024 1500000:2048 3000000:4096 6000000:6144",
     )
@@ -197,7 +196,6 @@ def test_step_batch_size_schedule_consistency_check_fails_when_batch_too_small()
     calc = mb_calculator.StepBatchsizeNumMicroBatchesCalculator(
         micro_batch_size=1,
         data_parallel_size=512,
-        decrease_batch_size_if_needed=False,
         rank=0,
         schedule="0:256 200000:512 600000:1024",
     )
@@ -206,31 +204,6 @@ def test_step_batch_size_schedule_consistency_check_fails_when_batch_too_small()
     # consistency_check=True should fail because 256 % 512 != 0.
     with pytest.raises(AssertionError):
         calc.update(0, consistency_check=True)
-
-
-def test_step_batch_size_schedule_decrease_batch_yields_zero_microbatches():
-    """Test that decrease_batch_size_if_needed=True with a batch size smaller
-    than micro_batch_size * data_parallel_size results in num_micro_batches=0.
-
-    This is a silent failure mode: the batch rounds down to 0 and training would
-    fail. The runtime check in setup_model_and_optimizer catches this by asserting
-    num_micro_batches >= 1.
-    """
-    calc = mb_calculator.StepBatchsizeNumMicroBatchesCalculator(
-        micro_batch_size=1,
-        data_parallel_size=512,
-        decrease_batch_size_if_needed=True,
-        rank=0,
-        schedule="0:256 200000:512 600000:1024",
-    )
-
-    # At consumed_samples=0, batch=256, rounds down to 0.
-    calc.update(0, consistency_check=True)
-    assert calc.num_micro_batches == 0
-
-    # After progressing past the threshold, batch=512 works.
-    calc.update(200000, consistency_check=True)
-    assert calc.num_micro_batches == 1
 
 
 def test_rampup_consistency_check_fails_when_batch_too_small():


### PR DESCRIPTION
Adds a new --step-batch-size-schedule argument that allows specifying arbitrary step-wise batch size schedules (e.g. "0:768 250B:1536 500B:3072"). Thresholds support K/M/B/T suffixes and are interpreted as tokens when --seq-length is provided, otherwise as samples. Mutually exclusive with --rampup-batch-size.

Includes deferred divisibility checking so early schedule entries smaller than the current GPU configuration don't crash at init, a runtime check in setup_model_and_optimizer that validates world size can accommodate the current batch size after checkpoint loading, and sample-based training iteration calculation via update_train_iters.