### PR TITLE
Fix THD RoPE offsets for local packed shards

### DIFF
--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -243,7 +243,9 @@ def _apply_rotary_pos_emb_thd(
             )
         freqs_packed = torch.cat(
             [
-                _get_thd_freqs_on_this_cp_rank(cp_rank, cp_size, x, freqs, seq_start_offset)
+                _get_thd_freqs_on_this_cp_rank(
+                    cp_rank, cp_size, x, freqs, int(seq_start_offset.item())
+                )
                 for x, seq_start_offset in zip(sequence_splits, offsets)
             ],
             dim=0,

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -183,6 +183,7 @@ def _apply_rotary_pos_emb_thd(
     multi_latent_attention: bool = False,
     mscale: float = 1.0,
     cp_group: torch.distributed.ProcessGroup = None,
+    **kwargs,
 ) -> Tensor:
     """A baseline implementation of applying RoPE for `thd` format.
 
@@ -206,7 +207,10 @@ def _apply_rotary_pos_emb_thd(
     # Handle two different frequency tensor formats:
     # 1. If freqs.size(0) == cu_seqlens[-1]: freqs contains all positions across all sequences
     #    -> Use offset-based mapping for exact positional correspondence
-    # 2. Otherwise: freqs contains only max sequence length positions
+    # 2. If kwargs has offsets: t is a local packed shard and freqs contains max sequence length
+    #    positions.
+    #    -> Use per-fragment offsets to recover the correct global positions.
+    # 3. Otherwise: freqs contains only max sequence length positions
     #    -> Use traditional mapping without offsets (map first :seqlen part)
     if freqs.dim() >= 1 and freqs.size(0) == cu_seqlens[-1]:
         # CASE 1: Exact mapping with offsets
@@ -229,8 +233,27 @@ def _apply_rotary_pos_emb_thd(
             multi_latent_attention=multi_latent_attention,
             mscale=mscale,
         ).squeeze(1)
+    elif 'offsets' in kwargs:
+        # CASE 2: Local packed shards with per-fragment offsets.
+        offsets = kwargs['offsets']
+        sequence_splits = torch.split(t, seqlens)
+        freqs_packed = torch.cat(
+            [
+                _get_thd_freqs_on_this_cp_rank(cp_rank, cp_size, x, freqs, seq_start_offset)
+                for x, seq_start_offset in zip(sequence_splits, offsets)
+            ],
+            dim=0,
+        )
+
+        return _apply_rotary_pos_emb_bshd(
+            t.unsqueeze(1),
+            freqs_packed,
+            rotary_interleaved=rotary_interleaved,
+            multi_latent_attention=multi_latent_attention,
+            mscale=mscale,
+        ).squeeze(1)
     else:
-        # CASE 2: Traditional mapping without offsets
+        # CASE 3: Traditional mapping without offsets
         # Build packed freqs for all sequences using the standard mapping, then apply once
         sequence_splits = torch.split(t, seqlens)
         freqs_packed = torch.cat(
@@ -254,6 +277,7 @@ def apply_rotary_pos_emb(
     cu_seqlens: Optional[Tensor] = None,
     mscale: float = 1.0,
     cp_group: torch.distributed.ProcessGroup = None,
+    **kwargs,
 ):
     """
     Reroute to the appropriate apply_rotary_pos_emb function depending on
@@ -313,6 +337,7 @@ def apply_rotary_pos_emb(
             multi_latent_attention=config.multi_latent_attention,
             mscale=mscale,
             cp_group=cp_group,
+            **kwargs,
         )
 
 

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -182,8 +182,8 @@ def _apply_rotary_pos_emb_thd(
     rotary_interleaved: bool = False,
     multi_latent_attention: bool = False,
     mscale: float = 1.0,
-    cp_group: torch.distributed.ProcessGroup = None,
-    **kwargs,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    offsets: Optional[Tensor] = None,
 ) -> Tensor:
     """A baseline implementation of applying RoPE for `thd` format.
 
@@ -207,7 +207,7 @@ def _apply_rotary_pos_emb_thd(
     # Handle two different frequency tensor formats:
     # 1. If freqs.size(0) == cu_seqlens[-1]: freqs contains all positions across all sequences
     #    -> Use offset-based mapping for exact positional correspondence
-    # 2. If kwargs has offsets: t is a local packed shard and freqs contains max sequence length
+    # 2. If offsets are provided: t is a local packed shard and freqs contains max sequence length
     #    positions.
     #    -> Use per-fragment offsets to recover the correct global positions.
     # 3. Otherwise: freqs contains only max sequence length positions
@@ -233,10 +233,14 @@ def _apply_rotary_pos_emb_thd(
             multi_latent_attention=multi_latent_attention,
             mscale=mscale,
         ).squeeze(1)
-    elif 'offsets' in kwargs:
+    elif offsets is not None:
         # CASE 2: Local packed shards with per-fragment offsets.
-        offsets = kwargs['offsets']
         sequence_splits = torch.split(t, seqlens)
+        if offsets.numel() != len(sequence_splits):
+            raise ValueError(
+                f"offsets must provide one entry per local sequence split, got {offsets.numel()} "
+                f"offsets for {len(sequence_splits)} splits."
+            )
         freqs_packed = torch.cat(
             [
                 _get_thd_freqs_on_this_cp_rank(cp_rank, cp_size, x, freqs, seq_start_offset)
@@ -276,9 +280,9 @@ def apply_rotary_pos_emb(
     config: TransformerConfig,
     cu_seqlens: Optional[Tensor] = None,
     mscale: float = 1.0,
-    cp_group: torch.distributed.ProcessGroup = None,
-    **kwargs,
-):
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    offsets: Optional[Tensor] = None,
+) -> Tensor:
     """
     Reroute to the appropriate apply_rotary_pos_emb function depending on
     fused/unfused kernels, or bshd (conventional) / thd (packed seq) format
@@ -310,15 +314,22 @@ def apply_rotary_pos_emb(
                 assert fused_apply_rotary_pos_emb is not None, "apply_rope_fusion is not available."
                 return fused_apply_rotary_pos_emb(t, freqs, interleaved=config.rotary_interleaved)
         else:
-            assert fused_apply_rotary_pos_emb_thd is not None, "apply_rope_fusion is not available."
-            return fused_apply_rotary_pos_emb_thd(
-                t,
-                cu_seqlens,
-                freqs,
-                cp_size=cp_group.size(),
-                cp_rank=cp_group.rank(),
-                interleaved=config.rotary_interleaved,
-            )
+            if offsets is not None:
+                warnings.warn(
+                    "offsets are not supported by fused THD RoPE. Using unfused implementation."
+                )
+            else:
+                assert (
+                    fused_apply_rotary_pos_emb_thd is not None
+                ), "apply_rope_fusion is not available."
+                return fused_apply_rotary_pos_emb_thd(
+                    t,
+                    cu_seqlens,
+                    freqs,
+                    cp_size=cp_group.size(),
+                    cp_rank=cp_group.rank(),
+                    interleaved=config.rotary_interleaved,
+                )
     # use unfused implementation
     if cu_seqlens is None:
         return _apply_rotary_pos_emb_bshd(
@@ -337,7 +348,7 @@ def apply_rotary_pos_emb(
             multi_latent_attention=config.multi_latent_attention,
             mscale=mscale,
             cp_group=cp_group,
-            **kwargs,
+            offsets=offsets,
         )
 
 

--- a/tests/unit_tests/transformer/test_rope.py
+++ b/tests/unit_tests/transformer/test_rope.py
@@ -229,3 +229,31 @@ def test_apply_rotary_pos_emb_thd_falls_back_from_fusion_when_offsets_are_provid
         )
 
     assert torch.allclose(output, expected)
+
+
+def test_apply_rotary_pos_emb_thd_converts_offsets_to_python_ints(monkeypatch):
+    config = TransformerConfig(
+        num_layers=1, hidden_size=4, num_attention_heads=1, apply_rope_fusion=False
+    )
+    cp_group = _FakeCpGroup(size=1, rank=0)
+
+    t = torch.tensor([[[1.0, 2.0, 3.0, 4.0]], [[2.0, 3.0, 4.0, 5.0]], [[6.0, 7.0, 8.0, 9.0]]])
+    freqs = (torch.arange(16, dtype=torch.float32).view(4, 1, 1, 4) + 1.0) / 10.0
+    cu_seqlens = torch.tensor([0, 2, 3], dtype=torch.int32)
+    offsets = torch.tensor([2, 1], dtype=torch.int32)
+
+    seen_offsets = []
+    original_get_freqs = rope_utils._get_thd_freqs_on_this_cp_rank
+
+    def _tracking_get_freqs(cp_rank, cp_size, x, freqs, offset=0):
+        seen_offsets.append(offset)
+        return original_get_freqs(cp_rank, cp_size, x, freqs, offset)
+
+    monkeypatch.setattr(rope_utils, "_get_thd_freqs_on_this_cp_rank", _tracking_get_freqs)
+
+    apply_rotary_pos_emb(
+        t, freqs, config, cu_seqlens=cu_seqlens, cp_group=cp_group, offsets=offsets
+    )
+
+    assert seen_offsets == [2, 1]
+    assert all(isinstance(offset, int) for offset in seen_offsets)

--- a/tests/unit_tests/transformer/test_rope.py
+++ b/tests/unit_tests/transformer/test_rope.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from megatron.core.models.common.embeddings import apply_rotary_pos_emb
+from megatron.core.models.common.embeddings.rope_utils import _apply_rotary_pos_emb_bshd
 from megatron.core.models.common.embeddings.rotary_pos_embedding import (
     MultimodalRotaryEmbedding,
     RotaryEmbedding,
@@ -150,3 +151,62 @@ class TestQKVRotaryEmbedding:
         ), f"Output sizes do not match for K: {k_out.shape} != {k_out_ref.shape}"
         assert torch.allclose(q_out_ref, q_out), f"Outputs do not match for Q"
         assert torch.allclose(k_out_ref, k_out), f"Outputs do not match for K"
+
+
+class _FakeCpGroup:
+    def __init__(self, size: int, rank: int):
+        self._size = size
+        self._rank = rank
+
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
+
+
+def test_apply_rotary_pos_emb_thd_uses_offsets_for_local_packed_shards():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=4,
+        num_attention_heads=1,
+        apply_rope_fusion=False,
+    )
+    cp_group = _FakeCpGroup(size=1, rank=0)
+
+    t = torch.tensor(
+        [
+            [[1.0, 2.0, 3.0, 4.0]],
+            [[2.0, 3.0, 4.0, 5.0]],
+            [[6.0, 7.0, 8.0, 9.0]],
+        ]
+    )
+    freqs = (torch.arange(16, dtype=torch.float32).view(4, 1, 1, 4) + 1.0) / 10.0
+    cu_seqlens = torch.tensor([0, 2, 3], dtype=torch.int32)
+    offsets = torch.tensor([2, 1], dtype=torch.int32)
+
+    expected_freqs = torch.cat([freqs[2:4], freqs[1:2]], dim=0)
+    expected = _apply_rotary_pos_emb_bshd(
+        t.unsqueeze(1),
+        expected_freqs,
+        rotary_interleaved=config.rotary_interleaved,
+        multi_latent_attention=config.multi_latent_attention,
+    ).squeeze(1)
+    legacy_expected = _apply_rotary_pos_emb_bshd(
+        t.unsqueeze(1),
+        torch.cat([freqs[:2], freqs[:1]], dim=0),
+        rotary_interleaved=config.rotary_interleaved,
+        multi_latent_attention=config.multi_latent_attention,
+    ).squeeze(1)
+
+    output = apply_rotary_pos_emb(
+        t,
+        freqs,
+        config,
+        cu_seqlens=cu_seqlens,
+        cp_group=cp_group,
+        offsets=offsets,
+    )
+
+    assert torch.allclose(output, expected)
+    assert not torch.allclose(output, legacy_expected)

--- a/tests/unit_tests/transformer/test_rope.py
+++ b/tests/unit_tests/transformer/test_rope.py
@@ -3,7 +3,7 @@
 import pytest
 import torch
 
-from megatron.core.models.common.embeddings import apply_rotary_pos_emb
+from megatron.core.models.common.embeddings import apply_rotary_pos_emb, rope_utils
 from megatron.core.models.common.embeddings.rope_utils import _apply_rotary_pos_emb_bshd
 from megatron.core.models.common.embeddings.rotary_pos_embedding import (
     MultimodalRotaryEmbedding,
@@ -154,33 +154,24 @@ class TestQKVRotaryEmbedding:
 
 
 class _FakeCpGroup:
-    def __init__(self, size: int, rank: int):
+    def __init__(self, size: int, rank: int) -> None:
         self._size = size
         self._rank = rank
 
-    def size(self):
+    def size(self) -> int:
         return self._size
 
-    def rank(self):
+    def rank(self) -> int:
         return self._rank
 
 
 def test_apply_rotary_pos_emb_thd_uses_offsets_for_local_packed_shards():
     config = TransformerConfig(
-        num_layers=1,
-        hidden_size=4,
-        num_attention_heads=1,
-        apply_rope_fusion=False,
+        num_layers=1, hidden_size=4, num_attention_heads=1, apply_rope_fusion=False
     )
     cp_group = _FakeCpGroup(size=1, rank=0)
 
-    t = torch.tensor(
-        [
-            [[1.0, 2.0, 3.0, 4.0]],
-            [[2.0, 3.0, 4.0, 5.0]],
-            [[6.0, 7.0, 8.0, 9.0]],
-        ]
-    )
+    t = torch.tensor([[[1.0, 2.0, 3.0, 4.0]], [[2.0, 3.0, 4.0, 5.0]], [[6.0, 7.0, 8.0, 9.0]]])
     freqs = (torch.arange(16, dtype=torch.float32).view(4, 1, 1, 4) + 1.0) / 10.0
     cu_seqlens = torch.tensor([0, 2, 3], dtype=torch.int32)
     offsets = torch.tensor([2, 1], dtype=torch.int32)
@@ -200,13 +191,41 @@ def test_apply_rotary_pos_emb_thd_uses_offsets_for_local_packed_shards():
     ).squeeze(1)
 
     output = apply_rotary_pos_emb(
-        t,
-        freqs,
-        config,
-        cu_seqlens=cu_seqlens,
-        cp_group=cp_group,
-        offsets=offsets,
+        t, freqs, config, cu_seqlens=cu_seqlens, cp_group=cp_group, offsets=offsets
     )
 
     assert torch.allclose(output, expected)
     assert not torch.allclose(output, legacy_expected)
+
+
+def test_apply_rotary_pos_emb_thd_falls_back_from_fusion_when_offsets_are_provided(monkeypatch):
+    monkeypatch.setattr(rope_utils, "fused_apply_rotary_pos_emb", object())
+
+    config = TransformerConfig(
+        num_layers=1, hidden_size=4, num_attention_heads=1, apply_rope_fusion=True
+    )
+    cp_group = _FakeCpGroup(size=1, rank=0)
+
+    t = torch.tensor([[[1.0, 2.0, 3.0, 4.0]], [[2.0, 3.0, 4.0, 5.0]], [[6.0, 7.0, 8.0, 9.0]]])
+    freqs = (torch.arange(16, dtype=torch.float32).view(4, 1, 1, 4) + 1.0) / 10.0
+    cu_seqlens = torch.tensor([0, 2, 3], dtype=torch.int32)
+    offsets = torch.tensor([2, 1], dtype=torch.int32)
+
+    def _unexpected_fused(*args, **kwargs):
+        raise AssertionError("fused THD RoPE should not be used when offsets are provided")
+
+    monkeypatch.setattr(rope_utils, "fused_apply_rotary_pos_emb_thd", _unexpected_fused)
+
+    expected = _apply_rotary_pos_emb_bshd(
+        t.unsqueeze(1),
+        torch.cat([freqs[2:4], freqs[1:2]], dim=0),
+        rotary_interleaved=config.rotary_interleaved,
+        multi_latent_attention=config.multi_latent_attention,
+    ).squeeze(1)
+
+    with pytest.warns(UserWarning, match="offsets are not supported by fused THD RoPE"):
+        output = apply_rotary_pos_emb(
+            t, freqs, config, cu_seqlens=cu_seqlens, cp_group=cp_group, offsets=offsets
+        )
+
+    assert torch.allclose(output, expected)


### PR DESCRIPTION
# What does this PR do ?
Preserves THD RoPE positions for local packed shards by honoring caller-provided `offsets` when `freqs` only contains max-sequence positions.

It also adds unit regressions for the local packed-shard offset path, the fused THD fallback path when `offsets` are provided, and the conversion of local offset scalars to Python `int` values before slicing.

Validation run for this PR:
- `python -m py_compile megatron/core/models/common/embeddings/rope_utils.py tests/unit_tests/transformer/test_rope.py`
- `PYTHONPATH=. uv run --no-project --isolated --with torch --with numpy --with packaging --with click --with requests --with pyyaml --with pytest==8.3.5 python -m pytest tests/unit_tests/transformer/test_rope.py -k 'python_ints or offsets or fusion_when_offsets' -q`
- `PYTHONPATH=. uv run --no-project --isolated --with black==24.4.2 --with isort==5.13.2 --with pylint==3.2.6 --with 'ruff~=0.9.0' --with mypy --with torch --with numpy --with packaging --with click --with requests --with pyyaml --with pytest==8.3.5 bash tools/autoformat.sh`

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
