### PR TITLE
Remove rampup batch size scheduler

### DIFF
--- a/examples/gpt3/gpt_config.yaml
+++ b/examples/gpt3/gpt_config.yaml
@@ -136,7 +136,6 @@ use_legacy_models: False
 spec: null
 micro_batch_size: 2
 global_batch_size: 128
-rampup_batch_size: [32, 32, 65324160] 
 check_for_nan_in_loss_and_grad: True
 num_layers_per_virtual_pipeline_stage: null
 

--- a/examples/gpt3/train_gpt3_175b_distributed.sh
+++ b/examples/gpt3/train_gpt3_175b_distributed.sh
@@ -37,8 +37,7 @@ GPT_MODEL_ARGS=(
 TRAINING_ARGS=(
     --micro-batch-size 1 
     --global-batch-size 1536 
-    --rampup-batch-size 16 16 5859375 
-    --train-iters 500000 
+    --train-iters 500000
     --weight-decay 0.1 
     --adam-beta1 0.9 
     --adam-beta2 0.95 

--- a/megatron/core/num_microbatches_calculator.py
+++ b/megatron/core/num_microbatches_calculator.py
@@ -4,14 +4,11 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
 # TODO: global_var merge into mcore?
-_GLOBAL_NUM_MICROBATCHES_CALCULATOR: Union[
-    'ConstantNumMicroBatchesCalculator', 'RampupBatchsizeNumMicroBatchesCalculator'
-] = None
+_GLOBAL_NUM_MICROBATCHES_CALCULATOR: 'ConstantNumMicroBatchesCalculator' = None
 
 
 def get_num_microbatches() -> int:
@@ -35,22 +32,6 @@ def get_current_running_global_batch_size() -> int:
     return _GLOBAL_NUM_MICROBATCHES_CALCULATOR.get_current_running_global_batch_size()
 
 
-def update_num_microbatches(
-    consumed_samples: int, consistency_check: bool = True, verbose: bool = False
-) -> None:
-    """Update number of microbatches.
-
-    Args:
-        consumed_samples (int):
-            Number of samples consumed.
-        consistency_check (bool, optional):
-            Option to check current schedule's consistency. Defaults to True.
-        verbose (bool, optional):
-            Option to control logging. Defaults to False.
-    """
-    _GLOBAL_NUM_MICROBATCHES_CALCULATOR.update(consumed_samples, consistency_check, verbose)
-
-
 def unset_num_microbatches_calculator():
     """Unset microbatches calculator.
 
@@ -63,7 +44,6 @@ def unset_num_microbatches_calculator():
 
 def init_num_microbatches_calculator(
     rank: int,
-    rampup_batch_size: Optional[List[int]],
     global_batch_size: int,
     micro_batch_size: int,
     data_parallel_size: int,
@@ -74,9 +54,6 @@ def init_num_microbatches_calculator(
     Args:
         rank (int):
             Rank of the GPU, only rank 0 will log the information.
-        rampup_batch_size (Optional[List[int]]):
-            Rampup batch size, should be in format of [start_global_batch_size,
-            batch_size_increment, ramup_samples].
         global_batch_size (int):
             Global batch size for the model.
         micro_batch_size (int):
@@ -89,7 +66,6 @@ def init_num_microbatches_calculator(
     """
     _configure_global_num_microbatches_calculator(
         rank,
-        rampup_batch_size,
         global_batch_size,
         micro_batch_size,
         data_parallel_size,
@@ -106,7 +82,6 @@ def destroy_num_microbatches_calculator():
 
 def reconfigure_num_microbatches_calculator(
     rank: int,
-    rampup_batch_size: Optional[List[int]],
     global_batch_size: int,
     micro_batch_size: int,
     data_parallel_size: int,
@@ -117,9 +92,6 @@ def reconfigure_num_microbatches_calculator(
     Args:
         rank (int):
             Rank of the GPU, only rank 0 will log the information.
-        rampup_batch_size (Optional[List[int]]):
-            Rampup batch size, should be in format of
-            [start_global_batch_size, batch_size_increment, ramup_samples].
         global_batch_size (int):
             Global batch size for the model.
         micro_batch_size (int):
@@ -132,7 +104,6 @@ def reconfigure_num_microbatches_calculator(
     """
     _configure_global_num_microbatches_calculator(
         rank,
-        rampup_batch_size,
         global_batch_size,
         micro_batch_size,
         data_parallel_size,
@@ -143,7 +114,6 @@ def reconfigure_num_microbatches_calculator(
 
 def _configure_global_num_microbatches_calculator(
     rank: int,
-    rampup_batch_size: Optional[List[int]],
     global_batch_size: int,
     micro_batch_size: int,
     data_parallel_size: int,
@@ -156,9 +126,6 @@ def _configure_global_num_microbatches_calculator(
     Args:
         rank (int):
             Rank of the GPU, only rank 0 will log the information.
-        rampup_batch_size (Optional[List[int]]):
-            Rampup batch size, should be in format of
-            [start_global_batch_size, batch_size_increment, ramup_samples].
         global_batch_size (int):
             Global batch size for the model.
         micro_batch_size (int):
@@ -178,84 +145,14 @@ def _configure_global_num_microbatches_calculator(
             _GLOBAL_NUM_MICROBATCHES_CALCULATOR is None
         ), 'num microbatches calculator is already initialized.'
 
-    _GLOBAL_NUM_MICROBATCHES_CALCULATOR = _build_num_microbatches_calculator(
-        rank,
-        rampup_batch_size,
-        global_batch_size,
-        micro_batch_size,
-        data_parallel_size,
-        decrease_batch_size_if_needed,
+    _GLOBAL_NUM_MICROBATCHES_CALCULATOR = ConstantNumMicroBatchesCalculator(
+        global_batch_size, micro_batch_size, data_parallel_size, decrease_batch_size_if_needed, rank
     )
-
-
-def _build_num_microbatches_calculator(
-    rank: int,
-    rampup_batch_size: Optional[List[int]],
-    global_batch_size: int,
-    micro_batch_size: int,
-    data_parallel_size: int,
-    decrease_batch_size_if_needed: bool,
-) -> Union['ConstantNumMicroBatchesCalculator', 'RampupBatchsizeNumMicroBatchesCalculator']:
-    """Build number of microbatches calculator. Internal helper method.
-
-    Args:
-        rank (int):
-            Rank of the GPU, only rank 0 will log the information.
-        rampup_batch_size (Optional[List[int]]):
-            Rampup batch size, should be in format of
-            [start_global_batch_size, batch_size_increment, ramup_samples].
-        global_batch_size (int):
-            Global batch size for the model.
-        micro_batch_size (int):
-            Micro batch size at initialization.
-        data_parallel_size (int):
-            Data parallel size.
-        decrease_batch_size_if_needed (bool):
-            If true, scale down batch size to ensure divisibility by DP size * microbatch size.
-
-    """
-
-    # Constant batch size.
-    if rampup_batch_size is None:
-        num_microbatches_calculator = ConstantNumMicroBatchesCalculator(
-            global_batch_size,
-            micro_batch_size,
-            data_parallel_size,
-            decrease_batch_size_if_needed,
-            rank,
+    if rank == 0:
+        logger.info(
+            f'setting number of microbatches to constant '
+            f'{_GLOBAL_NUM_MICROBATCHES_CALCULATOR.get()}'
         )
-        if rank == 0:
-            logger.info(
-                f'setting number of microbatches to constant {num_microbatches_calculator.get()}'
-            )
-    # Batch size ramp up.
-    else:
-        assert len(rampup_batch_size) == 3, (
-            'expected the following '
-            'format: --rampup-batch-size <start batch size> '
-            '<batch size incerement> <ramp-up samples>'
-        )
-        start_global_batch_size = int(rampup_batch_size[0])
-        batch_size_increment = int(rampup_batch_size[1])
-        ramup_samples = int(rampup_batch_size[2])
-        if rank == 0:
-            logger.info(
-                f'will use batch size rampup starting from global batch size '
-                f'{start_global_batch_size} to global batch size {global_batch_size} with batch'
-                f'size increments {batch_size_increment} over {ramup_samples} samples.'
-            )
-        num_microbatches_calculator = RampupBatchsizeNumMicroBatchesCalculator(
-            global_batch_size,
-            micro_batch_size,
-            data_parallel_size,
-            decrease_batch_size_if_needed,
-            rank,
-            start_global_batch_size,
-            batch_size_increment,
-            ramup_samples,
-        )
-
-    return num_microbatches_calculator
 
 
 def _round(batch_size: int, divisor: int) -> int:
@@ -291,7 +188,7 @@ class NumMicroBatchesCalculator(ABC):
 
     @abstractmethod
     def update(self, consumed_samples, consistency_check, verbose=False) -> None:
-        """Update number of microbatches depending on batch size rampup."""
+        """Update number of microbatches."""
         pass
 
 
@@ -355,154 +252,3 @@ class ConstantNumMicroBatchesCalculator(NumMicroBatchesCalculator):
 
     def update(self, consumed_samples, consistency_check, verbose=False) -> None:
         pass
-
-
-class RampupBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
-    """Calculator of number of microbatches with batch size rampup.
-    Over `steps = (global-batch-size - start-batch-size) / batch_size_increment` increment batch
-    size from start-batch-size to global-batch-size using rampup-samples / steps
-    samples.
-
-    Args:
-        global_batch_size (int):
-            Global batch size post rampup.
-        micro_batch_size (int):
-            Micro batch size.
-        data_parallel_size (int):
-            Data parallel size.
-        decrease_batch_size_if_needed (bool):
-            If true, decrease batch size to ensure divisibility by DP size * microbatch size
-            (if needed).
-        rank (int):
-            Rank (to determine whether logging should be performed).
-        start_global_batch_size (int):
-            Global batch size to start with.
-        batch_size_increment (int):
-            Global batch size increments.
-        ramup_samples (int):
-            Number of samples to use ramp up global
-            batch size from `start_global_batch_size` to `global_batch_size`.
-    """
-
-    def __init__(
-        self,
-        global_batch_size: int,
-        micro_batch_size: int,
-        data_parallel_size: int,
-        decrease_batch_size_if_needed: bool,
-        rank: int,
-        start_global_batch_size: int,
-        batch_size_increment: int,
-        ramup_samples: int,
-    ) -> None:
-        assert global_batch_size > 0, 'global batch size should be positive, got {}.'.format(
-            global_batch_size
-        )
-        assert start_global_batch_size > 0, 'start batch size should be positive, got {}.'.format(
-            start_global_batch_size
-        )
-        assert batch_size_increment > 0, 'batch size increment should be positive, got {}.'.format(
-            batch_size_increment
-        )
-        assert ramup_samples >= 0, 'ramp-up samples should be non-negative, got {}.'.format(
-            ramup_samples
-        )
-
-        self.global_batch_size = global_batch_size
-        self.micro_batch_size = micro_batch_size
-        self.data_parallel_size = data_parallel_size
-        self.decrease_batch_size_if_needed = decrease_batch_size_if_needed
-        self.rank = rank
-        self.start_global_batch_size = start_global_batch_size
-        self.batch_size_increment = batch_size_increment
-        self.ramup_samples = ramup_samples
-
-        self.micro_batch_times_data_parallel_size = self.micro_batch_size * self.data_parallel_size
-        assert self.micro_batch_times_data_parallel_size > 0
-        self.current_global_batch_size = None
-
-        diff_batch_size = self.global_batch_size - self.start_global_batch_size
-        assert diff_batch_size >= 0, (
-            'expected global batch size to be greater than or equal to start batch size, '
-            f'got {self.global_batch_size} and {self.start_global_batch_size}'
-        )
-        assert diff_batch_size % batch_size_increment == 0, (
-            'expected '
-            f'global batch size interval ({diff_batch_size}) to be divisible by global batch '
-            f'size increment ({batch_size_increment})'
-        )
-
-        num_increments = diff_batch_size // self.batch_size_increment
-        self.rampup_samples_per_increment = self.ramup_samples / num_increments
-
-        # Initialize number of microbatches.
-        self.update(0, consistency_check=False, verbose=True)
-
-    def update(self, consumed_samples: int, consistency_check: bool, verbose: bool = False) -> None:
-        """Update number of microbatches.
-
-        Args:
-            consumed_samples (int): Number of samples consumed.
-            consistency_check (bool): Option to check current schedule's consistency.
-            verbose (bool, optional): Option to control logging. Defaults to False.
-        """
-
-        # Update current global batch size.
-        global_batch_size_changed = False
-        old_current_global_batch_size = self.current_global_batch_size
-        if consumed_samples > self.ramup_samples:
-            self.current_global_batch_size = self.global_batch_size
-        else:
-            steps = int(consumed_samples / self.rampup_samples_per_increment)
-            self.current_global_batch_size = (
-                self.start_global_batch_size + steps * self.batch_size_increment
-            )
-            assert self.current_global_batch_size <= self.global_batch_size
-
-        if old_current_global_batch_size != self.current_global_batch_size:
-            global_batch_size_changed = True
-        if self.rank == 0 and global_batch_size_changed and verbose:
-            if old_current_global_batch_size is None:
-                logger.info(f'setting initial batch size to {self.current_global_batch_size}')
-            else:
-                logger.info(
-                    f'ramping up batch size from {old_current_global_batch_size} to '
-                    f'{self.current_global_batch_size}'
-                )
-
-        # Check consistency of the current global batch size.
-        if consistency_check and not self.decrease_batch_size_if_needed:
-            assert (
-                self.current_global_batch_size % self.micro_batch_times_data_parallel_size == 0
-            ), (
-                'current global '
-                'batch size ({}) is not divisible by micro-batch-size ({}) times'
-                'data parallel size ({})'.format(
-                    self.current_global_batch_size, self.micro_batch_size, self.data_parallel_size
-                )
-            )
-
-        if (
-            self.decrease_batch_size_if_needed
-            and self.current_global_batch_size % self.micro_batch_times_data_parallel_size != 0
-        ):
-            self.current_running_global_batch_size = _round(
-                self.current_global_batch_size, self.micro_batch_times_data_parallel_size
-            )
-            if self.rank == 0 and global_batch_size_changed and verbose:
-                logger.info(
-                    f'decreasing batch size from {self.current_global_batch_size} to '
-                    f'{self.current_running_global_batch_size} to keep divisiblity by '
-                    f'micro_batch_size={self.micro_batch_size} * '
-                    f'data_parallel_size={self.data_parallel_size}'
-                )
-            assert (
-                self.current_running_global_batch_size % self.micro_batch_times_data_parallel_size
-                == 0
-            )
-        else:
-            self.current_running_global_batch_size = self.current_global_batch_size
-
-        self.num_micro_batches = (
-            self.current_running_global_batch_size // self.micro_batch_times_data_parallel_size
-        )

--- a/megatron/legacy/model/transformer.py
+++ b/megatron/legacy/model/transformer.py
@@ -1454,7 +1454,7 @@ class ParallelTransformer(MegatronModule):
             ) if self.use_fp8 else nullcontext():
                 # Determine if the current iteration is first microbatch
                 if self.num_microbatches_in_previous_step != get_num_microbatches():
-                    self.microbatch_count = 0 # Reset count on new batch size rampup interval
+                    self.microbatch_count = 0
                 self.num_microbatches_in_previous_step = get_num_microbatches()
                 is_first_microbatch = self.microbatch_count % get_num_microbatches() == 0
 

--- a/megatron/rl/rl_utils.py
+++ b/megatron/rl/rl_utils.py
@@ -1501,9 +1501,8 @@ def prepare_data_for_update(
                     samples_ratio_per_step=samples_ratio_per_step,
                     num_bins_this_rank = len(packing_context.packed_trajs),
                     bin_seq_indices = packing_context.packing_info.bin_seq_indices,
-                    global_batch_size=args.global_batch_size, 
-                    rampup_batch_size=args.rampup_batch_size, 
-                    micro_batch_size=args.micro_batch_size, 
+                    global_batch_size=args.global_batch_size,
+                    micro_batch_size=args.micro_batch_size,
                     decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
                )
                 loader = get_microbatch_dataloader(len(packing_context.packed_trajs), args.micro_batch_size)
@@ -1528,9 +1527,8 @@ def prepare_data_for_update(
 
                 reconfigure_num_microbatches_calculator(
                     rank=torch.distributed.get_rank() if torch.distributed.is_initialized() else 0,
-                    global_batch_size=math.ceil(samples_ratio_per_step*total_turns_sampled), 
-                    rampup_batch_size=args.rampup_batch_size, 
-                    micro_batch_size=args.micro_batch_size, 
+                    global_batch_size=math.ceil(samples_ratio_per_step*total_turns_sampled),
+                    micro_batch_size=args.micro_batch_size,
                     decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
                     data_parallel_size=mpu.get_data_parallel_world_size(),
                 )

--- a/megatron/rl/sequence_packing_utils.py
+++ b/megatron/rl/sequence_packing_utils.py
@@ -1069,7 +1069,6 @@ def update_microbatch_calculator(
     num_bins_this_rank: int,
     bin_seq_indices: List[List[int]],
     global_batch_size: int,
-    rampup_batch_size: int,
     micro_batch_size: int,
     decrease_batch_size_if_needed: bool,
 ):
@@ -1079,7 +1078,6 @@ def update_microbatch_calculator(
         num_bins_this_rank: Amount of packing bins that belongs to current rank.
         bin_seq_indices: Global seq indices in the bin, see PackingInfo.
         global_batch_size: Current global batch size.
-        rampup_batch_size: Rampup batch size. See num_microbatches_calculator.py for more.
         micro_batch_size: Micro batch size at init.
         decrease_batch_size_if_needed: Scale down batch size. See num_microbatches_calculator.py for more.
 
@@ -1099,7 +1097,6 @@ def update_microbatch_calculator(
     old_num_microbatches = get_num_microbatches()
     reconfigure_num_microbatches_calculator(
         rank=torch.distributed.get_rank() if torch.distributed.is_initialized() else 0,
-        rampup_batch_size=rampup_batch_size,
         global_batch_size=bins_bs,
         micro_batch_size=micro_batch_size,
         data_parallel_size=dp_world_size,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -593,8 +593,6 @@ def validate_args(args, defaults={}):
         args.phase_transition_iterations = sorted(
             int(x.strip()) for x in args.phase_transition_iterations.split(",")
         )
-        assert args.rampup_batch_size is None, "multi-phase training does not support batch size ramp-up"
-
     # Batch size.
     assert args.micro_batch_size is not None
     assert args.micro_batch_size > 0
@@ -617,7 +615,6 @@ def validate_args(args, defaults={}):
             args.grpo_samples_per_iteration * args.grpo_iterations)
 
         # Ensure that the number of prompts we collect is a multiple of the global batch size.
-        # TODO: Make this account for batch size rampup?
         assert num_generated_samples_per_inference_iteration % args.global_batch_size == 0, \
             f"grpo_group_size * grpo_prompts_per_step * grpo_iterations should be divisible by global_batch_size"
 
@@ -1116,8 +1113,6 @@ def validate_args(args, defaults={}):
             'expected iteration-based learning rate decay'
         assert args.lr_warmup_samples == 0, \
             'expected iteration-based learning rate warmup'
-        assert args.rampup_batch_size is None, \
-            'expected no batch-size rampup for iteration-based training'
         if args.lr_warmup_fraction is not None:
             assert args.lr_warmup_iters == 0, \
                 'can only specify one of lr-warmup-fraction and lr-warmup-iters'
@@ -2908,8 +2903,7 @@ def _add_data_args(parser):
                        'This argument is exclusive to the other independent --*-data-path arguments.')
     group.add_argument('--phase-transition-iterations', type=str, default=None,
                        help='Comma-separated list of iterations where phase '
-                       'transitions occur. Requires fixed global batch size across phases. '
-                       'Does not support batch size ramp-up.')
+                       'transitions occur. Requires fixed global batch size across phases.')
     group.add_argument('--split', type=str, default=None,
                        help='Comma-separated list of proportions for training,'
                        ' validation, and test split. For example the split '

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -16,17 +16,6 @@ class TrainingConfig:
     data-parallel-size. If this value is None, then use micro-batch-size * data-parallel-size
     as the global batch size. This choice will result in 1 for number of micro-batches."""
 
-    rampup_batch_size: list[int] | None = field(default=None, metadata={"argparse_meta": {"nargs": 3}})
-    """Batch size ramp up with the following values: <start batch size>, <batch size increment>,
-    <ramp-up samples>
-    For example:
-        rampup-batch-size = [16, 8, 300000]
-        global-batch-size 1024
-    will start with global batch size 16 and over (1024 - 16) / 8 = 126 intervals will increase
-    the batch size linearly to 1024. In each interval we will use approximately
-    300000 / 126 = 2380 samples.
-    """
-
     decrease_batch_size_if_needed: bool = False
     """If set, decrease batch size if microbatch_size * dp_size does not 
     divide batch_size. Old batch_size will be restored if training is re-started 

--- a/megatron/training/global_vars.py
+++ b/megatron/training/global_vars.py
@@ -123,7 +123,6 @@ def set_global_variables(args, build_tokenizer=True):
 
     init_num_microbatches_calculator(
         args.rank,
-        args.rampup_batch_size,
         args.global_batch_size,
         args.micro_batch_size,
         args.data_parallel_size,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1285,29 +1285,7 @@ def update_train_iters(args):
     if args.train_iters:
         return
 
-    # Constant batch size with sample-based training.
-    if args.rampup_batch_size is None:
-        args.train_iters = args.train_samples // args.global_batch_size
-
-    else:
-        # Sample based training with rampup batch size.
-        iterations = 0
-        consumed_samples = 0
-        # Rampup phase.
-        while (
-            consumed_samples <= int(args.rampup_batch_size[2])
-            and consumed_samples <= args.train_samples
-        ):
-            update_num_microbatches(consumed_samples, consistency_check=False)
-            consumed_samples += get_current_global_batch_size()
-            iterations += 1
-        # Reset
-        update_num_microbatches(0, consistency_check=False)
-        # Constant phase
-        # Note that we throw away any partial last batch.
-        if args.train_samples > consumed_samples:
-            iterations += (args.train_samples - consumed_samples) // args.global_batch_size
-        args.train_iters = iterations
+    args.train_iters = args.train_samples // args.global_batch_size
 
     print_rank_0(f'setting training iterations to {args.train_iters}')
 
@@ -2679,7 +2657,6 @@ def train(
         # Then initialize with the correct perform_rl_step=True context
         init_num_microbatches_calculator(
             args.rank,
-            args.rampup_batch_size,
             args.global_batch_size,
             args.micro_batch_size,
             mpu.get_data_parallel_world_size(),
@@ -2935,8 +2912,8 @@ def train(
                 )
             else:
                 assert get_num_microbatches() > num_microbatches, (
-                    f"Number of microbatches should be increasing due to batch size rampup; "
-                    f"instead going from {num_microbatches} to {get_num_microbatches()}"
+                    f"Number of microbatches should not decrease; "
+                    f"going from {num_microbatches} to {get_num_microbatches()}"
                 )
                 if args.save is not None:
                     save_checkpoint_and_time(

--- a/megatron/training/yaml_arguments.py
+++ b/megatron/training/yaml_arguments.py
@@ -188,8 +188,6 @@ def validate_yaml(args, defaults={}):
             'expected iteration-based learning rate decay'
         assert args.lr_warmup_samples == 0, \
             'expected iteration-based learning rate warmup'
-        assert args.rampup_batch_size is None, \
-            'expected no batch-size rampup for iteration-based training'
         if args.lr_warmup_fraction is not None:
             assert args.lr_warmup_iters == 0, \
                 'can only specify one of lr-warmup-fraction and lr-warmup-iters'

--- a/tasks/finetune_utils.py
+++ b/tasks/finetune_utils.py
@@ -248,9 +248,6 @@ def finetune(train_valid_datasets_provider, model_provider,
     args = get_args()
     timers = get_timers()
 
-    assert args.rampup_batch_size is None, \
-        'batch size scaling is not supported for finetuning'
-
     # Train and validation data loaders.
     timers('train/valid/test dataset/dataloder', log_level=0).start()
     if args.epochs > 0:

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release/model_config.yaml
@@ -22,7 +22,6 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --rampup-batch-size: "[384 384 97656250]"
   --global-batch-size: 1152
   --train-samples: 19531250
   --manual-gc: true

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_gb200/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_gb200/model_config.yaml
@@ -24,7 +24,6 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --rampup-batch-size: "[384 384 97656250]"
   --global-batch-size: 1152
   --train-samples: 19531250
   --manual-gc: true

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm/model_config.yaml
@@ -22,7 +22,6 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --rampup-batch-size: "[384 384 97656250]"
   --global-batch-size: 1152
   --train-samples: 4882812
   --manual-gc: true

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm_gb200/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm_gb200/model_config.yaml
@@ -24,7 +24,6 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --rampup-batch-size: "[384 384 97656250]"
   --global-batch-size: 1152
   --train-samples: 19531250
   --manual-gc: true

--- a/tests/unit_tests/dist_checkpointing/test_pipeline_parallel_layout.py
+++ b/tests/unit_tests/dist_checkpointing/test_pipeline_parallel_layout.py
@@ -305,7 +305,7 @@ def test_save_and_load_checkpoint_vpp(
         args.load = ckpt_path
 
     set_tp_pp_vpp(*src_tp_pp_vpp, pp_layout=src_pp_layout, destroy_first=False)
-    init_num_microbatches_calculator(0, None, 1, 1, 1)
+    init_num_microbatches_calculator(0, 1, 1, 1)
 
     iteration = 123
     layer_spec_fn = get_gpt_decoder_block_spec if is_moe else gpt_te_spec

--- a/tests/unit_tests/distributed/test_torch_fully_sharded_parallel.py
+++ b/tests/unit_tests/distributed/test_torch_fully_sharded_parallel.py
@@ -39,7 +39,7 @@ class DummyModel(MegatronModule):
 def init_model_parallel():
     """Init torch distributed."""
     Utils.initialize_model_parallel(1, 1)
-    init_num_microbatches_calculator(0, None, 1, 1, 1)
+    init_num_microbatches_calculator(0, 1, 1, 1)
     model_parallel_cuda_manual_seed(123)
     yield  # Run the actual test.
     Utils.destroy_model_parallel()

--- a/tests/unit_tests/pipeline_parallel/test_pipeline_layout.py
+++ b/tests/unit_tests/pipeline_parallel/test_pipeline_layout.py
@@ -226,7 +226,7 @@ def test_forward_vpp(create_args, tmp_path_dist_ckpt, tp_pp_vpp, pp_layout, is_m
         args.pipeline_model_parallel_layout = pp_layout
 
     set_tp_pp_vpp(*tp_pp_vpp, pp_layout=pp_layout, destroy_first=False)
-    init_num_microbatches_calculator(0, None, 1, 1, 1)
+    init_num_microbatches_calculator(0, 1, 1, 1)
 
     def forward_step_func(data_iterator, model: GPTModel):
         """Forward training step. Copied from `pretrain_gpt.py`"""

--- a/tests/unit_tests/rl/test_sequence_packing_utils.py
+++ b/tests/unit_tests/rl/test_sequence_packing_utils.py
@@ -468,12 +468,7 @@ def test_get_bins_bs_and_steps(ratio, local_bins, world, expected_bs):
     global_bs_in_seq = int(n_seqs * ratio)
 
     def side_eff(
-        rank,
-        rampup_batch_size,
-        global_batch_size,
-        micro_batch_size,
-        data_parallel_size,
-        decrease_batch_size_if_needed,
+        rank, global_batch_size, micro_batch_size, data_parallel_size, decrease_batch_size_if_needed
     ):
         # Inside of the get_microbatch_dataloader, we compute the batch size in bins.
         # We want to test this variable.
@@ -491,7 +486,6 @@ def test_get_bins_bs_and_steps(ratio, local_bins, world, expected_bs):
                     num_bins_this_rank=local_bins,
                     bin_seq_indices=[],
                     global_batch_size=global_bs_in_seq,
-                    rampup_batch_size=1,
                     micro_batch_size=1,
                     decrease_batch_size_if_needed=False,
                 )

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -152,7 +152,7 @@ def create_ckpt_load_args(create_args):
 def init_model_parallel():
     """Init torch distributed."""
     Utils.initialize_model_parallel(1, 1)
-    init_num_microbatches_calculator(0, None, 1, 1, 1)
+    init_num_microbatches_calculator(0, 1, 1, 1)
     model_parallel_cuda_manual_seed(123)
     yield  # Run the actual test.
     Utils.destroy_model_parallel()

--- a/tests/unit_tests/test_num_microbatches_calculator.py
+++ b/tests/unit_tests/test_num_microbatches_calculator.py
@@ -1,5 +1,3 @@
-from typing import List, Optional
-
 import pytest
 
 import megatron.core.num_microbatches_calculator as mb_calculator
@@ -7,21 +5,21 @@ import megatron.core.num_microbatches_calculator as mb_calculator
 
 def test_init_num_microbatches_calculator():
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, False)
+    mb_calculator.init_num_microbatches_calculator(0, 32, 8, 2, False)
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 32
 
     with pytest.raises(AssertionError):
-        mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, False)
+        mb_calculator.init_num_microbatches_calculator(0, 32, 8, 2, False)
 
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 3, True)
+    mb_calculator.init_num_microbatches_calculator(0, 32, 8, 3, True)
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 32
     assert mb_calculator.get_current_running_global_batch_size() == 24
 
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 33, 8, 2, True)
+    mb_calculator.init_num_microbatches_calculator(0, 33, 8, 2, True)
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 33
     assert mb_calculator.get_current_running_global_batch_size() == 32
@@ -29,68 +27,35 @@ def test_init_num_microbatches_calculator():
 
 def test_reconfigure_num_microbatches_calculator():
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, False)
+    mb_calculator.init_num_microbatches_calculator(0, 32, 8, 2, False)
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 32
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, False)
-    assert mb_calculator.get_num_microbatches() == 1
-    assert mb_calculator.get_current_global_batch_size() == 16
-
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 16, 96], 32, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 8, 2, False)
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 16
 
 
 def test_get_num_microbatches():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 8, 2, False)
     assert mb_calculator.get_num_microbatches() == 1
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 3, True)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 4, 3, True)
     assert mb_calculator.get_num_microbatches() == 1
 
 
 def test_get_current_global_batch_size():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 4, 2, False)
     assert mb_calculator.get_current_global_batch_size() == 16
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 3, True)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 4, 3, True)
     assert mb_calculator.get_current_global_batch_size() == 16
     assert mb_calculator.get_current_running_global_batch_size() == 12
 
 
 def test_get_micro_batch_size():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 8, 2, False)
     assert mb_calculator.get_micro_batch_size() == 8
-
-
-def test_update_num_microbatches():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 8, 96], 32, 4, 2, False)
-    assert mb_calculator.get_num_microbatches() == 2
-    mb_calculator.update_num_microbatches(48, False)
-    assert mb_calculator.get_num_microbatches() == 3
-
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 8, 96], 32, 8, 2, False)
-    with pytest.raises(AssertionError):
-        mb_calculator.update_num_microbatches(49, True)
-
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 32, 8, 2, False)
-    mb_calculator.update_num_microbatches(16)
-    assert mb_calculator.get_num_microbatches() == 2
-
-
-def test_build_num_microbatches_calculator():
-    temp_calculator = mb_calculator._build_num_microbatches_calculator(0, None, 32, 8, 2, False)
-    assert temp_calculator.get() == 2
-    assert temp_calculator.get_current_global_batch_size() == 32
-    assert type(temp_calculator) is mb_calculator.ConstantNumMicroBatchesCalculator
-
-    temp_calculator = mb_calculator._build_num_microbatches_calculator(
-        0, [16, 16, 48], 32, 8, 2, False
-    )
-    assert temp_calculator.get() == 1
-    assert temp_calculator.get_current_global_batch_size() == 16
-    assert type(temp_calculator) is mb_calculator.RampupBatchsizeNumMicroBatchesCalculator
 
 
 class TestConstantNumMicroBatchesCalculator:
@@ -108,40 +73,3 @@ class TestConstantNumMicroBatchesCalculator:
 
     def test_get_current_global_batch_size(self):
         assert self.mb_calculator.get_current_global_batch_size() == 32
-
-
-class TestRampupBatchsizeNumMicroBatchesCalculator:
-    def setup_method(self, method):
-        self.mb_calculator = mb_calculator.RampupBatchsizeNumMicroBatchesCalculator(
-            32, 8, 2, False, 0, 16, 16, 48
-        )
-
-    def test_constructor(self):
-        assert type(self.mb_calculator) is mb_calculator.RampupBatchsizeNumMicroBatchesCalculator
-        assert self.mb_calculator.global_batch_size == 32
-        assert self.mb_calculator.micro_batch_size == 8
-        assert self.mb_calculator.data_parallel_size == 2
-        assert self.mb_calculator.start_global_batch_size == 16
-        assert self.mb_calculator.batch_size_increment == 16
-        assert self.mb_calculator.ramup_samples == 48
-        assert self.mb_calculator.micro_batch_times_data_parallel_size == 16
-        assert self.mb_calculator.num_micro_batches == 1
-
-    def test_get(self):
-        assert self.mb_calculator.get() == 1
-
-    def test_get_current_global_batch_size(self):
-        assert self.mb_calculator.get_current_global_batch_size() == 16
-
-
-def test_ramp_up():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 16, 96], 32, 8, 2, False)
-    consumed_samples = 0
-    count = 0
-    expected_consumed_samples = [0, 16, 32, 48, 64, 80, 96, 128, 160, 192, 224, 256]
-
-    while consumed_samples < 256:
-        consumed_samples += mb_calculator.get_current_global_batch_size()
-        count += 1
-        assert consumed_samples == expected_consumed_samples[count]
-        mb_calculator.update_num_microbatches(consumed_samples, True)

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -575,7 +575,6 @@ class TestTECudaGraphHelper:
         # Initialize num_microbatches calculator
         init_num_microbatches_calculator(
             rank=0,
-            rampup_batch_size=None,
             global_batch_size=micro_batch_size * num_microbatches,
             micro_batch_size=micro_batch_size,
             data_parallel_size=1,


### PR DESCRIPTION
## Summary
- Remove the `RampupBatchsizeNumMicroBatchesCalculator` class and all rampup batch size logic from the num microbatches calculator
- Remove the `rampup_batch_size` config field and CLI argument
- Clean up all associated assertions, call sites, tests, and example configs across the codebase (23 files)

## Test plan
- [ ] Existing unit tests pass (rampup-specific tests removed, constant batch size tests preserved)
- [ ] Functional tests for gpt3_15b_8t_release configs updated (removed `--rampup-batch-size` flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)