### PR TITLE
Fixes to inference CG + EP behavior

### DIFF
--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -572,6 +572,41 @@ class DynamicInferenceContext(BaseInferenceContext):
             "to have consistency between cuda graph sizes and the block table size."
         )
 
+        # MoE dispatcher detection. Both the NCCL allgather and the legacy
+        # transformer-engine A2A dispatcher require every EP rank to run the
+        # same-sized cuda graph; NVLS does not. These flags drive both
+        # match_graph_config's match_ep_token_counts and the phantom-padding
+        # reservation below.
+        self._nccl_ep_dispatcher = (
+            get_pg_size(self.expert_model_parallel_group) > 1
+            and model_config.inference_moe_token_dispatcher_type == 'nccl'
+        )
+        self._training_ep_dispatcher = (
+            get_pg_size(self.expert_model_parallel_group) > 1
+            and model_config.transformer_impl == "transformer_engine"
+        )
+
+        # Phantom padding (intentionally opposes the eager-fallback policy
+        # added in #4587): keep mixed/prefill cuda graphs enabled on the
+        # NCCL/training EP paths, and absorb cross-rank batch-dim divergence
+        # by reserving cuda_graph_mixed_prefill_count request slots up front.
+        # The MHA-metadata fill below distributes the leftover phantom tokens
+        # across the reserved slots so sum(query_lengths) == padded_token_count
+        # for layers that walk a packed [token_count, H] buffer (Mamba SSM
+        # scan, MoE token dispatch).
+        # NVLS does not sync (match_ep_token_counts=False), so phantom padding
+        # is only needed when the dispatcher requires identical graph sizing
+        # across EP ranks.
+        self._enable_phantom_padding = (
+            self._nccl_ep_dispatcher or self._training_ep_dispatcher
+        ) and (self.is_hybrid_model or self.num_speculative_tokens > 0)
+        prefill_reservation = (
+            (inference_config.cuda_graph_mixed_prefill_count or 1)
+            if self._enable_phantom_padding
+            else 0
+        )
+        self.max_schedulable_requests = self.max_requests - prefill_reservation
+
         # Attention metadata initialization (tensors are now handled by MHAMetadata classes)
 
         self.graph_attn_metadata = {}
@@ -600,27 +635,16 @@ class DynamicInferenceContext(BaseInferenceContext):
             ), "Router recording/replay requested but no MoE experts specified!"
             self.moe_routing_metadata = RoutingMetadata(self, model_config.moe_router_topk)
 
-        # are we using the inference_optimized nccl ep dispatcher for MoEs?
-        self._nccl_ep_dispatcher = (
-            get_pg_size(self.expert_model_parallel_group) > 1
-            and model_config.inference_moe_token_dispatcher_type == 'nccl'
-        )
-
-        # are we using the training a2a dispatcher for MoEs?
-        # Note that this is not optimal for speed.
-        self._training_ep_dispatcher = (
-            get_pg_size(self.expert_model_parallel_group) > 1
-            and model_config.transformer_impl == "transformer_engine"
-        )
-
-        # We only allow non-decode cuda graphs for the nvls dispatcher
-        force_disable_non_decode_cuda_graphs = (
-            self._nccl_ep_dispatcher or self._training_ep_dispatcher
-        )
-
+        # Honour the user's use_cuda_graphs_for_non_decode_steps verbatim —
+        # do NOT clamp it to False on the NCCL or training-EP path the way
+        # #4587 does. Phantom padding (above) is what guards the NCCL/training
+        # paths against synced batch dims overflowing max_requests; with that
+        # in place, non-decode cuda graphs are safe to keep enabled on every
+        # dispatcher. (#4587 takes the opposite trade-off — cheaper code but no
+        # mixed/prefill cuda graphs on NCCL/training EP. This PR is the
+        # backup if that trade-off proves too restrictive.)
         self.use_cuda_graphs_for_non_decode_steps = (
             inference_config.use_cuda_graphs_for_non_decode_steps
-            and not (force_disable_non_decode_cuda_graphs)
         )
 
         # CUDA graph config list.
@@ -2052,7 +2076,10 @@ class DynamicInferenceContext(BaseInferenceContext):
                     padded_decode_req_count = min(
                         self.max_requests, self.round_up_requests(self.num_decode_requests)
                     )
-                    padded_token_count = padded_decode_req_count * (self.num_speculative_tokens + 1)
+                    padded_token_count = min(
+                        self.max_tokens,
+                        padded_decode_req_count * (self.num_speculative_tokens + 1),
+                    )
                 else:
                     padded_token_count = min(
                         self.max_tokens,
@@ -2062,7 +2089,9 @@ class DynamicInferenceContext(BaseInferenceContext):
                     padded_decode_req_count = padded_token_count
                 padded_prefill_req_count = 0
             else:
-                padded_token_count = self.round_up_tokens(self.active_token_count)
+                padded_token_count = min(
+                    self.max_tokens, self.round_up_tokens(self.active_token_count)
+                )
                 target_padding_req_count = min(
                     self.max_requests,
                     self.round_up_requests(self.total_request_count - self.paused_request_count),
@@ -2168,6 +2197,39 @@ class DynamicInferenceContext(BaseInferenceContext):
         self._cpu_mha_block_table[:real_bs] = request_to_kv_block_ids_view[:real_bs]
         if real_bs < padded_bs:
             self._cpu_mha_block_table[real_bs:padded_bs] = -1
+
+        # Phantom padding: when EP-sync produces a graph dim larger than the
+        # real batch on this rank, fill phantom slots so sum(query_lengths)
+        # == padded_token_count. Layers that walk a packed [token_count, H]
+        # buffer (Mamba SSM scan, MoE token dispatch) read every token in
+        # the padded range; leaving phantom slots with q_len=0 leaves those
+        # token positions unowned. Recompute the cumulative sums over the
+        # phantom range and route phantom block-table rows at the dummy
+        # block so attention reads stay in-bounds.
+        if self._enable_phantom_padding and self.using_cuda_graph_this_step():
+            phantom_count = padded_bs - real_bs
+            phantom_tokens = self.padded_active_token_count - attn_dimensions.token_count
+            if phantom_count > 0 and phantom_tokens > 0:
+                per_phantom = phantom_tokens // phantom_count
+                rem_phantom = phantom_tokens % phantom_count
+                self._cpu_mha_query_lengths[real_bs:padded_bs] = per_phantom
+                if rem_phantom > 0:
+                    self._cpu_mha_query_lengths[real_bs : real_bs + rem_phantom] += 1
+                # Phantom requests have no prior KV: kv_seq_length = query_length.
+                self._cpu_mha_kv_seq_lengths[real_bs:padded_bs] = self._cpu_mha_query_lengths[
+                    real_bs:padded_bs
+                ]
+                self._cpu_mha_cu_query_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                    torch.cumsum(self._cpu_mha_query_lengths[real_bs:padded_bs], dim=0)
+                    + self._cpu_mha_cu_query_seq_lengths[real_bs]
+                )
+                self._cpu_mha_cu_kv_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                    torch.cumsum(self._cpu_mha_kv_seq_lengths[real_bs:padded_bs], dim=0)
+                    + self._cpu_mha_cu_kv_seq_lengths[real_bs]
+                )
+                self._cpu_mha_block_table[real_bs:padded_bs] = (
+                    self.kv_block_allocator.dummy_block_idx
+                )
 
         # Max sequence lengths (Python scalars; consumed as kernel launch args).
         if not self.using_cuda_graph_this_step() and real_bs > 0:
@@ -2592,9 +2654,12 @@ class DynamicInferenceContext(BaseInferenceContext):
         Check if the request can be added to the context.
         """
         # Note that for hybrid models checking the total request count is sufficient
-        # because we allocate a single set of Mamba state tensors for each request
+        # because we allocate a single set of Mamba state tensors for each request.
+        # max_schedulable_requests reserves spare slots for phantom padding (see
+        # _enable_phantom_padding); equals max_requests when phantom padding is off.
         request_can_be_added = (
-            self.total_request_count < self.max_requests and self.paused_request_count == 0
+            self.total_request_count < self.max_schedulable_requests
+            and self.paused_request_count == 0
         )
 
         (_, num_blocks_from_pool, _, _, _, effective_prefill_chunk_length) = (


### PR DESCRIPTION
# What does this PR do ?

The root problem here is a failure cause when the Mamba and MoE requirements conflict.    
Rank A has a P = 4, D = `max_requests-4` batch, rank B has a P=0, D=`max_requests` batch. The all-reduce asks for both ranks to run at P = 4, D = `max_requests`, which is unachievable. This breaks both the eager and the graphed path.

This PR fixes 3 current bugs that are all touching the same codepath. The first 2 are simple:

 - Sync `padded_token_count` for eager mode like it is synced for graphed mode, preventing shape mismatch crashes in the MoE kernels.
 - Clamp `padded_token_count` to `max_tokens` in all execution paths. Not all branches clamped, which was causing silent truncations in edge-cases.

Upon fixing these first 2 bugs, we uncover the 3rd bug.    
MoE + hybrid inference can spuriously fail when ranks regularly reach `max_requests` size of decode batches while other ranks are at `max_request` in a mixed prefill + decode batch, due to the conflict requirements of MoE + hybrid. MoE needs to sync `padded_token_count`, while mamba imposes its own constraints on `decode_token_count`.

We can only solve this by lowering `max_requests` whenever we are using a mamba + MoE model, and we do so with:
```
        ep_needs_reservation = (
            self.expert_model_parallel_group is not None
            and get_pg_size(self.expert_model_parallel_group) > 1
            and self.is_hybrid_model
        )
```

After this PR, we should never fallback to eager mode if we enable CUDA graphs. As long as `cuda_graph_mixed_prefill_request_count` is set correctly.


## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
