### PR TITLE
ci: Add --repo flag to gh pr view in configure job

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -162,7 +162,7 @@ jobs:
           PR_NUMBER=${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').number }}
 
           # Fetch all labels in a single API call; fall back to empty list if no PR
-          LABELS=$(gh pr view $PR_NUMBER --json labels --jq '[.labels[].name]') || LABELS='[]'
+          LABELS=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json labels --jq '[.labels[].name]') || LABELS='[]'
 
           HAS_RUN_TESTS=$(echo "$LABELS"      | jq 'any(. == "Run tests")')
           HAS_RUN_FUNCTIONAL=$(echo "$LABELS" | jq 'any(. == "Run functional tests")')


### PR DESCRIPTION
## Summary

- The `configure` job in `cicd-main.yml` calls `gh pr view $PR_NUMBER` without `--repo` and without a prior `actions/checkout`
- Without `--repo`, `gh` falls back to `git remote get-url origin` to discover the repo, which requires a `.git` directory — causing `fatal: not a git repository`
- The failure was silently swallowed by `|| LABELS='[]'`, making all label checks (`HAS_RUN_TESTS`, `HAS_RUN_FUNCTIONAL`, `HAS_LTS`, `HAS_MBRIDGE`) default to `false` and the CICD scope to always fall back to `mr-github-slim`
- Fix: add `--repo ${{ github.repository }}` so `gh` skips git-based repo discovery entirely

**Evidence of the bug:** https://github.com/NVIDIA/Megatron-LM/actions/runs/23368045786/job/68074183916#step:3:88

```
++ gh pr view 3902 --json labels --jq '[.labels[].name]'
failed to run git: fatal: not a git repository (or any of the parent directories): .git
+ LABELS=
+ LABELS='[]'
```

## Test plan

- [ ] Trigger a PR run and verify the `configure` step no longer emits `fatal: not a git repository`
- [ ] Verify labels are correctly read and the appropriate CICD scope is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)