### PR TITLE
Cudagraphs: Remove fwd_graph_input_surface weakref

### DIFF
--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1149,13 +1149,18 @@ class _CudaGraphRunner(torch.nn.Module):
                 return ref
 
             # Weak refs replace tensors with raw-pointer wrappers that do not hold a storage
-            # reference. This is safe for surfaces whose memory is managed by
-            # the CUDA graph pool (driver-pinned, stable addresses) but not safe for
-            # tensors allocated by the caching allocator, whose data_ptr() may be invalidated by
-            # block coalescing or empty_cache().
-            # We do not weakref tensors in fwd_graph_input_surface. These may be allocated from
-            # tensor_reuse_pool which is outside the scope of the graph pool. Weakref'ing them
-            # creates a dangling pointer if the caching allocator reclaims the block.
+            # reference. This is safe for surfaces whose memory is managed by the CUDA graph pool
+            # (driver-pinned, stable addresses) but not safe for tensors allocated by the caching
+            # allocator, whose data_ptr() may be invalidated by block coalescing or empty_cache().
+            def replace_with_weak_ref_for_input_surface(arg):
+                if torch.is_tensor(arg) and _CudagraphGlobalRecord.tensor_reuse_pool.owns(arg):
+                    return arg
+                return replace_with_weak_ref(arg)
+
+            self.fwd_graph_input_surface = tree_map(
+                replace_with_weak_ref_for_input_surface, self.fwd_graph_input_surface
+            )
+
             self.fwd_graph_input_args = tree_map(replace_with_weak_ref, self.fwd_graph_input_args)
             self.fwd_graph_input_kwargs = tree_map(
                 replace_with_weak_ref, self.fwd_graph_input_kwargs


### PR DESCRIPTION
# What does this PR do ?
Tensors in `fwd_graph_input_surface` which are not owned by the cudagraph memory pool should not be weakref'd. `_WeakRefTensor` takes a `data_ptr()` and constructs a weakref, then wraps that pointer back into a torch tensor based on a raw integer address, not the original tensor's storage object. Pytorch's reference counting hinges on the storage object refcount, and the caching allocator frees the block when refcount goes to 0.

The weakref created has a different storage object, so you have two tensors pointing to the same CUDA address, but only the original keeps the caching allocator from freeing it.`tensor_strong_refs` should keep this live in theory, but if the caching allocator is under pressure, or the cache is emptied, it might move the original tensor's `data_ptr()`. Since this tensor is in `tensor_strong_refs` and not the graph pool, it is not guaranteed a fixed address, leaving the weakref holding a stale data pointer has been freed, resulting in a segfault.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
