### PR TITLE
Cudagraphs: Fix sequence packing segfault more generally

### DIFF
--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1148,16 +1148,28 @@ class _CudaGraphRunner(torch.nn.Module):
                     ref.can_skip_replay_copy = arg.can_skip_replay_copy
                 return ref
 
-            # NOTE: Weak refs replace tensors with raw-pointer wrappers that do not hold a storage
-            # reference. This is safe for surfaces whose memory is managed by the CUDA graph pool
-            # (driver-pinned, stable addresses) but not safe for tensors allocated by the caching
-            # allocator, whose data_ptr() may be invalidated by block coalescing or empty_cache().
-            # fwd_graph_input_surface tensors have their addresses baked into the captured CUDA
-            # graph; they must keep strong references so the backing memory is never freed.
-            # Non-pool tensors (e.g. seq_idx created by PackedSeqParams.__post_init__ during
-            # dataclasses.replace inside tree_map) lose all other strong refs once
-            # fwd_graph_input_kwargs is weak-ref'd below; weak-ref'ing would cause a use-after-free
-            # error on replay manifesting as a segfault.
+            # Weak refs replace tensors with raw-pointer wrappers that do not hold a storage
+            # reference.  Only graph mempool tensors in the graph mempool (e.g. a previous layer's
+            # output reused as this graph's input) are safe to weak-ref since their memory is
+            # driver-pinned with stable addresses.  We identify them as tensors that are not owned
+            # by the reuse pool and have the attribute `can_skip_replay_copy` set by
+            # _resolve_input_buffer.  Everything else, including reuse-pool buffers, stray tensors
+            # from dataclass __post_init__ side-effects (e.g. seq_idx created by
+            # PackedSeqParams.__post_init__ during dataclasses.replace inside the tree_map) must
+            # retain strong refs, or it will cause a use-after-free on replay that manifests as a
+            # segfault under memory pressure.
+            def replace_with_weak_ref_for_input_surface(arg):
+                if not torch.is_tensor(arg):
+                    return replace_with_weak_ref(arg)
+                if not _CudagraphGlobalRecord.tensor_reuse_pool.owns(arg) and hasattr(
+                    arg, 'can_skip_replay_copy'
+                ):
+                    return replace_with_weak_ref(arg)
+                return arg
+
+            self.fwd_graph_input_surface = tree_map(
+                replace_with_weak_ref_for_input_surface, self.fwd_graph_input_surface
+            )
 
             self.fwd_graph_input_args = tree_map(replace_with_weak_ref, self.fwd_graph_input_args)
             self.fwd_graph_input_kwargs = tree_map(


### PR DESCRIPTION
# What does this PR do ?
Follow up to #3970. We must ensure that no tensor in the forward graph input surface is weakref'd. This was still segfaulting in the sequence packing case because the assumption made in filtering out only the tensors owned by the reuse pool is that all non-graph-pool tensors in `fwd_graph_input_surface` come from the reuse pool. This is true for normal tensor kwargs, but breaks for `PackedSeqParams` because of `__post_init__`. The bug gets triggered when a forward graph gets created:

1. `tree_map(_resolve_input_buffer, kwargs)` recurses into PackedSeqParams via `dataclasses.replace`
2. `_resolve_input_buffer` allocates pool buffers for cu_seqlens_q, cu_seqlens_kv, seq_idx, which are pool-owned. But dataclasses.replace triggers `__post_init__`, which recomputes seq_idx via torch.repeat_interleave, creating a new tensor which is not pool-owned. This new seq_idx replaces the pool buffer in the resolved PackedSeqParams.
4. `fwd_graph_input_surface` extracts this non-pool seq_idx, but `replace_with_weak_ref_for_input_surface` sees it's not pool-owned and weakrefs it
6. `tree_map(replace_with_weak_ref, fwd_graph_input_kwargs)` recurses into PackedSeqParams again, triggering `__post_init__` again, creating yet another seq_idx that replaces the one in kwargs
7. Now the original seq_idx (baked into the captured graph) has zero strong refs -> GC frees it -> graph replays against freed memory -> segfault

The solution is just to keep strong refs for the cudagraph input surface. We incur a minor memory overhead because we keep some strong references, but it is negligible. 

Additionally, the bug is latent on small jobs on 1 node and doesn't show up with a crash, or when `CUDA_LAUNCH_BLOCKING=1` is on because Python's refcount garbage collector frees the tensor immediately, but unless you're under a lot of memory pressure, the CUDA caching allocator just marks the block as free without reusing it, so the page stays mapped and the graph replay silently succeeds. 

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
