### PR TITLE
[docs] ci: fix version picker in 0.17.0 docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ import sys
 project = "Megatron Core"
 copyright = "2026, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = "nightly"
+release = "0.17.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,2 +1,2 @@
-{"name": "megatron-lm", "version": "nightly"}
+{"name": "megatron-lm", "version": "0.17.0"}
 

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -5,9 +5,14 @@
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/nightly/"
     },
     {
-        "name": "0.16.0 (latest)",
-        "version": "0.16.0",
+        "name": "0.17.0 (latest)",
+        "version": "0.17.0",
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/latest/"
+    },
+    {
+        "name": "0.16.0",
+        "version": "0.16.0",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.16.0/"
     },
     {
         "name": "0.15.0",


### PR DESCRIPTION
## Summary

- Fixes `release = "nightly"` → `"0.17.0"` in `docs/conf.py` so the Sphinx version picker correctly highlights **0.17.0** as the current version (instead of "nightly")
- Adds `0.17.0 (latest)` entry to `docs/versions1.json` so users can navigate to/from 0.17.0 in the picker
- Updates `docs/project.json` version to `0.17.0`

## Root cause

When `core_r0.17.0` was branched off, `conf.py` still had `release = "nightly"` and `versions1.json` had no `0.17.0` entry. The published docs at `/developer-guide/0.17.0/` therefore showed **nightly** selected in the version switcher.

## After merge

Re-trigger the [Release docs](https://github.com/NVIDIA/Megatron-LM/actions/workflows/release-docs.yml) workflow with:
- `dry-run: false`
- `publish-as-latest: true`
- `docs-version-override: 0.17.0`
- `build-docs-ref: core_r0.17.0`