### PR TITLE
[Kernel] Fused Indexer Loss Kernel

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -529,7 +529,7 @@ def fwd_fused_indexer_loss(
     softmax_scale: float,
     loss_coeff: float,
     sparse_loss: Optional[bool] = False,
-    index_mask: Optional[torch.Tensor] = None,
+    topk_indices: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     ASq, AB, AH, AD = attn_query.shape
     ASk = attn_key.shape[0]
@@ -545,6 +545,9 @@ def fwd_fused_indexer_loss(
     attn_num_sq_blocks = (ASq + BLOCK_SQ - 1) // BLOCK_SQ
 
     if sparse_loss:
+        index_mask = torch.full(
+            (AB, ASq, ASk), float("-inf"), dtype=torch.float32, device=index_scores.device
+        ).scatter_(-1, topk_indices, 0)
         stride_imb = index_mask.stride(0)
         stride_ims = index_mask.stride(1)
         stride_imk = index_mask.stride(2)
@@ -692,10 +695,11 @@ def fwd_fused_indexer_loss(
             dtype=tl_dtype,
         )
 
+        index_scores = index_scores.contiguous()
         if sparse_loss:
             out_loss = kernel(
                 attn_query, attn_key,
-                index_scores.contiguous(), 
+                index_scores, 
                 index_mask,
                 softmax_m, softmax_d,
                 softmax_m1, softmax_d1,
@@ -703,7 +707,7 @@ def fwd_fused_indexer_loss(
         else:
             out_loss = kernel(
                 attn_query, attn_key,
-                index_scores.contiguous(),
+                index_scores,
                 softmax_m, softmax_d,
                 softmax_m1, softmax_d1,
             )
@@ -1027,15 +1031,6 @@ def fwd_fused_indexer_loss_naive(
         )
     else:
         print("###############use fused indexer loss################")
-        sq, b, np, hn = query.size()
-        sk = key.size(0)
-
-        if sparse_loss:
-            index_mask = torch.full(
-                (b, sq, sk), float("-inf"), dtype=torch.float32, device=index_scores.device
-            ).scatter_(-1, topk_indices, 0)
-        else:
-            index_mask = None
         indexer_loss = fwd_fused_indexer_loss(
             index_scores,
             query,
@@ -1043,7 +1038,7 @@ def fwd_fused_indexer_loss_naive(
             softmax_scale,
             loss_coeff,
             sparse_loss,
-            index_mask,
+            topk_indices,
         )
 
     return topk_indices, indexer_loss

--- a/tests/unit_tests/transformer/experimental_attention_variant/benchmark_fused_kernel.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/benchmark_fused_kernel.py
@@ -1,0 +1,182 @@
+"""
+Test suite for DSA (Dynamic Sparse Attention) indexer loss backward pass.
+
+This file contains:
+1. backward_native: Pure PyTorch implementation of the manual backward pass
+2. Test functions to validate both implementations against PyTorch autograd
+
+The DSA indexer loss computes KL divergence between:
+- Index scores: Predicted importance scores from the indexer network
+- Attention scores: True attention scores from the full attention mechanism
+
+Backward pass computes gradients w.r.t.:
+- q: Indexer query embeddings [Sq, B, H, D]
+- weights: Indexer attention weights [Sq, B, H]  
+- k: Indexer key embeddings [Sk, B, D]
+"""
+import os
+
+import torch
+import torch.distributed as dist
+
+import numpy as np
+
+from megatron.core.transformer.experimental_attention_variant.dsa import compute_dsa_indexer_loss, fwd_fused_indexer_loss
+from megatron.core.transformer.experimental_attention_variant.dsa import fused_qk_topk_naive
+
+from tests.unit_tests.test_utilities import Utils
+from megatron.core.process_groups_config import ProcessGroupCollection
+
+USE_TILELANG = os.environ.get('USE_FUSED_INDEXER_LOSS', '0') == '2'
+
+def bench(fn, num_warmups: int = 5, num_tests: int = 50, post_fn=None, is_async=True):
+    # Flush L2 cache with 256 MB data
+    torch.cuda.synchronize()
+    cache = torch.empty(int(256e6 // 4), dtype=torch.int, device='cuda')
+
+    # Warmup
+    for _ in range(num_warmups):
+        fn()
+
+    # Flush L2
+    cache.zero_()
+
+    torch.cuda.synchronize()
+    if dist.is_initialized():
+        dist.barrier()
+
+    if is_async:
+        start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_tests)]
+        end_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_tests)]
+        for i in range(num_tests):
+            # Record
+            start_events[i].record()
+            fn()
+            end_events[i].record()
+            if post_fn is not None:
+                post_fn()
+
+        torch.cuda.synchronize()
+
+        times = np.array([s.elapsed_time(e) / 1e3 for s, e in zip(start_events, end_events)])[1:]
+        return np.median(times), np.min(times), np.max(times)
+    else:
+        start_events = torch.cuda.Event(enable_timing=True)
+        end_events = torch.cuda.Event(enable_timing=True)
+        start_events.record()
+        for _ in range(num_tests):
+            fn()
+            if post_fn is not None:
+                post_fn()
+        end_events.record()
+        
+        torch.cuda.synchronize()
+
+        times = start_events.elapsed_time(end_events) / 1e3 / num_tests
+
+        return times, times, times
+
+def benchmark_fused_loss_forward():
+    """Benchmark compute_index_scores_topk + DSA indexer loss: native PyTorch vs Triton."""
+    
+    configs = [
+        # (Sq, Sk, B, H, D, topk)
+        (4096, 4096, 1, 128, 7168, 2048),
+        (6144, 6144, 1, 128, 7168, 2048),
+        # (8192, 8192, 1, 128, 7168, 2048),
+    ]
+
+    Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+    pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp'])
+    
+    metrics_collection = []
+    for Sq, Sk, B, H, D, topk in configs:
+        # Setup
+        dtype = torch.bfloat16
+        q = torch.randn(Sq, B, H, D, device='cuda', dtype=dtype)
+        k = torch.randn(Sk, B, D, device='cuda', dtype=dtype)
+        weights = torch.randn(Sq, B, H, device='cuda', dtype=torch.float32)
+        mask = torch.triu(
+            torch.full((B, Sq, Sk), float('-inf'), dtype=torch.float32, device='cuda'),
+            diagonal=1,
+        )
+
+        attn_query = torch.randn(Sq, B, H, D, device='cuda', dtype=dtype)
+        attn_key = torch.randn(Sk, B, H, D, device='cuda', dtype=dtype)
+        softmax_scale = 1.0
+        loss_coeff = 1.0
+        for sparse_loss in [False, True]:
+            index_scores, topk_indices = fused_qk_topk_naive(q, k, weights, topk, mask)
+
+            native_lambda = lambda: compute_dsa_indexer_loss(
+                index_scores, 
+                topk_indices, 
+                attn_query, 
+                attn_key, 
+                softmax_scale, 
+                loss_coeff, 
+                sparse_loss,
+                pg_collection,
+            )
+            # TODO: remove accuracy_check after topk is fixed
+            triton_lambda = lambda: fwd_fused_indexer_loss(
+                index_scores,
+                attn_query,
+                attn_key,
+                softmax_scale,
+                loss_coeff,
+                sparse_loss,
+                topk_indices,
+            )
+
+            # check correctness, topk_indices has its unit test
+            native_indexer_loss = native_lambda()
+            triton_indexer_loss = triton_lambda()
+
+            match = torch.allclose(native_indexer_loss, triton_indexer_loss, atol=1e-4, rtol=1e-4)
+            torch.cuda.synchronize()
+            
+            # Benchmark PyTorch (reset peak stats first so memory is measured during bench)
+            torch.cuda.reset_peak_memory_stats()
+            pytorch_time, _, _ = bench(native_lambda, is_async=False, num_warmups=1, num_tests=1)
+            pytorch_time *= 1000
+            native_mem_gb = torch.cuda.max_memory_allocated() / 1024 ** 3
+
+            torch.cuda.synchronize()
+
+            # Benchmark Triton (reset peak stats first so memory is measured during bench)
+            torch.cuda.reset_peak_memory_stats()
+            triton_time, _, _ = bench(triton_lambda, is_async=False, num_warmups=1, num_tests=1)
+            triton_time *= 1000
+            triton_mem_gb = torch.cuda.max_memory_allocated() / 1024 ** 3
+
+            mem_saved_gb = triton_mem_gb / native_mem_gb
+            speedup = pytorch_time / triton_time
+            marker = "🚀" if speedup > 1.0 else ""
+            sparse_str = "Yes" if sparse_loss else "No"
+
+            metrics_collection.append((Sq, Sk, B, H, D, topk, sparse_str, pytorch_time, triton_time, speedup, match, native_mem_gb, triton_mem_gb, mem_saved_gb))
+
+            print(f"[Sq={Sq}, Sk={Sk}, B={B}, H={H}, D={D}, topk={topk}, sparse_loss={sparse_loss}] completes.")
+
+    print("\n" + "=" * 80)
+    kernel_name = "Triton" if not USE_TILELANG else "TileLang"
+    print(f"Benchmark: DSA Indexer (TopK + Loss) - PyTorch vs {kernel_name}")
+    print("=" * 80)
+
+    print(f"\n{'Sq':>4} {'Sk':>5} {'B':>3} {'H':>3} {'D':>3} {'TopK':>4} {'Sparse':>7} | {'PyTorch (ms)':>14} {f'{kernel_name} (ms)':>13} {'Speedup':>8} {'Match':>10} | {'Native (GB)':>12} {f'{kernel_name} (GB)':>12} {'Saved (GB)':>11}")
+    print("-" * 135)
+
+    for Sq, Sk, B, H, D, topk, sparse_str, pytorch_time, triton_time, speedup, match, native_mem_gb, triton_mem_gb, mem_saved_gb in metrics_collection:
+        saved_marker = "✓" if mem_saved_gb > 0 else ""
+        print(f"{Sq:>4} {Sk:>5} {B:>3} {H:>3} {D:>3} {topk:>4} {sparse_str:>7} | {pytorch_time:>14.2f}   {triton_time:>13.2f}   {speedup:>8.2f}x {marker} {str(match):>10} | {native_mem_gb:>12.3f} {triton_mem_gb:>12.3f} {mem_saved_gb:>10.3f} {saved_marker}")
+
+    print("\n" + "=" * 135)
+
+def main():
+    benchmark_fused_loss_forward()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->
Part of #2869 . This PR avoids materializing the `[seqlen_q, seqlen_k]` tensor by implementing split-K kernels.

Due to recomputation, this kernel turns out to save 60% memory at the cost of 32% performance degradation.
<img width="1904" height="384" alt="image" src="https://github.com/user-attachments/assets/688547e3-5782-4e88-91f6-31b6d2c0f2a3" />

A simple TileLang equivalent is also provided, currently underperforming.
<img width="1558" height="278" alt="image" src="https://github.com/user-attachments/assets/1353a2d4-a492-417b-9395-56a44a52fa3a" />

The Triton kernel has passed the accuracy test by running:
```
USE_FUSED_INDEXER_LOSS=1 pytest -xvs tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
```
while the TileLang runs:
```
USE_FUSED_INDEXER_LOSS=2 pytest -xvs tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
```
TP support is moved to another PR.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
