### PR TITLE
ci: mark test_fused_indexer_loss_gradient_tp_consistency as flaky_in_dev

### DIFF
--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -423,6 +423,7 @@ class TestFusedDSAIndexerLossGradient:
 class TestFusedDSAIndexerLossGradientTP:
     """Test FusedDSAIndexerLoss gradient consistency across different TP sizes."""
 
+    @pytest.mark.flaky_in_dev
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_fused_indexer_loss_gradient_tp_consistency(
         self, tensor_model_parallel_size, sparse_loss


### PR DESCRIPTION
## Summary

- Adds `@pytest.mark.flaky_in_dev` to `test_fused_indexer_loss_gradient_tp_consistency` in `tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py`.

## Test plan

- [ ] Verify `pytest --collect-only -m flaky_in_dev` includes this test

🤖 Generated with [Claude Code](https://claude.com/claude-code)