### PR TITLE
Fix Context Parallelism documentation link

### DIFF
--- a/megatron/core/README.md
+++ b/megatron/core/README.md
@@ -30,7 +30,7 @@ torchrun --nproc_per_node=2 examples/run_simple_mcore_train_loop.py
 ### Parallelism Strategies
 - **Tensor Parallelism (TP)**: Layer-wise parallelization (activation memory footprint can be further reduced using sequence parallelism)
 - **Pipeline Parallelism (PP)**: Depth-wise model splitting and pipelining of microbatches to improve efficiency
-- **Context Parallelism (CP)**: Long sequence handling ([documentation](https://docs.nvidia.com/megatron-core/developer-guide/latest/api-guide/context_parallel.html))
+- **Context Parallelism (CP)**: Long sequence handling ([documentation](https://docs.nvidia.com/megatron-core/developer-guide/latest/user-guide/features/context_parallel.html))
 - **Expert Parallelism (EP)**: Split experts of an MoE model across multiple GPUs
 
 


### PR DESCRIPTION
### Description
The documentation link for Context Parallelism (CP) in megatron/core/README.md is broken and returns a "This page no longer exists" error.

**Broken link:**
https://docs.nvidia.com/megatron-core/developer-guide/latest/api-guide/context_parallel.html

**Fixed link:**
https://docs.nvidia.com/megatron-core/developer-guide/latest/user-guide/features/context_parallel.html

### Changes
- Updated the CP documentation link from the old path to the new valid user-guide path

### Testing
- Verified the new link is accessible and points to the correct Context Parallelism documentation

