### PR TITLE
moe: align HybridEP buffer to combine-API chunk size to fix JIT failure

### DIFF
--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -13,6 +13,9 @@ try:
 except ImportError:
     HAVE_DEEP_EP = False
 
+import math
+import os
+
 import torch
 
 _buffer = None
@@ -267,12 +270,50 @@ else:
 
 try:
     from deep_ep import HybridEPBuffer
+    import hybrid_ep_cpp as _hybrid_ep_cpp
 
     HAVE_HYBRIDEP = True
 except ImportError:
+    _hybrid_ep_cpp = None
     HAVE_HYBRIDEP = False
 
 _hybrid_ep_buffer = None
+
+_HYBRID_EP_COMBINE_CHUNK_FALLBACK = 64
+
+
+def _get_hybrid_ep_buffer_alignment() -> int:
+    '''
+    Return the per-rank token-count alignment required by HybridEP's combine kernel.
+
+    HybridEP's ``combine_kernel`` contains the ``static_assert``::
+
+        static_assert(MAX_NUM_OF_TOKENS_PER_RANK % NUM_OF_TOKENS_PER_CHUNK == 0,
+                      "MAX_NUM_OF_TOKENS_PER_RANK must be multiple of NUM_OF_TOKENS_PER_CHUNK.");
+
+    (``csrc/hybrid_ep/backend/hybrid_ep_backend.cuh``). deep_ep's Python layer
+    (``HybridEPBuffer.__init__``) only aligns ``max_num_of_tokens_per_rank``
+    to 16 (for TMA), so a per-rank token count that is not a multiple of the
+    combine-API chunk size triggers a JIT compilation failure inside the
+    combine kernel.
+    '''
+    if _hybrid_ep_cpp is not None:
+        try:
+            probe = _hybrid_ep_cpp.Configurer(
+                hidden_dim=16,
+                max_num_of_tokens_per_rank=1,
+                num_local_experts=4,
+                num_of_ranks_per_node=1,
+                num_of_nodes=1,
+                use_fp8=False,
+            )
+            return int(probe.buffer_config.num_of_tokens_per_chunk_combine_api)
+        except Exception:
+            pass
+
+    return int(
+        os.getenv("NUM_OF_TOKENS_PER_CHUNK_COMBINE_API", str(_HYBRID_EP_COMBINE_CHUNK_FALLBACK))
+    )
 
 
 def init_hybrid_ep_buffer(
@@ -298,7 +339,12 @@ def init_hybrid_ep_buffer(
         hidden_dim (int):
             Hidden dimension of the input tensor.
         seq_len (int):
-            Maximum sequence length of the input tensor.
+            Maximum sequence length of the input tensor. The value is
+            rounded up to a multiple of HybridEP's combine-API chunk size
+            (queried directly from deep_ep) to satisfy the
+            ``combine_kernel``'s ``static_assert`` on
+            ``MAX_NUM_OF_TOKENS_PER_RANK``; see
+            :func:`_get_hybrid_ep_buffer_alignment` for details.
         num_local_experts (int):
             Number of local experts.
         num_sms_dispatch_api (int):
@@ -309,11 +355,15 @@ def init_hybrid_ep_buffer(
             Whether to use FP8 communication during the dispatch phase.
     '''
     assert not fp8_dispatch, "HybridEP dispatcher does not support fp8 dispatch now"
+
+    chunk_size = _get_hybrid_ep_buffer_alignment()
+    aligned_seq_len = math.ceil(seq_len / chunk_size) * chunk_size
+
     global _hybrid_ep_buffer
     _hybrid_ep_buffer = HybridEPBuffer(
         group=group,
         hidden_dim=hidden_dim,
-        max_num_of_tokens_per_rank=seq_len,
+        max_num_of_tokens_per_rank=aligned_seq_len,
         num_local_experts=num_local_experts,
         use_fp8=fp8_dispatch,
         num_sms_dispatch_api=num_sms_dispatch_api,
@@ -516,3 +566,4 @@ if HAVE_HYBRIDEP:
 else:
     hybrid_ep_dispatch = None
     hybrid_ep_combine = None
+

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -269,8 +269,8 @@ else:
 
 
 try:
-    from deep_ep import HybridEPBuffer
     import hybrid_ep_cpp as _hybrid_ep_cpp
+    from deep_ep import HybridEPBuffer
 
     HAVE_HYBRIDEP = True
 except ImportError:
@@ -566,4 +566,3 @@ if HAVE_HYBRIDEP:
 else:
     hybrid_ep_dispatch = None
     hybrid_ep_combine = None
-


### PR DESCRIPTION
# What does this PR do ?

Fix a JIT compile-time `static_assert` failure in deep_ep's HybridEP `combine_kernel`, triggered when the per-rank token count is aligned to 16 (deep_ep's TMA alignment) but not to the combine-API chunk size (default 64).

## Contribution process

This issue was originally reported and patched downstream in [NVIDIA-NeMo/Megatron-Bridge#3294](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3294). 

## Root cause
- `deep_ep/hybrid_ep_buffer.py:141-142` rounds `num_of_tokens_per_rank` up to a multiple of **16** for TMA load/store alignment. (hybrid-ep branch)
- `deep_ep/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh:4552`, inside `combine_kernel`, carries:
  ```cpp
  static_assert(MAX_NUM_OF_TOKENS_PER_RANK % NUM_OF_TOKENS_PER_CHUNK == 0,
                "MAX_NUM_OF_TOKENS_PER_RANK must be multiple of NUM_OF_TOKENS_PER_CHUNK.");
  ```
  where `NUM_OF_TOKENS_PER_CHUNK` defaults to 64 (configurable via `NUM_OF_TOKENS_PER_CHUNK_COMBINE_API`).
A value that is a multiple of 16 is **not** automatically a multiple of 64. For example, on H100 with TP=1, EP=8, PP=1, mbs=2, cur_len=1776, the per-rank token count is 3552, and `3552 % 64 = 32`. The Python layer happily lets it through, and the failure surfaces only at JIT compile time inside the combine kernel:

<img width="1907" height="372" alt="31d11c1cd6f5a1ef3ed61d9a8cb5ad03" src="https://github.com/user-attachments/assets/c52eb4c3-b7b9-4be8-a87d-5877ac35a7f0" />

<img width="1896" height="469" alt="4dfcaf80384cb14e7811042f121f661f" src="https://github.com/user-attachments/assets/a47df739-f3ea-415a-8715-3afed541d6d0" />


The relevant tail is:
```
RuntimeError: Failed to compile the code, compile command: nvcc ...
.../hybrid_ep/jit/.../2048-3552-32-...-64-...-rank-0-...so
```
where `3552` is `MAX_NUM_OF_TOKENS_PER_RANK` and `64` is `NUM_OF_TOKENS_PER_CHUNK` — exactly the values that violate the `static_assert`.

## Fix
In `megatron/core/transformer/moe/fused_a2a.py`:
- Add `_get_hybrid_ep_buffer_alignment()`, which **probes** the actual combine-API chunk size by instantiating a throw-away `hybrid_ep_cpp.Configurer` and reading `buffer_config.num_of_tokens_per_chunk_combine_api`. The `Configurer` constructor only queries CUDA device properties and fills a host-side `BufferConfig` struct — no communication-buffer allocation, no JIT compilation, no NCCL/group interaction — so this is a microsecond-scale probe.
- `init_hybrid_ep_buffer()` rounds `seq_len` up to that chunk size before constructing `HybridEPBuffer`.
Probing rather than reading the env var directly was chosen so that mcore:
- tracks deep_ep's built-in default across versions (e.g. 64 today, 128 in older builds) without having to hard-code anything;
- automatically honors any user-set `NUM_OF_TOKENS_PER_CHUNK_COMBINE_API` override, since deep_ep itself reads the same env var inside `Configurer`.
A best-effort fallback path (env var → hard-coded 64) is kept for the unlikely case that the probe fails (e.g. future deep_ep API change). It is not expected to be reachable on any currently-supported deep_ep release.
Only the **combine-API** chunk size needs alignment. The `dispatch_kernel` has no equivalent `static_assert` on `MAX_NUM_OF_TOKENS_PER_RANK`; its `num_of_dispatch_chunks` is sized via host-side ceil division and tolerates a non-aligned `max_num_of_tokens_per_rank`. Aligning to the combine chunk is therefore both necessary and sufficient.
