### PR TITLE
docs(pipeline_parallel): clarify seq_length behavior with variable_seq_lengths under PP

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -104,10 +104,20 @@ def get_forward_backward_func(pp_size: Optional[int] = None, vp_size: Optional[i
     num_microbatches (int, required):
         The number of microbatches to go through
 
-    seq_length (int, required): Sequence length of the current global batch. If this is a dual-stack
-        transformer, this is the encoder's sequence length. This is ignored if variable_seq_lengths
-        in the config is True. Otherwise, each microbatch in the current global batch size must use
-        this sequence length.
+    seq_length (int, required): Sequence length of the current global batch. If this is a
+        dual-stack transformer, this is the encoder's sequence length. Its effect depends on
+        which schedule is selected:
+
+        * ``forward_backward_no_pipelining`` (pp_size=1): ``seq_length`` is unused.
+        * ``forward_backward_pipelining_without_interleaving`` (pp_size>1, vp_size=None):
+          when ``config.variable_seq_lengths=True``, P2P activation tensor shapes are
+          exchanged dynamically and ``seq_length`` is ignored; otherwise every microbatch
+          in the current global batch must use exactly this ``seq_length``.
+        * ``forward_backward_pipelining_with_interleaving`` (pp_size>1, vp_size>1):
+          ``seq_length`` is always used to size the P2P activation buffer as
+          ``[seq_length, micro_batch_size, hidden_size]``. When
+          ``config.variable_seq_lengths=True`` it acts as the per-step maximum sequence
+          length used for P2P; actual microbatches may be shorter, but must not exceed it.
 
     micro_batch_size (int, required): The number of sequences in a microbatch.
 
@@ -910,6 +920,12 @@ def forward_backward_pipelining_with_interleaving(
 ):
     """Run interleaved 1F1B schedule (model split into model chunks), with
     communication between pipeline stages as needed.
+
+    ``seq_length`` is required and is always used here to size the P2P activation buffer as
+    ``[seq_length, micro_batch_size, hidden_size]`` (then divided by ``cp_group.size()`` and,
+    when sequence parallelism is enabled, by ``tp_group.size()``). When
+    ``config.variable_seq_lengths=True`` it acts as the per-step maximum sequence length;
+    actual microbatches may be shorter, but must not exceed it.
 
     Returns dictionary with losses if the last stage, empty dict otherwise."""
 
@@ -2051,8 +2067,13 @@ def forward_backward_pipelining_without_interleaving(
     ] = None,
     force_all_reduce: Optional[bool] = False,
 ):
-    """Run non-interleaved 1F1B schedule, with communication between pipeline
-    stages. Returns dictionary with losses if the last stage, empty dict otherwise."""
+    """Run non-interleaved 1F1B schedule, with communication between pipeline stages.
+
+    When ``config.variable_seq_lengths=True``, P2P activation tensor shapes are exchanged
+    dynamically (see ``get_tensor_shapes``) and ``seq_length`` is ignored. Otherwise every
+    microbatch in the current global batch must use exactly this ``seq_length``.
+
+    Returns dictionary with losses if the last stage, empty dict otherwise."""
 
     if isinstance(model, list):
         assert (


### PR DESCRIPTION
## Summary

Fixes #2064.

The shared docstring of [`get_forward_backward_func`](megatron/core/pipeline_parallel/schedules.py) said _"This is ignored if variable_seq_lengths in the config is True"_ for the `seq_length` argument. That is true for two of the three schedules but not for the third:

| Schedule | Code path | `variable_seq_lengths=True` behavior |
|---|---|---|
| `forward_backward_no_pipelining` (pp=1) | signature marks `seq_length: int,  # unused` ([schedules.py:598](megatron/core/pipeline_parallel/schedules.py#L598)) | unused, regardless of `variable_seq_lengths` |
| `forward_backward_pipelining_without_interleaving` (pp>1, vp=None) | calls `get_tensor_shapes(seq_length, ...)` which short-circuits to `[()]` in variable mode ([schedules.py:2035-2038](megatron/core/pipeline_parallel/schedules.py#L2035)) | ignored — shapes exchanged dynamically |
| `forward_backward_pipelining_with_interleaving` (pp>1, vp>1) | unconditionally builds `tensor_shape = [seq_length, micro_batch_size, hidden_size]` ([schedules.py:1084](megatron/core/pipeline_parallel/schedules.py#L1084)) | **still used** to size P2P buffers — acts as the per-step max sequence length |

I confirmed by grepping every reference to `variable_seq_lengths` between the start of the interleaved schedule and the start of `get_tensor_shapes`: there are zero hits in code (only the new docstring text). The interleaved schedule does not branch on `variable_seq_lengths` at all.

A user running PP>1 + virtual pipeline who reads the existing docstring and assumes \"variable mode means I can stop passing a real `seq_length`\" can hit either shape errors (if the value they pass is too small) or wasted P2P bandwidth/memory (if too large).

## Changes

Pure documentation. No code changes; no test changes.

- `megatron/core/pipeline_parallel/schedules.py`:
  - Replace the single \"this is ignored if variable_seq_lengths\" sentence in `get_forward_backward_func` with a per-schedule breakdown.
  - Add a one-paragraph note to `forward_backward_pipelining_with_interleaving` explicitly stating `seq_length` is always used to size the P2P buffer (and acts as the per-step max in variable mode).
  - Add a one-paragraph note to `forward_backward_pipelining_without_interleaving` stating `seq_length` is ignored in variable mode (shapes exchanged dynamically).

## Test plan

- [x] `uv run isort --check-only megatron/core/pipeline_parallel/schedules.py` — clean.
- [x] Manually walked the three schedule functions and verified each docstring claim against the actual control flow (see table above).
- [ ] Sphinx / autodoc rebuild — defer to CI to confirm RST renders.

The intent is to be a docs-only contribution that closes #2064 without altering any runtime behavior.