### PR TITLE
Clip mtp grads separately when mtp_detach_heads=True

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -394,6 +394,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         )
                         if hasattr(model_param, 'shared'):
                             shard_model_param.shared = model_param.shared
+                        if hasattr(model_param, 'is_mtp_param'):
+                            shard_model_param.is_mtp_param = model_param.is_mtp_param
 
                     # Generate main param.
                     if not config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
@@ -426,6 +428,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         )
                         if hasattr(model_param, 'shared'):
                             shard_main_param.shared = model_param.shared
+                        if hasattr(model_param, 'is_mtp_param'):
+                            shard_main_param.is_mtp_param = model_param.is_mtp_param
                     else:
                         # When using precision-aware optimizer, main params are held by FusedAdam.
                         shard_main_param = None
@@ -449,6 +453,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     )
                     if hasattr(model_param, 'shared'):
                         shard_model_param.shared = model_param.shared
+                    if hasattr(model_param, 'is_mtp_param'):
+                        shard_model_param.is_mtp_param = model_param.is_mtp_param
 
                 else:
                     raise TypeError(

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -57,7 +57,12 @@ from ..fp8_utils import dequantize_fp8_tensor, is_float8tensor, quantize_param_s
 from ..transformer.fsdp_dtensor_checkpoint import handle_experts_in_state_dict
 from ..transformer.module import MegatronModule
 from .grad_scaler import MegatronGradScaler
-from .optimizer import MixedPrecisionOptimizer, _zero_grad_group_helper, param_group_identifier_keys
+from .optimizer import (
+    MixedPrecisionOptimizer,
+    _zero_grad_group_helper,
+    copy_optimizer_param_metadata,
+    param_group_identifier_keys,
+)
 from .optimizer_config import OptimizerConfig
 from .param_layout import FullParamLayout, PerBufferParamLayout, pad_bucket_end, pad_param_start
 
@@ -392,10 +397,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         tensor_parallel.copy_tensor_model_parallel_attributes(
                             shard_model_param, model_param
                         )
-                        if hasattr(model_param, 'shared'):
-                            shard_model_param.shared = model_param.shared
-                        if hasattr(model_param, 'is_mtp_param'):
-                            shard_model_param.is_mtp_param = model_param.is_mtp_param
+                        copy_optimizer_param_metadata(shard_model_param, model_param)
 
                     # Generate main param.
                     if not config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
@@ -426,10 +428,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         tensor_parallel.copy_tensor_model_parallel_attributes(
                             shard_main_param, model_param
                         )
-                        if hasattr(model_param, 'shared'):
-                            shard_main_param.shared = model_param.shared
-                        if hasattr(model_param, 'is_mtp_param'):
-                            shard_main_param.is_mtp_param = model_param.is_mtp_param
+                        copy_optimizer_param_metadata(shard_main_param, model_param)
                     else:
                         # When using precision-aware optimizer, main params are held by FusedAdam.
                         shard_main_param = None
@@ -451,10 +450,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     tensor_parallel.copy_tensor_model_parallel_attributes(
                         shard_model_param, model_param
                     )
-                    if hasattr(model_param, 'shared'):
-                        shard_model_param.shared = model_param.shared
-                    if hasattr(model_param, 'is_mtp_param'):
-                        shard_model_param.is_mtp_param = model_param.is_mtp_param
+                    copy_optimizer_param_metadata(shard_model_param, model_param)
 
                 else:
                     raise TypeError(

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -704,12 +704,19 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         # similar to dist opt, always aggregate globally
         grads_for_norm = []
         for optimizer in self.chained_optimizers:
-            grads_for_norm += optimizer.get_main_grads_for_grad_norm()
+            grads_for_norm += optimizer.get_grads_for_grad_norm()
         grad_norm = get_grad_norm_fp32(grads_for_norm, grad_stats_parallel_group=None)
         return grad_norm
 
     def has_grad_norm_group(self, grad_norm_group: str) -> bool:
-        """Whether any global rank owns params for a registered grad-norm group."""
+        """Whether any global rank owns params for a registered grad-norm group.
+
+        Overrides ChainedOptimizer to use a single global all-reduce (group=None),
+        matching the scope of get_grad_norm and _get_grad_norm_for_group which also
+        reduce globally. All LayerWise grad-stats reductions are global (identical to
+        DistributedOptimizer's pattern), so the existence check must be too — using
+        a per-sub-optimizer group here would create a collective mismatch.
+        """
         _validate_grad_norm_group(grad_norm_group)
         if getattr(self, '_has_grad_norm_group_cache', None) is None:
             self._has_grad_norm_group_cache = {}
@@ -733,7 +740,7 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         # similar to dist opt, always aggregate globally
         grads_for_norm = []
         for optimizer in self.chained_optimizers:
-            grads_for_norm += optimizer.get_grads_for_grad_norm_group(grad_norm_group)
+            grads_for_norm += optimizer.get_grads_for_grad_norm(grad_norm_group)
         grad_norm = get_grad_norm_fp32(grads_for_norm, grad_stats_parallel_group=None)
         return grad_norm
 

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -19,6 +19,8 @@ from .optimizer import (
     Float16OptimizerWithFloat16Params,
     FP32Optimizer,
     MegatronOptimizer,
+    _get_param_grad_norm_group,
+    _validate_grad_norm_group,
 )
 from .optimizer_config import OptimizerConfig
 from .param_layout import (
@@ -703,6 +705,35 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         grads_for_norm = []
         for optimizer in self.chained_optimizers:
             grads_for_norm += optimizer.get_main_grads_for_grad_norm()
+        grad_norm = get_grad_norm_fp32(grads_for_norm, grad_stats_parallel_group=None)
+        return grad_norm
+
+    def has_grad_norm_group(self, grad_norm_group: str) -> bool:
+        """Whether any global rank owns params for a registered grad-norm group."""
+        _validate_grad_norm_group(grad_norm_group)
+        if getattr(self, '_has_grad_norm_group_cache', None) is None:
+            self._has_grad_norm_group_cache = {}
+        cache = self._has_grad_norm_group_cache
+        if grad_norm_group not in cache:
+            local = False
+            for optimizer in self.chained_optimizers:
+                for param in optimizer.get_parameters():
+                    param_grad_norm_group = _get_param_grad_norm_group(param)
+                    if param_grad_norm_group is None:
+                        continue
+                    _validate_grad_norm_group(param_grad_norm_group)
+                    local = local or param_grad_norm_group == grad_norm_group
+            flag = torch.tensor([1 if local else 0], dtype=torch.int, device='cuda')
+            torch.distributed.all_reduce(flag, op=torch.distributed.ReduceOp.MAX, group=None)
+            cache[grad_norm_group] = bool(flag.item() > 0)
+        return cache[grad_norm_group]
+
+    @torch.no_grad()
+    def _get_grad_norm_for_group(self, grad_norm_group: str):
+        # similar to dist opt, always aggregate globally
+        grads_for_norm = []
+        for optimizer in self.chained_optimizers:
+            grads_for_norm += optimizer.get_grads_for_grad_norm_group(grad_norm_group)
         grad_norm = get_grad_norm_fp32(grads_for_norm, grad_stats_parallel_group=None)
         return grad_norm
 

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -137,19 +137,24 @@ class MegatronOptimizer(ABC):
                     params.append(param)
         return params
 
-    def get_main_grads_for_grad_norm(self) -> List[torch.Tensor]:
-        """Collects gradients for norm calculation, filtering duplicates.
+    def _filter_grads_for_norm(
+        self,
+        params: List[torch.nn.Parameter],
+        param_filter: Optional[Callable[[torch.nn.Parameter], bool]] = None,
+    ) -> List[torch.Tensor]:
+        """Filter parameter gradients for norm computation.
 
-        This method filters parameters based on whether the gradient is not None,
-        the parameter is not shared (to avoid double-counting gradients), and
-        the parameter is not a replica due to tensor model parallelism.
-
-        Returns:
-            List[torch.Tensor]: A list of gradient tensors filtered for norm calculation.
+        Filter parameters based on:
+          - param_filter predicate, when provided.
+          - grad should not be None.
+          - parameter should not be shared (i.e., grads shouldn't be double counted while
+            computing norms).
+          - should not be a replica due to tensor model parallelism.
         """
-        params = self.get_parameters()
         grads_for_norm = []
         for param in params:
+            if param_filter is not None and not param_filter(param):
+                continue
             if self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8 or (
                 # Megatron-FSDP always uses decoupled_grad with FusedAdam.
                 self.config.use_precision_aware_optimizer
@@ -175,8 +180,46 @@ class MegatronOptimizer(ABC):
             )
             if grad_not_none and is_not_shared and is_not_tp_duplicate:
                 grads_for_norm.append(grad)
-
         return grads_for_norm
+
+    def get_main_grads_for_grad_norm(self) -> List[torch.Tensor]:
+        """Get main parameter gradients for grad norm, excluding MTP params when present."""
+        params = self.get_parameters()
+        has_mtp_params = any(getattr(p, 'is_mtp_param', False) for p in params)
+        if has_mtp_params:
+            return self._filter_grads_for_norm(
+                params, param_filter=lambda p: not getattr(p, 'is_mtp_param', False)
+            )
+        return self._filter_grads_for_norm(params)
+
+    def get_mtp_grads_for_grad_norm(self) -> List[torch.Tensor]:
+        """Get gradients from MTP parameters only, for independent MTP gradient clipping."""
+        params = self.get_parameters()
+        return self._filter_grads_for_norm(
+            params, param_filter=lambda p: getattr(p, 'is_mtp_param', False)
+        )
+
+    def has_mtp_params(self) -> bool:
+        """Whether any rank in this optimizer's grad-stats group owns MTP params.
+
+        ``is_mtp_param`` is tagged once at model construction (via
+        ``mtp_detach_heads``) and never changes, so the answer is computed with a
+        single global reduction the first time and cached thereafter. Gating the
+        MTP grad-norm collectives on a *globally consistent* flag is what keeps
+        the per-step reductions balanced across ranks -- a rank may locally own
+        no MTP shard while a peer does -- while avoiding an extra empty all-reduce
+        on every step of the common (no-MTP) case.
+        """
+        if getattr(self, '_has_mtp_params_cache', None) is None:
+            local = any(getattr(p, 'is_mtp_param', False) for p in self.get_parameters())
+            flag = torch.tensor([1 if local else 0], dtype=torch.int, device='cuda')
+            torch.distributed.all_reduce(
+                flag,
+                op=torch.distributed.ReduceOp.MAX,
+                group=self.get_grad_stats_parallel_group(),
+            )
+            self._has_mtp_params_cache = bool(flag.item() > 0)
+        return self._has_mtp_params_cache
 
     def get_grad_stats_parallel_group(self) -> torch.distributed.ProcessGroup:
         """Process group for reducing gradient statistics (num_zeros & norm).
@@ -218,7 +261,12 @@ class MegatronOptimizer(ABC):
         return total_norm
 
     def clip_grad_norm(self, clip_grad: float) -> float:
-        """Compute and return grad norm, also clip grads."""
+        """Compute and return grad norm, also clip grads.
+
+        When MTP parameters are tagged with is_mtp_param (via mtp_detach_heads), they are
+        excluded from the main gradient norm and clipped independently using their own norm.
+        The MTP gradient norm is stored in self.mtp_grad_norm for external reporting.
+        """
         params = self.get_parameters()
         if params:
             grads_for_norm = self.get_main_grads_for_grad_norm()
@@ -228,19 +276,45 @@ class MegatronOptimizer(ABC):
             grads_for_norm, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
         )
 
+        # Only reduce the MTP grad norm when MTP params are present anywhere in the
+        # grad-stats group; otherwise we would pay an extra empty all-reduce per step.
+        self.mtp_grad_norm = None
+        if self.has_mtp_params():
+            mtp_grads = self.get_mtp_grads_for_grad_norm()
+            mtp_grad_norm = get_grad_norm_fp32(
+                mtp_grads, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
+            )
+            self.mtp_grad_norm = mtp_grad_norm if mtp_grad_norm > 0.0 else None
+
         if params:
-            clip_grad_by_total_norm_fp32(
-                params,
-                clip_grad,
-                grad_norm,
-                # Decoupled Grad
-                use_decoupled_grad=self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8
-                or (
+
+            def use_decoupled_grad(param_list):
+                return self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8 or (
                     # Megatron-FSDP always uses decoupled_grad with FusedAdam.
                     self.config.use_precision_aware_optimizer
-                    and getattr(params[0], "__fsdp_param__", False)
-                ),
-            )
+                    and getattr(param_list[0], "__fsdp_param__", False)
+                )
+
+            main_params, mtp_params = [], []
+            for p in params:
+                if getattr(p, 'is_mtp_param', False):
+                    mtp_params.append(p)
+                else:
+                    main_params.append(p)
+            if main_params:
+                clip_grad_by_total_norm_fp32(
+                    main_params,
+                    clip_grad,
+                    grad_norm,
+                    use_decoupled_grad=use_decoupled_grad(main_params),
+                )
+            if mtp_params and self.mtp_grad_norm is not None:
+                clip_grad_by_total_norm_fp32(
+                    mtp_params,
+                    clip_grad,
+                    self.mtp_grad_norm,
+                    use_decoupled_grad=use_decoupled_grad(mtp_params),
+                )
         return grad_norm
 
     def count_zeros(self) -> float:
@@ -620,6 +694,7 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
     @torch.no_grad()
     def step(self):
         timers = self.config.timers
+        self.mtp_grad_norm = None
 
         found_inf_flag = self.prepare_grads()
         if found_inf_flag:
@@ -704,6 +779,8 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                             tensor_parallel.copy_tensor_model_parallel_attributes(main_param, param)
                             if hasattr(param, 'shared'):
                                 main_param.shared = param.shared
+                            if hasattr(param, 'is_mtp_param'):
+                                main_param.is_mtp_param = param.is_mtp_param
                             # Replace the optimizer params with the new fp32 copy.
                             param_group['params'][i] = main_param
 
@@ -990,6 +1067,7 @@ class FP32Optimizer(MegatronOptimizer):
         """Clip gradients (if needed) and step the base optimizer.
         Always return successful since there is no overflow."""
         timers = self.config.timers
+        self.mtp_grad_norm = None
 
         found_inf_flag = self.prepare_grads()
         if found_inf_flag:
@@ -1447,15 +1525,60 @@ class ChainedOptimizer(MegatronOptimizer):
                 )
             return num_zeros_in_grad
 
+    def has_mtp_params(self) -> bool:
+        """Whether any chained optimizer owns MTP params (globally, cached).
+
+        Aggregates each sub-optimizer's globally-consistent flag; the per-optimizer
+        reductions run over each sub-optimizer's own grad-stats group, so this is
+        safe in both the shared- and non-shared-group cases.
+        """
+        if getattr(self, '_has_mtp_params_cache', None) is None:
+            self._has_mtp_params_cache = any(
+                optimizer.has_mtp_params() for optimizer in self.chained_optimizers
+            )
+        return self._has_mtp_params_cache
+
+    @torch.no_grad()
+    def _get_mtp_grad_norm(self):
+        """Compute gradient norm for MTP parameters only."""
+        if self.grads_states_parallel_group_is_shared():
+            mtp_grads = []
+            for optimizer in self.chained_optimizers:
+                mtp_grads += optimizer.get_mtp_grads_for_grad_norm()
+            return get_grad_norm_fp32(
+                mtp_grads, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
+            )
+        else:
+            mtp_norms = []
+            for optimizer in self.chained_optimizers:
+                mtp_grads = optimizer.get_mtp_grads_for_grad_norm()
+                norm = get_grad_norm_fp32(
+                    mtp_grads, grad_stats_parallel_group=optimizer.get_grad_stats_parallel_group()
+                )
+                mtp_norms.append(norm if norm else 0.0)
+            return math.sqrt(sum([x**2 for x in mtp_norms]))
+
     @torch.no_grad()
     def step(self):
-        """ChainedOptimizer will step all optimizers one by one."""
+        """ChainedOptimizer will step all optimizers one by one.
+
+        When MTP parameters are tagged with is_mtp_param (via mtp_detach_heads), they are
+        excluded from the main gradient norm and clipped independently using their own norm.
+        """
+        self.mtp_grad_norm = None
         found_inf_flag = self.prepare_grads()
         if found_inf_flag:
             return False, None, None
 
         grad_norm = self.get_grad_norm()
         should_skip_update = False
+
+        # Only reduce the MTP grad norm when MTP params are present anywhere in the
+        # grad-stats group; otherwise we would pay an extra empty all-reduce per step.
+        # Store the MTP grad norm for external reporting.
+        if self.has_mtp_params():
+            mtp_grad_norm = self._get_mtp_grad_norm()
+            self.mtp_grad_norm = mtp_grad_norm if mtp_grad_norm > 0.0 else None
 
         # Clip gradients.
         for optimizer in self.chained_optimizers:
@@ -1464,22 +1587,41 @@ class ChainedOptimizer(MegatronOptimizer):
             parameters = optimizer.get_parameters()
             if len(parameters) == 0:
                 continue
-            if optimizer.config.clip_grad > 0.0:
-                clip_grad_by_total_norm_fp32(
-                    parameters,
-                    max_norm=optimizer.config.clip_grad,
-                    total_norm=grad_norm,
-                    use_decoupled_grad=(
-                        optimizer.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8
-                        or (
-                            # Megatron-FSDP always uses decoupled_grad with FusedAdam.
-                            self.config.use_precision_aware_optimizer
-                            and getattr(parameters[0], "__fsdp_param__", False)
-                        )
-                    ),
-                )
 
-            if grad_norm > optimizer.config.grad_norm_skip_threshold:
+            use_fsdp_decoupled_grad = (
+                # Megatron-FSDP always uses decoupled_grad with FusedAdam.
+                optimizer.config.use_precision_aware_optimizer
+                and getattr(parameters[0], "__fsdp_param__", False)
+            )
+            use_decoupled_grad = (
+                optimizer.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8
+                or use_fsdp_decoupled_grad
+            )
+
+            main_params, mtp_params = [], []
+            for p in parameters:
+                if getattr(p, 'is_mtp_param', False):
+                    mtp_params.append(p)
+                else:
+                    main_params.append(p)
+
+            if optimizer.config.clip_grad > 0.0:
+                if main_params:
+                    clip_grad_by_total_norm_fp32(
+                        main_params,
+                        max_norm=optimizer.config.clip_grad,
+                        total_norm=grad_norm,
+                        use_decoupled_grad=use_decoupled_grad,
+                    )
+                if mtp_params and self.mtp_grad_norm is not None:
+                    clip_grad_by_total_norm_fp32(
+                        mtp_params,
+                        max_norm=optimizer.config.clip_grad,
+                        total_norm=self.mtp_grad_norm,
+                        use_decoupled_grad=use_decoupled_grad,
+                    )
+
+            if grad_norm > optimizer.config.grad_norm_skip_threshold and main_params:
                 log_single_rank(
                     logger, logging.INFO, "skipping grad norm because it's too large %s", grad_norm
                 )

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -95,6 +95,39 @@ def _multi_tensor_copy_this_to_that(
 
 
 param_group_identifier_keys = ('wd_mult', 'lr_mult', 'is_expert_parallel', 'is_decoupled_lr')
+MTP_GRAD_NORM_GROUP = 'mtp'
+GRAD_NORM_GROUP_ATTR = 'grad_norm_group'
+SEPARATE_GRAD_NORM_GROUPS = (MTP_GRAD_NORM_GROUP,)
+
+
+def _get_param_grad_norm_group(param: torch.nn.Parameter) -> Optional[str]:
+    """Return the separate gradient-norm group for a parameter, if any."""
+    return getattr(param, GRAD_NORM_GROUP_ATTR, None)
+
+
+def _validate_grad_norm_group(grad_norm_group: str) -> None:
+    """Raise if the grad-norm group is not registered for separate clipping."""
+    if grad_norm_group not in SEPARATE_GRAD_NORM_GROUPS:
+        raise ValueError(
+            f"Unknown grad_norm_group '{grad_norm_group}'. Register it in "
+            "SEPARATE_GRAD_NORM_GROUPS before tagging parameters with it."
+        )
+
+
+def _is_separate_grad_norm_group(grad_norm_group: Optional[str]) -> bool:
+    """Return whether the optimizer computes a separate norm for this group."""
+    if grad_norm_group is None:
+        return False
+    _validate_grad_norm_group(grad_norm_group)
+    return True
+
+
+def copy_optimizer_param_metadata(destination: torch.Tensor, source: torch.Tensor) -> None:
+    """Copy optimizer-relevant metadata when creating param views/copies."""
+    if hasattr(source, 'shared'):
+        destination.shared = source.shared
+    if hasattr(source, GRAD_NORM_GROUP_ATTR):
+        setattr(destination, GRAD_NORM_GROUP_ATTR, getattr(source, GRAD_NORM_GROUP_ATTR))
 
 
 class MegatronOptimizer(ABC):
@@ -183,43 +216,48 @@ class MegatronOptimizer(ABC):
         return grads_for_norm
 
     def get_main_grads_for_grad_norm(self) -> List[torch.Tensor]:
-        """Get main parameter gradients for grad norm, excluding MTP params when present."""
-        params = self.get_parameters()
-        has_mtp_params = any(getattr(p, 'is_mtp_param', False) for p in params)
-        if has_mtp_params:
-            return self._filter_grads_for_norm(
-                params, param_filter=lambda p: not getattr(p, 'is_mtp_param', False)
-            )
-        return self._filter_grads_for_norm(params)
-
-    def get_mtp_grads_for_grad_norm(self) -> List[torch.Tensor]:
-        """Get gradients from MTP parameters only, for independent MTP gradient clipping."""
+        """Get gradients for the default/main gradient norm."""
         params = self.get_parameters()
         return self._filter_grads_for_norm(
-            params, param_filter=lambda p: getattr(p, 'is_mtp_param', False)
+            params,
+            param_filter=lambda p: not _is_separate_grad_norm_group(_get_param_grad_norm_group(p)),
         )
 
-    def has_mtp_params(self) -> bool:
-        """Whether any rank in this optimizer's grad-stats group owns MTP params.
+    def get_grads_for_grad_norm_group(self, grad_norm_group: str) -> List[torch.Tensor]:
+        """Get gradients from parameters in a named gradient-norm group."""
+        _validate_grad_norm_group(grad_norm_group)
+        params = self.get_parameters()
+        return self._filter_grads_for_norm(
+            params, param_filter=lambda p: _get_param_grad_norm_group(p) == grad_norm_group
+        )
 
-        ``is_mtp_param`` is tagged once at model construction (via
-        ``mtp_detach_heads``) and never changes, so the answer is computed with a
-        single global reduction the first time and cached thereafter. Gating the
-        MTP grad-norm collectives on a *globally consistent* flag is what keeps
+    def has_grad_norm_group(self, grad_norm_group: str) -> bool:
+        """Whether any rank in this optimizer's grad-stats group owns grouped params.
+
+        Gradient-norm groups are tagged once at model construction and never
+        change, so the answer is computed with a single global reduction the
+        first time and cached thereafter. Gating the group-specific grad-norm
+        collectives on a *globally consistent* flag is what keeps
         the per-step reductions balanced across ranks -- a rank may locally own
-        no MTP shard while a peer does -- while avoiding an extra empty all-reduce
-        on every step of the common (no-MTP) case.
+        no shard for the group while a peer does -- while avoiding an extra empty
+        all-reduce on every step of the common case.
         """
-        if getattr(self, '_has_mtp_params_cache', None) is None:
-            local = any(getattr(p, 'is_mtp_param', False) for p in self.get_parameters())
+        _validate_grad_norm_group(grad_norm_group)
+        if getattr(self, '_has_grad_norm_group_cache', None) is None:
+            self._has_grad_norm_group_cache = {}
+        cache = self._has_grad_norm_group_cache
+        if grad_norm_group not in cache:
+            local = False
+            for param in self.get_parameters():
+                param_grad_norm_group = _get_param_grad_norm_group(param)
+                if _is_separate_grad_norm_group(param_grad_norm_group):
+                    local = local or param_grad_norm_group == grad_norm_group
             flag = torch.tensor([1 if local else 0], dtype=torch.int, device='cuda')
             torch.distributed.all_reduce(
-                flag,
-                op=torch.distributed.ReduceOp.MAX,
-                group=self.get_grad_stats_parallel_group(),
+                flag, op=torch.distributed.ReduceOp.MAX, group=self.get_grad_stats_parallel_group()
             )
-            self._has_mtp_params_cache = bool(flag.item() > 0)
-        return self._has_mtp_params_cache
+            cache[grad_norm_group] = bool(flag.item() > 0)
+        return cache[grad_norm_group]
 
     def get_grad_stats_parallel_group(self) -> torch.distributed.ProcessGroup:
         """Process group for reducing gradient statistics (num_zeros & norm).
@@ -260,13 +298,26 @@ class MegatronOptimizer(ABC):
         )
         return total_norm
 
+    @torch.no_grad()
+    def _compute_grad_norms_by_group(self) -> Dict[str, float]:
+        """Compute gradient norms for registered separate grad-norm groups."""
+        self.grad_norms_by_group = {}
+        for grad_norm_group in SEPARATE_GRAD_NORM_GROUPS:
+            if self.has_grad_norm_group(grad_norm_group):
+                grouped_grads = self.get_grads_for_grad_norm_group(grad_norm_group)
+                group_grad_norm = get_grad_norm_fp32(
+                    grouped_grads, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
+                )
+                self.grad_norms_by_group[grad_norm_group] = group_grad_norm
+        return self.grad_norms_by_group
+
     def clip_grad_norm(self, clip_grad: float) -> float:
         """Compute and return grad norm, also clip grads.
 
-        When MTP parameters are tagged with is_mtp_param (via mtp_detach_heads), they are
-        excluded from the main gradient norm and clipped independently using their own norm.
-        The MTP gradient norm is stored in self.mtp_grad_norm for external reporting.
+        Parameters in a registered grad_norm_group are excluded from the main gradient
+        norm and clipped independently using their group norm.
         """
+        self.grad_norms_by_group = {}
         params = self.get_parameters()
         if params:
             grads_for_norm = self.get_main_grads_for_grad_norm()
@@ -276,17 +327,9 @@ class MegatronOptimizer(ABC):
             grads_for_norm, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
         )
 
-        # Only reduce the MTP grad norm when MTP params are present anywhere in the
-        # grad-stats group; otherwise we would pay an extra empty all-reduce per step.
-        self.mtp_grad_norm = None
-        if self.has_mtp_params():
-            mtp_grads = self.get_mtp_grads_for_grad_norm()
-            mtp_grad_norm = get_grad_norm_fp32(
-                mtp_grads, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
-            )
-            self.mtp_grad_norm = mtp_grad_norm if mtp_grad_norm > 0.0 else None
-
-        if params:
+        if clip_grad > 0.0 and params:
+            # Only reduce group grad norms when clipping can use them.
+            self._compute_grad_norms_by_group()
 
             def use_decoupled_grad(param_list):
                 return self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8 or (
@@ -295,10 +338,12 @@ class MegatronOptimizer(ABC):
                     and getattr(param_list[0], "__fsdp_param__", False)
                 )
 
-            main_params, mtp_params = [], []
+            main_params = []
+            params_by_grad_norm_group = {}
             for p in params:
-                if getattr(p, 'is_mtp_param', False):
-                    mtp_params.append(p)
+                grad_norm_group = _get_param_grad_norm_group(p)
+                if _is_separate_grad_norm_group(grad_norm_group):
+                    params_by_grad_norm_group.setdefault(grad_norm_group, []).append(p)
                 else:
                     main_params.append(p)
             if main_params:
@@ -308,12 +353,15 @@ class MegatronOptimizer(ABC):
                     grad_norm,
                     use_decoupled_grad=use_decoupled_grad(main_params),
                 )
-            if mtp_params and self.mtp_grad_norm is not None:
+            for grad_norm_group, grouped_params in params_by_grad_norm_group.items():
+                group_grad_norm = self.grad_norms_by_group.get(grad_norm_group)
+                if group_grad_norm is None:
+                    continue
                 clip_grad_by_total_norm_fp32(
-                    mtp_params,
+                    grouped_params,
                     clip_grad,
-                    self.mtp_grad_norm,
-                    use_decoupled_grad=use_decoupled_grad(mtp_params),
+                    group_grad_norm,
+                    use_decoupled_grad=use_decoupled_grad(grouped_params),
                 )
         return grad_norm
 
@@ -694,7 +742,7 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
     @torch.no_grad()
     def step(self):
         timers = self.config.timers
-        self.mtp_grad_norm = None
+        self.grad_norms_by_group = {}
 
         found_inf_flag = self.prepare_grads()
         if found_inf_flag:
@@ -777,10 +825,7 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                             main_param = param.detach().clone().float()
                             # Copy tensor model parallel attributes.
                             tensor_parallel.copy_tensor_model_parallel_attributes(main_param, param)
-                            if hasattr(param, 'shared'):
-                                main_param.shared = param.shared
-                            if hasattr(param, 'is_mtp_param'):
-                                main_param.is_mtp_param = param.is_mtp_param
+                            copy_optimizer_param_metadata(main_param, param)
                             # Replace the optimizer params with the new fp32 copy.
                             param_group['params'][i] = main_param
 
@@ -1067,7 +1112,7 @@ class FP32Optimizer(MegatronOptimizer):
         """Clip gradients (if needed) and step the base optimizer.
         Always return successful since there is no overflow."""
         timers = self.config.timers
-        self.mtp_grad_norm = None
+        self.grad_norms_by_group = {}
 
         found_inf_flag = self.prepare_grads()
         if found_inf_flag:
@@ -1525,47 +1570,64 @@ class ChainedOptimizer(MegatronOptimizer):
                 )
             return num_zeros_in_grad
 
-    def has_mtp_params(self) -> bool:
-        """Whether any chained optimizer owns MTP params (globally, cached).
+    def has_grad_norm_group(self, grad_norm_group: str) -> bool:
+        """Whether any chained optimizer owns params for a gradient-norm group.
 
         Aggregates each sub-optimizer's globally-consistent flag; the per-optimizer
         reductions run over each sub-optimizer's own grad-stats group, so this is
         safe in both the shared- and non-shared-group cases.
         """
-        if getattr(self, '_has_mtp_params_cache', None) is None:
-            self._has_mtp_params_cache = any(
-                optimizer.has_mtp_params() for optimizer in self.chained_optimizers
+        _validate_grad_norm_group(grad_norm_group)
+        if getattr(self, '_has_grad_norm_group_cache', None) is None:
+            self._has_grad_norm_group_cache = {}
+        cache = self._has_grad_norm_group_cache
+        if grad_norm_group not in cache:
+            cache[grad_norm_group] = any(
+                optimizer.has_grad_norm_group(grad_norm_group)
+                for optimizer in self.chained_optimizers
             )
-        return self._has_mtp_params_cache
+        return cache[grad_norm_group]
 
     @torch.no_grad()
-    def _get_mtp_grad_norm(self):
-        """Compute gradient norm for MTP parameters only."""
+    def _get_grad_norm_for_group(self, grad_norm_group: str):
+        """Compute gradient norm for a named parameter group."""
+        _validate_grad_norm_group(grad_norm_group)
         if self.grads_states_parallel_group_is_shared():
-            mtp_grads = []
+            grouped_grads = []
             for optimizer in self.chained_optimizers:
-                mtp_grads += optimizer.get_mtp_grads_for_grad_norm()
+                grouped_grads += optimizer.get_grads_for_grad_norm_group(grad_norm_group)
             return get_grad_norm_fp32(
-                mtp_grads, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
+                grouped_grads, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
             )
         else:
-            mtp_norms = []
+            group_norms = []
             for optimizer in self.chained_optimizers:
-                mtp_grads = optimizer.get_mtp_grads_for_grad_norm()
+                grouped_grads = optimizer.get_grads_for_grad_norm_group(grad_norm_group)
                 norm = get_grad_norm_fp32(
-                    mtp_grads, grad_stats_parallel_group=optimizer.get_grad_stats_parallel_group()
+                    grouped_grads,
+                    grad_stats_parallel_group=optimizer.get_grad_stats_parallel_group(),
                 )
-                mtp_norms.append(norm if norm else 0.0)
-            return math.sqrt(sum([x**2 for x in mtp_norms]))
+                group_norms.append(norm if norm else 0.0)
+            return math.sqrt(sum([x**2 for x in group_norms]))
+
+    @torch.no_grad()
+    def _compute_grad_norms_by_group(self) -> Dict[str, float]:
+        """Compute gradient norms for registered separate grad-norm groups."""
+        self.grad_norms_by_group = {}
+        for grad_norm_group in SEPARATE_GRAD_NORM_GROUPS:
+            if self.has_grad_norm_group(grad_norm_group):
+                group_grad_norm = self._get_grad_norm_for_group(grad_norm_group)
+                self.grad_norms_by_group[grad_norm_group] = group_grad_norm
+        return self.grad_norms_by_group
 
     @torch.no_grad()
     def step(self):
         """ChainedOptimizer will step all optimizers one by one.
 
-        When MTP parameters are tagged with is_mtp_param (via mtp_detach_heads), they are
-        excluded from the main gradient norm and clipped independently using their own norm.
+        Parameters in a registered grad_norm_group are excluded from the main gradient
+        norm and clipped independently using their group norm.
         """
-        self.mtp_grad_norm = None
+        self.grad_norms_by_group = {}
         found_inf_flag = self.prepare_grads()
         if found_inf_flag:
             return False, None, None
@@ -1573,12 +1635,13 @@ class ChainedOptimizer(MegatronOptimizer):
         grad_norm = self.get_grad_norm()
         should_skip_update = False
 
-        # Only reduce the MTP grad norm when MTP params are present anywhere in the
-        # grad-stats group; otherwise we would pay an extra empty all-reduce per step.
-        # Store the MTP grad norm for external reporting.
-        if self.has_mtp_params():
-            mtp_grad_norm = self._get_mtp_grad_norm()
-            self.mtp_grad_norm = mtp_grad_norm if mtp_grad_norm > 0.0 else None
+        should_clip = any(
+            not (hasattr(optimizer, 'is_stub_optimizer') and optimizer.is_stub_optimizer)
+            and optimizer.config.clip_grad > 0.0
+            for optimizer in self.chained_optimizers
+        )
+        if should_clip:
+            self._compute_grad_norms_by_group()
 
         # Clip gradients.
         for optimizer in self.chained_optimizers:
@@ -1598,10 +1661,12 @@ class ChainedOptimizer(MegatronOptimizer):
                 or use_fsdp_decoupled_grad
             )
 
-            main_params, mtp_params = [], []
+            main_params = []
+            params_by_grad_norm_group = {}
             for p in parameters:
-                if getattr(p, 'is_mtp_param', False):
-                    mtp_params.append(p)
+                grad_norm_group = _get_param_grad_norm_group(p)
+                if _is_separate_grad_norm_group(grad_norm_group):
+                    params_by_grad_norm_group.setdefault(grad_norm_group, []).append(p)
                 else:
                     main_params.append(p)
 
@@ -1613,11 +1678,14 @@ class ChainedOptimizer(MegatronOptimizer):
                         total_norm=grad_norm,
                         use_decoupled_grad=use_decoupled_grad,
                     )
-                if mtp_params and self.mtp_grad_norm is not None:
+                for grad_norm_group, grouped_params in params_by_grad_norm_group.items():
+                    group_grad_norm = self.grad_norms_by_group.get(grad_norm_group)
+                    if group_grad_norm is None:
+                        continue
                     clip_grad_by_total_norm_fp32(
-                        mtp_params,
+                        grouped_params,
                         max_norm=optimizer.config.clip_grad,
-                        total_norm=self.mtp_grad_norm,
+                        total_norm=group_grad_norm,
                         use_decoupled_grad=use_decoupled_grad,
                     )
 

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -215,21 +215,19 @@ class MegatronOptimizer(ABC):
                 grads_for_norm.append(grad)
         return grads_for_norm
 
-    def get_main_grads_for_grad_norm(self) -> List[torch.Tensor]:
-        """Get gradients for the default/main gradient norm."""
-        params = self.get_parameters()
-        return self._filter_grads_for_norm(
-            params,
-            param_filter=lambda p: not _is_separate_grad_norm_group(_get_param_grad_norm_group(p)),
-        )
+    def get_grads_for_grad_norm(self, grad_norm_group: Optional[str] = None) -> List[torch.Tensor]:
+        """Get gradients for norm computation.
 
-    def get_grads_for_grad_norm_group(self, grad_norm_group: str) -> List[torch.Tensor]:
-        """Get gradients from parameters in a named gradient-norm group."""
-        _validate_grad_norm_group(grad_norm_group)
-        params = self.get_parameters()
-        return self._filter_grads_for_norm(
-            params, param_filter=lambda p: _get_param_grad_norm_group(p) == grad_norm_group
-        )
+        When grad_norm_group is None, returns gradients for the main norm, excluding
+        parameters that belong to a registered separate grad-norm group.
+        When grad_norm_group is given, returns only gradients from that group.
+        """
+        if grad_norm_group is not None:
+            _validate_grad_norm_group(grad_norm_group)
+            param_filter = lambda p: _get_param_grad_norm_group(p) == grad_norm_group
+        else:
+            param_filter = lambda p: not _is_separate_grad_norm_group(_get_param_grad_norm_group(p))
+        return self._filter_grads_for_norm(self.get_parameters(), param_filter=param_filter)
 
     def has_grad_norm_group(self, grad_norm_group: str) -> bool:
         """Whether any rank in this optimizer's grad-stats group owns grouped params.
@@ -292,7 +290,7 @@ class MegatronOptimizer(ABC):
     @torch.no_grad()
     def get_grad_norm(self):
         """Compute and return grad norm."""
-        grads_for_norm = self.get_main_grads_for_grad_norm()
+        grads_for_norm = self.get_grads_for_grad_norm()
         total_norm = get_grad_norm_fp32(
             grads_for_norm, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
         )
@@ -304,7 +302,7 @@ class MegatronOptimizer(ABC):
         self.grad_norms_by_group = {}
         for grad_norm_group in SEPARATE_GRAD_NORM_GROUPS:
             if self.has_grad_norm_group(grad_norm_group):
-                grouped_grads = self.get_grads_for_grad_norm_group(grad_norm_group)
+                grouped_grads = self.get_grads_for_grad_norm(grad_norm_group)
                 group_grad_norm = get_grad_norm_fp32(
                     grouped_grads, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
                 )
@@ -320,7 +318,7 @@ class MegatronOptimizer(ABC):
         self.grad_norms_by_group = {}
         params = self.get_parameters()
         if params:
-            grads_for_norm = self.get_main_grads_for_grad_norm()
+            grads_for_norm = self.get_grads_for_grad_norm()
         else:
             grads_for_norm = []
         grad_norm = get_grad_norm_fp32(
@@ -1534,7 +1532,7 @@ class ChainedOptimizer(MegatronOptimizer):
         if self.grads_states_parallel_group_is_shared():
             grads_for_norm = []
             for optimizer in self.chained_optimizers:
-                grads_for_norm += optimizer.get_main_grads_for_grad_norm()
+                grads_for_norm += optimizer.get_grads_for_grad_norm()
             grad_norm = get_grad_norm_fp32(
                 grads_for_norm, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
             )
@@ -1595,14 +1593,14 @@ class ChainedOptimizer(MegatronOptimizer):
         if self.grads_states_parallel_group_is_shared():
             grouped_grads = []
             for optimizer in self.chained_optimizers:
-                grouped_grads += optimizer.get_grads_for_grad_norm_group(grad_norm_group)
+                grouped_grads += optimizer.get_grads_for_grad_norm(grad_norm_group)
             return get_grad_norm_fp32(
                 grouped_grads, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
             )
         else:
             group_norms = []
             for optimizer in self.chained_optimizers:
-                grouped_grads = optimizer.get_grads_for_grad_norm_group(grad_norm_group)
+                grouped_grads = optimizer.get_grads_for_grad_norm(grad_norm_group)
                 norm = get_grad_norm_fp32(
                     grouped_grads,
                     grad_stats_parallel_group=optimizer.get_grad_stats_parallel_group(),

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1683,6 +1683,11 @@ class MultiTokenPredictionBlock(MegatronModule):
         assert len(self.layers) > 0, "MultiTokenPredictionBlock must have at least one layer."
         self.cp_group = pg_collection.cp
 
+        if self.config.mtp_detach_heads:
+            # Set is_mtp_param on the mtp params so the optimizer can handle them separately from the main model params
+            for param in self.parameters():
+                param.is_mtp_param = True
+
     def _build_layers(self, pg_collection):
         # Determine number of depths to build
         if self.mtp_num_depths > 0:

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1684,9 +1684,9 @@ class MultiTokenPredictionBlock(MegatronModule):
         self.cp_group = pg_collection.cp
 
         if self.config.mtp_detach_heads:
-            # Set is_mtp_param on the mtp params so the optimizer can handle them separately from the main model params
+            # Tag MTP params so the optimizer can clip their gradients separately.
             for param in self.parameters():
-                param.is_mtp_param = True
+                param.grad_norm_group = 'mtp'
 
     def _build_layers(self, pg_collection):
         # Determine number of depths to build

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -365,6 +365,7 @@ def test_chained_optimizer_get_parameters():
 
 def test_chained_optimizer_reports_unsuccessful_when_grad_norm_skipped():
     """Test ChainedOptimizer reports skipped large-gradient updates as unsuccessful."""
+    from megatron.core import parallel_state
 
     class MockOptimizer:
         """Mock that mimics the ChainedOptimizer step interface."""
@@ -385,23 +386,254 @@ def test_chained_optimizer_reports_unsuccessful_when_grad_norm_skipped():
         def get_parameters(self):
             return [self.param]
 
+        def get_grad_stats_parallel_group(self):
+            return parallel_state.get_model_parallel_group()
+
+        def has_mtp_params(self):
+            return False
+
+        def get_mtp_grads_for_grad_norm(self):
+            return []
+
         def step_with_ready_grads(self):
             self.step_called = True
             return True
 
-    config = OptimizerConfig(clip_grad=0.0, grad_norm_skip_threshold=1.0)
-    param = torch.nn.Parameter(torch.ones(2, 2, device='cuda'))
-    param.grad = torch.ones_like(param)
-    optimizer = MockOptimizer(param, config)
-    chained_optimizer = ChainedOptimizer([optimizer])
+    Utils.initialize_model_parallel()
+    try:
+        config = OptimizerConfig(clip_grad=0.0, grad_norm_skip_threshold=1.0)
+        param = torch.nn.Parameter(torch.ones(2, 2, device='cuda'))
+        param.grad = torch.ones_like(param)
+        optimizer = MockOptimizer(param, config)
+        chained_optimizer = ChainedOptimizer([optimizer])
 
-    update_successful, grad_norm, num_zeros_in_grad = chained_optimizer.step()
+        update_successful, grad_norm, num_zeros_in_grad = chained_optimizer.step()
 
-    assert update_successful is False
-    assert grad_norm == 2.0
-    assert num_zeros_in_grad is None
-    assert optimizer.step_called is False
-    torch.testing.assert_close(param.grad, torch.ones_like(param.grad))
+        assert update_successful is False
+        assert grad_norm == 2.0
+        assert num_zeros_in_grad is None
+        assert optimizer.step_called is False
+        torch.testing.assert_close(param.grad, torch.ones_like(param.grad))
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_chained_optimizer_does_not_skip_update_for_large_mtp_grad_norm():
+    """Test ChainedOptimizer reports MTP grad norm without using it to skip the update."""
+    from megatron.core import parallel_state
+
+    class MockOptimizer:
+        """Mock that mimics the ChainedOptimizer step interface."""
+
+        def __init__(self, main_param, mtp_param, config):
+            self.config = config
+            self.main_param = main_param
+            self.mtp_param = mtp_param
+            self.param_groups = [{"params": [main_param, mtp_param]}]
+            self.step_called = False
+            self.is_stub_optimizer = False
+
+        def prepare_grads(self):
+            return False
+
+        def get_grad_norm(self):
+            return 0.5
+
+        def get_parameters(self):
+            return [self.main_param, self.mtp_param]
+
+        def get_grad_stats_parallel_group(self):
+            return parallel_state.get_model_parallel_group()
+
+        def has_mtp_params(self):
+            return True
+
+        def get_mtp_grads_for_grad_norm(self):
+            return [self.mtp_param.grad]
+
+        def step_with_ready_grads(self):
+            self.step_called = True
+            return True
+
+    Utils.initialize_model_parallel()
+    try:
+        config = OptimizerConfig(clip_grad=0.0, grad_norm_skip_threshold=1.0)
+        main_param = torch.nn.Parameter(torch.ones(2, 2, device='cuda'))
+        main_param.grad = torch.full_like(main_param, 0.25)
+        mtp_param = torch.nn.Parameter(torch.ones(2, 2, device='cuda'))
+        mtp_param.is_mtp_param = True
+        mtp_param.grad = torch.full_like(mtp_param, 10.0)
+        mtp_grad_before = mtp_param.grad.clone()
+        optimizer = MockOptimizer(main_param, mtp_param, config)
+        chained_optimizer = ChainedOptimizer([optimizer])
+
+        update_successful, grad_norm, num_zeros_in_grad = chained_optimizer.step()
+
+        assert update_successful is True
+        assert grad_norm == 0.5
+        assert num_zeros_in_grad is None
+        assert optimizer.step_called is True
+        assert chained_optimizer.mtp_grad_norm > config.grad_norm_skip_threshold
+        torch.testing.assert_close(mtp_param.grad, mtp_grad_before)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_mtp_grad_separation():
+    """Test that get_main_grads_for_grad_norm and get_mtp_grads_for_grad_norm
+    correctly separate gradients based on is_mtp_param attribute."""
+    from megatron.core.optimizer.optimizer import MegatronOptimizer
+
+    class MockOptimizer:
+        """Minimal mock of MegatronOptimizer for testing grad filtering."""
+
+        _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
+        get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
+        get_mtp_grads_for_grad_norm = MegatronOptimizer.get_mtp_grads_for_grad_norm
+
+        def __init__(self, params):
+            self.params = list(params)
+            self.config = OptimizerConfig(optimizer='adam', lr=0.01)
+
+        def get_parameters(self):
+            return self.params
+
+    Utils.initialize_model_parallel()
+    try:
+        # Create params: 2 main + 2 MTP
+        main_params = [torch.nn.Parameter(torch.randn(4, 4).cuda()) for _ in range(2)]
+        mtp_params = [torch.nn.Parameter(torch.randn(4, 4).cuda()) for _ in range(2)]
+        for p in mtp_params:
+            p.is_mtp_param = True
+
+        # Assign gradients
+        all_params = main_params + mtp_params
+        for p in all_params:
+            p.grad = torch.randn_like(p)
+
+        mock_opt = MockOptimizer(all_params)
+
+        main_grads = mock_opt.get_main_grads_for_grad_norm()
+        mtp_grads = mock_opt.get_mtp_grads_for_grad_norm()
+
+        assert len(main_grads) == 2
+        assert len(mtp_grads) == 2
+
+        # Verify the grads match the expected params
+        for grad, param in zip(main_grads, main_params):
+            assert torch.equal(grad, param.grad)
+        for grad, param in zip(mtp_grads, mtp_params):
+            assert torch.equal(grad, param.grad)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_mtp_grad_separation_no_mtp_params():
+    """Test that without is_mtp_param, all grads go to main."""
+    from megatron.core.optimizer.optimizer import MegatronOptimizer
+
+    class MockOptimizer:
+        _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
+        get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
+        get_mtp_grads_for_grad_norm = MegatronOptimizer.get_mtp_grads_for_grad_norm
+
+        def __init__(self, params):
+            self.params = list(params)
+            self.config = OptimizerConfig(optimizer='adam', lr=0.01)
+
+        def get_parameters(self):
+            return self.params
+
+    Utils.initialize_model_parallel()
+    try:
+        params = [torch.nn.Parameter(torch.randn(4, 4).cuda()) for _ in range(3)]
+        for p in params:
+            p.grad = torch.randn_like(p)
+
+        mock_opt = MockOptimizer(params)
+
+        main_grads = mock_opt.get_main_grads_for_grad_norm()
+        mtp_grads = mock_opt.get_mtp_grads_for_grad_norm()
+
+        assert len(main_grads) == 3
+        assert len(mtp_grads) == 0
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_has_mtp_params():
+    """has_mtp_params reflects whether any param is tagged is_mtp_param."""
+    from megatron.core.optimizer.optimizer import MegatronOptimizer
+
+    class MockOptimizer:
+        has_mtp_params = MegatronOptimizer.has_mtp_params
+        get_grad_stats_parallel_group = MegatronOptimizer.get_grad_stats_parallel_group
+
+        def __init__(self, params):
+            self.params = list(params)
+            self.config = OptimizerConfig(optimizer='adam', lr=0.01)
+
+        def get_parameters(self):
+            return self.params
+
+    Utils.initialize_model_parallel()
+    try:
+        plain = [torch.nn.Parameter(torch.randn(4, 4).cuda()) for _ in range(2)]
+        assert MockOptimizer(plain).has_mtp_params() is False
+
+        tagged = torch.nn.Parameter(torch.randn(4, 4).cuda())
+        tagged.is_mtp_param = True
+        assert MockOptimizer(plain + [tagged]).has_mtp_params() is True
+
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_mtp_grad_clipping_uses_separate_norms():
+    """clip_grad_norm clips MTP params by their own norm, independently of main params."""
+    from megatron.core.optimizer.optimizer import MegatronOptimizer
+
+    class MockOptimizer:
+        _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
+        get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
+        get_mtp_grads_for_grad_norm = MegatronOptimizer.get_mtp_grads_for_grad_norm
+        get_grad_stats_parallel_group = MegatronOptimizer.get_grad_stats_parallel_group
+        has_mtp_params = MegatronOptimizer.has_mtp_params
+        clip_grad_norm = MegatronOptimizer.clip_grad_norm
+
+        def __init__(self, params):
+            self.params = list(params)
+            self.config = OptimizerConfig(optimizer='adam', lr=0.01)
+
+        def get_parameters(self):
+            return self.params
+
+    Utils.initialize_model_parallel()
+    try:
+        clip = 1.0
+        # Main param: large grad (norm >> clip) -> should be scaled down.
+        main_param = torch.nn.Parameter(torch.randn(4, 4).cuda())
+        main_param.grad = torch.full((4, 4), 10.0, device='cuda')
+        main_norm_before = main_param.grad.norm().item()
+        # MTP param: tiny grad (norm < clip) -> below threshold, should be untouched.
+        mtp_param = torch.nn.Parameter(torch.randn(4, 4).cuda())
+        mtp_param.is_mtp_param = True
+        mtp_param.grad = torch.full((4, 4), 1e-3, device='cuda')
+        mtp_grad_before = mtp_param.grad.clone()
+
+        opt = MockOptimizer([main_param, mtp_param])
+        returned_norm = opt.clip_grad_norm(clip)
+
+        # Returned norm excludes MTP and reflects only the main params.
+        torch.testing.assert_close(float(returned_norm), main_norm_before, rtol=1e-4, atol=1e-4)
+        # Main grads were clipped down toward the threshold.
+        assert main_param.grad.norm().item() < main_norm_before
+        # MTP grads, below the clip threshold, are clipped independently and left unchanged.
+        torch.testing.assert_close(mtp_param.grad, mtp_grad_before)
+        # MTP norm is recorded separately for reporting.
+        assert opt.mtp_grad_norm is not None
+    finally:
+        Utils.destroy_model_parallel()
 
 
 def test_precision_aware_fused_adam():

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -389,10 +389,10 @@ def test_chained_optimizer_reports_unsuccessful_when_grad_norm_skipped():
         def get_grad_stats_parallel_group(self):
             return parallel_state.get_model_parallel_group()
 
-        def has_mtp_params(self):
+        def has_grad_norm_group(self, grad_norm_group):
             return False
 
-        def get_mtp_grads_for_grad_norm(self):
+        def get_grads_for_grad_norm_group(self, grad_norm_group):
             return []
 
         def step_with_ready_grads(self):
@@ -418,12 +418,17 @@ def test_chained_optimizer_reports_unsuccessful_when_grad_norm_skipped():
         Utils.destroy_model_parallel()
 
 
-def test_chained_optimizer_does_not_skip_update_for_large_mtp_grad_norm():
-    """Test ChainedOptimizer reports MTP grad norm without using it to skip the update."""
+def test_chained_optimizer_does_not_skip_update_for_large_mtp_grads():
+    """MTP grad magnitude does not influence the grad-norm skip check.
+
+    The skip threshold is evaluated against the main gradient norm only.
+    Even when MTP grads produce a norm far above the skip threshold, the
+    update proceeds as long as the main norm is within bounds.
+    """
     from megatron.core import parallel_state
 
     class MockOptimizer:
-        """Mock that mimics the ChainedOptimizer step interface."""
+        """Mock that exposes real MTP grads for group-norm computation."""
 
         def __init__(self, main_param, mtp_param, config):
             self.config = config
@@ -437,6 +442,7 @@ def test_chained_optimizer_does_not_skip_update_for_large_mtp_grad_norm():
             return False
 
         def get_grad_norm(self):
+            # Main grad norm safely below grad_norm_skip_threshold.
             return 0.5
 
         def get_parameters(self):
@@ -445,10 +451,10 @@ def test_chained_optimizer_does_not_skip_update_for_large_mtp_grad_norm():
         def get_grad_stats_parallel_group(self):
             return parallel_state.get_model_parallel_group()
 
-        def has_mtp_params(self):
+        def has_grad_norm_group(self, grad_norm_group):
             return True
 
-        def get_mtp_grads_for_grad_norm(self):
+        def get_grads_for_grad_norm_group(self, grad_norm_group):
             return [self.mtp_param.grad]
 
         def step_with_ready_grads(self):
@@ -457,31 +463,32 @@ def test_chained_optimizer_does_not_skip_update_for_large_mtp_grad_norm():
 
     Utils.initialize_model_parallel()
     try:
-        config = OptimizerConfig(clip_grad=0.0, grad_norm_skip_threshold=1.0)
+        skip_threshold = 1.0
+        config = OptimizerConfig(clip_grad=1.0, grad_norm_skip_threshold=skip_threshold)
         main_param = torch.nn.Parameter(torch.ones(2, 2, device='cuda'))
         main_param.grad = torch.full_like(main_param, 0.25)
         mtp_param = torch.nn.Parameter(torch.ones(2, 2, device='cuda'))
-        mtp_param.is_mtp_param = True
+        mtp_param.grad_norm_group = 'mtp'
+        # MTP grad norm (~20) is far above skip_threshold (1.0).
         mtp_param.grad = torch.full_like(mtp_param, 10.0)
-        mtp_grad_before = mtp_param.grad.clone()
+
         optimizer = MockOptimizer(main_param, mtp_param, config)
         chained_optimizer = ChainedOptimizer([optimizer])
 
         update_successful, grad_norm, num_zeros_in_grad = chained_optimizer.step()
 
+        # MTP group norm was computed and exceeds the skip threshold ...
+        mtp_group_norm = chained_optimizer.grad_norms_by_group.get('mtp', 0.0)
+        assert mtp_group_norm > skip_threshold
+        # ... yet the update was not skipped, because skip uses the main norm only.
         assert update_successful is True
-        assert grad_norm == 0.5
-        assert num_zeros_in_grad is None
         assert optimizer.step_called is True
-        assert chained_optimizer.mtp_grad_norm > config.grad_norm_skip_threshold
-        torch.testing.assert_close(mtp_param.grad, mtp_grad_before)
     finally:
         Utils.destroy_model_parallel()
 
 
 def test_mtp_grad_separation():
-    """Test that get_main_grads_for_grad_norm and get_mtp_grads_for_grad_norm
-    correctly separate gradients based on is_mtp_param attribute."""
+    """Test that grad-norm helpers separate gradients based on grad_norm_group."""
     from megatron.core.optimizer.optimizer import MegatronOptimizer
 
     class MockOptimizer:
@@ -489,7 +496,7 @@ def test_mtp_grad_separation():
 
         _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
         get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
-        get_mtp_grads_for_grad_norm = MegatronOptimizer.get_mtp_grads_for_grad_norm
+        get_grads_for_grad_norm_group = MegatronOptimizer.get_grads_for_grad_norm_group
 
         def __init__(self, params):
             self.params = list(params)
@@ -504,7 +511,7 @@ def test_mtp_grad_separation():
         main_params = [torch.nn.Parameter(torch.randn(4, 4).cuda()) for _ in range(2)]
         mtp_params = [torch.nn.Parameter(torch.randn(4, 4).cuda()) for _ in range(2)]
         for p in mtp_params:
-            p.is_mtp_param = True
+            p.grad_norm_group = 'mtp'
 
         # Assign gradients
         all_params = main_params + mtp_params
@@ -514,7 +521,7 @@ def test_mtp_grad_separation():
         mock_opt = MockOptimizer(all_params)
 
         main_grads = mock_opt.get_main_grads_for_grad_norm()
-        mtp_grads = mock_opt.get_mtp_grads_for_grad_norm()
+        mtp_grads = mock_opt.get_grads_for_grad_norm_group('mtp')
 
         assert len(main_grads) == 2
         assert len(mtp_grads) == 2
@@ -529,13 +536,13 @@ def test_mtp_grad_separation():
 
 
 def test_mtp_grad_separation_no_mtp_params():
-    """Test that without is_mtp_param, all grads go to main."""
+    """Test that without a registered separate grad-norm group, all grads go to main."""
     from megatron.core.optimizer.optimizer import MegatronOptimizer
 
     class MockOptimizer:
         _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
         get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
-        get_mtp_grads_for_grad_norm = MegatronOptimizer.get_mtp_grads_for_grad_norm
+        get_grads_for_grad_norm_group = MegatronOptimizer.get_grads_for_grad_norm_group
 
         def __init__(self, params):
             self.params = list(params)
@@ -553,7 +560,7 @@ def test_mtp_grad_separation_no_mtp_params():
         mock_opt = MockOptimizer(params)
 
         main_grads = mock_opt.get_main_grads_for_grad_norm()
-        mtp_grads = mock_opt.get_mtp_grads_for_grad_norm()
+        mtp_grads = mock_opt.get_grads_for_grad_norm_group('mtp')
 
         assert len(main_grads) == 3
         assert len(mtp_grads) == 0
@@ -561,12 +568,35 @@ def test_mtp_grad_separation_no_mtp_params():
         Utils.destroy_model_parallel()
 
 
-def test_has_mtp_params():
-    """has_mtp_params reflects whether any param is tagged is_mtp_param."""
+def test_unregistered_grad_norm_group_raises():
+    """Unknown grad-norm groups fail fast instead of silently joining the main norm."""
     from megatron.core.optimizer.optimizer import MegatronOptimizer
 
     class MockOptimizer:
-        has_mtp_params = MegatronOptimizer.has_mtp_params
+        _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
+        get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
+
+        def __init__(self, params):
+            self.params = list(params)
+            self.config = OptimizerConfig(optimizer='adam', lr=0.01)
+
+        def get_parameters(self):
+            return self.params
+
+    param = torch.nn.Parameter(torch.randn(4, 4).cuda())
+    param.grad_norm_group = 'unregistered'
+    param.grad = torch.randn_like(param)
+
+    with pytest.raises(ValueError, match="Unknown grad_norm_group"):
+        MockOptimizer([param]).get_main_grads_for_grad_norm()
+
+
+def test_has_grad_norm_group():
+    """has_grad_norm_group reflects whether any param is in the requested group."""
+    from megatron.core.optimizer.optimizer import MegatronOptimizer
+
+    class MockOptimizer:
+        has_grad_norm_group = MegatronOptimizer.has_grad_norm_group
         get_grad_stats_parallel_group = MegatronOptimizer.get_grad_stats_parallel_group
 
         def __init__(self, params):
@@ -579,11 +609,11 @@ def test_has_mtp_params():
     Utils.initialize_model_parallel()
     try:
         plain = [torch.nn.Parameter(torch.randn(4, 4).cuda()) for _ in range(2)]
-        assert MockOptimizer(plain).has_mtp_params() is False
+        assert MockOptimizer(plain).has_grad_norm_group('mtp') is False
 
         tagged = torch.nn.Parameter(torch.randn(4, 4).cuda())
-        tagged.is_mtp_param = True
-        assert MockOptimizer(plain + [tagged]).has_mtp_params() is True
+        tagged.grad_norm_group = 'mtp'
+        assert MockOptimizer(plain + [tagged]).has_grad_norm_group('mtp') is True
 
     finally:
         Utils.destroy_model_parallel()
@@ -596,9 +626,10 @@ def test_mtp_grad_clipping_uses_separate_norms():
     class MockOptimizer:
         _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
         get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
-        get_mtp_grads_for_grad_norm = MegatronOptimizer.get_mtp_grads_for_grad_norm
+        get_grads_for_grad_norm_group = MegatronOptimizer.get_grads_for_grad_norm_group
         get_grad_stats_parallel_group = MegatronOptimizer.get_grad_stats_parallel_group
-        has_mtp_params = MegatronOptimizer.has_mtp_params
+        has_grad_norm_group = MegatronOptimizer.has_grad_norm_group
+        _compute_grad_norms_by_group = MegatronOptimizer._compute_grad_norms_by_group
         clip_grad_norm = MegatronOptimizer.clip_grad_norm
 
         def __init__(self, params):
@@ -617,7 +648,7 @@ def test_mtp_grad_clipping_uses_separate_norms():
         main_norm_before = main_param.grad.norm().item()
         # MTP param: tiny grad (norm < clip) -> below threshold, should be untouched.
         mtp_param = torch.nn.Parameter(torch.randn(4, 4).cuda())
-        mtp_param.is_mtp_param = True
+        mtp_param.grad_norm_group = 'mtp'
         mtp_param.grad = torch.full((4, 4), 1e-3, device='cuda')
         mtp_grad_before = mtp_param.grad.clone()
 
@@ -630,8 +661,7 @@ def test_mtp_grad_clipping_uses_separate_norms():
         assert main_param.grad.norm().item() < main_norm_before
         # MTP grads, below the clip threshold, are clipped independently and left unchanged.
         torch.testing.assert_close(mtp_param.grad, mtp_grad_before)
-        # MTP norm is recorded separately for reporting.
-        assert opt.mtp_grad_norm is not None
+        assert 'mtp' in opt.grad_norms_by_group
     finally:
         Utils.destroy_model_parallel()
 

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -392,7 +392,7 @@ def test_chained_optimizer_reports_unsuccessful_when_grad_norm_skipped():
         def has_grad_norm_group(self, grad_norm_group):
             return False
 
-        def get_grads_for_grad_norm_group(self, grad_norm_group):
+        def get_grads_for_grad_norm(self, grad_norm_group=None):
             return []
 
         def step_with_ready_grads(self):
@@ -454,7 +454,7 @@ def test_chained_optimizer_does_not_skip_update_for_large_mtp_grads():
         def has_grad_norm_group(self, grad_norm_group):
             return True
 
-        def get_grads_for_grad_norm_group(self, grad_norm_group):
+        def get_grads_for_grad_norm(self, grad_norm_group=None):
             return [self.mtp_param.grad]
 
         def step_with_ready_grads(self):
@@ -495,8 +495,7 @@ def test_mtp_grad_separation():
         """Minimal mock of MegatronOptimizer for testing grad filtering."""
 
         _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
-        get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
-        get_grads_for_grad_norm_group = MegatronOptimizer.get_grads_for_grad_norm_group
+        get_grads_for_grad_norm = MegatronOptimizer.get_grads_for_grad_norm
 
         def __init__(self, params):
             self.params = list(params)
@@ -520,8 +519,8 @@ def test_mtp_grad_separation():
 
         mock_opt = MockOptimizer(all_params)
 
-        main_grads = mock_opt.get_main_grads_for_grad_norm()
-        mtp_grads = mock_opt.get_grads_for_grad_norm_group('mtp')
+        main_grads = mock_opt.get_grads_for_grad_norm()
+        mtp_grads = mock_opt.get_grads_for_grad_norm('mtp')
 
         assert len(main_grads) == 2
         assert len(mtp_grads) == 2
@@ -541,8 +540,7 @@ def test_mtp_grad_separation_no_mtp_params():
 
     class MockOptimizer:
         _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
-        get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
-        get_grads_for_grad_norm_group = MegatronOptimizer.get_grads_for_grad_norm_group
+        get_grads_for_grad_norm = MegatronOptimizer.get_grads_for_grad_norm
 
         def __init__(self, params):
             self.params = list(params)
@@ -559,8 +557,8 @@ def test_mtp_grad_separation_no_mtp_params():
 
         mock_opt = MockOptimizer(params)
 
-        main_grads = mock_opt.get_main_grads_for_grad_norm()
-        mtp_grads = mock_opt.get_grads_for_grad_norm_group('mtp')
+        main_grads = mock_opt.get_grads_for_grad_norm()
+        mtp_grads = mock_opt.get_grads_for_grad_norm('mtp')
 
         assert len(main_grads) == 3
         assert len(mtp_grads) == 0
@@ -574,7 +572,7 @@ def test_unregistered_grad_norm_group_raises():
 
     class MockOptimizer:
         _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
-        get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
+        get_grads_for_grad_norm = MegatronOptimizer.get_grads_for_grad_norm
 
         def __init__(self, params):
             self.params = list(params)
@@ -588,7 +586,7 @@ def test_unregistered_grad_norm_group_raises():
     param.grad = torch.randn_like(param)
 
     with pytest.raises(ValueError, match="Unknown grad_norm_group"):
-        MockOptimizer([param]).get_main_grads_for_grad_norm()
+        MockOptimizer([param]).get_grads_for_grad_norm()
 
 
 def test_has_grad_norm_group():
@@ -625,8 +623,7 @@ def test_mtp_grad_clipping_uses_separate_norms():
 
     class MockOptimizer:
         _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
-        get_main_grads_for_grad_norm = MegatronOptimizer.get_main_grads_for_grad_norm
-        get_grads_for_grad_norm_group = MegatronOptimizer.get_grads_for_grad_norm_group
+        get_grads_for_grad_norm = MegatronOptimizer.get_grads_for_grad_norm
         get_grad_stats_parallel_group = MegatronOptimizer.get_grad_stats_parallel_group
         has_grad_norm_group = MegatronOptimizer.has_grad_norm_group
         _compute_grad_norms_by_group = MegatronOptimizer._compute_grad_norms_by_group

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -109,11 +109,11 @@ class TestMultiTokenPredictionLayer:
         assert isinstance(mtp, MultiTokenPredictionBlock)
         assert mtp.config.mtp_detach_heads is True
 
-        # Verify all parameters are tagged with is_mtp_param
+        # Verify all parameters are tagged for separate MTP grad-norm handling.
         for name, param in mtp.named_parameters():
-            assert getattr(param, 'is_mtp_param', False), (
-                f"Parameter {name} missing is_mtp_param attribute"
-            )
+            assert (
+                getattr(param, 'grad_norm_group', None) == 'mtp'
+            ), f"Parameter {name} missing grad_norm_group attribute"
 
     @pytest.mark.parametrize(('tp'), [(1), (2), (4)])
     def test_constructor_local(self, tp):

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -109,6 +109,12 @@ class TestMultiTokenPredictionLayer:
         assert isinstance(mtp, MultiTokenPredictionBlock)
         assert mtp.config.mtp_detach_heads is True
 
+        # Verify all parameters are tagged with is_mtp_param
+        for name, param in mtp.named_parameters():
+            assert getattr(param, 'is_mtp_param', False), (
+                f"Parameter {name} missing is_mtp_param attribute"
+            )
+
     @pytest.mark.parametrize(('tp'), [(1), (2), (4)])
     def test_constructor_local(self, tp):
         """Test basic construction of MTP module."""


### PR DESCRIPTION
# What does this PR do ?
It accomplishes 2 things:
1. Calculate grad norms separately using `grad_norm_group` attribute per parameter, making it straightforward to add future separate-clipping groups without modifying per-optimizer logic.
2. When MTP heads are detached, `grad_norm_group = 'mtp'` is assigned to all the mtp params and hence grad norms for mtp and main models are calculated separately.

The grad norms are calculated separately per group during the optimizer step / grad clipping.

**Note:** This PR is built on top of the [PR](https://github.com/NVIDIA/Megatron-LM/pull/3456) (Detach MTP heads from the main model)

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
3. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
