### PR TITLE
Add Attention Residuals with Full/Block modes and optimized kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,21 @@ onelogger.err
 runs/
 /test_cases/
 **/dist/
+checkpoints/
+tensorboard_logs/
+benchmark_cache*/
+.triton_libcuda/
+tea_debug.log
+*.log
+
+# Local Attention Residuals experiment artifacts.
+examples/attention_residuals/data/
+examples/attention_residuals/logs/
+examples/attention_residuals/cache/
+examples/attention_residuals/checkpoints/
+examples/attention_residuals/*_venv/
+examples/attention_residuals/preprocess_deps/
+examples/attention_residuals/wandb_deps/
 
 # Sphinx documentation
 docs/_build

--- a/docs/user-guide/features/attention_residuals.md
+++ b/docs/user-guide/features/attention_residuals.md
@@ -1,0 +1,107 @@
+# Attention Residuals
+
+Attention Residuals replace fixed residual accumulation with a learned
+depth-wise attention over residual-producing hidden states. This implementation
+adds Full AttnRes and Block AttnRes to Megatron Core transformer blocks.
+
+The implementation follows the paper's convention that self-attention and MLP
+are separate residual-producing sublayers. For each transformer layer, AttnRes
+is applied before self-attention and before MLP, then the corresponding sublayer
+output is added to the AttnRes state. A final AttnRes aggregation is applied at
+the transformer block output before the final layer norm.
+
+## Variants
+
+Full AttnRes attends over all preceding residual-producing values:
+
+```bash
+--attention-residuals \
+--attention-residual-type full
+```
+
+Block AttnRes groups sublayer outputs into depth blocks and attends over
+completed block summaries plus the current partial block:
+
+```bash
+--attention-residuals \
+--attention-residual-type block \
+--attention-residual-num-blocks 8
+```
+
+For a decoder stack with `L` transformer layers, there are `2L` residual
+sublayers. With 16 transformer layers and 8 AttnRes blocks, each block contains
+4 residual sublayers.
+
+## Implementations
+
+The depth-attention scorer supports four implementation modes:
+
+```bash
+--attention-residual-implementation torch
+--attention-residual-implementation checkpointed
+--attention-residual-implementation triton
+--attention-residual-implementation triton_bwd
+```
+
+`torch` is the eager PyTorch reference. It is useful for correctness checks but
+saves more forward intermediates.
+
+`checkpointed` uses custom autograd and recomputes AttnRes internals in
+backward. This reduces saved forward intermediates and is a good memory-saving
+reference.
+
+`triton` uses Triton kernels for the forward reduction and accumulation path,
+with checkpointed PyTorch recomputation in backward.
+
+`triton_bwd` uses Triton kernels for both forward and backward recomputation.
+This is the recommended implementation for performance experiments when Triton
+is available.
+
+## RMSNorm
+
+By default, AttnRes applies RMSNorm to keys before depth-wise scoring:
+
+```bash
+--attention-residuals
+```
+
+Disable it with:
+
+```bash
+--no-attention-residual-rmsnorm
+```
+
+## Diagnostic Logging
+
+For short smoke tests, query gradient diagnostics can be enabled with:
+
+```bash
+--attention-residual-log-weights
+```
+
+This prints gradient norms for the AttnRes query parameters. It introduces GPU
+synchronization overhead and should stay disabled for timing comparisons.
+
+## Current Scope
+
+Supported and exercised:
+
+- Decoder-only dense GPT/Llama-style transformer layers.
+- Tensor parallelism and sequence parallelism.
+- Transformer Engine FP8 training path in the provided examples.
+- Full and Block AttnRes with `torch`, `checkpointed`, `triton`, and
+  `triton_bwd` implementations.
+
+Not yet supported or not yet validated:
+
+- MoE MLP layers.
+- Cross-attention layers.
+- Pipeline parallel configurations greater than one stage.
+- Full-layer activation recomputation with AttnRes.
+- Inference/KV-cache paths.
+
+## Example
+
+The example scripts under `examples/attention_residuals/` show how to launch
+baseline, Full AttnRes, and Block AttnRes runs with the same model/data
+configuration.

--- a/docs/user-guide/features/index.md
+++ b/docs/user-guide/features/index.md
@@ -15,6 +15,7 @@ Advanced feature guides for key Megatron Core capabilities.
 :maxdepth: 2
 
 fine_grained_activation_offloading
+attention_residuals
 moe
 context_parallel
 custom_fsdp

--- a/examples/attention_residuals/README.md
+++ b/examples/attention_residuals/README.md
@@ -1,0 +1,95 @@
+# Attention Residuals Examples
+
+This directory contains small, reproducible launch examples for the Megatron
+Core Attention Residuals implementation.
+
+The examples assume that tokenizer and preprocessed data already exist. They do
+not download model weights or datasets.
+
+## Required Inputs
+
+Set these paths before launching:
+
+```bash
+export TOKENIZER_MODEL=/path/to/llama3-tokenizer
+export DATA_PREFIX=/path/to/megatron_text_document
+```
+
+`DATA_PREFIX` should point to a Megatron indexed dataset prefix, without the
+`.bin` or `.idx` suffix.
+
+## Baseline
+
+```bash
+WANDB_PROJECT=attention-residuals \
+WANDB_EXP_NAME=baseline_1000steps \
+TOKENIZER_MODEL=$TOKENIZER_MODEL \
+DATA_PREFIX=$DATA_PREFIX \
+TRAIN_ITERS=1000 \
+LR_DECAY_ITERS=10000 \
+LR_WARMUP_ITERS=100 \
+./examples/attention_residuals/train_llama3_wikitext.sh baseline
+```
+
+## Full AttnRes
+
+```bash
+WANDB_PROJECT=attention-residuals \
+WANDB_EXP_NAME=full_triton_bwd_1000steps \
+TOKENIZER_MODEL=$TOKENIZER_MODEL \
+DATA_PREFIX=$DATA_PREFIX \
+TRAIN_ITERS=1000 \
+LR_DECAY_ITERS=10000 \
+LR_WARMUP_ITERS=100 \
+ATTENTION_RESIDUAL_TYPE=full \
+ATTENTION_RESIDUAL_IMPLEMENTATION=triton_bwd \
+./examples/attention_residuals/train_llama3_wikitext.sh attnres
+```
+
+## Block AttnRes
+
+```bash
+WANDB_PROJECT=attention-residuals \
+WANDB_EXP_NAME=block_n8_triton_bwd_1000steps \
+TOKENIZER_MODEL=$TOKENIZER_MODEL \
+DATA_PREFIX=$DATA_PREFIX \
+TRAIN_ITERS=1000 \
+LR_DECAY_ITERS=10000 \
+LR_WARMUP_ITERS=100 \
+ATTENTION_RESIDUAL_TYPE=block \
+ATTENTION_RESIDUAL_NUM_BLOCKS=8 \
+ATTENTION_RESIDUAL_IMPLEMENTATION=triton_bwd \
+./examples/attention_residuals/train_llama3_wikitext.sh attnres
+```
+
+## Common Knobs
+
+```bash
+NUM_LAYERS=16
+SEQ_LENGTH=1024
+MICRO_BATCH_SIZE=8
+GLOBAL_BATCH_SIZE=32
+TP_SIZE=2
+PP_SIZE=1
+CP_SIZE=1
+```
+
+Use `EXIT_DURATION_IN_MINS=30` for wall-clock-limited experiments. Leave it
+unset for step-limited experiments controlled by `TRAIN_ITERS`.
+
+## Implementation Modes
+
+```bash
+ATTENTION_RESIDUAL_IMPLEMENTATION=torch
+ATTENTION_RESIDUAL_IMPLEMENTATION=checkpointed
+ATTENTION_RESIDUAL_IMPLEMENTATION=triton
+ATTENTION_RESIDUAL_IMPLEMENTATION=triton_bwd
+```
+
+`triton_bwd` is the recommended mode when Triton is available.
+
+## Limitations
+
+The current implementation is intended for dense decoder-only GPT/Llama-style
+models. MoE, cross-attention, pipeline parallelism greater than one stage, and
+inference paths are not yet supported.

--- a/examples/attention_residuals/train_llama3_wikitext.sh
+++ b/examples/attention_residuals/train_llama3_wikitext.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE=${1:-baseline}
+case "$MODE" in
+    baseline)
+        ATTENTION_RESIDUALS_VALUE=0
+        ;;
+    attnres)
+        ATTENTION_RESIDUALS_VALUE=1
+        ;;
+    *)
+        echo "Usage: $0 baseline|attnres" >&2
+        exit 1
+        ;;
+esac
+
+TOKENIZER_MODEL=${TOKENIZER_MODEL:-}
+DATA_PREFIX=${DATA_PREFIX:-}
+if [[ -z "$TOKENIZER_MODEL" ]]; then
+    echo "Set TOKENIZER_MODEL=/path/to/tokenizer before running." >&2
+    exit 1
+fi
+if [[ -z "$DATA_PREFIX" ]]; then
+    echo "Set DATA_PREFIX=/path/to/megatron_text_document before running." >&2
+    exit 1
+fi
+
+CHECKPOINT_ROOT=${CHECKPOINT_ROOT:-checkpoints/attention_residuals}
+LOG_ROOT=${LOG_ROOT:-tensorboard_logs/attention_residuals}
+RUN_NAME=${RUN_NAME:-"${MODE}_layers${NUM_LAYERS:-16}_seq${SEQ_LENGTH:-1024}_$(date +'%y-%m-%d_%H-%M-%S')"}
+CHECKPOINT_PATH="${CHECKPOINT_ROOT}/${RUN_NAME}"
+TENSORBOARD_LOGS_PATH="${LOG_ROOT}/${RUN_NAME}"
+DATA_CACHE_PATH=${DATA_CACHE_PATH:-"benchmark_cache_attention_residuals/${RUN_NAME}"}
+
+mkdir -p "$CHECKPOINT_PATH" "$TENSORBOARD_LOGS_PATH" "$DATA_CACHE_PATH"
+
+export ATTENTION_RESIDUALS="$ATTENTION_RESIDUALS_VALUE"
+export ATTENTION_RESIDUAL_TYPE=${ATTENTION_RESIDUAL_TYPE:-full}
+export ATTENTION_RESIDUAL_NUM_BLOCKS=${ATTENTION_RESIDUAL_NUM_BLOCKS:-8}
+export ATTENTION_RESIDUAL_IMPLEMENTATION=${ATTENTION_RESIDUAL_IMPLEMENTATION:-triton_bwd}
+export ATTENTION_RESIDUAL_RMSNORM=${ATTENTION_RESIDUAL_RMSNORM:-1}
+export ATTENTION_RESIDUAL_LOG_WEIGHTS=${ATTENTION_RESIDUAL_LOG_WEIGHTS:-0}
+export DATA_CACHE_PATH
+
+bash examples/llama/train_llama3_8b_h100_fp8_2gpu_smoke.sh \
+  "$CHECKPOINT_PATH" \
+  "$TENSORBOARD_LOGS_PATH" \
+  "$TOKENIZER_MODEL" \
+  "$DATA_PREFIX"

--- a/examples/llama/train_llama3_8b_h100_fp8_2gpu_smoke.sh
+++ b/examples/llama/train_llama3_8b_h100_fp8_2gpu_smoke.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+set -euo pipefail
+
+# Two-GPU smoke test for the Llama-3 8B FP8 example.
+# It keeps the 8B model shape, but uses TP=2, mock data, a short sequence
+# length, and only a few iterations so the example can validate the stack.
+
+export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
+export TORCH_COMPILE_DISABLE=${TORCH_COMPILE_DISABLE:-1}
+
+# Triton/Inductor sometimes needs the unversioned libcuda.so linker name.
+# Apptainer --nv commonly exposes only libcuda.so.1 from the host driver.
+if [[ -e /usr/local/cuda/compat/lib/libcuda.so.1 ]]; then
+    TRITON_LIBCUDA_DIR=${TRITON_LIBCUDA_DIR:-"${PWD}/.triton_libcuda"}
+    mkdir -p "$TRITON_LIBCUDA_DIR"
+    ln -sf /usr/local/cuda/compat/lib/libcuda.so.1 "$TRITON_LIBCUDA_DIR/libcuda.so"
+    ln -sf /usr/local/cuda/compat/lib/libcuda.so.1 "$TRITON_LIBCUDA_DIR/libcuda.so.1"
+    ln -sf /usr/local/cuda/compat/lib/libcuda.so.1 /usr/local/cuda/compat/lib/libcuda.so 2>/dev/null || true
+    export TRITON_LIBCUDA_PATH="$TRITON_LIBCUDA_DIR"
+    export LD_LIBRARY_PATH="${TRITON_LIBCUDA_DIR}:/usr/local/cuda/compat/lib:${LD_LIBRARY_PATH:-}"
+    export LIBRARY_PATH="${TRITON_LIBCUDA_DIR}:/usr/local/cuda/compat/lib:${LIBRARY_PATH:-}"
+fi
+
+CHECKPOINT_PATH=${1:-"checkpoints/llama3_8b_fp8_2gpu_smoke"}
+TENSORBOARD_LOGS_PATH=${2:-"tensorboard_logs/llama3_8b_fp8_2gpu_smoke"}
+TOKENIZER_ARG=${3:-"MOCK"} # Path to tokenizer model, or "MOCK"
+DATA_ARG=${4:-"MOCK"}     # Data prefix, or "MOCK"
+
+mkdir -p "$CHECKPOINT_PATH" "$TENSORBOARD_LOGS_PATH"
+
+GPUS_PER_NODE=${GPUS_PER_NODE:-2}
+NUM_NODES=${NUM_NODES:-1}
+MASTER_ADDR=${MASTER_ADDR:-localhost}
+MASTER_PORT=${MASTER_PORT:-6000}
+NODE_RANK=${NODE_RANK:-0}
+
+PRETRAIN_SCRIPT_PATH="pretrain_gpt.py"
+
+TP_SIZE=${TP_SIZE:-2}
+CP_SIZE=${CP_SIZE:-1}
+PP_SIZE=${PP_SIZE:-1}
+MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE:-1}
+GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE:-2}
+TRAIN_ITERS=${TRAIN_ITERS:-5}
+LR_DECAY_ITERS=${LR_DECAY_ITERS:-$TRAIN_ITERS}
+if [[ -z "${LR_WARMUP_ITERS+x}" ]]; then
+    if (( TRAIN_ITERS <= 1 )); then
+        LR_WARMUP_ITERS=0
+    else
+        LR_WARMUP_ITERS=1
+    fi
+fi
+SEQ_LENGTH=${SEQ_LENGTH:-8192}
+MAX_POSITION_EMBEDDINGS=${MAX_POSITION_EMBEDDINGS:-8192}
+NUM_LAYERS=${NUM_LAYERS:-32}
+HIDDEN_SIZE=${HIDDEN_SIZE:-4096}
+FFN_HIDDEN_SIZE=${FFN_HIDDEN_SIZE:-14336}
+NUM_ATTENTION_HEADS=${NUM_ATTENTION_HEADS:-32}
+NUM_QUERY_GROUPS=${NUM_QUERY_GROUPS:-8}
+KV_CHANNELS=${KV_CHANNELS:-128}
+VOCAB_SIZE=${VOCAB_SIZE:-128256}
+SAVE_CHECKPOINTS=${SAVE_CHECKPOINTS:-0}
+EXIT_DURATION_IN_MINS=${EXIT_DURATION_IN_MINS:-}
+WANDB_PROJECT=${WANDB_PROJECT:-}
+WANDB_EXP_NAME=${WANDB_EXP_NAME:-}
+WANDB_SAVE_DIR=${WANDB_SAVE_DIR:-}
+WANDB_ENTITY=${WANDB_ENTITY:-}
+ATTENTION_RESIDUALS=${ATTENTION_RESIDUALS:-0}
+ATTENTION_RESIDUAL_TYPE=${ATTENTION_RESIDUAL_TYPE:-full}
+ATTENTION_RESIDUAL_NUM_BLOCKS=${ATTENTION_RESIDUAL_NUM_BLOCKS:-8}
+ATTENTION_RESIDUAL_RMSNORM=${ATTENTION_RESIDUAL_RMSNORM:-1}
+ATTENTION_RESIDUAL_IMPLEMENTATION=${ATTENTION_RESIDUAL_IMPLEMENTATION:-torch}
+ATTENTION_RESIDUAL_LOG_WEIGHTS=${ATTENTION_RESIDUAL_LOG_WEIGHTS:-0}
+
+DATA_CACHE_PATH=${DATA_CACHE_PATH:-"${PWD}/benchmark_cache_llama3_8b_fp8_2gpu_smoke"}
+mkdir -p "$DATA_CACHE_PATH"
+
+DISTRIBUTED_ARGS=(
+    --nproc_per_node "$GPUS_PER_NODE"
+    --nnodes "$NUM_NODES"
+    --node_rank "$NODE_RANK"
+    --master_addr "$MASTER_ADDR"
+    --master_port "$MASTER_PORT"
+)
+
+MODEL_ARGS=(
+    --use-mcore-models
+    --num-layers "$NUM_LAYERS"
+    --hidden-size "$HIDDEN_SIZE"
+    --ffn-hidden-size "$FFN_HIDDEN_SIZE"
+    --num-attention-heads "$NUM_ATTENTION_HEADS"
+    --group-query-attention
+    --num-query-groups "$NUM_QUERY_GROUPS"
+    --kv-channels "$KV_CHANNELS"
+    --seq-length "$SEQ_LENGTH"
+    --max-position-embeddings "$MAX_POSITION_EMBEDDINGS"
+    --position-embedding-type rope
+    --rotary-base 1000000
+    --rotary-percent 1.0
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+    --swiglu
+    --normalization RMSNorm
+    --init-method-std 0.0134
+    --attention-backend fused
+    --apply-layernorm-1p
+    --untie-embeddings-and-output-weights
+    --disable-bias-linear
+)
+
+if [[ "$ATTENTION_RESIDUALS" == "1" ]]; then
+    MODEL_ARGS+=(
+        --attention-residuals
+        --attention-residual-type "$ATTENTION_RESIDUAL_TYPE"
+        --attention-residual-num-blocks "$ATTENTION_RESIDUAL_NUM_BLOCKS"
+        --attention-residual-implementation "$ATTENTION_RESIDUAL_IMPLEMENTATION"
+    )
+    if [[ "$ATTENTION_RESIDUAL_RMSNORM" != "1" ]]; then
+        MODEL_ARGS+=(--no-attention-residual-rmsnorm)
+    fi
+    if [[ "$ATTENTION_RESIDUAL_LOG_WEIGHTS" == "1" ]]; then
+        MODEL_ARGS+=(--attention-residual-log-weights)
+    fi
+fi
+
+TRAINING_ARGS=(
+    --micro-batch-size "$MICRO_BATCH_SIZE"
+    --global-batch-size "$GLOBAL_BATCH_SIZE"
+    --train-iters "$TRAIN_ITERS"
+    --lr-decay-iters "$LR_DECAY_ITERS"
+    --lr-warmup-iters "$LR_WARMUP_ITERS"
+    --lr 0.00015
+    --min-lr 0.00001
+    --decoupled-lr 5.0e-4
+    --decoupled-min-lr 4.5e-5
+    --lr-decay-style cosine
+    --clip-grad 1.0
+    --weight-decay 0.1
+    --adam-beta1 0.9
+    --adam-beta2 0.95
+    --bf16
+    --grad-reduce-in-bf16
+    --cross-entropy-loss-fusion
+    --calculate-per-token-loss
+    --manual-gc
+    --empty-unused-memory-level 1
+    --recompute-activations
+    --use-distributed-optimizer
+    --overlap-grad-reduce
+    --overlap-param-gather
+)
+
+if [[ -n "$EXIT_DURATION_IN_MINS" ]]; then
+    TRAINING_ARGS+=(--exit-duration-in-mins "$EXIT_DURATION_IN_MINS")
+fi
+
+DTYPE_ARGS=(
+    --fp8-format hybrid
+    --fp8-amax-history-len 1024
+    --fp8-amax-compute-algo max
+    --fp8-param-gather
+)
+
+MODEL_PARALLEL_ARGS=(
+    --tensor-model-parallel-size "$TP_SIZE"
+    --context-parallel-size "$CP_SIZE"
+    --pipeline-model-parallel-size "$PP_SIZE"
+    --sequence-parallel
+)
+
+DATA_ARGS_LIST=()
+if [[ "$TOKENIZER_ARG" == "MOCK" ]] || [[ "$DATA_ARG" == "MOCK" ]] || [[ -z "$TOKENIZER_ARG" ]]; then
+    DATA_ARGS_LIST+=(
+        --mock-data
+        --tokenizer-type NullTokenizer
+        --vocab-size "$VOCAB_SIZE"
+        --data-cache-path "$DATA_CACHE_PATH"
+        --tiktoken-pattern v2
+        --split 99,1,0
+        --no-create-attention-mask-in-dataloader
+        --no-mmap-bin-files
+        --num-workers 1
+    )
+else
+    DATA_ARGS_LIST+=(
+        --data-path "$DATA_ARG"
+        --tokenizer-type HuggingFaceTokenizer
+        --tokenizer-model "$TOKENIZER_ARG"
+        --data-cache-path "$DATA_CACHE_PATH"
+        --split 99,1,0
+        --no-create-attention-mask-in-dataloader
+        --no-mmap-bin-files
+        --num-workers 1
+        --vocab-size "$VOCAB_SIZE"
+    )
+fi
+
+EVAL_AND_LOGGING_ARGS=(
+    --log-interval 1
+    --eval-iters 0
+    --eval-interval 1000
+    --log-throughput
+    --ckpt-format torch_dist
+    --distributed-timeout-minutes 60
+    --tensorboard-dir "$TENSORBOARD_LOGS_PATH"
+)
+
+if [[ "$SAVE_CHECKPOINTS" == "1" ]]; then
+    EVAL_AND_LOGGING_ARGS+=(
+        --save "$CHECKPOINT_PATH"
+        --save-interval "$TRAIN_ITERS"
+        --async-save
+        --async-strategy mcore
+    )
+fi
+
+if [[ -n "$WANDB_PROJECT" ]]; then
+    if [[ -z "$WANDB_EXP_NAME" ]]; then
+        echo "Error: WANDB_EXP_NAME must be set when WANDB_PROJECT is set." >&2
+        exit 1
+    fi
+    EVAL_AND_LOGGING_ARGS+=(
+        --wandb-project "$WANDB_PROJECT"
+        --wandb-exp-name "$WANDB_EXP_NAME"
+    )
+    if [[ -n "$WANDB_SAVE_DIR" ]]; then
+        EVAL_AND_LOGGING_ARGS+=(--wandb-save-dir "$WANDB_SAVE_DIR")
+    fi
+    if [[ -n "$WANDB_ENTITY" ]]; then
+        EVAL_AND_LOGGING_ARGS+=(--wandb-entity "$WANDB_ENTITY")
+    fi
+fi
+
+if [ ! -f "$PRETRAIN_SCRIPT_PATH" ]; then
+    echo "Error: pretrain_gpt.py not found at $PRETRAIN_SCRIPT_PATH"
+    echo "Run this script from the root of the Megatron-LM repository."
+    exit 1
+fi
+
+echo "Running Llama-3 FP8 smoke test on ${GPUS_PER_NODE} GPUs: layers=${NUM_LAYERS}, hidden=${HIDDEN_SIZE}, ffn=${FFN_HIDDEN_SIZE}, heads=${NUM_ATTENTION_HEADS}, query_groups=${NUM_QUERY_GROUPS}, TP=${TP_SIZE}, CP=${CP_SIZE}, PP=${PP_SIZE}, seq=${SEQ_LENGTH}, iters=${TRAIN_ITERS}, exit_mins=${EXIT_DURATION_IN_MINS:-none}, lr_decay_iters=${LR_DECAY_ITERS}, lr_warmup_iters=${LR_WARMUP_ITERS}, attn_res=${ATTENTION_RESIDUALS}, attn_res_type=${ATTENTION_RESIDUAL_TYPE}, attn_res_blocks=${ATTENTION_RESIDUAL_NUM_BLOCKS}, attn_res_impl=${ATTENTION_RESIDUAL_IMPLEMENTATION}, wandb_project=${WANDB_PROJECT:-none}"
+
+torchrun "${DISTRIBUTED_ARGS[@]}" \
+    "$PRETRAIN_SCRIPT_PATH" \
+    "${MODEL_ARGS[@]}" \
+    "${TRAINING_ARGS[@]}" \
+    "${DTYPE_ARGS[@]}" \
+    "${MODEL_PARALLEL_ARGS[@]}" \
+    "${DATA_ARGS_LIST[@]}" \
+    "${EVAL_AND_LOGGING_ARGS[@]}"

--- a/megatron/core/transformer/attention_residuals.py
+++ b/megatron/core/transformer/attention_residuals.py
@@ -1,0 +1,748 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Attention Residual modules.
+
+This file contains the standalone Full Attention Residual operator used by the
+Attention Residuals reproduction. Megatron transformer layers use hidden-state
+tensors shaped as [sequence, batch, hidden].
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Literal
+
+import torch
+from torch import Tensor
+
+try:
+    import triton
+    import triton.language as tl
+
+    _TRITON_AVAILABLE = True
+except ImportError:
+    triton = None
+    tl = None
+    _TRITON_AVAILABLE = False
+
+
+@dataclass
+class AttnResState:
+    """Mutable AttnRes history for one transformer block forward."""
+
+    history: list[Tensor] = field(default_factory=list)
+    residual_type: Literal['full', 'block'] = 'full'
+    num_sublayers: int | None = None
+    num_blocks: int = 8
+    completed_blocks: list[Tensor] = field(default_factory=list)
+    partial_block: Tensor | None = None
+    partial_block_count: int = 0
+    sublayer_count: int = 0
+
+    def append(self, value: Tensor) -> None:
+        if self.residual_type == 'full':
+            self.history.append(value)
+            return
+
+        if self.residual_type != 'block':
+            raise ValueError(f"unsupported AttnRes residual_type: {self.residual_type}")
+
+        self.partial_block = (
+            value if self.partial_block is None else self.partial_block + value
+        )
+        self.partial_block_count += 1
+        self.sublayer_count += 1
+
+        if self.partial_block_count >= self.block_size:
+            self.completed_blocks.append(self.partial_block)
+            self.partial_block = None
+            self.partial_block_count = 0
+
+    @property
+    def block_size(self) -> int:
+        if self.num_sublayers is None:
+            raise ValueError("num_sublayers is required for Block AttnRes")
+        return max(1, (self.num_sublayers + self.num_blocks - 1) // self.num_blocks)
+
+    def values(self) -> list[Tensor]:
+        if self.residual_type == 'full':
+            return self.history
+        if self.residual_type != 'block':
+            raise ValueError(f"unsupported AttnRes residual_type: {self.residual_type}")
+
+        values = list(self.completed_blocks)
+        if self.partial_block is not None:
+            values.append(self.partial_block)
+        return values
+
+    @classmethod
+    def full(cls, initial_value: Tensor) -> 'AttnResState':
+        return cls(history=[initial_value], residual_type='full')
+
+    @classmethod
+    def block(
+        cls, initial_value: Tensor, num_sublayers: int, num_blocks: int
+    ) -> 'AttnResState':
+        if num_sublayers <= 0:
+            raise ValueError(f"num_sublayers must be positive, got {num_sublayers}")
+        if num_blocks <= 0:
+            raise ValueError(f"num_blocks must be positive, got {num_blocks}")
+        return cls(
+            history=[],
+            residual_type='block',
+            num_sublayers=num_sublayers,
+            num_blocks=num_blocks,
+            completed_blocks=[initial_value],
+        )
+
+
+def _full_attn_res_compute(
+    values: Sequence[Tensor],
+    query: Tensor,
+    weight: Tensor,
+    hidden_size: int,
+    eps: float,
+    use_rmsnorm: bool,
+) -> Tensor:
+    """Compute Full AttnRes with regular PyTorch ops."""
+
+    reference = values[0]
+    query = query.to(dtype=reference.dtype)
+    weight = weight.to(dtype=reference.dtype)
+
+    logits = []
+    for value in values:
+        if use_rmsnorm:
+            variance = value.pow(2).mean(dim=-1, keepdim=True)
+            key = value * torch.rsqrt(variance + eps) * weight
+        else:
+            key = value
+        logits.append(torch.einsum("h,sbh->sb", query, key))
+
+    weights = torch.softmax(torch.stack(logits, dim=0), dim=0).to(dtype=reference.dtype)
+    output = torch.zeros_like(reference)
+    for depth, value in enumerate(values):
+        output = output + weights[depth].unsqueeze(-1) * value
+
+    return output
+
+
+if _TRITON_AVAILABLE:
+
+    @triton.jit
+    def _attn_res_reduce_kernel(
+        value,
+        query,
+        weight,
+        partial_dot,
+        partial_sq,
+        hidden_size: tl.constexpr,
+        num_hidden_blocks: tl.constexpr,
+        block_h: tl.constexpr,
+        use_rmsnorm: tl.constexpr,
+    ):
+        token_id = tl.program_id(0)
+        hidden_block_id = tl.program_id(1)
+        hidden_offsets = hidden_block_id * block_h + tl.arange(0, block_h)
+        hidden_mask = hidden_offsets < hidden_size
+
+        value_offsets = token_id * hidden_size + hidden_offsets
+        value_tile = tl.load(value + value_offsets, mask=hidden_mask, other=0.0).to(tl.float32)
+        query_tile = tl.load(query + hidden_offsets, mask=hidden_mask, other=0.0).to(tl.float32)
+
+        if use_rmsnorm:
+            weight_tile = tl.load(weight + hidden_offsets, mask=hidden_mask, other=0.0).to(tl.float32)
+            dot = tl.sum(value_tile * weight_tile * query_tile, axis=0)
+            sq = tl.sum(value_tile * value_tile, axis=0)
+        else:
+            dot = tl.sum(value_tile * query_tile, axis=0)
+            sq = 0.0
+
+        partial_offset = token_id * num_hidden_blocks + hidden_block_id
+        tl.store(partial_dot + partial_offset, dot)
+        tl.store(partial_sq + partial_offset, sq)
+
+    @triton.jit
+    def _attn_res_accum_kernel(
+        value,
+        depth_weights,
+        output,
+        hidden_size: tl.constexpr,
+        block_h: tl.constexpr,
+    ):
+        token_id = tl.program_id(0)
+        hidden_block_id = tl.program_id(1)
+        hidden_offsets = hidden_block_id * block_h + tl.arange(0, block_h)
+        hidden_mask = hidden_offsets < hidden_size
+
+        value_offsets = token_id * hidden_size + hidden_offsets
+        value_tile = tl.load(value + value_offsets, mask=hidden_mask, other=0.0)
+        output_tile = tl.load(output + value_offsets, mask=hidden_mask, other=0.0)
+        depth_weight = tl.load(depth_weights + token_id)
+
+        output_tile += depth_weight * value_tile
+        tl.store(output + value_offsets, output_tile, mask=hidden_mask)
+
+    @triton.jit
+    def _attn_res_backward_reduce_kernel(
+        value,
+        grad_output,
+        query,
+        weight,
+        partial_dot,
+        partial_sq,
+        partial_gv,
+        hidden_size: tl.constexpr,
+        num_hidden_blocks: tl.constexpr,
+        block_h: tl.constexpr,
+        use_rmsnorm: tl.constexpr,
+    ):
+        token_id = tl.program_id(0)
+        hidden_block_id = tl.program_id(1)
+        hidden_offsets = hidden_block_id * block_h + tl.arange(0, block_h)
+        hidden_mask = hidden_offsets < hidden_size
+
+        value_offsets = token_id * hidden_size + hidden_offsets
+        value_tile = tl.load(value + value_offsets, mask=hidden_mask, other=0.0).to(tl.float32)
+        grad_tile = tl.load(grad_output + value_offsets, mask=hidden_mask, other=0.0).to(
+            tl.float32
+        )
+        query_tile = tl.load(query + hidden_offsets, mask=hidden_mask, other=0.0).to(tl.float32)
+
+        if use_rmsnorm:
+            weight_tile = tl.load(weight + hidden_offsets, mask=hidden_mask, other=0.0).to(
+                tl.float32
+            )
+            dot = tl.sum(value_tile * weight_tile * query_tile, axis=0)
+            sq = tl.sum(value_tile * value_tile, axis=0)
+        else:
+            dot = tl.sum(value_tile * query_tile, axis=0)
+            sq = 0.0
+        gv = tl.sum(value_tile * grad_tile, axis=0)
+
+        partial_offset = token_id * num_hidden_blocks + hidden_block_id
+        tl.store(partial_dot + partial_offset, dot)
+        tl.store(partial_sq + partial_offset, sq)
+        tl.store(partial_gv + partial_offset, gv)
+
+    @triton.jit
+    def _attn_res_backward_apply_kernel(
+        value,
+        grad_output,
+        query,
+        weight,
+        alpha,
+        beta,
+        raw_dot,
+        inv_rms,
+        grad_value,
+        hidden_size: tl.constexpr,
+        block_h: tl.constexpr,
+        use_rmsnorm: tl.constexpr,
+    ):
+        token_id = tl.program_id(0)
+        hidden_block_id = tl.program_id(1)
+        hidden_offsets = hidden_block_id * block_h + tl.arange(0, block_h)
+        hidden_mask = hidden_offsets < hidden_size
+
+        value_offsets = token_id * hidden_size + hidden_offsets
+        value_tile = tl.load(value + value_offsets, mask=hidden_mask, other=0.0).to(tl.float32)
+        grad_tile = tl.load(grad_output + value_offsets, mask=hidden_mask, other=0.0).to(
+            tl.float32
+        )
+        query_tile = tl.load(query + hidden_offsets, mask=hidden_mask, other=0.0).to(tl.float32)
+
+        alpha_scalar = tl.load(alpha + token_id).to(tl.float32)
+        beta_scalar = tl.load(beta + token_id).to(tl.float32)
+
+        if use_rmsnorm:
+            weight_tile = tl.load(weight + hidden_offsets, mask=hidden_mask, other=0.0).to(
+                tl.float32
+            )
+            raw_dot_scalar = tl.load(raw_dot + token_id).to(tl.float32)
+            inv_scalar = tl.load(inv_rms + token_id).to(tl.float32)
+            inv_cubed = inv_scalar * inv_scalar * inv_scalar
+            grad_value_tile = alpha_scalar * grad_tile + beta_scalar * (
+                inv_scalar * query_tile * weight_tile
+                - raw_dot_scalar * inv_cubed * value_tile / hidden_size
+            )
+        else:
+            grad_value_tile = alpha_scalar * grad_tile + beta_scalar * query_tile
+
+        tl.store(grad_value + value_offsets, grad_value_tile, mask=hidden_mask)
+
+    @triton.jit
+    def _attn_res_backward_param_kernel(
+        value,
+        query,
+        weight,
+        beta,
+        inv_rms,
+        grad_query,
+        grad_weight,
+        num_tokens: tl.constexpr,
+        hidden_size: tl.constexpr,
+        block_t: tl.constexpr,
+        block_h: tl.constexpr,
+        use_rmsnorm: tl.constexpr,
+    ):
+        token_block_id = tl.program_id(0)
+        hidden_block_id = tl.program_id(1)
+        token_offsets = token_block_id * block_t + tl.arange(0, block_t)
+        hidden_offsets = hidden_block_id * block_h + tl.arange(0, block_h)
+        token_mask = token_offsets < num_tokens
+        hidden_mask = hidden_offsets < hidden_size
+
+        value_offsets = token_offsets[:, None] * hidden_size + hidden_offsets[None, :]
+        mask = token_mask[:, None] & hidden_mask[None, :]
+        value_tile = tl.load(value + value_offsets, mask=mask, other=0.0).to(tl.float32)
+        beta_tile = tl.load(beta + token_offsets, mask=token_mask, other=0.0).to(tl.float32)
+
+        if use_rmsnorm:
+            inv_tile = tl.load(inv_rms + token_offsets, mask=token_mask, other=0.0).to(tl.float32)
+            scale = beta_tile * inv_tile
+            query_tile = tl.load(query + hidden_offsets, mask=hidden_mask, other=0.0).to(tl.float32)
+            weight_tile = tl.load(weight + hidden_offsets, mask=hidden_mask, other=0.0).to(
+                tl.float32
+            )
+            grad_query_tile = tl.sum(scale[:, None] * value_tile * weight_tile[None, :], axis=0)
+            grad_weight_tile = tl.sum(scale[:, None] * value_tile * query_tile[None, :], axis=0)
+            tl.atomic_add(grad_weight + hidden_offsets, grad_weight_tile, sem="relaxed", mask=hidden_mask)
+        else:
+            grad_query_tile = tl.sum(beta_tile[:, None] * value_tile, axis=0)
+
+        tl.atomic_add(grad_query + hidden_offsets, grad_query_tile, sem="relaxed", mask=hidden_mask)
+
+
+def _full_attn_res_triton_forward(
+    values: Sequence[Tensor],
+    query: Tensor,
+    weight: Tensor,
+    hidden_size: int,
+    eps: float,
+    use_rmsnorm: bool,
+) -> Tensor:
+    """Compute Full AttnRes forward with Triton kernels when possible."""
+
+    if not _TRITON_AVAILABLE or not values[0].is_cuda:
+        return _full_attn_res_compute(values, query, weight, hidden_size, eps, use_rmsnorm)
+    if any(not value.is_contiguous() for value in values):
+        return _full_attn_res_compute(values, query, weight, hidden_size, eps, use_rmsnorm)
+
+    reference = values[0]
+    sequence_length, batch_size, local_hidden_size = reference.shape
+    if local_hidden_size != hidden_size:
+        raise ValueError(f"expected hidden size {hidden_size}, got {local_hidden_size}")
+
+    num_tokens = sequence_length * batch_size
+    num_depths = len(values)
+    block_h = 1024
+    num_hidden_blocks = triton.cdiv(hidden_size, block_h)
+
+    query_work = query.to(device=reference.device, dtype=reference.dtype).contiguous()
+    weight_work = weight.to(device=reference.device, dtype=reference.dtype).contiguous()
+    partial_dot = torch.empty(
+        (num_depths, num_tokens, num_hidden_blocks), device=reference.device, dtype=torch.float32
+    )
+    partial_sq = torch.empty_like(partial_dot)
+
+    grid = (num_tokens, num_hidden_blocks)
+    for depth, value in enumerate(values):
+        value_2d = value.reshape(num_tokens, hidden_size)
+        _attn_res_reduce_kernel[grid](
+            value_2d,
+            query_work,
+            weight_work,
+            partial_dot[depth],
+            partial_sq[depth],
+            hidden_size,
+            num_hidden_blocks,
+            block_h,
+            use_rmsnorm,
+        )
+
+    dot = partial_dot.sum(dim=-1)
+    if use_rmsnorm:
+        inv_rms = torch.rsqrt(partial_sq.sum(dim=-1) / hidden_size + eps)
+        logits = dot * inv_rms
+    else:
+        logits = dot
+
+    depth_weights = torch.softmax(logits, dim=0).to(dtype=reference.dtype)
+    output = torch.zeros((num_tokens, hidden_size), device=reference.device, dtype=reference.dtype)
+
+    for depth, value in enumerate(values):
+        value_2d = value.reshape(num_tokens, hidden_size)
+        _attn_res_accum_kernel[grid](
+            value_2d,
+            depth_weights[depth].contiguous(),
+            output,
+            hidden_size,
+            block_h,
+        )
+
+    return output.reshape(sequence_length, batch_size, hidden_size)
+
+
+def _full_attn_res_triton_backward(
+    grad_output: Tensor,
+    values: Sequence[Tensor],
+    query: Tensor,
+    weight: Tensor,
+    hidden_size: int,
+    eps: float,
+    use_rmsnorm: bool,
+) -> tuple[Tensor, Tensor, list[Tensor]]:
+    """Compute Full AttnRes backward gradients with Triton kernels."""
+
+    reference = values[0]
+    sequence_length, batch_size, local_hidden_size = reference.shape
+    if local_hidden_size != hidden_size:
+        raise ValueError(f"expected hidden size {hidden_size}, got {local_hidden_size}")
+
+    num_tokens = sequence_length * batch_size
+    num_depths = len(values)
+    block_h = 1024
+    num_hidden_blocks = triton.cdiv(hidden_size, block_h)
+
+    grad_output_2d = grad_output.contiguous().reshape(num_tokens, hidden_size)
+    query_work = query.to(device=reference.device, dtype=reference.dtype).contiguous()
+    weight_work = weight.to(device=reference.device, dtype=reference.dtype).contiguous()
+    partial_dot = torch.empty(
+        (num_depths, num_tokens, num_hidden_blocks), device=reference.device, dtype=torch.float32
+    )
+    partial_sq = torch.empty_like(partial_dot)
+    partial_gv = torch.empty_like(partial_dot)
+
+    grid = (num_tokens, num_hidden_blocks)
+    for depth, value in enumerate(values):
+        value_2d = value.reshape(num_tokens, hidden_size)
+        _attn_res_backward_reduce_kernel[grid](
+            value_2d,
+            grad_output_2d,
+            query_work,
+            weight_work,
+            partial_dot[depth],
+            partial_sq[depth],
+            partial_gv[depth],
+            hidden_size,
+            num_hidden_blocks,
+            block_h,
+            use_rmsnorm,
+        )
+
+    raw_dot = partial_dot.sum(dim=-1)
+    if use_rmsnorm:
+        inv_rms = torch.rsqrt(partial_sq.sum(dim=-1) / hidden_size + eps)
+        logits = raw_dot * inv_rms
+    else:
+        inv_rms = torch.empty_like(raw_dot)
+        logits = raw_dot
+
+    alpha = torch.softmax(logits, dim=0).to(dtype=reference.dtype)
+    gv = partial_gv.sum(dim=-1)
+    grad_output_dot_output = (alpha.float() * gv).sum(dim=0, keepdim=True)
+    beta = (alpha.float() * (gv - grad_output_dot_output)).to(dtype=reference.dtype)
+
+    grad_query = torch.zeros_like(query, dtype=torch.float32)
+    grad_weight = torch.zeros_like(weight, dtype=torch.float32)
+    grad_values = []
+    param_block_t = 16
+    param_block_h = 128
+    param_grid = (triton.cdiv(num_tokens, param_block_t), triton.cdiv(hidden_size, param_block_h))
+
+    for depth, value in enumerate(values):
+        value_2d = value.reshape(num_tokens, hidden_size)
+        grad_value_2d = torch.empty_like(value_2d)
+        _attn_res_backward_apply_kernel[grid](
+            value_2d,
+            grad_output_2d,
+            query_work,
+            weight_work,
+            alpha[depth].contiguous(),
+            beta[depth].contiguous(),
+            raw_dot[depth].contiguous(),
+            inv_rms[depth].contiguous(),
+            grad_value_2d,
+            hidden_size,
+            block_h,
+            use_rmsnorm,
+        )
+        _attn_res_backward_param_kernel[param_grid](
+            value_2d,
+            query_work,
+            weight_work,
+            beta[depth].contiguous(),
+            inv_rms[depth].contiguous(),
+            grad_query,
+            grad_weight,
+            num_tokens,
+            hidden_size,
+            param_block_t,
+            param_block_h,
+            use_rmsnorm,
+        )
+        grad_values.append(grad_value_2d.reshape_as(value))
+
+    if not use_rmsnorm:
+        grad_weight.zero_()
+
+    return grad_query.to(dtype=query.dtype), grad_weight.to(dtype=weight.dtype), grad_values
+
+
+class _FullAttnResCheckpointed(torch.autograd.Function):
+    """Full AttnRes with custom backward recomputation.
+
+    This keeps the Python/PyTorch implementation numerically aligned with the
+    default path, but avoids saving depth logits, softmax weights, and RMSNorm
+    intermediates from forward. Backward recomputes them under autograd.
+    """
+
+    @staticmethod
+    def forward(ctx, query, weight, hidden_size, eps, use_rmsnorm, *values):
+        ctx.hidden_size = hidden_size
+        ctx.eps = eps
+        ctx.use_rmsnorm = use_rmsnorm
+        ctx.save_for_backward(query, weight, *values)
+        with torch.no_grad():
+            return _full_attn_res_compute(values, query, weight, hidden_size, eps, use_rmsnorm)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        query, weight, *values = ctx.saved_tensors
+
+        query_recompute = query.detach().requires_grad_(True)
+        weight_recompute = weight.detach().requires_grad_(True)
+        values_recompute = [value.detach().requires_grad_(True) for value in values]
+
+        with torch.enable_grad():
+            output = _full_attn_res_compute(
+                values_recompute,
+                query_recompute,
+                weight_recompute,
+                ctx.hidden_size,
+                ctx.eps,
+                ctx.use_rmsnorm,
+            )
+
+        grads = torch.autograd.grad(
+            output,
+            (query_recompute, weight_recompute, *values_recompute),
+            grad_output,
+            allow_unused=True,
+        )
+
+        query_grad, weight_grad, *value_grads = grads
+        if query_grad is None:
+            query_grad = torch.zeros_like(query)
+        if weight_grad is None:
+            weight_grad = torch.zeros_like(weight)
+        value_grads = [
+            torch.zeros_like(value) if grad is None else grad
+            for value, grad in zip(values, value_grads)
+        ]
+        return query_grad, weight_grad, None, None, None, *value_grads
+
+
+class _FullAttnResTritonCheckpointed(torch.autograd.Function):
+    """Triton forward with checkpointed PyTorch backward recomputation."""
+
+    @staticmethod
+    def forward(ctx, query, weight, hidden_size, eps, use_rmsnorm, *values):
+        ctx.hidden_size = hidden_size
+        ctx.eps = eps
+        ctx.use_rmsnorm = use_rmsnorm
+        ctx.save_for_backward(query, weight, *values)
+        with torch.no_grad():
+            return _full_attn_res_triton_forward(
+                values, query, weight, hidden_size, eps, use_rmsnorm
+            )
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        query, weight, *values = ctx.saved_tensors
+
+        query_recompute = query.detach().requires_grad_(True)
+        weight_recompute = weight.detach().requires_grad_(True)
+        values_recompute = [value.detach().requires_grad_(True) for value in values]
+
+        with torch.enable_grad():
+            output = _full_attn_res_compute(
+                values_recompute,
+                query_recompute,
+                weight_recompute,
+                ctx.hidden_size,
+                ctx.eps,
+                ctx.use_rmsnorm,
+            )
+
+        grads = torch.autograd.grad(
+            output,
+            (query_recompute, weight_recompute, *values_recompute),
+            grad_output,
+            allow_unused=True,
+        )
+
+        query_grad, weight_grad, *value_grads = grads
+        if query_grad is None:
+            query_grad = torch.zeros_like(query)
+        if weight_grad is None:
+            weight_grad = torch.zeros_like(weight)
+        value_grads = [
+            torch.zeros_like(value) if grad is None else grad
+            for value, grad in zip(values, value_grads)
+        ]
+        return query_grad, weight_grad, None, None, None, *value_grads
+
+
+class _FullAttnResTritonBackward(torch.autograd.Function):
+    """Triton forward and Triton backward recomputation."""
+
+    @staticmethod
+    def forward(ctx, query, weight, hidden_size, eps, use_rmsnorm, *values):
+        ctx.hidden_size = hidden_size
+        ctx.eps = eps
+        ctx.use_rmsnorm = use_rmsnorm
+        ctx.save_for_backward(query, weight, *values)
+        with torch.no_grad():
+            return _full_attn_res_triton_forward(
+                values, query, weight, hidden_size, eps, use_rmsnorm
+            )
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        query, weight, *values = ctx.saved_tensors
+        grad_query, grad_weight, grad_values = _full_attn_res_triton_backward(
+            grad_output,
+            values,
+            query,
+            weight,
+            ctx.hidden_size,
+            ctx.eps,
+            ctx.use_rmsnorm,
+        )
+        return grad_query, grad_weight, None, None, None, *grad_values
+
+
+class FullAttnRes(torch.nn.Module):
+    """Depth-wise attention over previous residual-producing values.
+
+    Args:
+        hidden_size: Size of the hidden dimension.
+        eps: Epsilon used by the internal RMSNorm over keys.
+
+    Inputs are previous values shaped [S, B, H]. The module stacks them as
+    [N, S, B, H], applies RMSNorm to produce keys, scores each depth position
+    with one learned pseudo-query, and returns a weighted sum shaped [S, B, H].
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        use_rmsnorm: bool = True,
+        implementation: Literal['torch', 'checkpointed', 'triton', 'triton_bwd'] = 'torch',
+    ) -> None:
+        super().__init__()
+        if hidden_size <= 0:
+            raise ValueError(f"hidden_size must be positive, got {hidden_size}")
+        if implementation not in ('torch', 'checkpointed', 'triton', 'triton_bwd'):
+            raise ValueError(
+                "FullAttnRes implementation must be 'torch', 'checkpointed', "
+                "'triton', or 'triton_bwd', "
+                f"got {implementation}"
+            )
+
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.use_rmsnorm = use_rmsnorm
+        self.implementation = implementation
+        self.query = torch.nn.Parameter(torch.zeros(hidden_size))
+        self.weight = torch.nn.Parameter(torch.ones(hidden_size))
+
+    def _rms_norm(self, values: Tensor) -> Tensor:
+        variance = values.pow(2).mean(dim=-1, keepdim=True)
+        normalized = values * torch.rsqrt(variance + self.eps)
+        return normalized * self.weight.to(dtype=values.dtype)
+
+    def forward(self, values: Sequence[Tensor]) -> Tensor:
+        """Apply Full Attention Residuals to previous values.
+
+        Args:
+            values: Non-empty sequence of tensors shaped [S, B, H].
+
+        Returns:
+            Tensor shaped [S, B, H], with dtype matching the first value.
+        """
+
+        if len(values) == 0:
+            raise ValueError("FullAttnRes requires at least one value")
+
+        reference = values[0]
+        if reference.dim() != 3:
+            raise ValueError(
+                "FullAttnRes values must have shape [sequence, batch, hidden], "
+                f"got {tuple(reference.shape)}"
+            )
+        if reference.size(-1) != self.hidden_size:
+            raise ValueError(
+                f"expected hidden size {self.hidden_size}, got {reference.size(-1)}"
+            )
+
+        for index, value in enumerate(values[1:], start=1):
+            if value.shape != reference.shape:
+                raise ValueError(
+                    "all FullAttnRes values must have the same shape; "
+                    f"value 0 has {tuple(reference.shape)}, value {index} has {tuple(value.shape)}"
+                )
+
+        if self.implementation == 'checkpointed' and torch.is_grad_enabled():
+            return _FullAttnResCheckpointed.apply(
+                self.query,
+                self.weight,
+                self.hidden_size,
+                self.eps,
+                self.use_rmsnorm,
+                *values,
+            )
+        if self.implementation == 'triton' and torch.is_grad_enabled():
+            return _FullAttnResTritonCheckpointed.apply(
+                self.query,
+                self.weight,
+                self.hidden_size,
+                self.eps,
+                self.use_rmsnorm,
+                *values,
+            )
+        if self.implementation == 'triton_bwd' and torch.is_grad_enabled():
+            if (
+                _TRITON_AVAILABLE
+                and reference.is_cuda
+                and all(value.is_contiguous() for value in values)
+            ):
+                return _FullAttnResTritonBackward.apply(
+                    self.query,
+                    self.weight,
+                    self.hidden_size,
+                    self.eps,
+                    self.use_rmsnorm,
+                    *values,
+                )
+            return _FullAttnResCheckpointed.apply(
+                self.query,
+                self.weight,
+                self.hidden_size,
+                self.eps,
+                self.use_rmsnorm,
+                *values,
+            )
+
+        return _full_attn_res_compute(
+            values,
+            self.query,
+            self.weight,
+            self.hidden_size,
+            self.eps,
+            self.use_rmsnorm,
+        )

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -19,6 +19,7 @@ from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.utils import is_vp_first_stage, is_vp_last_stage
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.attention_residuals import AttnResState, FullAttnRes
 from megatron.core.transformer.enums import CudaGraphScope, LayerType
 from megatron.core.transformer.module import GraphableMegatronModule, MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
@@ -367,6 +368,16 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                 for i, layer_spec in enumerate(self.submodules.layer_specs)
             ]
         )
+
+        if self.config.attention_residuals and len(self.layers) > 0:
+            self.final_attn_res = FullAttnRes(
+                hidden_size=self.config.hidden_size,
+                eps=self.config.layernorm_epsilon,
+                use_rmsnorm=self.config.attention_residual_rmsnorm,
+                implementation=self.config.attention_residual_implementation,
+            )
+        else:
+            self.final_attn_res = None
 
         # @TODO: add back account_for_embedding_in_pipeline_split (see issue #293)
         # In pipeline parallelism, we want to add this LN only to the last stage of the pipeline
@@ -750,6 +761,24 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         #   already creates viewless tensors. That said, make_viewless_tensor()
         #   is called here to be future-proof and corner-case-proof.
         hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
+        attn_res_state = None
+        if self.config.attention_residuals:
+            if self.config.recompute_granularity == 'full' and self.training:
+                raise NotImplementedError(
+                    "AttnRes prototype is not wired into full-layer activation recomputation"
+                )
+            if self.config.attention_residual_type == 'full':
+                attn_res_state = AttnResState.full(hidden_states)
+            elif self.config.attention_residual_type == 'block':
+                attn_res_state = AttnResState.block(
+                    hidden_states,
+                    num_sublayers=len(self.layers) * 2,
+                    num_blocks=self.config.attention_residual_num_blocks,
+                )
+            else:
+                raise ValueError(
+                    f"unsupported attention_residual_type: {self.config.attention_residual_type}"
+                )
 
         if self.config.sequence_parallel:
             rng_context = tensor_parallel.get_cuda_rng_tracker().fork()
@@ -833,6 +862,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                             packed_seq_params=packed_seq_params,
                             sequence_len_offset=sequence_len_offset,
                             padding_mask=padding_mask,
+                            attn_res_state=attn_res_state,
                         )
 
                     if (
@@ -845,6 +875,9 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     # Extract intermediate embeddings using global layer index
                     if (l_no + layer_offset) in extract_layer_indices:
                         intermediate_hidden_states.append(hidden_states)
+
+        if attn_res_state is not None and self.final_attn_res is not None:
+            hidden_states = self.final_attn_res(attn_res_state.values())
 
         # Final layer norm.
         if self.final_layernorm is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -119,6 +119,36 @@ class TransformerConfig(ModelParallelConfig):
     hidden_size: int = field(default=0, metadata={"argparse_meta": {"default": None}})
     """Transformer hidden size."""
 
+    attention_residuals: bool = False
+    """Enable Attention Residuals (AttnRes) in the transformer stack.
+
+    When disabled, the model uses standard residual connections.
+    """
+
+    attention_residual_type: Literal['full', 'block'] = 'full'
+    """Attention Residual variant to use."""
+
+    attention_residual_num_blocks: int = 8
+    """Number of depth blocks for Block AttnRes."""
+
+    attention_residual_rmsnorm: bool = True
+    """Apply RMSNorm to AttnRes keys before depth-wise scoring."""
+
+    attention_residual_implementation: Literal[
+        'torch', 'checkpointed', 'triton', 'triton_bwd'
+    ] = 'torch'
+    """Full AttnRes implementation.
+
+    `torch` is the default eager PyTorch implementation. `checkpointed` uses a
+    custom autograd function that recomputes Full AttnRes internals during
+    backward to reduce saved forward intermediates. `triton` uses Triton kernels
+    for the forward pass and the same checkpointed PyTorch backward recomputation.
+    `triton_bwd` uses Triton kernels for both forward and backward recomputation.
+    """
+
+    attention_residual_log_weights: bool = False
+    """Log AttnRes depth-attention weight diagnostics when instrumentation is wired."""
+
     num_attention_heads: int = field(default=0, metadata={"argparse_meta": {"default": None}})
     """Number of transformer attention heads."""
 

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -38,6 +38,7 @@ from megatron.core.utils import (
 
 if TYPE_CHECKING:
     from megatron.core.inference.contexts import BaseInferenceContext
+    from megatron.core.transformer.attention_residuals import AttnResState
 
 logger = logging.getLogger(__name__)
 
@@ -401,6 +402,24 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         self.is_moe_layer = isinstance(self.mlp, MoELayer)
 
+        self.attn_res = None
+        self.mlp_attn_res = None
+        if self.config.attention_residuals:
+            from megatron.core.transformer.attention_residuals import FullAttnRes
+
+            self.attn_res = FullAttnRes(
+                self.config.hidden_size,
+                eps=self.config.layernorm_epsilon,
+                use_rmsnorm=self.config.attention_residual_rmsnorm,
+                implementation=self.config.attention_residual_implementation,
+            )
+            self.mlp_attn_res = FullAttnRes(
+                self.config.hidden_size,
+                eps=self.config.layernorm_epsilon,
+                use_rmsnorm=self.config.attention_residual_rmsnorm,
+                implementation=self.config.attention_residual_implementation,
+            )
+
         self.recompute_input_layernorm = False
         self.recompute_pre_mlp_layernorm = False
         self.recompute_mlp = False
@@ -540,6 +559,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
+        attn_res_state: Optional['AttnResState'] = None,
         *,
         inference_params: Optional[Any] = None,
     ):
@@ -575,6 +595,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         )
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
+
+        if self.config.attention_residuals:
+            if attn_res_state is None:
+                raise RuntimeError("AttnRes is enabled but no AttnRes state was provided")
+            assert self.attn_res is not None
+            hidden_states = self.attn_res(attn_res_state.values())
 
         # Optional Input Layer norm
         if self.recompute_input_layernorm:
@@ -636,7 +662,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # TODO: could we move `bias_dropout_add_exec_handler` itself
         # inside the module provided in the `bias_dropout_add_spec` module?
         nvtx_range_push(suffix="self_attn_bda")
-        if using_fused_tp_inference_kernel:
+        if self.config.attention_residuals:
+            hidden_states = self._get_attn_res_sublayer_output(
+                attention_output_with_bias, "self_attention"
+            )
+            assert attn_res_state is not None
+            attn_res_state.append(hidden_states)
+        elif using_fused_tp_inference_kernel:
             # In inference optimized transformer layer, there is no bias and dropout
             # The remaining residual add is already handled inside the
             # self attention module.
@@ -656,6 +688,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             )
 
         # Optional Layer norm after self-attention
+        if self.config.attention_residuals and not isinstance(self.cross_attention, IdentityOp):
+            raise NotImplementedError("AttnRes prototype currently supports decoder-only layers")
+
         pre_cross_attn_layernorm_output = apply_module(self.pre_cross_attn_layernorm)(hidden_states)
 
         if isinstance(pre_cross_attn_layernorm_output, tuple):
@@ -705,6 +740,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             hidden_states,
             kwargs.get("inference_context", None),
             padding_mask=kwargs.get("padding_mask", None),
+            attn_res_state=kwargs.get("attn_res_state", None),
         )
         return output, context
 
@@ -730,6 +766,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         hidden_states: Tensor,
         inference_context: BaseInferenceContext | None = None,
         padding_mask: Tensor | None = None,
+        attn_res_state: Optional['AttnResState'] = None,
     ) -> Tensor | list[Tensor | None]:
         """
         Perform a forward pass through the feed-forward layer.
@@ -745,6 +782,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         Returns:
             output (Tensor): Transformed hidden states of shape [s, b, h].
         """
+
+        if self.config.attention_residuals:
+            if attn_res_state is None:
+                raise RuntimeError("AttnRes is enabled but no AttnRes state was provided")
+            if self.is_moe_layer:
+                raise NotImplementedError("AttnRes prototype currently supports dense MLP layers")
+            assert self.mlp_attn_res is not None
+            hidden_states = self.mlp_attn_res(attn_res_state.values())
 
         # Optional Layer norm post the cross-attention.
         pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(hidden_states)
@@ -834,8 +879,37 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 for tensor in mlp_output_with_bias:
                     self.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(tensor)
             return list(mlp_output_with_bias) + [residual]
+        elif self.config.attention_residuals:
+            if self.recompute_pre_mlp_layernorm:
+                self.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(
+                    mlp_output_with_bias[0]
+                )
+            hidden_states = self._get_attn_res_sublayer_output(mlp_output_with_bias, "mlp")
+            assert attn_res_state is not None
+            attn_res_state.append(hidden_states)
+            return make_viewless_tensor(
+                inp=hidden_states, requires_grad=hidden_states.requires_grad, keep_graph=True
+            )
         else:
             return self._forward_post_mlp(mlp_output_with_bias, residual)
+
+    def _get_attn_res_sublayer_output(
+        self, output_with_bias: tuple[Tensor, Tensor | None], sublayer_name: str
+    ) -> Tensor:
+        """Extract the transform output to append to Full AttnRes history."""
+
+        if self.hidden_dropout != 0.0:
+            raise NotImplementedError("AttnRes prototype requires hidden_dropout=0.0")
+        if not isinstance(output_with_bias, tuple) or len(output_with_bias) != 2:
+            raise RuntimeError(
+                f"AttnRes expected {sublayer_name} to return (output, bias), "
+                f"got {type(output_with_bias)}"
+            )
+
+        output, bias = output_with_bias
+        if bias is not None:
+            raise NotImplementedError("AttnRes prototype requires bias-free sublayer outputs")
+        return output
 
     def _forward_post_mlp(
         self, mlp_output_with_bias: tuple[Tensor, Tensor | None], residual: Tensor

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1776,6 +1776,74 @@ def dummy_train_step(data_iterator):
             batch = get_batch_on_this_cp_rank(batch)
 
 
+def _log_attention_residual_grad_stats(model, iteration):
+    """Log local AttnRes query gradient statistics for smoke validation."""
+
+    args = get_args()
+    if not getattr(args, 'attention_residuals', False):
+        return
+    if not getattr(args, 'attention_residual_log_weights', False):
+        return
+
+    attn_sq_sum = 0.0
+    mlp_sq_sum = 0.0
+    final_sq_sum = 0.0
+    attn_nonzero = 0
+    mlp_nonzero = 0
+    final_nonzero = 0
+    attn_params = 0
+    mlp_params = 0
+    final_params = 0
+
+    for model_chunk in model:
+        unwrapped_model_chunk = unwrap_model(model_chunk)
+        for name, param in unwrapped_model_chunk.named_parameters():
+            if not name.endswith('.query'):
+                continue
+            if (
+                '.attn_res.' not in name
+                and '.mlp_attn_res.' not in name
+                and '.final_attn_res.' not in name
+            ):
+                continue
+
+            grad = getattr(param, 'main_grad', None)
+            if grad is None:
+                grad = param.grad
+            if grad is None:
+                continue
+
+            grad_float = grad.detach().float()
+            grad_sq_sum = grad_float.pow(2).sum().item()
+            grad_nonzero = torch.count_nonzero(grad_float).item()
+
+            if '.final_attn_res.' in name:
+                final_sq_sum += grad_sq_sum
+                final_nonzero += grad_nonzero
+                final_params += grad.numel()
+            elif '.mlp_attn_res.' in name:
+                mlp_sq_sum += grad_sq_sum
+                mlp_nonzero += grad_nonzero
+                mlp_params += grad.numel()
+            else:
+                attn_sq_sum += grad_sq_sum
+                attn_nonzero += grad_nonzero
+                attn_params += grad.numel()
+
+    attn_norm = math.sqrt(attn_sq_sum)
+    mlp_norm = math.sqrt(mlp_sq_sum)
+    final_norm = math.sqrt(final_sq_sum)
+    print_rank_0(
+        f' [AttnRes grad stats] iteration {iteration + 1} | '
+        f'attn query grad norm: {attn_norm:.6E} '
+        f'nonzero: {attn_nonzero}/{attn_params} | '
+        f'mlp query grad norm: {mlp_norm:.6E} '
+        f'nonzero: {mlp_nonzero}/{mlp_params} | '
+        f'final query grad norm: {final_norm:.6E} '
+        f'nonzero: {final_nonzero}/{final_params} |'
+    )
+
+
 def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_scheduler, config, forward_backward_func, iteration=None):
     """Single training step."""
     args = get_args()
@@ -1872,6 +1940,8 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     if args.vision_pretraining and args.vision_pretraining_type == "dino":
         unwrapped_model = unwrap_model(model[0])
         unwrapped_model.cancel_gradients_last_layer(args.curr_iteration)
+
+    _log_attention_residual_grad_stats(model, iteration)
 
     # Update parameters.
 
@@ -3288,11 +3358,6 @@ def evaluate(
     timers = get_timers()
 
     timers('evaluate', log_level=0).start(barrier=True)
-
-    if args.vision_pretraining and args.vision_pretraining_type == "dino":
-        from megatron.legacy.model.vision.knn_monitor import compute_feature_bank
-
-        compute_feature_bank(model)
 
     # Turn on evaluation mode which disables dropout.
     for model_module in model:

--- a/tests/unit_tests/transformer/test_attention_residuals.py
+++ b/tests/unit_tests/transformer/test_attention_residuals.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.transformer.attention_residuals import AttnResState, FullAttnRes
+
+
+def test_full_attn_res_single_value_returns_input():
+    module = FullAttnRes(hidden_size=4)
+    value = torch.randn(3, 2, 4)
+
+    output = module([value])
+
+    assert output.shape == value.shape
+    assert output.dtype == value.dtype
+    torch.testing.assert_close(output, value)
+
+
+def test_full_attn_res_zero_query_is_uniform_average():
+    module = FullAttnRes(hidden_size=4)
+    values = [torch.randn(3, 2, 4) for _ in range(3)]
+
+    output = module(values)
+    expected = torch.stack(values, dim=0).mean(dim=0)
+
+    assert output.shape == values[0].shape
+    torch.testing.assert_close(output, expected)
+
+
+def test_full_attn_res_backward_reaches_values_query_and_norm_weight():
+    module = FullAttnRes(hidden_size=4)
+    with torch.no_grad():
+        module.query.copy_(torch.tensor([0.25, -0.5, 0.75, 1.0]))
+
+    values = [torch.randn(3, 2, 4, requires_grad=True) for _ in range(3)]
+    output = module(values)
+    loss = output.pow(2).mean()
+
+    loss.backward()
+
+    assert module.query.grad is not None
+    assert torch.count_nonzero(module.query.grad).item() > 0
+    assert module.weight.grad is not None
+    assert torch.count_nonzero(module.weight.grad).item() > 0
+    for value in values:
+        assert value.grad is not None
+        assert torch.count_nonzero(value.grad).item() > 0
+
+
+@pytest.mark.parametrize("implementation", ["checkpointed", "triton", "triton_bwd"])
+def test_full_attn_res_custom_implementation_matches_torch_forward_and_backward(implementation):
+    torch.manual_seed(123)
+    eager = FullAttnRes(hidden_size=4, implementation='torch')
+    custom = FullAttnRes(hidden_size=4, implementation=implementation)
+    with torch.no_grad():
+        eager.query.copy_(torch.tensor([0.25, -0.5, 0.75, 1.0]))
+        custom.query.copy_(eager.query)
+        custom.weight.copy_(eager.weight)
+
+    eager_values = [torch.randn(3, 2, 4, requires_grad=True) for _ in range(3)]
+    custom_values = [value.detach().clone().requires_grad_(True) for value in eager_values]
+
+    eager_output = eager(eager_values)
+    custom_output = custom(custom_values)
+    torch.testing.assert_close(custom_output, eager_output)
+
+    eager_loss = eager_output.pow(2).mean()
+    custom_loss = custom_output.pow(2).mean()
+    eager_loss.backward()
+    custom_loss.backward()
+
+    torch.testing.assert_close(custom.query.grad, eager.query.grad)
+    torch.testing.assert_close(custom.weight.grad, eager.weight.grad)
+    for custom_value, eager_value in zip(custom_values, eager_values):
+        torch.testing.assert_close(custom_value.grad, eager_value.grad)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_full_attn_res_preserves_value_dtype(dtype):
+    module = FullAttnRes(hidden_size=4)
+    values = [torch.randn(3, 2, 4).to(dtype=dtype) for _ in range(2)]
+
+    output = module(values)
+
+    assert output.dtype == dtype
+
+
+def test_full_attn_res_rejects_empty_history():
+    module = FullAttnRes(hidden_size=4)
+
+    with pytest.raises(ValueError, match="at least one value"):
+        module([])
+
+
+def test_block_attn_res_state_groups_sublayers_into_partial_blocks():
+    initial = torch.full((2, 1, 4), 10.0)
+    state = AttnResState.block(initial, num_sublayers=4, num_blocks=2)
+
+    assert state.block_size == 2
+    values = state.values()
+    assert len(values) == 1
+    torch.testing.assert_close(values[0], initial)
+
+    first = torch.ones_like(initial)
+    second = torch.full_like(initial, 2.0)
+    third = torch.full_like(initial, 3.0)
+
+    state.append(first)
+    values = state.values()
+    assert len(values) == 2
+    torch.testing.assert_close(values[0], initial)
+    torch.testing.assert_close(values[1], first)
+
+    state.append(second)
+    values = state.values()
+    assert len(values) == 2
+    torch.testing.assert_close(values[0], initial)
+    torch.testing.assert_close(values[1], first + second)
+
+    state.append(third)
+    values = state.values()
+    assert len(values) == 3
+    torch.testing.assert_close(values[0], initial)
+    torch.testing.assert_close(values[1], first + second)
+    torch.testing.assert_close(values[2], third)


### PR DESCRIPTION
## Summary

This PR adds an implementation of Attention Residuals for Megatron-LM.

- Adds Full and Block Attention Residual modes.
- Integrates AttnRes into the transformer block/layer path.
- Supports multiple implementations:
  - `torch`
  - `checkpointed`
  - `triton`
  - `triton_bwd`
- Adds config flags, docs, and example scripts.
- Adds unit tests for the AttnRes module and block state logic.

## Current Scope

Supported:
- Dense GPT-style decoder models.
- Transformer Engine path.
- FP8 training path.
- Sequence parallelism.
- Selective activation recomputation.

Not yet supported:
- MoE layers.
- Cross-attention layers.
- Pipeline-parallel AttnRes state transfer.
- Full-layer recomputation with AttnRes.
- Inference/KV-cache path.

## Validation

- Unit tests for `FullAttnRes` and `AttnResState`.
- Smoke training on LLaMA-3-style 8B config with TP=2.
- WikiText-103 experiments comparing baseline, Full AttnRes, and Block AttnRes.
