### PR TITLE
Mamba inference opt

### DIFF
--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -40,9 +40,10 @@ class MambaMetadata:
             (self.max_requests,), -1, dtype=torch.int32, device=torch.cuda.current_device()
         )
 
-        # Map from requests to slots in the static Mamba state buffer for active decode requests
+        # Map from requests to slots in the static Mamba state buffer for active decode requests.
+        # int64 so selective_state_update can index directly without a per-layer upcast kernel;
         self._batch_indices_decode_buffer = torch.full(
-            (self.max_requests,), -1, dtype=torch.int32, device=self.device
+            (self.max_requests,), -1, dtype=torch.int64, device=self.device
         )
 
         # Map from requests to slots in the static Mamba state buffer for active prefill requests

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -1031,27 +1031,9 @@ class MambaMixer(MegatronModule):
             self._A_neg_exp_cache = cached
         return cached
 
-    def _get_decode_dt_bias_expanded(self) -> torch.Tensor:
-        """Cached ``dt_bias`` expanded to ``(nheads, headdim)`` for decode."""
-        cached = getattr(self, "_dt_bias_expanded_cache", None)
-        if cached is None:
-            cached = self.dt_bias.unsqueeze(-1).expand(-1, self.headdim)
-            self._dt_bias_expanded_cache = cached
-        return cached
-
-    def _get_decode_D_expanded(self) -> torch.Tensor:
-        """Cached ``D`` expanded to ``(nheads, headdim)`` for decode."""
-        cached = getattr(self, "_D_expanded_cache", None)
-        if cached is None:
-            cached = self.D.unsqueeze(-1).expand(-1, self.headdim)
-            self._D_expanded_cache = cached
-        return cached
-
     def train(self, mode: bool = True):
-        """Invalidate decode caches when switching modes (weights may update)."""
+        """Invalidate the decode A cache when switching modes (weights may update)."""
         self._A_neg_exp_cache = None
-        self._dt_bias_expanded_cache = None
-        self._D_expanded_cache = None
         return super().train(mode)
 
     def _ssm_decode(
@@ -1194,16 +1176,16 @@ class MambaMixer(MegatronModule):
             y = y.unsqueeze(1)  # Restore seq dimension
         else:
             A = self._get_decode_A_neg_exp()
-            dt_bias = self._get_decode_dt_bias_expanded()
-            D = self._get_decode_D_expanded()
 
-            # Reshape/broadcast inputs for the Triton kernel
-            dt = dt.unsqueeze(-1).expand(-1, -1, -1, self.headdim)
-            B = B.view(*B.shape[:-1], self.ngroups_local_tp, self.d_state)
-            C = C.view(*C.shape[:-1], self.ngroups_local_tp, self.d_state)
-            x_reshaped = x.view(*x.shape[:-1], self.nheads_local_tp, self.headdim)
+            # Incorporate sequence dimension in einops rearrengements
+            dt = repeat(dt, "b s h -> b s h p", p=self.headdim)
+            dt_bias = repeat(self.dt_bias, "h -> h p", p=self.headdim)
+            D = repeat(self.D, "h -> h p", p=self.headdim)
+            B = rearrange(B, "b s (g n) -> b s g n", g=self.ngroups_local_tp)
+            C = rearrange(C, "b s (g n) -> b s g n", g=self.ngroups_local_tp)
+            x_reshaped = rearrange(x, "b s (h p) -> b s h p", p=self.headdim)
             if not self.rmsnorm:
-                z = z.view(*z.shape[:-1], self.nheads_local_tp, self.headdim)
+                z = rearrange(z, "b s (h p) -> b s h p", p=self.headdim)
 
             y = selective_state_update(
                 ssm_state,

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -347,6 +347,14 @@ class MambaMixer(MegatronModule):
             self.A_log = nn.Parameter(A_log)
             setattr(self.A_log, "tensor_model_parallel", True)
             setattr(self.A_log, "partition_dim", 0)
+            # Persistent inference cache for -exp(A_log.float()). Allocated
+            # here (outside any later CUDA-graph capture) so its address
+            # lives in the default memory pool and stays valid across every
+            # graph capture and replay, including across RL train/eval
+            # cycles. Never freed -- the memory cost is ``nheads * 4B`` per
+            # layer (a few KB across a full model).
+            self._A_neg_exp_cache = torch.empty_like(A_log, dtype=torch.float32)
+            self._A_neg_exp_cache_stale = True
         # D "skip" parameter
         self.D = nn.Parameter(
             torch.ones(
@@ -1021,19 +1029,21 @@ class MambaMixer(MegatronModule):
         A_log is frozen during inference; recomputing it per token otherwise
         launches three small elementwise kernels (float cast, exp, neg) that
         rival ``selective_state_update`` itself in the decode profile. The
-        expand()-view carries stride 0 on headdim and dstate, which the kernel's
-        TIE_HDIM fast path relies on.
+        stride-0 expand view also triggers the kernel's TIE_HDIM fast path.
         """
-        cached = getattr(self, "_A_neg_exp_cache", None)
-        if cached is None:
+        if self.training or torch.is_grad_enabled():
             base = -torch.exp(self.A_log.float())
-            cached = base.view(-1, 1, 1).expand(-1, self.headdim, self.d_state)
-            self._A_neg_exp_cache = cached
-        return cached
+            return base.view(-1, 1, 1).expand(-1, self.headdim, self.d_state)
+        # Inference path. Refill when stale
+        if torch.cuda.is_current_stream_capturing() or self._A_neg_exp_cache_stale:
+            with torch.no_grad():
+                self._A_neg_exp_cache.copy_(-torch.exp(self.A_log.float()))
+            self._A_neg_exp_cache_stale = False
+        return self._A_neg_exp_cache.view(-1, 1, 1).expand(-1, self.headdim, self.d_state)
 
     def train(self, mode: bool = True):
-        """Invalidate the decode A cache when switching modes (weights may update)."""
-        self._A_neg_exp_cache = None
+        """Mark the decode cache stale; weights may have updated."""
+        self._A_neg_exp_cache_stale = True
         return super().train(mode)
 
     def _ssm_decode(

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -1016,21 +1016,42 @@ class MambaMixer(MegatronModule):
         return y
 
     def _get_decode_A_neg_exp(self) -> torch.Tensor:
-        """Cached ``-exp(A_log.float())`` for the decode path.
+        """Cached ``-exp(A_log.float())`` pre-expanded to ``(nheads, headdim, dstate)``.
 
         A_log is frozen during inference; recomputing it per token otherwise
         launches three small elementwise kernels (float cast, exp, neg) that
-        rival ``selective_state_update`` itself in the decode profile.
+        rival ``selective_state_update`` itself in the decode profile. The
+        expand()-view carries stride 0 on headdim and dstate, which the kernel's
+        TIE_HDIM fast path relies on.
         """
         cached = getattr(self, "_A_neg_exp_cache", None)
         if cached is None:
-            cached = -torch.exp(self.A_log.float())
+            base = -torch.exp(self.A_log.float())
+            cached = base.view(-1, 1, 1).expand(-1, self.headdim, self.d_state)
             self._A_neg_exp_cache = cached
         return cached
 
+    def _get_decode_dt_bias_expanded(self) -> torch.Tensor:
+        """Cached ``dt_bias`` expanded to ``(nheads, headdim)`` for decode."""
+        cached = getattr(self, "_dt_bias_expanded_cache", None)
+        if cached is None:
+            cached = self.dt_bias.unsqueeze(-1).expand(-1, self.headdim)
+            self._dt_bias_expanded_cache = cached
+        return cached
+
+    def _get_decode_D_expanded(self) -> torch.Tensor:
+        """Cached ``D`` expanded to ``(nheads, headdim)`` for decode."""
+        cached = getattr(self, "_D_expanded_cache", None)
+        if cached is None:
+            cached = self.D.unsqueeze(-1).expand(-1, self.headdim)
+            self._D_expanded_cache = cached
+        return cached
+
     def train(self, mode: bool = True):
-        """Invalidate the decode A cache when switching modes (weights may update)."""
+        """Invalidate decode caches when switching modes (weights may update)."""
         self._A_neg_exp_cache = None
+        self._dt_bias_expanded_cache = None
+        self._D_expanded_cache = None
         return super().train(mode)
 
     def _ssm_decode(
@@ -1111,10 +1132,10 @@ class MambaMixer(MegatronModule):
             ],
             dim=-1,
         )
-        A = self._get_decode_A_neg_exp()
-
         # SSM step
         if selective_state_update is None:
+            # Fallback uses 1D A; the decode cache is pre-expanded for Triton.
+            A = -torch.exp(self.A_log.float())
             # TODO(ksanthanam): Consider deprecating this path
             assert seq_len == 1, "Native PyTorch fallback only supports 1 token at a time"
 
@@ -1172,17 +1193,17 @@ class MambaMixer(MegatronModule):
 
             y = y.unsqueeze(1)  # Restore seq dimension
         else:
-            A = repeat(A, "h -> h p n", p=self.headdim, n=self.d_state).to(dtype=torch.float32)
+            A = self._get_decode_A_neg_exp()
+            dt_bias = self._get_decode_dt_bias_expanded()
+            D = self._get_decode_D_expanded()
 
-            # Incorporate sequence dimension in einops rearrengements
-            dt = repeat(dt, "b s h -> b s h p", p=self.headdim)
-            dt_bias = repeat(self.dt_bias, "h -> h p", p=self.headdim)
-            D = repeat(self.D, "h -> h p", p=self.headdim)
-            B = rearrange(B, "b s (g n) -> b s g n", g=self.ngroups_local_tp)
-            C = rearrange(C, "b s (g n) -> b s g n", g=self.ngroups_local_tp)
-            x_reshaped = rearrange(x, "b s (h p) -> b s h p", p=self.headdim)
+            # Reshape/broadcast inputs for the Triton kernel
+            dt = dt.unsqueeze(-1).expand(-1, -1, -1, self.headdim)
+            B = B.view(*B.shape[:-1], self.ngroups_local_tp, self.d_state)
+            C = C.view(*C.shape[:-1], self.ngroups_local_tp, self.d_state)
+            x_reshaped = x.view(*x.shape[:-1], self.nheads_local_tp, self.headdim)
             if not self.rmsnorm:
-                z = rearrange(z, "b s (h p) -> b s h p", p=self.headdim)
+                z = z.view(*z.shape[:-1], self.nheads_local_tp, self.headdim)
 
             y = selective_state_update(
                 ssm_state,

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -1015,6 +1015,24 @@ class MambaMixer(MegatronModule):
 
         return y
 
+    def _get_decode_A_neg_exp(self) -> torch.Tensor:
+        """Cached ``-exp(A_log.float())`` for the decode path.
+
+        A_log is frozen during inference; recomputing it per token otherwise
+        launches three small elementwise kernels (float cast, exp, neg) that
+        rival ``selective_state_update`` itself in the decode profile.
+        """
+        cached = getattr(self, "_A_neg_exp_cache", None)
+        if cached is None:
+            cached = -torch.exp(self.A_log.float())
+            self._A_neg_exp_cache = cached
+        return cached
+
+    def train(self, mode: bool = True):
+        """Invalidate the decode A cache when switching modes (weights may update)."""
+        self._A_neg_exp_cache = None
+        return super().train(mode)
+
     def _ssm_decode(
         self,
         zxBCdt: torch.Tensor,
@@ -1093,7 +1111,7 @@ class MambaMixer(MegatronModule):
             ],
             dim=-1,
         )
-        A = -torch.exp(self.A_log.float())
+        A = self._get_decode_A_neg_exp()
 
         # SSM step
         if selective_state_update is None:
@@ -1165,11 +1183,6 @@ class MambaMixer(MegatronModule):
             x_reshaped = rearrange(x, "b s (h p) -> b s h p", p=self.headdim)
             if not self.rmsnorm:
                 z = rearrange(z, "b s (h p) -> b s h p", p=self.headdim)
-
-            # Upcast the batch_indices to prevent integer overflow errors in the case of
-            # large max request counts.
-            if batch_indices is not None:
-                batch_indices = batch_indices.to(torch.int64)
 
             y = selective_state_update(
                 ssm_state,

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -776,7 +776,8 @@ def topk_routing_with_score_function(
                 group_topk=group_topk,
             )
         else:
-            return torch.topk(scores, k=topk, dim=1, sorted=False)
+            # Sorting top-k turned off during inference
+            return torch.topk(scores, k=topk, dim=1, sorted=torch.is_grad_enabled())
 
     def compute_topk(scores, topk, num_groups=None, group_topk=None):
         # Default behavior if no replay is active

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -776,7 +776,7 @@ def topk_routing_with_score_function(
                 group_topk=group_topk,
             )
         else:
-            return torch.topk(scores, k=topk, dim=1)
+            return torch.topk(scores, k=topk, dim=1, sorted=False)
 
     def compute_topk(scores, topk, num_groups=None, group_topk=None):
         # Default behavior if no replay is active


### PR DESCRIPTION
# What does this PR do ?
Inference optimizations for nano

Cached -exp(A_log.float()) in the Mamba decode path so the three elementwise kernels (float-cast, exp, neg) that ran per-layer per-token are now computed once per inference session. Moved the batch_indices int64 upcast from the per-layer forward into the MambaMetadata buffer allocation, eliminating a fourth small kernel from the hot path.


edit: we added more on here:
 | Config                      | Run 1  | Run 2  | Run 3  | Mean   | vs baseline | vs previous |
  |-----------------------------|--------|--------|--------|--------|-------------|-------------|
  | Baseline                    | 115.04 | 114.76 | 115.64 | 115.15 | —           | —           |                                                                
  | Opt1 (cached A + int64 buf) | 116.64 | 116.94 | 116.56 | 116.71 | +1.35%      | +1.35%      |
  | Opt2 (+ pre-expanded A)     | 117.63 | 118.47 | 118.47 | 118.19 | +2.64%      | +1.27%      |                                                                

MoE optimization not part of this graph
:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
