### PR TITLE
fix: correct 'Seperate'/'Seperated' typo in comments

### DIFF
--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -968,7 +968,7 @@ class MLASelfAttention(MultiLatentAttention):
             kv_cached, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
         )
 
-        # Seperated out the norm and linear
+        # Separated out the norm and linear
         kv, _ = self.linear_kv_up_proj_linear(kv_compressed)
 
         kv = kv.view(

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -68,7 +68,7 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
 
         return calc_dtensor_params_l2_norm(params)
 
-    # Seperate moe and dense params
+    # Separate moe and dense params
     params_data = []
     moe_params_data = []
     sharded_params_data = []


### PR DESCRIPTION
Two remaining comment typos following up on #3305:

- `megatron/training/utils.py`: `# Seperate moe and dense params` → `# Separate moe and dense params`
- `megatron/core/transformer/multi_latent_attention.py`: `# Seperated out the norm and linear` → `# Separated out the norm and linear`

Comment-only change, no runtime impact.