### PR TITLE
Overload factor logging (squashed)

### DIFF
--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional, Protocol
@@ -12,11 +13,13 @@ from megatron.core import parallel_state, tensor_parallel, utils
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.moe.moe_logging import get_moe_overload_factor_tracker
 from megatron.core.transformer.moe.moe_utils import (
     MoECudaGraphPartialCaptureSignal,
     MoECudaGraphTensorStore,
     get_default_pg_collection,
     maybe_skip_or_early_return_by_cudagraph,
+    record_dispatch_token_counts,
 )
 from megatron.core.transformer.moe.router import TopKRouter
 from megatron.core.transformer.moe.token_dispatcher import (
@@ -233,6 +236,8 @@ class MoELayer(BaseMoELayer):
         )
 
         self.tp_group = pg_collection.tp
+        self.tp_ep_group = pg_collection.tp_ep
+        self.dp_group = pg_collection.dp
 
         # Initialize router.
         self.router = self.submodules.router(
@@ -345,6 +350,11 @@ class MoELayer(BaseMoELayer):
         self.cudagraph_tensor_store = MoECudaGraphTensorStore()
         self.fwd_execution_map = ["route", "expert_compute", "postprocess"]
 
+        if self.config.log_overload_factor:
+            get_moe_overload_factor_tracker().set_process_groups(
+                tp_ep_group=self.tp_ep_group, dp_group=self.dp_group
+            )
+
         # Setup events and streams for delayed wgrad computation.
         self.setup_delayed_wgrad_for_dispatch_backward_overlap()
 
@@ -441,6 +451,15 @@ class MoELayer(BaseMoELayer):
         )
         return hidden_states, probs
 
+    @staticmethod
+    def _num_token_rows_from_moe_hidden_states(hidden_states: torch.Tensor) -> int:
+        """Product of all dimensions except the hidden/last dim (same as ``view(-1, H)`` row count)."""
+        if hidden_states.dim() < 2:
+            raise ValueError(
+                f"MoE hidden_states must be at least 2D [..., hidden_size], got shape {tuple(hidden_states.shape)}"
+            )
+        return int(math.prod(hidden_states.shape[:-1]))
+
     def dispatch(self, hidden_states: torch.Tensor, probs: torch.Tensor):
         """Dispatches tokens to assigned expert ranks via communication.
 
@@ -480,6 +499,36 @@ class MoELayer(BaseMoELayer):
 
         return shared_expert_output
 
+    def _maybe_record_overload_factor(
+        self, dispatched_input: torch.Tensor, tokens_per_expert: torch.Tensor
+    ) -> torch.Tensor:
+        """Wrap ``dispatched_input`` with overload logging when ``log_overload_factor`` is set.
+
+        Uses ``_overload_log_num_local_tokens`` captured from forward ``hidden_states`` and
+        applies AllGather fair-share scaling so ``report()``'s SUM over TP×EP matches one
+        global balanced count when the map is replicated on every rank.
+        """
+        if not self.config.log_overload_factor:
+            return dispatched_input
+        num_local_tokens = getattr(self, "_overload_log_num_local_tokens", None)
+        if num_local_tokens is None:
+            return dispatched_input
+        tp_ep_world_size = float(self.tp_ep_group.size())
+        local_balanced_count = float(num_local_tokens) * float(self.config.moe_router_topk)
+        token_dispatcher = self.token_dispatcher
+        if isinstance(token_dispatcher, MoEAllGatherTokenDispatcher) and (
+            token_dispatcher.tp_size > 1 or token_dispatcher.ep_size > 1
+        ):
+            local_balanced_count = local_balanced_count / tp_ep_world_size
+        local_balanced = torch.empty((), device=dispatched_input.device, dtype=torch.float32)
+        local_balanced.fill_(local_balanced_count)
+        return record_dispatch_token_counts(
+            tensor=dispatched_input,
+            tokens_per_expert=tokens_per_expert,
+            local_balanced_token_count=local_balanced,
+            layer_number=self.layer_number,
+        )
+
     @internal_api
     def routed_experts_compute(self, hidden_states: torch.Tensor, probs: torch.Tensor):
         """Computes the output of the routed experts on the dispatched tokens.
@@ -492,8 +541,12 @@ class MoELayer(BaseMoELayer):
             hidden_states = _RecordExpertDgradCompletion.apply(
                 self._delayed_wgrad_event, hidden_states
             )
+
         dispatched_input, tokens_per_expert, permuted_probs = (
             self.token_dispatcher.dispatch_postprocess(hidden_states, probs)
+        )
+        dispatched_input = self._maybe_record_overload_factor(
+            dispatched_input, tokens_per_expert
         )
         if (
             hasattr(self, "_inference_token_dispatcher")
@@ -576,6 +629,10 @@ class MoELayer(BaseMoELayer):
             try:
                 if "route" in self.fwd_execution_map:
                     shared_expert_output = self.shared_experts_compute(hidden_states)
+                    if self.config.log_overload_factor:
+                        self._overload_log_num_local_tokens = (
+                            self._num_token_rows_from_moe_hidden_states(hidden_states)
+                        )
                     probs, routing_map = self.route(hidden_states, padding_mask)
                     hidden_states, probs = self.preprocess(hidden_states, probs, routing_map)
 

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional, Protocol
@@ -13,11 +14,13 @@ from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.moe.moe_logging import get_moe_overload_factor_tracker
 from megatron.core.transformer.moe.moe_utils import (
     MoECudaGraphPartialCaptureSignal,
     MoECudaGraphTensorStore,
     get_default_pg_collection,
     maybe_skip_or_early_return_by_cudagraph,
+    record_dispatch_token_counts,
 )
 from megatron.core.transformer.moe.router import TopKRouter
 from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
@@ -254,6 +257,7 @@ class MoELayer(BaseMoELayer):
         )
 
         self.tp_group = pg_collection.tp
+        self.tp_ep_group = pg_collection.tp_ep
 
         # Initialize router.
         self.router = self.submodules.router(
@@ -379,6 +383,11 @@ class MoELayer(BaseMoELayer):
         self.cudagraph_tensor_store = MoECudaGraphTensorStore()
         self.fwd_execution_map = ["route", "expert_compute", "postprocess"]
 
+        if self.config.log_moe_overload_factor:
+            get_moe_overload_factor_tracker().set_process_groups(
+                tp_ep_group=self.tp_ep_group, expt_dp_group=pg_collection.expt_dp
+            )
+
         # Setup events and streams for delayed wgrad computation.
         self.setup_delayed_wgrad_for_dispatch_backward_overlap()
 
@@ -486,6 +495,16 @@ class MoELayer(BaseMoELayer):
         )
         return hidden_states, probs
 
+    @staticmethod
+    def _num_token_rows_from_moe_hidden_states(hidden_states: torch.Tensor) -> int:
+        """Product of all dims except the hidden/last (same as view(-1, H) row count)."""
+        if hidden_states.dim() < 2:
+            raise ValueError(
+                "MoE hidden_states must be at least 2D [..., hidden_size], "
+                f"got shape {tuple(hidden_states.shape)}"
+            )
+        return int(math.prod(hidden_states.shape[:-1]))
+
     def dispatch(self, hidden_states: torch.Tensor, probs: torch.Tensor):
         """Dispatches tokens to assigned expert ranks via communication.
 
@@ -525,6 +544,39 @@ class MoELayer(BaseMoELayer):
 
         return shared_expert_output
 
+    def _maybe_record_overload_factor(
+        self, dispatched_input: torch.Tensor, tokens_per_expert: torch.Tensor
+    ) -> torch.Tensor:
+        """Wrap dispatched_input with overload logging when log_moe_overload_factor is set.
+
+        Uses _overload_log_num_local_tokens captured from forward hidden_states and
+        applies AllGather fair-share scaling so report()'s SUM over TP×EP matches one
+        global balanced count when the map is replicated on every rank.
+
+        Recording is skipped when not in training mode (e.g. Megatron validation uses
+        model.eval()) so eval forwards do not pollute train-only overload stats.
+        """
+        if not self.config.log_moe_overload_factor or not self.training:
+            return dispatched_input
+        num_local_tokens = getattr(self, "_overload_log_num_local_tokens", None)
+        if num_local_tokens is None:
+            return dispatched_input
+        tp_ep_world_size = float(self.tp_ep_group.size())
+        local_balanced_count = float(num_local_tokens) * float(self.config.moe_router_topk)
+        token_dispatcher = self.token_dispatcher
+        if isinstance(token_dispatcher, MoEAllGatherTokenDispatcher) and (
+            token_dispatcher.tp_size > 1 or token_dispatcher.ep_size > 1
+        ):
+            local_balanced_count = local_balanced_count / tp_ep_world_size
+        local_balanced = torch.empty((), device=dispatched_input.device, dtype=torch.float32)
+        local_balanced.fill_(local_balanced_count)
+        return record_dispatch_token_counts(
+            tensor=dispatched_input,
+            tokens_per_expert=tokens_per_expert,
+            local_balanced_token_count=local_balanced,
+            layer_number=self.layer_number,
+        )
+
     @internal_api
     def routed_experts_compute(self, hidden_states: torch.Tensor, probs: torch.Tensor):
         """Computes the output of the routed experts on the dispatched tokens.
@@ -537,9 +589,11 @@ class MoELayer(BaseMoELayer):
             hidden_states = _RecordExpertDgradCompletion.apply(
                 self._delayed_wgrad_event, hidden_states
             )
+
         dispatched_input, tokens_per_expert, permuted_probs = (
             self.token_dispatcher.dispatch_postprocess(hidden_states, probs)
         )
+        dispatched_input = self._maybe_record_overload_factor(dispatched_input, tokens_per_expert)
         if hasattr(self, "_inference_token_dispatcher") and InferenceMode.is_active():
             routing_map = self.token_dispatcher.routing_map
             expert_output, mlp_bias = apply_module(self.experts)(
@@ -643,6 +697,10 @@ class MoELayer(BaseMoELayer):
             try:
                 if "route" in self.fwd_execution_map:
                     shared_expert_output = self.shared_experts_compute(hidden_states)
+                    if self.config.log_moe_overload_factor and self.training:
+                        self._overload_log_num_local_tokens = (
+                            self._num_token_rows_from_moe_hidden_states(hidden_states)
+                        )
                     probs, routing_map = self.route(hidden_states, padding_mask)
                     hidden_states, probs = self.preprocess(hidden_states, probs, routing_map)
 

--- a/megatron/core/transformer/moe/moe_logging.py
+++ b/megatron/core/transformer/moe/moe_logging.py
@@ -22,7 +22,7 @@ Usage:
 """
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -64,6 +64,372 @@ def destroy_moe_metrics_tracker() -> None:
     """Reset the global MoE metrics tracker to ``None``."""
     global _MOE_METRICS_TRACKER
     _MOE_METRICS_TRACKER = None
+
+
+# ---------------------------------------------------------------------------
+# MoE Overload Factor Tracker (same pattern as MoEMetricsTracker)
+# ---------------------------------------------------------------------------
+_MOE_OVERLOAD_FACTOR_TRACKER: Optional['MoEOverloadFactorTracker'] = None
+
+
+def get_moe_overload_factor_tracker() -> 'MoEOverloadFactorTracker':
+    """Return the global MoE overload factor tracker, creating it lazily if needed."""
+    global _MOE_OVERLOAD_FACTOR_TRACKER
+    if _MOE_OVERLOAD_FACTOR_TRACKER is None:
+        _MOE_OVERLOAD_FACTOR_TRACKER = MoEOverloadFactorTracker()
+    return _MOE_OVERLOAD_FACTOR_TRACKER
+
+
+def set_moe_overload_factor_tracker(tracker: 'MoEOverloadFactorTracker') -> None:
+    """Set the global MoE overload factor tracker."""
+    global _MOE_OVERLOAD_FACTOR_TRACKER
+    _MOE_OVERLOAD_FACTOR_TRACKER = tracker
+
+
+def destroy_moe_overload_factor_tracker() -> None:
+    """Reset the global MoE overload factor tracker to None."""
+    global _MOE_OVERLOAD_FACTOR_TRACKER
+    _MOE_OVERLOAD_FACTOR_TRACKER = None
+
+
+class MoEOverloadFactorTracker:
+    """Tracker for MoE overload-factor metrics.
+
+    Reductions are over tp_ep then expt_dp (expert data parallel), not dense dp,
+    so overload stats stay within the same expert partition across replicas.
+
+    Lifecycle: MoELayer records counts when log_moe_overload_factor is set (training only);
+    report() at step end (sync, aggregate, log, deferred clear) → repeat.
+
+    Example:
+        tracker = get_moe_overload_factor_tracker()
+        log_str = tracker.report(iteration=100, writer=tb_writer)
+    """
+
+    def __init__(self) -> None:
+        self._layer_fwd_tokens: Dict[int, List[torch.Tensor]] = {}
+        # layer_idx -> list of 0-dim float (tokens on rank)
+        self._layer_fwd_balanced: Dict[int, List[torch.Tensor]] = {}
+        # same keys as _layer_fwd_tokens, balanced token count per entry
+        self._cumulative_tokens_timeline: List[torch.Tensor] = []
+        # +actual tokens on forward, - on backward (mirrors balanced timeline).
+        self._cumulative_balanced_timeline: List[torch.Tensor] = []
+        self._tp_ep_group: Optional[torch.distributed.ProcessGroup] = None
+        self._expt_dp_group: Optional[torch.distributed.ProcessGroup] = None
+        self._pending_clear: bool = False
+
+    def set_process_groups(
+        self,
+        tp_ep_group: Optional[torch.distributed.ProcessGroup] = None,
+        expt_dp_group: Optional[torch.distributed.ProcessGroup] = None,
+    ) -> None:
+        """Set process groups for reduction (MoELayer.__init__ when log_moe_overload_factor)."""
+        if tp_ep_group is not None:
+            self._tp_ep_group = tp_ep_group
+        if expt_dp_group is not None:
+            self._expt_dp_group = expt_dp_group
+
+    def _clear_storage(self) -> None:
+        self._layer_fwd_tokens.clear()
+        self._layer_fwd_balanced.clear()
+        self._cumulative_tokens_timeline.clear()
+        self._cumulative_balanced_timeline.clear()
+
+    def _flush_pending_clear(self) -> None:
+        if self._pending_clear:
+            self._pending_clear = False
+            self._clear_storage()
+
+    def record_fwd(
+        self,
+        layer_number: Optional[int],
+        tokens_on_rank: torch.Tensor,
+        local_balanced_token_count: torch.Tensor,
+    ) -> None:
+        """Record forward token total on this rank (0-dim float) and balanced count scalar."""
+        self._flush_pending_clear()
+        if layer_number is None:
+            return
+        layer_idx = layer_number - 1
+        if layer_idx not in self._layer_fwd_tokens:
+            self._layer_fwd_tokens[layer_idx] = []
+            self._layer_fwd_balanced[layer_idx] = []
+        self._layer_fwd_tokens[layer_idx].append(tokens_on_rank.detach())
+        self._layer_fwd_balanced[layer_idx].append(local_balanced_token_count.detach())
+        self._cumulative_tokens_timeline.append(tokens_on_rank.detach())
+        self._cumulative_balanced_timeline.append(local_balanced_token_count.detach())
+
+    def record_bwd(
+        self, tokens_on_rank: torch.Tensor, local_balanced_token_count: torch.Tensor
+    ) -> None:
+        """Record backward-pass (negated actual and balanced count) for paired cumsums."""
+        self._flush_pending_clear()
+        self._cumulative_tokens_timeline.append(-tokens_on_rank.detach())
+        self._cumulative_balanced_timeline.append(-local_balanced_token_count.detach())
+
+    def _pipeline_group_and_use_reduce(
+        self,
+    ) -> Tuple[Optional[torch.distributed.ProcessGroup], bool]:
+        pp_group = (
+            parallel_state.get_pipeline_model_parallel_group(check_initialized=False)
+            if torch.distributed.is_initialized()
+            else None
+        )
+        use_pp_reduce = (
+            pp_group is not None and torch.distributed.get_world_size(group=pp_group) > 1
+        )
+        return pp_group, use_pp_reduce
+
+    def _flatten_recorded_tokens(self) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+        fwd_tensors: List[torch.Tensor] = []
+        balanced_tensors: List[torch.Tensor] = []
+        if self._layer_fwd_tokens:
+            for layer_idx in sorted(self._layer_fwd_tokens.keys()):
+                for t, b in zip(
+                    self._layer_fwd_tokens[layer_idx], self._layer_fwd_balanced[layer_idx]
+                ):
+                    fwd_tensors.append(t)
+                    balanced_tensors.append(b)
+        return fwd_tensors, balanced_tensors
+
+    def _pp_allreduce_empty_tracker(self, pp_group: torch.distributed.ProcessGroup) -> None:
+        """Ranks without MoE still join PP collectives so peers do not hang."""
+        device = (
+            torch.device('cuda', torch.cuda.current_device())
+            if torch.cuda.is_available()
+            else torch.device('cpu')
+        )
+        pp_buf = torch.zeros(2, device=device, dtype=torch.float32)
+        torch.distributed.all_reduce(pp_buf, group=pp_group, op=torch.distributed.ReduceOp.MAX)
+
+    def _validate_overload_tensor_lists(
+        self, num_entries: int, num_layers: int, num_balanced: int
+    ) -> None:
+        if num_entries % num_layers != 0:
+            raise ValueError(
+                f"Overload factor tracker: num_entries ({num_entries}) must be "
+                f"divisible by num_layers ({num_layers})."
+            )
+        if num_balanced != num_entries:
+            raise ValueError(
+                f"Overload factor tracker: balanced_tensors length ({num_balanced}) "
+                f"must match fwd_tensors ({num_entries})."
+            )
+
+    def _max_cum_overload_if_timeline(
+        self,
+        tp_ep_group: Optional[torch.distributed.ProcessGroup],
+        expt_dp_group: Optional[torch.distributed.ProcessGroup],
+    ) -> Optional[float]:
+        """Cumulative actual vs balanced token count; ratio of peaks across ranks."""
+        if not self._cumulative_tokens_timeline:
+            return None
+        if len(self._cumulative_balanced_timeline) != len(self._cumulative_tokens_timeline):
+            raise ValueError(
+                f"Overload tracker: _cumulative_tokens_timeline "
+                f"({len(self._cumulative_tokens_timeline)}) and "
+                f"_cumulative_balanced_timeline "
+                f"({len(self._cumulative_balanced_timeline)}) length mismatch."
+            )
+        fwd_bwd_stacked = torch.stack(
+            [t.float() for t in self._cumulative_tokens_timeline], dim=0
+        )  # [num_events]
+        balanced_fwd_bwd_stacked = torch.stack(
+            [t.float() for t in self._cumulative_balanced_timeline], dim=0
+        )
+        cum_actual = fwd_bwd_stacked.cumsum(dim=0)
+        cum_balanced = balanced_fwd_bwd_stacked.cumsum(dim=0)
+        local_actual_peak = cum_actual.max()
+        local_balanced_peak = cum_balanced.max()
+        cum_overload_ratio = torch.where(
+            local_balanced_peak > 0,
+            local_actual_peak / (local_balanced_peak + 1e-8),
+            local_actual_peak.new_zeros(()),
+        ).unsqueeze(0)
+        if tp_ep_group is not None:
+            torch.distributed.all_reduce(
+                cum_overload_ratio, group=tp_ep_group, op=torch.distributed.ReduceOp.MAX
+            )
+        if expt_dp_group is not None:
+            torch.distributed.all_reduce(
+                cum_overload_ratio, group=expt_dp_group, op=torch.distributed.ReduceOp.MAX
+            )
+        return cum_overload_ratio.item()
+
+    def _tp_ep_overload_from_lists(
+        self,
+        fwd_tensors: List[torch.Tensor],
+        balanced_tensors: List[torch.Tensor],
+        tp_ep_group: Optional[torch.distributed.ProcessGroup],
+    ) -> Tuple[torch.Tensor, torch.device]:
+        """Max actual per entry over tp_ep, balanced sum per entry, then overload ratio."""
+        actual_tokens_stacked = torch.stack([t.float() for t in fwd_tensors], dim=0)
+        device = actual_tokens_stacked.device
+        if tp_ep_group is not None:
+            tp_ep_world = float(tp_ep_group.size())
+            max_actual = actual_tokens_stacked.clone()
+            torch.distributed.all_reduce(
+                max_actual, group=tp_ep_group, op=torch.distributed.ReduceOp.MAX
+            )
+        else:
+            tp_ep_world = 1.0
+            max_actual = actual_tokens_stacked
+
+        balanced_stacked = torch.stack(
+            [b.to(device=device, dtype=torch.float32) for b in balanced_tensors], dim=0
+        )
+        if tp_ep_group is not None:
+            torch.distributed.all_reduce(balanced_stacked, group=tp_ep_group)
+        balanced_per_rank = balanced_stacked / tp_ep_world
+        tp_ep_overload = max_actual / (balanced_per_rank + 1e-8)
+        return tp_ep_overload, device
+
+    def _expt_dp_reduce_overload(
+        self, tp_ep_overload: torch.Tensor, expt_dp_group: Optional[torch.distributed.ProcessGroup]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Average and worst-case overload across expert-DP replicas (per entry)."""
+        if expt_dp_group is not None:
+            overload_avg = tp_ep_overload.clone()
+            torch.distributed.all_reduce(
+                overload_avg, group=expt_dp_group, op=torch.distributed.ReduceOp.AVG
+            )
+            overload_max = tp_ep_overload.clone()
+            torch.distributed.all_reduce(
+                overload_max, group=expt_dp_group, op=torch.distributed.ReduceOp.MAX
+            )
+        else:
+            overload_avg = tp_ep_overload
+            overload_max = tp_ep_overload
+        return overload_avg, overload_max
+
+    def _pp_reduce_max_overload_scalars(
+        self,
+        max_overload_factor: float,
+        max_cum_overload_factor: Optional[float],
+        device: torch.device,
+        pp_group: torch.distributed.ProcessGroup,
+    ) -> Tuple[float, float]:
+        max_cum_value = (
+            float(max_cum_overload_factor) if max_cum_overload_factor is not None else 0.0
+        )
+        pp_buf = torch.tensor(
+            [max_overload_factor, max_cum_value], device=device, dtype=torch.float32
+        )
+        torch.distributed.all_reduce(pp_buf, group=pp_group, op=torch.distributed.ReduceOp.MAX)
+        return pp_buf[0].item(), pp_buf[1].item()
+
+    def _log_overload_metrics(
+        self,
+        iteration: int,
+        writer,
+        wandb_writer,
+        avg_overload_factor: float,
+        max_overload_factor: float,
+        max_cum_overload_factor: Optional[float],
+        per_layer_logging: bool,
+        overload_avg: torch.Tensor,
+        overload_max: torch.Tensor,
+        num_layers: int,
+        num_entries: int,
+    ) -> None:
+        if writer is not None:
+            writer.add_scalar("moe/avg_overload_factor", avg_overload_factor, iteration)
+            writer.add_scalar("moe/max_overload_factor", max_overload_factor, iteration)
+            if max_cum_overload_factor is not None:
+                writer.add_scalar("moe/max_cum_overload_factor", max_cum_overload_factor, iteration)
+        if wandb_writer is not None:
+            wandb_writer.log({"moe/avg_overload_factor": avg_overload_factor}, iteration)
+            wandb_writer.log({"moe/max_overload_factor": max_overload_factor}, iteration)
+            if max_cum_overload_factor is not None:
+                wandb_writer.log(
+                    {"moe/max_cum_overload_factor": max_cum_overload_factor}, iteration
+                )
+
+        if per_layer_logging:
+            entries_per_layer = num_entries // num_layers
+            layer_avg = overload_avg.view(num_layers, entries_per_layer).mean(dim=1)
+            layer_max = overload_max.view(num_layers, entries_per_layer).max(dim=1).values
+            for i in range(num_layers):
+                avg_val, max_val = layer_avg[i].item(), layer_max[i].item()
+                if writer is not None:
+                    writer.add_scalar(f"moe/avg_overload_factor_layer_{i}", avg_val, iteration)
+                    writer.add_scalar(f"moe/max_overload_factor_layer_{i}", max_val, iteration)
+                if wandb_writer is not None:
+                    wandb_writer.log(
+                        {
+                            f"moe/avg_overload_factor_layer_{i}": avg_val,
+                            f"moe/max_overload_factor_layer_{i}": max_val,
+                        },
+                        iteration,
+                    )
+
+    def report(
+        self, iteration: int, writer=None, wandb_writer=None, per_layer_logging: bool = False
+    ) -> str:
+        """Reduce data, overload factors, log to TB/W&B, defer clear, return log string."""
+        pp_group, use_pp_reduce = self._pipeline_group_and_use_reduce()
+        tp_ep_group = self._tp_ep_group
+        expt_dp_group = self._expt_dp_group
+        fwd_tensors, balanced_tensors = self._flatten_recorded_tokens()
+
+        if not fwd_tensors:
+            if use_pp_reduce:
+                assert pp_group is not None
+                self._pp_allreduce_empty_tracker(pp_group)
+            self.clear()
+            return ""
+
+        num_entries = len(fwd_tensors)
+        num_layers = len(self._layer_fwd_tokens)
+        self._validate_overload_tensor_lists(num_entries, num_layers, len(balanced_tensors))
+
+        max_cum_overload_factor = self._max_cum_overload_if_timeline(tp_ep_group, expt_dp_group)
+        tp_ep_overload, device = self._tp_ep_overload_from_lists(
+            fwd_tensors, balanced_tensors, tp_ep_group
+        )
+        overload_avg, overload_max = self._expt_dp_reduce_overload(tp_ep_overload, expt_dp_group)
+
+        avg_overload_factor = overload_avg.mean().item()
+        max_overload_factor = overload_max.max().item()
+
+        if use_pp_reduce:
+            assert pp_group is not None
+            max_overload_factor, max_cum_reduced = self._pp_reduce_max_overload_scalars(
+                max_overload_factor, max_cum_overload_factor, device, pp_group
+            )
+            max_cum_overload_factor = max_cum_reduced
+
+        self._log_overload_metrics(
+            iteration,
+            writer,
+            wandb_writer,
+            avg_overload_factor,
+            max_overload_factor,
+            max_cum_overload_factor,
+            per_layer_logging,
+            overload_avg,
+            overload_max,
+            num_layers,
+            num_entries,
+        )
+
+        self.clear()
+
+        parts = [
+            f" avg overload factor: {avg_overload_factor:.3f} |",
+            f" max overload factor: {max_overload_factor:.3f} |",
+        ]
+        if max_cum_overload_factor is not None:
+            parts.append(f" max cum overload factor: {max_cum_overload_factor:.3f} |")
+        return "".join(parts)
+
+    def clear(self) -> None:
+        """Mark stored tensors for reset on the next record_fwd or record_bwd.
+
+        Does not drop list contents yet, so captured tensor references stay valid
+        until the next recording hook runs. Process groups are kept.
+        """
+        self._pending_clear = True
 
 
 class MoEMetricsTracker:

--- a/megatron/core/transformer/moe/moe_logging.py
+++ b/megatron/core/transformer/moe/moe_logging.py
@@ -1,0 +1,807 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""MoE metrics tracking and logging.
+
+Collects per-layer MoE metrics during forward passes, synchronizes them across
+distributed ranks, and writes scalar summaries to TensorBoard / W&B.
+
+Usage:
+    tracker = get_moe_metrics_tracker()
+
+    # In router forward pass:
+    tracker.record("load_balancing_loss", loss, layer_number=1, num_layers=32,
+                   reduce_group=tp_cp_group)
+
+    # At end of training step:
+    log_str = tracker.report(
+        loss_scale=1 / num_microbatches,
+        iteration=step,
+        writer=tb_writer,
+        num_layers=32,
+    )
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple, Union
+
+import torch
+
+from megatron.core import parallel_state
+from megatron.core.process_groups_config import ProcessGroupCollection
+
+
+@dataclass
+class MetricEntry:
+    """Per-layer metric with distributed reduction configuration."""
+
+    values: torch.Tensor
+    reduce_group: Optional[torch.distributed.ProcessGroup] = None
+    avg_group: Optional[torch.distributed.ProcessGroup] = None
+    needs_dp_avg: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Module-level global tracker (follows parallel_state / global_vars pattern)
+# ---------------------------------------------------------------------------
+_MOE_METRICS_TRACKER: Optional['MoEMetricsTracker'] = None
+
+
+def get_moe_metrics_tracker() -> 'MoEMetricsTracker':
+    """Return the global MoE metrics tracker, creating it lazily if needed."""
+    global _MOE_METRICS_TRACKER
+    if _MOE_METRICS_TRACKER is None:
+        _MOE_METRICS_TRACKER = MoEMetricsTracker()
+    return _MOE_METRICS_TRACKER
+
+
+def set_moe_metrics_tracker(tracker: 'MoEMetricsTracker') -> None:
+    """Set the global MoE metrics tracker."""
+    global _MOE_METRICS_TRACKER
+    _MOE_METRICS_TRACKER = tracker
+
+
+def destroy_moe_metrics_tracker() -> None:
+    """Reset the global MoE metrics tracker to ``None``."""
+    global _MOE_METRICS_TRACKER
+    _MOE_METRICS_TRACKER = None
+
+
+# ---------------------------------------------------------------------------
+# MoE Overload Factor Tracker (same pattern as MoEMetricsTracker)
+# ---------------------------------------------------------------------------
+_MOE_OVERLOAD_FACTOR_TRACKER: Optional['MoEOverloadFactorTracker'] = None
+
+
+def get_moe_overload_factor_tracker() -> 'MoEOverloadFactorTracker':
+    """Return the global MoE overload factor tracker, creating it lazily if needed."""
+    global _MOE_OVERLOAD_FACTOR_TRACKER
+    if _MOE_OVERLOAD_FACTOR_TRACKER is None:
+        _MOE_OVERLOAD_FACTOR_TRACKER = MoEOverloadFactorTracker()
+    return _MOE_OVERLOAD_FACTOR_TRACKER
+
+
+def set_moe_overload_factor_tracker(tracker: 'MoEOverloadFactorTracker') -> None:
+    """Set the global MoE overload factor tracker."""
+    global _MOE_OVERLOAD_FACTOR_TRACKER
+    _MOE_OVERLOAD_FACTOR_TRACKER = tracker
+
+
+def destroy_moe_overload_factor_tracker() -> None:
+    """Reset the global MoE overload factor tracker to ``None``."""
+    global _MOE_OVERLOAD_FACTOR_TRACKER
+    _MOE_OVERLOAD_FACTOR_TRACKER = None
+
+
+class MoEOverloadFactorTracker:
+    """Track MoE overload-factor metrics.
+
+    Recorded values
+    ---------------
+    - Per-layer **actual tokens on this rank** after dispatch:
+      ``tokens_per_expert.sum()`` (0-dim tensor per microbatch entry), in
+      ``_layer_fwd_tokens`` keyed by layer index; balanced counts in
+      ``_layer_fwd_balanced``.
+    - Per-layer **balanced token count** before overload is computed:
+      ``num_local_tokens * moe_router_topk``, with ``num_local_tokens`` taken from
+      ``MoELayer`` forward ``hidden_states`` (product of leading dimensions, same row
+      count as ``view(-1, hidden_size)``). Both are attached via an autograd hook on
+      ``dispatched_input`` (``RecordDispatchTokenCountsFunction`` in ``moe_utils``).
+    - ``_cumulative_tokens_timeline`` and ``_cumulative_balanced_timeline`` store a
+      time-ordered sequence of ``+fwd`` / ``-bwd`` events so cumulative peaks of
+      actual vs balanced token counts can be compared for ``max_cum`` style metrics.
+
+    How ``report()`` aggregates
+    -----------------------------
+    1. Over ``tp_ep_group``, ``all_reduce(MAX)`` on per-rank actual token totals per
+       entry, then divide by balanced tokens per rank (summed local balanced counts /
+       group size) to get **tp_ep overload** per entry.
+    2. Over ``dp_group``, ``all_reduce(AVG)`` and ``all_reduce(MAX)`` on that overload
+       for scalar summaries.
+    3. Over the **pipeline-parallel** group, ``max`` and ``max_cum`` use
+       ``all_reduce(MAX)`` so every stage agrees on the worst overload; ranks without
+       MoE layers contribute ``0``.
+    4. The **mean** overload scalar is not reduced across PP; each rank logs its local
+       mean (``0`` if nothing was recorded).
+
+    Lifecycle
+    ---------
+    ``set_process_groups()`` runs in ``MoELayer.__init__`` when ``log_overload_factor``
+    is enabled. ``record_fwd()`` / ``record_bwd()`` run during forward (hooked from
+    ``MoELayer``). ``report()`` runs at step end (sync, aggregate, log, then requests
+    deferred clear).
+
+    ``clear()`` behavior
+    --------------------
+    ``clear()`` does not immediately reset storage. It marks storage for reset on the
+    next ``record_fwd()`` or ``record_bwd()`` so tensor handles stay valid until Python
+    executes a recording hook again (for example across CUDA graph replay windows that
+    skip those hooks).
+    """
+
+    def __init__(self) -> None:
+        self._layer_fwd_tokens: Dict[int, List[torch.Tensor]] = {}
+        # layer_idx -> list of 0-dim float (tokens on rank)
+        self._layer_fwd_balanced: Dict[int, List[torch.Tensor]] = {}
+        # same keys as _layer_fwd_tokens, balanced token count per entry
+        self._cumulative_tokens_timeline: List[torch.Tensor] = []
+        # +actual tokens on forward, - on backward (mirrors balanced timeline).
+        self._cumulative_balanced_timeline: List[torch.Tensor] = []
+        self._tp_ep_group: Optional[torch.distributed.ProcessGroup] = None
+        self._dp_group: Optional[torch.distributed.ProcessGroup] = None
+        self._pending_clear: bool = False
+
+    def set_process_groups(
+        self,
+        tp_ep_group: Optional[torch.distributed.ProcessGroup] = None,
+        dp_group: Optional[torch.distributed.ProcessGroup] = None,
+    ) -> None:
+        """Set process groups for reduction (``MoELayer.__init__`` when ``log_overload_factor``)."""
+        if tp_ep_group is not None:
+            self._tp_ep_group = tp_ep_group
+        if dp_group is not None:
+            self._dp_group = dp_group
+
+    def _clear_storage(self) -> None:
+        self._layer_fwd_tokens.clear()
+        self._layer_fwd_balanced.clear()
+        self._cumulative_tokens_timeline.clear()
+        self._cumulative_balanced_timeline.clear()
+
+    def _flush_pending_clear(self) -> None:
+        if self._pending_clear:
+            self._pending_clear = False
+            self._clear_storage()
+
+    def record_fwd(
+        self,
+        layer_number: Optional[int],
+        tokens_on_rank: torch.Tensor,
+        local_balanced_token_count: torch.Tensor,
+    ) -> None:
+        """Record forward-pass token total on this rank (0-dim float) and balanced token count scalar."""
+        self._flush_pending_clear()
+        if layer_number is None:
+            return
+        layer_idx = layer_number - 1
+        if layer_idx not in self._layer_fwd_tokens:
+            self._layer_fwd_tokens[layer_idx] = []
+            self._layer_fwd_balanced[layer_idx] = []
+        self._layer_fwd_tokens[layer_idx].append(tokens_on_rank.detach())
+        self._layer_fwd_balanced[layer_idx].append(local_balanced_token_count.detach())
+        self._cumulative_tokens_timeline.append(tokens_on_rank.detach())
+        self._cumulative_balanced_timeline.append(local_balanced_token_count.detach())
+
+    def record_bwd(
+        self, tokens_on_rank: torch.Tensor, local_balanced_token_count: torch.Tensor
+    ) -> None:
+        """Record backward-pass (negated actual and balanced count) for paired cumsums."""
+        self._flush_pending_clear()
+        self._cumulative_tokens_timeline.append(-tokens_on_rank.detach())
+        self._cumulative_balanced_timeline.append(-local_balanced_token_count.detach())
+
+    def _pipeline_group_and_use_reduce(
+        self,
+    ) -> Tuple[Optional[torch.distributed.ProcessGroup], bool]:
+        pp_group = (
+            parallel_state.get_pipeline_model_parallel_group(check_initialized=False)
+            if torch.distributed.is_initialized()
+            else None
+        )
+        use_pp_reduce = (
+            pp_group is not None
+            and torch.distributed.get_world_size(group=pp_group) > 1
+        )
+        return pp_group, use_pp_reduce
+
+    def _flatten_recorded_tokens(
+        self,
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+        fwd_tensors: List[torch.Tensor] = []
+        balanced_tensors: List[torch.Tensor] = []
+        if self._layer_fwd_tokens:
+            for layer_idx in sorted(self._layer_fwd_tokens.keys()):
+                for t, b in zip(
+                    self._layer_fwd_tokens[layer_idx],
+                    self._layer_fwd_balanced[layer_idx],
+                ):
+                    fwd_tensors.append(t)
+                    balanced_tensors.append(b)
+        return fwd_tensors, balanced_tensors
+
+    def _pp_allreduce_empty_tracker(
+        self, pp_group: torch.distributed.ProcessGroup
+    ) -> None:
+        """Ranks without MoE still join PP collectives so peers do not hang."""
+        device = (
+            torch.device('cuda', torch.cuda.current_device())
+            if torch.cuda.is_available()
+            else torch.device('cpu')
+        )
+        pp_buf = torch.zeros(2, device=device, dtype=torch.float32)
+        torch.distributed.all_reduce(
+            pp_buf, group=pp_group, op=torch.distributed.ReduceOp.MAX
+        )
+
+    def _validate_overload_tensor_lists(
+        self, num_entries: int, num_layers: int, num_balanced: int
+    ) -> None:
+        if num_entries % num_layers != 0:
+            raise ValueError(
+                f"Overload factor tracker: num_entries ({num_entries}) must be "
+                f"divisible by num_layers ({num_layers})."
+            )
+        if num_balanced != num_entries:
+            raise ValueError(
+                f"Overload factor tracker: balanced_tensors length ({num_balanced}) "
+                f"must match fwd_tensors ({num_entries})."
+            )
+
+    def _max_cum_overload_if_timeline(
+        self,
+        tp_ep_group: Optional[torch.distributed.ProcessGroup],
+        dp_group: Optional[torch.distributed.ProcessGroup],
+    ) -> Optional[float]:
+        """Cumulative actual vs balanced token count; ratio of peaks across ranks."""
+        if not self._cumulative_tokens_timeline:
+            return None
+        if len(self._cumulative_balanced_timeline) != len(self._cumulative_tokens_timeline):
+            raise ValueError(
+                f"Overload tracker: _cumulative_tokens_timeline "
+                f"({len(self._cumulative_tokens_timeline)}) and "
+                f"_cumulative_balanced_timeline "
+                f"({len(self._cumulative_balanced_timeline)}) length mismatch."
+            )
+        fwd_bwd_stacked = torch.stack(
+            [t.float() for t in self._cumulative_tokens_timeline], dim=0
+        )  # [num_events]
+        balanced_fwd_bwd_stacked = torch.stack(
+            [t.float() for t in self._cumulative_balanced_timeline], dim=0
+        )
+        cum_actual = fwd_bwd_stacked.cumsum(dim=0)
+        cum_balanced = balanced_fwd_bwd_stacked.cumsum(dim=0)
+        local_actual_peak = cum_actual.max()
+        local_balanced_peak = cum_balanced.max()
+        cum_overload_ratio = torch.where(
+            local_balanced_peak > 0,
+            local_actual_peak / (local_balanced_peak + 1e-8),
+            local_actual_peak.new_zeros(()),
+        ).unsqueeze(0)
+        if tp_ep_group is not None:
+            torch.distributed.all_reduce(
+                cum_overload_ratio, group=tp_ep_group, op=torch.distributed.ReduceOp.MAX
+            )
+        if dp_group is not None:
+            torch.distributed.all_reduce(
+                cum_overload_ratio, group=dp_group, op=torch.distributed.ReduceOp.MAX
+            )
+        return cum_overload_ratio.item()
+
+    def _tp_ep_overload_from_lists(
+        self,
+        fwd_tensors: List[torch.Tensor],
+        balanced_tensors: List[torch.Tensor],
+        tp_ep_group: Optional[torch.distributed.ProcessGroup],
+    ) -> Tuple[torch.Tensor, torch.device]:
+        """Max actual per entry over tp_ep, balanced sum per entry, then overload ratio."""
+        actual_tokens_stacked = torch.stack([t.float() for t in fwd_tensors], dim=0)
+        device = actual_tokens_stacked.device
+        if tp_ep_group is not None:
+            tp_ep_world = float(tp_ep_group.size())
+            max_actual = actual_tokens_stacked.clone()
+            torch.distributed.all_reduce(
+                max_actual, group=tp_ep_group, op=torch.distributed.ReduceOp.MAX
+            )
+        else:
+            tp_ep_world = 1.0
+            max_actual = actual_tokens_stacked
+
+        balanced_stacked = torch.stack(
+            [b.to(device=device, dtype=torch.float32) for b in balanced_tensors], dim=0
+        )
+        if tp_ep_group is not None:
+            torch.distributed.all_reduce(balanced_stacked, group=tp_ep_group)
+        balanced_per_rank = balanced_stacked / tp_ep_world
+        tp_ep_overload = max_actual / (balanced_per_rank + 1e-8)
+        return tp_ep_overload, device
+
+    def _dp_reduce_overload(
+        self,
+        tp_ep_overload: torch.Tensor,
+        dp_group: Optional[torch.distributed.ProcessGroup],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Average and worst-case overload across DP replicas (per entry)."""
+        if dp_group is not None:
+            overload_avg = tp_ep_overload.clone()
+            torch.distributed.all_reduce(
+                overload_avg, group=dp_group, op=torch.distributed.ReduceOp.AVG
+            )
+            overload_max = tp_ep_overload.clone()
+            torch.distributed.all_reduce(
+                overload_max, group=dp_group, op=torch.distributed.ReduceOp.MAX
+            )
+        else:
+            overload_avg = tp_ep_overload
+            overload_max = tp_ep_overload
+        return overload_avg, overload_max
+
+    def _pp_reduce_max_overload_scalars(
+        self,
+        max_overload_factor: float,
+        max_cum_overload_factor: Optional[float],
+        device: torch.device,
+        pp_group: torch.distributed.ProcessGroup,
+    ) -> Tuple[float, float]:
+        max_cum_value = (
+            float(max_cum_overload_factor)
+            if max_cum_overload_factor is not None
+            else 0.0
+        )
+        pp_buf = torch.tensor(
+            [max_overload_factor, max_cum_value],
+            device=device,
+            dtype=torch.float32,
+        )
+        torch.distributed.all_reduce(
+            pp_buf, group=pp_group, op=torch.distributed.ReduceOp.MAX
+        )
+        return pp_buf[0].item(), pp_buf[1].item()
+
+    def _log_overload_metrics(
+        self,
+        iteration: int,
+        writer,
+        wandb_writer,
+        avg_overload_factor: float,
+        max_overload_factor: float,
+        max_cum_overload_factor: Optional[float],
+        per_layer_logging: bool,
+        overload_avg: torch.Tensor,
+        overload_max: torch.Tensor,
+        num_layers: int,
+        num_entries: int,
+    ) -> None:
+        if writer is not None:
+            writer.add_scalar("moe/avg_overload_factor", avg_overload_factor, iteration)
+            writer.add_scalar("moe/max_overload_factor", max_overload_factor, iteration)
+            if max_cum_overload_factor is not None:
+                writer.add_scalar(
+                    "moe/max_cum_overload_factor", max_cum_overload_factor, iteration
+                )
+        if wandb_writer is not None:
+            wandb_writer.log({"moe/avg_overload_factor": avg_overload_factor}, iteration)
+            wandb_writer.log({"moe/max_overload_factor": max_overload_factor}, iteration)
+            if max_cum_overload_factor is not None:
+                wandb_writer.log(
+                    {"moe/max_cum_overload_factor": max_cum_overload_factor}, iteration
+                )
+
+        if per_layer_logging:
+            entries_per_layer = num_entries // num_layers
+            layer_avg = overload_avg.view(num_layers, entries_per_layer).mean(dim=1)
+            layer_max = overload_max.view(num_layers, entries_per_layer).max(dim=1).values
+            for i in range(num_layers):
+                avg_val, max_val = layer_avg[i].item(), layer_max[i].item()
+                if writer is not None:
+                    writer.add_scalar(
+                        f"moe/avg_overload_factor_layer_{i}", avg_val, iteration
+                    )
+                    writer.add_scalar(
+                        f"moe/max_overload_factor_layer_{i}", max_val, iteration
+                    )
+                if wandb_writer is not None:
+                    wandb_writer.log(
+                        {
+                            f"moe/avg_overload_factor_layer_{i}": avg_val,
+                            f"moe/max_overload_factor_layer_{i}": max_val,
+                        },
+                        iteration,
+                    )
+
+    def report(
+        self,
+        iteration: int,
+        writer=None,
+        wandb_writer=None,
+        per_layer_logging: bool = False,
+    ) -> str:
+        """Reduce stored data, compute overload factors, log to TB/W&B, request deferred clear, return log string."""
+        pp_group, use_pp_reduce = self._pipeline_group_and_use_reduce()
+        tp_ep_group = self._tp_ep_group
+        dp_group = self._dp_group
+
+        fwd_tensors, balanced_tensors = self._flatten_recorded_tokens()
+
+        if not fwd_tensors:
+            if use_pp_reduce:
+                assert pp_group is not None
+                self._pp_allreduce_empty_tracker(pp_group)
+            self.clear()
+            return ""
+
+        num_entries = len(fwd_tensors)
+        num_layers = len(self._layer_fwd_tokens)
+        self._validate_overload_tensor_lists(num_entries, num_layers, len(balanced_tensors))
+
+        max_cum_overload_factor = self._max_cum_overload_if_timeline(tp_ep_group, dp_group)
+        tp_ep_overload, device = self._tp_ep_overload_from_lists(
+            fwd_tensors, balanced_tensors, tp_ep_group
+        )
+        overload_avg, overload_max = self._dp_reduce_overload(tp_ep_overload, dp_group)
+
+        avg_overload_factor = overload_avg.mean().item()
+        max_overload_factor = overload_max.max().item()
+
+        if use_pp_reduce:
+            assert pp_group is not None
+            max_overload_factor, max_cum_reduced = self._pp_reduce_max_overload_scalars(
+                max_overload_factor,
+                max_cum_overload_factor,
+                device,
+                pp_group,
+            )
+            max_cum_overload_factor = max_cum_reduced
+
+        self._log_overload_metrics(
+            iteration,
+            writer,
+            wandb_writer,
+            avg_overload_factor,
+            max_overload_factor,
+            max_cum_overload_factor,
+            per_layer_logging,
+            overload_avg,
+            overload_max,
+            num_layers,
+            num_entries,
+        )
+
+        self.clear()
+
+        parts = [
+            f" avg overload factor: {avg_overload_factor:.3f} |",
+            f" max overload factor: {max_overload_factor:.3f} |",
+        ]
+        if max_cum_overload_factor is not None:
+            parts.append(f" max cum overload factor: {max_cum_overload_factor:.3f} |")
+        return "".join(parts)
+
+    def clear(self) -> None:
+        """Mark stored tensors for reset on the next :meth:`record_fwd` or :meth:`record_bwd`.
+
+        Does not drop list contents yet, so captured tensor references stay valid
+        until the next recording hook runs. Process groups are kept.
+        """
+        self._pending_clear = True
+
+
+class MoEMetricsTracker:
+    """Tracker for MoE layer-wise metrics.
+
+    Lifecycle: ``record()`` per-layer values during forward → ``report()`` at
+    step end (sync, aggregate, log, clear) → repeat.
+
+    Example:
+        tracker = get_moe_metrics_tracker()
+        tracker.record("load_balancing_loss", loss, layer_number=1, num_layers=32)
+        log_str = tracker.report(loss_scale=1/8, iteration=100, writer=tb_writer,
+                                 num_layers=32)
+    """
+
+    def __init__(self):
+        self._metrics: Dict[str, MetricEntry] = {}
+
+    # =========================================================================
+    # Public API
+    # =========================================================================
+
+    @property
+    def metrics(self) -> Dict[str, MetricEntry]:
+        """Read-only access to the underlying metric entries."""
+        return self._metrics
+
+    def record(
+        self,
+        name: str,
+        value: torch.Tensor,
+        layer_number: int,
+        num_layers: int,
+        reduce_group: Optional[torch.distributed.ProcessGroup] = None,
+        avg_group: Optional[torch.distributed.ProcessGroup] = None,
+        needs_dp_avg: bool = True,
+    ) -> None:
+        """Accumulate a metric value for a specific layer.
+
+        Called during the router forward pass.  Lazily creates the metric entry
+        on first call for each metric name.
+
+        Args:
+            name: Metric name (e.g. ``"load_balancing_loss"``).
+            value: Scalar tensor to accumulate (will be detached).
+            layer_number: 1-based layer index.
+            num_layers: Total number of layers (determines tensor size).
+            reduce_group: Process group for sum-reduction (e.g. tp_cp_group).
+            avg_group: Process group for average-reduction.
+            needs_dp_avg: Whether to average across DP ranks after other reductions.
+        """
+        if layer_number is None:
+            return
+
+        if name not in self._metrics:
+            self._metrics[name] = MetricEntry(values=torch.zeros(num_layers, device=value.device))
+
+        entry = self._metrics[name]
+        entry.values[layer_number - 1] += value.detach()
+        entry.reduce_group = reduce_group
+        entry.avg_group = avg_group
+        entry.needs_dp_avg = needs_dp_avg
+
+    def report(
+        self,
+        loss_scale: float,
+        iteration: int,
+        writer=None,
+        wandb_writer=None,
+        per_layer_logging: bool = False,
+        force_initialize: bool = False,
+        track_names: Optional[Union[str, List[str]]] = None,
+        num_layers: Optional[int] = None,
+        moe_layer_freq: Optional[Union[int, List[int]]] = None,
+        mtp_num_layers: Optional[int] = None,
+        total_loss_dict: Optional[dict[str, torch.Tensor]] = None,
+        percentiles: Optional[Dict[str, List[float]]] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ) -> str:
+        """Sync metrics across ranks, aggregate, log, and clear.
+
+        This is the main entry point called once per training step.  It pairs
+        with :meth:`record`: you *record* individual data points during forward,
+        then *report* the summary at step end.
+
+        Args:
+            loss_scale: Scale factor for averaging across microbatches
+                (usually ``1 / num_microbatches``).
+            iteration: Current training iteration.
+            writer: TensorBoard ``SummaryWriter`` (optional).
+            wandb_writer: Weights & Biases run object (optional).
+            per_layer_logging: Whether to also write per-layer values.
+            force_initialize: If True, pre-create metric entries for *track_names*
+                that don't exist yet.  Required for PP ranks without MoE layers
+                whose tensor sizes must match ranks that do have MoE layers.
+            track_names: Metric name(s) to report.  ``None`` reports all.
+            num_layers: Total transformer layers (required when *force_initialize*).
+            moe_layer_freq: MoE layer frequency or binary pattern list.
+            mtp_num_layers: Extra layers from Multi-Token Prediction.
+            total_loss_dict: Megatron training-loop accumulator.  Metrics
+                ending with ``"loss"`` are accumulated here and excluded from
+                the returned console log string.
+            percentiles: Per-metric percentiles to compute, e.g.
+                ``{"load_imbalance": [0.5, 0.95]}``.
+            pg_collection: Custom process-group collection for reduction.
+
+        Returns:
+            Formatted log string for console output.
+        """
+        metric_names = self._resolve_names(track_names)
+
+        # Pre-create entries on PP ranks that lack MoE layers.
+        # Tensor size must be (num_layers + mtp_num_layers) to match ranks that
+        # recorded via record(), otherwise all_reduce across PP will hang.
+        if force_initialize:
+            if num_layers is None:
+                raise ValueError("num_layers must be provided when force_initialize=True.")
+            init_size = num_layers + (mtp_num_layers or 0)
+            for name in metric_names:
+                self.ensure_initialized(name, init_size)
+
+        self._sync_metrics(metric_names, pg_collection)
+
+        num_moe_layers = self._count_moe_layers(num_layers, moe_layer_freq, mtp_num_layers)
+        scalars = self._aggregate(loss_scale, num_moe_layers, metric_names, percentiles)
+
+        # Megatron integration: accumulate loss metrics into total_loss_dict
+        console_scalars = dict(scalars)
+        if total_loss_dict is not None:
+            for k, v in scalars.items():
+                if k.lower().endswith("loss"):
+                    if k in total_loss_dict:
+                        total_loss_dict[k] += v
+                    else:
+                        total_loss_dict[k] = v
+                    console_scalars.pop(k)
+
+        self._log_scalars(scalars, iteration, writer, wandb_writer)
+        if per_layer_logging:
+            self._log_per_layer(
+                loss_scale, metric_names, iteration, writer, wandb_writer, percentiles
+            )
+
+        log_string = self._format(console_scalars)
+        self.clear()
+        return log_string
+
+    def clear(self) -> None:
+        """Zero out all metric values (entries are kept for reuse)."""
+        for entry in self._metrics.values():
+            entry.values.zero_()
+
+    def ensure_initialized(
+        self, name: str, num_layers: int, device: Optional[Union[str, torch.device, int]] = None
+    ) -> None:
+        """Pre-create a metric entry if it does not already exist.
+
+        This is needed for PP ranks that have no MoE layers -- their tensor
+        size must match ranks that do, otherwise ``all_reduce`` across PP hangs.
+
+        Args:
+            name: Metric name.
+            num_layers: Tensor size (should include MTP layers).
+            device: Device for the zero tensor.  Defaults to current CUDA device.
+        """
+        if name not in self._metrics:
+            if device is None:
+                device = torch.cuda.current_device() if torch.cuda.is_available() else "cpu"
+            self._metrics[name] = MetricEntry(values=torch.zeros(num_layers, device=device))
+
+    # =========================================================================
+    # Private implementation
+    # =========================================================================
+
+    def _resolve_names(self, track_names: Optional[Union[str, List[str]]]) -> List[str]:
+        """Normalize *track_names* argument to a list of strings."""
+        if track_names is None:
+            return list(self._metrics.keys())
+        if isinstance(track_names, str):
+            return [track_names]
+        return track_names
+
+    def _sync_metrics(
+        self, metric_names: List[str], pg_collection: Optional[ProcessGroupCollection] = None
+    ) -> None:
+        """All-reduce metrics across distributed ranks.
+
+        Reduction order: PP collect → reduce_group sum → avg_group avg → DP avg.
+        """
+        if pg_collection is None:
+            pp_group = parallel_state.get_pipeline_model_parallel_group()
+            dp_group = parallel_state.get_data_parallel_group(
+                with_context_parallel=False, partial_data_parallel=False
+            )
+        else:
+            pp_group = pg_collection.pp
+            dp_group = pg_collection.dp
+
+        for name in metric_names:
+            if name not in self._metrics:
+                continue
+
+            entry = self._metrics[name]
+            v = entry.values
+
+            torch.distributed.all_reduce(v, group=pp_group)
+
+            if entry.reduce_group is not None:
+                torch.distributed.all_reduce(v, group=entry.reduce_group)
+
+            if entry.avg_group is not None:
+                torch.distributed.all_reduce(
+                    v, group=entry.avg_group, op=torch.distributed.ReduceOp.AVG
+                )
+
+            if entry.needs_dp_avg:
+                torch.distributed.all_reduce(v, group=dp_group, op=torch.distributed.ReduceOp.AVG)
+
+    @staticmethod
+    def _count_moe_layers(
+        num_layers: Optional[int],
+        moe_layer_freq: Optional[Union[int, List[int]]],
+        mtp_num_layers: Optional[int],
+    ) -> int:
+        """Compute the effective number of MoE layers from configuration."""
+        if moe_layer_freq is None:
+            n = num_layers
+        elif isinstance(moe_layer_freq, int):
+            assert isinstance(num_layers, int)
+            n = sum(1 for i in range(num_layers) if i % moe_layer_freq == 0)
+        elif isinstance(moe_layer_freq, list):
+            n = sum(moe_layer_freq)
+        else:
+            raise ValueError(f"Invalid moe_layer_freq: {moe_layer_freq}")
+
+        if mtp_num_layers is not None:
+            n += mtp_num_layers
+
+        return n
+
+    def _aggregate(
+        self,
+        loss_scale: float,
+        num_moe_layers: int,
+        metric_names: List[str],
+        percentiles: Optional[Dict[str, List[float]]] = None,
+    ) -> Dict[str, Union[float, torch.Tensor]]:
+        """Aggregate per-layer values into scalar summaries.
+
+        Always computes the mean across MoE layers.  If *percentiles* specifies
+        quantiles for a metric, those are computed over non-zero layer values and
+        added as ``"{name}_p{pct}"`` keys.
+        """
+        result: Dict[str, Union[float, torch.Tensor]] = {}
+
+        for name in metric_names:
+            if name not in self._metrics:
+                continue
+
+            values = self._metrics[name].values.float() * loss_scale
+
+            if percentiles and name in percentiles:
+                nonzero = values[values > 0]
+                if nonzero.numel() > 0:
+                    pcts = percentiles[name]
+                    pct_vals = torch.quantile(
+                        nonzero, torch.tensor(pcts, device=nonzero.device)
+                    ).tolist()
+                    for pct, pct_val in zip(pcts, pct_vals):
+                        result[f"{name}_p{int(pct * 100)}"] = pct_val
+
+            result[name] = values.sum() / num_moe_layers
+
+        return result
+
+    def _log_scalars(
+        self, scalars: Dict[str, Union[float, torch.Tensor]], iteration: int, writer, wandb_writer
+    ) -> None:
+        """Write scalar metrics to TensorBoard and/or W&B."""
+        for name, value in scalars.items():
+            if writer is not None:
+                writer.add_scalar(name, value, iteration)
+            if wandb_writer is not None:
+                wandb_writer.log({name: value}, iteration)
+
+    def _log_per_layer(
+        self,
+        loss_scale: float,
+        metric_names: List[str],
+        iteration: int,
+        writer,
+        wandb_writer,
+        percentiles: Optional[Dict[str, List[float]]] = None,
+    ) -> None:
+        """Write per-layer metric values to TensorBoard and/or W&B."""
+        for name in metric_names:
+            if name not in self._metrics:
+                continue
+
+            values = self._metrics[name].values.float() * loss_scale
+            is_sparse = percentiles is not None and name in percentiles
+            for i, val in enumerate(values.tolist()):
+                if is_sparse and val == 0:
+                    continue
+                if writer is not None:
+                    writer.add_scalar(f"moe/{name}_layer_{i}", val, iteration)
+                if wandb_writer is not None:
+                    wandb_writer.log({f"moe/{name}_layer_{i}": val}, iteration)
+
+    @staticmethod
+    def _format(scalars: Dict[str, Union[float, torch.Tensor]]) -> str:
+        """Format aggregated metrics as a console log string."""
+        return "".join(f" {k}: {v:.2f} |" for k, v in scalars.items())

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -20,6 +20,10 @@ from megatron.core.tensor_parallel import (
 from megatron.core.tensor_parallel.mappings import reduce_from_tensor_model_parallel_region
 from megatron.core.transformer.cuda_graphs import is_graph_capturing
 from megatron.core.transformer.enums import CudaGraphScope
+from megatron.core.transformer.moe.moe_logging import (
+    get_moe_metrics_tracker,
+    get_moe_overload_factor_tracker,
+)
 from megatron.core.transformer.moe.router_replay import RouterReplay
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import internal_api, is_te_min_version
@@ -986,6 +990,82 @@ def clear_aux_losses_tracker() -> None:
     tracker = get_moe_layer_wise_logging_tracker()
     for name in tracker:
         tracker[name]["values"].zero_()
+
+
+class RecordDispatchTokenCountsFunction(torch.autograd.Function):
+    """Autograd hook: record post-dispatch token totals for overload reporting (see ``report()``)."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        tensor: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        local_balanced_token_count: torch.Tensor,
+        layer_number: Optional[int],
+    ):
+        """Record actual token total and balanced count on forward; pass ``tensor`` through.
+
+        Args:
+            tensor: Tensor in the autograd graph (e.g. ``dispatched_input``) — pass-through.
+            tokens_per_expert: Per-local-expert counts from ``dispatch_postprocess`` (any device).
+            local_balanced_token_count: Scalar float, ``num_local_tokens * topk`` (token rows from forward ``hidden_states``).
+            layer_number: Layer index (1-based).
+
+        Returns:
+            ``tensor`` unchanged.
+        """
+        if layer_number is None:
+            return tensor
+
+        tokens_on_rank = tokens_per_expert.detach().sum().to(
+            device=tensor.device, dtype=torch.float32
+        )
+
+        balanced = local_balanced_token_count.detach().to(
+            device=tensor.device, dtype=torch.float32
+        )
+
+        tracker = get_moe_overload_factor_tracker()
+        tracker.record_fwd(layer_number, tokens_on_rank, balanced)
+
+        ctx.save_for_backward(tokens_on_rank, balanced)
+        return tensor
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Backward pass: append negated actual and balanced count for paired cumsums."""
+        if ctx.saved_tensors:
+            tokens_on_rank, balanced = ctx.saved_tensors
+            get_moe_overload_factor_tracker().record_bwd(tokens_on_rank, balanced)
+        return grad_output, None, None, None
+
+
+def record_dispatch_token_counts(
+    tensor: torch.Tensor,
+    tokens_per_expert: torch.Tensor,
+    local_balanced_token_count: torch.Tensor,
+    layer_number: Optional[int],
+) -> torch.Tensor:
+    """Wrap ``tensor`` with an autograd hook that records dispatch token counts for overload metrics.
+
+    Records ``tokens_per_expert.sum()`` on this rank and the **balanced token count** scalar.
+    Overload factors are computed later in ``MoEOverloadFactorTracker.report()``. Process groups
+    must already be registered on the global tracker (``MoELayer`` does this in ``__init__``
+    when ``log_overload_factor`` is enabled).
+
+    Args:
+        tensor: Tensor in the autograd graph (typically ``dispatched_input``).
+        tokens_per_expert: Output of ``dispatch_postprocess`` (per-expert counts).
+        local_balanced_token_count: Scalar float tensor,
+            ``num_local_tokens * moe_router_topk`` (``num_local_tokens`` from MoE forward ``hidden_states`` shape).
+        layer_number: Layer index (1-based).
+
+    Returns:
+        ``tensor`` unchanged.
+    """
+    return RecordDispatchTokenCountsFunction.apply(
+        tensor, tokens_per_expert, local_balanced_token_count, layer_number
+    )
 
 
 def reduce_aux_losses_tracker_across_ranks(

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -20,7 +20,10 @@ from megatron.core.tensor_parallel import (
 from megatron.core.tensor_parallel.mappings import reduce_from_tensor_model_parallel_region
 from megatron.core.transformer.cuda_graphs import is_graph_capturing
 from megatron.core.transformer.enums import CudaGraphModule
-from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
+from megatron.core.transformer.moe.moe_logging import (
+    get_moe_metrics_tracker,
+    get_moe_overload_factor_tracker,
+)
 from megatron.core.transformer.moe.router_replay import RouterReplay
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import deprecated, internal_api, is_te_min_version
@@ -1004,6 +1007,82 @@ def save_to_aux_losses_tracker(
 def clear_aux_losses_tracker() -> None:
     """Clear the auxiliary losses."""
     get_moe_metrics_tracker().clear()
+
+
+class RecordDispatchTokenCountsFunction(torch.autograd.Function):
+    """Autograd hook: post-dispatch token totals for overload reporting (see report())."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        tensor: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        local_balanced_token_count: torch.Tensor,
+        layer_number: Optional[int],
+    ):
+        """Record actual token total and balanced count on forward; pass tensor through.
+
+        Args:
+            tensor: Tensor in the autograd graph (e.g. dispatched_input) — pass-through.
+            tokens_per_expert: Per-local-expert counts from dispatch_postprocess (any
+                device).
+            local_balanced_token_count: Scalar float, num_local_tokens * topk (token
+                rows from forward hidden_states).
+            layer_number: Layer index (1-based).
+
+        Returns:
+            tensor unchanged.
+        """
+        if layer_number is None:
+            return tensor
+
+        tokens_on_rank = (
+            tokens_per_expert.detach().sum().to(device=tensor.device, dtype=torch.float32)
+        )
+
+        balanced = local_balanced_token_count.detach().to(device=tensor.device, dtype=torch.float32)
+
+        tracker = get_moe_overload_factor_tracker()
+        tracker.record_fwd(layer_number, tokens_on_rank, balanced)
+
+        ctx.save_for_backward(tokens_on_rank, balanced)
+        return tensor
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Backward pass: append negated actual and balanced count for paired cumsums."""
+        if ctx.saved_tensors:
+            tokens_on_rank, balanced = ctx.saved_tensors
+            get_moe_overload_factor_tracker().record_bwd(tokens_on_rank, balanced)
+        return grad_output, None, None, None
+
+
+def record_dispatch_token_counts(
+    tensor: torch.Tensor,
+    tokens_per_expert: torch.Tensor,
+    local_balanced_token_count: torch.Tensor,
+    layer_number: Optional[int],
+) -> torch.Tensor:
+    """Wrap tensor with an autograd hook for dispatch token counts (overload metrics).
+
+    Records tokens_per_expert.sum() on this rank and the balanced token count scalar.
+    Overload factors are computed later in MoEOverloadFactorTracker.report(). Process groups
+    must already be registered on the global tracker (MoELayer does this in __init__
+    when log_moe_overload_factor is enabled).
+
+    Args:
+        tensor: Tensor in the autograd graph (typically dispatched_input).
+        tokens_per_expert: Output of dispatch_postprocess (per-expert counts).
+        local_balanced_token_count: Scalar float, num_local_tokens * moe_router_topk
+            (num_local_tokens from MoE forward hidden_states shape).
+        layer_number: Layer index (1-based).
+
+    Returns:
+        tensor unchanged.
+    """
+    return RecordDispatchTokenCountsFunction.apply(
+        tensor, tokens_per_expert, local_balanced_token_count, layer_number
+    )
 
 
 @deprecated(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -725,6 +725,12 @@ class TransformerConfig(ModelParallelConfig):
     If negative, generates bias once per layer and reuses it (abs value is std).
     This is an experimental feature for benchmarking purposes."""
 
+    log_overload_factor: bool = False
+    """When True, log MoE overload metrics (avg/max vs balanced token count per step; max cum
+    overload = peak cumulative actual tokens / peak cumulative balanced count over interleaved
+    fwd/bwd) to TensorBoard/W&B and console. Records ``tokens_per_expert.sum()`` after dispatch;
+    use for debugging."""
+
     moe_grouped_gemm: bool = False
     """When there are multiple experts per rank, compress multiple local (potentially small) gemms
     in a single kernel launch to improve the utilization and performance by leveraging the Grouped

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -795,6 +795,12 @@ class TransformerConfig(ModelParallelConfig):
     Requires ``use_te_op_fuser=True`` and SwiGLU activation.
     """
 
+    log_moe_overload_factor: bool = False
+    """When True, log MoE overload metrics (avg/max vs balanced token count per step; max cum
+    overload = peak cumulative actual tokens / peak cumulative balanced count over interleaved
+    fwd/bwd) to TensorBoard/W&B and console. Records tokens_per_expert.sum() after dispatch;
+    use for debugging."""
+
     moe_grouped_gemm: bool = False
     """When there are multiple experts per rank, compress multiple local (potentially small) gemms
     in a single kernel launch to improve the utilization and performance by leveraging the Grouped

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -195,7 +195,10 @@ from megatron.training.datasets.data_samplers import build_pretraining_data_load
 from megatron.core.datasets.data_schedule import HybridCPDataLoaderWrapper
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.core.transformer.moe import upcycling_utils
-from megatron.core.transformer.moe.moe_utils import track_moe_metrics, clear_aux_losses_tracker
+from megatron.core.transformer.moe.moe_logging import (
+    get_moe_metrics_tracker,
+    get_moe_overload_factor_tracker,
+)
 from megatron.core.transformer.experimental_attention_variant.dsa import DSAIndexerLossLoggingHelper
 from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
 from megatron.core.parallel_state import (
@@ -2162,6 +2165,14 @@ def training_log(
             mtp_num_layers=args.mtp_num_layers,
             pg_collection=pg_collection,
         )
+        if getattr(args, 'log_overload_factor', False):
+            overload_log_string = get_moe_overload_factor_tracker().report(
+                iteration=iteration,
+                writer=writer,
+                wandb_writer=wandb_writer,
+                per_layer_logging=args.moe_per_layer_logging,
+            )
+            moe_log_string = moe_log_string + overload_log_string
 
     # Log MTP metrics.
     if args.mtp_num_layers is not None:
@@ -3196,7 +3207,9 @@ def train(
             if args.log_energy:
                 energy_monitor.resume()
             if args.num_experts is not None:
-                clear_aux_losses_tracker()
+                get_moe_metrics_tracker().clear()
+                if getattr(args, 'log_overload_factor', False):
+                    get_moe_overload_factor_tracker().clear()
 
         # Miscellaneous post-training-step functions (e.g., FT heartbeats, GC).
         # Some of these only happen at specific iterations. Capture updated FLOPs accumulator

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -118,7 +118,7 @@ from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
 from megatron.core.transformer.experimental_attention_variant.dsa import DSAIndexerLossLoggingHelper
 from megatron.core.transformer.module import Float16Module
 from megatron.core.transformer.moe import upcycling_utils
-from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
+from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker, get_moe_overload_factor_tracker
 from megatron.core.transformer.moe.paged_stash import PagedStashRunner
 from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
 from megatron.core.utils import (
@@ -2672,6 +2672,14 @@ def training_log(
             pg_collection=pg_collection,
             total_loss_dict=total_loss_dict,
         )
+        if getattr(args, 'log_moe_overload_factor', False):
+            overload_log_string = get_moe_overload_factor_tracker().report(
+                iteration=iteration,
+                writer=writer,
+                wandb_writer=wandb_writer,
+                per_layer_logging=args.moe_per_layer_logging,
+            )
+            moe_log_string = moe_log_string + overload_log_string
 
     # Log MTP metrics.
     if args.mtp_num_layers is not None:
@@ -3892,6 +3900,8 @@ def train(
                 energy_monitor.resume()
             if args.num_experts is not None:
                 get_moe_metrics_tracker().clear()
+                if getattr(args, 'log_moe_overload_factor', False):
+                    get_moe_overload_factor_tracker().clear()
 
         # Miscellaneous post-training-step functions (e.g., FT heartbeats, GC).
         # Some of these only happen at specific iterations. Capture updated FLOPs accumulator

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_resume_torch_dist_dist_optimizer/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_resume_torch_dist_dist_optimizer/model_config.yaml
@@ -67,5 +67,6 @@ MODEL_ARGS:
   --async-save: true
   --use-persistent-ckpt-worker: true
   --async-ckpt-use-cpu-shm: true
+  --log-moe-overload-factor: true
 TEST_TYPE: ckpt-resume
 LAUNCHER: ft_launcher

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -160,6 +160,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "linear_num_value_heads": 32,
     "linear_value_head_dim": 128,
     "log_max_attention_logit": False,
+    "log_moe_overload_factor": False,
     "mamba_head_dim": 64,
     "mamba_num_groups": 8,
     "mamba_num_heads": 64,


### PR DESCRIPTION
# What does this PR do ?

This PR introduces a utility to log overload factor through log_overload_factor.

# MoE overload factor
Overload factor is the ratio of the token count on the most loaded rank in a TP-EP group to the balanced token count per rank—the count each rank would see with perfectly balanced routing. It measures workload imbalance.

## moe/avg_overload_factor
Arithmetic mean of overload factor over all layer × microbatch x DP slice entries recorded on this rank in the step.

## moe/max_overload_factor
Maximum of overload factor over all layer × microbatch x DP slice entries. Useful for estimating peak buffer size for intermediate activations in the forward path.

## moe/max_cum_overload_factor
Reflects the cumulative fwd/bwd tokensL ratio of peak cumulative actual tokens to peak cumulative balanced count. Useful for estimating how much activation-related memory may need to be retained through backward.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
