### PR TITLE
Replace rampup batch size scheduler with custom step batch size schedules

### DIFF
--- a/examples/gpt3/gpt_config.yaml
+++ b/examples/gpt3/gpt_config.yaml
@@ -136,7 +136,7 @@ use_legacy_models: False
 spec: null
 micro_batch_size: 2
 global_batch_size: 128
-rampup_batch_size: [32, 32, 65324160] 
+step_batch_size_schedule: "0:32 90B:64 180B:96 270B:128"
 check_for_nan_in_loss_and_grad: True
 num_layers_per_virtual_pipeline_stage: null
 

--- a/examples/gpt3/train_gpt3_175b_distributed.sh
+++ b/examples/gpt3/train_gpt3_175b_distributed.sh
@@ -36,9 +36,9 @@ GPT_MODEL_ARGS=(
 
 TRAINING_ARGS=(
     --micro-batch-size 1 
-    --global-batch-size 1536 
-    --rampup-batch-size 16 16 5859375 
-    --train-iters 500000 
+    --global-batch-size 1536
+    --step-batch-size-schedule "0:16 2.4B:320 4.8B:624 7.2B:928 9.6B:1232 12B:1536"
+    --train-iters 500000
     --weight-decay 0.1 
     --adam-beta1 0.9 
     --adam-beta2 0.95 

--- a/megatron/core/num_microbatches_calculator.py
+++ b/megatron/core/num_microbatches_calculator.py
@@ -63,9 +63,10 @@ def unset_num_microbatches_calculator():
 
 def init_num_microbatches_calculator(
     rank: int,
-    global_batch_size: int,
-    micro_batch_size: int,
-    data_parallel_size: int,
+    rampup_batch_size: Optional[List[int]] = None,
+    global_batch_size: Optional[int] = None,
+    micro_batch_size: Optional[int] = None,
+    data_parallel_size: Optional[int] = None,
     decrease_batch_size_if_needed: bool = False,
     step_batch_size_schedule: Optional[str] = None,
     seq_length: Optional[int] = None,
@@ -75,11 +76,13 @@ def init_num_microbatches_calculator(
     Args:
         rank (int):
             Rank of the GPU, only rank 0 will log the information.
-        global_batch_size (int):
+        rampup_batch_size (Optional[List[int]]):
+            Deprecated. This argument is ignored. Use step_batch_size_schedule instead.
+        global_batch_size (Optional[int]):
             Global batch size for the model.
-        micro_batch_size (int):
+        micro_batch_size (Optional[int]):
             Micro batch size at initialization.
-        data_parallel_size (int):
+        data_parallel_size (Optional[int]):
             Data parallel size.
         decrease_batch_size_if_needed (bool, optional):
             If true, scale down batch size to ensure divisibility by DP size * microbatch size.
@@ -94,14 +97,19 @@ def init_num_microbatches_calculator(
             Sequence length for token-to-sample conversion when using step_batch_size_schedule.
             If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
     """
+    if rampup_batch_size is not None and rank == 0:
+        logger.warning(
+            'rampup_batch_size is deprecated and will be removed in a future release. '
+            'Use step_batch_size_schedule instead.'
+        )
     _configure_global_num_microbatches_calculator(
-        rank,
-        global_batch_size,
-        micro_batch_size,
-        data_parallel_size,
-        decrease_batch_size_if_needed,
-        step_batch_size_schedule,
-        seq_length,
+        rank=rank,
+        global_batch_size=global_batch_size,
+        micro_batch_size=micro_batch_size,
+        data_parallel_size=data_parallel_size,
+        decrease_batch_size_if_needed=decrease_batch_size_if_needed,
+        step_batch_size_schedule=step_batch_size_schedule,
+        seq_length=seq_length,
         init=True,
     )
 
@@ -114,9 +122,10 @@ def destroy_num_microbatches_calculator():
 
 def reconfigure_num_microbatches_calculator(
     rank: int,
-    global_batch_size: int,
-    micro_batch_size: int,
-    data_parallel_size: int,
+    rampup_batch_size: Optional[List[int]] = None,
+    global_batch_size: Optional[int] = None,
+    micro_batch_size: Optional[int] = None,
+    data_parallel_size: Optional[int] = None,
     decrease_batch_size_if_needed: bool = False,
     step_batch_size_schedule: Optional[str] = None,
     seq_length: Optional[int] = None,
@@ -126,11 +135,13 @@ def reconfigure_num_microbatches_calculator(
     Args:
         rank (int):
             Rank of the GPU, only rank 0 will log the information.
-        global_batch_size (int):
+        rampup_batch_size (Optional[List[int]]):
+            Deprecated. This argument is ignored. Use step_batch_size_schedule instead.
+        global_batch_size (Optional[int]):
             Global batch size for the model.
-        micro_batch_size (int):
+        micro_batch_size (Optional[int]):
             Micro batch size at initialization.
-        data_parallel_size (int):
+        data_parallel_size (Optional[int]):
             Data parallel size.
         decrease_batch_size_if_needed (bool, optional):
             If true, scale down batch size to ensure divisibility by DP size * microbatch size.
@@ -143,14 +154,19 @@ def reconfigure_num_microbatches_calculator(
             Sequence length for token-to-sample conversion when using step_batch_size_schedule.
             If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
     """
+    if rampup_batch_size is not None and rank == 0:
+        logger.warning(
+            'rampup_batch_size is deprecated and will be removed in a future release. '
+            'Use step_batch_size_schedule instead.'
+        )
     _configure_global_num_microbatches_calculator(
-        rank,
-        global_batch_size,
-        micro_batch_size,
-        data_parallel_size,
-        decrease_batch_size_if_needed,
-        step_batch_size_schedule,
-        seq_length,
+        rank=rank,
+        global_batch_size=global_batch_size,
+        micro_batch_size=micro_batch_size,
+        data_parallel_size=data_parallel_size,
+        decrease_batch_size_if_needed=decrease_batch_size_if_needed,
+        step_batch_size_schedule=step_batch_size_schedule,
+        seq_length=seq_length,
         init=False,
     )
 

--- a/megatron/core/num_microbatches_calculator.py
+++ b/megatron/core/num_microbatches_calculator.py
@@ -4,14 +4,14 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
 # TODO: global_var merge into mcore?
 _GLOBAL_NUM_MICROBATCHES_CALCULATOR: Union[
-    'ConstantNumMicroBatchesCalculator', 'RampupBatchsizeNumMicroBatchesCalculator'
-] = None
+    'ConstantNumMicroBatchesCalculator', 'StepBatchsizeNumMicroBatchesCalculator'
+] = None  # type: ignore[assignment]
 
 
 def get_num_microbatches() -> int:
@@ -63,20 +63,18 @@ def unset_num_microbatches_calculator():
 
 def init_num_microbatches_calculator(
     rank: int,
-    rampup_batch_size: Optional[List[int]],
     global_batch_size: int,
     micro_batch_size: int,
     data_parallel_size: int,
     decrease_batch_size_if_needed: bool = False,
+    step_batch_size_schedule: Optional[str] = None,
+    seq_length: Optional[int] = None,
 ) -> None:
     """Initialize number of microbatches calculator. Supporting backward compatibility.
 
     Args:
         rank (int):
             Rank of the GPU, only rank 0 will log the information.
-        rampup_batch_size (Optional[List[int]]):
-            Rampup batch size, should be in format of [start_global_batch_size,
-            batch_size_increment, ramup_samples].
         global_batch_size (int):
             Global batch size for the model.
         micro_batch_size (int):
@@ -86,14 +84,24 @@ def init_num_microbatches_calculator(
         decrease_batch_size_if_needed (bool, optional):
             If true, scale down batch size to ensure divisibility by DP size * microbatch size.
             Defaults to False.
+        step_batch_size_schedule (Optional[str]):
+            Step batch size schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
+            Thresholds are interpreted as samples unless seq_length is provided, in which case
+            thresholds are interpreted as tokens and converted to samples.
+            Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+            Example: "0:768 250B:1536 500B:3072 750B:6144"
+        seq_length (Optional[int]):
+            Sequence length for token-to-sample conversion when using step_batch_size_schedule.
+            If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
     """
     _configure_global_num_microbatches_calculator(
         rank,
-        rampup_batch_size,
         global_batch_size,
         micro_batch_size,
         data_parallel_size,
         decrease_batch_size_if_needed,
+        step_batch_size_schedule,
+        seq_length,
         init=True,
     )
 
@@ -106,20 +114,18 @@ def destroy_num_microbatches_calculator():
 
 def reconfigure_num_microbatches_calculator(
     rank: int,
-    rampup_batch_size: Optional[List[int]],
     global_batch_size: int,
     micro_batch_size: int,
     data_parallel_size: int,
     decrease_batch_size_if_needed: bool = False,
+    step_batch_size_schedule: Optional[str] = None,
+    seq_length: Optional[int] = None,
 ) -> None:
     """Reconfigure number of microbatches calculator. Supporting backward compatibility.
 
     Args:
         rank (int):
             Rank of the GPU, only rank 0 will log the information.
-        rampup_batch_size (Optional[List[int]]):
-            Rampup batch size, should be in format of
-            [start_global_batch_size, batch_size_increment, ramup_samples].
         global_batch_size (int):
             Global batch size for the model.
         micro_batch_size (int):
@@ -129,25 +135,34 @@ def reconfigure_num_microbatches_calculator(
         decrease_batch_size_if_needed (bool, optional):
             If true, scale down batch size to ensure divisibility by DP size * microbatch size.
             Defaults to False.
+        step_batch_size_schedule (Optional[str]):
+            Step batch size schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
+            Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+            Example: "0:768 250B:1536 500B:3072 750B:6144"
+        seq_length (Optional[int]):
+            Sequence length for token-to-sample conversion when using step_batch_size_schedule.
+            If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
     """
     _configure_global_num_microbatches_calculator(
         rank,
-        rampup_batch_size,
         global_batch_size,
         micro_batch_size,
         data_parallel_size,
         decrease_batch_size_if_needed,
+        step_batch_size_schedule,
+        seq_length,
         init=False,
     )
 
 
 def _configure_global_num_microbatches_calculator(
     rank: int,
-    rampup_batch_size: Optional[List[int]],
     global_batch_size: int,
     micro_batch_size: int,
     data_parallel_size: int,
     decrease_batch_size_if_needed: bool = False,
+    step_batch_size_schedule: Optional[str] = None,
+    seq_length: Optional[int] = None,
     init: bool = False,
 ) -> None:
     """Configure number of microbatches calculator. Can be used for initialization and
@@ -156,9 +171,6 @@ def _configure_global_num_microbatches_calculator(
     Args:
         rank (int):
             Rank of the GPU, only rank 0 will log the information.
-        rampup_batch_size (Optional[List[int]]):
-            Rampup batch size, should be in format of
-            [start_global_batch_size, batch_size_increment, ramup_samples].
         global_batch_size (int):
             Global batch size for the model.
         micro_batch_size (int):
@@ -168,6 +180,13 @@ def _configure_global_num_microbatches_calculator(
         decrease_batch_size_if_needed (bool, optional):
             If true, scale down batch size to ensure divisibility by DP size * microbatch size.
             Defaults to False.
+        step_batch_size_schedule (Optional[str]):
+            Step batch size schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
+            Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+            Example: "0:768 250B:1536 500B:3072 750B:6144"
+        seq_length (Optional[int]):
+            Sequence length for token-to-sample conversion when using step_batch_size_schedule.
+            If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
         init (bool, optional):
             If true, initialize the calculator. Defaults to False.
     """
@@ -180,43 +199,72 @@ def _configure_global_num_microbatches_calculator(
 
     _GLOBAL_NUM_MICROBATCHES_CALCULATOR = _build_num_microbatches_calculator(
         rank,
-        rampup_batch_size,
         global_batch_size,
         micro_batch_size,
         data_parallel_size,
         decrease_batch_size_if_needed,
+        step_batch_size_schedule,
+        seq_length,
     )
 
 
 def _build_num_microbatches_calculator(
     rank: int,
-    rampup_batch_size: Optional[List[int]],
-    global_batch_size: int,
+    global_batch_size: Optional[int],
     micro_batch_size: int,
     data_parallel_size: int,
     decrease_batch_size_if_needed: bool,
-) -> Union['ConstantNumMicroBatchesCalculator', 'RampupBatchsizeNumMicroBatchesCalculator']:
+    step_batch_size_schedule: Optional[str] = None,
+    seq_length: Optional[int] = None,
+) -> Union['ConstantNumMicroBatchesCalculator', 'StepBatchsizeNumMicroBatchesCalculator']:
     """Build number of microbatches calculator. Internal helper method.
 
     Args:
         rank (int):
             Rank of the GPU, only rank 0 will log the information.
-        rampup_batch_size (Optional[List[int]]):
-            Rampup batch size, should be in format of
-            [start_global_batch_size, batch_size_increment, ramup_samples].
-        global_batch_size (int):
-            Global batch size for the model.
+        global_batch_size (Optional[int]):
+            Global batch size for the model. Required for constant mode.
+            Ignored when step_batch_size_schedule is provided.
         micro_batch_size (int):
             Micro batch size at initialization.
         data_parallel_size (int):
             Data parallel size.
         decrease_batch_size_if_needed (bool):
             If true, scale down batch size to ensure divisibility by DP size * microbatch size.
-
+        step_batch_size_schedule (Optional[str]):
+            Step batch size schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
+            Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+            Example: "0:768 250B:1536 500B:3072 750B:6144"
+        seq_length (Optional[int]):
+            Sequence length for token-to-sample conversion when using step_batch_size_schedule.
+            If provided, thresholds are interpreted as tokens. If None, thresholds are samples.
     """
 
-    # Constant batch size.
-    if rampup_batch_size is None:
+    num_microbatches_calculator: Union[
+        'ConstantNumMicroBatchesCalculator', 'StepBatchsizeNumMicroBatchesCalculator'
+    ]
+
+    # Step batch size schedule
+    if step_batch_size_schedule is not None:
+        if decrease_batch_size_if_needed:
+            raise ValueError(
+                'Cannot specify both --step-batch-size-schedule and '
+                '--decrease-batch-size-if-needed'
+            )
+        num_microbatches_calculator = StepBatchsizeNumMicroBatchesCalculator(
+            micro_batch_size=micro_batch_size,
+            data_parallel_size=data_parallel_size,
+            decrease_batch_size_if_needed=decrease_batch_size_if_needed,
+            rank=rank,
+            schedule=step_batch_size_schedule,
+            seq_length=seq_length,
+        )
+
+    # Constant batch size
+    else:
+        assert (
+            global_batch_size is not None
+        ), '--global-batch-size is required when not using --step-batch-size-schedule'
         num_microbatches_calculator = ConstantNumMicroBatchesCalculator(
             global_batch_size,
             micro_batch_size,
@@ -228,32 +276,6 @@ def _build_num_microbatches_calculator(
             logger.info(
                 f'setting number of microbatches to constant {num_microbatches_calculator.get()}'
             )
-    # Batch size ramp up.
-    else:
-        assert len(rampup_batch_size) == 3, (
-            'expected the following '
-            'format: --rampup-batch-size <start batch size> '
-            '<batch size incerement> <ramp-up samples>'
-        )
-        start_global_batch_size = int(rampup_batch_size[0])
-        batch_size_increment = int(rampup_batch_size[1])
-        ramup_samples = int(rampup_batch_size[2])
-        if rank == 0:
-            logger.info(
-                f'will use batch size rampup starting from global batch size '
-                f'{start_global_batch_size} to global batch size {global_batch_size} with batch'
-                f'size increments {batch_size_increment} over {ramup_samples} samples.'
-            )
-        num_microbatches_calculator = RampupBatchsizeNumMicroBatchesCalculator(
-            global_batch_size,
-            micro_batch_size,
-            data_parallel_size,
-            decrease_batch_size_if_needed,
-            rank,
-            start_global_batch_size,
-            batch_size_increment,
-            ramup_samples,
-        )
 
     return num_microbatches_calculator
 
@@ -267,31 +289,35 @@ class NumMicroBatchesCalculator(ABC):
     """Base class for number of microbatches calculator."""
 
     def __init__(self) -> None:
-        self.num_micro_batches = None
-        self.current_global_batch_size = None
-        self.micro_batch_size = None
-        self.current_running_global_batch_size = None
+        self.num_micro_batches: Optional[int] = None
+        self.current_global_batch_size: Optional[int] = None
+        self.micro_batch_size: Optional[int] = None
+        self.current_running_global_batch_size: Optional[int] = None
 
     def get(self) -> int:
         """Get number of microbatches."""
+        assert self.num_micro_batches is not None
         return self.num_micro_batches
 
     def get_current_global_batch_size(self) -> int:
         """Get current global batch size."""
+        assert self.current_global_batch_size is not None
         return self.current_global_batch_size
 
     def get_micro_batch_size(self) -> int:
         """Get current global batch size."""
+        assert self.micro_batch_size is not None
         return self.micro_batch_size
 
     def get_current_running_global_batch_size(self) -> int:
         """Get current running global batch size. If decrease_batch_size_if_needed is False,
         this just equals global batch size."""
+        assert self.current_running_global_batch_size is not None
         return self.current_running_global_batch_size
 
     @abstractmethod
     def update(self, consumed_samples, consistency_check, verbose=False) -> None:
-        """Update number of microbatches depending on batch size rampup."""
+        """Update number of microbatches."""
         pass
 
 
@@ -320,6 +346,7 @@ class ConstantNumMicroBatchesCalculator(NumMicroBatchesCalculator):
         decrease_batch_size_if_needed: bool,
         rank: int,
     ) -> None:
+        super().__init__()
 
         micro_batch_times_data_parallel_size = micro_batch_size * data_parallel_size
         if decrease_batch_size_if_needed:
@@ -333,9 +360,7 @@ class ConstantNumMicroBatchesCalculator(NumMicroBatchesCalculator):
                     f'to keep divisiblity by micro_batch_size={micro_batch_size} * '
                     f'data_parallel_size={data_parallel_size}'
                 )
-            self.num_micro_batches = (
-                running_global_batch_size // micro_batch_times_data_parallel_size
-            )
+            num_micro_batches = running_global_batch_size // micro_batch_times_data_parallel_size
         else:
             assert global_batch_size % micro_batch_times_data_parallel_size == 0, (
                 'global batch size ({}) is not divisible by micro batch size ({})'
@@ -344,11 +369,12 @@ class ConstantNumMicroBatchesCalculator(NumMicroBatchesCalculator):
                 )
             )
             running_global_batch_size = global_batch_size
-            self.num_micro_batches = global_batch_size // micro_batch_times_data_parallel_size
+            num_micro_batches = global_batch_size // micro_batch_times_data_parallel_size
         assert (
-            self.num_micro_batches >= 1
-        ), 'number of microbatches should be at least 1, got {}.'.format(self.num_micro_batches)
+            num_micro_batches >= 1
+        ), 'number of microbatches should be at least 1, got {}.'.format(num_micro_batches)
 
+        self.num_micro_batches = num_micro_batches
         self.current_global_batch_size = global_batch_size
         self.current_running_global_batch_size = running_global_batch_size
         self.micro_batch_size = micro_batch_size
@@ -357,152 +383,195 @@ class ConstantNumMicroBatchesCalculator(NumMicroBatchesCalculator):
         pass
 
 
-class RampupBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
-    """Calculator of number of microbatches with batch size rampup.
-    Over `steps = (global-batch-size - start-batch-size) / batch_size_increment` increment batch
-    size from start-batch-size to global-batch-size using rampup-samples / steps
-    samples.
+class StepBatchsizeNumMicroBatchesCalculator(NumMicroBatchesCalculator):
+    """Calculator of number of microbatches with arbitrary step-wise batch size schedule.
 
     Args:
-        global_batch_size (int):
-            Global batch size post rampup.
-        micro_batch_size (int):
-            Micro batch size.
-        data_parallel_size (int):
-            Data parallel size.
-        decrease_batch_size_if_needed (bool):
-            If true, decrease batch size to ensure divisibility by DP size * microbatch size
-            (if needed).
-        rank (int):
-            Rank (to determine whether logging should be performed).
-        start_global_batch_size (int):
-            Global batch size to start with.
-        batch_size_increment (int):
-            Global batch size increments.
-        ramup_samples (int):
-            Number of samples to use ramp up global
-            batch size from `start_global_batch_size` to `global_batch_size`.
+        micro_batch_size (int): Micro batch size.
+        data_parallel_size (int): Data parallel size.
+        decrease_batch_size_if_needed (bool): Must be False. Step schedules do not support
+            decreasing batch size for divisibility.
+        rank (int): Rank for logging.
+        schedule (str): Schedule string in format "THRESHOLD:BS THRESHOLD:BS ...".
+            Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+            Examples:
+                "0:768 250B:1536 500B:3072 750B:6144" (thresholds in tokens)
+                "0:768 61035156250:1536" (thresholds in samples)
+        seq_length (int, optional): Sequence length for token-to-sample conversion.
+            If provided, thresholds are interpreted as tokens and converted to samples.
+            If None, thresholds are interpreted as samples directly.
     """
 
     def __init__(
         self,
-        global_batch_size: int,
         micro_batch_size: int,
         data_parallel_size: int,
         decrease_batch_size_if_needed: bool,
         rank: int,
-        start_global_batch_size: int,
-        batch_size_increment: int,
-        ramup_samples: int,
+        schedule: str,
+        seq_length: Optional[int] = None,
     ) -> None:
-        assert global_batch_size > 0, 'global batch size should be positive, got {}.'.format(
-            global_batch_size
-        )
-        assert start_global_batch_size > 0, 'start batch size should be positive, got {}.'.format(
-            start_global_batch_size
-        )
-        assert batch_size_increment > 0, 'batch size increment should be positive, got {}.'.format(
-            batch_size_increment
-        )
-        assert ramup_samples >= 0, 'ramp-up samples should be non-negative, got {}.'.format(
-            ramup_samples
-        )
+        super().__init__()
 
-        self.global_batch_size = global_batch_size
+        if decrease_batch_size_if_needed:
+            raise ValueError(
+                'Step batch size schedules do not support decrease_batch_size_if_needed'
+            )
+
         self.micro_batch_size = micro_batch_size
-        self.data_parallel_size = data_parallel_size
-        self.decrease_batch_size_if_needed = decrease_batch_size_if_needed
-        self.rank = rank
-        self.start_global_batch_size = start_global_batch_size
-        self.batch_size_increment = batch_size_increment
-        self.ramup_samples = ramup_samples
+        self.data_parallel_size: int = data_parallel_size
+        self.rank: int = rank
+        self.seq_length: Optional[int] = seq_length
 
-        self.micro_batch_times_data_parallel_size = self.micro_batch_size * self.data_parallel_size
+        self.micro_batch_times_data_parallel_size: int = micro_batch_size * data_parallel_size
         assert self.micro_batch_times_data_parallel_size > 0
+
+        # Parse schedule string
+        self.schedule = self._parse_schedule(schedule, seq_length)
+
+        # Validate schedule
+        self._validate_schedule()
+
+        self.global_batch_size: int = self.schedule[-1][1]
         self.current_global_batch_size = None
 
-        diff_batch_size = self.global_batch_size - self.start_global_batch_size
-        assert diff_batch_size >= 0, (
-            'expected global batch size to be greater than or equal to start batch size, '
-            f'got {self.global_batch_size} and {self.start_global_batch_size}'
-        )
-        assert diff_batch_size % batch_size_increment == 0, (
-            'expected '
-            f'global batch size interval ({diff_batch_size}) to be divisible by global batch '
-            f'size increment ({batch_size_increment})'
-        )
-
-        num_increments = diff_batch_size // self.batch_size_increment
-        self.rampup_samples_per_increment = self.ramup_samples / num_increments
-
-        # Initialize number of microbatches.
+        if rank == 0:
+            logger.info(f'> initializing step batch size schedule')
+            logger.info(f'  raw schedule string: "{schedule}"')
+            unit = "tokens" if seq_length else "samples"
+            logger.info(f'  seq_length: {seq_length}' f' (thresholds interpreted as {unit})')
+            logger.info(f'  micro_batch_size: {micro_batch_size}')
+            logger.info(f'  data_parallel_size: {data_parallel_size}')
+            logger.info(f'step batch size schedule ({len(self.schedule)} steps):')
+            for threshold, batch_size in self.schedule:
+                num_microbatches = batch_size // self.micro_batch_times_data_parallel_size
+                if seq_length:
+                    tokens = threshold * seq_length
+                    logger.info(
+                        f'  >= {tokens:,} tokens ({threshold:,} samples)'
+                        f' -> batch_size={batch_size},'
+                        f' num_microbatches={num_microbatches}'
+                    )
+                else:
+                    logger.info(
+                        f'  >= {threshold:,} samples'
+                        f' -> batch_size={batch_size},'
+                        f' num_microbatches={num_microbatches}'
+                    )
+        # Initialize
         self.update(0, consistency_check=False, verbose=True)
 
+    @staticmethod
+    def _parse_numeric_value(value_str: str) -> int:
+        """Parse numeric value with optional suffix (K, M, B, T)."""
+        value_str = value_str.strip().upper()
+
+        multiplier = 1
+        if value_str.endswith('T'):
+            multiplier = 1_000_000_000_000
+            value_str = value_str[:-1]
+        elif value_str.endswith('B'):
+            multiplier = 1_000_000_000
+            value_str = value_str[:-1]
+        elif value_str.endswith('M'):
+            multiplier = 1_000_000
+            value_str = value_str[:-1]
+        elif value_str.endswith('K'):
+            multiplier = 1_000
+            value_str = value_str[:-1]
+
+        return int(float(value_str) * multiplier)
+
+    @classmethod
+    def _parse_schedule(cls, schedule_str: str, seq_length: Optional[int]) -> List[Tuple[int, int]]:
+        """Parse schedule string into list of (threshold_samples, batch_size) tuples.
+
+        Args:
+            schedule_str: Space-separated "THRESHOLD:BATCH_SIZE" pairs.
+            seq_length: If provided, convert thresholds from tokens to samples.
+
+        Returns:
+            List of (threshold_samples, batch_size) tuples, sorted by threshold.
+        """
+        schedule = []
+        entries = schedule_str.strip().replace(',', ' ').split()
+
+        for entry in entries:
+            if ':' not in entry:
+                raise ValueError(
+                    f'Invalid schedule entry "{entry}". Expected format: "THRESHOLD:BATCH_SIZE"'
+                )
+
+            threshold_str, batch_size_str = entry.split(':', 1)
+            threshold = cls._parse_numeric_value(threshold_str)
+            batch_size = cls._parse_numeric_value(batch_size_str)
+
+            # Convert tokens to samples if seq_length provided
+            if seq_length is not None:
+                threshold = threshold // seq_length
+
+            schedule.append((threshold, batch_size))
+
+        # Sort by threshold ascending
+        schedule.sort(key=lambda x: x[0])
+
+        return schedule
+
+    def _validate_schedule(self) -> None:
+        """Validate the parsed schedule."""
+        assert len(self.schedule) > 0, 'schedule must have at least one entry'
+        assert (
+            self.schedule[0][0] == 0
+        ), f'first schedule entry must have threshold 0, got {self.schedule[0][0]}'
+
+        # Check strictly increasing thresholds
+        for i in range(1, len(self.schedule)):
+            assert self.schedule[i][0] > self.schedule[i - 1][0], (
+                f'schedule thresholds must be strictly increasing, '
+                f'got {self.schedule[i - 1][0]} before {self.schedule[i][0]}'
+            )
+
+        # Validate batch sizes are positive.
+        # NOTE: divisibility by micro_batch_size * data_parallel_size is NOT checked here
+        # because early schedule entries may be smaller than the current GPU configuration
+        # (e.g., after scaling up GPUs mid-training). Divisibility of the CURRENT batch size
+        # is checked at runtime in update() when consistency_check=True (after checkpoint loading).
+        for threshold, batch_size in self.schedule:
+            assert batch_size > 0, f'batch size must be positive, got {batch_size}'
+
+    def _get_batch_size_for_samples(self, consumed_samples: int) -> int:
+        """Get the batch size for the given number of consumed samples."""
+        batch_size = self.schedule[0][1]
+        for threshold, bs in self.schedule:
+            if consumed_samples >= threshold:
+                batch_size = bs
+            else:
+                break
+        return batch_size
+
     def update(self, consumed_samples: int, consistency_check: bool, verbose: bool = False) -> None:
-        """Update number of microbatches.
+        """Update number of microbatches based on consumed samples.
 
         Args:
             consumed_samples (int): Number of samples consumed.
-            consistency_check (bool): Option to check current schedule's consistency.
-            verbose (bool, optional): Option to control logging. Defaults to False.
+            consistency_check (bool): Check divisibility constraints.
+            verbose (bool): Enable logging.
         """
+        self.current_global_batch_size = self._get_batch_size_for_samples(consumed_samples)
+        assert self.current_global_batch_size is not None
 
-        # Update current global batch size.
-        global_batch_size_changed = False
-        old_current_global_batch_size = self.current_global_batch_size
-        if consumed_samples > self.ramup_samples:
-            self.current_global_batch_size = self.global_batch_size
-        else:
-            steps = int(consumed_samples / self.rampup_samples_per_increment)
-            self.current_global_batch_size = (
-                self.start_global_batch_size + steps * self.batch_size_increment
-            )
-            assert self.current_global_batch_size <= self.global_batch_size
-
-        if old_current_global_batch_size != self.current_global_batch_size:
-            global_batch_size_changed = True
-        if self.rank == 0 and global_batch_size_changed and verbose:
-            if old_current_global_batch_size is None:
-                logger.info(f'setting initial batch size to {self.current_global_batch_size}')
-            else:
-                logger.info(
-                    f'ramping up batch size from {old_current_global_batch_size} to '
-                    f'{self.current_global_batch_size}'
-                )
-
-        # Check consistency of the current global batch size.
-        if consistency_check and not self.decrease_batch_size_if_needed:
+        # Consistency check
+        if consistency_check:
             assert (
                 self.current_global_batch_size % self.micro_batch_times_data_parallel_size == 0
             ), (
-                'current global '
-                'batch size ({}) is not divisible by micro-batch-size ({}) times'
-                'data parallel size ({})'.format(
-                    self.current_global_batch_size, self.micro_batch_size, self.data_parallel_size
-                )
+                f'current global batch size ({self.current_global_batch_size}) is not divisible by '
+                f'micro_batch_size ({self.micro_batch_size}) * '
+                f'data_parallel_size ({self.data_parallel_size})'
             )
 
-        if (
-            self.decrease_batch_size_if_needed
-            and self.current_global_batch_size % self.micro_batch_times_data_parallel_size != 0
-        ):
-            self.current_running_global_batch_size = _round(
-                self.current_global_batch_size, self.micro_batch_times_data_parallel_size
-            )
-            if self.rank == 0 and global_batch_size_changed and verbose:
-                logger.info(
-                    f'decreasing batch size from {self.current_global_batch_size} to '
-                    f'{self.current_running_global_batch_size} to keep divisiblity by '
-                    f'micro_batch_size={self.micro_batch_size} * '
-                    f'data_parallel_size={self.data_parallel_size}'
-                )
-            assert (
-                self.current_running_global_batch_size % self.micro_batch_times_data_parallel_size
-                == 0
-            )
-        else:
-            self.current_running_global_batch_size = self.current_global_batch_size
-
+        self.current_running_global_batch_size = self.current_global_batch_size
+        assert self.current_running_global_batch_size is not None
         self.num_micro_batches = (
             self.current_running_global_batch_size // self.micro_batch_times_data_parallel_size
         )

--- a/megatron/legacy/model/transformer.py
+++ b/megatron/legacy/model/transformer.py
@@ -1454,7 +1454,7 @@ class ParallelTransformer(MegatronModule):
             ) if self.use_fp8 else nullcontext():
                 # Determine if the current iteration is first microbatch
                 if self.num_microbatches_in_previous_step != get_num_microbatches():
-                    self.microbatch_count = 0 # Reset count on new batch size rampup interval
+                    self.microbatch_count = 0
                 self.num_microbatches_in_previous_step = get_num_microbatches()
                 is_first_microbatch = self.microbatch_count % get_num_microbatches() == 0
 

--- a/megatron/rl/rl_utils.py
+++ b/megatron/rl/rl_utils.py
@@ -1501,9 +1501,8 @@ def prepare_data_for_update(
                     samples_ratio_per_step=samples_ratio_per_step,
                     num_bins_this_rank = len(packing_context.packed_trajs),
                     bin_seq_indices = packing_context.packing_info.bin_seq_indices,
-                    global_batch_size=args.global_batch_size, 
-                    rampup_batch_size=args.rampup_batch_size, 
-                    micro_batch_size=args.micro_batch_size, 
+                    global_batch_size=args.global_batch_size,
+                    micro_batch_size=args.micro_batch_size,
                     decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
                )
                 loader = get_microbatch_dataloader(len(packing_context.packed_trajs), args.micro_batch_size)
@@ -1528,9 +1527,8 @@ def prepare_data_for_update(
 
                 reconfigure_num_microbatches_calculator(
                     rank=torch.distributed.get_rank() if torch.distributed.is_initialized() else 0,
-                    global_batch_size=math.ceil(samples_ratio_per_step*total_turns_sampled), 
-                    rampup_batch_size=args.rampup_batch_size, 
-                    micro_batch_size=args.micro_batch_size, 
+                    global_batch_size=math.ceil(samples_ratio_per_step*total_turns_sampled),
+                    micro_batch_size=args.micro_batch_size,
                     decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
                     data_parallel_size=mpu.get_data_parallel_world_size(),
                 )

--- a/megatron/rl/sequence_packing_utils.py
+++ b/megatron/rl/sequence_packing_utils.py
@@ -1016,7 +1016,6 @@ def update_microbatch_calculator(
     num_bins_this_rank: int,
     bin_seq_indices: List[List[int]],
     global_batch_size: int,
-    rampup_batch_size: int,
     micro_batch_size: int,
     decrease_batch_size_if_needed: bool,
 ):
@@ -1026,7 +1025,6 @@ def update_microbatch_calculator(
         num_bins_this_rank: Amount of packing bins that belongs to current rank.
         bin_seq_indices: Global seq indices in the bin, see PackingInfo.
         global_batch_size: Current global batch size.
-        rampup_batch_size: Rampup batch size. See num_microbatches_calculator.py for more.
         micro_batch_size: Micro batch size at init.
         decrease_batch_size_if_needed: Scale down batch size. See num_microbatches_calculator.py for more.
 
@@ -1046,7 +1044,6 @@ def update_microbatch_calculator(
     old_num_microbatches = get_num_microbatches()
     reconfigure_num_microbatches_calculator(
         rank=torch.distributed.get_rank() if torch.distributed.is_initialized() else 0,
-        rampup_batch_size=rampup_batch_size,
         global_batch_size=bins_bs,
         micro_batch_size=micro_batch_size,
         data_parallel_size=dp_world_size,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -132,6 +132,8 @@ def parse_args(extra_args_provider=None, ignore_unknown_args=False):
     else:
         args = parser.parse_args()
 
+    args._is_global_batch_size_explicitly_specified = args.global_batch_size is not None
+
     # Experimental yaml
     if args.yaml_cfg is not None:
         from .yaml_arguments import load_yaml
@@ -593,11 +595,16 @@ def validate_args(args, defaults={}):
         args.phase_transition_iterations = sorted(
             int(x.strip()) for x in args.phase_transition_iterations.split(",")
         )
-        assert args.rampup_batch_size is None, "multi-phase training does not support batch size ramp-up"
-
     # Batch size.
     assert args.micro_batch_size is not None
     assert args.micro_batch_size > 0
+    is_global_batch_size_explicitly_specified = getattr(
+        args, '_is_global_batch_size_explicitly_specified', args.global_batch_size is not None
+    )
+    if args.step_batch_size_schedule is not None and is_global_batch_size_explicitly_specified:
+        raise ValueError(
+            'Cannot specify both --step-batch-size-schedule and --global-batch-size'
+        )
     if args.global_batch_size is None:
         args.global_batch_size = args.micro_batch_size * args.data_parallel_size
         print_rank_0('setting global batch size to {}'.format(args.global_batch_size))
@@ -617,7 +624,6 @@ def validate_args(args, defaults={}):
             args.grpo_samples_per_iteration * args.grpo_iterations)
 
         # Ensure that the number of prompts we collect is a multiple of the global batch size.
-        # TODO: Make this account for batch size rampup?
         assert num_generated_samples_per_inference_iteration % args.global_batch_size == 0, \
             f"grpo_group_size * grpo_prompts_per_step * grpo_iterations should be divisible by global_batch_size"
 
@@ -1116,8 +1122,6 @@ def validate_args(args, defaults={}):
             'expected iteration-based learning rate decay'
         assert args.lr_warmup_samples == 0, \
             'expected iteration-based learning rate warmup'
-        assert args.rampup_batch_size is None, \
-            'expected no batch-size rampup for iteration-based training'
         if args.lr_warmup_fraction is not None:
             assert args.lr_warmup_iters == 0, \
                 'can only specify one of lr-warmup-fraction and lr-warmup-iters'
@@ -2910,8 +2914,7 @@ def _add_data_args(parser):
                        'This argument is exclusive to the other independent --*-data-path arguments.')
     group.add_argument('--phase-transition-iterations', type=str, default=None,
                        help='Comma-separated list of iterations where phase '
-                       'transitions occur. Requires fixed global batch size across phases. '
-                       'Does not support batch size ramp-up.')
+                       'transitions occur. Requires fixed global batch size across phases.')
     group.add_argument('--split', type=str, default=None,
                        help='Comma-separated list of proportions for training,'
                        ' validation, and test split. For example the split '

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -16,6 +16,18 @@ class TrainingConfig:
     data-parallel-size. If this value is None, then use micro-batch-size * data-parallel-size
     as the global batch size. This choice will result in 1 for number of micro-batches."""
 
+    rampup_batch_size: list[int] | None = field(default=None, metadata={"argparse_meta": {"nargs": 3}})
+    """Batch size ramp up with the following values: <start batch size>, <batch size increment>,
+    <ramp-up samples>
+    For example:
+        rampup-batch-size = [16, 8, 300000]
+        global-batch-size 1024
+    will start with global batch size 16 and over (1024 - 16) / 8 = 126 intervals will increase
+    the batch size linearly to 1024. In each interval we will use approximately
+    300000 / 126 = 2380 samples.
+    Deprecated. Use step_batch_size_schedule instead.
+    """
+
     step_batch_size_schedule: str | None = None
     """Step-wise batch size schedule in format "THRESHOLD:BS THRESHOLD:BS ...".
     Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -16,21 +16,21 @@ class TrainingConfig:
     data-parallel-size. If this value is None, then use micro-batch-size * data-parallel-size
     as the global batch size. This choice will result in 1 for number of micro-batches."""
 
-    rampup_batch_size: list[int] | None = field(default=None, metadata={"argparse_meta": {"nargs": 3}})
-    """Batch size ramp up with the following values: <start batch size>, <batch size increment>,
-    <ramp-up samples>
-    For example:
-        rampup-batch-size = [16, 8, 300000]
-        global-batch-size 1024
-    will start with global batch size 16 and over (1024 - 16) / 8 = 126 intervals will increase
-    the batch size linearly to 1024. In each interval we will use approximately
-    300000 / 126 = 2380 samples.
+    step_batch_size_schedule: str | None = None
+    """Step-wise batch size schedule in format "THRESHOLD:BS THRESHOLD:BS ...".
+    Thresholds support suffixes: K (1e3), M (1e6), B (1e9), T (1e12).
+    If sequence length is provided, thresholds are interpreted as tokens; otherwise as samples.
+    Example:
+        step_batch_size_schedule = "0:768 250B:1536 500B:3072 750B:6144"
+    Cannot be used together with decrease_batch_size_if_needed.
     """
+
 
     decrease_batch_size_if_needed: bool = False
     """If set, decrease batch size if microbatch_size * dp_size does not 
     divide batch_size. Old batch_size will be restored if training is re-started 
-    with dp_size that divides batch_size // microbatch_size."""
+    with dp_size that divides batch_size // microbatch_size. Not supported with
+    step-batch-size-schedule."""
 
     empty_unused_memory_level: Literal[0, 1, 2] = 0
     """Call torch.cuda.empty_cache() each iteration (training and eval), to reduce fragmentation.

--- a/megatron/training/global_vars.py
+++ b/megatron/training/global_vars.py
@@ -125,11 +125,11 @@ def set_global_variables(args, build_tokenizer=True):
         print(f'> using step batch size schedule: {args.step_batch_size_schedule}')
 
     init_num_microbatches_calculator(
-        args.rank,
-        args.global_batch_size,
-        args.micro_batch_size,
-        args.data_parallel_size,
-        args.decrease_batch_size_if_needed,
+        rank=args.rank,
+        global_batch_size=args.global_batch_size,
+        micro_batch_size=args.micro_batch_size,
+        data_parallel_size=args.data_parallel_size,
+        decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
         step_batch_size_schedule=args.step_batch_size_schedule,
         seq_length=args.seq_length,
     )

--- a/megatron/training/global_vars.py
+++ b/megatron/training/global_vars.py
@@ -121,13 +121,17 @@ def set_global_variables(args, build_tokenizer=True):
     _ensure_var_is_not_initialized(_GLOBAL_ARGS, 'args')
     set_args(args)
 
+    if args.step_batch_size_schedule is not None:
+        print(f'> using step batch size schedule: {args.step_batch_size_schedule}')
+
     init_num_microbatches_calculator(
         args.rank,
-        args.rampup_batch_size,
         args.global_batch_size,
         args.micro_batch_size,
         args.data_parallel_size,
         args.decrease_batch_size_if_needed,
+        step_batch_size_schedule=args.step_batch_size_schedule,
+        seq_length=args.seq_length,
     )
     if build_tokenizer:
         _ = _build_tokenizer(args)

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2720,11 +2720,11 @@ def train(
         destroy_num_microbatches_calculator()
         # Then initialize with the correct perform_rl_step=True context
         init_num_microbatches_calculator(
-            args.rank,
-            args.global_batch_size,
-            args.micro_batch_size,
-            mpu.get_data_parallel_world_size(),
-            args.decrease_batch_size_if_needed,
+            rank=args.rank,
+            global_batch_size=args.global_batch_size,
+            micro_batch_size=args.micro_batch_size,
+            data_parallel_size=mpu.get_data_parallel_world_size(),
+            decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
             step_batch_size_schedule=args.step_batch_size_schedule,
             seq_length=args.seq_length,
         )

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1292,29 +1292,20 @@ def update_train_iters(args):
     if args.train_iters:
         return
 
-    # Constant batch size with sample-based training.
-    if args.rampup_batch_size is None:
-        args.train_iters = args.train_samples // args.global_batch_size
-
-    else:
-        # Sample based training with rampup batch size.
+    if args.step_batch_size_schedule is not None:
+        # Sample based training with step batch size schedule.
         iterations = 0
         consumed_samples = 0
-        # Rampup phase.
-        while (
-            consumed_samples <= int(args.rampup_batch_size[2])
-            and consumed_samples <= args.train_samples
-        ):
+        while consumed_samples < args.train_samples:
             update_num_microbatches(consumed_samples, consistency_check=False)
             consumed_samples += get_current_global_batch_size()
             iterations += 1
         # Reset
         update_num_microbatches(0, consistency_check=False)
-        # Constant phase
-        # Note that we throw away any partial last batch.
-        if args.train_samples > consumed_samples:
-            iterations += (args.train_samples - consumed_samples) // args.global_batch_size
         args.train_iters = iterations
+    else:
+        # Constant batch size with sample-based training.
+        args.train_iters = args.train_samples // args.global_batch_size
 
     print_rank_0(f'setting training iterations to {args.train_iters}')
 
@@ -1738,6 +1729,21 @@ def setup_model_and_optimizer(
     else:
         args.iteration = 0
         args.num_floating_point_operations_so_far = 0
+
+    # Validate that the world size can accommodate the current batch size.
+    # This catches the case where GPUs were scaled up mid-training but the
+    # current position in the batch size schedule yields a batch size that
+    # is too small for the number of data-parallel replicas.
+    num_microbatches = get_num_microbatches()
+    current_global_batch_size = get_current_global_batch_size()
+    data_parallel_size = mpu.get_data_parallel_world_size()
+    assert num_microbatches is not None and num_microbatches >= 1, (
+        f'current global batch size ({current_global_batch_size}) is too small for '
+        f'micro_batch_size ({args.micro_batch_size}) * data_parallel_size ({data_parallel_size}) = '
+        f'{args.micro_batch_size * data_parallel_size}. The world size cannot accommodate the '
+        f'batch size. This can happen when resuming with more GPUs than the current batch size '
+        f'schedule entry supports.'
+    )
 
     # get model without FP16 and/or DDP wrappers
     if (
@@ -2715,11 +2721,12 @@ def train(
         # Then initialize with the correct perform_rl_step=True context
         init_num_microbatches_calculator(
             args.rank,
-            args.rampup_batch_size,
             args.global_batch_size,
             args.micro_batch_size,
             mpu.get_data_parallel_world_size(),
-            args.decrease_batch_size_if_needed
+            args.decrease_batch_size_if_needed,
+            step_batch_size_schedule=args.step_batch_size_schedule,
+            seq_length=args.seq_length,
         )
         print_rank_0(f"> GRPO training: num_microbatches set to {get_num_microbatches()}")
 
@@ -2971,8 +2978,8 @@ def train(
                 )
             else:
                 assert get_num_microbatches() > num_microbatches, (
-                    f"Number of microbatches should be increasing due to batch size rampup; "
-                    f"instead going from {num_microbatches} to {get_num_microbatches()}"
+                    f"Number of microbatches should not decrease; "
+                    f"going from {num_microbatches} to {get_num_microbatches()}"
                 )
                 if args.save is not None:
                     save_checkpoint_and_time(

--- a/megatron/training/yaml_arguments.py
+++ b/megatron/training/yaml_arguments.py
@@ -103,6 +103,13 @@ def validate_yaml(args, defaults={}):
     # Batch size.
     assert args.micro_batch_size is not None
     assert args.micro_batch_size > 0
+    is_global_batch_size_explicitly_specified = getattr(
+        args, '_is_global_batch_size_explicitly_specified', args.global_batch_size is not None
+    )
+    if args.step_batch_size_schedule is not None and is_global_batch_size_explicitly_specified:
+        raise ValueError(
+            'Cannot specify both --step-batch-size-schedule and --global-batch-size'
+        )
     if args.global_batch_size is None:
         args.global_batch_size = args.micro_batch_size * args.data_parallel_size
         if args.rank == 0:
@@ -188,8 +195,6 @@ def validate_yaml(args, defaults={}):
             'expected iteration-based learning rate decay'
         assert args.lr_warmup_samples == 0, \
             'expected iteration-based learning rate warmup'
-        assert args.rampup_batch_size is None, \
-            'expected no batch-size rampup for iteration-based training'
         if args.lr_warmup_fraction is not None:
             assert args.lr_warmup_iters == 0, \
                 'can only specify one of lr-warmup-fraction and lr-warmup-iters'
@@ -430,5 +435,8 @@ def load_yaml(yaml_path):
         config_namespace = json.loads(json.dumps(config), object_hook=lambda item: SimpleNamespace(**item))
         # Add config location to namespace
         config_namespace.yaml_cfg = yaml_path
+        config_namespace._is_global_batch_size_explicitly_specified = (
+            getattr(config_namespace, "global_batch_size", None) is not None
+        )
         return config_namespace
 

--- a/tasks/finetune_utils.py
+++ b/tasks/finetune_utils.py
@@ -248,9 +248,6 @@ def finetune(train_valid_datasets_provider, model_provider,
     args = get_args()
     timers = get_timers()
 
-    assert args.rampup_batch_size is None, \
-        'batch size scaling is not supported for finetuning'
-
     # Train and validation data loaders.
     timers('train/valid/test dataset/dataloder', log_level=0).start()
     if args.epochs > 0:

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release/model_config.yaml
@@ -22,8 +22,8 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --rampup-batch-size: "[384 384 97656250]"
   --global-batch-size: 1152
+  --step-batch-size-schedule: "0:384 200B:768 400B:1152"
   --train-samples: 19531250
   --manual-gc: true
   # Transformer Engine args

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_gb200/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_gb200/model_config.yaml
@@ -24,8 +24,8 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --rampup-batch-size: "[384 384 97656250]"
   --global-batch-size: 1152
+  --step-batch-size-schedule: "0:384 200B:768 400B:1152"
   --train-samples: 19531250
   --manual-gc: true
   --cross-entropy-loss-fusion: true

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm/model_config.yaml
@@ -22,8 +22,8 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --rampup-batch-size: "[384 384 97656250]"
   --global-batch-size: 1152
+  --step-batch-size-schedule: "0:384 200B:768 400B:1152"
   --train-samples: 4882812
   --manual-gc: true
   # Transformer Engine args

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm_gb200/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm_gb200/model_config.yaml
@@ -24,8 +24,8 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --rampup-batch-size: "[384 384 97656250]"
   --global-batch-size: 1152
+  --step-batch-size-schedule: "0:384 200B:768 400B:1152"
   --train-samples: 19531250
   --manual-gc: true
   --cross-entropy-loss-fusion: true

--- a/tests/unit_tests/dist_checkpointing/test_pipeline_parallel_layout.py
+++ b/tests/unit_tests/dist_checkpointing/test_pipeline_parallel_layout.py
@@ -305,7 +305,9 @@ def test_save_and_load_checkpoint_vpp(
         args.load = ckpt_path
 
     set_tp_pp_vpp(*src_tp_pp_vpp, pp_layout=src_pp_layout, destroy_first=False)
-    init_num_microbatches_calculator(0, 1, 1, 1)
+    init_num_microbatches_calculator(
+        rank=0, global_batch_size=1, micro_batch_size=1, data_parallel_size=1
+    )
 
     iteration = 123
     layer_spec_fn = get_gpt_decoder_block_spec if is_moe else gpt_te_spec

--- a/tests/unit_tests/dist_checkpointing/test_pipeline_parallel_layout.py
+++ b/tests/unit_tests/dist_checkpointing/test_pipeline_parallel_layout.py
@@ -305,7 +305,7 @@ def test_save_and_load_checkpoint_vpp(
         args.load = ckpt_path
 
     set_tp_pp_vpp(*src_tp_pp_vpp, pp_layout=src_pp_layout, destroy_first=False)
-    init_num_microbatches_calculator(0, None, 1, 1, 1)
+    init_num_microbatches_calculator(0, 1, 1, 1)
 
     iteration = 123
     layer_spec_fn = get_gpt_decoder_block_spec if is_moe else gpt_te_spec

--- a/tests/unit_tests/distributed/test_torch_fully_sharded_parallel.py
+++ b/tests/unit_tests/distributed/test_torch_fully_sharded_parallel.py
@@ -39,7 +39,9 @@ class DummyModel(MegatronModule):
 def init_model_parallel():
     """Init torch distributed."""
     Utils.initialize_model_parallel(1, 1)
-    init_num_microbatches_calculator(0, 1, 1, 1)
+    init_num_microbatches_calculator(
+        rank=0, global_batch_size=1, micro_batch_size=1, data_parallel_size=1
+    )
     model_parallel_cuda_manual_seed(123)
     yield  # Run the actual test.
     Utils.destroy_model_parallel()

--- a/tests/unit_tests/distributed/test_torch_fully_sharded_parallel.py
+++ b/tests/unit_tests/distributed/test_torch_fully_sharded_parallel.py
@@ -39,7 +39,7 @@ class DummyModel(MegatronModule):
 def init_model_parallel():
     """Init torch distributed."""
     Utils.initialize_model_parallel(1, 1)
-    init_num_microbatches_calculator(0, None, 1, 1, 1)
+    init_num_microbatches_calculator(0, 1, 1, 1)
     model_parallel_cuda_manual_seed(123)
     yield  # Run the actual test.
     Utils.destroy_model_parallel()

--- a/tests/unit_tests/pipeline_parallel/test_pipeline_layout.py
+++ b/tests/unit_tests/pipeline_parallel/test_pipeline_layout.py
@@ -226,7 +226,9 @@ def test_forward_vpp(create_args, tmp_path_dist_ckpt, tp_pp_vpp, pp_layout, is_m
         args.pipeline_model_parallel_layout = pp_layout
 
     set_tp_pp_vpp(*tp_pp_vpp, pp_layout=pp_layout, destroy_first=False)
-    init_num_microbatches_calculator(0, 1, 1, 1)
+    init_num_microbatches_calculator(
+        rank=0, global_batch_size=1, micro_batch_size=1, data_parallel_size=1
+    )
 
     def forward_step_func(data_iterator, model: GPTModel):
         """Forward training step. Copied from `pretrain_gpt.py`"""

--- a/tests/unit_tests/pipeline_parallel/test_pipeline_layout.py
+++ b/tests/unit_tests/pipeline_parallel/test_pipeline_layout.py
@@ -226,7 +226,7 @@ def test_forward_vpp(create_args, tmp_path_dist_ckpt, tp_pp_vpp, pp_layout, is_m
         args.pipeline_model_parallel_layout = pp_layout
 
     set_tp_pp_vpp(*tp_pp_vpp, pp_layout=pp_layout, destroy_first=False)
-    init_num_microbatches_calculator(0, None, 1, 1, 1)
+    init_num_microbatches_calculator(0, 1, 1, 1)
 
     def forward_step_func(data_iterator, model: GPTModel):
         """Forward training step. Copied from `pretrain_gpt.py`"""

--- a/tests/unit_tests/rl/test_sequence_packing_utils.py
+++ b/tests/unit_tests/rl/test_sequence_packing_utils.py
@@ -465,12 +465,7 @@ def test_get_bins_bs_and_steps(ratio, local_bins, world, expected_bs):
     global_bs_in_seq = int(n_seqs * ratio)
 
     def side_eff(
-        rank,
-        rampup_batch_size,
-        global_batch_size,
-        micro_batch_size,
-        data_parallel_size,
-        decrease_batch_size_if_needed,
+        rank, global_batch_size, micro_batch_size, data_parallel_size, decrease_batch_size_if_needed
     ):
         # Inside of the get_microbatch_dataloader, we compute the batch size in bins.
         # We want to test this variable.
@@ -488,7 +483,6 @@ def test_get_bins_bs_and_steps(ratio, local_bins, world, expected_bs):
                     num_bins_this_rank=local_bins,
                     bin_seq_indices=[],
                     global_batch_size=global_bs_in_seq,
-                    rampup_batch_size=1,
                     micro_batch_size=1,
                     decrease_batch_size_if_needed=False,
                 )

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -152,7 +152,9 @@ def create_ckpt_load_args(create_args):
 def init_model_parallel():
     """Init torch distributed."""
     Utils.initialize_model_parallel(1, 1)
-    init_num_microbatches_calculator(0, 1, 1, 1)
+    init_num_microbatches_calculator(
+        rank=0, global_batch_size=1, micro_batch_size=1, data_parallel_size=1
+    )
     model_parallel_cuda_manual_seed(123)
     yield  # Run the actual test.
     Utils.destroy_model_parallel()

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -152,7 +152,7 @@ def create_ckpt_load_args(create_args):
 def init_model_parallel():
     """Init torch distributed."""
     Utils.initialize_model_parallel(1, 1)
-    init_num_microbatches_calculator(0, None, 1, 1, 1)
+    init_num_microbatches_calculator(0, 1, 1, 1)
     model_parallel_cuda_manual_seed(123)
     yield  # Run the actual test.
     Utils.destroy_model_parallel()

--- a/tests/unit_tests/test_num_microbatches_calculator.py
+++ b/tests/unit_tests/test_num_microbatches_calculator.py
@@ -7,21 +7,37 @@ import megatron.core.num_microbatches_calculator as mb_calculator
 
 def test_init_num_microbatches_calculator():
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, 32, 8, 2, False)
+    mb_calculator.init_num_microbatches_calculator(
+        rank=0, global_batch_size=32, micro_batch_size=8, data_parallel_size=2
+    )
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 32
 
     with pytest.raises(AssertionError):
-        mb_calculator.init_num_microbatches_calculator(0, 32, 8, 2, False)
+        mb_calculator.init_num_microbatches_calculator(
+            rank=0, global_batch_size=32, micro_batch_size=8, data_parallel_size=2
+        )
 
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, 32, 8, 3, True)
+    mb_calculator.init_num_microbatches_calculator(
+        rank=0,
+        global_batch_size=32,
+        micro_batch_size=8,
+        data_parallel_size=3,
+        decrease_batch_size_if_needed=True,
+    )
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 32
     assert mb_calculator.get_current_running_global_batch_size() == 24
 
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, 33, 8, 2, True)
+    mb_calculator.init_num_microbatches_calculator(
+        rank=0,
+        global_batch_size=33,
+        micro_batch_size=8,
+        data_parallel_size=2,
+        decrease_batch_size_if_needed=True,
+    )
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 33
     assert mb_calculator.get_current_running_global_batch_size() == 32
@@ -29,34 +45,56 @@ def test_init_num_microbatches_calculator():
 
 def test_reconfigure_num_microbatches_calculator():
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, 32, 8, 2, False)
+    mb_calculator.init_num_microbatches_calculator(
+        rank=0, global_batch_size=32, micro_batch_size=8, data_parallel_size=2
+    )
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 32
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(
+        rank=0, global_batch_size=16, micro_batch_size=8, data_parallel_size=2
+    )
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 16
 
 
 def test_get_num_microbatches():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(
+        rank=0, global_batch_size=16, micro_batch_size=8, data_parallel_size=2
+    )
     assert mb_calculator.get_num_microbatches() == 1
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 4, 3, True)
+    mb_calculator.reconfigure_num_microbatches_calculator(
+        rank=0,
+        global_batch_size=16,
+        micro_batch_size=4,
+        data_parallel_size=3,
+        decrease_batch_size_if_needed=True,
+    )
     assert mb_calculator.get_num_microbatches() == 1
 
 
 def test_get_current_global_batch_size():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 4, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(
+        rank=0, global_batch_size=16, micro_batch_size=4, data_parallel_size=2
+    )
     assert mb_calculator.get_current_global_batch_size() == 16
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 4, 3, True)
+    mb_calculator.reconfigure_num_microbatches_calculator(
+        rank=0,
+        global_batch_size=16,
+        micro_batch_size=4,
+        data_parallel_size=3,
+        decrease_batch_size_if_needed=True,
+    )
     assert mb_calculator.get_current_global_batch_size() == 16
     assert mb_calculator.get_current_running_global_batch_size() == 12
 
 
 def test_get_micro_batch_size():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(
+        rank=0, global_batch_size=16, micro_batch_size=8, data_parallel_size=2
+    )
     assert mb_calculator.get_micro_batch_size() == 8
 
 

--- a/tests/unit_tests/test_num_microbatches_calculator.py
+++ b/tests/unit_tests/test_num_microbatches_calculator.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import pytest
 
@@ -7,21 +7,21 @@ import megatron.core.num_microbatches_calculator as mb_calculator
 
 def test_init_num_microbatches_calculator():
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, False)
+    mb_calculator.init_num_microbatches_calculator(0, 32, 8, 2, False)
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 32
 
     with pytest.raises(AssertionError):
-        mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, False)
+        mb_calculator.init_num_microbatches_calculator(0, 32, 8, 2, False)
 
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 3, True)
+    mb_calculator.init_num_microbatches_calculator(0, 32, 8, 3, True)
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 32
     assert mb_calculator.get_current_running_global_batch_size() == 24
 
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 33, 8, 2, True)
+    mb_calculator.init_num_microbatches_calculator(0, 33, 8, 2, True)
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 33
     assert mb_calculator.get_current_running_global_batch_size() == 32
@@ -29,68 +29,47 @@ def test_init_num_microbatches_calculator():
 
 def test_reconfigure_num_microbatches_calculator():
     mb_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR = None
-    mb_calculator.init_num_microbatches_calculator(0, None, 32, 8, 2, False)
+    mb_calculator.init_num_microbatches_calculator(0, 32, 8, 2, False)
     assert mb_calculator.get_num_microbatches() == 2
     assert mb_calculator.get_current_global_batch_size() == 32
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, False)
-    assert mb_calculator.get_num_microbatches() == 1
-    assert mb_calculator.get_current_global_batch_size() == 16
-
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 16, 96], 32, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 8, 2, False)
     assert mb_calculator.get_num_microbatches() == 1
     assert mb_calculator.get_current_global_batch_size() == 16
 
 
 def test_get_num_microbatches():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 8, 2, False)
     assert mb_calculator.get_num_microbatches() == 1
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 3, True)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 4, 3, True)
     assert mb_calculator.get_num_microbatches() == 1
 
 
 def test_get_current_global_batch_size():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 4, 2, False)
     assert mb_calculator.get_current_global_batch_size() == 16
 
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 4, 3, True)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 4, 3, True)
     assert mb_calculator.get_current_global_batch_size() == 16
     assert mb_calculator.get_current_running_global_batch_size() == 12
 
 
 def test_get_micro_batch_size():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 16, 8, 2, False)
+    mb_calculator.reconfigure_num_microbatches_calculator(0, 16, 8, 2, False)
     assert mb_calculator.get_micro_batch_size() == 8
 
 
-def test_update_num_microbatches():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 8, 96], 32, 4, 2, False)
-    assert mb_calculator.get_num_microbatches() == 2
-    mb_calculator.update_num_microbatches(48, False)
-    assert mb_calculator.get_num_microbatches() == 3
-
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 8, 96], 32, 8, 2, False)
-    with pytest.raises(AssertionError):
-        mb_calculator.update_num_microbatches(49, True)
-
-    mb_calculator.reconfigure_num_microbatches_calculator(0, None, 32, 8, 2, False)
-    mb_calculator.update_num_microbatches(16)
-    assert mb_calculator.get_num_microbatches() == 2
-
-
 def test_build_num_microbatches_calculator():
-    temp_calculator = mb_calculator._build_num_microbatches_calculator(0, None, 32, 8, 2, False)
+    temp_calculator = mb_calculator._build_num_microbatches_calculator(0, 32, 8, 2, False)
     assert temp_calculator.get() == 2
     assert temp_calculator.get_current_global_batch_size() == 32
     assert type(temp_calculator) is mb_calculator.ConstantNumMicroBatchesCalculator
 
-    temp_calculator = mb_calculator._build_num_microbatches_calculator(
-        0, [16, 16, 48], 32, 8, 2, False
-    )
-    assert temp_calculator.get() == 1
-    assert temp_calculator.get_current_global_batch_size() == 16
-    assert type(temp_calculator) is mb_calculator.RampupBatchsizeNumMicroBatchesCalculator
+    with pytest.raises(ValueError):
+        mb_calculator._build_num_microbatches_calculator(
+            0, None, 8, 2, True, step_batch_size_schedule="0:16 100:32"
+        )
 
 
 class TestConstantNumMicroBatchesCalculator:
@@ -110,38 +89,73 @@ class TestConstantNumMicroBatchesCalculator:
         assert self.mb_calculator.get_current_global_batch_size() == 32
 
 
-class TestRampupBatchsizeNumMicroBatchesCalculator:
-    def setup_method(self, method):
-        self.mb_calculator = mb_calculator.RampupBatchsizeNumMicroBatchesCalculator(
-            32, 8, 2, False, 0, 16, 16, 48
+def test_step_batch_size_schedule_allows_past_entries_smaller_than_dp():
+    """Test that step batch size schedule does not crash when early schedule entries
+    are smaller than micro_batch_size * data_parallel_size.
+
+    This happens when scaling to more GPUs mid-training: the initial batch sizes
+    in the schedule are smaller than the new GPU count can support, but training
+    has progressed past those entries. The divisibility check should only apply
+    to the CURRENT batch size (after checkpoint loading), not all schedule entries.
+    """
+    # micro=1, dp=512, micro*dp=512
+    # Schedule starts at 256 which is < 512, but later entries are fine.
+    # This should NOT raise during construction.
+    calc = mb_calculator.StepBatchsizeNumMicroBatchesCalculator(
+        micro_batch_size=1,
+        data_parallel_size=512,
+        decrease_batch_size_if_needed=False,
+        rank=0,
+        schedule="0:256 200000:512 600000:1024 1500000:2048 3000000:4096 6000000:6144",
+    )
+
+    # At init (consumed_samples=0), batch=256 < micro*dp=512.
+    # No consistency_check at init, so no error.
+    assert calc.current_global_batch_size == 256
+
+    # After training past the first entry, batch=512. Consistency check passes.
+    calc.update(200000, consistency_check=True)
+    assert calc.current_global_batch_size == 512
+    assert calc.num_micro_batches == 1
+
+    # Later entries work fine.
+    calc.update(1500000, consistency_check=True)
+    assert calc.current_global_batch_size == 2048
+    assert calc.num_micro_batches == 4
+
+    calc.update(6000000, consistency_check=True)
+    assert calc.current_global_batch_size == 6144
+    assert calc.num_micro_batches == 12
+
+
+def test_step_batch_size_schedule_consistency_check_fails_when_batch_too_small():
+    """Test that consistency_check=True raises when current batch size is smaller
+    than micro_batch_size * data_parallel_size.
+
+    This is the scenario caught by the runtime check in setup_model_and_optimizer:
+    GPUs were scaled up but the current schedule entry yields a batch size too small
+    for the new world size.
+    """
+    calc = mb_calculator.StepBatchsizeNumMicroBatchesCalculator(
+        micro_batch_size=1,
+        data_parallel_size=512,
+        decrease_batch_size_if_needed=False,
+        rank=0,
+        schedule="0:256 200000:512 600000:1024",
+    )
+
+    # At consumed_samples=0, batch=256 < micro*dp=512.
+    # consistency_check=True should fail because 256 % 512 != 0.
+    with pytest.raises(AssertionError):
+        calc.update(0, consistency_check=True)
+
+
+def test_step_batch_size_schedule_rejects_decrease_batch_size_if_needed():
+    with pytest.raises(ValueError):
+        mb_calculator.StepBatchsizeNumMicroBatchesCalculator(
+            micro_batch_size=1,
+            data_parallel_size=512,
+            decrease_batch_size_if_needed=True,
+            rank=0,
+            schedule="0:256 200000:512 600000:1024",
         )
-
-    def test_constructor(self):
-        assert type(self.mb_calculator) is mb_calculator.RampupBatchsizeNumMicroBatchesCalculator
-        assert self.mb_calculator.global_batch_size == 32
-        assert self.mb_calculator.micro_batch_size == 8
-        assert self.mb_calculator.data_parallel_size == 2
-        assert self.mb_calculator.start_global_batch_size == 16
-        assert self.mb_calculator.batch_size_increment == 16
-        assert self.mb_calculator.ramup_samples == 48
-        assert self.mb_calculator.micro_batch_times_data_parallel_size == 16
-        assert self.mb_calculator.num_micro_batches == 1
-
-    def test_get(self):
-        assert self.mb_calculator.get() == 1
-
-    def test_get_current_global_batch_size(self):
-        assert self.mb_calculator.get_current_global_batch_size() == 16
-
-
-def test_ramp_up():
-    mb_calculator.reconfigure_num_microbatches_calculator(0, [16, 16, 96], 32, 8, 2, False)
-    consumed_samples = 0
-    count = 0
-    expected_consumed_samples = [0, 16, 32, 48, 64, 80, 96, 128, 160, 192, 224, 256]
-
-    while consumed_samples < 256:
-        consumed_samples += mb_calculator.get_current_global_batch_size()
-        count += 1
-        assert consumed_samples == expected_consumed_samples[count]
-        mb_calculator.update_num_microbatches(consumed_samples, True)

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -575,7 +575,6 @@ class TestTECudaGraphHelper:
         # Initialize num_microbatches calculator
         init_num_microbatches_calculator(
             rank=0,
-            rampup_batch_size=None,
             global_batch_size=micro_batch_size * num_microbatches,
             micro_batch_size=micro_batch_size,
             data_parallel_size=1,


### PR DESCRIPTION
## What does this PR do?

Re-lands #3779 (reverted in #4404) with backwards compatibility for the deprecated `rampup_batch_size` parameter.

### Step batch size schedule

The new `--step-batch-size-schedule` argument accepts a string of `THRESHOLD:BATCH_SIZE` pairs that define arbitrary step-wise batch size changes during training. Thresholds support K/M/B/T suffixes and are interpreted as tokens when `--seq-length` is provided, otherwise as samples.

Example:
```
--step-batch-size-schedule "0:768 250B:1536 500B:3072 750B:6144"
```

This is implemented via a new `StepBatchsizeNumMicroBatchesCalculator` class.

### Rampup batch size removal

The old `RampupBatchsizeNumMicroBatchesCalculator` and `--rampup-batch-size` argument are removed. Existing example configs are converted to equivalent step batch size schedules.

### Backwards compatibility

The `rampup_batch_size` parameter is re-added to `init_num_microbatches_calculator` and `reconfigure_num_microbatches_calculator` as a deprecated optional kwarg (default `None`). If passed, a deprecation warning is logged on rank 0. The parameter is otherwise ignored. All internal callers are updated to use keyword arguments.

### Files changed

- **`megatron/core/num_microbatches_calculator.py`**: Added `StepBatchsizeNumMicroBatchesCalculator`, removed `RampupBatchsizeNumMicroBatchesCalculator`, added deprecated `rampup_batch_size` kwarg for backwards compatibility.
- **`megatron/training/config/training_config.py`**: Replaced `rampup_batch_size` field with `step_batch_size_schedule`.
- **`megatron/training/arguments.py`**: Removed rampup-related assertions and help text.
- **`megatron/training/training.py`**: Updated `update_train_iters` to handle step schedule for sample-based training.
- **`megatron/training/global_vars.py`**: Updated `init_num_microbatches_calculator` call to use keyword arguments.
- **`examples/`**, **`tests/functional_tests/`**: Converted rampup configs to step batch size schedules.
- **`tests/unit_tests/test_num_microbatches_calculator.py`**: Replaced rampup tests with step schedule tests, updated all calls to use keyword arguments.