### PR TITLE
ci: add workflow_dispatch support to cicd-main.yml

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -86,9 +86,10 @@ jobs:
           IS_MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' }}
           IS_MERGE_GROUP: ${{ github.event_name == 'merge_group' }}
           SCHEDULED_JOB: ${{ github.event_name == 'schedule' }}
+          IS_WORKFLOW_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          # Skip SSO check for scheduled jobs, main branch, or merge groups
-          if [ "${{ env.SCHEDULED_JOB }}" == "true" ] || [ "${IS_MAIN_BRANCH}" == "true" ] || [ "${IS_MERGE_GROUP}" == "true" ]; then
+          # Skip SSO check for scheduled jobs, main branch, merge groups, or manual dispatches
+          if [ "${{ env.SCHEDULED_JOB }}" == "true" ] || [ "${IS_MAIN_BRANCH}" == "true" ] || [ "${IS_MERGE_GROUP}" == "true" ] || [ "${IS_WORKFLOW_DISPATCH}" == "true" ]; then
             echo "is_maintainer=true" | tee -a $GITHUB_OUTPUT
             exit 0
           fi
@@ -140,7 +141,7 @@ jobs:
 
   pre-flight:
     needs: [is-not-external-contributor]
-    if: github.repository == 'NVIDIA/Megatron-LM'
+    if: github.repository == 'NVIDIA/Megatron-LM' && github.event_name != 'workflow_dispatch'
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.73.2
 
   configure:
@@ -168,6 +169,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT }}
           IS_CI_WORKLOAD: ${{ needs.pre-flight.outputs.is_ci_workload }}
           IS_MERGE_GROUP: ${{ needs.pre-flight.outputs.is_merge_group }}
+          IS_WORKFLOW_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           PR_NUMBER=${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').number }}
 
@@ -179,8 +181,9 @@ jobs:
           HAS_LTS=$(echo "$LABELS"            | jq 'any(. == "container::lts")')
           HAS_MBRIDGE=$(echo "$LABELS"        | jq 'any(. == "Run MBridge tests")')
 
-          # Scheduled/CI workloads have no PR — treat as "Run functional tests"
+          # Scheduled/CI workloads and manual dispatches have no PR — treat as "Run functional tests"
           [ "$IS_CI_WORKLOAD" == "true" ] && HAS_RUN_FUNCTIONAL=true
+          [ "$IS_WORKFLOW_DISPATCH" == "true" ] && HAS_RUN_FUNCTIONAL=true
 
           if [ "$IS_MERGE_GROUP" == "true" ]; then
             SCOPE=mr-github; N_REPEAT=1; LIGHTWEIGHT=false
@@ -464,6 +467,7 @@ jobs:
         || needs.pre-flight.outputs.is_ci_workload == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
         || needs.pre-flight.outputs.force_run_all == 'true'
+        || github.event_name == 'workflow_dispatch'
       )
       && !cancelled()
     steps:
@@ -600,6 +604,7 @@ jobs:
         || needs.pre-flight.outputs.is_ci_workload == 'true'
         || needs.pre-flight.outputs.force_run_all == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
+        || github.event_name == 'workflow_dispatch'
       )
       && !cancelled()
     steps:
@@ -637,6 +642,7 @@ jobs:
         || needs.pre-flight.outputs.is_ci_workload == 'true'
         || needs.pre-flight.outputs.force_run_all == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
+        || github.event_name == 'workflow_dispatch'
       )
       && !cancelled()
     env:
@@ -677,6 +683,7 @@ jobs:
         || needs.pre-flight.outputs.force_run_all == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
         || needs.cicd-unit-tests-latest.result == 'skipped'
+        || github.event_name == 'workflow_dispatch'
       )
       && !cancelled()
     outputs:
@@ -750,6 +757,7 @@ jobs:
         || needs.pre-flight.outputs.force_run_all == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
         || needs.cicd-unit-tests-latest.result == 'skipped'
+        || github.event_name == 'workflow_dispatch'
       )
       && !cancelled()
     steps:
@@ -792,6 +800,7 @@ jobs:
         || needs.pre-flight.outputs.force_run_all == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
         || needs.cicd-unit-tests-latest.result == 'skipped'
+        || github.event_name == 'workflow_dispatch'
       )
       && !cancelled()
     outputs:
@@ -866,6 +875,7 @@ jobs:
         || needs.pre-flight.outputs.force_run_all == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
         || needs.cicd-unit-tests-latest.result == 'skipped'
+        || github.event_name == 'workflow_dispatch'
       )
       && !cancelled()
     steps:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -147,7 +147,7 @@ jobs:
   configure:
     runs-on: ubuntu-latest
     needs: [pre-flight]
-    if: github.repository == 'NVIDIA/Megatron-LM'
+    if: github.repository == 'NVIDIA/Megatron-LM' && (needs.pre-flight.result == 'success' || needs.pre-flight.result == 'skipped')
     outputs:
       scope:         ${{ steps.configure.outputs.scope }}
       n_repeat:      ${{ steps.configure.outputs.n_repeat }}

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -23,6 +23,11 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+    inputs:
+      test_cases:
+        description: "Comma-separated list of test cases to run, or 'all'"
+        required: false
+        default: "all"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.event.merge_group.head_ref || github.ref }}
@@ -145,6 +150,7 @@ jobs:
       lts:           ${{ steps.configure.outputs.lts }}
       mbridge_suite: ${{ steps.configure.outputs.mbridge_suite }}
       dev:           ${{ steps.configure.outputs.dev }}
+      test_cases:    ${{ steps.configure.outputs.test_cases }}
     steps:
       - name: Get PR info
         id: get-pr-info
@@ -190,12 +196,15 @@ jobs:
 
           DEV=true
 
+          TEST_CASES="${{ github.event.inputs.test_cases || 'all' }}"
+
           echo "scope=$SCOPE"                 | tee -a $GITHUB_OUTPUT
           echo "n_repeat=$N_REPEAT"           | tee -a $GITHUB_OUTPUT
           echo "lightweight=$LIGHTWEIGHT"     | tee -a $GITHUB_OUTPUT
           echo "lts=$HAS_LTS"                 | tee -a $GITHUB_OUTPUT
           echo "mbridge_suite=$MBRIDGE_SUITE" | tee -a $GITHUB_OUTPUT
           echo "dev=$DEV"                     | tee -a $GITHUB_OUTPUT
+          echo "test_cases=$TEST_CASES"       | tee -a $GITHUB_OUTPUT
 
           # Pre-compute active row markers for the decision tree
           _MG=$( [ "$IS_MERGE_GROUP" == "true" ]                                                                           && echo "**→**" || echo "" )
@@ -682,7 +691,7 @@ jobs:
           python tests/test_utils/python_scripts/generate_jet_trigger_job.py \
             --n-repeat 5 \
             --time-limit 2700 \
-            --test-cases all \
+            --test-cases "${{ needs.configure.outputs.test_cases }}" \
             --container-image mcore_ci_dev \
             --container-tag latest \
             --dependent-job functional:configure \
@@ -793,7 +802,7 @@ jobs:
           python tests/test_utils/python_scripts/generate_jet_trigger_job.py \
             --n-repeat 5 \
             --time-limit 2700 \
-            --test-cases all \
+            --test-cases "${{ needs.configure.outputs.test_cases }}" \
             --container-image mcore_ci_dev \
             --container-tag latest \
             --dependent-job functional:configure \

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -28,6 +28,10 @@ on:
         description: "Comma-separated list of test cases to run, or 'all'"
         required: false
         default: "all"
+      test_type:
+        description: "Which test types to run: 'both', 'unit', or 'functional'"
+        required: false
+        default: "both"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.event.merge_group.head_ref || github.ref }}
@@ -590,6 +594,7 @@ jobs:
       needs.pre-flight.result != 'cancelled'
       && needs.cicd-wait-in-queue.result != 'cancelled'
       && needs.cicd-container-build.result != 'cancelled'
+      && (github.event.inputs.test_type == '' || github.event.inputs.test_type == 'unit' || github.event.inputs.test_type == 'both')
       && (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
@@ -626,6 +631,7 @@ jobs:
       && needs.cicd-wait-in-queue.result != 'cancelled'
       && needs.cicd-container-build.result != 'cancelled'
       && needs.cicd-parse-unit-tests.result != 'cancelled'
+      && (github.event.inputs.test_type == '' || github.event.inputs.test_type == 'unit' || github.event.inputs.test_type == 'both')
       && (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
@@ -664,11 +670,13 @@ jobs:
       && needs.cicd-wait-in-queue.result != 'cancelled'
       && needs.cicd-container-build.result != 'cancelled'
       && needs.cicd-unit-tests-latest.result != 'cancelled'
+      && (github.event.inputs.test_type == '' || github.event.inputs.test_type == 'functional' || github.event.inputs.test_type == 'both')
       && (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
         || needs.pre-flight.outputs.force_run_all == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
+        || needs.cicd-unit-tests-latest.result == 'skipped'
       )
       && !cancelled()
     outputs:
@@ -735,11 +743,13 @@ jobs:
       && needs.cicd-wait-in-queue.result != 'cancelled'
       && needs.cicd-parse-integration-tests-h100.result != 'cancelled'
       && needs.cicd-unit-tests-latest.result != 'cancelled'
+      && (github.event.inputs.test_type == '' || github.event.inputs.test_type == 'functional' || github.event.inputs.test_type == 'both')
       && (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
         || needs.pre-flight.outputs.force_run_all == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
+        || needs.cicd-unit-tests-latest.result == 'skipped'
       )
       && !cancelled()
     steps:
@@ -775,11 +785,13 @@ jobs:
       && needs.cicd-wait-in-queue.result != 'cancelled'
       && needs.cicd-container-build.result != 'cancelled'
       && needs.cicd-unit-tests-latest.result != 'cancelled'
+      && (github.event.inputs.test_type == '' || github.event.inputs.test_type == 'functional' || github.event.inputs.test_type == 'both')
       && (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
         || needs.pre-flight.outputs.force_run_all == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
+        || needs.cicd-unit-tests-latest.result == 'skipped'
       )
       && !cancelled()
     outputs:
@@ -847,11 +859,13 @@ jobs:
       && needs.cicd-wait-in-queue.result != 'cancelled'
       && needs.cicd-parse-integration-tests-gb200.result != 'cancelled'
       && needs.cicd-unit-tests-latest.result != 'cancelled'
+      && (github.event.inputs.test_type == '' || github.event.inputs.test_type == 'functional' || github.event.inputs.test_type == 'both')
       && (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
         || needs.pre-flight.outputs.force_run_all == 'true'
         || needs.pre-flight.outputs.is_merge_group == 'true'
+        || needs.cicd-unit-tests-latest.result == 'skipped'
       )
       && !cancelled()
     steps:
@@ -907,6 +921,7 @@ jobs:
           UNIT_RESULT: ${{ needs.cicd-unit-tests-latest.result }}
           H100_RESULT: ${{ needs.cicd-integration-tests-latest-h100.result }}
           GB200_RESULT: ${{ needs.cicd-integration-tests-latest-gb200.result }}
+          TEST_TYPE: ${{ github.event.inputs.test_type }}
         run: |
           # Docs-only and deployment workflows intentionally skip all tests
           if [ "$DOCS_ONLY" == "true" ] || [ "$IS_DEPLOYMENT" == "true" ]; then
@@ -916,21 +931,28 @@ jobs:
 
           FAILED=false
 
-          # Unit tests must always succeed (never skipped or cancelled)
+          # Unit tests: allowed to be skipped when test_type == 'functional'
           if [ "$UNIT_RESULT" != "success" ]; then
-            echo "❌ cicd-unit-tests-latest: $UNIT_RESULT"
-            FAILED=true
+            if [ "$TEST_TYPE" == "functional" ] && [ "$UNIT_RESULT" == "skipped" ]; then
+              echo "⏭️ cicd-unit-tests-latest: skipped (test_type=functional)"
+            else
+              echo "❌ cicd-unit-tests-latest: $UNIT_RESULT"
+              FAILED=true
+            fi
           fi
 
-          # H100 integration tests must always succeed
+          # H100 integration tests: allowed to be skipped when test_type == 'unit'
           if [ "$H100_RESULT" != "success" ]; then
-            echo "❌ cicd-integration-tests-latest-h100: $H100_RESULT"
-            FAILED=true
+            if [ "$TEST_TYPE" == "unit" ] && [ "$H100_RESULT" == "skipped" ]; then
+              echo "⏭️ cicd-integration-tests-latest-h100: skipped (test_type=unit)"
+            else
+              echo "❌ cicd-integration-tests-latest-h100: $H100_RESULT"
+              FAILED=true
+            fi
           fi
 
-          # GB200 integration tests may be skipped only for non-maintainer PRs
-          # (no GB200 runners available); maintainer runs must always succeed
-          if [ "$GB200_RESULT" == "skipped" ] && [ "$IS_MAINTAINER" == "true" ]; then
+          # GB200 integration tests may be skipped for non-maintainer PRs or when test_type == 'unit'
+          if [ "$GB200_RESULT" == "skipped" ] && [ "$IS_MAINTAINER" == "true" ] && [ "$TEST_TYPE" != "unit" ]; then
             echo "❌ cicd-integration-tests-latest-gb200: skipped unexpectedly for a maintainer run"
             FAILED=true
           elif [ "$GB200_RESULT" != "success" ] && [ "$GB200_RESULT" != "skipped" ]; then


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` support to the GitHub Actions CI pipeline, enabling maintainers to trigger targeted test runs without a push or PR event.

- **`test_cases` input**: trigger with a comma-separated list of test cases instead of always running all tests (defaults to `all` for push/merge-group/schedule)
- **`test_type` input**: select which test types to run — `unit`, `functional`, or `both` (default); gates parse/run jobs accordingly and lets `Nemo_CICD_Test` tolerate intentionally-skipped results
- **Fix pre-flight skip**: `_cicd_preflight.yml@v0.73.2` unconditionally fires `get-pr-info` on `pull-request/*` branches even for `workflow_dispatch`, causing failures; skip pre-flight entirely for `workflow_dispatch` and propagate the skipped result through `is-not-external-contributor`, `configure`, and all 7 test-execution jobs
- **Fix configure skip**: when pre-flight is skipped, `configure` was also skipped by GitHub's default dependent-job behaviour, leaving `SCOPE` empty and causing `generate_jet_trigger_job.py` to fail with `Missing option '--output-path'`; fix by adding `|| github.event_name == 'workflow_dispatch'` to the `needs` condition

## Test plan

- [ ] Trigger via `workflow_dispatch` with `test_cases=gpt3_mcore_te_tp2_pp2_cp2` and verify only that test runs
- [ ] Trigger via `workflow_dispatch` with `test_type=functional` and verify unit tests are skipped
- [ ] Verify normal push / merge-group triggers are unaffected