### PR TITLE
[PP] Add initial overlap_p2p_comm support for non-interleaved steady-state 1F1B

### DIFF
--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -11,7 +11,84 @@ from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_
 from megatron.core.utils import nvtx_decorator
 
 # Types
-Shape = Union[List[int], torch.Size]
+Shape = Union[List[int], Tuple[int, ...], torch.Size]
+
+
+class P2PAsyncHandleSet:
+    """Lightweight container for async P2P communication handles."""
+
+    def __init__(self):
+        self.send_prev: List = []
+        self.send_next: List = []
+        self.recv_prev: List = []
+        self.recv_next: List = []
+
+    def extend_from_raw_reqs(self, raw_reqs):
+        """Aggregate direction-specific handles from the raw req mapping."""
+        if raw_reqs is None:
+            return
+
+        if not isinstance(raw_reqs, dict):
+            raise NotImplementedError(
+                "v1 overlap handle aggregation only supports dict-style raw reqs "
+                "(from _p2p_ops); batch_p2p_comm and ring_exchange are not supported"
+            )
+
+        if "send_prev" in raw_reqs:
+            self.send_prev.append(raw_reqs["send_prev"])
+        if "send_next" in raw_reqs:
+            self.send_next.append(raw_reqs["send_next"])
+        if "recv_prev" in raw_reqs:
+            self.recv_prev.append(raw_reqs["recv_prev"])
+        if "recv_next" in raw_reqs:
+            self.recv_next.append(raw_reqs["recv_next"])
+
+    def wait_send_prev(self):
+        for req in self.send_prev:
+            req.wait()
+        self.send_prev = []
+
+    def wait_send_next(self):
+        for req in self.send_next:
+            req.wait()
+        self.send_next = []
+
+    def wait_recv_prev(self):
+        for req in self.recv_prev:
+            req.wait()
+        self.recv_prev = []
+
+    def wait_recv_next(self):
+        for req in self.recv_next:
+            req.wait()
+        self.recv_next = []
+
+    def wait_all(self):
+        self.wait_send_prev()
+        self.wait_send_next()
+        self.wait_recv_prev()
+        self.wait_recv_next()
+
+
+def _normalize_tensor_shapes(tensor_shapes):
+    """Normalize tensor_shapes to always be a list of shapes."""
+    if is_single_shape(tensor_shapes):
+        return [tensor_shapes], True
+    return list(tensor_shapes), False
+
+
+def _normalize_optional_tensors(tensors, expected_len, name):
+    """Wrap a single tensor into a one-element list and validate length."""
+    unwrap_output = not isinstance(tensors, list)
+    tensor_list = [tensors] if unwrap_output else list(tensors)
+
+    if len(tensor_list) != expected_len:
+        raise ValueError(
+            f"{name} length ({len(tensor_list)}) does not match "
+            f"tensor_shapes length ({expected_len})"
+        )
+
+    return tensor_list, unwrap_output
 
 
 def _batched_p2p_ops(
@@ -303,7 +380,7 @@ class P2PCommunicator:
                 tensors sent and received in a single function call are
                 the same shape).
 
-            wait_on_reqs (boolean, optional, default=False):
+            wait_on_reqs (boolean, optional, default=True):
                 For non-batched p2p communication, wait on each request
                 before returning.
 
@@ -525,68 +602,104 @@ class P2PCommunicator:
 
     @nvtx_decorator()
     def send_forward_recv_backward(
-        self, output_tensors, tensor_shapes, is_last_stage: bool
-    ) -> Union[torch.Tensor, list[torch.Tensor]]:
-        """Batched send and recv with next rank in pipeline."""
+        self, output_tensors, tensor_shapes, is_last_stage: bool, overlap_p2p_comm: bool = False
+    ) -> Union[
+        torch.Tensor,
+        list[torch.Tensor],
+        Tuple[Union[torch.Tensor, list[torch.Tensor]], P2PAsyncHandleSet],
+    ]:
+        """Batched send and recv with next rank in pipeline.
+
+        When overlap_p2p_comm is True, the communication is issued
+        asynchronously and the method returns (output_tensor_grads, handle_set).
+        """
         config = self.config
-        unwrap_output_tensors = False
-        if not isinstance(output_tensors, list):
-            unwrap_output_tensors = True
-            output_tensors = [output_tensors]
-        if not isinstance(tensor_shapes, list):
-            tensor_shapes = [tensor_shapes]
-        output_tensor_grads = []
-        for output_tensor, tensor_shape in zip(output_tensors, tensor_shapes):
-            if is_last_stage:
-                output_tensor_grad = None
-            else:
+        tensor_shape_list, _ = _normalize_tensor_shapes(tensor_shapes)
+        output_tensor_list, unwrap_output = _normalize_optional_tensors(
+            output_tensors, expected_len=len(tensor_shape_list), name="output_tensors"
+        )
+
+        if is_last_stage:
+            output_tensor_grads = [None] * len(tensor_shape_list)
+            handle_set = P2PAsyncHandleSet()
+        else:
+            output_tensor_grads = []
+            handle_set = P2PAsyncHandleSet()
+            for output_tensor, tensor_shape in zip(output_tensor_list, tensor_shape_list):
                 if config.timers is not None:
                     config.timers('forward-send-backward-recv', log_level=2).start()
-                _, output_tensor_grad, _ = self._communicate(
+                _, output_tensor_grad, raw_reqs = self._communicate(
                     tensor_send_next=output_tensor,
                     tensor_send_prev=None,
                     recv_prev=False,
                     recv_next=True,
                     tensor_shape=tensor_shape,
+                    wait_on_reqs=(not overlap_p2p_comm),
                 )
                 if config.timers is not None:
                     config.timers('forward-send-backward-recv').stop()
-            output_tensor_grads.append(output_tensor_grad)
-        if unwrap_output_tensors:
-            return output_tensor_grads[0]
+                output_tensor_grads.append(output_tensor_grad)
+                if overlap_p2p_comm:
+                    handle_set.extend_from_raw_reqs(raw_reqs)
+
+        if unwrap_output:
+            output_tensor_grads = output_tensor_grads[0]
+
+        if overlap_p2p_comm:
+            return output_tensor_grads, handle_set
         return output_tensor_grads
 
     @nvtx_decorator()
     def send_backward_recv_forward(
-        self, input_tensor_grads, tensor_shapes, is_first_stage: bool
-    ) -> Union[torch.Tensor, list[torch.Tensor]]:
-        """Batched send and recv with previous rank in pipeline."""
+        self,
+        input_tensor_grads,
+        tensor_shapes,
+        is_first_stage: bool,
+        overlap_p2p_comm: bool = False,
+    ) -> Union[
+        torch.Tensor,
+        list[torch.Tensor],
+        Tuple[Union[torch.Tensor, list[torch.Tensor]], P2PAsyncHandleSet],
+    ]:
+        """Batched send and recv with previous rank in pipeline.
+
+        When overlap_p2p_comm is True, the communication is issued
+        asynchronously and the method returns (input_tensors, handle_set).
+        """
         config = self.config
-        unwrap_input_tensor_grads = False
-        if not isinstance(input_tensor_grads, list):
-            unwrap_input_tensor_grads = True
-            input_tensor_grads = [input_tensor_grads]
-        if not isinstance(tensor_shapes, list):
-            tensor_shapes = [tensor_shapes]
-        input_tensors = []
-        for input_tensor_grad, tensor_shape in zip(input_tensor_grads, tensor_shapes):
-            if is_first_stage:
-                input_tensor = None
-            else:
+        tensor_shape_list, _ = _normalize_tensor_shapes(tensor_shapes)
+        input_tensor_grad_list, unwrap_output = _normalize_optional_tensors(
+            input_tensor_grads, expected_len=len(tensor_shape_list), name="input_tensor_grads"
+        )
+
+        if is_first_stage:
+            input_tensors = [None] * len(tensor_shape_list)
+            handle_set = P2PAsyncHandleSet()
+        else:
+            input_tensors = []
+            handle_set = P2PAsyncHandleSet()
+            for input_tensor_grad, tensor_shape in zip(input_tensor_grad_list, tensor_shape_list):
                 if config.timers is not None:
                     config.timers('backward-send-forward-recv', log_level=2).start()
-                input_tensor, _, _ = self._communicate(
+                input_tensor, _, raw_reqs = self._communicate(
                     tensor_send_next=None,
                     tensor_send_prev=input_tensor_grad,
                     recv_prev=True,
                     recv_next=False,
                     tensor_shape=tensor_shape,
+                    wait_on_reqs=(not overlap_p2p_comm),
                 )
                 if config.timers is not None:
                     config.timers('backward-send-forward-recv').stop()
-            input_tensors.append(input_tensor)
-        if unwrap_input_tensor_grads:
-            return input_tensors[0]
+                input_tensors.append(input_tensor)
+                if overlap_p2p_comm:
+                    handle_set.extend_from_raw_reqs(raw_reqs)
+
+        if unwrap_output:
+            input_tensors = input_tensors[0]
+
+        if overlap_p2p_comm:
+            return input_tensors, handle_set
         return input_tensors
 
     @nvtx_decorator()

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -2066,10 +2066,6 @@ def forward_backward_pipelining_without_interleaving(
         data_iterator = data_iterator[0]
 
     config = get_model_config(model)
-    if config.overlap_p2p_comm:
-        raise ValueError(
-            "Non-interleaved pipeline parallelism does not support overlapping p2p communication"
-        )
 
     tp_group, cp_group, cp_size = None, None, None
 
@@ -2078,6 +2074,37 @@ def forward_backward_pipelining_without_interleaving(
     is_multimodule = isinstance(pg_collection, MultiModuleProcessGroupCollection) or isinstance(
         p2p_communicator, MultiModulePipelineCommunicator
     )
+
+    if config.overlap_p2p_comm:
+        if forward_only:
+            raise NotImplementedError(
+                "v1 non-interleaved overlap only supports training, not forward_only=True"
+            )
+        if is_multimodule:
+            raise NotImplementedError(
+                "v1 non-interleaved overlap does not support multimodule pipelines"
+            )
+        if adjust_tensor_shapes_fn is not None:
+            raise NotImplementedError(
+                "v1 non-interleaved overlap does not support adjust_tensor_shapes_fn"
+            )
+        if config.overlap_p2p_comm_warmup_flush:
+            raise NotImplementedError(
+                "v1 non-interleaved overlap only supports steady-state overlap, "
+                "not overlap_p2p_comm_warmup_flush"
+            )
+        if config.batch_p2p_comm:
+            raise ValueError("Can not use both overlap_p2p_comm and batch_p2p_comm")
+        if config.use_ring_exchange_p2p:
+            raise NotImplementedError(
+                "v1 non-interleaved overlap does not support use_ring_exchange_p2p"
+            )
+        if config.variable_seq_lengths:
+            raise NotImplementedError(
+                "v1 non-interleaved overlap does not support variable_seq_lengths"
+            )
+        if config.mtp_standalone:
+            raise NotImplementedError("v1 non-interleaved overlap does not support mtp_standalone")
 
     if p2p_communicator is None and pg_collection is None:
         # Default: single-module with parallel_state groups
@@ -2210,6 +2237,13 @@ def forward_backward_pipelining_without_interleaving(
             recv_tensor_shapes, send_tensor_shapes
         )
 
+    if config.overlap_p2p_comm:
+        if len(recv_tensor_shapes) != len(send_tensor_shapes):
+            raise NotImplementedError(
+                "v1 non-interleaved overlap expects matching recv/send tensor shape counts, "
+                f"got recv={len(recv_tensor_shapes)} vs send={len(send_tensor_shapes)}"
+            )
+
     # Input, output tensors only need to be saved when doing backward passes
     input_tensors = None
     output_tensors = None
@@ -2219,6 +2253,10 @@ def forward_backward_pipelining_without_interleaving(
         input_tensors = []
         output_tensors = []
     forward_data_store = []
+
+    pending_next_input_tensor = None
+    pending_bwd_fwd_handles = None
+    pending_fwd_bwd_handles = None
 
     # Run warmup forward passes.
     for i in range(num_warmup_microbatches):
@@ -2277,32 +2315,50 @@ def forward_backward_pipelining_without_interleaving(
         else:
             checkpoint_activations_microbatch = None
 
-        output_tensor, num_tokens = forward_step(
-            forward_step_func,
-            data_iterator,
-            model,
-            num_microbatches,
-            input_tensor,
-            forward_data_store,
-            config,
-            cp_group_size=cp_size,
-            collect_non_loss_data=collect_non_loss_data,
-            checkpoint_activations_microbatch=checkpoint_activations_microbatch,
-            is_first_microbatch=check_first_val_step(
-                first_val_step, forward_only, (i == 0) and (num_warmup_microbatches == 0)
-            ),
-            current_microbatch=i + num_warmup_microbatches,
-            is_last_stage=p2p_communicator.is_pp_last_stage,
-        )
-        total_num_tokens += num_tokens
-
         if forward_only:
+            output_tensor, num_tokens = forward_step(
+                forward_step_func,
+                data_iterator,
+                model,
+                num_microbatches,
+                input_tensor,
+                forward_data_store,
+                config,
+                cp_group_size=cp_size,
+                collect_non_loss_data=collect_non_loss_data,
+                checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+                is_first_microbatch=check_first_val_step(
+                    first_val_step, forward_only, (i == 0) and (num_warmup_microbatches == 0)
+                ),
+                current_microbatch=i + num_warmup_microbatches,
+                is_last_stage=p2p_communicator.is_pp_last_stage,
+            )
+            total_num_tokens += num_tokens
             p2p_communicator.send_forward(output_tensor, p2p_communicator.is_pp_last_stage)
             if not last_iteration:
                 input_tensor = p2p_communicator.recv_forward(
                     recv_tensor_shapes, p2p_communicator.is_pp_first_stage
                 )
-        else:
+        elif not config.overlap_p2p_comm:
+            output_tensor, num_tokens = forward_step(
+                forward_step_func,
+                data_iterator,
+                model,
+                num_microbatches,
+                input_tensor,
+                forward_data_store,
+                config,
+                cp_group_size=cp_size,
+                collect_non_loss_data=collect_non_loss_data,
+                checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+                is_first_microbatch=check_first_val_step(
+                    first_val_step, forward_only, (i == 0) and (num_warmup_microbatches == 0)
+                ),
+                current_microbatch=i + num_warmup_microbatches,
+                is_last_stage=p2p_communicator.is_pp_last_stage,
+            )
+            total_num_tokens += num_tokens
+
             output_tensor_grad = p2p_communicator.send_forward_recv_backward(
                 output_tensor, send_tensor_shapes, p2p_communicator.is_pp_last_stage
             )
@@ -2336,6 +2392,99 @@ def forward_backward_pipelining_without_interleaving(
                 input_tensor = p2p_communicator.send_backward_recv_forward(
                     input_tensor_grad, recv_tensor_shapes, p2p_communicator.is_pp_first_stage
                 )
+        else:
+            if i > 0:
+                pending_bwd_fwd_handles.wait_recv_prev()
+                input_tensor = pending_next_input_tensor
+                pending_next_input_tensor = None
+
+            output_tensor, num_tokens = forward_step(
+                forward_step_func,
+                data_iterator,
+                model,
+                num_microbatches,
+                input_tensor,
+                forward_data_store,
+                config,
+                cp_group_size=cp_size,
+                collect_non_loss_data=collect_non_loss_data,
+                checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+                is_first_microbatch=check_first_val_step(
+                    first_val_step, forward_only, (i == 0) and (num_warmup_microbatches == 0)
+                ),
+                current_microbatch=i + num_warmup_microbatches,
+                is_last_stage=p2p_communicator.is_pp_last_stage,
+            )
+            total_num_tokens += num_tokens
+
+            if i > 0 and pending_fwd_bwd_handles is not None:
+                # When deallocate_pipeline_outputs=True, the previous iteration already
+                # waited on wait_send_next() before deallocation, so this is a safe no-op.
+                pending_fwd_bwd_handles.wait_send_next()
+
+            output_tensor_grad, pending_fwd_bwd_handles = (
+                p2p_communicator.send_forward_recv_backward(
+                    output_tensor,
+                    send_tensor_shapes,
+                    p2p_communicator.is_pp_last_stage,
+                    overlap_p2p_comm=True,
+                )
+            )
+
+            input_tensors.append(input_tensor)
+            output_tensors.append(output_tensor)
+
+            if config.deallocate_pipeline_outputs:
+                # The send must complete before output_tensor is deallocated.
+                # wait_send_next() clears the handle list, so the next iteration can
+                # safely call wait_send_next() again as a no-op.
+                pending_fwd_bwd_handles.wait_send_next()
+            deallocate_output_tensor(output_tensor, config.deallocate_pipeline_outputs)
+
+            pending_fwd_bwd_handles.wait_recv_next()
+
+            input_tensor = input_tensors.pop(0)
+            output_tensor = output_tensors.pop(0)
+
+            if num_warmup_microbatches == 0 and last_iteration:
+                if config.grad_sync_func is None or p2p_communicator.is_pp_first_stage:
+                    enable_grad_sync()
+
+            input_tensor_grad = backward_func(
+                input_tensor, output_tensor, output_tensor_grad, config
+            )
+
+            if i > 0 and pending_bwd_fwd_handles is not None:
+                pending_bwd_fwd_handles.wait_send_prev()
+                pending_bwd_fwd_handles = None
+
+            if last_iteration:
+                input_tensor = None
+                p2p_communicator.send_backward(
+                    input_tensor_grad, p2p_communicator.is_pp_first_stage
+                )
+            else:
+                pending_next_input_tensor, pending_bwd_fwd_handles = (
+                    p2p_communicator.send_backward_recv_forward(
+                        input_tensor_grad,
+                        recv_tensor_shapes,
+                        p2p_communicator.is_pp_first_stage,
+                        overlap_p2p_comm=True,
+                    )
+                )
+
+    if config.overlap_p2p_comm and not forward_only:
+        if pending_fwd_bwd_handles is not None:
+            pending_fwd_bwd_handles.wait_send_next()
+            pending_fwd_bwd_handles = None
+        if pending_bwd_fwd_handles is not None:
+            pending_bwd_fwd_handles.wait_recv_prev()
+            pending_bwd_fwd_handles.wait_send_prev()
+            pending_bwd_fwd_handles = None
+            pending_next_input_tensor = None
+        assert pending_fwd_bwd_handles is None
+        assert pending_bwd_fwd_handles is None
+        assert pending_next_input_tensor is None
 
     # Run cooldown backward passes.
     if not forward_only:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -896,14 +896,22 @@ def validate_args(args, defaults={}):
                 'pipeline-model-parallel size should be greater than 2 to avoid having multiple '\
                 'p2p sends and recvs between same 2 ranks per communication batch'
     else:
-        # Overlap P2P communication is disabled if not using the interleaved schedule.
-        args.overlap_p2p_comm = False
-        args.align_param_gather = False
-        # Only print warning if PP size > 1.
-        if args.rank == 0 and args.pipeline_model_parallel_size > 1:
-            print('WARNING: Setting args.overlap_p2p_comm and args.align_param_gather to False '
-                'since non-interleaved schedule does not support overlapping p2p communication '
-                'and aligned param AG')
+        # v1: non-interleaved steady-state overlap is now allowed.
+        # align_param_gather is still unsupported for non-interleaved.
+        if args.align_param_gather:
+            args.align_param_gather = False
+            if args.rank == 0 and args.pipeline_model_parallel_size > 1:
+                print(
+                    'WARNING: Setting args.align_param_gather to False since '
+                    'non-interleaved schedule does not support aligned param AG'
+                )
+        if args.rank == 0 and args.pipeline_model_parallel_size > 1 and args.overlap_p2p_comm:
+            print(
+                'WARNING: Non-interleaved overlap_p2p_comm v1 only supports training + fixed-shape '
+                'steady-state 1F1B; adjust_tensor_shapes_fn, multimodule, forward_only, '
+                'variable_seq_lengths, mtp_standalone, overlap_p2p_comm_warmup_flush, and '
+                'ring_exchange remain unsupported'
+            )
 
     print_rank_0(
         f"Number of virtual stages per pipeline stage: {args.virtual_pipeline_model_parallel_size}"

--- a/megatron/training/yaml_arguments.py
+++ b/megatron/training/yaml_arguments.py
@@ -140,11 +140,22 @@ def validate_yaml(args, defaults={}):
             args.num_layers_per_virtual_pipeline_stage
     else:
         args.model_parallel.virtual_pipeline_model_parallel_size = None
-        # Overlap P2P communication is disabled if not using the interleaved schedule.
-        args.model_parallel.overlap_p2p_comm = False
-        if args.rank == 0:
-            print('WARNING: Setting args.overlap_p2p_comm to False since non-interleaved '
-                  'schedule does not support overlapping p2p communication')
+        # v1: non-interleaved steady-state overlap is now allowed.
+        # align_param_gather remains unsupported for non-interleaved.
+        if getattr(args, 'align_param_gather', False):
+            args.align_param_gather = False
+            if args.rank == 0 and args.model_parallel.pipeline_model_parallel_size > 1:
+                print('WARNING: Setting args.align_param_gather to False since '
+                      'non-interleaved schedule does not support aligned param AG')
+        if (
+            args.rank == 0
+            and args.model_parallel.pipeline_model_parallel_size > 1
+            and args.model_parallel.overlap_p2p_comm
+        ):
+            print('WARNING: Non-interleaved overlap_p2p_comm v1 only supports training + fixed-shape '
+                  'steady-state 1F1B; adjust_tensor_shapes_fn, multimodule, forward_only, '
+                  'variable_seq_lengths, mtp_standalone, overlap_p2p_comm_warmup_flush, and '
+                  'ring_exchange remain unsupported')
 
     if args.overlap_param_gather:
         assert args.use_distributed_optimizer, \

--- a/tests/unit_tests/pipeline_parallel/test_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedules.py
@@ -14,7 +14,10 @@ from megatron.core.distributed.finalize_model_grads import finalize_model_grads
 from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
-from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.process_groups_config import (
+    MultiModuleProcessGroupCollection,
+    ProcessGroupCollection,
+)
 from megatron.core.transformer.cuda_graphs import (
     convert_schedule_table_to_order,
     get_overlap_moe_expert_parallel_comm_order,
@@ -768,3 +771,421 @@ def test_forward_backward_no_pipelining_with_custom_pgs(mocker):
         assert l['loss_reduced'] == expected['loss_reduced']
 
     Utils.destroy_model_parallel()
+
+
+class _NonInterleavedPipelineTestModel(torch.nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.model_type = 'unit-test'
+        self.config = config
+        self.input_tensor = None
+        self.proj = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False).cuda()
+        torch.nn.init.constant_(self.proj.weight, 0.01)
+
+    def set_input_tensor(self, input_tensor):
+        if isinstance(input_tensor, list):
+            input_tensor = input_tensor[0]
+        self.input_tensor = input_tensor
+
+    def forward(self):
+        if self.input_tensor is None:
+            x = torch.ones(
+                512,
+                8,
+                self.config.hidden_size,
+                device='cuda',
+                dtype=self.config.pipeline_dtype,
+                requires_grad=True,
+            )
+        else:
+            x = self.input_tensor
+        return self.proj(x)
+
+
+def _make_non_interleaved_test_model(config):
+    return _NonInterleavedPipelineTestModel(config)
+
+
+def _make_non_interleaved_test_config(**overrides):
+    defaults = dict(
+        pipeline_model_parallel_size=4,
+        sequence_parallel=False,
+        pipeline_dtype=torch.float,
+        batch_p2p_comm=False,
+    )
+    defaults.update(overrides)
+    config = ModelParallelConfig(**defaults)
+    config.hidden_size = 256
+    return config
+
+
+def _make_non_interleaved_forward_step_func():
+    def forward_step_func(data_iterator, model):
+        output_tensor = model()
+
+        def loss_func(loss_tensor):
+            reduced = loss_tensor.sum()
+            return reduced, {'loss_reduced': reduced.detach().clone()}
+
+        return output_tensor, loss_func
+
+    return forward_step_func
+
+
+@pytest.mark.internal
+class TestNonInterleavedOverlapGuards:
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=2, pipeline_model_parallel_size=4
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        Utils.destroy_model_parallel()
+
+    def _call_kwargs(self, model, **overrides):
+        defaults = dict(
+            forward_step_func=_make_non_interleaved_forward_step_func(),
+            data_iterator=None,
+            model=[model],
+            num_microbatches=8,
+            seq_length=512,
+            micro_batch_size=8,
+            forward_only=False,
+        )
+        defaults.update(overrides)
+        return defaults
+
+    def test_rejects_forward_only(self):
+        config = _make_non_interleaved_test_config(overlap_p2p_comm=True)
+        model = _make_non_interleaved_test_model(config)
+        with pytest.raises(NotImplementedError, match="forward_only"):
+            schedule.forward_backward_pipelining_without_interleaving(
+                **self._call_kwargs(model, forward_only=True)
+            )
+
+    def test_rejects_adjust_tensor_shapes_fn(self):
+        config = _make_non_interleaved_test_config(overlap_p2p_comm=True)
+        model = _make_non_interleaved_test_model(config)
+        with pytest.raises(NotImplementedError, match="adjust_tensor_shapes_fn"):
+            schedule.forward_backward_pipelining_without_interleaving(
+                **self._call_kwargs(model, adjust_tensor_shapes_fn=lambda r, s: (r, s))
+            )
+
+    def test_rejects_multimodule(self):
+        config = _make_non_interleaved_test_config(overlap_p2p_comm=True)
+        model = _make_non_interleaved_test_model(config)
+        multimodule_pg_collection = MultiModuleProcessGroupCollection(
+            module_pgs={"llm": ProcessGroupCollection()}, language_model_module_name="llm"
+        )
+        with pytest.raises(NotImplementedError, match="multimodule"):
+            schedule.forward_backward_pipelining_without_interleaving(
+                **self._call_kwargs(model, pg_collection=multimodule_pg_collection)
+            )
+
+    def test_rejects_batch_p2p_comm(self):
+        config = _make_non_interleaved_test_config(overlap_p2p_comm=True, batch_p2p_comm=True)
+        model = _make_non_interleaved_test_model(config)
+        with pytest.raises(ValueError, match="batch_p2p_comm"):
+            schedule.forward_backward_pipelining_without_interleaving(**self._call_kwargs(model))
+
+    def test_rejects_ring_exchange(self):
+        config = _make_non_interleaved_test_config(
+            overlap_p2p_comm=True, use_ring_exchange_p2p=True
+        )
+        model = _make_non_interleaved_test_model(config)
+        with pytest.raises(NotImplementedError, match="use_ring_exchange_p2p"):
+            schedule.forward_backward_pipelining_without_interleaving(**self._call_kwargs(model))
+
+    def test_rejects_warmup_flush(self):
+        config = _make_non_interleaved_test_config(
+            overlap_p2p_comm=True, overlap_p2p_comm_warmup_flush=True
+        )
+        model = _make_non_interleaved_test_model(config)
+        with pytest.raises(NotImplementedError, match="overlap_p2p_comm_warmup_flush"):
+            schedule.forward_backward_pipelining_without_interleaving(**self._call_kwargs(model))
+
+    def test_rejects_variable_seq_lengths(self):
+        config = _make_non_interleaved_test_config(overlap_p2p_comm=True)
+        config.variable_seq_lengths = True
+        model = _make_non_interleaved_test_model(config)
+        with pytest.raises(NotImplementedError, match="variable_seq_lengths"):
+            schedule.forward_backward_pipelining_without_interleaving(**self._call_kwargs(model))
+
+    def test_rejects_mtp_standalone(self):
+        config = _make_non_interleaved_test_config(overlap_p2p_comm=True)
+        config.mtp_standalone = True
+        model = _make_non_interleaved_test_model(config)
+        with pytest.raises(NotImplementedError, match="mtp_standalone"):
+            schedule.forward_backward_pipelining_without_interleaving(**self._call_kwargs(model))
+
+    def test_rejects_shape_count_mismatch(self, mocker):
+        config = _make_non_interleaved_test_config(overlap_p2p_comm=True)
+        model = _make_non_interleaved_test_model(config)
+        mocker.patch(
+            "megatron.core.pipeline_parallel.schedules.get_tensor_shapes",
+            side_effect=[[(512, 8, 256)], [(512, 8, 256), (512, 8, 256)]],
+        )
+        with pytest.raises(NotImplementedError, match="matching recv/send tensor shape counts"):
+            schedule.forward_backward_pipelining_without_interleaving(**self._call_kwargs(model))
+
+
+@pytest.mark.internal
+class TestNonInterleavedOverlapExecution:
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=2, pipeline_model_parallel_size=4
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        Utils.destroy_model_parallel()
+
+    def _run_overlap_vs_baseline_training(self, deallocate_pipeline_outputs):
+        baseline_config = _make_non_interleaved_test_config(
+            overlap_p2p_comm=False, deallocate_pipeline_outputs=deallocate_pipeline_outputs
+        )
+        baseline_model = _make_non_interleaved_test_model(baseline_config)
+
+        overlap_config = _make_non_interleaved_test_config(
+            overlap_p2p_comm=True,
+            batch_p2p_comm=False,
+            deallocate_pipeline_outputs=deallocate_pipeline_outputs,
+        )
+        overlap_model = _make_non_interleaved_test_model(overlap_config)
+        overlap_model.load_state_dict(baseline_model.state_dict())
+
+        baseline_losses = schedule.forward_backward_pipelining_without_interleaving(
+            forward_step_func=_make_non_interleaved_forward_step_func(),
+            data_iterator=None,
+            model=[baseline_model],
+            num_microbatches=8,
+            seq_length=512,
+            micro_batch_size=8,
+            forward_only=False,
+        )
+
+        overlap_losses = schedule.forward_backward_pipelining_without_interleaving(
+            forward_step_func=_make_non_interleaved_forward_step_func(),
+            data_iterator=None,
+            model=[overlap_model],
+            num_microbatches=8,
+            seq_length=512,
+            micro_batch_size=8,
+            forward_only=False,
+        )
+
+        assert isinstance(baseline_losses, list)
+        assert isinstance(overlap_losses, list)
+        assert len(baseline_losses) == len(overlap_losses)
+        for baseline_loss, overlap_loss in zip(baseline_losses, overlap_losses):
+            assert baseline_loss.keys() == overlap_loss.keys()
+            assert torch.equal(baseline_loss['loss_reduced'], overlap_loss['loss_reduced'])
+
+    def _run_overlap_vs_baseline_gradients(self, deallocate_pipeline_outputs):
+        baseline_config = _make_non_interleaved_test_config(
+            overlap_p2p_comm=False, deallocate_pipeline_outputs=deallocate_pipeline_outputs
+        )
+        baseline_model = _make_non_interleaved_test_model(baseline_config)
+
+        overlap_config = _make_non_interleaved_test_config(
+            overlap_p2p_comm=True,
+            batch_p2p_comm=False,
+            deallocate_pipeline_outputs=deallocate_pipeline_outputs,
+        )
+        overlap_model = _make_non_interleaved_test_model(overlap_config)
+        overlap_model.load_state_dict(baseline_model.state_dict())
+
+        schedule.forward_backward_pipelining_without_interleaving(
+            forward_step_func=_make_non_interleaved_forward_step_func(),
+            data_iterator=None,
+            model=[baseline_model],
+            num_microbatches=8,
+            seq_length=512,
+            micro_batch_size=8,
+            forward_only=False,
+        )
+
+        schedule.forward_backward_pipelining_without_interleaving(
+            forward_step_func=_make_non_interleaved_forward_step_func(),
+            data_iterator=None,
+            model=[overlap_model],
+            num_microbatches=8,
+            seq_length=512,
+            micro_batch_size=8,
+            forward_only=False,
+        )
+
+        baseline_grads = {}
+        for name, param in baseline_model.named_parameters():
+            assert param.grad is not None, f"Expected baseline gradient for {name}"
+            baseline_grads[name] = param.grad.detach().clone()
+
+        overlap_grads = {}
+        for name, param in overlap_model.named_parameters():
+            assert param.grad is not None, f"Expected overlap gradient for {name}"
+            overlap_grads[name] = param.grad.detach().clone()
+
+        assert baseline_grads.keys() == overlap_grads.keys()
+        for name in baseline_grads:
+            assert torch.allclose(
+                baseline_grads[name], overlap_grads[name]
+            ), f"Gradient mismatch for {name}"
+
+    def test_overlap_matches_baseline_training(self):
+        self._run_overlap_vs_baseline_training(deallocate_pipeline_outputs=False)
+
+    def test_overlap_matches_baseline_training_with_deallocate_pipeline_outputs(self):
+        self._run_overlap_vs_baseline_training(deallocate_pipeline_outputs=True)
+
+    def test_overlap_matches_baseline_gradients(self):
+        self._run_overlap_vs_baseline_gradients(deallocate_pipeline_outputs=False)
+
+    def test_overlap_matches_baseline_gradients_with_deallocate_pipeline_outputs(self):
+        self._run_overlap_vs_baseline_gradients(deallocate_pipeline_outputs=True)
+
+    def test_wait_send_next_before_deallocate(self, mocker):
+        from megatron.core.pipeline_parallel.p2p_communication import P2PAsyncHandleSet
+
+        events = []
+        tracked_pairs = []
+        waited_output_seqs = set()
+        original_deallocate = schedule.deallocate_output_tensor
+        original_wait_send_next = P2PAsyncHandleSet.wait_send_next
+        original_send_forward_recv_backward = P2PCommunicator.send_forward_recv_backward
+
+        def _find_output_entry(output_tensor):
+            for entry in tracked_pairs:
+                if entry["output_tensor"] is output_tensor:
+                    return entry
+            return None
+
+        def _find_handle_entry(handle_set):
+            for entry in tracked_pairs:
+                if entry["handle_set"] is handle_set:
+                    return entry
+            return None
+
+        def tracking_send_forward_recv_backward(
+            self, output_tensors, tensor_shapes, is_last_stage, overlap_p2p_comm=False
+        ):
+            result = original_send_forward_recv_backward(
+                self, output_tensors, tensor_shapes, is_last_stage, overlap_p2p_comm
+            )
+            if overlap_p2p_comm:
+                _, handle_set = result
+                tracked_pairs.append(
+                    {
+                        "seq": len(tracked_pairs),
+                        "output_tensor": output_tensors,
+                        "handle_set": handle_set,
+                    }
+                )
+            return result
+
+        def tracking_deallocate(out, deallocate=False):
+            entry = _find_output_entry(out)
+            if deallocate and entry is not None:
+                events.append(("deallocate", entry["seq"]))
+            return original_deallocate(out, deallocate)
+
+        def tracking_wait_send_next(self):
+            entry = _find_handle_entry(self)
+            if entry is not None and entry["seq"] not in waited_output_seqs:
+                waited_output_seqs.add(entry["seq"])
+                events.append(("wait_send_next", entry["seq"]))
+            return original_wait_send_next(self)
+
+        mocker.patch.object(
+            P2PCommunicator, "send_forward_recv_backward", tracking_send_forward_recv_backward
+        )
+        mocker.patch(
+            "megatron.core.pipeline_parallel.schedules.deallocate_output_tensor",
+            side_effect=tracking_deallocate,
+        )
+        mocker.patch.object(P2PAsyncHandleSet, "wait_send_next", tracking_wait_send_next)
+
+        config = _make_non_interleaved_test_config(
+            overlap_p2p_comm=True, batch_p2p_comm=False, deallocate_pipeline_outputs=True
+        )
+        model = _make_non_interleaved_test_model(config)
+
+        schedule.forward_backward_pipelining_without_interleaving(
+            forward_step_func=_make_non_interleaved_forward_step_func(),
+            data_iterator=None,
+            model=[model],
+            num_microbatches=8,
+            seq_length=512,
+            micro_batch_size=8,
+            forward_only=False,
+        )
+
+        deallocate_events = [event for event in events if event[0] == "deallocate"]
+        assert deallocate_events, "Expected at least one steady-state overlap deallocation event."
+        for deallocate_event in deallocate_events:
+            wait_event = ("wait_send_next", deallocate_event[1])
+            assert wait_event in events, (
+                f"Missing wait_send_next for overlap output seq={deallocate_event[1]}. "
+                f"Events: {events}"
+            )
+            wait_index = events.index(wait_event)
+            deallocate_index = events.index(deallocate_event)
+            assert wait_index <= deallocate_index, (
+                f"wait_send_next (at {wait_index}) must happen before or at "
+                f"deallocate (at {deallocate_index}) for output seq={deallocate_event[1]}. "
+                f"Events: {events}"
+            )
+
+    def test_all_warmup_no_steady_state(self):
+        config = _make_non_interleaved_test_config(overlap_p2p_comm=True, batch_p2p_comm=False)
+        model = _make_non_interleaved_test_model(config)
+
+        losses = schedule.forward_backward_pipelining_without_interleaving(
+            forward_step_func=_make_non_interleaved_forward_step_func(),
+            data_iterator=None,
+            model=[model],
+            num_microbatches=1,
+            seq_length=512,
+            micro_batch_size=8,
+            forward_only=False,
+        )
+
+        assert isinstance(losses, list)
+
+    def test_single_steady_state_completes_and_waits_send_handles(self, mocker):
+        from megatron.core.pipeline_parallel.p2p_communication import P2PAsyncHandleSet
+
+        wait_events = []
+        original_wait_send_next = P2PAsyncHandleSet.wait_send_next
+        original_wait_send_prev = P2PAsyncHandleSet.wait_send_prev
+
+        def tracking_wait_send_next(self):
+            wait_events.append("wait_send_next")
+            return original_wait_send_next(self)
+
+        def tracking_wait_send_prev(self):
+            wait_events.append("wait_send_prev")
+            return original_wait_send_prev(self)
+
+        mocker.patch.object(P2PAsyncHandleSet, "wait_send_next", tracking_wait_send_next)
+        mocker.patch.object(P2PAsyncHandleSet, "wait_send_prev", tracking_wait_send_prev)
+
+        config = _make_non_interleaved_test_config(overlap_p2p_comm=True, batch_p2p_comm=False)
+        model = _make_non_interleaved_test_model(config)
+
+        losses = schedule.forward_backward_pipelining_without_interleaving(
+            forward_step_func=_make_non_interleaved_forward_step_func(),
+            data_iterator=None,
+            model=[model],
+            num_microbatches=4,
+            seq_length=512,
+            micro_batch_size=8,
+            forward_only=False,
+        )
+
+        assert isinstance(losses, list)
+        assert (
+            wait_events
+        ), "Expected at least one send-handle wait in the single steady-state case."

--- a/tests/unit_tests/test_training_arguments.py
+++ b/tests/unit_tests/test_training_arguments.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+
+from pathlib import Path
+import sys
+
+from megatron.core.num_microbatches_calculator import destroy_num_microbatches_calculator
+from megatron.training.arguments import core_transformer_config_from_args, parse_args, validate_args
+from megatron.training.global_vars import destroy_global_vars
+from megatron.training.yaml_arguments import (
+    core_transformer_config_from_yaml,
+    load_yaml,
+    validate_yaml,
+)
+from tests.unit_tests.dist_checkpointing import init_basic_mock_args
+
+GPT_YAML_CONFIG = Path(__file__).resolve().parents[2] / "examples" / "gpt3" / "gpt_config.yaml"
+
+
+def _reset_test_state():
+    destroy_global_vars()
+    destroy_num_microbatches_calculator()
+
+
+def _make_cli_args(**overrides):
+    _reset_test_state()
+
+    original_argv = sys.argv
+    sys.argv = ['test_training_arguments.py']
+    try:
+        args = parse_args(ignore_unknown_args=True)
+    finally:
+        sys.argv = original_argv
+
+    init_basic_mock_args(args, tp=1, pp=4, bf16=True)
+
+    args.num_layers = 4
+    args.hidden_size = 256
+    args.num_attention_heads = 8
+    args.max_position_embeddings = 512
+    args.world_size = 4
+    args.rank = 0
+    args.use_legacy_models = False
+    args.micro_batch_size = 2
+    args.global_batch_size = 8
+    args._is_global_batch_size_explicitly_specified = True
+    args.seq_length = 128
+    args.train_iters = 10
+    args.train_samples = None
+    args.lr = 3e-5
+    args.create_attention_mask_in_dataloader = True
+    args.bf16 = True
+    args.add_bias_linear = False
+    args.swiglu = True
+    args.use_distributed_optimizer = True
+    args.attention_backend = "unfused"
+    args.position_embedding_type = "rope"
+    args.rotary_percent = 1.0
+    args.hidden_dropout = 0.0
+    args.attention_dropout = 0.0
+    args.overlap_p2p_comm = True
+    args.align_param_gather = False
+    args.overlap_grad_reduce = False
+    args.overlap_param_gather = False
+    args.overlap_param_gather_with_optimizer_step = False
+    args.fp8_param_gather = False
+    args.fp4_param_gather = False
+    args.use_ring_exchange_p2p = False
+    args.batch_p2p_comm = False
+    args.overlap_p2p_comm_warmup_flush = False
+    args.variable_seq_lengths = False
+    args.num_layers_per_virtual_pipeline_stage = None
+    args.num_virtual_stages_per_pipeline_rank = None
+    args.hybrid_layer_pattern = None
+    args.decoder_first_pipeline_num_layers = None
+    args.decoder_last_pipeline_num_layers = None
+    args.account_for_embedding_in_pipeline_split = False
+    args.account_for_loss_in_pipeline_split = False
+
+    for key, value in overrides.items():
+        assert hasattr(args, key)
+        setattr(args, key, value)
+
+    return args
+
+
+def _make_yaml_args(**overrides):
+    _reset_test_state()
+
+    args = load_yaml(str(GPT_YAML_CONFIG))
+    args.world_size = 4
+    args.rank = 0
+    args.train_iters = 10
+    args.train_samples = None
+    args.lr_decay_samples = None
+    args.lr_warmup_samples = 0
+    args.lr_warmup_iters = 0
+    args.micro_batch_size = 2
+    args.global_batch_size = 8
+    args._is_global_batch_size_explicitly_specified = True
+    args.step_batch_size_schedule = None
+    args.seq_length = 128
+    args.max_position_embeddings = 512
+    args.use_distributed_optimizer = True
+    args.overlap_param_gather = False
+    args.overlap_grad_reduce = False
+    args.align_param_gather = False
+    args.model_parallel.tensor_model_parallel_size = 1
+    args.model_parallel.context_parallel_size = 1
+    args.model_parallel.pipeline_model_parallel_size = 4
+    args.model_parallel.virtual_pipeline_model_parallel_size = None
+    args.model_parallel.overlap_p2p_comm = True
+    args.model_parallel.variable_seq_lengths = False
+    args.model_parallel.tp_comm_overlap = False
+    args.model_parallel.sequence_parallel = False
+
+    for key, value in overrides.items():
+        if key.startswith("model_parallel__"):
+            setattr(args.model_parallel, key.split("__", 1)[1], value)
+        elif key.startswith("language_model__"):
+            setattr(args.language_model, key.split("__", 1)[1], value)
+        else:
+            assert hasattr(args, key)
+            setattr(args, key, value)
+
+    return args
+
+
+def test_cli_non_interleaved_overlap_not_force_disabled():
+    args = _make_cli_args(overlap_p2p_comm=True)
+
+    validated = validate_args(args)
+
+    assert validated.overlap_p2p_comm is True
+    assert validated.virtual_pipeline_model_parallel_size is None
+
+
+def test_cli_non_interleaved_align_param_gather_still_handled():
+    args = _make_cli_args(overlap_p2p_comm=True, align_param_gather=True)
+
+    validated = validate_args(args)
+
+    assert validated.overlap_p2p_comm is True
+    assert validated.align_param_gather is False
+
+
+def test_yaml_non_interleaved_overlap_not_force_disabled():
+    args = _make_yaml_args(model_parallel__overlap_p2p_comm=True)
+
+    validated = validate_yaml(args)
+
+    assert validated.overlap_p2p_comm is True
+    assert validated.model_parallel.overlap_p2p_comm is True
+    assert validated.virtual_pipeline_model_parallel_size is None
+
+
+def test_yaml_non_interleaved_align_param_gather_still_handled():
+    args = _make_yaml_args(align_param_gather=True, model_parallel__overlap_p2p_comm=True)
+
+    validated = validate_yaml(args)
+
+    assert validated.overlap_p2p_comm is True
+    assert validated.model_parallel.overlap_p2p_comm is True
+    assert validated.align_param_gather is False
+
+
+def test_core_transformer_config_keeps_batch_p2p_mapping():
+    cli_args = _make_cli_args(overlap_p2p_comm=True)
+    validated_cli_args = validate_args(cli_args)
+    cli_config = core_transformer_config_from_args(validated_cli_args)
+
+    yaml_args = _make_yaml_args(model_parallel__overlap_p2p_comm=True)
+    validated_yaml_args = validate_yaml(yaml_args)
+    yaml_config = core_transformer_config_from_yaml(validated_yaml_args)
+
+    assert cli_config.overlap_p2p_comm is True
+    assert cli_config.batch_p2p_comm is False
+    assert yaml_config.overlap_p2p_comm is True
+    assert yaml_config.batch_p2p_comm is False


### PR DESCRIPTION
## Summary

This PR adds initial `overlap_p2p_comm` support for the non-interleaved pipeline-parallel schedule, scoped to the fixed-shape steady-state 1F1B training path.

This is intentionally a narrow, correctness-first change rather than full feature parity with the interleaved schedule. Warmup and cooldown remain synchronous in this initial version.

## What this PR changes

- enables steady-state 1F1B P2P overlap for the supported non-interleaved training path
- updates non-interleaved schedule logic to use overlap-aware P2P communication in steady state
- preserves explicit guards for unsupported combinations
- keeps buffer lifetime handling correct when `deallocate_pipeline_outputs=True`
- updates argument validation to allow the supported non-interleaved overlap configuration

## Supported scope

This PR supports:

- non-interleaved pipeline parallelism
- training path only (`forward_only=False`)
- fixed-shape pipeline tensors
- steady-state 1F1B overlap
- `deallocate_pipeline_outputs=True/False`

## Explicitly out of scope

The following remain unsupported in this PR:

- `variable_seq_lengths`
- `mtp_standalone`
- `adjust_tensor_shapes_fn`
- multimodule pipelines / multimodule communicators
- `use_ring_exchange_p2p`
- `batch_p2p_comm`
- `overlap_p2p_comm_warmup_flush`
- `forward_only=True`

## Correctness notes

A key correctness requirement in this PR is buffer lifetime handling:

- when `deallocate_pipeline_outputs=True`, the corresponding forward send is completed before the output buffer is deallocated
- when `deallocate_pipeline_outputs=False`, deferred send handles are flushed before leaving the steady-state overlap region

## Validation

This PR includes/was validated with:

- loss parity against the non-overlap baseline
- gradient parity against the non-overlap baseline
- tests covering `deallocate_pipeline_outputs=True`
- argument validation coverage for the supported and unsupported configurations

## Related issue

Closes #4385