### PR TITLE
fix: Remove fail-fast (-x) and guard distributed teardown against deadlock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ exclude = '''
 '''
 
 [tool.pytest.ini_options]
-addopts = "--durations=15 -s -rA -x"
+addopts = "--durations=15 -s -rA"
 testpaths = ["tests"]
 python_files = "test_*.py"
 markers = [

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import os
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
@@ -42,7 +43,10 @@ def pytest_sessionfinish(session, exitstatus):
 def cleanup():
     yield
     if torch.distributed.is_initialized():
-        torch.distributed.barrier()
+        try:
+            torch.distributed.barrier(timeout=timedelta(seconds=30))
+        except Exception:
+            return
         torch.distributed.destroy_process_group()
 
 

--- a/tests/unit_tests/run_ci_test.sh
+++ b/tests/unit_tests/run_ci_test.sh
@@ -148,14 +148,14 @@ for i in $(seq $UNIT_TEST_REPEAT); do
         --data-file=.coverage.unit_tests \
         --source=megatron/core \
         -m pytest \
-        -xvs \
+        -vs \
         ${IGNORE_ARGS[@]} \
         -m "'not experimental and ${MARKER_ARG}'" $(echo "$BUCKET" | sed 's|/\*\*/\*\.py$||'))
     eval "$CMD"
 
     if [[ "$TAG" == "latest" ]]; then
         CMD=$(echo uv run --no-sync python -m torch.distributed.run ${DISTRIBUTED_ARGS[@]} -m pytest \
-            -xvs \
+            -vs \
             --experimental \
              ${IGNORE_ARGS[@]} \
             -m "'experimental and ${MARKER_ARG}'" $(echo "$BUCKET" | sed 's|/\*\*/\*\.py$||'))

--- a/tests/unit_tests/test_utilities.py
+++ b/tests/unit_tests/test_utilities.py
@@ -91,7 +91,11 @@ class Utils:
         os.environ.pop('NVTE_UNFUSED_ATTN', None)
         if not Utils.inited:
             return
-        torch.distributed.barrier()
+        try:
+            torch.distributed.barrier(timeout=timedelta(seconds=30))
+        except Exception:
+            Utils.inited = False
+            return
         ps.destroy_model_parallel()
         Utils.inited = False
 


### PR DESCRIPTION
## Problem

`-x` (fail-fast) was set in two places — `pyproject.toml` `addopts` **and** `run_ci_test.sh` — making one redundant. More importantly, through investigation we found that `-x` was being used as a workaround for the wrong problem.

The actual risk is that distributed fixture teardown deadlocks when a rank is hanging:

1. Rank 0 hangs inside an NCCL collective
2. Rank 1 fails a test → pytest proceeds to fixture teardown
3. Teardown calls `barrier()` + `destroy_process_group()` — both require all-rank coordination
4. Rank 0 can't participate → **both ranks deadlock indefinitely**

With `-x`, rank 1 exits fast enough that torchrun kills rank 0 before teardown runs, which avoided the symptom but not the cause.

## Fix

Guard the barrier before teardown with a 30s timeout in both teardown sites:

- `tests/unit_tests/conftest.py` — session-level `cleanup` fixture
- `tests/unit_tests/test_utilities.py` — `Utils.destroy_model_parallel()`

If the barrier times out, a rank is unresponsive and we bail without calling `destroy_process_group`, breaking the deadlock. The session still exits non-zero (torchrun already recorded the failure).

With this in place, `-x` is no longer needed for session safety, so it is removed from both `pyproject.toml` and `run_ci_test.sh`. This means on a real failure the full suite continues running on the non-failing ranks, giving a complete picture of what broke.

## Verification

Tested with a purpose-built scenario: rank 0 stuck in `dist.all_reduce()`, rank 1 fails before the collective. **Without this fix**, the session hung indefinitely (had to `docker kill`). **With this fix**, both `with -x` and `without -x` variants exit cleanly in ~6-7s.

```
Scenario2  WITH  fail-fast  →  7s  ✅
Scenario2  WITHOUT fail-fast →  6s  ✅  (previously: ∞, deadlock)
```

For the Python-level hang scenario (Scenario 1), removing `-x` produces the expected behaviour — rank 1 runs remaining tests after the failure, giving a fuller picture before torchrun kills the hanging rank:

```
Scenario1  WITH  fail-fast  →  13s  (stops at first failure)
Scenario1  WITHOUT fail-fast →  19s  (runs all remaining tests, +6s = 3×2s tests)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)