### PR TITLE
fix: NVRx async compatibility and defer resiliency import

### DIFF
--- a/megatron/core/dist_checkpointing/serialization.py
+++ b/megatron/core/dist_checkpointing/serialization.py
@@ -139,7 +139,12 @@ def load(
         ckpt_sharded_metadata,
     )
 
-    async_strategy = getattr(common_state_dict.get("args"), "async_strategy", "nvrx")
+    ckpt_args = common_state_dict.get("args")
+    async_strategy = (
+        getattr(ckpt_args, "async_strategy", "mcore")
+        if getattr(ckpt_args, "async_save", False)
+        else "mcore"
+    )
     loaded_state_dict = sharded_strategy.load(sharded_state_dict, checkpoint_dir, async_strategy)
 
     merge(common_state_dict, loaded_state_dict)

--- a/megatron/core/dist_checkpointing/strategies/fully_parallel.py
+++ b/megatron/core/dist_checkpointing/strategies/fully_parallel.py
@@ -189,7 +189,7 @@ class FullyParallelLoadStrategyWrapper:
         self,
         sharded_state_dict: ShardedStateDict,
         checkpoint_dir: Path,
-        async_strategy: str = "nvrx",
+        async_strategy: str = "mcore",
     ) -> StateDict:
         """Distributes the load and calls underlying strategy only for parts of the state dict.
 

--- a/megatron/core/dist_checkpointing/strategies/nvrx.py
+++ b/megatron/core/dist_checkpointing/strategies/nvrx.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """Helpers for interacting with the experimental nvidia-resiliency-ext API."""
 
 from importlib import import_module

--- a/megatron/core/dist_checkpointing/strategies/nvrx.py
+++ b/megatron/core/dist_checkpointing/strategies/nvrx.py
@@ -1,0 +1,71 @@
+"""Helpers for interacting with the experimental nvidia-resiliency-ext API."""
+
+import inspect
+from importlib import import_module
+from typing import Any, Callable, Dict
+
+
+def has_nvrx_async_support() -> bool:
+    """Checks whether the NVRx async checkpointing symbols Megatron uses are importable."""
+    try:
+        core = import_module("nvidia_resiliency_ext.checkpointing.async_ckpt.core")
+        filesystem_async = import_module(
+            "nvidia_resiliency_ext.checkpointing.async_ckpt.filesystem_async"
+        )
+        state_dict_saver = import_module(
+            "nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver"
+        )
+    except (ImportError, ModuleNotFoundError):
+        return False
+
+    required_symbols = (
+        getattr(core, "AsyncCallsQueue", None),
+        getattr(core, "AsyncRequest", None),
+        getattr(filesystem_async, "FileSystemWriterAsync", None),
+        getattr(filesystem_async, "_results_queue", None),
+        getattr(filesystem_async, "get_write_results_queue", None),
+        getattr(state_dict_saver, "CheckpointMetadataCache", None),
+        getattr(state_dict_saver, "save_state_dict_async_finalize", None),
+        getattr(state_dict_saver, "save_state_dict_async_plan", None),
+    )
+    return all(symbol is not None for symbol in required_symbols)
+
+
+def filter_supported_kwargs(fn: Callable[..., Any], kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Drops kwargs that are not accepted by the provided callable."""
+    try:
+        parameters = inspect.signature(fn).parameters.values()
+    except (TypeError, ValueError):
+        return {}
+
+    if any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters):
+        return kwargs
+
+    supported_names = {
+        parameter.name
+        for parameter in parameters
+        if parameter.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    }
+    return {name: value for name, value in kwargs.items() if name in supported_names}
+
+
+def make_nvrx_async_request(
+    async_request_cls: type,
+    async_fn: Callable[..., Any],
+    async_fn_args: Any,
+    finalize_fns: list[Callable[..., Any]],
+    async_fn_kwargs: Dict[str, Any] | None = None,
+    preload_fn: Callable[..., Any] | None = None,
+):
+    """Builds an AsyncRequest while tolerating API drift in optional fields."""
+    kwargs = filter_supported_kwargs(
+        async_request_cls,
+        {
+            "async_fn_kwargs": async_fn_kwargs or {},
+            "preload_fn": preload_fn,
+        },
+    )
+    return async_request_cls(async_fn, async_fn_args, finalize_fns, **kwargs)

--- a/megatron/core/dist_checkpointing/strategies/nvrx.py
+++ b/megatron/core/dist_checkpointing/strategies/nvrx.py
@@ -26,13 +26,14 @@ def has_nvrx_async_support() -> bool:
         getattr(core, "AsyncRequest", None),
         getattr(cached_metadata_reader, "CachedMetadataFileSystemReader", None),
         getattr(filesystem_async, "FileSystemWriterAsync", None),
-        getattr(filesystem_async, "_results_queue", None),
         getattr(filesystem_async, "get_write_results_queue", None),
         getattr(state_dict_saver, "CheckpointMetadataCache", None),
         getattr(state_dict_saver, "save_state_dict_async_finalize", None),
         getattr(state_dict_saver, "save_state_dict_async_plan", None),
     )
-    return all(symbol is not None for symbol in required_symbols)
+    return all(symbol is not None for symbol in required_symbols) and hasattr(
+        filesystem_async, "_results_queue"
+    )
 
 
 def filter_supported_kwargs(fn: Callable[..., Any], kwargs: Dict[str, Any]) -> Dict[str, Any]:

--- a/megatron/core/dist_checkpointing/strategies/nvrx.py
+++ b/megatron/core/dist_checkpointing/strategies/nvrx.py
@@ -1,6 +1,5 @@
 """Helpers for interacting with the experimental nvidia-resiliency-ext API."""
 
-import inspect
 from importlib import import_module
 from typing import Any, Callable, Dict
 
@@ -36,27 +35,6 @@ def has_nvrx_async_support() -> bool:
     )
 
 
-def filter_supported_kwargs(fn: Callable[..., Any], kwargs: Dict[str, Any]) -> Dict[str, Any]:
-    """Drops kwargs that are not accepted by the provided callable."""
-    try:
-        parameters = inspect.signature(fn).parameters.values()
-    except (TypeError, ValueError):
-        return {}
-
-    if any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters):
-        return kwargs
-
-    supported_names = {
-        parameter.name
-        for parameter in parameters
-        if parameter.kind in (
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        )
-    }
-    return {name: value for name, value in kwargs.items() if name in supported_names}
-
-
 def make_nvrx_async_request(
     async_request_cls: type,
     async_fn: Callable[..., Any],
@@ -65,12 +43,11 @@ def make_nvrx_async_request(
     async_fn_kwargs: Dict[str, Any] | None = None,
     preload_fn: Callable[..., Any] | None = None,
 ):
-    """Builds an AsyncRequest while tolerating API drift in optional fields."""
-    kwargs = filter_supported_kwargs(
-        async_request_cls,
-        {
-            "async_fn_kwargs": async_fn_kwargs or {},
-            "preload_fn": preload_fn,
-        },
+    """Builds an AsyncRequest using the expected NVRx API."""
+    return async_request_cls(
+        async_fn,
+        async_fn_args,
+        finalize_fns,
+        async_fn_kwargs=async_fn_kwargs or {},
+        preload_fn=preload_fn,
     )
-    return async_request_cls(async_fn, async_fn_args, finalize_fns, **kwargs)

--- a/megatron/core/dist_checkpointing/strategies/nvrx.py
+++ b/megatron/core/dist_checkpointing/strategies/nvrx.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Helpers for interacting with the experimental nvidia-resiliency-ext API."""
 

--- a/megatron/core/dist_checkpointing/strategies/nvrx.py
+++ b/megatron/core/dist_checkpointing/strategies/nvrx.py
@@ -9,6 +9,9 @@ def has_nvrx_async_support() -> bool:
     """Checks whether the NVRx async checkpointing symbols Megatron uses are importable."""
     try:
         core = import_module("nvidia_resiliency_ext.checkpointing.async_ckpt.core")
+        cached_metadata_reader = import_module(
+            "nvidia_resiliency_ext.checkpointing.async_ckpt.cached_metadata_filesystem_reader"
+        )
         filesystem_async = import_module(
             "nvidia_resiliency_ext.checkpointing.async_ckpt.filesystem_async"
         )
@@ -21,6 +24,7 @@ def has_nvrx_async_support() -> bool:
     required_symbols = (
         getattr(core, "AsyncCallsQueue", None),
         getattr(core, "AsyncRequest", None),
+        getattr(cached_metadata_reader, "CachedMetadataFileSystemReader", None),
         getattr(filesystem_async, "FileSystemWriterAsync", None),
         getattr(filesystem_async, "_results_queue", None),
         getattr(filesystem_async, "get_write_results_queue", None),

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from itertools import product
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 from packaging.version import Version as PkgVersion
 import torch
 from torch.distributed import checkpoint
@@ -52,14 +52,14 @@ from .async_utils import AsyncRequest
 from .checkpointable import CheckpointableShardedTensor, LocalShardsContainer
 from .nvrx import filter_supported_kwargs, has_nvrx_async_support, make_nvrx_async_request
 
-try:
+if TYPE_CHECKING:
     from nvidia_resiliency_ext.checkpointing.async_ckpt.core import AsyncRequest as NVRxAsyncRequest
     from nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver import (
         CheckpointMetadataCache,
     )
-except (ImportError, ModuleNotFoundError):
-    CheckpointMetadataCache = ABC
-    NVRxAsyncRequest = ABC
+else:
+    CheckpointMetadataCache = Any
+    NVRxAsyncRequest = Any
 
 HAVE_NVRX = has_nvrx_async_support()
 

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -6,15 +6,15 @@ import io
 import os
 import pickle
 import warnings
-from abc import ABC
 from collections import defaultdict
 from contextlib import contextmanager
 from itertools import product
 from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union, cast
-from packaging.version import Version as PkgVersion
+
 import torch
+from packaging.version import Version as PkgVersion
 from torch.distributed import checkpoint
 from torch.distributed._shard.metadata import ShardMetadata
 from torch.distributed._shard.sharded_tensor import Shard
@@ -651,9 +651,7 @@ class TorchDistSaveShardedStrategy:
 
     def save(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path):
         """Sync save always uses the built-in implementation."""
-        async_request = self.async_save(
-            sharded_state_dict, checkpoint_dir, async_strategy="mcore"
-        )
+        async_request = self.async_save(sharded_state_dict, checkpoint_dir, async_strategy="mcore")
         async_request.execute_sync()
         del async_request
 
@@ -704,9 +702,8 @@ class TorchDistSaveShardedStrategy:
         if async_strategy == "nvrx":
             if self._metadata_cache is None:
                 self._metadata_cache = checkpointable_metadata_cache()
-                if (
-                    self.cached_global_metadata is not None
-                    and hasattr(self._metadata_cache, "set_cached_global_metadata")
+                if self.cached_global_metadata is not None and hasattr(
+                    self._metadata_cache, "set_cached_global_metadata"
                 ):
                     self._metadata_cache.set_cached_global_metadata(self.cached_global_metadata)
             # Define additional arguments

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -101,6 +101,7 @@ class MCoreSavePlan:
 
 
 logger = getLogger(__name__)
+_logged_mcore_async_deprecation = False
 
 
 def flatten_state_dict(
@@ -670,11 +671,14 @@ class TorchDistSaveShardedStrategy:
 
         Returns: None
         """
+        global _logged_mcore_async_deprecation
         if async_strategy == "mcore":
-            logger.warning(
-                "MCore's async save is deprecated and will be removed in the future releases. "
-                "Please, use NVRx async solution by setting `async_strategy` to `nvrx`."
-            )
+            if not _logged_mcore_async_deprecation:
+                logger.warning(
+                    "MCore's async save is deprecated and will be removed in the future releases. "
+                    "Please, use NVRx async solution by setting `async_strategy` to `nvrx`."
+                )
+                _logged_mcore_async_deprecation = True
 
         # Translate the state dict
         (sharded_state_dict, flat_mapping, rename_mapping) = (

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -13,7 +13,7 @@ from itertools import product
 from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
-
+from packaging.version import Version as PkgVersion
 import torch
 from torch.distributed import checkpoint
 from torch.distributed._shard.metadata import ShardMetadata

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 
 import torch
-from packaging.version import Version as PkgVersion
 from torch.distributed import checkpoint
 from torch.distributed._shard.metadata import ShardMetadata
 from torch.distributed._shard.sharded_tensor import Shard
@@ -51,19 +50,18 @@ from ..mapping import (
 )
 from .async_utils import AsyncRequest
 from .checkpointable import CheckpointableShardedTensor, LocalShardsContainer
+from .nvrx import filter_supported_kwargs, has_nvrx_async_support, make_nvrx_async_request
 
 try:
     from nvidia_resiliency_ext.checkpointing.async_ckpt.core import AsyncRequest as NVRxAsyncRequest
     from nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver import (
         CheckpointMetadataCache,
     )
-
-    HAVE_NVRX = True
 except (ImportError, ModuleNotFoundError):
     CheckpointMetadataCache = ABC
     NVRxAsyncRequest = ABC
 
-    HAVE_NVRX = False
+HAVE_NVRX = has_nvrx_async_support()
 
 try:
     if not torch.cuda.is_available():
@@ -651,9 +649,10 @@ class TorchDistSaveShardedStrategy:
         self.validated_loaded_metadata_reuse = False
 
     def save(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path):
-        """Each async strategy can be trivially used as a sync strategy."""
-        strategy = "nvrx" if HAVE_NVRX else "mcore"
-        async_request = self.async_save(sharded_state_dict, checkpoint_dir, async_strategy=strategy)
+        """Sync save always uses the built-in implementation."""
+        async_request = self.async_save(
+            sharded_state_dict, checkpoint_dir, async_strategy="mcore"
+        )
         async_request.execute_sync()
         del async_request
 
@@ -701,7 +700,10 @@ class TorchDistSaveShardedStrategy:
         if async_strategy == "nvrx":
             if self._metadata_cache is None:
                 self._metadata_cache = checkpointable_metadata_cache()
-                if self.cached_global_metadata is not None:
+                if (
+                    self.cached_global_metadata is not None
+                    and hasattr(self._metadata_cache, "set_cached_global_metadata")
+                ):
                     self._metadata_cache.set_cached_global_metadata(self.cached_global_metadata)
             # Define additional arguments
             async_writer_kwargs["use_cached_data_structure"] = self.use_cached_ckpt_structure
@@ -717,8 +719,15 @@ class TorchDistSaveShardedStrategy:
                         "use_cpu_shm_for_gpu_tensors. Update nvidia-resiliency-ext "
                         "to enable cpu_shm_mode."
                     )
-            state_dict_saver_kwargs["enable_cache"] = self.use_cached_ckpt_structure
-            state_dict_saver_kwargs["metadata_cache"] = self._metadata_cache
+            state_dict_saver_kwargs.update(
+                filter_supported_kwargs(
+                    save_state_dict_async_plan,
+                    {
+                        "enable_cache": self.use_cached_ckpt_structure,
+                        "metadata_cache": self._metadata_cache,
+                    },
+                )
+            )
         else:
             # MCore's async implementation
             args_cached_plans = None
@@ -740,10 +749,15 @@ class TorchDistSaveShardedStrategy:
         # Use PyT saving mechanism
         writer = async_writer(
             checkpoint_dir,
-            separation_hint=self.separation_hint,
-            thread_count=self.thread_count,
-            use_msc=MultiStorageClientFeature.is_enabled(),
-            **async_writer_kwargs,
+            **filter_supported_kwargs(
+                async_writer,
+                {
+                    "separation_hint": self.separation_hint,
+                    "thread_count": self.thread_count,
+                    "use_msc": MultiStorageClientFeature.is_enabled(),
+                    **async_writer_kwargs,
+                },
+            ),
         )
 
         # This should be set differently if we run in a smaller process group than the default
@@ -818,11 +832,13 @@ class TorchDistSaveShardedStrategy:
         def finalize_fn():
             save_state_dict_async_finalize(*save_state_dict_ret)
 
-        return async_request(save_fn, save_args, [finalize_fn], preload_fn=preload_fn)
+        return make_nvrx_async_request(
+            async_request, save_fn, save_args, [finalize_fn], preload_fn=preload_fn
+        )
 
 
 def _get_filesystem_reader(
-    checkpoint_dir: Union[str, Path], cache_metadata: bool = False, async_strategy: str = "nvrx"
+    checkpoint_dir: Union[str, Path], cache_metadata: bool = False, async_strategy: str = "mcore"
 ) -> FileSystemReader:
     if MultiStorageClientFeature.is_enabled():
         msc = MultiStorageClientFeature.import_package()
@@ -846,7 +862,7 @@ class TorchDistLoadShardedStrategy:
         self,
         sharded_state_dict: ShardedStateDict,
         checkpoint_dir: Path,
-        async_strategy: str = "nvrx",
+        async_strategy: str = "mcore",
     ) -> StateDict:
         """Translates MCore ShardedTensors to PyT ShardedTensors & loads from PyT Distributed fmt.
 
@@ -1030,9 +1046,14 @@ def get_async_strategy(async_strategy: str = "nvrx", module: str = None) -> tupl
     if async_strategy == "nvrx":
         try:
             # nvrx async imports
-            from nvidia_resiliency_ext.checkpointing.async_ckpt.cached_metadata_filesystem_reader import (  # pylint: disable=line-too-long
-                CachedMetadataFileSystemReader,
-            )
+            try:
+                from nvidia_resiliency_ext.checkpointing.async_ckpt.cached_metadata_filesystem_reader import (  # pylint: disable=line-too-long
+                    CachedMetadataFileSystemReader,
+                )
+            except (ImportError, ModuleNotFoundError):
+                from megatron.core.dist_checkpointing.strategies.cached_metadata_filesystem_reader import (  # pylint: disable=line-too-long
+                    CachedMetadataFileSystemReader,
+                )
             from nvidia_resiliency_ext.checkpointing.async_ckpt.core import (
                 AsyncCallsQueue,
                 AsyncRequest,
@@ -1062,9 +1083,8 @@ def get_async_strategy(async_strategy: str = "nvrx", module: str = None) -> tupl
             async_strategy = "nvrx"
         except (ImportError, ModuleNotFoundError):
             raise ModuleNotFoundError(
-                "nvidia-resiliency-ext package is not installed. "
-                "Please, install nvidia-resiliency-ext package or set `async_strategy` to `mcore` "
-                "to enable async save strategy."
+                "A compatible `nvidia-resiliency-ext` installation is required for "
+                '`async_strategy="nvrx"`. Please install it or set `async_strategy` to `mcore`.'
             )
     elif async_strategy == "mcore":
         # do mcore async imports

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -1046,14 +1046,9 @@ def get_async_strategy(async_strategy: str = "nvrx", module: str = None) -> tupl
     if async_strategy == "nvrx":
         try:
             # nvrx async imports
-            try:
-                from nvidia_resiliency_ext.checkpointing.async_ckpt.cached_metadata_filesystem_reader import (  # pylint: disable=line-too-long
-                    CachedMetadataFileSystemReader,
-                )
-            except (ImportError, ModuleNotFoundError):
-                from megatron.core.dist_checkpointing.strategies.cached_metadata_filesystem_reader import (  # pylint: disable=line-too-long
-                    CachedMetadataFileSystemReader,
-                )
+            from nvidia_resiliency_ext.checkpointing.async_ckpt.cached_metadata_filesystem_reader import (  # pylint: disable=line-too-long
+                CachedMetadataFileSystemReader,
+            )
             from nvidia_resiliency_ext.checkpointing.async_ckpt.core import (
                 AsyncCallsQueue,
                 AsyncRequest,

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -50,7 +50,7 @@ from ..mapping import (
 )
 from .async_utils import AsyncRequest
 from .checkpointable import CheckpointableShardedTensor, LocalShardsContainer
-from .nvrx import filter_supported_kwargs, has_nvrx_async_support, make_nvrx_async_request
+from .nvrx import has_nvrx_async_support, make_nvrx_async_request
 
 if TYPE_CHECKING:
     from nvidia_resiliency_ext.checkpointing.async_ckpt.core import AsyncRequest as NVRxAsyncRequest
@@ -723,15 +723,8 @@ class TorchDistSaveShardedStrategy:
                         "use_cpu_shm_for_gpu_tensors. Update nvidia-resiliency-ext "
                         "to enable cpu_shm_mode."
                     )
-            state_dict_saver_kwargs.update(
-                filter_supported_kwargs(
-                    save_state_dict_async_plan,
-                    {
-                        "enable_cache": self.use_cached_ckpt_structure,
-                        "metadata_cache": self._metadata_cache,
-                    },
-                )
-            )
+            state_dict_saver_kwargs["enable_cache"] = self.use_cached_ckpt_structure
+            state_dict_saver_kwargs["metadata_cache"] = self._metadata_cache
         else:
             # MCore's async implementation
             args_cached_plans = None
@@ -753,15 +746,10 @@ class TorchDistSaveShardedStrategy:
         # Use PyT saving mechanism
         writer = async_writer(
             checkpoint_dir,
-            **filter_supported_kwargs(
-                async_writer,
-                {
-                    "separation_hint": self.separation_hint,
-                    "thread_count": self.thread_count,
-                    "use_msc": MultiStorageClientFeature.is_enabled(),
-                    **async_writer_kwargs,
-                },
-            ),
+            separation_hint=self.separation_hint,
+            thread_count=self.thread_count,
+            use_msc=MultiStorageClientFeature.is_enabled(),
+            **async_writer_kwargs,
         )
 
         # This should be set differently if we run in a smaller process group than the default

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1529,6 +1529,9 @@ def validate_args(args, defaults={}):
             )
             args.async_save = False
 
+    if not args.async_save:
+        args.async_strategy = "mcore"
+
     # Inference args
     if args.inference_batch_times_seqlen_threshold > -1:
         assert args.pipeline_model_parallel_size > 1, \

--- a/megatron/training/async_utils.py
+++ b/megatron/training/async_utils.py
@@ -8,6 +8,7 @@ import inspect
 import logging
 import time
 from abc import ABC
+from typing import TYPE_CHECKING, Any
 
 from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest
 from megatron.core.dist_checkpointing.strategies.nvrx import (
@@ -18,8 +19,12 @@ from megatron.core.dist_checkpointing.strategies.torch import get_async_strategy
 from megatron.training import get_args
 from megatron.training.utils import print_rank_0
 
-try:
+if TYPE_CHECKING:
     from nvidia_resiliency_ext.checkpointing.async_ckpt.core import AsyncRequest as NVRxAsyncRequest
+else:
+    NVRxAsyncRequest = Any
+
+try:
     from nvidia_resiliency_ext.checkpointing.async_ckpt.filesystem_async import _results_queue
     from nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver import (
         save_state_dict_async_finalize,
@@ -29,8 +34,6 @@ except (ImportError, ModuleNotFoundError):
     from megatron.core.dist_checkpointing.strategies.state_dict_saver import (
         save_state_dict_async_finalize,
     )
-
-    NVRxAsyncRequest = ABC
 
 logger = logging.getLogger(__name__)
 

--- a/megatron/training/async_utils.py
+++ b/megatron/training/async_utils.py
@@ -166,16 +166,21 @@ def reset_persistent_async_worker(async_strategy):
     module.clear_metadata_cache()
 
 
-def get_save_and_finalize_callbacks(writer, save_state_dict_ret) -> NVRxAsyncRequest:
+def get_save_and_finalize_callbacks(
+    writer, save_state_dict_ret, async_strategy: str = "nvrx"
+) -> AsyncRequest | NVRxAsyncRequest:
     """Creates an async save request for fsdp_dtensor & torch_dcp with a finalize function."""
     save_fn, preload_fn, save_args = writer.get_save_function_and_args()
+    _, async_modules = get_async_strategy(async_strategy)
+    async_request_cls = async_modules["AsyncRequest"]
+    save_state_dict_async_finalize = async_modules["save_state_dict_async_finalize"]
 
     def finalize_fn():
         """Finalizes async checkpointing and synchronizes processes."""
         save_state_dict_async_finalize(*save_state_dict_ret)
 
     return make_nvrx_async_request(
-        NVRxAsyncRequest,
+        async_request_cls,
         save_fn,
         save_args,
         [finalize_fn],

--- a/megatron/training/async_utils.py
+++ b/megatron/training/async_utils.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any
 
 from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest
 from megatron.core.dist_checkpointing.strategies.nvrx import (
-    filter_supported_kwargs,
     make_nvrx_async_request,
 )
 from megatron.core.dist_checkpointing.strategies.torch import get_async_strategy
@@ -91,17 +90,18 @@ def init_persistent_async_worker(rank: int, mp_mode: str = 'spawn'):
             )
     AsyncCallsQueue.warmup_persistent_caller(
         rank,
-        **filter_supported_kwargs(
-            AsyncCallsQueue.warmup_persistent_caller,
-            {
-                "cpu_priority": args.async_ckpt_cpu_priority,
-                "io_priority": args.async_ckpt_io_priority,
-                **warmup_kwargs,
-            },
-        ),
+        cpu_priority=args.async_ckpt_cpu_priority,
+        io_priority=args.async_ckpt_io_priority,
+        **warmup_kwargs,
     )
     # initialize ckpt write results queue
-    get_write_results_queue(**filter_supported_kwargs(get_write_results_queue, {"mp_mode": "fork"}))
+    if async_strategy == "nvrx":
+        if "mp_mode" not in inspect.signature(get_write_results_queue).parameters:
+            raise AssertionError(
+                "Installed nvidia-resiliency-ext does not support "
+                "get_write_results_queue(mp_mode=...). Update nvidia-resiliency-ext."
+            )
+    get_write_results_queue(mp_mode="fork")
     if rank == 0:
         print(f"init_persistent_async_worker: rank {rank}, Async Caller Started in {time.time() - time_start} seconds", flush=True)
 

--- a/megatron/training/async_utils.py
+++ b/megatron/training/async_utils.py
@@ -10,6 +10,10 @@ import time
 from abc import ABC
 
 from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest
+from megatron.core.dist_checkpointing.strategies.nvrx import (
+    filter_supported_kwargs,
+    make_nvrx_async_request,
+)
 from megatron.core.dist_checkpointing.strategies.torch import get_async_strategy
 from megatron.training import get_args
 from megatron.training.utils import print_rank_0
@@ -70,13 +74,13 @@ def init_persistent_async_worker(rank: int, mp_mode: str = 'spawn'):
         ),
     )
     # initialize the persistent caller with QoS priorities from args
-    kwargs = {}
+    warmup_kwargs = {}
     if async_strategy == "mcore":
         # Note: nvidia-resiliency-ext uses is_daemon instead of mp_mode (always spawns)
-        kwargs["mp_mode"] = mp_mode
+        warmup_kwargs["mp_mode"] = mp_mode
     elif async_strategy == "nvrx":
         if "cpu_shm_mode" in inspect.signature(AsyncCallsQueue.warmup_persistent_caller).parameters:
-            kwargs["cpu_shm_mode"] = args.async_ckpt_use_cpu_shm
+            warmup_kwargs["cpu_shm_mode"] = args.async_ckpt_use_cpu_shm
         elif args.async_ckpt_use_cpu_shm:
             raise AssertionError(
                 "Installed nvidia-resiliency-ext does not support cpu_shm_mode. "
@@ -84,12 +88,17 @@ def init_persistent_async_worker(rank: int, mp_mode: str = 'spawn'):
             )
     AsyncCallsQueue.warmup_persistent_caller(
         rank,
-        cpu_priority=args.async_ckpt_cpu_priority,
-        io_priority=args.async_ckpt_io_priority,
-        **kwargs,
+        **filter_supported_kwargs(
+            AsyncCallsQueue.warmup_persistent_caller,
+            {
+                "cpu_priority": args.async_ckpt_cpu_priority,
+                "io_priority": args.async_ckpt_io_priority,
+                **warmup_kwargs,
+            },
+        ),
     )
     # initialize ckpt write results queue
-    get_write_results_queue('fork')
+    get_write_results_queue(**filter_supported_kwargs(get_write_results_queue, {"mp_mode": "fork"}))
     if rank == 0:
         print(f"init_persistent_async_worker: rank {rank}, Async Caller Started in {time.time() - time_start} seconds", flush=True)
 
@@ -165,6 +174,11 @@ def get_save_and_finalize_callbacks(writer, save_state_dict_ret) -> NVRxAsyncReq
         """Finalizes async checkpointing and synchronizes processes."""
         save_state_dict_async_finalize(*save_state_dict_ret)
 
-    return NVRxAsyncRequest(
-        save_fn, save_args, [finalize_fn], async_fn_kwargs={}, preload_fn=preload_fn
+    return make_nvrx_async_request(
+        NVRxAsyncRequest,
+        save_fn,
+        save_args,
+        [finalize_fn],
+        async_fn_kwargs={},
+        preload_fn=preload_fn,
     )

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -33,6 +33,7 @@ from megatron.core.dist_checkpointing.strategies.fully_parallel import (
 from megatron.core.dist_checkpointing.strategies.torch import (
     TorchDistLoadShardedStrategy,
     TorchDistSaveShardedStrategy,
+    get_async_strategy,
 )
 from megatron.core.msc_utils import MultiStorageClientFeature, open_file
 from megatron.core.num_microbatches_calculator import update_num_microbatches
@@ -71,19 +72,6 @@ try:
 except Exception:
     has_nvidia_modelopt = False
 
-
-try:
-    from nvidia_resiliency_ext.checkpointing.async_ckpt.filesystem_async import (
-        FileSystemWriterAsync,
-    )
-    from nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver import (
-        save_state_dict_async_plan,
-    )
-
-    HAVE_NVRX = True
-except (ImportError, ModuleNotFoundError):
-
-    HAVE_NVRX = False
 
 _CHECKPOINT_VERSION = None
 _LOADED_ITERATION = None
@@ -693,6 +681,9 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
             if args.async_save:
                 planner = torch.distributed.checkpoint.DefaultSavePlanner()
                 coordinator_rank = 0
+                _, async_modules = get_async_strategy(args.async_strategy)
+                FileSystemWriterAsync = async_modules["FileSystemWriterAsync"]
+                save_state_dict_async_plan = async_modules["save_state_dict_async_plan"]
                 _cpu_shm = getattr(args, 'async_ckpt_use_cpu_shm', False)
                 _writer_kwargs = {}
                 if _cpu_shm:
@@ -717,7 +708,9 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
                 save_state_dict_ret = save_state_dict_async_plan(
                     state_dict, fs_storage_writer, None, coordinator_rank, planner=planner, enable_cache=args.ckpt_assume_constant_structure
                 )
-                async_save_request = get_save_and_finalize_callbacks(fs_storage_writer, save_state_dict_ret)
+                async_save_request = get_save_and_finalize_callbacks(
+                    fs_storage_writer, save_state_dict_ret, args.async_strategy
+                )
             else:
                 fs_storage_writer = torch.distributed.checkpoint.FileSystemWriter(checkpoint_name)
                 torch.distributed.checkpoint.save(

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -575,13 +575,20 @@ class CheckpointConfig:
     """Number of machines storing the replica of a given rank's data."""
 
     def __post_init__(self):
-        from megatron.training.utils import has_nvrx_installed
+        from megatron.training.utils import has_nvrx_checkpointing_async_support
 
         assert self.async_strategy in ["nvrx", "mcore"], \
             f"async_strategy {self.async_strategy} is not supported. Available strategies: nvrx, mcore."
 
-        if self.async_save and self.ckpt_format in ["torch_dcp", "fsdp_dtensor"]:
-            assert has_nvrx_installed(), (
-                "nvidia-resiliency-ext is not installed. "
-                "Please, install nvidia-resiliency-ext to enable async save."
+        if not self.async_save:
+            self.async_strategy = "mcore"
+
+        if (
+            self.async_save
+            and self.async_strategy == "nvrx"
+            and self.ckpt_format in ["torch_dcp", "fsdp_dtensor"]
+        ):
+            assert has_nvrx_checkpointing_async_support(), (
+                "A compatible nvidia-resiliency-ext installation is required to enable "
+                "async save with async_strategy='nvrx'."
             )

--- a/megatron/training/inprocess_restart.py
+++ b/megatron/training/inprocess_restart.py
@@ -1,15 +1,10 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
+import importlib
 import os
 import socket
-from datetime import timedelta
-
-try:
-    import nvidia_resiliency_ext.inprocess as inprocess
-except ImportError:
-    inprocess = None
-
 import warnings
+from datetime import timedelta
 
 import torch
 
@@ -22,12 +17,20 @@ from megatron.training.async_utils import (
 from . import arguments
 
 
+def _get_inprocess_module():
+    try:
+        return importlib.import_module("nvidia_resiliency_ext.inprocess")
+    except ImportError:
+        return None
+
+
 def destroy_state():
     from . import training
     training.destroy_global_state()
     rerun_state_machine.destroy_rerun_state_machine()
 
 def inprocess_restart(train, args):
+    inprocess = _get_inprocess_module()
     if inprocess is None:
         warnings.warn('In-process restart is not available')
         return train

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -124,12 +124,6 @@ try:
 except ImportError:
     has_nvidia_modelopt = False
 
-try:
-    from nvidia_resiliency_ext.inprocess import CallWrapper
-except ImportError:
-    CallWrapper = type(None)
-
-
 from megatron.core import mpu, tensor_parallel
 from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
     is_linear_attention_variant,
@@ -839,7 +833,7 @@ def pretrain(
     get_position_embedding_ranks=None,
     non_loss_data_func=None,
     store=None,
-    inprocess_call_wrapper: Optional[CallWrapper] = None,
+    inprocess_call_wrapper: Optional[Any] = None,
 ):
     """Main training program.
 

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -13,6 +13,7 @@ import torch
 
 from megatron.core.msc_utils import MultiStorageClientFeature, open_file
 from megatron.core._rank_utils import safe_get_rank as _safe_get_rank
+from megatron.core.dist_checkpointing.strategies.nvrx import has_nvrx_async_support
 
 try:
     from transformer_engine.pytorch.optimizers import multi_tensor_applier, multi_tensor_l2norm
@@ -791,3 +792,8 @@ def has_nvrx_installed():
         return True
     except (ImportError, ModuleNotFoundError):
         return False
+
+
+def has_nvrx_checkpointing_async_support():
+    """Checks whether the installed NVRx package exposes the async checkpointing API Megatron uses."""
+    return has_nvrx_async_support()

--- a/tests/unit_tests/dist_checkpointing/test_async_save.py
+++ b/tests/unit_tests/dist_checkpointing/test_async_save.py
@@ -107,3 +107,11 @@ class TestAsyncSave:
 
                 assert strategy == "mcore"
                 assert module == MCoreAsyncRequest
+
+    def test_get_async_strategy_missing_nvrx_cached_metadata_reader(self):
+        with mock.patch.dict(
+            'sys.modules',
+            {'nvidia_resiliency_ext.checkpointing.async_ckpt.cached_metadata_filesystem_reader': None},
+        ):
+            with pytest.raises(ModuleNotFoundError):
+                get_async_strategy("nvrx", module="CachedMetadataFileSystemReader")

--- a/tests/unit_tests/dist_checkpointing/test_async_save.py
+++ b/tests/unit_tests/dist_checkpointing/test_async_save.py
@@ -111,7 +111,9 @@ class TestAsyncSave:
     def test_get_async_strategy_missing_nvrx_cached_metadata_reader(self):
         with mock.patch.dict(
             'sys.modules',
-            {'nvidia_resiliency_ext.checkpointing.async_ckpt.cached_metadata_filesystem_reader': None},
+            {
+                'nvidia_resiliency_ext.checkpointing.async_ckpt.cached_metadata_filesystem_reader': None
+            },
         ):
             with pytest.raises(ModuleNotFoundError):
                 get_async_strategy("nvrx", module="CachedMetadataFileSystemReader")


### PR DESCRIPTION
# What does this PR do ?
  This PR tightens Megatron’s NVRx async checkpoint integration and removes
  unnecessary resiliency dependencies from non-NVRx paths.

  Summary:
  - require the NVRx async checkpointing symbols Megatron actually depends on
  - remove the local MCore fallback for CachedMetadataFileSystemReader
  - route async save helpers through async-strategy-specific modules
  - defer in-process restart imports until the feature is enabled
  - avoid eager type-only NVRx imports at module import time
  - fail fast on async signature mismatches instead of silently filtering kwargs

  Validated with:
  - PyPI nvidia-resiliency-ext showing expected incompatibility on old async APIs
  - compatible NVRx commits including 15a851565a4ce846c04431ecb0cf09903ab4837e and
    1c7f1a8ea60599a28835b0caf6353550a38d2db8
  - sync save with and without nvidia-resiliency-ext installed
  - normal training imports when in-process restart is not enabled

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
