### PR TITLE
[Dev] Fix TE version check for retain_pinned_cpu_buffers in cpu offload

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2650,8 +2650,8 @@ try:
         retain_pinned_cpu_buffers,
     ):
         """Get CPU offload context and sync function."""
-        if is_te_min_version("2.5.0"):
-            # Enables the additional double buffering switch for activations during LLM training
+        if is_te_min_version("2.10.0"):
+            # TE 2.10+ supports retain_pinned_cpu_buffers
             context, sync_func = _get_cpu_offload_context(
                 enabled,
                 num_layers,
@@ -2660,6 +2660,16 @@ try:
                 weight_offloading,
                 double_buffering,
                 retain_pinned_cpu_buffers=retain_pinned_cpu_buffers,
+            )
+        elif is_te_min_version("2.5.0"):
+            # TE 2.5-2.9 supports double_buffering but not retain_pinned_cpu_buffers
+            context, sync_func = _get_cpu_offload_context(
+                enabled,
+                num_layers,
+                model_layers,
+                activation_offloading,
+                weight_offloading,
+                double_buffering,
             )
         elif is_te_min_version("1.10.0.dev0"):
             context, sync_func = _get_cpu_offload_context(


### PR DESCRIPTION
## Summary
- Fix incorrect TransformerEngine version gate for `retain_pinned_cpu_buffers` parameter in `get_cpu_offload_context`
- The `retain_pinned_cpu_buffers` parameter was added in TE v2.10 (NVIDIA/TransformerEngine#1762), but the version check was gating on `2.5.0`, causing a `TypeError` for TE 2.5–2.9 users
- Add an intermediate branch for TE 2.5–2.9 that passes `double_buffering` but not `retain_pinned_cpu_buffers`
- [PR](https://github.com/NVIDIA/Megatron-LM/pull/4267) for main branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)