### PR TITLE
fix: interpolate version correctly in release Slack notification

### DIFF
--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -486,13 +486,8 @@ jobs:
     secrets: inherit
 
   notify:
-    needs: [build-test-publish-wheels, create-gh-release]
+    needs: [build-test-publish-wheels, create-gh-release, bump-next-version]
     runs-on: ubuntu-latest
-    env:
-      GH_URL: https://github.com/${{ github.repository }}/releases/tag/v${{ needs.build-test-publish-wheels.outputs.version }}
-      PYPI_URL: https://${{ inputs.dry-run == true && 'test.' || '' }}pypi.org/project/${{ needs.build-test-publish-wheels.outputs.pypi-name }}/${{ needs.build-test-publish-wheels.outputs.version }}/
-      PROJECT_NAME: Megatron Core
-      VERSION: ${{ needs.build-test-publish-wheels.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -505,10 +500,10 @@ jobs:
         uses: ./send-slack-alert/.github/actions/send-slack-alert
         env:
           MESSAGE: |
-            ${{ inputs.dry-run == true && 'This is a dry-run, nothing actually happened: ' || '' }}We have released `${{ env.VERSION }}` of `NVIDIA ${{ env.PROJECT_NAME }}` 🚀✨🎉
+            ${{ inputs.dry-run == true && 'This is a dry-run, nothing actually happened: ' || '' }}We have released `${{ needs.bump-next-version.outputs.release-version }}` of `NVIDIA Megatron Core` 🚀✨🎉
 
-            • <${{ env.GH_URL }}|GitHub release>
-            • <${{ env.PYPI_URL }}|PyPi release>
+            • <https://github.com/${{ github.repository }}/releases/tag/core_v${{ needs.bump-next-version.outputs.release-version }}|GitHub release>
+            • <https://${{ inputs.dry-run == true && 'test.' || '' }}pypi.org/project/megatron-core/${{ needs.bump-next-version.outputs.release-version }}/|PyPi release>
 
         with:
           message: ${{ env.MESSAGE }}


### PR DESCRIPTION
## Summary

- `env.VERSION` inside an `env:` block was never interpolated — GitHub Actions only supports the `env` context in `run` steps
- `needs.build-test-publish-wheels.outputs.version` and `.outputs.pypi-name` don't exist (the called workflow defines no outputs), so both resolved to empty strings
- Fixed by sourcing version from `needs.bump-next-version.outputs.release-version` and inlining all expressions directly in `MESSAGE`

## Before / After

**Before** (broken — empty version in Slack message):
```
We have released `` of `NVIDIA ` 🚀✨🎉
• <|GitHub release>
• <|PyPi release>
```

**After** (working):
```
We have released `0.12.0rc1` of `NVIDIA Megatron Core` 🚀✨🎉
• <https://github.com/NVIDIA/Megatron-LM/releases/tag/core_v0.12.0rc1|GitHub release>
• <https://pypi.org/project/megatron-core/0.12.0rc1/|PyPi release>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)