### PR TITLE
[docs] ci: fix version picker in 0.16.0 docs

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -5,9 +5,14 @@
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/nightly/"
     },
     {
-        "name": "0.16.0 (latest)",
-        "version": "0.16.0",
+        "name": "0.17.0 (latest)",
+        "version": "0.17.0",
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/latest/"
+    },
+    {
+        "name": "0.16.0",
+        "version": "0.16.0",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.16.0/"
     },
     {
         "name": "0.15.0",


### PR DESCRIPTION
## Summary

- Adds `0.17.0 (latest)` entry to `docs/versions1.json` so users on 0.16.0 docs can navigate to 0.17.0
- Renames `0.16.0 (latest)` → `0.16.0` and points it to the versioned URL (`/0.16.0/`) instead of `/latest/`

## Root cause

The `versions1.json` on `core_r0.16.0` was never updated after 0.17.0 was released, so users viewing the 0.16.0 docs had no way to navigate to 0.17.0 via the version picker.

## After merge

Re-trigger the [Release docs](https://github.com/NVIDIA/Megatron-LM/actions/workflows/release-docs.yml) workflow with:
- `dry-run: false`
- `publish-as-latest: false`
- `docs-version-override: 0.16.0`
- `build-docs-ref: core_r0.16.0`