### PR TITLE
Add conditions_embeddings argument to TransformerBlock, TransformerLayer for DiT (diffusion transformer)

### DIFF
--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -450,6 +450,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         packed_seq_params: PackedSeqParams,
         use_inner_quantization_context: bool,
         padding_mask: Optional[Tensor] = None,
+        conditions_embeddings: Optional[Tensor] = None,
         extract_layer_indices: Optional[Set[int]] = None,
         layer_offset: int = 0,
     ):
@@ -479,6 +480,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                 context_mask,
                 rotary_pos_emb,
                 padding_mask=None,
+                conditions_embeddings=None,
             ):
                 for index in range(start, end):
                     layer = self._get_layer(index)
@@ -510,6 +512,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                             inference_context=None,
                             packed_seq_params=packed_seq_params,
                             padding_mask=padding_mask,
+                            conditions_embeddings=conditions_embeddings,
                         )
                 return hidden_states, context
 
@@ -530,6 +533,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     context_mask,
                     rotary_pos_emb,
                     padding_mask,
+                    conditions_embeddings,
                 )
             else:
                 return tensor_parallel.checkpoint(
@@ -541,6 +545,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     context_mask,
                     rotary_pos_emb,
                     padding_mask,
+                    conditions_embeddings,
                 )
 
         if self.config.recompute_method == 'uniform':
@@ -657,6 +662,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
+        conditions_embeddings: Optional[Tensor] = None,
         extract_layer_indices: Optional[Set[int]] = None,
         *,
         inference_params: Optional[BaseInferenceContext] = None,
@@ -694,6 +700,9 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                 which to extract intermediate hidden states. If
                 non-empty, the forward pass will collect hidden_states
                 after each specified layer.
+            conditions_embeddings (Tensor, optional): Condition embeddings for diffusion models
+                (e.g. timestep or text embeddings). Shape [batch_size, embeddings_dim].
+                Passed through to each transformer layer's forward().
             dynamic_inference_decode_only: Optional[bool]: If true, indicates that the current
                 inference context is for decode-only. This args is only used to uniquely
                 identify decode and non-decode cuda graph runners in the cuda graph manager.
@@ -791,6 +800,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     packed_seq_params=packed_seq_params,
                     use_inner_quantization_context=use_inner_quantization_context,
                     padding_mask=padding_mask,
+                    conditions_embeddings=conditions_embeddings,
                     extract_layer_indices=extract_layer_indices,
                     layer_offset=layer_offset,
                 )
@@ -833,6 +843,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                             packed_seq_params=packed_seq_params,
                             sequence_len_offset=sequence_len_offset,
                             padding_mask=padding_mask,
+                            conditions_embeddings=conditions_embeddings,
                         )
 
                     if (

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -700,6 +700,10 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         This method calls the core computation of a transformer layer, including
         self-attention, cross-attention (if applicable), and feed-forward operations.
         """
+        # Condition embeddings for diffusion models (e.g. timestep or text embeddings),
+        # shape [batch_size, embeddings_dim]. Consumed here so it is not forwarded to
+        # _forward_attention. Subclasses that override forward() can use this directly.
+        conditions_embeddings = kwargs.pop("conditions_embeddings", None)
         hidden_states, context = self._forward_attention(*args, **kwargs)
         output = self._forward_mlp(
             hidden_states,


### PR DESCRIPTION
# What does this PR do ?
The PR is for introducing an extra argument `conditions_embeddings` for TransformerLayer, TransformerBlock.
This argument is for providing timesteps embeddings for all diffusion models.
Currently, to inject timesteps embeddings, we need workaround method:
 - Wan/Cosmos text-to-video: using attention_mask as a place holder [(link),](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/d442550e73e1cf8d0e44be57ed3b12cb212dc21a/src/megatron/bridge/diffusion/models/wan/wan_layer_spec.py#L192) which is not a good practice
 - FLUX: overriding TransformerLayer to support that argument, and avoid TransformerBlock all together [(link)](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/d442550e73e1cf8d0e44be57ed3b12cb212dc21a/src/megatron/bridge/diffusion/models/flux/flux_model.py#L132)

Since this timesteps/conditions embeddings are used by almost all diffusion models, it would be reasonable to add official argument for it.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
