### PR TITLE
Fix gated delta net cp comm type

### DIFF
--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -84,6 +84,7 @@ class GatedDeltaNet(MegatronModule):
         use_qk_l2norm: bool = True,
         A_init_range: Tuple[float, float] = (1, 16),
         pg_collection: ProcessGroupCollection = None,
+        cp_comm_type: Optional[str] = None,
     ):
         """
         Args:
@@ -97,7 +98,13 @@ class GatedDeltaNet(MegatronModule):
             A_init_range: The initialization range for the attention weights.
             pg_collection: The required process groups to use for tensor model parallel and context
                 parallel.
+            cp_comm_type: Context-parallel communication type. Accepted for interface
+                compatibility with the attention submodule builder in TransformerLayer
+                (which injects this kwarg whenever config.context_parallel_size > 1).
+                GatedDeltaNet implements its own context-parallel communication via
+                ``pg_collection.cp``, so the value is currently unused.
         """
+        del cp_comm_type  # unused; see docstring
 
         if not HAVE_FLA:
             raise ImportError(

--- a/tests/unit_tests/ssm/test_gated_delta_net.py
+++ b/tests/unit_tests/ssm/test_gated_delta_net.py
@@ -201,6 +201,36 @@ class TestGatedDeltaNet:
         assert g.shape == alpha.shape
         assert beta_sig.shape == beta.shape
 
+    def test_accepts_cp_comm_type_kwarg(self):
+        """Regression: TransformerLayer injects ``cp_comm_type`` into the
+        attention-submodule constructor whenever ``context_parallel_size > 1``
+        (see ``megatron/core/transformer/transformer_layer.py``). Without the
+        kwarg being declared, GDN build fails with ``TypeError`` for any
+        hybrid model using Gated Delta Net layers with CP>1 (e.g. Qwen3-Next /
+        Qwen3.5). GatedDeltaNet handles CP communication via
+        ``pg_collection.cp`` (added in #2642), so the value itself is unused."""
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        cp_group = parallel_state.get_context_parallel_group()
+        pg_collection = ProcessGroupCollection(tp=tp_group, cp=cp_group)
+        gdn_submodules = get_experimental_attention_variant_module_spec(
+            config=self.transformer_config
+        ).submodules
+
+        # Must accept and ignore cp_comm_type without raising.
+        gdn = GatedDeltaNet(
+            self.transformer_config,
+            submodules=gdn_submodules,
+            layer_number=1,
+            bias=False,
+            conv_bias=False,
+            conv_init=1.0,
+            use_qk_l2norm=True,
+            A_init_range=(1, 16),
+            pg_collection=pg_collection,
+            cp_comm_type="p2p",
+        )
+        assert gdn is not None
+
 
 @pytest.mark.parametrize(
     ("tp", "sp", "cp"),


### PR DESCRIPTION
# What does this PR do ?

Accept `cp_comm_type` in `GatedDeltaNet.__init__`, fixing a `TypeError` that blocks any model using Gated Delta Net layers with `context_parallel_size > 1`.

## Background

`TransformerLayer` unconditionally injects `cp_comm_type` into the self-attention submodule constructor whenever `config.context_parallel_size > 1` (`megatron/core/transformer/transformer_layer.py:313–321`). This path predates the GDN + CP work in #2642, so when a GDN layer is bound as the self-attention submodule (e.g. for Qwen3-Next / Qwen3.5 hybrid models), build fails with:

    TypeError: GatedDeltaNet.__init__() got an unexpected keyword argument 'cp_comm_type'

## Why #2642 didn't catch this

#2642 changed three files: `gated_delta_net.py`, `transformer_config.py`, and `tests/unit_tests/ssm/test_gated_delta_net.py`. It did not touch `transformer_layer.py`. The added tests instantiate `GatedDeltaNet` directly rather than through `build_module(submodules.self_attention, ..., **attention_optional_kwargs)` inside `TransformerLayer`, so the kwarg-contract mismatch never surfaced. No shipped recipe exercises GDN with `CP>1` either (e.g. `NVIDIA-NeMo/Megatron-Bridge`'s `qwen3_next.py` pins `CP=1`).

## Fix

Declare `cp_comm_type: Optional[str] = None` on `GatedDeltaNet.__init__` and silently ignore it — `GatedDeltaNet` handles context-parallel communication via `pg_collection.cp` (added in #2642), so the value has no current meaning for GDN.

## Test

- Added regression unit test `TestGatedDeltaNet::test_accepts_cp_comm_type_kwarg` that constructs `GatedDeltaNet` with the kwarg and verifies it does not raise.
- End-to-end: reproduced the crash before this fix and confirmed the fix unblocks training on Qwen3.5-35B-A3B (Gated Delta Net every 3 of 4 layers) with TP=2 PP=1 CP=2 EP=8 on 8× B200. GRPO training with verl + vLLM 0.18 + mbridge is now stable at ~150 s/step; rewards improved from 0.14 to
   0.70 over 33 steps.

## Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests  *(not applicable — interface-contract fix; E2E reproducer in PR description)*
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR