### PR TITLE
feat(moe): add DenseMixer dense forward pass for improved router grad…

### DIFF
--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -540,6 +540,102 @@ class MoELayer(BaseMoELayer):
         hidden_states, probs, residual = self.preprocess(hidden_states, probs, routing_map)
         return hidden_states, probs, residual
 
+    def dense_moe_forward(
+        self, hidden_states: torch.Tensor, padding_mask: Optional[torch.Tensor] = None
+    ):
+        """DenseMixer dense forward pass for improved router gradient estimation.
+
+        Implements the DenseMixer algorithm (https://github.com/yaof20/DenseMixer):
+        - Forward: routes tokens to ALL local experts (dense), computes the output as a
+          weighted sum using ALL experts with full (non-sparse) routing scores as weights.
+        - Backward: gradients flow to the router from ALL experts, not just the Top-K
+          selected ones, greatly improving routing quality during post-training (SFT/RL).
+
+        At inference time, the standard sparse Top-K routing is used (no overhead).
+        The train/inference discrepancy (dense vs sparse) is acceptable because the model
+        learns to route better - the relative expert preferences are preserved.
+
+        Constraints:
+        - Only supports SequentialMLP (requires access to individual expert MLPs).
+        - Does not support Expert Parallelism (EP size must be 1).
+        - Does not support shared experts.
+        - Does not support moe_latent_size.
+
+        Args:
+            hidden_states (torch.Tensor): Input tensor [seq_length, bsz, hidden_size].
+            padding_mask (torch.Tensor, optional): Boolean mask [seq_length, bsz].
+
+        Returns:
+            Tuple[torch.Tensor, None]: (output tensor, None for mlp_bias).
+        """
+        from megatron.core.transformer.moe.experts import SequentialMLP
+
+        assert isinstance(self.experts, SequentialMLP), (
+            "moe_dense_forward_for_router_grad only supports SequentialMLP experts. "
+            "Please set moe_grouped_gemm=False."
+        )
+        assert (
+            not self.use_shared_expert
+        ), "moe_dense_forward_for_router_grad is not supported with shared experts."
+        assert utils.get_pg_size(self.ep_group) == 1, (
+            "moe_dense_forward_for_router_grad does not support expert parallelism (EP size > 1). "
+            "Please set expert_model_parallel_size=1 when using this feature."
+        )
+        assert (
+            self.config.moe_latent_size is None
+        ), "moe_dense_forward_for_router_grad is not supported with moe_latent_size."
+
+        seq_len, bsz, hidden_size = hidden_states.shape
+        num_tokens = seq_len * bsz
+        hidden_flat = hidden_states.view(num_tokens, hidden_size)
+
+        # 1. Get full routing scores from router gating (dense, all experts)
+        #    We call gating() directly to get logits, then compute full scores.
+        #    The router's aux losses are still applied via the standard router.forward() call.
+        router = self.router
+
+        # Apply standard router.forward() to compute sparse probs (for aux losses to attach)
+        # The z-loss, aux-loss etc. are attached to `probs` via MoEAuxLossAutoScaler.
+        sparse_probs, _ = router(hidden_states, padding_mask)
+        # sparse_probs: [num_tokens, num_experts] with non-zero only for top-k
+
+        # Compute full dense scores using the same score function as the router.
+        # We get logits from the router's gating layer.
+        logits = router.gating(hidden_flat)  # [num_tokens, num_experts]
+        score_function = router.config.moe_router_score_function
+        if score_function == "sigmoid":
+            full_scores = torch.sigmoid(logits)
+        else:  # softmax (default) or other
+            full_scores = torch.softmax(logits, dim=-1, dtype=torch.float32).to(logits.dtype)
+
+        # Detach full_scores from the gating computation to avoid double-counting gradients.
+        # Gradients to the router flow through sparse_probs (via aux-loss autograd).
+        # The dense computation provides gradient signal via full_scores for ALL experts.
+        # We keep full_scores in the compute graph so all experts contribute gradients.
+
+        # 2. Run ALL local experts on all tokens with full (dense) scores
+        expert_outputs = []
+        for expert_idx, expert in enumerate(self.experts.local_experts):
+            global_expert_idx = self.local_expert_indices[expert_idx]
+            # per_token_scale: [num_tokens] - full score for this expert (all tokens, all experts)
+            expert_score = full_scores[:, global_expert_idx]  # [num_tokens]
+            # Run expert forward: output is weighted by expert_score inside the MLP
+            expert_out, _ = expert(hidden_flat, expert_score)  # [num_tokens, hidden_size]
+            expert_outputs.append(expert_out)
+
+        # 3. Sum weighted expert outputs (dense weighted combination)
+        dense_output = sum(expert_outputs)  # [num_tokens, hidden_size]
+
+        # 4. Attach sparse_probs to the computation graph to preserve aux-loss gradients.
+        #    sparse_probs has the aux-loss autograd hooks attached; we add a zero contribution
+        #    from it so its gradients still flow during backward.
+        #    This is a no-op numerically but keeps the gradient graph intact.
+        aux_loss_anchor = sparse_probs.sum() * 0.0
+        output = dense_output + aux_loss_anchor
+
+        output = output.view(seq_len, bsz, hidden_size)
+        return output, None
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -570,6 +666,10 @@ class MoELayer(BaseMoELayer):
         # Transpose from [bsz, seq_length] to [seq_length, bsz] to align with hidden_states
         if padding_mask is not None:
             padding_mask = padding_mask.transpose(0, 1).bool()
+
+        # DenseMixer: use dense forward for improved router gradient estimation during training
+        if self.training and self.config.moe_dense_forward_for_router_grad:
+            return self.dense_moe_forward(hidden_states, padding_mask)
 
         # MoE forward: route -> dispatch -> compute -> combine
         def custom_forward(hidden_states, intermediate_tensors=None, padding_mask=None):

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -1664,3 +1664,41 @@ def maybe_skip_or_early_return_by_cudagraph(step_condition):
         return wrapped_func
 
     return decorator
+
+
+class DenseMixerSTE(torch.autograd.Function):
+    """Straight-Through Estimator for DenseMixer dense forward pass.
+
+    During the forward pass, replaces the sparse Top-K routing map with a dense
+    all-ones mask so that ALL experts receive tokens and contribute to the output.
+    During the backward pass, passes gradients straight through to the original
+    sparse routing map, enabling the router to receive gradient signal from all
+    experts rather than only the selected Top-K ones.
+
+    This implements the core idea from DenseMixer (https://github.com/yaof20/DenseMixer):
+    use dense forward for better router gradient estimation while keeping sparse
+    routing at inference time (no inference overhead).
+
+    Args:
+        sparse_routing_map: Bool tensor [num_tokens, num_experts], True for Top-K selected experts.
+        dense_routing_map: Bool tensor [num_tokens, num_experts], all True (dense mask).
+
+    Returns:
+        dense_routing_map with gradients flowing to sparse_routing_map in backward.
+    """
+
+    @staticmethod
+    def forward(
+        ctx, sparse_routing_map: torch.Tensor, dense_routing_map: torch.Tensor
+    ) -> torch.Tensor:
+        """Return dense_routing_map in forward; remember sparse for backward."""
+        ctx.save_for_backward(sparse_routing_map)
+        return dense_routing_map
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple:
+        """Pass gradient through to sparse_routing_map unchanged (STE)."""
+        (sparse_routing_map,) = ctx.saved_tensors
+        # Gradient w.r.t. sparse_routing_map: straight-through (identity)
+        # Gradient w.r.t. dense_routing_map: None (it's a constant)
+        return grad_output, None

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -797,6 +797,16 @@ class TransformerConfig(ModelParallelConfig):
     moe_apply_probs_on_input: bool = False
     """Apply probs on input of experts instead of applying after activation and glu."""
 
+    moe_dense_forward_for_router_grad: bool = False
+    """[DenseMixer] Enable dense forward pass during training for better router gradient estimation.
+    When enabled, the forward pass computes outputs from ALL experts (not just the Top-K selected
+    ones) using a Straight-Through Estimator (STE). The final output uses the standard sparse Top-K
+    combination (no inference overhead), but the backward pass provides gradients to the router
+    from all experts, improving routing quality during post-training (SFT/RL fine-tuning).
+    FLOPs overhead: ~1.46x. Memory overhead: negligible (expert weights already in GPU memory).
+    Reference: DenseMixer (https://github.com/yaof20/DenseMixer).
+    Note: Only supported with SequentialMLP experts (moe_grouped_gemm=False)."""
+
     moe_latent_size: Optional[int] = None
     """Latent projection dimension for MoE. If None, MoE latent projections are not used."""
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -3102,6 +3102,16 @@ def _add_moe_args(parser):
                        help='Determines the load balancing strategy for the router. "aux_loss" corresponds to the load balancing loss used in GShard and SwitchTransformer; "seq_aux_loss" corresponds to the load balancing loss used in DeepSeekV2, which computes the loss for each individual sample; "sinkhorn" corresponds to the balancing algorithm used in S-BASE, and "none" implies no load balancing. The default is "aux_loss".')
     group.add_argument('--moe-aux-loss-coeff', type=float, nargs='+', default=0.0,
                        help='Scaling coefficient for the aux loss: a starting value of 1e-2 is recommended.')
+    group.add_argument('--moe-dense-forward-for-router-grad', action='store_true',
+                       help='Enable DenseMixer-style dense forward pass for better router gradient '
+                            'estimation during post-training (SFT/RL). When enabled, all experts '
+                            'process all tokens during training and outputs are combined as a '
+                            'weighted sum using full (non-sparse) routing scores, allowing router '
+                            'gradients to flow from all experts rather than only Top-K selected '
+                            'ones. At inference, standard sparse Top-K routing is used with no '
+                            'overhead. Only supported with SequentialMLP (no --moe-grouped-gemm) '
+                            'and expert-model-parallel-size=1. '
+                            'See https://github.com/yaof20/DenseMixer for details.')
     # Token dispatcher arguments
     # MoE communication overlap arguments
 

--- a/tests/unit_tests/transformer/moe/test_moe_layer.py
+++ b/tests/unit_tests/transformer/moe/test_moe_layer.py
@@ -131,6 +131,476 @@ class TestMoELayerInit:
         Utils.destroy_model_parallel()
 
 
+class TestDenseMixerForward:
+    """Test DenseMixer dense forward pass for router gradient estimation."""
+
+    def setup_method(self, method):
+        pass
+
+    @pytest.mark.parametrize("num_moe_experts", [2, 4])
+    @pytest.mark.parametrize("moe_router_topk", [1, 2])
+    def test_dense_moe_forward_shape_and_grad(self, num_moe_experts, moe_router_topk):
+        """Test that dense forward produces correct shape and all expert weights receive grads."""
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+
+        hidden_size = 16
+        sequence_length = 8
+        micro_batch_size = 2
+        ffn_hidden_size = 32
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=hidden_size,
+            num_attention_heads=4,
+            num_moe_experts=num_moe_experts,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_load_balancing_type="aux_loss",
+            moe_router_topk=moe_router_topk,
+            moe_router_pre_softmax=moe_router_topk == 1,  # required when topk=1
+            moe_aux_loss_coeff=0.01,
+            moe_grouped_gemm=False,  # required for DenseMixer
+            moe_ffn_hidden_size=ffn_hidden_size,
+            add_bias_linear=False,
+            moe_dense_forward_for_router_grad=True,
+        )
+        submodules = get_gpt_layer_local_submodules(
+            num_experts=num_moe_experts, moe_grouped_gemm=False
+        )
+        moe_layer = MoELayer(config, submodules.mlp.submodules)
+        moe_layer.cuda()
+        moe_layer.train()
+
+        hidden_states = torch.randn(
+            sequence_length,
+            micro_batch_size,
+            hidden_size,
+            device=torch.cuda.current_device(),
+            requires_grad=True,
+        )
+
+        output, mlp_bias = moe_layer(hidden_states)
+
+        assert mlp_bias is None
+        assert (
+            output.shape == hidden_states.shape
+        ), f"Output shape {output.shape} != input shape {hidden_states.shape}"
+
+        loss = output.sum()
+        loss.backward()
+
+        # All expert parameters should receive gradients (dense forward touches all experts)
+        for name, param in moe_layer.named_parameters():
+            if param.requires_grad:
+                assert (
+                    param.grad is not None
+                ), f"Parameter {name} should have gradient in dense forward mode"
+
+        # Router weight should have gradients
+        assert moe_layer.router.weight.grad is not None, "Router weight should have gradient"
+
+        Utils.destroy_model_parallel()
+
+    def test_dense_forward_all_experts_receive_grad_from_all_tokens(self):
+        """Core DenseMixer invariant: every expert processes every token in dense mode.
+
+        DenseMixer spec: when moe_dense_forward_for_router_grad=True, the forward pass
+        runs ALL experts on ALL tokens regardless of routing decisions. This means every
+        expert's fc1 weight must receive non-zero gradient after backward, even if the
+        router would not have selected that expert for any token under standard routing.
+
+        We verify this in contrast to sparse mode: with a deterministic router biased
+        toward expert 0 (topk=1), sparse routing gives expert 0 all tokens and leaves
+        experts 1-3 with zero tokens (zero fc1 grad). Dense mode must give all experts
+        non-zero fc1 grad regardless.
+        """
+        Utils.initialize_model_parallel(1, 1)
+
+        num_moe_experts = 4
+        hidden_size = 16
+
+        def make_layer(dense: bool) -> MoELayer:
+            config = TransformerConfig(
+                num_layers=1,
+                hidden_size=hidden_size,
+                num_attention_heads=4,
+                num_moe_experts=num_moe_experts,
+                use_cpu_initialization=True,
+                moe_token_dispatcher_type="allgather",
+                moe_router_load_balancing_type="none",
+                moe_router_topk=1,
+                moe_router_pre_softmax=True,
+                moe_aux_loss_coeff=0.0,
+                moe_grouped_gemm=False,
+                moe_ffn_hidden_size=32,
+                add_bias_linear=False,
+                moe_dense_forward_for_router_grad=dense,
+            )
+            submodules = get_gpt_layer_local_submodules(
+                num_experts=num_moe_experts, moe_grouped_gemm=False
+            )
+            layer = MoELayer(config, submodules.mlp.submodules).cuda().train()
+            return layer
+
+        # Construct input and router weights such that logit[0] >> logit[1,2,3] for all tokens:
+        # Set router.weight[i] = e_i (standard basis vector in hidden_size), and
+        # set hidden = e_0 (unit vector along dim 0) for all tokens.
+        # Then logit_0 = 1.0, logit_1 = logit_2 = logit_3 = 0.0 -> expert 0 always wins topk=1.
+        basis = torch.zeros(hidden_size, device='cuda')
+        basis[0] = 1.0
+        hidden_states = basis.view(1, 1, hidden_size).expand(8, 2, hidden_size).clone()
+
+        # --- Sparse mode: expert 0 gets all tokens, experts 1-3 get zero tokens ---
+        sparse_layer = make_layer(dense=False)
+        with torch.no_grad():
+            for i in range(num_moe_experts):
+                sparse_layer.router.weight.data[i] = torch.zeros(hidden_size, device='cuda')
+                sparse_layer.router.weight.data[i][i] = 1.0  # weight[i] = e_i
+
+        sparse_layer(hidden_states.detach())[0].sum().backward()
+        sparse_fc1_grads = [
+            e.linear_fc1.weight.grad.norm().item() for e in sparse_layer.experts.local_experts
+        ]
+
+        assert sparse_fc1_grads[0] > 0, "Sparse mode: expert 0 should receive tokens"
+        assert all(g == 0.0 for g in sparse_fc1_grads[1:]), (
+            f"Sparse mode: experts 1-3 should receive zero tokens (topk=1, input=e_0), "
+            f"got fc1 grad norms: {sparse_fc1_grads[1:]}"
+        )
+
+        # --- Dense mode: all experts process all tokens, all must have non-zero fc1 grad ---
+        dense_layer = make_layer(dense=True)
+        with torch.no_grad():
+            for i in range(num_moe_experts):
+                dense_layer.router.weight.data[i] = torch.zeros(hidden_size, device='cuda')
+                dense_layer.router.weight.data[i][i] = 1.0
+
+        dense_layer(hidden_states.detach())[0].sum().backward()
+        dense_fc1_grads = [
+            e.linear_fc1.weight.grad.norm().item() for e in dense_layer.experts.local_experts
+        ]
+
+        for i, norm in enumerate(dense_fc1_grads):
+            assert norm > 0, (
+                f"Dense mode: expert {i} must have non-zero fc1 gradient "
+                f"(DenseMixer runs all experts on all tokens), got {norm}"
+            )
+
+        Utils.destroy_model_parallel()
+
+    def test_dense_forward_aux_loss_gradient_flows(self):
+        """Verify that aux loss gradients still reach the router in dense forward mode."""
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            num_moe_experts=4,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_load_balancing_type="aux_loss",
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.1,
+            moe_grouped_gemm=False,
+            moe_ffn_hidden_size=32,
+            add_bias_linear=False,
+            moe_dense_forward_for_router_grad=True,
+        )
+        submodules = get_gpt_layer_local_submodules(num_experts=4, moe_grouped_gemm=False)
+        moe_layer = MoELayer(config, submodules.mlp.submodules).cuda().train()
+
+        hidden_states = torch.randn(4, 2, 16, device=torch.cuda.current_device())
+        output, _ = moe_layer(hidden_states)
+        output.sum().backward()
+
+        # Router weight must have gradient (aux loss contributes via sparse_probs anchor)
+        assert moe_layer.router.weight.grad is not None
+        assert (
+            moe_layer.router.weight.grad.abs().sum() > 0
+        ), "Router weight gradient should be non-zero with aux_loss enabled"
+
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("score_function", ["softmax", "sigmoid"])
+    def test_dense_forward_score_functions(self, score_function):
+        """DenseMixer should work with both softmax and sigmoid score functions."""
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            num_moe_experts=4,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.0,
+            moe_grouped_gemm=False,
+            moe_ffn_hidden_size=32,
+            add_bias_linear=False,
+            moe_dense_forward_for_router_grad=True,
+            moe_router_score_function=score_function,
+        )
+        submodules = get_gpt_layer_local_submodules(num_experts=4, moe_grouped_gemm=False)
+        moe_layer = MoELayer(config, submodules.mlp.submodules).cuda().train()
+
+        hidden_states = torch.randn(4, 2, 16, device=torch.cuda.current_device())
+        output, _ = moe_layer(hidden_states)
+        assert output.shape == hidden_states.shape
+
+        output.sum().backward()
+        assert moe_layer.router.weight.grad is not None
+
+        Utils.destroy_model_parallel()
+
+    def test_dense_moe_forward_eval_uses_sparse(self):
+        """Test that eval mode uses standard sparse forward (not dense)."""
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            num_moe_experts=4,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.0,
+            moe_grouped_gemm=False,
+            moe_ffn_hidden_size=32,
+            add_bias_linear=False,
+            moe_dense_forward_for_router_grad=True,
+        )
+        submodules = get_gpt_layer_local_submodules(num_experts=4, moe_grouped_gemm=False)
+        moe_layer = MoELayer(config, submodules.mlp.submodules)
+        moe_layer.cuda()
+
+        hidden_states = torch.randn(4, 2, 16, device=torch.cuda.current_device())
+
+        # Eval mode should use standard sparse forward
+        moe_layer.eval()
+        with torch.no_grad():
+            output_eval, _ = moe_layer(hidden_states)
+        assert output_eval.shape == hidden_states.shape
+
+        Utils.destroy_model_parallel()
+
+    def test_dense_forward_no_nan_inf(self):
+        """DenseMixer output and gradients must be finite (no NaN/Inf)."""
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            num_moe_experts=4,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.01,
+            moe_grouped_gemm=False,
+            moe_ffn_hidden_size=32,
+            add_bias_linear=False,
+            moe_dense_forward_for_router_grad=True,
+        )
+        submodules = get_gpt_layer_local_submodules(num_experts=4, moe_grouped_gemm=False)
+        moe_layer = MoELayer(config, submodules.mlp.submodules).cuda().train()
+
+        hidden_states = torch.randn(
+            8, 2, 16, device=torch.cuda.current_device(), requires_grad=True
+        )
+        output, _ = moe_layer(hidden_states)
+
+        assert torch.isfinite(output).all(), "DenseMixer output contains NaN or Inf"
+
+        output.sum().backward()
+        assert torch.isfinite(
+            hidden_states.grad
+        ).all(), "DenseMixer input gradient contains NaN or Inf"
+        for name, param in moe_layer.named_parameters():
+            if param.grad is not None:
+                assert torch.isfinite(param.grad).all(), f"Gradient of {name} contains NaN or Inf"
+
+        Utils.destroy_model_parallel()
+
+    def test_dense_forward_with_padding_mask(self):
+        """DenseMixer dense forward must handle padding_mask without errors."""
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+
+        seq_len, bsz, hidden_size = 8, 2, 16
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=hidden_size,
+            num_attention_heads=4,
+            num_moe_experts=4,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.0,
+            moe_grouped_gemm=False,
+            moe_ffn_hidden_size=32,
+            add_bias_linear=False,
+            moe_dense_forward_for_router_grad=True,
+        )
+        submodules = get_gpt_layer_local_submodules(num_experts=4, moe_grouped_gemm=False)
+        moe_layer = MoELayer(config, submodules.mlp.submodules).cuda().train()
+
+        hidden_states = torch.randn(seq_len, bsz, hidden_size, device=torch.cuda.current_device())
+        # padding_mask: [bsz, seq_len], False = padding token
+        padding_mask = torch.ones(
+            bsz, seq_len, device=torch.cuda.current_device(), dtype=torch.bool
+        )
+        padding_mask[:, -2:] = False  # last 2 positions are padding
+
+        output, _ = moe_layer(hidden_states, padding_mask=padding_mask)
+        assert output.shape == hidden_states.shape
+        assert torch.isfinite(output).all(), "Output contains NaN/Inf with padding mask"
+
+        output.sum().backward()
+
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("load_balancing_type", ["aux_loss", "seq_aux_loss"])
+    def test_dense_forward_load_balancing_types(self, load_balancing_type):
+        """DenseMixer should work with different load balancing loss types."""
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            num_moe_experts=4,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_load_balancing_type=load_balancing_type,
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.01,
+            moe_grouped_gemm=False,
+            moe_ffn_hidden_size=32,
+            add_bias_linear=False,
+            moe_dense_forward_for_router_grad=True,
+        )
+        submodules = get_gpt_layer_local_submodules(num_experts=4, moe_grouped_gemm=False)
+        moe_layer = MoELayer(config, submodules.mlp.submodules).cuda().train()
+
+        hidden_states = torch.randn(4, 2, 16, device=torch.cuda.current_device())
+        output, _ = moe_layer(hidden_states)
+        assert output.shape == hidden_states.shape
+        output.sum().backward()
+        assert moe_layer.router.weight.grad is not None
+
+        Utils.destroy_model_parallel()
+
+    def test_dense_forward_flag_false_uses_sparse(self):
+        """Regression guard: when flag is False (default), standard sparse forward is used.
+
+        We verify this by checking that dense_moe_forward is NOT called when the flag is off.
+        We use topk=1 with deterministic routing (input=e_0, weights=basis), so with sparse
+        routing expert 0 gets all tokens while experts 1-3 get zero tokens (fc1 grad == 0).
+        """
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+
+        num_moe_experts = 4
+        hidden_size = 16
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=hidden_size,
+            num_attention_heads=4,
+            num_moe_experts=num_moe_experts,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_load_balancing_type="none",
+            moe_router_topk=1,
+            moe_router_pre_softmax=True,
+            moe_aux_loss_coeff=0.0,
+            moe_grouped_gemm=False,
+            moe_ffn_hidden_size=32,
+            add_bias_linear=False,
+            moe_dense_forward_for_router_grad=False,  # default: sparse
+        )
+        submodules = get_gpt_layer_local_submodules(
+            num_experts=num_moe_experts, moe_grouped_gemm=False
+        )
+        moe_layer = MoELayer(config, submodules.mlp.submodules).cuda().train()
+
+        # Deterministic routing: input = e_0, router.weight[i] = e_i -> expert 0 always wins
+        basis = torch.zeros(hidden_size, device='cuda')
+        basis[0] = 1.0
+        hidden_states = basis.view(1, 1, hidden_size).expand(8, 2, hidden_size).clone()
+        with torch.no_grad():
+            for i in range(num_moe_experts):
+                moe_layer.router.weight.data[i] = torch.zeros(hidden_size, device='cuda')
+                moe_layer.router.weight.data[i][i] = 1.0
+
+        output, _ = moe_layer(hidden_states)
+        assert output.shape == hidden_states.shape
+        output.sum().backward()
+
+        fc1_grads = [
+            e.linear_fc1.weight.grad.norm().item() for e in moe_layer.experts.local_experts
+        ]
+
+        # Sparse mode with topk=1: only expert 0 should have non-zero fc1 gradient
+        assert fc1_grads[0] > 0, "flag=False: expert 0 should receive tokens"
+        assert all(
+            g == 0.0 for g in fc1_grads[1:]
+        ), f"flag=False (sparse): experts 1-3 should have zero fc1 grad, got {fc1_grads[1:]}"
+
+        Utils.destroy_model_parallel()
+
+    def test_dense_forward_guard_grouped_gemm(self):
+        """DenseMixer must raise AssertionError when experts is not SequentialMLP.
+
+        We verify the guard by directly calling dense_moe_forward on a layer whose experts
+        have been replaced with a mock non-SequentialMLP object, bypassing the submodules
+        constructor (which may fall back to SequentialMLP when TE is unavailable).
+        """
+        import types
+
+        Utils.initialize_model_parallel(1, 1)
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            num_moe_experts=4,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.0,
+            moe_grouped_gemm=False,
+            moe_ffn_hidden_size=32,
+            add_bias_linear=False,
+            moe_dense_forward_for_router_grad=True,
+        )
+        submodules = get_gpt_layer_local_submodules(num_experts=4, moe_grouped_gemm=False)
+        moe_layer = MoELayer(config, submodules.mlp.submodules).cuda().train()
+
+        # Replace experts with a non-SequentialMLP mock to trigger the guard.
+        # Use _modules directly to bypass nn.Module's type check on setattr.
+        original_experts = moe_layer.experts
+        moe_layer._modules['experts'] = torch.nn.Linear(1, 1)  # not a SequentialMLP
+
+        hidden_states = torch.randn(4, 2, 16, device=torch.cuda.current_device())
+        with pytest.raises(AssertionError, match="SequentialMLP"):
+            moe_layer.dense_moe_forward(hidden_states)
+
+        moe_layer.experts = original_experts  # restore
+        Utils.destroy_model_parallel()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+
 class TestInterleaveTransformerBlock:
 
     @pytest.mark.parametrize("moe_layer_freq", [2, eval("[0,1,1,1]"), eval("[0]*2+[1]*2")])


### PR DESCRIPTION

# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

Implements [DenseMixer](https://github.com/yaof20/DenseMixer) in Megatron-LM to improve MoE router gradient estimation during post-training (SFT/RL).

**Problem**: Top-K routing is non-differentiable. The router only receives gradients from the K selected experts, leaving all other experts with zero gradient signal, which degrades routing quality in post-training scenarios.

**Solution**: When `moe_dense_forward_for_router_grad=True`, the forward pass runs ALL local experts on ALL tokens. Routing scores from all experts flow into the weighted sum, giving the router a full gradient signal. At inference, standard sparse Top-K routing is used — zero overhead.

## References

- Paper/blog: https://fengyao.notion.site/moe-posttraining
- Original implementation: https://github.com/yaof20/DenseMixer
- Related issue: NVIDIA/Megatron-LM#4169

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
