### PR TITLE
fix merges_file typo in megatron_hf_tokenizer

### DIFF
--- a/megatron/core/tokenizers/text/libraries/megatron_hf_tokenizer.py
+++ b/megatron/core/tokenizers/text/libraries/megatron_hf_tokenizer.py
@@ -95,7 +95,7 @@ class MegatronHFTokenizer(HuggingFaceTokenizer):
             )
 
         vocab_file = self._get_vocab_file(tokenizer_name, vocab_file)
-        merges_file = self._get_merges_file(tokenizer_name, vocab_file)
+        merges_file = self._get_merges_file(tokenizer_name, merges_file)
         tokenizer_path = MEGATRON_CONFIG_MAP[tokenizer_name]["tokenizer_name"]
         super().__init__(tokenizer_path, vocab_file, merges_file, **kwargs)
 


### PR DESCRIPTION
# What does this PR do ?
Fixes #4391 by replacing `vocab_file` with `merges_file` in [megatron_hf_tokenizer.py](https://github.com/NVIDIA/Megatron-LM/blob/30461822692a5da057c3db171d26fbee1d7c49d2/megatron/core/tokenizers/text/libraries/megatron_hf_tokenizer.py#L98)
