### PR TITLE
Add Python-side guardrail for HybridEP InfiniBand limit and rename seq_len

### DIFF
--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -278,7 +278,7 @@ _hybrid_ep_buffer = None
 def init_hybrid_ep_buffer(
     group: torch.distributed.ProcessGroup,
     hidden_dim: int,
-    seq_len: int,
+    num_tokens: int,
     num_local_experts: int,
     num_sms_dispatch_api: int,
     num_sms_combine_api: int,
@@ -313,7 +313,7 @@ def init_hybrid_ep_buffer(
     _hybrid_ep_buffer = HybridEPBuffer(
         group=group,
         hidden_dim=hidden_dim,
-        max_num_of_tokens_per_rank=seq_len,
+        max_num_of_tokens_per_rank=num_tokens,
         num_local_experts=num_local_experts,
         use_fp8=fp8_dispatch,
         num_sms_dispatch_api=num_sms_dispatch_api,

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -351,12 +351,26 @@ class HybridEPDispatch(torch.autograd.Function):
         Forward pass of fused dispatch of the HybridEP backend
         '''
         if _hybrid_ep_buffer is None:
-            seq_len, hidden_dim = x.shape[-2:]
+            num_tokens, hidden_dim = x.shape[-2:]
+
+            # --- Hardware Limit Gaurdrail ---
+            # DeepEP calculates tx_depth = 3 * num_tokens + 1.
+            # # InfiniBand strictly asserts tx_depth < 65536.
+            tx_depth = 3 * num_tokens + 1
+            if tx_depth >= 65536:
+                raise ValueError(
+                    f"HybridEP RDMA Queue Pair depth ({tx_depth}) exceeds the InfiniBand "
+                    f"hardware limit of 65535. This occurs because the total tokens per rank "
+                    f"({num_tokens}) is too high. Please reduce sequence length or micro-batch size, "
+                    f"or increase Tensor Parallelism (TP) / Context Parallelism (CP) to reduce "
+                    f"the number of tokens processed per rank."
+                )
+            
             fp8_dispatch = False  # Currently, we do not support fp8 dispatch
             init_hybrid_ep_buffer(
                 group,
                 hidden_dim,
-                seq_len,
+                num_tokens,
                 num_local_experts,
                 num_sms_dispatch_api,
                 num_sms_combine_api,

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -353,19 +353,18 @@ class HybridEPDispatch(torch.autograd.Function):
         if _hybrid_ep_buffer is None:
             num_tokens, hidden_dim = x.shape[-2:]
 
-            # --- Hardware Limit Gaurdrail ---
+            # --- Hardware Limit Guardrail ---
             # DeepEP calculates tx_depth = 3 * num_tokens + 1.
-            # # InfiniBand strictly asserts tx_depth < 65536.
+            # InfiniBand strictly asserts tx_depth < 65536.
             tx_depth = 3 * num_tokens + 1
             if tx_depth >= 65536:
                 raise ValueError(
                     f"HybridEP RDMA Queue Pair depth ({tx_depth}) exceeds the InfiniBand "
                     f"hardware limit of 65535. This occurs because the total tokens per rank "
-                    f"({num_tokens}) is too high. Please reduce sequence length or micro-batch size, "
+                    f"({num_tokens}) too high. Reduce sequence length or micro-batch size, "
                     f"or increase Tensor Parallelism (TP) / Context Parallelism (CP) to reduce "
                     f"the number of tokens processed per rank."
                 )
-            
             fp8_dispatch = False  # Currently, we do not support fp8 dispatch
             init_hybrid_ep_buffer(
                 group,


### PR DESCRIPTION
**Description** 

Currently, when running multi-node MoE training with the HybridEP backend, passing a total token count (`seq_length * micro_batch_size`) that results in a DeepEP Queue Pair depth (`tx_depth = 3 * num_tokens + 1`) greater than 65535 causes an immediate and ungraceful C++ `SIGABRT` across all ranks due to InfiniBand hardware limits.

Following the architectural discussion in the issue thread, this PR improves the UX around this hardware limitation by catching the overflow in Python and raising a clean, actionable error message.

**Changes**

* **Reverted** the previous attempt to alter the tensor shape logic in token_dispatcher.py, as DeepEP intentionally expects the fully flattened batch.

* **Renamed** `seq_len` to `num_tokens` in `fused_a2a.py` (`init_hybrid_ep_buffer` and `HybridEPDispatch.forward`) to accurately reflect that the variable holds the folded `seq_length * batch_size`.

* **Added** a `ValueError` guardrail in `HybridEPDispatch.forward`. If the calculated `tx_depth` breaches the InfiniBand limit, it now raises a clear error advising the user to reduce sequence length/batch size or increase their TP/CP degrees, rather than dumping core.

**Testing**

Tested locally to ensure Python syntax and logic are sound. Relying on CI to verify no regressions in the standard dispatch workflow.