### PR TITLE
M-FSDP: Trigger initial backward prefetch at root module pre-backward stage

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -910,6 +910,25 @@ class MegatronFSDP(torch.nn.Module):
                         ag_pipeline.bucket_can_be_released[
                             ag_pipeline.get_bucket_key(bucket_id, bwd=False)
                         ] = True
+
+            # Seed asynchronous backward prefetch from the last gradient-bearing bucket.
+            last_param = next(
+                (
+                    group.params[0]
+                    for group in reversed(self.param_and_grad_buffer.parameter_groups)
+                    if group.requires_grad
+                ),
+                None,
+            )
+            if last_param is not None:
+                self.all_gather_and_wait_parameters_ready(
+                    params=[last_param],
+                    prefetch=True,
+                    prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER,
+                    wait_bucket_ready=False,
+                    bwd=True,
+                )
+
             # Track parameters that require gradient reduction and optimization.
             self._params_require_handle_grad = set()
             for param_group in self.param_and_grad_buffer.parameter_groups:


### PR DESCRIPTION
Previously, the first backward prefetch could be delayed until deeper in the autograd execution, which may leave a gap where communication is not effectively overlapped with computation. By initiating the prefetch earlier—at the root module pre-backward stage—we ensure that parameter shards for the upcoming backward pass are requested as soon as possible.

This PR addresses the issue where the unshard communication of the first layer in the backward pass does not properly overlap with computation.

Before the fix:
<img width="3452" height="1988" alt="image (2)" src="https://github.com/user-attachments/assets/044f03cb-c5e6-46e4-83d9-c0dc2522e0aa" />
After the fix:
<img width="3452" height="1988" alt="image (1)" src="https://github.com/user-attachments/assets/27efa690-2a6d-4a06-ab1c-3b417e32e021" />


# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
