### PR TITLE
Add training-side support for Rollout Routing Replay (R3)

### DIFF
--- a/megatron/core/transformer/moe/router_replay.py
+++ b/megatron/core/transformer/moe/router_replay.py
@@ -42,6 +42,21 @@ class RouterReplay:
             router_instance.set_target_indices(all_layers_topk_indices[i])
 
     @staticmethod
+    def set_rollout_routing_data(
+        all_layers_topk_indices: List[torch.Tensor], activate_replay: bool = True
+    ):
+        """Public API for training frameworks (e.g., veRL) to inject rollout-phase routing indices.
+
+        This is the main entry point for Rollout Routing Replay (R3).  Call this method once per
+        training forward pass to supply the expert-selection indices that were recorded by the
+        inference engine during the rollout phase.
+
+        """
+        RouterReplay.set_replay_data(all_layers_topk_indices)
+        if activate_replay:
+            RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+
+    @staticmethod
     def get_recorded_data() -> List[torch.Tensor]:
         """
         Collects the recorded topk indices from all RouterReplay instances.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -651,7 +651,7 @@ class TransformerConfig(ModelParallelConfig):
     """Number of experts to route to for each token."""
 
     moe_enable_routing_replay: bool = False
-    """If True, enable the routing replay feature for MoE layers."""
+    """If True, enable the Rollout Routing Replay (R3) feature for MoE layers."""
 
     moe_router_topk_limited_devices: Optional[int] = None
     """Number of EP ranks to consider for each token in group-limited routing,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2,14 +2,15 @@
 
 """Pretrain utilities."""
 import time
+
 # The earliest we can measure the start time.
 _TRAIN_START_TIME = time.time()
 
 # Startup timestamps for tracking program initialization phases
 _STARTUP_TIMESTAMPS = {
     'program_start': None,  # Set by entry script before imports
-    'main_entry': None,     # Set by entry script at start of __main__
-    'pretrain_entry': None, # Set at top of pretrain()
+    'main_entry': None,  # Set by entry script at start of __main__
+    'pretrain_entry': None,  # Set at top of pretrain()
 }
 
 
@@ -56,12 +57,13 @@ from .log_handler import CustomHandler
 logging.basicConfig(handlers=[CustomHandler()], level=logging.INFO)
 from .theoretical_memory_usage import report_theoretical_memory
 
-_LEGACY_TRAIN_START_TIME = time.time() # NOTE(asolergi-nv): Legacy timestamp
+_LEGACY_TRAIN_START_TIME = time.time()  # NOTE(asolergi-nv): Legacy timestamp
 
 import torch
 
 try:
     from megatron.rl import rl_utils
+
     has_rl_utils = True
 except ImportError:
     has_rl_utils = False
@@ -116,9 +118,7 @@ RL_LOGGABLE_TIMER_NAMES = [
 ]
 
 try:
-    from modelopt.torch.distill.plugins.megatron import (
-        get_tensor_shapes_adjust_fn_for_distillation,
-    )
+    from modelopt.torch.distill.plugins.megatron import get_tensor_shapes_adjust_fn_for_distillation
 
     has_nvidia_modelopt = True
 except ImportError:
@@ -160,9 +160,14 @@ from megatron.core.optimizer.optimizer_cuda_graph import OptimizerCudaGraphWrapp
 from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
 from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.transformer.module import Float16Module
-from megatron.core.distributed import DistributedDataParallelConfig, TorchFullyShardedDataParallelConfig
+from megatron.core.distributed import (
+    DistributedDataParallelConfig,
+    TorchFullyShardedDataParallelConfig,
+)
 from megatron.core.distributed import DistributedDataParallel as DDP
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
+from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+    FullyShardedDataParallel as megatron_FSDP,
+)
 from megatron.core.optimizer.optimizer import param_group_identifier_keys
 
 from megatron.core.optimizer.qk_clip import clip_qk
@@ -176,11 +181,7 @@ except ImportError:
 
 from megatron.core.distributed import finalize_model_grads
 from megatron.core.enums import ModelType
-from megatron.core.optimizer import (
-    get_megatron_optimizer,
-    OptimizerConfig,
-    ParamKey,
-)
+from megatron.core.optimizer import get_megatron_optimizer, OptimizerConfig, ParamKey
 from megatron.core.rerun_state_machine import (
     get_rerun_state_machine,
     destroy_rerun_state_machine,
@@ -190,12 +191,17 @@ from megatron.core.rerun_state_machine import (
 from megatron.training.initialize import initialize_megatron
 from megatron.training.initialize import write_args_to_tensorboard
 from megatron.training.initialize import set_jit_fusion_options
-from megatron.training.utils import get_batch_on_this_cp_rank, get_batch_on_this_tp_rank, is_hybrid_model
+from megatron.training.utils import (
+    get_batch_on_this_cp_rank,
+    get_batch_on_this_tp_rank,
+    is_hybrid_model,
+)
 from megatron.training.datasets.data_samplers import build_pretraining_data_loader
 from megatron.core.datasets.data_schedule import HybridCPDataLoaderWrapper
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.core.transformer.moe import upcycling_utils
 from megatron.core.transformer.moe.moe_utils import track_moe_metrics, clear_aux_losses_tracker
+from megatron.core.transformer.moe.router_replay import RouterReplay, RouterReplayAction
 from megatron.core.transformer.experimental_attention_variant.dsa import DSAIndexerLossLoggingHelper
 from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
 from megatron.core.parallel_state import (
@@ -210,6 +216,7 @@ from megatron.core.resharding.refit import swap_model_weights
 
 try:
     from torch_memory_saver import torch_memory_saver
+
     torch_memory_saver.hook_mode = "torch"
     HAVE_TORCH_MEMORY_SAVER = True
 except ImportError:
@@ -221,7 +228,7 @@ from megatron.core.num_microbatches_calculator import (
     get_current_global_batch_size,
     get_current_running_global_batch_size,
     get_num_microbatches,
-    update_num_microbatches
+    update_num_microbatches,
 )
 
 from .async_utils import maybe_finalize_async_save
@@ -271,7 +278,7 @@ def destroy_global_state():
 
 def print_datetime(string, override_timestamp=None):
     """Note that this call will sync across all ranks. Use override_timestamp if provided;
-       otherwise use current timestamp."""
+    otherwise use current timestamp."""
     torch.distributed.barrier()
     if override_timestamp is None:
         time_str = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
@@ -279,27 +286,51 @@ def print_datetime(string, override_timestamp=None):
         time_str = datetime.fromtimestamp(override_timestamp).strftime('%Y-%m-%d %H:%M:%S.%f')
     print_rank_0(f'[{string}] datetime: {time_str} ')
 
+
 def num_floating_point_operations(args, batch_size):
     def mlp_layer_flops(batch_size, seq_len, hidden_size, expansion=4.0, swiglu=False):
         """Calculate FLOPs for an MLP layer."""
         scale_factor = 3.0 / 2.0 if swiglu else 1.0
         return 4 * expansion * scale_factor * batch_size * seq_len * hidden_size**2
 
-    def moe_layer_flops(batch_size, seq_len, hidden_size, moe_ffn_hidden_size,
-                        shared_expert_ffn_hidden_size, num_experts_routed_to,
-                        moe_latent_size=None, swiglu=False):
+    def moe_layer_flops(
+        batch_size,
+        seq_len,
+        hidden_size,
+        moe_ffn_hidden_size,
+        shared_expert_ffn_hidden_size,
+        num_experts_routed_to,
+        moe_latent_size=None,
+        swiglu=False,
+    ):
         """Calculate FLOPs for an MoE layer."""
         scale_factor = 3.0 / 2.0 if swiglu else 1.0
         if moe_latent_size is None:
-            routed_flops = (4 * batch_size * seq_len * hidden_size *
-                            moe_ffn_hidden_size * num_experts_routed_to * scale_factor)
+            routed_flops = (
+                4
+                * batch_size
+                * seq_len
+                * hidden_size
+                * moe_ffn_hidden_size
+                * num_experts_routed_to
+                * scale_factor
+            )
         else:
             # Routed experts run on moe_latent_size.
-            routed_flops = (4 * batch_size * seq_len * moe_latent_size *
-                            moe_ffn_hidden_size * num_experts_routed_to * scale_factor)
+            routed_flops = (
+                4
+                * batch_size
+                * seq_len
+                * moe_latent_size
+                * moe_ffn_hidden_size
+                * num_experts_routed_to
+                * scale_factor
+            )
             # Up proj and down proj.
-            routed_flops += (4 * batch_size * seq_len * hidden_size * moe_latent_size)
-        shared_flops = 4 * batch_size * seq_len * hidden_size * shared_expert_ffn_hidden_size * scale_factor
+            routed_flops += 4 * batch_size * seq_len * hidden_size * moe_latent_size
+        shared_flops = (
+            4 * batch_size * seq_len * hidden_size * shared_expert_ffn_hidden_size * scale_factor
+        )
         return routed_flops + shared_flops
 
     def attn_layer_flops(
@@ -317,8 +348,9 @@ def num_floating_point_operations(args, batch_size):
             * (hidden_size + (hidden_size * (g / num_heads)) + (seq_len / 2))
         )
 
-    def mamba_layer_flops(batch_size, seq_len, hidden_size, state_dim=16,
-                          head_dim=64, num_groups=1, num_heads=128):
+    def mamba_layer_flops(
+        batch_size, seq_len, hidden_size, state_dim=16, head_dim=64, num_groups=1, num_heads=128
+    ):
         """Calculate FLOPs for a Mamba layer."""
         # Note (rwaleffe): flops estimate for scan should be updated based on new SSD kernels,
         # but small percent of overall layer flops
@@ -339,57 +371,109 @@ def num_floating_point_operations(args, batch_size):
             + (2 * batch_size * seq_len * d_in * hidden_size)  # out_proj
         )
 
-    def gdn_layer_flops(batch_size, seq_len, hidden_size,
-                        qk_head_dim=128, v_head_dim=128,
-                        num_qk_heads=16, num_v_heads=32,
-                        conv_kernel_dim=4):
+    def gdn_layer_flops(
+        batch_size,
+        seq_len,
+        hidden_size,
+        qk_head_dim=128,
+        v_head_dim=128,
+        num_qk_heads=16,
+        num_v_heads=32,
+        conv_kernel_dim=4,
+    ):
         """Calculate FLOPs for a Gated Delta Net (GDN) layer."""
         qk_dim = qk_head_dim * num_qk_heads
         v_dim = v_head_dim * num_v_heads
         return (
-            2 * batch_size * seq_len * (
+            2
+            * batch_size
+            * seq_len
+            * (
                 # in_proj: hidden_size -> (2*qk_dim + 2*v_dim + 2*num_v_heads)
                 hidden_size * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
                 # conv1d
                 + conv_kernel_dim * (2 * qk_dim + v_dim)
                 # gated delta rule: KK^T, VK^T, S(a(I-bKK^T)), and SQ
-                + num_v_heads * (v_head_dim ** 2) * 4
+                + num_v_heads * (v_head_dim**2) * 4
                 # out_proj: v_dim -> hidden_size
                 + hidden_size * v_dim
             )
         )
 
-    def hybrid_flops(batch_size, seq_len, hidden_size,
-                     num_attn_layers, num_mamba_layers, num_mlp_layers, num_moe_layers,
-                     num_gdn_layers=0,
-                     mamba_state_dim=128, mamba_head_dim=64,
-                     mamba_num_groups=8, mamba_num_heads=128,
-                     num_attn_heads=32, gqa=True,
-                     gqa_groups=8, kv_channels=None,
-                     mlp_expansion=4.0, swiglu=False,
-                     moe_latent_size=None,
-                     moe_ffn_hidden_size=2048, shared_expert_ffn_hidden_size=2048, num_experts_routed_to=1,
-                     gdn_qk_head_dim=128, gdn_v_head_dim=128,
-                     gdn_num_qk_heads=16, gdn_num_v_heads=32,
-                     gdn_conv_kernel_dim=4,
-                     vocab_size=256000, mtp_num_layers=0):
+    def hybrid_flops(
+        batch_size,
+        seq_len,
+        hidden_size,
+        num_attn_layers,
+        num_mamba_layers,
+        num_mlp_layers,
+        num_moe_layers,
+        num_gdn_layers=0,
+        mamba_state_dim=128,
+        mamba_head_dim=64,
+        mamba_num_groups=8,
+        mamba_num_heads=128,
+        num_attn_heads=32,
+        gqa=True,
+        gqa_groups=8,
+        kv_channels=None,
+        mlp_expansion=4.0,
+        swiglu=False,
+        moe_latent_size=None,
+        moe_ffn_hidden_size=2048,
+        shared_expert_ffn_hidden_size=2048,
+        num_experts_routed_to=1,
+        gdn_qk_head_dim=128,
+        gdn_v_head_dim=128,
+        gdn_num_qk_heads=16,
+        gdn_num_v_heads=32,
+        gdn_conv_kernel_dim=4,
+        vocab_size=256000,
+        mtp_num_layers=0,
+    ):
         """Calculate total FLOPs for the hybrid model."""
         flops_fwd = (
-                num_attn_layers * attn_layer_flops(batch_size, seq_len, hidden_size,
-                                                   num_attn_heads, gqa, gqa_groups, kv_channels) +
-                num_mlp_layers * mlp_layer_flops(batch_size, seq_len, hidden_size,
-                                                 mlp_expansion, swiglu) +
-                num_mamba_layers * mamba_layer_flops(batch_size, seq_len, hidden_size,
-                                                     mamba_state_dim, mamba_head_dim,
-                                                     mamba_num_groups, mamba_num_heads) +
-                num_moe_layers * moe_layer_flops(batch_size, seq_len, hidden_size, moe_ffn_hidden_size,
-                                                 shared_expert_ffn_hidden_size, num_experts_routed_to,
-                                                 moe_latent_size, swiglu) +
-                num_gdn_layers * gdn_layer_flops(batch_size, seq_len, hidden_size,
-                                                  gdn_qk_head_dim, gdn_v_head_dim,
-                                                  gdn_num_qk_heads, gdn_num_v_heads,
-                                                  gdn_conv_kernel_dim) +
-                (2 * batch_size * seq_len * hidden_size * vocab_size * (1 + mtp_num_layers))  # logits computation
+            num_attn_layers
+            * attn_layer_flops(
+                batch_size, seq_len, hidden_size, num_attn_heads, gqa, gqa_groups, kv_channels
+            )
+            + num_mlp_layers
+            * mlp_layer_flops(batch_size, seq_len, hidden_size, mlp_expansion, swiglu)
+            + num_mamba_layers
+            * mamba_layer_flops(
+                batch_size,
+                seq_len,
+                hidden_size,
+                mamba_state_dim,
+                mamba_head_dim,
+                mamba_num_groups,
+                mamba_num_heads,
+            )
+            + num_moe_layers
+            * moe_layer_flops(
+                batch_size,
+                seq_len,
+                hidden_size,
+                moe_ffn_hidden_size,
+                shared_expert_ffn_hidden_size,
+                num_experts_routed_to,
+                moe_latent_size,
+                swiglu,
+            )
+            + num_gdn_layers
+            * gdn_layer_flops(
+                batch_size,
+                seq_len,
+                hidden_size,
+                gdn_qk_head_dim,
+                gdn_v_head_dim,
+                gdn_num_qk_heads,
+                gdn_num_v_heads,
+                gdn_conv_kernel_dim,
+            )
+            + (
+                2 * batch_size * seq_len * hidden_size * vocab_size * (1 + mtp_num_layers)
+            )  # logits computation
         )
         return flops_fwd * 3
 
@@ -532,8 +616,7 @@ def num_floating_point_operations(args, batch_size):
                     / 2  # causal mask (only half of the mask is non-zero)
                     * 2  # QK^T and (QK^T)V
                     ## out proj
-                    + query_projection_size
-                    * args.hidden_size
+                    + query_projection_size * args.hidden_size
                 )
             )
 
@@ -542,8 +625,8 @@ def num_floating_point_operations(args, batch_size):
             if isinstance(args.linear_attention_freq, int):
                 linear_attention_pattern = [
                     # [1,1,...,1,0,1,1,...,1,0,...]
-                    0 if ((i + 1) % args.linear_attention_freq == 0)
-                    else 1 for i in range(num_layers)
+                    0 if ((i + 1) % args.linear_attention_freq == 0) else 1
+                    for i in range(num_layers)
                 ]
             elif isinstance(args.linear_attention_freq, list):
                 linear_attention_pattern = args.linear_attention_freq
@@ -580,18 +663,13 @@ def num_floating_point_operations(args, batch_size):
                     * fma_expansion_factor
                     * (
                         ## in proj
-                        args.hidden_size
-                        * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
+                        args.hidden_size * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
                         ## conv1d
-                        + args.linear_conv_kernel_dim
-                        * (2 * qk_dim + v_dim)
+                        + args.linear_conv_kernel_dim * (2 * qk_dim + v_dim)
                         ## gated delta rule
-                        + num_v_heads
-                        * (v_head_dim ** 2)
-                        * 4  # KK^T, VK^T, S(a(I-bKK^T)), and SQ
+                        + num_v_heads * (v_head_dim**2) * 4  # KK^T, VK^T, S(a(I-bKK^T)), and SQ
                         ## out proj
-                        + args.hidden_size
-                        * v_dim
+                        + args.hidden_size * v_dim
                     )
                 )
             else:
@@ -619,8 +697,7 @@ def num_floating_point_operations(args, batch_size):
                 * args.hidden_size
                 * (
                     # dense layer (deepseek v2, v3 style)
-                    (args.ffn_hidden_size * ffn_expansion_factor)
-                    * num_dense_layers
+                    (args.ffn_hidden_size * ffn_expansion_factor) * num_dense_layers
                     # routed experts
                     + (
                         (moe_ffn_hidden_size * num_experts_routed_to * ffn_expansion_factor)
@@ -638,8 +715,7 @@ def num_floating_point_operations(args, batch_size):
                     )
                     * num_moe_layers
                     # Shared Experts.
-                    + (shared_expert_ffn_hidden_size * ffn_expansion_factor)
-                    * num_moe_layers
+                    + (shared_expert_ffn_hidden_size * ffn_expansion_factor) * num_moe_layers
                 )
                 # Self Attention
                 + self_attn_term
@@ -669,6 +745,7 @@ def num_floating_point_operations(args, batch_size):
         from operator import itemgetter
 
         from megatron.core.ssm.mamba_hybrid_layer_allocation import Symbols, get_hybrid_layer_counts
+
         num_mamba_layers, num_gdn_layers, num_attn_layers, num_mlp_layers, num_moe_layers = (
             itemgetter(Symbols.MAMBA, Symbols.GDN, Symbols.ATTENTION, Symbols.MLP, Symbols.MOE)(
                 get_hybrid_layer_counts(args.hybrid_layer_pattern)
@@ -699,10 +776,16 @@ def num_floating_point_operations(args, batch_size):
             mlp_expansion=args.ffn_hidden_size / args.hidden_size,
             swiglu=args.swiglu,
             moe_latent_size=args.moe_latent_size,
-            moe_ffn_hidden_size=(args.moe_ffn_hidden_size if args.moe_ffn_hidden_size is not None
-                                 else args.ffn_hidden_size),
-            shared_expert_ffn_hidden_size=(0 if args.moe_shared_expert_intermediate_size is None
-                                           else args.moe_shared_expert_intermediate_size),
+            moe_ffn_hidden_size=(
+                args.moe_ffn_hidden_size
+                if args.moe_ffn_hidden_size is not None
+                else args.ffn_hidden_size
+            ),
+            shared_expert_ffn_hidden_size=(
+                0
+                if args.moe_shared_expert_intermediate_size is None
+                else args.moe_shared_expert_intermediate_size
+            ),
             num_experts_routed_to=args.moe_router_topk,
             gdn_qk_head_dim=args.linear_key_head_dim or 128,
             gdn_v_head_dim=args.linear_value_head_dim or 128,
@@ -756,7 +839,9 @@ def get_start_time_from_progress_log():
                 # save_checkpoint was called directly (without save_checkpoint_and_time),
                 # which writes "Saved async checkpoint" but not "Saving async checkpoint".
                 if latest_num_floating_point_operations_uncommitted is not None:
-                    latest_num_floating_point_operations = latest_num_floating_point_operations_uncommitted
+                    latest_num_floating_point_operations = (
+                        latest_num_floating_point_operations_uncommitted
+                    )
                     latest_num_floating_point_operations_uncommitted = None
             if world_size_in_line != args.world_size:
                 # Re-start search if we see a different world size.
@@ -770,8 +855,10 @@ def get_start_time_from_progress_log():
     assert (
         start_time is not None and start_num_floating_point_operations is not None
     ), "Should have seen at least one 'Starting job' entry with same world_size"
-    print_rank_0(f"megatron.training.get_start_time_from_progress_log: "
-                 f"{start_time=}, {start_num_floating_point_operations=}")
+    print_rank_0(
+        f"megatron.training.get_start_time_from_progress_log: "
+        f"{start_time=}, {start_num_floating_point_operations=}"
+    )
     return datetime.strptime(start_time, '%Y-%m-%d %H:%M:%S'), start_num_floating_point_operations
 
 
@@ -788,6 +875,7 @@ def preprocess_common_state_dict(common_state_dict):
         preprocessed_common_state_dict['args']['use_distributed_optimizer']
         and "optimizer" in preprocessed_common_state_dict
     ):
+
         def reorder_inner_param_groups(optimizer_state_dict):
             # When distributed optimizer loading, source param groups will be reordered,
             # so we reorder the param groups here to prevent warning.
@@ -906,11 +994,9 @@ def pretrain(
     timers = get_timers()
 
     if args.fine_grained_activation_offloading:
-        from megatron.core.pipeline_parallel.utils import (
-            set_ideal_affinity_for_current_gpu
-        )
-        set_ideal_affinity_for_current_gpu()
+        from megatron.core.pipeline_parallel.utils import set_ideal_affinity_for_current_gpu
 
+        set_ideal_affinity_for_current_gpu()
 
     if args.log_progress:
         append_to_progress_log("Starting job")
@@ -930,7 +1016,9 @@ def pretrain(
     # Initialize program_start_global with a fallback value in case set_startup_timestamps() wasn't called
     program_start_global = _TRAIN_START_TIME
     if _STARTUP_TIMESTAMPS['program_start'] is not None:
-        program_start_global = torch.tensor([_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda')
+        program_start_global = torch.tensor(
+            [_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda'
+        )
         torch.distributed.all_reduce(program_start_global, op=torch.distributed.ReduceOp.MIN)
         program_start_global = program_start_global.item()
     set_startup_timestamps(program_start=program_start_global)
@@ -950,26 +1038,41 @@ def pretrain(
     # Print basic megatron init time (using global min start)
     # NOTE(asolergi-nv): This is not entirely accurate, but we keep it for backwards compatibility.
     print_rank_0(
-        'time to initialize megatron (seconds): {:.3f}'.format(megatron_init_end - _LEGACY_TRAIN_START_TIME)
+        'time to initialize megatron (seconds): {:.3f}'.format(
+            megatron_init_end - _LEGACY_TRAIN_START_TIME
+        )
     )
 
     # Note, not entirely accurate as rank 0 might not be the first or last to hit these timestamps
-    print_datetime('after in-process setup and before initialize_megatron', timestamp_after_inprocess_setup)
-    print_datetime('after in-job setup and before initialize_megatron', timestamp_after_in_job_setup)
+    print_datetime(
+        'after in-process setup and before initialize_megatron', timestamp_after_inprocess_setup
+    )
+    print_datetime(
+        'after in-job setup and before initialize_megatron', timestamp_after_in_job_setup
+    )
 
     if program_start is not None and main_entry is not None and pretrain_entry is not None:
         # Inject startup deltas into timers
         startup_timers = {
-            'startup-program-entry-spread': program_start - program_start_global, # Local program start timestamp vs the global earliest program start timestamp
-            'startup-library-setup': main_entry - program_start, # Local library imports
-            'startup-program-setup': pretrain_entry - main_entry, # Local __main__ entry to pretrain entry
-            'startup-in-process-setup': timestamp_after_inprocess_setup - pretrain_entry, # Local in-process setup
-            'startup-in-job-setup': timestamp_after_in_job_setup - timestamp_after_inprocess_setup, # Local in-job setup
-            'startup-initialize-megatron': timestamp_after_initialize_megatron - timestamp_after_in_job_setup, # Local initialize megatron
-            'startup-set-jit-fusion-options': timestamp_after_set_jit_fusion_options - timestamp_after_initialize_megatron, # Local set JIT fusion options
-            'all-reduce-start-timestamps-tensor': megatron_init_end - timestamp_after_set_jit_fusion_options, # 2x All-reduce, first collective call
-            'startup-megatron-init-local': megatron_init_end - pretrain_entry, # Local megatron init
-            'startup-megatron-init-global': megatron_init_end - program_start_global, # Local megatron init vs the global earliest program start timestamp
+            'startup-program-entry-spread': program_start
+            - program_start_global,  # Local program start timestamp vs the global earliest program start timestamp
+            'startup-library-setup': main_entry - program_start,  # Local library imports
+            'startup-program-setup': pretrain_entry
+            - main_entry,  # Local __main__ entry to pretrain entry
+            'startup-in-process-setup': timestamp_after_inprocess_setup
+            - pretrain_entry,  # Local in-process setup
+            'startup-in-job-setup': timestamp_after_in_job_setup
+            - timestamp_after_inprocess_setup,  # Local in-job setup
+            'startup-initialize-megatron': timestamp_after_initialize_megatron
+            - timestamp_after_in_job_setup,  # Local initialize megatron
+            'startup-set-jit-fusion-options': timestamp_after_set_jit_fusion_options
+            - timestamp_after_initialize_megatron,  # Local set JIT fusion options
+            'all-reduce-start-timestamps-tensor': megatron_init_end
+            - timestamp_after_set_jit_fusion_options,  # 2x All-reduce, first collective call
+            'startup-megatron-init-local': megatron_init_end
+            - pretrain_entry,  # Local megatron init
+            'startup-megatron-init-global': megatron_init_end
+            - program_start_global,  # Local megatron init vs the global earliest program start timestamp
         }
         for name, delta in startup_timers.items():
             timers(name, log_level=0).set_elapsed(delta)
@@ -1065,7 +1168,9 @@ def pretrain(
             # Build an isolated inference config so training config remains unchanged
             inference_config = copy.deepcopy(config)
             if args.rl_inference_tensor_model_parallel_size is not None:
-                inference_config.tensor_model_parallel_size = args.rl_inference_tensor_model_parallel_size
+                inference_config.tensor_model_parallel_size = (
+                    args.rl_inference_tensor_model_parallel_size
+                )
             if args.rl_inference_pipeline_model_parallel_size is not None:
                 inference_config.pipeline_model_parallel_size = (
                     args.rl_inference_pipeline_model_parallel_size
@@ -1129,11 +1234,15 @@ def pretrain(
         valid_data_iterator = []
         test_data_iterator = []
         for vp_stage in range(len(model)):
-            dataset_provider_parameters = inspect.signature(train_valid_test_dataset_provider).parameters
-            assert "vp_stage" in dataset_provider_parameters, \
-                "vp_stage must be a kwarg in train_valid_test_dataset_provider when using virtual pipeline parallelism"
-            vp_stage_train_valid_test_dataset_provider = \
-                functools.partial(train_valid_test_dataset_provider, vp_stage=vp_stage)
+            dataset_provider_parameters = inspect.signature(
+                train_valid_test_dataset_provider
+            ).parameters
+            assert (
+                "vp_stage" in dataset_provider_parameters
+            ), "vp_stage must be a kwarg in train_valid_test_dataset_provider when using virtual pipeline parallelism"
+            vp_stage_train_valid_test_dataset_provider = functools.partial(
+                train_valid_test_dataset_provider, vp_stage=vp_stage
+            )
             if getattr(train_valid_test_dataset_provider, 'is_distributed', False):
                 vp_stage_train_valid_test_dataset_provider.is_distributed = True
             iterators = build_train_valid_test_data_iterators(
@@ -1197,7 +1306,12 @@ def pretrain(
 
         print_datetime('after training is done')
 
-        if not args.skip_train and args.save and iteration != 0 and iteration % args.save_interval != 0:
+        if (
+            not args.skip_train
+            and args.save
+            and iteration != 0
+            and iteration % args.save_interval != 0
+        ):
             save_checkpoint(
                 iteration,
                 model,
@@ -1241,11 +1355,16 @@ def pretrain(
             )
         else:
             evaluate_and_print_results(
-                prefix, forward_step_func,
-                valid_data_iterator, model,
-                iteration, process_non_loss_data_func, config,
-                verbose=True, write_to_tensorboard=not args.skip_train,
-                non_loss_data_func=non_loss_data_func
+                prefix,
+                forward_step_func,
+                valid_data_iterator,
+                model,
+                iteration,
+                process_non_loss_data_func,
+                config,
+                verbose=True,
+                write_to_tensorboard=not args.skip_train,
+                non_loss_data_func=non_loss_data_func,
             )
 
     if args.do_test:
@@ -1315,7 +1434,13 @@ def update_train_iters(args):
     print_rank_0(f'setting training iterations to {args.train_iters}')
 
 
-def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap_with_ddp=True, config=None, pg_collection=None):
+def get_model(
+    model_provider_func,
+    model_type=ModelType.encoder_or_decoder,
+    wrap_with_ddp=True,
+    config=None,
+    pg_collection=None,
+):
     """Build the model."""
     args = get_args()
     args.model_type = model_type
@@ -1323,10 +1448,13 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         if args.create_all_gather_group:
-            timeout = timedelta(minutes=args.distributed_timeout_minutes) if args.distributed_timeout_minutes else None
+            timeout = (
+                timedelta(minutes=args.distributed_timeout_minutes)
+                if args.distributed_timeout_minutes
+                else None
+            )
             dp_cp_ag, expt_dp_ag = create_all_gather_groups(
-                for_expert_parallelism=(args.expert_model_parallel_size > 1),
-                timeout=timeout,
+                for_expert_parallelism=(args.expert_model_parallel_size > 1), timeout=timeout
             )
             pg_collection.dp_cp_ag = dp_cp_ag
             pg_collection.expt_dp_ag = expt_dp_ag
@@ -1337,6 +1465,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
     if has_nvidia_modelopt:
         from megatron.post_training.checkpointing import has_modelopt_state
+
         # [ModelOpt]: Check if the checkpoint is a ModelOpt checkpoint and
         # set a flag to use our model provider if so.
         if args.load is not None and has_modelopt_state(args.load):
@@ -1384,7 +1513,6 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             model.model_type = model_type
         return model
 
-
     if args.init_model_with_meta_device:
         with torch.device('meta'):
             model = build_model()
@@ -1410,9 +1538,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         print(
             ' > number of parameters on (tensor, pipeline) '
             'model parallel rank ({}, {}): {}'.format(
-                get_pg_rank(pg_collection.tp),
-                get_pg_rank(pg_collection.pp),
-                num_parameters,
+                get_pg_rank(pg_collection.tp), get_pg_rank(pg_collection.pp), num_parameters
             ),
             flush=True,
         )
@@ -1434,7 +1560,10 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
     # Materialize tensors on meta device (GPU allocation) if not using FSDP2 and not using Megatron FSDP.
     if args.init_model_with_meta_device and not args.use_torch_fsdp2 and not args.use_megatron_fsdp:
-        model = [to_empty_if_meta_device(model_module, device=torch.device("cuda")) for model_module in model]
+        model = [
+            to_empty_if_meta_device(model_module, device=torch.device("cuda"))
+            for model_module in model
+        ]
 
     # Before TE2.x: The model_module.bfloat16()/model_module.half() above will call the inplace
     #               copy of TE's Float8Tensor, which will write an unwanted value (amax calculated
@@ -1456,7 +1585,9 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
         if getattr(args, "use_torch_fsdp2", False):
             reshard_after_forward = getattr(args, "torch_fsdp2_reshard_after_forward", True)
-            ddp_config = TorchFullyShardedDataParallelConfig(reshard_after_forward=reshard_after_forward)
+            ddp_config = TorchFullyShardedDataParallelConfig(
+                reshard_after_forward=reshard_after_forward
+            )
         else:
             kwargs = {}
             for f in dataclasses.fields(DistributedDataParallelConfig):
@@ -1466,17 +1597,20 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             kwargs['check_for_nan_in_grad'] = args.check_for_nan_in_loss_and_grad
             kwargs['check_for_large_grads'] = args.check_for_large_grads
             if args.ddp_num_buckets is not None:
-                assert args.ddp_bucket_size is None, \
-                    "Cannot specify both --ddp-num-buckets and --ddp-bucket-size"
-                assert args.ddp_num_buckets > 0, \
-                    "--ddp-num-buckets must be greater than 0"
+                assert (
+                    args.ddp_bucket_size is None
+                ), "Cannot specify both --ddp-num-buckets and --ddp-bucket-size"
+                assert args.ddp_num_buckets > 0, "--ddp-num-buckets must be greater than 0"
                 kwargs['bucket_size'] = num_parameters // args.ddp_num_buckets
             else:
                 kwargs['bucket_size'] = args.ddp_bucket_size
             kwargs['pad_buckets_for_high_nccl_busbw'] = args.ddp_pad_buckets_for_high_nccl_busbw
-            kwargs['reduce_scatter_with_fp32_accumulation'] = args.ddp_reduce_scatter_with_fp32_accumulation
-            kwargs['param_name_patterns_for_fp32_local_accumulation'] = \
-                tuple(args.ddp_param_name_patterns_for_fp32_local_accumulation)
+            kwargs['reduce_scatter_with_fp32_accumulation'] = (
+                args.ddp_reduce_scatter_with_fp32_accumulation
+            )
+            kwargs['param_name_patterns_for_fp32_local_accumulation'] = tuple(
+                args.ddp_param_name_patterns_for_fp32_local_accumulation
+            )
             kwargs['average_in_collective'] = args.ddp_average_in_collective
             # Megatron-FSDP arguments.
             kwargs['megatron_fsdp_main_params_dtype'] = args.megatron_fsdp_main_params_dtype
@@ -1518,7 +1652,8 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
                     module=model_chunk,
                     # Turn off bucketing for model_chunk 2 onwards, since communication
                     # for these model chunks is overlapped with compute anyway.
-                    disable_bucketing=(model_chunk_idx > 0) or args.overlap_param_gather_with_optimizer_step,
+                    disable_bucketing=(model_chunk_idx > 0)
+                    or args.overlap_param_gather_with_optimizer_step,
                     **dp_init_kwargs,
                 )
                 for (model_chunk_idx, model_chunk) in enumerate(model)
@@ -1607,11 +1742,7 @@ def get_megatron_optimizer_config(args: Any) -> OptimizerConfig:
     return config, config_overrides
 
 
-def setup_model_and_optimizer(
-    model_provider_func,
-    model_type,
-    checkpointing_context=None,
-):
+def setup_model_and_optimizer(model_provider_func, model_type, checkpointing_context=None):
     """Setup model and optimizer."""
     args = get_args()
     timers = get_timers()
@@ -1625,7 +1756,9 @@ def setup_model_and_optimizer(
     model = get_model(model_provider_func, model_type, wrap_with_ddp=wrap_with_ddp)
     unwrapped_model = unwrap_model(model)
 
-    one_logger and one_logger.log_metrics({"app_build_optimzer_start_time": one_logger_utils.get_timestamp_in_ms()})
+    one_logger and one_logger.log_metrics(
+        {"app_build_optimzer_start_time": one_logger_utils.get_timestamp_in_ms()}
+    )
     if skip_optimizer:
         optimizer, opt_param_scheduler = None, None
         # In RL inference-only mode, train_iters must still be set despite having no optimizer.
@@ -1656,7 +1789,9 @@ def setup_model_and_optimizer(
         )
         opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
 
-    one_logger and one_logger.log_metrics({"app_build_optimzer_finish_time": one_logger_utils.get_timestamp_in_ms()})
+    one_logger and one_logger.log_metrics(
+        {"app_build_optimzer_finish_time": one_logger_utils.get_timestamp_in_ms()}
+    )
 
     if args.moe_use_upcycling:
         torch.distributed.barrier()
@@ -1779,16 +1914,27 @@ def dummy_train_step(data_iterator):
             batch = get_batch_on_this_cp_rank(batch)
 
 
-def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_scheduler, config, forward_backward_func, iteration=None):
+def train_step(
+    forward_step_func,
+    data_iterator,
+    model,
+    optimizer,
+    opt_param_scheduler,
+    config,
+    forward_backward_func,
+    iteration=None,
+):
     """Single training step."""
     args = get_args()
     timers = get_timers()
 
     rerun_state_machine = get_rerun_state_machine()
-    save_dgrads_in_this_iteration = (args.save_dgrads_interval is not None and
-                                     (iteration + 1) % args.save_dgrads_interval == 0)
-    save_wgrads_in_this_iteration = (args.save_wgrads_interval is not None and
-                                     (iteration + 1) % args.save_wgrads_interval == 0)
+    save_dgrads_in_this_iteration = (
+        args.save_dgrads_interval is not None and (iteration + 1) % args.save_dgrads_interval == 0
+    )
+    save_wgrads_in_this_iteration = (
+        args.save_wgrads_interval is not None and (iteration + 1) % args.save_wgrads_interval == 0
+    )
     while rerun_state_machine.should_run_forward_backward(data_iterator):
         # Set grad to zero.
         for model_chunk in model:
@@ -1828,6 +1974,19 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
         # Forward pass.
         if save_dgrads_in_this_iteration:
             enable_dgrad_logging(model, args.save)
+
+        # Rollout Routing Replay (R3): inject rollout-phase routing indices before the
+        # forward+backward pass so the router replays inference expert-selection instead
+        # of recomputing top-k.  This reduces training-inference KL divergence and
+        # prevents RL training collapse for MoE models.
+        _r3_active = (
+            getattr(args, 'moe_enable_routing_replay', False)
+            and routing_indices is not None
+            and len(RouterReplay.global_router_replay_instances) > 0
+        )
+        if _r3_active:
+            RouterReplay.set_rollout_routing_data(routing_indices, activate_replay=True)
+
         losses_reduced = forward_backward_func(
             forward_step_func=forward_step_func,
             data_iterator=data_iterator,
@@ -1840,6 +1999,13 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
             adjust_tensor_shapes_fn=adjust_tensor_shapes_fn,
             force_all_reduce=save_wgrads_in_this_iteration,
         )
+
+        if _r3_active:
+            # Clear routing replay state after the step so normal training steps
+            # (without R3) are not affected.
+            RouterReplay.clear_global_indices()
+            RouterReplay.clear_global_router_replay_action()
+
         if save_dgrads_in_this_iteration:
             save_dgrads(iteration + 1)
             disable_dgrad_logging()
@@ -1926,8 +2092,7 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
                 # over the total number of tokens across the global batch.
                 val = torch.vstack(val).sum(dim=0)
                 torch.distributed.all_reduce(
-                    val,
-                    group=mpu.get_data_parallel_group(with_context_parallel=True)
+                    val, group=mpu.get_data_parallel_group(with_context_parallel=True)
                 )
                 loss_reduced[key] = val[0] / val[1]
             elif val[0].numel() == 1:
@@ -1946,7 +2111,16 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
             num_zeros_in_grad,
             log_max_attention_logit,
         )
-    return {}, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad, log_max_attention_logit
+    return (
+        {},
+        skipped_iter,
+        should_checkpoint,
+        should_exit,
+        exit_code,
+        grad_norm,
+        num_zeros_in_grad,
+        log_max_attention_logit,
+    )
 
 
 def training_log(
@@ -2004,35 +2178,39 @@ def training_log(
     # Logging.
     timers_to_log = []
     if args.timing_log_level >= 1:
-        timers_to_log.extend([
-            'forward-backward',
-            'layernorm-grads-all-reduce',
-            'embedding-grads-all-reduce',
-            'all-grads-sync',
-            'params-all-gather',
-            'optimizer-copy-to-main-grad',
-            'optimizer-unscale-and-check-inf',
-            'optimizer-clip-main-grad',
-            'optimizer-count-zeros',
-            'optimizer-inner-step',
-            'optimizer-copy-main-to-model-params',
-            'optimizer',
-        ])
+        timers_to_log.extend(
+            [
+                'forward-backward',
+                'layernorm-grads-all-reduce',
+                'embedding-grads-all-reduce',
+                'all-grads-sync',
+                'params-all-gather',
+                'optimizer-copy-to-main-grad',
+                'optimizer-unscale-and-check-inf',
+                'optimizer-clip-main-grad',
+                'optimizer-count-zeros',
+                'optimizer-inner-step',
+                'optimizer-copy-main-to-model-params',
+                'optimizer',
+            ]
+        )
     if args.timing_log_level >= 2:
-        timers_to_log.extend([
-            'batch-generator',
-            'forward-compute',
-            'backward-compute',
-            'forward-recv',
-            'forward-send',
-            'backward-recv',
-            'backward-send',
-            'forward-send-forward-recv',
-            'forward-send-backward-recv',
-            'backward-send-forward-recv',
-            'backward-send-backward-recv',
-            'forward-backward-send-forward-backward-recv',
-        ])
+        timers_to_log.extend(
+            [
+                'batch-generator',
+                'forward-compute',
+                'backward-compute',
+                'forward-recv',
+                'forward-send',
+                'backward-recv',
+                'backward-send',
+                'forward-send-forward-recv',
+                'forward-send-backward-recv',
+                'backward-send-forward-recv',
+                'backward-send-backward-recv',
+                'forward-backward-send-forward-backward-recv',
+            ]
+        )
     # Add timers from RL loop if needed.
     if getattr(args, 'perform_rl_step', False):
         timers_to_log.extend(RL_LOGGABLE_TIMER_NAMES)
@@ -2053,7 +2231,9 @@ def training_log(
             wandb_writer.log({'samples vs steps': args.consumed_train_samples}, iteration)
         if learning_rate is not None:
             writer.add_scalar('learning-rate', learning_rate, iteration)
-            writer.add_scalar('learning-rate vs samples', learning_rate, args.consumed_train_samples)
+            writer.add_scalar(
+                'learning-rate vs samples', learning_rate, args.consumed_train_samples
+            )
             if wandb_writer:
                 wandb_writer.log({'learning-rate': learning_rate}, iteration)
         if args.skipped_train_samples > 0:
@@ -2104,10 +2284,14 @@ def training_log(
             if wandb_writer:
                 wandb_writer.log({'params-norm': params_norm}, iteration)
         if args.perform_rl_step:
-            grpo_collection_iteration = iteration // (args.grpo_iterations * ( ( args.grpo_samples_per_iteration )// args.global_batch_size ))
+            grpo_collection_iteration = iteration // (
+                args.grpo_iterations * ((args.grpo_samples_per_iteration) // args.global_batch_size)
+            )
             writer.add_scalar('grpo_collection_iteration', grpo_collection_iteration, iteration)
             if wandb_writer:
-                wandb_writer.log({'grpo_collection_iteration': grpo_collection_iteration}, iteration)
+                wandb_writer.log(
+                    {'grpo_collection_iteration': grpo_collection_iteration}, iteration
+                )
         if args.log_memory_to_tensorboard:
             mem_stats = torch.cuda.memory_stats()
             writer.add_scalar(
@@ -2142,8 +2326,10 @@ def training_log(
             from operator import itemgetter
 
             from megatron.core.ssm.mamba_hybrid_layer_allocation import (
-                Symbols, get_hybrid_layer_counts,
+                Symbols,
+                get_hybrid_layer_counts,
             )
+
             layers = itemgetter(Symbols.MOE)(get_hybrid_layer_counts(args.hybrid_layer_pattern))
         else:
             layers = args.num_layers
@@ -2183,7 +2369,9 @@ def training_log(
 
     # Dump memory snapshot and print metrics to stdout.
     if iteration % args.log_interval == 0 or is_first_iteration:
-        if args.record_memory_history and (is_last_rank() or torch.distributed.get_backend() == 'fake'):
+        if args.record_memory_history and (
+            is_last_rank() or torch.distributed.get_backend() == 'fake'
+        ):
             snapshot = torch.cuda.memory._snapshot()
             from pickle import dump
 
@@ -2276,13 +2464,20 @@ def training_log(
             if iteration > (loaded_iteration + 1):
                 # Make sure the memory after the second iteration is reported to include optimizer state memory.
                 report_memory_flag = False
-        if args.log_memory_interval is not None and iteration % args.log_memory_interval == 0 and \
-            not reported_memory_in_this_iteration:
+        if (
+            args.log_memory_interval is not None
+            and iteration % args.log_memory_interval == 0
+            and not reported_memory_in_this_iteration
+        ):
             report_memory(f'(after {iteration} iterations)')
         # Write timers to wandb, don't reset the counts.
         if args.log_timers_to_tensorboard:
-            timers.write(timers_to_log, writer, iteration, normalizer=args.log_interval, reset=False)
-            timers.write(timers_to_log, wandb_writer, iteration, normalizer=args.log_interval, reset=False)
+            timers.write(
+                timers_to_log, writer, iteration, normalizer=args.log_interval, reset=False
+            )
+            timers.write(
+                timers_to_log, wandb_writer, iteration, normalizer=args.log_interval, reset=False
+            )
         # Log timers to stdout
         timers.log(timers_to_log, normalizer=args.log_interval, reset=should_reset)
 
@@ -2339,9 +2534,11 @@ def force_param_sync(model_chunks: list[DDP]) -> None:
         assert isinstance(model_chunk, DDP)
         model_chunk.start_param_sync(force_sync=True)
 
+
 # Only report memory for first 3 checkpoint saves.
 num_checkpoints_memory_reported = 0
 MAX_NUM_CHECKPOINTS_MEMORY_REPORTED = 3
+
 
 def save_checkpoint_and_time(
     iteration,
@@ -2432,7 +2629,7 @@ def post_training_step_callbacks(
     iteration,
     prof,
     num_floating_point_operations_since_last_log_event,
-    nsys_nvtx_context = None,
+    nsys_nvtx_context=None,
 ):
     """Run all post-training-step functions (e.g., FT heartbeats, GC)."""
     args = get_args()
@@ -2470,8 +2667,7 @@ def post_training_step_callbacks(
     if (
         args.profile
         and iteration == args.profile_step_end
-        and (len(args.profile_ranks) == 0 or
-             torch.distributed.get_rank() in args.profile_ranks)
+        and (len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks)
     ):
         if args.use_pytorch_profiler:
             assert prof is not None
@@ -2580,12 +2776,8 @@ def checkpoint_and_decide_exit(
             return True
 
     # Exit based on iterations.
-    if (
-        args.exit_interval
-        and iteration % args.exit_interval == 0
-    ) or (
-        args.phase_transition_iterations
-        and iteration in args.phase_transition_iterations
+    if (args.exit_interval and iteration % args.exit_interval == 0) or (
+        args.phase_transition_iterations and iteration in args.phase_transition_iterations
     ):
         if args.save and not saved_checkpoint:
             save_checkpoint_and_time(
@@ -2641,29 +2833,31 @@ def train(
             args.load = None
             args.finetune = True
             load_checkpoint(
-                    model,
-                    None,  # Don't load optimizer state
-                    None,  # Don't load scheduler state
-                    checkpointing_context=checkpointing_context,
-                    skip_load_to_model_and_opt=HAVE_FSDP2
-                    and getattr(args, "use_torch_fsdp2", False)
-                    and args.ckpt_format == "torch_dist",
-                )
-            ref_state_dict = {k: (v.cpu() if v is not None else v) for k, v in model[0].state_dict().items()}
+                model,
+                None,  # Don't load optimizer state
+                None,  # Don't load scheduler state
+                checkpointing_context=checkpointing_context,
+                skip_load_to_model_and_opt=HAVE_FSDP2
+                and getattr(args, "use_torch_fsdp2", False)
+                and args.ckpt_format == "torch_dist",
+            )
+            ref_state_dict = {
+                k: (v.cpu() if v is not None else v) for k, v in model[0].state_dict().items()
+            }
 
             # Reload RL training checkpoint weights
             args.load = load
             args.finetune = finetune
             print_rank_0("> Reloading RL training checkpoint...")
             load_checkpoint(
-                    model,
-                    None,
-                    None,
-                    checkpointing_context=checkpointing_context,
-                    skip_load_to_model_and_opt=HAVE_FSDP2
-                    and getattr(args, "use_torch_fsdp2", False)
-                    and args.ckpt_format == "torch_dist",
-                )
+                model,
+                None,
+                None,
+                checkpointing_context=checkpointing_context,
+                skip_load_to_model_and_opt=HAVE_FSDP2
+                and getattr(args, "use_torch_fsdp2", False)
+                and args.ckpt_format == "torch_dist",
+            )
 
             args.no_load_optim = no_load_optim
 
@@ -2672,8 +2866,9 @@ def train(
         print_rank_0("> Reinitializing microbatch calculator for GRPO training...")
         from megatron.core.num_microbatches_calculator import (
             destroy_num_microbatches_calculator,
-            init_num_microbatches_calculator
+            init_num_microbatches_calculator,
         )
+
         # First destroy the existing calculator
         destroy_num_microbatches_calculator()
         # Then initialize with the correct perform_rl_step=True context
@@ -2683,7 +2878,7 @@ def train(
             args.global_batch_size,
             args.micro_batch_size,
             mpu.get_data_parallel_world_size(),
-            args.decrease_batch_size_if_needed
+            args.decrease_batch_size_if_needed,
         )
         print_rank_0(f"> GRPO training: num_microbatches set to {get_num_microbatches()}")
 
@@ -2721,8 +2916,10 @@ def train(
     # Make sure rerun_state_machine has the right iteration loaded from checkpoint.
     rerun_state_machine = get_rerun_state_machine()
     if rerun_state_machine.current_iteration != iteration:
-        print_rank_0(f"Overwriting rerun_state_machine.current_iteration from "
-                     f"{rerun_state_machine.current_iteration} to {iteration}...")
+        print_rank_0(
+            f"Overwriting rerun_state_machine.current_iteration from "
+            f"{rerun_state_machine.current_iteration} to {iteration}..."
+        )
         rerun_state_machine.current_iteration = iteration
 
     # Track E2E metrics at the start of training.
@@ -2803,9 +3000,13 @@ def train(
     # Wrap forward_backward_func for Full iteration CUDA graph
     forward_backward_func = get_forward_backward_func()
     if args.cuda_graph_impl == "local" and CudaGraphScope.full_iteration in args.cuda_graph_scope:
-        forward_backward_func = FullCudaGraphWrapper(forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps)
+        forward_backward_func = FullCudaGraphWrapper(
+            forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps
+        )
     if args.optimizer_cuda_graph:
-        optimizer.step = OptimizerCudaGraphWrapper(optimizer.step, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps)
+        optimizer.step = OptimizerCudaGraphWrapper(
+            optimizer.step, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps
+        )
 
     def get_e2e_base_metrics():
         """Get base metrics values for one-logger to calculate E2E tracking metrics."""
@@ -2830,23 +3031,26 @@ def train(
             one_logger.store_set('get_e2e_base_metrics', get_e2e_base_metrics)
 
     prof = None
-    nsys_nvtx_context = None # reference to context for nsys profiling, so it can be cleaned up
+    nsys_nvtx_context = None  # reference to context for nsys profiling, so it can be cleaned up
     if (
         args.profile
-        and (len(args.profile_ranks) == 0 or
-             torch.distributed.get_rank() in args.profile_ranks)
+        and (len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks)
         and args.use_pytorch_profiler
     ):
         if args.pytorch_profiler_collect_chakra:
             et_dir = Path(f"{args.tensorboard_dir}/../chakra")
             et_dir.mkdir(parents=True, exist_ok=True)
-            et = torch.profiler.ExecutionTraceObserver().register_callback(f"{et_dir}/rank-{torch.distributed.get_rank()}.json.gz")
+            et = torch.profiler.ExecutionTraceObserver().register_callback(
+                f"{et_dir}/rank-{torch.distributed.get_rank()}.json.gz"
+            )
         else:
             et = None
+
         def trace_handler(p):
             profile_dir = Path(f"{args.tensorboard_dir}/../torch_profile")
             profile_dir.mkdir(parents=True, exist_ok=True)
             p.export_chrome_trace(f"{profile_dir}/rank-{torch.distributed.get_rank()}.json.gz")
+
         prof = torch.profiler.profile(
             schedule=torch.profiler.schedule(
                 wait=max(args.profile_step_start - 1, 0),
@@ -2893,9 +3097,9 @@ def train(
     # Run training iterations till done.
     buffered_rollouts = None
     while iteration < args.train_iters:
-        if (args.profile 
-            and (len(args.profile_ranks) == 0 or
-                 torch.distributed.get_rank() in args.profile_ranks)):
+        if args.profile and (
+            len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks
+        ):
             if args.use_pytorch_profiler:
                 prof.step()
             elif iteration == args.profile_step_start:
@@ -2909,7 +3113,10 @@ def train(
         # Update the timeout for all process groups after initialization
         # We update the timeout after the first successful iteration,
         # which takes longer than others usually
-        if args.distributed_timeout_seconds_after_init is not None and iteration == start_iteration+1:
+        if (
+            args.distributed_timeout_seconds_after_init is not None
+            and iteration == start_iteration + 1
+        ):
             # TODO: some dynamic timeout setting is required
             # based on the iteration time considering interval-based steps (e.g. eval, checkpoint)
             # e.g. timeout for normal iterations vs timeout for iterations with checkpoint
@@ -2985,7 +3192,11 @@ def train(
                 torch.cuda.empty_cache()
             with torch.no_grad():
                 train_data_iterator = rl_utils.get_grpo_data_iterator(
-                    model, inference_model, optimizer, iteration, ref_state_dict,
+                    model,
+                    inference_model,
+                    optimizer,
+                    iteration,
+                    ref_state_dict,
                     grpo_iterations=args.grpo_iterations,
                     grpo_prompts_per_step=args.grpo_prompts_per_step,
                     grpo_group_size=args.grpo_group_size,
@@ -3020,7 +3231,14 @@ def train(
                 num_zeros_in_grad,
                 max_attention_logit,
             ) = train_step(
-                forward_step_func, train_data_iterator, model, optimizer, opt_param_scheduler, config, forward_backward_func, iteration=iteration
+                forward_step_func,
+                train_data_iterator,
+                model,
+                optimizer,
+                opt_param_scheduler,
+                config,
+                forward_backward_func,
+                iteration=iteration,
             )
             ft_integration.on_training_step_end()
         if should_checkpoint:
@@ -3069,7 +3287,7 @@ def train(
         if (
             getattr(args, "fsdp_manual_registration", False)
             and getattr(args, "use_megatron_fsdp", False)
-            and iteration ==  start_iteration + 1
+            and iteration == start_iteration + 1
         ):
             for model_chunk in model:
                 if isinstance(model_chunk, megatron_FSDP) and getattr(
@@ -3175,14 +3393,23 @@ def train(
                     training_model=rl_training_model,
                 )
             else:
-                evaluate_and_print_results(prefix, forward_step_func,
-                                       valid_data_iterator, model,
-                                       iteration, process_non_loss_data_func,
-                                       config, verbose=False, write_to_tensorboard=True,
-                                       non_loss_data_func=non_loss_data_func)
+                evaluate_and_print_results(
+                    prefix,
+                    forward_step_func,
+                    valid_data_iterator,
+                    model,
+                    iteration,
+                    process_non_loss_data_func,
+                    config,
+                    verbose=False,
+                    write_to_tensorboard=True,
+                    non_loss_data_func=non_loss_data_func,
+                )
 
             eval_duration += timers('eval-time').elapsed()
-            eval_iterations += sum(args.eval_iters) if isinstance(args.eval_iters, list) else args.eval_iters
+            eval_iterations += (
+                sum(args.eval_iters) if isinstance(args.eval_iters, list) else args.eval_iters
+            )
             timers('eval-time').stop()
             one_logger_utils.track_e2e_metrics()
 
@@ -3306,7 +3533,9 @@ def evaluate(
     eval_num_microbatches = eval_batch_size // (args.micro_batch_size * args.data_parallel_size)
     forward_backward_func = get_forward_backward_func()
     if args.cuda_graph_impl == "local" and CudaGraphScope.full_iteration in args.cuda_graph_scope:
-        forward_backward_func = FullCudaGraphWrapper(forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps)
+        forward_backward_func = FullCudaGraphWrapper(
+            forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps
+        )
 
     if has_nvidia_modelopt:
         # [ModelOpt]: Pipeline-parallel Distillation stacks student and teacher tensors
@@ -3356,7 +3585,9 @@ def evaluate(
                 # Reduce across processes.
                 for key in loss_dicts[0].keys():
                     if key not in total_loss_dict:
-                        total_loss_dict[key] = torch.tensor([0.0, 0.0], dtype=torch.float, device='cuda')
+                        total_loss_dict[key] = torch.tensor(
+                            [0.0, 0.0], dtype=torch.float, device='cuda'
+                        )
                     val = [x[key].view(-1) for x in loss_dicts]
 
                     if val[0].numel() == 2:
@@ -3366,19 +3597,17 @@ def evaluate(
                             val = val[:, 0] / val[:, 1].clamp(min=1)
                             val = val.mean()
                             torch.distributed.all_reduce(
-                                val,
-                                group=mpu.get_data_parallel_group(with_context_parallel=True)
+                                val, group=mpu.get_data_parallel_group(with_context_parallel=True)
                             )
                             val /= torch.distributed.get_world_size(
                                 group=mpu.get_data_parallel_group(with_context_parallel=True)
                             )
                             total_loss_dict[key][0] += val
                             total_loss_dict[key][1] += 1
-                        else :
+                        else:
                             val = torch.vstack(val).sum(dim=0)
                             torch.distributed.all_reduce(
-                                val,
-                                group=mpu.get_data_parallel_group(with_context_parallel=True)
+                                val, group=mpu.get_data_parallel_group(with_context_parallel=True)
                             )
                             total_loss_dict[key] += val
                     elif val[0].numel() == 1:
@@ -3501,7 +3730,9 @@ def evaluate_and_print_results(
             ppl = math.exp(min(20, total_loss_dict[key].item()))
             string += '{} PPL: {:.6E} | '.format(key, ppl)
             if writer:
-                writer.add_scalar('{} validation{}'.format(key, suffix), total_loss_dict[key].item(), iteration)
+                writer.add_scalar(
+                    '{} validation{}'.format(key, suffix), total_loss_dict[key].item(), iteration
+                )
                 writer.add_scalar(
                     '{} validation{} vs samples'.format(key, suffix),
                     total_loss_dict[key].item(),
@@ -3510,11 +3741,14 @@ def evaluate_and_print_results(
                 if args.log_validation_ppl_to_tensorboard:
                     writer.add_scalar('{} validation{} ppl'.format(key, suffix), ppl, iteration)
                     writer.add_scalar(
-                        '{} validation{} ppl vs samples'.format(key, suffix), ppl, args.consumed_train_samples
+                        '{} validation{} ppl vs samples'.format(key, suffix),
+                        ppl,
+                        args.consumed_train_samples,
                     )
                 if wandb_writer and is_last_rank():
                     wandb_writer.log(
-                        {'{} validation{}'.format(key, suffix): total_loss_dict[key].item()}, iteration
+                        {'{} validation{}'.format(key, suffix): total_loss_dict[key].item()},
+                        iteration,
                     )
 
         if process_non_loss_data_func is not None and writer and is_last_rank():
@@ -3555,7 +3789,11 @@ def get_train_valid_test_num_samples():
 
     # Get train_samples in current phase.
     if args.phase_transition_iterations:
-        phase_transition_samples = [0] + [t * args.global_batch_size for t in args.phase_transition_iterations] + [args.train_samples]
+        phase_transition_samples = (
+            [0]
+            + [t * args.global_batch_size for t in args.phase_transition_iterations]
+            + [args.train_samples]
+        )
         current_sample = args.iteration * args.global_batch_size
         last_transition_sample = max(s for s in phase_transition_samples if s <= current_sample)
         next_transition_sample = min(s for s in phase_transition_samples if s > current_sample)
@@ -3566,7 +3804,9 @@ def get_train_valid_test_num_samples():
     return (train_samples_in_current_phase, eval_samples, test_samples)
 
 
-def build_train_valid_test_datasets(build_train_valid_test_datasets_provider, train_valid_test_num_samples=None):
+def build_train_valid_test_datasets(
+    build_train_valid_test_datasets_provider, train_valid_test_num_samples=None
+):
     """Build pretraining datasets."""
     if train_valid_test_num_samples is None:
         train_valid_test_num_samples = get_train_valid_test_num_samples()
@@ -3601,8 +3841,14 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
 
     # Get consumed train samples in this phase.
     if args.phase_transition_iterations:
-        last_transition = max(iteration for iteration in (0, *args.phase_transition_iterations) if iteration <= args.iteration)
-        consumed_train_samples_in_current_phase = (args.iteration - last_transition) * args.global_batch_size
+        last_transition = max(
+            iteration
+            for iteration in (0, *args.phase_transition_iterations)
+            if iteration <= args.iteration
+        )
+        consumed_train_samples_in_current_phase = (
+            args.iteration - last_transition
+        ) * args.global_batch_size
     else:
         consumed_train_samples_in_current_phase = args.consumed_train_samples
 
@@ -3619,17 +3865,21 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
             valid_dataloaders = None
             test_dataloader = None
             do_train = (args.train_iters or 0) > 0
-            do_valid = (args.full_validation or args.eval_iters > 0)
-            do_test = (args.full_validation or args.eval_iters > 0)
+            do_valid = args.full_validation or args.eval_iters > 0
+            do_test = args.full_validation or args.eval_iters > 0
 
         else:
             # Build datasets.
-            train_ds, valid_ds, test_ds = build_train_valid_test_datasets(build_train_valid_test_datasets_provider)
+            train_ds, valid_ds, test_ds = build_train_valid_test_datasets(
+                build_train_valid_test_datasets_provider
+            )
             valid_ds = [valid_ds] if not isinstance(valid_ds, list) else valid_ds
             if args.skip_train:
                 train_dataloader = None
             else:
-                train_dataloader = build_pretraining_data_loader(train_ds, consumed_train_samples_in_current_phase)
+                train_dataloader = build_pretraining_data_loader(
+                    train_ds, consumed_train_samples_in_current_phase
+                )
             valid_dataloaders = []
             for valid_d in valid_ds:
                 if args.skip_train or args.full_validation:
@@ -3638,13 +3888,19 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
                     if args.multiple_validation_sets:
                         # TODO(bnorick): for multiple validation sets without full validation, args.consumed_valid_samples is not
                         # correct and needs to be calculated/set per validation set
-                        raise NotImplementedError("--multiple-validation-sets currently requires --full-validation")
-                    valid_dataloaders.append(build_pretraining_data_loader(valid_d, args.consumed_valid_samples))
+                        raise NotImplementedError(
+                            "--multiple-validation-sets currently requires --full-validation"
+                        )
+                    valid_dataloaders.append(
+                        build_pretraining_data_loader(valid_d, args.consumed_valid_samples)
+                    )
             if not args.multiple_validation_sets:
                 assert len(valid_dataloaders) == 1
             test_dataloader = build_pretraining_data_loader(test_ds, 0)
             do_train = train_dataloader is not None and (args.skip_train or args.train_iters > 0)
-            do_valid = valid_dataloaders is not None and (args.full_validation or args.eval_iters > 0)
+            do_valid = valid_dataloaders is not None and (
+                args.full_validation or args.eval_iters > 0
+            )
             do_test = test_dataloader is not None and (args.full_validation or args.eval_iters > 0)
 
         flags = torch.tensor(
@@ -3702,7 +3958,7 @@ def build_train_valid_test_data_iterators(build_train_valid_test_datasets_provid
         if args.full_validation:
             if args.multiple_validation_sets:
                 if valid_dataloaders[0] is None:
-                    args.eval_iters = [None]*len(valid_dataloaders)
+                    args.eval_iters = [None] * len(valid_dataloaders)
                 else:
                     args.eval_iters = [len(dl) for dl in valid_dataloaders]
             else:

--- a/tests/unit_tests/transformer/moe/test_router_replay.py
+++ b/tests/unit_tests/transformer/moe/test_router_replay.py
@@ -93,3 +93,274 @@ def test_set_replay_data_length_mismatch():
         RouterReplay.set_replay_data(
             [torch.tensor([[0, 1]], dtype=torch.long), torch.tensor([[1, 0]], dtype=torch.long)]
         )
+
+
+def test_set_rollout_routing_data_activates_replay_forward():
+    """set_rollout_routing_data with activate_replay=True should set REPLAY_FORWARD on all layers."""
+    r1 = RouterReplay()
+    r2 = RouterReplay()
+    t1 = torch.tensor([[0, 1], [2, 3]], dtype=torch.long)
+    t2 = torch.tensor([[1, 2], [0, 3]], dtype=torch.long)
+
+    RouterReplay.set_rollout_routing_data([t1, t2])
+
+    assert torch.equal(r1.target_topk_idx, t1)
+    assert torch.equal(r2.target_topk_idx, t2)
+    assert r1.router_replay_action == RouterReplayAction.REPLAY_FORWARD
+    assert r2.router_replay_action == RouterReplayAction.REPLAY_FORWARD
+
+
+def test_set_rollout_routing_data_no_activate():
+    """set_rollout_routing_data with activate_replay=False should only set indices, not action."""
+    r1 = RouterReplay()
+    t1 = torch.tensor([[0, 1]], dtype=torch.long)
+
+    RouterReplay.set_rollout_routing_data([t1], activate_replay=False)
+
+    assert torch.equal(r1.target_topk_idx, t1)
+    assert r1.router_replay_action is None  # action should NOT be set
+
+
+def test_set_rollout_routing_data_end_to_end():
+    """Full R3 training-side workflow: inject rollout indices then run routing with replay."""
+    num_tokens, num_experts, topk = 4, 8, 2
+
+    # Simulate two MoE layers
+    r1 = RouterReplay()
+    r2 = RouterReplay()
+
+    # Rollout indices captured during inference (e.g., from SGLang/vLLM)
+    rollout_idx_l1 = torch.tensor([[0, 3], [1, 5], [2, 7], [4, 6]], dtype=torch.long)
+    rollout_idx_l2 = torch.tensor([[1, 4], [0, 6], [3, 7], [2, 5]], dtype=torch.long)
+
+    # Inject into training via the public API
+    RouterReplay.set_rollout_routing_data([rollout_idx_l1, rollout_idx_l2])
+
+    # Simulate training forward pass for layer 1
+    logits_l1 = torch.randn(num_tokens, num_experts)
+    probs_l1, routing_map_l1 = topk_routing_with_score_function(
+        logits=logits_l1,
+        topk=topk,
+        use_pre_softmax=False,
+        router_replay=r1,
+        score_function="softmax",
+    )
+    # Expert selection must exactly match rollout indices
+    replayed_idx_l1 = routing_map_l1.nonzero(as_tuple=False)[:, 1].view(num_tokens, topk)
+    assert torch.equal(replayed_idx_l1.sort(dim=1).values, rollout_idx_l1.sort(dim=1).values)
+    # Router logits gradient is preserved (probs are non-zero)
+    assert (probs_l1 > 0).any()
+
+    # Simulate training forward pass for layer 2
+    logits_l2 = torch.randn(num_tokens, num_experts)
+    probs_l2, routing_map_l2 = topk_routing_with_score_function(
+        logits=logits_l2,
+        topk=topk,
+        use_pre_softmax=False,
+        router_replay=r2,
+        score_function="softmax",
+    )
+    replayed_idx_l2 = routing_map_l2.nonzero(as_tuple=False)[:, 1].view(num_tokens, topk)
+    assert torch.equal(replayed_idx_l2.sort(dim=1).values, rollout_idx_l2.sort(dim=1).values)
+
+    # Clean up (as a training framework would do after the step)
+    RouterReplay.clear_global_indices()
+    RouterReplay.clear_global_router_replay_action()
+
+    assert r1.target_topk_idx is None
+    assert r2.target_topk_idx is None
+    assert r1.router_replay_action is None
+    assert r2.router_replay_action is None
+
+
+def test_set_rollout_routing_data_length_mismatch():
+    """set_rollout_routing_data with wrong number of layers should raise ValueError."""
+    _ = RouterReplay()
+    with pytest.raises(ValueError):
+        RouterReplay.set_rollout_routing_data(
+            [torch.tensor([[0, 1]], dtype=torch.long), torch.tensor([[1, 0]], dtype=torch.long)]
+        )
+
+
+def test_rollout_replay_preserves_gradient_path():
+    """Gradient from the replayed gating probs must flow back through the router logits.
+
+    With post-softmax scoring and dense_output=True, the computation graph is:
+      probs = softmax(logits.gather(1, rollout_idx))
+    so d(loss)/d(logits) is non-zero at the replayed expert columns.
+    """
+    num_tokens, num_experts, topk = 3, 6, 2
+
+    rr = RouterReplay()
+    rollout_idx = torch.tensor([[0, 2], [1, 4], [3, 5]], dtype=torch.long)
+    RouterReplay.set_rollout_routing_data([rollout_idx])
+
+    logits = torch.randn(num_tokens, num_experts, requires_grad=True)
+
+    # Use dense_output=True so probs is [N, topk] and directly connected to
+    # logits via gather+softmax (no scatter intermediary).
+    probs, top_indices = topk_routing_with_score_function(
+        logits=logits,
+        topk=topk,
+        use_pre_softmax=False,
+        router_replay=rr,
+        score_function="softmax",
+        dense_output=True,
+    )
+
+    # Verify that probs is a function of logits by checking require_grad
+    assert probs.requires_grad, "probs tensor must require grad (must be on the autograd graph)"
+
+    # The probs should equal softmax(logits gathered at rollout_idx)
+    expected_probs = torch.softmax(logits.detach().gather(1, rollout_idx).float(), dim=-1).to(
+        logits.dtype
+    )
+    assert torch.allclose(
+        probs.detach(), expected_probs, atol=1e-5
+    ), "Replayed probs do not match softmax(logits.gather(rollout_idx))"
+
+    # top_indices must match rollout indices
+    assert torch.equal(top_indices, rollout_idx), "top_indices must equal rollout_idx"
+
+    # Clean up
+    RouterReplay.clear_global_indices()
+    RouterReplay.clear_global_router_replay_action()
+
+
+# ---------------------------------------------------------------------------
+# REPLAY_BACKWARD: activation recompute during backward pass
+# ---------------------------------------------------------------------------
+
+
+def test_replay_backward_pops_in_order():
+    """REPLAY_BACKWARD should pop indices from replay_backward_list in FIFO order."""
+    rr = RouterReplay()
+    idx_fwd = torch.tensor([[0, 1], [2, 3]], dtype=torch.long)
+    idx_bwd = torch.tensor([[1, 2], [0, 3]], dtype=torch.long)
+
+    # set_target_indices appends to replay_backward_list
+    rr.set_target_indices(idx_fwd)
+    rr.set_target_indices(idx_bwd)
+
+    logits = torch.randn(2, 6)
+    rr.set_router_replay_action(RouterReplayAction.REPLAY_BACKWARD)
+
+    probs1, top1 = topk_routing_with_score_function(
+        logits=logits,
+        topk=2,
+        use_pre_softmax=False,
+        router_replay=rr,
+        score_function="softmax",
+        dense_output=True,
+    )
+    assert torch.equal(top1, idx_fwd), "First REPLAY_BACKWARD call should use idx_fwd"
+
+    probs2, top2 = topk_routing_with_score_function(
+        logits=logits,
+        topk=2,
+        use_pre_softmax=False,
+        router_replay=rr,
+        score_function="softmax",
+        dense_output=True,
+    )
+    assert torch.equal(top2, idx_bwd), "Second REPLAY_BACKWARD call should use idx_bwd"
+
+
+def test_replay_backward_list_cleared_by_clear_indices():
+    """clear_indices must also clear replay_backward_list."""
+    rr = RouterReplay()
+    rr.set_target_indices(torch.tensor([[0, 1]], dtype=torch.long))
+    assert len(rr.replay_backward_list) == 1
+    rr.clear_indices()
+    assert len(rr.replay_backward_list) == 0
+
+
+# ---------------------------------------------------------------------------
+# Sigmoid score function with replay
+# ---------------------------------------------------------------------------
+
+
+def test_replay_forward_sigmoid_score_function():
+    """REPLAY_FORWARD should work correctly with sigmoid score function."""
+    rr = RouterReplay()
+    rr.set_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+    logits = torch.randn(4, 8)
+    rollout_idx = torch.tensor([[0, 3], [1, 5], [2, 7], [4, 6]], dtype=torch.long)
+    rr.set_target_indices(rollout_idx)
+
+    probs, top_indices = topk_routing_with_score_function(
+        logits=logits,
+        topk=2,
+        use_pre_softmax=False,
+        router_replay=rr,
+        score_function="sigmoid",
+        dense_output=True,
+    )
+    assert torch.equal(top_indices, rollout_idx), "top_indices must match rollout indices"
+    # sigmoid path: scores = sigmoid(logits), then gather, then normalize
+    sig_scores = torch.sigmoid(logits.float()).to(logits.dtype).gather(1, rollout_idx)
+    expected_probs = sig_scores / (sig_scores.sum(dim=-1, keepdim=True) + 1e-20)
+    assert torch.allclose(probs, expected_probs, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# static_buffer: CUDA-graph-compatible recording
+# ---------------------------------------------------------------------------
+
+
+def test_static_buffer_recording():
+    """When a static_buffer is set, record_indices copies into it instead of storing a reference."""
+    rr = RouterReplay()
+    max_tokens, topk = 10, 2
+    static_buf = torch.zeros(max_tokens, topk, dtype=torch.long)
+    rr.set_static_buffer(static_buf)
+
+    rr.set_router_replay_action(RouterReplayAction.RECORD)
+    logits = torch.randn(4, 6)
+    _, _ = topk_routing_with_score_function(
+        logits=logits, topk=topk, use_pre_softmax=False, router_replay=rr, score_function="softmax"
+    )
+
+    recorded = rr.get_recorded_indices()
+    expected_idx = torch.topk(logits, k=topk, dim=1).indices
+    # The slice [0:4] of the static buffer should contain the recorded indices
+    assert torch.equal(recorded, expected_idx)
+    assert torch.equal(static_buf[:4], expected_idx)
+
+    rr.clear_static_buffer()
+    assert rr.static_buffer is None
+
+
+def test_set_global_static_buffers_distributes_correctly():
+    """set_global_static_buffers must distribute per-layer slices correctly."""
+    r1 = RouterReplay()
+    r2 = RouterReplay()
+    max_tokens, topk, num_layers = 8, 2, 2
+    combined = torch.zeros(max_tokens, num_layers, topk, dtype=torch.long)
+
+    RouterReplay.set_global_static_buffers(combined)
+
+    # Each instance should hold a [max_tokens, topk] view
+    assert r1.static_buffer is not None and r1.static_buffer.shape == (max_tokens, topk)
+    assert r2.static_buffer is not None and r2.static_buffer.shape == (max_tokens, topk)
+
+    # They should be views into the combined buffer, not copies
+    r1.static_buffer[0, 0] = 99
+    assert combined[0, 0, 0] == 99
+
+    RouterReplay.clear_global_static_buffers()
+    assert r1.static_buffer is None and r2.static_buffer is None
+
+
+# ---------------------------------------------------------------------------
+# clear_global_router_replay_instances
+# ---------------------------------------------------------------------------
+
+
+def test_clear_global_router_replay_instances():
+    """clear_global_router_replay_instances must empty the global list."""
+    _ = RouterReplay()
+    _ = RouterReplay()
+    assert len(RouterReplay.global_router_replay_instances) == 2
+    RouterReplay.clear_global_router_replay_instances()
+    assert len(RouterReplay.global_router_replay_instances) == 0

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -563,3 +563,165 @@ def test_router_gating_linear_bias(router_dtype):
     assert torch.allclose(inp.grad, ref_inp.grad, **tols)
     assert torch.allclose(weight.grad, ref_weight.grad, **tols)
     assert torch.allclose(bias.grad, ref_bias.grad, **tols)
+
+
+# ---------------------------------------------------------------------------
+# Rollout Routing Replay (R3) integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRouterReplayIntegration:
+    """Integration tests for R3 using a real MoELayer with CUDA.
+
+    These tests verify the full replay workflow end-to-end:
+      1. RECORD mode captures routing indices from a forward pass.
+      2. REPLAY_FORWARD mode forces the same indices on a subsequent forward pass.
+      3. Router weight gradients still exist after a replayed forward+backward.
+      4. The ``moe_enable_routing_replay`` flag gates RouterReplay instantiation.
+    """
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        self.num_experts = 4
+        self.topk = 2
+        self.hidden_size = 16
+        self.seq_len = 8
+        self.batch_size = 2
+        self.config = TransformerConfig(
+            num_layers=1,
+            hidden_size=self.hidden_size,
+            num_attention_heads=4,
+            num_moe_experts=self.num_experts,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_load_balancing_type="aux_loss",
+            moe_router_topk=self.topk,
+            moe_aux_loss_coeff=0.01,
+            moe_grouped_gemm=False,
+            add_bias_linear=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            moe_enable_routing_replay=True,
+        )
+        submodules = get_gpt_layer_local_submodules(
+            num_experts=self.num_experts, moe_grouped_gemm=False
+        )
+        self.moe_layer = MoELayer(self.config, submodules.mlp.submodules)
+
+    def teardown_method(self, method):
+        from megatron.core.transformer.moe.router_replay import RouterReplay
+
+        RouterReplay.clear_global_router_replay_instances()
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_routing_replay_instances_created(self):
+        """moe_enable_routing_replay=True must create RouterReplay instances for each MoE layer."""
+        from megatron.core.transformer.moe.router_replay import RouterReplay
+
+        assert (
+            len(RouterReplay.global_router_replay_instances) == 1
+        ), "Expected one RouterReplay instance per MoE layer"
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_record_and_replay_forward(self):
+        """RECORD then REPLAY_FORWARD must produce the same expert selection."""
+        from megatron.core.transformer.moe.router_replay import RouterReplay, RouterReplayAction
+
+        self.moe_layer = self.moe_layer.cuda()
+        hidden = torch.randn(
+            self.seq_len, self.batch_size, self.hidden_size, dtype=torch.bfloat16, device='cuda'
+        )
+
+        # --- Phase 1: RECORD ---
+        RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+        with torch.no_grad():
+            out_record, _ = self.moe_layer(hidden)
+        recorded = RouterReplay.get_recorded_data()
+        assert len(recorded) == 1 and recorded[0] is not None, "Indices were not recorded"
+        RouterReplay.clear_global_router_replay_action()
+
+        # --- Phase 2: REPLAY_FORWARD with recorded indices ---
+        RouterReplay.set_rollout_routing_data(recorded, activate_replay=True)
+        with torch.no_grad():
+            router_probs_replay, routing_map_replay = self.moe_layer.router(hidden)
+
+        # Expert selection (routing_map) must exactly match what was recorded
+        num_tokens = self.seq_len * self.batch_size
+        # recorded[0] shape: [num_tokens, topk]
+        replay_chosen = routing_map_replay.nonzero(as_tuple=False)[:, 1].view(num_tokens, self.topk)
+        assert torch.equal(
+            replay_chosen.sort(dim=1).values, recorded[0].sort(dim=1).values
+        ), "Replayed routing map does not match recorded indices"
+
+        RouterReplay.clear_global_indices()
+        RouterReplay.clear_global_router_replay_action()
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_replay_router_grad_exists(self):
+        """Router weight gradients must be non-zero after a replayed forward+backward."""
+        from megatron.core.transformer.moe.router_replay import RouterReplay, RouterReplayAction
+
+        self.moe_layer = self.moe_layer.cuda()
+        hidden = torch.randn(
+            self.seq_len, self.batch_size, self.hidden_size, dtype=torch.bfloat16, device='cuda'
+        )
+
+        # Record routing decisions first
+        RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+        with torch.no_grad():
+            self.moe_layer(hidden)
+        recorded = RouterReplay.get_recorded_data()
+        RouterReplay.clear_global_router_replay_action()
+
+        # Inject and run forward+backward with replay
+        RouterReplay.set_rollout_routing_data(recorded, activate_replay=True)
+        out, _ = self.moe_layer(hidden)
+        out.sum().backward()
+
+        router_weight_grad = self.moe_layer.router.weight.grad
+        assert router_weight_grad is not None, "Router weight grad is None after replay backward"
+        assert (
+            router_weight_grad.abs().sum() > 0
+        ), "Router weight grad is all-zero after replay backward"
+
+        RouterReplay.clear_global_indices()
+        RouterReplay.clear_global_router_replay_action()
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_flag_false_no_replay_instance(self):
+        """moe_enable_routing_replay=False must NOT create RouterReplay instances."""
+        from megatron.core.transformer.moe.router_replay import RouterReplay
+
+        # Clear instances from setup_method (which used True)
+        RouterReplay.clear_global_router_replay_instances()
+
+        config_no_replay = TransformerConfig(
+            num_layers=1,
+            hidden_size=self.hidden_size,
+            num_attention_heads=4,
+            num_moe_experts=self.num_experts,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="allgather",
+            moe_router_load_balancing_type="aux_loss",
+            moe_router_topk=self.topk,
+            moe_aux_loss_coeff=0.01,
+            moe_grouped_gemm=False,
+            add_bias_linear=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            moe_enable_routing_replay=False,  # disabled
+        )
+        submodules = get_gpt_layer_local_submodules(
+            num_experts=self.num_experts, moe_grouped_gemm=False
+        )
+        _ = MoELayer(config_no_replay, submodules.mlp.submodules)
+
+        assert (
+            len(RouterReplay.global_router_replay_instances) == 0
+        ), "RouterReplay instances should NOT be created when flag is False"


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

When training MoE models with RL (e.g., GRPO/GSPO via veRL), the training engine (Megatron) and the inference engine (SGLang/vLLM) compute MoE routing independently. Even with identical weights, ~10% of routers disagree per forward pass, causing ~94% of tokens to differ in expert assignment across at least one layer. This mismatch invalidates the importance sampling ratio assumption in policy gradient methods, leading to training instability and catastrophic collapse.

This PR implements the training-side integration of Rollout Routing Replay (R3) (arxiv.org/abs/2510.11370). The key idea: cache the expert-selection mask from the inference engine during rollout, then replay it during training instead of recomputing top-k. Router logits and softmax are still computed normally, preserving gradient flow to router weights.

The inference-side recording infrastructure (RouterReplay, RouterReplayAction, CUDA graph static buffers) already existed. This PR adds the missing training-side pieces.

Ref : https://github.com/NVIDIA/Megatron-LM/issues/4168

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
