### PR TITLE
chore: bump FW-CI-templates to v0.80.2

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -32,7 +32,7 @@ jobs:
   build-docs:
     needs: [pre-flight]
     if: needs.pre-flight.outputs.is_deployment_workflow != 'true'
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@ko3n1g/fix/linkcheck-retry-backoff
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.80.2
 
   build-docs-summary:
     needs: [pre-flight, build-docs]


### PR DESCRIPTION
## Summary
- Bumps `NVIDIA-NeMo/FW-CI-templates` reference in `build-docs.yml` from `v0.57.0` to `v0.80.2`
- v0.80.2 includes retry with exponential backoff for Sphinx linkcheck to handle transient failures

## Test plan
- [ ] Verify the `build-docs` workflow triggers and passes after this bump