### PR TITLE
cp: `build: bump DeepEP to 34152ae (#4228)` into `core_r0.17.0`

### DIFF
--- a/docker/Dockerfile.ci.dev
+++ b/docker/Dockerfile.ci.dev
@@ -71,7 +71,7 @@ RUN bash -ex <<"EOF"
 
     git clone --branch hybrid-ep https://github.com/deepseek-ai/DeepEP.git
     pushd DeepEP
-        git checkout eb9cee7de5a24193bf09500668d3a619d3d3f3fb
+        git checkout 34152ae28f80bcc3ee38d7a12cb2ad87cfd4ea72
         patch -p1 < /workspace/deepep.patch
     popd
     TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" uv pip install --no-build-isolation -v DeepEP/.

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import os
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
@@ -42,7 +43,10 @@ def pytest_sessionfinish(session, exitstatus):
 def cleanup():
     yield
     if torch.distributed.is_initialized():
-        torch.distributed.barrier()
+        try:
+            torch.distributed.barrier(timeout=timedelta(seconds=300))
+        except Exception:
+            return
         torch.distributed.destroy_process_group()
 
 

--- a/tests/unit_tests/test_utilities.py
+++ b/tests/unit_tests/test_utilities.py
@@ -91,7 +91,15 @@ class Utils:
         os.environ.pop('NVTE_UNFUSED_ATTN', None)
         if not Utils.inited:
             return
-        torch.distributed.barrier()
+
+        try:
+            # Flush pending CUDA work before the barrier so slow ranks don't
+            # time out while fast ranks tear down process groups.
+            torch.cuda.synchronize()
+            torch.distributed.barrier(timeout=timedelta(seconds=300))
+        except Exception:
+            Utils.inited = False
+            return
         ps.destroy_model_parallel()
         Utils.inited = False
 


### PR DESCRIPTION
## Summary

Cherry-pick of #4228 (`build: bump DeepEP to 34152ae`) onto `core_r0.17.0`.

Conflicts in `tests/unit_tests/conftest.py` and `tests/unit_tests/test_utilities.py` were resolved by taking the incoming changes (distributed barrier with 300 s timeout + exception handling). Missing `from datetime import timedelta` import was also added to `conftest.py`.

## Changes

- `setup.py` / build config: bump DeepEP dependency to `34152ae`
- `tests/unit_tests/conftest.py`: barrier with timeout + exception guard; add `timedelta` import
- `tests/unit_tests/test_utilities.py`: `cuda.synchronize()` + barrier with timeout + exception guard