### PR TITLE
Add preliminary Muon+M-FSDP support

### DIFF
--- a/examples/megatron_fsdp/train_llama3_8b_fsdp_h100_fp8.sh
+++ b/examples/megatron_fsdp/train_llama3_8b_fsdp_h100_fp8.sh
@@ -5,6 +5,7 @@ TENSORBOARD_LOGS_PATH=${2:-"tensorboard_logs/llama3_8b_fsdp_fp8"}
 TOKENIZER_ARG=${3:-"MOCK"} # Path to tokenizer model, or "MOCK"
 DATA_ARG=${4:-"MOCK"}     # Data prefix, or "MOCK"
 PROFILE=${PROFILE:-0}
+EMPTY_UNUSED_MEMORY_LEVEL=${EMPTY_UNUSED_MEMORY_LEVEL:-0}
 
 # Create directories if they don't exist
 mkdir -p "$(dirname "$CHECKPOINT_PATH")"
@@ -91,7 +92,7 @@ TRAINING_ARGS=(
     --bf16
     --cross-entropy-loss-fusion
     --manual-gc
-    --empty-unused-memory-level 1
+    --empty-unused-memory-level ${EMPTY_UNUSED_MEMORY_LEVEL}
     --exit-duration-in-mins 235
 )
 

--- a/examples/megatron_fsdp/train_llama3_8b_fsdp_h100_fp8.sh
+++ b/examples/megatron_fsdp/train_llama3_8b_fsdp_h100_fp8.sh
@@ -4,6 +4,7 @@ CHECKPOINT_PATH=${1:-"checkpoints/llama3_8b_fsdp_fp8"}
 TENSORBOARD_LOGS_PATH=${2:-"tensorboard_logs/llama3_8b_fsdp_fp8"}
 TOKENIZER_ARG=${3:-"MOCK"} # Path to tokenizer model, or "MOCK"
 DATA_ARG=${4:-"MOCK"}     # Data prefix, or "MOCK"
+PROFILE=${PROFILE:-0}
 
 # Create directories if they don't exist
 mkdir -p "$(dirname "$CHECKPOINT_PATH")"
@@ -24,10 +25,9 @@ PRETRAIN_SCRIPT_PATH="pretrain_gpt.py"
 # Model & Training Parameters
 USE_MEGATRON_FSDP=${USE_MEGATRON_FSDP:-1}
 SHARDING_STRATEGY=${SHARDING_STRATEGY:-"optim_grads_params"}
-OUTER_SHARDING_STRATEGY=${OUTER_SHARDING_STRATEGY:-"no_shard"}
+OUTER_SHARDING_STRATEGY=${OUTER_SHARDING_STRATEGY:-"optim"}
 TP_SIZE=1
 CP_SIZE=1
-PP_SIZE=1
 MICRO_BATCH_SIZE=1
 GLOBAL_BATCH_SIZE=128
 NUM_LAYERS=32
@@ -84,6 +84,7 @@ TRAINING_ARGS=(
     --decoupled-min-lr 4.5e-5
     --lr-decay-style cosine
     --clip-grad 1.0
+    --optimizer adam
     --weight-decay 0.1
     --adam-beta1 0.9
     --adam-beta2 0.95
@@ -183,14 +184,28 @@ EVAL_AND_LOGGING_ARGS=(
     --eval-interval 100
     --save-interval 1000
     --log-throughput
-    --profile
-    --profile-step-start 4
-    --profile-step-end 6
     --distributed-timeout-minutes 60
     --save "$CHECKPOINT_PATH"
     --load "$CHECKPOINT_PATH" 
     --tensorboard-dir "$TENSORBOARD_LOGS_PATH"
 )
+
+# Profiling (PROFILE=1 bash ...)
+if [ "${PROFILE}" = 1 ]; then
+    EVAL_AND_LOGGING_ARGS+=(
+        --profile
+        --profile-step-start 4
+        --profile-step-end 6
+        --profile-ranks 0
+    )
+    PROFILE_CMD="nsys profile --sample=none --cpuctxsw=none \
+        --trace=cuda,nvtx,cublas,cudnn \
+        --capture-range=cudaProfilerApi --capture-range-end=stop \
+        --cuda-graph-trace=node --cuda-memory-usage=true \
+        -f true -x true"
+else
+    PROFILE_CMD=""
+fi
 
 # Ensure pretrain_gpt.py is found
 if [ ! -f "$PRETRAIN_SCRIPT_PATH" ]; then
@@ -200,7 +215,7 @@ if [ ! -f "$PRETRAIN_SCRIPT_PATH" ]; then
 fi
 
 # Run the training command
-torchrun ${DISTRIBUTED_ARGS[@]} \
+${PROFILE_CMD} torchrun ${DISTRIBUTED_ARGS[@]} \
     "$PRETRAIN_SCRIPT_PATH" \
     ${MODEL_ARGS[@]} \
     ${TRAINING_ARGS[@]} \

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -216,6 +216,7 @@ class FullyShardedDataParallel(_BaseDataParallel):
         self.zero_grad_buffer = self.module.zero_grad_buffer
         self.broadcast_params = self.module.broadcast_params
         self.synchronize_param_gather = self.module.synchronize_param_gather
+        self.install_optimized_model_weights = self.module.install_optimized_model_weights
         self.module.state_dict_for_save_checkpoint = self.module.state_dict
         self.state_dict_for_save_checkpoint = self.state_dict
         self.module.config = config

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -1297,6 +1297,7 @@ class MegatronFSDP(torch.nn.Module):
             # Asynchronous reduce-scatter from overlap_grad_reduce=True,
             # i.e. when sharding optimizer and gradients.
             self.grad_reduce_pipeline.wait_for_previous_grad_reduce(0)
+            self.grad_reduce_pipeline.finish_pending_outer_fsdp_grad_reduce()
             self.grad_reduce_pipeline.reset()
         else:
             # Synchronous gradient all-reduce when sharding optimizer state or not sharding.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -3421,8 +3421,10 @@ class GradReducePipeline:
             # If there are multiple FSDP groups, we need to reduce gradients across groups.
             self.outer_fsdp_group_grad_reduce = True
             self.outer_fsdp_group_grad_reduce_stream = torch.cuda.Stream()
+            self._pending_outer_fsdp_grad_reduce_buckets = set()
         else:
             self.outer_fsdp_group_grad_reduce = False
+            self._pending_outer_fsdp_grad_reduce_buckets = set()
 
     @property
     def num_buckets(self):
@@ -3432,6 +3434,7 @@ class GradReducePipeline:
     def reset(self):
         """Handle the processing tasks and reset the pipeline."""
         self.wait_for_previous_grad_reduce(0)
+        self.finish_pending_outer_fsdp_grad_reduce()
         for bucket_id, grad_ready_params in enumerate(self.bucket_grad_ready_params):
             param_list = self.buffer.parameter_groups[bucket_id].params
             n_params = len(param_list)
@@ -3582,6 +3585,89 @@ class GradReducePipeline:
             return param_group.hfsdp_helper_gbuf
         return param_group.main_grad_buffer
 
+    def finish_pending_outer_fsdp_grad_reduce(self) -> None:
+        """Complete delayed HSDP/HFSDP outer-DP gradient reduction.
+
+        With `optim_grads` and `optim_grads_params`, the inner-DP reduce-scatter
+        can be issued from backward hooks before the final microbatch is known to
+        the wrapper. In that case the outer-DP reduction is delayed until
+        `finish_grad_sync()`, after all inner-DP reductions have completed and
+        before optimizer gradients are attached.
+        """
+        if not self._pending_outer_fsdp_grad_reduce_buckets:
+            return
+        if not self.buffer.dist_index.use_hybrid_fsdp:
+            self._pending_outer_fsdp_grad_reduce_buckets.clear()
+            return
+
+        bucket_group = sorted(self._pending_outer_fsdp_grad_reduce_buckets)
+        ddp_config = self.buffer.ddp_config
+        mp_policy = self.buffer.mp_policy
+        current_stream = torch.cuda.current_stream()
+        self.outer_fsdp_group_grad_reduce_stream.wait_stream(current_stream)
+        outer_fsdp_group = self.buffer.dist_index.get_outer_fsdp_group()
+
+        with torch.cuda.stream(self.outer_fsdp_group_grad_reduce_stream):
+            with _coalescing_manager(outer_fsdp_group):
+                grad_accum_closure = []
+                for bucket_id in bucket_group:
+                    if ddp_config.average_in_collective:
+                        reduce_op = torch.distributed.ReduceOp.AVG
+                    else:
+                        reduce_op = torch.distributed.ReduceOp.SUM
+
+                    main_grad_buffer = self.buffer.parameter_groups[bucket_id].main_grad_buffer
+                    fsdp_grad_buffer = self.get_fsdp_buffer(bucket_id)
+                    unreduced_grad = fsdp_grad_buffer.data
+                    assert (
+                        main_grad_buffer.dtype == fsdp_grad_buffer.dtype
+                    ), "Main and DP-Shard gradient buffer must share the exact same dtype."
+
+                    custom_grad_comm_dtype = (
+                        mp_policy.grad_comm_dtype is not None
+                        and unreduced_grad.dtype != mp_policy.grad_comm_dtype
+                    )
+                    if custom_grad_comm_dtype:
+                        hsdp_comm_gbuf = self.buffer.parameter_groups[bucket_id].hsdp_comm_gbuf
+                        unreduced_grad = hsdp_comm_gbuf.allocate_bucket_storage(
+                            shard=fsdp_grad_buffer.is_data_distributed,
+                            dtype=mp_policy.grad_comm_dtype,
+                            device=unreduced_grad.device,
+                            init_values=unreduced_grad,
+                        ).data
+
+                    if ddp_config.outer_dp_sharding_strategy != "no_shard":
+                        main_grad_shard = main_grad_buffer.get_shard_from_local_buffer()
+                        if custom_grad_comm_dtype:
+                            dp_outer_rank = outer_fsdp_group.rank()
+                            output_buffer = unreduced_grad[
+                                dp_outer_rank
+                                * main_grad_shard.numel() : (dp_outer_rank + 1)
+                                * main_grad_shard.numel()
+                            ]
+                        else:
+                            output_buffer = main_grad_shard
+                        torch.distributed.reduce_scatter_tensor(
+                            output=output_buffer,
+                            input=unreduced_grad,
+                            op=reduce_op,
+                            group=outer_fsdp_group,
+                        )
+                        if custom_grad_comm_dtype:
+                            grad_accum_closure.append((main_grad_shard, output_buffer))
+                    else:
+                        torch.distributed.all_reduce(
+                            unreduced_grad, group=outer_fsdp_group, op=reduce_op
+                        )
+                        if custom_grad_comm_dtype:
+                            grad_accum_closure.append((main_grad_buffer.data, unreduced_grad))
+
+            for main_grad_buffer, reduced_grad in grad_accum_closure:
+                main_grad_buffer.copy_(reduced_grad)
+
+        current_stream.wait_stream(self.outer_fsdp_group_grad_reduce_stream)
+        self._pending_outer_fsdp_grad_reduce_buckets.clear()
+
     def _bucket_group_gradient_reduce(
         self,
         bucket_group: List[int],
@@ -3703,6 +3789,12 @@ class GradReducePipeline:
             # Record a checkpoint for the event to synchronize against the reduce-scatter stream.
             reduce_scatter_view_out_event = reduce_scatter_stream.record_event()
 
+        if self.buffer.dist_index.use_hybrid_fsdp:
+            if outer_fsdp_group_grad_reduce:
+                self._pending_outer_fsdp_grad_reduce_buckets.difference_update(bucket_group)
+            else:
+                self._pending_outer_fsdp_grad_reduce_buckets.update(bucket_group)
+
         # DP-Outer Gradient Reduction
         if outer_fsdp_group_grad_reduce:
             # Wait on the DP-Shard reduction before further reduction.
@@ -3795,6 +3887,7 @@ class GradReducePipeline:
                     main_grad_buffer.copy_(reduced_grad)
 
             reduce_scatter_view_out_event = self.outer_fsdp_group_grad_reduce_stream.record_event()
+            self._pending_outer_fsdp_grad_reduce_buckets.difference_update(bucket_group)
 
         free_up_grad_bucket_func = {}
         for bucket_id in bucket_group:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
@@ -359,12 +359,56 @@ def uneven_dtensor_to_full_tensor(dtensor: DTensor) -> torch.Tensor:
 
     # Reconstruct the full tensor by placing chunks at their correct offsets
     full_tensor = torch.empty(dtensor.shape, dtype=dtensor.dtype, device=dtensor.device)
+    assigned_numel = 0
     for chunk_info, local_chunk in zip(local_chunks_info, all_local_chunks):
         offset = chunk_info["offset"]
         slices = tuple(slice(o, o + s) for o, s in zip(offset, local_chunk.shape))
         full_tensor[slices] = local_chunk
+        assigned_numel += local_chunk.numel()
+
+    _assert_chunks_cover_full_tensor(dtensor.shape, local_chunks_info, assigned_numel)
 
     return full_tensor
+
+
+def _assert_chunks_cover_full_tensor(full_shape, chunks_info, assigned_numel: int) -> None:
+    """Check that chunk metadata covers every index of the reconstructed tensor."""
+    full_numel = torch.Size(full_shape).numel()
+    assert assigned_numel == full_numel, (
+        "Uneven DTensor gather did not assign the full tensor: "
+        f"assigned {assigned_numel} of {full_numel} elements."
+    )
+
+    full_shape = torch.Size(full_shape)
+    varying_dims = [
+        dim
+        for dim in range(len(full_shape))
+        if any(
+            chunk_info["offset"][dim] != 0 or chunk_info["shape"][dim] != full_shape[dim]
+            for chunk_info in chunks_info
+        )
+    ]
+    if len(varying_dims) != 1:
+        return
+
+    shard_dim = varying_dims[0]
+    cursor = 0
+    for start, stop in sorted(
+        (
+            chunk_info["offset"][shard_dim],
+            chunk_info["offset"][shard_dim] + chunk_info["shape"][shard_dim],
+        )
+        for chunk_info in chunks_info
+    ):
+        assert start == cursor, (
+            "Uneven DTensor gather chunk metadata does not cover the full tensor: "
+            f"expected next offset {cursor}, got interval ({start}, {stop})."
+        )
+        cursor = stop
+    assert cursor == full_shape[shard_dim], (
+        "Uneven DTensor gather chunk metadata does not cover the full tensor: "
+        f"covered shard dimension until {cursor}, expected {full_shape[shard_dim]}."
+    )
 
 
 def redistribute_uneven_dtensor_to_replicated(dtensor: DTensor) -> DTensor:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
@@ -358,7 +358,7 @@ def uneven_dtensor_to_full_tensor(dtensor: DTensor) -> torch.Tensor:
         buffer_offset += chunk_numel
 
     # Reconstruct the full tensor by placing chunks at their correct offsets
-    full_tensor = torch.zeros(dtensor.shape, dtype=dtensor.dtype, device=dtensor.device)
+    full_tensor = torch.empty(dtensor.shape, dtype=dtensor.dtype, device=dtensor.device)
     for chunk_info, local_chunk in zip(local_chunks_info, all_local_chunks):
         offset = chunk_info["offset"]
         slices = tuple(slice(o, o + s) for o, s in zip(offset, local_chunk.shape))

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
@@ -293,7 +293,8 @@ def uneven_dtensor_to_full_tensor(dtensor: DTensor) -> torch.Tensor:
     if not isinstance(dtensor, DTensor):
         raise TypeError(f"Input must be a DTensor, got {type(dtensor).__name__}.")
 
-    # Ensure chunk metadata is available for uneven shards
+    # Ensure chunk metadata is available for uneven shards. If the metadata exists,
+    # skip the all-gather collectives required to produce the metadata.
     if not hasattr(dtensor._local_tensor, "__create_chunk_list__"):
         update_uneven_dtensor_chunk_metadata(dtensor)
 

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -741,8 +741,9 @@ def _build_megatron_fsdp_emerging_optimizer(
 
       1. Builds the linear-only Muon optimizer (plain `TensorParallelMuon` for
          `no_shard`; `FSDPZeROTensorParallelMuon` for sharded strategies, which
-         allgathers DP row-shards before NS) over a frozen-grad view of the
-         model so `_get_param_groups` only emits Muon-managed params.
+         gathers only split rank-boundary DTensor parameters before NS) over a
+         frozen-grad view of the model so `_get_param_groups` only emits
+         Muon-managed params.
       2. Falls back to `get_megatron_optimizer` for the non-linear params,
          which routes through the standard Megatron-FSDP path for Adam.
       3. Wraps the chained result with `FSDPMuonChainedOptimizer`, which drives
@@ -756,9 +757,9 @@ def _build_megatron_fsdp_emerging_optimizer(
     # Choose Muon variant based on the inner-DP sharding strategy.
     # - "no_shard" (ZeRO-0): params/grads are full Replicate DTensors, so the
     #   plain TensorParallelMuon works without any DP communication.
-    # - Sharded strategies (ZeRO-1/2/3): finish_grad_sync() reduce-scatters
-    #   gradients into Shard(0) row-shards. FSDPZeROTensorParallelMuon
-    #   allgathers across the DP group before NS and re-shards the result.
+    # - Sharded strategies (ZeRO-1/2/3): FSDPZeROTensorParallelMuon gathers
+    #   only split boundary parameters across the DP group before NS and
+    #   re-shards the result.
     fsdp_strategy = getattr(
         model_chunks[0].ddp_config, "data_parallel_sharding_strategy", "no_shard"
     )
@@ -813,8 +814,8 @@ def _build_megatron_fsdp_emerging_optimizer(
     optimizers: List[Any] = []
     init_fns: List[Callable] = []
     if linear_param_groups:
-        # ZeRO-1/2/3: gradients are reduce-scattered over `dp_cp` for dense
-        # params, so the FSDPZero variant must allgather over the same group.
+        # ZeRO-1/2/3: split dense boundary params are sharded over `dp_cp`, so
+        # the FSDPZero variant must gather over the same group.
         dense_kwargs = dict(eopt_kwargs)
         if use_fsdp_zero_muon:
             dense_kwargs["dp_group"] = pg_collection.dp_cp

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -64,7 +64,9 @@ from .distrib_optimizer import DistributedOptimizer
 from .emerging_optimizers import (
     _EMERGING_OPTIMIZERS,
     HAVE_EMERGING_OPTIMIZERS,
+    FSDPMuonChainedOptimizer,
     _create_emerging_optimizer,
+    _get_mfsdp_models,
 )
 from .grad_scaler import ConstantGradScaler, DynamicGradScaler
 from .layer_wise_optimizer import LayerWiseDistributedOptimizer
@@ -721,6 +723,169 @@ def check_config_overrides_consistency(
     return True
 
 
+def _build_megatron_fsdp_emerging_optimizer(
+    config: OptimizerConfig,
+    model_chunks: List[MegatronModule],
+    config_overrides: Dict[ParamKey, ParamGroupOverride],
+    pg_collection: ProcessGroupCollection,
+    eopt_name: str,
+    use_layer_wise: bool,
+) -> "FSDPMuonChainedOptimizer":
+    """Build an emerging optimizer (currently only Muon) for Megatron-FSDP.
+
+    The standard emerging-optimizer flow assumes `main_grad` buffers populated
+    by DDP. With Megatron-FSDP, gradients arrive via `finish_grad_sync()` on
+    DTensor parameters, which makes `Float16OptimizerWithFloat16Params`
+    incompatible. This helper:
+
+      1. Builds the linear-only `TensorParallelMuon` over a frozen-grad view of
+         the model so `_get_param_groups` only emits Muon-managed params.
+      2. Falls back to `get_megatron_optimizer` for the non-linear params,
+         which routes through the standard Megatron-FSDP path for Adam.
+      3. Wraps the chained result with `FSDPMuonChainedOptimizer`, which drives
+         `finish_grad_sync` and `install_optimized_model_weights`.
+
+    Only the inner `no_shard` (ZeRO-0) sharding strategy is fully supported in
+    the initial implementation. Other strategies route through the same factory
+    but require `FSDPZeROTensorParallelMuon` for correctness (added later).
+    """
+    # Lazy import to avoid pulling Muon-specific symbols when emerging_optimizers
+    # is unavailable; entry already validated upstream.
+    entry = _EMERGING_OPTIMIZERS[eopt_name]
+    optimizer_cls = entry.optimizer_cls
+    init_state_fn = entry.init_state_fn
+
+    log_single_rank(
+        logger,
+        logging.INFO,
+        f"Setting up Megatron-FSDP emerging optimizer ({eopt_name}) with config {config}",
+    )
+
+    # Sort parameters into linear (Muon-managed) vs nonlinear (Adam-managed).
+    linear_params: List[torch.nn.Parameter] = []
+    nonlinear_params: List[torch.nn.Parameter] = []
+    for model_chunk in model_chunks:
+        for _, param in model_chunk.named_parameters():
+            if not param.requires_grad:
+                continue
+            if (
+                not getattr(param, "is_embedding_or_output_parameter", False)
+                and len(param.shape) == 2
+            ):
+                linear_params.append(param)
+            else:
+                nonlinear_params.append(param)
+
+    # Build the Muon optimizer for linear params.
+
+    for p in nonlinear_params:
+        p.requires_grad = False
+    linear_param_groups = _get_param_groups(model_chunks, config, config_overrides)
+
+    expert_param_groups: List[Dict[str, Any]] = []
+    if not use_layer_wise:
+        # Build a fresh list rather than calling `linear_param_groups.remove(group)`:
+        # `list.remove` falls back to `dict.__eq__` when the elements are dicts,
+        # which compares values and trips on tensor params with
+        # `RuntimeError: Boolean value of Tensor with more than one value is ambiguous`.
+        non_expert_groups: List[Dict[str, Any]] = []
+        for group in linear_param_groups:
+            if group["is_expert_parallel"]:
+                expert_param_groups.append(group)
+            else:
+                non_expert_groups.append(group)
+        linear_param_groups = non_expert_groups
+
+    eopt_kwargs: Dict[str, Any] = {}
+    if entry.config_to_kwargs is not None:
+        eopt_kwargs = entry.config_to_kwargs(config, model_chunks, pg_collection)
+
+    optimizers: List[Any] = []
+    init_fns: List[Callable] = []
+    if linear_param_groups:
+        muon_base = optimizer_cls(linear_param_groups, **eopt_kwargs)
+        muon_opt = FP32Optimizer(muon_base, config, init_state_fn)
+        setattr(muon_opt, "grad_stats_parallel_group", pg_collection.mp)
+        setattr(muon_opt, "tp_group", pg_collection.tp)
+        optimizers.append(muon_opt)
+        init_fns.append(init_state_fn)
+
+    if expert_param_groups:
+        expert_kwargs = dict(eopt_kwargs)
+        expert_muon_base = optimizer_cls(expert_param_groups, **expert_kwargs)
+        expert_muon_opt = FP32Optimizer(expert_muon_base, config, init_state_fn)
+        setattr(expert_muon_opt, "grad_stats_parallel_group", pg_collection.tp_ep_pp)
+        setattr(expert_muon_opt, "tp_group", pg_collection.tp)
+        optimizers.append(expert_muon_opt)
+        init_fns.append(init_state_fn)
+
+    # Build Adam for non-linear params via the standard FSDP path.
+
+    for p in nonlinear_params:
+        p.requires_grad = True
+    for p in linear_params:
+        p.requires_grad = False
+
+    saved_optimizer = config.optimizer
+    saved_use_lwd = config.use_layer_wise_distributed_optimizer
+    config.optimizer = "adam"
+    config.use_layer_wise_distributed_optimizer = False
+    try:
+        chained_adam = get_megatron_optimizer(
+            config, model_chunks, config_overrides=config_overrides, pg_collection=pg_collection
+        )
+    finally:
+        config.optimizer = saved_optimizer
+        config.use_layer_wise_distributed_optimizer = saved_use_lwd
+
+    for p in linear_params:
+        p.requires_grad = True
+
+    adam_optimizers = list(getattr(chained_adam, "chained_optimizers", [chained_adam]))
+    optimizers += adam_optimizers
+
+    def _adam_init_state_fn(opt: Any, config: Any = None) -> None:
+        for group in opt.param_groups:
+            for p in group["params"]:
+                if len(opt.state[p]) == 0:
+                    if config is None or not config.use_precision_aware_optimizer:
+                        opt.state[p]["exp_avg"] = torch.zeros_like(p.data)
+                        opt.state[p]["exp_avg_sq"] = torch.zeros_like(p.data)
+                    else:
+                        opt.initialize_state(p)
+
+    init_fns += [_adam_init_state_fn] * len(adam_optimizers)
+
+    # Combine and wrap with the FSDP-protocol adapter.
+
+    if use_layer_wise:
+        # Float16OptimizerWithFloat16Params is incompatible with FSDP DTensor
+        # params (no .main_grad), so temporarily clear bf16 to prevent the
+        # LayerWiseDistributedOptimizer from re-wrapping each sub-optimizer.
+        # async_allgather=False because FSDP doesn't expose DDP buckets.
+        log_single_rank(
+            logger,
+            logging.INFO,
+            f"Using LayerWiseDistributedOptimizer for {eopt_name} + Megatron-FSDP",
+        )
+        saved_bf16 = config.bf16
+        config.bf16 = False
+        try:
+            inner: Any = LayerWiseDistributedOptimizer(
+                optimizers,
+                config,
+                pg_collection,
+                init_state_fn_list=init_fns,
+                async_allgather=False,
+            )
+        finally:
+            config.bf16 = saved_bf16
+    else:
+        inner = ChainedOptimizer(optimizers)
+
+    return FSDPMuonChainedOptimizer(inner, _get_mfsdp_models(model_chunks))
+
+
 def _get_megatron_emerging_optimizer(
     config: OptimizerConfig,
     model_chunks: List[MegatronModule],
@@ -778,7 +943,23 @@ def _get_megatron_emerging_optimizer(
             if 'linear_qkv.weight' in name and len(param.shape) == 2:
                 param.is_qkv = True
 
-    # Apply optimizer-specific default param overrides (e.g. muon: non-linear -> adam).
+    # Megatron-FSDP needs a separate code path: gradients are attached via
+    # `finish_grad_sync()` rather than via `main_grad` buffers, so the
+    # standard Float16OptimizerWithFloat16Params wrapper is incompatible.
+    # In addition, the resulting optimizer must be wrapped to invoke FSDP's
+    # `finish_grad_sync()` / `install_optimized_model_weights()` hooks
+    # around each step.
+    if getattr(model_chunks[0].ddp_config, 'use_megatron_fsdp', False):
+        return _build_megatron_fsdp_emerging_optimizer(
+            config=config,
+            model_chunks=model_chunks,
+            config_overrides=config_overrides,
+            pg_collection=pg_collection,
+            eopt_name=eopt_name,
+            use_layer_wise=use_layer_wise,
+        )
+
+    # Apply optimizer-specific default param overrides (e.g., muon: non-linear -> adam).
     config_overrides.update(_EMERGING_OPTIMIZERS[eopt_name].default_param_overrides)
 
     # Build param groups and bucket by (optimizer_name, is_expert_parallel).

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -65,6 +65,7 @@ from .emerging_optimizers import (
     _EMERGING_OPTIMIZERS,
     HAVE_EMERGING_OPTIMIZERS,
     FSDPMuonChainedOptimizer,
+    FSDPZeROTensorParallelMuon,
     _create_emerging_optimizer,
     _get_mfsdp_models,
 )
@@ -738,22 +739,31 @@ def _build_megatron_fsdp_emerging_optimizer(
     DTensor parameters, which makes `Float16OptimizerWithFloat16Params`
     incompatible. This helper:
 
-      1. Builds the linear-only `TensorParallelMuon` over a frozen-grad view of
-         the model so `_get_param_groups` only emits Muon-managed params.
+      1. Builds the linear-only Muon optimizer (plain `TensorParallelMuon` for
+         `no_shard`; `FSDPZeROTensorParallelMuon` for sharded strategies, which
+         allgathers DP row-shards before NS) over a frozen-grad view of the
+         model so `_get_param_groups` only emits Muon-managed params.
       2. Falls back to `get_megatron_optimizer` for the non-linear params,
          which routes through the standard Megatron-FSDP path for Adam.
       3. Wraps the chained result with `FSDPMuonChainedOptimizer`, which drives
          `finish_grad_sync` and `install_optimized_model_weights`.
-
-    Only the inner `no_shard` (ZeRO-0) sharding strategy is fully supported in
-    the initial implementation. Other strategies route through the same factory
-    but require `FSDPZeROTensorParallelMuon` for correctness (added later).
     """
     # Lazy import to avoid pulling Muon-specific symbols when emerging_optimizers
     # is unavailable; entry already validated upstream.
     entry = _EMERGING_OPTIMIZERS[eopt_name]
-    optimizer_cls = entry.optimizer_cls
     init_state_fn = entry.init_state_fn
+
+    # Choose Muon variant based on the inner-DP sharding strategy.
+    # - "no_shard" (ZeRO-0): params/grads are full Replicate DTensors, so the
+    #   plain TensorParallelMuon works without any DP communication.
+    # - Sharded strategies (ZeRO-1/2/3): finish_grad_sync() reduce-scatters
+    #   gradients into Shard(0) row-shards. FSDPZeROTensorParallelMuon
+    #   allgathers across the DP group before NS and re-shards the result.
+    fsdp_strategy = getattr(
+        model_chunks[0].ddp_config, "data_parallel_sharding_strategy", "no_shard"
+    )
+    use_fsdp_zero_muon = fsdp_strategy != "no_shard"
+    optimizer_cls = FSDPZeROTensorParallelMuon if use_fsdp_zero_muon else entry.optimizer_cls
 
     log_single_rank(
         logger,
@@ -803,7 +813,12 @@ def _build_megatron_fsdp_emerging_optimizer(
     optimizers: List[Any] = []
     init_fns: List[Callable] = []
     if linear_param_groups:
-        muon_base = optimizer_cls(linear_param_groups, **eopt_kwargs)
+        # ZeRO-1/2/3: gradients are reduce-scattered over `dp_cp` for dense
+        # params, so the FSDPZero variant must allgather over the same group.
+        dense_kwargs = dict(eopt_kwargs)
+        if use_fsdp_zero_muon:
+            dense_kwargs["dp_group"] = pg_collection.dp_cp
+        muon_base = optimizer_cls(linear_param_groups, **dense_kwargs)
         muon_opt = FP32Optimizer(muon_base, config, init_state_fn)
         setattr(muon_opt, "grad_stats_parallel_group", pg_collection.mp)
         setattr(muon_opt, "tp_group", pg_collection.tp)
@@ -811,7 +826,11 @@ def _build_megatron_fsdp_emerging_optimizer(
         init_fns.append(init_state_fn)
 
     if expert_param_groups:
+        # Expert params reduce-scatter over `expt_dp` (the expert
+        # data-parallel group), not `dp_cp`.
         expert_kwargs = dict(eopt_kwargs)
+        if use_fsdp_zero_muon:
+            expert_kwargs["dp_group"] = pg_collection.expt_dp
         expert_muon_base = optimizer_cls(expert_param_groups, **expert_kwargs)
         expert_muon_opt = FP32Optimizer(expert_muon_base, config, init_state_fn)
         setattr(expert_muon_opt, "grad_stats_parallel_group", pg_collection.tp_ep_pp)

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -57,6 +57,7 @@ from megatron.core.optimizer_param_scheduler import (
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.fsdp_dtensor_checkpoint import get_global_unique_param_name
 
+from ..distributed.fsdp import FullyShardedDataParallel
 from ..distributed.param_and_grad_buffer import _ParamAndGradBuffer
 from ..transformer.module import MegatronModule
 from ..utils import get_model_config, get_pg_rank, get_pg_size, is_te_min_version, log_single_rank
@@ -727,7 +728,7 @@ def _get_mfsdp_models(model_chunks):
     """Extract list of MegatronFSDP instances from FSDP-wrapped model chunks."""
     mfsdp_models = []
     for chunk in model_chunks:
-        if hasattr(chunk, "finish_grad_sync") and hasattr(chunk, "module"):
+        if isinstance(chunk, FullyShardedDataParallel):
             mfsdp_models.append(chunk.module)
     if not mfsdp_models:
         raise RuntimeError(

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -850,8 +850,15 @@ def _build_megatron_fsdp_emerging_optimizer(
     config.optimizer = "adam"
     config.use_layer_wise_distributed_optimizer = False
     try:
+        # `pg_collection` is always provided here, so Gloo process groups
+        # must be disabled on the recursive call (setup_process_groups_for_optimizer
+        # rejects the combination).
         chained_adam = get_megatron_optimizer(
-            config, model_chunks, config_overrides=config_overrides, pg_collection=pg_collection
+            config,
+            model_chunks,
+            config_overrides=config_overrides,
+            pg_collection=pg_collection,
+            use_gloo_process_groups=False,
         )
     finally:
         config.optimizer = saved_optimizer
@@ -881,7 +888,6 @@ def _build_megatron_fsdp_emerging_optimizer(
         # Float16OptimizerWithFloat16Params is incompatible with FSDP DTensor
         # params (no .main_grad), so temporarily clear bf16 to prevent the
         # LayerWiseDistributedOptimizer from re-wrapping each sub-optimizer.
-        # async_allgather=False because FSDP doesn't expose DDP buckets.
         log_single_rank(
             logger,
             logging.INFO,
@@ -891,11 +897,7 @@ def _build_megatron_fsdp_emerging_optimizer(
         config.bf16 = False
         try:
             inner: Any = LayerWiseDistributedOptimizer(
-                optimizers,
-                config,
-                pg_collection,
-                init_state_fn_list=init_fns,
-                async_allgather=False,
+                optimizers, config, pg_collection, init_state_fn_list=init_fns
             )
         finally:
             config.bf16 = saved_bf16

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -64,10 +64,9 @@ from .distrib_optimizer import DistributedOptimizer
 from .emerging_optimizers import (
     _EMERGING_OPTIMIZERS,
     HAVE_EMERGING_OPTIMIZERS,
-    FSDPMuonChainedOptimizer,
-    FSDPZeROTensorParallelMuon,
+    FSDPTensorParallelMuon,
     _create_emerging_optimizer,
-    _get_mfsdp_models,
+    _is_nonlinear_or_embedding,
 )
 from .grad_scaler import ConstantGradScaler, DynamicGradScaler
 from .layer_wise_optimizer import LayerWiseDistributedOptimizer
@@ -724,30 +723,34 @@ def check_config_overrides_consistency(
     return True
 
 
+def _get_mfsdp_models(model_chunks):
+    """Extract list of MegatronFSDP instances from FSDP-wrapped model chunks."""
+    mfsdp_models = []
+    for chunk in model_chunks:
+        if hasattr(chunk, "finish_grad_sync") and hasattr(chunk, "module"):
+            mfsdp_models.append(chunk.module)
+    if not mfsdp_models:
+        raise RuntimeError(
+            "Could not find any MegatronFSDP instances in model_chunks. "
+            "Ensure the model is wrapped with FullyShardedDataParallel."
+        )
+    return mfsdp_models
+
+
 def _build_megatron_fsdp_emerging_optimizer(
     config: OptimizerConfig,
     model_chunks: List[MegatronModule],
     config_overrides: Dict[ParamKey, ParamGroupOverride],
     pg_collection: ProcessGroupCollection,
     eopt_name: str,
-    use_layer_wise: bool,
-) -> "FSDPMuonChainedOptimizer":
+) -> ChainedOptimizer:
     """Build an emerging optimizer (currently only Muon) for Megatron-FSDP.
 
-    The standard emerging-optimizer flow assumes `main_grad` buffers populated
-    by DDP. With Megatron-FSDP, gradients arrive via `finish_grad_sync()` on
-    DTensor parameters, which makes `Float16OptimizerWithFloat16Params`
-    incompatible. This helper:
-
-      1. Builds the linear-only Muon optimizer (plain `TensorParallelMuon` for
-         `no_shard`; `FSDPZeROTensorParallelMuon` for sharded strategies, which
-         gathers only split rank-boundary DTensor parameters before NS) over a
-         frozen-grad view of the model so `_get_param_groups` only emits
-         Muon-managed params.
-      2. Falls back to `get_megatron_optimizer` for the non-linear params,
-         which routes through the standard Megatron-FSDP path for Adam.
-      3. Wraps the chained result with `FSDPMuonChainedOptimizer`, which drives
-         `finish_grad_sync` and `install_optimized_model_weights`.
+    M-FSDP shards parameters unevenly across DP ranks; params split at rank
+    boundaries must be gathered before Newton-Schulz orthogonalization.
+    Linear params go to Muon (``FSDPTensorParallelMuon`` for sharded
+    strategies, plain ``TensorParallelMuon`` for ``no_shard``); non-linear
+    params fall back to Adam via the standard Megatron-FSDP path.
     """
     # Lazy import to avoid pulling Muon-specific symbols when emerging_optimizers
     # is unavailable; entry already validated upstream.
@@ -757,20 +760,26 @@ def _build_megatron_fsdp_emerging_optimizer(
     # Choose Muon variant based on the inner-DP sharding strategy.
     # - "no_shard" (ZeRO-0): params/grads are full Replicate DTensors, so the
     #   plain TensorParallelMuon works without any DP communication.
-    # - Sharded strategies (ZeRO-1/2/3): FSDPZeROTensorParallelMuon gathers
+    # - Sharded strategies (ZeRO-1/2/3): FSDPTensorParallelMuon gathers
     #   only split boundary parameters across the DP group before NS and
     #   re-shards the result.
     fsdp_strategy = getattr(
         model_chunks[0].ddp_config, "data_parallel_sharding_strategy", "no_shard"
     )
     use_fsdp_zero_muon = fsdp_strategy != "no_shard"
-    optimizer_cls = FSDPZeROTensorParallelMuon if use_fsdp_zero_muon else entry.optimizer_cls
+    optimizer_cls = FSDPTensorParallelMuon if use_fsdp_zero_muon else entry.optimizer_cls
 
     log_single_rank(
         logger,
         logging.INFO,
         f"Setting up Megatron-FSDP emerging optimizer ({eopt_name}) with config {config}",
     )
+
+    # Ensure Megatron-FSDP module parameters are the (sharded) DTensor main weights,
+    # not the raw/unsharded compute params, before optimizer initialization as a
+    # safety precaution against Megatron-FSDP state changes.
+    for mfsdp in _get_mfsdp_models(model_chunks):
+        mfsdp._replace_param_with_distributed_if_needed()
 
     # Sort parameters into linear (Muon-managed) vs nonlinear (Adam-managed).
     linear_params: List[torch.nn.Parameter] = []
@@ -779,40 +788,31 @@ def _build_megatron_fsdp_emerging_optimizer(
         for _, param in model_chunk.named_parameters():
             if not param.requires_grad:
                 continue
-            if (
-                not getattr(param, "is_embedding_or_output_parameter", False)
-                and len(param.shape) == 2
-            ):
-                linear_params.append(param)
-            else:
+            if _is_nonlinear_or_embedding(param):
                 nonlinear_params.append(param)
+            else:
+                linear_params.append(param)
 
     # Build the Muon optimizer for linear params.
-
     for p in nonlinear_params:
         p.requires_grad = False
     linear_param_groups = _get_param_groups(model_chunks, config, config_overrides)
 
+    # Distinguish expert and non-expert parameter groups.
     expert_param_groups: List[Dict[str, Any]] = []
-    if not use_layer_wise:
-        # Build a fresh list rather than calling `linear_param_groups.remove(group)`:
-        # `list.remove` falls back to `dict.__eq__` when the elements are dicts,
-        # which compares values and trips on tensor params with
-        # `RuntimeError: Boolean value of Tensor with more than one value is ambiguous`.
-        non_expert_groups: List[Dict[str, Any]] = []
-        for group in linear_param_groups:
-            if group["is_expert_parallel"]:
-                expert_param_groups.append(group)
-            else:
-                non_expert_groups.append(group)
-        linear_param_groups = non_expert_groups
+    non_expert_groups: List[Dict[str, Any]] = []
+    for group in linear_param_groups:
+        if group["is_expert_parallel"]:
+            expert_param_groups.append(group)
+        else:
+            non_expert_groups.append(group)
+    linear_param_groups = non_expert_groups
 
     eopt_kwargs: Dict[str, Any] = {}
     if entry.config_to_kwargs is not None:
         eopt_kwargs = entry.config_to_kwargs(config, model_chunks, pg_collection)
 
     optimizers: List[Any] = []
-    init_fns: List[Callable] = []
     if linear_param_groups:
         # ZeRO-1/2/3: split dense boundary params are sharded over `dp_cp`, so
         # the FSDPZero variant must gather over the same group.
@@ -820,11 +820,21 @@ def _build_megatron_fsdp_emerging_optimizer(
         if use_fsdp_zero_muon:
             dense_kwargs["dp_group"] = pg_collection.dp_cp
         muon_base = optimizer_cls(linear_param_groups, **dense_kwargs)
-        muon_opt = FP32Optimizer(muon_base, config, init_state_fn)
+        muon_opt = DistributedOptimizer(
+            muon_base,
+            config,
+            None,  # grad_scaler: None for bf16, Muon carries no loss scale
+            init_state_fn,
+            model_chunks=model_chunks,
+            per_model_buffers={},
+            data_parallel_group=pg_collection.dp_cp,
+            data_parallel_group_gloo=None,
+            data_parallel_group_idx=get_pg_rank(pg_collection.mp),
+            distributed_optimizer_instance_id=0,
+        )
         setattr(muon_opt, "grad_stats_parallel_group", pg_collection.mp)
         setattr(muon_opt, "tp_group", pg_collection.tp)
         optimizers.append(muon_opt)
-        init_fns.append(init_state_fn)
 
     if expert_param_groups:
         # Expert params reduce-scatter over `expt_dp` (the expert
@@ -833,19 +843,28 @@ def _build_megatron_fsdp_emerging_optimizer(
         if use_fsdp_zero_muon:
             expert_kwargs["dp_group"] = pg_collection.expt_dp
         expert_muon_base = optimizer_cls(expert_param_groups, **expert_kwargs)
-        expert_muon_opt = FP32Optimizer(expert_muon_base, config, init_state_fn)
+        expert_muon_opt = DistributedOptimizer(
+            expert_muon_base,
+            config,
+            None,  # grad_scaler: None for bf16
+            init_state_fn,
+            model_chunks=model_chunks,
+            per_model_buffers={},
+            data_parallel_group=pg_collection.expt_dp,
+            data_parallel_group_gloo=None,
+            data_parallel_group_idx=get_pg_rank(pg_collection.tp_ep_pp),
+            distributed_optimizer_instance_id=0,
+        )
         setattr(expert_muon_opt, "grad_stats_parallel_group", pg_collection.tp_ep_pp)
         setattr(expert_muon_opt, "tp_group", pg_collection.tp)
         optimizers.append(expert_muon_opt)
-        init_fns.append(init_state_fn)
 
     # Build Adam for non-linear params via the standard FSDP path.
-
     for p in nonlinear_params:
         p.requires_grad = True
     for p in linear_params:
         p.requires_grad = False
-
+    # DRY-reuse get_megatron_optimizer to build (Fused)Adam.
     saved_optimizer = config.optimizer
     saved_use_lwd = config.use_layer_wise_distributed_optimizer
     config.optimizer = "adam"
@@ -871,41 +890,7 @@ def _build_megatron_fsdp_emerging_optimizer(
     adam_optimizers = list(getattr(chained_adam, "chained_optimizers", [chained_adam]))
     optimizers += adam_optimizers
 
-    def _adam_init_state_fn(opt: Any, config: Any = None) -> None:
-        for group in opt.param_groups:
-            for p in group["params"]:
-                if len(opt.state[p]) == 0:
-                    if config is None or not config.use_precision_aware_optimizer:
-                        opt.state[p]["exp_avg"] = torch.zeros_like(p.data)
-                        opt.state[p]["exp_avg_sq"] = torch.zeros_like(p.data)
-                    else:
-                        opt.initialize_state(p)
-
-    init_fns += [_adam_init_state_fn] * len(adam_optimizers)
-
-    # Combine and wrap with the FSDP-protocol adapter.
-
-    if use_layer_wise:
-        # Float16OptimizerWithFloat16Params is incompatible with FSDP DTensor
-        # params (no .main_grad), so temporarily clear bf16 to prevent the
-        # LayerWiseDistributedOptimizer from re-wrapping each sub-optimizer.
-        log_single_rank(
-            logger,
-            logging.INFO,
-            f"Using LayerWiseDistributedOptimizer for {eopt_name} + Megatron-FSDP",
-        )
-        saved_bf16 = config.bf16
-        config.bf16 = False
-        try:
-            inner: Any = LayerWiseDistributedOptimizer(
-                optimizers, config, pg_collection, init_state_fn_list=init_fns
-            )
-        finally:
-            config.bf16 = saved_bf16
-    else:
-        inner = ChainedOptimizer(optimizers)
-
-    return FSDPMuonChainedOptimizer(inner, _get_mfsdp_models(model_chunks))
+    return ChainedOptimizer(optimizers)
 
 
 def _get_megatron_emerging_optimizer(
@@ -965,20 +950,20 @@ def _get_megatron_emerging_optimizer(
             if 'linear_qkv.weight' in name and len(param.shape) == 2:
                 param.is_qkv = True
 
-    # Megatron-FSDP needs a separate code path: gradients are attached via
-    # `finish_grad_sync()` rather than via `main_grad` buffers, so the
-    # standard Float16OptimizerWithFloat16Params wrapper is incompatible.
-    # In addition, the resulting optimizer must be wrapped to invoke FSDP's
-    # `finish_grad_sync()` / `install_optimized_model_weights()` hooks
-    # around each step.
     if getattr(model_chunks[0].ddp_config, 'use_megatron_fsdp', False):
+        if use_layer_wise:
+            log_single_rank(
+                logger,
+                logging.WARNING,
+                f"use_layer_wise_distributed_optimizer is ignored for {eopt_name} + Megatron-FSDP: "
+                f"parameter sharding is already built into M-FSDP's DTensor layout.",
+            )
         return _build_megatron_fsdp_emerging_optimizer(
             config=config,
             model_chunks=model_chunks,
             config_overrides=config_overrides,
             pg_collection=pg_collection,
             eopt_name=eopt_name,
-            use_layer_wise=use_layer_wise,
         )
 
     # Apply optimizer-specific default param overrides (e.g., muon: non-linear -> adam).

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -820,6 +820,9 @@ def _build_megatron_fsdp_emerging_optimizer(
         dense_kwargs = dict(eopt_kwargs)
         if use_fsdp_zero_muon:
             dense_kwargs["dp_group"] = pg_collection.dp_cp
+            dense_kwargs["fsdp_batched_all_gather"] = getattr(
+                config, "muon_fsdp_batched_all_gather", False
+            )
         muon_base = optimizer_cls(linear_param_groups, **dense_kwargs)
         muon_opt = DistributedOptimizer(
             muon_base,
@@ -843,6 +846,9 @@ def _build_megatron_fsdp_emerging_optimizer(
         expert_kwargs = dict(eopt_kwargs)
         if use_fsdp_zero_muon:
             expert_kwargs["dp_group"] = pg_collection.expt_dp
+            expert_kwargs["fsdp_batched_all_gather"] = getattr(
+                config, "muon_fsdp_batched_all_gather", False
+            )
         expert_muon_base = optimizer_cls(expert_param_groups, **expert_kwargs)
         expert_muon_opt = DistributedOptimizer(
             expert_muon_base,

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -821,7 +821,7 @@ def _build_megatron_fsdp_emerging_optimizer(
         if use_fsdp_zero_muon:
             dense_kwargs["dp_group"] = pg_collection.dp_cp
             dense_kwargs["fsdp_batched_all_gather"] = getattr(
-                config, "muon_fsdp_batched_all_gather", False
+                config, "muon_fsdp_batched_all_gather", True
             )
         muon_base = optimizer_cls(linear_param_groups, **dense_kwargs)
         muon_opt = DistributedOptimizer(
@@ -847,7 +847,7 @@ def _build_megatron_fsdp_emerging_optimizer(
         if use_fsdp_zero_muon:
             expert_kwargs["dp_group"] = pg_collection.expt_dp
             expert_kwargs["fsdp_batched_all_gather"] = getattr(
-                config, "muon_fsdp_batched_all_gather", False
+                config, "muon_fsdp_batched_all_gather", True
             )
         expert_muon_base = optimizer_cls(expert_param_groups, **expert_kwargs)
         expert_muon_opt = DistributedOptimizer(

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -742,6 +742,7 @@ def _get_muon_fsdp_kwargs(config: OptimizerConfig) -> dict[str, Any]:
     """Map Muon+M-FSDP optimizer config fields to FSDPTensorParallelMuon kwargs."""
     return {
         "fsdp_batched_all_gather": getattr(config, "muon_fsdp_batched_all_gather", False),
+        "fsdp_flat_batched_all_gather": getattr(config, "muon_fsdp_flat_batched_all_gather", False),
         "fsdp_reuse_gather_scratch": getattr(config, "muon_fsdp_reuse_gather_scratch", False),
         "fsdp_padded_all_gather": getattr(config, "muon_fsdp_padded_all_gather", False),
         "fsdp_padded_all_gather_pad_factor": getattr(

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -738,6 +738,25 @@ def _get_mfsdp_models(model_chunks):
     return mfsdp_models
 
 
+def _get_muon_fsdp_kwargs(config: OptimizerConfig) -> dict[str, Any]:
+    """Map Muon+M-FSDP optimizer config fields to FSDPTensorParallelMuon kwargs."""
+    return {
+        "fsdp_batched_all_gather": getattr(config, "muon_fsdp_batched_all_gather", False),
+        "fsdp_reuse_gather_scratch": getattr(config, "muon_fsdp_reuse_gather_scratch", False),
+        "fsdp_padded_all_gather": getattr(config, "muon_fsdp_padded_all_gather", False),
+        "fsdp_padded_all_gather_pad_factor": getattr(
+            config, "muon_fsdp_padded_all_gather_pad_factor", 1.25
+        ),
+        "fsdp_batch_max_gather_bytes": getattr(
+            config, "muon_fsdp_batch_max_gather_bytes", 1024 * 1024 * 1024
+        ),
+        "fsdp_padded_all_gather_zero_pad": getattr(
+            config, "muon_fsdp_padded_all_gather_zero_pad", True
+        ),
+        "fsdp_fast_reconstruct": getattr(config, "muon_fsdp_fast_reconstruct", True),
+    }
+
+
 def _build_megatron_fsdp_emerging_optimizer(
     config: OptimizerConfig,
     model_chunks: List[MegatronModule],
@@ -820,9 +839,7 @@ def _build_megatron_fsdp_emerging_optimizer(
         dense_kwargs = dict(eopt_kwargs)
         if use_fsdp_zero_muon:
             dense_kwargs["dp_group"] = pg_collection.dp_cp
-            dense_kwargs["fsdp_batched_all_gather"] = getattr(
-                config, "muon_fsdp_batched_all_gather", True
-            )
+            dense_kwargs.update(_get_muon_fsdp_kwargs(config))
         muon_base = optimizer_cls(linear_param_groups, **dense_kwargs)
         muon_opt = DistributedOptimizer(
             muon_base,
@@ -846,9 +863,7 @@ def _build_megatron_fsdp_emerging_optimizer(
         expert_kwargs = dict(eopt_kwargs)
         if use_fsdp_zero_muon:
             expert_kwargs["dp_group"] = pg_collection.expt_dp
-            expert_kwargs["fsdp_batched_all_gather"] = getattr(
-                config, "muon_fsdp_batched_all_gather", True
-            )
+            expert_kwargs.update(_get_muon_fsdp_kwargs(config))
         expert_muon_base = optimizer_cls(expert_param_groups, **expert_kwargs)
         expert_muon_opt = DistributedOptimizer(
             expert_muon_base,

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -754,6 +754,7 @@ def _get_muon_fsdp_kwargs(config: OptimizerConfig) -> dict[str, Any]:
             config, "muon_fsdp_padded_all_gather_zero_pad", True
         ),
         "fsdp_fast_reconstruct": getattr(config, "muon_fsdp_fast_reconstruct", True),
+        "fsdp_overlap_comm_compute": getattr(config, "muon_fsdp_overlap_comm_compute", False),
     }
 
 

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -49,7 +49,12 @@ except ImportError:
 
 from ..tensor_parallel import param_is_not_tensor_parallel_duplicate
 from ..transformer.module import param_is_not_shared
-from ..utils import get_data_parallel_group_if_dtensor, to_local_if_dtensor
+from ..utils import (
+    append_unique_process_group,
+    contains_process_group,
+    get_dtensor_data_parallel_shard_groups,
+    to_local_if_dtensor,
+)
 
 
 def get_grad_norm_fp32(
@@ -59,18 +64,18 @@ def get_grad_norm_fp32(
 ) -> float:
     """Calculate the p-norm of gradients in FP32 precision.
 
-    This function is adapted from `torch.nn.utils.clip_grad.clip_grad_norm_` 
-    and extends it with functionality to handle model-parallel parameters. 
-    It ensures that the norm is correctly computed and reduced across 
-    the specified process group (typically the model-parallel group for 
+    This function is adapted from `torch.nn.utils.clip_grad.clip_grad_norm_`
+    and extends it with functionality to handle model-parallel parameters.
+    It ensures that the norm is correctly computed and reduced across
+    the specified process group (typically the model-parallel group for
     non-distributed optimizers or the entire world for distributed optimizers).
 
     Args:
-        grads_for_norm (Union[List[torch.Tensor], torch.Tensor]): An iterable 
+        grads_for_norm (Union[List[torch.Tensor], torch.Tensor]): An iterable
             of Tensors or a single Tensor used to calculate the gradient norm.
-        norm_type (Union[int, float]): The type of the p-norm to use. Can be 
+        norm_type (Union[int, float]): The type of the p-norm to use. Can be
             'inf' for infinity norm. Defaults to 2.
-        grad_stats_parallel_group (ProcessGroup, optional): The process group 
+        grad_stats_parallel_group (ProcessGroup, optional): The process group
             used for reducing gradient statistics (e.g., norms and zero counts).
 
     Returns:
@@ -80,9 +85,10 @@ def get_grad_norm_fp32(
     if isinstance(grads_for_norm, torch.Tensor):
         grads_for_norm = [grads_for_norm]
 
-    data_parallel_group = None
+    data_parallel_groups = []
     for grad in grads_for_norm:
-        data_parallel_group = get_data_parallel_group_if_dtensor(grad, data_parallel_group)
+        for group in get_dtensor_data_parallel_shard_groups(grad):
+            append_unique_process_group(data_parallel_groups, group)
 
     grads_for_norm = [to_local_if_dtensor(grad) for grad in grads_for_norm]
 
@@ -94,14 +100,16 @@ def get_grad_norm_fp32(
     if norm_type == inf:
         total_norm = max(grad.abs().max() for grad in grads_for_norm)
         total_norm_cuda = torch.tensor([float(total_norm)], dtype=torch.float, device='cuda')
-        # Take max across all data-parallel GPUs if using FSDP and then all model-parallel GPUs.
-        if data_parallel_group:
+        # Take max across all data-parallel shard groups if using FSDP and then all
+        # model-parallel GPUs.
+        for data_parallel_group in data_parallel_groups:
             torch.distributed.all_reduce(
                 total_norm_cuda, op=torch.distributed.ReduceOp.MAX, group=data_parallel_group
             )
-        torch.distributed.all_reduce(
-            total_norm_cuda, op=torch.distributed.ReduceOp.MAX, group=grad_stats_parallel_group
-        )
+        if not contains_process_group(data_parallel_groups, grad_stats_parallel_group):
+            torch.distributed.all_reduce(
+                total_norm_cuda, op=torch.distributed.ReduceOp.MAX, group=grad_stats_parallel_group
+            )
         total_norm = total_norm_cuda[0].item()
 
     else:
@@ -128,14 +136,16 @@ def get_grad_norm_fp32(
                 grad_norm = torch.norm(grad, norm_type)
                 total_norm += grad_norm**norm_type
 
-        # Sum across all data-parallel GPUs if using FSDP and then all model-parallel GPUs.
-        if data_parallel_group:
+        # Sum across all data-parallel shard groups if using FSDP and then all
+        # model-parallel GPUs.
+        for data_parallel_group in data_parallel_groups:
             torch.distributed.all_reduce(
                 total_norm, op=torch.distributed.ReduceOp.SUM, group=data_parallel_group
             )
-        torch.distributed.all_reduce(
-            total_norm, op=torch.distributed.ReduceOp.SUM, group=grad_stats_parallel_group
-        )
+        if not contains_process_group(data_parallel_groups, grad_stats_parallel_group):
+            torch.distributed.all_reduce(
+                total_norm, op=torch.distributed.ReduceOp.SUM, group=grad_stats_parallel_group
+            )
         if multi_tensor_scale_tensor_impl is not None:
             total_norm = total_norm.pow(1.0 / norm_type)
         else:
@@ -155,13 +165,13 @@ def clip_grad_by_total_norm_fp32(
     Note that the gradients are modified in-place.
 
     Args:
-        parameters (Union[List[torch.Tensor], torch.Tensor]): An iterable of 
+        parameters (Union[List[torch.Tensor], torch.Tensor]): An iterable of
             Tensors or a single Tensor that will have gradients normalized.
-        max_norm (Union[int, float]): The maximum permissible total norm 
+        max_norm (Union[int, float]): The maximum permissible total norm
             of the gradients.
         total_norm (float): The current total norm of the gradients.
-        use_decoupled_grad (bool, optional): Whether to read from the 
-            '.decoupled_grad' attribute instead of the standard '.grad'. 
+        use_decoupled_grad (bool, optional): Whether to read from the
+            '.decoupled_grad' attribute instead of the standard '.grad'.
             Defaults to False.
     """
     # Grads.
@@ -204,19 +214,19 @@ def count_zeros_fp32(
 ) -> float:
     """Counts the number of zero values in the gradients of the given parameters.
 
-    The count is performed in FP32. This method filters parameters to ensure 
-    gradients are not double-counted by checking if the gradient is not None, 
-    the parameter is not shared, and the parameter is not a replica due 
-    to tensor model parallelism. It also handles parameters managed by 
+    The count is performed in FP32. This method filters parameters to ensure
+    gradients are not double-counted by checking if the gradient is not None,
+    the parameter is not shared, and the parameter is not a replica due
+    to tensor model parallelism. It also handles parameters managed by
     Megatron FSDP specifically.
 
     Args:
-        parameters (Union[List[torch.Tensor], torch.Tensor]): An iterable of 
+        parameters (Union[List[torch.Tensor], torch.Tensor]): An iterable of
             Tensors or a single Tensor whose gradients will be checked for zeros.
-        grad_stats_parallel_group (ProcessGroup): The process group used for 
+        grad_stats_parallel_group (ProcessGroup): The process group used for
             reducing the zero count across distributed ranks.
-        use_decoupled_grad (bool, optional): If True, reads from the 
-            '.decoupled_grad' attribute instead of the standard '.grad'. 
+        use_decoupled_grad (bool, optional): If True, reads from the
+            '.decoupled_grad' attribute instead of the standard '.grad'.
             Defaults to False.
 
     Returns:
@@ -231,43 +241,30 @@ def count_zeros_fp32(
     #   - parameter should not be shared
     #   - should not be a replica due to tensor model parallelism
     total_num_zeros = torch.zeros(1, dtype=torch.int64, device='cuda')
-    data_parallel_group = None
-    use_megatron_fsdp = False
+    data_parallel_groups = []
     for param in parameters:
-        if getattr(param, "__fsdp_param__", False) and param.grad is not None:
-            # If the parameter is managed by Megatron FSDP, we need to handle it differently.
-            use_megatron_fsdp = True
-            grad = param.grad._local_tensor
-            num_zeros = grad.numel() - torch.count_nonzero(grad)
-            total_num_zeros += num_zeros
-            continue
-
         grad_attr = "decoupled_grad" if use_decoupled_grad else "grad"
         grad_not_none = hasattr(param, grad_attr) and getattr(param, grad_attr) is not None
         is_not_shared = param_is_not_shared(param)
         is_not_tp_duplicate = param_is_not_tensor_parallel_duplicate(param, tp_group=tp_group)
         if grad_not_none and is_not_shared and is_not_tp_duplicate:
             grad_obj = getattr(param, grad_attr)
-            data_parallel_group = get_data_parallel_group_if_dtensor(grad_obj, data_parallel_group)
+            for group in get_dtensor_data_parallel_shard_groups(grad_obj):
+                append_unique_process_group(data_parallel_groups, group)
             grad = to_local_if_dtensor(grad_obj).detach()
             num_zeros = grad.numel() - torch.count_nonzero(grad)
             total_num_zeros = num_zeros + total_num_zeros
 
-    if use_megatron_fsdp and data_parallel_group is not None:
-        raise ValueError(
-            "Unexpected use of Megatron FSDP with data parallel group. "
-            "Please ensure that the parameters are properly managed by Megatron FSDP."
-        )
-
-    # Sum across all data-parallel GPUs if using FSDP.
-    if data_parallel_group:
+    # Sum across all data-parallel shard groups if using FSDP.
+    for data_parallel_group in data_parallel_groups:
         torch.distributed.all_reduce(
             total_num_zeros, op=torch.distributed.ReduceOp.SUM, group=data_parallel_group
         )
     # Sum across all model-parallel GPUs.
-    torch.distributed.all_reduce(
-        total_num_zeros, op=torch.distributed.ReduceOp.SUM, group=grad_stats_parallel_group
-    )
+    if not contains_process_group(data_parallel_groups, grad_stats_parallel_group):
+        torch.distributed.all_reduce(
+            total_num_zeros, op=torch.distributed.ReduceOp.SUM, group=grad_stats_parallel_group
+        )
 
     total_num_zeros = total_num_zeros.item()
 

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -20,20 +20,21 @@ from ..dist_checkpointing.optimizer import KEEP_VARS_HINT
 HAVE_APEX_OR_TE = True
 USING_TE_OPTIMIZER = False
 USING_APEX_OPTIMIZER = False
+# pylint: disable=unused-import
 try:
-    # pylint: disable=unused-import
     from transformer_engine.pytorch.optimizers import FusedAdam as Adam
 
     USING_TE_OPTIMIZER = True
 except ImportError:
     try:
-        from apex.optimizers import FusedAdam as Adam  # pylint: disable=unused-import
+        from apex.optimizers import FusedAdam as Adam
 
         USING_APEX_OPTIMIZER = True
     except ImportError:
-        from torch.optim import Adam as Adam  # pylint: disable=unused-import
+        from torch.optim import Adam as Adam
 
         HAVE_APEX_OR_TE = False
+# pylint: enable=unused-import
 
 from megatron.core.optimizer.cpu_offloading import HybridDeviceOptimizer
 

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -2713,7 +2713,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             # Update Megatron-FSDP's compute weights with optimized main weights.
             # If using quantized parameters, this will also perform quantization.
             for model_chunk in self.model_chunks:
-                model_chunk.param_and_grad_buffer.copy_main_weights_to_model_weights()
+                model_chunk.install_optimized_model_weights()
             return
 
         # When using precision-aware optimizer, main params are held by self.optimizer. It will also
@@ -2976,31 +2976,34 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         copy_group_params(self.model_fp32_groups, self.shard_fp32_groups)
 
     @torch.no_grad()
-    def step_with_ready_grads(self) -> bool:
+    def step_with_ready_grads(self, update_model_params: bool = True) -> bool:
         """Step the optimizer with ready gradients, return successful.
         Under the hood, either launch synchronous param all-gathers or get ready to launch
         asynchorous all-gathers that get overlapped with the next forward pass.
         """
-        update_successful = super().step_with_ready_grads()
+        update_successful = super().step_with_ready_grads(update_model_params=update_model_params)
 
-        timers = self.config.timers
-        if timers is not None:
-            timers('params-all-gather', log_level=1).start(barrier=self.config.barrier_with_L1_time)
+        if update_model_params:
+            timers = self.config.timers
+            if timers is not None:
+                timers('params-all-gather', log_level=1).start(
+                    barrier=self.config.barrier_with_L1_time
+                )
 
-        if self.ddp_config.use_megatron_fsdp:
-            # Optionally all-gather Megatron-FSDP sharded main weights
-            # early in preparation for the subsequent forward pass.
-            for model_chunk in self.model_chunks:
-                model_chunk.start_param_sync()
-        else:
-            # If not overlapping all-gather for parameters, launch synchronous all-gather
-            # communication calls here. If overlapping all-gather for parameters, the following
-            # the first all-gather is launched asynchronously in the next optimizer.zero_grad()
-            # call and subsequent all-gathers are launched in the forward pre-hook.
-            if not self.ddp_config.overlap_param_gather:
+            if self.ddp_config.use_megatron_fsdp:
+                # Optionally all-gather Megatron-FSDP sharded main weights
+                # early in preparation for the subsequent forward pass.
                 for model_chunk in self.model_chunks:
                     model_chunk.start_param_sync()
-        if timers is not None:
-            timers('params-all-gather').stop()
+            else:
+                # If not overlapping all-gather for parameters, launch synchronous all-gather
+                # communication calls here. If overlapping all-gather for parameters, the following
+                # the first all-gather is launched asynchronously in the next optimizer.zero_grad()
+                # call and subsequent all-gathers are launched in the forward pre-hook.
+                if not self.ddp_config.overlap_param_gather:
+                    for model_chunk in self.model_chunks:
+                        model_chunk.start_param_sync()
+            if timers is not None:
+                timers('params-all-gather').stop()
 
         return update_successful

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -21,16 +21,17 @@ HAVE_APEX_OR_TE = True
 USING_TE_OPTIMIZER = False
 USING_APEX_OPTIMIZER = False
 try:
+    # pylint: disable=unused-import
     from transformer_engine.pytorch.optimizers import FusedAdam as Adam
 
     USING_TE_OPTIMIZER = True
 except ImportError:
     try:
-        from apex.optimizers import FusedAdam as Adam
+        from apex.optimizers import FusedAdam as Adam  # pylint: disable=unused-import
 
         USING_APEX_OPTIMIZER = True
     except ImportError:
-        from torch.optim import Adam as Adam
+        from torch.optim import Adam as Adam  # pylint: disable=unused-import
 
         HAVE_APEX_OR_TE = False
 
@@ -660,14 +661,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         for model_chunk in self.model_chunks:
             assert self.ddp_config == model_chunk.ddp_config
         self.distributed_optimizer_instance_id = distributed_optimizer_instance_id
-
-        assert (
-            isinstance(optimizer, (Adam, torch.optim.AdamW, HybridDeviceOptimizer))
-            or optimizer is None
-        ), (
-            "Only Adam and HybridDeviceOptimizer currently supported, "
-            "due to checkpointing requirements."
-        )
 
         # when freezing sub-models we have no real optimizer
         # but still need a stub DistributedOptimizer class

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -147,6 +147,67 @@ _EMERGING_OPTIMIZERS: Dict[str, EmergingOptimizerEntry] = {}
 
 
 # ===========================================================================
+# Megatron-FSDP integration
+# ===========================================================================
+
+
+def _get_mfsdp_models(model_chunks):
+    """Extract list of MegatronFSDP instances from FSDP-wrapped model chunks."""
+    mfsdp_models = []
+    for chunk in model_chunks:
+        # FullyShardedDataParallel delegates finish_grad_sync / start_param_sync
+        # from its .module (MegatronFSDP). install_optimized_model_weights lives
+        # directly on MegatronFSDP, so we need the inner module reference.
+        if hasattr(chunk, "finish_grad_sync") and hasattr(chunk, "module"):
+            mfsdp_models.append(chunk.module)
+    if not mfsdp_models:
+        raise RuntimeError(
+            "Could not find any MegatronFSDP instances in model_chunks. "
+            "Ensure the model is wrapped with FullyShardedDataParallel."
+        )
+    return mfsdp_models
+
+
+class FSDPMuonChainedOptimizer:
+    """Thin FSDP-protocol adapter wrapping a Muon-based MegatronOptimizer.
+
+    Injects the MegatronFSDP step contract around the inner optimizer:
+      1. `finish_grad_sync()` – waits for async grad sync, attaches grads
+         (allreduces for `no_shard`; reduce-scatters for ZeRO-1/2/3).
+      2. `inner_optimizer.step()` – Muon NS + weight update + Adam.
+      3. `install_optimized_model_weights()` – copies fp32 main weights
+         back into the model's bf16 (sharded for ZeRO-3) buffer.
+
+    All other attribute accesses are delegated to the inner optimizer via
+    `__getattr__`, making this class transparent to the training loop.
+    """
+
+    def __init__(self, inner: Any, mfsdp_models: list) -> None:
+        # Use object.__setattr__ to avoid triggering our own __getattr__ during init.
+        object.__setattr__(self, "inner", inner)
+        object.__setattr__(self, "_mfsdp_models", mfsdp_models)
+
+    @torch.no_grad()  # type: ignore[misc]
+    def step(self) -> Any:
+        """FSDP-aware optimizer step: sync grads -> inner step -> install weights."""
+        for mfsdp in self._mfsdp_models:
+            if not mfsdp.model_auto_sync:
+                mfsdp.finish_grad_sync()
+        result = self.inner.step()
+        for mfsdp in self._mfsdp_models:
+            mfsdp.install_optimized_model_weights()
+        return result
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        """Zero optimizer gradients. FSDP grad buffer is zeroed by the training loop."""
+        self.inner.zero_grad(set_to_none)
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate all other attribute accesses to the inner optimizer."""
+        return getattr(object.__getattribute__(self, "inner"), name)
+
+
+# ===========================================================================
 # Muon
 # ===========================================================================
 

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -984,6 +984,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                         sum(chunk_info["numel"] for chunk_info in chunks_info)
                         for chunks_info in stage_chunks_info
                     ],
+                    "rank_chunk_counts": [len(chunks_info) for chunks_info in stage_chunks_info],
                 }
             )
             local_chunks_info = [
@@ -1017,16 +1018,19 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         if max_rank_numel == 0:
             raise AssertionError("Cannot padded-all-gather an empty uneven DTensor batch.")
 
-        padded_local_buffer = self._get_fsdp_gather_scratch_tensor(
-            ("padded_local_buffer", id(shard_group), local_buffer.dtype, local_buffer.device),
-            max_rank_numel,
-            dtype=local_buffer.dtype,
-            device=local_buffer.device,
-        )
-        if local_buffer.numel() > 0:
-            padded_local_buffer[: local_buffer.numel()].copy_(local_buffer)
-        if self.fsdp_padded_all_gather_zero_pad and local_buffer.numel() < max_rank_numel:
-            padded_local_buffer[local_buffer.numel() : max_rank_numel].zero_()
+        if local_buffer.numel() == max_rank_numel:
+            padded_local_buffer = local_buffer
+        else:
+            padded_local_buffer = self._get_fsdp_gather_scratch_tensor(
+                ("padded_local_buffer", id(shard_group), local_buffer.dtype, local_buffer.device),
+                max_rank_numel,
+                dtype=local_buffer.dtype,
+                device=local_buffer.device,
+            )
+            if local_buffer.numel() > 0:
+                padded_local_buffer[: local_buffer.numel()].copy_(local_buffer)
+            if self.fsdp_padded_all_gather_zero_pad:
+                padded_local_buffer[local_buffer.numel() : max_rank_numel].zero_()
 
         gathered_padded_buffer = self._get_fsdp_gather_scratch_tensor(
             (
@@ -1055,6 +1059,24 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             gathered_padded_buffer, padded_local_buffer, group=shard_group
         )
         return gathered_padded_buffer, max_rank_numel
+
+    def _flatten_tensor_for_uneven_gather(self, tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.is_contiguous():
+            return tensor.view(-1)
+        return tensor.reshape(-1)
+
+    def _rank_buffers_from_pending_uneven_gather_stage(
+        self, pending_stage: dict[str, Any]
+    ) -> list[torch.Tensor]:
+        group_size = pending_stage["group_size"]
+        if pending_stage["use_padded_all_gather"]:
+            gathered_padded_buffer = pending_stage["gathered_padded_buffer"]
+            max_rank_numel = pending_stage["max_rank_numel"]
+            return [
+                gathered_padded_buffer[rank * max_rank_numel : (rank + 1) * max_rank_numel]
+                for rank in range(group_size)
+            ]
+        return pending_stage["group_tensors"]
 
     def _reconstruct_full_tensor_from_rank_buffers(
         self,
@@ -1140,6 +1162,89 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
         return full_tensor
 
+    def _reconstruct_full_tensor_from_final_stage_buffers(
+        self,
+        dtensor_ref,
+        plan: dict[str, Any],
+        stage_idx: int,
+        rank_buffers: list[torch.Tensor],
+        rank_buffer_offsets: list[int],
+    ) -> torch.Tensor:
+        if stage_idx != len(plan["stages"]) - 1:
+            raise AssertionError(
+                "Direct uneven DTensor reconstruction requires the final gather stage: "
+                f"got stage={stage_idx}, final={len(plan['stages']) - 1}."
+            )
+
+        stage = plan["stages"][stage_idx]
+        if len(rank_buffers) != len(stage["rank_numels"]):
+            raise AssertionError(
+                "Uneven DTensor reconstruction rank buffer count mismatch: "
+                f"got {len(rank_buffers)}, expected {len(stage['rank_numels'])}."
+            )
+
+        rank_chunk_counts = stage["rank_chunk_counts"]
+        if self.fsdp_fast_reconstruct and plan["is_contiguous_full_order"]:
+            chunks = []
+            assigned_numel = 0
+            for rank, rank_buffer in enumerate(rank_buffers):
+                rank_numel = stage["rank_numels"][rank]
+                if rank_numel == 0:
+                    continue
+                source_offset = rank_buffer_offsets[rank]
+                chunks.append(rank_buffer[source_offset : source_offset + rank_numel])
+                assigned_numel += rank_numel
+            if assigned_numel != plan["full_numel"]:
+                raise AssertionError(
+                    "Fast batched uneven DTensor reconstruction did not cover the full tensor: "
+                    f"assigned={assigned_numel}, expected={plan['full_numel']}."
+                )
+            if assigned_numel == 0:
+                return torch.empty(
+                    dtensor_ref.shape, dtype=rank_buffers[0].dtype, device=rank_buffers[0].device
+                )
+            if len(chunks) == 1:
+                full_flat = chunks[0].clone()
+            else:
+                full_flat = torch.cat(chunks)
+            return full_flat.view(dtensor_ref.shape)
+
+        full_tensor = torch.empty(
+            dtensor_ref.shape, dtype=rank_buffers[0].dtype, device=rank_buffers[0].device
+        )
+        assigned_numel = 0
+        chunk_info_idx = 0
+        for rank, rank_buffer in enumerate(rank_buffers):
+            source_offset = rank_buffer_offsets[rank]
+            expected_source_end = source_offset + stage["rank_numels"][rank]
+            for _ in range(rank_chunk_counts[rank]):
+                chunk_info = plan["chunk_infos"][chunk_info_idx]
+                chunk_info_idx += 1
+                chunk_shape = chunk_info["shape"]
+                chunk_numel = chunk_info["numel"]
+                if chunk_numel == 0:
+                    continue
+                gathered_tensor = rank_buffer[source_offset : source_offset + chunk_numel]
+                source_offset += chunk_numel
+                offset = chunk_info["offset"]
+                slices = tuple(slice(o, o + s) for o, s in zip(offset, chunk_shape))
+                full_tensor[slices] = gathered_tensor.view(chunk_shape)
+                assigned_numel += chunk_numel
+            if source_offset != expected_source_end:
+                raise AssertionError(
+                    "Batched uneven DTensor reconstruction consumed an unexpected rank size: "
+                    f"rank={rank}, consumed={source_offset - rank_buffer_offsets[rank]}, "
+                    f"expected={stage['rank_numels'][rank]}."
+                )
+
+        if chunk_info_idx != len(plan["chunk_infos"]):
+            raise AssertionError(
+                "Batched uneven DTensor reconstruction consumed an unexpected chunk count: "
+                f"consumed={chunk_info_idx}, expected={len(plan['chunk_infos'])}."
+            )
+        _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
+        return full_tensor
+
     def _gather_full_uneven_local_tensor_like(
         self, dtensor_ref, local_tensor: torch.Tensor
     ) -> torch.Tensor | None:
@@ -1158,7 +1263,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             self._copy_dtensor_chunk_metadata(dtensor_ref, local_dtensor)
             return None if local_tensor.numel() == 0 else full_tensor
 
-        local_buffer = local_tensor.contiguous().view(-1)
+        local_buffer = self._flatten_tensor_for_uneven_gather(local_tensor)
         if len(plan["stages"]) == 1:
             stage = plan["stages"][0]
             shard_group = stage["shard_group"]
@@ -1291,16 +1396,23 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
     ) -> None:
         item_indices = batch["item_indices"]
         plans = batch["plans"]
-        current_buffers = [items[item_idx][1].contiguous().view(-1) for item_idx in item_indices]
+        current_buffers = [
+            self._flatten_tensor_for_uneven_gather(items[item_idx][1]) for item_idx in item_indices
+        ]
+        final_stage_idx = len(plans[0]["stages"]) - 1
 
         for stage_idx, stage in enumerate(plans[0]["stages"]):
             stage_state = self._prepare_uneven_gather_stage(
                 current_buffers, plans, batch, stage_idx, stage
             )
             pending_stage = self._start_uneven_gather_stage(stage_state, async_op=False)
+            if stage_idx == final_stage_idx:
+                self._wait_uneven_gather_stage(pending_stage)
+                self._store_uneven_gather_batch_results_from_stage(
+                    items, results, batch, pending_stage
+                )
+                return
             current_buffers = self._finish_uneven_gather_stage(pending_stage)
-
-        self._store_uneven_gather_batch_results(items, results, batch, current_buffers)
 
     def _prepare_uneven_gather_stage(
         self,
@@ -1318,29 +1430,39 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             plan["stages"][stage_idx]["rank_numels"][group_rank] for plan in plans
         ]
         expected_local_numel = sum(expected_item_numels)
-        local_buffer = self._get_fsdp_gather_scratch_tensor(
-            ("batch_local_buffer", stage_idx, id(shard_group), batch["dtype"], batch["device"]),
-            expected_local_numel,
-            dtype=batch["dtype"],
-            device=batch["device"],
-        )
-        local_offset = 0
-        for buffer, expected_numel in zip(current_buffers, expected_item_numels):
-            if buffer.numel() != expected_numel:
+
+        if len(current_buffers) == 1:
+            local_buffer = current_buffers[0]
+            if local_buffer.numel() != expected_local_numel:
                 raise AssertionError(
                     "Batched uneven DTensor gather stage buffer size mismatch: "
-                    f"stage={stage_idx}, got {buffer.numel()}, expected {expected_numel}."
+                    f"stage={stage_idx}, got {local_buffer.numel()}, expected "
+                    f"{expected_local_numel}."
                 )
-            if expected_numel == 0:
-                continue
-            local_buffer[local_offset : local_offset + expected_numel].copy_(buffer)
-            local_offset += expected_numel
-
-        if local_offset != expected_local_numel:
-            raise AssertionError(
-                "Batched uneven DTensor gather local buffer size mismatch: "
-                f"stage={stage_idx}, packed {local_offset}, expected {expected_local_numel}."
+        else:
+            local_buffer = self._get_fsdp_gather_scratch_tensor(
+                ("batch_local_buffer", stage_idx, id(shard_group), batch["dtype"], batch["device"]),
+                expected_local_numel,
+                dtype=batch["dtype"],
+                device=batch["device"],
             )
+            local_offset = 0
+            for buffer, expected_numel in zip(current_buffers, expected_item_numels):
+                if buffer.numel() != expected_numel:
+                    raise AssertionError(
+                        "Batched uneven DTensor gather stage buffer size mismatch: "
+                        f"stage={stage_idx}, got {buffer.numel()}, expected {expected_numel}."
+                    )
+                if expected_numel == 0:
+                    continue
+                local_buffer[local_offset : local_offset + expected_numel].copy_(buffer)
+                local_offset += expected_numel
+
+            if local_offset != expected_local_numel:
+                raise AssertionError(
+                    "Batched uneven DTensor gather local buffer size mismatch: "
+                    f"stage={stage_idx}, packed {local_offset}, expected {expected_local_numel}."
+                )
 
         rank_offsets: list[list[int]] = []
         rank_total_numels: list[int] = []
@@ -1452,18 +1574,8 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         batch = pending_stage["batch"]
         plans = pending_stage["plans"]
         stage_idx = pending_stage["stage_idx"]
-        group_size = pending_stage["group_size"]
         rank_offsets = pending_stage["rank_offsets"]
-
-        if pending_stage["use_padded_all_gather"]:
-            gathered_padded_buffer = pending_stage["gathered_padded_buffer"]
-            max_rank_numel = pending_stage["max_rank_numel"]
-            rank_buffers = [
-                gathered_padded_buffer[rank * max_rank_numel : (rank + 1) * max_rank_numel]
-                for rank in range(group_size)
-            ]
-        else:
-            rank_buffers = pending_stage["group_tensors"]
+        rank_buffers = self._rank_buffers_from_pending_uneven_gather_stage(pending_stage)
 
         next_buffers = []
         for batch_item_idx, plan in enumerate(plans):
@@ -1533,15 +1645,45 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             )
         return item_indices
 
+    def _store_uneven_gather_batch_results_from_stage(
+        self,
+        items: list[tuple[torch.Tensor, torch.Tensor]],
+        results: list[torch.Tensor | None],
+        batch: dict[str, Any],
+        pending_stage: dict[str, Any],
+    ) -> list[int]:
+        item_indices = batch["item_indices"]
+        plans = batch["plans"]
+        stage_idx = pending_stage["stage_idx"]
+        rank_offsets = pending_stage["rank_offsets"]
+        rank_buffers = self._rank_buffers_from_pending_uneven_gather_stage(pending_stage)
+
+        for batch_item_idx, item_idx in enumerate(item_indices):
+            dtensor_ref, local_tensor = items[item_idx]
+            if local_tensor.numel() == 0:
+                results[item_idx] = None
+                continue
+
+            rank_buffer_offsets = [
+                rank_offsets[rank][batch_item_idx] for rank in range(pending_stage["group_size"])
+            ]
+            results[item_idx] = self._reconstruct_full_tensor_from_final_stage_buffers(
+                dtensor_ref, plans[batch_item_idx], stage_idx, rank_buffers, rank_buffer_offsets
+            )
+        return item_indices
+
     def _start_gather_full_uneven_local_tensor_batch_async(
         self, items: list[tuple[torch.Tensor, torch.Tensor]], batch: dict[str, Any]
     ) -> dict[str, Any]:
         item_indices = batch["item_indices"]
         plans = batch["plans"]
-        current_buffers = [items[item_idx][1].contiguous().view(-1) for item_idx in item_indices]
+        current_buffers = [
+            self._flatten_tensor_for_uneven_gather(items[item_idx][1]) for item_idx in item_indices
+        ]
 
         if batch["device"].type == "cuda" and len(plans[0]["stages"]) > 1:
             pending_stages = []
+            final_stage_idx = len(plans[0]["stages"]) - 1
             with torch.cuda.device(batch["device"]):
                 comm_stream = self._get_fsdp_comm_stream(batch["device"])
                 comm_stream.wait_stream(torch.cuda.current_stream())
@@ -1553,6 +1695,9 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                         pending_stage = self._issue_uneven_gather_stage(
                             stage_state, async_op=True, comm_stream=comm_stream
                         )
+                        if stage_idx == final_stage_idx:
+                            pending_stages.append(pending_stage)
+                            break
                         if not self._block_current_stream_on_uneven_gather_stage(pending_stage):
                             if stage_idx == 0:
                                 return {
@@ -1571,20 +1716,15 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             return {
                 "items": items,
                 "batch": batch,
-                "current_buffers": current_buffers,
-                "pending_stages": pending_stages,
+                "pending_stages": pending_stages[:-1],
+                "final_pending_stage": pending_stages[-1],
             }
 
         stage_state = self._prepare_uneven_gather_stage(
             current_buffers, plans, batch, 0, plans[0]["stages"][0]
         )
         pending_stage = self._start_uneven_gather_stage(stage_state, async_op=True)
-        return {
-            "items": items,
-            "batch": batch,
-            "current_buffers": current_buffers,
-            "pending_stage": pending_stage,
-        }
+        return {"items": items, "batch": batch, "pending_stage": pending_stage}
 
     def _finish_gather_full_uneven_local_tensor_batch_async(
         self, pending: dict[str, Any], results: list[torch.Tensor | None]
@@ -1592,11 +1732,20 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         items = pending["items"]
         batch = pending["batch"]
         plans = batch["plans"]
-        if "pending_stages" in pending:
+        if "final_pending_stage" in pending:
             for pending_stage in pending["pending_stages"]:
                 self._wait_uneven_gather_stage(pending_stage)
-            return self._store_uneven_gather_batch_results(
-                items, results, batch, pending["current_buffers"]
+            final_pending_stage = pending["final_pending_stage"]
+            self._wait_uneven_gather_stage(final_pending_stage)
+            return self._store_uneven_gather_batch_results_from_stage(
+                items, results, batch, final_pending_stage
+            )
+
+        final_stage_idx = len(plans[0]["stages"]) - 1
+        if final_stage_idx == 0:
+            self._wait_uneven_gather_stage(pending["pending_stage"])
+            return self._store_uneven_gather_batch_results_from_stage(
+                items, results, batch, pending["pending_stage"]
             )
 
         current_buffers = self._finish_uneven_gather_stage(pending["pending_stage"])
@@ -1606,9 +1755,14 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 current_buffers, plans, batch, stage_idx, plans[0]["stages"][stage_idx]
             )
             pending_stage = self._start_uneven_gather_stage(stage_state, async_op=False)
+            if stage_idx == final_stage_idx:
+                self._wait_uneven_gather_stage(pending_stage)
+                return self._store_uneven_gather_batch_results_from_stage(
+                    items, results, batch, pending_stage
+                )
             current_buffers = self._finish_uneven_gather_stage(pending_stage)
 
-        return self._store_uneven_gather_batch_results(items, results, batch, current_buffers)
+        raise AssertionError("Batched uneven DTensor gather did not reach its final stage.")
 
     def _local_shard_from_full_update_like(self, dtensor_ref, full_update: torch.Tensor):
         if not hasattr(dtensor_ref._local_tensor, "__create_chunk_list__"):
@@ -1623,7 +1777,12 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             slice(offset, offset + size)
             for offset, size in zip(shard_metadata.offsets, shard_metadata.sizes)
         )
-        return full_update[slices].contiguous().to(dtype=dtensor_ref._local_tensor.dtype)
+        local_update = full_update[slices]
+        if not local_update.is_contiguous():
+            local_update = local_update.contiguous()
+        if local_update.dtype != dtensor_ref._local_tensor.dtype:
+            local_update = local_update.to(dtype=dtensor_ref._local_tensor.dtype)
+        return local_update
 
     @torch.no_grad()  # type: ignore[misc]
     def _local_muon_update(

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -162,67 +162,6 @@ _EMERGING_OPTIMIZERS: Dict[str, EmergingOptimizerEntry] = {}
 
 
 # ===========================================================================
-# Megatron-FSDP integration
-# ===========================================================================
-
-
-def _get_mfsdp_models(model_chunks):
-    """Extract list of MegatronFSDP instances from FSDP-wrapped model chunks."""
-    mfsdp_models = []
-    for chunk in model_chunks:
-        # FullyShardedDataParallel delegates finish_grad_sync / start_param_sync
-        # from its .module (MegatronFSDP). install_optimized_model_weights lives
-        # directly on MegatronFSDP, so we need the inner module reference.
-        if hasattr(chunk, "finish_grad_sync") and hasattr(chunk, "module"):
-            mfsdp_models.append(chunk.module)
-    if not mfsdp_models:
-        raise RuntimeError(
-            "Could not find any MegatronFSDP instances in model_chunks. "
-            "Ensure the model is wrapped with FullyShardedDataParallel."
-        )
-    return mfsdp_models
-
-
-class FSDPMuonChainedOptimizer:
-    """Thin FSDP-protocol adapter wrapping a Muon-based MegatronOptimizer.
-
-    Injects the MegatronFSDP step contract around the inner optimizer:
-      1. `finish_grad_sync()` – waits for async grad sync, attaches grads
-         (allreduces for `no_shard`; reduce-scatters for ZeRO-1/2/3).
-      2. `inner_optimizer.step()` – Muon NS + weight update + Adam.
-      3. `install_optimized_model_weights()` – copies fp32 main weights
-         back into the model's bf16 (sharded for ZeRO-3) buffer.
-
-    All other attribute accesses are delegated to the inner optimizer via
-    `__getattr__`, making this class transparent to the training loop.
-    """
-
-    def __init__(self, inner: Any, mfsdp_models: list) -> None:
-        # Use object.__setattr__ to avoid triggering our own __getattr__ during init.
-        object.__setattr__(self, "inner", inner)
-        object.__setattr__(self, "_mfsdp_models", mfsdp_models)
-
-    @torch.no_grad()  # type: ignore[misc]
-    def step(self) -> Any:
-        """FSDP-aware optimizer step: sync grads -> inner step -> install weights."""
-        for mfsdp in self._mfsdp_models:
-            if not mfsdp.model_auto_sync:
-                mfsdp.finish_grad_sync()
-        result = self.inner.step()
-        for mfsdp in self._mfsdp_models:
-            mfsdp.install_optimized_model_weights()
-        return result
-
-    def zero_grad(self, set_to_none: bool = True) -> None:
-        """Zero optimizer gradients. FSDP grad buffer is zeroed by the training loop."""
-        self.inner.zero_grad(set_to_none)
-
-    def __getattr__(self, name: str) -> Any:
-        """Delegate all other attribute accesses to the inner optimizer."""
-        return getattr(object.__getattribute__(self, "inner"), name)
-
-
-# ===========================================================================
 # Muon
 # ===========================================================================
 
@@ -352,19 +291,21 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         return grad
 
 
-class FSDPZeROTensorParallelMuon(TensorParallelMuon):
-    """`TensorParallelMuon` extended for Megatron-FSDP ZeRO-1/2/3.
+class FSDPTensorParallelMuon(TensorParallelMuon):
+    """TensorParallelMuon for Megatron-FSDP ZeRO-1/2/3.
 
-    Megatron-FSDP shards a flat parameter buffer across DP ranks. Most 2D
-    parameters are either fully local on one rank or empty on the others; only
-    rank-boundary parameters are split across two ranks. Muon needs the full
-    matrix for Newton-Schulz, so this class gathers only those boundary
-    parameters and runs local NS for fully-local parameters.
+    M-FSDP shards parameters unevenly across DP ranks; params split at rank
+    boundaries must be gathered before Newton-Schulz orthogonalization. Fully
+    local params are orthogonalized without any collective.
     """
 
     def __init__(
         self, params: ParamsT, dp_group: torch.distributed.ProcessGroup | None = None, **kwargs: Any
     ) -> None:
+        assert _HAVE_DTENSOR, (
+            "[Megatron-FSDP] torch.distributed.tensor.DTensor "
+            f"is required to use {type(self).__name__}."
+        )
         self.dp_group = dp_group
         super().__init__(params, **kwargs)
 
@@ -372,42 +313,97 @@ class FSDPZeROTensorParallelMuon(TensorParallelMuon):
     def step(self, closure: Callable | None = None) -> float | None:
         """Muon step for Megatron-FSDP ZeRO-1/2/3.
 
-        Ranks must enter collectives in the same order, so local boundary
-        decisions are unioned across the DP group before the parameter loop.
+        Separates collective (AG) and local (NS) work into three phases so that
+        no rank is blocked waiting on another rank computing NS to reach AG:
+          1. Compute momentum updates locally for all params.
+          2. All-gather boundary params — all collectives, no NS interleaved.
+          3. Newton-Schulz + weight update locally for all params.
         """
-        if closure is None:
-            loss = None
-        else:
-            loss = closure()
+        loss = None if closure is None else closure()
 
+        if self.dp_group is None or get_pg_size(self.dp_group) == 1:
+            for group in self.param_groups:
+                self._init_group(group, skip_non_grad_params=False)
+                for p in group["params"]:
+                    if p.grad is None:
+                        continue
+                    self._local_muon_update(p, p.grad, group)
+            return loss
+
+        # (param, pre_ns_grad, is_gathered, lr, group_kwargs)
+        all_updates: list = []
+
+        # Phase 1: Compute momentum updates (fully local).
         for group in self.param_groups:
             self._init_group(group, skip_non_grad_params=False)
             gather_param_indices = self._get_boundary_gather_param_indices(group)
+            lr = group["lr"]
+            group_kwargs = {k: v for k, v in group.items() if k != "params"}
 
             for param_idx, p in enumerate(group["params"]):
-                self._muon_step_one(p, group, gather_full=param_idx in gather_param_indices)
+                p_local = p.to_local()
+                needs_gather = param_idx in gather_param_indices
+                if p_local.numel() == 0 and not needs_gather:
+                    continue
+
+                state = self.state[p]
+                mom_local = state["momentum_buffer"].to_local()
+
+                grad = p.grad
+                local_grad = grad.to_local() if grad is not None else torch.zeros_like(mom_local)
+
+                self._apply_weight_decay_inplace(p_local, local_grad, lr, group["weight_decay"])
+                mom_local.lerp_(local_grad, 1 - group["momentum"])
+                if self.nesterov:
+                    pre_ns_grad = local_grad.lerp(mom_local, group["momentum"])
+                else:
+                    pre_ns_grad = mom_local
+
+                all_updates.append((p, pre_ns_grad, needs_gather, lr, group_kwargs))
+
+        # Phase 2: AG all boundary params — all collectives here, no NS interleaved.
+        for i, (p, pre_ns_grad, needs_gather, lr, group_kwargs) in enumerate(all_updates):
+            if not needs_gather:
+                continue
+            if gather_uneven_dtensor_to_full_tensor is None:
+                raise RuntimeError(
+                    "Megatron-FSDP `gather_uneven_dtensor_to_full_tensor` is required "
+                    "to gather un-evenly sharded parameters for Muon step()."
+                )
+            pre_ns_grad_dtensor = self._dtensor_from_local_like(p, pre_ns_grad.contiguous())
+            full_pre_ns_grad = gather_uneven_dtensor_to_full_tensor(pre_ns_grad_dtensor).to_local()
+            all_updates[i] = (p, full_pre_ns_grad, True, lr, group_kwargs)
+
+        # Phase 3: NS orthogonalization and weight update (fully local).
+        from emerging_optimizers import utils
+
+        with utils.fp32_matmul_precision(self.fp32_matmul_prec):
+            for p, pre_ns_grad, is_gathered, lr, group_kwargs in all_updates:
+                p_local = p.to_local()
+                if is_gathered:
+                    orth_update = super(FSDPTensorParallelMuon, self).orthogonalize(
+                        p, pre_ns_grad, **group_kwargs
+                    )
+                    sharded_update = self._reshard_full_update_like(p, orth_update)
+                    self.pre_weight_update_fn_inplace(p, sharded_update)
+                    p.add_(sharded_update, alpha=-lr)
+                    self.post_weight_update_fn_inplace(p)
+                else:
+                    orth_update = (
+                        super(FSDPTensorParallelMuon, self)
+                        .orthogonalize(p, pre_ns_grad, **group_kwargs)
+                        .to(dtype=p_local.dtype)
+                    )
+                    self.pre_weight_update_fn_inplace(p_local, orth_update)
+                    p_local.add_(orth_update, alpha=-lr)
+                    self.post_weight_update_fn_inplace(p_local)
 
         return loss
 
-    def _as_dtensor(self, value: Any):
-        """Return `value` or `value.data` when either is a DTensor."""
-        if not _HAVE_DTENSOR:
-            return None
-        if isinstance(value, _DTensor):
-            return value
-        data = getattr(value, "data", None)
-        if isinstance(data, _DTensor):
-            return data
-        return None
-
-    def _is_nonempty_dtensor_param(self, param: torch.Tensor) -> bool:
-        dtensor = self._as_dtensor(param)
-        return dtensor is not None and dtensor.to_local().numel() > 0
-
-    def _needs_boundary_gather(self, param: torch.Tensor) -> bool:
-        dtensor = self._as_dtensor(param)
-        if dtensor is None:
-            return False
+    def _needs_boundary_gather(self, dtensor: torch.Tensor) -> bool:
+        assert isinstance(
+            dtensor, _DTensor
+        ), f"Detected non-DTensor during {type(self).__name__}: {dtensor}"
         local_tensor = dtensor.to_local()
         return local_tensor.numel() > 0 and tuple(dtensor.shape) != tuple(local_tensor.shape)
 
@@ -461,75 +457,6 @@ class FSDPZeROTensorParallelMuon(TensorParallelMuon):
         )
         local_update = full_update[slices].contiguous().to(dtype=value.to_local().dtype)
         return self._dtensor_from_local_like(value, local_update)
-
-    @torch.no_grad()  # type: ignore[misc]
-    def _muon_step_one(
-        self, p: torch.Tensor, group: Dict[str, Any], gather_full: bool = False
-    ) -> None:
-        """Per-param Muon update that participates in DP collectives on every rank."""
-        # Fall back to the plain parent step for the single-rank / unsharded case.
-        if self.dp_group is None or get_pg_size(self.dp_group) == 1:
-            if p.grad is None:
-                return
-            return self._local_muon_update(p, p.grad, group)
-
-        value = self._as_dtensor(p)
-        if value is None:
-            if p.grad is None:
-                return
-            return self._local_muon_update(p, p.grad, group)
-
-        p_local = value.to_local()
-        if p_local.numel() == 0 and not gather_full:
-            return
-
-        state = self.state[p]
-        mom_buffer = state["momentum_buffer"]
-        mom_dtensor = self._as_dtensor(mom_buffer)
-        mom_local = mom_dtensor.to_local() if mom_dtensor is not None else mom_buffer
-
-        grad = p.grad
-        if grad is None:
-            local_grad = torch.zeros_like(mom_local)
-        else:
-            grad_dtensor = self._as_dtensor(grad)
-            local_grad = grad_dtensor.to_local() if grad_dtensor is not None else grad
-
-        lr = group["lr"]
-        self._apply_weight_decay_inplace(p_local, local_grad, lr, group["weight_decay"])
-
-        mom_local.lerp_(local_grad, 1 - group["momentum"])
-        if self.nesterov:
-            update_local = local_grad.lerp(mom_local, group["momentum"])
-        else:
-            update_local = mom_local
-
-        from emerging_optimizers import utils
-
-        with utils.fp32_matmul_precision(self.fp32_matmul_prec):
-            group_kwargs = {k: v for k, v in group.items() if k != "params"}
-            if gather_full:
-                if gather_uneven_dtensor_to_full_tensor is None:
-                    raise RuntimeError("DTensor support is required for Megatron-FSDP Muon.")
-                update_dtensor = self._dtensor_from_local_like(value, update_local.contiguous())
-                full_update = gather_uneven_dtensor_to_full_tensor(update_dtensor).to_local()
-                orth_full_update = super(FSDPZeROTensorParallelMuon, self).orthogonalize(
-                    p, full_update, **group_kwargs
-                )
-                sharded_update = self._reshard_full_update_like(value, orth_full_update)
-                self.pre_weight_update_fn_inplace(p, sharded_update)
-                update_target = p if isinstance(p, _DTensor) else value
-                update_target.add_(sharded_update, alpha=-lr)
-                self.post_weight_update_fn_inplace(p)
-            else:
-                orth_local_update = (
-                    super(FSDPZeROTensorParallelMuon, self)
-                    .orthogonalize(p, update_local, **group_kwargs)
-                    .to(dtype=p_local.dtype)
-                )
-                self.pre_weight_update_fn_inplace(p_local, orth_local_update)
-                p_local.add_(orth_local_update, alpha=-lr)
-                self.post_weight_update_fn_inplace(p_local)
 
     @torch.no_grad()  # type: ignore[misc]
     def _local_muon_update(

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -10,7 +10,6 @@ To add a new emerging optimizer:
 
 import inspect
 import logging
-import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Literal, Optional, get_args
 
@@ -64,26 +63,6 @@ except ImportError:
 
 
 logger = logging.getLogger(__name__)
-
-
-def _env_flag(name: str, default: bool = False) -> bool:
-    value = os.getenv(name)
-    if value is None:
-        return default
-    return value.strip().lower() not in {"0", "false", "no", "off", ""}
-
-
-def _env_float(name: str, default: float) -> float:
-    value = os.getenv(name)
-    if value is None:
-        return default
-    try:
-        return float(value)
-    except ValueError:
-        log_single_rank(
-            logger, logging.WARNING, "Ignoring invalid %s=%r; using %s.", name, value, default
-        )
-        return default
 
 
 def _should_use_padded_all_gather(rank_total_numels: list[int], pad_factor: float) -> bool:
@@ -371,7 +350,13 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         self,
         params: ParamsT,
         dp_group: torch.distributed.ProcessGroup | None = None,
-        fsdp_batched_all_gather: bool = True,
+        fsdp_batched_all_gather: bool = False,
+        fsdp_reuse_gather_scratch: bool = False,
+        fsdp_padded_all_gather: bool = False,
+        fsdp_padded_all_gather_pad_factor: float = 1.25,
+        fsdp_batch_max_gather_bytes: int = 1024 * 1024 * 1024,
+        fsdp_padded_all_gather_zero_pad: bool = True,
+        fsdp_fast_reconstruct: bool = True,
         **kwargs: Any,
     ) -> None:
         assert _HAVE_DTENSOR, (
@@ -380,18 +365,12 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         )
         self.dp_group = dp_group
         self.fsdp_batched_all_gather = fsdp_batched_all_gather
-        self.fsdp_reuse_gather_scratch = _env_flag("MUON_FSDP_REUSE_GATHER_SCRATCH", True)
-        self.fsdp_padded_all_gather = _env_flag("MUON_FSDP_PADDED_ALL_GATHER", True)
-        self.fsdp_padded_all_gather_pad_factor = _env_float(
-            "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR", 1.25
-        )
-        self.fsdp_batch_max_gather_bytes = int(
-            _env_float("MUON_FSDP_BATCH_MAX_GATHER_BYTES", 1024 * 1024 * 1024)
-        )
-        self.fsdp_padded_all_gather_zero_pad = _env_flag(
-            "MUON_FSDP_PADDED_ALL_GATHER_ZERO_PAD", True
-        )
-        self.fsdp_fast_reconstruct = _env_flag("MUON_FSDP_FAST_RECONSTRUCT", True)
+        self.fsdp_reuse_gather_scratch = fsdp_reuse_gather_scratch
+        self.fsdp_padded_all_gather = fsdp_padded_all_gather
+        self.fsdp_padded_all_gather_pad_factor = fsdp_padded_all_gather_pad_factor
+        self.fsdp_batch_max_gather_bytes = fsdp_batch_max_gather_bytes
+        self.fsdp_padded_all_gather_zero_pad = fsdp_padded_all_gather_zero_pad
+        self.fsdp_fast_reconstruct = fsdp_fast_reconstruct
         self._boundary_gather_indices_cache: dict[tuple[int, ...], set[int]] = {}
         self._uneven_gather_plan_cache: dict[int, dict[str, Any]] = {}
         self._fsdp_gather_scratch_cache: dict[tuple[Any, ...], Any] = {}

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -622,8 +622,11 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 )
 
         if len(shard_mesh_dims) != 1:
-            # M-FSDP optimizer shards are expected to have one sharded mesh
-            # dimension. Keep the generic helper as a conservative fallback.
+            # The fast path below issues one all-gather over one process group,
+            # so it is only correct for layouts with a single sharded mesh
+            # dimension. HFSDP layouts shard over both DP-inner and DP-outer
+            # mesh dimensions and must use the generic M-FSDP helper, which
+            # gathers each sharded mesh dimension in order.
             return None
 
         if not hasattr(dtensor_ref._local_tensor, "__create_chunk_list__"):
@@ -654,7 +657,11 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             if chunks_info is not None
             for chunk_info in chunks_info
         ]
-        plan = {"shard_group": shard_group, "chunk_infos": chunk_infos}
+        plan = {
+            "shard_group": shard_group,
+            "shard_mesh_dims": tuple(shard_mesh_dims),
+            "chunk_infos": chunk_infos,
+        }
         self._uneven_gather_plan_cache[cache_key] = plan
         return plan
 
@@ -675,6 +682,13 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             full_tensor = redistribute_uneven_dtensor_to_replicated(local_dtensor)._local_tensor
             self._copy_dtensor_chunk_metadata(dtensor_ref, local_dtensor)
             return None if local_tensor.numel() == 0 else full_tensor
+
+        if len(plan["shard_mesh_dims"]) != 1:
+            raise AssertionError(
+                "Single-group uneven DTensor gather plan was created for a layout with "
+                f"{len(plan['shard_mesh_dims'])} sharded mesh dimensions. "
+                "HFSDP/multi-shard layouts must use redistribute_uneven_dtensor_to_replicated."
+            )
 
         local_buffer = local_tensor.contiguous().view(-1)
         group_tensors = [
@@ -722,6 +736,11 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     dtensor_ref, local_tensor
                 )
                 continue
+            if len(plan["shard_mesh_dims"]) != 1:
+                raise AssertionError(
+                    "Batched uneven DTensor gather only supports single-shard layouts; "
+                    "multi-shard layouts must use redistribute_uneven_dtensor_to_replicated."
+                )
 
             key = (id(plan["shard_group"]), local_tensor.dtype, local_tensor.device)
             batch = batches.setdefault(

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -356,6 +356,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         params: ParamsT,
         dp_group: torch.distributed.ProcessGroup | None = None,
         fsdp_batched_all_gather: bool = False,
+        fsdp_flat_batched_all_gather: bool = False,
         fsdp_reuse_gather_scratch: bool = False,
         fsdp_padded_all_gather: bool = False,
         fsdp_padded_all_gather_pad_factor: float = 1.25,
@@ -371,6 +372,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         )
         self.dp_group = dp_group
         self.fsdp_batched_all_gather = fsdp_batched_all_gather
+        self.fsdp_flat_batched_all_gather = fsdp_flat_batched_all_gather
         self.fsdp_reuse_gather_scratch = fsdp_reuse_gather_scratch
         self.fsdp_padded_all_gather = fsdp_padded_all_gather
         self.fsdp_padded_all_gather_pad_factor = fsdp_padded_all_gather_pad_factor
@@ -380,6 +382,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         self.fsdp_overlap_comm_compute = fsdp_overlap_comm_compute
         self._boundary_gather_indices_cache: dict[tuple[int, ...], set[int]] = {}
         self._uneven_gather_plan_cache: dict[int, dict[str, Any]] = {}
+        self._flat_uneven_gather_plan_cache: dict[tuple[int, int], dict[str, Any] | None] = {}
         self._fsdp_gather_scratch_cache: dict[tuple[Any, ...], Any] = {}
         self._fsdp_comm_stream_cache: dict[torch.device, torch.cuda.Stream] = {}
         super().__init__(params, **kwargs)
@@ -459,6 +462,57 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 gathered_numel = sum(candidate_rank_total_numels)
             max_stage_bytes = max(max_stage_bytes, gathered_numel * element_size)
         return max_stage_bytes
+
+    def _candidate_rank_batch_gather_bytes(
+        self, rank_total_numels: list[int], candidate_rank_numels: list[int], *, element_size: int
+    ) -> int:
+        candidate_rank_total_numels = [
+            total_numel + candidate_numel
+            for total_numel, candidate_numel in zip(rank_total_numels, candidate_rank_numels)
+        ]
+        if self.fsdp_padded_all_gather:
+            gathered_numel = max(candidate_rank_total_numels) * len(candidate_rank_total_numels)
+        else:
+            gathered_numel = sum(candidate_rank_total_numels)
+        return gathered_numel * element_size
+
+    def _process_group_size_if_member(
+        self, group: torch.distributed.ProcessGroup | None
+    ) -> int | None:
+        if group is None:
+            return None
+        try:
+            torch.distributed.get_rank(group)
+            return get_pg_size(group)
+        except (RuntimeError, ValueError):
+            return None
+
+    def _get_existing_flat_uneven_gather_group(
+        self, dtensor_ref, plan: dict[str, Any]
+    ) -> torch.distributed.ProcessGroup | None:
+        product_size = 1
+        for stage in plan["stages"]:
+            product_size *= len(stage["rank_numels"])
+
+        if self._process_group_size_if_member(self.dp_group) == product_size:
+            return self.dp_group
+        try:
+            if torch.distributed.get_world_size() == product_size:
+                return torch.distributed.group.WORLD
+        except RuntimeError:
+            pass
+
+        mesh_dim_names = getattr(dtensor_ref.device_mesh, "mesh_dim_names", None)
+        if mesh_dim_names is not None:
+            shard_names = tuple(mesh_dim_names[dim] for dim in plan["shard_mesh_dims"])
+            try:
+                flat_mesh = dtensor_ref.device_mesh[shard_names]
+                flat_group = flat_mesh.get_group()
+            except (KeyError, RuntimeError, ValueError, TypeError, AttributeError):
+                flat_group = None
+            if self._process_group_size_if_member(flat_group) == product_size:
+                return flat_group
+        return None
 
     @torch.no_grad()  # type: ignore[misc]
     def step(self, closure: Callable | None = None) -> float | None:
@@ -628,7 +682,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         boundary_items = [(all_updates[i][0], all_updates[i][1]) for i in boundary_update_indices]
         gathered_boundary_updates: list[torch.Tensor | None] = [None] * len(boundary_items)
         completed_item_indices: set[int] = set()
-        batches = self._build_full_uneven_local_tensor_batches(
+        batches = self._build_full_uneven_local_tensor_gather_batches(
             boundary_items, gathered_boundary_updates, completed_item_indices
         )
 
@@ -1007,6 +1061,101 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         self._uneven_gather_plan_cache[cache_key] = plan
         return plan
 
+    def _get_flat_uneven_gather_plan(
+        self, dtensor_ref, plan: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        if not self.fsdp_flat_batched_all_gather:
+            return None
+        if len(plan["stages"]) <= 1:
+            return None
+        if not plan["is_contiguous_full_order"]:
+            return None
+
+        shard_placement_types = (Shard, _StridedShard)
+        for mesh_dim in plan["shard_mesh_dims"]:
+            placement = dtensor_ref.placements[mesh_dim]
+            if not isinstance(placement, shard_placement_types):
+                return None
+            if getattr(placement, "dim", None) != 0:
+                return None
+
+        flat_group = self._get_existing_flat_uneven_gather_group(dtensor_ref, plan)
+        if flat_group is None:
+            return None
+
+        cache_key = (id(dtensor_ref), id(flat_group))
+        if cache_key in self._flat_uneven_gather_plan_cache:
+            return self._flat_uneven_gather_plan_cache[cache_key]
+
+        if not hasattr(dtensor_ref._local_tensor, "__create_chunk_list__"):
+            update_uneven_dtensor_chunk_metadata(dtensor_ref)
+
+        chunk_metadata_list = dtensor_ref._local_tensor.__create_chunk_list__()
+        if len(chunk_metadata_list) != 1:
+            self._flat_uneven_gather_plan_cache[cache_key] = None
+            return None
+
+        local_chunk_metadata = chunk_metadata_list[0]
+
+        def _normalize_chunk_info(chunk_info: dict[str, Any]) -> dict[str, Any]:
+            shape = torch.Size(chunk_info["shape"])
+            return {"shape": shape, "offset": tuple(chunk_info["offset"]), "numel": shape.numel()}
+
+        local_chunk_info = _normalize_chunk_info(
+            {
+                "shape": torch.Size(dtensor_ref._local_tensor.shape),
+                "offset": tuple(local_chunk_metadata.offsets),
+            }
+        )
+
+        flat_group_size = get_pg_size(flat_group)
+        group_chunks_info: list[dict[str, Any] | None] = [None] * flat_group_size
+        torch.distributed.all_gather_object(group_chunks_info, local_chunk_info, group=flat_group)
+        if any(chunk_info is None for chunk_info in group_chunks_info):
+            self._flat_uneven_gather_plan_cache[cache_key] = None
+            return None
+
+        flat_chunk_infos = [
+            _normalize_chunk_info(chunk_info)
+            for chunk_info in group_chunks_info
+            if chunk_info is not None
+        ]
+        flat_rank_numels = [chunk_info["numel"] for chunk_info in flat_chunk_infos]
+        assigned_numel = sum(flat_rank_numels)
+        try:
+            _assert_chunks_cover_full_tensor(dtensor_ref.shape, flat_chunk_infos, assigned_numel)
+        except AssertionError:
+            self._flat_uneven_gather_plan_cache[cache_key] = None
+            return None
+
+        full_shape = torch.Size(dtensor_ref.shape)
+
+        def _chunk_flat_start(chunk_info: dict[str, Any]) -> int:
+            flat_start = 0
+            stride = 1
+            for dim in range(len(full_shape) - 1, -1, -1):
+                flat_start += chunk_info["offset"][dim] * stride
+                stride *= full_shape[dim]
+            return flat_start
+
+        flat_sorted_rank_indices = sorted(
+            range(flat_group_size), key=lambda rank: _chunk_flat_start(flat_chunk_infos[rank])
+        )
+        flat_sorted_chunk_infos = [flat_chunk_infos[rank] for rank in flat_sorted_rank_indices]
+        flat_plan = {
+            "flat_group": flat_group,
+            "flat_group_size": flat_group_size,
+            "flat_group_rank": torch.distributed.get_rank(flat_group),
+            "flat_rank_numels": flat_rank_numels,
+            "flat_chunk_infos": flat_chunk_infos,
+            "flat_sorted_rank_indices": flat_sorted_rank_indices,
+            "flat_sorted_is_contiguous_full_order": _chunk_infos_are_contiguous_full_order(
+                full_shape, flat_sorted_chunk_infos
+            ),
+        }
+        self._flat_uneven_gather_plan_cache[cache_key] = flat_plan
+        return flat_plan
+
     def _prepare_padded_all_gather_buffers(
         self,
         local_buffer: torch.Tensor,
@@ -1245,6 +1394,65 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
         return full_tensor
 
+    def _reconstruct_full_tensor_from_flat_rank_buffers(
+        self,
+        dtensor_ref,
+        flat_plan: dict[str, Any],
+        rank_buffers: list[torch.Tensor],
+        rank_buffer_offsets: list[int],
+    ) -> torch.Tensor:
+        flat_chunk_infos = flat_plan["flat_chunk_infos"]
+        flat_rank_numels = flat_plan["flat_rank_numels"]
+        if len(rank_buffers) != len(flat_rank_numels):
+            raise AssertionError(
+                "Flat uneven DTensor reconstruction rank buffer count mismatch: "
+                f"got {len(rank_buffers)}, expected {len(flat_rank_numels)}."
+            )
+
+        if self.fsdp_fast_reconstruct and flat_plan["flat_sorted_is_contiguous_full_order"]:
+            chunks = []
+            assigned_numel = 0
+            for rank in flat_plan["flat_sorted_rank_indices"]:
+                chunk_numel = flat_rank_numels[rank]
+                if chunk_numel == 0:
+                    continue
+                source_offset = rank_buffer_offsets[rank]
+                chunks.append(rank_buffers[rank][source_offset : source_offset + chunk_numel])
+                assigned_numel += chunk_numel
+            if assigned_numel != torch.Size(dtensor_ref.shape).numel():
+                raise AssertionError(
+                    "Fast flat uneven DTensor reconstruction did not cover the full tensor: "
+                    f"assigned={assigned_numel}, expected={torch.Size(dtensor_ref.shape).numel()}."
+                )
+            if assigned_numel == 0:
+                return torch.empty(
+                    dtensor_ref.shape, dtype=rank_buffers[0].dtype, device=rank_buffers[0].device
+                )
+            if len(chunks) == 1:
+                full_flat = chunks[0].clone()
+            else:
+                full_flat = torch.cat(chunks)
+            return full_flat.view(dtensor_ref.shape)
+
+        full_tensor = torch.empty(
+            dtensor_ref.shape, dtype=rank_buffers[0].dtype, device=rank_buffers[0].device
+        )
+        assigned_numel = 0
+        for rank, (rank_buffer, chunk_info) in enumerate(zip(rank_buffers, flat_chunk_infos)):
+            chunk_shape = chunk_info["shape"]
+            chunk_numel = chunk_info["numel"]
+            if chunk_numel == 0:
+                continue
+            source_offset = rank_buffer_offsets[rank]
+            gathered_tensor = rank_buffer[source_offset : source_offset + chunk_numel]
+            offset = chunk_info["offset"]
+            slices = tuple(slice(o, o + s) for o, s in zip(offset, chunk_shape))
+            full_tensor[slices] = gathered_tensor.view(chunk_shape)
+            assigned_numel += chunk_numel
+
+        _assert_chunks_cover_full_tensor(dtensor_ref.shape, flat_chunk_infos, assigned_numel)
+        return full_tensor
+
     def _gather_full_uneven_local_tensor_like(
         self, dtensor_ref, local_tensor: torch.Tensor
     ) -> torch.Tensor | None:
@@ -1315,10 +1523,14 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         items: list[tuple[torch.Tensor, torch.Tensor]],
         results: list[torch.Tensor | None],
         completed_item_indices: set[int] | None = None,
+        skip_item_indices: set[int] | None = None,
     ) -> list[dict[str, Any]]:
         batches: dict[tuple[int, torch.dtype, torch.device], list[dict[str, Any]]] = {}
 
         for item_idx, (dtensor_ref, local_tensor) in enumerate(items):
+            if skip_item_indices is not None and item_idx in skip_item_indices:
+                continue
+
             plan = self._get_uneven_gather_plan(dtensor_ref)
             if plan is None:
                 results[item_idx] = self._gather_full_uneven_local_tensor_like(
@@ -1368,6 +1580,87 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
 
         return [batch for key_batches in batches.values() for batch in key_batches]
 
+    def _build_flat_full_uneven_local_tensor_batches(
+        self, items: list[tuple[torch.Tensor, torch.Tensor]], skip_item_indices: set[int]
+    ) -> list[dict[str, Any]]:
+        batches: dict[tuple[int, torch.dtype, torch.device], list[dict[str, Any]]] = {}
+
+        for item_idx, (dtensor_ref, local_tensor) in enumerate(items):
+            if item_idx in skip_item_indices:
+                continue
+
+            plan = self._get_uneven_gather_plan(dtensor_ref)
+            if plan is None:
+                continue
+            flat_plan = self._get_flat_uneven_gather_plan(dtensor_ref, plan)
+            if flat_plan is None:
+                continue
+
+            key = (id(flat_plan["flat_group"]), local_tensor.dtype, local_tensor.device)
+            key_batches = batches.setdefault(key, [])
+            element_size = local_tensor.element_size()
+            if not key_batches:
+                key_batches.append(
+                    {
+                        "is_flat": True,
+                        "dtype": local_tensor.dtype,
+                        "device": local_tensor.device,
+                        "item_indices": [],
+                        "plans": [],
+                        "flat_plans": [],
+                        "flat_rank_total_numels": [0] * flat_plan["flat_group_size"],
+                    }
+                )
+            batch = key_batches[-1]
+            if batch["item_indices"]:
+                candidate_bytes = self._candidate_rank_batch_gather_bytes(
+                    batch["flat_rank_total_numels"],
+                    flat_plan["flat_rank_numels"],
+                    element_size=element_size,
+                )
+                if candidate_bytes > self.fsdp_batch_max_gather_bytes:
+                    batch = {
+                        "is_flat": True,
+                        "dtype": local_tensor.dtype,
+                        "device": local_tensor.device,
+                        "item_indices": [],
+                        "plans": [],
+                        "flat_plans": [],
+                        "flat_rank_total_numels": [0] * flat_plan["flat_group_size"],
+                    }
+                    key_batches.append(batch)
+
+            batch["item_indices"].append(item_idx)
+            batch["plans"].append(plan)
+            batch["flat_plans"].append(flat_plan)
+            for rank, rank_numel in enumerate(flat_plan["flat_rank_numels"]):
+                batch["flat_rank_total_numels"][rank] += rank_numel
+            skip_item_indices.add(item_idx)
+
+        return [batch for key_batches in batches.values() for batch in key_batches]
+
+    def _build_full_uneven_local_tensor_gather_batches(
+        self,
+        items: list[tuple[torch.Tensor, torch.Tensor]],
+        results: list[torch.Tensor | None],
+        completed_item_indices: set[int] | None = None,
+    ) -> list[dict[str, Any]]:
+        skip_item_indices = set(completed_item_indices or ())
+        batches = []
+        if self.fsdp_flat_batched_all_gather:
+            batches.extend(
+                self._build_flat_full_uneven_local_tensor_batches(items, skip_item_indices)
+            )
+        batches.extend(
+            self._build_full_uneven_local_tensor_batches(
+                items,
+                results,
+                completed_item_indices=completed_item_indices,
+                skip_item_indices=skip_item_indices,
+            )
+        )
+        return batches
+
     def _gather_full_uneven_local_tensors_like(
         self, items: list[tuple[torch.Tensor, torch.Tensor]]
     ) -> list[torch.Tensor | None]:
@@ -1381,12 +1674,133 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         reconstruct or orthogonalize the full boundary tensor.
         """
         results: list[torch.Tensor | None] = [None] * len(items)
-        batches = self._build_full_uneven_local_tensor_batches(items, results)
+        batches = self._build_full_uneven_local_tensor_gather_batches(items, results)
 
         for batch in batches:
-            self._gather_full_uneven_local_tensor_batch(items, results, batch)
+            if batch.get("is_flat", False):
+                self._gather_flat_full_uneven_local_tensor_batch(items, results, batch)
+            else:
+                self._gather_full_uneven_local_tensor_batch(items, results, batch)
 
         return results
+
+    def _gather_flat_full_uneven_local_tensor_batch(
+        self,
+        items: list[tuple[torch.Tensor, torch.Tensor]],
+        results: list[torch.Tensor | None],
+        batch: dict[str, Any],
+    ) -> None:
+        stage_state = self._prepare_flat_uneven_gather_batch(items, batch)
+        pending_stage = self._start_uneven_gather_stage(stage_state, async_op=False)
+        self._wait_uneven_gather_stage(pending_stage)
+        self._store_flat_uneven_gather_batch_results(items, results, batch, pending_stage)
+
+    def _prepare_flat_uneven_gather_batch(
+        self, items: list[tuple[torch.Tensor, torch.Tensor]], batch: dict[str, Any]
+    ) -> dict[str, Any]:
+        item_indices = batch["item_indices"]
+        flat_plans = batch["flat_plans"]
+        flat_group = flat_plans[0]["flat_group"]
+        group_size = get_pg_size(flat_group)
+        group_rank = torch.distributed.get_rank(flat_group)
+
+        expected_item_numels = [
+            flat_plan["flat_rank_numels"][group_rank] for flat_plan in flat_plans
+        ]
+        expected_local_numel = sum(expected_item_numels)
+        current_buffers = [
+            self._flatten_tensor_for_uneven_gather(items[item_idx][1]) for item_idx in item_indices
+        ]
+        if len(current_buffers) == 1:
+            local_buffer = current_buffers[0]
+            if local_buffer.numel() != expected_local_numel:
+                raise AssertionError(
+                    "Flat batched uneven DTensor gather buffer size mismatch: "
+                    f"got {local_buffer.numel()}, expected {expected_local_numel}."
+                )
+        else:
+            local_buffer = self._get_fsdp_gather_scratch_tensor(
+                ("flat_batch_local_buffer", id(flat_group), batch["dtype"], batch["device"]),
+                expected_local_numel,
+                dtype=batch["dtype"],
+                device=batch["device"],
+            )
+            local_offset = 0
+            for buffer, expected_numel in zip(current_buffers, expected_item_numels):
+                if buffer.numel() != expected_numel:
+                    raise AssertionError(
+                        "Flat batched uneven DTensor gather buffer size mismatch: "
+                        f"got {buffer.numel()}, expected {expected_numel}."
+                    )
+                if expected_numel == 0:
+                    continue
+                local_buffer[local_offset : local_offset + expected_numel].copy_(buffer)
+                local_offset += expected_numel
+            if local_offset != expected_local_numel:
+                raise AssertionError(
+                    "Flat batched uneven DTensor gather local buffer size mismatch: "
+                    f"packed {local_offset}, expected {expected_local_numel}."
+                )
+
+        rank_offsets: list[list[int]] = []
+        rank_total_numels: list[int] = []
+        for rank in range(group_size):
+            offsets = []
+            total_numel = 0
+            for flat_plan in flat_plans:
+                offsets.append(total_numel)
+                total_numel += flat_plan["flat_rank_numels"][rank]
+            rank_offsets.append(offsets)
+            rank_total_numels.append(total_numel)
+
+        if rank_total_numels != batch["flat_rank_total_numels"]:
+            raise AssertionError(
+                "Flat batched uneven DTensor gather rank totals changed after batching."
+            )
+
+        use_padded_all_gather = (
+            self.fsdp_padded_all_gather
+            and hasattr(torch.distributed, "all_gather_into_tensor")
+            and _should_use_padded_all_gather(
+                rank_total_numels, self.fsdp_padded_all_gather_pad_factor
+            )
+        )
+        return {
+            "batch": batch,
+            "plans": batch["plans"],
+            "flat_plans": flat_plans,
+            "stage_idx": 0,
+            "shard_group": flat_group,
+            "group_size": group_size,
+            "rank_offsets": rank_offsets,
+            "rank_total_numels": rank_total_numels,
+            "local_buffer": local_buffer,
+            "use_padded_all_gather": use_padded_all_gather,
+        }
+
+    def _store_flat_uneven_gather_batch_results(
+        self,
+        items: list[tuple[torch.Tensor, torch.Tensor]],
+        results: list[torch.Tensor | None],
+        batch: dict[str, Any],
+        pending_stage: dict[str, Any],
+    ) -> list[int]:
+        rank_offsets = pending_stage["rank_offsets"]
+        rank_buffers = self._rank_buffers_from_pending_uneven_gather_stage(pending_stage)
+
+        for batch_item_idx, item_idx in enumerate(batch["item_indices"]):
+            dtensor_ref, local_tensor = items[item_idx]
+            if local_tensor.numel() == 0:
+                results[item_idx] = None
+                continue
+
+            rank_buffer_offsets = [
+                rank_offsets[rank][batch_item_idx] for rank in range(pending_stage["group_size"])
+            ]
+            results[item_idx] = self._reconstruct_full_tensor_from_flat_rank_buffers(
+                dtensor_ref, batch["flat_plans"][batch_item_idx], rank_buffers, rank_buffer_offsets
+            )
+        return batch["item_indices"]
 
     def _gather_full_uneven_local_tensor_batch(
         self,
@@ -1675,6 +2089,11 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
     def _start_gather_full_uneven_local_tensor_batch_async(
         self, items: list[tuple[torch.Tensor, torch.Tensor]], batch: dict[str, Any]
     ) -> dict[str, Any]:
+        if batch.get("is_flat", False):
+            stage_state = self._prepare_flat_uneven_gather_batch(items, batch)
+            pending_stage = self._start_uneven_gather_stage(stage_state, async_op=True)
+            return {"items": items, "batch": batch, "pending_flat_stage": pending_stage}
+
         item_indices = batch["item_indices"]
         plans = batch["plans"]
         current_buffers = [
@@ -1732,6 +2151,13 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         items = pending["items"]
         batch = pending["batch"]
         plans = batch["plans"]
+        if "pending_flat_stage" in pending:
+            pending_stage = pending["pending_flat_stage"]
+            self._wait_uneven_gather_stage(pending_stage)
+            return self._store_flat_uneven_gather_batch_results(
+                items, results, batch, pending_stage
+            )
+
         if "final_pending_stage" in pending:
             for pending_stage in pending["pending_stages"]:
                 self._wait_uneven_gather_stage(pending_stage)

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -376,6 +376,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         self._boundary_gather_indices_cache: dict[tuple[int, ...], set[int]] = {}
         self._uneven_gather_plan_cache: dict[int, dict[str, Any]] = {}
         self._fsdp_gather_scratch_cache: dict[tuple[Any, ...], Any] = {}
+        self._fsdp_comm_stream_cache: dict[torch.device, torch.cuda.Stream] = {}
         super().__init__(params, **kwargs)
 
     def _fsdp_gather_scratch_cache_bytes(self) -> int:
@@ -394,6 +395,14 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
     def clear_fsdp_gather_scratch_cache(self) -> None:
         """Clear the gather scratch buffer."""
         self._fsdp_gather_scratch_cache.clear()
+
+    def _get_fsdp_comm_stream(self, device: torch.device) -> torch.cuda.Stream:
+        cached = self._fsdp_comm_stream_cache.get(device)
+        if cached is None:
+            with torch.cuda.device(device):
+                cached = torch.cuda.Stream()
+            self._fsdp_comm_stream_cache[device] = cached
+        return cached
 
     def _get_fsdp_gather_scratch_tensor(
         self, key: tuple[Any, ...], numel: int, *, dtype: torch.dtype, device: torch.device
@@ -467,21 +476,50 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     self._local_muon_update(p, p.grad, group)
             return loss
 
+        overlap_enabled = self.fsdp_overlap_comm_compute and self.fsdp_batched_all_gather
+
         # Track all parameters to update ordered by parameter group index.
         # (param, pre_ns_grad, is_gathered, lr, group_kwargs)
         all_updates: list = []
 
-        # Phase 1: Compute momentum updates (fully local).
+        group_contexts = []
         for group in self.param_groups:
             self._init_group(group, skip_non_grad_params=False)
-            gather_param_indices = self._get_boundary_gather_param_indices(group)
-            lr = group["lr"]
-            group_kwargs = {k: v for k, v in group.items() if k != "params"}
+            group_contexts.append(
+                (
+                    group,
+                    self._get_boundary_gather_param_indices(group),
+                    group["lr"],
+                    {k: v for k, v in group.items() if k != "params"},
+                )
+            )
 
+        early_gather_state = None
+        boundary_update_indices = []
+        if overlap_enabled:
+            # Boundary pre-NS tensors are the only values needed by the
+            # all-gather. Compute them first and launch communication before
+            # spending time on non-boundary momentum and NS work.
+            for group, gather_param_indices, lr, group_kwargs in group_contexts:
+                for param_idx, p in enumerate(group["params"]):
+                    if param_idx not in gather_param_indices:
+                        continue
+                    pre_ns_grad = self._compute_local_pre_ns_grad(p, group, lr)
+                    boundary_update_indices.append(len(all_updates))
+                    all_updates.append((p, pre_ns_grad, True, lr, group_kwargs))
+
+            if boundary_update_indices:
+                early_gather_state = self._start_overlap_boundary_gathers(
+                    all_updates, boundary_update_indices
+                )
+
+        # Phase 1: Compute remaining momentum updates (fully local).
+        for group, gather_param_indices, lr, group_kwargs in group_contexts:
             for param_idx, p in enumerate(group["params"]):
-                p_local = p._local_tensor
                 needs_gather = param_idx in gather_param_indices
-                if p_local.numel() == 0 and not needs_gather:
+                if overlap_enabled and needs_gather:
+                    continue
+                if p._local_tensor.numel() == 0 and not needs_gather:
                     # If this parameter is not split by Megatron-FSDP,
                     # and is empty on this DP rank, then we can skip this
                     # update for all TP ranks, as tensor parallelism uses
@@ -489,36 +527,23 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     # assign any fraction of the parameter to this DP rank.
                     continue
 
-                state = self.state[p]
-                mom_local = state["momentum_buffer"]._local_tensor
-
-                grad = p.grad
-                local_grad = grad._local_tensor if grad is not None else torch.zeros_like(mom_local)
-
-                self._apply_weight_decay_inplace(p_local, local_grad, lr, group["weight_decay"])
-                mom_local.lerp_(local_grad, 1 - group["momentum"])
-                if self.nesterov:
-                    pre_ns_grad = local_grad.lerp(mom_local, group["momentum"])
-                else:
-                    pre_ns_grad = mom_local
-
+                pre_ns_grad = self._compute_local_pre_ns_grad(p, group, lr)
                 all_updates.append((p, pre_ns_grad, needs_gather, lr, group_kwargs))
 
         # Phase 2: AG all boundary gradients.
-        boundary_update_indices = [
-            i for i, (_, _, needs_gather, _, _) in enumerate(all_updates) if needs_gather
-        ]
+        if not overlap_enabled:
+            boundary_update_indices = [
+                i for i, (_, _, needs_gather, _, _) in enumerate(all_updates) if needs_gather
+            ]
 
         # Phase 3: NS orthogonalization and weight update (fully local).
         from emerging_optimizers import utils
 
         with utils.fp32_matmul_precision(self.fp32_matmul_prec):
-            if (
-                self.fsdp_overlap_comm_compute
-                and self.fsdp_batched_all_gather
-                and boundary_update_indices
-            ):
-                self._overlap_boundary_gather_and_update(all_updates, boundary_update_indices)
+            if overlap_enabled and boundary_update_indices:
+                self._overlap_boundary_gather_and_update(
+                    all_updates, boundary_update_indices, early_gather_state
+                )
             else:
                 if boundary_update_indices:
                     boundary_items = [
@@ -545,6 +570,22 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     )
 
         return loss
+
+    def _compute_local_pre_ns_grad(
+        self, p: torch.Tensor, group: dict[str, Any], lr: float
+    ) -> torch.Tensor:
+        p_local = p._local_tensor
+        state = self.state[p]
+        mom_local = state["momentum_buffer"]._local_tensor
+
+        grad = p.grad
+        local_grad = grad._local_tensor if grad is not None else torch.zeros_like(mom_local)
+
+        self._apply_weight_decay_inplace(p_local, local_grad, lr, group["weight_decay"])
+        mom_local.lerp_(local_grad, 1 - group["momentum"])
+        if self.nesterov:
+            return local_grad.lerp(mom_local, group["momentum"])
+        return mom_local
 
     def _apply_precomputed_muon_update(
         self,
@@ -576,9 +617,9 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         p._local_tensor.add_(orth_update, alpha=-lr)
         self.post_weight_update_fn_inplace(p._local_tensor)
 
-    def _overlap_boundary_gather_and_update(
+    def _start_overlap_boundary_gathers(
         self, all_updates: list, boundary_update_indices: list[int]
-    ) -> None:
+    ) -> dict[str, Any]:
         boundary_items = [(all_updates[i][0], all_updates[i][1]) for i in boundary_update_indices]
         gathered_boundary_updates: list[torch.Tensor | None] = [None] * len(boundary_items)
         completed_item_indices: set[int] = set()
@@ -594,9 +635,37 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 boundary_items, first_batch
             )
 
-        for p, pre_ns_grad, is_gathered, lr, group_kwargs in all_updates:
-            if not is_gathered:
-                self._apply_precomputed_muon_update(p, pre_ns_grad, is_gathered, lr, group_kwargs)
+        return {
+            "boundary_items": boundary_items,
+            "gathered_boundary_updates": gathered_boundary_updates,
+            "completed_item_indices": completed_item_indices,
+            "batch_iter": batch_iter,
+            "pending": pending,
+        }
+
+    def _overlap_boundary_gather_and_update(
+        self,
+        all_updates: list,
+        boundary_update_indices: list[int],
+        gather_state: dict[str, Any] | None = None,
+    ) -> None:
+        if gather_state is None:
+            gather_state = self._start_overlap_boundary_gathers(
+                all_updates, boundary_update_indices
+            )
+
+        boundary_items = gather_state["boundary_items"]
+        gathered_boundary_updates = gather_state["gathered_boundary_updates"]
+        completed_item_indices = gather_state["completed_item_indices"]
+        batch_iter = gather_state["batch_iter"]
+        pending = gather_state["pending"]
+
+        local_updates = [(idx, update) for idx, update in enumerate(all_updates) if not update[2]]
+        local_updates.sort(
+            key=lambda item: self._local_update_work_estimate(item[1][0], item[1][1]), reverse=True
+        )
+        for _, (p, pre_ns_grad, is_gathered, lr, group_kwargs) in local_updates:
+            self._apply_precomputed_muon_update(p, pre_ns_grad, is_gathered, lr, group_kwargs)
 
         processed_item_indices: set[int] = set()
 
@@ -637,6 +706,11 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 "Muon+M-FSDP overlap step missed boundary updates: "
                 f"missing_boundary_item_indices={missing}."
             )
+
+    def _local_update_work_estimate(self, p: torch.Tensor, pre_ns_grad: torch.Tensor | None) -> int:
+        if pre_ns_grad is not None:
+            return pre_ns_grad.numel()
+        return p._local_tensor.numel()
 
     def _needs_boundary_gather(self, dtensor: torch.Tensor) -> bool:
         assert isinstance(
@@ -976,32 +1050,36 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         rank_buffers: list[torch.Tensor],
         rank_buffer_offsets: list[int] | None = None,
     ) -> torch.Tensor:
-        full_tensor = torch.empty(
-            dtensor_ref.shape, dtype=rank_buffers[0].dtype, device=rank_buffers[0].device
-        )
-        assigned_numel = 0
-
         if self.fsdp_fast_reconstruct and plan["is_contiguous_full_order"]:
-            full_flat = full_tensor.view(-1)
-            dest_offset = 0
+            chunks = []
+            assigned_numel = 0
             for rank, rank_buffer in enumerate(rank_buffers):
                 chunk_info = plan["chunk_infos"][rank]
                 chunk_numel = chunk_info["numel"]
                 if chunk_numel == 0:
                     continue
                 source_offset = 0 if rank_buffer_offsets is None else rank_buffer_offsets[rank]
-                full_flat[dest_offset : dest_offset + chunk_numel].copy_(
-                    rank_buffer[source_offset : source_offset + chunk_numel]
-                )
-                dest_offset += chunk_numel
+                chunks.append(rank_buffer[source_offset : source_offset + chunk_numel])
                 assigned_numel += chunk_numel
             if assigned_numel != plan["full_numel"]:
                 raise AssertionError(
                     "Fast uneven DTensor reconstruction did not cover the full tensor: "
                     f"assigned={assigned_numel}, expected={plan['full_numel']}."
                 )
-            return full_tensor
+            if assigned_numel == 0:
+                return torch.empty(
+                    dtensor_ref.shape, dtype=rank_buffers[0].dtype, device=rank_buffers[0].device
+                )
+            if len(chunks) == 1:
+                full_flat = chunks[0].clone()
+            else:
+                full_flat = torch.cat(chunks)
+            return full_flat.view(dtensor_ref.shape)
 
+        full_tensor = torch.empty(
+            dtensor_ref.shape, dtype=rank_buffers[0].dtype, device=rank_buffers[0].device
+        )
+        assigned_numel = 0
         for rank, rank_buffer in enumerate(rank_buffers):
             chunk_info = plan["chunk_infos"][rank]
             chunk_numel = chunk_info["numel"]
@@ -1288,7 +1366,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         comm_stream = None
         if async_op and device.type == "cuda":
             with torch.cuda.device(device):
-                comm_stream = torch.cuda.Stream()
+                comm_stream = self._get_fsdp_comm_stream(device)
                 comm_stream.wait_stream(torch.cuda.current_stream())
                 with torch.cuda.stream(comm_stream):
                     return self._issue_uneven_gather_stage(
@@ -1377,6 +1455,30 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         next_buffers = []
         for batch_item_idx, plan in enumerate(plans):
             item_numel = sum(plan["stages"][stage_idx]["rank_numels"])
+            if plan["is_contiguous_full_order"]:
+                chunks = []
+                assigned_numel = 0
+                for rank, rank_buffer in enumerate(rank_buffers):
+                    chunk_numel = plan["stages"][stage_idx]["rank_numels"][rank]
+                    if chunk_numel == 0:
+                        continue
+                    source_offset = rank_offsets[rank][batch_item_idx]
+                    chunks.append(rank_buffer[source_offset : source_offset + chunk_numel])
+                    assigned_numel += chunk_numel
+                if assigned_numel != item_numel:
+                    raise AssertionError(
+                        "Batched uneven DTensor stage unpack did not cover the item: "
+                        f"stage={stage_idx}, assigned={assigned_numel}, expected={item_numel}."
+                    )
+                if item_numel == 0:
+                    item_buffer = torch.empty(0, dtype=batch["dtype"], device=batch["device"])
+                elif len(chunks) == 1:
+                    item_buffer = chunks[0].clone()
+                else:
+                    item_buffer = torch.cat(chunks)
+                next_buffers.append(item_buffer)
+                continue
+
             item_buffer = torch.empty(item_numel, dtype=batch["dtype"], device=batch["device"])
             item_offset = 0
             for rank, rank_buffer in enumerate(rank_buffers):
@@ -1428,7 +1530,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         if batch["device"].type == "cuda" and len(plans[0]["stages"]) > 1:
             pending_stages = []
             with torch.cuda.device(batch["device"]):
-                comm_stream = torch.cuda.Stream()
+                comm_stream = self._get_fsdp_comm_stream(batch["device"])
                 comm_stream.wait_stream(torch.cuda.current_stream())
                 with torch.cuda.stream(comm_stream):
                     for stage_idx, stage in enumerate(plans[0]["stages"]):

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -23,16 +23,22 @@ from .optimizer_config import ParamKey, ParamPredicate
 
 try:
     from torch.distributed.tensor import DTensor as _DTensor
+    from torch.distributed.tensor.placement_types import Replicate, Shard, _StridedShard
 
     from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
-        gather_uneven_dtensor_to_full_tensor,
+        _assert_chunks_cover_full_tensor,
+        uneven_dtensor_to_full_tensor,
         update_uneven_dtensor_chunk_metadata,
     )
 
     _HAVE_DTENSOR = True
 except ImportError:
     _DTensor = None  # type: ignore[assignment,misc]
-    gather_uneven_dtensor_to_full_tensor = None  # type: ignore[assignment]
+    Replicate = None  # type: ignore[assignment,misc]
+    Shard = None  # type: ignore[assignment,misc]
+    _StridedShard = None  # type: ignore[assignment,misc]
+    _assert_chunks_cover_full_tensor = None  # type: ignore[assignment]
+    uneven_dtensor_to_full_tensor = None  # type: ignore[assignment]
     update_uneven_dtensor_chunk_metadata = None  # type: ignore[assignment]
     _HAVE_DTENSOR = False
 
@@ -307,6 +313,8 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             f"is required to use {type(self).__name__}."
         )
         self.dp_group = dp_group
+        self._boundary_gather_indices_cache: Dict[tuple[int, ...], set[int]] = {}
+        self._uneven_gather_plan_cache: Dict[int, Dict[str, Any]] = {}
         super().__init__(params, **kwargs)
 
     @torch.no_grad()  # type: ignore[misc]
@@ -371,22 +379,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         for i, (p, pre_ns_grad, needs_gather, lr, group_kwargs) in enumerate(all_updates):
             if not needs_gather:
                 continue
-            # Un-shard the un-evenly sharded gradient.
-            if gather_uneven_dtensor_to_full_tensor is None:
-                raise RuntimeError(
-                    "Megatron-FSDP `gather_uneven_dtensor_to_full_tensor` is required "
-                    "to gather un-evenly sharded parameters for Muon step()."
-                )
-            pre_ns_grad_dtensor = self._dtensor_from_local_like(p, pre_ns_grad.contiguous())
-            # Compute the global shape and offset for re-sharding the gradient.
-            if not hasattr(pre_ns_grad_dtensor._local_tensor, "__create_chunk_list__"):
-                update_uneven_dtensor_chunk_metadata(pre_ns_grad_dtensor)
-            # Unsharded Gradient DTensor
-            full_pre_ns_grad = gather_uneven_dtensor_to_full_tensor(pre_ns_grad_dtensor).to_local()
-            # Mirror the uneven sharding metadata to Megatron-FSDP DTensor parameters.
-            # By doing this, we can avoid unnecessary AG, as the parameters and gradients
-            # are globally and locally symmetrical in shape and offset.
-            self._copy_dtensor_chunk_metadata(p, pre_ns_grad_dtensor)
+            full_pre_ns_grad = self._gather_full_uneven_local_tensor_like(p, pre_ns_grad)
             all_updates[i] = (p, full_pre_ns_grad, True, lr, group_kwargs)
 
         # Phase 3: NS orthogonalization and weight update (fully local).
@@ -398,9 +391,9 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     orth_update = super(FSDPTensorParallelMuon, self).orthogonalize(
                         p, pre_ns_grad, **group_kwargs
                     )
-                    sharded_update = self._reshard_full_update_like(p, orth_update)
-                    self.pre_weight_update_fn_inplace(p._local_tensor, sharded_update._local_tensor)
-                    p.add_(sharded_update, alpha=-lr)  # DTensors
+                    local_update = self._local_shard_from_full_update_like(p, orth_update)
+                    self.pre_weight_update_fn_inplace(p._local_tensor, local_update)
+                    p._local_tensor.add_(local_update, alpha=-lr)
                     self.post_weight_update_fn_inplace(p._local_tensor)
                 else:
                     orth_update = (
@@ -423,25 +416,43 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         return local_tensor.numel() > 0 and tuple(dtensor.shape) != tuple(local_tensor.shape)
 
     def _get_boundary_gather_param_indices(self, group: Dict[str, Any]) -> set[int]:
-        """Return globally-agreed parameter indices that need a boundary all-gather."""
+        """Return globally-agreed first/last local params needing a boundary all-gather.
+
+        Within a single M-FSDP DataParallelBuffer bucket, a DP rank owns one contiguous shard of
+        that bucket, so only the first/last non-empty params in that bucket can be partial.
+        """
         params = group["params"]
-        local_boundary_indices = [
-            idx for idx, param in enumerate(params) if self._needs_boundary_gather(param)
+        cache_key = tuple(id(param) for param in params)
+        cached_indices = self._boundary_gather_indices_cache.get(cache_key)
+        if cached_indices is not None:
+            return cached_indices
+
+        non_empty_indices = [
+            idx for idx, param in enumerate(params) if param.to_local().numel() > 0
         ]
+        local_boundary_indices: list[int] = []
+        if non_empty_indices:
+            for idx in {non_empty_indices[0], non_empty_indices[-1]}:
+                if self._needs_boundary_gather(params[idx]):
+                    local_boundary_indices.append(idx)
 
         if self.dp_group is None or get_pg_size(self.dp_group) == 1:
-            return set(local_boundary_indices)
+            result = set(local_boundary_indices)
+            self._boundary_gather_indices_cache[cache_key] = result
+            return result
 
         gathered_indices: list[list[int] | None] = [None] * get_pg_size(self.dp_group)
         torch.distributed.all_gather_object(
             gathered_indices, local_boundary_indices, group=self.dp_group
         )
-        return {
+        result = {
             idx
             for rank_indices in gathered_indices
             if rank_indices is not None
             for idx in rank_indices
         }
+        self._boundary_gather_indices_cache[cache_key] = result
+        return result
 
     def _copy_dtensor_chunk_metadata(self, dst, src) -> None:
         if hasattr(src._local_tensor, "__create_chunk_list__"):
@@ -460,7 +471,106 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         self._copy_dtensor_chunk_metadata(dtensor, dtensor_ref)
         return dtensor
 
-    def _reshard_full_update_like(self, dtensor_ref, full_update: torch.Tensor):
+    def _get_uneven_gather_plan(self, dtensor_ref) -> dict[str, Any] | None:
+        """Return static metadata needed to gather a Megatron-FSDP uneven DTensor.
+
+        The parameter layout is fixed after M-FSDP construction, so the chunk
+        offsets/shapes only need to be exchanged once per boundary parameter.
+        """
+        cache_key = id(dtensor_ref)
+        cached_plan = self._uneven_gather_plan_cache.get(cache_key)
+        if cached_plan is not None:
+            return cached_plan
+
+        shard_mesh_dims = []
+        for mesh_dim, placement in enumerate(dtensor_ref.placements):
+            if isinstance(placement, (Shard, _StridedShard)):
+                shard_mesh_dims.append(mesh_dim)
+            elif isinstance(placement, Replicate):
+                continue
+            else:
+                raise ValueError(
+                    f"Unexpected placement {placement} at mesh dimension {mesh_dim}. "
+                    "Expected Shard, _StridedShard, or Replicate."
+                )
+
+        if len(shard_mesh_dims) != 1:
+            # M-FSDP optimizer shards are expected to have one sharded mesh
+            # dimension. Keep the generic helper as a conservative fallback.
+            return None
+
+        if not hasattr(dtensor_ref._local_tensor, "__create_chunk_list__"):
+            update_uneven_dtensor_chunk_metadata(dtensor_ref)
+
+        chunk_metadata_list = dtensor_ref._local_tensor.__create_chunk_list__()
+        if len(chunk_metadata_list) != 1:
+            raise ValueError(
+                f"Expected exactly one chunk metadata per rank, got {len(chunk_metadata_list)}."
+            )
+
+        local_tensor = dtensor_ref.to_local()
+        local_chunk_metadata = chunk_metadata_list[0]
+        local_chunks_info = [
+            {"shape": torch.Size(local_tensor.shape), "offset": tuple(local_chunk_metadata.offsets)}
+        ]
+        shard_group = dtensor_ref.device_mesh.get_group(shard_mesh_dims[0])
+        group_chunks_info: list[list[dict[str, Any]] | None] = [None] * shard_group.size()
+        torch.distributed.all_gather_object(group_chunks_info, local_chunks_info, group=shard_group)
+
+        chunk_infos = [
+            {
+                "shape": torch.Size(chunk_info["shape"]),
+                "offset": tuple(chunk_info["offset"]),
+                "numel": torch.Size(chunk_info["shape"]).numel(),
+            }
+            for chunks_info in group_chunks_info
+            if chunks_info is not None
+            for chunk_info in chunks_info
+        ]
+        plan = {"shard_group": shard_group, "chunk_infos": chunk_infos}
+        self._uneven_gather_plan_cache[cache_key] = plan
+        return plan
+
+    def _gather_full_uneven_local_tensor_like(
+        self, dtensor_ref, local_tensor: torch.Tensor
+    ) -> torch.Tensor:
+        """Gather a local tensor using the uneven sharding layout of `dtensor_ref`."""
+        plan = self._get_uneven_gather_plan(dtensor_ref)
+        if plan is None:
+            if uneven_dtensor_to_full_tensor is None:
+                raise RuntimeError(
+                    "Megatron-FSDP `uneven_dtensor_to_full_tensor` is required "
+                    "to gather un-evenly sharded parameters for Muon step()."
+                )
+            local_dtensor = self._dtensor_from_local_like(dtensor_ref, local_tensor.contiguous())
+            if not hasattr(local_dtensor._local_tensor, "__create_chunk_list__"):
+                update_uneven_dtensor_chunk_metadata(local_dtensor)
+            full_tensor = uneven_dtensor_to_full_tensor(local_dtensor)
+            self._copy_dtensor_chunk_metadata(dtensor_ref, local_dtensor)
+            return full_tensor
+
+        local_buffer = local_tensor.contiguous().view(-1)
+        group_tensors = [
+            torch.empty(chunk_info["numel"], dtype=local_tensor.dtype, device=local_tensor.device)
+            for chunk_info in plan["chunk_infos"]
+        ]
+        torch.distributed.all_gather(group_tensors, local_buffer, group=plan["shard_group"])
+
+        full_tensor = torch.empty(
+            dtensor_ref.shape, dtype=local_tensor.dtype, device=local_tensor.device
+        )
+        assigned_numel = 0
+        for chunk_info, gathered_tensor in zip(plan["chunk_infos"], group_tensors):
+            chunk_shape = chunk_info["shape"]
+            offset = chunk_info["offset"]
+            slices = tuple(slice(o, o + s) for o, s in zip(offset, chunk_shape))
+            full_tensor[slices] = gathered_tensor.view(chunk_shape)
+            assigned_numel += chunk_info["numel"]
+
+        _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
+        return full_tensor
+
+    def _local_shard_from_full_update_like(self, dtensor_ref, full_update: torch.Tensor):
         if not hasattr(dtensor_ref._local_tensor, "__create_chunk_list__"):
             raise ValueError(
                 f"{dtensor_ref} is not a Megatron-FSDP DTensor parameter "
@@ -473,8 +583,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             slice(offset, offset + size)
             for offset, size in zip(shard_metadata.offsets, shard_metadata.sizes)
         )
-        local_update = full_update[slices].contiguous().to(dtype=dtensor_ref._local_tensor.dtype)
-        return self._dtensor_from_local_like(dtensor_ref, local_update)
+        return full_update[slices].contiguous().to(dtype=dtensor_ref._local_tensor.dtype)
 
     @torch.no_grad()  # type: ignore[misc]
     def _local_muon_update(

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -17,7 +17,12 @@ import torch
 from torch.optim.optimizer import ParamsT
 
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.utils import get_pg_size, log_single_rank
+from megatron.core.utils import (
+    append_unique_process_group,
+    get_dtensor_data_parallel_shard_groups,
+    get_pg_size,
+    log_single_rank,
+)
 
 from .optimizer_config import ParamKey, ParamPredicate
 
@@ -719,6 +724,42 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         local_tensor = dtensor._local_tensor
         return local_tensor.numel() > 0 and tuple(dtensor.shape) != tuple(local_tensor.shape)
 
+    def _collect_boundary_indices_across_shard_groups(
+        self, params: list[torch.Tensor], local_indices: list[int]
+    ) -> set[int]:
+        """Propagate boundary-gather decisions over all DTensor FSDP shard dimensions.
+
+        In plain FSDP the optimizer's ``dp_group`` is the only shard group. In
+        HFSDP, however, the optimizer wrapper may be scoped to the inner DP
+        group while a DTensor can also be sharded on the outer DP dimension.
+        Boundary parameters must be selected consistently by every rank that
+        participates in any of the uneven gather stages.
+        """
+        result = set(local_indices)
+
+        shard_groups: list[torch.distributed.ProcessGroup] = []
+        for param in params:
+            if isinstance(param, _DTensor):
+                for shard_group in get_dtensor_data_parallel_shard_groups(param):
+                    append_unique_process_group(shard_groups, shard_group)
+
+        if not shard_groups and self.dp_group is not None:
+            append_unique_process_group(shard_groups, self.dp_group)
+
+        for shard_group in shard_groups:
+            if get_pg_size(shard_group) <= 1:
+                continue
+            gathered_indices: list[list[int] | None] = [None] * get_pg_size(shard_group)
+            torch.distributed.all_gather_object(gathered_indices, sorted(result), group=shard_group)
+            result.update(
+                idx
+                for rank_indices in gathered_indices
+                if rank_indices is not None
+                for idx in rank_indices
+            )
+
+        return result
+
     def _get_mfsdp_param_layout(self, param: torch.Tensor, param_idx: int):
         """Return M-FSDP flat-buffer layout metadata for `param`.
 
@@ -828,8 +869,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
 
         has_mfsdp_params = any(getattr(param, "orig_param", None) is not None for param in params)
         if has_mfsdp_params:
-            result = set()
-            local_split_indices = []
+            local_boundary_indices = []
             for idx, param in enumerate(params):
                 if getattr(param, "orig_param", None) is None:
                     raise AssertionError(
@@ -837,46 +877,19 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                         f"M-FSDP bucket metadata: param_idx={idx}."
                     )
                 if self._mfsdp_param_crosses_shard_boundary(param, idx):
-                    result.add(idx)
+                    local_boundary_indices.append(idx)
                 elif self._needs_boundary_gather(param):
-                    local_split_indices.append(idx)
-            if self.dp_group is not None and get_pg_size(self.dp_group) > 1:
-                gathered_local_split_indices: list[list[int] | None] = [None] * get_pg_size(
-                    self.dp_group
-                )
-                torch.distributed.all_gather_object(
-                    gathered_local_split_indices, local_split_indices, group=self.dp_group
-                )
-                result.update(
-                    idx
-                    for rank_indices in gathered_local_split_indices
-                    if rank_indices is not None
-                    for idx in rank_indices
-                )
-            else:
-                result.update(local_split_indices)
+                    local_boundary_indices.append(idx)
+            result = self._collect_boundary_indices_across_shard_groups(
+                params, local_boundary_indices
+            )
             self._boundary_gather_indices_cache[cache_key] = result
             return result
 
         local_boundary_indices = [
             idx for idx, param in enumerate(params) if self._needs_boundary_gather(param)
         ]
-
-        if self.dp_group is None or get_pg_size(self.dp_group) == 1:
-            result = set(local_boundary_indices)
-            self._boundary_gather_indices_cache[cache_key] = result
-            return result
-
-        gathered_indices: list[list[int] | None] = [None] * get_pg_size(self.dp_group)
-        torch.distributed.all_gather_object(
-            gathered_indices, local_boundary_indices, group=self.dp_group
-        )
-        result = {
-            idx
-            for rank_indices in gathered_indices
-            if rank_indices is not None
-            for idx in rank_indices
-        }
+        result = self._collect_boundary_indices_across_shard_groups(params, local_boundary_indices)
         self._boundary_gather_indices_cache[cache_key] = result
         return result
 

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -306,13 +306,18 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
     """
 
     def __init__(
-        self, params: ParamsT, dp_group: torch.distributed.ProcessGroup | None = None, **kwargs: Any
+        self,
+        params: ParamsT,
+        dp_group: torch.distributed.ProcessGroup | None = None,
+        fsdp_batched_all_gather: bool = False,
+        **kwargs: Any,
     ) -> None:
         assert _HAVE_DTENSOR, (
             "[Megatron-FSDP] torch.distributed.tensor.DTensor "
             f"is required to use {type(self).__name__}."
         )
         self.dp_group = dp_group
+        self.fsdp_batched_all_gather = fsdp_batched_all_gather
         self._boundary_gather_indices_cache: Dict[tuple[int, ...], set[int]] = {}
         self._uneven_gather_plan_cache: Dict[int, Dict[str, Any]] = {}
         super().__init__(params, **kwargs)
@@ -380,9 +385,18 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             i for i, (_, _, needs_gather, _, _) in enumerate(all_updates) if needs_gather
         ]
         if boundary_update_indices:
-            gathered_boundary_updates = self._gather_full_uneven_local_tensors_like(
-                [(all_updates[i][0], all_updates[i][1]) for i in boundary_update_indices]
-            )
+            boundary_items = [
+                (all_updates[i][0], all_updates[i][1]) for i in boundary_update_indices
+            ]
+            if self.fsdp_batched_all_gather:
+                gathered_boundary_updates = self._gather_full_uneven_local_tensors_like(
+                    boundary_items
+                )
+            else:
+                gathered_boundary_updates = [
+                    self._gather_full_uneven_local_tensor_like(p, local_tensor)
+                    for p, local_tensor in boundary_items
+                ]
             for i, full_pre_ns_grad in zip(boundary_update_indices, gathered_boundary_updates):
                 p, _, _, lr, group_kwargs = all_updates[i]
                 all_updates[i] = (p, full_pre_ns_grad, True, lr, group_kwargs)
@@ -422,11 +436,48 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         local_tensor = dtensor.to_local()
         return local_tensor.numel() > 0 and tuple(dtensor.shape) != tuple(local_tensor.shape)
 
-    def _get_boundary_gather_param_indices(self, group: Dict[str, Any]) -> set[int]:
-        """Return globally-agreed first/last local params needing a boundary all-gather.
+    def _get_mfsdp_bucket_key_and_offset(self, param: torch.Tensor, param_idx: int):
+        """Return the M-FSDP bucket identity and flat-buffer offset for `param`.
 
-        Within a single M-FSDP DataParallelBuffer bucket, a DP rank owns one contiguous shard of
-        that bucket, so only the first/last non-empty params in that bucket can be partial.
+        FSDP optimizer params keep a pointer to the original module parameter.
+        M-FSDP attaches the original parameter's buffer and item id there, which
+        lets Muon reason about first/last params in the same flat bucket instead
+        of in the larger optimizer param group.
+        """
+        orig_param = getattr(param, "orig_param", None)
+        if orig_param is None:
+            return None
+
+        gbuf = getattr(orig_param, "_gbuf", None)
+        item_id = getattr(orig_param, "_item_id", None)
+        if gbuf is None or item_id is None or not hasattr(gbuf, "item_index_map"):
+            raise AssertionError(
+                "M-FSDP optimizer parameter is missing bucket metadata required "
+                f"for Muon boundary gather detection: param_idx={param_idx}."
+            )
+
+        item_index = gbuf.item_index_map.get(item_id)
+        if item_index is None or not hasattr(item_index, "global_data_index"):
+            raise AssertionError(
+                "M-FSDP optimizer parameter has invalid bucket item metadata required "
+                f"for Muon boundary gather detection: param_idx={param_idx}, "
+                f"item_id={item_id}."
+            )
+
+        bucket_index = getattr(gbuf, "bucket_index", None)
+        bucket_id = getattr(bucket_index, "bucket_id", getattr(gbuf, "bucket_id", None))
+        bucket_key = (id(gbuf), bucket_id)
+        order_key = (int(item_index.global_data_index), param_idx)
+        return bucket_key, order_key
+
+    def _get_boundary_gather_param_indices(self, group: Dict[str, Any]) -> set[int]:
+        """Return globally-agreed bucket-boundary params needing all-gather.
+
+        Megatron-FSDP assigns each DP rank a contiguous slice within each flat
+        parameter bucket. Therefore, only the first and last non-empty Muon
+        parameters owned by a rank in each M-FSDP bucket can cross a DP
+        boundary. A Muon optimizer group may span multiple M-FSDP buckets, so
+        this detection must be bucket-aware.
         """
         params = group["params"]
         cache_key = tuple(id(param) for param in params)
@@ -434,12 +485,30 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         if cached_indices is not None:
             return cached_indices
 
-        non_empty_indices = [
-            idx for idx, param in enumerate(params) if param.to_local().numel() > 0
-        ]
+        has_mfsdp_params = any(getattr(param, "orig_param", None) is not None for param in params)
+        bucket_param_indices: dict[Any, list[tuple[tuple[int, int], int]]] = {}
+        for idx, param in enumerate(params):
+            if param.to_local().numel() == 0:
+                continue
+
+            bucket_metadata = self._get_mfsdp_bucket_key_and_offset(param, idx)
+            if bucket_metadata is None:
+                if has_mfsdp_params:
+                    raise AssertionError(
+                        "Muon optimizer group mixes M-FSDP params with params lacking "
+                        f"M-FSDP bucket metadata: param_idx={idx}."
+                    )
+                bucket_key = ("optimizer_group", 0)
+                order_key = (idx, idx)
+            else:
+                bucket_key, order_key = bucket_metadata
+
+            bucket_param_indices.setdefault(bucket_key, []).append((order_key, idx))
+
         local_boundary_indices: list[int] = []
-        if non_empty_indices:
-            for idx in {non_empty_indices[0], non_empty_indices[-1]}:
+        for param_indices in bucket_param_indices.values():
+            param_indices.sort(key=lambda item: item[0])
+            for idx in {param_indices[0][1], param_indices[-1][1]}:
                 if self._needs_boundary_gather(params[idx]):
                     local_boundary_indices.append(idx)
 

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -387,34 +387,126 @@ class FSDPZeROTensorParallelMuon(TensorParallelMuon):
         self.dp_group = dp_group
         super().__init__(params, **kwargs)
 
-    def orthogonalize(self, p: torch.Tensor, grad: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-        """Orthogonalize with DP-shard allgather for FSDP ZeRO >= 1."""
-        if self.dp_group is None or get_pg_size(self.dp_group) == 1:
-            return super().orthogonalize(p, grad, **kwargs)
+    @torch.no_grad()  # type: ignore[misc]
+    def step(self, closure: Callable | None = None) -> float | None:
+        """Muon step for Megatron-FSDP ZeRO-1/2/3.
 
+        M-FSDP shards a flat grad buffer across DP, so the per-param local
+        shard can be empty on some ranks (`p.grad is None`) or variable in
+        size – unlike a uniform `Shard(0)` DTensor. The standard
+        `OrthogonalizedOptimizer.step` skips params with `grad is None`,
+        which desyncs the DP collective inside `orthogonalize` (different
+        ranks process different params → allgather mismatch → hang).
+
+        We fix that here by processing every param on every rank in lockstep.
+        Each param's full gradient is reconstructed via a DP-wide all-gather
+        (supports variable-size local shards), but Newton-Schulz is run on a
+        single owner rank (round-robin by param index) and broadcast back,
+        so NS compute is amortised across DP rather than duplicated 8×.
+        """
+        if closure is None:
+            loss = None
+        else:
+            loss = closure()
+
+        for group in self.param_groups:
+            # `skip_non_grad_params=False`: we must create momentum buffers
+            # for every param, because even params with empty local grad shards
+            # on this rank need to participate in the DP-collective orthogonalize.
+            self._init_group(group, skip_non_grad_params=False)
+
+            for p in group["params"]:
+                self._muon_step_one(p, group)
+
+        return loss
+
+    @torch.no_grad()  # type: ignore[misc]
+    def _muon_step_one(self, p: torch.Tensor, group: Dict[str, Any]) -> None:
+        """Per-param Muon update that participates in DP collectives on every rank."""
+        # Fall back to the plain parent step for the single-rank / unsharded case.
+        if self.dp_group is None or get_pg_size(self.dp_group) == 1:
+            if p.grad is None:
+                return
+            return self._local_muon_update(p, p.grad, group)
+
+        # Skip params that aren't DTensors (shouldn't happen in M-FSDP).
+        if not (_HAVE_DTENSOR and isinstance(p, _DTensor)):
+            if p.grad is None:
+                return
+            return self._local_muon_update(p, p.grad, group)
+
+        # Every rank processes every param in lockstep (regardless of whether
+        # the local grad shard is empty) so the DP collectives below stay in
+        # sync. M-FSDP's flat-buffer sharding means local shard sizes vary
+        # per rank and per param, so we operate on DTensors and use
+        # `full_tensor()` to reconstruct the full matrix.
+
+        # Use local views to mutate momentum and param. Momentum is kept
+        # per-shard (same size as p.to_local()); the initial buffer was
+        # allocated via `torch.zeros_like(p.data)` in `_init_group` which,
+        # for a DTensor p, yields a Shard(0) DTensor with the correct local
+        # shape on this rank.
+        state = self.state[p]
+        mom_buffer = state["momentum_buffer"]
+        mom_local = mom_buffer.to_local() if isinstance(mom_buffer, _DTensor) else mom_buffer
+
+        # Derive this rank's local grad. If p.grad is None (empty shard on
+        # this rank), use a zero tensor of the expected local shape so the
+        # local lerp_ / weight-decay math is a no-op while still letting us
+        # participate in the full_tensor() allgather below.
+        grad = p.grad
+        if grad is None:
+            local_grad = torch.zeros_like(mom_local)
+        else:
+            local_grad = grad.to_local() if isinstance(grad, _DTensor) else grad
+
+        p_local = p.to_local()
+
+        # Local weight decay on this rank's param/grad slice.
+        wd = group["weight_decay"]
+        lr = group["lr"]
+        if wd != 0.0:
+            # Decoupled weight decay: p *= (1 - lr * wd)
+            p_local.mul_(1.0 - lr * wd)
+
+        # Local momentum EMA update.
+        mom_local.lerp_(local_grad, 1 - group["momentum"])
+
+        # Assemble the pre-NS gradient (local).
+        if self.nesterov:
+            pre_local = local_grad.lerp(mom_local, group["momentum"])
+        else:
+            pre_local = mom_local
+
+        # Gather per-rank local row counts so we can allocate a per-rank
+        # destination for the allgather. M-FSDP uses a flat-buffer grad
+        # sharding → local shard sizes vary per rank, which
+        # `all_gather_into_tensor` (equal-size) and DTensor `full_tensor`
+        # (assumes uniform Shard(0)) both handle poorly. We use
+        # `all_gather(tensor_list, input)`, which supports variable sizes.
         dp_size = get_pg_size(self.dp_group)
         dp_rank = get_pg_rank(self.dp_group)
+        row_counts = torch.zeros(dp_size, dtype=torch.long, device=p_local.device)
+        row_counts[dp_rank] = pre_local.shape[0]
+        torch.distributed.all_reduce(row_counts, group=self.dp_group)
+        row_counts_cpu = row_counts.tolist()
 
-        # The momentum buffer (grad) and param (p) may be Shard(0) DTensors whose
-        # `.shape[0]` is the global row count. Always extract the local shard so
-        # "shard_rows" reflects the per-rank row count.
-        grad_local = grad.to_local() if (_HAVE_DTENSOR and isinstance(grad, _DTensor)) else grad
-        shard_rows = grad_local.shape[0]
+        # Build per-rank output buffers of the right row count.
+        gathered = [
+            torch.empty(
+                (row_counts_cpu[r], *pre_local.shape[1:]),
+                device=pre_local.device,
+                dtype=pre_local.dtype,
+            )
+            for r in range(dp_size)
+        ]
+        torch.distributed.all_gather(gathered, pre_local.contiguous(), group=self.dp_group)
+        full_grad = torch.cat(gathered, dim=0)
 
-        # Allgather DP row-shards to reconstruct the TP-local, DP-full grad.
-        # FSDP guarantees equal shard sizes across DP ranks (buckets are padded
-        # to `dp_size * inner_dim`), so a single all_gather_into_tensor works.
-        full_grad = torch.empty(
-            shard_rows * dp_size,
-            *grad_local.shape[1:],
-            device=grad_local.device,
-            dtype=grad_local.dtype,
-        )
-        torch.distributed.all_gather_into_tensor(
-            full_grad, grad_local.contiguous(), group=self.dp_group
-        )
-
-        # Trim FSDP bucket-padding rows back to the param's TP-local row count.
+        # Trim any trailing FSDP bucket padding rows so NS sees only the real
+        # parameter. `p.shape[0]` is the FSDP-declared global row count
+        # (= sum of per-rank shard rows, possibly including padding at the
+        # tail); the true param row count is the global shape from the DTensor.
         tp_group = (
             (
                 self.pg_collection.expt_tp
@@ -427,60 +519,66 @@ class FSDPZeROTensorParallelMuon(TensorParallelMuon):
         partition_dim = None if self.tp_mode == "blockwise" else getattr(p, "partition_dim", None)
         if partition_dim == -1:
             partition_dim = None
-
         tp_size_dim0 = get_pg_size(tp_group) if (partition_dim == 0 and tp_group is not None) else 1
+        tp_local_rows = p.shape[0] // max(tp_size_dim0, 1)
+        if full_grad.shape[0] > tp_local_rows:
+            full_grad = full_grad[:tp_local_rows]
 
-        if _HAVE_DTENSOR and isinstance(p, _DTensor):
-            # Production: `p.shape[0]` is the FSDP-declared global row count
-            # (already includes bucket padding); divide by `tp_size_dim0`
-            # to get the TP-local row count.
-            tp_local_rows = p.shape[0] // max(tp_size_dim0, 1)
-        else:
-            # Plain-tensor unit-test path: `p` is treated as the per-rank
-            # shard (`p.shape[0] == shard_rows`), so the TP-local row count
-            # must be reconstructed from the allgather, not read from `p`.
-            tp_local_rows = shard_rows * dp_size
+        # Newton-Schulz on the full matrix. We run it on every rank (duplicated
+        # compute across DP) intentionally. A partition-and-broadcast scheme
+        # was tried (owner does NS; others bcast) but the per-param serial
+        # loop turns the broadcast into a per-param sync, negating the
+        # parallelism across ranks – it measured slightly slower in practice.
+        # An effective scheme would need to pipeline NS with the allgather/
+        # broadcast for the *next* param; left as future work.
+        from emerging_optimizers import utils
 
-        full_grad = full_grad[:tp_local_rows]
+        with utils.fp32_matmul_precision(self.fp32_matmul_prec):
+            group_kwargs = {k: v for k, v in group.items() if k != "params"}
+            orth_full_grad = super(FSDPZeROTensorParallelMuon, self).orthogonalize(
+                p, full_grad, **group_kwargs
+            )
 
-        # Apply NS to the TP-local, DP-full gradient. `super().orthogonalize`
-        # re-derives `tp_group` / `partition_dim` internally; the TP
-        # dimension of the reconstructed `full_grad` is unchanged.
-        orth_full_grad = super().orthogonalize(p, full_grad, **kwargs)
-
-        # Extract this rank's DP row-shard. If the last rank held fewer real
-        # rows than `shard_rows` (FSDP padding), zero-fill the extra rows so
-        # padded slots get a no-op update.
-        start_row = dp_rank * shard_rows
-        end_row = min(start_row + shard_rows, tp_local_rows)
-        orth_shard = orth_full_grad[start_row:end_row]
-
-        if orth_shard.shape[0] < shard_rows:
-            pad_rows = shard_rows - orth_shard.shape[0]
+        # Slice out this rank's contribution. Exclusive prefix sum of
+        # row_counts gives the offset; we saved it above.
+        start = sum(row_counts_cpu[:dp_rank])
+        end = start + row_counts_cpu[dp_rank]
+        # Guard against the last rank holding only padding rows: clamp end.
+        end = min(end, orth_full_grad.shape[0])
+        orth_local = orth_full_grad[start:end].to(dtype=p_local.dtype)
+        # If this rank's shard was purely padding (no real rows), orth_local
+        # may be shorter than p_local; pad with zeros so the add_ lines up.
+        if orth_local.shape[0] < p_local.shape[0]:
             pad = torch.zeros(
-                pad_rows, *grad_local.shape[1:], device=grad_local.device, dtype=grad_local.dtype
+                (p_local.shape[0] - orth_local.shape[0], *p_local.shape[1:]),
+                device=p_local.device,
+                dtype=p_local.dtype,
             )
-            orth_shard = torch.cat([orth_shard, pad], dim=0)
+            orth_local = torch.cat([orth_local, pad], dim=0)
 
-        # Wrap the plain result back into a DTensor if the input was a DTensor.
-        # `OrthogonalizedOptimizer.step` does `p.add_(grad, alpha=-lr)`; for
-        # a Shard(0) DTensor `p` the update tensor must also be a DTensor with
-        # matching placements, otherwise PyTorch promotes it to `Replicate`
-        # and fails the global-shape check. Recent PyTorch versions require
-        # `shape` and `stride` to be passed together; for a Shard(0)
-        # contiguous local the global stride matches the local stride.
-        if _HAVE_DTENSOR and isinstance(grad, _DTensor):
-            local_contig = orth_shard.contiguous()
-            orth_shard = _DTensor.from_local(
-                local_contig,
-                device_mesh=grad.device_mesh,
-                placements=grad.placements,
-                shape=grad.shape,
-                stride=local_contig.stride(),
-                run_check=False,
-            )
+        # In-place weight update on this rank's local shard.
+        p_local.add_(orth_local, alpha=-lr)
 
-        return orth_shard
+    @torch.no_grad()  # type: ignore[misc]
+    def _local_muon_update(
+        self, p: torch.Tensor, grad: torch.Tensor, group: dict[str, Any]
+    ) -> None:
+        """Local (non-DP) Muon update – identical to OrthogonalizedOptimizer.step body."""
+        from emerging_optimizers import utils
+
+        state = self.state[p]
+        self._apply_weight_decay_inplace(p, grad, group["lr"], group["weight_decay"])
+        state["momentum_buffer"].lerp_(grad, 1 - group["momentum"])
+        if self.nesterov:
+            grad = grad.lerp(state["momentum_buffer"], group["momentum"])
+        else:
+            grad = state["momentum_buffer"]
+        with utils.fp32_matmul_precision(self.fp32_matmul_prec):
+            group_kwargs = {k: v for k, v in group.items() if k != "params"}
+            orth_grad = self.orthogonalize(p, grad, **group_kwargs)
+        self.pre_weight_update_fn_inplace(p, orth_grad)
+        p.add_(orth_grad, alpha=-group["lr"])
+        self.post_weight_update_fn_inplace(p)
 
 
 class TensorParallelAdaptiveMuon(TensorParallelMuon, AdaptiveMuon):

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -27,7 +27,7 @@ try:
 
     from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
         _assert_chunks_cover_full_tensor,
-        uneven_dtensor_to_full_tensor,
+        redistribute_uneven_dtensor_to_replicated,
         update_uneven_dtensor_chunk_metadata,
     )
 
@@ -38,7 +38,7 @@ except ImportError:
     Shard = None  # type: ignore[assignment,misc]
     _StridedShard = None  # type: ignore[assignment,misc]
     _assert_chunks_cover_full_tensor = None  # type: ignore[assignment]
-    uneven_dtensor_to_full_tensor = None  # type: ignore[assignment]
+    redistribute_uneven_dtensor_to_replicated = None  # type: ignore[assignment]
     update_uneven_dtensor_chunk_metadata = None  # type: ignore[assignment]
     _HAVE_DTENSOR = False
 
@@ -436,13 +436,13 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         local_tensor = dtensor.to_local()
         return local_tensor.numel() > 0 and tuple(dtensor.shape) != tuple(local_tensor.shape)
 
-    def _get_mfsdp_bucket_key_and_offset(self, param: torch.Tensor, param_idx: int):
-        """Return the M-FSDP bucket identity and flat-buffer offset for `param`.
+    def _get_mfsdp_param_layout(self, param: torch.Tensor, param_idx: int):
+        """Return M-FSDP flat-buffer layout metadata for `param`.
 
         FSDP optimizer params keep a pointer to the original module parameter.
-        M-FSDP attaches the original parameter's buffer and item id there, which
-        lets Muon reason about first/last params in the same flat bucket instead
-        of in the larger optimizer param group.
+        M-FSDP attaches the original parameter's backing buffer and item id
+        there, which lets Muon test whether the parameter's flat item interval
+        crosses a shard boundary exactly.
         """
         orig_param = getattr(param, "orig_param", None)
         if orig_param is None:
@@ -457,7 +457,11 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             )
 
         item_index = gbuf.item_index_map.get(item_id)
-        if item_index is None or not hasattr(item_index, "global_data_index"):
+        if (
+            item_index is None
+            or not hasattr(item_index, "global_data_index")
+            or not hasattr(item_index, "size")
+        ):
             raise AssertionError(
                 "M-FSDP optimizer parameter has invalid bucket item metadata required "
                 f"for Muon boundary gather detection: param_idx={param_idx}, "
@@ -465,20 +469,76 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             )
 
         bucket_index = getattr(gbuf, "bucket_index", None)
-        bucket_id = getattr(bucket_index, "bucket_id", getattr(gbuf, "bucket_id", None))
-        bucket_key = (id(gbuf), bucket_id)
-        order_key = (int(item_index.global_data_index), param_idx)
-        return bucket_key, order_key
+        shard_bucket_index = getattr(gbuf, "shard_bucket_index", None)
+        if (
+            bucket_index is None
+            or shard_bucket_index is None
+            or not hasattr(bucket_index, "global_data_index")
+            or not hasattr(bucket_index, "size")
+            or not hasattr(shard_bucket_index, "size")
+        ):
+            raise AssertionError(
+                "M-FSDP optimizer parameter is missing bucket/shard metadata required "
+                f"for Muon boundary gather detection: param_idx={param_idx}."
+            )
 
-    def _get_boundary_gather_param_indices(self, group: Dict[str, Any]) -> set[int]:
-        """Return globally-agreed bucket-boundary params needing all-gather.
+        return gbuf, item_index, bucket_index, shard_bucket_index
 
-        Megatron-FSDP assigns each DP rank a contiguous slice within each flat
-        parameter bucket. Therefore, only the first and last non-empty Muon
-        parameters owned by a rank in each M-FSDP bucket can cross a DP
-        boundary. A Muon optimizer group may span multiple M-FSDP buckets, so
-        this detection must be bucket-aware.
-        """
+    def _mfsdp_param_crosses_shard_boundary(self, param: torch.Tensor, param_idx: int) -> bool:
+        """Return whether `param`'s flat M-FSDP item interval spans DP shards."""
+        layout = self._get_mfsdp_param_layout(param, param_idx)
+        if layout is None:
+            raise AssertionError(
+                "Expected M-FSDP parameter metadata while checking Muon boundary "
+                f"gather requirement: param_idx={param_idx}."
+            )
+
+        gbuf, item_index, bucket_index, shard_bucket_index = layout
+        if not getattr(gbuf, "is_data_distributed", True):
+            return False
+
+        item_size = int(item_index.size)
+        if item_size == 0:
+            return False
+
+        bucket_start = int(bucket_index.global_data_index)
+        bucket_size = int(bucket_index.size)
+        shard_size = int(shard_bucket_index.size)
+        if shard_size <= 0 or bucket_size % shard_size != 0:
+            raise AssertionError(
+                "Invalid M-FSDP shard metadata for Muon boundary gather detection: "
+                f"param_idx={param_idx}, bucket_size={bucket_size}, shard_size={shard_size}."
+            )
+
+        item_start = int(item_index.global_data_index)
+        item_end = item_start + item_size
+        if item_start < bucket_start or item_end > bucket_start + bucket_size:
+            raise AssertionError(
+                "M-FSDP item interval falls outside its bucket during Muon boundary "
+                f"gather detection: param_idx={param_idx}, item=({item_start}, {item_end}), "
+                f"bucket=({bucket_start}, {bucket_start + bucket_size})."
+            )
+
+        first_shard = (item_start - bucket_start) // shard_size
+        last_shard = (item_end - 1 - bucket_start) // shard_size
+        crosses_boundary = first_shard != last_shard
+
+        local_tensor = param.to_local()
+        if local_tensor.numel() > 0:
+            local_is_partial = tuple(param.shape) != tuple(local_tensor.shape)
+            if local_is_partial and not crosses_boundary:
+                raise AssertionError(
+                    "M-FSDP DTensor local shape indicates a split parameter, but flat "
+                    "bucket metadata does not cross a shard boundary: "
+                    f"param_idx={param_idx}, item=({item_start}, {item_end}), "
+                    f"shard_size={shard_size}, global_shape={tuple(param.shape)}, "
+                    f"local_shape={tuple(local_tensor.shape)}."
+                )
+
+        return crosses_boundary
+
+    def _get_boundary_gather_param_indices(self, group: dict[str, Any]) -> set[int]:
+        """Return globally-agreed parameters whose flat items cross FSDP shard boundaries."""
         params = group["params"]
         cache_key = tuple(id(param) for param in params)
         cached_indices = self._boundary_gather_indices_cache.get(cache_key)
@@ -486,31 +546,22 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             return cached_indices
 
         has_mfsdp_params = any(getattr(param, "orig_param", None) is not None for param in params)
-        bucket_param_indices: dict[Any, list[tuple[tuple[int, int], int]]] = {}
-        for idx, param in enumerate(params):
-            if param.to_local().numel() == 0:
-                continue
-
-            bucket_metadata = self._get_mfsdp_bucket_key_and_offset(param, idx)
-            if bucket_metadata is None:
-                if has_mfsdp_params:
+        if has_mfsdp_params:
+            result = set()
+            for idx, param in enumerate(params):
+                if getattr(param, "orig_param", None) is None:
                     raise AssertionError(
                         "Muon optimizer group mixes M-FSDP params with params lacking "
                         f"M-FSDP bucket metadata: param_idx={idx}."
                     )
-                bucket_key = ("optimizer_group", 0)
-                order_key = (idx, idx)
-            else:
-                bucket_key, order_key = bucket_metadata
+                if self._mfsdp_param_crosses_shard_boundary(param, idx):
+                    result.add(idx)
+            self._boundary_gather_indices_cache[cache_key] = result
+            return result
 
-            bucket_param_indices.setdefault(bucket_key, []).append((order_key, idx))
-
-        local_boundary_indices: list[int] = []
-        for param_indices in bucket_param_indices.values():
-            param_indices.sort(key=lambda item: item[0])
-            for idx in {param_indices[0][1], param_indices[-1][1]}:
-                if self._needs_boundary_gather(params[idx]):
-                    local_boundary_indices.append(idx)
+        local_boundary_indices = [
+            idx for idx, param in enumerate(params) if self._needs_boundary_gather(param)
+        ]
 
         if self.dp_group is None or get_pg_size(self.dp_group) == 1:
             result = set(local_boundary_indices)
@@ -609,21 +660,21 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
 
     def _gather_full_uneven_local_tensor_like(
         self, dtensor_ref, local_tensor: torch.Tensor
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | None:
         """Gather a local tensor using the uneven sharding layout of `dtensor_ref`."""
         plan = self._get_uneven_gather_plan(dtensor_ref)
         if plan is None:
-            if uneven_dtensor_to_full_tensor is None:
+            if redistribute_uneven_dtensor_to_replicated is None:
                 raise RuntimeError(
-                    "Megatron-FSDP `uneven_dtensor_to_full_tensor` is required "
+                    "Megatron-FSDP `redistribute_uneven_dtensor_to_replicated` is required "
                     "to gather un-evenly sharded parameters for Muon step()."
                 )
             local_dtensor = self._dtensor_from_local_like(dtensor_ref, local_tensor.contiguous())
             if not hasattr(local_dtensor._local_tensor, "__create_chunk_list__"):
                 update_uneven_dtensor_chunk_metadata(local_dtensor)
-            full_tensor = uneven_dtensor_to_full_tensor(local_dtensor)
+            full_tensor = redistribute_uneven_dtensor_to_replicated(local_dtensor).to_local()
             self._copy_dtensor_chunk_metadata(dtensor_ref, local_dtensor)
-            return full_tensor
+            return None if local_tensor.numel() == 0 else full_tensor
 
         local_buffer = local_tensor.contiguous().view(-1)
         group_tensors = [
@@ -631,6 +682,9 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             for chunk_info in plan["chunk_infos"]
         ]
         torch.distributed.all_gather(group_tensors, local_buffer, group=plan["shard_group"])
+
+        if local_tensor.numel() == 0:
+            return None
 
         full_tensor = torch.empty(
             dtensor_ref.shape, dtype=local_tensor.dtype, device=local_tensor.device

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -621,12 +621,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     "Expected Shard, _StridedShard, or Replicate."
                 )
 
-        if len(shard_mesh_dims) != 1:
-            # The fast path below issues one all-gather over one process group,
-            # so it is only correct for layouts with a single sharded mesh
-            # dimension. HFSDP layouts shard over both DP-inner and DP-outer
-            # mesh dimensions and must use the generic M-FSDP helper, which
-            # gathers each sharded mesh dimension in order.
+        if not shard_mesh_dims:
             return None
 
         if not hasattr(dtensor_ref._local_tensor, "__create_chunk_list__"):
@@ -640,28 +635,57 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
 
         local_tensor = dtensor_ref._local_tensor
         local_chunk_metadata = chunk_metadata_list[0]
-        local_chunks_info = [
-            {"shape": torch.Size(local_tensor.shape), "offset": tuple(local_chunk_metadata.offsets)}
-        ]
-        shard_group = dtensor_ref.device_mesh.get_group(shard_mesh_dims[0])
-        group_chunks_info: list[list[dict[str, Any]] | None] = [None] * shard_group.size()
-        torch.distributed.all_gather_object(group_chunks_info, local_chunks_info, group=shard_group)
 
-        chunk_infos = [
-            {
-                "shape": torch.Size(chunk_info["shape"]),
-                "offset": tuple(chunk_info["offset"]),
-                "numel": torch.Size(chunk_info["shape"]).numel(),
-            }
-            for chunks_info in group_chunks_info
-            if chunks_info is not None
-            for chunk_info in chunks_info
+        def _normalize_chunk_info(chunk_info: dict[str, Any]) -> dict[str, Any]:
+            shape = torch.Size(chunk_info["shape"])
+            return {"shape": shape, "offset": tuple(chunk_info["offset"]), "numel": shape.numel()}
+
+        local_chunks_info = [
+            _normalize_chunk_info(
+                {
+                    "shape": torch.Size(local_tensor.shape),
+                    "offset": tuple(local_chunk_metadata.offsets),
+                }
+            )
         ]
+        stages = []
+        for shard_mesh_dim in shard_mesh_dims:
+            shard_group = dtensor_ref.device_mesh.get_group(shard_mesh_dim)
+            group_chunks_info: list[list[dict[str, Any]] | None] = [None] * shard_group.size()
+            torch.distributed.all_gather_object(
+                group_chunks_info, local_chunks_info, group=shard_group
+            )
+            if any(chunks_info is None for chunks_info in group_chunks_info):
+                raise AssertionError(
+                    "Uneven DTensor gather metadata exchange returned an incomplete result."
+                )
+
+            stage_chunks_info = [
+                [_normalize_chunk_info(chunk_info) for chunk_info in chunks_info]
+                for chunks_info in group_chunks_info
+                if chunks_info is not None
+            ]
+            stages.append(
+                {
+                    "shard_group": shard_group,
+                    "rank_numels": [
+                        sum(chunk_info["numel"] for chunk_info in chunks_info)
+                        for chunks_info in stage_chunks_info
+                    ],
+                }
+            )
+            local_chunks_info = [
+                chunk_info for chunks_info in stage_chunks_info for chunk_info in chunks_info
+            ]
+
+        chunk_infos = local_chunks_info
         plan = {
-            "shard_group": shard_group,
             "shard_mesh_dims": tuple(shard_mesh_dims),
+            "stages": stages,
             "chunk_infos": chunk_infos,
         }
+        if len(stages) == 1:
+            plan["shard_group"] = stages[0]["shard_group"]
         self._uneven_gather_plan_cache[cache_key] = plan
         return plan
 
@@ -683,19 +707,55 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             self._copy_dtensor_chunk_metadata(dtensor_ref, local_dtensor)
             return None if local_tensor.numel() == 0 else full_tensor
 
-        if len(plan["shard_mesh_dims"]) != 1:
-            raise AssertionError(
-                "Single-group uneven DTensor gather plan was created for a layout with "
-                f"{len(plan['shard_mesh_dims'])} sharded mesh dimensions. "
-                "HFSDP/multi-shard layouts must use redistribute_uneven_dtensor_to_replicated."
-            )
-
         local_buffer = local_tensor.contiguous().view(-1)
-        group_tensors = [
-            torch.empty(chunk_info["numel"], dtype=local_tensor.dtype, device=local_tensor.device)
-            for chunk_info in plan["chunk_infos"]
-        ]
-        torch.distributed.all_gather(group_tensors, local_buffer, group=plan["shard_group"])
+        if len(plan["stages"]) == 1:
+            stage = plan["stages"][0]
+            shard_group = stage["shard_group"]
+            group_rank = torch.distributed.get_rank(shard_group)
+            expected_local_numel = stage["rank_numels"][group_rank]
+            if local_buffer.numel() != expected_local_numel:
+                raise AssertionError(
+                    "Uneven DTensor gather local buffer size mismatch: "
+                    f"got {local_buffer.numel()}, expected {expected_local_numel}."
+                )
+            group_tensors = [
+                torch.empty(numel, dtype=local_tensor.dtype, device=local_tensor.device)
+                for numel in stage["rank_numels"]
+            ]
+            torch.distributed.all_gather(group_tensors, local_buffer, group=shard_group)
+
+            if local_tensor.numel() == 0:
+                return None
+
+            full_tensor = torch.empty(
+                dtensor_ref.shape, dtype=local_tensor.dtype, device=local_tensor.device
+            )
+            assigned_numel = 0
+            for chunk_info, gathered_tensor in zip(plan["chunk_infos"], group_tensors):
+                chunk_shape = chunk_info["shape"]
+                offset = chunk_info["offset"]
+                slices = tuple(slice(o, o + s) for o, s in zip(offset, chunk_shape))
+                full_tensor[slices] = gathered_tensor.view(chunk_shape)
+                assigned_numel += chunk_info["numel"]
+
+            _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
+            return full_tensor
+
+        for stage in plan["stages"]:
+            shard_group = stage["shard_group"]
+            group_rank = torch.distributed.get_rank(shard_group)
+            expected_local_numel = stage["rank_numels"][group_rank]
+            if local_buffer.numel() != expected_local_numel:
+                raise AssertionError(
+                    "Uneven DTensor gather local buffer size mismatch: "
+                    f"got {local_buffer.numel()}, expected {expected_local_numel}."
+                )
+            group_tensors = [
+                torch.empty(numel, dtype=local_tensor.dtype, device=local_tensor.device)
+                for numel in stage["rank_numels"]
+            ]
+            torch.distributed.all_gather(group_tensors, local_buffer, group=shard_group)
+            local_buffer = torch.cat(group_tensors)
 
         if local_tensor.numel() == 0:
             return None
@@ -704,12 +764,16 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             dtensor_ref.shape, dtype=local_tensor.dtype, device=local_tensor.device
         )
         assigned_numel = 0
-        for chunk_info, gathered_tensor in zip(plan["chunk_infos"], group_tensors):
+        buffer_offset = 0
+        for chunk_info in plan["chunk_infos"]:
             chunk_shape = chunk_info["shape"]
+            chunk_numel = chunk_info["numel"]
+            gathered_tensor = local_buffer[buffer_offset : buffer_offset + chunk_numel]
+            buffer_offset += chunk_numel
             offset = chunk_info["offset"]
             slices = tuple(slice(o, o + s) for o, s in zip(offset, chunk_shape))
             full_tensor[slices] = gathered_tensor.view(chunk_shape)
-            assigned_numel += chunk_info["numel"]
+            assigned_numel += chunk_numel
 
         _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
         return full_tensor
@@ -737,10 +801,10 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 )
                 continue
             if len(plan["shard_mesh_dims"]) != 1:
-                raise AssertionError(
-                    "Batched uneven DTensor gather only supports single-shard layouts; "
-                    "multi-shard layouts must use redistribute_uneven_dtensor_to_replicated."
+                results[item_idx] = self._gather_full_uneven_local_tensor_like(
+                    dtensor_ref, local_tensor
                 )
+                continue
 
             key = (id(plan["shard_group"]), local_tensor.dtype, local_tensor.device)
             batch = batches.setdefault(

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -330,6 +330,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     self._local_muon_update(p, p.grad, group)
             return loss
 
+        # Track all parameters to update ordered by parameter group index.
         # (param, pre_ns_grad, is_gathered, lr, group_kwargs)
         all_updates: list = []
 
@@ -344,6 +345,11 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 p_local = p.to_local()
                 needs_gather = param_idx in gather_param_indices
                 if p_local.numel() == 0 and not needs_gather:
+                    # If this parameter is not split by Megatron-FSDP,
+                    # and is empty on this DP rank, then we can skip this
+                    # update for all TP ranks, as tensor parallelism uses
+                    # even sharding, so empty implies that FSDP did not
+                    # assign any fraction of the parameter to this DP rank.
                     continue
 
                 state = self.state[p]
@@ -361,17 +367,26 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
 
                 all_updates.append((p, pre_ns_grad, needs_gather, lr, group_kwargs))
 
-        # Phase 2: AG all boundary params — all collectives here, no NS interleaved.
+        # Phase 2: AG all boundary gradients.
         for i, (p, pre_ns_grad, needs_gather, lr, group_kwargs) in enumerate(all_updates):
             if not needs_gather:
                 continue
+            # Un-shard the un-evenly sharded gradient.
             if gather_uneven_dtensor_to_full_tensor is None:
                 raise RuntimeError(
                     "Megatron-FSDP `gather_uneven_dtensor_to_full_tensor` is required "
                     "to gather un-evenly sharded parameters for Muon step()."
                 )
             pre_ns_grad_dtensor = self._dtensor_from_local_like(p, pre_ns_grad.contiguous())
+            # Compute the global shape and offset for re-sharding the gradient.
+            if not hasattr(pre_ns_grad_dtensor._local_tensor, "__create_chunk_list__"):
+                update_uneven_dtensor_chunk_metadata(pre_ns_grad_dtensor)
+            # Unsharded Gradient DTensor
             full_pre_ns_grad = gather_uneven_dtensor_to_full_tensor(pre_ns_grad_dtensor).to_local()
+            # Mirror the uneven sharding metadata to Megatron-FSDP DTensor parameters.
+            # By doing this, we can avoid unnecessary AG, as the parameters and gradients
+            # are globally and locally symmetrical in shape and offset.
+            self._copy_dtensor_chunk_metadata(p, pre_ns_grad_dtensor)
             all_updates[i] = (p, full_pre_ns_grad, True, lr, group_kwargs)
 
         # Phase 3: NS orthogonalization and weight update (fully local).
@@ -379,24 +394,24 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
 
         with utils.fp32_matmul_precision(self.fp32_matmul_prec):
             for p, pre_ns_grad, is_gathered, lr, group_kwargs in all_updates:
-                p_local = p.to_local()
                 if is_gathered:
                     orth_update = super(FSDPTensorParallelMuon, self).orthogonalize(
                         p, pre_ns_grad, **group_kwargs
                     )
                     sharded_update = self._reshard_full_update_like(p, orth_update)
-                    self.pre_weight_update_fn_inplace(p, sharded_update)
-                    p.add_(sharded_update, alpha=-lr)
-                    self.post_weight_update_fn_inplace(p)
+                    self.pre_weight_update_fn_inplace(p._local_tensor, sharded_update._local_tensor)
+                    p.add_(sharded_update, alpha=-lr)  # DTensors
+                    self.post_weight_update_fn_inplace(p._local_tensor)
                 else:
                     orth_update = (
                         super(FSDPTensorParallelMuon, self)
                         .orthogonalize(p, pre_ns_grad, **group_kwargs)
-                        .to(dtype=p_local.dtype)
+                        .to(dtype=p._local_tensor.dtype)
                     )
-                    self.pre_weight_update_fn_inplace(p_local, orth_update)
-                    p_local.add_(orth_update, alpha=-lr)
-                    self.post_weight_update_fn_inplace(p_local)
+                    # Apply a Tensor step.
+                    self.pre_weight_update_fn_inplace(p._local_tensor, orth_update)
+                    p._local_tensor.add_(orth_update, alpha=-lr)
+                    self.post_weight_update_fn_inplace(p._local_tensor)
 
         return loss
 
@@ -434,29 +449,32 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         if hasattr(src._local_tensor, "__create_write_items__"):
             dst._local_tensor.__create_write_items__ = src._local_tensor.__create_write_items__
 
-    def _dtensor_from_local_like(self, value, local_tensor: torch.Tensor):
+    def _dtensor_from_local_like(self, dtensor_ref, local_tensor: torch.Tensor):
         dtensor = _DTensor.from_local(
             local_tensor=local_tensor,
-            device_mesh=value.device_mesh,
-            placements=value.placements,
-            shape=value.shape,
-            stride=value.stride(),
+            device_mesh=dtensor_ref.device_mesh,
+            placements=dtensor_ref.placements,
+            shape=dtensor_ref.shape,
+            stride=dtensor_ref.stride(),
         )
-        self._copy_dtensor_chunk_metadata(dtensor, value)
+        self._copy_dtensor_chunk_metadata(dtensor, dtensor_ref)
         return dtensor
 
-    def _reshard_full_update_like(self, value, full_update: torch.Tensor):
-        if not hasattr(value._local_tensor, "__create_chunk_list__"):
-            if update_uneven_dtensor_chunk_metadata is None:
-                raise RuntimeError("DTensor support is required for Megatron-FSDP Muon.")
-            update_uneven_dtensor_chunk_metadata(value)
-        value_metadata = value._local_tensor.__create_chunk_list__()[0]
+    def _reshard_full_update_like(self, dtensor_ref, full_update: torch.Tensor):
+        if not hasattr(dtensor_ref._local_tensor, "__create_chunk_list__"):
+            raise ValueError(
+                f"{dtensor_ref} is not a Megatron-FSDP DTensor parameter "
+                "with DTensor._local_tensor.__create_chunk_list__. "
+                "Verify that `update_uneven_dtensor_chunk_metadata` "
+                "has been called on this uneven DTensor."
+            )
+        shard_metadata = dtensor_ref._local_tensor.__create_chunk_list__()[0]
         slices = tuple(
             slice(offset, offset + size)
-            for offset, size in zip(value_metadata.offsets, value_metadata.sizes)
+            for offset, size in zip(shard_metadata.offsets, shard_metadata.sizes)
         )
-        local_update = full_update[slices].contiguous().to(dtype=value.to_local().dtype)
-        return self._dtensor_from_local_like(value, local_update)
+        local_update = full_update[slices].contiguous().to(dtype=dtensor_ref._local_tensor.dtype)
+        return self._dtensor_from_local_like(dtensor_ref, local_update)
 
     @torch.no_grad()  # type: ignore[misc]
     def _local_muon_update(

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -527,13 +527,11 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         if local_tensor.numel() > 0:
             local_is_partial = tuple(param.shape) != tuple(local_tensor.shape)
             if local_is_partial and not crosses_boundary:
-                raise AssertionError(
-                    "M-FSDP DTensor local shape indicates a split parameter, but flat "
-                    "bucket metadata does not cross a shard boundary: "
-                    f"param_idx={param_idx}, item=({item_start}, {item_end}), "
-                    f"shard_size={shard_size}, global_shape={tuple(param.shape)}, "
-                    f"local_shape={tuple(local_tensor.shape)}."
-                )
+                # HFSDP can introduce a second sharding dimension after the
+                # flat bucket metadata has identified an inner-DP shard. The
+                # caller globally unions these local split observations so
+                # empty ranks still participate in the required collective.
+                return False
 
         return crosses_boundary
 
@@ -548,6 +546,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         has_mfsdp_params = any(getattr(param, "orig_param", None) is not None for param in params)
         if has_mfsdp_params:
             result = set()
+            local_split_indices = []
             for idx, param in enumerate(params):
                 if getattr(param, "orig_param", None) is None:
                     raise AssertionError(
@@ -556,6 +555,23 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     )
                 if self._mfsdp_param_crosses_shard_boundary(param, idx):
                     result.add(idx)
+                elif self._needs_boundary_gather(param):
+                    local_split_indices.append(idx)
+            if self.dp_group is not None and get_pg_size(self.dp_group) > 1:
+                gathered_local_split_indices: list[list[int] | None] = [None] * get_pg_size(
+                    self.dp_group
+                )
+                torch.distributed.all_gather_object(
+                    gathered_local_split_indices, local_split_indices, group=self.dp_group
+                )
+                result.update(
+                    idx
+                    for rank_indices in gathered_local_split_indices
+                    if rank_indices is not None
+                    for idx in rank_indices
+                )
+            else:
+                result.update(local_split_indices)
             self._boundary_gather_indices_cache[cache_key] = result
             return result
 

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -17,9 +17,17 @@ import torch
 from torch.optim.optimizer import ParamsT
 
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.utils import get_pg_size, log_single_rank
+from megatron.core.utils import get_pg_rank, get_pg_size, log_single_rank
 
 from .optimizer_config import ParamKey, ParamPredicate
+
+try:
+    from torch.distributed.tensor import DTensor as _DTensor
+
+    _HAVE_DTENSOR = True
+except ImportError:
+    _DTensor = None  # type: ignore[assignment,misc]
+    _HAVE_DTENSOR = False
 
 try:
     from emerging_optimizers import registry
@@ -335,6 +343,144 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         else:
             grad = self.scaled_orthogonalize_fn(grad, tp_group, partition_dim)
         return grad
+
+
+class FSDPZeROTensorParallelMuon(TensorParallelMuon):
+    """`TensorParallelMuon` extended for Megatron-FSDP ZeRO-1/2/3.
+
+    Supports all three sharded strategies:
+
+    * `optim` (ZeRO-1): optimizer state sharded; grads reduce-scattered.
+    * `optim_grads` (ZeRO-2): optimizer state + grads sharded.
+    * `optim_grads_params` (ZeRO-3): optimizer state + grads + params sharded.
+
+    For all three, `finish_grad_sync()` reduce-scatters gradients so each DP
+    rank holds only a contiguous `Shard(0)` row-shard of the full TP-local 2D
+    gradient. Newton-Schulz needs the full matrix, so this class:
+
+      1. Extracts the local shard via `.to_local()` for any Shard(0) DTensor.
+      2. Allgathers the DP row-shards across the DP group to reconstruct the
+         TP-local, DP-full gradient matrix.
+      3. Trims FSDP bucket-padding rows using the declared global shape from the
+         DTensor.
+      4. Delegates to `TensorParallelMuon.orthogonalize` which handles the
+         remaining TP dimension via `newton_schulz_tp`.
+      5. Extracts the local DP row-shard of the orthogonalized result, padding
+         the last rank with zeros when FSDP bucket padding is present so the
+         per-rank shard size stays uniform.
+      6. Re-wraps the result as a DTensor matching the input's placements so
+         `OrthogonalizedOptimizer.step` can apply the in-place update without
+         placement promotion.
+
+    Memory note for ZeRO-3: each Muon step allocates a temporary `full_grad`
+    of shape `(tp_local_rows, C)` per Muon parameter for the allgather, plus
+    the NS output. Peak extra memory is roughly
+    `3 * (m * n) * sizeof(float32)` per linear layer; momentum stays sharded.
+
+    For "no_shard" or single-rank DP this falls back transparently to the
+    parent implementation.
+    """
+
+    def __init__(
+        self, params: ParamsT, dp_group: torch.distributed.ProcessGroup | None = None, **kwargs: Any
+    ) -> None:
+        self.dp_group = dp_group
+        super().__init__(params, **kwargs)
+
+    def orthogonalize(self, p: torch.Tensor, grad: torch.Tensor, **kwargs: Any) -> torch.Tensor:
+        """Orthogonalize with DP-shard allgather for FSDP ZeRO >= 1."""
+        if self.dp_group is None or get_pg_size(self.dp_group) == 1:
+            return super().orthogonalize(p, grad, **kwargs)
+
+        dp_size = get_pg_size(self.dp_group)
+        dp_rank = get_pg_rank(self.dp_group)
+
+        # The momentum buffer (grad) and param (p) may be Shard(0) DTensors whose
+        # `.shape[0]` is the global row count. Always extract the local shard so
+        # "shard_rows" reflects the per-rank row count.
+        grad_local = grad.to_local() if (_HAVE_DTENSOR and isinstance(grad, _DTensor)) else grad
+        shard_rows = grad_local.shape[0]
+
+        # Allgather DP row-shards to reconstruct the TP-local, DP-full grad.
+        # FSDP guarantees equal shard sizes across DP ranks (buckets are padded
+        # to `dp_size * inner_dim`), so a single all_gather_into_tensor works.
+        full_grad = torch.empty(
+            shard_rows * dp_size,
+            *grad_local.shape[1:],
+            device=grad_local.device,
+            dtype=grad_local.dtype,
+        )
+        torch.distributed.all_gather_into_tensor(
+            full_grad, grad_local.contiguous(), group=self.dp_group
+        )
+
+        # Trim FSDP bucket-padding rows back to the param's TP-local row count.
+        tp_group = (
+            (
+                self.pg_collection.expt_tp
+                if getattr(p, "expert_tp", False)
+                else self.pg_collection.tp
+            )
+            if self.pg_collection
+            else None
+        )
+        partition_dim = None if self.tp_mode == "blockwise" else getattr(p, "partition_dim", None)
+        if partition_dim == -1:
+            partition_dim = None
+
+        tp_size_dim0 = get_pg_size(tp_group) if (partition_dim == 0 and tp_group is not None) else 1
+
+        if _HAVE_DTENSOR and isinstance(p, _DTensor):
+            # Production: `p.shape[0]` is the FSDP-declared global row count
+            # (already includes bucket padding); divide by `tp_size_dim0`
+            # to get the TP-local row count.
+            tp_local_rows = p.shape[0] // max(tp_size_dim0, 1)
+        else:
+            # Plain-tensor unit-test path: `p` is treated as the per-rank
+            # shard (`p.shape[0] == shard_rows`), so the TP-local row count
+            # must be reconstructed from the allgather, not read from `p`.
+            tp_local_rows = shard_rows * dp_size
+
+        full_grad = full_grad[:tp_local_rows]
+
+        # Apply NS to the TP-local, DP-full gradient. `super().orthogonalize`
+        # re-derives `tp_group` / `partition_dim` internally; the TP
+        # dimension of the reconstructed `full_grad` is unchanged.
+        orth_full_grad = super().orthogonalize(p, full_grad, **kwargs)
+
+        # Extract this rank's DP row-shard. If the last rank held fewer real
+        # rows than `shard_rows` (FSDP padding), zero-fill the extra rows so
+        # padded slots get a no-op update.
+        start_row = dp_rank * shard_rows
+        end_row = min(start_row + shard_rows, tp_local_rows)
+        orth_shard = orth_full_grad[start_row:end_row]
+
+        if orth_shard.shape[0] < shard_rows:
+            pad_rows = shard_rows - orth_shard.shape[0]
+            pad = torch.zeros(
+                pad_rows, *grad_local.shape[1:], device=grad_local.device, dtype=grad_local.dtype
+            )
+            orth_shard = torch.cat([orth_shard, pad], dim=0)
+
+        # Wrap the plain result back into a DTensor if the input was a DTensor.
+        # `OrthogonalizedOptimizer.step` does `p.add_(grad, alpha=-lr)`; for
+        # a Shard(0) DTensor `p` the update tensor must also be a DTensor with
+        # matching placements, otherwise PyTorch promotes it to `Replicate`
+        # and fails the global-shape check. Recent PyTorch versions require
+        # `shape` and `stride` to be passed together; for a Shard(0)
+        # contiguous local the global stride matches the local stride.
+        if _HAVE_DTENSOR and isinstance(grad, _DTensor):
+            local_contig = orth_shard.contiguous()
+            orth_shard = _DTensor.from_local(
+                local_contig,
+                device_mesh=grad.device_mesh,
+                placements=grad.placements,
+                shape=grad.shape,
+                stride=local_contig.stride(),
+                run_check=False,
+            )
+
+        return orth_shard
 
 
 class TensorParallelAdaptiveMuon(TensorParallelMuon, AdaptiveMuon):

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -355,7 +355,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             group_kwargs = {k: v for k, v in group.items() if k != "params"}
 
             for param_idx, p in enumerate(group["params"]):
-                p_local = p.to_local()
+                p_local = p._local_tensor
                 needs_gather = param_idx in gather_param_indices
                 if p_local.numel() == 0 and not needs_gather:
                     # If this parameter is not split by Megatron-FSDP,
@@ -366,10 +366,10 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     continue
 
                 state = self.state[p]
-                mom_local = state["momentum_buffer"].to_local()
+                mom_local = state["momentum_buffer"]._local_tensor
 
                 grad = p.grad
-                local_grad = grad.to_local() if grad is not None else torch.zeros_like(mom_local)
+                local_grad = grad._local_tensor if grad is not None else torch.zeros_like(mom_local)
 
                 self._apply_weight_decay_inplace(p_local, local_grad, lr, group["weight_decay"])
                 mom_local.lerp_(local_grad, 1 - group["momentum"])
@@ -433,7 +433,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         assert isinstance(
             dtensor, _DTensor
         ), f"Detected non-DTensor during {type(self).__name__}: {dtensor}"
-        local_tensor = dtensor.to_local()
+        local_tensor = dtensor._local_tensor
         return local_tensor.numel() > 0 and tuple(dtensor.shape) != tuple(local_tensor.shape)
 
     def _get_mfsdp_param_layout(self, param: torch.Tensor, param_idx: int):
@@ -523,7 +523,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         last_shard = (item_end - 1 - bucket_start) // shard_size
         crosses_boundary = first_shard != last_shard
 
-        local_tensor = param.to_local()
+        local_tensor = param._local_tensor
         if local_tensor.numel() > 0:
             local_is_partial = tuple(param.shape) != tuple(local_tensor.shape)
             if local_is_partial and not crosses_boundary:
@@ -635,7 +635,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 f"Expected exactly one chunk metadata per rank, got {len(chunk_metadata_list)}."
             )
 
-        local_tensor = dtensor_ref.to_local()
+        local_tensor = dtensor_ref._local_tensor
         local_chunk_metadata = chunk_metadata_list[0]
         local_chunks_info = [
             {"shape": torch.Size(local_tensor.shape), "offset": tuple(local_chunk_metadata.offsets)}
@@ -672,7 +672,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             local_dtensor = self._dtensor_from_local_like(dtensor_ref, local_tensor.contiguous())
             if not hasattr(local_dtensor._local_tensor, "__create_chunk_list__"):
                 update_uneven_dtensor_chunk_metadata(local_dtensor)
-            full_tensor = redistribute_uneven_dtensor_to_replicated(local_dtensor).to_local()
+            full_tensor = redistribute_uneven_dtensor_to_replicated(local_dtensor)._local_tensor
             self._copy_dtensor_chunk_metadata(dtensor_ref, local_dtensor)
             return None if local_tensor.numel() == 0 else full_tensor
 

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -376,11 +376,16 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 all_updates.append((p, pre_ns_grad, needs_gather, lr, group_kwargs))
 
         # Phase 2: AG all boundary gradients.
-        for i, (p, pre_ns_grad, needs_gather, lr, group_kwargs) in enumerate(all_updates):
-            if not needs_gather:
-                continue
-            full_pre_ns_grad = self._gather_full_uneven_local_tensor_like(p, pre_ns_grad)
-            all_updates[i] = (p, full_pre_ns_grad, True, lr, group_kwargs)
+        boundary_update_indices = [
+            i for i, (_, _, needs_gather, _, _) in enumerate(all_updates) if needs_gather
+        ]
+        if boundary_update_indices:
+            gathered_boundary_updates = self._gather_full_uneven_local_tensors_like(
+                [(all_updates[i][0], all_updates[i][1]) for i in boundary_update_indices]
+            )
+            for i, full_pre_ns_grad in zip(boundary_update_indices, gathered_boundary_updates):
+                p, _, _, lr, group_kwargs = all_updates[i]
+                all_updates[i] = (p, full_pre_ns_grad, True, lr, group_kwargs)
 
         # Phase 3: NS orthogonalization and weight update (fully local).
         from emerging_optimizers import utils
@@ -388,6 +393,8 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         with utils.fp32_matmul_precision(self.fp32_matmul_prec):
             for p, pre_ns_grad, is_gathered, lr, group_kwargs in all_updates:
                 if is_gathered:
+                    if pre_ns_grad is None:
+                        continue
                     orth_update = super(FSDPTensorParallelMuon, self).orthogonalize(
                         p, pre_ns_grad, **group_kwargs
                     )
@@ -569,6 +576,116 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
 
         _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
         return full_tensor
+
+    def _gather_full_uneven_local_tensors_like(
+        self, items: list[tuple[torch.Tensor, torch.Tensor]]
+    ) -> list[torch.Tensor | None]:
+        """Batch uneven gathers for boundary tensors.
+
+        Each boundary parameter still needs the same logical data as
+        `_gather_full_uneven_local_tensor_like`. Batching concatenates local
+        shards with the same dtype/device/group so the optimizer issues one
+        all-gather per batch instead of one all-gather per boundary parameter.
+        Ranks with empty local shards participate in the collective but do not
+        reconstruct or orthogonalize the full boundary tensor.
+        """
+        results: list[torch.Tensor | None] = [None] * len(items)
+        batches: dict[tuple[int, torch.dtype, torch.device], Dict[str, Any]] = {}
+
+        for item_idx, (dtensor_ref, local_tensor) in enumerate(items):
+            plan = self._get_uneven_gather_plan(dtensor_ref)
+            if plan is None:
+                results[item_idx] = self._gather_full_uneven_local_tensor_like(
+                    dtensor_ref, local_tensor
+                )
+                continue
+
+            key = (id(plan["shard_group"]), local_tensor.dtype, local_tensor.device)
+            batch = batches.setdefault(
+                key,
+                {
+                    "shard_group": plan["shard_group"],
+                    "dtype": local_tensor.dtype,
+                    "device": local_tensor.device,
+                    "item_indices": [],
+                    "plans": [],
+                },
+            )
+            batch["item_indices"].append(item_idx)
+            batch["plans"].append(plan)
+
+        for batch in batches.values():
+            self._gather_full_uneven_local_tensor_batch(items, results, batch)
+
+        return results
+
+    def _gather_full_uneven_local_tensor_batch(
+        self,
+        items: list[tuple[torch.Tensor, torch.Tensor]],
+        results: list[torch.Tensor | None],
+        batch: dict[str, Any],
+    ) -> None:
+        shard_group = batch["shard_group"]
+        group_size = get_pg_size(shard_group)
+        group_rank = torch.distributed.get_rank(shard_group)
+        item_indices = batch["item_indices"]
+        plans = batch["plans"]
+
+        local_chunks = [items[item_idx][1].contiguous().view(-1) for item_idx in item_indices]
+        local_buffer = (
+            torch.cat(local_chunks)
+            if local_chunks and sum(chunk.numel() for chunk in local_chunks) > 0
+            else torch.empty(0, dtype=batch["dtype"], device=batch["device"])
+        )
+        expected_local_numel = sum(plan["chunk_infos"][group_rank]["numel"] for plan in plans)
+        if local_buffer.numel() != expected_local_numel:
+            raise AssertionError(
+                "Batched uneven DTensor gather local buffer size mismatch: "
+                f"got {local_buffer.numel()}, expected {expected_local_numel}."
+            )
+
+        rank_offsets: list[list[int]] = []
+        rank_total_numels: list[int] = []
+        for rank in range(group_size):
+            offsets = []
+            total_numel = 0
+            for plan in plans:
+                offsets.append(total_numel)
+                total_numel += plan["chunk_infos"][rank]["numel"]
+            rank_offsets.append(offsets)
+            rank_total_numels.append(total_numel)
+
+        group_tensors = [
+            torch.empty(total_numel, dtype=batch["dtype"], device=batch["device"])
+            for total_numel in rank_total_numels
+        ]
+        torch.distributed.all_gather(group_tensors, local_buffer, group=shard_group)
+
+        for batch_item_idx, item_idx in enumerate(item_indices):
+            dtensor_ref, local_tensor = items[item_idx]
+            if local_tensor.numel() == 0:
+                results[item_idx] = None
+                continue
+
+            full_tensor = torch.empty(
+                dtensor_ref.shape, dtype=local_tensor.dtype, device=local_tensor.device
+            )
+            assigned_numel = 0
+            plan = plans[batch_item_idx]
+            for rank, gathered_rank_tensor in enumerate(group_tensors):
+                chunk_info = plan["chunk_infos"][rank]
+                chunk_numel = chunk_info["numel"]
+                if chunk_numel == 0:
+                    continue
+                offset = rank_offsets[rank][batch_item_idx]
+                chunk_shape = chunk_info["shape"]
+                chunk_tensor = gathered_rank_tensor[offset : offset + chunk_numel].view(chunk_shape)
+                slices = tuple(slice(o, o + s) for o, s in zip(chunk_info["offset"], chunk_shape))
+                full_tensor[slices] = chunk_tensor
+                assigned_numel += chunk_numel
+
+            _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
+            results[item_idx] = full_tensor
 
     def _local_shard_from_full_update_like(self, dtensor_ref, full_update: torch.Tensor):
         if not hasattr(dtensor_ref._local_tensor, "__create_chunk_list__"):

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -357,6 +357,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         fsdp_batch_max_gather_bytes: int = 1024 * 1024 * 1024,
         fsdp_padded_all_gather_zero_pad: bool = True,
         fsdp_fast_reconstruct: bool = True,
+        fsdp_overlap_comm_compute: bool = False,
         **kwargs: Any,
     ) -> None:
         assert _HAVE_DTENSOR, (
@@ -371,6 +372,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         self.fsdp_batch_max_gather_bytes = fsdp_batch_max_gather_bytes
         self.fsdp_padded_all_gather_zero_pad = fsdp_padded_all_gather_zero_pad
         self.fsdp_fast_reconstruct = fsdp_fast_reconstruct
+        self.fsdp_overlap_comm_compute = fsdp_overlap_comm_compute
         self._boundary_gather_indices_cache: dict[tuple[int, ...], set[int]] = {}
         self._uneven_gather_plan_cache: dict[int, dict[str, Any]] = {}
         self._fsdp_gather_scratch_cache: dict[tuple[Any, ...], Any] = {}
@@ -506,50 +508,135 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         boundary_update_indices = [
             i for i, (_, _, needs_gather, _, _) in enumerate(all_updates) if needs_gather
         ]
-        if boundary_update_indices:
-            boundary_items = [
-                (all_updates[i][0], all_updates[i][1]) for i in boundary_update_indices
-            ]
-            if self.fsdp_batched_all_gather:
-                gathered_boundary_updates = self._gather_full_uneven_local_tensors_like(
-                    boundary_items
-                )
-            else:
-                gathered_boundary_updates = [
-                    self._gather_full_uneven_local_tensor_like(p, local_tensor)
-                    for p, local_tensor in boundary_items
-                ]
-            for i, full_pre_ns_grad in zip(boundary_update_indices, gathered_boundary_updates):
-                p, _, _, lr, group_kwargs = all_updates[i]
-                all_updates[i] = (p, full_pre_ns_grad, True, lr, group_kwargs)
 
         # Phase 3: NS orthogonalization and weight update (fully local).
         from emerging_optimizers import utils
 
         with utils.fp32_matmul_precision(self.fp32_matmul_prec):
-            for p, pre_ns_grad, is_gathered, lr, group_kwargs in all_updates:
-                if is_gathered:
-                    if pre_ns_grad is None:
-                        continue
-                    orth_update = super(FSDPTensorParallelMuon, self).orthogonalize(
-                        p, pre_ns_grad, **group_kwargs
+            if (
+                self.fsdp_overlap_comm_compute
+                and self.fsdp_batched_all_gather
+                and boundary_update_indices
+            ):
+                self._overlap_boundary_gather_and_update(all_updates, boundary_update_indices)
+            else:
+                if boundary_update_indices:
+                    boundary_items = [
+                        (all_updates[i][0], all_updates[i][1]) for i in boundary_update_indices
+                    ]
+                    if self.fsdp_batched_all_gather:
+                        gathered_boundary_updates = self._gather_full_uneven_local_tensors_like(
+                            boundary_items
+                        )
+                    else:
+                        gathered_boundary_updates = [
+                            self._gather_full_uneven_local_tensor_like(p, local_tensor)
+                            for p, local_tensor in boundary_items
+                        ]
+                    for i, full_pre_ns_grad in zip(
+                        boundary_update_indices, gathered_boundary_updates
+                    ):
+                        p, _, _, lr, group_kwargs = all_updates[i]
+                        all_updates[i] = (p, full_pre_ns_grad, True, lr, group_kwargs)
+
+                for p, pre_ns_grad, is_gathered, lr, group_kwargs in all_updates:
+                    self._apply_precomputed_muon_update(
+                        p, pre_ns_grad, is_gathered, lr, group_kwargs
                     )
-                    local_update = self._local_shard_from_full_update_like(p, orth_update)
-                    self.pre_weight_update_fn_inplace(p._local_tensor, local_update)
-                    p._local_tensor.add_(local_update, alpha=-lr)
-                    self.post_weight_update_fn_inplace(p._local_tensor)
-                else:
-                    orth_update = (
-                        super(FSDPTensorParallelMuon, self)
-                        .orthogonalize(p, pre_ns_grad, **group_kwargs)
-                        .to(dtype=p._local_tensor.dtype)
-                    )
-                    # Apply a Tensor step.
-                    self.pre_weight_update_fn_inplace(p._local_tensor, orth_update)
-                    p._local_tensor.add_(orth_update, alpha=-lr)
-                    self.post_weight_update_fn_inplace(p._local_tensor)
 
         return loss
+
+    def _apply_precomputed_muon_update(
+        self,
+        p: torch.Tensor,
+        pre_ns_grad: torch.Tensor | None,
+        is_gathered: bool,
+        lr: float,
+        group_kwargs: dict[str, Any],
+    ) -> None:
+        if is_gathered:
+            if pre_ns_grad is None:
+                return
+            orth_update = super(FSDPTensorParallelMuon, self).orthogonalize(
+                p, pre_ns_grad, **group_kwargs
+            )
+            local_update = self._local_shard_from_full_update_like(p, orth_update)
+            self.pre_weight_update_fn_inplace(p._local_tensor, local_update)
+            p._local_tensor.add_(local_update, alpha=-lr)
+            self.post_weight_update_fn_inplace(p._local_tensor)
+            return
+
+        assert pre_ns_grad is not None
+        orth_update = (
+            super(FSDPTensorParallelMuon, self)
+            .orthogonalize(p, pre_ns_grad, **group_kwargs)
+            .to(dtype=p._local_tensor.dtype)
+        )
+        self.pre_weight_update_fn_inplace(p._local_tensor, orth_update)
+        p._local_tensor.add_(orth_update, alpha=-lr)
+        self.post_weight_update_fn_inplace(p._local_tensor)
+
+    def _overlap_boundary_gather_and_update(
+        self, all_updates: list, boundary_update_indices: list[int]
+    ) -> None:
+        boundary_items = [(all_updates[i][0], all_updates[i][1]) for i in boundary_update_indices]
+        gathered_boundary_updates: list[torch.Tensor | None] = [None] * len(boundary_items)
+        completed_item_indices: set[int] = set()
+        batches = self._build_full_uneven_local_tensor_batches(
+            boundary_items, gathered_boundary_updates, completed_item_indices
+        )
+
+        pending = None
+        batch_iter = iter(batches)
+        first_batch = next(batch_iter, None)
+        if first_batch is not None:
+            pending = self._start_gather_full_uneven_local_tensor_batch_async(
+                boundary_items, first_batch
+            )
+
+        for p, pre_ns_grad, is_gathered, lr, group_kwargs in all_updates:
+            if not is_gathered:
+                self._apply_precomputed_muon_update(p, pre_ns_grad, is_gathered, lr, group_kwargs)
+
+        processed_item_indices: set[int] = set()
+
+        def process_completed_items(item_indices: set[int] | list[int]) -> None:
+            for item_idx in item_indices:
+                if item_idx in processed_item_indices:
+                    continue
+                update_idx = boundary_update_indices[item_idx]
+                p, _, _, lr, group_kwargs = all_updates[update_idx]
+                self._apply_precomputed_muon_update(
+                    p, gathered_boundary_updates[item_idx], True, lr, group_kwargs
+                )
+                processed_item_indices.add(item_idx)
+
+        process_completed_items(completed_item_indices)
+
+        for next_batch in batch_iter:
+            assert pending is not None
+            finished_item_indices = self._finish_gather_full_uneven_local_tensor_batch_async(
+                pending, gathered_boundary_updates
+            )
+            pending = self._start_gather_full_uneven_local_tensor_batch_async(
+                boundary_items, next_batch
+            )
+            process_completed_items(finished_item_indices)
+
+        if pending is not None:
+            finished_item_indices = self._finish_gather_full_uneven_local_tensor_batch_async(
+                pending, gathered_boundary_updates
+            )
+            process_completed_items(finished_item_indices)
+        elif len(processed_item_indices) != len(boundary_update_indices):
+            process_completed_items(set(range(len(boundary_update_indices))))
+
+        if len(processed_item_indices) != len(boundary_update_indices):
+            missing = sorted(set(range(len(boundary_update_indices))) - processed_item_indices)
+            raise AssertionError(
+                "Muon+M-FSDP overlap step missed boundary updates: "
+                f"missing_boundary_item_indices={missing}."
+            )
 
     def _needs_boundary_gather(self, dtensor: torch.Tensor) -> bool:
         assert isinstance(
@@ -832,12 +919,12 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         self._uneven_gather_plan_cache[cache_key] = plan
         return plan
 
-    def _all_gather_padded_equal_size(
+    def _prepare_padded_all_gather_buffers(
         self,
         local_buffer: torch.Tensor,
         rank_total_numels: list[int],
         shard_group: torch.distributed.ProcessGroup,
-    ) -> tuple[torch.Tensor, int]:
+    ) -> tuple[torch.Tensor, torch.Tensor, int]:
         max_rank_numel = max(rank_total_numels)
         group_size = len(rank_total_numels)
         if max_rank_numel == 0:
@@ -865,6 +952,17 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             group_size * max_rank_numel,
             dtype=local_buffer.dtype,
             device=local_buffer.device,
+        )
+        return padded_local_buffer, gathered_padded_buffer, max_rank_numel
+
+    def _all_gather_padded_equal_size(
+        self,
+        local_buffer: torch.Tensor,
+        rank_total_numels: list[int],
+        shard_group: torch.distributed.ProcessGroup,
+    ) -> tuple[torch.Tensor, int]:
+        padded_local_buffer, gathered_padded_buffer, max_rank_numel = (
+            self._prepare_padded_all_gather_buffers(local_buffer, rank_total_numels, shard_group)
         )
         torch.distributed.all_gather_into_tensor(
             gathered_padded_buffer, padded_local_buffer, group=shard_group
@@ -1016,19 +1114,12 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
 
         return self._reconstruct_full_tensor_from_flat_buffer(dtensor_ref, plan, local_buffer)
 
-    def _gather_full_uneven_local_tensors_like(
-        self, items: list[tuple[torch.Tensor, torch.Tensor]]
-    ) -> list[torch.Tensor | None]:
-        """Batch uneven gathers for boundary tensors.
-
-        Each boundary parameter still needs the same logical data as
-        `_gather_full_uneven_local_tensor_like`. Batching concatenates local
-        shards with the same dtype/device/group so the optimizer issues one
-        all-gather per batch instead of one all-gather per boundary parameter.
-        Ranks with empty local shards participate in the collective but do not
-        reconstruct or orthogonalize the full boundary tensor.
-        """
-        results: list[torch.Tensor | None] = [None] * len(items)
+    def _build_full_uneven_local_tensor_batches(
+        self,
+        items: list[tuple[torch.Tensor, torch.Tensor]],
+        results: list[torch.Tensor | None],
+        completed_item_indices: set[int] | None = None,
+    ) -> list[dict[str, Any]]:
         batches: dict[tuple[int, torch.dtype, torch.device], list[dict[str, Any]]] = {}
 
         for item_idx, (dtensor_ref, local_tensor) in enumerate(items):
@@ -1037,6 +1128,8 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 results[item_idx] = self._gather_full_uneven_local_tensor_like(
                     dtensor_ref, local_tensor
                 )
+                if completed_item_indices is not None:
+                    completed_item_indices.add(item_idx)
                 continue
 
             stage_group_key = tuple(id(stage["shard_group"]) for stage in plan["stages"])
@@ -1077,9 +1170,25 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 for rank, rank_numel in enumerate(stage["rank_numels"]):
                     batch["stage_rank_total_numels"][stage_idx][rank] += rank_numel
 
-        for key_batches in batches.values():
-            for batch in key_batches:
-                self._gather_full_uneven_local_tensor_batch(items, results, batch)
+        return [batch for key_batches in batches.values() for batch in key_batches]
+
+    def _gather_full_uneven_local_tensors_like(
+        self, items: list[tuple[torch.Tensor, torch.Tensor]]
+    ) -> list[torch.Tensor | None]:
+        """Batch uneven gathers for boundary tensors.
+
+        Each boundary parameter still needs the same logical data as
+        `_gather_full_uneven_local_tensor_like`. Batching concatenates local
+        shards with the same dtype/device/group so the optimizer issues one
+        all-gather per batch instead of one all-gather per boundary parameter.
+        Ranks with empty local shards participate in the collective but do not
+        reconstruct or orthogonalize the full boundary tensor.
+        """
+        results: list[torch.Tensor | None] = [None] * len(items)
+        batches = self._build_full_uneven_local_tensor_batches(items, results)
+
+        for batch in batches:
+            self._gather_full_uneven_local_tensor_batch(items, results, batch)
 
         return results
 
@@ -1094,105 +1203,209 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         current_buffers = [items[item_idx][1].contiguous().view(-1) for item_idx in item_indices]
 
         for stage_idx, stage in enumerate(plans[0]["stages"]):
-            shard_group = stage["shard_group"]
-            group_size = get_pg_size(shard_group)
-            group_rank = torch.distributed.get_rank(shard_group)
-
-            expected_item_numels = [
-                plan["stages"][stage_idx]["rank_numels"][group_rank] for plan in plans
-            ]
-            expected_local_numel = sum(expected_item_numels)
-            local_buffer = self._get_fsdp_gather_scratch_tensor(
-                ("batch_local_buffer", stage_idx, id(shard_group), batch["dtype"], batch["device"]),
-                expected_local_numel,
-                dtype=batch["dtype"],
-                device=batch["device"],
+            stage_state = self._prepare_uneven_gather_stage(
+                current_buffers, plans, batch, stage_idx, stage
             )
-            local_offset = 0
-            for buffer, expected_numel in zip(current_buffers, expected_item_numels):
-                if buffer.numel() != expected_numel:
-                    raise AssertionError(
-                        "Batched uneven DTensor gather stage buffer size mismatch: "
-                        f"stage={stage_idx}, got {buffer.numel()}, expected {expected_numel}."
-                    )
-                if expected_numel == 0:
-                    continue
-                local_buffer[local_offset : local_offset + expected_numel].copy_(buffer)
-                local_offset += expected_numel
+            pending_stage = self._start_uneven_gather_stage(stage_state, async_op=False)
+            current_buffers = self._finish_uneven_gather_stage(pending_stage)
 
-            if local_offset != expected_local_numel:
+        self._store_uneven_gather_batch_results(items, results, batch, current_buffers)
+
+    def _prepare_uneven_gather_stage(
+        self,
+        current_buffers: list[torch.Tensor],
+        plans: list[dict[str, Any]],
+        batch: dict[str, Any],
+        stage_idx: int,
+        stage: dict[str, Any],
+    ) -> dict[str, Any]:
+        shard_group = stage["shard_group"]
+        group_size = get_pg_size(shard_group)
+        group_rank = torch.distributed.get_rank(shard_group)
+
+        expected_item_numels = [
+            plan["stages"][stage_idx]["rank_numels"][group_rank] for plan in plans
+        ]
+        expected_local_numel = sum(expected_item_numels)
+        local_buffer = self._get_fsdp_gather_scratch_tensor(
+            ("batch_local_buffer", stage_idx, id(shard_group), batch["dtype"], batch["device"]),
+            expected_local_numel,
+            dtype=batch["dtype"],
+            device=batch["device"],
+        )
+        local_offset = 0
+        for buffer, expected_numel in zip(current_buffers, expected_item_numels):
+            if buffer.numel() != expected_numel:
                 raise AssertionError(
-                    "Batched uneven DTensor gather local buffer size mismatch: "
-                    f"stage={stage_idx}, packed {local_offset}, expected {expected_local_numel}."
+                    "Batched uneven DTensor gather stage buffer size mismatch: "
+                    f"stage={stage_idx}, got {buffer.numel()}, expected {expected_numel}."
                 )
+            if expected_numel == 0:
+                continue
+            local_buffer[local_offset : local_offset + expected_numel].copy_(buffer)
+            local_offset += expected_numel
 
-            rank_offsets: list[list[int]] = []
-            rank_total_numels: list[int] = []
-            for rank in range(group_size):
-                offsets = []
-                total_numel = 0
-                for plan in plans:
-                    offsets.append(total_numel)
-                    total_numel += plan["stages"][stage_idx]["rank_numels"][rank]
-                rank_offsets.append(offsets)
-                rank_total_numels.append(total_numel)
-
-            use_padded_all_gather = (
-                self.fsdp_padded_all_gather
-                and hasattr(torch.distributed, "all_gather_into_tensor")
-                and _should_use_padded_all_gather(
-                    rank_total_numels, self.fsdp_padded_all_gather_pad_factor
-                )
+        if local_offset != expected_local_numel:
+            raise AssertionError(
+                "Batched uneven DTensor gather local buffer size mismatch: "
+                f"stage={stage_idx}, packed {local_offset}, expected {expected_local_numel}."
             )
-            gathered_padded_buffer = None
-            max_rank_numel = 0
-            group_tensors = None
-            if use_padded_all_gather:
-                gathered_padded_buffer, max_rank_numel = self._all_gather_padded_equal_size(
+
+        rank_offsets: list[list[int]] = []
+        rank_total_numels: list[int] = []
+        for rank in range(group_size):
+            offsets = []
+            total_numel = 0
+            for plan in plans:
+                offsets.append(total_numel)
+                total_numel += plan["stages"][stage_idx]["rank_numels"][rank]
+            rank_offsets.append(offsets)
+            rank_total_numels.append(total_numel)
+
+        use_padded_all_gather = (
+            self.fsdp_padded_all_gather
+            and hasattr(torch.distributed, "all_gather_into_tensor")
+            and _should_use_padded_all_gather(
+                rank_total_numels, self.fsdp_padded_all_gather_pad_factor
+            )
+        )
+        return {
+            "batch": batch,
+            "plans": plans,
+            "stage_idx": stage_idx,
+            "shard_group": shard_group,
+            "group_size": group_size,
+            "rank_offsets": rank_offsets,
+            "rank_total_numels": rank_total_numels,
+            "local_buffer": local_buffer,
+            "use_padded_all_gather": use_padded_all_gather,
+        }
+
+    def _start_uneven_gather_stage(
+        self, stage_state: dict[str, Any], *, async_op: bool
+    ) -> dict[str, Any]:
+        device = stage_state["batch"]["device"]
+        comm_stream = None
+        if async_op and device.type == "cuda":
+            with torch.cuda.device(device):
+                comm_stream = torch.cuda.Stream()
+                comm_stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(comm_stream):
+                    return self._issue_uneven_gather_stage(
+                        stage_state, async_op=True, comm_stream=comm_stream
+                    )
+        return self._issue_uneven_gather_stage(
+            stage_state, async_op=async_op, comm_stream=comm_stream
+        )
+
+    def _issue_uneven_gather_stage(
+        self, stage_state: dict[str, Any], *, async_op: bool, comm_stream: torch.cuda.Stream | None
+    ) -> dict[str, Any]:
+        batch = stage_state["batch"]
+        shard_group = stage_state["shard_group"]
+        local_buffer = stage_state["local_buffer"]
+        rank_total_numels = stage_state["rank_total_numels"]
+        pending = dict(stage_state)
+        pending["comm_stream"] = comm_stream
+
+        if stage_state["use_padded_all_gather"]:
+            padded_local_buffer, gathered_padded_buffer, max_rank_numel = (
+                self._prepare_padded_all_gather_buffers(
                     local_buffer, rank_total_numels, shard_group
                 )
-            else:
-                group_tensors = self._get_uneven_group_tensors(
-                    rank_total_numels,
-                    dtype=batch["dtype"],
-                    device=batch["device"],
-                    shard_group=shard_group,
+            )
+            pending["padded_local_buffer"] = padded_local_buffer
+            pending["gathered_padded_buffer"] = gathered_padded_buffer
+            pending["max_rank_numel"] = max_rank_numel
+            pending["work"] = torch.distributed.all_gather_into_tensor(
+                gathered_padded_buffer, padded_local_buffer, group=shard_group, async_op=async_op
+            )
+        else:
+            group_tensors = self._get_uneven_group_tensors(
+                rank_total_numels,
+                dtype=batch["dtype"],
+                device=batch["device"],
+                shard_group=shard_group,
+            )
+            pending["group_tensors"] = group_tensors
+            pending["work"] = torch.distributed.all_gather(
+                group_tensors, local_buffer, group=shard_group, async_op=async_op
+            )
+        return pending
+
+    def _wait_uneven_gather_stage(self, pending_stage: dict[str, Any]) -> None:
+        work = pending_stage.get("work")
+        if work is not None:
+            work.wait()
+        comm_stream = pending_stage.get("comm_stream")
+        if comm_stream is not None:
+            device = pending_stage["batch"]["device"]
+            with torch.cuda.device(device):
+                torch.cuda.current_stream().wait_stream(comm_stream)
+
+    def _block_current_stream_on_uneven_gather_stage(self, pending_stage: dict[str, Any]) -> bool:
+        work = pending_stage.get("work")
+        if work is None:
+            return True
+        block_current_stream = getattr(work, "block_current_stream", None)
+        if block_current_stream is None:
+            return False
+        block_current_stream()
+        return True
+
+    def _finish_uneven_gather_stage(self, pending_stage: dict[str, Any]) -> list[torch.Tensor]:
+        self._wait_uneven_gather_stage(pending_stage)
+        return self._unpack_uneven_gather_stage(pending_stage)
+
+    def _unpack_uneven_gather_stage(self, pending_stage: dict[str, Any]) -> list[torch.Tensor]:
+        batch = pending_stage["batch"]
+        plans = pending_stage["plans"]
+        stage_idx = pending_stage["stage_idx"]
+        group_size = pending_stage["group_size"]
+        rank_offsets = pending_stage["rank_offsets"]
+
+        if pending_stage["use_padded_all_gather"]:
+            gathered_padded_buffer = pending_stage["gathered_padded_buffer"]
+            max_rank_numel = pending_stage["max_rank_numel"]
+            rank_buffers = [
+                gathered_padded_buffer[rank * max_rank_numel : (rank + 1) * max_rank_numel]
+                for rank in range(group_size)
+            ]
+        else:
+            rank_buffers = pending_stage["group_tensors"]
+
+        next_buffers = []
+        for batch_item_idx, plan in enumerate(plans):
+            item_numel = sum(plan["stages"][stage_idx]["rank_numels"])
+            item_buffer = torch.empty(item_numel, dtype=batch["dtype"], device=batch["device"])
+            item_offset = 0
+            for rank, rank_buffer in enumerate(rank_buffers):
+                chunk_numel = plan["stages"][stage_idx]["rank_numels"][rank]
+                if chunk_numel == 0:
+                    continue
+                source_offset = rank_offsets[rank][batch_item_idx]
+                item_buffer[item_offset : item_offset + chunk_numel].copy_(
+                    rank_buffer[source_offset : source_offset + chunk_numel]
                 )
-                torch.distributed.all_gather(group_tensors, local_buffer, group=shard_group)
+                item_offset += chunk_numel
+            if item_offset != item_numel:
+                raise AssertionError(
+                    "Batched uneven DTensor stage unpack did not cover the item: "
+                    f"stage={stage_idx}, assigned={item_offset}, expected={item_numel}."
+                )
+            next_buffers.append(item_buffer)
 
-            if use_padded_all_gather:
-                assert gathered_padded_buffer is not None
-                rank_buffers = [
-                    gathered_padded_buffer[rank * max_rank_numel : (rank + 1) * max_rank_numel]
-                    for rank in range(group_size)
-                ]
-            else:
-                assert group_tensors is not None
-                rank_buffers = group_tensors
+        return next_buffers
 
-            next_buffers = []
-            for batch_item_idx, plan in enumerate(plans):
-                item_numel = sum(plan["stages"][stage_idx]["rank_numels"])
-                item_buffer = torch.empty(item_numel, dtype=batch["dtype"], device=batch["device"])
-                item_offset = 0
-                for rank, rank_buffer in enumerate(rank_buffers):
-                    chunk_numel = plan["stages"][stage_idx]["rank_numels"][rank]
-                    if chunk_numel == 0:
-                        continue
-                    source_offset = rank_offsets[rank][batch_item_idx]
-                    item_buffer[item_offset : item_offset + chunk_numel].copy_(
-                        rank_buffer[source_offset : source_offset + chunk_numel]
-                    )
-                    item_offset += chunk_numel
-                if item_offset != item_numel:
-                    raise AssertionError(
-                        "Batched uneven DTensor stage unpack did not cover the item: "
-                        f"stage={stage_idx}, assigned={item_offset}, expected={item_numel}."
-                    )
-                next_buffers.append(item_buffer)
-
-            current_buffers = next_buffers
-
+    def _store_uneven_gather_batch_results(
+        self,
+        items: list[tuple[torch.Tensor, torch.Tensor]],
+        results: list[torch.Tensor | None],
+        batch: dict[str, Any],
+        current_buffers: list[torch.Tensor],
+    ) -> list[int]:
+        item_indices = batch["item_indices"]
+        plans = batch["plans"]
         for batch_item_idx, item_idx in enumerate(item_indices):
             dtensor_ref, local_tensor = items[item_idx]
             if local_tensor.numel() == 0:
@@ -1203,6 +1416,84 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             results[item_idx] = self._reconstruct_full_tensor_from_flat_buffer(
                 dtensor_ref, plan, current_buffers[batch_item_idx]
             )
+        return item_indices
+
+    def _start_gather_full_uneven_local_tensor_batch_async(
+        self, items: list[tuple[torch.Tensor, torch.Tensor]], batch: dict[str, Any]
+    ) -> dict[str, Any]:
+        item_indices = batch["item_indices"]
+        plans = batch["plans"]
+        current_buffers = [items[item_idx][1].contiguous().view(-1) for item_idx in item_indices]
+
+        if batch["device"].type == "cuda" and len(plans[0]["stages"]) > 1:
+            pending_stages = []
+            with torch.cuda.device(batch["device"]):
+                comm_stream = torch.cuda.Stream()
+                comm_stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(comm_stream):
+                    for stage_idx, stage in enumerate(plans[0]["stages"]):
+                        stage_state = self._prepare_uneven_gather_stage(
+                            current_buffers, plans, batch, stage_idx, stage
+                        )
+                        pending_stage = self._issue_uneven_gather_stage(
+                            stage_state, async_op=True, comm_stream=comm_stream
+                        )
+                        if not self._block_current_stream_on_uneven_gather_stage(pending_stage):
+                            if stage_idx == 0:
+                                return {
+                                    "items": items,
+                                    "batch": batch,
+                                    "current_buffers": current_buffers,
+                                    "pending_stage": pending_stage,
+                                }
+                            raise AssertionError(
+                                "Muon+M-FSDP async multi-stage gather requires "
+                                "torch.distributed.Work.block_current_stream()."
+                            )
+                        pending_stages.append(pending_stage)
+                        current_buffers = self._unpack_uneven_gather_stage(pending_stage)
+
+            return {
+                "items": items,
+                "batch": batch,
+                "current_buffers": current_buffers,
+                "pending_stages": pending_stages,
+            }
+
+        stage_state = self._prepare_uneven_gather_stage(
+            current_buffers, plans, batch, 0, plans[0]["stages"][0]
+        )
+        pending_stage = self._start_uneven_gather_stage(stage_state, async_op=True)
+        return {
+            "items": items,
+            "batch": batch,
+            "current_buffers": current_buffers,
+            "pending_stage": pending_stage,
+        }
+
+    def _finish_gather_full_uneven_local_tensor_batch_async(
+        self, pending: dict[str, Any], results: list[torch.Tensor | None]
+    ) -> list[int]:
+        items = pending["items"]
+        batch = pending["batch"]
+        plans = batch["plans"]
+        if "pending_stages" in pending:
+            for pending_stage in pending["pending_stages"]:
+                self._wait_uneven_gather_stage(pending_stage)
+            return self._store_uneven_gather_batch_results(
+                items, results, batch, pending["current_buffers"]
+            )
+
+        current_buffers = self._finish_uneven_gather_stage(pending["pending_stage"])
+
+        for stage_idx in range(1, len(plans[0]["stages"])):
+            stage_state = self._prepare_uneven_gather_stage(
+                current_buffers, plans, batch, stage_idx, plans[0]["stages"][stage_idx]
+            )
+            pending_stage = self._start_uneven_gather_stage(stage_state, async_op=False)
+            current_buffers = self._finish_uneven_gather_stage(pending_stage)
+
+        return self._store_uneven_gather_batch_results(items, results, batch, current_buffers)
 
     def _local_shard_from_full_update_like(self, dtensor_ref, full_update: torch.Tensor):
         if not hasattr(dtensor_ref._local_tensor, "__create_chunk_list__"):

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -17,16 +17,23 @@ import torch
 from torch.optim.optimizer import ParamsT
 
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.utils import get_pg_rank, get_pg_size, log_single_rank
+from megatron.core.utils import get_pg_size, log_single_rank
 
 from .optimizer_config import ParamKey, ParamPredicate
 
 try:
     from torch.distributed.tensor import DTensor as _DTensor
 
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+        gather_uneven_dtensor_to_full_tensor,
+        update_uneven_dtensor_chunk_metadata,
+    )
+
     _HAVE_DTENSOR = True
 except ImportError:
     _DTensor = None  # type: ignore[assignment,misc]
+    gather_uneven_dtensor_to_full_tensor = None  # type: ignore[assignment]
+    update_uneven_dtensor_chunk_metadata = None  # type: ignore[assignment]
     _HAVE_DTENSOR = False
 
 try:
@@ -348,37 +355,11 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
 class FSDPZeROTensorParallelMuon(TensorParallelMuon):
     """`TensorParallelMuon` extended for Megatron-FSDP ZeRO-1/2/3.
 
-    Supports all three sharded strategies:
-
-    * `optim` (ZeRO-1): optimizer state sharded; grads reduce-scattered.
-    * `optim_grads` (ZeRO-2): optimizer state + grads sharded.
-    * `optim_grads_params` (ZeRO-3): optimizer state + grads + params sharded.
-
-    For all three, `finish_grad_sync()` reduce-scatters gradients so each DP
-    rank holds only a contiguous `Shard(0)` row-shard of the full TP-local 2D
-    gradient. Newton-Schulz needs the full matrix, so this class:
-
-      1. Extracts the local shard via `.to_local()` for any Shard(0) DTensor.
-      2. Allgathers the DP row-shards across the DP group to reconstruct the
-         TP-local, DP-full gradient matrix.
-      3. Trims FSDP bucket-padding rows using the declared global shape from the
-         DTensor.
-      4. Delegates to `TensorParallelMuon.orthogonalize` which handles the
-         remaining TP dimension via `newton_schulz_tp`.
-      5. Extracts the local DP row-shard of the orthogonalized result, padding
-         the last rank with zeros when FSDP bucket padding is present so the
-         per-rank shard size stays uniform.
-      6. Re-wraps the result as a DTensor matching the input's placements so
-         `OrthogonalizedOptimizer.step` can apply the in-place update without
-         placement promotion.
-
-    Memory note for ZeRO-3: each Muon step allocates a temporary `full_grad`
-    of shape `(tp_local_rows, C)` per Muon parameter for the allgather, plus
-    the NS output. Peak extra memory is roughly
-    `3 * (m * n) * sizeof(float32)` per linear layer; momentum stays sharded.
-
-    For "no_shard" or single-rank DP this falls back transparently to the
-    parent implementation.
+    Megatron-FSDP shards a flat parameter buffer across DP ranks. Most 2D
+    parameters are either fully local on one rank or empty on the others; only
+    rank-boundary parameters are split across two ranks. Muon needs the full
+    matrix for Newton-Schulz, so this class gathers only those boundary
+    parameters and runs local NS for fully-local parameters.
     """
 
     def __init__(
@@ -391,18 +372,8 @@ class FSDPZeROTensorParallelMuon(TensorParallelMuon):
     def step(self, closure: Callable | None = None) -> float | None:
         """Muon step for Megatron-FSDP ZeRO-1/2/3.
 
-        M-FSDP shards a flat grad buffer across DP, so the per-param local
-        shard can be empty on some ranks (`p.grad is None`) or variable in
-        size – unlike a uniform `Shard(0)` DTensor. The standard
-        `OrthogonalizedOptimizer.step` skips params with `grad is None`,
-        which desyncs the DP collective inside `orthogonalize` (different
-        ranks process different params → allgather mismatch → hang).
-
-        We fix that here by processing every param on every rank in lockstep.
-        Each param's full gradient is reconstructed via a DP-wide all-gather
-        (supports variable-size local shards), but Newton-Schulz is run on a
-        single owner rank (round-robin by param index) and broadcast back,
-        so NS compute is amortised across DP rather than duplicated 8×.
+        Ranks must enter collectives in the same order, so local boundary
+        decisions are unioned across the DP group before the parameter loop.
         """
         if closure is None:
             loss = None
@@ -410,18 +381,91 @@ class FSDPZeROTensorParallelMuon(TensorParallelMuon):
             loss = closure()
 
         for group in self.param_groups:
-            # `skip_non_grad_params=False`: we must create momentum buffers
-            # for every param, because even params with empty local grad shards
-            # on this rank need to participate in the DP-collective orthogonalize.
             self._init_group(group, skip_non_grad_params=False)
+            gather_param_indices = self._get_boundary_gather_param_indices(group)
 
-            for p in group["params"]:
-                self._muon_step_one(p, group)
+            for param_idx, p in enumerate(group["params"]):
+                self._muon_step_one(p, group, gather_full=param_idx in gather_param_indices)
 
         return loss
 
+    def _as_dtensor(self, value: Any):
+        """Return `value` or `value.data` when either is a DTensor."""
+        if not _HAVE_DTENSOR:
+            return None
+        if isinstance(value, _DTensor):
+            return value
+        data = getattr(value, "data", None)
+        if isinstance(data, _DTensor):
+            return data
+        return None
+
+    def _is_nonempty_dtensor_param(self, param: torch.Tensor) -> bool:
+        dtensor = self._as_dtensor(param)
+        return dtensor is not None and dtensor.to_local().numel() > 0
+
+    def _needs_boundary_gather(self, param: torch.Tensor) -> bool:
+        dtensor = self._as_dtensor(param)
+        if dtensor is None:
+            return False
+        local_tensor = dtensor.to_local()
+        return local_tensor.numel() > 0 and tuple(dtensor.shape) != tuple(local_tensor.shape)
+
+    def _get_boundary_gather_param_indices(self, group: Dict[str, Any]) -> set[int]:
+        """Return globally-agreed parameter indices that need a boundary all-gather."""
+        params = group["params"]
+        local_boundary_indices = [
+            idx for idx, param in enumerate(params) if self._needs_boundary_gather(param)
+        ]
+
+        if self.dp_group is None or get_pg_size(self.dp_group) == 1:
+            return set(local_boundary_indices)
+
+        gathered_indices: list[list[int] | None] = [None] * get_pg_size(self.dp_group)
+        torch.distributed.all_gather_object(
+            gathered_indices, local_boundary_indices, group=self.dp_group
+        )
+        return {
+            idx
+            for rank_indices in gathered_indices
+            if rank_indices is not None
+            for idx in rank_indices
+        }
+
+    def _copy_dtensor_chunk_metadata(self, dst, src) -> None:
+        if hasattr(src._local_tensor, "__create_chunk_list__"):
+            dst._local_tensor.__create_chunk_list__ = src._local_tensor.__create_chunk_list__
+        if hasattr(src._local_tensor, "__create_write_items__"):
+            dst._local_tensor.__create_write_items__ = src._local_tensor.__create_write_items__
+
+    def _dtensor_from_local_like(self, value, local_tensor: torch.Tensor):
+        dtensor = _DTensor.from_local(
+            local_tensor=local_tensor,
+            device_mesh=value.device_mesh,
+            placements=value.placements,
+            shape=value.shape,
+            stride=value.stride(),
+        )
+        self._copy_dtensor_chunk_metadata(dtensor, value)
+        return dtensor
+
+    def _reshard_full_update_like(self, value, full_update: torch.Tensor):
+        if not hasattr(value._local_tensor, "__create_chunk_list__"):
+            if update_uneven_dtensor_chunk_metadata is None:
+                raise RuntimeError("DTensor support is required for Megatron-FSDP Muon.")
+            update_uneven_dtensor_chunk_metadata(value)
+        value_metadata = value._local_tensor.__create_chunk_list__()[0]
+        slices = tuple(
+            slice(offset, offset + size)
+            for offset, size in zip(value_metadata.offsets, value_metadata.sizes)
+        )
+        local_update = full_update[slices].contiguous().to(dtype=value.to_local().dtype)
+        return self._dtensor_from_local_like(value, local_update)
+
     @torch.no_grad()  # type: ignore[misc]
-    def _muon_step_one(self, p: torch.Tensor, group: Dict[str, Any]) -> None:
+    def _muon_step_one(
+        self, p: torch.Tensor, group: Dict[str, Any], gather_full: bool = False
+    ) -> None:
         """Per-param Muon update that participates in DP collectives on every rank."""
         # Fall back to the plain parent step for the single-rank / unsharded case.
         if self.dp_group is None or get_pg_size(self.dp_group) == 1:
@@ -429,135 +473,63 @@ class FSDPZeROTensorParallelMuon(TensorParallelMuon):
                 return
             return self._local_muon_update(p, p.grad, group)
 
-        # Skip params that aren't DTensors (shouldn't happen in M-FSDP).
-        if not (_HAVE_DTENSOR and isinstance(p, _DTensor)):
+        value = self._as_dtensor(p)
+        if value is None:
             if p.grad is None:
                 return
             return self._local_muon_update(p, p.grad, group)
 
-        # Every rank processes every param in lockstep (regardless of whether
-        # the local grad shard is empty) so the DP collectives below stay in
-        # sync. M-FSDP's flat-buffer sharding means local shard sizes vary
-        # per rank and per param, so we operate on DTensors and use
-        # `full_tensor()` to reconstruct the full matrix.
+        p_local = value.to_local()
+        if p_local.numel() == 0 and not gather_full:
+            return
 
-        # Use local views to mutate momentum and param. Momentum is kept
-        # per-shard (same size as p.to_local()); the initial buffer was
-        # allocated via `torch.zeros_like(p.data)` in `_init_group` which,
-        # for a DTensor p, yields a Shard(0) DTensor with the correct local
-        # shape on this rank.
         state = self.state[p]
         mom_buffer = state["momentum_buffer"]
-        mom_local = mom_buffer.to_local() if isinstance(mom_buffer, _DTensor) else mom_buffer
+        mom_dtensor = self._as_dtensor(mom_buffer)
+        mom_local = mom_dtensor.to_local() if mom_dtensor is not None else mom_buffer
 
-        # Derive this rank's local grad. If p.grad is None (empty shard on
-        # this rank), use a zero tensor of the expected local shape so the
-        # local lerp_ / weight-decay math is a no-op while still letting us
-        # participate in the full_tensor() allgather below.
         grad = p.grad
         if grad is None:
             local_grad = torch.zeros_like(mom_local)
         else:
-            local_grad = grad.to_local() if isinstance(grad, _DTensor) else grad
+            grad_dtensor = self._as_dtensor(grad)
+            local_grad = grad_dtensor.to_local() if grad_dtensor is not None else grad
 
-        p_local = p.to_local()
-
-        # Local weight decay on this rank's param/grad slice.
-        wd = group["weight_decay"]
         lr = group["lr"]
-        if wd != 0.0:
-            # Decoupled weight decay: p *= (1 - lr * wd)
-            p_local.mul_(1.0 - lr * wd)
+        self._apply_weight_decay_inplace(p_local, local_grad, lr, group["weight_decay"])
 
-        # Local momentum EMA update.
         mom_local.lerp_(local_grad, 1 - group["momentum"])
-
-        # Assemble the pre-NS gradient (local).
         if self.nesterov:
-            pre_local = local_grad.lerp(mom_local, group["momentum"])
+            update_local = local_grad.lerp(mom_local, group["momentum"])
         else:
-            pre_local = mom_local
+            update_local = mom_local
 
-        # Gather per-rank local row counts so we can allocate a per-rank
-        # destination for the allgather. M-FSDP uses a flat-buffer grad
-        # sharding → local shard sizes vary per rank, which
-        # `all_gather_into_tensor` (equal-size) and DTensor `full_tensor`
-        # (assumes uniform Shard(0)) both handle poorly. We use
-        # `all_gather(tensor_list, input)`, which supports variable sizes.
-        dp_size = get_pg_size(self.dp_group)
-        dp_rank = get_pg_rank(self.dp_group)
-        row_counts = torch.zeros(dp_size, dtype=torch.long, device=p_local.device)
-        row_counts[dp_rank] = pre_local.shape[0]
-        torch.distributed.all_reduce(row_counts, group=self.dp_group)
-        row_counts_cpu = row_counts.tolist()
-
-        # Build per-rank output buffers of the right row count.
-        gathered = [
-            torch.empty(
-                (row_counts_cpu[r], *pre_local.shape[1:]),
-                device=pre_local.device,
-                dtype=pre_local.dtype,
-            )
-            for r in range(dp_size)
-        ]
-        torch.distributed.all_gather(gathered, pre_local.contiguous(), group=self.dp_group)
-        full_grad = torch.cat(gathered, dim=0)
-
-        # Trim any trailing FSDP bucket padding rows so NS sees only the real
-        # parameter. `p.shape[0]` is the FSDP-declared global row count
-        # (= sum of per-rank shard rows, possibly including padding at the
-        # tail); the true param row count is the global shape from the DTensor.
-        tp_group = (
-            (
-                self.pg_collection.expt_tp
-                if getattr(p, "expert_tp", False)
-                else self.pg_collection.tp
-            )
-            if self.pg_collection
-            else None
-        )
-        partition_dim = None if self.tp_mode == "blockwise" else getattr(p, "partition_dim", None)
-        if partition_dim == -1:
-            partition_dim = None
-        tp_size_dim0 = get_pg_size(tp_group) if (partition_dim == 0 and tp_group is not None) else 1
-        tp_local_rows = p.shape[0] // max(tp_size_dim0, 1)
-        if full_grad.shape[0] > tp_local_rows:
-            full_grad = full_grad[:tp_local_rows]
-
-        # Newton-Schulz on the full matrix. We run it on every rank (duplicated
-        # compute across DP) intentionally. A partition-and-broadcast scheme
-        # was tried (owner does NS; others bcast) but the per-param serial
-        # loop turns the broadcast into a per-param sync, negating the
-        # parallelism across ranks – it measured slightly slower in practice.
-        # An effective scheme would need to pipeline NS with the allgather/
-        # broadcast for the *next* param; left as future work.
         from emerging_optimizers import utils
 
         with utils.fp32_matmul_precision(self.fp32_matmul_prec):
             group_kwargs = {k: v for k, v in group.items() if k != "params"}
-            orth_full_grad = super(FSDPZeROTensorParallelMuon, self).orthogonalize(
-                p, full_grad, **group_kwargs
-            )
-
-        # Slice out this rank's contribution. Exclusive prefix sum of
-        # row_counts gives the offset; we saved it above.
-        start = sum(row_counts_cpu[:dp_rank])
-        end = start + row_counts_cpu[dp_rank]
-        # Guard against the last rank holding only padding rows: clamp end.
-        end = min(end, orth_full_grad.shape[0])
-        orth_local = orth_full_grad[start:end].to(dtype=p_local.dtype)
-        # If this rank's shard was purely padding (no real rows), orth_local
-        # may be shorter than p_local; pad with zeros so the add_ lines up.
-        if orth_local.shape[0] < p_local.shape[0]:
-            pad = torch.zeros(
-                (p_local.shape[0] - orth_local.shape[0], *p_local.shape[1:]),
-                device=p_local.device,
-                dtype=p_local.dtype,
-            )
-            orth_local = torch.cat([orth_local, pad], dim=0)
-
-        # In-place weight update on this rank's local shard.
-        p_local.add_(orth_local, alpha=-lr)
+            if gather_full:
+                if gather_uneven_dtensor_to_full_tensor is None:
+                    raise RuntimeError("DTensor support is required for Megatron-FSDP Muon.")
+                update_dtensor = self._dtensor_from_local_like(value, update_local.contiguous())
+                full_update = gather_uneven_dtensor_to_full_tensor(update_dtensor).to_local()
+                orth_full_update = super(FSDPZeROTensorParallelMuon, self).orthogonalize(
+                    p, full_update, **group_kwargs
+                )
+                sharded_update = self._reshard_full_update_like(value, orth_full_update)
+                self.pre_weight_update_fn_inplace(p, sharded_update)
+                update_target = p if isinstance(p, _DTensor) else value
+                update_target.add_(sharded_update, alpha=-lr)
+                self.post_weight_update_fn_inplace(p)
+            else:
+                orth_local_update = (
+                    super(FSDPZeROTensorParallelMuon, self)
+                    .orthogonalize(p, update_local, **group_kwargs)
+                    .to(dtype=p_local.dtype)
+                )
+                self.pre_weight_update_fn_inplace(p_local, orth_local_update)
+                p_local.add_(orth_local_update, alpha=-lr)
+                self.post_weight_update_fn_inplace(p_local)
 
     @torch.no_grad()  # type: ignore[misc]
     def _local_muon_update(

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -10,6 +10,7 @@ To add a new emerging optimizer:
 
 import inspect
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Literal, Optional, get_args
 
@@ -63,6 +64,67 @@ except ImportError:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        log_single_rank(
+            logger, logging.WARNING, "Ignoring invalid %s=%r; using %s.", name, value, default
+        )
+        return default
+
+
+def _should_use_padded_all_gather(rank_total_numels: list[int], pad_factor: float) -> bool:
+    total_numel = sum(rank_total_numels)
+    if total_numel == 0:
+        return False
+    max_rank_numel = max(rank_total_numels)
+    if max_rank_numel == 0 or pad_factor <= 0:
+        return False
+    return max_rank_numel * len(rank_total_numels) <= pad_factor * total_numel
+
+
+def _chunk_infos_are_contiguous_full_order(
+    full_shape: torch.Size, chunk_infos: list[dict[str, Any]]
+) -> bool:
+    """Return whether row-sharded chunks cover `full_shape` in row-major order."""
+    full_shape = torch.Size(full_shape)
+    if full_shape.numel() == 0:
+        return all(chunk_info["numel"] == 0 for chunk_info in chunk_infos)
+
+    expected_flat_start = 0
+    trailing_numel = torch.Size(full_shape[1:]).numel() if len(full_shape) > 1 else 1
+    for chunk_info in chunk_infos:
+        chunk_numel = chunk_info["numel"]
+        if chunk_numel == 0:
+            continue
+
+        offset = tuple(chunk_info["offset"])
+        chunk_shape = torch.Size(chunk_info["shape"])
+        if len(offset) != len(full_shape) or len(chunk_shape) != len(full_shape):
+            return False
+        if len(full_shape) > 1:
+            for dim in range(1, len(full_shape)):
+                if offset[dim] != 0 or chunk_shape[dim] != full_shape[dim]:
+                    return False
+        flat_start = offset[0] * trailing_numel
+        if flat_start != expected_flat_start:
+            return False
+        expected_flat_start += chunk_numel
+
+    return expected_flat_start == full_shape.numel()
 
 
 def get_supported_coefficient_types() -> tuple[str, ...]:
@@ -309,7 +371,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         self,
         params: ParamsT,
         dp_group: torch.distributed.ProcessGroup | None = None,
-        fsdp_batched_all_gather: bool = False,
+        fsdp_batched_all_gather: bool = True,
         **kwargs: Any,
     ) -> None:
         assert _HAVE_DTENSOR, (
@@ -318,9 +380,90 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         )
         self.dp_group = dp_group
         self.fsdp_batched_all_gather = fsdp_batched_all_gather
-        self._boundary_gather_indices_cache: Dict[tuple[int, ...], set[int]] = {}
-        self._uneven_gather_plan_cache: Dict[int, Dict[str, Any]] = {}
+        self.fsdp_reuse_gather_scratch = _env_flag("MUON_FSDP_REUSE_GATHER_SCRATCH", True)
+        self.fsdp_padded_all_gather = _env_flag("MUON_FSDP_PADDED_ALL_GATHER", True)
+        self.fsdp_padded_all_gather_pad_factor = _env_float(
+            "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR", 1.25
+        )
+        self.fsdp_batch_max_gather_bytes = int(
+            _env_float("MUON_FSDP_BATCH_MAX_GATHER_BYTES", 1024 * 1024 * 1024)
+        )
+        self.fsdp_padded_all_gather_zero_pad = _env_flag(
+            "MUON_FSDP_PADDED_ALL_GATHER_ZERO_PAD", True
+        )
+        self.fsdp_fast_reconstruct = _env_flag("MUON_FSDP_FAST_RECONSTRUCT", True)
+        self._boundary_gather_indices_cache: dict[tuple[int, ...], set[int]] = {}
+        self._uneven_gather_plan_cache: dict[int, dict[str, Any]] = {}
+        self._fsdp_gather_scratch_cache: dict[tuple[Any, ...], Any] = {}
         super().__init__(params, **kwargs)
+
+    def _fsdp_gather_scratch_cache_bytes(self) -> int:
+        total = 0
+        for value in self._fsdp_gather_scratch_cache.values():
+            if isinstance(value, torch.Tensor):
+                total += value.numel() * value.element_size()
+            elif isinstance(value, list):
+                total += sum(
+                    tensor.numel() * tensor.element_size()
+                    for tensor in value
+                    if isinstance(tensor, torch.Tensor)
+                )
+        return total
+
+    def clear_fsdp_gather_scratch_cache(self) -> None:
+        """Clear the gather scratch buffer."""
+        self._fsdp_gather_scratch_cache.clear()
+
+    def _get_fsdp_gather_scratch_tensor(
+        self, key: tuple[Any, ...], numel: int, *, dtype: torch.dtype, device: torch.device
+    ) -> torch.Tensor:
+        if not self.fsdp_reuse_gather_scratch:
+            return torch.empty(numel, dtype=dtype, device=device)
+
+        cached = self._fsdp_gather_scratch_cache.get(key)
+        if (
+            not isinstance(cached, torch.Tensor)
+            or cached.numel() < numel
+            or cached.dtype != dtype
+            or cached.device != device
+        ):
+            cached = torch.empty(numel, dtype=dtype, device=device)
+            self._fsdp_gather_scratch_cache[key] = cached
+        return cached[:numel]
+
+    def _get_uneven_group_tensors(
+        self,
+        rank_numels: list[int],
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+        shard_group: torch.distributed.ProcessGroup,
+    ) -> list[torch.Tensor]:
+        if not self.fsdp_reuse_gather_scratch:
+            return [torch.empty(numel, dtype=dtype, device=device) for numel in rank_numels]
+
+        key = ("uneven_group_tensors", id(shard_group), dtype, device, tuple(rank_numels))
+        cached = self._fsdp_gather_scratch_cache.get(key)
+        if not isinstance(cached, list):
+            cached = [torch.empty(numel, dtype=dtype, device=device) for numel in rank_numels]
+            self._fsdp_gather_scratch_cache[key] = cached
+        return cached
+
+    def _candidate_batch_gather_bytes(
+        self, stage_rank_total_numels: list[list[int]], plan: dict[str, Any], *, element_size: int
+    ) -> int:
+        max_stage_bytes = 0
+        for stage_idx, stage in enumerate(plan["stages"]):
+            candidate_rank_total_numels = [
+                stage_rank_total_numels[stage_idx][rank] + stage["rank_numels"][rank]
+                for rank in range(len(stage["rank_numels"]))
+            ]
+            if self.fsdp_padded_all_gather:
+                gathered_numel = max(candidate_rank_total_numels) * len(candidate_rank_total_numels)
+            else:
+                gathered_numel = sum(candidate_rank_total_numels)
+            max_stage_bytes = max(max_stage_bytes, gathered_numel * element_size)
+        return max_stage_bytes
 
     @torch.no_grad()  # type: ignore[misc]
     def step(self, closure: Callable | None = None) -> float | None:
@@ -695,15 +838,139 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
             ]
 
         chunk_infos = local_chunks_info
+        full_shape = torch.Size(dtensor_ref.shape)
         plan = {
             "shard_mesh_dims": tuple(shard_mesh_dims),
             "stages": stages,
             "chunk_infos": chunk_infos,
+            "full_numel": full_shape.numel(),
+            "is_contiguous_full_order": _chunk_infos_are_contiguous_full_order(
+                full_shape, chunk_infos
+            ),
         }
         if len(stages) == 1:
             plan["shard_group"] = stages[0]["shard_group"]
         self._uneven_gather_plan_cache[cache_key] = plan
         return plan
+
+    def _all_gather_padded_equal_size(
+        self,
+        local_buffer: torch.Tensor,
+        rank_total_numels: list[int],
+        shard_group: torch.distributed.ProcessGroup,
+    ) -> tuple[torch.Tensor, int]:
+        max_rank_numel = max(rank_total_numels)
+        group_size = len(rank_total_numels)
+        if max_rank_numel == 0:
+            raise AssertionError("Cannot padded-all-gather an empty uneven DTensor batch.")
+
+        padded_local_buffer = self._get_fsdp_gather_scratch_tensor(
+            ("padded_local_buffer", id(shard_group), local_buffer.dtype, local_buffer.device),
+            max_rank_numel,
+            dtype=local_buffer.dtype,
+            device=local_buffer.device,
+        )
+        if local_buffer.numel() > 0:
+            padded_local_buffer[: local_buffer.numel()].copy_(local_buffer)
+        if self.fsdp_padded_all_gather_zero_pad and local_buffer.numel() < max_rank_numel:
+            padded_local_buffer[local_buffer.numel() : max_rank_numel].zero_()
+
+        gathered_padded_buffer = self._get_fsdp_gather_scratch_tensor(
+            (
+                "gathered_padded_buffer",
+                id(shard_group),
+                local_buffer.dtype,
+                local_buffer.device,
+                group_size,
+            ),
+            group_size * max_rank_numel,
+            dtype=local_buffer.dtype,
+            device=local_buffer.device,
+        )
+        torch.distributed.all_gather_into_tensor(
+            gathered_padded_buffer, padded_local_buffer, group=shard_group
+        )
+        return gathered_padded_buffer, max_rank_numel
+
+    def _reconstruct_full_tensor_from_rank_buffers(
+        self,
+        dtensor_ref,
+        plan: dict[str, Any],
+        rank_buffers: list[torch.Tensor],
+        rank_buffer_offsets: list[int] | None = None,
+    ) -> torch.Tensor:
+        full_tensor = torch.empty(
+            dtensor_ref.shape, dtype=rank_buffers[0].dtype, device=rank_buffers[0].device
+        )
+        assigned_numel = 0
+
+        if self.fsdp_fast_reconstruct and plan["is_contiguous_full_order"]:
+            full_flat = full_tensor.view(-1)
+            dest_offset = 0
+            for rank, rank_buffer in enumerate(rank_buffers):
+                chunk_info = plan["chunk_infos"][rank]
+                chunk_numel = chunk_info["numel"]
+                if chunk_numel == 0:
+                    continue
+                source_offset = 0 if rank_buffer_offsets is None else rank_buffer_offsets[rank]
+                full_flat[dest_offset : dest_offset + chunk_numel].copy_(
+                    rank_buffer[source_offset : source_offset + chunk_numel]
+                )
+                dest_offset += chunk_numel
+                assigned_numel += chunk_numel
+            if assigned_numel != plan["full_numel"]:
+                raise AssertionError(
+                    "Fast uneven DTensor reconstruction did not cover the full tensor: "
+                    f"assigned={assigned_numel}, expected={plan['full_numel']}."
+                )
+            return full_tensor
+
+        for rank, rank_buffer in enumerate(rank_buffers):
+            chunk_info = plan["chunk_infos"][rank]
+            chunk_numel = chunk_info["numel"]
+            if chunk_numel == 0:
+                continue
+            source_offset = 0 if rank_buffer_offsets is None else rank_buffer_offsets[rank]
+            chunk_shape = chunk_info["shape"]
+            chunk_tensor = rank_buffer[source_offset : source_offset + chunk_numel].view(
+                chunk_shape
+            )
+            slices = tuple(slice(o, o + s) for o, s in zip(chunk_info["offset"], chunk_shape))
+            full_tensor[slices] = chunk_tensor
+            assigned_numel += chunk_numel
+
+        _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
+        return full_tensor
+
+    def _reconstruct_full_tensor_from_flat_buffer(
+        self, dtensor_ref, plan: dict[str, Any], full_flat_buffer: torch.Tensor
+    ) -> torch.Tensor:
+        if full_flat_buffer.numel() != plan["full_numel"]:
+            raise AssertionError(
+                "Uneven DTensor flat reconstruction buffer size mismatch: "
+                f"got {full_flat_buffer.numel()}, expected {plan['full_numel']}."
+            )
+
+        if self.fsdp_fast_reconstruct and plan["is_contiguous_full_order"]:
+            return full_flat_buffer.view(dtensor_ref.shape)
+
+        full_tensor = torch.empty(
+            dtensor_ref.shape, dtype=full_flat_buffer.dtype, device=full_flat_buffer.device
+        )
+        assigned_numel = 0
+        buffer_offset = 0
+        for chunk_info in plan["chunk_infos"]:
+            chunk_shape = chunk_info["shape"]
+            chunk_numel = chunk_info["numel"]
+            gathered_tensor = full_flat_buffer[buffer_offset : buffer_offset + chunk_numel]
+            buffer_offset += chunk_numel
+            offset = chunk_info["offset"]
+            slices = tuple(slice(o, o + s) for o, s in zip(offset, chunk_shape))
+            full_tensor[slices] = gathered_tensor.view(chunk_shape)
+            assigned_numel += chunk_numel
+
+        _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
+        return full_tensor
 
     def _gather_full_uneven_local_tensor_like(
         self, dtensor_ref, local_tensor: torch.Tensor
@@ -734,28 +1001,18 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     "Uneven DTensor gather local buffer size mismatch: "
                     f"got {local_buffer.numel()}, expected {expected_local_numel}."
                 )
-            group_tensors = [
-                torch.empty(numel, dtype=local_tensor.dtype, device=local_tensor.device)
-                for numel in stage["rank_numels"]
-            ]
+            group_tensors = self._get_uneven_group_tensors(
+                stage["rank_numels"],
+                dtype=local_tensor.dtype,
+                device=local_tensor.device,
+                shard_group=shard_group,
+            )
             torch.distributed.all_gather(group_tensors, local_buffer, group=shard_group)
 
             if local_tensor.numel() == 0:
                 return None
 
-            full_tensor = torch.empty(
-                dtensor_ref.shape, dtype=local_tensor.dtype, device=local_tensor.device
-            )
-            assigned_numel = 0
-            for chunk_info, gathered_tensor in zip(plan["chunk_infos"], group_tensors):
-                chunk_shape = chunk_info["shape"]
-                offset = chunk_info["offset"]
-                slices = tuple(slice(o, o + s) for o, s in zip(offset, chunk_shape))
-                full_tensor[slices] = gathered_tensor.view(chunk_shape)
-                assigned_numel += chunk_info["numel"]
-
-            _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
-            return full_tensor
+            return self._reconstruct_full_tensor_from_rank_buffers(dtensor_ref, plan, group_tensors)
 
         for stage in plan["stages"]:
             shard_group = stage["shard_group"]
@@ -766,33 +1023,19 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     "Uneven DTensor gather local buffer size mismatch: "
                     f"got {local_buffer.numel()}, expected {expected_local_numel}."
                 )
-            group_tensors = [
-                torch.empty(numel, dtype=local_tensor.dtype, device=local_tensor.device)
-                for numel in stage["rank_numels"]
-            ]
+            group_tensors = self._get_uneven_group_tensors(
+                stage["rank_numels"],
+                dtype=local_tensor.dtype,
+                device=local_tensor.device,
+                shard_group=shard_group,
+            )
             torch.distributed.all_gather(group_tensors, local_buffer, group=shard_group)
             local_buffer = torch.cat(group_tensors)
 
         if local_tensor.numel() == 0:
             return None
 
-        full_tensor = torch.empty(
-            dtensor_ref.shape, dtype=local_tensor.dtype, device=local_tensor.device
-        )
-        assigned_numel = 0
-        buffer_offset = 0
-        for chunk_info in plan["chunk_infos"]:
-            chunk_shape = chunk_info["shape"]
-            chunk_numel = chunk_info["numel"]
-            gathered_tensor = local_buffer[buffer_offset : buffer_offset + chunk_numel]
-            buffer_offset += chunk_numel
-            offset = chunk_info["offset"]
-            slices = tuple(slice(o, o + s) for o, s in zip(offset, chunk_shape))
-            full_tensor[slices] = gathered_tensor.view(chunk_shape)
-            assigned_numel += chunk_numel
-
-        _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
-        return full_tensor
+        return self._reconstruct_full_tensor_from_flat_buffer(dtensor_ref, plan, local_buffer)
 
     def _gather_full_uneven_local_tensors_like(
         self, items: list[tuple[torch.Tensor, torch.Tensor]]
@@ -807,7 +1050,7 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         reconstruct or orthogonalize the full boundary tensor.
         """
         results: list[torch.Tensor | None] = [None] * len(items)
-        batches: dict[tuple[int, torch.dtype, torch.device], Dict[str, Any]] = {}
+        batches: dict[tuple[int, torch.dtype, torch.device], list[dict[str, Any]]] = {}
 
         for item_idx, (dtensor_ref, local_tensor) in enumerate(items):
             plan = self._get_uneven_gather_plan(dtensor_ref)
@@ -816,28 +1059,48 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                     dtensor_ref, local_tensor
                 )
                 continue
-            if len(plan["shard_mesh_dims"]) != 1:
-                results[item_idx] = self._gather_full_uneven_local_tensor_like(
-                    dtensor_ref, local_tensor
-                )
-                continue
 
-            key = (id(plan["shard_group"]), local_tensor.dtype, local_tensor.device)
-            batch = batches.setdefault(
-                key,
-                {
-                    "shard_group": plan["shard_group"],
-                    "dtype": local_tensor.dtype,
-                    "device": local_tensor.device,
-                    "item_indices": [],
-                    "plans": [],
-                },
-            )
+            stage_group_key = tuple(id(stage["shard_group"]) for stage in plan["stages"])
+            key = (stage_group_key, local_tensor.dtype, local_tensor.device)
+            key_batches = batches.setdefault(key, [])
+            element_size = local_tensor.element_size()
+            if not key_batches:
+                key_batches.append(
+                    {
+                        "dtype": local_tensor.dtype,
+                        "device": local_tensor.device,
+                        "item_indices": [],
+                        "plans": [],
+                        "stage_rank_total_numels": [
+                            [0] * len(stage["rank_numels"]) for stage in plan["stages"]
+                        ],
+                    }
+                )
+            batch = key_batches[-1]
+            if batch["item_indices"]:
+                candidate_bytes = self._candidate_batch_gather_bytes(
+                    batch["stage_rank_total_numels"], plan, element_size=element_size
+                )
+                if candidate_bytes > self.fsdp_batch_max_gather_bytes:
+                    batch = {
+                        "dtype": local_tensor.dtype,
+                        "device": local_tensor.device,
+                        "item_indices": [],
+                        "plans": [],
+                        "stage_rank_total_numels": [
+                            [0] * len(stage["rank_numels"]) for stage in plan["stages"]
+                        ],
+                    }
+                    key_batches.append(batch)
             batch["item_indices"].append(item_idx)
             batch["plans"].append(plan)
+            for stage_idx, stage in enumerate(plan["stages"]):
+                for rank, rank_numel in enumerate(stage["rank_numels"]):
+                    batch["stage_rank_total_numels"][stage_idx][rank] += rank_numel
 
-        for batch in batches.values():
-            self._gather_full_uneven_local_tensor_batch(items, results, batch)
+        for key_batches in batches.values():
+            for batch in key_batches:
+                self._gather_full_uneven_local_tensor_batch(items, results, batch)
 
         return results
 
@@ -847,41 +1110,109 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
         results: list[torch.Tensor | None],
         batch: dict[str, Any],
     ) -> None:
-        shard_group = batch["shard_group"]
-        group_size = get_pg_size(shard_group)
-        group_rank = torch.distributed.get_rank(shard_group)
         item_indices = batch["item_indices"]
         plans = batch["plans"]
+        current_buffers = [items[item_idx][1].contiguous().view(-1) for item_idx in item_indices]
 
-        local_chunks = [items[item_idx][1].contiguous().view(-1) for item_idx in item_indices]
-        local_buffer = (
-            torch.cat(local_chunks)
-            if local_chunks and sum(chunk.numel() for chunk in local_chunks) > 0
-            else torch.empty(0, dtype=batch["dtype"], device=batch["device"])
-        )
-        expected_local_numel = sum(plan["chunk_infos"][group_rank]["numel"] for plan in plans)
-        if local_buffer.numel() != expected_local_numel:
-            raise AssertionError(
-                "Batched uneven DTensor gather local buffer size mismatch: "
-                f"got {local_buffer.numel()}, expected {expected_local_numel}."
+        for stage_idx, stage in enumerate(plans[0]["stages"]):
+            shard_group = stage["shard_group"]
+            group_size = get_pg_size(shard_group)
+            group_rank = torch.distributed.get_rank(shard_group)
+
+            expected_item_numels = [
+                plan["stages"][stage_idx]["rank_numels"][group_rank] for plan in plans
+            ]
+            expected_local_numel = sum(expected_item_numels)
+            local_buffer = self._get_fsdp_gather_scratch_tensor(
+                ("batch_local_buffer", stage_idx, id(shard_group), batch["dtype"], batch["device"]),
+                expected_local_numel,
+                dtype=batch["dtype"],
+                device=batch["device"],
             )
+            local_offset = 0
+            for buffer, expected_numel in zip(current_buffers, expected_item_numels):
+                if buffer.numel() != expected_numel:
+                    raise AssertionError(
+                        "Batched uneven DTensor gather stage buffer size mismatch: "
+                        f"stage={stage_idx}, got {buffer.numel()}, expected {expected_numel}."
+                    )
+                if expected_numel == 0:
+                    continue
+                local_buffer[local_offset : local_offset + expected_numel].copy_(buffer)
+                local_offset += expected_numel
 
-        rank_offsets: list[list[int]] = []
-        rank_total_numels: list[int] = []
-        for rank in range(group_size):
-            offsets = []
-            total_numel = 0
-            for plan in plans:
-                offsets.append(total_numel)
-                total_numel += plan["chunk_infos"][rank]["numel"]
-            rank_offsets.append(offsets)
-            rank_total_numels.append(total_numel)
+            if local_offset != expected_local_numel:
+                raise AssertionError(
+                    "Batched uneven DTensor gather local buffer size mismatch: "
+                    f"stage={stage_idx}, packed {local_offset}, expected {expected_local_numel}."
+                )
 
-        group_tensors = [
-            torch.empty(total_numel, dtype=batch["dtype"], device=batch["device"])
-            for total_numel in rank_total_numels
-        ]
-        torch.distributed.all_gather(group_tensors, local_buffer, group=shard_group)
+            rank_offsets: list[list[int]] = []
+            rank_total_numels: list[int] = []
+            for rank in range(group_size):
+                offsets = []
+                total_numel = 0
+                for plan in plans:
+                    offsets.append(total_numel)
+                    total_numel += plan["stages"][stage_idx]["rank_numels"][rank]
+                rank_offsets.append(offsets)
+                rank_total_numels.append(total_numel)
+
+            use_padded_all_gather = (
+                self.fsdp_padded_all_gather
+                and hasattr(torch.distributed, "all_gather_into_tensor")
+                and _should_use_padded_all_gather(
+                    rank_total_numels, self.fsdp_padded_all_gather_pad_factor
+                )
+            )
+            gathered_padded_buffer = None
+            max_rank_numel = 0
+            group_tensors = None
+            if use_padded_all_gather:
+                gathered_padded_buffer, max_rank_numel = self._all_gather_padded_equal_size(
+                    local_buffer, rank_total_numels, shard_group
+                )
+            else:
+                group_tensors = self._get_uneven_group_tensors(
+                    rank_total_numels,
+                    dtype=batch["dtype"],
+                    device=batch["device"],
+                    shard_group=shard_group,
+                )
+                torch.distributed.all_gather(group_tensors, local_buffer, group=shard_group)
+
+            if use_padded_all_gather:
+                assert gathered_padded_buffer is not None
+                rank_buffers = [
+                    gathered_padded_buffer[rank * max_rank_numel : (rank + 1) * max_rank_numel]
+                    for rank in range(group_size)
+                ]
+            else:
+                assert group_tensors is not None
+                rank_buffers = group_tensors
+
+            next_buffers = []
+            for batch_item_idx, plan in enumerate(plans):
+                item_numel = sum(plan["stages"][stage_idx]["rank_numels"])
+                item_buffer = torch.empty(item_numel, dtype=batch["dtype"], device=batch["device"])
+                item_offset = 0
+                for rank, rank_buffer in enumerate(rank_buffers):
+                    chunk_numel = plan["stages"][stage_idx]["rank_numels"][rank]
+                    if chunk_numel == 0:
+                        continue
+                    source_offset = rank_offsets[rank][batch_item_idx]
+                    item_buffer[item_offset : item_offset + chunk_numel].copy_(
+                        rank_buffer[source_offset : source_offset + chunk_numel]
+                    )
+                    item_offset += chunk_numel
+                if item_offset != item_numel:
+                    raise AssertionError(
+                        "Batched uneven DTensor stage unpack did not cover the item: "
+                        f"stage={stage_idx}, assigned={item_offset}, expected={item_numel}."
+                    )
+                next_buffers.append(item_buffer)
+
+            current_buffers = next_buffers
 
         for batch_item_idx, item_idx in enumerate(item_indices):
             dtensor_ref, local_tensor = items[item_idx]
@@ -889,25 +1220,10 @@ class FSDPTensorParallelMuon(TensorParallelMuon):
                 results[item_idx] = None
                 continue
 
-            full_tensor = torch.empty(
-                dtensor_ref.shape, dtype=local_tensor.dtype, device=local_tensor.device
-            )
-            assigned_numel = 0
             plan = plans[batch_item_idx]
-            for rank, gathered_rank_tensor in enumerate(group_tensors):
-                chunk_info = plan["chunk_infos"][rank]
-                chunk_numel = chunk_info["numel"]
-                if chunk_numel == 0:
-                    continue
-                offset = rank_offsets[rank][batch_item_idx]
-                chunk_shape = chunk_info["shape"]
-                chunk_tensor = gathered_rank_tensor[offset : offset + chunk_numel].view(chunk_shape)
-                slices = tuple(slice(o, o + s) for o, s in zip(chunk_info["offset"], chunk_shape))
-                full_tensor[slices] = chunk_tensor
-                assigned_numel += chunk_numel
-
-            _assert_chunks_cover_full_tensor(dtensor_ref.shape, plan["chunk_infos"], assigned_numel)
-            results[item_idx] = full_tensor
+            results[item_idx] = self._reconstruct_full_tensor_from_flat_buffer(
+                dtensor_ref, plan, current_buffers[batch_item_idx]
+            )
 
     def _local_shard_from_full_update_like(self, dtensor_ref, full_update: torch.Tensor):
         if not hasattr(dtensor_ref._local_tensor, "__create_chunk_list__"):

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -635,17 +635,24 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         # helper function to flatten local params, all-gather,
         # unflatten and copy to model params
         def _allgather_helper(params_list, group):
+            # For Megatron-FSDP, params are DTensors whose local storage lives in
+            # `_local_tensor`. Plain DDP params fall back to `.data`.
+            def _get_local(p):
+                local = getattr(p, "_local_tensor", None)
+                return local if local is not None else p.data
+
             device = params_list[0][0].device
             dtype = params_list[0][0].dtype
             rank = get_pg_rank(group)
             dp_size = get_pg_size(group)
-            # Flatten this rank's params.
+            local_params = [[_get_local(p) for p in params] for params in params_list]
+            # Flatten this rank's local tensors.
             src = (
-                _flatten_dense_tensors(params_list[rank])
-                if len(params_list[rank]) > 0
+                _flatten_dense_tensors(local_params[rank])
+                if len(local_params[rank]) > 0
                 else torch.empty(0, device=device, dtype=dtype)
             )
-            flat_sizes = [sum(p.numel() for p in params) for params in params_list]
+            flat_sizes = [sum(t.numel() for t in lp) for lp in local_params]
             if max(flat_sizes) == 0:
                 return
 
@@ -661,13 +668,13 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
 
             torch.distributed.all_gather(gather_list, src, group=group)
 
-            # Unflatten and copy gathered params for each rank.
-            for idx, params in enumerate(params_list):
-                if len(params) == 0 or idx == rank:
+            # Unflatten and copy gathered params back into local storage.
+            for idx, lp in enumerate(local_params):
+                if len(lp) == 0 or idx == rank:
                     continue
-                updated_params = _unflatten_dense_tensors(gather_list[idx], params)
-                for updated_p, model_p in zip(updated_params, params):
-                    model_p.data.copy_(updated_p)
+                updated_params = _unflatten_dense_tensors(gather_list[idx], lp)
+                for updated_p, local_t in zip(updated_params, lp):
+                    local_t.copy_(updated_p)
 
         if self.pg_collection is None:
             return

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -635,24 +635,17 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         # helper function to flatten local params, all-gather,
         # unflatten and copy to model params
         def _allgather_helper(params_list, group):
-            # For Megatron-FSDP, params are DTensors whose local storage lives in
-            # `_local_tensor`. Plain DDP params fall back to `.data`.
-            def _get_local(p):
-                local = getattr(p, "_local_tensor", None)
-                return local if local is not None else p.data
-
             device = params_list[0][0].device
             dtype = params_list[0][0].dtype
             rank = get_pg_rank(group)
             dp_size = get_pg_size(group)
-            local_params = [[_get_local(p) for p in params] for params in params_list]
-            # Flatten this rank's local tensors.
+            # Flatten this rank's params.
             src = (
-                _flatten_dense_tensors(local_params[rank])
-                if len(local_params[rank]) > 0
+                _flatten_dense_tensors(params_list[rank])
+                if len(params_list[rank]) > 0
                 else torch.empty(0, device=device, dtype=dtype)
             )
-            flat_sizes = [sum(t.numel() for t in lp) for lp in local_params]
+            flat_sizes = [sum(p.numel() for p in params) for params in params_list]
             if max(flat_sizes) == 0:
                 return
 
@@ -668,13 +661,13 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
 
             torch.distributed.all_gather(gather_list, src, group=group)
 
-            # Unflatten and copy gathered params back into local storage.
-            for idx, lp in enumerate(local_params):
-                if len(lp) == 0 or idx == rank:
+            # Unflatten and copy gathered params for each rank.
+            for idx, params in enumerate(params_list):
+                if len(params) == 0 or idx == rank:
                     continue
-                updated_params = _unflatten_dense_tensors(gather_list[idx], lp)
-                for updated_p, local_t in zip(updated_params, lp):
-                    local_t.copy_(updated_p)
+                updated_params = _unflatten_dense_tensors(gather_list[idx], params)
+                for updated_p, model_p in zip(updated_params, params):
+                    model_p.data.copy_(updated_p)
 
         if self.pg_collection is None:
             return

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -156,16 +156,10 @@ class MegatronOptimizer(ABC):
                 and getattr(param, "__fsdp_param__", False)
             ):
                 grad = param.decoupled_grad if hasattr(param, "decoupled_grad") else None
-                if (
-                    getattr(param, "__fsdp_param__", False)
-                    and grad is not None
-                    and hasattr(grad, "_local_tensor")
-                ):
-                    # Megatron-FSDP gradients are DTensors.
-                    grad = grad._local_tensor
             elif getattr(param, "__fsdp_param__", False):
-                # Megatron-FSDP gradients are DTensors.
-                grad = param.grad._local_tensor if param.grad is not None else None
+                # Megatron-FSDP gradients are DTensors. Keep the DTensor
+                # wrapper so grad-norm code can reduce over FSDP shard groups.
+                grad = param.grad
             else:
                 grad = param.grad
             grad_not_none = grad is not None

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -198,7 +198,7 @@ class MegatronOptimizer(ABC):
         return False
 
     @abstractmethod
-    def step_with_ready_grads(self) -> bool:
+    def step_with_ready_grads(self, update_model_params: bool = True) -> bool:
         """Step the optimizer with ready gradients, return successful."""
         return True
 
@@ -579,7 +579,7 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
         return False
 
     @torch.no_grad()
-    def step_with_ready_grads(self) -> bool:
+    def step_with_ready_grads(self, update_model_params: bool = True) -> bool:
         """Step the optimizer with ready gradients, return successful."""
         timers = self.config.timers
         # Step the optimizer.
@@ -593,21 +593,22 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
             timers('optimizer-inner-step').stop()
 
         # Update params from main params.
-        if timers is not None:
-            timers('optimizer-copy-main-to-model-params', log_level=1).start(
-                barrier=self.config.barrier_with_L1_time
-            )
-        if not self.is_stub_optimizer:
-            if self.config.reuse_grad_buf_for_mxfp8_param_ag:
-                # In the case of overlap_param_gather,
-                # copy is manually called in the training loop
-                if not self.config.overlap_param_gather:
-                    self._copy_main_params_to_param_buffer()
-            else:
-                self._copy_main_params_to_model_params()
+        if update_model_params:
+            if timers is not None:
+                timers('optimizer-copy-main-to-model-params', log_level=1).start(
+                    barrier=self.config.barrier_with_L1_time
+                )
+            if not self.is_stub_optimizer:
+                if self.config.reuse_grad_buf_for_mxfp8_param_ag:
+                    # In the case of overlap_param_gather,
+                    # copy is manually called in the training loop
+                    if not self.config.overlap_param_gather:
+                        self._copy_main_params_to_param_buffer()
+                else:
+                    self._copy_main_params_to_model_params()
 
-        if timers is not None:
-            timers('optimizer-copy-main-to-model-params').stop()
+            if timers is not None:
+                timers('optimizer-copy-main-to-model-params').stop()
 
         return True
 
@@ -962,7 +963,7 @@ class FP32Optimizer(MegatronOptimizer):
         return False
 
     @torch.no_grad()
-    def step_with_ready_grads(self) -> bool:
+    def step_with_ready_grads(self, update_model_params: bool = True) -> bool:
         """Step the optimizer with ready gradients, return successful."""
         if self.is_stub_optimizer:
             return True
@@ -1274,16 +1275,63 @@ class ChainedOptimizer(MegatronOptimizer):
 
         return found_inf_flag
 
+    def _get_deferred_megatron_fsdp_model_chunks(self) -> list[Any]:
+        """Return Megatron-FSDP model chunks whose weight install can be deferred."""
+        if len(self.chained_optimizers) <= 1:
+            return []
+
+        model_chunks = []
+        seen_model_chunks = set()
+        for optimizer in self.chained_optimizers:
+            for model_chunk in getattr(optimizer, 'model_chunks', []):
+                ddp_config = getattr(model_chunk, 'ddp_config', None)
+                if not getattr(ddp_config, 'use_megatron_fsdp', False):
+                    continue
+                if not hasattr(model_chunk, 'install_optimized_model_weights'):
+                    continue
+                model_chunk_id = id(model_chunk)
+                if model_chunk_id in seen_model_chunks:
+                    continue
+                seen_model_chunks.add(model_chunk_id)
+                model_chunks.append(model_chunk)
+
+        return model_chunks
+
+    def _uses_deferred_megatron_fsdp_weight_install(self, optimizer, model_chunk_ids: set) -> bool:
+        """Check whether an inner optimizer owns model chunks with deferred install."""
+        return any(
+            id(model_chunk) in model_chunk_ids
+            for model_chunk in getattr(optimizer, 'model_chunks', [])
+        )
+
     @torch.no_grad()
-    def step_with_ready_grads(self) -> bool:
+    def step_with_ready_grads(self, update_model_params: bool = True) -> bool:
         """Step the optimizer with ready gradients, return successful."""
+        fsdp_model_chunks = (
+            self._get_deferred_megatron_fsdp_model_chunks() if update_model_params else []
+        )
+        fsdp_model_chunk_ids = {id(model_chunk) for model_chunk in fsdp_model_chunks}
         success = True
         for optimizer_idx, optimizer in enumerate(self.chained_optimizers):
-            success &= optimizer.step_with_ready_grads()
-            if self.config.overlap_param_gather_with_optimizer_step and optimizer_idx == 0:
+            defer_weight_install = (
+                self._uses_deferred_megatron_fsdp_weight_install(optimizer, fsdp_model_chunk_ids)
+                or not update_model_params
+            )
+            success &= optimizer.step_with_ready_grads(update_model_params=not defer_weight_install)
+            if (
+                update_model_params
+                and not fsdp_model_chunks
+                and self.config.overlap_param_gather_with_optimizer_step
+                and optimizer_idx == 0
+            ):
                 assert success
                 assert len(optimizer.model_chunks) == 1
                 optimizer.model_chunks[0].start_param_sync(force_dispatch=True)
+
+        if fsdp_model_chunks and success:
+            for model_chunk in fsdp_model_chunks:
+                model_chunk.install_optimized_model_weights()
+                model_chunk.start_param_sync()
 
         return success
 

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -289,6 +289,11 @@ class OptimizerConfig:
     """Optimizer for nonlinear parameters (embeddings, biases, norms) when using muon.
     One of 'adam' or 'lion'. Defaults to 'adam'."""
 
+    muon_fsdp_batched_all_gather: bool = False
+    """If True, batch Muon+M-FSDP boundary parameter all-gathers by dtype/device/group.
+    This can reduce collective count but increases temporary peak memory.
+    """
+
     # Lion.
     lion_beta1: float = 0.95
     """First beta coefficient for Lion optimizer (used in sign update). Defaults to 0.95."""

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -290,7 +290,7 @@ class OptimizerConfig:
     One of 'adam' or 'lion'. Defaults to 'adam'."""
 
     muon_fsdp_batched_all_gather: bool = False
-    """If True, batch Muon+M-FSDP boundary parameter all-gathers by dtype/device/group.
+    """If True, batch Muon+M-FSDP boundary parameter all-gathers by dtype/device/param-group.
     This can reduce collective count but increases temporary peak memory.
     """
 

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -289,9 +289,31 @@ class OptimizerConfig:
     """Optimizer for nonlinear parameters (embeddings, biases, norms) when using muon.
     One of 'adam' or 'lion'. Defaults to 'adam'."""
 
-    muon_fsdp_batched_all_gather: bool = True
-    """If True, batch Muon+M-FSDP boundary parameter all-gathers by dtype/device/group.
-    This reduces collective count but increases temporary peak memory.
+    muon_fsdp_batched_all_gather: bool = False
+    """If True, batch Muon+M-FSDP boundary parameter all-gathers by dtype/device/group. This reduces
+    collective count but increases temporary peak memory. Defaults to False.
+    """
+
+    muon_fsdp_reuse_gather_scratch: bool = False
+    """If True, cache and reuse Muon+M-FSDP gather scratch buffers. Defaults to False."""
+
+    muon_fsdp_padded_all_gather: bool = False
+    """If True, use padded equal-size all_gather_into_tensor for Muon+M-FSDP batched gathers when
+    padding overhead is within the configured threshold. Defaults to False.
+    """
+
+    muon_fsdp_padded_all_gather_pad_factor: float = 1.25
+    """Maximum padded-gather size as a multiple of the uneven gathered size."""
+
+    muon_fsdp_batch_max_gather_bytes: int = 1024 * 1024 * 1024
+    """Maximum gathered bytes per Muon+M-FSDP batched gather stage."""
+
+    muon_fsdp_padded_all_gather_zero_pad: bool = True
+    """If True, zero-fill unused padding before Muon+M-FSDP padded gathers."""
+
+    muon_fsdp_fast_reconstruct: bool = True
+    """If True, view contiguous gathered Muon+M-FSDP buffers without an additional reconstruction
+    copy.
     """
 
     # Lion.

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -316,6 +316,11 @@ class OptimizerConfig:
     copy.
     """
 
+    muon_fsdp_overlap_comm_compute: bool = False
+    """If True, overlap Muon+M-FSDP boundary all-gathers with local Newton-Schulz/update work.
+    Requires batched all-gather to take effect. Defaults to False.
+    """
+
     # Lion.
     lion_beta1: float = 0.95
     """First beta coefficient for Lion optimizer (used in sign update). Defaults to 0.95."""

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -294,6 +294,11 @@ class OptimizerConfig:
     collective count but increases temporary peak memory. Defaults to False.
     """
 
+    muon_fsdp_flat_batched_all_gather: bool = False
+    """If True, use a flattened one-collective Muon+M-FSDP batched gather for eligible multi-stage
+    shard layouts. Defaults to False.
+    """
+
     muon_fsdp_reuse_gather_scratch: bool = False
     """If True, cache and reuse Muon+M-FSDP gather scratch buffers. Defaults to False."""
 

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -289,9 +289,9 @@ class OptimizerConfig:
     """Optimizer for nonlinear parameters (embeddings, biases, norms) when using muon.
     One of 'adam' or 'lion'. Defaults to 'adam'."""
 
-    muon_fsdp_batched_all_gather: bool = False
-    """If True, batch Muon+M-FSDP boundary parameter all-gathers by dtype/device/param-group.
-    This can reduce collective count but increases temporary peak memory.
+    muon_fsdp_batched_all_gather: bool = True
+    """If True, batch Muon+M-FSDP boundary parameter all-gathers by dtype/device/group.
+    This reduces collective count but increases temporary peak memory.
     """
 
     # Lion.

--- a/megatron/core/tokenizers/text/libraries/huggingface_tokenizer.py
+++ b/megatron/core/tokenizers/text/libraries/huggingface_tokenizer.py
@@ -7,7 +7,7 @@ try:
     from transformers import AutoTokenizer
 
     HAVE_TRANSFORMERS = True
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     HAVE_TRANSFORMERS = False
 
 from megatron.core.utils import log_single_rank

--- a/megatron/core/tokenizers/text/libraries/sft_tokenizer.py
+++ b/megatron/core/tokenizers/text/libraries/sft_tokenizer.py
@@ -9,7 +9,7 @@ try:
     import transformers
 
     HAVE_TRANSFORMERS = True
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     HAVE_TRANSFORMERS = False
 
 

--- a/megatron/core/transformer/fsdp_dtensor_checkpoint.py
+++ b/megatron/core/transformer/fsdp_dtensor_checkpoint.py
@@ -359,30 +359,45 @@ def handle_swiglu_in_state_dict(model, model_state_dict, optimizer_state_dict):
             f"skipped {_swiglu_skip_count} keys in non-GLU layers (e.g. vision encoder)."
         )
 
+    def _split_swiglu_in_single_opt_state(opt_sd):
+        """Apply swiglu splitting to a single optimizer's state dict (has a 'state' key)."""
+        if len(opt_sd["state"]) == 0:
+            return
+        opt_state = opt_sd["state"]
+        new_opt_state = {}
+        for key in list(opt_state.keys()):
+            if not is_swiglu_key(key) or not _key_in_glu_layer(key):
+                new_opt_state[key] = opt_state[key]
+                continue
+            new_opt_state[f"{key}_w"] = opt_state[key].copy()
+            new_opt_state[f"{key}_v"] = opt_state[key].copy()
+            tensor_subkeys = [
+                sk for sk, sv in opt_state[key].items() if isinstance(sv, torch.Tensor)
+            ]
+            for subkey in tensor_subkeys:
+                dist_param = model.get_parameter(
+                    expert_param_local_key(key[len("module.") :], num_experts)
+                )
+                weight_w, weight_v = split_swiglu_linear_fc1(
+                    opt_state[key][subkey],
+                    dist_param,
+                    swiglu_shard_axis=0,
+                    is_expert_param="mlp.experts" in key,
+                )
+                new_opt_state[f"{key}_w"][subkey] = weight_w
+                new_opt_state[f"{key}_v"][subkey] = weight_v
+        opt_sd["state"] = new_opt_state
+
     if optimizer_state_dict is not None:
         optimizer_state_dict = optimizer_state_dict.copy()
-        if len(optimizer_state_dict["state"]) != 0:
-            opt_state_dict = optimizer_state_dict["state"]
-            new_opt_state_dict = {}
-            for key in list(opt_state_dict.keys()):
-                if not is_swiglu_key(key) or not _key_in_glu_layer(key):
-                    new_opt_state_dict[key] = opt_state_dict[key]
-                    continue
-                new_opt_state_dict[f"{key}_w"] = opt_state_dict[key].copy()
-                new_opt_state_dict[f"{key}_v"] = opt_state_dict[key].copy()
-                for subkey in ["exp_avg", "exp_avg_sq"]:
-                    dist_param = model.get_parameter(
-                        expert_param_local_key(key[len("module.") :], num_experts)
-                    )
-                    weight_w, weight_v = split_swiglu_linear_fc1(
-                        opt_state_dict[key][subkey],
-                        dist_param,
-                        swiglu_shard_axis=0,
-                        is_expert_param="mlp.experts" in key,
-                    )
-                    new_opt_state_dict[f"{key}_w"][subkey] = weight_w
-                    new_opt_state_dict[f"{key}_v"][subkey] = weight_v
-            optimizer_state_dict["state"] = new_opt_state_dict
+        # ChainedOptimizer state dicts use integer keys; single optimizer dicts have "state"
+        # directly.
+        if "state" in optimizer_state_dict:
+            _split_swiglu_in_single_opt_state(optimizer_state_dict)
+        else:
+            for sub_sd in optimizer_state_dict.values():
+                if isinstance(sub_sd, dict) and "state" in sub_sd:
+                    _split_swiglu_in_single_opt_state(sub_sd)
 
     return model_state_dict, optimizer_state_dict
 
@@ -532,26 +547,41 @@ def handle_gdn_in_state_dict(model, model_state_dict, optimizer_state_dict):
             f"(in_proj/conv1d → query/key/value/...)."
         )
 
+    def _split_gdn_in_single_opt_state(opt_sd):
+        """Apply GDN splitting to a single optimizer's state dict (has a 'state' key)."""
+        if len(opt_sd["state"]) == 0:
+            return
+        opt_state = opt_sd["state"]
+        new_opt_state = {}
+        for key in list(opt_state.keys()):
+            match = _match_gdn_key(key)
+            if match is None:
+                new_opt_state[key] = opt_state[key]
+                continue
+            sizes, names, dim = match
+            for sub_name in names:
+                new_opt_state[f"{key}.{sub_name}"] = opt_state[key].copy()
+            tensor_subkeys = [
+                sk for sk, sv in opt_state[key].items() if isinstance(sv, torch.Tensor)
+            ]
+            for subkey in tensor_subkeys:
+                dist_param = model.get_parameter(key[len("module.") :])
+                sub_tensors = split_gdn_fused(opt_state[key][subkey], dist_param, sizes, dim)
+                for sub_name, tensor in zip(names, sub_tensors):
+                    new_opt_state[f"{key}.{sub_name}"][subkey] = tensor
+        opt_sd["state"] = new_opt_state
+
     # ---- Optimizer state dict --------------------------------------------
     if optimizer_state_dict is not None:
         optimizer_state_dict = optimizer_state_dict.copy()
-        if len(optimizer_state_dict["state"]) != 0:
-            opt_state = optimizer_state_dict["state"]
-            new_opt_state = {}
-            for key in list(opt_state.keys()):
-                match = _match_gdn_key(key)
-                if match is None:
-                    new_opt_state[key] = opt_state[key]
-                    continue
-                sizes, names, dim = match
-                for sub_name in names:
-                    new_opt_state[f"{key}.{sub_name}"] = opt_state[key].copy()
-                for subkey in ["exp_avg", "exp_avg_sq"]:
-                    dist_param = model.get_parameter(key[len("module.") :])
-                    sub_tensors = split_gdn_fused(opt_state[key][subkey], dist_param, sizes, dim)
-                    for sub_name, tensor in zip(names, sub_tensors):
-                        new_opt_state[f"{key}.{sub_name}"][subkey] = tensor
-            optimizer_state_dict["state"] = new_opt_state
+        # ChainedOptimizer state dicts use integer keys; single optimizer dicts have "state"
+        # directly.
+        if "state" in optimizer_state_dict:
+            _split_gdn_in_single_opt_state(optimizer_state_dict)
+        else:
+            for sub_sd in optimizer_state_dict.values():
+                if isinstance(sub_sd, dict) and "state" in sub_sd:
+                    _split_gdn_in_single_opt_state(sub_sd)
 
     return model_state_dict, optimizer_state_dict
 

--- a/megatron/core/transformer/fsdp_dtensor_checkpoint.py
+++ b/megatron/core/transformer/fsdp_dtensor_checkpoint.py
@@ -390,8 +390,7 @@ def handle_swiglu_in_state_dict(model, model_state_dict, optimizer_state_dict):
 
     if optimizer_state_dict is not None:
         optimizer_state_dict = optimizer_state_dict.copy()
-        # ChainedOptimizer state dicts use integer keys; single optimizer dicts have "state"
-        # directly.
+        # Megatron Optimizer vs. Megatron ChainedOptimizer
         if "state" in optimizer_state_dict:
             _split_swiglu_in_single_opt_state(optimizer_state_dict)
         else:
@@ -574,8 +573,7 @@ def handle_gdn_in_state_dict(model, model_state_dict, optimizer_state_dict):
     # ---- Optimizer state dict --------------------------------------------
     if optimizer_state_dict is not None:
         optimizer_state_dict = optimizer_state_dict.copy()
-        # ChainedOptimizer state dicts use integer keys; single optimizer dicts have "state"
-        # directly.
+        # Megatron Optimizer vs. Megatron ChainedOptimizer
         if "state" in optimizer_state_dict:
             _split_gdn_in_single_opt_state(optimizer_state_dict)
         else:

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -38,9 +38,17 @@ try:
     from torch.distributed._tensor import DTensor
     from torch.distributed.tensor.placement_types import Shard
 
+    try:
+        from torch.distributed.tensor.placement_types import _StridedShard
+    except ImportError:
+        _StridedShard = None
+
     HAVE_DTENSOR = True
 except ImportError:
     HAVE_DTENSOR = False
+    DTensor = None
+    Shard = None
+    _StridedShard = None
 
 from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.mapping import ShardedTensor
@@ -1050,6 +1058,67 @@ def to_local_if_dtensor(tensor: Union[torch.Tensor, "DTensor"]) -> torch.Tensor:
     """Returns the local shard of the given tensor if it is a DTensor."""
     with torch.no_grad():
         return tensor.to_local() if HAVE_DTENSOR and isinstance(tensor, DTensor) else tensor
+
+
+def is_same_process_group(
+    group: torch.distributed.ProcessGroup | None, other: torch.distributed.ProcessGroup | None
+) -> bool:
+    """Returns whether two process groups contain the same ranks."""
+    if group is other:
+        return True
+    if group is None or other is None:
+        return False
+    try:
+        return torch.distributed.get_process_group_ranks(
+            group
+        ) == torch.distributed.get_process_group_ranks(other)
+    except (RuntimeError, ValueError):
+        return False
+
+
+def contains_process_group(
+    groups: list[torch.distributed.ProcessGroup], group: torch.distributed.ProcessGroup | None
+) -> bool:
+    """Returns whether `groups` already contains a process group with `group`'s ranks."""
+    return any(is_same_process_group(group, existing) for existing in groups)
+
+
+def append_unique_process_group(
+    groups: list[torch.distributed.ProcessGroup], group: torch.distributed.ProcessGroup | None
+) -> None:
+    """Appends `group` to `groups` if an equivalent process group is not already present."""
+    if group is None:
+        return
+    if not contains_process_group(groups, group):
+        groups.append(group)
+
+
+def get_dtensor_data_parallel_shard_groups(
+    tensor: "torch.Tensor | DTensor",
+) -> list[torch.distributed.ProcessGroup]:
+    """Return DTensor shard groups that should contribute to global grad stats.
+
+    Megatron-FSDP represents HSDP/HFSDP with DTensors whose FSDP dimensions are named `dp_cp` and
+    optionally `outer_fsdp_dp`, while tensor parallelism uses `tp`. Grad stats should reduce over
+    FSDP shard dimensions and leave tensor/model-parallel reductions to the caller.
+    """
+    if not HAVE_DTENSOR or not isinstance(tensor, DTensor):
+        return []
+
+    shard_placement_types = (Shard,) if _StridedShard is None else (Shard, _StridedShard)
+    mesh = tensor.device_mesh
+    mesh_dim_names = getattr(mesh, "mesh_dim_names", None)
+    groups = []
+    for mesh_dim, placement in enumerate(tensor.placements):
+        if not isinstance(placement, shard_placement_types):
+            continue
+        mesh_dim_name = None
+        if mesh_dim_names is not None and mesh_dim < len(mesh_dim_names):
+            mesh_dim_name = mesh_dim_names[mesh_dim]
+        if mesh_dim_name == "tp":
+            continue
+        append_unique_process_group(groups, mesh.get_group(mesh_dim))
+    return groups
 
 
 def get_data_parallel_group_if_dtensor(

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1556,11 +1556,11 @@ def validate_args(args, defaults={}):
             args.use_layer_wise_distributed_optimizer = True
 
         if args.use_distributed_optimizer:
-            # Megatron-FSDP already shards optimizer state itself (ZeRO-1/2/3
-            # via `--data-parallel-sharding-strategy`). Layering
-            # `LayerWiseDistributedOptimizer` on top would double-shard and,
-            # in practice, trips `TypeErrors` in its constructor call from
-            # `_build_megatron_fsdp_emerging_optimizer`.
+            # Megatron-FSDP is not compatible with LayerwiseDistributedOptimizer.
+            # Already un-evenly shards parameters, so composing per-parameter
+            # distribution with un-even distribution will assign parameters
+            # to inconsistent DP ranks, e.g. DP ranks with empty parameters
+            # can be incorrectly chosen by the layer-wise distribution.
             if not args.use_megatron_fsdp:
                 args.use_layer_wise_distributed_optimizer = True
                 args.use_distributed_optimizer = False
@@ -1570,8 +1570,8 @@ def validate_args(args, defaults={}):
             assert args.optimizer == "muon", (
                 "Emerging optimizer with Megatron-FSDP is currently only supported for Muon."
             )
-            # Megatron-FSDP itself requires `fsdp_dtensor` (asserted above), so
-            # the emerging-optimizer path must accept it here to avoid a
+            # Megatron-FSDP itself requires `fsdp_dtensor` (asserted above),
+            # so the emerging-optimizer path must accept it here to avoid a
             # contradictory assertion pair.
             assert args.ckpt_format == "fsdp_dtensor", (
                 "Emerging optimizer with Megatron-FSDP requires "

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2356,6 +2356,13 @@ def _add_regularization_args(parser):
                        help='Batch Muon+M-FSDP boundary parameter all-gathers by '
                        'dtype/device/group. This reduces collective count but increases '
                        'temporary peak memory. Defaults to false.')
+    group.add_argument('--muon-fsdp-flat-batched-all-gather',
+                       action=argparse.BooleanOptionalAction,
+                       default=False,
+                       help='Use a flattened one-collective Muon+M-FSDP batched gather '
+                       'for eligible multi-stage shard layouts. Requires batched '
+                       'all-gather and falls back to the staged path when ineligible. '
+                       'Defaults to false.')
     group.add_argument('--muon-fsdp-reuse-gather-scratch',
                        action=argparse.BooleanOptionalAction,
                        default=False,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1557,7 +1557,14 @@ def validate_args(args, defaults={}):
             args.use_distributed_optimizer = False
 
         assert not args.use_torch_fsdp2, "Emerging optimizer does not support Torch-FSDP2 for now."
-        assert not args.use_megatron_fsdp, "Emerging optimizer does not support Megatron-FSDP for now."
+        if args.use_megatron_fsdp:
+            assert args.optimizer == "muon", (
+                "Emerging optimizer with Megatron-FSDP is currently only supported for Muon."
+            )
+            assert args.outer_dp_sharding_strategy == "no_shard", (
+                "Emerging optimizer with Megatron-FSDP does not support HSDP "
+                "(--outer-dp-sharding-strategy != no_shard) yet."
+            )
         assert args.ckpt_format in ["torch", "torch_dist"], "Emerging optimizer supports torch and torch_dist checkpoint format."
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2350,9 +2350,11 @@ def _add_regularization_args(parser):
                        choices=['adam', 'lion'],
                        help='Optimizer for scalar parameters (embeddings, biases, norms) '
                        'when using muon. Defaults to adam.')
-    group.add_argument('--muon-fsdp-batched-all-gather', action='store_true',
+    group.add_argument('--muon-fsdp-batched-all-gather',
+                       action=argparse.BooleanOptionalAction,
+                       default=True,
                        help='Batch Muon+M-FSDP boundary parameter all-gathers by '
-                       'dtype/device/group. This can reduce collective count but increases '
+                       'dtype/device/group. This reduces collective count but increases '
                        'temporary peak memory.')
     group.add_argument('--lion-beta1', type=float, default=0.95,
                        help='First beta coefficient for Lion optimizer '

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1560,8 +1560,7 @@ def validate_args(args, defaults={}):
             # via `--data-parallel-sharding-strategy`). Layering
             # `LayerWiseDistributedOptimizer` on top would double-shard and,
             # in practice, trips `TypeErrors` in its constructor call from
-            # `_build_megatron_fsdp_emerging_optimizer`. The M-FSDP factory
-            # already handles the "distributed" part via `FSDPMuonChainedOptimizer`.
+            # `_build_megatron_fsdp_emerging_optimizer`.
             if not args.use_megatron_fsdp:
                 args.use_layer_wise_distributed_optimizer = True
                 args.use_distributed_optimizer = False
@@ -1570,10 +1569,6 @@ def validate_args(args, defaults={}):
         if args.use_megatron_fsdp:
             assert args.optimizer == "muon", (
                 "Emerging optimizer with Megatron-FSDP is currently only supported for Muon."
-            )
-            assert args.outer_dp_sharding_strategy == "no_shard", (
-                "Emerging optimizer with Megatron-FSDP does not support HSDP "
-                "(--outer-dp-sharding-strategy != no_shard) yet."
             )
             # Megatron-FSDP itself requires `fsdp_dtensor` (asserted above), so
             # the emerging-optimizer path must accept it here to avoid a

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1119,8 +1119,11 @@ def validate_args(args, defaults={}):
         args.use_distributed_optimizer = True
         # Optimizer step MXFP8 buffer operation that is not relevant or supported for Megatron-FSDP.
         args.reuse_grad_buf_for_mxfp8_param_ag = False
-        # Optimizer compatibility check.
-        assert args.optimizer in ('sgd', 'adam'), \
+        # Optimizer compatibility check. Muon is supported via the
+        # _build_megatron_fsdp_emerging_optimizer path; other emerging
+        # optimizers (Lion, SOAP, adaptive_muon) don't yet have the
+        # FSDP-aware step contract wired up.
+        assert args.optimizer in ('sgd', 'adam', 'muon'), \
             f"Megatron-FSDP does not support the {args.optimizer} optimizer yet."
 
         if (
@@ -1553,8 +1556,15 @@ def validate_args(args, defaults={}):
             args.use_layer_wise_distributed_optimizer = True
 
         if args.use_distributed_optimizer:
-            args.use_layer_wise_distributed_optimizer = True
-            args.use_distributed_optimizer = False
+            # Megatron-FSDP already shards optimizer state itself (ZeRO-1/2/3
+            # via `--data-parallel-sharding-strategy`). Layering
+            # `LayerWiseDistributedOptimizer` on top would double-shard and,
+            # in practice, trips `TypeErrors` in its constructor call from
+            # `_build_megatron_fsdp_emerging_optimizer`. The M-FSDP factory
+            # already handles the "distributed" part via `FSDPMuonChainedOptimizer`.
+            if not args.use_megatron_fsdp:
+                args.use_layer_wise_distributed_optimizer = True
+                args.use_distributed_optimizer = False
 
         assert not args.use_torch_fsdp2, "Emerging optimizer does not support Torch-FSDP2 for now."
         if args.use_megatron_fsdp:
@@ -1565,7 +1575,15 @@ def validate_args(args, defaults={}):
                 "Emerging optimizer with Megatron-FSDP does not support HSDP "
                 "(--outer-dp-sharding-strategy != no_shard) yet."
             )
-        assert args.ckpt_format in ["torch", "torch_dist"], "Emerging optimizer supports torch and torch_dist checkpoint format."
+            # Megatron-FSDP itself requires `fsdp_dtensor` (asserted above), so
+            # the emerging-optimizer path must accept it here to avoid a
+            # contradictory assertion pair.
+            assert args.ckpt_format == "fsdp_dtensor", (
+                "Emerging optimizer with Megatron-FSDP requires "
+                "--ckpt-format fsdp_dtensor."
+            )
+        else:
+            assert args.ckpt_format in ["torch", "torch_dist"], "Emerging optimizer supports torch and torch_dist checkpoint format."
 
 
     # Make sure all functionality that requires Gloo process groups is disabled.

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2350,6 +2350,10 @@ def _add_regularization_args(parser):
                        choices=['adam', 'lion'],
                        help='Optimizer for scalar parameters (embeddings, biases, norms) '
                        'when using muon. Defaults to adam.')
+    group.add_argument('--muon-fsdp-batched-all-gather', action='store_true',
+                       help='Batch Muon+M-FSDP boundary parameter all-gathers by '
+                       'dtype/device/group. This can reduce collective count but increases '
+                       'temporary peak memory.')
     group.add_argument('--lion-beta1', type=float, default=0.95,
                        help='First beta coefficient for Lion optimizer '
                        '(used in sign update). Default: 0.95.')

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2384,6 +2384,12 @@ def _add_regularization_args(parser):
                        default=True,
                        help='View contiguous gathered Muon+M-FSDP buffers without an '
                        'additional reconstruction copy. Defaults to true.')
+    group.add_argument('--muon-fsdp-overlap-comm-compute',
+                       action=argparse.BooleanOptionalAction,
+                       default=False,
+                       help='Overlap Muon+M-FSDP boundary all-gathers with local '
+                       'Newton-Schulz/update work. Requires batched all-gather. '
+                       'Defaults to false.')
     group.add_argument('--lion-beta1', type=float, default=0.95,
                        help='First beta coefficient for Lion optimizer '
                        '(used in sign update). Default: 0.95.')

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2352,10 +2352,38 @@ def _add_regularization_args(parser):
                        'when using muon. Defaults to adam.')
     group.add_argument('--muon-fsdp-batched-all-gather',
                        action=argparse.BooleanOptionalAction,
-                       default=True,
+                       default=False,
                        help='Batch Muon+M-FSDP boundary parameter all-gathers by '
                        'dtype/device/group. This reduces collective count but increases '
-                       'temporary peak memory.')
+                       'temporary peak memory. Defaults to false.')
+    group.add_argument('--muon-fsdp-reuse-gather-scratch',
+                       action=argparse.BooleanOptionalAction,
+                       default=False,
+                       help='Cache and reuse Muon+M-FSDP gather scratch buffers. '
+                       'Defaults to false.')
+    group.add_argument('--muon-fsdp-padded-all-gather',
+                       action=argparse.BooleanOptionalAction,
+                       default=False,
+                       help='Use padded equal-size all_gather_into_tensor for Muon+M-FSDP '
+                       'batched gathers when padding overhead is within the configured '
+                       'threshold. Defaults to false.')
+    group.add_argument('--muon-fsdp-padded-all-gather-pad-factor', type=float, default=1.25,
+                       help='Maximum padded-gather size as a multiple of the uneven '
+                       'gathered size for Muon+M-FSDP. Default: 1.25.')
+    group.add_argument('--muon-fsdp-batch-max-gather-bytes', type=int,
+                       default=1024 * 1024 * 1024,
+                       help='Maximum gathered bytes per Muon+M-FSDP batched gather stage. '
+                       'Default: 1073741824.')
+    group.add_argument('--muon-fsdp-padded-all-gather-zero-pad',
+                       action=argparse.BooleanOptionalAction,
+                       default=True,
+                       help='Zero-fill unused padding before Muon+M-FSDP padded gathers. '
+                       'Defaults to true.')
+    group.add_argument('--muon-fsdp-fast-reconstruct',
+                       action=argparse.BooleanOptionalAction,
+                       default=True,
+                       help='View contiguous gathered Muon+M-FSDP buffers without an '
+                       'additional reconstruction copy. Defaults to true.')
     group.add_argument('--lion-beta1', type=float, default=0.95,
                        help='First beta coefficient for Lion optimizer '
                        '(used in sign update). Default: 0.95.')

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
@@ -16,6 +16,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import HAV
 from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.optimizer import OptimizerConfig
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+from megatron.core.optimizer.emerging_optimizers import HAVE_EMERGING_OPTIMIZERS
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer import TransformerConfig
 from megatron.core.utils import is_torch_min_version
@@ -850,11 +851,21 @@ class TestMegatronFSDPE2E:
             ),
             pytest.param(
                 dict(data_parallel_sharding_strategy="optim_grads", fsdp_double_buffer=True),
-                id="optim_grads_no_double_buffer",
+                id="optim_grads_double_buffer",
             ),
             pytest.param(
                 dict(data_parallel_sharding_strategy="optim", fsdp_double_buffer=False),
-                id="optim_double_buffer",
+                id="optim_no_double_buffer",
+            ),
+            pytest.param(
+                dict(
+                    data_parallel_sharding_strategy="optim_grads_params",
+                    fsdp_double_buffer=False,
+                    optimizer="muon",
+                    bf16=True,
+                    clip_grad=0.0,
+                ),
+                id="optim_grads_params_muon",
             ),
         ],
     )
@@ -864,11 +875,17 @@ class TestMegatronFSDPE2E:
         ):
             pytest.skip("Requires PyTorch & CUDA device with TE MXFP8Tensor support")
 
+        if spec_configs.get("optimizer") == "muon" and not HAVE_EMERGING_OPTIMIZERS:
+            pytest.skip("Muon requires the emerging-optimizers package")
+
         nd_topology_str = "_".join([f"{k}{v}" for k, v in nd_topology.items()])
-        if nd_topology_str not in ref_cache:
+        # Non-Adam optimizers use their own reference entry so they don't pollute the Adam cache.
+        optimizer = spec_configs.get("optimizer", "adam")
+        cache_key = nd_topology_str if optimizer == "adam" else f"{nd_topology_str}_{optimizer}"
+        if cache_key not in ref_cache:
             distopt_spec_configs = copy.deepcopy(spec_configs)
             distopt_spec_configs["fp8_param_gather"] = False
-            ref_cache[nd_topology_str] = TestMegatronFSDPE2E._training_loop(
+            ref_cache[cache_key] = TestMegatronFSDPE2E._training_loop(
                 use_distributed_optimizer=True, **distopt_spec_configs
             )
 
@@ -879,7 +896,7 @@ class TestMegatronFSDPE2E:
             gradient_accumulation_fusion=False,
             **spec_configs,
         )
-        reference_outputs = ref_cache[nd_topology_str]
+        reference_outputs = ref_cache[cache_key]
 
         if torch.distributed.get_rank() == 0:
             for step, (output, ref_output) in enumerate(zip(outputs, reference_outputs)):

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -1,0 +1,698 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""
+Tests for Muon + Megatron-FSDP integration.
+
+Organized by implementation phase:
+  Phase 1: FSDPMuonChainedOptimizer (protocol adapter, no_shard dispatch)
+  Phase 2: FSDPZeROTensorParallelMuon.orthogonalize() (core allgather -> NS -> reshard)
+  Phase 3: Factory integration + end-to-end
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+from packaging.version import Version
+
+from megatron.core.optimizer.emerging_optimizers import (
+    FSDPMuonChainedOptimizer,
+    FSDPZeROTensorParallelMuon,
+    TensorParallelMuon,
+    _get_mfsdp_models,
+)
+from tests.unit_tests.test_utilities import Utils
+
+# Skip all tests in this file for LTS versions
+pytestmark = pytest.mark.skipif(
+    Version(os.getenv("NVIDIA_PYTORCH_VERSION", "24.01")) <= Version("25.05"),
+    reason="Skip muon FSDP optimizer for LTS test",
+)
+
+WORLD_SIZE = int(os.getenv("WORLD_SIZE", "1"))
+
+
+# Helpers
+
+
+def make_sharded_grad(full_rows, cols, dp_size, dp_rank, seed=42, device="cuda"):
+    """Create full grad and return `(full_grad, padded_grad, local_shard, shard_rows)`.
+
+    The full gradient is split into `dp_size` equal-sized shards along dim-0.
+    When `full_rows` is not divisible by `dp_size`, the last shard is
+    zero-padded so all shards have the same size (mimicking FSDP bucket padding).
+    Both the unpadded (`full_grad`) and padded (`padded_grad`) views are
+    returned so reference computations can choose either.
+    """
+    torch.manual_seed(seed)
+    full_grad = torch.randn(full_rows, cols, device=device, dtype=torch.float32)
+
+    shard_rows = (full_rows + dp_size - 1) // dp_size  # ceil division
+    # Pad full_grad so it can be evenly split
+    padded_rows = shard_rows * dp_size
+    if padded_rows > full_rows:
+        pad = torch.zeros(padded_rows - full_rows, cols, device=device, dtype=torch.float32)
+        padded_grad = torch.cat([full_grad, pad], dim=0)
+    else:
+        padded_grad = full_grad
+
+    local_shard = padded_grad[dp_rank * shard_rows : (dp_rank + 1) * shard_rows].clone()
+    return full_grad, padded_grad, local_shard, shard_rows
+
+
+def make_reference_orthogonalize(full_grad, param_like=None, **muon_kwargs):
+    """Run `TensorParallelMuon.orthogonalize` on full grad as reference.
+
+    Returns the orthogonalized full gradient (plain tensor, no sharding).
+    """
+    if param_like is None:
+        param_like = torch.randn_like(full_grad)
+    opt = TensorParallelMuon(
+        params=[torch.nn.Parameter(param_like)],
+        pg_collection=None,
+        tp_mode="duplicated",
+        **muon_kwargs,
+    )
+    return opt.orthogonalize(param_like, full_grad)
+
+
+def make_dp_device_mesh(dp_size):
+    """Create 1D device mesh for DP-only DTensor tests."""
+    from torch.distributed.device_mesh import init_device_mesh
+
+    return init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+
+
+# Phase 1: FSDPMuonChainedOptimizer (single-rank, mock-based)
+
+
+class TestPhase1ChainedOptimizer:
+    """Phase 1 tests for FSDPMuonChainedOptimizer protocol adapter."""
+
+    @staticmethod
+    def _make_mfsdp_mock(model_auto_sync=False):
+        """Create a mock MegatronFSDP model."""
+        mock = MagicMock()
+        mock.model_auto_sync = model_auto_sync
+        return mock
+
+    @staticmethod
+    def _make_inner_mock():
+        """Create a mock inner optimizer."""
+        mock = MagicMock()
+        mock.step.return_value = (True, 1.0, 0)
+        return mock
+
+    @pytest.mark.parametrize("model_auto_sync", [True, False])
+    def test_phase1_chained_optimizer_step_protocol(self, model_auto_sync):
+        """Verify step() call order: finish_grad_sync -> inner.step -> install.
+
+        When `model_auto_sync=True`, finish_grad_sync is NOT called (FSDP handles it).
+        """
+        inner = self._make_inner_mock()
+        mfsdp = self._make_mfsdp_mock(model_auto_sync=model_auto_sync)
+        wrapper = FSDPMuonChainedOptimizer(inner, [mfsdp])
+
+        wrapper.step()
+
+        if model_auto_sync:
+            mfsdp.finish_grad_sync.assert_not_called()
+        else:
+            mfsdp.finish_grad_sync.assert_called_once()
+
+        inner.step.assert_called_once()
+        mfsdp.install_optimized_model_weights.assert_called_once()
+
+        if not model_auto_sync:
+            all_calls = []
+            all_calls.append(("finish_grad_sync", mfsdp.finish_grad_sync.call_count))
+            all_calls.append(("step", inner.step.call_count))
+            all_calls.append(("install", mfsdp.install_optimized_model_weights.call_count))
+            assert all(c[1] == 1 for c in all_calls)
+
+    def test_phase1_chained_optimizer_getattr_delegation(self):
+        """Verify attribute delegation to inner optimizer."""
+        inner = self._make_inner_mock()
+        inner.param_groups = [{"lr": 0.01}]
+        inner.state_dict.return_value = {"state": {}, "param_groups": []}
+        mfsdp = self._make_mfsdp_mock()
+
+        wrapper = FSDPMuonChainedOptimizer(inner, [mfsdp])
+
+        assert wrapper.param_groups == [{"lr": 0.01}]
+
+        sd = wrapper.state_dict()
+        inner.state_dict.assert_called_once()
+        assert sd == {"state": {}, "param_groups": []}
+
+        wrapper.load_state_dict({"state": {}, "param_groups": []})
+        inner.load_state_dict.assert_called_once()
+
+    @pytest.mark.parametrize("set_to_none", [True, False])
+    def test_phase1_chained_optimizer_zero_grad(self, set_to_none):
+        """Verify zero_grad delegates to inner with correct args."""
+        inner = self._make_inner_mock()
+        mfsdp = self._make_mfsdp_mock()
+        wrapper = FSDPMuonChainedOptimizer(inner, [mfsdp])
+
+        wrapper.zero_grad(set_to_none=set_to_none)
+        inner.zero_grad.assert_called_once_with(set_to_none)
+
+    def test_phase1_get_mfsdp_models_error(self):
+        """`_get_mfsdp_models` raises RuntimeError for non-FSDP modules."""
+        with pytest.raises(RuntimeError, match="Could not find any MegatronFSDP"):
+            _get_mfsdp_models([nn.Module()])
+
+    def test_phase1_get_mfsdp_models_success(self):
+        """`_get_mfsdp_models` extracts inner module from FSDP-wrapped chunks."""
+        inner_module = MagicMock()
+        chunk = MagicMock()
+        chunk.module = inner_module
+        chunk.finish_grad_sync = MagicMock()
+
+        result = _get_mfsdp_models([chunk])
+        assert result == [inner_module]
+
+    def test_phase1_multiple_mfsdp_models(self):
+        """`step()` calls finish_grad_sync and install on ALL mfsdp models."""
+        inner = self._make_inner_mock()
+        mfsdps = [self._make_mfsdp_mock(model_auto_sync=False) for _ in range(3)]
+        wrapper = FSDPMuonChainedOptimizer(inner, mfsdps)
+
+        wrapper.step()
+
+        for mfsdp in mfsdps:
+            mfsdp.finish_grad_sync.assert_called_once()
+            mfsdp.install_optimized_model_weights.assert_called_once()
+
+
+# Phase 2: FSDPZeROTensorParallelMuon.orthogonalize() (multi-rank)
+
+
+def _skip_if_single_rank():
+    return pytest.mark.skipif(WORLD_SIZE <= 1, reason="Multi-rank test requires WORLD_SIZE > 1")
+
+
+def _skip_if_no_dtensor():
+    return pytest.mark.skipif(
+        Version(torch.__version__.split("+")[0]) < Version("2.4.0"),
+        reason="DTensor tests require PyTorch >= 2.4.0",
+    )
+
+
+@_skip_if_single_rank()
+class TestPhase2Orthogonalize:
+    """Phase 2 tests for FSDPZeROTensorParallelMuon.orthogonalize().
+
+    These are the most critical tests verifying mathematical correctness
+    of the allgather -> Newton-Schulz -> reshard cycle.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Initialize distributed for multi-rank tests."""
+        Utils.initialize_model_parallel()
+        yield
+        Utils.destroy_model_parallel()
+
+    def _make_fsdp_muon(self, dp_group=None, **kwargs):
+        """Create an FSDPZeROTensorParallelMuon with a dummy param."""
+        defaults = dict(
+            lr=0.01,
+            momentum=0.95,
+            weight_decay=0.0,
+            num_ns_steps=5,
+            pg_collection=None,
+            tp_mode="duplicated",
+        )
+        defaults.update(kwargs)
+        dummy = torch.nn.Parameter(torch.randn(4, 4, device="cuda"))
+        return FSDPZeROTensorParallelMuon(params=[dummy], dp_group=dp_group, **defaults)
+
+    def test_phase2_orthogonalize_fallback_dp_group_none(self):
+        """`dp_group=None` delegates to parent `TensorParallelMuon.orthogonalize`."""
+        M, C = 64, 32
+        torch.manual_seed(42)
+        grad = torch.randn(M, C, device="cuda")
+        p = torch.randn(M, C, device="cuda")
+
+        fsdp_muon = self._make_fsdp_muon(dp_group=None)
+        result_fsdp = fsdp_muon.orthogonalize(p, grad.clone())
+
+        ref_result = make_reference_orthogonalize(grad.clone(), param_like=p)
+
+        torch.testing.assert_close(result_fsdp, ref_result, atol=1e-6, rtol=1e-5)
+
+    @pytest.mark.parametrize("shape", [(64, 32), (48, 24), (100, 50)])
+    def test_phase2_orthogonalize_correctness_plain_tensors(self, shape):
+        """Core invariant: allgather -> NS -> reshard == NS(padded_G)[shard_slice].
+
+        `FSDPZeROTensorParallelMuon` runs Newton-Schulz on the *padded* full
+        matrix because (a) production FSDP feeds it the padded global DTensor
+        shape and (b) `get_muon_scale_factor` is dimension-dependent, so the
+        scale only matches if both reference and code see the same padded
+        dimensions. We therefore reference NS on `padded_grad`, not on the
+        unpadded `full_grad`.
+        """
+        M, C = shape
+        dp_group = torch.distributed.group.WORLD
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+
+        _, padded_grad, local_shard, shard_rows = make_sharded_grad(M, C, dp_size, dp_rank, seed=42)
+
+        ref_full = make_reference_orthogonalize(padded_grad)
+        start = dp_rank * shard_rows
+        end = start + shard_rows
+        ref_shard = ref_full[start:end]
+
+        p = torch.randn(shard_rows, C, device="cuda")
+        fsdp_muon = self._make_fsdp_muon(dp_group=dp_group)
+        result = fsdp_muon.orthogonalize(p, local_shard)
+
+        torch.testing.assert_close(result, ref_shard, atol=1e-5, rtol=1e-4)
+
+    @pytest.mark.parametrize("M", [30, 31, 33])
+    def test_phase2_orthogonalize_padding_correctness(self, M):
+        """Padding correctness when `M % dp_size != 0`.
+
+        Per the design described in
+        `test_phase2_orthogonalize_correctness_plain_tensors`, the
+        reference runs NS on the *padded* matrix so that scale-factor and NS
+        cycle dimensions agree. We therefore expect `result` to match the
+        padded reference for the entire shard (real and padding rows alike).
+        """
+        C = 16
+        dp_group = torch.distributed.group.WORLD
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+
+        _, padded_grad, local_shard, shard_rows = make_sharded_grad(
+            M, C, dp_size, dp_rank, seed=123
+        )
+
+        ref_full = make_reference_orthogonalize(padded_grad)
+        start = dp_rank * shard_rows
+        end = start + shard_rows
+        ref_shard = ref_full[start:end]
+
+        p = torch.randn(shard_rows, C, device="cuda")
+        fsdp_muon = self._make_fsdp_muon(dp_group=dp_group)
+        result = fsdp_muon.orthogonalize(p, local_shard)
+
+        torch.testing.assert_close(result, ref_shard, atol=1e-5, rtol=1e-4)
+
+    @_skip_if_no_dtensor()
+    @pytest.mark.parametrize("shape", [(64, 32), (48, 24)])
+    def test_phase2_orthogonalize_dtensor_output_invariants(self, shape):
+        """DTensor input produces DTensor output with correct metadata.
+
+        Input: Shard(0) DTensor on a 1D DP device mesh.
+        Output: must be DTensor with same device_mesh, placements, global shape.
+        Also verifies mathematical correctness.
+        """
+        from torch.distributed.tensor import DTensor, Shard
+
+        M, C = shape
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = make_dp_device_mesh(dp_size)
+        dp_group = device_mesh.get_group("dp")
+
+        _, padded_grad, local_shard, shard_rows = make_sharded_grad(M, C, dp_size, dp_rank, seed=42)
+
+        # The global shape is declared as `(shard_rows * dp_size, C)` to match
+        # the padded total; FSDP bucket padding makes all shards equal.
+        padded_rows = shard_rows * dp_size
+        grad_dtensor = DTensor.from_local(
+            local_shard,
+            device_mesh=device_mesh,
+            placements=[Shard(0)],
+            shape=torch.Size([padded_rows, C]),
+            stride=local_shard.stride(),
+            run_check=False,
+        )
+
+        # Param is also a DTensor: `FSDPZeROTensorParallelMuon` reads
+        # `p.shape[0]` for the DTensor path.
+        p_local = torch.randn(shard_rows, C, device="cuda")
+        p_dtensor = DTensor.from_local(
+            p_local,
+            device_mesh=device_mesh,
+            placements=[Shard(0)],
+            shape=torch.Size([padded_rows, C]),
+            stride=p_local.stride(),
+            run_check=False,
+        )
+
+        fsdp_muon = self._make_fsdp_muon(dp_group=dp_group)
+        result = fsdp_muon.orthogonalize(p_dtensor, grad_dtensor)
+
+        assert isinstance(result, DTensor), "Output should be a DTensor"
+        assert result.device_mesh == device_mesh, "Device mesh should match"
+        assert result.placements == grad_dtensor.placements, "Placements should match"
+        assert result.shape == grad_dtensor.shape, "Global shape should match"
+        assert result.to_local().shape == local_shard.shape, "Local shape should match shard"
+
+        ref_full = make_reference_orthogonalize(padded_grad)
+        start = dp_rank * shard_rows
+        end = start + shard_rows
+        ref_shard = ref_full[start:end]
+
+        torch.testing.assert_close(result.to_local(), ref_shard, atol=1e-5, rtol=1e-4)
+
+    @pytest.mark.parametrize("shape", [(64, 32), (48, 24)])
+    def test_phase2_full_step_cycle_plain_tensors(self, shape):
+        """Full FSDPZeROTensorParallelMuon.step() cycles with plain tensors.
+
+        Runs 3 complete optimization steps through the
+        `OrthogonalizedOptimizer.step()` path, testing the full chain:
+        momentum -> Nesterov -> orthogonalize -> `p.add_()`.
+        """
+        M, C = shape
+        dp_group = torch.distributed.group.WORLD
+        dp_size = torch.distributed.get_world_size()
+
+        shard_rows = (M + dp_size - 1) // dp_size
+
+        torch.manual_seed(42)
+        p = torch.nn.Parameter(torch.randn(shard_rows, C, device="cuda"))
+
+        optimizer = FSDPZeROTensorParallelMuon(
+            params=[p],
+            dp_group=dp_group,
+            lr=0.01,
+            momentum=0.95,
+            weight_decay=0.0,
+            num_ns_steps=5,
+            pg_collection=None,
+            tp_mode="duplicated",
+        )
+
+        weights_history = [p.data.clone()]
+        for step_i in range(3):
+            torch.manual_seed(100 + step_i)
+            p.grad = torch.randn_like(p)
+
+            optimizer.step()
+            optimizer.zero_grad(set_to_none=True)
+            weights_history.append(p.data.clone())
+
+        for i in range(len(weights_history) - 1):
+            assert not torch.equal(
+                weights_history[i], weights_history[i + 1]
+            ), f"Weight should change at step {i}"
+
+    @_skip_if_no_dtensor()
+    @pytest.mark.parametrize("shape", [(64, 32), (48, 24)])
+    def test_phase2_full_step_cycle_dtensors(self, shape):
+        """Full step() cycles with Shard(0) DTensor params and grads.
+
+        Critical integration test for the DTensor return-type fix:
+        `p.add_(orthogonalized_dtensor)` must work without dispatch errors.
+        """
+        from torch.distributed.tensor import DTensor, Shard
+
+        M, C = shape
+        dp_size = torch.distributed.get_world_size()
+        device_mesh = make_dp_device_mesh(dp_size)
+        dp_group = device_mesh.get_group("dp")
+
+        shard_rows = (M + dp_size - 1) // dp_size
+        padded_rows = shard_rows * dp_size
+
+        torch.manual_seed(42)
+        p_local = torch.randn(shard_rows, C, device="cuda")
+        p_dtensor = torch.nn.Parameter(
+            DTensor.from_local(
+                p_local,
+                device_mesh=device_mesh,
+                placements=[Shard(0)],
+                shape=torch.Size([padded_rows, C]),
+                stride=p_local.stride(),
+                run_check=False,
+            )
+        )
+        initial_local = p_dtensor.data.to_local().clone()
+
+        optimizer = FSDPZeROTensorParallelMuon(
+            params=[p_dtensor],
+            dp_group=dp_group,
+            lr=0.01,
+            momentum=0.95,
+            weight_decay=0.0,
+            num_ns_steps=5,
+            pg_collection=None,
+            tp_mode="duplicated",
+        )
+
+        for step_i in range(3):
+            torch.manual_seed(200 + step_i)
+            grad_local = torch.randn(shard_rows, C, device="cuda")
+            p_dtensor.grad = DTensor.from_local(
+                grad_local,
+                device_mesh=device_mesh,
+                placements=[Shard(0)],
+                shape=torch.Size([padded_rows, C]),
+                stride=grad_local.stride(),
+                run_check=False,
+            )
+            optimizer.step()
+            optimizer.zero_grad(set_to_none=True)
+
+        final_local = p_dtensor.data.to_local()
+        assert not torch.equal(
+            final_local, initial_local
+        ), "DTensor param should be updated after 3 steps"
+        assert isinstance(p_dtensor.data, DTensor), "Param should remain a DTensor"
+
+
+# Phase 3: Factory integration + end-to-end
+
+
+@_skip_if_single_rank()
+class TestPhase3FactoryIntegration:
+    """Phase 3 tests for `_build_megatron_fsdp_emerging_optimizer` factory."""
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Initialize distributed for multi-rank tests."""
+        Utils.initialize_model_parallel()
+        yield
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("strategy", ["no_shard", "optim", "optim_grads", "optim_grads_params"])
+    def test_phase3_factory_dispatches_correct_muon_cls(self, strategy):
+        """Factory dispatches `TensorParallelMuon` for "no_shard",
+        `FSDPZeROTensorParallelMuon` otherwise.
+
+        Uses mocks to avoid needing a real FSDP-wrapped model for the dispatch logic.
+        """
+        from megatron.core.optimizer import OptimizerConfig, _build_megatron_fsdp_emerging_optimizer
+        from megatron.core.process_groups_config import ProcessGroupCollection
+
+        model_chunk = MagicMock()
+        model_chunk.config.num_attention_heads = 8
+        model_chunk.config.num_query_groups = 8
+        model_chunk.config.kv_channels = 16
+
+        # 2D linear param (Muon-managed).
+        linear_weight = torch.nn.Parameter(torch.randn(32, 16, device="cuda"))
+        linear_weight.requires_grad = True
+        linear_weight.is_embedding_or_output_parameter = False
+
+        # 1D bias (routed to Adam by the default param overrides).
+        bias_param = torch.nn.Parameter(torch.randn(32, device="cuda"))
+        bias_param.requires_grad = True
+        bias_param.is_embedding_or_output_parameter = False
+
+        model_chunk.named_parameters.return_value = [
+            ("layer.linear.weight", linear_weight),
+            ("layer.linear.bias", bias_param),
+        ]
+        model_chunk.parameters.return_value = iter([linear_weight, bias_param])
+
+        model_chunk.ddp_config.use_megatron_fsdp = True
+        model_chunk.ddp_config.data_parallel_sharding_strategy = strategy
+
+        config = OptimizerConfig(
+            optimizer="muon",
+            lr=0.01,
+            weight_decay=0.01,
+            bf16=False,
+            fp16=False,
+            use_distributed_optimizer=False,
+            muon_momentum=0.95,
+            muon_nesterov=True,
+            muon_fp32_matmul_prec="medium",
+            muon_num_ns_steps=5,
+            muon_scale_mode="spectral",
+            muon_tp_mode="duplicated",
+            muon_split_qkv=False,
+            muon_extra_scale_factor=1.0,
+        )
+
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+        # `_get_param_groups` would call into Megatron internals
+        # (`get_global_unique_param_name` etc.) that don't work on MagicMock
+        # chunks, so we stub it out with a minimal one-group fake.
+        def fake_get_param_groups(model_chunks, config, overrides):
+            return [
+                {
+                    "params": [linear_weight],
+                    "is_expert_parallel": False,
+                    "wd_mult": 1.0,
+                    "lr_mult": 1.0,
+                }
+            ]
+
+        # Mock get_megatron_optimizer to avoid full FSDP setup for Adam. Pin
+        # the mocked sub-optimizer's `config` to the real config so the
+        # ChainedOptimizer assertion that all sub-optimizers share a config
+        # passes (defaults would auto-spawn a fresh MagicMock that is unequal).
+        with patch("megatron.core.optimizer._get_param_groups", side_effect=fake_get_param_groups):
+            with patch("megatron.core.optimizer.get_megatron_optimizer") as mock_get_opt:
+                mock_adam = MagicMock()
+                mock_adam_sub = MagicMock()
+                mock_adam_sub.config = config
+                mock_adam.chained_optimizers = [mock_adam_sub]
+                mock_get_opt.return_value = mock_adam
+
+                with patch("megatron.core.optimizer._get_mfsdp_models") as mock_mfsdp:
+                    mock_mfsdp.return_value = [MagicMock()]
+
+                    result = _build_megatron_fsdp_emerging_optimizer(
+                        config=config,
+                        model_chunks=[model_chunk],
+                        config_overrides={},
+                        pg_collection=pg_collection,
+                        eopt_name="muon",
+                        use_layer_wise=False,
+                    )
+
+        assert isinstance(result, FSDPMuonChainedOptimizer)
+
+        from megatron.core.optimizer.optimizer import ChainedOptimizer, FP32Optimizer
+
+        inner = object.__getattribute__(result, "inner")
+        assert isinstance(inner, ChainedOptimizer)
+
+        muon_wrapper = inner.chained_optimizers[0]
+        assert isinstance(muon_wrapper, FP32Optimizer)
+
+        base_opt = muon_wrapper.optimizer
+        if strategy == "no_shard":
+            assert isinstance(base_opt, TensorParallelMuon)
+            assert not isinstance(base_opt, FSDPZeROTensorParallelMuon)
+        else:
+            assert isinstance(base_opt, FSDPZeROTensorParallelMuon)
+            assert base_opt.dp_group is not None
+
+    def test_phase3_factory_expert_dp_group(self):
+        """Verify expert Muon uses `expt_dp` group, non-expert uses `dp_cp`."""
+        from megatron.core.optimizer import OptimizerConfig, _build_megatron_fsdp_emerging_optimizer
+        from megatron.core.process_groups_config import ProcessGroupCollection
+
+        model_chunk = MagicMock()
+        model_chunk.config.num_attention_heads = 8
+        model_chunk.config.num_query_groups = 8
+        model_chunk.config.kv_channels = 16
+
+        linear_weight = torch.nn.Parameter(torch.randn(32, 16, device="cuda"))
+        linear_weight.requires_grad = True
+        linear_weight.is_embedding_or_output_parameter = False
+
+        expert_weight = torch.nn.Parameter(torch.randn(32, 16, device="cuda"))
+        expert_weight.requires_grad = True
+        expert_weight.is_embedding_or_output_parameter = False
+
+        model_chunk.named_parameters.return_value = [
+            ("layer.linear.weight", linear_weight),
+            ("layer.experts.0.linear.weight", expert_weight),
+        ]
+        model_chunk.parameters.return_value = iter([linear_weight, expert_weight])
+
+        model_chunk.ddp_config.use_megatron_fsdp = True
+        model_chunk.ddp_config.data_parallel_sharding_strategy = "optim"
+
+        config = OptimizerConfig(
+            optimizer="muon",
+            lr=0.01,
+            weight_decay=0.01,
+            bf16=False,
+            fp16=False,
+            use_distributed_optimizer=False,
+            muon_momentum=0.95,
+            muon_nesterov=True,
+            muon_fp32_matmul_prec="medium",
+            muon_num_ns_steps=5,
+            muon_scale_mode="spectral",
+            muon_tp_mode="duplicated",
+            muon_split_qkv=False,
+            muon_extra_scale_factor=1.0,
+        )
+
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+        def fake_get_param_groups(model_chunks, config, overrides):
+            groups = []
+            for chunk in model_chunks:
+                for name, param in chunk.named_parameters():
+                    if not param.requires_grad:
+                        continue
+                    if len(param.shape) != 2:
+                        continue
+                    is_expert = "experts" in name and "shared" not in name
+                    groups.append(
+                        {
+                            "params": [param],
+                            "is_expert_parallel": is_expert,
+                            "wd_mult": 1.0,
+                            "lr_mult": 1.0,
+                        }
+                    )
+            return groups
+
+        with patch("megatron.core.optimizer._get_param_groups", side_effect=fake_get_param_groups):
+            with patch("megatron.core.optimizer.get_megatron_optimizer") as mock_get_opt:
+                mock_adam = MagicMock()
+                mock_adam_sub = MagicMock()
+                mock_adam_sub.config = config
+                mock_adam.chained_optimizers = [mock_adam_sub]
+                mock_get_opt.return_value = mock_adam
+
+                with patch("megatron.core.optimizer._get_mfsdp_models") as mock_mfsdp:
+                    mock_mfsdp.return_value = [MagicMock()]
+
+                    result = _build_megatron_fsdp_emerging_optimizer(
+                        config=config,
+                        model_chunks=[model_chunk],
+                        config_overrides={},
+                        pg_collection=pg_collection,
+                        eopt_name="muon",
+                        use_layer_wise=False,
+                    )
+
+        from megatron.core.optimizer.optimizer import ChainedOptimizer, FP32Optimizer
+
+        inner = object.__getattribute__(result, "inner")
+        assert isinstance(inner, ChainedOptimizer)
+
+        # Expect at least 3 optimizers: non-expert Muon, expert Muon, Adam.
+        assert len(inner.chained_optimizers) >= 3, (
+            f"Expected >= 3 chained optimizers (muon + expert_muon + adam), "
+            f"got {len(inner.chained_optimizers)}"
+        )
+
+        non_expert_muon = inner.chained_optimizers[0]
+        assert isinstance(non_expert_muon, FP32Optimizer)
+        assert isinstance(non_expert_muon.optimizer, FSDPZeROTensorParallelMuon)
+        assert non_expert_muon.optimizer.dp_group == pg_collection.dp_cp
+
+        expert_muon = inner.chained_optimizers[1]
+        assert isinstance(expert_muon, FP32Optimizer)
+        assert isinstance(expert_muon.optimizer, FSDPZeROTensorParallelMuon)
+        assert expert_muon.optimizer.dp_group == pg_collection.expt_dp

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -151,8 +151,6 @@ class TestFSDPTensorParallelMuon:
         from torch.distributed.device_mesh import init_device_mesh
         from torch.distributed.tensor import DTensor
 
-        from megatron.core.optimizer import emerging_optimizers as eopt_mod
-
         dp_size = torch.distributed.get_world_size()
         dp_rank = torch.distributed.get_rank()
         device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
@@ -204,14 +202,14 @@ class TestFSDPTensorParallelMuon:
                 g1.shape
             ), "boundary param grad should be unevenly sharded (local != global shape)"
 
-        real_gather = eopt_mod.gather_uneven_dtensor_to_full_tensor
+        real_gather = optimizer._gather_full_uneven_local_tensor_like
         gather_shapes = []
 
-        def counting_gather(value):
+        def counting_gather(value, local_tensor):
             gather_shapes.append(tuple(value.shape))
-            return real_gather(value)
+            return real_gather(value, local_tensor)
 
-        with patch.object(eopt_mod, "gather_uneven_dtensor_to_full_tensor", counting_gather):
+        with patch.object(optimizer, "_gather_full_uneven_local_tensor_like", counting_gather):
             optimizer.step()
 
         assert gather_shapes == [(6, cols)]
@@ -251,7 +249,7 @@ class TestFSDPTensorParallelMuon:
             )
             assert not torch.equal(local_value, initial_locals[idx])
 
-    def test_boundary_detector_includes_middle_split_params(self):
+    def test_boundary_detector_uses_first_and_last_non_empty_params(self):
         from torch.distributed.device_mesh import init_device_mesh
 
         dp_size = torch.distributed.get_world_size()
@@ -260,9 +258,10 @@ class TestFSDPTensorParallelMuon:
         dp_group = device_mesh.get_group("dp")
         cols = 4
 
-        # Optimizer groups can exclude Adam-managed tensors that are present in
-        # the underlying M-FSDP flat buffer. After that filtering, a split Muon
-        # tensor is not guaranteed to be first or last in the Muon param group.
+        # Even if more than two params look uneven in a synthetic layout, the
+        # M-FSDP flat-buffer assignment means only the first and last non-empty
+        # params on each DP rank can cross rank boundaries. Gathering every
+        # uneven DTensor is the expensive behavior this integration avoids.
         plans = [{0: 2, 1: 2}, {0: 1, 1: 3}, {0: 3, 1: 1}]
 
         params = []
@@ -273,12 +272,10 @@ class TestFSDPTensorParallelMuon:
 
         optimizer = _make_fsdp_muon(params, dp_group=dp_group)
 
-        assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0, 1, 2}
+        assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0, 2}
 
     def test_step_no_gather_when_all_params_local(self):
         from torch.distributed.device_mesh import init_device_mesh
-
-        from megatron.core.optimizer import emerging_optimizers as eopt_mod
 
         dp_size = torch.distributed.get_world_size()
         dp_rank = torch.distributed.get_rank()
@@ -301,19 +298,60 @@ class TestFSDPTensorParallelMuon:
 
         optimizer = _make_fsdp_muon(params, dp_group=dp_group)
 
-        real_gather = eopt_mod.gather_uneven_dtensor_to_full_tensor
+        real_gather = optimizer._gather_full_uneven_local_tensor_like
         gather_calls = []
 
-        def counting_gather(value):
+        def counting_gather(value, local_tensor):
             gather_calls.append(tuple(value.shape))
-            return real_gather(value)
+            return real_gather(value, local_tensor)
 
-        with patch.object(eopt_mod, "gather_uneven_dtensor_to_full_tensor", counting_gather):
+        with patch.object(optimizer, "_gather_full_uneven_local_tensor_like", counting_gather):
             optimizer.step()
 
         assert (
             gather_calls == []
         ), f"Expected no all-gathers for fully-local params, got {gather_calls}"
+
+    def test_boundary_metadata_collectives_are_cached_across_steps(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        plans = [{0: 4}, {0: 2, 1: 4}, {1: 5}]
+        full_params = [
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) / 100
+            for rows in (4, 6, 5)
+        ]
+        full_grads = [
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) / 50
+            + 0.1
+            for rows in (4, 6, 5)
+        ]
+
+        params = []
+        for full_param, plan in zip(full_params, plans):
+            local_param = _local_slice(full_param, plan, dp_rank).contiguous()
+            params.append(nn.Parameter(_make_dtensor(local_param, full_param.shape, device_mesh)))
+
+        for param, full_grad, plan in zip(params, full_grads, plans):
+            local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+            param.grad = _make_dtensor(local_grad, full_grad.shape, device_mesh)
+
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
+
+        with patch(
+            "torch.distributed.all_gather_object", wraps=torch.distributed.all_gather_object
+        ) as mocked_all_gather_object:
+            optimizer.step()
+            first_step_calls = mocked_all_gather_object.call_count
+            optimizer.step()
+
+        assert first_step_calls > 0
+        assert mocked_all_gather_object.call_count == first_step_calls
 
     def test_step_momentum_accumulates_across_steps(self):
         from torch.distributed.device_mesh import init_device_mesh

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -421,6 +421,40 @@ class TestFSDPTensorParallelMuon:
             gather_calls == [] and batch_calls == []
         ), f"Expected no all-gathers for fully-local params, got {gather_calls}, {batch_calls}"
 
+    def test_step_skips_boundary_ns_on_empty_local_shards(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        plan = {0: 2, 1: 2}
+        full_param = torch.arange(4 * cols, device="cuda", dtype=torch.float32).view(4, cols) / 100
+        full_grad = torch.arange(4 * cols, device="cuda", dtype=torch.float32).view(4, cols) / 50
+
+        local_param = _local_slice(full_param, plan, dp_rank).contiguous()
+        param = nn.Parameter(_make_dtensor(local_param, full_param.shape, device_mesh))
+        local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+        param.grad = _make_dtensor(local_grad, full_grad.shape, device_mesh)
+
+        optimizer = _make_fsdp_muon([param], dp_group=dp_group)
+        orthogonalize_calls = []
+        real_orthogonalize = TensorParallelMuon.orthogonalize
+
+        def counting_orthogonalize(self, p, grad, **kwargs):
+            orthogonalize_calls.append(tuple(grad.shape))
+            return real_orthogonalize(self, p, grad, **kwargs)
+
+        with patch.object(TensorParallelMuon, "orthogonalize", counting_orthogonalize):
+            optimizer.step()
+
+        if local_param.numel() == 0:
+            assert orthogonalize_calls == []
+        else:
+            assert orthogonalize_calls == [tuple(full_grad.shape)]
+
     def test_step_batches_multiple_split_boundary_params(self):
         from torch.distributed.device_mesh import init_device_mesh
 

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -3,6 +3,7 @@
 """Tests for Muon + Megatron-FSDP integration."""
 
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -114,6 +115,15 @@ def _make_dtensor(local_tensor, global_shape, device_mesh):
     return dtensor
 
 
+def _attach_fake_mfsdp_bucket_metadata(param, bucket, item_id, offset):
+    bucket.item_index_map[item_id] = SimpleNamespace(global_data_index=offset)
+    param.orig_param = SimpleNamespace(_gbuf=bucket, _item_id=item_id)
+
+
+def _make_fake_mfsdp_bucket(bucket_id):
+    return SimpleNamespace(item_index_map={}, bucket_index=SimpleNamespace(bucket_id=bucket_id))
+
+
 class TestGetMFSDPModels:
     def test_error_on_plain_module(self):
         with pytest.raises(RuntimeError, match="Could not find any MegatronFSDP"):
@@ -202,17 +212,17 @@ class TestFSDPTensorParallelMuon:
                 g1.shape
             ), "boundary param grad should be unevenly sharded (local != global shape)"
 
-        real_gather = optimizer._gather_full_uneven_local_tensors_like
-        gather_batches = []
+        real_gather = optimizer._gather_full_uneven_local_tensor_like
+        gather_calls = []
 
-        def counting_gather(items):
-            gather_batches.append([tuple(value.shape) for value, _ in items])
-            return real_gather(items)
+        def counting_gather(dtensor_ref, local_tensor):
+            gather_calls.append(tuple(dtensor_ref.shape))
+            return real_gather(dtensor_ref, local_tensor)
 
-        with patch.object(optimizer, "_gather_full_uneven_local_tensors_like", counting_gather):
+        with patch.object(optimizer, "_gather_full_uneven_local_tensor_like", counting_gather):
             optimizer.step()
 
-        assert gather_batches == [[(6, cols)]]
+        assert gather_calls == [(6, cols)]
 
         # Post-step: momentum buffers are DTensors in optimizer state.
         for idx, (param, plan) in enumerate(zip(params, plans)):
@@ -258,10 +268,9 @@ class TestFSDPTensorParallelMuon:
         dp_group = device_mesh.get_group("dp")
         cols = 4
 
-        # Even if more than two params look uneven in a synthetic layout, the
-        # M-FSDP flat-buffer assignment means only the first and last non-empty
-        # params on each DP rank can cross rank boundaries. Gathering every
-        # uneven DTensor is the expensive behavior this integration avoids.
+        # Without M-FSDP bucket metadata, the helper treats the group as one
+        # synthetic bucket and only selects the first/last non-empty params.
+        # Real M-FSDP optimizer params exercise bucket-aware detection below.
         plans = [{0: 2, 1: 2}, {0: 1, 1: 3}, {0: 3, 1: 1}]
 
         params = []
@@ -273,6 +282,86 @@ class TestFSDPTensorParallelMuon:
         optimizer = _make_fsdp_muon(params, dp_group=dp_group)
 
         assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0, 2}
+
+    def test_boundary_detector_uses_first_and_last_non_empty_params_per_mfsdp_bucket(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        # Param 2 is split across the rank 0/1 boundary, but it is neither the
+        # first nor last non-empty param in the overall optimizer group on
+        # either rank. It is the only non-empty param in its M-FSDP bucket, so
+        # bucket-aware boundary detection must still select it.
+        plans = [{0: 4}, {1: 4}, {0: 2, 1: 2}, {0: 4}, {1: 4}]
+        full_params = []
+        full_grads = []
+        params = []
+        for idx, plan in enumerate(plans):
+            rows = sum(plan.values())
+            full_param = (
+                torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) / 100
+                + idx
+            )
+            full_grad = (
+                torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) / 50
+                + 0.1
+                + idx
+            )
+            full_params.append(full_param)
+            full_grads.append(full_grad)
+            local_param = _local_slice(full_param, plan, dp_rank).contiguous()
+            params.append(nn.Parameter(_make_dtensor(local_param, full_param.shape, device_mesh)))
+
+        for param, full_grad, plan in zip(params, full_grads, plans):
+            local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+            param.grad = _make_dtensor(local_grad, full_grad.shape, device_mesh)
+
+        buckets = [
+            _make_fake_mfsdp_bucket(0),
+            _make_fake_mfsdp_bucket(1),
+            _make_fake_mfsdp_bucket(2),
+        ]
+        bucket_assignments = [
+            (buckets[0], 0, 0),
+            (buckets[0], 1, 4 * cols),
+            (buckets[1], 0, 0),
+            (buckets[2], 0, 0),
+            (buckets[2], 1, 4 * cols),
+        ]
+        for param, (bucket, item_id, offset) in zip(params, bucket_assignments):
+            _attach_fake_mfsdp_bucket_metadata(param, bucket, item_id, offset)
+
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
+
+        assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {2}
+
+        real_gather = optimizer._gather_full_uneven_local_tensor_like
+        gather_calls = []
+
+        def counting_gather(dtensor_ref, local_tensor):
+            gather_calls.append(tuple(dtensor_ref.shape))
+            return real_gather(dtensor_ref, local_tensor)
+
+        with patch.object(optimizer, "_gather_full_uneven_local_tensor_like", counting_gather):
+            optimizer.step()
+
+        assert gather_calls == [(4, cols)]
+
+        if params[2].data.to_local().numel() > 0:
+            lr = optimizer.param_groups[0]["lr"]
+            expected_update = _reference_update(full_grads[2])
+            expected_local = _local_slice(full_params[2] - lr * expected_update, plans[2], dp_rank)
+            torch.testing.assert_close(
+                params[2].data.to_local(),
+                expected_local,
+                atol=1e-5,
+                rtol=1e-4,
+                msg=f"middle bucket-boundary param update mismatch on rank {dp_rank}",
+            )
 
     def test_step_no_gather_when_all_params_local(self):
         from torch.distributed.device_mesh import init_device_mesh
@@ -298,19 +387,29 @@ class TestFSDPTensorParallelMuon:
 
         optimizer = _make_fsdp_muon(params, dp_group=dp_group)
 
-        real_gather = optimizer._gather_full_uneven_local_tensors_like
+        real_gather = optimizer._gather_full_uneven_local_tensor_like
         gather_calls = []
+        batch_calls = []
 
-        def counting_gather(items):
-            gather_calls.append([tuple(value.shape) for value, _ in items])
-            return real_gather(items)
+        def counting_gather(dtensor_ref, local_tensor):
+            gather_calls.append(tuple(dtensor_ref.shape))
+            return real_gather(dtensor_ref, local_tensor)
 
-        with patch.object(optimizer, "_gather_full_uneven_local_tensors_like", counting_gather):
+        def counting_batch_gather(items):
+            batch_calls.append([tuple(value.shape) for value, _ in items])
+            return []
+
+        with (
+            patch.object(optimizer, "_gather_full_uneven_local_tensor_like", counting_gather),
+            patch.object(
+                optimizer, "_gather_full_uneven_local_tensors_like", counting_batch_gather
+            ),
+        ):
             optimizer.step()
 
         assert (
-            gather_calls == []
-        ), f"Expected no all-gathers for fully-local params, got {gather_calls}"
+            gather_calls == [] and batch_calls == []
+        ), f"Expected no all-gathers for fully-local params, got {gather_calls}, {batch_calls}"
 
     def test_step_batches_multiple_split_boundary_params(self):
         from torch.distributed.device_mesh import init_device_mesh
@@ -341,7 +440,7 @@ class TestFSDPTensorParallelMuon:
             local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
             param.grad = _make_dtensor(local_grad, full_grad.shape, device_mesh)
 
-        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group, fsdp_batched_all_gather=True)
         assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0, 2}
 
         real_gather = optimizer._gather_full_uneven_local_tensors_like
@@ -609,6 +708,7 @@ class TestFSDPFactoryIntegration:
             muon_tp_mode="duplicated",
             muon_split_qkv=False,
             muon_extra_scale_factor=1.0,
+            muon_fsdp_batched_all_gather=True,
         )
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
@@ -649,3 +749,4 @@ class TestFSDPFactoryIntegration:
         else:
             assert isinstance(base_opt, FSDPTensorParallelMuon)
             assert base_opt.dp_group is not None
+            assert base_opt.fsdp_batched_all_gather

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -10,15 +10,13 @@ import torch
 import torch.nn as nn
 from packaging.version import Version
 
+from megatron.core.optimizer import _get_mfsdp_models
 from megatron.core.optimizer.emerging_optimizers import (
-    FSDPMuonChainedOptimizer,
-    FSDPZeROTensorParallelMuon,
     HAVE_EMERGING_OPTIMIZERS,
+    FSDPTensorParallelMuon,
     TensorParallelMuon,
-    _get_mfsdp_models,
 )
 from tests.unit_tests.test_utilities import Utils
-
 
 pytestmark = [
     pytest.mark.skipif(
@@ -56,7 +54,7 @@ def _make_fsdp_muon(params, dp_group=None, **kwargs):
         split_qkv=False,
     )
     defaults.update(kwargs)
-    return FSDPZeROTensorParallelMuon(params=params, dp_group=dp_group, **defaults)
+    return FSDPTensorParallelMuon(params=params, dp_group=dp_group, **defaults)
 
 
 def _reference_update(full_grad, **kwargs):
@@ -111,60 +109,12 @@ def _make_dtensor(local_tensor, global_shape, device_mesh):
     return dtensor
 
 
-class TestFSDPMuonChainedOptimizer:
-    @staticmethod
-    def _make_mfsdp_mock(model_auto_sync=False):
-        mock = MagicMock()
-        mock.model_auto_sync = model_auto_sync
-        return mock
-
-    @staticmethod
-    def _make_inner_mock():
-        mock = MagicMock()
-        mock.step.return_value = (True, 1.0, 0)
-        return mock
-
-    @pytest.mark.parametrize("model_auto_sync", [True, False])
-    def test_step_protocol(self, model_auto_sync):
-        inner = self._make_inner_mock()
-        mfsdp = self._make_mfsdp_mock(model_auto_sync=model_auto_sync)
-        wrapper = FSDPMuonChainedOptimizer(inner, [mfsdp])
-
-        wrapper.step()
-
-        if model_auto_sync:
-            mfsdp.finish_grad_sync.assert_not_called()
-        else:
-            mfsdp.finish_grad_sync.assert_called_once()
-        inner.step.assert_called_once()
-        mfsdp.install_optimized_model_weights.assert_called_once()
-
-    def test_getattr_delegation(self):
-        inner = self._make_inner_mock()
-        inner.param_groups = [{"lr": 0.01}]
-        inner.state_dict.return_value = {"state": {}, "param_groups": []}
-        wrapper = FSDPMuonChainedOptimizer(inner, [self._make_mfsdp_mock()])
-
-        assert wrapper.param_groups == [{"lr": 0.01}]
-        assert wrapper.state_dict() == {"state": {}, "param_groups": []}
-
-        wrapper.load_state_dict({"state": {}, "param_groups": []})
-        inner.load_state_dict.assert_called_once()
-
-    @pytest.mark.parametrize("set_to_none", [True, False])
-    def test_zero_grad_delegates(self, set_to_none):
-        inner = self._make_inner_mock()
-        wrapper = FSDPMuonChainedOptimizer(inner, [self._make_mfsdp_mock()])
-
-        wrapper.zero_grad(set_to_none=set_to_none)
-
-        inner.zero_grad.assert_called_once_with(set_to_none)
-
-    def test_get_mfsdp_models_error(self):
+class TestGetMFSDPModels:
+    def test_error_on_plain_module(self):
         with pytest.raises(RuntimeError, match="Could not find any MegatronFSDP"):
             _get_mfsdp_models([nn.Module()])
 
-    def test_get_mfsdp_models_success(self):
+    def test_extracts_inner_module(self):
         inner_module = MagicMock()
         chunk = MagicMock()
         chunk.module = inner_module
@@ -172,10 +122,22 @@ class TestFSDPMuonChainedOptimizer:
 
         assert _get_mfsdp_models([chunk]) == [inner_module]
 
+    def test_extracts_from_multiple_chunks(self):
+        chunks, inner_modules = [], []
+        for _ in range(3):
+            inner = MagicMock()
+            chunk = MagicMock()
+            chunk.module = inner
+            chunk.finish_grad_sync = MagicMock()
+            chunks.append(chunk)
+            inner_modules.append(inner)
+
+        assert _get_mfsdp_models(chunks) == inner_modules
+
 
 @_skip_if_single_rank()
 @_skip_if_no_dtensor()
-class TestFSDPZeROTensorParallelMuon:
+class TestFSDPTensorParallelMuon:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         Utils.initialize_model_parallel()
@@ -184,6 +146,7 @@ class TestFSDPZeROTensorParallelMuon:
 
     def test_step_gathers_only_split_boundary_params(self):
         from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import DTensor
 
         from megatron.core.optimizer import emerging_optimizers as eopt_mod
 
@@ -222,6 +185,22 @@ class TestFSDPZeROTensorParallelMuon:
         optimizer = _make_fsdp_muon(params, dp_group=dp_group)
         assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {1}
 
+        # Pre-step: grads are DTensors, non-null, non-zero.
+        for idx, (param, plan) in enumerate(zip(params, plans)):
+            if _local_rows(plan, dp_rank) == 0:
+                continue
+            assert param.grad is not None, f"param {idx} grad should not be None"
+            assert isinstance(param.grad, DTensor), f"param {idx} grad should be a DTensor"
+            local_grad = param.grad.to_local()
+            assert local_grad.numel() > 0, f"param {idx} local grad should be non-empty"
+            assert not torch.all(local_grad == 0), f"param {idx} local grad should be non-zero"
+        # Boundary param (idx=1) spans two ranks: local shape != global shape.
+        if dp_rank in plans[1]:
+            g1 = params[1].grad
+            assert tuple(g1.to_local().shape) != tuple(
+                g1.shape
+            ), "boundary param grad should be unevenly sharded (local != global shape)"
+
         real_gather = eopt_mod.gather_uneven_dtensor_to_full_tensor
         gather_shapes = []
 
@@ -233,6 +212,20 @@ class TestFSDPZeROTensorParallelMuon:
             optimizer.step()
 
         assert gather_shapes == [(6, cols)]
+
+        # Post-step: momentum buffers are DTensors in optimizer state.
+        for idx, (param, plan) in enumerate(zip(params, plans)):
+            if _local_rows(plan, dp_rank) == 0:
+                continue
+            assert (
+                param in optimizer.state and optimizer.state[param]
+            ), f"param {idx} should have optimizer state after step"
+            state = optimizer.state[param]
+            assert "momentum_buffer" in state, f"param {idx} missing momentum_buffer in state"
+            mom = state["momentum_buffer"]
+            assert isinstance(mom, DTensor), f"param {idx} momentum_buffer should be a DTensor"
+            local_mom = mom.to_local()
+            assert local_mom.numel() > 0, f"param {idx} local momentum should be non-empty"
 
         lr = optimizer.param_groups[0]["lr"]
         for idx, (param, full_param, full_grad, plan) in enumerate(
@@ -279,6 +272,123 @@ class TestFSDPZeROTensorParallelMuon:
 
         assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0, 1, 2}
 
+    def test_step_no_gather_when_all_params_local(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from megatron.core.optimizer import emerging_optimizers as eopt_mod
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+        rows = 4
+
+        # Each param is fully owned by exactly one rank — no boundary splits.
+        plans = [{0: rows}, {1: rows}]
+        params = []
+        for plan in plans:
+            full_param = torch.ones(rows, cols, device="cuda") * 0.1
+            local_p = _local_slice(full_param, plan, dp_rank).contiguous()
+            param = nn.Parameter(_make_dtensor(local_p, full_param.shape, device_mesh))
+            full_grad = torch.ones(rows, cols, device="cuda") * 0.2
+            local_g = _local_slice(full_grad, plan, dp_rank).contiguous()
+            param.grad = _make_dtensor(local_g, full_grad.shape, device_mesh)
+            params.append(param)
+
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
+
+        real_gather = eopt_mod.gather_uneven_dtensor_to_full_tensor
+        gather_calls = []
+
+        def counting_gather(value):
+            gather_calls.append(tuple(value.shape))
+            return real_gather(value)
+
+        with patch.object(eopt_mod, "gather_uneven_dtensor_to_full_tensor", counting_gather):
+            optimizer.step()
+
+        assert (
+            gather_calls == []
+        ), f"Expected no all-gathers for fully-local params, got {gather_calls}"
+
+    def test_step_momentum_accumulates_across_steps(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+        rows = 4
+        m = 0.95
+
+        plan = {0: rows}
+        full_param = torch.zeros(rows, cols, device="cuda")
+        local_p = _local_slice(full_param, plan, dp_rank).contiguous()
+        param = nn.Parameter(_make_dtensor(local_p, full_param.shape, device_mesh))
+
+        optimizer = _make_fsdp_muon([param], dp_group=dp_group, momentum=m, nesterov=False)
+
+        grad1 = torch.full((rows, cols), 0.5, device="cuda")
+        grad2 = torch.full((rows, cols), 1.0, device="cuda")
+
+        # Step 1.
+        local_g1 = _local_slice(grad1, plan, dp_rank).contiguous()
+        param.grad = _make_dtensor(local_g1, grad1.shape, device_mesh)
+        optimizer.step()
+
+        if local_p.numel() > 0:
+            mom = optimizer.state[param]["momentum_buffer"].to_local()
+            # buf = 0 * m + grad1 * (1 - m)
+            torch.testing.assert_close(mom, (1 - m) * local_g1, atol=1e-6, rtol=0)
+
+        # Step 2 with a different gradient.
+        local_g2 = _local_slice(grad2, plan, dp_rank).contiguous()
+        param.grad = _make_dtensor(local_g2, grad2.shape, device_mesh)
+        optimizer.step()
+
+        if local_p.numel() > 0:
+            mom = optimizer.state[param]["momentum_buffer"].to_local()
+            expected = m * (1 - m) * local_g1 + (1 - m) * local_g2
+            torch.testing.assert_close(mom, expected, atol=1e-6, rtol=0)
+
+    def test_step_none_grad_boundary_param_does_not_crash(self):
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import DTensor
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        # param 0: fully local on rank 0; param 1: boundary split across ranks 0 and 1.
+        plans = [{0: 4}, {0: 2, 1: 4}]
+        params = []
+        for plan in plans:
+            rows = sum(plan.values())
+            full_param = torch.ones(rows, cols, device="cuda") * 0.1
+            local_p = _local_slice(full_param, plan, dp_rank).contiguous()
+            params.append(nn.Parameter(_make_dtensor(local_p, full_param.shape, device_mesh)))
+
+        # Give param 0 a gradient; leave param 1 (the boundary param) with grad=None.
+        full_grad0 = torch.ones(4, cols, device="cuda") * 0.3
+        local_g0 = _local_slice(full_grad0, plans[0], dp_rank).contiguous()
+        params[0].grad = _make_dtensor(local_g0, full_grad0.shape, device_mesh)
+        # params[1].grad remains None
+
+        initial_local1 = params[1].data.to_local().clone()
+
+        # Must not raise even though the boundary param has no gradient.
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
+        optimizer.step()
+
+        # Boundary param with grad=None should not receive a meaningful weight update
+        # (NS of an all-zeros update produces ~zero; the param is essentially unchanged).
+        final_local1 = params[1].data.to_local()
+        torch.testing.assert_close(final_local1, initial_local1, atol=1e-4, rtol=1e-3)
+
 
 @_skip_if_single_rank()
 class TestFSDPFactoryIntegration:
@@ -290,9 +400,13 @@ class TestFSDPFactoryIntegration:
 
     @pytest.mark.parametrize("strategy", ["no_shard", "optim", "optim_grads", "optim_grads_params"])
     def test_factory_dispatches_correct_muon_cls(self, strategy):
-        from megatron.core.optimizer import OptimizerConfig, _build_megatron_fsdp_emerging_optimizer
+        from megatron.core.optimizer import (
+            DistributedOptimizer,
+            OptimizerConfig,
+            _build_megatron_fsdp_emerging_optimizer,
+        )
+        from megatron.core.optimizer.optimizer import ChainedOptimizer
         from megatron.core.process_groups_config import ProcessGroupCollection
-        from megatron.core.optimizer.optimizer import ChainedOptimizer, FP32Optimizer
 
         model_chunk = MagicMock()
         model_chunk.config.num_attention_heads = 8
@@ -354,19 +468,16 @@ class TestFSDPFactoryIntegration:
                         config_overrides={},
                         pg_collection=pg_collection,
                         eopt_name="muon",
-                        use_layer_wise=False,
                     )
 
-        assert isinstance(result, FSDPMuonChainedOptimizer)
-        inner = object.__getattribute__(result, "inner")
-        assert isinstance(inner, ChainedOptimizer)
+        assert isinstance(result, ChainedOptimizer)
 
-        muon_wrapper = inner.chained_optimizers[0]
-        assert isinstance(muon_wrapper, FP32Optimizer)
+        muon_wrapper = result.chained_optimizers[0]
+        assert isinstance(muon_wrapper, DistributedOptimizer)
         base_opt = muon_wrapper.optimizer
         if strategy == "no_shard":
             assert isinstance(base_opt, TensorParallelMuon)
-            assert not isinstance(base_opt, FSDPZeROTensorParallelMuon)
+            assert not isinstance(base_opt, FSDPTensorParallelMuon)
         else:
-            assert isinstance(base_opt, FSDPZeROTensorParallelMuon)
+            assert isinstance(base_opt, FSDPTensorParallelMuon)
             assert base_opt.dp_group is not None

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -392,6 +392,89 @@ class TestFSDPTensorParallelMuon:
         final_local1 = params[1].data.to_local()
         torch.testing.assert_close(final_local1, initial_local1, atol=1e-4, rtol=1e-3)
 
+    def test_step_matches_unsharded_muon_optimizer_step_numerics(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        plans = [{0: 4}, {0: 2, 1: 3}, {0: 1, 1: 5}, {1: 4}]
+        row_counts = [sum(plan.values()) for plan in plans]
+        full_params = [
+            (
+                torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols)
+                + 1.3 * (idx + 1)
+            )
+            / (17 + idx)
+            for idx, rows in enumerate(row_counts)
+        ]
+        full_grads_by_step = [
+            [
+                (
+                    torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols)
+                    + 0.7 * (idx + 1)
+                    + step
+                )
+                / (23 + idx + step)
+                for idx, rows in enumerate(row_counts)
+            ]
+            for step in range(2)
+        ]
+        optimizer_kwargs = dict(
+            lr=0.03, momentum=0.25, nesterov=True, weight_decay=0.02, num_ns_steps=3
+        )
+
+        unsharded_params = [nn.Parameter(full_param.clone()) for full_param in full_params]
+        unsharded_optimizer = TensorParallelMuon(
+            params=unsharded_params,
+            pg_collection=None,
+            tp_mode="duplicated",
+            split_qkv=False,
+            **optimizer_kwargs,
+        )
+
+        sharded_params = []
+        for full_param, plan in zip(full_params, plans):
+            local_param = _local_slice(full_param, plan, dp_rank).contiguous()
+            sharded_params.append(
+                nn.Parameter(_make_dtensor(local_param, full_param.shape, device_mesh))
+            )
+        sharded_optimizer = _make_fsdp_muon(sharded_params, dp_group=dp_group, **optimizer_kwargs)
+
+        for step, full_grads in enumerate(full_grads_by_step, start=1):
+            for param, full_grad in zip(unsharded_params, full_grads):
+                param.grad = full_grad.clone()
+            for param, full_grad, plan in zip(sharded_params, full_grads, plans):
+                local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+                param.grad = _make_dtensor(local_grad, full_grad.shape, device_mesh)
+
+            unsharded_optimizer.step()
+            sharded_optimizer.step()
+
+            for idx, (sharded_param, unsharded_param, plan) in enumerate(
+                zip(sharded_params, unsharded_params, plans)
+            ):
+                expected_local = _local_slice(unsharded_param.detach(), plan, dp_rank)
+                local_value = sharded_param.data.to_local()
+
+                if local_value.numel() == 0:
+                    assert local_value.shape[0] == 0
+                    continue
+
+                torch.testing.assert_close(
+                    local_value,
+                    expected_local,
+                    atol=1e-5,
+                    rtol=1e-4,
+                    msg=(
+                        "Muon+M-FSDP diverged from unsharded Muon "
+                        f"on step {step}, param {idx}, rank {dp_rank}"
+                    ),
+                )
+
 
 @_skip_if_single_rank()
 class TestFSDPFactoryIntegration:

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -116,12 +116,23 @@ def _make_dtensor(local_tensor, global_shape, device_mesh):
 
 
 def _attach_fake_mfsdp_bucket_metadata(param, bucket, item_id, offset):
-    bucket.item_index_map[item_id] = SimpleNamespace(global_data_index=offset)
+    bucket.item_index_map[item_id] = SimpleNamespace(
+        global_data_index=offset, size=torch.Size(param.shape).numel()
+    )
     param.orig_param = SimpleNamespace(_gbuf=bucket, _item_id=item_id)
 
 
-def _make_fake_mfsdp_bucket(bucket_id):
-    return SimpleNamespace(item_index_map={}, bucket_index=SimpleNamespace(bucket_id=bucket_id))
+def _make_fake_mfsdp_bucket(bucket_id, dp_rank, dp_size, shard_size):
+    return SimpleNamespace(
+        item_index_map={},
+        is_data_distributed=True,
+        bucket_index=SimpleNamespace(
+            bucket_id=bucket_id, global_data_index=0, size=shard_size * dp_size
+        ),
+        shard_bucket_index=SimpleNamespace(
+            bucket_id=bucket_id, global_data_index=shard_size * dp_rank, size=shard_size
+        ),
+    )
 
 
 class TestGetMFSDPModels:
@@ -259,7 +270,7 @@ class TestFSDPTensorParallelMuon:
             )
             assert not torch.equal(local_value, initial_locals[idx])
 
-    def test_boundary_detector_uses_first_and_last_non_empty_params(self):
+    def test_boundary_detector_without_mfsdp_metadata_includes_all_split_params(self):
         from torch.distributed.device_mesh import init_device_mesh
 
         dp_size = torch.distributed.get_world_size()
@@ -268,9 +279,9 @@ class TestFSDPTensorParallelMuon:
         dp_group = device_mesh.get_group("dp")
         cols = 4
 
-        # Without M-FSDP bucket metadata, the helper treats the group as one
-        # synthetic bucket and only selects the first/last non-empty params.
-        # Real M-FSDP optimizer params exercise bucket-aware detection below.
+        # Without M-FSDP bucket metadata, the safe fallback is to gather every
+        # globally split DTensor. Real M-FSDP optimizer params exercise the
+        # exact flat-interval detection below.
         plans = [{0: 2, 1: 2}, {0: 1, 1: 3}, {0: 3, 1: 1}]
 
         params = []
@@ -281,9 +292,9 @@ class TestFSDPTensorParallelMuon:
 
         optimizer = _make_fsdp_muon(params, dp_group=dp_group)
 
-        assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0, 2}
+        assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0, 1, 2}
 
-    def test_boundary_detector_uses_first_and_last_non_empty_params_per_mfsdp_bucket(self):
+    def test_boundary_detector_uses_mfsdp_flat_item_intervals(self):
         from torch.distributed.device_mesh import init_device_mesh
 
         dp_size = torch.distributed.get_world_size()
@@ -292,10 +303,9 @@ class TestFSDPTensorParallelMuon:
         dp_group = device_mesh.get_group("dp")
         cols = 4
 
-        # Param 2 is split across the rank 0/1 boundary, but it is neither the
-        # first nor last non-empty param in the overall optimizer group on
-        # either rank. It is the only non-empty param in its M-FSDP bucket, so
-        # bucket-aware boundary detection must still select it.
+        # Param 2 is split across the rank 0/1 flat-buffer boundary. The
+        # detector should select it from M-FSDP item interval metadata without
+        # relying on optimizer-group first/last parameter positions.
         plans = [{0: 4}, {1: 4}, {0: 2, 1: 2}, {0: 4}, {1: 4}]
         full_params = []
         full_grads = []
@@ -321,9 +331,9 @@ class TestFSDPTensorParallelMuon:
             param.grad = _make_dtensor(local_grad, full_grad.shape, device_mesh)
 
         buckets = [
-            _make_fake_mfsdp_bucket(0),
-            _make_fake_mfsdp_bucket(1),
-            _make_fake_mfsdp_bucket(2),
+            _make_fake_mfsdp_bucket(0, dp_rank, dp_size, shard_size=4 * cols),
+            _make_fake_mfsdp_bucket(1, dp_rank, dp_size, shard_size=2 * cols),
+            _make_fake_mfsdp_bucket(2, dp_rank, dp_size, shard_size=4 * cols),
         ]
         bucket_assignments = [
             (buckets[0], 0, 0),

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -31,6 +31,11 @@ pytestmark = [
 WORLD_SIZE = int(os.getenv("WORLD_SIZE", "1"))
 
 
+class _FakeFSDP:
+    def __init__(self, module):
+        self.module = module
+
+
 def _skip_if_single_rank():
     return pytest.mark.skipif(WORLD_SIZE <= 1, reason="Multi-rank test requires WORLD_SIZE > 1")
 
@@ -116,23 +121,21 @@ class TestGetMFSDPModels:
 
     def test_extracts_inner_module(self):
         inner_module = MagicMock()
-        chunk = MagicMock()
-        chunk.module = inner_module
-        chunk.finish_grad_sync = MagicMock()
+        chunk = _FakeFSDP(inner_module)
 
-        assert _get_mfsdp_models([chunk]) == [inner_module]
+        with patch("megatron.core.optimizer.FullyShardedDataParallel", _FakeFSDP):
+            assert _get_mfsdp_models([chunk]) == [inner_module]
 
     def test_extracts_from_multiple_chunks(self):
         chunks, inner_modules = [], []
         for _ in range(3):
             inner = MagicMock()
-            chunk = MagicMock()
-            chunk.module = inner
-            chunk.finish_grad_sync = MagicMock()
+            chunk = _FakeFSDP(inner)
             chunks.append(chunk)
             inner_modules.append(inner)
 
-        assert _get_mfsdp_models(chunks) == inner_modules
+        with patch("megatron.core.optimizer.FullyShardedDataParallel", _FakeFSDP):
+            assert _get_mfsdp_models(chunks) == inner_modules
 
 
 @_skip_if_single_rank()

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -202,17 +202,17 @@ class TestFSDPTensorParallelMuon:
                 g1.shape
             ), "boundary param grad should be unevenly sharded (local != global shape)"
 
-        real_gather = optimizer._gather_full_uneven_local_tensor_like
-        gather_shapes = []
+        real_gather = optimizer._gather_full_uneven_local_tensors_like
+        gather_batches = []
 
-        def counting_gather(value, local_tensor):
-            gather_shapes.append(tuple(value.shape))
-            return real_gather(value, local_tensor)
+        def counting_gather(items):
+            gather_batches.append([tuple(value.shape) for value, _ in items])
+            return real_gather(items)
 
-        with patch.object(optimizer, "_gather_full_uneven_local_tensor_like", counting_gather):
+        with patch.object(optimizer, "_gather_full_uneven_local_tensors_like", counting_gather):
             optimizer.step()
 
-        assert gather_shapes == [(6, cols)]
+        assert gather_batches == [[(6, cols)]]
 
         # Post-step: momentum buffers are DTensors in optimizer state.
         for idx, (param, plan) in enumerate(zip(params, plans)):
@@ -298,19 +298,63 @@ class TestFSDPTensorParallelMuon:
 
         optimizer = _make_fsdp_muon(params, dp_group=dp_group)
 
-        real_gather = optimizer._gather_full_uneven_local_tensor_like
+        real_gather = optimizer._gather_full_uneven_local_tensors_like
         gather_calls = []
 
-        def counting_gather(value, local_tensor):
-            gather_calls.append(tuple(value.shape))
-            return real_gather(value, local_tensor)
+        def counting_gather(items):
+            gather_calls.append([tuple(value.shape) for value, _ in items])
+            return real_gather(items)
 
-        with patch.object(optimizer, "_gather_full_uneven_local_tensor_like", counting_gather):
+        with patch.object(optimizer, "_gather_full_uneven_local_tensors_like", counting_gather):
             optimizer.step()
 
         assert (
             gather_calls == []
         ), f"Expected no all-gathers for fully-local params, got {gather_calls}"
+
+    def test_step_batches_multiple_split_boundary_params(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        plans = [{0: 2, 1: 2}, {0: 4}, {0: 3, 1: 1}]
+        full_params = [
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) / 100
+            for rows in (4, 4, 4)
+        ]
+        full_grads = [
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) / 50
+            + 0.1
+            for rows in (4, 4, 4)
+        ]
+
+        params = []
+        for full_param, plan in zip(full_params, plans):
+            local_param = _local_slice(full_param, plan, dp_rank).contiguous()
+            params.append(nn.Parameter(_make_dtensor(local_param, full_param.shape, device_mesh)))
+
+        for param, full_grad, plan in zip(params, full_grads, plans):
+            local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+            param.grad = _make_dtensor(local_grad, full_grad.shape, device_mesh)
+
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
+        assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0, 2}
+
+        real_gather = optimizer._gather_full_uneven_local_tensors_like
+        gather_batches = []
+
+        def counting_gather(items):
+            gather_batches.append([tuple(value.shape) for value, _ in items])
+            return real_gather(items)
+
+        with patch.object(optimizer, "_gather_full_uneven_local_tensors_like", counting_gather):
+            optimizer.step()
+
+        assert gather_batches == [[(4, cols), (4, cols)]]
 
     def test_boundary_metadata_collectives_are_cached_across_steps(self):
         from torch.distributed.device_mesh import init_device_mesh

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -1,13 +1,6 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-"""
-Tests for Muon + Megatron-FSDP integration.
-
-Organized by implementation phase:
-  Phase 1: FSDPMuonChainedOptimizer (protocol adapter, no_shard dispatch)
-  Phase 2: FSDPZeROTensorParallelMuon.orthogonalize() (core allgather -> NS -> reshard)
-  Phase 3: Factory integration + end-to-end
-"""
+"""Tests for Muon + Megatron-FSDP integration."""
 
 import os
 from unittest.mock import MagicMock, patch
@@ -20,175 +13,24 @@ from packaging.version import Version
 from megatron.core.optimizer.emerging_optimizers import (
     FSDPMuonChainedOptimizer,
     FSDPZeROTensorParallelMuon,
+    HAVE_EMERGING_OPTIMIZERS,
     TensorParallelMuon,
     _get_mfsdp_models,
 )
 from tests.unit_tests.test_utilities import Utils
 
-# Skip all tests in this file for LTS versions
-pytestmark = pytest.mark.skipif(
-    Version(os.getenv("NVIDIA_PYTORCH_VERSION", "24.01")) <= Version("25.05"),
-    reason="Skip muon FSDP optimizer for LTS test",
-)
+
+pytestmark = [
+    pytest.mark.skipif(
+        Version(os.getenv("NVIDIA_PYTORCH_VERSION", "99.99")) <= Version("25.05"),
+        reason="Skip Muon FSDP optimizer tests on LTS containers",
+    ),
+    pytest.mark.skipif(
+        not HAVE_EMERGING_OPTIMIZERS, reason="Muon tests require the emerging-optimizers package"
+    ),
+]
 
 WORLD_SIZE = int(os.getenv("WORLD_SIZE", "1"))
-
-
-# Helpers
-
-
-def make_sharded_grad(full_rows, cols, dp_size, dp_rank, seed=42, device="cuda"):
-    """Create full grad and return `(full_grad, padded_grad, local_shard, shard_rows)`.
-
-    The full gradient is split into `dp_size` equal-sized shards along dim-0.
-    When `full_rows` is not divisible by `dp_size`, the last shard is
-    zero-padded so all shards have the same size (mimicking FSDP bucket padding).
-    Both the unpadded (`full_grad`) and padded (`padded_grad`) views are
-    returned so reference computations can choose either.
-    """
-    torch.manual_seed(seed)
-    full_grad = torch.randn(full_rows, cols, device=device, dtype=torch.float32)
-
-    shard_rows = (full_rows + dp_size - 1) // dp_size  # ceil division
-    # Pad full_grad so it can be evenly split
-    padded_rows = shard_rows * dp_size
-    if padded_rows > full_rows:
-        pad = torch.zeros(padded_rows - full_rows, cols, device=device, dtype=torch.float32)
-        padded_grad = torch.cat([full_grad, pad], dim=0)
-    else:
-        padded_grad = full_grad
-
-    local_shard = padded_grad[dp_rank * shard_rows : (dp_rank + 1) * shard_rows].clone()
-    return full_grad, padded_grad, local_shard, shard_rows
-
-
-def make_reference_orthogonalize(full_grad, param_like=None, **muon_kwargs):
-    """Run `TensorParallelMuon.orthogonalize` on full grad as reference.
-
-    Returns the orthogonalized full gradient (plain tensor, no sharding).
-    """
-    if param_like is None:
-        param_like = torch.randn_like(full_grad)
-    opt = TensorParallelMuon(
-        params=[torch.nn.Parameter(param_like)],
-        pg_collection=None,
-        tp_mode="duplicated",
-        **muon_kwargs,
-    )
-    return opt.orthogonalize(param_like, full_grad)
-
-
-def make_dp_device_mesh(dp_size):
-    """Create 1D device mesh for DP-only DTensor tests."""
-    from torch.distributed.device_mesh import init_device_mesh
-
-    return init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
-
-
-# Phase 1: FSDPMuonChainedOptimizer (single-rank, mock-based)
-
-
-class TestPhase1ChainedOptimizer:
-    """Phase 1 tests for FSDPMuonChainedOptimizer protocol adapter."""
-
-    @staticmethod
-    def _make_mfsdp_mock(model_auto_sync=False):
-        """Create a mock MegatronFSDP model."""
-        mock = MagicMock()
-        mock.model_auto_sync = model_auto_sync
-        return mock
-
-    @staticmethod
-    def _make_inner_mock():
-        """Create a mock inner optimizer."""
-        mock = MagicMock()
-        mock.step.return_value = (True, 1.0, 0)
-        return mock
-
-    @pytest.mark.parametrize("model_auto_sync", [True, False])
-    def test_phase1_chained_optimizer_step_protocol(self, model_auto_sync):
-        """Verify step() call order: finish_grad_sync -> inner.step -> install.
-
-        When `model_auto_sync=True`, finish_grad_sync is NOT called (FSDP handles it).
-        """
-        inner = self._make_inner_mock()
-        mfsdp = self._make_mfsdp_mock(model_auto_sync=model_auto_sync)
-        wrapper = FSDPMuonChainedOptimizer(inner, [mfsdp])
-
-        wrapper.step()
-
-        if model_auto_sync:
-            mfsdp.finish_grad_sync.assert_not_called()
-        else:
-            mfsdp.finish_grad_sync.assert_called_once()
-
-        inner.step.assert_called_once()
-        mfsdp.install_optimized_model_weights.assert_called_once()
-
-        if not model_auto_sync:
-            all_calls = []
-            all_calls.append(("finish_grad_sync", mfsdp.finish_grad_sync.call_count))
-            all_calls.append(("step", inner.step.call_count))
-            all_calls.append(("install", mfsdp.install_optimized_model_weights.call_count))
-            assert all(c[1] == 1 for c in all_calls)
-
-    def test_phase1_chained_optimizer_getattr_delegation(self):
-        """Verify attribute delegation to inner optimizer."""
-        inner = self._make_inner_mock()
-        inner.param_groups = [{"lr": 0.01}]
-        inner.state_dict.return_value = {"state": {}, "param_groups": []}
-        mfsdp = self._make_mfsdp_mock()
-
-        wrapper = FSDPMuonChainedOptimizer(inner, [mfsdp])
-
-        assert wrapper.param_groups == [{"lr": 0.01}]
-
-        sd = wrapper.state_dict()
-        inner.state_dict.assert_called_once()
-        assert sd == {"state": {}, "param_groups": []}
-
-        wrapper.load_state_dict({"state": {}, "param_groups": []})
-        inner.load_state_dict.assert_called_once()
-
-    @pytest.mark.parametrize("set_to_none", [True, False])
-    def test_phase1_chained_optimizer_zero_grad(self, set_to_none):
-        """Verify zero_grad delegates to inner with correct args."""
-        inner = self._make_inner_mock()
-        mfsdp = self._make_mfsdp_mock()
-        wrapper = FSDPMuonChainedOptimizer(inner, [mfsdp])
-
-        wrapper.zero_grad(set_to_none=set_to_none)
-        inner.zero_grad.assert_called_once_with(set_to_none)
-
-    def test_phase1_get_mfsdp_models_error(self):
-        """`_get_mfsdp_models` raises RuntimeError for non-FSDP modules."""
-        with pytest.raises(RuntimeError, match="Could not find any MegatronFSDP"):
-            _get_mfsdp_models([nn.Module()])
-
-    def test_phase1_get_mfsdp_models_success(self):
-        """`_get_mfsdp_models` extracts inner module from FSDP-wrapped chunks."""
-        inner_module = MagicMock()
-        chunk = MagicMock()
-        chunk.module = inner_module
-        chunk.finish_grad_sync = MagicMock()
-
-        result = _get_mfsdp_models([chunk])
-        assert result == [inner_module]
-
-    def test_phase1_multiple_mfsdp_models(self):
-        """`step()` calls finish_grad_sync and install on ALL mfsdp models."""
-        inner = self._make_inner_mock()
-        mfsdps = [self._make_mfsdp_mock(model_auto_sync=False) for _ in range(3)]
-        wrapper = FSDPMuonChainedOptimizer(inner, mfsdps)
-
-        wrapper.step()
-
-        for mfsdp in mfsdps:
-            mfsdp.finish_grad_sync.assert_called_once()
-            mfsdp.install_optimized_model_weights.assert_called_once()
-
-
-# Phase 2: FSDPZeROTensorParallelMuon.orthogonalize() (multi-rank)
 
 
 def _skip_if_single_rank():
@@ -202,310 +44,264 @@ def _skip_if_no_dtensor():
     )
 
 
+def _make_fsdp_muon(params, dp_group=None, **kwargs):
+    defaults = dict(
+        lr=0.05,
+        momentum=0.0,
+        nesterov=False,
+        weight_decay=0.0,
+        num_ns_steps=2,
+        pg_collection=None,
+        tp_mode="duplicated",
+        split_qkv=False,
+    )
+    defaults.update(kwargs)
+    return FSDPZeROTensorParallelMuon(params=params, dp_group=dp_group, **defaults)
+
+
+def _reference_update(full_grad, **kwargs):
+    from emerging_optimizers import utils
+
+    defaults = dict(
+        lr=0.05,
+        momentum=0.0,
+        nesterov=False,
+        weight_decay=0.0,
+        num_ns_steps=2,
+        pg_collection=None,
+        tp_mode="duplicated",
+        split_qkv=False,
+    )
+    defaults.update(kwargs)
+    param = nn.Parameter(torch.zeros_like(full_grad))
+    optimizer = TensorParallelMuon(params=[param], **defaults)
+    with utils.fp32_matmul_precision(optimizer.fp32_matmul_prec):
+        return optimizer.orthogonalize(param, full_grad)
+
+
+def _local_rows(plan, rank):
+    return plan.get(rank, 0)
+
+
+def _local_slice(full_tensor, plan, rank):
+    start = sum(_local_rows(plan, r) for r in range(rank))
+    rows = _local_rows(plan, rank)
+    return full_tensor[start : start + rows].clone()
+
+
+def _make_dtensor(local_tensor, global_shape, device_mesh):
+    from torch.distributed.tensor import DTensor, Shard
+
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+        update_uneven_dtensor_chunk_metadata,
+    )
+
+    global_stride = torch.empty(
+        global_shape, dtype=local_tensor.dtype, device=local_tensor.device
+    ).stride()
+    dtensor = DTensor.from_local(
+        local_tensor=local_tensor,
+        device_mesh=device_mesh,
+        placements=[Shard(0)],
+        shape=torch.Size(global_shape),
+        stride=global_stride,
+        run_check=False,
+    )
+    update_uneven_dtensor_chunk_metadata(dtensor)
+    return dtensor
+
+
+class TestFSDPMuonChainedOptimizer:
+    @staticmethod
+    def _make_mfsdp_mock(model_auto_sync=False):
+        mock = MagicMock()
+        mock.model_auto_sync = model_auto_sync
+        return mock
+
+    @staticmethod
+    def _make_inner_mock():
+        mock = MagicMock()
+        mock.step.return_value = (True, 1.0, 0)
+        return mock
+
+    @pytest.mark.parametrize("model_auto_sync", [True, False])
+    def test_step_protocol(self, model_auto_sync):
+        inner = self._make_inner_mock()
+        mfsdp = self._make_mfsdp_mock(model_auto_sync=model_auto_sync)
+        wrapper = FSDPMuonChainedOptimizer(inner, [mfsdp])
+
+        wrapper.step()
+
+        if model_auto_sync:
+            mfsdp.finish_grad_sync.assert_not_called()
+        else:
+            mfsdp.finish_grad_sync.assert_called_once()
+        inner.step.assert_called_once()
+        mfsdp.install_optimized_model_weights.assert_called_once()
+
+    def test_getattr_delegation(self):
+        inner = self._make_inner_mock()
+        inner.param_groups = [{"lr": 0.01}]
+        inner.state_dict.return_value = {"state": {}, "param_groups": []}
+        wrapper = FSDPMuonChainedOptimizer(inner, [self._make_mfsdp_mock()])
+
+        assert wrapper.param_groups == [{"lr": 0.01}]
+        assert wrapper.state_dict() == {"state": {}, "param_groups": []}
+
+        wrapper.load_state_dict({"state": {}, "param_groups": []})
+        inner.load_state_dict.assert_called_once()
+
+    @pytest.mark.parametrize("set_to_none", [True, False])
+    def test_zero_grad_delegates(self, set_to_none):
+        inner = self._make_inner_mock()
+        wrapper = FSDPMuonChainedOptimizer(inner, [self._make_mfsdp_mock()])
+
+        wrapper.zero_grad(set_to_none=set_to_none)
+
+        inner.zero_grad.assert_called_once_with(set_to_none)
+
+    def test_get_mfsdp_models_error(self):
+        with pytest.raises(RuntimeError, match="Could not find any MegatronFSDP"):
+            _get_mfsdp_models([nn.Module()])
+
+    def test_get_mfsdp_models_success(self):
+        inner_module = MagicMock()
+        chunk = MagicMock()
+        chunk.module = inner_module
+        chunk.finish_grad_sync = MagicMock()
+
+        assert _get_mfsdp_models([chunk]) == [inner_module]
+
+
 @_skip_if_single_rank()
-class TestPhase2Orthogonalize:
-    """Phase 2 tests for FSDPZeROTensorParallelMuon.orthogonalize().
-
-    These are the most critical tests verifying mathematical correctness
-    of the allgather -> Newton-Schulz -> reshard cycle.
-    """
-
+@_skip_if_no_dtensor()
+class TestFSDPZeROTensorParallelMuon:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
-        """Initialize distributed for multi-rank tests."""
         Utils.initialize_model_parallel()
         yield
         Utils.destroy_model_parallel()
 
-    def _make_fsdp_muon(self, dp_group=None, **kwargs):
-        """Create an FSDPZeROTensorParallelMuon with a dummy param."""
-        defaults = dict(
-            lr=0.01,
-            momentum=0.95,
-            weight_decay=0.0,
-            num_ns_steps=5,
-            pg_collection=None,
-            tp_mode="duplicated",
-        )
-        defaults.update(kwargs)
-        dummy = torch.nn.Parameter(torch.randn(4, 4, device="cuda"))
-        return FSDPZeROTensorParallelMuon(params=[dummy], dp_group=dp_group, **defaults)
+    def test_step_gathers_only_split_boundary_params(self):
+        from torch.distributed.device_mesh import init_device_mesh
 
-    def test_phase2_orthogonalize_fallback_dp_group_none(self):
-        """`dp_group=None` delegates to parent `TensorParallelMuon.orthogonalize`."""
-        M, C = 64, 32
-        torch.manual_seed(42)
-        grad = torch.randn(M, C, device="cuda")
-        p = torch.randn(M, C, device="cuda")
+        from megatron.core.optimizer import emerging_optimizers as eopt_mod
 
-        fsdp_muon = self._make_fsdp_muon(dp_group=None)
-        result_fsdp = fsdp_muon.orthogonalize(p, grad.clone())
-
-        ref_result = make_reference_orthogonalize(grad.clone(), param_like=p)
-
-        torch.testing.assert_close(result_fsdp, ref_result, atol=1e-6, rtol=1e-5)
-
-    @pytest.mark.parametrize("shape", [(64, 32), (48, 24), (100, 50)])
-    def test_phase2_orthogonalize_correctness_plain_tensors(self, shape):
-        """Core invariant: allgather -> NS -> reshard == NS(padded_G)[shard_slice].
-
-        `FSDPZeROTensorParallelMuon` runs Newton-Schulz on the *padded* full
-        matrix because (a) production FSDP feeds it the padded global DTensor
-        shape and (b) `get_muon_scale_factor` is dimension-dependent, so the
-        scale only matches if both reference and code see the same padded
-        dimensions. We therefore reference NS on `padded_grad`, not on the
-        unpadded `full_grad`.
-        """
-        M, C = shape
-        dp_group = torch.distributed.group.WORLD
         dp_size = torch.distributed.get_world_size()
         dp_rank = torch.distributed.get_rank()
-
-        _, padded_grad, local_shard, shard_rows = make_sharded_grad(M, C, dp_size, dp_rank, seed=42)
-
-        ref_full = make_reference_orthogonalize(padded_grad)
-        start = dp_rank * shard_rows
-        end = start + shard_rows
-        ref_shard = ref_full[start:end]
-
-        p = torch.randn(shard_rows, C, device="cuda")
-        fsdp_muon = self._make_fsdp_muon(dp_group=dp_group)
-        result = fsdp_muon.orthogonalize(p, local_shard)
-
-        torch.testing.assert_close(result, ref_shard, atol=1e-5, rtol=1e-4)
-
-    @pytest.mark.parametrize("M", [30, 31, 33])
-    def test_phase2_orthogonalize_padding_correctness(self, M):
-        """Padding correctness when `M % dp_size != 0`.
-
-        Per the design described in
-        `test_phase2_orthogonalize_correctness_plain_tensors`, the
-        reference runs NS on the *padded* matrix so that scale-factor and NS
-        cycle dimensions agree. We therefore expect `result` to match the
-        padded reference for the entire shard (real and padding rows alike).
-        """
-        C = 16
-        dp_group = torch.distributed.group.WORLD
-        dp_size = torch.distributed.get_world_size()
-        dp_rank = torch.distributed.get_rank()
-
-        _, padded_grad, local_shard, shard_rows = make_sharded_grad(
-            M, C, dp_size, dp_rank, seed=123
-        )
-
-        ref_full = make_reference_orthogonalize(padded_grad)
-        start = dp_rank * shard_rows
-        end = start + shard_rows
-        ref_shard = ref_full[start:end]
-
-        p = torch.randn(shard_rows, C, device="cuda")
-        fsdp_muon = self._make_fsdp_muon(dp_group=dp_group)
-        result = fsdp_muon.orthogonalize(p, local_shard)
-
-        torch.testing.assert_close(result, ref_shard, atol=1e-5, rtol=1e-4)
-
-    @_skip_if_no_dtensor()
-    @pytest.mark.parametrize("shape", [(64, 32), (48, 24)])
-    def test_phase2_orthogonalize_dtensor_output_invariants(self, shape):
-        """DTensor input produces DTensor output with correct metadata.
-
-        Input: Shard(0) DTensor on a 1D DP device mesh.
-        Output: must be DTensor with same device_mesh, placements, global shape.
-        Also verifies mathematical correctness.
-        """
-        from torch.distributed.tensor import DTensor, Shard
-
-        M, C = shape
-        dp_size = torch.distributed.get_world_size()
-        dp_rank = torch.distributed.get_rank()
-        device_mesh = make_dp_device_mesh(dp_size)
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
         dp_group = device_mesh.get_group("dp")
+        cols = 4
 
-        _, padded_grad, local_shard, shard_rows = make_sharded_grad(M, C, dp_size, dp_rank, seed=42)
+        # Param 0 is fully local on rank 0. Param 1 crosses the rank 0/1
+        # boundary. Param 2 is fully local on rank 1. Other ranks hold empty
+        # local shards and still participate in the boundary gather for param 1.
+        plans = [{0: 4}, {0: 2, 1: 4}, {1: 5}]
+        full_params = [
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) / 100
+            for rows in (4, 6, 5)
+        ]
+        full_grads = [
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) / 50
+            + 0.1
+            for rows in (4, 6, 5)
+        ]
 
-        # The global shape is declared as `(shard_rows * dp_size, C)` to match
-        # the padded total; FSDP bucket padding makes all shards equal.
-        padded_rows = shard_rows * dp_size
-        grad_dtensor = DTensor.from_local(
-            local_shard,
-            device_mesh=device_mesh,
-            placements=[Shard(0)],
-            shape=torch.Size([padded_rows, C]),
-            stride=local_shard.stride(),
-            run_check=False,
-        )
+        params = []
+        initial_locals = []
+        for full_param, plan in zip(full_params, plans):
+            local_param = _local_slice(full_param, plan, dp_rank).contiguous()
+            param = nn.Parameter(_make_dtensor(local_param, full_param.shape, device_mesh))
+            params.append(param)
+            initial_locals.append(local_param.clone())
 
-        # Param is also a DTensor: `FSDPZeROTensorParallelMuon` reads
-        # `p.shape[0]` for the DTensor path.
-        p_local = torch.randn(shard_rows, C, device="cuda")
-        p_dtensor = DTensor.from_local(
-            p_local,
-            device_mesh=device_mesh,
-            placements=[Shard(0)],
-            shape=torch.Size([padded_rows, C]),
-            stride=p_local.stride(),
-            run_check=False,
-        )
+        for param, full_grad, plan in zip(params, full_grads, plans):
+            local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+            param.grad = _make_dtensor(local_grad, full_grad.shape, device_mesh)
 
-        fsdp_muon = self._make_fsdp_muon(dp_group=dp_group)
-        result = fsdp_muon.orthogonalize(p_dtensor, grad_dtensor)
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
+        assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {1}
 
-        assert isinstance(result, DTensor), "Output should be a DTensor"
-        assert result.device_mesh == device_mesh, "Device mesh should match"
-        assert result.placements == grad_dtensor.placements, "Placements should match"
-        assert result.shape == grad_dtensor.shape, "Global shape should match"
-        assert result.to_local().shape == local_shard.shape, "Local shape should match shard"
+        real_gather = eopt_mod.gather_uneven_dtensor_to_full_tensor
+        gather_shapes = []
 
-        ref_full = make_reference_orthogonalize(padded_grad)
-        start = dp_rank * shard_rows
-        end = start + shard_rows
-        ref_shard = ref_full[start:end]
+        def counting_gather(value):
+            gather_shapes.append(tuple(value.shape))
+            return real_gather(value)
 
-        torch.testing.assert_close(result.to_local(), ref_shard, atol=1e-5, rtol=1e-4)
-
-    @pytest.mark.parametrize("shape", [(64, 32), (48, 24)])
-    def test_phase2_full_step_cycle_plain_tensors(self, shape):
-        """Full FSDPZeROTensorParallelMuon.step() cycles with plain tensors.
-
-        Runs 3 complete optimization steps through the
-        `OrthogonalizedOptimizer.step()` path, testing the full chain:
-        momentum -> Nesterov -> orthogonalize -> `p.add_()`.
-        """
-        M, C = shape
-        dp_group = torch.distributed.group.WORLD
-        dp_size = torch.distributed.get_world_size()
-
-        shard_rows = (M + dp_size - 1) // dp_size
-
-        torch.manual_seed(42)
-        p = torch.nn.Parameter(torch.randn(shard_rows, C, device="cuda"))
-
-        optimizer = FSDPZeROTensorParallelMuon(
-            params=[p],
-            dp_group=dp_group,
-            lr=0.01,
-            momentum=0.95,
-            weight_decay=0.0,
-            num_ns_steps=5,
-            pg_collection=None,
-            tp_mode="duplicated",
-        )
-
-        weights_history = [p.data.clone()]
-        for step_i in range(3):
-            torch.manual_seed(100 + step_i)
-            p.grad = torch.randn_like(p)
-
+        with patch.object(eopt_mod, "gather_uneven_dtensor_to_full_tensor", counting_gather):
             optimizer.step()
-            optimizer.zero_grad(set_to_none=True)
-            weights_history.append(p.data.clone())
 
-        for i in range(len(weights_history) - 1):
-            assert not torch.equal(
-                weights_history[i], weights_history[i + 1]
-            ), f"Weight should change at step {i}"
+        assert gather_shapes == [(6, cols)]
 
-    @_skip_if_no_dtensor()
-    @pytest.mark.parametrize("shape", [(64, 32), (48, 24)])
-    def test_phase2_full_step_cycle_dtensors(self, shape):
-        """Full step() cycles with Shard(0) DTensor params and grads.
+        lr = optimizer.param_groups[0]["lr"]
+        for idx, (param, full_param, full_grad, plan) in enumerate(
+            zip(params, full_params, full_grads, plans)
+        ):
+            expected_update = _reference_update(full_grad)
+            expected_local = _local_slice(full_param - lr * expected_update, plan, dp_rank)
+            local_value = param.data.to_local()
 
-        Critical integration test for the DTensor return-type fix:
-        `p.add_(orthogonalized_dtensor)` must work without dispatch errors.
-        """
-        from torch.distributed.tensor import DTensor, Shard
+            if local_value.numel() == 0:
+                assert local_value.shape[0] == 0
+                continue
 
-        M, C = shape
+            torch.testing.assert_close(
+                local_value,
+                expected_local,
+                atol=1e-5,
+                rtol=1e-4,
+                msg=f"param {idx} local update mismatch on rank {dp_rank}",
+            )
+            assert not torch.equal(local_value, initial_locals[idx])
+
+    def test_boundary_detector_includes_middle_split_params(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
         dp_size = torch.distributed.get_world_size()
-        device_mesh = make_dp_device_mesh(dp_size)
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
         dp_group = device_mesh.get_group("dp")
+        cols = 4
 
-        shard_rows = (M + dp_size - 1) // dp_size
-        padded_rows = shard_rows * dp_size
+        # Optimizer groups can exclude Adam-managed tensors that are present in
+        # the underlying M-FSDP flat buffer. After that filtering, a split Muon
+        # tensor is not guaranteed to be first or last in the Muon param group.
+        plans = [{0: 2, 1: 2}, {0: 1, 1: 3}, {0: 3, 1: 1}]
 
-        torch.manual_seed(42)
-        p_local = torch.randn(shard_rows, C, device="cuda")
-        p_dtensor = torch.nn.Parameter(
-            DTensor.from_local(
-                p_local,
-                device_mesh=device_mesh,
-                placements=[Shard(0)],
-                shape=torch.Size([padded_rows, C]),
-                stride=p_local.stride(),
-                run_check=False,
-            )
-        )
-        initial_local = p_dtensor.data.to_local().clone()
+        params = []
+        for plan in plans:
+            full_param = torch.zeros(sum(plan.values()), cols, device="cuda")
+            local_param = _local_slice(full_param, plan, dp_rank).contiguous()
+            params.append(nn.Parameter(_make_dtensor(local_param, full_param.shape, device_mesh)))
 
-        optimizer = FSDPZeROTensorParallelMuon(
-            params=[p_dtensor],
-            dp_group=dp_group,
-            lr=0.01,
-            momentum=0.95,
-            weight_decay=0.0,
-            num_ns_steps=5,
-            pg_collection=None,
-            tp_mode="duplicated",
-        )
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
 
-        for step_i in range(3):
-            torch.manual_seed(200 + step_i)
-            grad_local = torch.randn(shard_rows, C, device="cuda")
-            p_dtensor.grad = DTensor.from_local(
-                grad_local,
-                device_mesh=device_mesh,
-                placements=[Shard(0)],
-                shape=torch.Size([padded_rows, C]),
-                stride=grad_local.stride(),
-                run_check=False,
-            )
-            optimizer.step()
-            optimizer.zero_grad(set_to_none=True)
-
-        final_local = p_dtensor.data.to_local()
-        assert not torch.equal(
-            final_local, initial_local
-        ), "DTensor param should be updated after 3 steps"
-        assert isinstance(p_dtensor.data, DTensor), "Param should remain a DTensor"
-
-
-# Phase 3: Factory integration + end-to-end
+        assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0, 1, 2}
 
 
 @_skip_if_single_rank()
-class TestPhase3FactoryIntegration:
-    """Phase 3 tests for `_build_megatron_fsdp_emerging_optimizer` factory."""
-
+class TestFSDPFactoryIntegration:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
-        """Initialize distributed for multi-rank tests."""
         Utils.initialize_model_parallel()
         yield
         Utils.destroy_model_parallel()
 
     @pytest.mark.parametrize("strategy", ["no_shard", "optim", "optim_grads", "optim_grads_params"])
-    def test_phase3_factory_dispatches_correct_muon_cls(self, strategy):
-        """Factory dispatches `TensorParallelMuon` for "no_shard",
-        `FSDPZeROTensorParallelMuon` otherwise.
-
-        Uses mocks to avoid needing a real FSDP-wrapped model for the dispatch logic.
-        """
+    def test_factory_dispatches_correct_muon_cls(self, strategy):
         from megatron.core.optimizer import OptimizerConfig, _build_megatron_fsdp_emerging_optimizer
         from megatron.core.process_groups_config import ProcessGroupCollection
+        from megatron.core.optimizer.optimizer import ChainedOptimizer, FP32Optimizer
 
         model_chunk = MagicMock()
         model_chunk.config.num_attention_heads = 8
         model_chunk.config.num_query_groups = 8
         model_chunk.config.kv_channels = 16
 
-        # 2D linear param (Muon-managed).
-        linear_weight = torch.nn.Parameter(torch.randn(32, 16, device="cuda"))
-        linear_weight.requires_grad = True
+        linear_weight = nn.Parameter(torch.randn(32, 16, device="cuda"))
         linear_weight.is_embedding_or_output_parameter = False
-
-        # 1D bias (routed to Adam by the default param overrides).
-        bias_param = torch.nn.Parameter(torch.randn(32, device="cuda"))
-        bias_param.requires_grad = True
+        bias_param = nn.Parameter(torch.randn(32, device="cuda"))
         bias_param.is_embedding_or_output_parameter = False
 
         model_chunk.named_parameters.return_value = [
@@ -513,7 +309,6 @@ class TestPhase3FactoryIntegration:
             ("layer.linear.bias", bias_param),
         ]
         model_chunk.parameters.return_value = iter([linear_weight, bias_param])
-
         model_chunk.ddp_config.use_megatron_fsdp = True
         model_chunk.ddp_config.data_parallel_sharding_strategy = strategy
 
@@ -533,12 +328,8 @@ class TestPhase3FactoryIntegration:
             muon_split_qkv=False,
             muon_extra_scale_factor=1.0,
         )
-
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
-        # `_get_param_groups` would call into Megatron internals
-        # (`get_global_unique_param_name` etc.) that don't work on MagicMock
-        # chunks, so we stub it out with a minimal one-group fake.
         def fake_get_param_groups(model_chunks, config, overrides):
             return [
                 {
@@ -549,10 +340,6 @@ class TestPhase3FactoryIntegration:
                 }
             ]
 
-        # Mock get_megatron_optimizer to avoid full FSDP setup for Adam. Pin
-        # the mocked sub-optimizer's `config` to the real config so the
-        # ChainedOptimizer assertion that all sub-optimizers share a config
-        # passes (defaults would auto-spawn a fresh MagicMock that is unequal).
         with patch("megatron.core.optimizer._get_param_groups", side_effect=fake_get_param_groups):
             with patch("megatron.core.optimizer.get_megatron_optimizer") as mock_get_opt:
                 mock_adam = MagicMock()
@@ -560,10 +347,7 @@ class TestPhase3FactoryIntegration:
                 mock_adam_sub.config = config
                 mock_adam.chained_optimizers = [mock_adam_sub]
                 mock_get_opt.return_value = mock_adam
-
-                with patch("megatron.core.optimizer._get_mfsdp_models") as mock_mfsdp:
-                    mock_mfsdp.return_value = [MagicMock()]
-
+                with patch("megatron.core.optimizer._get_mfsdp_models", return_value=[MagicMock()]):
                     result = _build_megatron_fsdp_emerging_optimizer(
                         config=config,
                         model_chunks=[model_chunk],
@@ -574,15 +358,11 @@ class TestPhase3FactoryIntegration:
                     )
 
         assert isinstance(result, FSDPMuonChainedOptimizer)
-
-        from megatron.core.optimizer.optimizer import ChainedOptimizer, FP32Optimizer
-
         inner = object.__getattribute__(result, "inner")
         assert isinstance(inner, ChainedOptimizer)
 
         muon_wrapper = inner.chained_optimizers[0]
         assert isinstance(muon_wrapper, FP32Optimizer)
-
         base_opt = muon_wrapper.optimizer
         if strategy == "no_shard":
             assert isinstance(base_opt, TensorParallelMuon)
@@ -590,109 +370,3 @@ class TestPhase3FactoryIntegration:
         else:
             assert isinstance(base_opt, FSDPZeROTensorParallelMuon)
             assert base_opt.dp_group is not None
-
-    def test_phase3_factory_expert_dp_group(self):
-        """Verify expert Muon uses `expt_dp` group, non-expert uses `dp_cp`."""
-        from megatron.core.optimizer import OptimizerConfig, _build_megatron_fsdp_emerging_optimizer
-        from megatron.core.process_groups_config import ProcessGroupCollection
-
-        model_chunk = MagicMock()
-        model_chunk.config.num_attention_heads = 8
-        model_chunk.config.num_query_groups = 8
-        model_chunk.config.kv_channels = 16
-
-        linear_weight = torch.nn.Parameter(torch.randn(32, 16, device="cuda"))
-        linear_weight.requires_grad = True
-        linear_weight.is_embedding_or_output_parameter = False
-
-        expert_weight = torch.nn.Parameter(torch.randn(32, 16, device="cuda"))
-        expert_weight.requires_grad = True
-        expert_weight.is_embedding_or_output_parameter = False
-
-        model_chunk.named_parameters.return_value = [
-            ("layer.linear.weight", linear_weight),
-            ("layer.experts.0.linear.weight", expert_weight),
-        ]
-        model_chunk.parameters.return_value = iter([linear_weight, expert_weight])
-
-        model_chunk.ddp_config.use_megatron_fsdp = True
-        model_chunk.ddp_config.data_parallel_sharding_strategy = "optim"
-
-        config = OptimizerConfig(
-            optimizer="muon",
-            lr=0.01,
-            weight_decay=0.01,
-            bf16=False,
-            fp16=False,
-            use_distributed_optimizer=False,
-            muon_momentum=0.95,
-            muon_nesterov=True,
-            muon_fp32_matmul_prec="medium",
-            muon_num_ns_steps=5,
-            muon_scale_mode="spectral",
-            muon_tp_mode="duplicated",
-            muon_split_qkv=False,
-            muon_extra_scale_factor=1.0,
-        )
-
-        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
-
-        def fake_get_param_groups(model_chunks, config, overrides):
-            groups = []
-            for chunk in model_chunks:
-                for name, param in chunk.named_parameters():
-                    if not param.requires_grad:
-                        continue
-                    if len(param.shape) != 2:
-                        continue
-                    is_expert = "experts" in name and "shared" not in name
-                    groups.append(
-                        {
-                            "params": [param],
-                            "is_expert_parallel": is_expert,
-                            "wd_mult": 1.0,
-                            "lr_mult": 1.0,
-                        }
-                    )
-            return groups
-
-        with patch("megatron.core.optimizer._get_param_groups", side_effect=fake_get_param_groups):
-            with patch("megatron.core.optimizer.get_megatron_optimizer") as mock_get_opt:
-                mock_adam = MagicMock()
-                mock_adam_sub = MagicMock()
-                mock_adam_sub.config = config
-                mock_adam.chained_optimizers = [mock_adam_sub]
-                mock_get_opt.return_value = mock_adam
-
-                with patch("megatron.core.optimizer._get_mfsdp_models") as mock_mfsdp:
-                    mock_mfsdp.return_value = [MagicMock()]
-
-                    result = _build_megatron_fsdp_emerging_optimizer(
-                        config=config,
-                        model_chunks=[model_chunk],
-                        config_overrides={},
-                        pg_collection=pg_collection,
-                        eopt_name="muon",
-                        use_layer_wise=False,
-                    )
-
-        from megatron.core.optimizer.optimizer import ChainedOptimizer, FP32Optimizer
-
-        inner = object.__getattribute__(result, "inner")
-        assert isinstance(inner, ChainedOptimizer)
-
-        # Expect at least 3 optimizers: non-expert Muon, expert Muon, Adam.
-        assert len(inner.chained_optimizers) >= 3, (
-            f"Expected >= 3 chained optimizers (muon + expert_muon + adam), "
-            f"got {len(inner.chained_optimizers)}"
-        )
-
-        non_expert_muon = inner.chained_optimizers[0]
-        assert isinstance(non_expert_muon, FP32Optimizer)
-        assert isinstance(non_expert_muon.optimizer, FSDPZeROTensorParallelMuon)
-        assert non_expert_muon.optimizer.dp_group == pg_collection.dp_cp
-
-        expert_muon = inner.chained_optimizers[1]
-        assert isinstance(expert_muon, FP32Optimizer)
-        assert isinstance(expert_muon.optimizer, FSDPZeROTensorParallelMuon)
-        assert expert_muon.optimizer.dp_group == pg_collection.expt_dp

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -804,6 +804,59 @@ class TestFSDPTensorParallelMuon:
         assert optimizer._mfsdp_param_crosses_shard_boundary(param, 0) is False
         assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0}
 
+    @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP boundary test requires at least 4 ranks")
+    def test_hfsdp_boundary_detector_uses_dtensor_shard_groups_not_optimizer_dp_group(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        outer_size = 2
+        inner_size = dp_size // outer_size
+        if dp_size % outer_size != 0:
+            pytest.skip("HFSDP boundary test requires an even world size")
+
+        device_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("outer_fsdp_dp", "dp_cp")
+        )
+        outer_rank, inner_rank = device_mesh.get_coordinate()
+        logical_rank = inner_rank * outer_size + outer_rank
+
+        rows, cols = dp_size * 2 + 1, 4
+        full_param = torch.zeros(rows, cols, device="cuda")
+        rows_per_logical_rank = [
+            rows // dp_size + (1 if rank < rows % dp_size else 0) for rank in range(dp_size)
+        ]
+        row_start = sum(rows_per_logical_rank[:logical_rank])
+        row_count = rows_per_logical_rank[logical_rank]
+        local_param = full_param[row_start : row_start + row_count].contiguous()
+        param = nn.Parameter(_make_hfsdp_dtensor(local_param, full_param.shape, device_mesh))
+
+        # The fake flat bucket metadata says the item does not cross an inner
+        # FSDP boundary. The DTensor itself is sharded on both inner and outer
+        # HFSDP dimensions, so boundary-index agreement must not be limited to
+        # the optimizer's inner-DP group.
+        bucket = _make_fake_mfsdp_bucket(
+            bucket_id=0,
+            dp_rank=torch.distributed.get_rank(),
+            dp_size=dp_size,
+            shard_size=full_param.numel() * 2,
+        )
+        _attach_fake_mfsdp_bucket_metadata(param, bucket, item_id=0, offset=0)
+
+        inner_group = device_mesh.get_group("dp_cp")
+        optimizer = _make_fsdp_muon([param], dp_group=inner_group)
+
+        seen_group_ranks = []
+        real_all_gather_object = torch.distributed.all_gather_object
+
+        def recording_all_gather_object(output_list, obj, group=None):
+            seen_group_ranks.append(tuple(torch.distributed.get_process_group_ranks(group)))
+            return real_all_gather_object(output_list, obj, group=group)
+
+        with patch("torch.distributed.all_gather_object", recording_all_gather_object):
+            assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0}
+
+        assert len(set(seen_group_ranks)) == 2
+
     def test_step_batches_multiple_split_boundary_params(self):
         from torch.distributed.device_mesh import init_device_mesh
 

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -848,6 +848,84 @@ class TestFSDPTensorParallelMuon:
 
         assert gather_batches == [[(4, cols), (4, cols)]]
 
+    def test_overlap_path_starts_boundary_gather_before_local_updates(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        replicated_param = (
+            torch.arange(4 * cols, device="cuda", dtype=torch.float32).view(4, cols) / 100
+        )
+        replicated_grad = replicated_param + 0.2
+        plan = {0: 2, 1: 4}
+        boundary_param = (
+            torch.arange(6 * cols, device="cuda", dtype=torch.float32).view(6, cols) / 80
+        )
+        boundary_grad = boundary_param + 0.3
+
+        local_boundary_param = _local_slice(boundary_param, plan, dp_rank).contiguous()
+        params = [
+            nn.Parameter(
+                _make_replicated_dtensor(
+                    replicated_param.clone(), replicated_param.shape, device_mesh
+                )
+            ),
+            nn.Parameter(_make_dtensor(local_boundary_param, boundary_param.shape, device_mesh)),
+        ]
+        params[0].grad = _make_replicated_dtensor(
+            replicated_grad.clone(), replicated_grad.shape, device_mesh
+        )
+        params[1].grad = _make_dtensor(
+            _local_slice(boundary_grad, plan, dp_rank).contiguous(),
+            boundary_grad.shape,
+            device_mesh,
+        )
+
+        optimizer = _make_fsdp_muon(
+            params,
+            dp_group=dp_group,
+            fsdp_batched_all_gather=True,
+            fsdp_reuse_gather_scratch=True,
+            fsdp_padded_all_gather=True,
+            fsdp_padded_all_gather_pad_factor=1000,
+            fsdp_overlap_comm_compute=True,
+        )
+        events = []
+        real_start = optimizer._start_gather_full_uneven_local_tensor_batch_async
+        real_finish = optimizer._finish_gather_full_uneven_local_tensor_batch_async
+        real_apply = optimizer._apply_precomputed_muon_update
+
+        def recording_start(*args, **kwargs):
+            events.append("start")
+            return real_start(*args, **kwargs)
+
+        def recording_finish(*args, **kwargs):
+            events.append("finish")
+            return real_finish(*args, **kwargs)
+
+        def recording_apply(p, pre_ns_grad, is_gathered, lr, group_kwargs):
+            events.append("apply_gathered" if is_gathered else "apply_local")
+            return real_apply(p, pre_ns_grad, is_gathered, lr, group_kwargs)
+
+        with (
+            patch.object(
+                optimizer, "_start_gather_full_uneven_local_tensor_batch_async", recording_start
+            ),
+            patch.object(
+                optimizer, "_finish_gather_full_uneven_local_tensor_batch_async", recording_finish
+            ),
+            patch.object(optimizer, "_apply_precomputed_muon_update", recording_apply),
+        ):
+            optimizer.step()
+
+        assert events[0] == "start"
+        assert events.index("start") < events.index("apply_local") < events.index("finish")
+        assert events.index("finish") < events.index("apply_gathered")
+
     def test_padded_batch_gather_matches_uneven_batch_and_reuses_scratch(self):
         from torch.distributed.device_mesh import init_device_mesh
 
@@ -896,14 +974,14 @@ class TestFSDPTensorParallelMuon:
             fsdp_reuse_gather_scratch=True,
         )
         padded_calls = []
-        real_padded_gather = padded_optimizer._all_gather_padded_equal_size
+        real_prepare_padded_buffers = padded_optimizer._prepare_padded_all_gather_buffers
 
-        def counting_padded_gather(*args, **kwargs):
+        def counting_prepare_padded_buffers(*args, **kwargs):
             padded_calls.append(args[1])
-            return real_padded_gather(*args, **kwargs)
+            return real_prepare_padded_buffers(*args, **kwargs)
 
         with patch.object(
-            padded_optimizer, "_all_gather_padded_equal_size", counting_padded_gather
+            padded_optimizer, "_prepare_padded_all_gather_buffers", counting_prepare_padded_buffers
         ):
             padded_results = padded_optimizer._gather_full_uneven_local_tensors_like(items)
             scratch_bytes_after_first = padded_optimizer._fsdp_gather_scratch_cache_bytes()
@@ -994,10 +1072,12 @@ class TestFSDPTensorParallelMuon:
             fsdp_padded_all_gather_pad_factor=1.0,
         )
 
-        def fail_padded_gather(*_args, **_kwargs):
+        def fail_prepare_padded_buffers(*_args, **_kwargs):
             raise AssertionError("padding threshold should select the uneven gather path")
 
-        with patch.object(optimizer, "_all_gather_padded_equal_size", fail_padded_gather):
+        with patch.object(
+            optimizer, "_prepare_padded_all_gather_buffers", fail_prepare_padded_buffers
+        ):
             result = optimizer._gather_full_uneven_local_tensors_like([(param, local_grad)])[0]
 
         if local_grad.numel() == 0:
@@ -1241,7 +1321,8 @@ class TestFSDPTensorParallelMuon:
         final_local1 = params[1].data.to_local()
         torch.testing.assert_close(final_local1, initial_local1, atol=1e-4, rtol=1e-3)
 
-    def test_step_matches_unsharded_muon_optimizer_step_numerics(self):
+    @pytest.mark.parametrize("overlap_comm_compute", [False, True])
+    def test_step_matches_unsharded_muon_optimizer_step_numerics(self, overlap_comm_compute):
         from torch.distributed.device_mesh import init_device_mesh
 
         dp_size = torch.distributed.get_world_size()
@@ -1291,7 +1372,18 @@ class TestFSDPTensorParallelMuon:
             sharded_params.append(
                 nn.Parameter(_make_dtensor(local_param, full_param.shape, device_mesh))
             )
-        sharded_optimizer = _make_fsdp_muon(sharded_params, dp_group=dp_group, **optimizer_kwargs)
+        sharded_optimizer_kwargs = dict(optimizer_kwargs)
+        if overlap_comm_compute:
+            sharded_optimizer_kwargs.update(
+                fsdp_batched_all_gather=True,
+                fsdp_reuse_gather_scratch=True,
+                fsdp_padded_all_gather=True,
+                fsdp_padded_all_gather_pad_factor=1000,
+                fsdp_overlap_comm_compute=True,
+            )
+        sharded_optimizer = _make_fsdp_muon(
+            sharded_params, dp_group=dp_group, **sharded_optimizer_kwargs
+        )
 
         for step, full_grads in enumerate(full_grads_by_step, start=1):
             for param, full_grad in zip(unsharded_params, full_grads):
@@ -1326,7 +1418,10 @@ class TestFSDPTensorParallelMuon:
 
     @pytest.mark.skipif(WORLD_SIZE < 4, reason="Hybrid topology numerics test requires 4+ ranks")
     @pytest.mark.parametrize("topology", ["hsdp", "hfsdp"])
-    def test_hybrid_step_matches_unsharded_muon_optimizer_step_numerics(self, topology):
+    @pytest.mark.parametrize("overlap_comm_compute", [False, True])
+    def test_hybrid_step_matches_unsharded_muon_optimizer_step_numerics(
+        self, topology, overlap_comm_compute
+    ):
         from torch.distributed.device_mesh import init_device_mesh
 
         dp_size = torch.distributed.get_world_size()
@@ -1413,8 +1508,17 @@ class TestFSDPTensorParallelMuon:
             )
             local_slice_fns.append(local_slice)
 
+        sharded_optimizer_kwargs = dict(optimizer_kwargs)
+        if overlap_comm_compute:
+            sharded_optimizer_kwargs.update(
+                fsdp_batched_all_gather=True,
+                fsdp_reuse_gather_scratch=True,
+                fsdp_padded_all_gather=True,
+                fsdp_padded_all_gather_pad_factor=1000,
+                fsdp_overlap_comm_compute=True,
+            )
         sharded_optimizer = _make_fsdp_muon(
-            sharded_params, dp_group=optimizer_dp_group, **optimizer_kwargs
+            sharded_params, dp_group=optimizer_dp_group, **sharded_optimizer_kwargs
         )
 
         for step, full_grads in enumerate(full_grads_by_step, start=1):
@@ -1472,6 +1576,7 @@ class TestFSDPFactoryIntegration:
         assert config.muon_fsdp_batch_max_gather_bytes == 1024 * 1024 * 1024
         assert config.muon_fsdp_padded_all_gather_zero_pad
         assert config.muon_fsdp_fast_reconstruct
+        assert not config.muon_fsdp_overlap_comm_compute
 
     @pytest.mark.parametrize("strategy", ["no_shard", "optim", "optim_grads", "optim_grads_params"])
     def test_factory_dispatches_correct_muon_cls(self, strategy):
@@ -1523,6 +1628,7 @@ class TestFSDPFactoryIntegration:
             muon_fsdp_batch_max_gather_bytes=123456,
             muon_fsdp_padded_all_gather_zero_pad=False,
             muon_fsdp_fast_reconstruct=False,
+            muon_fsdp_overlap_comm_compute=True,
         )
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
@@ -1570,3 +1676,4 @@ class TestFSDPFactoryIntegration:
             assert base_opt.fsdp_batch_max_gather_bytes == 123456
             assert not base_opt.fsdp_padded_all_gather_zero_pad
             assert not base_opt.fsdp_fast_reconstruct
+            assert base_opt.fsdp_overlap_comm_compute

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -575,6 +575,49 @@ class TestFSDPTensorParallelMuon:
         assert first_step_calls > 0
         assert mocked_all_gather_object.call_count == first_step_calls
 
+    @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP boundary test requires at least 4 ranks")
+    def test_hfsdp_boundary_detector_uses_local_split_union_when_flat_metadata_misses_outer_split(
+        self,
+    ):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        outer_size = 2
+        inner_size = dp_size // outer_size
+        if dp_size % outer_size != 0:
+            pytest.skip("HFSDP boundary test requires an even world size")
+
+        device_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("dp_outer", "dp")
+        )
+        outer_rank, inner_rank = device_mesh.get_coordinate()
+        logical_rank = inner_rank * outer_size + outer_rank
+
+        rows, cols = dp_size * 2 + 1, 4
+        full_param = torch.zeros(rows, cols, device="cuda")
+        rows_per_logical_rank = [
+            rows // dp_size + (1 if rank < rows % dp_size else 0) for rank in range(dp_size)
+        ]
+        row_start = sum(rows_per_logical_rank[:logical_rank])
+        row_count = rows_per_logical_rank[logical_rank]
+        local_param = full_param[row_start : row_start + row_count].contiguous()
+        param = nn.Parameter(_make_hfsdp_dtensor(local_param, full_param.shape, device_mesh))
+
+        # The fake flat bucket says the item is wholly inside one shard. HFSDP
+        # still exposes a partial local DTensor shard, so Muon must gather it.
+        bucket = _make_fake_mfsdp_bucket(
+            bucket_id=0,
+            dp_rank=torch.distributed.get_rank(),
+            dp_size=dp_size,
+            shard_size=full_param.numel() * 2,
+        )
+        _attach_fake_mfsdp_bucket_metadata(param, bucket, item_id=0, offset=0)
+
+        optimizer = _make_fsdp_muon([param], dp_group=torch.distributed.group.WORLD)
+
+        assert optimizer._mfsdp_param_crosses_shard_boundary(param, 0) is False
+        assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0}
+
     def test_step_batches_multiple_split_boundary_params(self):
         from torch.distributed.device_mesh import init_device_mesh
 

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -707,11 +707,23 @@ class TestFSDPTensorParallelMuon:
         def fail_scalar_gather(*_args, **_kwargs):
             raise AssertionError("HFSDP batched gather should not use the scalar fallback")
 
-        with patch.object(optimizer, "_gather_full_uneven_local_tensor_like", fail_scalar_gather):
+        unpack_calls = 0
+        real_unpack_stage = optimizer._unpack_uneven_gather_stage
+
+        def counting_unpack_stage(*args, **kwargs):
+            nonlocal unpack_calls
+            unpack_calls += 1
+            return real_unpack_stage(*args, **kwargs)
+
+        with (
+            patch.object(optimizer, "_gather_full_uneven_local_tensor_like", fail_scalar_gather),
+            patch.object(optimizer, "_unpack_uneven_gather_stage", counting_unpack_stage),
+        ):
             gathered = optimizer._gather_full_uneven_local_tensors_like([(param, local_update)])[0]
         ref_dtensor = optimizer._dtensor_from_local_like(param, local_update)
         expected = redistribute_uneven_dtensor_to_replicated(ref_dtensor)._local_tensor
 
+        assert unpack_calls == len(plan["stages"]) - 1
         assert torch.equal(gathered, expected), "Batched HFSDP gather produced wrong tensor"
 
     @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP cache test requires at least 4 ranks")
@@ -1089,6 +1101,51 @@ class TestFSDPTensorParallelMuon:
             torch.testing.assert_close(padded, full_grad, atol=0, rtol=0)
             torch.testing.assert_close(padded_second, full_grad_second, atol=0, rtol=0)
             torch.testing.assert_close(padded, uneven, atol=0, rtol=0, msg=f"param {idx}")
+
+    def test_batched_gather_reconstructs_final_stage_without_item_unpack(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        plans = [{0: 2, 1: 3}, {0: 1, 1: 4}]
+        full_grads = [
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) + idx
+            for idx, rows in enumerate([5, 5])
+        ]
+        params = []
+        items = []
+        for full_grad, plan in zip(full_grads, plans):
+            local_value = _local_slice(torch.zeros_like(full_grad), plan, dp_rank).contiguous()
+            param = nn.Parameter(_make_dtensor(local_value, full_grad.shape, device_mesh))
+            local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+            params.append(param)
+            items.append((param, local_grad))
+
+        optimizer = _make_fsdp_muon(
+            params,
+            dp_group=dp_group,
+            fsdp_batched_all_gather=True,
+            fsdp_padded_all_gather=True,
+            fsdp_padded_all_gather_pad_factor=1000,
+            fsdp_reuse_gather_scratch=True,
+            fsdp_fast_reconstruct=True,
+        )
+
+        def fail_unpack_stage(*_args, **_kwargs):
+            raise AssertionError("single-stage batched gather should reconstruct from final stage")
+
+        with patch.object(optimizer, "_unpack_uneven_gather_stage", fail_unpack_stage):
+            results = optimizer._gather_full_uneven_local_tensors_like(items)
+
+        for result, full_grad, (_, local_grad) in zip(results, full_grads, items):
+            if local_grad.numel() == 0:
+                assert result is None
+                continue
+            torch.testing.assert_close(result, full_grad, atol=0, rtol=0)
 
     def test_gather_scratch_reuse_can_be_disabled(self):
         from torch.distributed.device_mesh import init_device_mesh

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -878,41 +878,38 @@ class TestFSDPTensorParallelMuon:
             local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
             items_second.append((param, local_grad))
 
-        with patch.dict(
-            os.environ,
-            {"MUON_FSDP_PADDED_ALL_GATHER": "0", "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1000"},
+        uneven_optimizer = _make_fsdp_muon(
+            params,
+            dp_group=dp_group,
+            fsdp_batched_all_gather=True,
+            fsdp_padded_all_gather=False,
+            fsdp_padded_all_gather_pad_factor=1000,
+        )
+        uneven_results = uneven_optimizer._gather_full_uneven_local_tensors_like(items)
+
+        padded_optimizer = _make_fsdp_muon(
+            params,
+            dp_group=dp_group,
+            fsdp_batched_all_gather=True,
+            fsdp_padded_all_gather=True,
+            fsdp_padded_all_gather_pad_factor=1000,
+            fsdp_reuse_gather_scratch=True,
+        )
+        padded_calls = []
+        real_padded_gather = padded_optimizer._all_gather_padded_equal_size
+
+        def counting_padded_gather(*args, **kwargs):
+            padded_calls.append(args[1])
+            return real_padded_gather(*args, **kwargs)
+
+        with patch.object(
+            padded_optimizer, "_all_gather_padded_equal_size", counting_padded_gather
         ):
-            uneven_optimizer = _make_fsdp_muon(
-                params, dp_group=dp_group, fsdp_batched_all_gather=True
+            padded_results = padded_optimizer._gather_full_uneven_local_tensors_like(items)
+            scratch_bytes_after_first = padded_optimizer._fsdp_gather_scratch_cache_bytes()
+            padded_results_second = padded_optimizer._gather_full_uneven_local_tensors_like(
+                items_second
             )
-            uneven_results = uneven_optimizer._gather_full_uneven_local_tensors_like(items)
-
-        with patch.dict(
-            os.environ,
-            {
-                "MUON_FSDP_PADDED_ALL_GATHER": "1",
-                "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1000",
-                "MUON_FSDP_REUSE_GATHER_SCRATCH": "1",
-            },
-        ):
-            padded_optimizer = _make_fsdp_muon(
-                params, dp_group=dp_group, fsdp_batched_all_gather=True
-            )
-            padded_calls = []
-            real_padded_gather = padded_optimizer._all_gather_padded_equal_size
-
-            def counting_padded_gather(*args, **kwargs):
-                padded_calls.append(args[1])
-                return real_padded_gather(*args, **kwargs)
-
-            with patch.object(
-                padded_optimizer, "_all_gather_padded_equal_size", counting_padded_gather
-            ):
-                padded_results = padded_optimizer._gather_full_uneven_local_tensors_like(items)
-                scratch_bytes_after_first = padded_optimizer._fsdp_gather_scratch_cache_bytes()
-                padded_results_second = padded_optimizer._gather_full_uneven_local_tensors_like(
-                    items_second
-                )
 
         assert len(padded_calls) == 2
         assert padded_optimizer._fsdp_gather_scratch_cache_bytes() == scratch_bytes_after_first
@@ -958,16 +955,15 @@ class TestFSDPTensorParallelMuon:
         param = nn.Parameter(_make_dtensor(local_value, full_grad.shape, device_mesh))
         local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
 
-        with patch.dict(
-            os.environ,
-            {
-                "MUON_FSDP_PADDED_ALL_GATHER": "1",
-                "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1000",
-                "MUON_FSDP_REUSE_GATHER_SCRATCH": "0",
-            },
-        ):
-            optimizer = _make_fsdp_muon([param], dp_group=dp_group, fsdp_batched_all_gather=True)
-            result = optimizer._gather_full_uneven_local_tensors_like([(param, local_grad)])[0]
+        optimizer = _make_fsdp_muon(
+            [param],
+            dp_group=dp_group,
+            fsdp_batched_all_gather=True,
+            fsdp_padded_all_gather=True,
+            fsdp_padded_all_gather_pad_factor=1000,
+            fsdp_reuse_gather_scratch=False,
+        )
+        result = optimizer._gather_full_uneven_local_tensors_like([(param, local_grad)])[0]
 
         assert optimizer._fsdp_gather_scratch_cache_bytes() == 0
         if local_grad.numel() == 0:
@@ -990,17 +986,19 @@ class TestFSDPTensorParallelMuon:
         param = nn.Parameter(_make_dtensor(local_value, full_grad.shape, device_mesh))
         local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
 
-        with patch.dict(
-            os.environ,
-            {"MUON_FSDP_PADDED_ALL_GATHER": "1", "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1.0"},
-        ):
-            optimizer = _make_fsdp_muon([param], dp_group=dp_group, fsdp_batched_all_gather=True)
+        optimizer = _make_fsdp_muon(
+            [param],
+            dp_group=dp_group,
+            fsdp_batched_all_gather=True,
+            fsdp_padded_all_gather=True,
+            fsdp_padded_all_gather_pad_factor=1.0,
+        )
 
-            def fail_padded_gather(*_args, **_kwargs):
-                raise AssertionError("padding threshold should select the uneven gather path")
+        def fail_padded_gather(*_args, **_kwargs):
+            raise AssertionError("padding threshold should select the uneven gather path")
 
-            with patch.object(optimizer, "_all_gather_padded_equal_size", fail_padded_gather):
-                result = optimizer._gather_full_uneven_local_tensors_like([(param, local_grad)])[0]
+        with patch.object(optimizer, "_all_gather_padded_equal_size", fail_padded_gather):
+            result = optimizer._gather_full_uneven_local_tensors_like([(param, local_grad)])[0]
 
         if local_grad.numel() == 0:
             assert result is None
@@ -1048,22 +1046,24 @@ class TestFSDPTensorParallelMuon:
             params.append(param)
             items.append((param, local_grad))
 
-        with patch.dict(
-            os.environ,
-            {"MUON_FSDP_PADDED_ALL_GATHER": "1", "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1000"},
+        optimizer = _make_fsdp_muon(
+            params,
+            dp_group=dp_group,
+            fsdp_batched_all_gather=True,
+            fsdp_padded_all_gather=True,
+            fsdp_padded_all_gather_pad_factor=1000,
+        )
+        batch_sizes = []
+        real_batch_gather = optimizer._gather_full_uneven_local_tensor_batch
+
+        def counting_batch_gather(items_arg, results_arg, batch):
+            batch_sizes.append(len(batch["item_indices"]))
+            return real_batch_gather(items_arg, results_arg, batch)
+
+        with patch.object(
+            optimizer, "_gather_full_uneven_local_tensor_batch", counting_batch_gather
         ):
-            optimizer = _make_fsdp_muon(params, dp_group=dp_group, fsdp_batched_all_gather=True)
-            batch_sizes = []
-            real_batch_gather = optimizer._gather_full_uneven_local_tensor_batch
-
-            def counting_batch_gather(items_arg, results_arg, batch):
-                batch_sizes.append(len(batch["item_indices"]))
-                return real_batch_gather(items_arg, results_arg, batch)
-
-            with patch.object(
-                optimizer, "_gather_full_uneven_local_tensor_batch", counting_batch_gather
-            ):
-                results = optimizer._gather_full_uneven_local_tensors_like(items)
+            results = optimizer._gather_full_uneven_local_tensors_like(items)
 
         assert batch_sizes == [1, 1]
         for result, full_grad, (_, local_grad) in zip(results, full_grads, items):
@@ -1096,26 +1096,25 @@ class TestFSDPTensorParallelMuon:
             params.append(param)
             items.append((param, local_grad))
 
-        with patch.dict(
-            os.environ,
-            {
-                "MUON_FSDP_PADDED_ALL_GATHER": "1",
-                "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1000",
-                "MUON_FSDP_BATCH_MAX_GATHER_BYTES": "64",
-            },
+        optimizer = _make_fsdp_muon(
+            params,
+            dp_group=dp_group,
+            fsdp_batched_all_gather=True,
+            fsdp_padded_all_gather=True,
+            fsdp_padded_all_gather_pad_factor=1000,
+            fsdp_batch_max_gather_bytes=64,
+        )
+        batch_sizes = []
+        real_batch_gather = optimizer._gather_full_uneven_local_tensor_batch
+
+        def counting_batch_gather(items_arg, results_arg, batch):
+            batch_sizes.append(len(batch["item_indices"]))
+            return real_batch_gather(items_arg, results_arg, batch)
+
+        with patch.object(
+            optimizer, "_gather_full_uneven_local_tensor_batch", counting_batch_gather
         ):
-            optimizer = _make_fsdp_muon(params, dp_group=dp_group, fsdp_batched_all_gather=True)
-            batch_sizes = []
-            real_batch_gather = optimizer._gather_full_uneven_local_tensor_batch
-
-            def counting_batch_gather(items_arg, results_arg, batch):
-                batch_sizes.append(len(batch["item_indices"]))
-                return real_batch_gather(items_arg, results_arg, batch)
-
-            with patch.object(
-                optimizer, "_gather_full_uneven_local_tensor_batch", counting_batch_gather
-            ):
-                results = optimizer._gather_full_uneven_local_tensors_like(items)
+            results = optimizer._gather_full_uneven_local_tensors_like(items)
 
         assert batch_sizes == [1, 1]
         for result, full_grad, (_, local_grad) in zip(results, full_grads, items):
@@ -1461,6 +1460,19 @@ class TestFSDPFactoryIntegration:
         yield
         Utils.destroy_model_parallel()
 
+    def test_muon_fsdp_gather_fast_paths_default_to_opt_in(self):
+        from megatron.core.optimizer import OptimizerConfig
+
+        config = OptimizerConfig(optimizer="muon")
+
+        assert not config.muon_fsdp_batched_all_gather
+        assert not config.muon_fsdp_reuse_gather_scratch
+        assert not config.muon_fsdp_padded_all_gather
+        assert config.muon_fsdp_padded_all_gather_pad_factor == 1.25
+        assert config.muon_fsdp_batch_max_gather_bytes == 1024 * 1024 * 1024
+        assert config.muon_fsdp_padded_all_gather_zero_pad
+        assert config.muon_fsdp_fast_reconstruct
+
     @pytest.mark.parametrize("strategy", ["no_shard", "optim", "optim_grads", "optim_grads_params"])
     def test_factory_dispatches_correct_muon_cls(self, strategy):
         from megatron.core.optimizer import (
@@ -1505,6 +1517,12 @@ class TestFSDPFactoryIntegration:
             muon_split_qkv=False,
             muon_extra_scale_factor=1.0,
             muon_fsdp_batched_all_gather=True,
+            muon_fsdp_reuse_gather_scratch=True,
+            muon_fsdp_padded_all_gather=True,
+            muon_fsdp_padded_all_gather_pad_factor=2.0,
+            muon_fsdp_batch_max_gather_bytes=123456,
+            muon_fsdp_padded_all_gather_zero_pad=False,
+            muon_fsdp_fast_reconstruct=False,
         )
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
@@ -1546,3 +1564,9 @@ class TestFSDPFactoryIntegration:
             assert isinstance(base_opt, FSDPTensorParallelMuon)
             assert base_opt.dp_group is not None
             assert base_opt.fsdp_batched_all_gather
+            assert base_opt.fsdp_reuse_gather_scratch
+            assert base_opt.fsdp_padded_all_gather
+            assert base_opt.fsdp_padded_all_gather_pad_factor == 2.0
+            assert base_opt.fsdp_batch_max_gather_bytes == 123456
+            assert not base_opt.fsdp_padded_all_gather_zero_pad
+            assert not base_opt.fsdp_fast_reconstruct

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -115,6 +115,29 @@ def _make_dtensor(local_tensor, global_shape, device_mesh):
     return dtensor
 
 
+def _make_hfsdp_dtensor(local_tensor, global_shape, device_mesh):
+    from torch.distributed.tensor import DTensor, Shard
+
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+        update_uneven_dtensor_chunk_metadata,
+    )
+
+    global_stride = torch.empty(
+        global_shape, dtype=local_tensor.dtype, device=local_tensor.device
+    ).stride()
+    setattr(device_mesh, "_shard_order", [1, 0])
+    dtensor = DTensor.from_local(
+        local_tensor=local_tensor,
+        device_mesh=device_mesh,
+        placements=[Shard(0), Shard(0)],
+        shape=torch.Size(global_shape),
+        stride=global_stride,
+        run_check=False,
+    )
+    update_uneven_dtensor_chunk_metadata(dtensor)
+    return dtensor
+
+
 def _attach_fake_mfsdp_bucket_metadata(param, bucket, item_id, offset):
     bucket.item_index_map[item_id] = SimpleNamespace(
         global_data_index=offset, size=torch.Size(param.shape).numel()
@@ -454,6 +477,53 @@ class TestFSDPTensorParallelMuon:
             assert orthogonalize_calls == []
         else:
             assert orthogonalize_calls == [tuple(full_grad.shape)]
+
+    @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP gather test requires at least 4 ranks")
+    def test_hfsdp_boundary_gather_matches_generic_redistribute_bitwise(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+            redistribute_uneven_dtensor_to_replicated,
+        )
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        outer_size = 2
+        inner_size = dp_size // outer_size
+        if dp_size % outer_size != 0:
+            pytest.skip("HFSDP gather test requires an even world size")
+
+        device_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("dp_outer", "dp")
+        )
+        outer_rank, inner_rank = device_mesh.get_coordinate()
+        logical_rank = inner_rank * outer_size + outer_rank
+
+        rows, cols = dp_size * 3 + 5, 4
+        full_update = (
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) + 13
+        )
+        rows_per_logical_rank = [
+            rows // dp_size + (1 if rank < rows % dp_size else 0) for rank in range(dp_size)
+        ]
+        row_start = sum(rows_per_logical_rank[:logical_rank])
+        row_count = rows_per_logical_rank[logical_rank]
+        local_update = full_update[row_start : row_start + row_count].contiguous()
+
+        dtensor = _make_hfsdp_dtensor(local_update.clone(), full_update.shape, device_mesh)
+        param = nn.Parameter(dtensor)
+        optimizer = _make_fsdp_muon([param], dp_group=device_mesh.get_group("dp"))
+
+        assert optimizer._get_uneven_gather_plan(param) is None
+
+        gathered = optimizer._gather_full_uneven_local_tensor_like(param, local_update)
+        ref_dtensor = optimizer._dtensor_from_local_like(param, local_update)
+        expected = redistribute_uneven_dtensor_to_replicated(ref_dtensor)._local_tensor
+
+        assert torch.equal(
+            expected, full_update
+        ), f"generic HFSDP gather mismatch on rank {dp_rank}"
+        assert torch.equal(gathered, expected), f"Muon HFSDP gather mismatch on rank {dp_rank}"
 
     def test_step_batches_multiple_split_boundary_params(self):
         from torch.distributed.device_mesh import init_device_mesh

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -857,33 +857,33 @@ class TestFSDPTensorParallelMuon:
         dp_group = device_mesh.get_group("dp")
         cols = 4
 
-        replicated_param = (
-            torch.arange(4 * cols, device="cuda", dtype=torch.float32).view(4, cols) / 100
-        )
-        replicated_grad = replicated_param + 0.2
+        small_param = torch.arange(2 * cols, device="cuda", dtype=torch.float32).view(2, cols) / 100
+        small_grad = small_param + 0.2
         plan = {0: 2, 1: 4}
         boundary_param = (
             torch.arange(6 * cols, device="cuda", dtype=torch.float32).view(6, cols) / 80
         )
         boundary_grad = boundary_param + 0.3
+        large_param = torch.arange(4 * cols, device="cuda", dtype=torch.float32).view(4, cols) / 70
+        large_grad = large_param + 0.4
 
         local_boundary_param = _local_slice(boundary_param, plan, dp_rank).contiguous()
         params = [
             nn.Parameter(
-                _make_replicated_dtensor(
-                    replicated_param.clone(), replicated_param.shape, device_mesh
-                )
+                _make_replicated_dtensor(small_param.clone(), small_param.shape, device_mesh)
             ),
             nn.Parameter(_make_dtensor(local_boundary_param, boundary_param.shape, device_mesh)),
+            nn.Parameter(
+                _make_replicated_dtensor(large_param.clone(), large_param.shape, device_mesh)
+            ),
         ]
-        params[0].grad = _make_replicated_dtensor(
-            replicated_grad.clone(), replicated_grad.shape, device_mesh
-        )
+        params[0].grad = _make_replicated_dtensor(small_grad.clone(), small_grad.shape, device_mesh)
         params[1].grad = _make_dtensor(
             _local_slice(boundary_grad, plan, dp_rank).contiguous(),
             boundary_grad.shape,
             device_mesh,
         )
+        params[2].grad = _make_replicated_dtensor(large_grad.clone(), large_grad.shape, device_mesh)
 
         optimizer = _make_fsdp_muon(
             params,
@@ -895,9 +895,19 @@ class TestFSDPTensorParallelMuon:
             fsdp_overlap_comm_compute=True,
         )
         events = []
+        real_compute = optimizer._compute_local_pre_ns_grad
         real_start = optimizer._start_gather_full_uneven_local_tensor_batch_async
         real_finish = optimizer._finish_gather_full_uneven_local_tensor_batch_async
         real_apply = optimizer._apply_precomputed_muon_update
+
+        def recording_compute(p, group, lr):
+            if p is params[1]:
+                events.append("compute_boundary")
+            elif p is params[2]:
+                events.append("compute_large_local")
+            else:
+                events.append("compute_small_local")
+            return real_compute(p, group, lr)
 
         def recording_start(*args, **kwargs):
             events.append("start")
@@ -908,10 +918,16 @@ class TestFSDPTensorParallelMuon:
             return real_finish(*args, **kwargs)
 
         def recording_apply(p, pre_ns_grad, is_gathered, lr, group_kwargs):
-            events.append("apply_gathered" if is_gathered else "apply_local")
+            if is_gathered:
+                events.append("apply_gathered")
+            elif p is params[2]:
+                events.append("apply_large_local")
+            else:
+                events.append("apply_small_local")
             return real_apply(p, pre_ns_grad, is_gathered, lr, group_kwargs)
 
         with (
+            patch.object(optimizer, "_compute_local_pre_ns_grad", recording_compute),
             patch.object(
                 optimizer, "_start_gather_full_uneven_local_tensor_batch_async", recording_start
             ),
@@ -922,8 +938,11 @@ class TestFSDPTensorParallelMuon:
         ):
             optimizer.step()
 
-        assert events[0] == "start"
-        assert events.index("start") < events.index("apply_local") < events.index("finish")
+        assert events.index("compute_boundary") < events.index("start")
+        assert events.index("start") < events.index("compute_small_local")
+        assert events.index("start") < events.index("compute_large_local")
+        assert events.index("start") < events.index("apply_large_local") < events.index("finish")
+        assert events.index("apply_large_local") < events.index("apply_small_local")
         assert events.index("finish") < events.index("apply_gathered")
 
     def test_padded_batch_gather_matches_uneven_batch_and_reuses_scratch(self):

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -12,6 +12,7 @@ import torch.nn as nn
 from packaging.version import Version
 
 from megatron.core.optimizer import _get_mfsdp_models
+from megatron.core.optimizer.clip_grads import get_grad_norm_fp32
 from megatron.core.optimizer.emerging_optimizers import (
     HAVE_EMERGING_OPTIMIZERS,
     FSDPTensorParallelMuon,
@@ -138,6 +139,54 @@ def _make_hfsdp_dtensor(local_tensor, global_shape, device_mesh):
     return dtensor
 
 
+def _make_hsdp_dtensor(local_tensor, global_shape, device_mesh):
+    from torch.distributed.tensor import DTensor, Replicate, Shard
+
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+        update_uneven_dtensor_chunk_metadata,
+    )
+
+    global_stride = torch.empty(
+        global_shape, dtype=local_tensor.dtype, device=local_tensor.device
+    ).stride()
+    dtensor = DTensor.from_local(
+        local_tensor=local_tensor,
+        device_mesh=device_mesh,
+        placements=[Replicate(), Shard(0)],
+        shape=torch.Size(global_shape),
+        stride=global_stride,
+        run_check=False,
+    )
+    update_uneven_dtensor_chunk_metadata(dtensor)
+    return dtensor
+
+
+def _make_replicated_dtensor(local_tensor, global_shape, device_mesh):
+    from torch.distributed.tensor import DTensor, Replicate
+
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+        update_uneven_dtensor_chunk_metadata,
+    )
+
+    global_stride = torch.empty(
+        global_shape, dtype=local_tensor.dtype, device=local_tensor.device
+    ).stride()
+    dtensor = DTensor.from_local(
+        local_tensor=local_tensor,
+        device_mesh=device_mesh,
+        placements=[Replicate()],
+        shape=torch.Size(global_shape),
+        stride=global_stride,
+        run_check=False,
+    )
+    update_uneven_dtensor_chunk_metadata(dtensor)
+    return dtensor
+
+
+def _as_float(value):
+    return float(value.item()) if isinstance(value, torch.Tensor) else float(value)
+
+
 def _attach_fake_mfsdp_bucket_metadata(param, bucket, item_id, offset):
     bucket.item_index_map[item_id] = SimpleNamespace(
         global_data_index=offset, size=torch.Size(param.shape).numel()
@@ -191,6 +240,90 @@ class TestFSDPTensorParallelMuon:
         yield
         Utils.destroy_model_parallel()
 
+    def test_dtensor_grad_norm_reduces_only_fsdp_shard_dims(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from megatron.core import parallel_state
+
+        world_size = torch.distributed.get_world_size()
+        world_rank = torch.distributed.get_rank()
+        mp_group = parallel_state.get_model_parallel_group()
+
+        fsdp_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp_cp",))
+        rows_per_rank = 2
+        cols = 3
+        local = torch.full(
+            (rows_per_rank, cols), float(world_rank + 1), device="cuda", dtype=torch.float32
+        )
+        fsdp_grad = _make_dtensor(local, (world_size * rows_per_rank, cols), fsdp_mesh)
+        local_norm = torch.linalg.vector_norm(local).item()
+        expected_sq = torch.linalg.vector_norm(local).pow(2)
+        torch.distributed.all_reduce(expected_sq, group=fsdp_mesh.get_group("dp_cp"))
+        expected = expected_sq.sqrt().item()
+
+        observed = _as_float(get_grad_norm_fp32([fsdp_grad], grad_stats_parallel_group=mp_group))
+        observed_with_duplicate_stats_group = _as_float(
+            get_grad_norm_fp32([fsdp_grad], grad_stats_parallel_group=fsdp_mesh.get_group("dp_cp"))
+        )
+
+        assert observed != pytest.approx(local_norm)
+        assert observed == pytest.approx(expected, rel=1e-6, abs=1e-6)
+        assert observed_with_duplicate_stats_group == pytest.approx(expected, rel=1e-6, abs=1e-6)
+
+        if world_size < 4 or world_size % 2 != 0:
+            return
+
+        outer_size = 2
+        inner_size = world_size // outer_size
+        hsdp_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("outer_fsdp_dp", "dp_cp")
+        )
+        inner_group = hsdp_mesh.get_group("dp_cp")
+        inner_rank = torch.distributed.get_rank(inner_group)
+        hsdp_local = torch.full(
+            (rows_per_rank, cols), float(inner_rank + 1), device="cuda", dtype=torch.float32
+        )
+        hsdp_grad = _make_hsdp_dtensor(hsdp_local, (inner_size * rows_per_rank, cols), hsdp_mesh)
+        hsdp_expected_sq = torch.linalg.vector_norm(hsdp_local).pow(2)
+        torch.distributed.all_reduce(hsdp_expected_sq, group=inner_group)
+        hsdp_expected = hsdp_expected_sq.sqrt().item()
+        hsdp_world_expected_sq = torch.linalg.vector_norm(hsdp_local).pow(2)
+        torch.distributed.all_reduce(hsdp_world_expected_sq)
+        hsdp_world_expected = hsdp_world_expected_sq.sqrt().item()
+
+        hsdp_observed = _as_float(
+            get_grad_norm_fp32([hsdp_grad], grad_stats_parallel_group=mp_group)
+        )
+        hsdp_observed_with_duplicate_stats_group = _as_float(
+            get_grad_norm_fp32([hsdp_grad], grad_stats_parallel_group=inner_group)
+        )
+
+        assert hsdp_observed == pytest.approx(hsdp_expected, rel=1e-6, abs=1e-6)
+        assert hsdp_observed_with_duplicate_stats_group == pytest.approx(
+            hsdp_expected, rel=1e-6, abs=1e-6
+        )
+        assert hsdp_observed != pytest.approx(hsdp_world_expected)
+
+        hfsdp_local = torch.full(
+            (rows_per_rank, cols), float(world_rank + 1), device="cuda", dtype=torch.float32
+        )
+        hfsdp_grad = _make_hfsdp_dtensor(hfsdp_local, (world_size * rows_per_rank, cols), hsdp_mesh)
+        hfsdp_expected_sq = torch.linalg.vector_norm(hfsdp_local).pow(2)
+        torch.distributed.all_reduce(hfsdp_expected_sq)
+        hfsdp_expected = hfsdp_expected_sq.sqrt().item()
+
+        hfsdp_observed = _as_float(
+            get_grad_norm_fp32([hfsdp_grad], grad_stats_parallel_group=mp_group)
+        )
+        hfsdp_observed_with_duplicate_stats_group = _as_float(
+            get_grad_norm_fp32([hfsdp_grad], grad_stats_parallel_group=inner_group)
+        )
+
+        assert hfsdp_observed == pytest.approx(hfsdp_expected, rel=1e-6, abs=1e-6)
+        assert hfsdp_observed_with_duplicate_stats_group == pytest.approx(
+            hfsdp_expected, rel=1e-6, abs=1e-6
+        )
+
     def test_step_gathers_only_split_boundary_params(self):
         from torch.distributed.device_mesh import init_device_mesh
         from torch.distributed.tensor import DTensor
@@ -227,7 +360,7 @@ class TestFSDPTensorParallelMuon:
             local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
             param.grad = _make_dtensor(local_grad, full_grad.shape, device_mesh)
 
-        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group, fsdp_batched_all_gather=False)
         assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {1}
 
         # Pre-step: grads are DTensors, non-null, non-zero.
@@ -313,7 +446,7 @@ class TestFSDPTensorParallelMuon:
             local_param = _local_slice(full_param, plan, dp_rank).contiguous()
             params.append(nn.Parameter(_make_dtensor(local_param, full_param.shape, device_mesh)))
 
-        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group, fsdp_batched_all_gather=False)
 
         assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {0, 1, 2}
 
@@ -368,7 +501,7 @@ class TestFSDPTensorParallelMuon:
         for param, (bucket, item_id, offset) in zip(params, bucket_assignments):
             _attach_fake_mfsdp_bucket_metadata(param, bucket, item_id, offset)
 
-        optimizer = _make_fsdp_muon(params, dp_group=dp_group)
+        optimizer = _make_fsdp_muon(params, dp_group=dp_group, fsdp_batched_all_gather=False)
 
         assert optimizer._get_boundary_gather_param_indices(optimizer.param_groups[0]) == {2}
 
@@ -528,6 +661,59 @@ class TestFSDPTensorParallelMuon:
         ), f"generic HFSDP gather mismatch on rank {dp_rank}"
         assert torch.equal(gathered, expected), f"Muon HFSDP gather mismatch on rank {dp_rank}"
 
+    @pytest.mark.skipif(
+        WORLD_SIZE < 4, reason="HFSDP batched gather test requires at least 4 ranks"
+    )
+    def test_hfsdp_batched_gather_uses_multi_stage_path_bitwise(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+            redistribute_uneven_dtensor_to_replicated,
+        )
+
+        dp_size = torch.distributed.get_world_size()
+        outer_size = 2
+        inner_size = dp_size // outer_size
+        if dp_size % outer_size != 0:
+            pytest.skip("HFSDP batched gather test requires an even world size")
+
+        device_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("dp_outer", "dp")
+        )
+        outer_rank, inner_rank = device_mesh.get_coordinate()
+        logical_rank = inner_rank * outer_size + outer_rank
+
+        rows, cols = dp_size * 3 + 5, 4
+        full_update = (
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) + 17
+        )
+        rows_per_logical_rank = [
+            rows // dp_size + (1 if rank < rows % dp_size else 0) for rank in range(dp_size)
+        ]
+        row_start = sum(rows_per_logical_rank[:logical_rank])
+        row_count = rows_per_logical_rank[logical_rank]
+        local_update = full_update[row_start : row_start + row_count].contiguous()
+
+        param = nn.Parameter(
+            _make_hfsdp_dtensor(local_update.clone(), full_update.shape, device_mesh)
+        )
+        optimizer = _make_fsdp_muon(
+            [param], dp_group=torch.distributed.group.WORLD, fsdp_batched_all_gather=True
+        )
+        plan = optimizer._get_uneven_gather_plan(param)
+        assert plan is not None
+        assert len(plan["stages"]) == 2
+
+        def fail_scalar_gather(*_args, **_kwargs):
+            raise AssertionError("HFSDP batched gather should not use the scalar fallback")
+
+        with patch.object(optimizer, "_gather_full_uneven_local_tensor_like", fail_scalar_gather):
+            gathered = optimizer._gather_full_uneven_local_tensors_like([(param, local_update)])[0]
+        ref_dtensor = optimizer._dtensor_from_local_like(param, local_update)
+        expected = redistribute_uneven_dtensor_to_replicated(ref_dtensor)._local_tensor
+
+        assert torch.equal(gathered, expected), "Batched HFSDP gather produced wrong tensor"
+
     @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP cache test requires at least 4 ranks")
     def test_hfsdp_boundary_metadata_collectives_are_cached_across_steps(self):
         from torch.distributed.device_mesh import init_device_mesh
@@ -661,6 +847,282 @@ class TestFSDPTensorParallelMuon:
             optimizer.step()
 
         assert gather_batches == [[(4, cols), (4, cols)]]
+
+    def test_padded_batch_gather_matches_uneven_batch_and_reuses_scratch(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        plans = [{0: 2, 1: 3}, {0: 1, 1: 4}]
+        full_grads = [
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) + idx
+            for idx, rows in enumerate([5, 5])
+        ]
+        full_grads_second = [
+            full_grad + 1000 * (idx + 1) for idx, full_grad in enumerate(full_grads)
+        ]
+        params = []
+        items = []
+        items_second = []
+        for full_grad, plan in zip(full_grads, plans):
+            local_value = _local_slice(torch.zeros_like(full_grad), plan, dp_rank).contiguous()
+            param = nn.Parameter(_make_dtensor(local_value, full_grad.shape, device_mesh))
+            local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+            items.append((param, local_grad))
+            params.append(param)
+        for param, full_grad, plan in zip(params, full_grads_second, plans):
+            local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+            items_second.append((param, local_grad))
+
+        with patch.dict(
+            os.environ,
+            {"MUON_FSDP_PADDED_ALL_GATHER": "0", "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1000"},
+        ):
+            uneven_optimizer = _make_fsdp_muon(
+                params, dp_group=dp_group, fsdp_batched_all_gather=True
+            )
+            uneven_results = uneven_optimizer._gather_full_uneven_local_tensors_like(items)
+
+        with patch.dict(
+            os.environ,
+            {
+                "MUON_FSDP_PADDED_ALL_GATHER": "1",
+                "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1000",
+                "MUON_FSDP_REUSE_GATHER_SCRATCH": "1",
+            },
+        ):
+            padded_optimizer = _make_fsdp_muon(
+                params, dp_group=dp_group, fsdp_batched_all_gather=True
+            )
+            padded_calls = []
+            real_padded_gather = padded_optimizer._all_gather_padded_equal_size
+
+            def counting_padded_gather(*args, **kwargs):
+                padded_calls.append(args[1])
+                return real_padded_gather(*args, **kwargs)
+
+            with patch.object(
+                padded_optimizer, "_all_gather_padded_equal_size", counting_padded_gather
+            ):
+                padded_results = padded_optimizer._gather_full_uneven_local_tensors_like(items)
+                scratch_bytes_after_first = padded_optimizer._fsdp_gather_scratch_cache_bytes()
+                padded_results_second = padded_optimizer._gather_full_uneven_local_tensors_like(
+                    items_second
+                )
+
+        assert len(padded_calls) == 2
+        assert padded_optimizer._fsdp_gather_scratch_cache_bytes() == scratch_bytes_after_first
+
+        for idx, (
+            padded,
+            padded_second,
+            uneven,
+            full_grad,
+            full_grad_second,
+            (_, local_grad),
+        ) in enumerate(
+            zip(
+                padded_results,
+                padded_results_second,
+                uneven_results,
+                full_grads,
+                full_grads_second,
+                items,
+            )
+        ):
+            if local_grad.numel() == 0:
+                assert padded is None
+                assert padded_second is None
+                assert uneven is None
+                continue
+            torch.testing.assert_close(padded, full_grad, atol=0, rtol=0)
+            torch.testing.assert_close(padded_second, full_grad_second, atol=0, rtol=0)
+            torch.testing.assert_close(padded, uneven, atol=0, rtol=0, msg=f"param {idx}")
+
+    def test_gather_scratch_reuse_can_be_disabled(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        plan = {0: 2, 1: 3}
+        full_grad = torch.arange(5 * cols, device="cuda", dtype=torch.float32).view(5, cols)
+        local_value = _local_slice(torch.zeros_like(full_grad), plan, dp_rank).contiguous()
+        param = nn.Parameter(_make_dtensor(local_value, full_grad.shape, device_mesh))
+        local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+
+        with patch.dict(
+            os.environ,
+            {
+                "MUON_FSDP_PADDED_ALL_GATHER": "1",
+                "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1000",
+                "MUON_FSDP_REUSE_GATHER_SCRATCH": "0",
+            },
+        ):
+            optimizer = _make_fsdp_muon([param], dp_group=dp_group, fsdp_batched_all_gather=True)
+            result = optimizer._gather_full_uneven_local_tensors_like([(param, local_grad)])[0]
+
+        assert optimizer._fsdp_gather_scratch_cache_bytes() == 0
+        if local_grad.numel() == 0:
+            assert result is None
+        else:
+            torch.testing.assert_close(result, full_grad, atol=0, rtol=0)
+
+    def test_padded_batch_gather_respects_padding_threshold(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        plan = {0: 1, 1: 5}
+        full_grad = torch.arange(6 * cols, device="cuda", dtype=torch.float32).view(6, cols)
+        local_value = _local_slice(torch.zeros_like(full_grad), plan, dp_rank).contiguous()
+        param = nn.Parameter(_make_dtensor(local_value, full_grad.shape, device_mesh))
+        local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+
+        with patch.dict(
+            os.environ,
+            {"MUON_FSDP_PADDED_ALL_GATHER": "1", "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1.0"},
+        ):
+            optimizer = _make_fsdp_muon([param], dp_group=dp_group, fsdp_batched_all_gather=True)
+
+            def fail_padded_gather(*_args, **_kwargs):
+                raise AssertionError("padding threshold should select the uneven gather path")
+
+            with patch.object(optimizer, "_all_gather_padded_equal_size", fail_padded_gather):
+                result = optimizer._gather_full_uneven_local_tensors_like([(param, local_grad)])[0]
+
+        if local_grad.numel() == 0:
+            assert result is None
+        else:
+            torch.testing.assert_close(result, full_grad, atol=0, rtol=0)
+
+    def test_batched_gather_plan_none_falls_back_to_replicated_dtensor(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        full_grad = torch.arange(5 * 4, device="cuda", dtype=torch.float32).view(5, 4)
+        param = nn.Parameter(
+            _make_replicated_dtensor(full_grad.clone(), full_grad.shape, device_mesh)
+        )
+
+        optimizer = _make_fsdp_muon([param], dp_group=dp_group, fsdp_batched_all_gather=True)
+        result = optimizer._gather_full_uneven_local_tensors_like([(param, full_grad.clone())])[0]
+
+        torch.testing.assert_close(result, full_grad, atol=0, rtol=0)
+
+    def test_batched_gather_partitions_by_dtype(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+        plan = {0: 2, 1: 3}
+        dtypes = [torch.float32, torch.bfloat16]
+        full_grads = [
+            (torch.arange(5 * cols, device="cuda", dtype=torch.float32).view(5, cols) + idx).to(
+                dtype=dtype
+            )
+            for idx, dtype in enumerate(dtypes)
+        ]
+        params = []
+        items = []
+        for full_grad in full_grads:
+            local_value = _local_slice(torch.zeros_like(full_grad), plan, dp_rank).contiguous()
+            param = nn.Parameter(_make_dtensor(local_value, full_grad.shape, device_mesh))
+            local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+            params.append(param)
+            items.append((param, local_grad))
+
+        with patch.dict(
+            os.environ,
+            {"MUON_FSDP_PADDED_ALL_GATHER": "1", "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1000"},
+        ):
+            optimizer = _make_fsdp_muon(params, dp_group=dp_group, fsdp_batched_all_gather=True)
+            batch_sizes = []
+            real_batch_gather = optimizer._gather_full_uneven_local_tensor_batch
+
+            def counting_batch_gather(items_arg, results_arg, batch):
+                batch_sizes.append(len(batch["item_indices"]))
+                return real_batch_gather(items_arg, results_arg, batch)
+
+            with patch.object(
+                optimizer, "_gather_full_uneven_local_tensor_batch", counting_batch_gather
+            ):
+                results = optimizer._gather_full_uneven_local_tensors_like(items)
+
+        assert batch_sizes == [1, 1]
+        for result, full_grad, (_, local_grad) in zip(results, full_grads, items):
+            if local_grad.numel() == 0:
+                assert result is None
+                continue
+            assert result.dtype == full_grad.dtype
+            torch.testing.assert_close(result, full_grad, atol=0, rtol=0)
+
+    def test_batched_gather_splits_on_gather_byte_budget(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        plans = [{0: 2, 1: 3}, {0: 2, 1: 3}]
+        full_grads = [
+            torch.arange(5 * cols, device="cuda", dtype=torch.float32).view(5, cols) + idx
+            for idx in range(2)
+        ]
+        params = []
+        items = []
+        for full_grad, plan in zip(full_grads, plans):
+            local_value = _local_slice(torch.zeros_like(full_grad), plan, dp_rank).contiguous()
+            param = nn.Parameter(_make_dtensor(local_value, full_grad.shape, device_mesh))
+            local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+            params.append(param)
+            items.append((param, local_grad))
+
+        with patch.dict(
+            os.environ,
+            {
+                "MUON_FSDP_PADDED_ALL_GATHER": "1",
+                "MUON_FSDP_PADDED_ALL_GATHER_PAD_FACTOR": "1000",
+                "MUON_FSDP_BATCH_MAX_GATHER_BYTES": "64",
+            },
+        ):
+            optimizer = _make_fsdp_muon(params, dp_group=dp_group, fsdp_batched_all_gather=True)
+            batch_sizes = []
+            real_batch_gather = optimizer._gather_full_uneven_local_tensor_batch
+
+            def counting_batch_gather(items_arg, results_arg, batch):
+                batch_sizes.append(len(batch["item_indices"]))
+                return real_batch_gather(items_arg, results_arg, batch)
+
+            with patch.object(
+                optimizer, "_gather_full_uneven_local_tensor_batch", counting_batch_gather
+            ):
+                results = optimizer._gather_full_uneven_local_tensors_like(items)
+
+        assert batch_sizes == [1, 1]
+        for result, full_grad, (_, local_grad) in zip(results, full_grads, items):
+            if local_grad.numel() == 0:
+                assert result is None
+            else:
+                torch.testing.assert_close(result, full_grad, atol=0, rtol=0)
 
     def test_boundary_metadata_collectives_are_cached_across_steps(self):
         from torch.distributed.device_mesh import init_device_mesh
@@ -860,6 +1322,133 @@ class TestFSDPTensorParallelMuon:
                     msg=(
                         "Muon+M-FSDP diverged from unsharded Muon "
                         f"on step {step}, param {idx}, rank {dp_rank}"
+                    ),
+                )
+
+    @pytest.mark.skipif(WORLD_SIZE < 4, reason="Hybrid topology numerics test requires 4+ ranks")
+    @pytest.mark.parametrize("topology", ["hsdp", "hfsdp"])
+    def test_hybrid_step_matches_unsharded_muon_optimizer_step_numerics(self, topology):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        world_rank = torch.distributed.get_rank()
+        outer_size = 2
+        inner_size = dp_size // outer_size
+        if dp_size % outer_size != 0:
+            pytest.skip("Hybrid topology numerics test requires an even world size")
+
+        device_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("outer_fsdp_dp", "dp_cp")
+        )
+        outer_rank, inner_rank = device_mesh.get_coordinate()
+        optimizer_dp_group = torch.distributed.group.WORLD
+        cols = 4
+        rows_by_param = [dp_size + 3, dp_size * 2 + 1, dp_size + 5]
+        optimizer_kwargs = dict(
+            lr=0.03, momentum=0.25, nesterov=True, weight_decay=0.02, num_ns_steps=3
+        )
+
+        full_params = [
+            (
+                torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols)
+                + 1.7 * (idx + 1)
+            )
+            / (19 + idx)
+            for idx, rows in enumerate(rows_by_param)
+        ]
+        full_grads_by_step = [
+            [
+                (
+                    torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols)
+                    + 0.9 * (idx + 1)
+                    + step
+                )
+                / (29 + idx + step)
+                for idx, rows in enumerate(rows_by_param)
+            ]
+            for step in range(2)
+        ]
+
+        unsharded_params = [nn.Parameter(full_param.clone()) for full_param in full_params]
+        unsharded_optimizer = TensorParallelMuon(
+            params=unsharded_params,
+            pg_collection=None,
+            tp_mode="duplicated",
+            split_qkv=False,
+            **optimizer_kwargs,
+        )
+
+        sharded_params = []
+        local_slice_fns = []
+        for full_param in full_params:
+            if topology == "hsdp":
+                rows_per_inner_rank = [
+                    full_param.shape[0] // inner_size
+                    + (1 if rank < full_param.shape[0] % inner_size else 0)
+                    for rank in range(inner_size)
+                ]
+                row_start = sum(rows_per_inner_rank[:inner_rank])
+                row_count = rows_per_inner_rank[inner_rank]
+                make_dtensor = _make_hsdp_dtensor
+
+                def local_slice(tensor, start=row_start, count=row_count):
+                    return tensor[start : start + count].contiguous()
+
+            else:
+                logical_rank = inner_rank * outer_size + outer_rank
+                rows_per_logical_rank = [
+                    full_param.shape[0] // dp_size
+                    + (1 if rank < full_param.shape[0] % dp_size else 0)
+                    for rank in range(dp_size)
+                ]
+                row_start = sum(rows_per_logical_rank[:logical_rank])
+                row_count = rows_per_logical_rank[logical_rank]
+                make_dtensor = _make_hfsdp_dtensor
+
+                def local_slice(tensor, start=row_start, count=row_count):
+                    return tensor[start : start + count].contiguous()
+
+            local_param = local_slice(full_param)
+            sharded_params.append(
+                nn.Parameter(make_dtensor(local_param, full_param.shape, device_mesh))
+            )
+            local_slice_fns.append(local_slice)
+
+        sharded_optimizer = _make_fsdp_muon(
+            sharded_params, dp_group=optimizer_dp_group, **optimizer_kwargs
+        )
+
+        for step, full_grads in enumerate(full_grads_by_step, start=1):
+            for param, full_grad in zip(unsharded_params, full_grads):
+                param.grad = full_grad.clone()
+            for param, full_grad, local_slice, full_param in zip(
+                sharded_params, full_grads, local_slice_fns, full_params
+            ):
+                local_grad = local_slice(full_grad)
+                make_dtensor = _make_hsdp_dtensor if topology == "hsdp" else _make_hfsdp_dtensor
+                param.grad = make_dtensor(local_grad, full_param.shape, device_mesh)
+
+            unsharded_optimizer.step()
+            sharded_optimizer.step()
+
+            for idx, (sharded_param, unsharded_param, local_slice) in enumerate(
+                zip(sharded_params, unsharded_params, local_slice_fns)
+            ):
+                expected_local = local_slice(unsharded_param.detach())
+                local_value = sharded_param.data.to_local()
+
+                if local_value.numel() == 0:
+                    assert local_value.shape[0] == 0
+                    continue
+
+                torch.testing.assert_close(
+                    local_value,
+                    expected_local,
+                    atol=1e-5,
+                    rtol=1e-4,
+                    msg=(
+                        f"Muon+M-FSDP {topology} diverged from unsharded Muon "
+                        f"on step {step}, param {idx}, rank {world_rank}"
                     ),
                 )
 

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -512,9 +512,12 @@ class TestFSDPTensorParallelMuon:
 
         dtensor = _make_hfsdp_dtensor(local_update.clone(), full_update.shape, device_mesh)
         param = nn.Parameter(dtensor)
-        optimizer = _make_fsdp_muon([param], dp_group=device_mesh.get_group("dp"))
+        optimizer = _make_fsdp_muon([param], dp_group=torch.distributed.group.WORLD)
 
-        assert optimizer._get_uneven_gather_plan(param) is None
+        plan = optimizer._get_uneven_gather_plan(param)
+        assert plan is not None
+        assert plan["shard_mesh_dims"] == (0, 1)
+        assert len(plan["stages"]) == 2
 
         gathered = optimizer._gather_full_uneven_local_tensor_like(param, local_update)
         ref_dtensor = optimizer._dtensor_from_local_like(param, local_update)
@@ -524,6 +527,53 @@ class TestFSDPTensorParallelMuon:
             expected, full_update
         ), f"generic HFSDP gather mismatch on rank {dp_rank}"
         assert torch.equal(gathered, expected), f"Muon HFSDP gather mismatch on rank {dp_rank}"
+
+    @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP cache test requires at least 4 ranks")
+    def test_hfsdp_boundary_metadata_collectives_are_cached_across_steps(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        outer_size = 2
+        inner_size = dp_size // outer_size
+        if dp_size % outer_size != 0:
+            pytest.skip("HFSDP cache test requires an even world size")
+
+        device_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("dp_outer", "dp")
+        )
+        outer_rank, inner_rank = device_mesh.get_coordinate()
+        logical_rank = inner_rank * outer_size + outer_rank
+
+        rows, cols = dp_size * 3 + 5, 4
+        full_param = (
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) / 100
+        )
+        full_grad = (
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) / 50
+            + 0.1
+        )
+        rows_per_logical_rank = [
+            rows // dp_size + (1 if rank < rows % dp_size else 0) for rank in range(dp_size)
+        ]
+        row_start = sum(rows_per_logical_rank[:logical_rank])
+        row_count = rows_per_logical_rank[logical_rank]
+
+        local_param = full_param[row_start : row_start + row_count].contiguous()
+        param = nn.Parameter(_make_hfsdp_dtensor(local_param, full_param.shape, device_mesh))
+        local_grad = full_grad[row_start : row_start + row_count].contiguous()
+        param.grad = _make_hfsdp_dtensor(local_grad, full_grad.shape, device_mesh)
+
+        optimizer = _make_fsdp_muon([param], dp_group=torch.distributed.group.WORLD)
+
+        with patch(
+            "torch.distributed.all_gather_object", wraps=torch.distributed.all_gather_object
+        ) as mocked_all_gather_object:
+            optimizer.step()
+            first_step_calls = mocked_all_gather_object.call_count
+            optimizer.step()
+
+        assert first_step_calls > 0
+        assert mocked_all_gather_object.call_count == first_step_calls
 
     def test_step_batches_multiple_split_boundary_params(self):
         from torch.distributed.device_mesh import init_device_mesh

--- a/tests/unit_tests/test_muon_fsdp_optimizer.py
+++ b/tests/unit_tests/test_muon_fsdp_optimizer.py
@@ -726,6 +726,301 @@ class TestFSDPTensorParallelMuon:
         assert unpack_calls == len(plan["stages"]) - 1
         assert torch.equal(gathered, expected), "Batched HFSDP gather produced wrong tensor"
 
+    @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP flat gather test requires at least 4 ranks")
+    def test_hfsdp_flat_batched_gather_matches_generic_bitwise(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+            redistribute_uneven_dtensor_to_replicated,
+        )
+
+        dp_size = torch.distributed.get_world_size()
+        outer_size = 2
+        inner_size = dp_size // outer_size
+        if dp_size % outer_size != 0:
+            pytest.skip("HFSDP flat gather test requires an even world size")
+
+        device_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("dp_outer", "dp")
+        )
+        outer_rank, inner_rank = device_mesh.get_coordinate()
+        logical_rank = inner_rank * outer_size + outer_rank
+        cols = 4
+
+        def local_hfsdp_shard(full_tensor):
+            rows_per_logical_rank = [
+                full_tensor.shape[0] // dp_size
+                + (1 if rank < full_tensor.shape[0] % dp_size else 0)
+                for rank in range(dp_size)
+            ]
+            row_start = sum(rows_per_logical_rank[:logical_rank])
+            row_count = rows_per_logical_rank[logical_rank]
+            return full_tensor[row_start : row_start + row_count].contiguous()
+
+        full_updates = [
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) + idx
+            for idx, rows in enumerate([dp_size * 3 + 5, dp_size - 1])
+        ]
+        params = []
+        items = []
+        for full_update in full_updates:
+            local_update = local_hfsdp_shard(full_update)
+            param = nn.Parameter(
+                _make_hfsdp_dtensor(local_update.clone(), full_update.shape, device_mesh)
+            )
+            params.append(param)
+            items.append((param, local_update))
+
+        optimizer = _make_fsdp_muon(
+            params,
+            dp_group=torch.distributed.group.WORLD,
+            fsdp_batched_all_gather=True,
+            fsdp_flat_batched_all_gather=True,
+            fsdp_padded_all_gather=True,
+            fsdp_padded_all_gather_pad_factor=1000,
+        )
+        for param in params:
+            plan = optimizer._get_uneven_gather_plan(param)
+            assert plan is not None
+            flat_plan = optimizer._get_flat_uneven_gather_plan(param, plan)
+            assert flat_plan is not None
+            assert flat_plan["flat_group_size"] == dp_size
+
+        padded_calls = []
+        real_prepare_padded_buffers = optimizer._prepare_padded_all_gather_buffers
+
+        def counting_prepare_padded_buffers(*args, **kwargs):
+            padded_calls.append(args[1])
+            return real_prepare_padded_buffers(*args, **kwargs)
+
+        def fail_staged_batch(*_args, **_kwargs):
+            raise AssertionError("eligible HFSDP flat gather should not use staged batches")
+
+        with (
+            patch.object(optimizer, "_gather_full_uneven_local_tensor_batch", fail_staged_batch),
+            patch.object(
+                optimizer, "_prepare_padded_all_gather_buffers", counting_prepare_padded_buffers
+            ),
+        ):
+            gathered = optimizer._gather_full_uneven_local_tensors_like(items)
+
+        assert len(padded_calls) == 1
+        for result, (param, local_update), full_update in zip(gathered, items, full_updates):
+            ref_dtensor = optimizer._dtensor_from_local_like(param, local_update)
+            expected = redistribute_uneven_dtensor_to_replicated(ref_dtensor)._local_tensor
+            assert torch.equal(expected, full_update)
+            if local_update.numel() == 0:
+                assert result is None
+                continue
+            assert torch.equal(result, expected)
+
+    @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP flat cache test requires at least 4 ranks")
+    def test_hfsdp_flat_gather_metadata_is_cached(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        outer_size = 2
+        inner_size = dp_size // outer_size
+        if dp_size % outer_size != 0:
+            pytest.skip("HFSDP flat gather cache test requires an even world size")
+
+        device_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("dp_outer", "dp")
+        )
+        outer_rank, inner_rank = device_mesh.get_coordinate()
+        logical_rank = inner_rank * outer_size + outer_rank
+        rows, cols = dp_size * 3 + 5, 4
+        full_update = (
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) + 29
+        )
+        rows_per_logical_rank = [
+            rows // dp_size + (1 if rank < rows % dp_size else 0) for rank in range(dp_size)
+        ]
+        row_start = sum(rows_per_logical_rank[:logical_rank])
+        row_count = rows_per_logical_rank[logical_rank]
+        local_update = full_update[row_start : row_start + row_count].contiguous()
+
+        param = nn.Parameter(
+            _make_hfsdp_dtensor(local_update.clone(), full_update.shape, device_mesh)
+        )
+        optimizer = _make_fsdp_muon(
+            [param],
+            dp_group=torch.distributed.group.WORLD,
+            fsdp_batched_all_gather=True,
+            fsdp_flat_batched_all_gather=True,
+        )
+
+        optimizer._gather_full_uneven_local_tensors_like([(param, local_update)])
+        with patch(
+            "torch.distributed.all_gather_object", wraps=torch.distributed.all_gather_object
+        ) as mocked_all_gather_object:
+            optimizer._gather_full_uneven_local_tensors_like([(param, local_update)])
+
+        assert mocked_all_gather_object.call_count == 0
+
+    @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP flat gather test requires at least 4 ranks")
+    def test_hfsdp_flat_batched_gather_uses_uneven_path_when_padding_too_expensive(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+            redistribute_uneven_dtensor_to_replicated,
+        )
+
+        dp_size = torch.distributed.get_world_size()
+        outer_size = 2
+        inner_size = dp_size // outer_size
+        if dp_size % outer_size != 0:
+            pytest.skip("HFSDP flat gather test requires an even world size")
+
+        device_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("dp_outer", "dp")
+        )
+        outer_rank, inner_rank = device_mesh.get_coordinate()
+        logical_rank = inner_rank * outer_size + outer_rank
+        rows, cols = dp_size * 3 + 1, 4
+        full_update = torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols)
+        rows_per_logical_rank = [
+            rows // dp_size + (1 if rank < rows % dp_size else 0) for rank in range(dp_size)
+        ]
+        row_start = sum(rows_per_logical_rank[:logical_rank])
+        row_count = rows_per_logical_rank[logical_rank]
+        local_update = full_update[row_start : row_start + row_count].contiguous()
+
+        param = nn.Parameter(
+            _make_hfsdp_dtensor(local_update.clone(), full_update.shape, device_mesh)
+        )
+        optimizer = _make_fsdp_muon(
+            [param],
+            dp_group=torch.distributed.group.WORLD,
+            fsdp_batched_all_gather=True,
+            fsdp_flat_batched_all_gather=True,
+            fsdp_padded_all_gather=True,
+            fsdp_padded_all_gather_pad_factor=1.0,
+        )
+
+        def fail_padded_path(*_args, **_kwargs):
+            raise AssertionError("padding threshold should use the uneven flat gather path")
+
+        def fail_staged_batch(*_args, **_kwargs):
+            raise AssertionError("eligible HFSDP flat gather should not use staged batches")
+
+        with (
+            patch.object(optimizer, "_prepare_padded_all_gather_buffers", fail_padded_path),
+            patch.object(optimizer, "_gather_full_uneven_local_tensor_batch", fail_staged_batch),
+        ):
+            result = optimizer._gather_full_uneven_local_tensors_like([(param, local_update)])[0]
+
+        ref_dtensor = optimizer._dtensor_from_local_like(param, local_update)
+        expected = redistribute_uneven_dtensor_to_replicated(ref_dtensor)._local_tensor
+        if local_update.numel() == 0:
+            assert result is None
+        else:
+            assert torch.equal(result, expected)
+
+    @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP flat budget test requires at least 4 ranks")
+    def test_hfsdp_flat_batched_gather_splits_on_gather_byte_budget(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        outer_size = 2
+        inner_size = dp_size // outer_size
+        if dp_size % outer_size != 0:
+            pytest.skip("HFSDP flat budget test requires an even world size")
+
+        device_mesh = init_device_mesh(
+            "cuda", (outer_size, inner_size), mesh_dim_names=("dp_outer", "dp")
+        )
+        outer_rank, inner_rank = device_mesh.get_coordinate()
+        logical_rank = inner_rank * outer_size + outer_rank
+        rows, cols = dp_size * 3 + 5, 4
+
+        full_updates = [
+            torch.arange(rows * cols, device="cuda", dtype=torch.float32).view(rows, cols) + idx
+            for idx in range(2)
+        ]
+        params = []
+        items = []
+        for full_update in full_updates:
+            rows_per_logical_rank = [
+                rows // dp_size + (1 if rank < rows % dp_size else 0) for rank in range(dp_size)
+            ]
+            row_start = sum(rows_per_logical_rank[:logical_rank])
+            row_count = rows_per_logical_rank[logical_rank]
+            local_update = full_update[row_start : row_start + row_count].contiguous()
+            param = nn.Parameter(
+                _make_hfsdp_dtensor(local_update.clone(), full_update.shape, device_mesh)
+            )
+            params.append(param)
+            items.append((param, local_update))
+
+        first_item_bytes = full_updates[0].numel() * full_updates[0].element_size()
+        optimizer = _make_fsdp_muon(
+            params,
+            dp_group=torch.distributed.group.WORLD,
+            fsdp_batched_all_gather=True,
+            fsdp_flat_batched_all_gather=True,
+            fsdp_batch_max_gather_bytes=first_item_bytes + full_updates[0].element_size(),
+        )
+        batch_sizes = []
+        real_flat_batch_gather = optimizer._gather_flat_full_uneven_local_tensor_batch
+
+        def counting_flat_batch_gather(items_arg, results_arg, batch):
+            batch_sizes.append(len(batch["item_indices"]))
+            return real_flat_batch_gather(items_arg, results_arg, batch)
+
+        def fail_staged_batch(*_args, **_kwargs):
+            raise AssertionError("eligible HFSDP flat gather should not use staged batches")
+
+        with (
+            patch.object(
+                optimizer, "_gather_flat_full_uneven_local_tensor_batch", counting_flat_batch_gather
+            ),
+            patch.object(optimizer, "_gather_full_uneven_local_tensor_batch", fail_staged_batch),
+        ):
+            results = optimizer._gather_full_uneven_local_tensors_like(items)
+
+        assert batch_sizes == [1, 1]
+        for result, full_update, (_, local_update) in zip(results, full_updates, items):
+            if local_update.numel() == 0:
+                assert result is None
+            else:
+                assert torch.equal(result, full_update)
+
+    def test_flat_batched_gather_falls_back_for_single_stage_fsdp(self):
+        from torch.distributed.device_mesh import init_device_mesh
+
+        dp_size = torch.distributed.get_world_size()
+        dp_rank = torch.distributed.get_rank()
+        device_mesh = init_device_mesh("cuda", (dp_size,), mesh_dim_names=("dp",))
+        dp_group = device_mesh.get_group("dp")
+        cols = 4
+
+        plan = {0: 2, 1: 3}
+        full_grad = torch.arange(5 * cols, device="cuda", dtype=torch.float32).view(5, cols)
+        local_value = _local_slice(torch.zeros_like(full_grad), plan, dp_rank).contiguous()
+        param = nn.Parameter(_make_dtensor(local_value, full_grad.shape, device_mesh))
+        local_grad = _local_slice(full_grad, plan, dp_rank).contiguous()
+
+        optimizer = _make_fsdp_muon(
+            [param],
+            dp_group=dp_group,
+            fsdp_batched_all_gather=True,
+            fsdp_flat_batched_all_gather=True,
+        )
+
+        def fail_flat_batch(*_args, **_kwargs):
+            raise AssertionError("single-stage FSDP should use the staged path")
+
+        with patch.object(
+            optimizer, "_gather_flat_full_uneven_local_tensor_batch", fail_flat_batch
+        ):
+            result = optimizer._gather_full_uneven_local_tensors_like([(param, local_grad)])[0]
+
+        if local_grad.numel() == 0:
+            assert result is None
+        else:
+            torch.testing.assert_close(result, full_grad, atol=0, rtol=0)
+
     @pytest.mark.skipif(WORLD_SIZE < 4, reason="HFSDP cache test requires at least 4 ranks")
     def test_hfsdp_boundary_metadata_collectives_are_cached_across_steps(self):
         from torch.distributed.device_mesh import init_device_mesh
@@ -1699,6 +1994,7 @@ class TestFSDPFactoryIntegration:
         config = OptimizerConfig(optimizer="muon")
 
         assert not config.muon_fsdp_batched_all_gather
+        assert not config.muon_fsdp_flat_batched_all_gather
         assert not config.muon_fsdp_reuse_gather_scratch
         assert not config.muon_fsdp_padded_all_gather
         assert config.muon_fsdp_padded_all_gather_pad_factor == 1.25
@@ -1751,6 +2047,7 @@ class TestFSDPFactoryIntegration:
             muon_split_qkv=False,
             muon_extra_scale_factor=1.0,
             muon_fsdp_batched_all_gather=True,
+            muon_fsdp_flat_batched_all_gather=True,
             muon_fsdp_reuse_gather_scratch=True,
             muon_fsdp_padded_all_gather=True,
             muon_fsdp_padded_all_gather_pad_factor=2.0,
@@ -1799,6 +2096,7 @@ class TestFSDPFactoryIntegration:
             assert isinstance(base_opt, FSDPTensorParallelMuon)
             assert base_opt.dp_group is not None
             assert base_opt.fsdp_batched_all_gather
+            assert base_opt.fsdp_flat_batched_all_gather
             assert base_opt.fsdp_reuse_gather_scratch
             assert base_opt.fsdp_padded_all_gather
             assert base_opt.fsdp_padded_all_gather_pad_factor == 2.0

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -324,6 +325,46 @@ def test_chained_optimizer():
 
     assert list(optimizer_1.state.values())[0]["exp_avg"].is_cuda
     assert list(optimizer_2.state.values())[0]["momentum_buffer"].is_cuda
+
+
+def test_chained_optimizer_defers_megatron_fsdp_weight_install():
+    """Chained M-FSDP optimizers install weights once after all inner steps."""
+
+    class MockMegatronFSDP:
+        def __init__(self):
+            self.ddp_config = SimpleNamespace(use_megatron_fsdp=True)
+
+        def install_optimized_model_weights(self):
+            events.append("install")
+
+        def start_param_sync(self):
+            events.append("sync")
+
+    class MockOptimizer:
+        def __init__(self, name, config, model_chunk):
+            self.name = name
+            self.config = config
+            self.model_chunks = [model_chunk]
+            self.update_model_params_values = []
+            self.param_groups = []
+
+        def step_with_ready_grads(self, update_model_params=True):
+            self.update_model_params_values.append(update_model_params)
+            events.append(f"step:{self.name}:{update_model_params}")
+            return True
+
+    events = []
+    config = SimpleNamespace(overlap_param_gather_with_optimizer_step=False)
+    model_chunk = MockMegatronFSDP()
+    muon_optimizer = MockOptimizer("muon", config, model_chunk)
+    adam_optimizer = MockOptimizer("adam", config, model_chunk)
+    chained_optimizer = ChainedOptimizer([muon_optimizer, adam_optimizer])
+
+    assert chained_optimizer.step_with_ready_grads()
+
+    assert muon_optimizer.update_model_params_values == [False]
+    assert adam_optimizer.update_model_params_values == [False]
+    assert events == ["step:muon:False", "step:adam:False", "install", "sync"]
 
 
 def test_chained_optimizer_get_parameters():


### PR DESCRIPTION
Introduce Muon support to M-FSDP. Currently 1.5×–2.7× as slow compared to an Adam baseline with a 1B–8B DeepSeek-V3 proxy model. Peak memory slightly lower than with Adam (4–7 % less).