### PR TITLE
fix(dev): correct params->parameters typo in ChainedOptimizer.step()

### DIFF
--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1377,7 +1377,7 @@ class ChainedOptimizer(MegatronOptimizer):
                         or (
                             # Megatron-FSDP always uses decoupled_grad with FusedAdam.
                             self.config.use_precision_aware_optimizer
-                            and getattr(params[0], "__fsdp_param__", False)
+                            and getattr(parameters[0], "__fsdp_param__", False)
                         )
                     ),
                 )

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
@@ -816,6 +816,7 @@ class TestMegatronFSDPE2E:
                     data_parallel_sharding_strategy="optim_grads_params",
                     megatron_fsdp_main_params_dtype=torch.float32,
                     use_precision_aware_optimizer=True,
+                    fp8="hybrid",
                     fp8_recipe="delayed",
                     fp8_param_gather=True,
                     bf16=True,


### PR DESCRIPTION
## Summary

Port of #4277 to the `dev` branch.

Dev hits the same NameError that #4277 fixed on `main`:

```
File "megatron/core/optimizer/optimizer.py", line 1380, in step
    and getattr(params[0], "__fsdp_param__", False)
NameError: name 'params' is not defined
```

The surrounding `clip_grad_by_total_norm_fp32` call already binds the local `parameters`, so this is a pure typo fix.

## Changes

- `megatron/core/optimizer/optimizer.py` — `params[0]` → `parameters[0]` in `ChainedOptimizer.step()` (the Megatron-FSDP + `use_precision_aware_optimizer` branch).
- `tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py` — add `fp8="hybrid"` to the `optim_grads_params_fused_adam_e2e` param block so the FSDP e2e test actually exercises the fixed code path.

The `@pytest.mark.flaky_in_dev` decorator is intentionally left in place on `dev` — whether the typo was the sole cause of flakiness is unclear, so the safeguard is preserved here even though #4277 removed it on `main`.

## Test plan

- [ ] CI green on `dev`
- [ ] `test_compatible_with_nd_parallel[optim_grads_params_fused_adam_e2e-*]` no longer raises `NameError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)