### PR TITLE
Revert "Add conditions_embeddings argument to TransformerBlock, Trans…

### DIFF
--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -450,7 +450,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         packed_seq_params: PackedSeqParams,
         use_inner_quantization_context: bool,
         padding_mask: Optional[Tensor] = None,
-        conditions_embeddings: Optional[Tensor] = None,
         extract_layer_indices: Optional[Set[int]] = None,
         layer_offset: int = 0,
     ):
@@ -480,7 +479,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                 context_mask,
                 rotary_pos_emb,
                 padding_mask=None,
-                conditions_embeddings=None,
             ):
                 for index in range(start, end):
                     layer = self._get_layer(index)
@@ -512,7 +510,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                             inference_context=None,
                             packed_seq_params=packed_seq_params,
                             padding_mask=padding_mask,
-                            conditions_embeddings=conditions_embeddings,
                         )
                 return hidden_states, context
 
@@ -533,7 +530,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     context_mask,
                     rotary_pos_emb,
                     padding_mask,
-                    conditions_embeddings,
                 )
             else:
                 return tensor_parallel.checkpoint(
@@ -545,7 +541,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     context_mask,
                     rotary_pos_emb,
                     padding_mask,
-                    conditions_embeddings,
                 )
 
         if self.config.recompute_method == 'uniform':
@@ -662,7 +657,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
-        conditions_embeddings: Optional[Tensor] = None,
         extract_layer_indices: Optional[Set[int]] = None,
         *,
         inference_params: Optional[BaseInferenceContext] = None,
@@ -700,9 +694,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                 which to extract intermediate hidden states. If
                 non-empty, the forward pass will collect hidden_states
                 after each specified layer.
-            conditions_embeddings (Tensor, optional): Condition embeddings for diffusion models
-                (e.g. timestep or text embeddings). Shape [batch_size, embeddings_dim].
-                Passed through to each transformer layer's forward().
             dynamic_inference_decode_only: Optional[bool]: If true, indicates that the current
                 inference context is for decode-only. This args is only used to uniquely
                 identify decode and non-decode cuda graph runners in the cuda graph manager.
@@ -800,7 +791,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     packed_seq_params=packed_seq_params,
                     use_inner_quantization_context=use_inner_quantization_context,
                     padding_mask=padding_mask,
-                    conditions_embeddings=conditions_embeddings,
                     extract_layer_indices=extract_layer_indices,
                     layer_offset=layer_offset,
                 )
@@ -843,7 +833,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                             packed_seq_params=packed_seq_params,
                             sequence_len_offset=sequence_len_offset,
                             padding_mask=padding_mask,
-                            conditions_embeddings=conditions_embeddings,
                         )
 
                     if (

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -700,10 +700,6 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         This method calls the core computation of a transformer layer, including
         self-attention, cross-attention (if applicable), and feed-forward operations.
         """
-        # Condition embeddings for diffusion models (e.g. timestep or text embeddings),
-        # shape [batch_size, embeddings_dim]. Consumed here so it is not forwarded to
-        # _forward_attention. Subclasses that override forward() can use this directly.
-        conditions_embeddings = kwargs.pop("conditions_embeddings", None)
         hidden_states, context = self._forward_attention(*args, **kwargs)
         output = self._forward_mlp(
             hidden_states,


### PR DESCRIPTION
…formerLayer for DiT (diffusion transformer) (#4134)"

This reverts commit 1daa19f898e5ddecc171ced9fee67292049fd2be.

# What does this PR do ?

Breaks LoRa on MBridge

```
mx_v1_perf/0 [rank2]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1884, in _call_impl
mx_v1_perf/0 [rank2]:     return inner()
mx_v1_perf/0 [rank2]:            ^^^^^^^
mx_v1_perf/0 [rank2]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1832, in inner
mx_v1_perf/0 [rank2]:     result = forward_call(*args, **kwargs)
mx_v1_perf/0 [rank2]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mx_v1_perf/0 [rank2]:   File "/opt/Megatron-Bridge/3rdparty/Megatron-LM/megatron/core/transformer/transformer_block.py", line 832, in forward
mx_v1_perf/0 [rank2]:     hidden_states, context = layer(
mx_v1_perf/0 [rank2]:                              ^^^^^^
mx_v1_perf/0 [rank2]:   File "/opt/Megatron-Bridge/3rdparty/Megatron-LM/megatron/core/transformer/module.py", line 355, in __call__
mx_v1_perf/0 [rank2]:     return cuda_graph_func(*args, **kwargs)
mx_v1_perf/0 [rank2]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mx_v1_perf/0 [rank2]:   File "/opt/Megatron-Bridge/3rdparty/Megatron-LM/megatron/core/transformer/transformer_layer.py", line 1084, in _te_cuda_graph_replay
mx_v1_perf/0 [rank2]:     hidden_states, context = self._forward_attention(*args, **kwargs)
mx_v1_perf/0 [rank2]:                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mx_v1_perf/0 [rank2]: TypeError: TransformerLayer._forward_attention() got an unexpected keyword argument 'conditions_embeddings'
mx_v1_perf/0 [rank0]:[W411 21:04:20.894589602 ProcessGroupNCCL.cpp:1569] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
mx_v1_perf/0 [rank4]:[W411 21:04:23.757924157 TCPStore.cpp:125] [c10d] recvValue failed on SocketImpl(fd=74, addr=[theia0168.lyris.clusters.nvidia.com]:47726, remote=[theia0167.lyris.clusters.nvidia.com]:61287): Failed to recv, got 0 bytes. Connection was likely closed. Did the remote server shutdown or crash?
```

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
