### PR TITLE
feat(energy-monitor): Add per-GPU power CSV logging via --log-energy-csv-dir

### DIFF
--- a/megatron/core/energy_monitor.py
+++ b/megatron/core/energy_monitor.py
@@ -24,7 +24,10 @@ class EnergyMonitor:
     Energy monitoring using NVML.
 
     All ranks in the process group are expected to call functions lap() and get_total().
-    Energy is monitored across all ranks and aggregated with an all-reduce.
+    Energy is monitored across all ranks and gathered with an all-gather.
+
+    Per-GPU energy from the most recent lap() call is available via
+    get_last_lap_per_gpu(), enabling per-GPU power analysis and CSV export.
     """
 
     def __init__(self) -> None:
@@ -33,6 +36,7 @@ class EnergyMonitor:
         self._lap_energy = 0
         self._last_energy = 0
         self._handle = None
+        self._last_lap_per_gpu: list[float] = []
 
     def setup(self) -> None:
         """Setup the NVML Handler."""
@@ -64,7 +68,10 @@ class EnergyMonitor:
             return self._last_energy  # return *something* if it errors
 
     def lap(self) -> float:
-        """Returns lap (iteration) energy (J) and updates total energy."""
+        """Returns lap (iteration) energy (J) and updates total energy.
+
+        Also stores per-GPU energy (J) accessible via get_last_lap_per_gpu().
+        """
         if not has_nvml:
             return 0.0
 
@@ -76,9 +83,24 @@ class EnergyMonitor:
         self._last_energy = energy
 
         lap_tensor = torch.tensor([lap_energy], dtype=torch.int64, device='cuda')
-        dist.all_reduce(lap_tensor, op=dist.ReduceOp.SUM)
 
-        return lap_tensor.item() / 1000.0
+        # all_gather preserves per-GPU values for optional per-GPU analysis
+        world_size = dist.get_world_size()
+        gathered = [torch.zeros_like(lap_tensor) for _ in range(world_size)]
+        dist.all_gather(gathered, lap_tensor)
+
+        # Store per-GPU energy in Joules
+        self._last_lap_per_gpu = [g.item() / 1000.0 for g in gathered]
+
+        return sum(self._last_lap_per_gpu)
+
+    def get_last_lap_per_gpu(self) -> list[float]:
+        """Returns per-GPU energy (J) from the most recent lap() call.
+
+        Each element corresponds to one rank's GPU energy consumption
+        since the previous lap() call. The list is ordered by rank.
+        """
+        return self._last_lap_per_gpu
 
     def get_total(self) -> float:
         """Get total energy consumption (J) across all GPUs."""

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1128,6 +1128,9 @@ def validate_args(args, defaults={}):
             assert args.save_retain_interval % args.save_interval == 0
     if args.log_memory_interval is not None:
         assert args.log_memory_interval % args.log_interval == 0
+    # --log-energy-csv-dir implies --log-energy
+    if args.log_energy_csv_dir is not None:
+        args.log_energy = True
     # Mixed precision checks.
     if args.fp16_lm_cross_entropy:
         assert args.fp16, 'lm cross entropy in fp16 only support in fp16 mode.'

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -318,6 +318,10 @@ class LoggerConfig:
     log_energy: bool = False
     """If set, log energy consumption (in Joules)."""
 
+    log_energy_csv_dir: str | None = None
+    """Directory to save per-GPU power CSV. If not set, no CSV is written.
+    When set, implies --log-energy (aggregate power logging is also enabled)."""
+
     save_config_filepath: str | None = None
     """If set, save the task configuration (ConfigContainer) to this file."""
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -33,6 +33,7 @@ def set_startup_timestamps(program_start=None, main_entry=None):
 
 from collections import defaultdict
 import copy
+import csv
 import dataclasses
 from datetime import datetime, timedelta
 import functools
@@ -57,6 +58,10 @@ logging.basicConfig(handlers=[CustomHandler()], level=logging.INFO)
 from .theoretical_memory_usage import report_theoretical_memory
 
 _LEGACY_TRAIN_START_TIME = time.time() # NOTE(asolergi-nv): Legacy timestamp
+
+# Per-GPU power CSV state (set up in train(), used in training_log())
+_POWER_CSV_FILE = None
+_POWER_CSV_WRITER = None
 
 import torch
 
@@ -2226,6 +2231,19 @@ def training_log(
             if wandb_writer:
                 wandb_writer.log({'iter-energy/gpu': energy}, iteration)
                 wandb_writer.log({'power/gpu': power}, iteration)
+            # Per-GPU power CSV (rank 0 only, when --log-energy-csv-dir is set)
+            if _POWER_CSV_WRITER is not None:
+                per_gpu_energy = energy_monitor.get_last_lap_per_gpu()
+                if per_gpu_energy:
+                    total_elapsed = elapsed_time_per_iteration * total_iterations
+                    per_gpu_power = [e / total_elapsed for e in per_gpu_energy]
+                    avg_power = sum(per_gpu_power) / len(per_gpu_power)
+                    _POWER_CSV_WRITER.writerow(
+                        [iteration, datetime.now().isoformat()]
+                        + [f'{p:.1f}' for p in per_gpu_power]
+                        + [f'{avg_power:.1f}']
+                    )
+                    _POWER_CSV_FILE.flush()
         # Decoupled_learning_rate should be not None only on first and last pipeline stage.
         if learning_rate is not None:
             log_string += f' learning rate: {learning_rate:.6E} |'
@@ -2756,6 +2774,18 @@ def train(
         energy_monitor.setup()
         energy_monitor.resume()
 
+    # Per-GPU power CSV setup (rank 0 only)
+    global _POWER_CSV_FILE, _POWER_CSV_WRITER
+    if args.log_energy_csv_dir is not None and args.rank == 0:
+        os.makedirs(args.log_energy_csv_dir, exist_ok=True)
+        csv_path = os.path.join(args.log_energy_csv_dir, 'power_per_gpu.csv')
+        _POWER_CSV_FILE = open(csv_path, 'w', newline='')
+        _POWER_CSV_WRITER = csv.writer(_POWER_CSV_FILE)
+        header = (['iteration', 'timestamp']
+                  + [f'gpu_{i}_power_w' for i in range(args.world_size)]
+                  + ['avg_power_w'])
+        _POWER_CSV_WRITER.writerow(header)
+
     timers('interval-time', log_level=0).start(barrier=True)
     print_datetime('before the start of training step')
     report_memory_flag = True
@@ -3239,6 +3269,10 @@ def train(
         total_energy = energy_monitor.get_total()
         print_rank_0(f"Total training energy (GPU): {total_energy / 1e6:.3f} MJ")
         energy_monitor.shutdown()
+
+    # Close per-GPU power CSV
+    if _POWER_CSV_FILE is not None:
+        _POWER_CSV_FILE.close()
 
     # If any exit conditions (signal handler, duration, iterations) have been reached, exit.
     if should_exit:


### PR DESCRIPTION
Extends EnergyMonitor to provide per-GPU power data for power research and analysis.

Problem:

The existing --log-energy flag logs average energy/power per GPU to the training log line, TensorBoard, and WandB. The average is computed via all_reduce(SUM) which destroys per-GPU granularity needed for power research (e.g., analyzing per-GPU power variance, identifying imbalanced workloads).

Solution:

Replace all_reduce with all_gather in EnergyMonitor.lap() to preserve per-GPU energy values. Add a new --log-energy-csv-dir argument that enables per-GPU power CSV export on rank 0.

Default behavior: when --log-energy-csv-dir is not set, no CSV is written and per-GPU collection is not triggered. Existing --log-energy behavior is completely unchanged.

Changes:

1. megatron/core/energy_monitor.py:
   - Replace all_reduce with all_gather in lap()
   - Store per-GPU energy (Joules) in _last_lap_per_gpu
   - Add get_last_lap_per_gpu() getter
   - lap() return type unchanged (float) — fully backward compatible

2. megatron/training/config/training_config.py:
   - Add log_energy_csv_dir: str | None to LoggerConfig
   - Docstring clarifies: no CSV when not set, implies --log-energy when set

3. megatron/training/arguments.py:
   - --log-energy-csv-dir implies --log-energy

4. megatron/training/training.py:
   - CSV setup in train() (rank 0 only)
   - Per-GPU power write in training_log() with empty-list guard
   - CSV cleanup at end of training

Output: power_per_gpu.csv with columns:
iteration, timestamp, gpu_0_power_w, ..., gpu_N_power_w, avg_power_w

Validated (GB300 NVL cluster, nemo:25.07 container):
- Single-node: 1 node, 4 GPUs
- Multi-node: 4 nodes, 16 GPUs — both data-parallel (symmetric power) and pipeline-parallel (asymmetric power) topologies
- Cross-validated against nvidia-smi power.draw: <1% agreement across all 16 GPUs over matched time windows
- Multi-node data-parallel also validated on nemo:26.02 container

What does NOT change:
- lap() return type (still float)
- All existing --log-energy behavior (log line, TensorBoard, WandB)
- setup(), shutdown(), pause(), resume(), get_total() signatures
- No new dependencies

# What does this PR do ?
Add per-GPU power CSV logging (`--log-energy-csv-dir`) to EnergyMonitor, replacing `all_reduce` with `all_gather` to preserve per-GPU granularity for power research and analysis.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [X] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [X] I have added relevant documentation
- [X] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
