### PR TITLE
Cuda graph fix

### DIFF
--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -85,6 +85,10 @@ class InferenceBatchDimensions:
         Returns:
             True if the config is valid, False otherwise
         """
+        # A zero-token batch is never valid
+        if self.token_count == 0:
+            return False
+
         # Check if total requests exceed maximum
         if self.prefill_req_count + self.decode_req_count > max_requests:
             return False
@@ -436,6 +440,12 @@ class CUDAGraphBatchDimensionBuilder:
                 decode_req_count = min(size // (num_speculative_tokens + 1), max_requests)
                 token_count = decode_req_count * (num_speculative_tokens + 1)
                 token_count = token_count // tp_size * tp_size
+                # Skip zero-token graphs: when size < (num_speculative_tokens + 1),
+                # decode_req_count rounds down to 0, producing a zero-token batch.
+                # CUDA graph warmup clones these as empty tensors, causing TE's
+                # CheckInputTensor to fail with "Input x is not allocated".
+                if token_count == 0:
+                    continue
                 add_if_valid(
                     token_count=token_count, prefill_req_count=0, decode_req_count=decode_req_count
                 )

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
@@ -228,8 +228,11 @@ def _coerce_arguments_mapping(arguments):
 def _sanitize_messages_for_template(messages):
     """Prepare messages so tokenizer chat templates can safely consume them.
 
-    This only normalizes tool-call argument payloads inside each message:
+    Normalizes:
     - messages[*].tool_calls[*].function.arguments is coerced to a dict.
+    - multimodal content lists are flattened to plain strings.
+    - tool role messages preserve tool_call_id and name (identity fields used
+      by Qwen3 and other chat templates to correlate tool results with calls).
 
     Example transformation:
     Input:
@@ -249,6 +252,7 @@ def _sanitize_messages_for_template(messages):
             continue
         msg_copy = dict(message)
         content = msg_copy.get("content")
+        role = msg_copy.get("role")
         # OpenAI-style multimodal/text content may arrive as a list of blocks.
         # HF/Jinja chat templates used by this server expect plain strings.
         if isinstance(content, list):
@@ -264,9 +268,12 @@ def _sanitize_messages_for_template(messages):
             msg_copy["content"] = "".join(text_chunks)
         elif isinstance(content, dict):
             msg_copy["content"] = str(content.get("text", ""))
-        elif content is None:
+        elif content is None and role != "tool":
+            # For tool result messages, preserve None content so the chat
+            # template can distinguish "no result" from "empty string result".
+            # For other roles, coerce to empty string for template safety.
             msg_copy["content"] = ""
-        elif not isinstance(content, str):
+        elif not isinstance(content, str) and content is not None:
             msg_copy["content"] = str(content)
 
         tool_calls = msg_copy.get("tool_calls")


### PR DESCRIPTION
# What does this PR do ?
## Summary
This MR includes the first two commits on the branch and fixes two inference-time issues:
1. Prevents zero-token CUDA graph warmup entries that can crash TransformerEngine during server startup.
2. Preserves `None` content for `tool` role messages during chat sanitization so templates can correctly distinguish `None` vs empty string (`""`).
## Problem
- In CUDA graph dimension building, certain small-shape scenarios (e.g., with speculative decoding) can produce `token_count == 0`.  
  Those entries caused empty tensor clones during warmup and triggered TE error:
  `CheckInputTensor: Input x is not allocated`.
- Message sanitization previously converted `None -> ""` for all roles, including `tool`.  
  For tool messages, this breaks template semantics and tool-call/result correlation logic in agentic flows.
## Changes
- `megatron/core/inference/batch_dimensions_utils.py`
  - Added guard in `InferenceBatchDimensions.is_valid()` to reject zero-token dimensions.
  - Updated `CUDAGraphBatchDimensionBuilder` to skip zero-token entries.
- `megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py`
  - Updated `_sanitize_messages_for_template` to keep `content=None` for `role=="tool"`.
  - Non-tool roles still normalize `None` to empty string where appropriate.
## Impact
- Improves inference server robustness by avoiding warmup-time TE crashes.
- Restores correct tool-message behavior for agentic/benchmark workflows where tools may return no output (e.g., BFCL v4, SWE-bench, TAU-bench scenarios).

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
