### PR TITLE
Checkpoint shared storage when inputs are returned

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -728,6 +728,7 @@ class TENorm:
             **_get_extra_te_kwargs(config),
         )
 
+        instance.returns_residual = use_fused_residual
         return cast(LayerNormInterface, instance)
 
 

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1071,6 +1071,7 @@ class TENorm:
             **_get_extra_te_kwargs(config),
         )
 
+        instance.returns_residual = use_fused_residual
         return cast(LayerNormInterface, instance)
 
 

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -540,7 +540,9 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                 mlp_norm_manager = off_interface(layer.offload_mlp_norm, hidden_states, "mlp_norm")
                 node.layer_state.mlp_norm_manager = mlp_norm_manager
                 if layer.recompute_pre_mlp_layernorm:
-                    layer.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+                    layer.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
+                        retain_input_tensors=layer._pre_mlp_layernorm_returns_residual,
+                    )
                     with mlp_norm_manager as hidden_states:
                         pre_mlp_layernorm_output = layer.pre_mlp_norm_checkpoint.checkpoint(
                             apply_module(layer.pre_mlp_layernorm), hidden_states

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -554,13 +554,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                 # When using fused residual norm (e.g. TEFusedResidualRMSNorm),
                 # the layernorm returns (normalized_output, residual). Unpack
                 # and use the fused residual for the downstream BDA connection.
-                if isinstance(pre_mlp_layernorm_output, tuple):
-                    if len(pre_mlp_layernorm_output) != 2:
-                        raise ValueError(
-                            f"When the output of pre_mlp_layernorm is a tuple, it is "
-                            f"expected to have 2 elements (output, residual), but "
-                            f"got {len(pre_mlp_layernorm_output)}"
-                        )
+                if layer._pre_mlp_layernorm_returns_residual:
                     pre_mlp_layernorm_output, hidden_states = pre_mlp_layernorm_output
 
                 shared_expert_output = layer.mlp.shared_experts_compute(pre_mlp_layernorm_output)

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -541,7 +541,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                 node.layer_state.mlp_norm_manager = mlp_norm_manager
                 if layer.recompute_pre_mlp_layernorm:
                     layer.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
-                        retain_input_tensors=layer._pre_mlp_layernorm_returns_residual,
+                        retain_input_tensors=layer._pre_mlp_layernorm_returns_residual
                     )
                     with mlp_norm_manager as hidden_states:
                         pre_mlp_layernorm_output = layer.pre_mlp_norm_checkpoint.checkpoint(

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -117,13 +117,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                 # When using fused residual norm (e.g. TEFusedResidualRMSNorm),
                 # the layernorm returns (normalized_output, residual). Unpack
                 # and use the fused residual for the downstream BDA connection.
-                if isinstance(pre_mlp_layernorm_output, tuple):
-                    if len(pre_mlp_layernorm_output) != 2:
-                        raise ValueError(
-                            f"When the output of pre_mlp_layernorm is a tuple, it is "
-                            f"expected to have 2 elements (output, residual), but "
-                            f"got {len(pre_mlp_layernorm_output)}"
-                        )
+                if layer._pre_mlp_layernorm_returns_residual:
                     pre_mlp_layernorm_output, hidden_states = pre_mlp_layernorm_output
 
                 shared_expert_output = layer.mlp.shared_experts_compute(pre_mlp_layernorm_output)

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -103,7 +103,9 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                 mlp_norm_manager = off_interface(layer.offload_mlp_norm, hidden_states, "mlp_norm")
                 node.layer_state.mlp_norm_manager = mlp_norm_manager
                 if layer.recompute_pre_mlp_layernorm:
-                    layer.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+                    layer.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
+                        retain_input_tensors=layer._pre_mlp_layernorm_returns_residual,
+                    )
                     with mlp_norm_manager as hidden_states:
                         pre_mlp_layernorm_output = layer.pre_mlp_norm_checkpoint.checkpoint(
                             apply_module(layer.pre_mlp_layernorm), hidden_states

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -104,7 +104,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                 node.layer_state.mlp_norm_manager = mlp_norm_manager
                 if layer.recompute_pre_mlp_layernorm:
                     layer.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
-                        retain_input_tensors=layer._pre_mlp_layernorm_returns_residual,
+                        retain_input_tensors=layer._pre_mlp_layernorm_returns_residual
                     )
                     with mlp_norm_manager as hidden_states:
                         pre_mlp_layernorm_output = layer.pre_mlp_norm_checkpoint.checkpoint(

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -816,10 +816,18 @@ class CheckpointWithoutOutput(object):
         if is_graph_warmup():
             return
 
-        # use resize to release the output tensor memory and still keep the metadata in the tensors.
-        # the metadata is still needed for backward
+        # Release output tensor memory while keeping metadata for backward.
+        # Skip outputs whose storage is shared with a saved input — freeing those
+        # would destroy the data needed for recomputation (e.g. fused residual norms
+        # where MakeExtraOutput returns the input tensor itself as an extra output).
+        saved_ptrs = {
+            t.untyped_storage().data_ptr()
+            for t in self.ctx.saved_tensors
+            if isinstance(t, torch.Tensor)
+        }
         for output in self.outputs:
-            output.untyped_storage().resize_(0)
+            if output.untyped_storage().data_ptr() not in saved_ptrs:
+                output.untyped_storage().resize_(0)
 
         # register the recomputation as a backward hook, when the the gradient of the hook_tensor
         # is computed, the recomputation will be triggered. The hook_tensor should be selected

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -818,8 +818,8 @@ class CheckpointWithoutOutput(object):
 
         # Release output tensor memory while keeping metadata for backward.
         # Skip outputs whose storage is shared with a saved input — freeing those
-        # would destroy the data needed for recomputation (e.g. fused residual norms
-        # where MakeExtraOutput returns the input tensor itself as an extra output).
+        # would destroy the data needed for recomputation (e.g. TE.ops.Sequential 
+        # operations with MakeExtraOutput).
         saved_ptrs = {
             t.untyped_storage().data_ptr()
             for t in self.ctx.saved_tensors

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -800,7 +800,8 @@ class CheckpointWithoutOutput(object):
         #   - No tensor version-counter bump (no autograd complaint)
         share_storage = _get_share_storage()
         for output, recomputation_output in zip(self.outputs, outputs):
-            share_storage(output, recomputation_output)
+            if output.untyped_storage().data_ptr() != recomputation_output.untyped_storage().data_ptr():
+                share_storage(output, recomputation_output)
 
         self.ctx.outputs = outputs
         self.ctx.inputs = inputs

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -800,7 +800,10 @@ class CheckpointWithoutOutput(object):
         #   - No tensor version-counter bump (no autograd complaint)
         share_storage = _get_share_storage()
         for output, recomputation_output in zip(self.outputs, outputs):
-            if output.untyped_storage().data_ptr() != recomputation_output.untyped_storage().data_ptr():
+            if (
+                output.untyped_storage().data_ptr()
+                != recomputation_output.untyped_storage().data_ptr()
+            ):
                 share_storage(output, recomputation_output)
 
         self.ctx.outputs = outputs
@@ -826,7 +829,7 @@ class CheckpointWithoutOutput(object):
         # Release output tensor memory while keeping metadata for backward.
         if self.retain_input_tensors:
             # Skip outputs whose storage is shared with a saved input — freeing those
-            # would destroy the data needed for recomputation (e.g. TE.ops.Sequential 
+            # would destroy the data needed for recomputation (e.g. TE.ops.Sequential
             # operations with MakeExtraOutput).
             for output in self.outputs:
                 if output.untyped_storage().data_ptr() not in self._saved_input_ptrs:

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -737,6 +737,13 @@ class CheckpointWithoutOutput(object):
         self.outputs = outputs
         if isinstance(self.outputs, torch.Tensor):
             self.outputs = (self.outputs,)
+
+        self._saved_input_ptrs = {
+            t.untyped_storage().data_ptr()
+            for t in self.ctx.saved_tensors
+            if isinstance(t, torch.Tensor)
+        }
+
         return outputs
 
     def _recompute(self, _):
@@ -818,15 +825,10 @@ class CheckpointWithoutOutput(object):
 
         # Release output tensor memory while keeping metadata for backward.
         # Skip outputs whose storage is shared with a saved input — freeing those
-        # would destroy the data needed for recomputation (e.g. TE.ops.Sequential 
-        # operations with MakeExtraOutput).
-        saved_ptrs = {
-            t.untyped_storage().data_ptr()
-            for t in self.ctx.saved_tensors
-            if isinstance(t, torch.Tensor)
-        }
+        # would destroy the data needed for recomputation (e.g. fused residual norms
+        # where MakeExtraOutput returns the input tensor itself as an extra output).
         for output in self.outputs:
-            if output.untyped_storage().data_ptr() not in saved_ptrs:
+            if output.untyped_storage().data_ptr() not in self._saved_input_ptrs:
                 output.untyped_storage().resize_(0)
 
         # register the recomputation as a backward hook, when the the gradient of the hook_tensor

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -710,8 +710,9 @@ class CheckpointWithoutOutput(object):
     discarded output tensors are directly saved in the following modules for backward computation.
     """
 
-    def __init__(self, fp8=False):
+    def __init__(self, fp8=False, retain_input_tensors=False):
         self.fp8 = fp8 is not None
+        self.retain_input_tensors = retain_input_tensors
         self.run_function = None
         self.fwd_cpu_rng_state = None
         self.fwd_cuda_rng_state = None
@@ -733,17 +734,15 @@ class CheckpointWithoutOutput(object):
 
         self.rng_states = _get_all_rng_states()
 
+        if self.retain_input_tensors:
+            self._saved_input_ptrs = {
+                t.untyped_storage().data_ptr() for t in args if isinstance(t, torch.Tensor)
+            }
+
         outputs = CheckpointWithoutOutputFunction.apply(run_function, self, *args)
         self.outputs = outputs
         if isinstance(self.outputs, torch.Tensor):
             self.outputs = (self.outputs,)
-
-        self._saved_input_ptrs = {
-            t.untyped_storage().data_ptr()
-            for t in self.ctx.saved_tensors
-            if isinstance(t, torch.Tensor)
-        }
-
         return outputs
 
     def _recompute(self, _):
@@ -824,11 +823,15 @@ class CheckpointWithoutOutput(object):
             return
 
         # Release output tensor memory while keeping metadata for backward.
-        # Skip outputs whose storage is shared with a saved input — freeing those
-        # would destroy the data needed for recomputation (e.g. fused residual norms
-        # where MakeExtraOutput returns the input tensor itself as an extra output).
-        for output in self.outputs:
-            if output.untyped_storage().data_ptr() not in self._saved_input_ptrs:
+        if self.retain_input_tensors:
+            # Skip outputs whose storage is shared with a saved input — freeing those
+            # would destroy the data needed for recomputation (e.g. TE.ops.Sequential 
+            # operations with MakeExtraOutput).
+            for output in self.outputs:
+                if output.untyped_storage().data_ptr() not in self._saved_input_ptrs:
+                    output.untyped_storage().resize_(0)
+        else:
+            for output in self.outputs:
                 output.untyped_storage().resize_(0)
 
         # register the recomputation as a backward hook, when the the gradient of the hook_tensor

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -860,7 +860,7 @@ class CheckpointWithoutOutput(object):
     discarded output tensors are directly saved in the following modules for backward computation.
     """
 
-    def __init__(self, fp8=False, ckpt_manager=None):
+    def __init__(self, fp8=False, ckpt_manager=None, retain_input_tensors=False):
         """
         Initialize CheckpointWithoutOutput.
 
@@ -878,9 +878,12 @@ class CheckpointWithoutOutput(object):
                          checkpoint() will auto-register to the manager, and
                          discard_output_and_register_recompute() will only discard
                          output without registering individual hooks.
+            retain_input_tensors: Whether outputs sharing storage with checkpoint inputs
+                                  should be retained when discarding outputs.
         """
         self.fp8 = fp8 is not None
         self.ckpt_manager = ckpt_manager
+        self.retain_input_tensors = retain_input_tensors
         self.run_function = None
         self.fwd_cpu_rng_state = None
         self.fwd_cuda_rng_state = None
@@ -907,16 +910,15 @@ class CheckpointWithoutOutput(object):
 
         self.rng_states = _get_all_rng_states()
 
+        if self.retain_input_tensors:
+            self._saved_input_ptrs = {
+                t.untyped_storage().data_ptr() for t in args if isinstance(t, torch.Tensor)
+            }
+
         outputs = CheckpointWithoutOutputFunction.apply(run_function, self, *args)
         self.outputs = outputs
         if isinstance(self.outputs, torch.Tensor):
             self.outputs = (self.outputs,)
-
-        self._saved_input_ptrs = {
-            t.untyped_storage().data_ptr()
-            for t in self.ctx.saved_tensors
-            if isinstance(t, torch.Tensor)
-        }
 
         # Auto-register to manager if provided
         if self.ckpt_manager is not None:
@@ -994,11 +996,15 @@ class CheckpointWithoutOutput(object):
             return
 
         # Release output tensor memory while keeping metadata for backward.
-        # Skip outputs whose storage is shared with a saved input — freeing those
-        # would destroy the data needed for recomputation (e.g. fused residual norms
-        # where MakeExtraOutput returns the input tensor itself as an extra output).
-        for output in self.outputs:
-            if output.untyped_storage().data_ptr() not in self._saved_input_ptrs:
+        if self.retain_input_tensors:
+            # Skip outputs whose storage is shared with a saved input — freeing those
+            # would destroy the data needed for recomputation (e.g. TE.ops.Sequential
+            # operations with MakeExtraOutput).
+            for output in self.outputs:
+                if output.untyped_storage().data_ptr() not in self._saved_input_ptrs:
+                    output.untyped_storage().resize_(0)
+        else:
+            for output in self.outputs:
                 output.untyped_storage().resize_(0)
 
         # register the recomputation as a backward hook, when the the gradient of the hook_tensor

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -912,6 +912,12 @@ class CheckpointWithoutOutput(object):
         if isinstance(self.outputs, torch.Tensor):
             self.outputs = (self.outputs,)
 
+        self._saved_input_ptrs = {
+            t.untyped_storage().data_ptr()
+            for t in self.ctx.saved_tensors
+            if isinstance(t, torch.Tensor)
+        }
+
         # Auto-register to manager if provided
         if self.ckpt_manager is not None:
             self.ckpt_manager.add_checkpoint(self)
@@ -989,15 +995,10 @@ class CheckpointWithoutOutput(object):
 
         # Release output tensor memory while keeping metadata for backward.
         # Skip outputs whose storage is shared with a saved input — freeing those
-        # would destroy the data needed for recomputation (e.g. TE.ops.Sequential 
-        # operations with MakeExtraOutput).
-        saved_ptrs = {
-            t.untyped_storage().data_ptr()
-            for t in self.ctx.saved_tensors
-            if isinstance(t, torch.Tensor)
-        }
+        # would destroy the data needed for recomputation (e.g. fused residual norms
+        # where MakeExtraOutput returns the input tensor itself as an extra output).
         for output in self.outputs:
-            if output.untyped_storage().data_ptr() not in saved_ptrs:
+            if output.untyped_storage().data_ptr() not in self._saved_input_ptrs:
                 output.untyped_storage().resize_(0)
 
         # register the recomputation as a backward hook, when the the gradient of the hook_tensor

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -989,8 +989,8 @@ class CheckpointWithoutOutput(object):
 
         # Release output tensor memory while keeping metadata for backward.
         # Skip outputs whose storage is shared with a saved input — freeing those
-        # would destroy the data needed for recomputation (e.g. fused residual norms
-        # where MakeExtraOutput returns the input tensor itself as an extra output).
+        # would destroy the data needed for recomputation (e.g. TE.ops.Sequential 
+        # operations with MakeExtraOutput).
         saved_ptrs = {
             t.untyped_storage().data_ptr()
             for t in self.ctx.saved_tensors

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -832,8 +832,7 @@ class CheckpointWithoutOutputManager:
     def discard_all_outputs_and_register_unified_recompute(self, hook_tensor):
         """Discard all checkpoint outputs to save memory and register unified recompute hook."""
         for ckpt in self.checkpoints:
-            for output in ckpt.outputs:
-                output.untyped_storage().resize_(0)
+            ckpt._discard_outputs()
 
         # Register unified recompute hook
         if hook_tensor.requires_grad:
@@ -983,6 +982,19 @@ class CheckpointWithoutOutput(object):
         self.outputs = None
         self.ctx = None
 
+    def _discard_outputs(self):
+        """Release output storage, preserving outputs that alias retained inputs."""
+        if self.retain_input_tensors:
+            # Skip outputs whose storage is shared with a saved input — freeing those
+            # would destroy the data needed for recomputation (e.g. TE.ops.Sequential
+            # operations with MakeExtraOutput).
+            for output in self.outputs:
+                if output.untyped_storage().data_ptr() not in self._saved_input_ptrs:
+                    output.untyped_storage().resize_(0)
+        else:
+            for output in self.outputs:
+                output.untyped_storage().resize_(0)
+
     def discard_output_and_register_recompute(self, hook_tensor):
         """
         Release the output tensor storages and register the recompute function as a grad hook of
@@ -1000,16 +1012,7 @@ class CheckpointWithoutOutput(object):
             return
 
         # Release output tensor memory while keeping metadata for backward.
-        if self.retain_input_tensors:
-            # Skip outputs whose storage is shared with a saved input — freeing those
-            # would destroy the data needed for recomputation (e.g. TE.ops.Sequential
-            # operations with MakeExtraOutput).
-            for output in self.outputs:
-                if output.untyped_storage().data_ptr() not in self._saved_input_ptrs:
-                    output.untyped_storage().resize_(0)
-        else:
-            for output in self.outputs:
-                output.untyped_storage().resize_(0)
+        self._discard_outputs()
 
         # register the recomputation as a backward hook, when the the gradient of the hook_tensor
         # is computed, the recomputation will be triggered. The hook_tensor should be selected

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -972,7 +972,10 @@ class CheckpointWithoutOutput(object):
         #   - No tensor version-counter bump (no autograd complaint)
         share_storage = _get_share_storage()
         for output, recomputation_output in zip(self.outputs, outputs):
-            if output.untyped_storage().data_ptr() != recomputation_output.untyped_storage().data_ptr():
+            if (
+                output.untyped_storage().data_ptr()
+                != recomputation_output.untyped_storage().data_ptr()
+            ):
                 share_storage(output, recomputation_output)
 
         self.ctx.outputs = outputs

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -987,10 +987,18 @@ class CheckpointWithoutOutput(object):
         if self.ckpt_manager is not None or is_graph_warmup():
             return
 
-        # use resize to release the output tensor memory and still keep the metadata in the tensors.
-        # the metadata is still needed for backward
+        # Release output tensor memory while keeping metadata for backward.
+        # Skip outputs whose storage is shared with a saved input — freeing those
+        # would destroy the data needed for recomputation (e.g. fused residual norms
+        # where MakeExtraOutput returns the input tensor itself as an extra output).
+        saved_ptrs = {
+            t.untyped_storage().data_ptr()
+            for t in self.ctx.saved_tensors
+            if isinstance(t, torch.Tensor)
+        }
         for output in self.outputs:
-            output.untyped_storage().resize_(0)
+            if output.untyped_storage().data_ptr() not in saved_ptrs:
+                output.untyped_storage().resize_(0)
 
         # register the recomputation as a backward hook, when the the gradient of the hook_tensor
         # is computed, the recomputation will be triggered. The hook_tensor should be selected

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -972,7 +972,8 @@ class CheckpointWithoutOutput(object):
         #   - No tensor version-counter bump (no autograd complaint)
         share_storage = _get_share_storage()
         for output, recomputation_output in zip(self.outputs, outputs):
-            share_storage(output, recomputation_output)
+            if output.untyped_storage().data_ptr() != recomputation_output.untyped_storage().data_ptr():
+                share_storage(output, recomputation_output)
 
         self.ctx.outputs = outputs
         self.ctx.inputs = inputs

--- a/megatron/core/transformer/torch_norm.py
+++ b/megatron/core/transformer/torch_norm.py
@@ -11,6 +11,8 @@ from megatron.core.utils import is_torch_min_version
 class LayerNormInterface(Protocol):
     """Interface that all LayerNorm implementations should follow."""
 
+    returns_residual: bool
+
     def forward(self, x: torch.Tensor, /) -> torch.Tensor:
         """Forward method for a LayerNorm implementation."""
         ...
@@ -66,7 +68,9 @@ class WrappedTorchNorm:
         else:
             raise Exception("Only LayerNorm, RMSNorm and L2Norm are currently supported")
 
-        return norm_cls(normalized_shape=hidden_size, eps=eps)
+        instance = norm_cls(normalized_shape=hidden_size, eps=eps)
+        instance.returns_residual = False
+        return instance
 
 
 class L2Norm(torch.nn.Module, LayerNormInterface):

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -354,6 +354,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
         )
+        self._input_layernorm_returns_residual = getattr(
+            self.input_layernorm, 'returns_residual', False
+        )
 
         attention_optional_kwargs = {}
         if config.context_parallel_size > 1 and config.cp_comm_type is not None:
@@ -387,6 +390,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
         )
+        self._pre_cross_attn_layernorm_returns_residual = getattr(
+            self.pre_cross_attn_layernorm, 'returns_residual', False
+        )
 
         # [Module 5: CrossAttention]
         self.cross_attention = build_module(
@@ -405,6 +411,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             config=self.config,
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
+        )
+        self._pre_mlp_layernorm_returns_residual = getattr(
+            self.pre_mlp_layernorm, 'returns_residual', False
         )
         # [Module 8: MLP block]
         # import here to avoid circular import
@@ -625,13 +634,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             with attn_norm_manager as hidden_states:
                 input_layernorm_output = apply_module(self.input_layernorm)(hidden_states)
 
-        if isinstance(input_layernorm_output, tuple):
-            if len(input_layernorm_output) != 2:
-                raise ValueError(
-                    f"When the output of input_layernorm is a tuple, it is "
-                    f"expected to have 2 elements (output, residual), but "
-                    f"got {len(input_layernorm_output)}"
-                )
+        if self._input_layernorm_returns_residual:
             input_layernorm_output, residual = input_layernorm_output
         else:
             residual = hidden_states
@@ -695,14 +698,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # Optional Layer norm after self-attention
         pre_cross_attn_layernorm_output = apply_module(self.pre_cross_attn_layernorm)(hidden_states)
 
-        if isinstance(pre_cross_attn_layernorm_output, tuple):
-            if len(pre_cross_attn_layernorm_output) != 2:
-                raise ValueError(
-                    f"When the output of pre_cross_attn_layernorm_output "
-                    f"is a tuple, it is expected to have 2 elements "
-                    f"(output, residual), but "
-                    f"got {len(pre_cross_attn_layernorm_output)}"
-                )
+        if self._pre_cross_attn_layernorm_returns_residual:
             pre_cross_attn_layernorm_output, residual = pre_cross_attn_layernorm_output
         else:
             residual = hidden_states
@@ -783,16 +779,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # Optional Layer norm post the cross-attention.
         pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(hidden_states)
 
-        if isinstance(pre_mlp_layernorm_output, tuple):
-            if len(pre_mlp_layernorm_output) != 2:
-                raise ValueError(
-                    f"When the output of pre_mlp_layernorm is a tuple, it is "
-                    f"expected to have 2 elements (output, residual), but "
-                    f"got {len(pre_mlp_layernorm_output)}"
-                )
+        if self._pre_mlp_layernorm_returns_residual:
             pre_mlp_layernorm_output, residual = pre_mlp_layernorm_output
         else:
-            # Residual connection.
             residual = hidden_states
 
         if self.config.fp32_residual_connection:
@@ -1265,13 +1254,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 if not self.is_moe_layer:
                     return residual, None, None, None
                 hidden_states = apply_module(self.pre_mlp_layernorm)(residual)
-                if isinstance(hidden_states, tuple):
-                    if len(hidden_states) != 2:
-                        raise ValueError(
-                            f"When the output of pre_mlp_layernorm is a tuple, it is "
-                            f"expected to have 2 elements (output, residual), but "
-                            f"got {len(hidden_states)}"
-                        )
+                if self._pre_mlp_layernorm_returns_residual:
                     hidden_states, residual = hidden_states
 
                 shared_expert_output = self.mlp.shared_experts_compute(hidden_states)
@@ -1575,13 +1558,7 @@ class MoETransformerLayer(TransformerLayer):
 
         self.mlp.fwd_execution_map = "route"
         pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(hidden_states)
-        if isinstance(pre_mlp_layernorm_output, tuple):
-            if len(pre_mlp_layernorm_output) != 2:
-                raise ValueError(
-                    f"When the output of pre_mlp_layernorm is a tuple, it is "
-                    f"expected to have 2 elements (output, residual), but "
-                    f"got {len(pre_mlp_layernorm_output)}"
-                )
+        if self._pre_mlp_layernorm_returns_residual:
             pre_mlp_layernorm_output, residual = pre_mlp_layernorm_output
         else:
             residual = hidden_states

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -626,7 +626,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         attn_norm_manager = self.off_interface(self.offload_attn_norm, hidden_states, "attn_norm")
         if self.recompute_input_layernorm:
             self.input_layernorm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
-                retain_input_tensors=self._input_layernorm_returns_residual,
+                retain_input_tensors=self._input_layernorm_returns_residual
             )
             with attn_norm_manager as hidden_states:
                 input_layernorm_output = self.input_layernorm_checkpoint.checkpoint(
@@ -747,7 +747,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
         if self.recompute_pre_mlp_layernorm:
             self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
-                retain_input_tensors=self._pre_mlp_layernorm_returns_residual,
+                retain_input_tensors=self._pre_mlp_layernorm_returns_residual
             )
             with self.mlp_norm_manager as hidden_states:
                 pre_mlp_layernorm_output = self.pre_mlp_norm_checkpoint.checkpoint(

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -625,7 +625,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # Optional Input Layer norm
         attn_norm_manager = self.off_interface(self.offload_attn_norm, hidden_states, "attn_norm")
         if self.recompute_input_layernorm:
-            self.input_layernorm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+            self.input_layernorm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
+                retain_input_tensors=self._input_layernorm_returns_residual,
+            )
             with attn_norm_manager as hidden_states:
                 input_layernorm_output = self.input_layernorm_checkpoint.checkpoint(
                     apply_module(self.input_layernorm), hidden_states
@@ -744,7 +746,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
     def _forward_pre_mlp_layernorm(self, hidden_states: Tensor):
         self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
         if self.recompute_pre_mlp_layernorm:
-            self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+            self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
+                retain_input_tensors=self._pre_mlp_layernorm_returns_residual,
+            )
             with self.mlp_norm_manager as hidden_states:
                 pre_mlp_layernorm_output = self.pre_mlp_norm_checkpoint.checkpoint(
                     apply_module(self.pre_mlp_layernorm), hidden_states

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -712,7 +712,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         self._input_layernorm_checkpoint_active = self.recompute_input_layernorm
         if self._input_layernorm_checkpoint_active:
             self.input_layernorm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
-                retain_input_tensors=self._input_layernorm_returns_residual,
+                retain_input_tensors=self._input_layernorm_returns_residual
             )
             with self.attn_norm_manager as hidden_states:
                 input_layernorm_output = self.input_layernorm_checkpoint.checkpoint(
@@ -819,7 +819,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
         if self.recompute_pre_mlp_layernorm:
             self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
-                retain_input_tensors=self._pre_mlp_layernorm_returns_residual,
+                retain_input_tensors=self._pre_mlp_layernorm_returns_residual
             )
             with self.mlp_norm_manager as hidden_states:
                 pre_mlp_layernorm_output = self.pre_mlp_norm_checkpoint.checkpoint(

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -711,7 +711,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         )
         self._input_layernorm_checkpoint_active = self.recompute_input_layernorm
         if self._input_layernorm_checkpoint_active:
-            self.input_layernorm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+            self.input_layernorm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
+                retain_input_tensors=self._input_layernorm_returns_residual,
+            )
             with self.attn_norm_manager as hidden_states:
                 input_layernorm_output = self.input_layernorm_checkpoint.checkpoint(
                     apply_module(self.input_layernorm), hidden_states
@@ -816,7 +818,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
     def _forward_pre_mlp_layernorm(self, hidden_states: Tensor):
         self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
         if self.recompute_pre_mlp_layernorm:
-            self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+            self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
+                retain_input_tensors=self._pre_mlp_layernorm_returns_residual,
+            )
             with self.mlp_norm_manager as hidden_states:
                 pre_mlp_layernorm_output = self.pre_mlp_norm_checkpoint.checkpoint(
                     apply_module(self.pre_mlp_layernorm), hidden_states

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -370,6 +370,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
         )
+        self._input_layernorm_returns_residual = getattr(
+            self.input_layernorm, 'returns_residual', False
+        )
 
         attention_optional_kwargs = {}
         if config.context_parallel_size > 1 and config.cp_comm_type is not None:
@@ -403,6 +406,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
         )
+        self._pre_cross_attn_layernorm_returns_residual = getattr(
+            self.pre_cross_attn_layernorm, 'returns_residual', False
+        )
 
         # [Module 5: CrossAttention]
         self.cross_attention = build_module(
@@ -421,6 +427,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             config=self.config,
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
+        )
+        self._pre_mlp_layernorm_returns_residual = getattr(
+            self.pre_mlp_layernorm, 'returns_residual', False
         )
         # [Module 8: MLP block]
         # import here to avoid circular import
@@ -711,13 +720,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             with self.attn_norm_manager as hidden_states:
                 input_layernorm_output = apply_module(self.input_layernorm)(hidden_states)
 
-        if isinstance(input_layernorm_output, tuple):
-            if len(input_layernorm_output) != 2:
-                raise ValueError(
-                    f"When the output of input_layernorm is a tuple, it is "
-                    f"expected to have 2 elements (output, residual), but "
-                    f"got {len(input_layernorm_output)}"
-                )
+        if self._input_layernorm_returns_residual:
             input_layernorm_output, residual = input_layernorm_output
         else:
             residual = hidden_states
@@ -763,14 +766,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         """Optional pre-cross-attn layernorm + cross-attention + bda block."""
         pre_cross_attn_layernorm_output = apply_module(self.pre_cross_attn_layernorm)(hidden_states)
 
-        if isinstance(pre_cross_attn_layernorm_output, tuple):
-            if len(pre_cross_attn_layernorm_output) != 2:
-                raise ValueError(
-                    f"When the output of pre_cross_attn_layernorm_output "
-                    f"is a tuple, it is expected to have 2 elements "
-                    f"(output, residual), but "
-                    f"got {len(pre_cross_attn_layernorm_output)}"
-                )
+        if self._pre_cross_attn_layernorm_returns_residual:
             pre_cross_attn_layernorm_output, residual = pre_cross_attn_layernorm_output
         else:
             residual = hidden_states
@@ -882,16 +878,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         """
         pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(hidden_states)
 
-        if isinstance(pre_mlp_layernorm_output, tuple):
-            if len(pre_mlp_layernorm_output) != 2:
-                raise ValueError(
-                    f"When the output of pre_mlp_layernorm is a tuple, it is "
-                    f"expected to have 2 elements (output, residual), but "
-                    f"got {len(pre_mlp_layernorm_output)}"
-                )
+        if self._pre_mlp_layernorm_returns_residual:
             pre_mlp_layernorm_output, residual = pre_mlp_layernorm_output
         else:
-            # Residual connection.
             residual = hidden_states
 
         if self.config.fp32_residual_connection:
@@ -1449,13 +1438,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 if not self.is_moe_layer:
                     return residual, None, None, None
                 hidden_states = apply_module(self.pre_mlp_layernorm)(residual)
-                if isinstance(hidden_states, tuple):
-                    if len(hidden_states) != 2:
-                        raise ValueError(
-                            f"When the output of pre_mlp_layernorm is a tuple, it is "
-                            f"expected to have 2 elements (output, residual), but "
-                            f"got {len(hidden_states)}"
-                        )
+                if self._pre_mlp_layernorm_returns_residual:
                     hidden_states, residual = hidden_states
 
                 shared_expert_output = self.mlp.shared_experts_compute(hidden_states)

--- a/tests/unit_tests/tensor_parallel/test_random.py
+++ b/tests/unit_tests/tensor_parallel/test_random.py
@@ -296,3 +296,77 @@ def test_checkpoint_without_output_view_sharing_regression():
         assert torch.allclose(weight1.grad, weight2.grad)
     finally:
         Utils.destroy_model_parallel()
+
+
+class _FusedResidualNorm(torch.autograd.Function):
+    """Mimics TEFusedResidualRMSNorm: returns (norm(input), input) where the
+    residual shares storage with the input (the MakeExtraOutput pattern).
+    Backward combines grad_norm and grad_residual into a single grad_input."""
+
+    @staticmethod
+    def forward(ctx, x, weight):
+        rms = x.float().pow(2).mean(-1, keepdim=True).add(1e-6).rsqrt()
+        normed = (x.float() * rms).to(x.dtype) * weight
+        ctx.save_for_backward(x, weight, rms)
+        return normed, x
+
+    @staticmethod
+    def backward(ctx, grad_normed, grad_residual):
+        x, weight, rms = ctx.saved_tensors
+        x_float = x.float()
+        normed_float = x_float * rms
+        grad_normed_float = (grad_normed * weight).float()
+        d = x.shape[-1]
+        grad_x = (
+            grad_normed_float * rms
+            - normed_float * (grad_normed_float * normed_float).sum(-1, keepdim=True) / d
+        )
+        grad_x = grad_x.to(x.dtype) + grad_residual
+        grad_weight = (grad_normed * normed_float.to(x.dtype)).sum(
+            dim=tuple(range(grad_normed.ndim - 1))
+        )
+        return grad_x, grad_weight
+
+
+def test_checkpoint_without_output_retain_input_tensors():
+    """CheckpointWithoutOutput with retain_input_tensors=True must not free
+    outputs that share storage with inputs (the fused residual norm pattern)."""
+
+    hidden = 32
+
+    def fused_norm(x):
+        return _FusedResidualNorm.apply(x, weight)
+
+    def normal_forward(x):
+        normed, residual = fused_norm(x)
+        return normed + residual
+
+    def checkpoint_forward(x):
+        ckpt = CheckpointWithoutOutput(retain_input_tensors=True)
+        normed, residual = ckpt.checkpoint(fused_norm, x)
+        y = normed + residual
+        ckpt.discard_output_and_register_recompute(y)
+        return y
+
+    Utils.initialize_model_parallel()
+    try:
+        weight = torch.randn(hidden, requires_grad=True)
+        input_ref = torch.randn((4, hidden), requires_grad=True)
+
+        input1 = input_ref.detach().clone().requires_grad_(True)
+        output1 = normal_forward(input1)
+
+        input2 = input_ref.detach().clone().requires_grad_(True)
+        weight.grad = None
+        output2 = checkpoint_forward(input2)
+        assert torch.allclose(output1, output2)
+
+        grad = torch.randn_like(output1)
+        output1.backward(grad)
+        ref_input_grad = input1.grad.clone()
+
+        weight.grad = None
+        output2.backward(grad)
+        assert torch.allclose(ref_input_grad, input2.grad)
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/tensor_parallel/test_random.py
+++ b/tests/unit_tests/tensor_parallel/test_random.py
@@ -5,6 +5,7 @@ import torch
 
 from megatron.core.tensor_parallel.random import (
     CheckpointWithoutOutput,
+    CheckpointWithoutOutputManager,
     CudaRNGStatesTracker,
     checkpoint,
     convert_cuda_rng_state,
@@ -328,7 +329,8 @@ class _FusedResidualNorm(torch.autograd.Function):
         return grad_x, grad_weight
 
 
-def test_checkpoint_without_output_retain_input_tensors():
+@pytest.mark.parametrize("use_manager", [False, True])
+def test_checkpoint_without_output_retain_input_tensors(use_manager):
     """CheckpointWithoutOutput with retain_input_tensors=True must not free
     outputs that share storage with inputs (the fused residual norm pattern)."""
 
@@ -342,10 +344,14 @@ def test_checkpoint_without_output_retain_input_tensors():
         return normed + residual
 
     def checkpoint_forward(x):
-        ckpt = CheckpointWithoutOutput(retain_input_tensors=True)
+        manager = CheckpointWithoutOutputManager() if use_manager else None
+        ckpt = CheckpointWithoutOutput(ckpt_manager=manager, retain_input_tensors=True)
         normed, residual = ckpt.checkpoint(fused_norm, x)
         y = normed + residual
-        ckpt.discard_output_and_register_recompute(y)
+        if manager is None:
+            ckpt.discard_output_and_register_recompute(y)
+        else:
+            manager.discard_all_outputs_and_register_unified_recompute(y)
         return y
 
     Utils.initialize_model_parallel()


### PR DESCRIPTION
# What does this PR do ?

Fix activation checkpointing for fused rmsnorm residual (and other such functions)
Checkpointing is sometimes deleting tensors that are then required in the backwards pass, causing segfaults.


Summary:
1. For activation checkpointing, dont delete output tensors which share storage with input tensors.
2. Simplify implementation of fused RMSNorm residual.

Details:
1. The most important change is to the activation checkpointing. Currently, when we discard the outputs, we just destroy the storage from all of them. In some cases, one of the output may share storage with the input tensors. When this is the case, we are destroying the tensor that is stored in the ctx for backward().
2. Changes to the fused RMSnorm to formalize what it expects in the interface. This allows us to know whether it returns the residual by checking the flag rather than doing an isinstance() check, simplifying the code.


:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
