### PR TITLE
Megatron-FSDP: log mcore detection only after imports succeed

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -46,11 +46,12 @@ logger = logging.getLogger(__name__)
 
 try:
     # Default to Megatron-LM FW.
-    logger.info("Detected Megatron Core, using Megatron-FSDP with Megatron.")
     from megatron.core.distributed.distributed_data_parallel_config import (
         DistributedDataParallelConfig,
     )
     from megatron.core.utils import is_submodule
+
+    logger.info("Detected Megatron Core, using Megatron-FSDP with Megatron.")
 except ImportError:
     # Megatron-LM is not installed, use Megatron-FSDP as a standalone module.
     logger.info("Megatron Core is not installed, Megatron-FSDP will run without Megatron Core.")


### PR DESCRIPTION
## Summary
- In `megatron_fsdp.py`, the `"Detected Megatron Core…"` log was emitted *before* the `megatron.core` imports inside the `try` block. When mcore isn't installed, the user saw `"Detected…"` immediately followed by the fallback `"not installed"` log — confusing and misleading.

## Test plan
- [x] `isort` + `python -m py_compile` on the edited file
- [x] CI (`Run tests` label — log-ordering only, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)