### PR TITLE
docs: bump project.json and versions1.json to 0.17.0

### DIFF
--- a/docs/project.json
+++ b/docs/project.json
@@ -1,2 +1,2 @@
-{"name": "megatron-lm", "version": "nightly"}
+{"name": "megatron-lm", "version": "0.17.0"}
 

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -5,9 +5,14 @@
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/nightly/"
     },
     {
-        "name": "0.16.0 (latest)",
-        "version": "0.16.0",
+        "name": "0.17.0 (latest)",
+        "version": "0.17.0",
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/latest/"
+    },
+    {
+        "name": "0.16.0",
+        "version": "0.16.0",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.16.0/"
     },
     {
         "name": "0.15.0",


### PR DESCRIPTION
## Summary

- `project.json`: version `nightly` → `0.17.0` (matches `core_r0.16.0` pattern)
- `versions1.json`: adds `0.17.0 (latest)` entry, demotes `0.16.0` to versioned URL

## Before / After

**`project.json` before:**
```json
{"name": "megatron-lm", "version": "nightly"}
```
**`project.json` after:**
```json
{"name": "megatron-lm", "version": "0.17.0"}
```

**`versions1.json` before:**
```json
{ "name": "0.16.0 (latest)", "version": "0.16.0", "url": ".../latest/" }
```
**`versions1.json` after:**
```json
{ "name": "0.17.0 (latest)", "version": "0.17.0", "url": ".../latest/" },
{ "name": "0.16.0",          "version": "0.16.0",  "url": ".../0.16.0/" }
```