### PR TITLE
fix: pre-stage CUDA tensors in training process for persistent ckpt worker

### DIFF
--- a/megatron/training/async_utils.py
+++ b/megatron/training/async_utils.py
@@ -77,10 +77,42 @@ def init_persistent_async_worker(rank: int, mp_mode: str = 'spawn'):
 def schedule_async_save(async_request: AsyncRequest | NVRxAsyncRequest):
     """Schedule the async save request.
 
+    When using a persistent checkpoint worker the AsyncRequest is serialized into a
+    multiprocessing queue.  Any CUDA tensors inside it are transferred between processes
+    via ``pidfd_getfd``-based IPC handles.  If the parent-process file descriptors backing
+    those handles are closed (e.g. by GC) before the worker calls ``queue.get()``, the
+    reconstruction fails with ``RuntimeError: pidfd_getfd: Bad file descriptor``.  This is
+    more likely on large models that use virtual pipeline parallelism (VPP > 1) because
+    ``write_buckets`` is proportionally larger, leading to more IPC handles and a longer
+    pipe transit time.
+
+    To avoid this, pre-stage CUDA tensors to CPU (call ``preload_fn``) in the training
+    process before the request enters the queue.  The worker then receives only CPU tensors
+    and no CUDA IPC is required.
+
     Args:
         async_request (AsyncRequest | NVRxAsyncRequest): the async save request.
     """
-    _get_async_calls_queue().schedule_async_request(async_request)
+    args = get_args()
+    queue = _get_async_calls_queue()
+    # Pre-stage CUDA tensors to CPU before queuing to avoid CUDA IPC pidfd_getfd failures
+    # with the persistent worker (see filesystem_async.py TODO on shared memory).
+    # The persistent worker serialises the AsyncRequest through a multiprocessing queue.
+    # In spawn/forkserver mode CUDA tensors are transferred via pidfd_getfd IPC handles;
+    # if the parent closes those handles (e.g. via GC) before the worker's queue.get()
+    # reconstructs them, the call fails with EBADF.  This is reliably triggered on
+    # configs with VPP > 1 because write_buckets is proportionally larger.
+    if (
+        getattr(args, 'use_persistent_ckpt_worker', False)
+        and getattr(async_request, 'preload_fn', None) is not None
+    ):
+        preloaded_args = list(async_request.async_fn_args)
+        preloaded_args[1] = async_request.preload_fn()
+        async_request = async_request._replace(
+            async_fn_args=tuple(preloaded_args),
+            preload_fn=None,
+        )
+    queue.schedule_async_request(async_request)
 
 
 def maybe_finalize_async_save(blocking: bool = False, terminate=False):

--- a/tests/test_utils/recipes/gb200/gpt.yaml
+++ b/tests/test_utils/recipes/gb200/gpt.yaml
@@ -161,7 +161,7 @@ products:
   - test_case: [gpt3_mcore_te_tp1_pp4_vp1]
     products:
       - environment: [dev]
-        scope: [nightly]
+        scope: [mr-github]
         platforms: [dgx_gb200]
   - test_case: [gpt3_mcore_te_tp1_pp4_vp1_resume_torch_decoupled_lr]
     products:
@@ -186,7 +186,7 @@ products:
   - test_case: [gpt3_mcore_te_tp1_pp4_vp1_tunable_overlap]
     products:
       - environment: [dev]
-        scope: [nightly]
+        scope: [mr-github]
         platforms: [dgx_gb200]
   - test_case: [gpt3_mcore_te_tp1_pp4_vp1_uneven_pipeline]
     products:

--- a/tests/test_utils/recipes/h100/gpt.yaml
+++ b/tests/test_utils/recipes/h100/gpt.yaml
@@ -240,7 +240,7 @@ products:
   - test_case: [gpt3_mcore_te_tp1_pp4_vp1_tunable_overlap]
     products:
       - environment: [dev]
-        scope: [mr]
+        scope: [mr, mr-github]
         platforms: [dgx_h100]
       - environment: [lts]
         scope: [nightly]


### PR DESCRIPTION
## Summary

Fixes `RuntimeError: pidfd_getfd: Bad file descriptor` that crashes the NVRx persistent checkpoint worker on configs with virtual pipeline parallelism (VPP > 1), e.g. `gpt3_15b_8t_release_gb200`.

**Root cause**: when `--use-persistent-ckpt-worker` is set, `schedule_async_save` puts an `AsyncRequest` containing CUDA tensors (`write_buckets`) into a `multiprocessing.Queue` backed by a spawn/forkserver process. In that mode PyTorch transfers CUDA tensors via `pidfd_getfd`-based IPC handles. If the parent's file descriptors backing those handles are closed (e.g. by GC) before the worker's `queue.get()` reconstructs them, you get:

```
RuntimeError: pidfd_getfd: Bad file descriptor
```

**Why VPP > 1 specifically**: with `--num-layers-per-virtual-pipeline-stage N`, `write_buckets` grows proportionally with the number of virtual stages (8× for VPP=8). This means more CUDA IPC file descriptors to keep alive and a longer queue pipe transit time, making the race condition reliably reproducible.

**Fix**: call `preload_fn()` (GPU→CPU D2H) in the training process before the request enters the queue. The worker then receives only CPU tensors — no CUDA IPC is required. Training was already blocking on D2H completion (via the `persistent_preload_q.join()` rendezvous in the mcore path), so there is no change in effective timing.

```python
# Before: CUDA tensors sent into queue → pidfd_getfd EBADF race
queue.schedule_async_request(async_request)

# After: D2H done in training process, only CPU tensors reach the queue
if use_persistent_ckpt_worker and async_request.preload_fn is not None:
    preloaded_args[1] = async_request.preload_fn()   # GPU → CPU
    async_request = async_request._replace(async_fn_args=..., preload_fn=None)
queue.schedule_async_request(async_request)
```

## Test plan

- [ ] Verify `gpt3_15b_8t_release_gb200` no longer crashes with `pidfd_getfd: Bad file descriptor`
- [ ] Verify `gpt3_15b_8t_release_sm` (same flags, no VPP) continues to pass
- [ ] Confirm other configs using `--async-save --use-persistent-ckpt-worker` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)