### PR TITLE
fix: use no_mask in local ViT layer spec

### DIFF
--- a/megatron/core/models/vision/vit_layer_specs.py
+++ b/megatron/core/models/vision/vit_layer_specs.py
@@ -69,7 +69,7 @@ def get_vit_layer_with_local_spec() -> ModuleSpec:
             input_layernorm=LNImpl,
             self_attention=ModuleSpec(
                 module=SelfAttention,
-                params={"attn_mask_type": AttnMaskType.causal},
+                params={"attn_mask_type": AttnMaskType.no_mask},
                 submodules=SelfAttentionSubmodules(
                     linear_qkv=ColumnParallelLinear,
                     core_attention=DotProductAttention,


### PR DESCRIPTION
## Summary

- Changes `AttnMaskType.causal` → `AttnMaskType.no_mask` in `get_vit_layer_with_local_spec()` (`megatron/core/models/vision/vit_layer_specs.py:72`) to match the TE spec.
- ViTs use bidirectional self-attention over image patches; causal masking is incorrect.
- Commit 20abc8599 ("fix vit mask") fixed this in the TE path but missed the local path.

Fixes #1791

## Test plan

- [ ] Confirm `pretrain_vlm.py` with `--transformer-impl local` produces correct ViT behavior
- [ ] Existing vision unit tests (`tests/unit_tests/transformer/test_vision_cuda_graphs.py`) still pass
- [ ] No regression in TE path (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)