### PR TITLE
Fix unnecessary permute padding for non-quantized MoE dispatch

### DIFF
--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -1313,7 +1313,7 @@ class _DeepepManager(_DispatchManager):
             num_out_tokens=self.tokens_per_expert.sum().item(),
             fused=self.permute_fusion,
             tokens_per_expert=self.tokens_per_expert,
-            align_size=get_align_size_for_quantization(self.config),
+            align_size=get_align_size_for_quantization(self.config) if self.config.fp8 or self.config.fp4 else -1,
         )
         if self.router_dtype == "fp64":
             permuted_probs = permuted_probs.to(torch.float64)


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->
Fix unnecessary permute padding for non-quantized MoE dispatch.

Only FP8/FP4 dispatch paths require padding during permute, but `get_align_size_for_quantization()` returns 16 by default. This causes non-quantized dtypes such as BF16 to take the padded permute path unexpectedly.

This changes dispatch tensor shapes for non-quantized runs and can cause checkpoint resume mismatches.

This PR restricts permute padding to quantized dispatch modes only, so BF16 and other non-quantized paths preserve their original token layout while FP8/FP4 behavior remains unchanged.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>