### PR TITLE
[Dev] Fix mis-set decoupled gradient for Megatron-FSDP.

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -975,6 +975,8 @@ def get_megatron_optimizer(
                 # applied to the Megatron-FSDP main weight and extended to FusedAdam
                 # main weights. Override this here.
                 setattr(optimizer_part.optimizer, "master_weights", False)
+                # Megatron-FSDP always uses a decoupled gradient when using FusedAdam.
+                setattr(optimizer_part.optimizer, "use_decoupled_grad", True)
 
             optimizers.append(optimizer_part)
             model_chunk_offset += 1

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
@@ -736,15 +736,21 @@ class TestMegatronFSDPE2E:
             train_iters=NUM_TRAINING_STEPS,
             **kwargs,
         )
-        if kwargs.get("use_megatron_fsdp", False) and kwargs.get(
+        megatron_fsdp_te_fused_adam = kwargs.get("use_megatron_fsdp", False) and kwargs.get(
             "use_precision_aware_optimizer", False
-        ):
+        )
+        if megatron_fsdp_te_fused_adam:
             assert (
                 not optim.optimizer.master_weights
             ), "Megatron-FSDP should not use FusedAdam master weights."
             assert (
                 optim.optimizer.use_decoupled_grad
             ), "Megatron-FSDP should be using a decoupled gradient with FusedAdam."
+            assert model_chunks[
+                0
+            ].module.param_and_grad_buffer.use_decoupled_grad, (
+                "Megatron-FSDP is installing gradients into param.decoupled_grad."
+            )
 
         # Prepare data iterator
         data_iterator = make_gpt_mock_data_iterator(
@@ -767,6 +773,17 @@ class TestMegatronFSDPE2E:
                 micro_batch_size=MICRO_BATCH_SIZE,
                 num_micro_batches=GLOBAL_BATCH_SIZE // MICRO_BATCH_SIZE // DP_GROUP.size(),
             )
+            # Check that at least one non-null / non-zero gradient
+            # exists when using Megatron-FSDP.
+            if kwargs.get("use_megatron_fsdp", False):
+                grad_attr = "decoupled_grad" if megatron_fsdp_te_fused_adam else "grad"
+                assert any(
+                    [
+                        getattr(p, grad_attr, None) is not None
+                        and getattr(p, grad_attr, None)._local_tensor.any()
+                        for p in model_chunks[0].parameters()
+                    ]
+                ), f"[Megatron-FSDP] Missing gradient in Parameter.{grad_attr}..."
             optim.step()
 
             # Collect loss

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
@@ -742,6 +742,9 @@ class TestMegatronFSDPE2E:
             assert (
                 not optim.optimizer.master_weights
             ), "Megatron-FSDP should not use FusedAdam master weights."
+            assert (
+                optim.optimizer.use_decoupled_grad
+            ), "Megatron-FSDP should be using a decoupled gradient with FusedAdam."
 
         # Prepare data iterator
         data_iterator = make_gpt_mock_data_iterator(
@@ -773,7 +776,6 @@ class TestMegatronFSDPE2E:
 
         return outputs
 
-    @pytest.mark.flaky_in_dev
     @pytest.mark.skipif(
         not is_torch_min_version("2.4.0"), reason="Test needs to be updated for torch >= 2.4.0"
     )


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

- FusedAdam.use_decoupled_grad not set with FSDP, which is a bug introduced in https://github.com/NVIDIA/Megatron-LM/pull/4133.
  - While we have a [TransformerEngine MXFP8 + FusedAdam + CPU offloading V2 test](https://github.com/NVIDIA/TransformerEngine/blob/main/qa/L1_pytorch_mcore_fsdp_integration/test.sh) for this, `param.grad = None` is a no-op for `FusedAdam.step()` which doesn't throw an error or reveal that Megatron-FSDP + FusedAdam would not converge.
  - Related to this MBridge PR that mirrors the decoupled gradient logic in MLM: https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3510

Main Branch: https://github.com/NVIDIA/Megatron-LM/pull/4427

## Related Consequences

- Megatron-Bridge logic also needs to be updated to have `use_precision_aware_optimizer` activate `megatron_fsdp_use_decoupled_grad`. This caused seg-faults with `clip_grad_norm` when MLPerf upgraded MCore + MBridge and `param.decoupled_grad = None` while `clip_grad_norm(use_decoupled_grad=True)`.

## Testing

- While FP8-Delayed does converge even without this fix, now MXFP8 (which falls outside of the scope of `use_precision_aware_optimizer_no_fp8_or_ds_fp8` originally responsible for setting `use_decoupled_grad=True`) now also converges:
```
# MXFP8 + FusedAdam(use_decoupled_grad=True)
[2026-04-23 19:40:32.890713] iteration      100/15258789 | consumed samples:        12800 | elapsed time per iteration (ms): 10401.4 | throughput per GPU (TFLOP/s/GPU): 1297.3 | learning rate: 4.915263E-05 | global batch size:   128 | lm loss: 1.168019E-02 | loss scale: 1.0 | grad norm: 0.294 | num zeros: 0 | number of skipped iterations:   0 | number of nan iterations:   0 |
```

## TODO

- Update the TransformerEngine E2E test to print out loss for every training step, and update the MCore commit hash to point to this PR's fix.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
