### PR TITLE
fix(ci): wrap uv install in retry block

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -83,7 +83,11 @@ runs:
           echo "apt attempt $i failed, retrying..."
           sleep 10
         done
-        curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh
+        for i in 1 2 3; do
+          curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh && break
+          echo "uv install attempt $i failed, retrying..."
+          sleep 10
+        done
 
     - name: Create run-script (unit test)
       shell: bash -x -e -u -o pipefail {0}


### PR DESCRIPTION
## Summary

- Wraps the `uv` installer curl command in a retry loop (3 attempts, 10 s sleep between attempts), consistent with the existing `apt-get` retry pattern above it.

## Motivation

The install occasionally fails due to transient network issues. Without a retry, the entire CI job fails hard on a flaky download.

## Example

```yaml
for i in 1 2 3; do
  curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh && break
  echo "uv install attempt $i failed, retrying..."
  sleep 10
done
```
