### PR TITLE
docs: bump versions1.json to 0.17.0 (latest)

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -5,9 +5,14 @@
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/nightly/"
     },
     {
-        "name": "0.16.0 (latest)",
-        "version": "0.16.0",
+        "name": "0.17.0 (latest)",
+        "version": "0.17.0",
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/latest/"
+    },
+    {
+        "name": "0.16.0",
+        "version": "0.16.0",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.16.0/"
     },
     {
         "name": "0.15.0",


### PR DESCRIPTION
## Summary

- Adds `0.17.0 (latest)` entry pointing to `latest/` URL
- Demotes `0.16.0` to a versioned entry pointing to `0.16.0/` URL

## Before / After

**Before:**
```json
{ "name": "0.16.0 (latest)", "version": "0.16.0", "url": ".../latest/" }
```

**After:**
```json
{ "name": "0.17.0 (latest)", "version": "0.17.0", "url": ".../latest/" },
{ "name": "0.16.0",          "version": "0.16.0",  "url": ".../0.16.0/" }
```