### PR TITLE
docs: add developer-guide skill with CI/CD and failure navigation guidance

### DIFF
--- a/skills/build-and-test/SKILL.md
+++ b/skills/build-and-test/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: developer-guide
+name: build-and-test
 description: Developer environment setup, CI/CD workflows, and CI failure debugging for Megatron-LM. Covers container-based development, uv package management, linting, running tests, CI failure investigation, and common pitfalls. Use when onboarding, setting up a dev environment, troubleshooting build issues, or investigating CI failures.
 ---
 


### PR DESCRIPTION
## Summary

- Restructures agent guidance from `AGENTS.md` into `skills/developer-guide/SKILL.md` to match the Claude Code skill format used in NeMo-LM
- Adds YAML frontmatter (`name` + `description`) so the file is usable as an invocable skill
- Removes numbered section headers in favour of prose-style section names
- **Developer setup**: container-based workflow (pre-built vs. scratch image), `uv` dependency groups, linting
- **Test onboarding**: execution model (single DGX H100 node, 8 GPUs, nemo-run `DockerExecutor`), recipe YAML structure, unit/functional test onboarding, CI scope labels
- **CI failure triage**: locating PRs from `pull-request/<number>` branches, reading runner logs, chunking large artifact log files, identifying root cause, correlating with PR changeset
- **Common pitfalls**: table of known issues with causes and fixes

## Example

Invoke the skill in Claude Code:

```
/developer-guide
```

## Test plan

- [ ] Verify `docker/.ngc_version.dev` and `docker/.ngc_version.lts` are read correctly in the build commands
- [ ] Spot-check the recipe YAML example against an existing recipe in `tests/test_utils/recipes/h100/`
- [ ] Confirm artifact download commands work against a recent CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)