### PR TITLE
test: skip mfsdp_fully_shard cases when world_size < mesh size

### DIFF
--- a/tests/unit_tests/distributed/megatron_fsdp/test_mfsdp_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mfsdp_fully_shard.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import logging
+import math
 import shutil
 from contextlib import nullcontext
 from copy import deepcopy
@@ -210,6 +211,14 @@ def build_distributed_environment(mesh_dim_config: tuple):
     Order of dimensions is (DP_OUTER, DP_SHARD, CP, TP).
     """
     from torch.distributed.device_mesh import init_device_mesh
+
+    required_world_size = math.prod(mesh_dim_config)
+    world_size = torch.distributed.get_world_size()
+    if world_size < required_world_size:
+        pytest.skip(
+            f"This test requires {required_world_size} GPUs for mesh "
+            f"{mesh_dim_config}, but only {world_size} are available"
+        )
 
     # Construct device mesh.
     device_mesh = init_device_mesh(


### PR DESCRIPTION
## Summary

- `tests/unit_tests/distributed/megatron_fsdp/test_mfsdp_fully_shard.py` builds an 8-rank `init_device_mesh` unconditionally, so launching the file with fewer GPUs (e.g. 2) errors out with `Mesh should not be bigger than default world size N, but found 8 ranks!` instead of skipping.
- Added a guard in `build_distributed_environment` that computes the required world size from `mesh_dim_config` and calls `pytest.skip(...)` when the launched world size is too small. This mirrors the existing `world_size != dp_size` skip in the sibling `test_mcore_fully_sharded_data_parallel.py`.
- No behavior change in CI (still 8 GPUs); only affects developer runs with fewer GPUs.

## Test plan

- [x] `torch.distributed.run --nproc_per_node 2 ... pytest test_mfsdp_fully_shard.py` — previously failed with mesh-size errors, now reports `6 passed, 314 skipped, 6 xfailed, 0 failed`.
- [ ] CI on 8 GPUs to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)