### PR TITLE
[docs] ci: use parent-relative json_url for version picker

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ if not skip_autodoc:
 html_theme = "nvidia_sphinx_theme"
 html_theme_options = {
     "switcher": {
-        "json_url": "versions1.json",
+        "json_url": "../versions1.json",
         "version_match": release,
     },
     "icon_links": [


### PR DESCRIPTION
## Summary

Changes `json_url` from `"versions1.json"` (per-version local copy) to `"../versions1.json"` (parent directory) so the version picker always reads from the centrally-maintained `developer-guide/versions1.json` — the same file that `update-version-picker` keeps current on every release.

This matches the behaviour of the 0.15.0 docs, where no local `versions1.json` is bundled and the platform serves the picker from the parent directory.

## Example

| Before | After |
|--------|-------|
| Fetches stale `developer-guide/0.16.0/versions1.json` bundled at publish time | Fetches live `developer-guide/versions1.json` updated on every release |