### PR TITLE
Async scheduling: speculative forward passes for continuous GPU decode

### DIFF
--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -143,6 +143,7 @@ class InferenceBatchDimensions:
         smallest_non_decode_cuda_graph_size: int,
         ep_group: Optional[torch.distributed.ProcessGroup] = None,
         num_speculative_tokens: int = 0,
+        ep_zmq_communicator=None,
     ) -> Optional["InferenceBatchDimensions"]:
         """Adjusted cuda graph batch dimensions for expert parallelism.
             We take the max token count across expert model parallel group.
@@ -154,6 +155,11 @@ class InferenceBatchDimensions:
             ep_group: Optional expert parallel process group. If None, uses global parallel state.
                       When using different EP sizes for inference vs training, pass the
                       inference EP group explicitly.
+            ep_zmq_communicator: Optional AsyncZMQCommunicator over the EP group. When
+                      provided, the cross-rank MAX reduction runs on the CPU via ZMQ
+                      (no GPU kernel, no H2D/D2H), avoiding a per-step NCCL AllReduce
+                      on the compute stream. When absent, falls back to
+                      torch.distributed.all_reduce on a GPU tensor.
 
         Return:
             (InferenceBatchDimensions) A new InferenceBatchDimensions object with
@@ -166,21 +172,41 @@ class InferenceBatchDimensions:
 
         is_non_decode = local_batch_dims.prefill_req_count > 0
 
-        sync_tensor = torch.tensor(
-            [
+        if ep_zmq_communicator is not None:
+            # CPU-only sync via ZMQ: avoids a NCCL AllReduce kernel on the
+            # compute stream plus the H2D/D2H pair that sandwiches it.
+            (
+                max_token_count,
+                max_is_non_decode,
+                max_prefill_count,
+                max_decode_count,
+            ) = ep_zmq_communicator.sync_all_reduce_max(
                 local_batch_dims.token_count,
                 int(is_non_decode),
                 local_batch_dims.prefill_req_count,
                 local_batch_dims.decode_req_count,
-            ],
-            dtype=torch.int32,
-            device=torch.cuda.current_device(),
-        )
+            )
+        else:
+            sync_tensor = torch.tensor(
+                [
+                    local_batch_dims.token_count,
+                    int(is_non_decode),
+                    local_batch_dims.prefill_req_count,
+                    local_batch_dims.decode_req_count,
+                ],
+                dtype=torch.int32,
+                device=torch.cuda.current_device(),
+            )
+            torch.distributed.all_reduce(
+                sync_tensor, op=torch.distributed.ReduceOp.MAX, group=ep_group
+            )
+            sync_tensor = sync_tensor.cpu()
+            max_token_count = int(sync_tensor[0].item())
+            max_is_non_decode = int(sync_tensor[1].item())
+            max_prefill_count = int(sync_tensor[2].item())
+            max_decode_count = int(sync_tensor[3].item())
 
-        torch.distributed.all_reduce(sync_tensor, op=torch.distributed.ReduceOp.MAX, group=ep_group)
-
-        sync_tensor = sync_tensor.cpu()
-        is_any_ep_rank_in_non_decode = sync_tensor[1].item() == 1
+        is_any_ep_rank_in_non_decode = max_is_non_decode == 1
 
         # We force eager mode for scenarios where some ranks will run with CUDA graphs
         # while others will not. Without this check, communication in the
@@ -191,7 +217,7 @@ class InferenceBatchDimensions:
         if is_any_ep_rank_in_non_decode and decode_only_cuda_graphs:
             return None  # indicate no match, run in eager mode
 
-        adjusted_token_count = int(sync_tensor[0].item())
+        adjusted_token_count = max_token_count
 
         # Sync request counts across EP ranks when strict matching is enabled
         # or when speculative tokens are used.  With speculative tokens,
@@ -203,12 +229,10 @@ class InferenceBatchDimensions:
             is_any_ep_rank_in_non_decode and num_speculative_tokens > 0
         )
         adjusted_prefill_req_count = (
-            int(sync_tensor[2].item())
-            if sync_request_counts
-            else local_batch_dims.prefill_req_count
+            max_prefill_count if sync_request_counts else local_batch_dims.prefill_req_count
         )
         adjusted_decode_req_count = (
-            int(sync_tensor[3].item()) if sync_request_counts else local_batch_dims.decode_req_count
+            max_decode_count if sync_request_counts else local_batch_dims.decode_req_count
         )
 
         # When any EP rank has prefill requests (non-strict mode), elevate
@@ -511,6 +535,7 @@ class CUDAGraphBatchDimensionBuilder:
         decode_only_cuda_graphs: bool = False,
         ep_group: Optional[torch.distributed.ProcessGroup] = None,
         num_speculative_tokens: int = 0,
+        ep_zmq_communicator=None,
     ) -> Optional[InferenceBatchDimensions]:
         """
         Matches the best CUDA graph batch dimension for the given real batch dimension.
@@ -526,6 +551,10 @@ class CUDAGraphBatchDimensionBuilder:
             ep_group: Optional expert parallel process group. If None, uses global parallel state.
                       When using different EP sizes for inference vs training, pass the
                       inference EP group explicitly.
+            ep_zmq_communicator: Optional AsyncZMQCommunicator over the EP group. When
+                      provided, batch-dimension MAX reduction uses a CPU-only ZMQ sync
+                      instead of a GPU NCCL AllReduce. Forwarded to
+                      adjust_batch_dims_for_expert_parallelism.
         Returns:
             The best matching CUDA graph batch dimension, or None if no applicable match is found
         """
@@ -541,6 +570,7 @@ class CUDAGraphBatchDimensionBuilder:
             ep_group=ep_group,
             smallest_non_decode_cuda_graph_size=smallest_non_decode_cuda_graph_size,
             num_speculative_tokens=num_speculative_tokens,
+            ep_zmq_communicator=ep_zmq_communicator,
         )
 
         if adjusted_batch_dim is None:

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -303,6 +303,21 @@ class InferenceConfig:
     consisting of the string label, the target dtype, and whether to store the data on GPU.
     """
 
+    async_scheduling: bool = True
+    """Whether to enable async scheduling (speculative forward chain on pure-decode
+    steps). When True, the engine launches the next forward immediately after
+    sampling without waiting for CPU bookkeeping; CPU bookkeeping verifies
+    retroactively. Falls back to serial behavior on prefill or boundary events.
+    """
+
+    finished_sync_period: int = 32
+    """Periodic CPU/GPU sync interval (in speculative decode steps) used to clean
+    up finished requests that would otherwise keep consuming compute in the
+    speculative chain. The sync only fires when finished_pending > 0. Set to 0
+    to disable the periodic sync (rely solely on add/pause/evict for syncs).
+    Only applies when async_scheduling is True.
+    """
+
     use_synchronous_zmq_collectives: bool = False
     """Whether to use synchronous ZMQ collectives for inference. If True, the
     all_reduce_max operation will be performed synchronously, which can help reduce

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -357,9 +357,19 @@ class MambaMetadata:
         max_count = self.max_intermediate_count
 
         if intermediate_offsets_gpu is not None and real_prefill_count > 0:
-            # Transfer counts to CPU (single sync) for per_request_counts and total check
+            # counts_list is CPU-cheap (source is already CPU from MambaSlotAllocator).
             counts_list = intermediate_counts_gpu.tolist()
             total = sum(counts_list)
+
+            # Ensure GPU copies for vectorized GPU ops below.
+            if not intermediate_offsets_gpu.is_cuda:
+                intermediate_offsets_gpu = intermediate_offsets_gpu.to(
+                    self.device, non_blocking=True,
+                )
+            if not intermediate_counts_gpu.is_cuda:
+                intermediate_counts_gpu = intermediate_counts_gpu.to(
+                    self.device, non_blocking=True,
+                )
 
             if total > 0:
                 # Compute cumulative chunk counts from cu_seqlens (already on GPU)

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -35,9 +35,9 @@ class MambaMetadata:
         # Maximum possible chunks across all batch configurations
         self.max_chunks = max_tokens // mamba_chunk_size + max_requests
 
-        # Map from requests to slots in the static Mamba state buffer
+        # Map from requests to slots in the static Mamba state buffer (CPU for bookkeeping).
         self.request_to_mamba_state_idx = torch.full(
-            (self.max_requests,), -1, dtype=torch.int32, device=torch.cuda.current_device()
+            (self.max_requests,), -1, dtype=torch.int32, device='cpu',
         )
 
         # Map from requests to slots in the static Mamba state buffer for active decode requests
@@ -84,9 +84,9 @@ class MambaMetadata:
         self._conv_seq_idx_buffer = torch.zeros(max_tokens, dtype=torch.int32, device=self.device)
         self._conv_seq_start_buffer = torch.zeros(max_tokens, dtype=torch.int32, device=self.device)
 
-        # Allocator for Mamba state slots
+        # Allocator for Mamba state slots (CPU for bookkeeping).
         self.mamba_state_free_slots = torch.arange(
-            self.max_requests, dtype=torch.int32, device=torch.cuda.current_device()
+            self.max_requests, dtype=torch.int32, device='cpu',
         )
         self.mamba_state_free_slot_count = self.max_requests
 
@@ -119,7 +119,7 @@ class MambaMetadata:
 
         # Re-initialize the free slot pool
         self.mamba_state_free_slots = torch.arange(
-            self.max_requests, dtype=torch.int32, device=torch.cuda.current_device()
+            self.max_requests, dtype=torch.int32, device='cpu',
         )
         self.mamba_state_free_slot_count = self.max_requests
 

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -107,7 +107,30 @@ class MambaMetadata:
         else:
             self.conv_gather_offsets = None
 
+        # Coalesced production path: pinned CPU views + shared GPU views bound
+        # by DynamicInferenceContext so that the 9 per-step Mamba fields ride
+        # along with the single coalesced H2D in transfer_bookkeeping_to_gpu.
+        # The legacy update() path above keeps using the standalone _*_buffer
+        # tensors (exercised only by unit tests that construct MambaMetadata
+        # without a context).
+        self._cpu_bufs = None
+        self._gpu_view = None
+
         self.reset_varlen_metadata()
+
+    def bind_cpu_buffers(self, bufs: dict) -> None:
+        """Attach pinned CPU views from DynamicInferenceContext._cpu_bookkeeping_buf.
+
+        ``bufs`` maps field names to 1D (or (1, max_tokens) for ``seq_idx``)
+        pinned CPU views that compute_cpu_metadata writes into. The matching
+        GPU views on the other side of the H2D are exposed via
+        :meth:`bind_gpu_buffers`.
+        """
+        self._cpu_bufs = bufs
+
+    def bind_gpu_buffers(self, gpu_view) -> None:
+        """Attach shared GPU views from the context's :class:`ContextGPUView`."""
+        self._gpu_view = gpu_view
 
     def reset(self) -> None:
         """
@@ -339,6 +362,7 @@ class MambaMetadata:
         intermediate_offsets_gpu: Optional[torch.Tensor],
         intermediate_counts_gpu: Optional[torch.Tensor],
         real_prefill_count: int,
+        cu_seqlens_gpu: Optional[torch.Tensor] = None,
     ) -> None:
         """Precompute intermediate extraction metadata for CUDA graph compatibility.
 
@@ -352,9 +376,15 @@ class MambaMetadata:
             intermediate_counts_gpu: [real_prefill_count] int32 GPU tensor of
                 per-request offset counts (0-3), or None.
             real_prefill_count: Number of real (non-padding) prefill requests.
+            cu_seqlens_gpu: GPU cu_seqlens tensor to read from. Defaults to
+                the legacy standalone ``_cu_seqlens_buffer`` used by
+                :meth:`update`; the coalesced production path passes the
+                shared ``ContextGPUView.mamba_cu_seqlens`` view.
         """
         chunk_size = self.mamba_chunk_size
         max_count = self.max_intermediate_count
+        if cu_seqlens_gpu is None:
+            cu_seqlens_gpu = self._cu_seqlens_buffer
 
         if intermediate_offsets_gpu is not None and real_prefill_count > 0:
             # counts_list is CPU-cheap (source is already CPU from MambaSlotAllocator).
@@ -373,7 +403,7 @@ class MambaMetadata:
 
             if total > 0:
                 # Compute cumulative chunk counts from cu_seqlens (already on GPU)
-                cu = self._cu_seqlens_buffer[: real_prefill_count + 1]
+                cu = cu_seqlens_gpu[: real_prefill_count + 1]
                 seq_lens = (cu[1 : real_prefill_count + 1] - cu[:real_prefill_count]).to(
                     torch.int64
                 )
@@ -450,10 +480,13 @@ class MambaMetadata:
         intermediate_offsets_gpu: Optional[torch.Tensor] = None,
         intermediate_counts_gpu: Optional[torch.Tensor] = None,
     ) -> dict:
-        """Compute all Mamba metadata on CPU. Returns dict for load_from_cpu().
+        """Compute all Mamba metadata on CPU, writing directly into the bound
+        pinned CPU views.
 
-        This performs the same computation as update() but entirely on CPU,
-        producing CPU tensors that are later copied to GPU buffers.
+        The values written here are transferred to GPU by the single coalesced
+        H2D in :meth:`DynamicInferenceContext.transfer_bookkeeping_to_gpu`.
+        The returned dict contains only Python scalars + the intermediate GPU
+        tensors, which :meth:`load_from_cpu` consumes after the H2D.
 
         Args:
             active_mamba_indices: CPU tensor of Mamba slot indices for active requests.
@@ -465,6 +498,9 @@ class MambaMetadata:
             intermediate_offsets_gpu: GPU tensor of per-request intermediate offsets, or None.
             intermediate_counts_gpu: GPU tensor of per-request intermediate counts, or None.
         """
+        assert self._cpu_bufs is not None, "bind_cpu_buffers() must be called first"
+        bufs = self._cpu_bufs
+
         real_decode_count = batch_dimensions.decode_req_count
         real_prefill_count = batch_dimensions.prefill_req_count
         padded_decode_count = padded_batch_dimensions.decode_req_count
@@ -480,21 +516,23 @@ class MambaMetadata:
             "real_prefill_count": real_prefill_count,
         }
 
-        # Decode batch indices.
+        # Decode batch indices (write into pinned view; padded slots = -1).
         if padded_decode_count > 0:
-            cpu_decode = torch.full((padded_decode_count,), -1, dtype=torch.int32)
-            cpu_decode[:real_decode_count] = active_mamba_indices[:real_decode_count]
-            result["batch_indices_decode"] = cpu_decode
+            bufs['batch_indices_decode'][:real_decode_count] = active_mamba_indices[
+                :real_decode_count
+            ]
+            if padded_decode_count > real_decode_count:
+                bufs['batch_indices_decode'][real_decode_count:padded_decode_count] = -1
 
-        # Prefill batch indices.
+        # Prefill batch indices, seq_idx, cu_seqlens, chunk/conv metadata.
         if padded_prefill_count > 0:
-            cpu_prefill = torch.full((padded_prefill_count,), -1, dtype=torch.int32)
             if real_prefill_count > 0:
                 start = real_decode_count
-                cpu_prefill[:real_prefill_count] = active_mamba_indices[
+                bufs['batch_indices_prefill'][:real_prefill_count] = active_mamba_indices[
                     start : start + real_prefill_count
                 ]
-            result["batch_indices_prefill"] = cpu_prefill
+            if padded_prefill_count > real_prefill_count:
+                bufs['batch_indices_prefill'][real_prefill_count:padded_prefill_count] = -1
 
             # seq_idx: normalized token-to-request mapping for prefill tokens.
             prefill_start_req = real_decode_count
@@ -503,32 +541,32 @@ class MambaMetadata:
             end_token = cpu_cu_query[end_prefill_req].item()
             seq_len = end_token - start_token
 
-            cpu_seq_idx = torch.full((padded_token_count,), -1, dtype=torch.int32)
             if seq_len > 0:
                 raw = token_to_request_idx[start_token:end_token]
-                cpu_seq_idx[:seq_len] = raw - raw[0]
-            result["seq_idx"] = cpu_seq_idx
+                bufs['seq_idx'][0, :seq_len] = raw - raw[0]
+            if padded_token_count > seq_len:
+                bufs['seq_idx'][0, seq_len:padded_token_count] = -1
             result["seq_len"] = seq_len
 
             # cu_seqlens for prefill.
-            cpu_cu_seqlens = torch.zeros(padded_prefill_count + 1, dtype=torch.int32)
+            cu_seqlens_view = bufs['cu_seqlens']
+            cu_seqlens_view[0] = 0
             if real_prefill_count > 0:
-                cpu_cu_seqlens[1 : real_prefill_count + 1] = (
+                cu_seqlens_view[1 : real_prefill_count + 1] = (
                     cpu_cu_query[prefill_start_req + 1 : end_prefill_req + 1]
                     - cpu_cu_query[prefill_start_req]
                 )
             if real_prefill_count < padded_prefill_count:
-                last_val = cpu_cu_seqlens[real_prefill_count].item()
-                cpu_cu_seqlens[real_prefill_count + 1 :] = last_val
-            result["cu_seqlens"] = cpu_cu_seqlens
+                last_val = cu_seqlens_view[real_prefill_count].item()
+                cu_seqlens_view[real_prefill_count + 1 : padded_prefill_count + 1] = last_val
 
-            cu_seqlens_list = cpu_cu_seqlens[: real_prefill_count + 1].tolist()
+            cu_seqlens_list = cu_seqlens_view[: real_prefill_count + 1].tolist()
             real_prefill_tokens = cu_seqlens_list[real_prefill_count] if real_prefill_count > 0 else 0
             result["cu_seqlens_list"] = cu_seqlens_list
             result["real_prefill_token_count"] = real_prefill_tokens
 
             # Chunk metadata (Python loop, pure CPU).
-            cu_seqlens_all = cpu_cu_seqlens[: padded_prefill_count + 1].tolist()
+            cu_seqlens_all = cu_seqlens_view[: padded_prefill_count + 1].tolist()
             chunk_boundaries = [0]
             last_chunk_idx_list = []
             chunk_to_seq_list = []
@@ -553,38 +591,36 @@ class MambaMetadata:
                 chunk_to_seq_list.extend([0] * pad_s)
 
             n_cu = padded_max_chunks + 1
-            result["cu_chunk_seqlens"] = torch.tensor(
+            bufs['cu_chunk_seqlens'][:n_cu] = torch.tensor(
                 chunk_boundaries[:n_cu], dtype=torch.int32,
             )
-            result["last_chunk_indices"] = torch.tensor(
+            bufs['last_chunk_indices'][:padded_prefill_count] = torch.tensor(
                 last_chunk_idx_list, dtype=torch.int32,
             )
-            result["seq_idx_for_varlen"] = torch.tensor(
+            bufs['seq_idx_for_varlen'][:padded_max_chunks] = torch.tensor(
                 chunk_to_seq_list[:padded_max_chunks], dtype=torch.int32,
             )
             result["padded_max_chunks"] = padded_max_chunks
 
             # Conv1d per-token metadata (CPU repeat_interleave).
+            conv_seq_idx_view = bufs['conv_seq_idx']
+            conv_seq_start_view = bufs['conv_seq_start']
             if real_prefill_tokens > 0:
-                cu_t = cpu_cu_seqlens[: real_prefill_count + 1]
+                cu_t = cu_seqlens_view[: real_prefill_count + 1]
                 lengths = (cu_t[1:] - cu_t[:-1]).to(torch.int64)
                 seq_indices = torch.arange(real_prefill_count, dtype=torch.int32)
                 seq_starts = cu_t[:real_prefill_count].to(torch.int32)
-                cpu_conv_seq_idx = torch.zeros(padded_token_count, dtype=torch.int32)
-                cpu_conv_seq_start = torch.zeros(padded_token_count, dtype=torch.int32)
-                cpu_conv_seq_idx[:real_prefill_tokens] = torch.repeat_interleave(
+                conv_seq_idx_view[:real_prefill_tokens] = torch.repeat_interleave(
                     seq_indices, lengths,
                 )
-                cpu_conv_seq_start[:real_prefill_tokens] = torch.repeat_interleave(
+                conv_seq_start_view[:real_prefill_tokens] = torch.repeat_interleave(
                     seq_starts, lengths,
                 )
-            else:
-                cpu_conv_seq_idx = torch.zeros(padded_token_count, dtype=torch.int32)
-                cpu_conv_seq_start = torch.zeros(padded_token_count, dtype=torch.int32)
-            result["conv_seq_idx"] = cpu_conv_seq_idx
-            result["conv_seq_start"] = cpu_conv_seq_start
+            if padded_token_count > real_prefill_tokens:
+                conv_seq_idx_view[real_prefill_tokens:padded_token_count] = 0
+                conv_seq_start_view[real_prefill_tokens:padded_token_count] = 0
 
-            # Intermediate metadata (needs GPU data -- defer to load_from_cpu).
+            # Intermediate metadata still requires GPU data: defer to load_from_cpu.
             result["intermediate_offsets_gpu"] = intermediate_offsets_gpu
             result["intermediate_counts_gpu"] = intermediate_counts_gpu
 
@@ -599,73 +635,48 @@ class MambaMetadata:
         return result
 
     def load_from_cpu(self, d: dict) -> None:
-        """Copy pre-computed CPU metadata into GPU buffers.
+        """Point state attributes at the freshly-transferred shared GPU views.
+
+        No H2D copies happen here: the 9 Mamba fields were transferred as
+        part of the coalesced bookkeeping H2D. This method just slices the
+        bound GPU views to the per-step sizes and runs the intermediate
+        metadata computation (which reads from the now-valid GPU cu_seqlens).
 
         Args:
             d: Dict returned by compute_cpu_metadata().
         """
+        assert self._gpu_view is not None, "bind_gpu_buffers() must be called first"
+        v = self._gpu_view
+
         padded_decode_count = d["padded_decode_count"]
         padded_prefill_count = d["padded_prefill_count"]
         padded_token_count = d["padded_token_count"]
         real_prefill_count = d["real_prefill_count"]
 
         if padded_decode_count > 0:
-            self._batch_indices_decode_buffer[:padded_decode_count].copy_(
-                d["batch_indices_decode"], non_blocking=True,
-            )
-            self.batch_indices_decode = self._batch_indices_decode_buffer[:padded_decode_count]
+            self.batch_indices_decode = v.mamba_batch_indices_decode[:padded_decode_count]
 
         if padded_prefill_count > 0:
-            self._batch_indices_prefill_buffer[:padded_prefill_count].copy_(
-                d["batch_indices_prefill"], non_blocking=True,
-            )
-            self.batch_indices_prefill = self._batch_indices_prefill_buffer[:padded_prefill_count]
-
-            seq_len = d["seq_len"]
-            self._seq_idx_buffer[:, :padded_token_count].copy_(
-                d["seq_idx"][:padded_token_count].unsqueeze(0), non_blocking=True,
-            )
-            self.seq_idx = self._seq_idx_buffer[:, :padded_token_count]
-
-            self._cu_seqlens_buffer[: padded_prefill_count + 1].copy_(
-                d["cu_seqlens"], non_blocking=True,
-            )
-            self.cu_seqlens = self._cu_seqlens_buffer[: padded_prefill_count + 1]
+            self.batch_indices_prefill = v.mamba_batch_indices_prefill[:padded_prefill_count]
+            self.seq_idx = v.mamba_seq_idx[:, :padded_token_count]
+            self.cu_seqlens = v.mamba_cu_seqlens[: padded_prefill_count + 1]
             self.cu_seqlens_list = d["cu_seqlens_list"]
             self.real_prefill_token_count = d["real_prefill_token_count"]
 
             padded_max_chunks = d["padded_max_chunks"]
-            n_cu = padded_max_chunks + 1
-            self._cu_chunk_seqlens_buffer[:n_cu].copy_(
-                d["cu_chunk_seqlens"], non_blocking=True,
-            )
-            self.cu_chunk_seqlens = self._cu_chunk_seqlens_buffer[:n_cu]
+            self.cu_chunk_seqlens = v.mamba_cu_chunk_seqlens[: padded_max_chunks + 1]
+            self.last_chunk_indices = v.mamba_last_chunk_indices[:padded_prefill_count]
+            self.seq_idx_for_varlen = v.mamba_seq_idx_for_varlen[:padded_max_chunks]
+            self.conv_seq_idx = v.mamba_conv_seq_idx[:padded_token_count]
+            self.conv_seq_start = v.mamba_conv_seq_start[:padded_token_count]
 
-            self._last_chunk_indices_buffer[:padded_prefill_count].copy_(
-                d["last_chunk_indices"], non_blocking=True,
-            )
-            self.last_chunk_indices = self._last_chunk_indices_buffer[:padded_prefill_count]
-
-            self._seq_idx_for_varlen_buffer[:padded_max_chunks].copy_(
-                d["seq_idx_for_varlen"], non_blocking=True,
-            )
-            self.seq_idx_for_varlen = self._seq_idx_for_varlen_buffer[:padded_max_chunks]
-
-            self._conv_seq_idx_buffer[:padded_token_count].copy_(
-                d["conv_seq_idx"][:padded_token_count], non_blocking=True,
-            )
-            self.conv_seq_idx = self._conv_seq_idx_buffer[:padded_token_count]
-
-            self._conv_seq_start_buffer[:padded_token_count].copy_(
-                d["conv_seq_start"][:padded_token_count], non_blocking=True,
-            )
-            self.conv_seq_start = self._conv_seq_start_buffer[:padded_token_count]
-
-            # Intermediate metadata still requires GPU computation.
+            # Intermediate metadata reads from the just-transferred cu_seqlens
+            # to compute chunk indices & absolute positions for state extraction.
             self._update_intermediate_metadata(
                 d["intermediate_offsets_gpu"],
                 d["intermediate_counts_gpu"],
                 real_prefill_count,
+                cu_seqlens_gpu=v.mamba_cu_seqlens,
             )
 
         if padded_decode_count > 0 and padded_prefill_count > 0:

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -429,6 +429,240 @@ class MambaMetadata:
             self.intermediate_chunk_indices = self._intermediate_chunk_indices_buffer[:max_count]
             self.intermediate_abs_positions = self._intermediate_abs_positions_buffer[:max_count]
 
+    def compute_cpu_metadata(
+        self,
+        active_mamba_indices: torch.Tensor,
+        token_to_request_idx: torch.Tensor,
+        cpu_cu_query: torch.Tensor,
+        batch_dimensions: InferenceBatchDimensions,
+        padded_batch_dimensions: InferenceBatchDimensions,
+        enable_chunked_prefill: bool,
+        intermediate_offsets_gpu: Optional[torch.Tensor] = None,
+        intermediate_counts_gpu: Optional[torch.Tensor] = None,
+    ) -> dict:
+        """Compute all Mamba metadata on CPU. Returns dict for load_from_cpu().
+
+        This performs the same computation as update() but entirely on CPU,
+        producing CPU tensors that are later copied to GPU buffers.
+
+        Args:
+            active_mamba_indices: CPU tensor of Mamba slot indices for active requests.
+            token_to_request_idx: CPU tensor mapping tokens to request indices.
+            cpu_cu_query: CPU cumulative query lengths from MHA metadata computation.
+            batch_dimensions: Dimensions of the current batch.
+            padded_batch_dimensions: Dimensions of the padded batch.
+            enable_chunked_prefill: Whether chunked prefill is enabled.
+            intermediate_offsets_gpu: GPU tensor of per-request intermediate offsets, or None.
+            intermediate_counts_gpu: GPU tensor of per-request intermediate counts, or None.
+        """
+        real_decode_count = batch_dimensions.decode_req_count
+        real_prefill_count = batch_dimensions.prefill_req_count
+        padded_decode_count = padded_batch_dimensions.decode_req_count
+        padded_prefill_count = padded_batch_dimensions.prefill_req_count
+        padded_token_count = padded_batch_dimensions.token_count
+        chunk_size = self.mamba_chunk_size
+
+        result = {
+            "padded_decode_count": padded_decode_count,
+            "padded_prefill_count": padded_prefill_count,
+            "padded_token_count": padded_token_count,
+            "real_decode_count": real_decode_count,
+            "real_prefill_count": real_prefill_count,
+        }
+
+        # Decode batch indices.
+        if padded_decode_count > 0:
+            cpu_decode = torch.full((padded_decode_count,), -1, dtype=torch.int32)
+            cpu_decode[:real_decode_count] = active_mamba_indices[:real_decode_count]
+            result["batch_indices_decode"] = cpu_decode
+
+        # Prefill batch indices.
+        if padded_prefill_count > 0:
+            cpu_prefill = torch.full((padded_prefill_count,), -1, dtype=torch.int32)
+            if real_prefill_count > 0:
+                start = real_decode_count
+                cpu_prefill[:real_prefill_count] = active_mamba_indices[
+                    start : start + real_prefill_count
+                ]
+            result["batch_indices_prefill"] = cpu_prefill
+
+            # seq_idx: normalized token-to-request mapping for prefill tokens.
+            prefill_start_req = real_decode_count
+            end_prefill_req = real_decode_count + real_prefill_count
+            start_token = cpu_cu_query[prefill_start_req].item()
+            end_token = cpu_cu_query[end_prefill_req].item()
+            seq_len = end_token - start_token
+
+            cpu_seq_idx = torch.full((padded_token_count,), -1, dtype=torch.int32)
+            if seq_len > 0:
+                raw = token_to_request_idx[start_token:end_token]
+                cpu_seq_idx[:seq_len] = raw - raw[0]
+            result["seq_idx"] = cpu_seq_idx
+            result["seq_len"] = seq_len
+
+            # cu_seqlens for prefill.
+            cpu_cu_seqlens = torch.zeros(padded_prefill_count + 1, dtype=torch.int32)
+            if real_prefill_count > 0:
+                cpu_cu_seqlens[1 : real_prefill_count + 1] = (
+                    cpu_cu_query[prefill_start_req + 1 : end_prefill_req + 1]
+                    - cpu_cu_query[prefill_start_req]
+                )
+            if real_prefill_count < padded_prefill_count:
+                last_val = cpu_cu_seqlens[real_prefill_count].item()
+                cpu_cu_seqlens[real_prefill_count + 1 :] = last_val
+            result["cu_seqlens"] = cpu_cu_seqlens
+
+            cu_seqlens_list = cpu_cu_seqlens[: real_prefill_count + 1].tolist()
+            real_prefill_tokens = cu_seqlens_list[real_prefill_count] if real_prefill_count > 0 else 0
+            result["cu_seqlens_list"] = cu_seqlens_list
+            result["real_prefill_token_count"] = real_prefill_tokens
+
+            # Chunk metadata (Python loop, pure CPU).
+            cu_seqlens_all = cpu_cu_seqlens[: padded_prefill_count + 1].tolist()
+            chunk_boundaries = [0]
+            last_chunk_idx_list = []
+            chunk_to_seq_list = []
+
+            for i in range(padded_prefill_count):
+                start = cu_seqlens_all[i]
+                end = cu_seqlens_all[i + 1]
+                s_len = end - start
+                n_chunks = max(1, (s_len + chunk_size - 1) // chunk_size)
+                boundaries = [min(start + (k + 1) * chunk_size, end) for k in range(n_chunks)]
+                chunk_boundaries.extend(boundaries)
+                chunk_to_seq_list.extend([i] * n_chunks)
+                last_chunk_idx_list.append(len(chunk_boundaries) - 2)
+
+            padded_max_chunks = padded_token_count // chunk_size + padded_prefill_count
+            last_boundary = chunk_boundaries[-1]
+            pad_b = padded_max_chunks + 1 - len(chunk_boundaries)
+            if pad_b > 0:
+                chunk_boundaries.extend([last_boundary] * pad_b)
+            pad_s = padded_max_chunks - len(chunk_to_seq_list)
+            if pad_s > 0:
+                chunk_to_seq_list.extend([0] * pad_s)
+
+            n_cu = padded_max_chunks + 1
+            result["cu_chunk_seqlens"] = torch.tensor(
+                chunk_boundaries[:n_cu], dtype=torch.int32,
+            )
+            result["last_chunk_indices"] = torch.tensor(
+                last_chunk_idx_list, dtype=torch.int32,
+            )
+            result["seq_idx_for_varlen"] = torch.tensor(
+                chunk_to_seq_list[:padded_max_chunks], dtype=torch.int32,
+            )
+            result["padded_max_chunks"] = padded_max_chunks
+
+            # Conv1d per-token metadata (CPU repeat_interleave).
+            if real_prefill_tokens > 0:
+                cu_t = cpu_cu_seqlens[: real_prefill_count + 1]
+                lengths = (cu_t[1:] - cu_t[:-1]).to(torch.int64)
+                seq_indices = torch.arange(real_prefill_count, dtype=torch.int32)
+                seq_starts = cu_t[:real_prefill_count].to(torch.int32)
+                cpu_conv_seq_idx = torch.zeros(padded_token_count, dtype=torch.int32)
+                cpu_conv_seq_start = torch.zeros(padded_token_count, dtype=torch.int32)
+                cpu_conv_seq_idx[:real_prefill_tokens] = torch.repeat_interleave(
+                    seq_indices, lengths,
+                )
+                cpu_conv_seq_start[:real_prefill_tokens] = torch.repeat_interleave(
+                    seq_starts, lengths,
+                )
+            else:
+                cpu_conv_seq_idx = torch.zeros(padded_token_count, dtype=torch.int32)
+                cpu_conv_seq_start = torch.zeros(padded_token_count, dtype=torch.int32)
+            result["conv_seq_idx"] = cpu_conv_seq_idx
+            result["conv_seq_start"] = cpu_conv_seq_start
+
+            # Intermediate metadata (needs GPU data -- defer to load_from_cpu).
+            result["intermediate_offsets_gpu"] = intermediate_offsets_gpu
+            result["intermediate_counts_gpu"] = intermediate_counts_gpu
+
+        # device_decode_prefill scalars.
+        if padded_decode_count > 0 and padded_prefill_count > 0:
+            result["decode_prefill_0"] = cpu_cu_query[real_decode_count].item()
+            result["decode_prefill_1"] = (
+                cpu_cu_query[real_decode_count + real_prefill_count].item()
+                - cpu_cu_query[real_decode_count].item()
+            )
+
+        return result
+
+    def load_from_cpu(self, d: dict) -> None:
+        """Copy pre-computed CPU metadata into GPU buffers.
+
+        Args:
+            d: Dict returned by compute_cpu_metadata().
+        """
+        padded_decode_count = d["padded_decode_count"]
+        padded_prefill_count = d["padded_prefill_count"]
+        padded_token_count = d["padded_token_count"]
+        real_prefill_count = d["real_prefill_count"]
+
+        if padded_decode_count > 0:
+            self._batch_indices_decode_buffer[:padded_decode_count].copy_(
+                d["batch_indices_decode"], non_blocking=True,
+            )
+            self.batch_indices_decode = self._batch_indices_decode_buffer[:padded_decode_count]
+
+        if padded_prefill_count > 0:
+            self._batch_indices_prefill_buffer[:padded_prefill_count].copy_(
+                d["batch_indices_prefill"], non_blocking=True,
+            )
+            self.batch_indices_prefill = self._batch_indices_prefill_buffer[:padded_prefill_count]
+
+            seq_len = d["seq_len"]
+            self._seq_idx_buffer[:, :padded_token_count].copy_(
+                d["seq_idx"][:padded_token_count].unsqueeze(0), non_blocking=True,
+            )
+            self.seq_idx = self._seq_idx_buffer[:, :padded_token_count]
+
+            self._cu_seqlens_buffer[: padded_prefill_count + 1].copy_(
+                d["cu_seqlens"], non_blocking=True,
+            )
+            self.cu_seqlens = self._cu_seqlens_buffer[: padded_prefill_count + 1]
+            self.cu_seqlens_list = d["cu_seqlens_list"]
+            self.real_prefill_token_count = d["real_prefill_token_count"]
+
+            padded_max_chunks = d["padded_max_chunks"]
+            n_cu = padded_max_chunks + 1
+            self._cu_chunk_seqlens_buffer[:n_cu].copy_(
+                d["cu_chunk_seqlens"], non_blocking=True,
+            )
+            self.cu_chunk_seqlens = self._cu_chunk_seqlens_buffer[:n_cu]
+
+            self._last_chunk_indices_buffer[:padded_prefill_count].copy_(
+                d["last_chunk_indices"], non_blocking=True,
+            )
+            self.last_chunk_indices = self._last_chunk_indices_buffer[:padded_prefill_count]
+
+            self._seq_idx_for_varlen_buffer[:padded_max_chunks].copy_(
+                d["seq_idx_for_varlen"], non_blocking=True,
+            )
+            self.seq_idx_for_varlen = self._seq_idx_for_varlen_buffer[:padded_max_chunks]
+
+            self._conv_seq_idx_buffer[:padded_token_count].copy_(
+                d["conv_seq_idx"][:padded_token_count], non_blocking=True,
+            )
+            self.conv_seq_idx = self._conv_seq_idx_buffer[:padded_token_count]
+
+            self._conv_seq_start_buffer[:padded_token_count].copy_(
+                d["conv_seq_start"][:padded_token_count], non_blocking=True,
+            )
+            self.conv_seq_start = self._conv_seq_start_buffer[:padded_token_count]
+
+            # Intermediate metadata still requires GPU computation.
+            self._update_intermediate_metadata(
+                d["intermediate_offsets_gpu"],
+                d["intermediate_counts_gpu"],
+                real_prefill_count,
+            )
+
+        if padded_decode_count > 0 and padded_prefill_count > 0:
+            self._device_decode_prefill_buffer[0] = d["decode_prefill_0"]
+            self._device_decode_prefill_buffer[1] = d["decode_prefill_1"]
+            self.device_decode_prefill = self._device_decode_prefill_buffer
+
     def allocate_slot(self) -> Optional[int]:
         """
         Allocates a new slot for a request in the Mamba state buffers.

--- a/megatron/core/inference/contexts/attention_context/mha_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mha_metadata.py
@@ -168,12 +168,13 @@ class MHAMetadata(MetadataBase):
     def reset(self):
         """
         Reset the metadata for the next batch.
+
+        The GPU buffers (query_lengths, cu_query_seq_lengths, cu_kv_seq_lengths,
+        kv_seq_lengths, block_table) are fully overwritten by the next update()
+        or load_from_cpu() call, and state_data slices them to exactly the range
+        that will be re-written. Clearing them here would launch 5 redundant
+        CUDA kernels per step with no correctness benefit.
         """
-        self._query_lengths_buf.fill_(0)
-        self._cu_query_seq_lengths_buf.fill_(0)
-        self._cu_kv_seq_lengths_buf.fill_(0)
-        self._kv_seq_lengths_buf.fill_(0)
-        self._block_table_buf.fill_(0)
         self._max_seqlen_q = 0
         self._max_seqlen_k = 0
 

--- a/megatron/core/inference/contexts/attention_context/mha_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mha_metadata.py
@@ -1,261 +1,84 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 import torch
 
-from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensions
-
 from .metadata_base import MetadataBase
 
 
 class MHAMetadata(MetadataBase):
     """
     Metadata for MHA layer using flash-attention.
+
+    GPU storage for the per-step fields (``query_lengths``,
+    ``cu_query_seq_lengths``, ``kv_seq_lengths``, ``cu_kv_seq_lengths``,
+    ``block_table``) lives inside the context's :class:`ContextGPUView`
+    unified buffer. Both :class:`GraphedMHAMetadata` and
+    :class:`NonGraphedMHAMetadata` bind to the same GPU views (only one is
+    active per step), so the single coalesced H2D in
+    :meth:`DynamicInferenceContext.transfer_bookkeeping_to_gpu` covers the
+    MHA fields along with the rest of the bookkeeping state.
     """
 
     def __init__(
         self, block_count_total, max_kv_block_count, max_requests, block_size_tokens, max_seqlen
     ):
         super().__init__()
-        device = torch.cuda.current_device()
-        self.device = device
+        self.device = torch.cuda.current_device()
         self.max_blocks = block_count_total
         self.max_kv_blocks = max_kv_block_count
         self.max_bs = max_requests
         self.max_seqlen = max_seqlen
-        self._query_lengths_buf = torch.zeros(self.max_bs, dtype=torch.int32, device=device)
-        self._cu_query_seq_lengths_buf = torch.zeros(
-            self.max_bs + 1, dtype=torch.int32, device=device
-        )
-        self._cu_kv_seq_lengths_buf = torch.zeros(self.max_bs + 1, dtype=torch.int32, device=device)
-        self._kv_seq_lengths_buf = torch.zeros(self.max_bs, dtype=torch.int32, device=device)
-        self._block_table_buf = torch.zeros(
-            (self.max_bs, self.max_kv_blocks), dtype=torch.int32, device=device
-        )
         self._max_seqlen_q = 0
         self._max_seqlen_k = 0
         self.state_data = {}
+        # Set by bind_gpu_buffers(); references shared views in ContextGPUView._buf.
+        self._gpu_view = None
 
-    def update(
-        self,
-        request_query_lengths: torch.Tensor,
-        request_kv_length_offsets: torch.Tensor,
-        request_to_kv_block_ids: torch.Tensor,
-        batch_dimensions: InferenceBatchDimensions,
-        padded_batch_dimensions: InferenceBatchDimensions,
-        num_speculative_tokens: int = 0,
-    ):
+    def bind_gpu_buffers(self, gpu_view) -> None:
+        """Attach shared GPU buffer views from the context's ContextGPUView.
+
+        Called by :class:`DynamicInferenceContext` after ``self.gpu_view`` is
+        constructed. Both graphed and non-graphed MHA metadata bind to the
+        same views; only one is active per step, so sharing storage is safe.
         """
-        Args:
-            request_query_lengths: (>real_batch_size,)
-            request_kv_length_offsets: (>real_batch_size,)
-            request_to_kv_block_ids: (>real_batch_size, max_kv_blocks)
-            batch_dimensions: Configuration object containing real batch settings
-            padded_batch_dimensions: Configuration object containing padded batch settings
-            num_speculative_tokens: Number of speculative tokens
+        self._gpu_view = gpu_view
+
+    def set_state_data(
+        self, padded_active_request_count: int, max_seqlen_q: int, max_seqlen_k: int
+    ) -> None:
+        """Build ``state_data`` slices into the bound GPU buffers.
+
+        Called once per step from ``transfer_bookkeeping_to_gpu`` after the
+        coalesced H2D copy. No ``.copy_()`` calls, no kernel launches.
         """
-        # Extract values from configs
-        real_batch_size = batch_dimensions.req_count
-        padded_active_token_count = padded_batch_dimensions.token_count
-        padded_active_request_count = padded_batch_dimensions.req_count
-
-        assert real_batch_size <= padded_active_request_count <= self.max_bs
-        assert request_query_lengths.shape[0] == real_batch_size
-        assert request_kv_length_offsets.shape[0] == real_batch_size
-        assert request_to_kv_block_ids.shape[0] == real_batch_size
-
-        self.tensor_copy_and_pad(
-            self._query_lengths_buf,
-            request_query_lengths,
-            real_batch_size,
-            padded_active_request_count,
-        )
-        self._cu_query_seq_lengths_buf[0] = 0
-        self.tensor_copy_and_pad(
-            self._cu_query_seq_lengths_buf[1:],
-            torch.cumsum(request_query_lengths, dim=0),
-            real_batch_size,
-            padded_active_request_count,
-            is_cumulative_tensor=True,
-        )
-        self.tensor_copy_and_pad(
-            self._kv_seq_lengths_buf,
-            request_kv_length_offsets + request_query_lengths,
-            real_batch_size,
-            padded_active_request_count,
-        )
-        self.tensor_copy_and_pad(
-            self._block_table_buf,
-            request_to_kv_block_ids,
-            real_batch_size,
-            padded_active_request_count,
-            pad_value=torch.tensor(self.max_kv_blocks, dtype=torch.int32, device=self.device).fill_(
-                -1
-            ),
-        )
-        self._cu_kv_seq_lengths_buf[0] = 0
-        self.tensor_copy_and_pad(
-            self._cu_kv_seq_lengths_buf[1:],
-            torch.cumsum(self._kv_seq_lengths_buf, dim=0),
-            real_batch_size,
-            padded_active_request_count,
-            is_cumulative_tensor=True,
-        )
-
-        if padded_batch_dimensions.prefill_req_count == 0:
-            self._max_seqlen_q = num_speculative_tokens + 1
-        else:
-            # Make sure we will launch the prefill kernel for prefill graphs
-            self._max_seqlen_q = max(2, padded_batch_dimensions.token_count)
-
-        self._max_seqlen_k = self.max_seqlen
-
-        self.state_data = {
-            "query_lengths": self._query_lengths_buf[:padded_active_request_count],
-            "cu_query_seq_lengths": self._cu_query_seq_lengths_buf[
-                : padded_active_request_count + 1
-            ],
-            "cu_kv_seq_lengths": self._cu_kv_seq_lengths_buf[: padded_active_request_count + 1],
-            "kv_seq_lengths": self._kv_seq_lengths_buf[:padded_active_request_count],
-            "block_table": self._block_table_buf[0:padded_active_request_count, :],
-            "max_seqlen_q": self._max_seqlen_q,
-            "max_seqlen_k": self._max_seqlen_k,
-        }
-
-    def load_from_cpu(
-        self,
-        query_lengths: torch.Tensor,
-        cu_query_seq_lengths: torch.Tensor,
-        kv_seq_lengths: torch.Tensor,
-        cu_kv_seq_lengths: torch.Tensor,
-        block_table: torch.Tensor,
-        max_seqlen_q: int,
-        max_seqlen_k: int,
-        padded_active_request_count: int,
-    ):
-        """Load pre-computed CPU metadata into GPU buffers.
-
-        All computation (cumsum, padding) has already been done on CPU.
-        This method only performs H2D copies into the fixed-address GPU buffers.
-
-        Args:
-            query_lengths: Padded query lengths, shape (padded_active_request_count,).
-            cu_query_seq_lengths: Padded cumulative query lengths, shape (padded_active_request_count + 1,).
-            kv_seq_lengths: Padded KV lengths, shape (padded_active_request_count,).
-            cu_kv_seq_lengths: Padded cumulative KV lengths, shape (padded_active_request_count + 1,).
-            block_table: Padded block table, shape (padded_active_request_count, max_kv_blocks).
-            max_seqlen_q: Maximum query sequence length.
-            max_seqlen_k: Maximum KV sequence length.
-            padded_active_request_count: Number of padded active requests.
-        """
+        assert self._gpu_view is not None, "bind_gpu_buffers() must be called first"
         n = padded_active_request_count
-        self._query_lengths_buf[:n].copy_(query_lengths[:n], non_blocking=True)
-        self._cu_query_seq_lengths_buf[: n + 1].copy_(cu_query_seq_lengths[: n + 1], non_blocking=True)
-        self._kv_seq_lengths_buf[:n].copy_(kv_seq_lengths[:n], non_blocking=True)
-        self._cu_kv_seq_lengths_buf[: n + 1].copy_(cu_kv_seq_lengths[: n + 1], non_blocking=True)
-        self._block_table_buf[:n].copy_(block_table[:n], non_blocking=True)
+        v = self._gpu_view
         self._max_seqlen_q = max_seqlen_q
         self._max_seqlen_k = max_seqlen_k
-
         self.state_data = {
-            "query_lengths": self._query_lengths_buf[:n],
-            "cu_query_seq_lengths": self._cu_query_seq_lengths_buf[: n + 1],
-            "cu_kv_seq_lengths": self._cu_kv_seq_lengths_buf[: n + 1],
-            "kv_seq_lengths": self._kv_seq_lengths_buf[:n],
-            "block_table": self._block_table_buf[:n, :],
-            "max_seqlen_q": self._max_seqlen_q,
-            "max_seqlen_k": self._max_seqlen_k,
+            "query_lengths": v.mha_query_lengths[:n],
+            "cu_query_seq_lengths": v.mha_cu_query_seq_lengths[: n + 1],
+            "cu_kv_seq_lengths": v.mha_cu_kv_seq_lengths[: n + 1],
+            "kv_seq_lengths": v.mha_kv_seq_lengths[:n],
+            "block_table": v.mha_block_table[:n, :],
+            "max_seqlen_q": max_seqlen_q,
+            "max_seqlen_k": max_seqlen_k,
         }
 
     def reset(self):
-        """
-        Reset the metadata for the next batch.
+        """Reset the metadata for the next batch.
 
-        The GPU buffers (query_lengths, cu_query_seq_lengths, cu_kv_seq_lengths,
-        kv_seq_lengths, block_table) are fully overwritten by the next update()
-        or load_from_cpu() call, and state_data slices them to exactly the range
-        that will be re-written. Clearing them here would launch 5 redundant
-        CUDA kernels per step with no correctness benefit.
+        The GPU buffers live in the context's unified buffer and are fully
+        overwritten by the next H2D copy; clearing them here would launch
+        redundant CUDA kernels with no correctness benefit.
         """
         self._max_seqlen_q = 0
         self._max_seqlen_k = 0
 
 
 class GraphedMHAMetadata(MHAMetadata):
-    """
-    Metadata for MHA layer using flash-attention with CUDA graphs.
-    """
-
-    def __init__(
-        self, block_count_total, max_kv_block_count, max_requests, block_size_tokens, max_seqlen
-    ):
-        super().__init__(
-            block_count_total, max_kv_block_count, max_requests, block_size_tokens, max_seqlen
-        )
-
-    def update(
-        self,
-        request_query_lengths: torch.Tensor,
-        request_kv_length_offsets: torch.Tensor,
-        request_to_kv_block_ids: torch.Tensor,
-        batch_dimensions: InferenceBatchDimensions,
-        padded_batch_dimensions: InferenceBatchDimensions,
-        num_speculative_tokens: int = 0,
-    ):
-        """
-        Args:
-            request_query_lengths: (>real_batch_size,)
-            request_kv_length_offsets: (>real_batch_size,)
-            request_to_kv_block_ids: (>real_batch_size, max_kv_blocks)
-            batch_dimensions: Configuration object containing real batch settings
-            padded_batch_dimensions: Configuration object containing padded batch settings
-            num_speculative_tokens: Number of speculative tokens
-        """
-        super().update(
-            request_query_lengths,
-            request_kv_length_offsets,
-            request_to_kv_block_ids,
-            batch_dimensions,
-            padded_batch_dimensions,
-            num_speculative_tokens,
-        )
-
-    def reset(self):
-        super().reset()
+    """MHA metadata for CUDA-graphed execution."""
 
 
 class NonGraphedMHAMetadata(MHAMetadata):
-    """
-    Metadata for MHA layer using flash-attention without CUDA graphs.
-    """
-
-    def update(
-        self,
-        request_query_lengths: torch.Tensor,
-        request_kv_length_offsets: torch.Tensor,
-        request_to_kv_block_ids: torch.Tensor,
-        batch_dimensions: InferenceBatchDimensions,
-        padded_batch_dimensions: InferenceBatchDimensions,
-        num_speculative_tokens: int = 0,
-    ):
-        """
-        Args:
-            request_query_lengths: (>real_batch_size,)
-            request_kv_length_offsets: (>real_batch_size,)
-            request_to_kv_block_ids: (>real_batch_size, max_kv_blocks)
-            batch_dimensions: Configuration object containing real batch settings
-            padded_batch_dimensions: Configuration object containing padded batch settings
-            num_speculative_tokens: Number of speculative tokens
-        """
-        super().update(
-            request_query_lengths,
-            request_kv_length_offsets,
-            request_to_kv_block_ids,
-            batch_dimensions,
-            padded_batch_dimensions,
-            num_speculative_tokens,
-        )
-        if len(self.state_data["query_lengths"]) > 0:
-            self.state_data["max_seqlen_q"] = torch.max(self.state_data["query_lengths"]).item()
-            self.state_data["max_seqlen_k"] = torch.max(self.state_data["kv_seq_lengths"]).item()
-        else:
-            self.state_data["max_seqlen_q"] = num_speculative_tokens + 1
-            self.state_data["max_seqlen_k"] = 1
+    """MHA metadata for non-graphed (eager) execution."""

--- a/megatron/core/inference/contexts/attention_context/mha_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mha_metadata.py
@@ -120,6 +120,51 @@ class MHAMetadata(MetadataBase):
             "max_seqlen_k": self._max_seqlen_k,
         }
 
+    def load_from_cpu(
+        self,
+        query_lengths: torch.Tensor,
+        cu_query_seq_lengths: torch.Tensor,
+        kv_seq_lengths: torch.Tensor,
+        cu_kv_seq_lengths: torch.Tensor,
+        block_table: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        padded_active_request_count: int,
+    ):
+        """Load pre-computed CPU metadata into GPU buffers.
+
+        All computation (cumsum, padding) has already been done on CPU.
+        This method only performs H2D copies into the fixed-address GPU buffers.
+
+        Args:
+            query_lengths: Padded query lengths, shape (padded_active_request_count,).
+            cu_query_seq_lengths: Padded cumulative query lengths, shape (padded_active_request_count + 1,).
+            kv_seq_lengths: Padded KV lengths, shape (padded_active_request_count,).
+            cu_kv_seq_lengths: Padded cumulative KV lengths, shape (padded_active_request_count + 1,).
+            block_table: Padded block table, shape (padded_active_request_count, max_kv_blocks).
+            max_seqlen_q: Maximum query sequence length.
+            max_seqlen_k: Maximum KV sequence length.
+            padded_active_request_count: Number of padded active requests.
+        """
+        n = padded_active_request_count
+        self._query_lengths_buf[:n].copy_(query_lengths[:n], non_blocking=True)
+        self._cu_query_seq_lengths_buf[: n + 1].copy_(cu_query_seq_lengths[: n + 1], non_blocking=True)
+        self._kv_seq_lengths_buf[:n].copy_(kv_seq_lengths[:n], non_blocking=True)
+        self._cu_kv_seq_lengths_buf[: n + 1].copy_(cu_kv_seq_lengths[: n + 1], non_blocking=True)
+        self._block_table_buf[:n].copy_(block_table[:n], non_blocking=True)
+        self._max_seqlen_q = max_seqlen_q
+        self._max_seqlen_k = max_seqlen_k
+
+        self.state_data = {
+            "query_lengths": self._query_lengths_buf[:n],
+            "cu_query_seq_lengths": self._cu_query_seq_lengths_buf[: n + 1],
+            "cu_kv_seq_lengths": self._cu_kv_seq_lengths_buf[: n + 1],
+            "kv_seq_lengths": self._kv_seq_lengths_buf[:n],
+            "block_table": self._block_table_buf[:n, :],
+            "max_seqlen_q": self._max_seqlen_q,
+            "max_seqlen_k": self._max_seqlen_k,
+        }
+
     def reset(self):
         """
         Reset the metadata for the next batch.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -863,28 +863,89 @@ class DynamicInferenceContext(BaseInferenceContext):
             for label, dtype, _ in self.request_metadata_types
         }
 
-        # Per-token state (CPU, pinned memory for fast H2D transfer).
-        self.token_to_input_ids = torch.full(
-            (self.max_tokens,), 0, dtype=torch.long, device='cpu', pin_memory=True,
+        # Coalesced pinned CPU buffer for the 9 bookkeeping fields that get
+        # transferred to GPU each step via transfer_bookkeeping_to_gpu().
+        # Layout matches ContextGPUView._buf so a single cudaMemcpyAsync
+        # suffices. Int64 token fields come first (8-byte aligned automatically),
+        # then int32 token fields, then int32 request-staging fields.
+        #   token_to_input_ids                         (int64, max_tokens)
+        #   token_to_pos_ids                           (int64, max_tokens)
+        #   token_to_block_idx                         (int32, max_tokens)
+        #   token_to_local_position_within_kv_block    (int32, max_tokens)
+        #   token_to_request_idx                       (int32, max_tokens)
+        #   token_to_position_in_request               (int32, max_tokens)
+        #   request_in_prefill_status  (staging)       (int32, max_requests)
+        #   request_query_lengths      (staging)       (int32, max_requests)
+        #   request_kv_length_offsets  (staging)       (int32, max_requests)
+        #
+        # Token fields are aliased with the source-of-truth attributes
+        # (`self.token_to_input_ids`, etc.) because the forward pass reads
+        # `gpu_view.token_to_input_ids[:n_tok]` which matches the CPU slot
+        # layout `[0, n_tok)`. Request fields, however, are read on GPU at
+        # `[:n_active]` but on CPU at `[paused_count:total_count)` — so the
+        # staging slots here are refreshed each step by copying the active
+        # slice from the persistent `request_*` tensors above.
+        _tok_int64_bytes = self.max_tokens * 8
+        _tok_int32_bytes = self.max_tokens * 4
+        _req_int32_bytes = self.max_requests * 4
+        _total_bytes = 2 * _tok_int64_bytes + 4 * _tok_int32_bytes + 3 * _req_int32_bytes
+        self._cpu_bookkeeping_buf = torch.empty(
+            _total_bytes, dtype=torch.uint8, device='cpu', pin_memory=True,
         )
-        self.token_to_pos_ids = torch.full(
-            (self.max_tokens,), 0, dtype=torch.long, device='cpu', pin_memory=True,
+        # token_to_input_ids and token_to_pos_ids were previously torch.full(0);
+        # zero the whole buffer so their views start at 0 too, and so the
+        # request staging slots start with a deterministic value.
+        self._cpu_bookkeeping_buf.fill_(0)
+
+        _off = 0
+        # Per-token state (source-of-truth lives in the coalesced buffer since
+        # the CPU-side bookkeeping and the GPU forward pass use the same
+        # `[:n_tok]` slice).
+        self.token_to_input_ids = self._cpu_bookkeeping_buf[_off : _off + _tok_int64_bytes].view(
+            torch.long
         )
-        self.token_to_request_idx = torch.empty(
-            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        _off += _tok_int64_bytes
+        self.token_to_pos_ids = self._cpu_bookkeeping_buf[_off : _off + _tok_int64_bytes].view(
+            torch.long
         )
-        self.token_to_block_idx = torch.empty(
-            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        _off += _tok_int64_bytes
+        self.token_to_block_idx = self._cpu_bookkeeping_buf[_off : _off + _tok_int32_bytes].view(
+            torch.int32
         )
+        _off += _tok_int32_bytes
         # i.e For a set of tokens A B C D E F ..  and block_size 4:
         # token_to_position_in_request is  [0, 1, 2, 3, 4, 5]
         # token_to_local_position_within_kv_block is [0 , 1, 2, 3, 0, 1, 2]
-        self.token_to_position_in_request = torch.empty(
-            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
-        )
-        self.token_to_local_position_within_kv_block = torch.empty(
-            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
-        )
+        self.token_to_local_position_within_kv_block = self._cpu_bookkeeping_buf[
+            _off : _off + _tok_int32_bytes
+        ].view(torch.int32)
+        _off += _tok_int32_bytes
+        self.token_to_request_idx = self._cpu_bookkeeping_buf[
+            _off : _off + _tok_int32_bytes
+        ].view(torch.int32)
+        _off += _tok_int32_bytes
+        self.token_to_position_in_request = self._cpu_bookkeeping_buf[
+            _off : _off + _tok_int32_bytes
+        ].view(torch.int32)
+        _off += _tok_int32_bytes
+
+        # Request-level staging views into the coalesced buffer. Write-only on
+        # CPU (refreshed from persistent tensors in transfer_bookkeeping_to_gpu);
+        # read-only on GPU via matching slots in ContextGPUView._buf.
+        self._staging_request_in_prefill_status = self._cpu_bookkeeping_buf[
+            _off : _off + _req_int32_bytes
+        ].view(torch.int32)
+        _off += _req_int32_bytes
+        self._staging_request_query_lengths = self._cpu_bookkeeping_buf[
+            _off : _off + _req_int32_bytes
+        ].view(torch.int32)
+        _off += _req_int32_bytes
+        self._staging_request_kv_length_offsets = self._cpu_bookkeeping_buf[
+            _off : _off + _req_int32_bytes
+        ].view(torch.int32)
+        _off += _req_int32_bytes
+
+        assert _off == _total_bytes, f"layout bug: wrote {_off} of {_total_bytes} bytes"
 
         # GPU view: the single interface for GPU code to read context state.
         # Populated per-step by transfer_bookkeeping_to_gpu().
@@ -1920,41 +1981,33 @@ class DynamicInferenceContext(BaseInferenceContext):
         Called after initialize_attention_state() and before the forward pass.
         All copies use non_blocking=True with pinned CPU memory. CUDA stream
         ordering guarantees the forward pass sees completed transfers.
+
+        The 9 bookkeeping fields are backed by one contiguous pinned CPU buffer
+        and one contiguous GPU buffer; a single cudaMemcpyAsync suffices.
+        Request-level staging slots are refreshed from the persistent CPU
+        tensors immediately before the H2D (GPU reads them at `[:n_active]`
+        while CPU bookkeeping keeps them at `[paused_count:total_count)`).
         """
-        n_tok = self.padded_active_token_count
-
-        # Token-level transfers.
-        self.gpu_view.token_to_input_ids[:n_tok].copy_(
-            self.token_to_input_ids[:n_tok], non_blocking=True,
-        )
-        self.gpu_view.token_to_pos_ids[:n_tok].copy_(
-            self.token_to_pos_ids[:n_tok], non_blocking=True,
-        )
-        self.gpu_view.token_to_block_idx[:n_tok].copy_(
-            self.token_to_block_idx[:n_tok], non_blocking=True,
-        )
-        self.gpu_view.token_to_local_position_within_kv_block[:n_tok].copy_(
-            self.token_to_local_position_within_kv_block[:n_tok], non_blocking=True,
-        )
-        self.gpu_view.token_to_request_idx[:n_tok].copy_(
-            self.token_to_request_idx[:n_tok], non_blocking=True,
-        )
-        self.gpu_view.token_to_position_in_request[:n_tok].copy_(
-            self.token_to_position_in_request[:n_tok], non_blocking=True,
-        )
-
-        # Request-level transfers (consumed by sampling, log-probs, speculative verification).
-        active_slice = slice(self.paused_request_count, self.total_request_count)
         n_active = self.total_request_count - self.paused_request_count
-        self.gpu_view.request_in_prefill_status[:n_active].copy_(
-            self.request_in_prefill_status_tensor[active_slice], non_blocking=True,
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+
+        # Refresh request-level staging slots from the persistent CPU source.
+        # CPU-to-CPU slice assignment on pinned memory (~7.5 KB total for 3
+        # int32 fields at max_requests=624). Negligible vs. the launch overhead
+        # we save by merging 9 H2D memcpys into 1.
+        self._staging_request_in_prefill_status[:n_active] = (
+            self.request_in_prefill_status_tensor[active_slice]
         )
-        self.gpu_view.request_query_lengths[:n_active].copy_(
-            self.request_query_lengths[active_slice], non_blocking=True,
-        )
-        self.gpu_view.request_kv_length_offsets[:n_active].copy_(
-            self.request_kv_length_offsets[active_slice], non_blocking=True,
-        )
+        self._staging_request_query_lengths[:n_active] = self.request_query_lengths[active_slice]
+        self._staging_request_kv_length_offsets[:n_active] = self.request_kv_length_offsets[
+            active_slice
+        ]
+
+        # Coalesced H2D: one cudaMemcpyAsync for the entire bookkeeping buffer.
+        # Copying the whole (max_tokens + max_requests)-sized buffer including
+        # unused slots is cheap (~71 KB total, ~3-5 us on PCIe Gen4) and saves
+        # 8 redundant launch overheads vs. the prior per-field copies.
+        self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
 
         # MHA metadata transfer.
         if hasattr(self, '_pending_mha_transfer') and self._pending_mha_transfer is not None:

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -779,10 +779,11 @@ class DynamicInferenceContext(BaseInferenceContext):
             # active region is the only part written.
             self._spec_mamba_conv_shadow = torch.empty_like(self.mamba_conv_states)
             self._spec_mamba_ssm_shadow = torch.empty_like(self.mamba_ssm_states)
-            # Slot indices saved (set at save time; consumed by restore or
-            # cleared on consume). None when no speculative pre-launch is
-            # in flight.
-            self._spec_mamba_active_indices: Optional[Tensor] = None
+            # True after save_mamba_state_for_speculation has copied live
+            # state into the shadow but before either restore (rejection)
+            # or drop (consume) has fired. Used to make restore/drop no-ops
+            # when no pre-launch is in flight.
+            self._spec_mamba_saved: bool = False
             if self.num_speculative_tokens > 0:
                 self.mamba_intermediate_conv_states = torch.empty(
                     (
@@ -834,7 +835,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata = None
             self._spec_mamba_conv_shadow = None
             self._spec_mamba_ssm_shadow = None
-            self._spec_mamba_active_indices = None
+            self._spec_mamba_saved = False
 
     def initialize_all_tensors(self) -> None:
         """Allocate all GPU state during initial construction."""
@@ -1443,21 +1444,29 @@ class DynamicInferenceContext(BaseInferenceContext):
         self._spec_advance_state = None
 
     def save_mamba_state_for_speculation(self) -> None:
-        """Snapshot Mamba conv/ssm states for the active requests so a
-        speculative forward's mutations can be rolled back on rejection.
+        """Snapshot Mamba conv/ssm states so a speculative forward's
+        mutations can be rolled back on rejection.
 
         Mamba's forward advances ``mamba_conv_states`` and ``mamba_ssm_states``
         in place per-active-request slot; unlike attention's KV writes it is
         not idempotent under re-run. The async-scheduling pre-launch issues a
         speculative forward whose result may be discarded (rejection event),
-        and the serial re-launch must read pre-spec state. We snapshot the
-        active slices here, queued on the stream right before the speculative
-        forward so it sees pre-save state and writes post-advance state on
-        top. :meth:`restore_mamba_state_for_speculation` (called from the
-        engine's drain helper after stream sync) copies the saved slices
-        back; :meth:`drop_mamba_state_speculation` (called when the
-        pre-launch is consumed normally) drops the snapshot without
-        restoring.
+        and the serial re-launch must read pre-spec state. The save is
+        queued on the stream right before the speculative forward so it
+        sees pre-save state and writes post-advance state on top.
+        :meth:`restore_mamba_state_for_speculation` (from the engine's
+        drain helper after stream sync) copies the snapshot back;
+        :meth:`drop_mamba_state_speculation` (when the pre-launch is
+        consumed normally) drops the snapshot without restoring.
+
+        Implementation note: this is a contiguous full-pool copy rather
+        than a scatter of just the active slots. PyTorch's fancy indexing
+        produced ~20 ms per save on nanov3 (large mamba state, scatter
+        access pattern); a contiguous copy of the same buffer is
+        bandwidth-bound at ~hundreds of µs. Inactive slot bytes are
+        copied too (essentially dead memory), but writing them back on
+        restore is harmless: any future use of a free slot zeros it via
+        ``_execute_pending_mamba_ops`` before use.
 
         No-op for non-hybrid models or when the active request count is zero.
         """
@@ -1466,47 +1475,42 @@ class DynamicInferenceContext(BaseInferenceContext):
         n_active = self.total_request_count - self.paused_request_count
         if n_active == 0:
             return
-        assert self._spec_mamba_active_indices is None, (
+        assert self._spec_mamba_saved is False, (
             "previous speculative mamba snapshot has not been resolved"
         )
-        active_slice = slice(self.paused_request_count, self.total_request_count)
-        # request_to_mamba_state_idx is on CPU; the GPU shadow scatter wants
-        # a GPU index tensor.
-        active_indices_gpu = (
-            self.mamba_metadata.request_to_mamba_state_idx[active_slice]
-            .to(self.mamba_conv_states.device, non_blocking=True)
-            .long()
+        self._spec_mamba_conv_shadow.copy_(
+            self.mamba_conv_states, non_blocking=True
         )
-        self._spec_mamba_conv_shadow[:, active_indices_gpu] = (
-            self.mamba_conv_states[:, active_indices_gpu]
+        self._spec_mamba_ssm_shadow.copy_(
+            self.mamba_ssm_states, non_blocking=True
         )
-        self._spec_mamba_ssm_shadow[:, active_indices_gpu] = (
-            self.mamba_ssm_states[:, active_indices_gpu]
-        )
-        self._spec_mamba_active_indices = active_indices_gpu
+        self._spec_mamba_saved = True
 
     def restore_mamba_state_for_speculation(self) -> None:
         """Reverse :meth:`save_mamba_state_for_speculation` after a rejection.
 
-        Should be called after the engine has drained the speculative GPU
-        work via stream synchronize so the in-place mamba state mutations
-        from the discarded forward are settled. The scatter copies are
-        queued on the stream; the next forward (the serial re-launch)
-        reads the restored state.
+        Called from the engine drain helper after the stream has been
+        synchronized so the discarded forward's in-place mamba mutations
+        are settled. Queues a contiguous copy from shadow back to live
+        state; the next forward (the serial re-launch) reads the restored
+        state.
         """
-        if self._spec_mamba_active_indices is None:
+        if not self._spec_mamba_saved:
             return
-        idx = self._spec_mamba_active_indices
-        self.mamba_conv_states[:, idx] = self._spec_mamba_conv_shadow[:, idx]
-        self.mamba_ssm_states[:, idx] = self._spec_mamba_ssm_shadow[:, idx]
-        self._spec_mamba_active_indices = None
+        self.mamba_conv_states.copy_(
+            self._spec_mamba_conv_shadow, non_blocking=True
+        )
+        self.mamba_ssm_states.copy_(
+            self._spec_mamba_ssm_shadow, non_blocking=True
+        )
+        self._spec_mamba_saved = False
 
     def drop_mamba_state_speculation(self) -> None:
         """Drop the speculative mamba snapshot when the pre-launch is consumed
         normally (no rejection). The advance was real, so we keep the live
         state and discard the pre-spec snapshot.
         """
-        self._spec_mamba_active_indices = None
+        self._spec_mamba_saved = False
 
     def append_key_value_cache(self, layer_number: int, key: Tensor, value: Tensor) -> None:
         """Append to KV cache.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -888,6 +888,11 @@ class DynamicInferenceContext(BaseInferenceContext):
             device=torch.cuda.current_device(),
         )
 
+        # Deferred Mamba GPU operations.  Populated by add_request() /
+        # update_requests() (CPU phase), executed by transfer_bookkeeping_to_gpu().
+        self._pending_mamba_zeros: list = []
+        self._pending_mamba_restores: list = []
+
         # NOTE: Need to build this outside the UVM / TMS context to avoid IMA.
         if self.is_hybrid_model:
             self.mamba_metadata = MambaMetadata(
@@ -1480,8 +1485,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                     raise ContextOverflowError(
                         requests[logical_idx].request_id, "No Mamba slots available"
                     )
-                self.mamba_conv_states[:, mamba_idx] = 0.0
-                self.mamba_ssm_states[:, mamba_idx] = 0.0
+                self._pending_mamba_zeros.append(mamba_idx)
                 self.mamba_metadata.request_to_mamba_state_idx[request_idx] = mamba_idx
 
         self.active_token_count = token_end
@@ -1857,6 +1861,32 @@ class DynamicInferenceContext(BaseInferenceContext):
             else:
                 self.moe_routing_metadata.disable_static_buffer_recording()
 
+    def _execute_pending_mamba_ops(self) -> None:
+        """Execute Mamba GPU operations deferred from add_request() / update_requests().
+
+        This runs at the start of transfer_bookkeeping_to_gpu() so that all GPU
+        Mamba state is correct before the forward pass.
+        """
+        if not (self._pending_mamba_restores or self._pending_mamba_zeros):
+            return
+
+        # Restore cached Mamba state to live buffers.  On failure, fall back to zeroing.
+        for request_idx, block_id, mamba_idx in self._pending_mamba_restores:
+            restored = self.mamba_slot_allocator.restore_to_live(request_idx, block_id)
+            if not restored:
+                self._pending_mamba_zeros.append(mamba_idx)
+        self._pending_mamba_restores.clear()
+
+        # Batch-zero newly allocated Mamba slots.
+        if self._pending_mamba_zeros:
+            device = self.mamba_conv_states.device
+            indices = torch.tensor(
+                self._pending_mamba_zeros, dtype=torch.long, device=device,
+            )
+            self.mamba_conv_states[:, indices] = 0.0
+            self.mamba_ssm_states[:, indices] = 0.0
+            self._pending_mamba_zeros.clear()
+
     def transfer_bookkeeping_to_gpu(self) -> None:
         """Batch transfer CPU bookkeeping state to GPU staging buffers.
 
@@ -1864,6 +1894,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         All copies use non_blocking=True with pinned CPU memory. CUDA stream
         ordering guarantees the forward pass sees completed transfers.
         """
+        # Execute deferred Mamba GPU operations first (state zeroing, restore, offsets).
+        self._execute_pending_mamba_ops()
+
         n_tok = self.padded_active_token_count
 
         # Token-level transfers.
@@ -2439,17 +2472,18 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             # Restore Mamba state from the block corresponding to prefix_skip_tokens
             restore_block_count = prefix_skip_tokens // self.block_size_tokens
-            restored = False
             if restore_block_count > 0 and self.mamba_slot_allocator is not None:
                 restore_block_id = matched_block_ids[restore_block_count - 1]
-                restored = self.mamba_slot_allocator.restore_to_live(
-                    self.total_request_count, restore_block_id
+                self._pending_mamba_restores.append(
+                    (self.total_request_count, restore_block_id, mamba_idx)
                 )
-            if not restored:
-                self.mamba_conv_states[:, mamba_idx] = 0.0
-                self.mamba_ssm_states[:, mamba_idx] = 0.0
+            else:
+                self._pending_mamba_zeros.append(mamba_idx)
 
-            # Compute intermediate offsets for state extraction during forward pass
+            # compute_and_store_offsets sets both CPU state (hash_to_block_id,
+            # _eos_cache_block_id_gpu) and GPU staging buffers.  Runs immediately
+            # because commit_intermediate_states() reads the CPU state after the
+            # forward pass.
             if self.mamba_slot_allocator is not None:
                 self.mamba_slot_allocator.compute_and_store_offsets(
                     req,

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -770,6 +770,19 @@ class DynamicInferenceContext(BaseInferenceContext):
                 dtype=self.mamba_ssm_states_dtype,
                 device=torch.cuda.current_device(),
             )
+            # Shadow buffers used by save/restore_mamba_state_for_speculation:
+            # the speculative async-scheduling pre-launch's forward advances
+            # mamba_{conv,ssm}_states in place per-active-request; on rejection
+            # we copy these saved slices back so step N+1's serial re-launch
+            # reads pre-spec state. Allocated full-size for direct slot
+            # indexing (active slot indices are scattered in the pool); the
+            # active region is the only part written.
+            self._spec_mamba_conv_shadow = torch.empty_like(self.mamba_conv_states)
+            self._spec_mamba_ssm_shadow = torch.empty_like(self.mamba_ssm_states)
+            # Slot indices saved (set at save time; consumed by restore or
+            # cleared on consume). None when no speculative pre-launch is
+            # in flight.
+            self._spec_mamba_active_indices: Optional[Tensor] = None
             if self.num_speculative_tokens > 0:
                 self.mamba_intermediate_conv_states = torch.empty(
                     (
@@ -819,6 +832,9 @@ class DynamicInferenceContext(BaseInferenceContext):
                     )
         else:
             self.mamba_metadata = None
+            self._spec_mamba_conv_shadow = None
+            self._spec_mamba_ssm_shadow = None
+            self._spec_mamba_active_indices = None
 
     def initialize_all_tensors(self) -> None:
         """Allocate all GPU state during initial construction."""
@@ -1331,25 +1347,18 @@ class DynamicInferenceContext(BaseInferenceContext):
     def can_speculate_decode_step(self, advance: int = 1) -> bool:
         """Predicate: can we run the next ``advance`` decode steps speculatively?
 
-        Returns True only when the next step's metadata can be derived from the
-        current state by a position bump alone — no allocator activity, no
-        speculative-decoding interaction, no Mamba SSM advance. Tighter than
-        the original block-budget check because the speculative advance path
-        implemented in :meth:`speculatively_advance_for_next_decode_step` does
-        not yet handle block-boundary crossings, speculative decoding
-        (num_speculative_tokens > 0), or hybrid models (Mamba SSM forward
-        advances per-request conv/ssm state and would require per-step rollback
-        of large GPU buffers). The engine falls back to serial when this
-        returns False.
+        Returns True only when the next step's metadata can be derived from
+        the current state by a position bump alone — no allocator activity
+        and no speculative-decoding interaction. For hybrid (Mamba) models,
+        :meth:`save_mamba_state_for_speculation` and its restore counterpart
+        snapshot the per-active-request SSM/conv slices around the
+        speculative forward so a rejection drain can roll the in-place
+        mutations back. The engine falls back to serial when this returns
+        False.
         """
         if not self.is_decode_only():
             return False
         if self.num_speculative_tokens > 0:
-            return False
-        if self.is_hybrid_model:
-            # Mamba SSM state is mutated in-place by forward; speculative
-            # rollback would require saving/restoring per-request conv/ssm
-            # state buffers. Gate off until that is implemented.
             return False
         # Boundary-crossing requires allocator work that the speculative advance
         # cannot replay safely; defer to serial when any active request would
@@ -1432,6 +1441,72 @@ class DynamicInferenceContext(BaseInferenceContext):
             'request_last_kv_block_offset'
         ]
         self._spec_advance_state = None
+
+    def save_mamba_state_for_speculation(self) -> None:
+        """Snapshot Mamba conv/ssm states for the active requests so a
+        speculative forward's mutations can be rolled back on rejection.
+
+        Mamba's forward advances ``mamba_conv_states`` and ``mamba_ssm_states``
+        in place per-active-request slot; unlike attention's KV writes it is
+        not idempotent under re-run. The async-scheduling pre-launch issues a
+        speculative forward whose result may be discarded (rejection event),
+        and the serial re-launch must read pre-spec state. We snapshot the
+        active slices here, queued on the stream right before the speculative
+        forward so it sees pre-save state and writes post-advance state on
+        top. :meth:`restore_mamba_state_for_speculation` (called from the
+        engine's drain helper after stream sync) copies the saved slices
+        back; :meth:`drop_mamba_state_speculation` (called when the
+        pre-launch is consumed normally) drops the snapshot without
+        restoring.
+
+        No-op for non-hybrid models or when the active request count is zero.
+        """
+        if not self.is_hybrid_model:
+            return
+        n_active = self.total_request_count - self.paused_request_count
+        if n_active == 0:
+            return
+        assert self._spec_mamba_active_indices is None, (
+            "previous speculative mamba snapshot has not been resolved"
+        )
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        # request_to_mamba_state_idx is on CPU; the GPU shadow scatter wants
+        # a GPU index tensor.
+        active_indices_gpu = (
+            self.mamba_metadata.request_to_mamba_state_idx[active_slice]
+            .to(self.mamba_conv_states.device, non_blocking=True)
+            .long()
+        )
+        self._spec_mamba_conv_shadow[:, active_indices_gpu] = (
+            self.mamba_conv_states[:, active_indices_gpu]
+        )
+        self._spec_mamba_ssm_shadow[:, active_indices_gpu] = (
+            self.mamba_ssm_states[:, active_indices_gpu]
+        )
+        self._spec_mamba_active_indices = active_indices_gpu
+
+    def restore_mamba_state_for_speculation(self) -> None:
+        """Reverse :meth:`save_mamba_state_for_speculation` after a rejection.
+
+        Should be called after the engine has drained the speculative GPU
+        work via stream synchronize so the in-place mamba state mutations
+        from the discarded forward are settled. The scatter copies are
+        queued on the stream; the next forward (the serial re-launch)
+        reads the restored state.
+        """
+        if self._spec_mamba_active_indices is None:
+            return
+        idx = self._spec_mamba_active_indices
+        self.mamba_conv_states[:, idx] = self._spec_mamba_conv_shadow[:, idx]
+        self.mamba_ssm_states[:, idx] = self._spec_mamba_ssm_shadow[:, idx]
+        self._spec_mamba_active_indices = None
+
+    def drop_mamba_state_speculation(self) -> None:
+        """Drop the speculative mamba snapshot when the pre-launch is consumed
+        normally (no rejection). The advance was real, so we keep the live
+        state and discard the pre-spec snapshot.
+        """
+        self._spec_mamba_active_indices = None
 
     def append_key_value_cache(self, layer_number: int, key: Tensor, value: Tensor) -> None:
         """Append to KV cache.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -888,7 +888,23 @@ class DynamicInferenceContext(BaseInferenceContext):
         _tok_int64_bytes = self.max_tokens * 8
         _tok_int32_bytes = self.max_tokens * 4
         _req_int32_bytes = self.max_requests * 4
-        _total_bytes = 2 * _tok_int64_bytes + 4 * _tok_int32_bytes + 3 * _req_int32_bytes
+        # MHA section: 5 fields (int32) shared between GraphedMHAMetadata and
+        # NonGraphedMHAMetadata. max_bs == max_requests.
+        _mha_query_lengths_bytes = self.max_requests * 4
+        _mha_cu_query_seq_lengths_bytes = (self.max_requests + 1) * 4
+        _mha_kv_seq_lengths_bytes = self.max_requests * 4
+        _mha_cu_kv_seq_lengths_bytes = (self.max_requests + 1) * 4
+        _mha_block_table_bytes = self.max_requests * self.max_kv_block_count * 4
+        _total_bytes = (
+            2 * _tok_int64_bytes
+            + 4 * _tok_int32_bytes
+            + 3 * _req_int32_bytes
+            + _mha_query_lengths_bytes
+            + _mha_cu_query_seq_lengths_bytes
+            + _mha_kv_seq_lengths_bytes
+            + _mha_cu_kv_seq_lengths_bytes
+            + _mha_block_table_bytes
+        )
         self._cpu_bookkeeping_buf = torch.empty(
             _total_bytes, dtype=torch.uint8, device='cpu', pin_memory=True,
         )
@@ -945,6 +961,33 @@ class DynamicInferenceContext(BaseInferenceContext):
         ].view(torch.int32)
         _off += _req_int32_bytes
 
+        # MHA flash-attention metadata views (write-only on CPU, read-only on
+        # GPU via the matching region of ContextGPUView._buf). Populated per
+        # step by initialize_attention_state(); transferred as part of the
+        # single coalesced H2D in transfer_bookkeeping_to_gpu().
+        self._cpu_mha_query_lengths = self._cpu_bookkeeping_buf[
+            _off : _off + _mha_query_lengths_bytes
+        ].view(torch.int32)
+        _off += _mha_query_lengths_bytes
+        self._cpu_mha_cu_query_seq_lengths = self._cpu_bookkeeping_buf[
+            _off : _off + _mha_cu_query_seq_lengths_bytes
+        ].view(torch.int32)
+        _off += _mha_cu_query_seq_lengths_bytes
+        self._cpu_mha_kv_seq_lengths = self._cpu_bookkeeping_buf[
+            _off : _off + _mha_kv_seq_lengths_bytes
+        ].view(torch.int32)
+        _off += _mha_kv_seq_lengths_bytes
+        self._cpu_mha_cu_kv_seq_lengths = self._cpu_bookkeeping_buf[
+            _off : _off + _mha_cu_kv_seq_lengths_bytes
+        ].view(torch.int32)
+        _off += _mha_cu_kv_seq_lengths_bytes
+        self._cpu_mha_block_table = (
+            self._cpu_bookkeeping_buf[_off : _off + _mha_block_table_bytes]
+            .view(torch.int32)
+            .view(self.max_requests, self.max_kv_block_count)
+        )
+        _off += _mha_block_table_bytes
+
         assert _off == _total_bytes, f"layout bug: wrote {_off} of {_total_bytes} bytes"
 
         # GPU view: the single interface for GPU code to read context state.
@@ -952,8 +995,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.gpu_view = ContextGPUView(
             max_requests=self.max_requests,
             max_tokens=self.max_tokens,
+            max_kv_blocks=self.max_kv_block_count,
             device=torch.cuda.current_device(),
         )
+
+        # Bind the shared MHA GPU views to both graph and non-graph metadata;
+        # only one is active per step, so sharing storage is safe.
+        self.graph_attn_metadata["mha_metadata"].bind_gpu_buffers(self.gpu_view)
+        self.non_graph_attn_metadata["mha_metadata"].bind_gpu_buffers(self.gpu_view)
 
         # Deferred Mamba GPU operations.  Populated by add_request() /
         # update_requests() (CPU phase), executed by transfer_bookkeeping_to_gpu().
@@ -1666,7 +1715,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.active_token_count = T
         self.num_prefill_requests = N_prefill
 
-        # 2. Per-request state consumed by mha_metadata.update().
+        # 2. Per-request state consumed by initialize_attention_state().
         #    Decode requests come first, followed by prefill requests.
         self.request_query_lengths[0:N_decode].fill_(tokens_per_decode_request)
         if N_prefill > 0:
@@ -1858,46 +1907,59 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         assert self.active_attn_metadata is not None
 
-        # Compute MHA metadata on CPU (ephemeral locals, not persistent attributes).
+        # Compute MHA metadata directly into the pinned CPU section of
+        # _cpu_bookkeeping_buf. The single coalesced H2D in
+        # transfer_bookkeeping_to_gpu() covers these fields along with the rest
+        # of the bookkeeping state, so no ephemeral tensors and no per-field
+        # cudaMemcpyAsyncs.
         real_bs = attn_dimensions.req_count
         padded_bs = self.padded_batch_dimensions.req_count
         mha = self.active_attn_metadata["mha_metadata"]
 
-        # Query lengths (padded).
-        cpu_query_lengths = torch.zeros(padded_bs, dtype=torch.int32)
-        cpu_query_lengths[:real_bs] = query_lengths_view[:real_bs]
-
-        # Cumulative query lengths (padded).
-        cpu_cu_query = torch.zeros(padded_bs + 1, dtype=torch.int32)
-        if real_bs > 0:
-            cpu_cu_query[1 : real_bs + 1] = torch.cumsum(query_lengths_view[:real_bs], dim=0)
+        # Query lengths: [0:real_bs] real data, [real_bs:padded_bs] zero pad.
+        self._cpu_mha_query_lengths[:real_bs] = query_lengths_view[:real_bs]
         if real_bs < padded_bs:
-            cpu_cu_query[real_bs + 1 : padded_bs + 1] = cpu_cu_query[real_bs]
+            self._cpu_mha_query_lengths[real_bs:padded_bs] = 0
 
-        # KV sequence lengths (padded).
-        cpu_kv_lengths = torch.zeros(padded_bs, dtype=torch.int32)
-        cpu_kv_lengths[:real_bs] = (
+        # Cumulative query lengths (padded slots repeat cu[real_bs]).
+        self._cpu_mha_cu_query_seq_lengths[0] = 0
+        if real_bs > 0:
+            self._cpu_mha_cu_query_seq_lengths[1 : real_bs + 1] = torch.cumsum(
+                query_lengths_view[:real_bs], dim=0
+            )
+        if real_bs < padded_bs:
+            self._cpu_mha_cu_query_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                self._cpu_mha_cu_query_seq_lengths[real_bs]
+            )
+
+        # KV sequence lengths: [0:real_bs] = kv_offsets + query_lengths.
+        self._cpu_mha_kv_seq_lengths[:real_bs] = (
             request_kv_length_offsets_view[:real_bs] + query_lengths_view[:real_bs]
         )
-
-        # Cumulative KV lengths (padded).
-        cpu_cu_kv = torch.zeros(padded_bs + 1, dtype=torch.int32)
-        if real_bs > 0:
-            cpu_cu_kv[1 : real_bs + 1] = torch.cumsum(cpu_kv_lengths[:real_bs], dim=0)
         if real_bs < padded_bs:
-            cpu_cu_kv[real_bs + 1 : padded_bs + 1] = cpu_cu_kv[real_bs]
+            self._cpu_mha_kv_seq_lengths[real_bs:padded_bs] = 0
 
-        # Block table (padded).
-        cpu_block_table = torch.full(
-            (padded_bs, mha.max_kv_blocks), -1, dtype=torch.int32,
-        )
-        cpu_block_table[:real_bs] = request_to_kv_block_ids_view[:real_bs]
+        # Cumulative KV lengths.
+        self._cpu_mha_cu_kv_seq_lengths[0] = 0
+        if real_bs > 0:
+            self._cpu_mha_cu_kv_seq_lengths[1 : real_bs + 1] = torch.cumsum(
+                self._cpu_mha_kv_seq_lengths[:real_bs], dim=0
+            )
+        if real_bs < padded_bs:
+            self._cpu_mha_cu_kv_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                self._cpu_mha_cu_kv_seq_lengths[real_bs]
+            )
 
-        # Max sequence lengths.
+        # Block table: [0:real_bs] real, [real_bs:padded_bs] = -1 sentinel.
+        self._cpu_mha_block_table[:real_bs] = request_to_kv_block_ids_view[:real_bs]
+        if real_bs < padded_bs:
+            self._cpu_mha_block_table[real_bs:padded_bs] = -1
+
+        # Max sequence lengths (Python scalars; consumed as kernel launch args).
         if not self.using_cuda_graph_this_step() and real_bs > 0:
             # NonGraphedMHAMetadata: use actual max values.
-            max_seqlen_q = cpu_query_lengths[:real_bs].max().item()
-            max_seqlen_k = cpu_kv_lengths[:real_bs].max().item()
+            max_seqlen_q = self._cpu_mha_query_lengths[:real_bs].max().item()
+            max_seqlen_k = self._cpu_mha_kv_seq_lengths[:real_bs].max().item()
         else:
             # GraphedMHAMetadata: use conservative bounds.
             if self.padded_batch_dimensions.prefill_req_count == 0:
@@ -1909,16 +1971,11 @@ class DynamicInferenceContext(BaseInferenceContext):
             max_seqlen_q = self.num_speculative_tokens + 1
             max_seqlen_k = 1
 
-        # Store for transfer_bookkeeping_to_gpu().
+        # Scalars consumed by set_state_data() after the single H2D completes.
         self._pending_mha_transfer = {
-            "query_lengths": cpu_query_lengths,
-            "cu_query_seq_lengths": cpu_cu_query,
-            "kv_seq_lengths": cpu_kv_lengths,
-            "cu_kv_seq_lengths": cpu_cu_kv,
-            "block_table": cpu_block_table,
+            "padded_active_request_count": padded_bs,
             "max_seqlen_q": max_seqlen_q,
             "max_seqlen_k": max_seqlen_k,
-            "padded_active_request_count": padded_bs,
         }
 
         if self.is_hybrid_model:
@@ -1935,7 +1992,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self._pending_mamba_transfer = self.mamba_metadata.compute_cpu_metadata(
                 active_mamba_indices=self.mamba_metadata.request_to_mamba_state_idx[active_slice],
                 token_to_request_idx=self.token_to_request_idx[: self.active_token_count],
-                cpu_cu_query=cpu_cu_query,
+                cpu_cu_query=self._cpu_mha_cu_query_seq_lengths,
                 batch_dimensions=attn_dimensions,
                 padded_batch_dimensions=self.padded_batch_dimensions,
                 enable_chunked_prefill=self.is_chunked_prefill_enabled(),
@@ -2009,19 +2066,16 @@ class DynamicInferenceContext(BaseInferenceContext):
         # 8 redundant launch overheads vs. the prior per-field copies.
         self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
 
-        # MHA metadata transfer.
+        # MHA metadata: buffers already covered by the coalesced H2D above.
+        # All that's left is pointing state_data at the correct GPU slices and
+        # stashing the per-step max_seqlen scalars.
         if hasattr(self, '_pending_mha_transfer') and self._pending_mha_transfer is not None:
             mha = self.active_attn_metadata["mha_metadata"]
             d = self._pending_mha_transfer
-            mha.load_from_cpu(
-                query_lengths=d["query_lengths"],
-                cu_query_seq_lengths=d["cu_query_seq_lengths"],
-                kv_seq_lengths=d["kv_seq_lengths"],
-                cu_kv_seq_lengths=d["cu_kv_seq_lengths"],
-                block_table=d["block_table"],
+            mha.set_state_data(
+                padded_active_request_count=d["padded_active_request_count"],
                 max_seqlen_q=d["max_seqlen_q"],
                 max_seqlen_k=d["max_seqlen_k"],
-                padded_active_request_count=d["padded_active_request_count"],
             )
             self._pending_mha_transfer = None
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -38,6 +38,7 @@ from megatron.core.utils import get_pg_size, internal_api
 from .attention_context.mamba_metadata import MambaMetadata
 from .attention_context.mha_metadata import GraphedMHAMetadata, NonGraphedMHAMetadata
 from .base_context import BaseInferenceContext
+from .gpu_view import ContextGPUView
 from .kv_block_allocator import KVBlockAllocator
 from .mamba_slot_allocator import MambaSlotAllocator
 from .routing_metadata import RoutingMetadata
@@ -810,49 +811,82 @@ class DynamicInferenceContext(BaseInferenceContext):
                 f"Please move tensor '{key}'."
             )
 
-        # Per-request state.
+        # Per-request state (CPU, pinned memory for fast H2D transfer).
         self.request_ids = torch.full(
-            (self.max_requests,), -1, dtype=torch.int32, device=torch.cuda.current_device()
+            (self.max_requests,), -1, dtype=torch.int32, device='cpu', pin_memory=True,
         )
         # request_query_lengths is the input prompt tokens length during prefill phase (1st step) and then 1 for the decode phase (i.e During generation)
-        self.request_query_lengths = torch.empty_like(self.request_ids)
+        self.request_query_lengths = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # True only for a new request , then after a forward pass it is set to False
-        self.request_in_prefill_status_tensor = torch.empty_like(self.request_ids)
+        self.request_in_prefill_status_tensor = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # request_output_lengths is len(input_prompt_tokens) + num_tokens_to_generate
-        self.request_output_lengths = torch.empty_like(self.request_ids)
+        self.request_output_lengths = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # request_kv_length_offsets is the same as query length during prefill phase (1st step) and then 1 for the decode phase (i.e During generation)
-        self.request_kv_length_offsets = torch.empty_like(self.request_ids)
-        self.request_kv_block_counts = torch.empty_like(self.request_ids)
-        self.request_last_kv_block_id = torch.empty_like(self.request_ids)
+        self.request_kv_length_offsets = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
+        self.request_kv_block_counts = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
+        self.request_last_kv_block_id = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # request_last_kv_block_offset represents number of tokens in the last kv block
-        self.request_last_kv_block_offset = torch.empty_like(self.request_ids)
+        self.request_last_kv_block_offset = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         self.request_to_kv_block_ids = torch.full(
             (self.max_requests, self.max_kv_block_count),
             -1,
             dtype=torch.int,
-            device=torch.cuda.current_device(),
+            device='cpu',
+            pin_memory=True,
         )
 
         # Track request metadata.
         self.request_metadata = {
             label: torch.empty(
-                (self.max_requests,), dtype=dtype, device=torch.cuda.current_device()
+                (self.max_requests,), dtype=dtype, device='cpu', pin_memory=True,
             )
             for label, dtype, _ in self.request_metadata_types
         }
 
-        # Per-token state.
+        # Per-token state (CPU, pinned memory for fast H2D transfer).
         self.token_to_input_ids = torch.full(
-            (self.max_tokens,), 0, dtype=torch.long, device=torch.cuda.current_device()
+            (self.max_tokens,), 0, dtype=torch.long, device='cpu', pin_memory=True,
         )
-        self.token_to_pos_ids = torch.full_like(self.token_to_input_ids, 0)
-        self.token_to_request_idx = torch.empty_like(self.token_to_input_ids)
-        self.token_to_block_idx = torch.empty_like(self.token_to_input_ids)
+        self.token_to_pos_ids = torch.full(
+            (self.max_tokens,), 0, dtype=torch.long, device='cpu', pin_memory=True,
+        )
+        self.token_to_request_idx = torch.empty(
+            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
+        self.token_to_block_idx = torch.empty(
+            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # i.e For a set of tokens A B C D E F ..  and block_size 4:
         # token_to_position_in_request is  [0, 1, 2, 3, 4, 5]
         # token_to_local_position_within_kv_block is [0 , 1, 2, 3, 0, 1, 2]
-        self.token_to_position_in_request = torch.empty_like(self.token_to_input_ids)
-        self.token_to_local_position_within_kv_block = torch.empty_like(self.token_to_input_ids)
+        self.token_to_position_in_request = torch.empty(
+            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
+        self.token_to_local_position_within_kv_block = torch.empty(
+            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
+
+        # GPU view: the single interface for GPU code to read context state.
+        # Populated per-step by transfer_bookkeeping_to_gpu().
+        self.gpu_view = ContextGPUView(
+            max_requests=self.max_requests,
+            max_tokens=self.max_tokens,
+            device=torch.cuda.current_device(),
+        )
 
         # NOTE: Need to build this outside the UVM / TMS context to avoid IMA.
         if self.is_hybrid_model:
@@ -1074,12 +1108,12 @@ class DynamicInferenceContext(BaseInferenceContext):
                 value=value,
                 memory_buffer=self.memory_buffer,
                 padded_active_token_count=self.padded_active_token_count,
-                token_to_block_idx=self.token_to_block_idx,
-                token_to_local_position_within_kv_block=self.token_to_local_position_within_kv_block,
+                token_to_block_idx=self.gpu_view.token_to_block_idx,
+                token_to_local_position_within_kv_block=self.gpu_view.token_to_local_position_within_kv_block,
             )
 
-        block_idx = self.token_to_block_idx[: self.padded_active_token_count]
-        local_kv_seq_idx = self.token_to_local_position_within_kv_block[
+        block_idx = self.gpu_view.token_to_block_idx[: self.padded_active_token_count]
+        local_kv_seq_idx = self.gpu_view.token_to_local_position_within_kv_block[
             : self.padded_active_token_count
         ]
 
@@ -1215,7 +1249,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # use .view instead of .reshape to avoid extra transpose operations
         query_rope, key_rope = flashinfer.rope.apply_rope_with_cos_sin_cache(
-            positions=self.token_to_pos_ids[:n],
+            positions=self.gpu_view.token_to_pos_ids[:n],
             query=query[:n].reshape(n, num_q_heads * head_size),
             key=key[:n].reshape(n, num_k_heads * head_size),
             head_size=head_size,
@@ -1248,7 +1282,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             (Tensor) Query tensor after applying rotary embeddings.
         """
         n = self.padded_active_token_count
-        query_seq_idx = self.token_to_pos_ids[:n]
+        query_seq_idx = self.gpu_view.token_to_pos_ids[:n]
         query_emb = query_emb[query_seq_idx]
         query[:n] = apply_rotary_pos_emb(
             t=query[:n],
@@ -1280,7 +1314,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             (Tensor) Key tensor after applying rotary embeddings.
         """
         n = self.padded_active_token_count
-        key_seq_idx = self.token_to_position_in_request[:n]
+        key_seq_idx = self.gpu_view.token_to_position_in_request[:n]
         key_emb = key_emb[key_seq_idx]
         if self.is_decode_only():
             if key.shape[0] != n:
@@ -1387,7 +1421,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_kv_block_counts[request_slice] = block_counts
         for i, (label, dtype, _) in enumerate(self.request_metadata_types):
             self.request_metadata[label][request_slice] = torch.tensor(
-                metadata_cols[i], dtype=dtype, device=torch.cuda.current_device()
+                metadata_cols[i], dtype=dtype, device='cpu',
             )
 
         dummy_block_idx = self.kv_block_allocator.dummy_block_idx
@@ -1469,7 +1503,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Pre-construct shared objects (safe due to deep copy in DynamicInferenceRequest.__post_init__)
         shared_sampling_params = SamplingParams(num_tokens_to_generate=1, termination_id=-1)
         shared_decode_tokens = torch.zeros(
-            self.num_speculative_tokens + 1, dtype=torch.long, device=torch.cuda.current_device()
+            self.num_speculative_tokens + 1, dtype=torch.long, device='cpu',
         )
 
         decode_requests = [
@@ -1500,7 +1534,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Create a single large tensor and slice from it for each prefill request
         max_prefill_tokens = per_prefill_tokens + (1 if rem_prefill_tokens > 0 else 0)
         shared_prefill_tokens = torch.zeros(
-            max_prefill_tokens, dtype=torch.long, device=torch.cuda.current_device()
+            max_prefill_tokens, dtype=torch.long, device='cpu',
         )
 
         prefill_requests = [
@@ -1733,37 +1767,89 @@ class DynamicInferenceContext(BaseInferenceContext):
                 )
 
         assert self.active_attn_metadata is not None
-        self.active_attn_metadata["mha_metadata"].update(
-            request_query_lengths=query_lengths_view,
-            request_kv_length_offsets=request_kv_length_offsets_view,
-            request_to_kv_block_ids=request_to_kv_block_ids_view,
-            batch_dimensions=attn_dimensions,
-            padded_batch_dimensions=self.padded_batch_dimensions,
-            num_speculative_tokens=self.num_speculative_tokens,
+
+        # Compute MHA metadata on CPU (ephemeral locals, not persistent attributes).
+        real_bs = attn_dimensions.req_count
+        padded_bs = self.padded_batch_dimensions.req_count
+        mha = self.active_attn_metadata["mha_metadata"]
+
+        # Query lengths (padded).
+        cpu_query_lengths = torch.zeros(padded_bs, dtype=torch.int32)
+        cpu_query_lengths[:real_bs] = query_lengths_view[:real_bs]
+
+        # Cumulative query lengths (padded).
+        cpu_cu_query = torch.zeros(padded_bs + 1, dtype=torch.int32)
+        if real_bs > 0:
+            cpu_cu_query[1 : real_bs + 1] = torch.cumsum(query_lengths_view[:real_bs], dim=0)
+        if real_bs < padded_bs:
+            cpu_cu_query[real_bs + 1 : padded_bs + 1] = cpu_cu_query[real_bs]
+
+        # KV sequence lengths (padded).
+        cpu_kv_lengths = torch.zeros(padded_bs, dtype=torch.int32)
+        cpu_kv_lengths[:real_bs] = (
+            request_kv_length_offsets_view[:real_bs] + query_lengths_view[:real_bs]
         )
 
+        # Cumulative KV lengths (padded).
+        cpu_cu_kv = torch.zeros(padded_bs + 1, dtype=torch.int32)
+        if real_bs > 0:
+            cpu_cu_kv[1 : real_bs + 1] = torch.cumsum(cpu_kv_lengths[:real_bs], dim=0)
+        if real_bs < padded_bs:
+            cpu_cu_kv[real_bs + 1 : padded_bs + 1] = cpu_cu_kv[real_bs]
+
+        # Block table (padded).
+        cpu_block_table = torch.full(
+            (padded_bs, mha.max_kv_blocks), -1, dtype=torch.int32,
+        )
+        cpu_block_table[:real_bs] = request_to_kv_block_ids_view[:real_bs]
+
+        # Max sequence lengths.
+        if not self.using_cuda_graph_this_step() and real_bs > 0:
+            # NonGraphedMHAMetadata: use actual max values.
+            max_seqlen_q = cpu_query_lengths[:real_bs].max().item()
+            max_seqlen_k = cpu_kv_lengths[:real_bs].max().item()
+        else:
+            # GraphedMHAMetadata: use conservative bounds.
+            if self.padded_batch_dimensions.prefill_req_count == 0:
+                max_seqlen_q = self.num_speculative_tokens + 1
+            else:
+                max_seqlen_q = max(2, self.padded_batch_dimensions.token_count)
+            max_seqlen_k = mha.max_seqlen
+        if not self.using_cuda_graph_this_step() and real_bs == 0:
+            max_seqlen_q = self.num_speculative_tokens + 1
+            max_seqlen_k = 1
+
+        # Store for transfer_bookkeeping_to_gpu().
+        self._pending_mha_transfer = {
+            "query_lengths": cpu_query_lengths,
+            "cu_query_seq_lengths": cpu_cu_query,
+            "kv_seq_lengths": cpu_kv_lengths,
+            "cu_kv_seq_lengths": cpu_cu_kv,
+            "block_table": cpu_block_table,
+            "max_seqlen_q": max_seqlen_q,
+            "max_seqlen_k": max_seqlen_k,
+            "padded_active_request_count": padded_bs,
+        }
+
         if self.is_hybrid_model:
-            active_mamba_indices_view = self.mamba_metadata.request_to_mamba_state_idx[active_slice]
-            token_to_request_idx_view = self.token_to_request_idx[: self.active_token_count]
-            cu_seqlens = self.active_attn_metadata["mha_metadata"].state_data[
-                "cu_query_seq_lengths"
-            ]
+            # Mamba metadata update is deferred to transfer_bookkeeping_to_gpu()
+            # because it writes to GPU buffers. Store the parameters here.
             intermediate_offsets_gpu = None
             intermediate_counts_gpu = None
             if self.mamba_slot_allocator is not None:
                 intermediate_offsets_gpu, intermediate_counts_gpu = (
                     self.mamba_slot_allocator.get_intermediate_gpu_data()
                 )
-            self.mamba_metadata.update(
-                active_mamba_indices_view,
-                token_to_request_idx_view,
-                cu_seqlens,
-                batch_dimensions=attn_dimensions,
-                padded_batch_dimensions=self.padded_batch_dimensions,
-                enable_chunked_prefill=self.is_chunked_prefill_enabled(),
-                intermediate_offsets_gpu=intermediate_offsets_gpu,
-                intermediate_counts_gpu=intermediate_counts_gpu,
-            )
+            self._pending_mamba_transfer = {
+                "active_mamba_indices": self.mamba_metadata.request_to_mamba_state_idx[active_slice],
+                "token_to_request_idx": self.token_to_request_idx[: self.active_token_count],
+                "cu_seqlens": cpu_cu_query,
+                "batch_dimensions": attn_dimensions,
+                "padded_batch_dimensions": self.padded_batch_dimensions,
+                "enable_chunked_prefill": self.is_chunked_prefill_enabled(),
+                "intermediate_offsets_gpu": intermediate_offsets_gpu,
+                "intermediate_counts_gpu": intermediate_counts_gpu,
+            }
 
         if self.moe_enable_routing_replay:
             if self.using_cuda_graph_this_step():
@@ -1771,8 +1857,85 @@ class DynamicInferenceContext(BaseInferenceContext):
             else:
                 self.moe_routing_metadata.disable_static_buffer_recording()
 
+    def transfer_bookkeeping_to_gpu(self) -> None:
+        """Batch transfer CPU bookkeeping state to GPU staging buffers.
+
+        Called after initialize_attention_state() and before the forward pass.
+        All copies use non_blocking=True with pinned CPU memory. CUDA stream
+        ordering guarantees the forward pass sees completed transfers.
+        """
+        n_tok = self.padded_active_token_count
+
+        # Token-level transfers.
+        self.gpu_view.token_to_input_ids[:n_tok].copy_(
+            self.token_to_input_ids[:n_tok], non_blocking=True,
+        )
+        self.gpu_view.token_to_pos_ids[:n_tok].copy_(
+            self.token_to_pos_ids[:n_tok], non_blocking=True,
+        )
+        self.gpu_view.token_to_block_idx[:n_tok].copy_(
+            self.token_to_block_idx[:n_tok], non_blocking=True,
+        )
+        self.gpu_view.token_to_local_position_within_kv_block[:n_tok].copy_(
+            self.token_to_local_position_within_kv_block[:n_tok], non_blocking=True,
+        )
+        self.gpu_view.token_to_request_idx[:n_tok].copy_(
+            self.token_to_request_idx[:n_tok], non_blocking=True,
+        )
+        self.gpu_view.token_to_position_in_request[:n_tok].copy_(
+            self.token_to_position_in_request[:n_tok], non_blocking=True,
+        )
+
+        # Request-level transfers (consumed by sampling, log-probs, speculative verification).
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        n_active = self.total_request_count - self.paused_request_count
+        self.gpu_view.request_in_prefill_status[:n_active].copy_(
+            self.request_in_prefill_status_tensor[active_slice], non_blocking=True,
+        )
+        self.gpu_view.request_query_lengths[:n_active].copy_(
+            self.request_query_lengths[active_slice], non_blocking=True,
+        )
+        self.gpu_view.request_kv_length_offsets[:n_active].copy_(
+            self.request_kv_length_offsets[active_slice], non_blocking=True,
+        )
+
+        # MHA metadata transfer.
+        if hasattr(self, '_pending_mha_transfer') and self._pending_mha_transfer is not None:
+            mha = self.active_attn_metadata["mha_metadata"]
+            d = self._pending_mha_transfer
+            mha.load_from_cpu(
+                query_lengths=d["query_lengths"],
+                cu_query_seq_lengths=d["cu_query_seq_lengths"],
+                kv_seq_lengths=d["kv_seq_lengths"],
+                cu_kv_seq_lengths=d["cu_kv_seq_lengths"],
+                block_table=d["block_table"],
+                max_seqlen_q=d["max_seqlen_q"],
+                max_seqlen_k=d["max_seqlen_k"],
+                padded_active_request_count=d["padded_active_request_count"],
+            )
+            self._pending_mha_transfer = None
+
+        # Mamba metadata transfer (update writes to GPU buffers).
+        if hasattr(self, '_pending_mamba_transfer') and self._pending_mamba_transfer is not None:
+            d = self._pending_mamba_transfer
+            # cu_seqlens needs to be on GPU for the Mamba metadata update.
+            cu_seqlens_gpu = self.active_attn_metadata["mha_metadata"].state_data[
+                "cu_query_seq_lengths"
+            ]
+            self.mamba_metadata.update(
+                d["active_mamba_indices"],
+                d["token_to_request_idx"],
+                cu_seqlens_gpu,
+                batch_dimensions=d["batch_dimensions"],
+                padded_batch_dimensions=d["padded_batch_dimensions"],
+                enable_chunked_prefill=d["enable_chunked_prefill"],
+                intermediate_offsets_gpu=d["intermediate_offsets_gpu"],
+                intermediate_counts_gpu=d["intermediate_counts_gpu"],
+            )
+            self._pending_mamba_transfer = None
+
     def reset_tensors(self) -> None:
-        """Fill all GPU tensors with sentinel values."""
+        """Fill all bookkeeping tensors with sentinel values."""
 
         # Reset request indexes.
         self.request_ids.fill_(-1)
@@ -1876,8 +2039,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.num_speculative_tokens + 1
         )
         return (
-            self.token_to_input_ids[:num_tokens].unsqueeze(0),
-            self.token_to_pos_ids[:num_tokens].unsqueeze(0),
+            self.gpu_view.token_to_input_ids[:num_tokens].unsqueeze(0),
+            self.gpu_view.token_to_pos_ids[:num_tokens].unsqueeze(0),
         )
 
     def speculative_required_logit_indices(self, device: torch.device) -> Tensor:
@@ -1899,12 +2062,12 @@ class DynamicInferenceContext(BaseInferenceContext):
         num_decode = self.num_decode_requests
 
         decode_token_count = num_decode * (self.num_speculative_tokens + 1)
-        decode_indices = torch.arange(decode_token_count, device=device)
+        decode_indices = torch.arange(decode_token_count, device='cpu')
 
         cumsum = torch.cumsum(query_lengths, dim=0)
         prefill_last_indices = cumsum[num_decode:] - 1
 
-        return torch.cat([decode_indices, prefill_last_indices])
+        return torch.cat([decode_indices, prefill_last_indices]).to(device, non_blocking=True)
 
     def last_token_logits(self, logits: Tensor) -> Tensor:
         """Select the logit positions needed for token generation.
@@ -1937,7 +2100,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         total = self.total_request_count
         query_lengths = self.request_query_lengths[paused:total]
         last_token_idxs = torch.cumsum(query_lengths, dim=0) - 1
-        return logits_2d[last_token_idxs, :]
+        return logits_2d[last_token_idxs.to(logits.device, non_blocking=True), :]
 
     def _compute_prefix_match(
         self, req: DynamicInferenceRequest, prefill_chunk_length: int
@@ -2151,7 +2314,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Increment ref counts and update timestamps for matched (shared) blocks
         if num_matched_blocks > 0:
             matched_tensor = torch.tensor(
-                matched_block_ids, dtype=torch.int32, device=torch.cuda.current_device()
+                matched_block_ids, dtype=torch.int32, device='cpu',
             )
             self.kv_block_allocator.block_ref_counts[matched_tensor] += 1
             if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
@@ -2550,7 +2713,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             -1,
             -1,
             dtype=paused_block_counts_cumsum.dtype,
-            device=torch.cuda.current_device(),
+            device='cpu',
         )
         net_block_counts = paused_block_counts_cumsum - remaining_paused_request_counts
         evict_request_count = torch.nonzero(net_block_counts >= 0)[0].item() + 1
@@ -2559,7 +2722,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         evict_start_idx = self.paused_request_count - evict_request_count
         evict_end_idx = self.paused_request_count
         evict_request_idxs = torch.arange(
-            evict_start_idx, evict_end_idx, device=torch.cuda.current_device()
+            evict_start_idx, evict_end_idx, device='cpu',
         )
         # Clone needed: subsequent release_memory_blocks_from_request_indexes and
         # _swap_book_keeping_tensors calls mutate self.request_ids in place.
@@ -2575,24 +2738,24 @@ class DynamicInferenceContext(BaseInferenceContext):
             src_idxs = torch.arange(
                 self.paused_request_count - evict_request_count,
                 self.paused_request_count,
-                device=torch.cuda.current_device(),
+                device='cpu',
             )
             dst_idxs = torch.arange(
                 self.total_request_count - evict_request_count,
                 self.total_request_count,
-                device=torch.cuda.current_device(),
+                device='cpu',
             )
         else:
             # Swap all active requests with left-most evicted requests.
             src_idxs = torch.arange(
                 self.paused_request_count - evict_request_count,
                 self.paused_request_count - evict_request_count + active_request_count,
-                device=torch.cuda.current_device(),
+                device='cpu',
             )
             dst_idxs = torch.arange(
                 self.paused_request_count,
                 self.paused_request_count + active_request_count,
-                device=torch.cuda.current_device(),
+                device='cpu',
             )
 
         # Swap evicted and active requests.
@@ -2667,6 +2830,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         # 1. The active token mask tells us which requests are still active and which are completed
         # active_request_count -> This corresponds to requests that have not reached EOD or max length
         # finished_request_count are requests that have reached the termination criterion
+
+        # Ensure all inputs are on CPU for bookkeeping operations.
+        if active_requests_mask.is_cuda:
+            active_requests_mask = active_requests_mask.cpu()
+        if new_tokens.is_cuda:
+            new_tokens = new_tokens.cpu()
+        if new_speculative_tokens is not None and new_speculative_tokens.is_cuda:
+            new_speculative_tokens = new_speculative_tokens.cpu()
 
         self.num_prefill_requests = 0  # all turns to decode
         # All request that were in prefill become decode requests.
@@ -2972,14 +3143,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.token_to_pos_ids[: self.active_token_count] = self.request_kv_length_offsets[
             self.paused_request_count : self.total_request_count
         ].repeat_interleave(num_generated_tokens) + torch.arange(
-            num_generated_tokens, device=torch.cuda.current_device()
+            num_generated_tokens, device='cpu'
         ).repeat(
             active_request_count
         )
         #
         # Token to request idx : [0, 0, 0, 1, 1, 1, 2, 2, 2 ...]
         self.token_to_request_idx[: self.active_token_count] = torch.arange(
-            self.paused_request_count, self.total_request_count, device=torch.cuda.current_device()
+            self.paused_request_count, self.total_request_count, device='cpu'
         ).repeat_interleave(num_generated_tokens)
 
         self.token_to_position_in_request[: self.active_token_count] = self.token_to_pos_ids[
@@ -3001,7 +3172,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         raw_positions = (
             old_offsets[:, None]
             + 1  # Offset by 1 because old_offsets points to the LAST token
-            + torch.arange(num_generated_tokens, device=torch.cuda.current_device())[None, :]
+            + torch.arange(num_generated_tokens, device='cpu')[None, :]
         )
         #
         # A token crosses to the next block if its raw_position >= block_size
@@ -3117,10 +3288,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         #
         #   active_token_ids[new_token_idx] = new_tokens
         #                       : [ 52 | 12 | 16  3 | 12 72 24 88 86 ]
-        active_token_ids = self.token_to_input_ids[: self.active_token_count].roll(-1, 0)
-        active_query_lengths = self.request_query_lengths[
-            self.paused_request_count : self.total_request_count
-        ]
+        n_active = self.total_request_count - self.paused_request_count
+        active_token_ids = self.gpu_view.token_to_input_ids[: self.active_token_count].roll(-1, 0)
+        active_query_lengths = self.gpu_view.request_query_lengths[:n_active]
 
         new_token_idx = active_query_lengths.cumsum(0) - 1
         active_token_ids[new_token_idx] = new_tokens

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -4,7 +4,7 @@ import logging
 import math
 import warnings
 from contextlib import nullcontext
-from typing import List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import torch  # type: ignore
 import torch.nn.functional as F  # type: ignore
@@ -966,6 +966,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         # request staging slots start with a deterministic value.
         self._cpu_bookkeeping_buf.fill_(0)
 
+        # Snapshot used by speculatively_advance_for_next_decode_step /
+        # restore_after_speculative_advance. None when no speculative advance
+        # is currently outstanding.
+        self._spec_advance_state: Optional[Dict[str, Tensor]] = None
+
         _off = 0
         # Per-token state (source-of-truth lives in the coalesced buffer since
         # the CPU-side bookkeeping and the GPU forward pass use the same
@@ -1326,17 +1331,99 @@ class DynamicInferenceContext(BaseInferenceContext):
     def can_speculate_decode_step(self, advance: int = 1) -> bool:
         """Predicate: can we run the next ``advance`` decode steps speculatively?
 
-        Returns True when the speculation chain is safe to continue: pure decode
-        only, and either no new blocks are needed or all needed blocks are
-        available without eviction. Used by the engine in C3 to gate the
-        async-scheduling fast path.
+        Returns True only when the next step's metadata can be derived from the
+        current state by a position bump alone — no allocator activity, no
+        speculative-decoding interaction. Tighter than the original block-budget
+        check because the speculative advance path implemented in
+        :meth:`speculatively_advance_for_next_decode_step` does not yet handle
+        block-boundary crossings or speculative decoding (num_speculative_tokens
+        > 0); the engine falls back to serial whenever this returns False.
         """
         if not self.is_decode_only():
             return False
-        blocks_needed = self.predict_decode_blocks_needed(advance=advance)
-        if blocks_needed == 0:
-            return True
-        return self.kv_block_allocator.is_memory_available(blocks_needed)
+        if self.num_speculative_tokens > 0:
+            return False
+        # Boundary-crossing requires allocator work that the speculative advance
+        # cannot replay safely; defer to serial when any active request would
+        # need a fresh block at the next step.
+        return self.predict_decode_blocks_needed(advance=advance) == 0
+
+    def speculatively_advance_for_next_decode_step(self) -> None:
+        """Advance state to what update_requests would produce after the next
+        pure-decode step, assuming no termination/pause/eviction events.
+
+        Called by the engine async-scheduling path to populate the pinned
+        bookkeeping buffer for step N+1 before step N's update_requests has
+        run. Reversible via :meth:`restore_after_speculative_advance`, which
+        the engine invokes after queueing step N+1's H2D + forward + sample
+        on the stream so that step N's update_requests sees pre-speculation
+        canonical state.
+
+        Preconditions (caller-enforced via :meth:`can_speculate_decode_step`):
+            - ``is_decode_only()``
+            - ``num_speculative_tokens == 0``
+            - No active request crosses a block boundary at the next step.
+        """
+        assert self.is_decode_only(), "speculative advance requires pure decode"
+        assert self.num_speculative_tokens == 0, (
+            "speculative advance not yet supported alongside speculative decoding"
+        )
+        assert self._spec_advance_state is None, (
+            "previous speculative advance has not been restored"
+        )
+
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        n_active = self.total_request_count - self.paused_request_count
+
+        # Snapshot persistent tensors that the advance mutates. Pinned-buffer
+        # token-level fields (token_to_pos_ids, etc.) are intentionally not
+        # snapshotted: they are overwritten by the upcoming update_requests
+        # call on the canonical post-step-N state, which will produce the same
+        # values we wrote here in the no-event case.
+        self._spec_advance_state = {
+            'request_kv_length_offsets': self.request_kv_length_offsets[active_slice].clone(),
+            'request_last_kv_block_offset': self.request_last_kv_block_offset[
+                active_slice
+            ].clone(),
+        }
+
+        # Advance per-request offsets: kv_offsets += query_lengths (==1 in pure
+        # decode), and last_kv_block_offset rolls forward by one mod block size.
+        query_lens = self.request_query_lengths[active_slice]
+        self.request_kv_length_offsets[active_slice] += query_lens
+        self.request_last_kv_block_offset[active_slice] = (
+            self.request_last_kv_block_offset[active_slice] + 1
+        ) % self.block_size_tokens
+
+        # Advance pinned token-level fields (aliased into _cpu_bookkeeping_buf
+        # so writes here flow into the next H2D source). For pure decode with
+        # num_speculative_tokens == 0 there is exactly one token per active
+        # request; per-token pos_ids equal the per-request kv_offset.
+        new_kv_offsets = self.request_kv_length_offsets[active_slice]
+        self.token_to_pos_ids[:n_active] = new_kv_offsets
+        self.token_to_position_in_request[:n_active] = new_kv_offsets
+        self.token_to_local_position_within_kv_block[:n_active] = (
+            new_kv_offsets % self.block_size_tokens
+        )
+
+    def restore_after_speculative_advance(self) -> None:
+        """Reverse a prior :meth:`speculatively_advance_for_next_decode_step`.
+
+        Restores only the persistent tensors. The pinned-buffer token-level
+        fields are intentionally left at their speculatively-advanced values;
+        update_requests for the just-completed step will overwrite them with
+        the canonical post-step-N values during normal bookkeeping.
+        """
+        assert self._spec_advance_state is not None, (
+            "no speculative advance to restore"
+        )
+        state = self._spec_advance_state
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        self.request_kv_length_offsets[active_slice] = state['request_kv_length_offsets']
+        self.request_last_kv_block_offset[active_slice] = state[
+            'request_last_kv_block_offset'
+        ]
+        self._spec_advance_state = None
 
     def append_key_value_cache(self, layer_number: int, key: Tensor, value: Tensor) -> None:
         """Append to KV cache.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1644,6 +1644,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         Return:
             None.
         """
+        # Launch deferred Mamba GPU ops first (state zeroing/restore) so they
+        # overlap with the CPU work below.  These are non-blocking GPU kernels.
+        self._execute_pending_mamba_ops()
+
         self.is_creating_cuda_graphs = construct_graph_dimensions is not None
         assert not (
             self.is_creating_cuda_graphs and is_expert_parallel_dummy_cuda_graph_step
@@ -1894,9 +1898,6 @@ class DynamicInferenceContext(BaseInferenceContext):
         All copies use non_blocking=True with pinned CPU memory. CUDA stream
         ordering guarantees the forward pass sees completed transfers.
         """
-        # Execute deferred Mamba GPU operations first (state zeroing, restore, offsets).
-        self._execute_pending_mamba_ops()
-
         n_tok = self.padded_active_token_count
 
         # Token-level transfers.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -320,6 +320,12 @@ class DynamicInferenceContext(BaseInferenceContext):
         else:
             self.expert_model_parallel_group = None
 
+        # Optional CPU-side collective for EP batch-dimension sync. Populated by
+        # the engine via set_ep_zmq_communicator() when available. When set,
+        # match_graph_config() uses this to perform the MAX reduction on the
+        # CPU, avoiding a per-step NCCL AllReduce kernel on the compute stream.
+        self._ep_zmq_communicator = None
+
         # Mamba states.
         mamba_inference_state_config = inference_config.mamba_inference_state_config
         self.is_hybrid_model = mamba_inference_state_config is not None
@@ -1338,6 +1344,20 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
         return key
 
+    def set_ep_zmq_communicator(self, communicator) -> None:
+        """Attach an EP-group ZMQ communicator for CPU-side sync collectives.
+
+        When set, match_graph_config() uses this communicator's
+        sync_all_reduce_max() to perform the EP batch-dimension MAX reduction on
+        the CPU instead of launching a NCCL AllReduce kernel on the compute
+        stream. Expected to be called once by the inference engine after both
+        the context and the communicator have been created.
+
+        Args:
+            communicator: AsyncZMQCommunicator over the EP process group.
+        """
+        self._ep_zmq_communicator = communicator
+
     def reset_attention_state(self) -> None:
         """Reset state used within attention, after each step."""
         # Attention metadata reset is now handled by MHAMetadata.reset()
@@ -1681,6 +1701,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             decode_only_cuda_graphs=(not self.use_cuda_graphs_for_non_decode_steps),
             ep_group=self.expert_model_parallel_group,
             num_speculative_tokens=self.num_speculative_tokens,
+            ep_zmq_communicator=self._ep_zmq_communicator,
         )
         self._using_cuda_graph_this_step = best_graph is not None
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -740,8 +740,26 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata = MambaMetadata(
                 max_requests=self.max_requests,
                 max_tokens=self.max_tokens,
+                mamba_chunk_size=self.mamba_chunk_size,
                 d_conv=self.mamba_conv_states_shape[-1],
             )
+            # Bind the unified CPU/GPU buffers so the 9 per-step Mamba fields
+            # ride along with the single coalesced H2D in
+            # transfer_bookkeeping_to_gpu().
+            self.mamba_metadata.bind_cpu_buffers(
+                {
+                    "batch_indices_decode": self._cpu_mamba_batch_indices_decode,
+                    "batch_indices_prefill": self._cpu_mamba_batch_indices_prefill,
+                    "seq_idx": self._cpu_mamba_seq_idx,
+                    "cu_seqlens": self._cpu_mamba_cu_seqlens,
+                    "cu_chunk_seqlens": self._cpu_mamba_cu_chunk_seqlens,
+                    "last_chunk_indices": self._cpu_mamba_last_chunk_indices,
+                    "seq_idx_for_varlen": self._cpu_mamba_seq_idx_for_varlen,
+                    "conv_seq_idx": self._cpu_mamba_conv_seq_idx,
+                    "conv_seq_start": self._cpu_mamba_conv_seq_start,
+                }
+            )
+            self.mamba_metadata.bind_gpu_buffers(self.gpu_view)
             self.mamba_conv_states = torch.empty(
                 (self.num_mamba_layers, self.max_requests) + self.mamba_conv_states_shape,
                 dtype=self.mamba_conv_states_dtype,
@@ -895,6 +913,32 @@ class DynamicInferenceContext(BaseInferenceContext):
         _mha_kv_seq_lengths_bytes = self.max_requests * 4
         _mha_cu_kv_seq_lengths_bytes = (self.max_requests + 1) * 4
         _mha_block_table_bytes = self.max_requests * self.max_kv_block_count * 4
+        # Mamba section: 9 int32 fields (hybrid models only). Must match the
+        # MambaMetadata shapes (mirrors the layout documented in ContextGPUView).
+        if self.is_hybrid_model:
+            self._max_mamba_chunks = (
+                self.max_tokens // self.mamba_chunk_size + self.max_requests
+            )
+            _mamba_batch_indices_decode_bytes = self.max_requests * 4
+            _mamba_batch_indices_prefill_bytes = self.max_requests * 4
+            _mamba_seq_idx_bytes = self.max_tokens * 4
+            _mamba_cu_seqlens_bytes = (self.max_requests + 1) * 4
+            _mamba_cu_chunk_seqlens_bytes = (self._max_mamba_chunks + 1) * 4
+            _mamba_last_chunk_indices_bytes = self.max_requests * 4
+            _mamba_seq_idx_for_varlen_bytes = self._max_mamba_chunks * 4
+            _mamba_conv_seq_idx_bytes = self.max_tokens * 4
+            _mamba_conv_seq_start_bytes = self.max_tokens * 4
+        else:
+            self._max_mamba_chunks = 0
+            _mamba_batch_indices_decode_bytes = 0
+            _mamba_batch_indices_prefill_bytes = 0
+            _mamba_seq_idx_bytes = 0
+            _mamba_cu_seqlens_bytes = 0
+            _mamba_cu_chunk_seqlens_bytes = 0
+            _mamba_last_chunk_indices_bytes = 0
+            _mamba_seq_idx_for_varlen_bytes = 0
+            _mamba_conv_seq_idx_bytes = 0
+            _mamba_conv_seq_start_bytes = 0
         _total_bytes = (
             2 * _tok_int64_bytes
             + 4 * _tok_int32_bytes
@@ -904,6 +948,15 @@ class DynamicInferenceContext(BaseInferenceContext):
             + _mha_kv_seq_lengths_bytes
             + _mha_cu_kv_seq_lengths_bytes
             + _mha_block_table_bytes
+            + _mamba_batch_indices_decode_bytes
+            + _mamba_batch_indices_prefill_bytes
+            + _mamba_seq_idx_bytes
+            + _mamba_cu_seqlens_bytes
+            + _mamba_cu_chunk_seqlens_bytes
+            + _mamba_last_chunk_indices_bytes
+            + _mamba_seq_idx_for_varlen_bytes
+            + _mamba_conv_seq_idx_bytes
+            + _mamba_conv_seq_start_bytes
         )
         self._cpu_bookkeeping_buf = torch.empty(
             _total_bytes, dtype=torch.uint8, device='cpu', pin_memory=True,
@@ -988,6 +1041,49 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
         _off += _mha_block_table_bytes
 
+        # Mamba varlen metadata views (hybrid models only). Populated per step
+        # by MambaMetadata.compute_cpu_metadata(); transferred as part of the
+        # single coalesced H2D in transfer_bookkeeping_to_gpu().
+        if self.is_hybrid_model:
+            self._cpu_mamba_batch_indices_decode = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_batch_indices_decode_bytes
+            ].view(torch.int32)
+            _off += _mamba_batch_indices_decode_bytes
+            self._cpu_mamba_batch_indices_prefill = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_batch_indices_prefill_bytes
+            ].view(torch.int32)
+            _off += _mamba_batch_indices_prefill_bytes
+            self._cpu_mamba_seq_idx = (
+                self._cpu_bookkeeping_buf[_off : _off + _mamba_seq_idx_bytes]
+                .view(torch.int32)
+                .view(1, self.max_tokens)
+            )
+            _off += _mamba_seq_idx_bytes
+            self._cpu_mamba_cu_seqlens = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_cu_seqlens_bytes
+            ].view(torch.int32)
+            _off += _mamba_cu_seqlens_bytes
+            self._cpu_mamba_cu_chunk_seqlens = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_cu_chunk_seqlens_bytes
+            ].view(torch.int32)
+            _off += _mamba_cu_chunk_seqlens_bytes
+            self._cpu_mamba_last_chunk_indices = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_last_chunk_indices_bytes
+            ].view(torch.int32)
+            _off += _mamba_last_chunk_indices_bytes
+            self._cpu_mamba_seq_idx_for_varlen = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_seq_idx_for_varlen_bytes
+            ].view(torch.int32)
+            _off += _mamba_seq_idx_for_varlen_bytes
+            self._cpu_mamba_conv_seq_idx = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_conv_seq_idx_bytes
+            ].view(torch.int32)
+            _off += _mamba_conv_seq_idx_bytes
+            self._cpu_mamba_conv_seq_start = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_conv_seq_start_bytes
+            ].view(torch.int32)
+            _off += _mamba_conv_seq_start_bytes
+
         assert _off == _total_bytes, f"layout bug: wrote {_off} of {_total_bytes} bytes"
 
         # GPU view: the single interface for GPU code to read context state.
@@ -997,6 +1093,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             max_tokens=self.max_tokens,
             max_kv_blocks=self.max_kv_block_count,
             device=torch.cuda.current_device(),
+            max_mamba_chunks=self._max_mamba_chunks,
         )
 
         # Bind the shared MHA GPU views to both graph and non-graph metadata;
@@ -1008,15 +1105,6 @@ class DynamicInferenceContext(BaseInferenceContext):
         # update_requests() (CPU phase), executed by transfer_bookkeeping_to_gpu().
         self._pending_mamba_zeros: list = []
         self._pending_mamba_restores: list = []
-
-        # NOTE: Need to build this outside the UVM / TMS context to avoid IMA.
-        if self.is_hybrid_model:
-            self.mamba_metadata = MambaMetadata(
-                max_requests=self.max_requests,
-                max_tokens=self.max_tokens,
-                mamba_chunk_size=self.mamba_chunk_size,
-                d_conv=self.mamba_conv_states_shape[-1],
-            )
 
         # Allocate large non-graphed buffers.
         need_static_addr = (

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1842,11 +1842,13 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.is_hybrid_model:
             # Mamba metadata update is deferred to transfer_bookkeeping_to_gpu()
             # because it writes to GPU buffers. Store the parameters here.
+            # intermediate_offsets_gpu / intermediate_counts_gpu get the CPU-side
+            # slices here; H2D transfer happens in transfer_bookkeeping_to_gpu().
             intermediate_offsets_gpu = None
             intermediate_counts_gpu = None
             if self.mamba_slot_allocator is not None:
                 intermediate_offsets_gpu, intermediate_counts_gpu = (
-                    self.mamba_slot_allocator.get_intermediate_gpu_data()
+                    self.mamba_slot_allocator.get_intermediate_cpu_data()
                 )
             self._pending_mamba_transfer = self.mamba_metadata.compute_cpu_metadata(
                 active_mamba_indices=self.mamba_metadata.request_to_mamba_state_idx[active_slice],
@@ -2594,13 +2596,13 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.is_hybrid_model:
             self.mamba_metadata.free_slots(request_indexes)
 
-        # Clear intermediate offset entries for released requests
+        # Clear intermediate offset entries for released requests (CPU writes).
         if self.mamba_slot_allocator is not None:
             sa = self.mamba_slot_allocator
-            sa._intermediate_counts_gpu[request_indexes] = 0
-            sa._intermediate_offsets_gpu[request_indexes] = 0
-            sa._intermediate_block_ids_gpu[request_indexes] = -1
-            sa._eos_cache_block_id_gpu[request_indexes] = -1
+            sa._intermediate_counts_cpu[request_indexes] = 0
+            sa._intermediate_offsets_cpu[request_indexes] = 0
+            sa._intermediate_block_ids_cpu[request_indexes] = -1
+            sa._eos_cache_block_id_cpu[request_indexes] = -1
 
     def resume_paused_requests(
         self, active_request_count: int, newly_paused_request_ids: torch.Tensor

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1848,16 +1848,16 @@ class DynamicInferenceContext(BaseInferenceContext):
                 intermediate_offsets_gpu, intermediate_counts_gpu = (
                     self.mamba_slot_allocator.get_intermediate_gpu_data()
                 )
-            self._pending_mamba_transfer = {
-                "active_mamba_indices": self.mamba_metadata.request_to_mamba_state_idx[active_slice],
-                "token_to_request_idx": self.token_to_request_idx[: self.active_token_count],
-                "cu_seqlens": cpu_cu_query,
-                "batch_dimensions": attn_dimensions,
-                "padded_batch_dimensions": self.padded_batch_dimensions,
-                "enable_chunked_prefill": self.is_chunked_prefill_enabled(),
-                "intermediate_offsets_gpu": intermediate_offsets_gpu,
-                "intermediate_counts_gpu": intermediate_counts_gpu,
-            }
+            self._pending_mamba_transfer = self.mamba_metadata.compute_cpu_metadata(
+                active_mamba_indices=self.mamba_metadata.request_to_mamba_state_idx[active_slice],
+                token_to_request_idx=self.token_to_request_idx[: self.active_token_count],
+                cpu_cu_query=cpu_cu_query,
+                batch_dimensions=attn_dimensions,
+                padded_batch_dimensions=self.padded_batch_dimensions,
+                enable_chunked_prefill=self.is_chunked_prefill_enabled(),
+                intermediate_offsets_gpu=intermediate_offsets_gpu,
+                intermediate_counts_gpu=intermediate_counts_gpu,
+            )
 
         if self.moe_enable_routing_replay:
             if self.using_cuda_graph_this_step():
@@ -1949,23 +1949,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
             self._pending_mha_transfer = None
 
-        # Mamba metadata transfer (update writes to GPU buffers).
+        # Mamba metadata: copy pre-computed CPU tensors to GPU buffers.
         if hasattr(self, '_pending_mamba_transfer') and self._pending_mamba_transfer is not None:
-            d = self._pending_mamba_transfer
-            # cu_seqlens needs to be on GPU for the Mamba metadata update.
-            cu_seqlens_gpu = self.active_attn_metadata["mha_metadata"].state_data[
-                "cu_query_seq_lengths"
-            ]
-            self.mamba_metadata.update(
-                d["active_mamba_indices"],
-                d["token_to_request_idx"],
-                cu_seqlens_gpu,
-                batch_dimensions=d["batch_dimensions"],
-                padded_batch_dimensions=d["padded_batch_dimensions"],
-                enable_chunked_prefill=d["enable_chunked_prefill"],
-                intermediate_offsets_gpu=d["intermediate_offsets_gpu"],
-                intermediate_counts_gpu=d["intermediate_counts_gpu"],
-            )
+            self.mamba_metadata.load_from_cpu(self._pending_mamba_transfer)
             self._pending_mamba_transfer = None
 
     def reset_tensors(self) -> None:

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1333,15 +1333,23 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         Returns True only when the next step's metadata can be derived from the
         current state by a position bump alone — no allocator activity, no
-        speculative-decoding interaction. Tighter than the original block-budget
-        check because the speculative advance path implemented in
-        :meth:`speculatively_advance_for_next_decode_step` does not yet handle
-        block-boundary crossings or speculative decoding (num_speculative_tokens
-        > 0); the engine falls back to serial whenever this returns False.
+        speculative-decoding interaction, no Mamba SSM advance. Tighter than
+        the original block-budget check because the speculative advance path
+        implemented in :meth:`speculatively_advance_for_next_decode_step` does
+        not yet handle block-boundary crossings, speculative decoding
+        (num_speculative_tokens > 0), or hybrid models (Mamba SSM forward
+        advances per-request conv/ssm state and would require per-step rollback
+        of large GPU buffers). The engine falls back to serial when this
+        returns False.
         """
         if not self.is_decode_only():
             return False
         if self.num_speculative_tokens > 0:
+            return False
+        if self.is_hybrid_model:
+            # Mamba SSM state is mutated in-place by forward; speculative
+            # rollback would require saving/restoring per-request conv/ssm
+            # state buffers. Gate off until that is implemented.
             return False
         # Boundary-crossing requires allocator work that the speculative advance
         # cannot replay safely; defer to serial when any active request would

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1299,6 +1299,45 @@ class DynamicInferenceContext(BaseInferenceContext):
         """Returns the current number of active requests."""
         return self.total_request_count - self.paused_request_count
 
+    def predict_decode_blocks_needed(self, advance: int = 1) -> int:
+        """Predict total new KV blocks needed if active requests advance by ``advance``
+        decode tokens.
+
+        Used by async scheduling to decide whether the next forward can be issued
+        speculatively (no new blocks needed) or whether we must drop out of the
+        speculative chain (request would cross a block boundary and require fresh
+        allocation).
+
+        Returns the count of new blocks needed across all active requests.
+        Returns 0 if no active requests cross a block boundary.
+        """
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        seq_lens = self.request_kv_length_offsets[active_slice] + self.request_query_lengths[
+            active_slice
+        ]
+        # Current blocks used per request = ceil(seq_len / block_size_tokens).
+        current_blocks = (seq_lens + self.block_size_tokens - 1) // self.block_size_tokens
+        # Blocks used per request after advancing by `advance` decode tokens.
+        future_blocks = (
+            seq_lens + advance + self.block_size_tokens - 1
+        ) // self.block_size_tokens
+        return int((future_blocks - current_blocks).sum().item())
+
+    def can_speculate_decode_step(self, advance: int = 1) -> bool:
+        """Predicate: can we run the next ``advance`` decode steps speculatively?
+
+        Returns True when the speculation chain is safe to continue: pure decode
+        only, and either no new blocks are needed or all needed blocks are
+        available without eviction. Used by the engine in C3 to gate the
+        async-scheduling fast path.
+        """
+        if not self.is_decode_only():
+            return False
+        blocks_needed = self.predict_decode_blocks_needed(advance=advance)
+        if blocks_needed == 0:
+            return True
+        return self.kv_block_allocator.is_memory_available(blocks_needed)
+
     def append_key_value_cache(self, layer_number: int, key: Tensor, value: Tensor) -> None:
         """Append to KV cache.
 

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -30,10 +30,13 @@ class ContextGPUView:
         max_tokens: int,
         max_kv_blocks: int,
         device: torch.device,
+        max_mamba_chunks: int = 0,
     ):
         # Field layout (must match DynamicInferenceContext's CPU buffer layout):
         #   int64 token fields first (auto 8-byte alignment), then int32 token
-        #   fields, then int32 request fields, then int32 MHA fields.
+        #   fields, then int32 request fields, then int32 MHA fields, then
+        #   int32 Mamba fields (hybrid models only; omitted when
+        #   max_mamba_chunks == 0).
         tok_int64_bytes = max_tokens * 8  # 2 fields of int64 = 8 bytes/elem
         tok_int32_bytes = max_tokens * 4  # 4 fields of int32 = 4 bytes/elem
         req_int32_bytes = max_requests * 4  # 3 fields of int32
@@ -53,6 +56,37 @@ class ContextGPUView:
         mha_cu_kv_seq_lengths_bytes = (max_bs + 1) * 4
         mha_block_table_bytes = max_bs * max_kv_blocks * 4
 
+        # Mamba section: 9 int32 fields, only present for hybrid models.
+        #   mamba_batch_indices_decode    int32 (max_bs,)
+        #   mamba_batch_indices_prefill   int32 (max_bs,)
+        #   mamba_seq_idx                 int32 (1, max_tokens)
+        #   mamba_cu_seqlens              int32 (max_bs + 1,)
+        #   mamba_cu_chunk_seqlens        int32 (max_mamba_chunks + 1,)
+        #   mamba_last_chunk_indices      int32 (max_bs,)
+        #   mamba_seq_idx_for_varlen      int32 (max_mamba_chunks,)
+        #   mamba_conv_seq_idx            int32 (max_tokens,)
+        #   mamba_conv_seq_start          int32 (max_tokens,)
+        if max_mamba_chunks > 0:
+            mamba_batch_indices_decode_bytes = max_bs * 4
+            mamba_batch_indices_prefill_bytes = max_bs * 4
+            mamba_seq_idx_bytes = max_tokens * 4
+            mamba_cu_seqlens_bytes = (max_bs + 1) * 4
+            mamba_cu_chunk_seqlens_bytes = (max_mamba_chunks + 1) * 4
+            mamba_last_chunk_indices_bytes = max_bs * 4
+            mamba_seq_idx_for_varlen_bytes = max_mamba_chunks * 4
+            mamba_conv_seq_idx_bytes = max_tokens * 4
+            mamba_conv_seq_start_bytes = max_tokens * 4
+        else:
+            mamba_batch_indices_decode_bytes = 0
+            mamba_batch_indices_prefill_bytes = 0
+            mamba_seq_idx_bytes = 0
+            mamba_cu_seqlens_bytes = 0
+            mamba_cu_chunk_seqlens_bytes = 0
+            mamba_last_chunk_indices_bytes = 0
+            mamba_seq_idx_for_varlen_bytes = 0
+            mamba_conv_seq_idx_bytes = 0
+            mamba_conv_seq_start_bytes = 0
+
         total_bytes = (
             2 * tok_int64_bytes
             + 4 * tok_int32_bytes
@@ -62,6 +96,15 @@ class ContextGPUView:
             + mha_kv_seq_lengths_bytes
             + mha_cu_kv_seq_lengths_bytes
             + mha_block_table_bytes
+            + mamba_batch_indices_decode_bytes
+            + mamba_batch_indices_prefill_bytes
+            + mamba_seq_idx_bytes
+            + mamba_cu_seqlens_bytes
+            + mamba_cu_chunk_seqlens_bytes
+            + mamba_last_chunk_indices_bytes
+            + mamba_seq_idx_for_varlen_bytes
+            + mamba_conv_seq_idx_bytes
+            + mamba_conv_seq_start_bytes
         )
 
         # Zero-initialized so pre-transfer reads see zeros (matches prior semantics).
@@ -114,5 +157,59 @@ class ContextGPUView:
             .view(max_bs, max_kv_blocks)
         )
         off += mha_block_table_bytes
+
+        # Mamba varlen metadata (hybrid models only). Each GPU view matches a
+        # pinned CPU view in DynamicInferenceContext._cpu_bookkeeping_buf; the
+        # per-step coalesced H2D copy covers both MHA and Mamba alongside the
+        # token/request bookkeeping.
+        if max_mamba_chunks > 0:
+            self.mamba_batch_indices_decode = self._buf[
+                off : off + mamba_batch_indices_decode_bytes
+            ].view(torch.int32)
+            off += mamba_batch_indices_decode_bytes
+            self.mamba_batch_indices_prefill = self._buf[
+                off : off + mamba_batch_indices_prefill_bytes
+            ].view(torch.int32)
+            off += mamba_batch_indices_prefill_bytes
+            self.mamba_seq_idx = (
+                self._buf[off : off + mamba_seq_idx_bytes]
+                .view(torch.int32)
+                .view(1, max_tokens)
+            )
+            off += mamba_seq_idx_bytes
+            self.mamba_cu_seqlens = self._buf[off : off + mamba_cu_seqlens_bytes].view(
+                torch.int32
+            )
+            off += mamba_cu_seqlens_bytes
+            self.mamba_cu_chunk_seqlens = self._buf[
+                off : off + mamba_cu_chunk_seqlens_bytes
+            ].view(torch.int32)
+            off += mamba_cu_chunk_seqlens_bytes
+            self.mamba_last_chunk_indices = self._buf[
+                off : off + mamba_last_chunk_indices_bytes
+            ].view(torch.int32)
+            off += mamba_last_chunk_indices_bytes
+            self.mamba_seq_idx_for_varlen = self._buf[
+                off : off + mamba_seq_idx_for_varlen_bytes
+            ].view(torch.int32)
+            off += mamba_seq_idx_for_varlen_bytes
+            self.mamba_conv_seq_idx = self._buf[
+                off : off + mamba_conv_seq_idx_bytes
+            ].view(torch.int32)
+            off += mamba_conv_seq_idx_bytes
+            self.mamba_conv_seq_start = self._buf[
+                off : off + mamba_conv_seq_start_bytes
+            ].view(torch.int32)
+            off += mamba_conv_seq_start_bytes
+        else:
+            self.mamba_batch_indices_decode = None
+            self.mamba_batch_indices_prefill = None
+            self.mamba_seq_idx = None
+            self.mamba_cu_seqlens = None
+            self.mamba_cu_chunk_seqlens = None
+            self.mamba_last_chunk_indices = None
+            self.mamba_seq_idx_for_varlen = None
+            self.mamba_conv_seq_idx = None
+            self.mamba_conv_seq_start = None
 
         assert off == total_bytes, f"layout bug: wrote {off} of {total_bytes} bytes"

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -24,15 +24,45 @@ class ContextGPUView:
     single ``cudaMemcpyAsync`` instead of nine small ones.
     """
 
-    def __init__(self, max_requests: int, max_tokens: int, device: torch.device):
+    def __init__(
+        self,
+        max_requests: int,
+        max_tokens: int,
+        max_kv_blocks: int,
+        device: torch.device,
+    ):
         # Field layout (must match DynamicInferenceContext's CPU buffer layout):
         #   int64 token fields first (auto 8-byte alignment), then int32 token
-        #   fields, then int32 request fields.
+        #   fields, then int32 request fields, then int32 MHA fields.
         tok_int64_bytes = max_tokens * 8  # 2 fields of int64 = 8 bytes/elem
         tok_int32_bytes = max_tokens * 4  # 4 fields of int32 = 4 bytes/elem
         req_int32_bytes = max_requests * 4  # 3 fields of int32
 
-        total_bytes = 2 * tok_int64_bytes + 4 * tok_int32_bytes + 3 * req_int32_bytes
+        # MHA section: 5 fields shared by both graphed and non-graphed MHAMetadata
+        # (only one is active per step, so sharing storage is fine).
+        #   mha_query_lengths          int32 (max_bs,)         = max_bs   * 4
+        #   mha_cu_query_seq_lengths   int32 (max_bs + 1,)     = (max_bs+1) * 4
+        #   mha_kv_seq_lengths         int32 (max_bs,)         = max_bs   * 4
+        #   mha_cu_kv_seq_lengths      int32 (max_bs + 1,)     = (max_bs+1) * 4
+        #   mha_block_table            int32 (max_bs, max_kv_blocks)
+        # max_bs == max_requests in DynamicInferenceContext.
+        max_bs = max_requests
+        mha_query_lengths_bytes = max_bs * 4
+        mha_cu_query_seq_lengths_bytes = (max_bs + 1) * 4
+        mha_kv_seq_lengths_bytes = max_bs * 4
+        mha_cu_kv_seq_lengths_bytes = (max_bs + 1) * 4
+        mha_block_table_bytes = max_bs * max_kv_blocks * 4
+
+        total_bytes = (
+            2 * tok_int64_bytes
+            + 4 * tok_int32_bytes
+            + 3 * req_int32_bytes
+            + mha_query_lengths_bytes
+            + mha_cu_query_seq_lengths_bytes
+            + mha_kv_seq_lengths_bytes
+            + mha_cu_kv_seq_lengths_bytes
+            + mha_block_table_bytes
+        )
 
         # Zero-initialized so pre-transfer reads see zeros (matches prior semantics).
         self._buf = torch.zeros(total_bytes, dtype=torch.uint8, device=device)
@@ -63,5 +93,26 @@ class ContextGPUView:
         off += req_int32_bytes
         self.request_kv_length_offsets = self._buf[off : off + req_int32_bytes].view(torch.int32)
         off += req_int32_bytes
+
+        # MHA flash-attention metadata (shared between GraphedMHAMetadata and
+        # NonGraphedMHAMetadata — only one is active per step).
+        self.mha_query_lengths = self._buf[off : off + mha_query_lengths_bytes].view(torch.int32)
+        off += mha_query_lengths_bytes
+        self.mha_cu_query_seq_lengths = self._buf[
+            off : off + mha_cu_query_seq_lengths_bytes
+        ].view(torch.int32)
+        off += mha_cu_query_seq_lengths_bytes
+        self.mha_kv_seq_lengths = self._buf[off : off + mha_kv_seq_lengths_bytes].view(torch.int32)
+        off += mha_kv_seq_lengths_bytes
+        self.mha_cu_kv_seq_lengths = self._buf[
+            off : off + mha_cu_kv_seq_lengths_bytes
+        ].view(torch.int32)
+        off += mha_cu_kv_seq_lengths_bytes
+        self.mha_block_table = (
+            self._buf[off : off + mha_block_table_bytes]
+            .view(torch.int32)
+            .view(max_bs, max_kv_blocks)
+        )
+        off += mha_block_table_bytes
 
         assert off == total_bytes, f"layout bug: wrote {off} of {total_bytes} bytes"

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -16,28 +16,52 @@ class ContextGPUView:
     Convention:
         ``context.foo``      -> CPU (source of truth, used by bookkeeping)
         ``context.gpu_view.foo`` -> GPU (snapshot, used by forward pass)
+
+    Layout note: the 9 bookkeeping fields are backed by a single contiguous
+    ``uint8`` buffer (``self._buf``). Each field is a ``view(dtype)`` onto a
+    slice of that buffer. This matches the pinned-CPU-buffer layout in
+    :class:`DynamicInferenceContext` so that the per-step H2D transfer is a
+    single ``cudaMemcpyAsync`` instead of nine small ones.
     """
 
     def __init__(self, max_requests: int, max_tokens: int, device: torch.device):
+        # Field layout (must match DynamicInferenceContext's CPU buffer layout):
+        #   int64 token fields first (auto 8-byte alignment), then int32 token
+        #   fields, then int32 request fields.
+        tok_int64_bytes = max_tokens * 8  # 2 fields of int64 = 8 bytes/elem
+        tok_int32_bytes = max_tokens * 4  # 4 fields of int32 = 4 bytes/elem
+        req_int32_bytes = max_requests * 4  # 3 fields of int32
+
+        total_bytes = 2 * tok_int64_bytes + 4 * tok_int32_bytes + 3 * req_int32_bytes
+
+        # Zero-initialized so pre-transfer reads see zeros (matches prior semantics).
+        self._buf = torch.zeros(total_bytes, dtype=torch.uint8, device=device)
+
         # Token-level tensors (consumed by embedding, RoPE, KV append, Mamba).
-        self.token_to_input_ids = torch.zeros(max_tokens, dtype=torch.long, device=device)
-        self.token_to_pos_ids = torch.zeros(max_tokens, dtype=torch.long, device=device)
-        self.token_to_block_idx = torch.zeros(max_tokens, dtype=torch.int32, device=device)
-        self.token_to_local_position_within_kv_block = torch.zeros(
-            max_tokens, dtype=torch.int32, device=device,
+        off = 0
+        self.token_to_input_ids = self._buf[off : off + tok_int64_bytes].view(torch.long)
+        off += tok_int64_bytes
+        self.token_to_pos_ids = self._buf[off : off + tok_int64_bytes].view(torch.long)
+        off += tok_int64_bytes
+        self.token_to_block_idx = self._buf[off : off + tok_int32_bytes].view(torch.int32)
+        off += tok_int32_bytes
+        self.token_to_local_position_within_kv_block = self._buf[
+            off : off + tok_int32_bytes
+        ].view(torch.int32)
+        off += tok_int32_bytes
+        self.token_to_request_idx = self._buf[off : off + tok_int32_bytes].view(torch.int32)
+        off += tok_int32_bytes
+        self.token_to_position_in_request = self._buf[off : off + tok_int32_bytes].view(
+            torch.int32
         )
-        self.token_to_request_idx = torch.zeros(max_tokens, dtype=torch.int32, device=device)
-        self.token_to_position_in_request = torch.zeros(
-            max_tokens, dtype=torch.int32, device=device,
-        )
+        off += tok_int32_bytes
 
         # Request-level tensors (consumed by sampling, log-probs, speculative verification, MTP).
-        self.request_in_prefill_status = torch.zeros(
-            max_requests, dtype=torch.int32, device=device,
-        )
-        self.request_query_lengths = torch.zeros(
-            max_requests, dtype=torch.int32, device=device,
-        )
-        self.request_kv_length_offsets = torch.zeros(
-            max_requests, dtype=torch.int32, device=device,
-        )
+        self.request_in_prefill_status = self._buf[off : off + req_int32_bytes].view(torch.int32)
+        off += req_int32_bytes
+        self.request_query_lengths = self._buf[off : off + req_int32_bytes].view(torch.int32)
+        off += req_int32_bytes
+        self.request_kv_length_offsets = self._buf[off : off + req_int32_bytes].view(torch.int32)
+        off += req_int32_bytes
+
+        assert off == total_bytes, f"layout bug: wrote {off} of {total_bytes} bytes"

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import torch
+
+
+class ContextGPUView:
+    """GPU-resident snapshot of context bookkeeping data for the forward pass.
+
+    This is the ONLY interface GPU code (attention kernels, KV append, RoPE,
+    sampling, log-probs, speculative verification) uses to read context state.
+    CPU bookkeeping code accesses context tensors directly.
+
+    Populated once per step by ``DynamicInferenceContext.transfer_bookkeeping_to_gpu()``.
+    All tensors have fixed addresses for CUDA graph compatibility.
+
+    Convention:
+        ``context.foo``      -> CPU (source of truth, used by bookkeeping)
+        ``context.gpu_view.foo`` -> GPU (snapshot, used by forward pass)
+    """
+
+    def __init__(self, max_requests: int, max_tokens: int, device: torch.device):
+        # Token-level tensors (consumed by embedding, RoPE, KV append, Mamba).
+        self.token_to_input_ids = torch.zeros(max_tokens, dtype=torch.long, device=device)
+        self.token_to_pos_ids = torch.zeros(max_tokens, dtype=torch.long, device=device)
+        self.token_to_block_idx = torch.zeros(max_tokens, dtype=torch.int32, device=device)
+        self.token_to_local_position_within_kv_block = torch.zeros(
+            max_tokens, dtype=torch.int32, device=device,
+        )
+        self.token_to_request_idx = torch.zeros(max_tokens, dtype=torch.int32, device=device)
+        self.token_to_position_in_request = torch.zeros(
+            max_tokens, dtype=torch.int32, device=device,
+        )
+
+        # Request-level tensors (consumed by sampling, log-probs, speculative verification, MTP).
+        self.request_in_prefill_status = torch.zeros(
+            max_requests, dtype=torch.int32, device=device,
+        )
+        self.request_query_lengths = torch.zeros(
+            max_requests, dtype=torch.int32, device=device,
+        )
+        self.request_kv_length_offsets = torch.zeros(
+            max_requests, dtype=torch.int32, device=device,
+        )

--- a/megatron/core/inference/contexts/kv_block_allocator.py
+++ b/megatron/core/inference/contexts/kv_block_allocator.py
@@ -47,15 +47,15 @@ class KVBlockAllocator:
         assert self.active_count >= 1  # ensures paused_count < total_count - 1
         self.dummy_block_idx = self.total_count - 1
 
-        # Initialize block pool as a "stack" data structure
+        # Initialize block pool as a "stack" data structure (CPU for bookkeeping).
         self.block_bag = torch.arange(
-            self.total_count, dtype=torch.int32, device=torch.cuda.current_device()
+            self.total_count, dtype=torch.int32, device='cpu',
         )
 
         if self.enable_prefix_caching:
             # Block hash tracking for prefix caching: -1 = uncomputed, positive = valid hash
             self.block_hashes = torch.full(
-                (self.total_count,), -1, dtype=torch.int64, device=torch.cuda.current_device()
+                (self.total_count,), -1, dtype=torch.int64, device='cpu',
             )
 
             # Hash-to-block mapping for O(1) prefix lookup
@@ -63,14 +63,14 @@ class KVBlockAllocator:
 
             # Reference count per block: 0 = cached (evictable), >0 = actively used
             self.block_ref_counts = torch.zeros(
-                (self.total_count,), dtype=torch.int32, device=torch.cuda.current_device()
+                (self.total_count,), dtype=torch.int32, device='cpu',
             )
 
             # LRU timestamps for eviction ordering (higher = more recently used)
             # Only needed in LRU mode; RZ mode evicts immediately on ref_count==0
             if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
                 self.block_timestamps = torch.zeros(
-                    (self.total_count,), dtype=torch.int64, device=torch.cuda.current_device()
+                    (self.total_count,), dtype=torch.int64, device='cpu',
                 )
 
     def __str__(self):
@@ -240,7 +240,7 @@ class KVBlockAllocator:
         # requests will point to each other's memory blocks, resulting in faulty
         # generations.
         self.block_bag = torch.arange(
-            self.total_count, dtype=torch.int32, device=torch.cuda.current_device()
+            self.total_count, dtype=torch.int32, device='cpu',
         )
 
         self.total_avail = self.total_count - 1

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -73,21 +73,29 @@ class MambaSlotAllocator:
         # Hash-to-block mapping: only blocks with cached Mamba state
         self.hash_to_block_id: Dict[int, int] = {}
 
-        # Per-request intermediate state storage (GPU tensors, fixed-size per request).
-        # These are consumed by Triton kernels during the forward pass.
-        # 0 = no offset, -1 = no block
+        # Per-request intermediate state storage.
+        # offsets_cpu and counts_cpu: CPU source of truth.  GPU copies are
+        # populated by transfer_bookkeeping_to_gpu() since Triton kernels read them.
+        # block_ids and eos_cache_block_id: CPU only (consumed by CPU code).
         k = MAX_INTERMEDIATE_OFFSETS_PER_REQUEST
+        self._intermediate_offsets_cpu = torch.zeros(
+            (context.max_requests, k), dtype=torch.int32, device='cpu',
+        )
+        self._intermediate_counts_cpu = torch.zeros(
+            context.max_requests, dtype=torch.int32, device='cpu',
+        )
         self._intermediate_offsets_gpu = torch.zeros(
             (context.max_requests, k), dtype=torch.int32, device=gpu_device,
-        )
-        self._intermediate_block_ids_gpu = torch.full(
-            (context.max_requests, k), -1, dtype=torch.int32, device=gpu_device,
         )
         self._intermediate_counts_gpu = torch.zeros(
             context.max_requests, dtype=torch.int32, device=gpu_device,
         )
-        self._eos_cache_block_id_gpu = torch.full(
-            (context.max_requests,), -1, dtype=torch.int32, device=gpu_device,
+        # CPU-only: consumed by _collect_commit_data() which needs .tolist() anyway.
+        self._intermediate_block_ids_cpu = torch.full(
+            (context.max_requests, k), -1, dtype=torch.int32, device='cpu',
+        )
+        self._eos_cache_block_id_cpu = torch.full(
+            (context.max_requests,), -1, dtype=torch.int32, device='cpu',
         )
         # CPU flag to skip GPU sync when no intermediates exist
         self._has_intermediates = False
@@ -418,42 +426,41 @@ class MambaSlotAllocator:
         offsets = sorted(offsets_set)
         count = len(offsets)
 
-        # Vectorized block ID lookup: GPU gather avoids per-block .item() syncs
+        # CPU bookkeeping writes (no GPU kernel launches).
         if count > 0:
-            device = self._intermediate_offsets_gpu.device
-            abs_tokens = torch.tensor(
-                [skip_tokens + o for o in offsets], dtype=torch.int64, device=device
+            abs_tokens_cpu = torch.tensor(
+                [skip_tokens + o for o in offsets], dtype=torch.int64,
             )
-            block_indices = abs_tokens // ctx.block_size_tokens - 1
-            bids = ctx.request_to_kv_block_ids[current_id][block_indices.cpu()].to(device)
+            block_indices_cpu = abs_tokens_cpu // ctx.block_size_tokens - 1
+            bids_cpu = ctx.request_to_kv_block_ids[current_id][block_indices_cpu]
 
-            self._intermediate_offsets_gpu[current_id, :count] = torch.tensor(
-                offsets, dtype=torch.int32, device=device
+            self._intermediate_offsets_cpu[current_id, :count] = torch.tensor(
+                offsets, dtype=torch.int32,
             )
-            self._intermediate_block_ids_gpu[current_id, :count] = bids.to(torch.int32)
+            self._intermediate_block_ids_cpu[current_id, :count] = bids_cpu.to(torch.int32)
             self._has_intermediates = True
-        self._intermediate_counts_gpu[current_id] = count
+        self._intermediate_counts_cpu[current_id] = count
 
         # Block-aligned EOS: prompt_len is exactly block-aligned
         if last_aligned_abs == prompt_len and prompt_len > 0:
             last_block_idx = prompt_len // ctx.block_size_tokens - 1
             if last_block_idx >= 0:
-                self._eos_cache_block_id_gpu[current_id] = ctx.request_to_kv_block_ids[current_id][
+                self._eos_cache_block_id_cpu[current_id] = ctx.request_to_kv_block_ids[current_id][
                     last_block_idx
                 ]
                 self._has_intermediates = True
             else:
-                self._eos_cache_block_id_gpu[current_id] = -1
+                self._eos_cache_block_id_cpu[current_id] = -1
         else:
-            self._eos_cache_block_id_gpu[current_id] = -1
+            self._eos_cache_block_id_cpu[current_id] = -1
 
-    def get_intermediate_gpu_data(self):
-        """Get intermediate offsets and counts as GPU tensor slices for current prefill batch.
+    def get_intermediate_cpu_data(self):
+        """Get intermediate offsets and counts as CPU tensor slices for current prefill batch.
 
         Returns:
-            Tuple of (offsets_gpu, counts_gpu) where:
-                offsets_gpu: [prefill_count, 3] int32 GPU tensor
-                counts_gpu: [prefill_count] int32 GPU tensor
+            Tuple of (offsets_cpu, counts_cpu) where:
+                offsets_cpu: [prefill_count, 3] int32 CPU tensor
+                counts_cpu: [prefill_count] int32 CPU tensor
             Returns (None, None) if no prefill requests or no intermediates.
         """
         if not self._has_intermediates:
@@ -468,9 +475,32 @@ class MambaSlotAllocator:
         decode_count = ctx.batch_dimensions.decode_req_count
         prefill_start = active_start + decode_count
 
-        offsets = self._intermediate_offsets_gpu[prefill_start : prefill_start + prefill_count]
-        counts = self._intermediate_counts_gpu[prefill_start : prefill_start + prefill_count]
+        offsets = self._intermediate_offsets_cpu[prefill_start : prefill_start + prefill_count]
+        counts = self._intermediate_counts_cpu[prefill_start : prefill_start + prefill_count]
         return offsets, counts
+
+    def transfer_intermediate_to_gpu(self, prefill_start: int, prefill_count: int):
+        """Copy intermediate offsets/counts slice from CPU to GPU for Mamba kernels.
+
+        Returns the GPU tensor views for the forward-pass kernels to consume.
+        """
+        if prefill_count == 0:
+            return None, None
+        offsets_cpu = self._intermediate_offsets_cpu[
+            prefill_start : prefill_start + prefill_count
+        ]
+        counts_cpu = self._intermediate_counts_cpu[
+            prefill_start : prefill_start + prefill_count
+        ]
+        offsets_gpu = self._intermediate_offsets_gpu[
+            prefill_start : prefill_start + prefill_count
+        ]
+        counts_gpu = self._intermediate_counts_gpu[
+            prefill_start : prefill_start + prefill_count
+        ]
+        offsets_gpu.copy_(offsets_cpu, non_blocking=True)
+        counts_gpu.copy_(counts_cpu, non_blocking=True)
+        return offsets_gpu, counts_gpu
 
     # =========================================================================
     # Intermediate state commit
@@ -522,14 +552,14 @@ class MambaSlotAllocator:
         decode_count = ctx.batch_dimensions.decode_req_count
         prefill_start = active_start + decode_count
 
-        # Batch-transfer block IDs and EOS block IDs from GPU (2 GPU syncs)
+        # Block IDs and EOS block IDs live on CPU (no GPU sync needed).
         intermediate_count = metadata.intermediate_count
         per_request_counts = metadata.per_request_intermediate_counts
 
-        all_block_ids_cpu = self._intermediate_block_ids_gpu[
+        all_block_ids_cpu = self._intermediate_block_ids_cpu[
             prefill_start : prefill_start + prefill_count
         ].tolist()
-        eos_bids_cpu = self._eos_cache_block_id_gpu[
+        eos_bids_cpu = self._eos_cache_block_id_cpu[
             prefill_start : prefill_start + prefill_count
         ].tolist()
 
@@ -591,10 +621,10 @@ class MambaSlotAllocator:
             decode_count = ctx.batch_dimensions.decode_req_count
             prefill_start = active_start + decode_count
             end = prefill_start + prefill_count
-            self._intermediate_counts_gpu[prefill_start:end].fill_(0)
-            self._intermediate_offsets_gpu[prefill_start:end].fill_(0)
-            self._intermediate_block_ids_gpu[prefill_start:end].fill_(-1)
-            self._eos_cache_block_id_gpu[prefill_start:end].fill_(-1)
+            self._intermediate_counts_cpu[prefill_start:end].fill_(0)
+            self._intermediate_offsets_cpu[prefill_start:end].fill_(0)
+            self._intermediate_block_ids_cpu[prefill_start:end].fill_(-1)
+            self._eos_cache_block_id_cpu[prefill_start:end].fill_(-1)
         self._has_intermediates = False
 
     # =========================================================================
@@ -612,8 +642,8 @@ class MambaSlotAllocator:
         self.hash_to_block_id.clear()
         self.intermediate_ssm_out.zero_()
         self.intermediate_conv_out.zero_()
-        self._intermediate_offsets_gpu.fill_(0)
-        self._intermediate_block_ids_gpu.fill_(-1)
-        self._intermediate_counts_gpu.fill_(0)
-        self._eos_cache_block_id_gpu.fill_(-1)
+        self._intermediate_offsets_cpu.fill_(0)
+        self._intermediate_counts_cpu.fill_(0)
+        self._intermediate_block_ids_cpu.fill_(-1)
+        self._eos_cache_block_id_cpu.fill_(-1)
         self._has_intermediates = False

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -47,59 +47,62 @@ class MambaSlotAllocator:
         self.max_slots = max_slots
         self.num_mamba_layers = num_mamba_layers
 
-        device = torch.cuda.current_device()
+        gpu_device = torch.cuda.current_device()
         num_blocks = context.kv_block_allocator.total_count
 
-        # Block <-> slot mappings
-        self.block_to_slot = torch.full((num_blocks,), -1, dtype=torch.int32, device=device)
-        self.slot_to_block = torch.full((max_slots,), -1, dtype=torch.int32, device=device)
+        # Block <-> slot mappings (CPU for bookkeeping).
+        self.block_to_slot = torch.full((num_blocks,), -1, dtype=torch.int32, device='cpu')
+        self.slot_to_block = torch.full((max_slots,), -1, dtype=torch.int32, device='cpu')
 
-        # Free slot pool (stack)
-        self.free_slots = torch.arange(max_slots, dtype=torch.int32, device=device)
+        # Free slot pool (stack, CPU).
+        self.free_slots = torch.arange(max_slots, dtype=torch.int32, device='cpu')
         self.free_count = max_slots
 
-        # State tensors
+        # State tensors (GPU - accessed by Mamba CUDA kernels).
         self.conv_states = torch.zeros(
             (num_mamba_layers, max_slots) + conv_states_shape,
             dtype=conv_states_dtype,
-            device=device,
+            device=gpu_device,
         )
         self.ssm_states = torch.zeros(
-            (num_mamba_layers, max_slots) + ssm_states_shape, dtype=ssm_states_dtype, device=device
+            (num_mamba_layers, max_slots) + ssm_states_shape,
+            dtype=ssm_states_dtype,
+            device=gpu_device,
         )
 
         # Hash-to-block mapping: only blocks with cached Mamba state
         self.hash_to_block_id: Dict[int, int] = {}
 
-        # Per-request intermediate state storage (GPU tensors, fixed-size per request)
+        # Per-request intermediate state storage (GPU tensors, fixed-size per request).
+        # These are consumed by Triton kernels during the forward pass.
         # 0 = no offset, -1 = no block
         k = MAX_INTERMEDIATE_OFFSETS_PER_REQUEST
         self._intermediate_offsets_gpu = torch.zeros(
-            (context.max_requests, k), dtype=torch.int32, device=device
+            (context.max_requests, k), dtype=torch.int32, device=gpu_device,
         )
         self._intermediate_block_ids_gpu = torch.full(
-            (context.max_requests, k), -1, dtype=torch.int32, device=device
+            (context.max_requests, k), -1, dtype=torch.int32, device=gpu_device,
         )
         self._intermediate_counts_gpu = torch.zeros(
-            context.max_requests, dtype=torch.int32, device=device
+            context.max_requests, dtype=torch.int32, device=gpu_device,
         )
         self._eos_cache_block_id_gpu = torch.full(
-            (context.max_requests,), -1, dtype=torch.int32, device=device
+            (context.max_requests,), -1, dtype=torch.int32, device=gpu_device,
         )
         # CPU flag to skip GPU sync when no intermediates exist
         self._has_intermediates = False
 
-        # Pre-allocated output buffers for CUDA graph compatible extraction
+        # Pre-allocated output buffers for CUDA graph compatible extraction (GPU).
         self.max_intermediate_count = MAX_INTERMEDIATE_OFFSETS_PER_REQUEST * context.max_requests
         self.intermediate_ssm_out = torch.zeros(
             (num_mamba_layers, self.max_intermediate_count) + ssm_states_shape,
             dtype=ssm_states_dtype,
-            device=device,
+            device=gpu_device,
         )
         self.intermediate_conv_out = torch.zeros(
             (num_mamba_layers, self.max_intermediate_count) + conv_states_shape,
             dtype=conv_states_dtype,
-            device=device,
+            device=gpu_device,
         )
 
     # =========================================================================
@@ -320,9 +323,11 @@ class MambaSlotAllocator:
             return
         device = self.conv_states.device
         slot_tensor = torch.tensor(slots, dtype=torch.int64, device=device)
-        req_tensor = torch.tensor(request_indices, dtype=torch.int64, device=device)
-        # Batch lookup mamba state indices (1 GPU sync)
-        mamba_indices = self.context.mamba_metadata.request_to_mamba_state_idx[req_tensor].tolist()
+        # Lookup mamba indices from CPU bookkeeping, then move to GPU for state copy.
+        req_tensor_cpu = torch.tensor(request_indices, dtype=torch.int64)
+        mamba_indices = self.context.mamba_metadata.request_to_mamba_state_idx[
+            req_tensor_cpu
+        ].tolist()
         mamba_idx_tensor = torch.tensor(mamba_indices, dtype=torch.int64, device=device)
         # Fancy-indexed copy (2 kernel launches instead of 2E)
         self.conv_states[:, slot_tensor] = self.context.mamba_conv_states[:, mamba_idx_tensor]
@@ -420,7 +425,7 @@ class MambaSlotAllocator:
                 [skip_tokens + o for o in offsets], dtype=torch.int64, device=device
             )
             block_indices = abs_tokens // ctx.block_size_tokens - 1
-            bids = ctx.request_to_kv_block_ids[current_id][block_indices]
+            bids = ctx.request_to_kv_block_ids[current_id][block_indices.cpu()].to(device)
 
             self._intermediate_offsets_gpu[current_id, :count] = torch.tensor(
                 offsets, dtype=torch.int32, device=device
@@ -601,7 +606,7 @@ class MambaSlotAllocator:
         self.block_to_slot.fill_(-1)
         self.slot_to_block.fill_(-1)
         self.free_slots = torch.arange(
-            self.max_slots, dtype=torch.int32, device=torch.cuda.current_device()
+            self.max_slots, dtype=torch.int32, device='cpu',
         )
         self.free_count = self.max_slots
         self.hash_to_block_id.clear()

--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -131,6 +131,45 @@ class AsyncZMQCommunicator:
                 except zmq.Again:
                     await asyncio.sleep(0.001)
 
+    def sync_all_reduce_max(self, *local_vals: int) -> int | tuple[int, ...]:
+        """Synchronous (non-asyncio) variant of all_reduce_max.
+
+        Uses blocking ZMQ sends/recvs so it can be called from synchronous
+        call sites that need a CPU-only MAX reduction across the process
+        group. Intended for tiny payloads (e.g. a few integers) that would
+        otherwise force a NCCL AllReduce kernel on the compute stream.
+
+        Note: when called from inside a running asyncio event loop, the
+        blocking recv will pause other coroutines on this rank until all
+        peers respond. This is acceptable here because every rank reaches
+        the call simultaneously and the message size is trivial.
+
+        Returns a single int when called with one argument, otherwise a tuple.
+        """
+        n = len(local_vals)
+        if n == 0:
+            raise ValueError("sync_all_reduce_max requires at least one value")
+
+        if self.world_size <= 1:
+            return local_vals[0] if n == 1 else local_vals
+
+        fmt = f'!{n}i'
+        payload = struct.pack(fmt, *local_vals)
+
+        if self.is_leader:
+            rows = [local_vals]
+            while len(rows) < self.world_size:
+                msg = self.gather_sock.recv()
+                rows.append(struct.unpack(fmt, msg))
+            maxes = tuple(max(row[i] for row in rows) for i in range(n))
+            self.bcast_sock.send(struct.pack(fmt, *maxes))
+            return maxes[0] if n == 1 else maxes
+        else:
+            self.gather_sock.send(payload)
+            msg = self.bcast_sock.recv()
+            result = struct.unpack(fmt, msg)
+            return result[0] if n == 1 else result
+
     def close(self):
         """
         Close the ZMQ sockets.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -303,6 +303,19 @@ class DynamicInferenceEngine(AbstractEngine):
         self.step_end_event = torch.cuda.Event(enable_timing=True)
         self.capture_stats = None
 
+        # Async-scheduling buffers and events. The pre-fetched sample buffer
+        # holds sample_N's CPU copy across the speculative chain so we can
+        # D2H sample_N before sample_{N+1} clobbers _sampled_tokens_cuda.
+        # Events are used to gate CPU work on stream completion: _d2h_done
+        # so we know sample_N is on CPU; _h2d_done so we know step N+1's
+        # H2D has executed before update_requests mutates the pinned buffer.
+        max_requests = self.context.max_requests
+        self._pre_fetched_sample_buf = torch.empty(
+            max_requests, dtype=torch.int64, device='cpu', pin_memory=True
+        )
+        self._d2h_done_event = torch.cuda.Event()
+        self._h2d_done_event = torch.cuda.Event()
+
         # Runtime state.
         self._loop = get_asyncio_loop(getattr(self, "_loop", None))
         self._cond = asyncio.Condition()
@@ -2047,21 +2060,65 @@ class DynamicInferenceEngine(AbstractEngine):
     async def _async_step_serial(
         self,
     ) -> Tuple[List[DynamicInferenceRequest], List[DynamicInferenceRequest], float]:
-        """Serial step path: forward + sample, then CPU bookkeeping. Today's behavior."""
+        """Serial step path: forward + sample, then CPU bookkeeping. Today's behavior.
+
+        If a prior iteration left a speculative pre-launch in flight (e.g.
+        async-scheduling fired a rejection), drain it on the stream so the
+        canonical state can launch step N afresh without races.
+        """
+        if self._pending_launch_state is not None:
+            self._drain_pending_launch()
+        self._clear_rejection()
         last_step_data = await self.async_forward()
         return await self.async_bookkeep(*last_step_data)
+
+    def _drain_pending_launch(self) -> None:
+        """Synchronize the stream and discard a stale speculative pre-launch.
+
+        Called when async scheduling has fallen back to the serial path (e.g.
+        a finish/pause/evict event triggered a rejection). The pending pre-
+        launch's GPU work is allowed to complete; its results are discarded
+        because step N+1 will be re-launched from canonical state.
+        """
+        torch.cuda.current_stream().synchronize()
+        self._pending_launch_state = None
 
     async def _async_step_speculative(
         self,
     ) -> Tuple[List[DynamicInferenceRequest], List[DynamicInferenceRequest], float]:
-        """Speculative step path: launch the next forward immediately after sampling
-        so the GPU runs forward -> sample -> forward without waiting on CPU
-        bookkeeping. CPU bookkeeping runs in parallel and verifies retroactively.
+        """Speculative step path: planned to launch step N+1 ahead of step N's
+        bookkeep so the GPU runs ``forward → sample → forward → sample``
+        continuously on pure-decode chains.
 
-        Stub for C3.5: currently identical to the serial path. The launch-ahead
-        and reconciliation logic is added in C4 alongside the rejection-event
-        handling. Splitting the structural routing into its own commit keeps the
-        engine-loop refactor reviewable.
+        C5.3 status: still a stub identical to the serial path. The launch-
+        ahead loop and rejection drain-and-rewind are landed in a follow-up
+        commit. The infrastructure required by that follow-up is in place:
+
+        - ``self._pre_fetched_sample_buf`` and ``self._d2h_done_event`` /
+          ``self._h2d_done_event`` events (engine ``__init__``).
+        - ``self._pending_launch_state`` field threaded through serial path
+          via ``_drain_pending_launch``.
+        - ``self._signal_rejection`` / ``_clear_rejection`` and the
+          ``len(waiting_request_ids) > 0`` gate in
+          ``_async_scheduling_active``.
+        - ``controller._launch_decode_step`` / ``_bookkeep_decode_step``
+          split (C5.1) and ``sample_cpu_override`` parameter on the bookkeep
+          path so the engine can D2H sample_N once and pass it through
+          without racing against a subsequent speculative sample_{N+1}.
+        - ``context.speculatively_advance_for_next_decode_step`` /
+          ``restore_after_speculative_advance`` (C5.2).
+
+        A naive launch-ahead wiring (sync sample_N, mirror it into pinned
+        token_to_input_ids, speculatively advance, pre-launch step N+1, run
+        update_requests in parallel) was prototyped on this branch but
+        produced divergent tokens vs. the serial baseline starting at the
+        first decode iteration after a mid-chain rejection (e.g. when a new
+        request is added). The proximate cause appears to be state pollution
+        from the discarded pre-launch (KV writes / attention metadata /
+        rotated MHA tensors); resolving it cleanly requires either a shadow
+        bookkeeping buffer or a more thorough rollback than the persistent-
+        tensor restore that exists today. Deferred to a follow-up so the
+        infrastructure here can land separately.
         """
         last_step_data = await self.async_forward()
         return await self.async_bookkeep(*last_step_data)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -235,6 +235,11 @@ class DynamicInferenceEngine(AbstractEngine):
         # Tracks how many requests have finished but not yet been removed from
         # the active batch via a sync. Used by the periodic-sync backstop.
         self._finished_pending_count = 0
+        # Holds the launch_state dict produced by a prior iteration's
+        # speculative pre-launch of step N+1. The next iteration consumes it
+        # instead of launching fresh. None when no speculative launch is in
+        # flight (warmup, after rejection, or async scheduling disabled).
+        self._pending_launch_state: Optional[Dict] = None
         self.cuda_graph_impl = model_config.cuda_graph_impl
         self.cuda_graph_scope = model_config.cuda_graph_scope
         # Initialize engine.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -225,6 +225,8 @@ class DynamicInferenceEngine(AbstractEngine):
         self.logging_step_interval = inference_config.logging_step_interval
         self.unified_memory_level = inference_config.unified_memory_level
         self.use_synchronous_zmq_collectives = inference_config.use_synchronous_zmq_collectives
+        self.async_scheduling = inference_config.async_scheduling
+        self.finished_sync_period = inference_config.finished_sync_period
         self.cuda_graph_impl = model_config.cuda_graph_impl
         self.cuda_graph_scope = model_config.cuda_graph_scope
         # Initialize engine.
@@ -1956,6 +1958,26 @@ class DynamicInferenceEngine(AbstractEngine):
             "step_time": step_time,
             "cuda_graph_request_count": cuda_graph_request_count,
         }
+
+    def _async_scheduling_active(self) -> bool:
+        """Engine-level gate for the async-scheduling speculative chain.
+
+        Returns True when the current step is eligible to launch the next
+        forward speculatively without waiting for CPU bookkeeping. Used by the
+        engine loop in the launch-ahead refactor to decide whether to chain
+        the next forward on the stream or to fall back to serial behavior.
+
+        False when:
+        - async_scheduling is disabled by configuration.
+        - The current step is not pure decode (prefill present).
+        - The next step would require new KV blocks that aren't available.
+
+        Refined in C4 to also detect rejection events (add/pause/evict) and
+        the periodic finished-pending sync.
+        """
+        if not self.async_scheduling:
+            return False
+        return self.context.can_speculate_decode_step()
 
     async def async_step(
         self,

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -2096,15 +2096,21 @@ class DynamicInferenceEngine(AbstractEngine):
         launch's GPU work is allowed to complete; its results are discarded
         because step N+1 will be re-launched from canonical state.
 
-        Also rolls back the controller's sampling RNG state to the snapshot
-        taken before the discarded pre-launch's sample. Without this rollback
-        the serial re-sample would observe an RNG state advanced by the
-        discarded sample and produce a token different from the baseline.
+        Rolls back two pieces of non-idempotent state advanced by the
+        discarded forward+sample:
+          - ``controller.sampling_rng`` — sampling consumes the CUDA
+            generator state; without a rollback the serial re-sample would
+            see an advanced RNG and produce a different token.
+          - ``mamba_{conv,ssm}_states`` — Mamba's forward advances per-
+            active-request SSM/conv slices in place. The shadow copy
+            captured before the speculative forward is scattered back so
+            the serial re-launch's forward reads pre-spec state.
         """
         torch.cuda.current_stream().synchronize()
         if self._pre_launch_rng_state is not None:
             self.controller.sampling_rng.set_state(self._pre_launch_rng_state)
             self._pre_launch_rng_state = None
+        self.context.restore_mamba_state_for_speculation()
         self._pending_launch_state = None
 
     async def _async_step_speculative(
@@ -2187,12 +2193,13 @@ class DynamicInferenceEngine(AbstractEngine):
         else:
             launch_state_N = self._pending_launch_state
             self._pending_launch_state = None
-            # The RNG state snapshot is paired with the consumed pre-launch:
-            # the pre-launch's sample has already advanced the RNG. We are now
-            # consuming that sample, so the advance is "real" and we drop the
-            # snapshot — only a future rejection that discards a pre-launch
-            # would need to roll back.
+            # The RNG and mamba snapshots are paired with the consumed pre-
+            # launch: its forward + sample have already advanced both, and
+            # we are now consuming the result. The advance is real, so drop
+            # the snapshots without restoring — only a rejection that
+            # discards a pre-launch needs the rollback.
             self._pre_launch_rng_state = None
+            self.context.drop_mamba_state_speculation()
 
         if launch_state_N is None:
             # Nothing to step (no active requests).
@@ -2210,10 +2217,12 @@ class DynamicInferenceEngine(AbstractEngine):
         active_count = launch_state_N["_active_request_count"]
         sample_N_cpu = self.controller._sampled_tokens_cuda[:active_count].cpu()
 
-        # 3. Pre-launch step N+1 if eligible. Snapshot the RNG state first
-        # so we can roll back if the pre-launch is later discarded.
+        # 3. Pre-launch step N+1 if eligible. Snapshot the RNG and mamba
+        # state first so we can roll back if the pre-launch is later
+        # discarded.
         if self.context.can_speculate_decode_step():
             self._pre_launch_rng_state = self.controller.sampling_rng.get_state()
+            self.context.save_mamba_state_for_speculation()
 
             # 4. Mirror sample_N into pinned token_to_input_ids before the
             # speculative H2D so step N+1's forward reads sample_N as its
@@ -2232,6 +2241,7 @@ class DynamicInferenceEngine(AbstractEngine):
                     # No active requests after speculative advance (very rare,
                     # but handle cleanly): nothing to roll back.
                     self._pre_launch_rng_state = None
+                    self.context.drop_mamba_state_speculation()
             finally:
                 self.context.restore_after_speculative_advance()
 

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1164,10 +1164,15 @@ class DynamicInferenceEngine(AbstractEngine):
                         request.ttft = (
                             first_token_event.timestamp - request.event_add_engine.timestamp
                         )
-                    if request.tpot is None:
-                        request.tpot = []
-                    per_token_step_time = step_time / len(tokens)
-                    request.tpot.extend([per_token_step_time] * len(tokens))
+                    # TPOT is observability-only. step_time is 0.0 on
+                    # non-logging steps (async_forward skips the event sync),
+                    # so gate the update to keep the metric a truthful sparse
+                    # sample instead of polluting it with zeros.
+                    if step_time > 0:
+                        if request.tpot is None:
+                            request.tpot = []
+                        per_token_step_time = step_time / len(tokens)
+                        request.tpot.extend([per_token_step_time] * len(tokens))
 
                 # Check for stop words (after token is appended).
                 # With speculative decoding, a stop word may end before the last
@@ -1649,56 +1654,74 @@ class DynamicInferenceEngine(AbstractEngine):
         # schedule requests
         self.schedule_waiting_requests()
 
-        # Saving pre-step state, for printing output below.
+        # The print block (async_bookkeep) and metrics block both fire on this
+        # condition after step_count is incremented. Predict it up-front so we
+        # can skip the GPU-timing sync and the context_state dict builds that
+        # only exist to feed those logging/metrics blocks.
+        will_log_this_step = (
+            self.logging_step_interval > 0
+            and (self.context.step_count + 1) % self.logging_step_interval == 0
+        )
+
         is_decode_only = self.context.is_decode_only()
-        pre_step_context_state = {
-            "is_decode_only": is_decode_only,
-            "max_requests": self.context.max_requests,
-            "total_request_count": self.context.total_request_count,
-            "paused_request_count": self.context.paused_request_count,
-            "active_token_count": self.context.active_token_count,
-            "step_count": self.context.step_count,
-        }
+        if will_log_this_step:
+            pre_step_context_state = {
+                "is_decode_only": is_decode_only,
+                "max_requests": self.context.max_requests,
+                "total_request_count": self.context.total_request_count,
+                "paused_request_count": self.context.paused_request_count,
+                "active_token_count": self.context.active_token_count,
+                "step_count": self.context.step_count,
+            }
+        else:
+            # active_token_count and step_count are still consumed by
+            # post_process_requests' pre_fwd_* args (for add_event_generated_token);
+            # the other four fields are only read in the gated print block.
+            pre_step_context_state = {
+                "active_token_count": self.context.active_token_count,
+                "step_count": self.context.step_count,
+            }
 
         # Generate tokens.
         nvtx_range_push("Prefill" if not is_decode_only else "Decode")
         # TODO @TDE: Account for this line when overlapping forward and bookkeep.
         self.is_decode_only = is_decode_only
 
-        self.step_start_event.record()
+        if will_log_this_step:
+            self.step_start_event.record()
         result = await self.controller.async_generate_output_tokens_dynamic_batch()
-        self.step_end_event.record()
-        self.step_end_event.synchronize()
-        step_time = self.step_start_event.elapsed_time(self.step_end_event) / 1e3
+        if will_log_this_step:
+            self.step_end_event.record()
+            self.step_end_event.synchronize()
+            step_time = self.step_start_event.elapsed_time(self.step_end_event) / 1e3
+        else:
+            step_time = 0.0
         self.context.step_count += 1
         self.context.prefix_cache_lru_clock += 1
 
         nvtx_range_pop("Prefill" if not is_decode_only else "Decode")
 
-        if (
-            self.logging_step_interval > 0
-            and self.context.step_count > 0
-            and self.context.step_count % self.logging_step_interval == 0
-            and self.metrics_writer is not None
-        ):
-            kvcache_util_stats = self.context.get_kvcache_utilization_stats()
+        if will_log_this_step:
+            kvcache_util_stats = (
+                self.context.get_kvcache_utilization_stats()
+                if self.metrics_writer is not None
+                else None
+            )
+            post_step_context_state = {
+                "waiting_request_count": len(self.waiting_request_ids),
+                "finished_request_count": self.finished_request_count,
+                "evicted_request_count": self.evicted_request_count,
+                "kv_stats": kvcache_util_stats,
+                "total_active_block_count": self.context.kv_block_allocator.active_count,
+                "total_paused_block_count": self.context.kv_block_allocator.paused_count,
+                "total_active_used_blocks": self.context.kv_block_allocator.get_active_used(),
+                "total_paused_used_blocks": self.context.kv_block_allocator.get_paused_used(),
+            }
+            context_state = {**pre_step_context_state, **post_step_context_state}
         else:
-            kvcache_util_stats = None
-
-        post_step_context_state = {
-            "waiting_request_count": len(self.waiting_request_ids),
-            "finished_request_count": self.finished_request_count,
-            "evicted_request_count": self.evicted_request_count,
-            "kv_stats": kvcache_util_stats,
-            "padded_active_token_count": self.context.padded_active_token_count,
-            "using_cuda_graph_this_step": self.context.using_cuda_graph_this_step(),
-            "total_active_block_count": self.context.kv_block_allocator.active_count,
-            "total_paused_block_count": self.context.kv_block_allocator.paused_count,
-            "total_active_used_blocks": self.context.kv_block_allocator.get_active_used(),
-            "total_paused_used_blocks": self.context.kv_block_allocator.get_paused_used(),
-        }
-
-        context_state = {**pre_step_context_state, **post_step_context_state}
+            # Keep kv_stats=None so the metrics-block gate at `async_bookkeep`
+            # (`if context_state["kv_stats"] is not None`) remains well-typed.
+            context_state = {**pre_step_context_state, "kv_stats": None}
 
         return result, context_state, step_time
 

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -227,6 +227,14 @@ class DynamicInferenceEngine(AbstractEngine):
         self.use_synchronous_zmq_collectives = inference_config.use_synchronous_zmq_collectives
         self.async_scheduling = inference_config.async_scheduling
         self.finished_sync_period = inference_config.finished_sync_period
+        # Set when CPU bookkeeping detects an event (add/pause/evict) that
+        # would invalidate the speculative chain. Read by _async_scheduling_active
+        # to drop out of speculation; cleared after the engine drains the
+        # in-flight forwards and applies the corrected state.
+        self._rejection_pending = False
+        # Tracks how many requests have finished but not yet been removed from
+        # the active batch via a sync. Used by the periodic-sync backstop.
+        self._finished_pending_count = 0
         self.cuda_graph_impl = model_config.cuda_graph_impl
         self.cuda_graph_scope = model_config.cuda_graph_scope
         # Initialize engine.
@@ -1967,17 +1975,47 @@ class DynamicInferenceEngine(AbstractEngine):
         engine loop in the launch-ahead refactor to decide whether to chain
         the next forward on the stream or to fall back to serial behavior.
 
-        False when:
+        False when any of the following is true:
         - async_scheduling is disabled by configuration.
+        - A rejection event (add/pause/evict) is pending and must be applied.
         - The current step is not pure decode (prefill present).
         - The next step would require new KV blocks that aren't available.
-
-        Refined in C4 to also detect rejection events (add/pause/evict) and
-        the periodic finished-pending sync.
+        - The periodic finished-pending sync is due (every K steps when
+          finished requests are accumulated).
         """
         if not self.async_scheduling:
             return False
+        if self._rejection_pending:
+            return False
+        if self._finished_sync_due():
+            return False
         return self.context.can_speculate_decode_step()
+
+    def _finished_sync_due(self) -> bool:
+        """Check whether the periodic finished-pending sync is due this step.
+
+        Fires when finished_sync_period > 0, finished requests are pending, and
+        step_count is at a sync-period boundary. Used as a backstop so finished
+        slots can't accumulate indefinitely in the speculative chain.
+        """
+        if self.finished_sync_period <= 0:
+            return False
+        if self._finished_pending_count <= 0:
+            return False
+        return self.context.step_count % self.finished_sync_period == 0
+
+    def _signal_rejection(self) -> None:
+        """Mark a rejection event so the next step drops out of speculation.
+
+        Called by CPU bookkeeping when an add/pause/evict event makes the
+        speculative metadata invalid. Cleared after the engine drains in-flight
+        forwards and applies the corrected state via transfer_bookkeeping_to_gpu.
+        """
+        self._rejection_pending = True
+
+    def _clear_rejection(self) -> None:
+        """Clear the rejection-pending flag after the engine has resynced."""
+        self._rejection_pending = False
 
     async def async_step(
         self,

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -610,6 +610,10 @@ class DynamicInferenceEngine(AbstractEngine):
             self.expert_parallel_zmq_communicator = AsyncZMQCommunicator(
                 self.zmq_context, process_group=self.pg_collection.ep, hostname=hostname
             )
+            # Give the context a CPU-side MAX-reduction primitive so
+            # match_graph_config() can avoid a per-step NCCL AllReduce kernel.
+            if hasattr(self.context, "set_ep_zmq_communicator"):
+                self.context.set_ep_zmq_communicator(self.expert_parallel_zmq_communicator)
 
         # initialize zmq-based world communicator for consensus barriers
         total_world_size = torch.distributed.get_world_size()

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1987,16 +1987,41 @@ class DynamicInferenceEngine(AbstractEngine):
         match vLLM API. Uses `asyncio` for continuous generation which allows this
         method to sleep and wake up when new requests are available.
 
+        Routes to the speculative path when async scheduling is active and the
+        current step satisfies the speculation predicate; otherwise runs the
+        serial path (today's behavior).
+
         Returns:
             A tuple comprised of:
                 1. Requests that ran in the last step and are still active.
                 2. Requests that ran in the last step and have now finished.
                 3. The step time in seconds.
         """
+        if self._async_scheduling_active():
+            return await self._async_step_speculative()
+        return await self._async_step_serial()
+
+    async def _async_step_serial(
+        self,
+    ) -> Tuple[List[DynamicInferenceRequest], List[DynamicInferenceRequest], float]:
+        """Serial step path: forward + sample, then CPU bookkeeping. Today's behavior."""
         last_step_data = await self.async_forward()
-        ret = await self.async_bookkeep(*last_step_data)
-        # Keep for compatibility with current test suite.
-        return ret
+        return await self.async_bookkeep(*last_step_data)
+
+    async def _async_step_speculative(
+        self,
+    ) -> Tuple[List[DynamicInferenceRequest], List[DynamicInferenceRequest], float]:
+        """Speculative step path: launch the next forward immediately after sampling
+        so the GPU runs forward -> sample -> forward without waiting on CPU
+        bookkeeping. CPU bookkeeping runs in parallel and verifies retroactively.
+
+        Stub for C3.5: currently identical to the serial path. The launch-ahead
+        and reconciliation logic is added in C4 alongside the rejection-event
+        handling. Splitting the structural routing into its own commit keeps the
+        engine-loop refactor reviewable.
+        """
+        last_step_data = await self.async_forward()
+        return await self.async_bookkeep(*last_step_data)
 
     def _run_coroutine_sync(self, coro):
         """Run a coroutine synchronously, handling the case when already in an event loop.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -226,15 +226,14 @@ class DynamicInferenceEngine(AbstractEngine):
         self.unified_memory_level = inference_config.unified_memory_level
         self.use_synchronous_zmq_collectives = inference_config.use_synchronous_zmq_collectives
         self.async_scheduling = inference_config.async_scheduling
-        self.finished_sync_period = inference_config.finished_sync_period
-        # Set when CPU bookkeeping detects an event (add/pause/evict) that
-        # would invalidate the speculative chain. Read by _async_scheduling_active
+        # Set when CPU bookkeeping detects a pause/evict event that would
+        # invalidate the speculative chain. Read by _async_scheduling_active
         # to drop out of speculation; cleared after the engine drains the
-        # in-flight forwards and applies the corrected state.
+        # in-flight pre-launch and applies the corrected state. Finishes
+        # are caught earlier (via _would_any_finish) and never reach the
+        # bookkeep with a stale pre-launch in flight, so they don't signal
+        # rejection.
         self._rejection_pending = False
-        # Tracks how many requests have finished but not yet been removed from
-        # the active batch via a sync. Used by the periodic-sync backstop.
-        self._finished_pending_count = 0
         # Holds the launch_state dict produced by a prior iteration's
         # speculative pre-launch of step N+1. The next iteration consumes it
         # instead of launching fresh. None when no speculative launch is in
@@ -1995,57 +1994,82 @@ class DynamicInferenceEngine(AbstractEngine):
     def _async_scheduling_active(self) -> bool:
         """Engine-level gate for the async-scheduling speculative chain.
 
-        Returns True when the current step is eligible to launch the next
-        forward speculatively without waiting for CPU bookkeeping. Used by the
-        engine loop in the launch-ahead refactor to decide whether to chain
-        the next forward on the stream or to fall back to serial behavior.
-
-        False when any of the following is true:
+        Returns True when the speculative path is allowed for this step.
+        False when:
         - async_scheduling is disabled by configuration.
-        - A rejection event (add/pause/evict) is pending and must be applied.
-        - The current step is not pure decode (prefill present).
-        - The next step would require new KV blocks that aren't available.
-        - The periodic finished-pending sync is due (every K steps when
-          finished requests are accumulated).
+        - A pause/evict event in the prior bookkeep marked a rejection that
+          still needs applying.
+        - The context predicate (`can_speculate_decode_step`) is not satisfied
+          (prefill present, boundary crossing, speculative decoding active).
+
+        Note: speculation also requires checks the engine performs *inside*
+        the iteration: a batch-composition change after `schedule_waiting_
+        requests` aborts the consume-pending path, and a `_would_any_finish`
+        check on the just-sampled tokens skips the speculative pre-launch.
+        Together those make the gate's job simpler — finishes never reach
+        bookkeep with a stale pending pre-launch in flight, and adds are
+        caught the moment they happen.
         """
         if not self.async_scheduling:
             return False
         if self._rejection_pending:
             return False
-        if self._finished_sync_due():
-            return False
-        # Requests waiting in the queue would change batch composition at
-        # the next iteration. Drop to the serial path so the schedule call
-        # can integrate them and re-launch from canonical state.
-        if len(self.waiting_request_ids) > 0:
-            return False
         return self.context.can_speculate_decode_step()
-
-    def _finished_sync_due(self) -> bool:
-        """Check whether the periodic finished-pending sync is due this step.
-
-        Fires when finished_sync_period > 0, finished requests are pending, and
-        step_count is at a sync-period boundary. Used as a backstop so finished
-        slots can't accumulate indefinitely in the speculative chain.
-        """
-        if self.finished_sync_period <= 0:
-            return False
-        if self._finished_pending_count <= 0:
-            return False
-        return self.context.step_count % self.finished_sync_period == 0
 
     def _signal_rejection(self) -> None:
         """Mark a rejection event so the next step drops out of speculation.
 
-        Called by CPU bookkeeping when an add/pause/evict event makes the
+        Called by CPU bookkeeping when a pause/evict event makes the
         speculative metadata invalid. Cleared after the engine drains in-flight
         forwards and applies the corrected state via transfer_bookkeeping_to_gpu.
+
+        Finishes are *not* signalled here — the engine catches finishes via
+        :meth:`_would_any_finish` before pre-launching, skipping the
+        speculative forward when any request would terminate this step.
+        That avoids the wasted forward that a post-bookkeep rejection
+        would have caused.
         """
         self._rejection_pending = True
 
     def _clear_rejection(self) -> None:
         """Clear the rejection-pending flag after the engine has resynced."""
         self._rejection_pending = False
+
+    def _would_any_finish(self, sample_cpu: torch.Tensor, active_count: int) -> bool:
+        """Predict whether any active request will be marked finished by
+        :meth:`_dynamic_step_context_bookkeeping` for the just-sampled tokens.
+
+        Mirrors the active-request-mask computation done inside the
+        controller's bookkeep so the engine can decide whether to issue the
+        speculative pre-launch *before* committing GPU work. If any request
+        would finish, the bookkeep will compact the batch — invalidating any
+        pre-launch that used the old batch composition. Skipping the pre-
+        launch in that case avoids wasted GPU work.
+
+        A finish is detected when sample == termination_id, or when the
+        request's sequence length after this step would equal/exceed its
+        ``max_sequence_length``, or (if a stop-word callback is registered)
+        the callback flags the request id.
+        """
+        active_slice = slice(
+            self.context.paused_request_count,
+            self.context.paused_request_count + active_count,
+        )
+        term_ids = self.controller._request_metadata["termination_id"][active_slice]
+        if (sample_cpu[:active_count] == term_ids).any().item():
+            return True
+        active_seq_lens = self.context.get_active_sequence_lengths() + 1
+        max_seq_lens = self.context.get_max_sequence_lengths()
+        if (active_seq_lens >= max_seq_lens).any().item():
+            return True
+        if self.controller._get_stop_word_finished_ids_callback is not None:
+            request_ids = self.context.request_ids[active_slice].tolist()
+            stop_finished = self.controller._get_stop_word_finished_ids_callback(request_ids)
+            if stop_finished:
+                for rid in request_ids:
+                    if rid in stop_finished:
+                        return True
+        return False
 
     async def async_step(
         self,
@@ -2157,7 +2181,20 @@ class DynamicInferenceEngine(AbstractEngine):
             raise EngineSuspendedError(self.context.step_count)
 
         # async_forward equivalents needed before any launch.
+        # Track total_request_count across schedule so we can detect new
+        # arrivals — those would change the batch composition and invalidate
+        # any pending pre-launch issued for the prior batch.
+        pre_schedule_total = self.context.total_request_count
         self.schedule_waiting_requests()
+        if (
+            self._pending_launch_state is not None
+            and self.context.total_request_count != pre_schedule_total
+        ):
+            # New request was scheduled this iter; the pending pre-launch
+            # was computed for the smaller batch. Drain the stale pre-launch
+            # and continue this iter as if there was no pending state.
+            self._drain_pending_launch()
+            self._clear_rejection()
 
         will_log_this_step = (
             self.logging_step_interval > 0
@@ -2217,10 +2254,22 @@ class DynamicInferenceEngine(AbstractEngine):
         active_count = launch_state_N["_active_request_count"]
         sample_N_cpu = self.controller._sampled_tokens_cuda[:active_count].cpu()
 
-        # 3. Pre-launch step N+1 if eligible. Snapshot the RNG and mamba
-        # state first so we can roll back if the pre-launch is later
-        # discarded.
-        if self.context.can_speculate_decode_step():
+        # 3. Pre-launch step N+1 if eligible. Two checks:
+        #    a) The context predicate (`can_speculate_decode_step`) — pure
+        #       decode, no boundary crossing, no speculative-decoding interaction.
+        #    b) `_would_any_finish` — if any request would terminate this step,
+        #       the bookkeep will compact the batch and any pre-launch we issue
+        #       here would be operating on a stale batch. Skipping the
+        #       pre-launch costs one cycle of GPU idle time but saves a wasted
+        #       forward + sample plus a serial drain on the next iter.
+        #
+        # Snapshot RNG + mamba state before the pre-launch so a *future*
+        # pause/evict rejection can roll them back; finishes never reach this
+        # path because we gate them at (b).
+        if (
+            self.context.can_speculate_decode_step()
+            and not self._would_any_finish(sample_N_cpu, active_count)
+        ):
             self._pre_launch_rng_state = self.controller.sampling_rng.get_state()
             self.context.save_mamba_state_for_speculation()
 
@@ -2262,13 +2311,12 @@ class DynamicInferenceEngine(AbstractEngine):
         self.context.prefix_cache_lru_clock += 1
         nvtx_range_pop("Decode")
 
-        # 7. Detect events that invalidate the speculative chain. Any of
-        # finish / pause / evict triggers a rejection so the next iteration's
-        # serial path drains and re-launches from canonical state.
-        finished_request_ids = bookkeep_state.get("finished_request_ids")
-        if finished_request_ids is not None and len(finished_request_ids) > 0:
-            self._finished_pending_count += int(len(finished_request_ids))
-            self._signal_rejection()
+        # 7. Detect events that invalidate any pre-launch we just queued.
+        # Finishes never reach this point with a pre-launch in flight — the
+        # `_would_any_finish` gate above skipped the pre-launch on this iter.
+        # Pause/evict can still happen inside update_requests when memory
+        # pressure forces a request out; signal rejection so the next iter's
+        # serial path drains the stale pre-launch.
         if bookkeep_state.get("newly_paused_request_ids") is not None:
             self._signal_rejection()
         if bookkeep_state.get("evict_request_ids") is not None:

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -240,6 +240,13 @@ class DynamicInferenceEngine(AbstractEngine):
         # instead of launching fresh. None when no speculative launch is in
         # flight (warmup, after rejection, or async scheduling disabled).
         self._pending_launch_state: Optional[Dict] = None
+        # Snapshot of controller.sampling_rng state captured immediately
+        # before the speculative pre-launch's sample. Used to roll the RNG
+        # back when the pre-launch is discarded (rejection drain) so the
+        # serial re-sample reads from the same RNG state the baseline
+        # would have observed at that step. None when no pre-launch is in
+        # flight.
+        self._pre_launch_rng_state: Optional[torch.Tensor] = None
         self.cuda_graph_impl = model_config.cuda_graph_impl
         self.cuda_graph_scope = model_config.cuda_graph_scope
         # Initialize engine.
@@ -2007,6 +2014,11 @@ class DynamicInferenceEngine(AbstractEngine):
             return False
         if self._finished_sync_due():
             return False
+        # Requests waiting in the queue would change batch composition at
+        # the next iteration. Drop to the serial path so the schedule call
+        # can integrate them and re-launch from canonical state.
+        if len(self.waiting_request_ids) > 0:
+            return False
         return self.context.can_speculate_decode_step()
 
     def _finished_sync_due(self) -> bool:
@@ -2066,9 +2078,13 @@ class DynamicInferenceEngine(AbstractEngine):
         async-scheduling fired a rejection), drain it on the stream so the
         canonical state can launch step N afresh without races.
         """
+        # Drain a stale speculative pre-launch (and roll back its RNG / clear
+        # rejection state) only when one is actually pending. When there is no
+        # pre-launch in flight this branch is a no-op so the serial path is
+        # byte-identical to the pre-async-scheduling code path.
         if self._pending_launch_state is not None:
             self._drain_pending_launch()
-        self._clear_rejection()
+            self._clear_rejection()
         last_step_data = await self.async_forward()
         return await self.async_bookkeep(*last_step_data)
 
@@ -2079,49 +2095,197 @@ class DynamicInferenceEngine(AbstractEngine):
         a finish/pause/evict event triggered a rejection). The pending pre-
         launch's GPU work is allowed to complete; its results are discarded
         because step N+1 will be re-launched from canonical state.
+
+        Also rolls back the controller's sampling RNG state to the snapshot
+        taken before the discarded pre-launch's sample. Without this rollback
+        the serial re-sample would observe an RNG state advanced by the
+        discarded sample and produce a token different from the baseline.
         """
         torch.cuda.current_stream().synchronize()
+        if self._pre_launch_rng_state is not None:
+            self.controller.sampling_rng.set_state(self._pre_launch_rng_state)
+            self._pre_launch_rng_state = None
         self._pending_launch_state = None
 
     async def _async_step_speculative(
         self,
     ) -> Tuple[List[DynamicInferenceRequest], List[DynamicInferenceRequest], float]:
-        """Speculative step path: planned to launch step N+1 ahead of step N's
-        bookkeep so the GPU runs ``forward → sample → forward → sample``
-        continuously on pure-decode chains.
+        """Speculative step path: launch step N+1 ahead of step N's bookkeep
+        so the GPU runs ``forward → sample → forward → sample`` continuously
+        on pure-decode chains.
 
-        C5.3 status: still a stub identical to the serial path. The launch-
-        ahead loop and rejection drain-and-rewind are landed in a follow-up
-        commit. The infrastructure required by that follow-up is in place:
+        Stream order maintained per iteration::
 
-        - ``self._pre_fetched_sample_buf`` and ``self._d2h_done_event`` /
-          ``self._h2d_done_event`` events (engine ``__init__``).
-        - ``self._pending_launch_state`` field threaded through serial path
-          via ``_drain_pending_launch``.
-        - ``self._signal_rejection`` / ``_clear_rejection`` and the
-          ``len(waiting_request_ids) > 0`` gate in
-          ``_async_scheduling_active``.
-        - ``controller._launch_decode_step`` / ``_bookkeep_decode_step``
-          split (C5.1) and ``sample_cpu_override`` parameter on the bookkeep
-          path so the engine can D2H sample_N once and pass it through
-          without racing against a subsequent speculative sample_{N+1}.
-        - ``context.speculatively_advance_for_next_decode_step`` /
-          ``restore_after_speculative_advance`` (C5.2).
+            H2D_N → forward_N → sample_N → H2D_{N+1} → forward_{N+1} → sample_{N+1}
 
-        A naive launch-ahead wiring (sync sample_N, mirror it into pinned
-        token_to_input_ids, speculatively advance, pre-launch step N+1, run
-        update_requests in parallel) was prototyped on this branch but
-        produced divergent tokens vs. the serial baseline starting at the
-        first decode iteration after a mid-chain rejection (e.g. when a new
-        request is added). The proximate cause appears to be state pollution
-        from the discarded pre-launch (KV writes / attention metadata /
-        rotated MHA tensors); resolving it cleanly requires either a shadow
-        bookkeeping buffer or a more thorough rollback than the persistent-
-        tensor restore that exists today. Deferred to a follow-up so the
-        infrastructure here can land separately.
+        CPU sequence per iteration:
+            1. Acquire step N's launch state — consume the pending pre-launch
+               from the prior iteration, or launch fresh on warmup.
+            2. ``.cpu()`` _sampled_tokens_cuda — synchronous wait that blocks
+               CPU until sample_N completes. GPU is busy with forward_N →
+               sample_N during this wait, so no GPU idle time.
+            3. Snapshot the sampling RNG state so the next sample (the
+               speculative one) can be rolled back if the chain rejects.
+            4. Mirror sample_N into pinned ``token_to_input_ids`` so step
+               N+1's H2D copies the correct input to ``gpu_view``.
+            5. Speculatively advance state and pre-launch step N+1 (queues
+               H2D, forward, sample on the stream, advances RNG).
+            6. Run step N's full ``update_requests`` bookkeeping in parallel
+               with GPU step N+1. update_requests overwrites pinned token-
+               level fields but only ~100+ µs into its execution, by which
+               time the small (~5 µs) H2D for step N+1 has long completed.
+
+        Rejection events (finish/pause/evict) at the end of bookkeep set
+        ``_rejection_pending`` so the next iteration drops to the serial
+        path. The serial path's drain helper synchronizes the stream,
+        discards the pre-launched step's results, and restores the
+        sampling RNG so the re-sample matches the baseline byte-for-byte.
+
+        Speculation is gated off (via ``can_speculate_decode_step``) for
+        hybrid models because Mamba's SSM forward advances per-request
+        ``conv_states`` / ``ssm_states`` in place; rolling those back on
+        rejection would require saving/restoring large GPU buffers per
+        active request. Implementing that is left for a follow-up.
         """
-        last_step_data = await self.async_forward()
-        return await self.async_bookkeep(*last_step_data)
+        if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
+            raise EngineSuspendedError(self.context.step_count)
+
+        # async_forward equivalents needed before any launch.
+        self.schedule_waiting_requests()
+
+        will_log_this_step = (
+            self.logging_step_interval > 0
+            and (self.context.step_count + 1) % self.logging_step_interval == 0
+        )
+        is_decode_only = self.context.is_decode_only()
+        if will_log_this_step:
+            pre_step_context_state = {
+                "is_decode_only": is_decode_only,
+                "max_requests": self.context.max_requests,
+                "total_request_count": self.context.total_request_count,
+                "paused_request_count": self.context.paused_request_count,
+                "active_token_count": self.context.active_token_count,
+                "step_count": self.context.step_count,
+            }
+        else:
+            pre_step_context_state = {
+                "active_token_count": self.context.active_token_count,
+                "step_count": self.context.step_count,
+            }
+
+        nvtx_range_push("Decode")
+        self.is_decode_only = is_decode_only
+
+        if will_log_this_step:
+            self.step_start_event.record()
+
+        # 1. Acquire step N's launch state. Either consume the pending pre-
+        # launch from the prior iteration's speculation, or launch fresh
+        # (warmup or post-rejection).
+        if self._pending_launch_state is None:
+            launch_state_N = await self.controller._launch_decode_step()
+        else:
+            launch_state_N = self._pending_launch_state
+            self._pending_launch_state = None
+            # The RNG state snapshot is paired with the consumed pre-launch:
+            # the pre-launch's sample has already advanced the RNG. We are now
+            # consuming that sample, so the advance is "real" and we drop the
+            # snapshot — only a future rejection that discards a pre-launch
+            # would need to roll back.
+            self._pre_launch_rng_state = None
+
+        if launch_state_N is None:
+            # Nothing to step (no active requests).
+            nvtx_range_pop("Decode")
+            if will_log_this_step:
+                self.step_end_event.record()
+                self.step_end_event.synchronize()
+            return await self.async_bookkeep(
+                None, {**pre_step_context_state, "kv_stats": None}, 0.0
+            )
+
+        # 2. D2H sample_N. Synchronous: blocks CPU until sample_N completes
+        # on the stream. GPU stays busy with forward_N → sample_N during the
+        # wait so the wait does not introduce a GPU-side gap.
+        active_count = launch_state_N["_active_request_count"]
+        sample_N_cpu = self.controller._sampled_tokens_cuda[:active_count].cpu()
+
+        # 3. Pre-launch step N+1 if eligible. Snapshot the RNG state first
+        # so we can roll back if the pre-launch is later discarded.
+        if self.context.can_speculate_decode_step():
+            self._pre_launch_rng_state = self.controller.sampling_rng.get_state()
+
+            # 4. Mirror sample_N into pinned token_to_input_ids before the
+            # speculative H2D so step N+1's forward reads sample_N as its
+            # input. update_requests would do this assignment near the end
+            # of step N's bookkeep, but we must do it here because the next
+            # H2D needs the value now.
+            self.context.token_to_input_ids[:active_count] = sample_N_cpu
+
+            # 5. Speculatively advance per-request state and pre-launch.
+            self.context.speculatively_advance_for_next_decode_step()
+            try:
+                pending = await self.controller._launch_decode_step()
+                if pending is not None:
+                    self._pending_launch_state = pending
+                else:
+                    # No active requests after speculative advance (very rare,
+                    # but handle cleanly): nothing to roll back.
+                    self._pre_launch_rng_state = None
+            finally:
+                self.context.restore_after_speculative_advance()
+
+        # 6. CPU bookkeep step N using the pre-fetched sample. Runs in
+        # parallel with GPU step N+1 if speculation queued one.
+        bookkeep_state = self.controller._bookkeep_decode_step(
+            launch_state_N, sample_cpu_override=sample_N_cpu
+        )
+
+        if will_log_this_step:
+            self.step_end_event.record()
+            self.step_end_event.synchronize()
+            step_time = self.step_start_event.elapsed_time(self.step_end_event) / 1e3
+        else:
+            step_time = 0.0
+
+        self.context.step_count += 1
+        self.context.prefix_cache_lru_clock += 1
+        nvtx_range_pop("Decode")
+
+        # 7. Detect events that invalidate the speculative chain. Any of
+        # finish / pause / evict triggers a rejection so the next iteration's
+        # serial path drains and re-launches from canonical state.
+        finished_request_ids = bookkeep_state.get("finished_request_ids")
+        if finished_request_ids is not None and len(finished_request_ids) > 0:
+            self._finished_pending_count += int(len(finished_request_ids))
+            self._signal_rejection()
+        if bookkeep_state.get("newly_paused_request_ids") is not None:
+            self._signal_rejection()
+        if bookkeep_state.get("evict_request_ids") is not None:
+            self._signal_rejection()
+
+        # Build context_state for async_bookkeep (matches async_forward's shape).
+        if will_log_this_step:
+            kvcache_util_stats = (
+                self.context.get_kvcache_utilization_stats()
+                if self.metrics_writer is not None
+                else None
+            )
+            post_step_context_state = {
+                "waiting_request_count": len(self.waiting_request_ids),
+                "finished_request_count": self.finished_request_count,
+                "evicted_request_count": self.evicted_request_count,
+                "kv_stats": kvcache_util_stats,
+                "total_active_block_count": self.context.kv_block_allocator.active_count,
+                "total_paused_block_count": self.context.kv_block_allocator.paused_count,
+                "total_active_used_blocks": self.context.kv_block_allocator.get_active_used(),
+                "total_paused_used_blocks": self.context.kv_block_allocator.get_paused_used(),
+            }
+            context_state = {**pre_step_context_state, **post_step_context_state}
+        else:
+            context_state = {**pre_step_context_state, "kv_stats": None}
+
+        return await self.async_bookkeep(bookkeep_state, context_state, step_time)
 
     def _run_coroutine_sync(self, coro):
         """Run a coroutine synchronously, handling the case when already in an event loop.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, OrderedDict, Tuple, Union
 import torch
 import torch.nn.functional as F
 from torch import Tensor
+from torch.cuda.nvtx import range_pop, range_push
 
 from megatron.core import parallel_state
 from megatron.core.inference.async_stream import AsyncStream
@@ -576,10 +577,12 @@ class TextGenerationController:
         model_config = get_model_config(unwrapped_model)
 
         # Initialize attention state.
+        range_push("initialize_attention_state")
         context.initialize_attention_state(
             construct_graph_dimensions=construct_graph_dimensions,
             is_expert_parallel_dummy_cuda_graph_step=is_dummy_forward,
         )
+        range_pop()
 
         # If using symmetric kernels and we are using using nccl
         # for prefill turn off symmetric kernels
@@ -1753,6 +1756,7 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
+        range_push("active_request_mask")
         # Active sequence lengths.
         active_request_ids = context.request_ids[active_request_slice].long()
         active_sequence_lengths = context.get_active_sequence_lengths()
@@ -1788,7 +1792,9 @@ class TextGenerationController:
         # Clone needed: update_requests mutates next_tokens in-place via tensor_swap,
         # which would corrupt the reused _sampled_tokens_cuda buffer.
         new_sample_copy = self._sampled_tokens_cuda[:active_request_count].clone()
+        range_pop()
 
+        range_push("update_requests")
         # Update requests.
         # _sampled_mtp_tokens_cuda has shape [num_speculative_tokens, max_requests]
         if self.num_speculative_tokens > 0:
@@ -1798,6 +1804,7 @@ class TextGenerationController:
         update_result = context.update_requests(
             active_request_mask, new_sample_copy, sampled_mtp_tokens_cuda
         )
+        range_pop()
 
         return {
             "active_request_ids": active_request_ids,
@@ -1845,6 +1852,7 @@ class TextGenerationController:
 
             # Forward pass produces only base logits. When speculative decoding is
             # active, MTP logits are computed serially after verification.
+            range_push("forward_pass")
             logits = self._dynamic_step_forward_logits(input_ids, position_ids)
 
             # Commit Mamba intermediate states before update_requests, which
@@ -1856,6 +1864,7 @@ class TextGenerationController:
 
             # Collect routing indices per request (must be done before context transitions)
             routing_indices_per_request = self._router_record_bookkeeping()
+            range_pop()
 
         # This is the best place to yield control back to event loop.
         # At this point we have enqueued FW pass GPU kernels asynchronously.
@@ -1867,6 +1876,7 @@ class TextGenerationController:
         await asyncio.sleep(0)
 
         with torch.inference_mode():
+            range_push("sampling")
             return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
 
             self._dynamic_step_sample_bookkeeping()
@@ -1904,6 +1914,7 @@ class TextGenerationController:
                         top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs(
                             logits, log_probs_tensor
                         )
+            range_pop()
 
             if skip_bookkeeping:
                 request_bookkeeping = {}

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1779,14 +1779,17 @@ class TextGenerationController:
             sampled_mtp_tokens_cpu = None
         return sampled_tokens_cpu, sampled_mtp_tokens_cpu
 
-    def _dynamic_step_context_bookkeeping(self) -> Dict[str, Tensor]:
+    def _dynamic_step_context_bookkeeping(
+        self, sample_cpu_override: Optional[Tensor] = None
+    ) -> Dict[str, Tensor]:
         """Update the dynamic inference context after sampling.
 
         Args:
-            new_sample (Tensor): The newly sampled tokens.
-            request_metadata (Optional[Dict[str, Tensor]]): An override for the tensors
-                that manage request metadata, such as sampling parameters. By default, this
-                metadata is retrieved from the context.
+            sample_cpu_override (Optional[Tensor]): Pre-fetched CPU sample tensor.
+                When provided, skips the internal D2H transfer of the sample and uses
+                this tensor directly. Used by the engine async-scheduling path which
+                issues the D2H earlier (before the next step's sample clobbers
+                ``_sampled_tokens_cuda``) and synchronizes on a CUDA event.
 
         Return:
             Dict [str, Tensor]: A dictionary containing:
@@ -1798,12 +1801,19 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
-        # Batch GPU-to-CPU transfer of all sampled tokens.
-        range_push("transfer_samples_to_cpu")
-        sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
-            active_request_count,
-        )
-        range_pop()
+        if sample_cpu_override is not None:
+            # The engine has already D2H'd sample_N to a separate pinned buffer
+            # so reading _sampled_tokens_cuda here would race against the
+            # subsequent speculative step's sample kernel.
+            sampled_tokens_cpu = sample_cpu_override
+            sampled_mtp_tokens_cpu = None
+        else:
+            # Batch GPU-to-CPU transfer of all sampled tokens.
+            range_push("transfer_samples_to_cpu")
+            sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
+                active_request_count,
+            )
+            range_pop()
 
         range_push("active_request_mask")
         # Everything below is 100% CPU.
@@ -1969,7 +1979,10 @@ class TextGenerationController:
         }
 
     def _bookkeep_decode_step(
-        self, launch_state: Dict, skip_bookkeeping: bool = False
+        self,
+        launch_state: Dict,
+        skip_bookkeeping: bool = False,
+        sample_cpu_override: Optional[Tensor] = None,
     ) -> Dict:
         """Run CPU bookkeeping for a previously launched decode step.
 
@@ -1977,6 +1990,14 @@ class TextGenerationController:
         to complete) and ``update_requests`` to advance canonical context
         state. Combined with ``launch_state`` from :meth:`_launch_decode_step`
         produces the same return dict shape as the legacy single-call path.
+
+        Args:
+            launch_state: Result of :meth:`_launch_decode_step`.
+            skip_bookkeeping: When True, only D2H the sample and skip
+                update_requests. Used by the dummy expert-parallel forward.
+            sample_cpu_override: Pre-fetched CPU copy of the sample tensor.
+                When provided, skips the internal D2H. Used by the async
+                scheduling path which issues the D2H earlier on the stream.
         """
         active_request_count = launch_state["_active_request_count"]
         with torch.inference_mode():
@@ -1984,13 +2005,18 @@ class TextGenerationController:
                 # _transfer_samples_to_cpu wasn't invoked on this path, so do
                 # a one-shot D2H here to keep "sample" as a CPU tensor for
                 # downstream consumers.
-                request_bookkeeping = {
-                    "sample": self._sampled_tokens_cuda[:active_request_count].cpu(),
-                }
+                if sample_cpu_override is not None:
+                    request_bookkeeping = {"sample": sample_cpu_override}
+                else:
+                    request_bookkeeping = {
+                        "sample": self._sampled_tokens_cuda[:active_request_count].cpu(),
+                    }
             else:
                 # request_bookkeeping supplies "sample" as the already-CPU
                 # tensor produced by _transfer_samples_to_cpu.
-                request_bookkeeping = self._dynamic_step_context_bookkeeping()
+                request_bookkeeping = self._dynamic_step_context_bookkeeping(
+                    sample_cpu_override=sample_cpu_override
+                )
 
             ret = {
                 "accepted_tokens": (

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1746,6 +1746,28 @@ class TextGenerationController:
                     pp_group=self.pp_group,
                 )
 
+    def _transfer_samples_to_cpu(
+        self, active_request_count: int
+    ) -> tuple:
+        """Batch GPU-to-CPU transfer of sampled tokens.
+
+        Called at the boundary between GPU sampling and CPU bookkeeping.
+        After this returns, all sampled data is on CPU and the remainder
+        of the step is 100% CPU.
+
+        Returns:
+            tuple: (sampled_tokens_cpu, sampled_mtp_tokens_cpu) where
+                sampled_mtp_tokens_cpu is None when speculative decoding is off.
+        """
+        sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
+        if self.num_speculative_tokens > 0:
+            sampled_mtp_tokens_cpu = self._sampled_mtp_tokens_cuda[
+                :, :active_request_count
+            ].cpu()
+        else:
+            sampled_mtp_tokens_cpu = None
+        return sampled_tokens_cpu, sampled_mtp_tokens_cpu
+
     def _dynamic_step_context_bookkeeping(self) -> Dict[str, Tensor]:
         """Update the dynamic inference context after sampling.
 
@@ -1765,13 +1787,15 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
-        # GPU-to-CPU transfer of sampled tokens (single batch D2H).
+        # Batch GPU-to-CPU transfer of all sampled tokens.
         range_push("transfer_samples_to_cpu")
-        sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
+        sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
+            active_request_count,
+        )
         range_pop()
 
         range_push("active_request_mask")
-        # Active sequence lengths (CPU, from context bookkeeping).
+        # Everything below is 100% CPU.
         active_request_ids = context.request_ids[active_request_slice].long()
         active_sequence_lengths = context.get_active_sequence_lengths()
 
@@ -1783,14 +1807,11 @@ class TextGenerationController:
         max_sequence_lengths = context.get_max_sequence_lengths()
 
         # Request finished if termination_id or length >= max_sequence_length.
-        # Note: termination_id tensor has per-request termination IDs from mixed sampling.
-        # All comparisons are on CPU (sampled_tokens_cpu, _request_metadata, context tensors).
         active_request_mask = (
             sampled_tokens_cpu
             != self._request_metadata["termination_id"][active_request_slice]
         ).byte() & torch.less(active_sequence_lengths, max_sequence_lengths).byte()
 
-        # Mark requests as finished if they hit stop words (detected in previous step's post_process_requests)
         if self._get_stop_word_finished_ids_callback is not None:
             request_ids_list = active_request_ids.tolist()
             stop_word_finished_ids = self._get_stop_word_finished_ids_callback(request_ids_list)
@@ -1810,12 +1831,6 @@ class TextGenerationController:
         range_pop()
 
         range_push("update_requests")
-        # Update requests (100% CPU).
-        # _sampled_mtp_tokens_cuda has shape [num_speculative_tokens, max_requests]
-        if self.num_speculative_tokens > 0:
-            sampled_mtp_tokens_cpu = self._sampled_mtp_tokens_cuda[:, :active_request_count].cpu()
-        else:
-            sampled_mtp_tokens_cpu = None
         update_result = context.update_requests(
             active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
         )

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1227,6 +1227,17 @@ class TextGenerationController:
 
             self._sampled_tokens_cuda[sampled_indices] = sampled_tokens
 
+        # Mirror sampled tokens into gpu_view so the next forward's CUDA
+        # graph can read them directly. Pure-decode, non-speculative only —
+        # other layouts are handled by the existing CPU+H2D path.
+        if context.is_decode_only() and not self.num_speculative_tokens:
+            active_request_count = (
+                context.total_request_count - context.paused_request_count
+            )
+            context.gpu_view.token_to_input_ids[:active_request_count].copy_(
+                self._sampled_tokens_cuda[:active_request_count]
+            )
+
     def _dynamic_step_log_probs_bookkeeping(self) -> Tuple[bool, bool]:
         """Perform bookkeeping necessary to compute log probs for dynamic batching.
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1839,6 +1839,11 @@ class TextGenerationController:
         return {
             "active_request_ids": active_request_ids,
             "finished_request_ids": finished_request_ids,
+            # Already a CPU tensor (independent of _sampled_tokens_cuda via the
+            # .cpu() in _transfer_samples_to_cpu; update_requests only mutates
+            # the separate new_sample_copy). Returning the CPU copy avoids a
+            # D2H sync when the engine later calls sample.tolist().
+            "sample": sampled_tokens_cpu,
             **(update_result or {}),
         }
 
@@ -1947,13 +1952,18 @@ class TextGenerationController:
             range_pop()
 
             if skip_bookkeeping:
-                request_bookkeeping = {}
+                # _transfer_samples_to_cpu wasn't invoked on this path, so do
+                # a one-shot D2H here to keep "sample" as a CPU tensor for
+                # downstream consumers.
+                request_bookkeeping = {
+                    "sample": self._sampled_tokens_cuda[:active_request_count].cpu(),
+                }
             else:
+                # request_bookkeeping supplies "sample" as the already-CPU
+                # tensor produced by _transfer_samples_to_cpu.
                 request_bookkeeping = self._dynamic_step_context_bookkeeping()
 
             ret = {
-                # Clone needed: _sampled_tokens_cuda is a reused buffer overwritten each step.
-                "sample": self._sampled_tokens_cuda[:active_request_count].clone(),
                 "accepted_tokens": (
                     # Clone needed: .fill_(-1) on line 1480 would corrupt the returned value.
                     self._accepted_tokens_per_request.clone()

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -576,12 +576,17 @@ class TextGenerationController:
         unwrapped_model = unwrap_model(self.inference_wrapped_model.model)
         model_config = get_model_config(unwrapped_model)
 
-        # Initialize attention state.
+        # Initialize attention state (100% CPU computation).
         range_push("initialize_attention_state")
         context.initialize_attention_state(
             construct_graph_dimensions=construct_graph_dimensions,
             is_expert_parallel_dummy_cuda_graph_step=is_dummy_forward,
         )
+        range_pop()
+
+        # Single batch CPU-to-GPU transfer of bookkeeping state.
+        range_push("transfer_bookkeeping_to_gpu")
+        context.transfer_bookkeeping_to_gpu()
         range_pop()
 
         # If using symmetric kernels and we are using using nccl
@@ -614,12 +619,11 @@ class TextGenerationController:
                 unwrapped_model.set_symmetric_ar(None)
 
         # Get request metadata for this step.
+        # Context metadata is now on CPU, so copy is CPU-to-CPU (fast).
         for label, dtype, on_gpu in context.request_metadata_types:
-            if not on_gpu:
-                # We need a D2H copy from the context to the pinned memory buffer.
-                self._request_metadata[label].copy_(
-                    context.request_metadata[label], non_blocking=True
-                )
+            self._request_metadata[label].copy_(
+                context.request_metadata[label], non_blocking=True
+            )
 
         # Get flat tokens, position ids.
         # If we are running a dummy forward step we want to use the token count agreed upon
@@ -722,9 +726,11 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
-        # Get the accepted token counts for each request
+        # Get the accepted token counts for each request (move to CPU for bookkeeping ops).
         # Note: _accepted_token_counts is indexed from 0 to active_request_count-1
         accepted_tokens_per_request = self._accepted_token_counts_per_request[:active_request_count]
+        if accepted_tokens_per_request.is_cuda:
+            accepted_tokens_per_request = accepted_tokens_per_request.cpu()
 
         # Number of tokens to rewind (rejected speculative tokens)
         num_tokens_to_rewind = self.num_speculative_tokens - accepted_tokens_per_request
@@ -791,14 +797,15 @@ class TextGenerationController:
             # Release the blocks back to the allocator
             context.kv_block_allocator.release_memory_blocks(blocks_to_release)
 
-        # Mamba speculative rewind state update
+        # Mamba speculative rewind state update.
+        # Indices are computed on CPU, then moved to GPU for indexing into GPU Mamba state buffers.
         if context.is_hybrid_model:
             active_mamba_indices = context.mamba_metadata.request_to_mamba_state_idx[
                 active_request_slice
             ]
             is_decode_mask = context.request_in_prefill_status_tensor[active_request_slice] == 0
-            decode_mamba_indices = active_mamba_indices[is_decode_mask]
-            accepted_tokens_per_decode_request = accepted_tokens_per_request[is_decode_mask]
+            decode_mamba_indices = active_mamba_indices[is_decode_mask].cuda()
+            accepted_tokens_per_decode_request = accepted_tokens_per_request[is_decode_mask].cuda()
 
             if decode_mamba_indices.numel() > 0:
                 context.mamba_conv_states[:, decode_mamba_indices] = (
@@ -877,11 +884,15 @@ class TextGenerationController:
             last_accepted_hidden = None
 
         # Compute position IDs for the next tokens.
-        # After rewind, request_kv_length_offsets has been adjusted. The actual
-        # KV cache length is: adjusted_offset + processed_tokens.
-        # The next position to predict starts at that cache length.
-        adjusted_offsets = context.request_kv_length_offsets[active_slice]
-        processed_tokens = context.request_query_lengths[active_slice]
+        # After rewind, request_kv_length_offsets has been adjusted. Read from
+        # CPU context (post-rewind values), NOT gpu_view (stale pre-rewind snapshot).
+        cuda_device = torch.cuda.current_device()
+        adjusted_offsets = context.request_kv_length_offsets[active_slice].to(
+            cuda_device, non_blocking=True,
+        )
+        processed_tokens = context.request_query_lengths[active_slice].to(
+            cuda_device, non_blocking=True,
+        )
         base_position = adjusted_offsets + processed_tokens
 
         # Start with the freshly sampled base token.
@@ -972,6 +983,7 @@ class TextGenerationController:
         Returns:
             tuple: (output_tokens, repeats) where output_tokens has shape [total_required_tokens]
         """
+        # request_in_prefill_status_tensor is already on GPU (from gpu_view).
         repeats = torch.where(
             request_in_prefill_status_tensor == 0, 1 + self.num_speculative_tokens, 1
         )
@@ -1101,12 +1113,11 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
 
-        request_in_prefill_status_tensor = context.request_in_prefill_status_tensor[
-            context.paused_request_count : context.total_request_count
+        # Use gpu_view for data consumed by GPU operations (sampling, verification).
+        request_in_prefill_status_tensor = context.gpu_view.request_in_prefill_status[
+            :active_request_count
         ]
-        request_query_lengths = context.request_query_lengths[
-            context.paused_request_count : context.total_request_count
-        ]
+        request_query_lengths = context.gpu_view.request_query_lengths[:active_request_count]
 
         num_prefill_requests = request_in_prefill_status_tensor.sum().item()
         num_decode_requests = active_request_count - num_prefill_requests
@@ -1326,12 +1337,11 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
 
-        request_in_prefill_status_tensor = context.request_in_prefill_status_tensor[
-            context.paused_request_count : context.total_request_count
+        # Use gpu_view for data consumed by GPU log-probs operations.
+        request_in_prefill_status_tensor = context.gpu_view.request_in_prefill_status[
+            :active_request_count
         ]
-        request_query_lengths = context.request_query_lengths[
-            context.paused_request_count : context.total_request_count
-        ]
+        request_query_lengths = context.gpu_view.request_query_lengths[:active_request_count]
 
         num_prefill_requests = request_in_prefill_status_tensor.sum().item()
         num_decode_requests = active_request_count - num_prefill_requests
@@ -1392,7 +1402,7 @@ class TextGenerationController:
                 ]
                 log_probs_list_prefill = [[lp.item()] for lp in selected_log_probs]
             else:
-                prefill_token_ids = context.token_to_input_ids[
+                prefill_token_ids = context.gpu_view.token_to_input_ids[
                     decode_len : context.active_token_count
                 ].roll(-1, 0)
                 prefill_query_lengths = request_query_lengths[request_in_prefill_status_tensor == 1]
@@ -1436,12 +1446,11 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
-        request_in_prefill_status_tensor = context.request_in_prefill_status_tensor[
-            context.paused_request_count : context.total_request_count
+        # Use gpu_view for data consumed by GPU top-n operations.
+        request_in_prefill_status_tensor = context.gpu_view.request_in_prefill_status[
+            :active_request_count
         ]
-        request_query_lengths = context.request_query_lengths[
-            context.paused_request_count : context.total_request_count
-        ]
+        request_query_lengths = context.gpu_view.request_query_lengths[:active_request_count]
 
         num_prefill_requests = request_in_prefill_status_tensor.sum().item()
         num_decode_requests = active_request_count - num_prefill_requests
@@ -1756,8 +1765,13 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
+        # GPU-to-CPU transfer of sampled tokens (single batch D2H).
+        range_push("transfer_samples_to_cpu")
+        sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
+        range_pop()
+
         range_push("active_request_mask")
-        # Active sequence lengths.
+        # Active sequence lengths (CPU, from context bookkeeping).
         active_request_ids = context.request_ids[active_request_slice].long()
         active_sequence_lengths = context.get_active_sequence_lengths()
 
@@ -1769,9 +1783,10 @@ class TextGenerationController:
         max_sequence_lengths = context.get_max_sequence_lengths()
 
         # Request finished if termination_id or length >= max_sequence_length.
-        # Note: termination_id tensor has per-request termination IDs from mixed sampling
+        # Note: termination_id tensor has per-request termination IDs from mixed sampling.
+        # All comparisons are on CPU (sampled_tokens_cpu, _request_metadata, context tensors).
         active_request_mask = (
-            self._sampled_tokens_cuda[:active_request_count]
+            sampled_tokens_cpu
             != self._request_metadata["termination_id"][active_request_slice]
         ).byte() & torch.less(active_sequence_lengths, max_sequence_lengths).byte()
 
@@ -1790,19 +1805,19 @@ class TextGenerationController:
         finished_request_ids = context.request_ids[finished_idxs]
 
         # Clone needed: update_requests mutates next_tokens in-place via tensor_swap,
-        # which would corrupt the reused _sampled_tokens_cuda buffer.
-        new_sample_copy = self._sampled_tokens_cuda[:active_request_count].clone()
+        # which would corrupt the reused buffer.
+        new_sample_copy = sampled_tokens_cpu.clone()
         range_pop()
 
         range_push("update_requests")
-        # Update requests.
+        # Update requests (100% CPU).
         # _sampled_mtp_tokens_cuda has shape [num_speculative_tokens, max_requests]
         if self.num_speculative_tokens > 0:
-            sampled_mtp_tokens_cuda = self._sampled_mtp_tokens_cuda[:, :active_request_count]
+            sampled_mtp_tokens_cpu = self._sampled_mtp_tokens_cuda[:, :active_request_count].cpu()
         else:
-            sampled_mtp_tokens_cuda = None
+            sampled_mtp_tokens_cpu = None
         update_result = context.update_requests(
-            active_request_mask, new_sample_copy, sampled_mtp_tokens_cuda
+            active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
         )
         range_pop()
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1858,22 +1858,20 @@ class TextGenerationController:
             **(update_result or {}),
         }
 
-    async def async_generate_output_tokens_dynamic_batch(
-        self, skip_bookkeeping: Optional[bool] = False
-    ) -> Optional[Dict]:
-        """Forward step the model and update the inference context.
+    async def _launch_decode_step(self) -> Optional[Dict]:
+        """Queue a decode step's GPU work: H2D + forward + sample.
 
-        Args:
-            skip_bookkeeping (Optional[bool]): If true, skip the context bookkeeping step.
+        Yields once between the forward and sample blocks so the event loop
+        can run other coroutines while the GPU is processing the forward pass.
+        Performs no D2H or update_requests work; the post-sample CPU work
+        lives in :meth:`_bookkeep_decode_step`. The split lets the engine
+        async-scheduling path queue the next step's launches before the
+        previous step's bookkeeping runs.
 
-        Return:
-            (Optional[Dict]): A dictionary containing:
-                active_request_ids (Tensor): Current active request IDs.
-                newly_paused_request_ids (Tensor): Newly paused request IDs.
-                finished_request_ids (Tensor): Finished request IDs.
-                sample (Tensor): New sample.
-                log_probs (Optional[Tensor]): Log probabilities of the new sample, if requested.
-                cuda_graph_request_count (Optional[int]): Size of cuda graph used for this step.
+        Returns:
+            Optional[Dict]: launch-side state consumed by
+            :meth:`_bookkeep_decode_step`, or ``None`` if there is nothing
+            to step (no active requests and no queued tokens).
         """
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
@@ -1962,6 +1960,26 @@ class TextGenerationController:
                         )
             range_pop()
 
+        return {
+            "_active_request_count": active_request_count,
+            "log_probs": log_probs,
+            "top_n_logprobs": top_n_logprobs,
+            "routing_indices_per_request": routing_indices_per_request,
+            "cuda_graph_request_count": cuda_graph_request_count,
+        }
+
+    def _bookkeep_decode_step(
+        self, launch_state: Dict, skip_bookkeeping: bool = False
+    ) -> Dict:
+        """Run CPU bookkeeping for a previously launched decode step.
+
+        Performs the D2H sample transfer (which implicitly waits for sample
+        to complete) and ``update_requests`` to advance canonical context
+        state. Combined with ``launch_state`` from :meth:`_launch_decode_step`
+        produces the same return dict shape as the legacy single-call path.
+        """
+        active_request_count = launch_state["_active_request_count"]
+        with torch.inference_mode():
             if skip_bookkeeping:
                 # _transfer_samples_to_cpu wasn't invoked on this path, so do
                 # a one-shot D2H here to keep "sample" as a CPU tensor for
@@ -1981,16 +1999,44 @@ class TextGenerationController:
                     if self.num_speculative_tokens > 0
                     else None
                 ),
-                "log_probs": log_probs,
-                "top_n_logprobs": top_n_logprobs,
-                "routing_indices_per_request": routing_indices_per_request,
-                "cuda_graph_request_count": cuda_graph_request_count,
+                "log_probs": launch_state["log_probs"],
+                "top_n_logprobs": launch_state["top_n_logprobs"],
+                "routing_indices_per_request": launch_state["routing_indices_per_request"],
+                "cuda_graph_request_count": launch_state["cuda_graph_request_count"],
             }
             if self.num_speculative_tokens > 0:
                 self._accepted_tokens_per_request.fill_(-1)
                 self._accepted_token_counts_per_request.fill_(0)
             ret.update(request_bookkeeping)
             return ret
+
+    async def async_generate_output_tokens_dynamic_batch(
+        self, skip_bookkeeping: Optional[bool] = False
+    ) -> Optional[Dict]:
+        """Forward step the model and update the inference context.
+
+        Thin orchestrator over :meth:`_launch_decode_step` (queues GPU work)
+        and :meth:`_bookkeep_decode_step` (post-sample CPU work). Async
+        scheduling reuses the launch and bookkeep paths separately so the
+        next step's launches can be queued before the prior step's
+        bookkeeping runs.
+
+        Args:
+            skip_bookkeeping (Optional[bool]): If true, skip the context bookkeeping step.
+
+        Return:
+            (Optional[Dict]): A dictionary containing:
+                active_request_ids (Tensor): Current active request IDs.
+                newly_paused_request_ids (Tensor): Newly paused request IDs.
+                finished_request_ids (Tensor): Finished request IDs.
+                sample (Tensor): New sample.
+                log_probs (Optional[Tensor]): Log probabilities of the new sample, if requested.
+                cuda_graph_request_count (Optional[int]): Size of cuda graph used for this step.
+        """
+        launch_state = await self._launch_decode_step()
+        if launch_state is None:
+            return None
+        return self._bookkeep_decode_step(launch_state, skip_bookkeeping=skip_bookkeeping)
 
     @torch.inference_mode()
     def generate_output_tokens_dynamic_batch(

--- a/megatron/inference/utils.py
+++ b/megatron/inference/utils.py
@@ -362,6 +362,8 @@ def get_inference_config_from_model_and_args(model: MegatronModule, args):
         logging_step_interval=args.inference_logging_step_interval,
         num_speculative_tokens=args.num_speculative_tokens,
         use_synchronous_zmq_collectives=args.inference_use_synchronous_zmq_collectives,
+        async_scheduling=getattr(args, 'inference_dynamic_batching_async_scheduling', True),
+        finished_sync_period=getattr(args, 'inference_dynamic_batching_finished_sync_period', 32),
     )
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1987,6 +1987,18 @@ def _add_inference_args(parser):
                        help='Dtype for the Mamba inference SSM states tensor')
     group.add_argument('--inference-use-synchronous-zmq-collectives', action=argparse.BooleanOptionalAction,
                        required=False, default=False, help='Use synchronous ZMQ collectives for inference. Helps in reducing performance variability for MoEs.')
+    group.add_argument('--inference-dynamic-batching-async-scheduling',
+                       action=argparse.BooleanOptionalAction, default=True,
+                       help='Enable async scheduling: speculatively launch the next '
+                       'forward immediately after sampling so the GPU runs '
+                       'forward -> sample -> forward -> sample without waiting on CPU '
+                       'bookkeeping. Active only on pure-decode steps; falls back to '
+                       'serial behavior on prefill or boundary events.')
+    group.add_argument('--inference-dynamic-batching-finished-sync-period',
+                       type=int, default=32,
+                       help='Force a CPU/GPU sync every N speculative decode steps '
+                       'when finished requests are pending, so finished slots stop '
+                       'consuming compute. Set to 0 to disable the periodic sync.')
     return parser
 
 

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -454,6 +454,64 @@ class TestDynamicContext:
 
     @pytest.mark.internal
     @rounder_override(64)
+    def test_predict_decode_blocks_needed_no_boundary(self):
+        """predict_decode_blocks_needed returns 0 when no active request would
+        cross a block boundary at the next decode step."""
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=4,
+            kv_channels=8,
+            num_attention_heads=2,
+            max_sequence_length=512,
+            buffer_size_gb=0.03,
+            block_size_tokens=128,
+            max_tokens=None,
+            is_hybrid_model=False,
+        )
+        # 100 tokens fits within block 0 (0..127). Next step (+1 = 101) still in block 0.
+        dynamic_context.add_request(
+            DynamicInferenceRequest(
+                request_id=0,
+                prompt_tokens=torch.arange(0, 100, dtype=torch.long, device='cpu'),
+                sampling_params=SamplingParams(
+                    num_tokens_to_generate=dynamic_context.max_tokens - 100
+                ),
+            )
+        )
+        assert dynamic_context.predict_decode_blocks_needed(advance=1) == 0
+        # Cannot speculate during prefill phase regardless of block status.
+        assert dynamic_context.can_speculate_decode_step(advance=1) is False
+
+    @pytest.mark.internal
+    @rounder_override(64)
+    def test_predict_decode_blocks_needed_crosses_boundary(self):
+        """predict_decode_blocks_needed returns 1 when a request at exactly a
+        block boundary needs a new block at the next decode step."""
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=4,
+            kv_channels=8,
+            num_attention_heads=2,
+            max_sequence_length=512,
+            buffer_size_gb=0.03,
+            block_size_tokens=128,
+            max_tokens=None,
+            is_hybrid_model=False,
+        )
+        # 128 tokens fills block 0 exactly. Next step (+1 = 129) needs block 1.
+        dynamic_context.add_request(
+            DynamicInferenceRequest(
+                request_id=0,
+                prompt_tokens=torch.arange(0, 128, dtype=torch.long, device='cpu'),
+                sampling_params=SamplingParams(
+                    num_tokens_to_generate=dynamic_context.max_tokens - 128
+                ),
+            )
+        )
+        assert dynamic_context.predict_decode_blocks_needed(advance=1) == 1
+
+    @pytest.mark.internal
+    @rounder_override(64)
     def test_add_dummy_requests_parallel_populates_state(self):
 
         dynamic_context = self._get_dynamic_context(

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -512,6 +512,123 @@ class TestDynamicContext:
 
     @pytest.mark.internal
     @rounder_override(64)
+    def test_speculatively_advance_and_restore_roundtrip(self):
+        """Speculative advance bumps positions; restore reverses persistent state."""
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=4,
+            kv_channels=8,
+            num_attention_heads=2,
+            max_sequence_length=512,
+            buffer_size_gb=0.03,
+            block_size_tokens=128,
+            max_tokens=None,
+            is_hybrid_model=False,
+        )
+        # Drive a single request through prefill and update_requests so the
+        # context lands in pure-decode steady state (is_decode_only() == True).
+        dynamic_context.add_request(
+            DynamicInferenceRequest(
+                request_id=0,
+                prompt_tokens=torch.arange(0, 16, dtype=torch.long, device='cpu'),
+                sampling_params=SamplingParams(
+                    num_tokens_to_generate=dynamic_context.max_tokens - 16
+                ),
+            )
+        )
+        dynamic_context.update_requests(
+            active_requests_mask=torch.tensor([1], dtype=torch.int32),
+            new_tokens=torch.tensor([42]),
+        )
+        assert dynamic_context.is_decode_only()
+
+        active_slice = slice(
+            dynamic_context.paused_request_count, dynamic_context.total_request_count
+        )
+        kv_offsets_before = dynamic_context.request_kv_length_offsets[active_slice].clone()
+        last_block_offset_before = dynamic_context.request_last_kv_block_offset[
+            active_slice
+        ].clone()
+
+        dynamic_context.speculatively_advance_for_next_decode_step()
+
+        # kv_offsets advanced by query_lengths (1 in pure decode).
+        kv_offsets_after = dynamic_context.request_kv_length_offsets[active_slice]
+        assert torch.equal(kv_offsets_after, kv_offsets_before + 1)
+        # last_kv_block_offset rolled forward mod block_size.
+        assert torch.equal(
+            dynamic_context.request_last_kv_block_offset[active_slice],
+            (last_block_offset_before + 1) % dynamic_context.block_size_tokens,
+        )
+        # Pinned token-level pos_ids reflect the advanced kv_offsets.
+        n_active = dynamic_context.total_request_count - dynamic_context.paused_request_count
+        assert torch.equal(
+            dynamic_context.token_to_pos_ids[:n_active], kv_offsets_after
+        )
+
+        dynamic_context.restore_after_speculative_advance()
+        assert torch.equal(
+            dynamic_context.request_kv_length_offsets[active_slice], kv_offsets_before
+        )
+        assert torch.equal(
+            dynamic_context.request_last_kv_block_offset[active_slice],
+            last_block_offset_before,
+        )
+        # A second restore must fail loudly to surface unbalanced advance/restore.
+        with pytest.raises(AssertionError):
+            dynamic_context.restore_after_speculative_advance()
+
+    @pytest.mark.internal
+    @rounder_override(64)
+    def test_can_speculate_decode_step_rejects_boundary_crossing(self):
+        """can_speculate_decode_step returns False whenever a request would cross
+        a block boundary at the next step, regardless of allocator availability.
+        """
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=4,
+            kv_channels=8,
+            num_attention_heads=2,
+            max_sequence_length=512,
+            buffer_size_gb=0.03,
+            block_size_tokens=128,
+            max_tokens=None,
+            is_hybrid_model=False,
+        )
+        # Drive a 16-token request into pure decode, then nudge its kv_offset
+        # to exactly fill block 0 so the next decode step would cross into
+        # block 1.
+        dynamic_context.add_request(
+            DynamicInferenceRequest(
+                request_id=0,
+                prompt_tokens=torch.arange(0, 16, dtype=torch.long, device='cpu'),
+                sampling_params=SamplingParams(
+                    num_tokens_to_generate=dynamic_context.max_tokens - 16
+                ),
+            )
+        )
+        dynamic_context.update_requests(
+            active_requests_mask=torch.tensor([1], dtype=torch.int32),
+            new_tokens=torch.tensor([42]),
+        )
+        assert dynamic_context.is_decode_only()
+        # Force kv_offset to (block_size - query_length) so the next step lands
+        # exactly at the block boundary and demands a fresh allocation.
+        active_slice = slice(
+            dynamic_context.paused_request_count, dynamic_context.total_request_count
+        )
+        dynamic_context.request_kv_length_offsets[active_slice] = (
+            dynamic_context.block_size_tokens
+            - dynamic_context.request_query_lengths[active_slice]
+        )
+        assert dynamic_context.predict_decode_blocks_needed(advance=1) >= 1
+        # Even though the allocator has free blocks, speculation must defer to
+        # the serial path because the speculative advance cannot replay block
+        # allocation safely.
+        assert dynamic_context.can_speculate_decode_step(advance=1) is False
+
+    @pytest.mark.internal
+    @rounder_override(64)
     def test_add_dummy_requests_parallel_populates_state(self):
 
         dynamic_context = self._get_dynamic_context(

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -577,6 +577,10 @@ class TestDynamicContext:
 
         mamba_idx = dynamic_context.mamba_metadata.request_to_mamba_state_idx[0].item()
         assert mamba_idx >= 0
+
+        # Mamba state zeroing is deferred until transfer_bookkeeping_to_gpu().
+        dynamic_context.initialize_attention_state()
+        dynamic_context.transfer_bookkeeping_to_gpu()
         assert torch.all(dynamic_context.mamba_conv_states[:, mamba_idx] == 0)
         assert torch.all(dynamic_context.mamba_ssm_states[:, mamba_idx] == 0)
 

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -221,7 +221,7 @@ class TestDynamicContext:
                 dynamic_context.add_request(
                     DynamicInferenceRequest(
                         request_id=i,
-                        prompt_tokens=torch.zeros(10, device='cuda'),
+                        prompt_tokens=torch.zeros(10, device='cpu'),
                         sampling_params=SamplingParams(
                             num_tokens_to_generate=dynamic_context.max_tokens - 10
                         ),
@@ -249,7 +249,7 @@ class TestDynamicContext:
             dynamic_context.add_request(
                 DynamicInferenceRequest(
                     request_id=1,
-                    prompt_tokens=torch.arange(0, 225, device='cuda'),
+                    prompt_tokens=torch.arange(0, 225, device='cpu'),
                     sampling_params=SamplingParams(
                         num_tokens_to_generate=dynamic_context.max_tokens - 25
                     ),
@@ -279,7 +279,7 @@ class TestDynamicContext:
         dynamic_context.paused_request_count = 5
         dynamic_context.padded_active_token_count = 10
         dynamic_context.padded_active_request_count = 5
-        dynamic_context.paused_tokens = torch.tensor([1, 2, 3], device='cuda')
+        dynamic_context.paused_tokens = torch.tensor([1, 2, 3], device='cpu')
         dynamic_context.request_ids.fill_(1)
         dynamic_context.request_query_lengths.fill_(1)
         dynamic_context.request_kv_length_offsets.fill_(1)
@@ -363,7 +363,7 @@ class TestDynamicContext:
         )
         assert dynamic_context.kv_block_allocator.total_avail == expected_block_count_avail
         dynamic_context.kv_block_allocator.release_memory_blocks(
-            torch.tensor(expected_memory_blocks[-2:], device='cuda')
+            torch.tensor(expected_memory_blocks[-2:], device='cpu')
         )
         assert dynamic_context.kv_block_allocator.total_avail == expected_block_count_avail + 2
         assert (
@@ -400,7 +400,7 @@ class TestDynamicContext:
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=0,
-                prompt_tokens=torch.arange(0, context_length, dtype=torch.long, device='cuda'),
+                prompt_tokens=torch.arange(0, context_length, dtype=torch.long, device='cpu'),
                 sampling_params=SamplingParams(
                     num_tokens_to_generate=dynamic_context.max_tokens - context_length
                 ),
@@ -419,15 +419,15 @@ class TestDynamicContext:
         assert dynamic_context.request_last_kv_block_offset[0].item() == 15
         assert torch.all(
             dynamic_context.token_to_pos_ids[0:context_length]
-            == torch.arange(0, context_length, dtype=torch.long, device='cuda')
+            == torch.arange(0, context_length, dtype=torch.long, device='cpu')
         )
         assert torch.all(
             dynamic_context.token_to_input_ids[0:context_length]
-            == torch.arange(0, context_length, dtype=torch.long, device='cuda')
+            == torch.arange(0, context_length, dtype=torch.long, device='cpu')
         )
         assert torch.all(
             dynamic_context.token_to_position_in_request[0:context_length]
-            == torch.arange(0, context_length, dtype=torch.long, device='cuda')
+            == torch.arange(0, context_length, dtype=torch.long, device='cpu')
         )
 
         # Verify token_to_block_idx and token_to_local_position_within_kv_block based on assigned blocks
@@ -448,7 +448,7 @@ class TestDynamicContext:
         )
         assert torch.all(
             dynamic_context.token_to_local_position_within_kv_block[0:context_length]
-            == torch.arange(0, context_length, dtype=torch.long, device='cuda')
+            == torch.arange(0, context_length, dtype=torch.long, device='cpu')
             % dynamic_context.block_size_tokens
         )
 
@@ -470,12 +470,12 @@ class TestDynamicContext:
         requests = [
             DynamicInferenceRequest(
                 request_id=100,
-                prompt_tokens=torch.arange(0, 3, device='cuda'),
+                prompt_tokens=torch.arange(0, 3, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=2, termination_id=7),
             ),
             DynamicInferenceRequest(
                 request_id=101,
-                prompt_tokens=torch.arange(3, 9, device='cuda'),
+                prompt_tokens=torch.arange(3, 9, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=1, termination_id=8),
             ),
         ]
@@ -492,12 +492,12 @@ class TestDynamicContext:
         assert dynamic_context.kv_block_allocator.total_avail == block_avail_before
 
         expected_tokens = torch.cat(
-            [torch.arange(0, 3, device='cuda'), torch.arange(3, 9, device='cuda')]
+            [torch.arange(0, 3, device='cpu'), torch.arange(3, 9, device='cpu')]
         )
         assert torch.equal(dynamic_context.token_to_input_ids[:total_tokens], expected_tokens)
 
         expected_positions = torch.tensor(
-            [0, 1, 2, 0, 1, 2, 3, 4, 5], device='cuda', dtype=torch.long
+            [0, 1, 2, 0, 1, 2, 3, 4, 5], device='cpu', dtype=torch.long
         )
         assert torch.equal(
             dynamic_context.token_to_position_in_request[:total_tokens], expected_positions
@@ -505,7 +505,7 @@ class TestDynamicContext:
         assert torch.equal(dynamic_context.token_to_pos_ids[:total_tokens], expected_positions)
 
         expected_request_indices = torch.tensor(
-            [0, 0, 0, 1, 1, 1, 1, 1, 1], device='cuda', dtype=torch.long
+            [0, 0, 0, 1, 1, 1, 1, 1, 1], device='cpu', dtype=torch.long
         )
         assert torch.equal(
             dynamic_context.token_to_request_idx[:total_tokens], expected_request_indices
@@ -521,15 +521,15 @@ class TestDynamicContext:
 
         assert torch.equal(
             dynamic_context.request_query_lengths[: len(requests)],
-            torch.tensor(lengths, device='cuda', dtype=torch.int32),
+            torch.tensor(lengths, device='cpu', dtype=torch.int32),
         )
         assert torch.equal(
             dynamic_context.request_output_lengths[: len(requests)],
-            torch.tensor([5, 7], device='cuda', dtype=torch.int32),
+            torch.tensor([5, 7], device='cpu', dtype=torch.int32),
         )
         assert torch.equal(
             dynamic_context.request_kv_block_counts[: len(requests)],
-            torch.tensor([1, 2], device='cuda', dtype=torch.int32),
+            torch.tensor([1, 2], device='cpu', dtype=torch.int32),
         )
         assert torch.all(
             dynamic_context.request_to_kv_block_ids[0, :1] == dummy_block_idx
@@ -542,12 +542,12 @@ class TestDynamicContext:
         assert torch.all(dynamic_context.request_last_kv_block_id[:2] == dummy_block_idx)
         assert torch.equal(
             dynamic_context.request_last_kv_block_offset[:2],
-            torch.tensor([2, 1], device='cuda', dtype=torch.int32),
+            torch.tensor([2, 1], device='cpu', dtype=torch.int32),
         )
 
         assert torch.equal(
             dynamic_context.request_metadata["termination_id"][:2],
-            torch.tensor([7.0, 8.0], device='cuda'),
+            torch.tensor([7.0, 8.0], device='cpu'),
         )
 
     @pytest.mark.internal
@@ -569,7 +569,7 @@ class TestDynamicContext:
 
         request = DynamicInferenceRequest(
             request_id=55,
-            prompt_tokens=torch.arange(0, 5, device='cuda'),
+            prompt_tokens=torch.arange(0, 5, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=4, termination_id=9),
         )
 
@@ -597,7 +597,7 @@ class TestDynamicContext:
 
         request = DynamicInferenceRequest(
             request_id=5,
-            prompt_tokens=torch.arange(0, 1, device='cuda'),
+            prompt_tokens=torch.arange(0, 1, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=1, termination_id=2),
         )
 
@@ -663,10 +663,10 @@ class TestDynamicContext:
             is_hybrid_model=is_hybrid_model,
         )
 
-        active_requests_mask = torch.Tensor([1, 0, 1, 1, 1, 0, 0, 1]).cuda().int()
-        next_tokens = torch.arange(2, 10, device='cuda').int()
+        active_requests_mask = torch.Tensor([1, 0, 1, 1, 1, 0, 0, 1]).int()
+        next_tokens = torch.arange(2, 10, device='cpu').int()
         dynamic_context.paused_request_count = 2
-        dynamic_context.paused_tokens = torch.Tensor([0, 1]).cuda().int()
+        dynamic_context.paused_tokens = torch.Tensor([0, 1]).int()
         dynamic_context.total_request_count = 5
 
         # Total req count should be equal to paused + num elements in active request mask.
@@ -723,7 +723,7 @@ class TestDynamicContext:
 
         # Then set up the test data
         dynamic_context.request_ids[0:10] = torch.tensor(
-            [0, 1, 5, 6, 4, 2, 9, 7, 8, 9], device=torch.cuda.current_device()
+            [0, 1, 5, 6, 4, 2, 9, 7, 8, 9], device='cpu'
         )
 
         # Now verify the values
@@ -850,12 +850,12 @@ class TestDynamicContext:
 
         # Create an active_requests_mask where requests 0, 2, and 4 are finished (0),
         # and requests 1 and 3 are still active (1)
-        active_requests_mask = torch.tensor([0, 1, 0, 1, 0], device=torch.cuda.current_device())
+        active_requests_mask = torch.tensor([0, 1, 0, 1, 0], device='cpu')
 
         # Call update_requests with these parameters
         dynamic_context.update_requests(
             active_requests_mask=active_requests_mask,
-            new_tokens=torch.tensor([10, 11, 12, 13, 14], device=torch.cuda.current_device()),
+            new_tokens=torch.tensor([10, 11, 12, 13, 14], device='cpu'),
         )
 
         # After the update, we should have released 3 blocks (for requests 0, 2, and 4)
@@ -939,12 +939,12 @@ class TestDynamicContext:
                 dynamic_context.mamba_metadata.mamba_state_free_slot_count -= 1
 
         # Create an active_requests_mask where all requests are finished
-        active_requests_mask = torch.tensor([0, 0, 0], device=torch.cuda.current_device())
+        active_requests_mask = torch.tensor([0, 0, 0], device='cpu')
 
         # Call update_requests with these parameters
         dynamic_context.update_requests(
             active_requests_mask=active_requests_mask,
-            new_tokens=torch.tensor([10, 11, 12], device=torch.cuda.current_device()),
+            new_tokens=torch.tensor([10, 11, 12], device='cpu'),
         )
 
         # After the update, we should have released all 6 blocks and have 0 active requests
@@ -994,7 +994,7 @@ class TestDynamicContext:
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=0,
-                prompt_tokens=torch.arange(0, context_length, dtype=torch.long, device='cuda'),
+                prompt_tokens=torch.arange(0, context_length, dtype=torch.long, device='cpu'),
                 sampling_params=SamplingParams(
                     num_tokens_to_generate=dynamic_context.max_tokens - 10
                 ),
@@ -1047,17 +1047,17 @@ class TestDynamicContext:
         # Add a few requests to the context
         request_data = {
             1001: {
-                "tokens": torch.randint(0, 100, (10,), device='cuda'),
+                "tokens": torch.randint(0, 100, (10,), device='cpu'),
                 "prefill_len": 10,
                 "initial_token_offset": 0,
             },
             1002: {
-                "tokens": torch.randint(0, 100, (5,), device='cuda'),
+                "tokens": torch.randint(0, 100, (5,), device='cpu'),
                 "prefill_len": 5,
                 "initial_token_offset": 10,
             },
             1003: {
-                "tokens": torch.randint(0, 100, (7,), device='cuda'),
+                "tokens": torch.randint(0, 100, (7,), device='cpu'),
                 "prefill_len": 7,
                 "initial_token_offset": 15,
             },
@@ -1081,7 +1081,12 @@ class TestDynamicContext:
         # Simulate prefill step
         total_active_tokens = dynamic_context.active_token_count
         vocab_size = 50000
-        # logits will have shape [1, total_active_tokens, vocab_size]
+
+        # Populate gpu_view for calculate_log_probs (which reads from gpu_view).
+        dynamic_context.initialize_attention_state()
+        dynamic_context.transfer_bookkeeping_to_gpu()
+
+        # logits and new_tokens must be on GPU (calculate_log_probs uses gpu_view).
         prefill_logits = torch.randn(
             1, total_active_tokens, vocab_size, device='cuda', dtype=torch.float32
         )
@@ -1122,11 +1127,15 @@ class TestDynamicContext:
 
         # Simulate decode step
         # All requests are active, so the mask will be all ones for the current active requests
-        active_requests_mask = torch.ones(dynamic_context.total_request_count, device='cuda').int()
+        active_requests_mask = torch.ones(dynamic_context.total_request_count, device='cpu').int()
 
         dynamic_context.update_requests(
             active_requests_mask=active_requests_mask, new_tokens=prefill_new_tokens
         )
+
+        # Populate gpu_view again after update_requests modified bookkeeping state.
+        dynamic_context.initialize_attention_state()
+        dynamic_context.transfer_bookkeeping_to_gpu()
 
         # Generate new logits for the decode step. Now each request contributes 1 token.
         decode_logits = torch.randn(
@@ -1153,7 +1162,7 @@ class TestDynamicContext:
 
         # Add a new prefill request to the existing context
         new_request_id = 1004
-        new_request_tokens = torch.randint(0, 100, (12,), device='cuda').long()
+        new_request_tokens = torch.randint(0, 100, (12,), device='cpu').long()
         new_request_prefill_len = new_request_tokens.shape[0]
         initial_token_offset_new_request = dynamic_context.active_token_count
         dynamic_context.add_request(
@@ -1175,6 +1184,7 @@ class TestDynamicContext:
         # This step will involve both prefill (for the new request) and decode (for existing requests).
 
         dynamic_context.initialize_attention_state()
+        dynamic_context.transfer_bookkeeping_to_gpu()
 
         total_active_tokens_mixed_step = dynamic_context.active_token_count
         mixed_step_logits = torch.randn(
@@ -1299,7 +1309,7 @@ class TestDynamicContext:
             ),
         )
 
-        # Collect the total block counts on each rank
+        # Collect the total block counts on each rank (CUDA needed for NCCL all_gather)
         local_total_blocks = torch.tensor(
             [context.kv_block_allocator.total_count], device='cuda', dtype=torch.long
         )
@@ -1654,14 +1664,14 @@ class TestDynamicContext:
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=10,
-                prompt_tokens=torch.arange(0, 2, device='cuda'),
+                prompt_tokens=torch.arange(0, 2, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=10),
             )
         )
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=11,
-                prompt_tokens=torch.arange(0, 2, device='cuda'),
+                prompt_tokens=torch.arange(0, 2, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=10),
             )
         )
@@ -1669,7 +1679,7 @@ class TestDynamicContext:
         # Add Chunk 1 of the chunked prefill request
         req_999 = DynamicInferenceRequest(
             request_id=999,
-            prompt_tokens=torch.arange(0, 8, device='cuda'),
+            prompt_tokens=torch.arange(0, 8, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=10),
         )
         dynamic_context.add_request(req_999, prefill_chunk_length=4)
@@ -1683,8 +1693,8 @@ class TestDynamicContext:
         assert kv_block_before != -1
 
         # Step 1: Forward pass for all 3 requests
-        active_requests_mask = torch.tensor([1, 1, 1], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([100, 101, 102], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([1, 1, 1], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([100, 101, 102], dtype=torch.int32, device='cpu')
         dynamic_context.update_requests(active_requests_mask, new_tokens)
 
         # At this point, req 999 is hidden at index 2. total_request_count is 2 (req 10, 11).
@@ -1692,8 +1702,8 @@ class TestDynamicContext:
         assert dynamic_context.request_ids[2].item() == 999
 
         # Step 2: Forward pass where req 10 finishes, req 11 continues. Req 999 is NOT scheduled.
-        active_requests_mask = torch.tensor([0, 1], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([103, 104], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([0, 1], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([103, 104], dtype=torch.int32, device='cpu')
         dynamic_context.update_requests(active_requests_mask, new_tokens)
 
         # At this point, req 10 is evicted. Req 11 shifts to index 0. total_request_count becomes 1.
@@ -1756,14 +1766,14 @@ class TestDynamicContext:
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=10,
-                prompt_tokens=torch.arange(0, 2, device='cuda'),
+                prompt_tokens=torch.arange(0, 2, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=10),
             )
         )
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=11,
-                prompt_tokens=torch.arange(0, 2, device='cuda'),
+                prompt_tokens=torch.arange(0, 2, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=10),
             )
         )
@@ -1771,7 +1781,7 @@ class TestDynamicContext:
         # Add Chunk 1 of a chunked prefill request
         req_999 = DynamicInferenceRequest(
             request_id=999,
-            prompt_tokens=torch.arange(0, 8, device='cuda'),
+            prompt_tokens=torch.arange(0, 8, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=10),
         )
         dynamic_context.add_request(req_999, prefill_chunk_length=4)
@@ -1781,8 +1791,8 @@ class TestDynamicContext:
         assert kv_block_before != -1
 
         # Step 1: All 3 requests are active, process forward pass
-        active_requests_mask = torch.tensor([1, 1, 1], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([100, 101, 102], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([1, 1, 1], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([100, 101, 102], dtype=torch.int32, device='cpu')
         dynamic_context.update_requests(active_requests_mask, new_tokens)
 
         # Chunked prefill is now hidden at position 2, total_request_count = 2
@@ -1791,8 +1801,8 @@ class TestDynamicContext:
 
         # Step 2: Both decode requests finish, chunked prefill NOT scheduled this step.
         # This must NOT crash even though active_request_count becomes 0.
-        active_requests_mask = torch.tensor([0, 0], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([103, 104], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([0, 0], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([103, 104], dtype=torch.int32, device='cpu')
         dynamic_context.update_requests(active_requests_mask, new_tokens)
 
         # total_request_count should be 0 (both finished, chunked prefill hidden)
@@ -1839,10 +1849,10 @@ class TestDynamicContext:
         ctx.request_to_kv_block_ids[:2, 0] = torch.tensor([0, 1])
         ctx.request_last_kv_block_id[:2] = torch.tensor([0, 1])
 
-        active_requests_mask = torch.tensor([1, 1], device='cuda')
-        new_tokens = torch.tensor([99, 100], device='cuda')  # Sampled tokens
+        active_requests_mask = torch.tensor([1, 1], device='cpu')
+        new_tokens = torch.tensor([99, 100], device='cpu')  # Sampled tokens
         new_speculative_tokens = torch.tensor(
-            [[991, 1001], [992, 1002]], device='cuda'
+            [[991, 1001], [992, 1002]], device='cpu'
         )  # Spec tokens
 
         ctx.update_requests(
@@ -1854,15 +1864,15 @@ class TestDynamicContext:
         # Each request generates 1 (sampled) + 2 (speculative) = 3 tokens.
         assert ctx.active_token_count == 6
         assert torch.equal(
-            ctx.request_query_lengths[:2], torch.tensor([3, 3], dtype=torch.int32, device='cuda')
+            ctx.request_query_lengths[:2], torch.tensor([3, 3], dtype=torch.int32, device='cpu')
         )
         assert torch.equal(
             ctx.request_kv_length_offsets[:2],
-            torch.tensor([6, 9], dtype=torch.int32, device='cuda'),
+            torch.tensor([6, 9], dtype=torch.int32, device='cpu'),
         )
 
         # Check interleaving: [sampled_1, spec1_1, spec2_1, sampled_2, spec1_2, spec2_2]
-        expected_tokens = torch.tensor([99, 991, 992, 100, 1001, 1002], device='cuda')
+        expected_tokens = torch.tensor([99, 991, 992, 100, 1001, 1002], device='cpu')
         assert torch.equal(ctx.token_to_input_ids[:6], expected_tokens)
 
     @pytest.mark.internal
@@ -1903,9 +1913,9 @@ class TestDynamicContext:
         ctx.request_to_kv_block_ids[0, 0] = first_block
         ctx.request_last_kv_block_id[0] = first_block
 
-        active_requests_mask = torch.tensor([1], device='cuda')
-        new_tokens = torch.tensor([50], device='cuda')
-        new_speculative_tokens = torch.tensor([[51], [52]], device='cuda')
+        active_requests_mask = torch.tensor([1], device='cpu')
+        new_tokens = torch.tensor([50], device='cpu')
+        new_speculative_tokens = torch.tensor([[51], [52]], device='cpu')
 
         # Run update_requests natively. It will automatically:
         # 1. Detect the boundary crossing and pause the request.
@@ -1929,7 +1939,7 @@ class TestDynamicContext:
         # Token 1 (offset 3) -> first_block
         # Token 2 (offset 4) -> second_block
         expected_blocks = torch.tensor(
-            [first_block, first_block, second_block], dtype=torch.int, device='cuda'
+            [first_block, first_block, second_block], dtype=torch.int, device='cpu'
         )
 
         assert torch.equal(ctx.token_to_block_idx[:3], expected_blocks)
@@ -1979,10 +1989,10 @@ class TestDynamicContext:
         ctx.kv_block_allocator.total_avail = 0
         ctx.kv_block_allocator.paused_count = 100  # Ensure it doesn't get completely evicted either
 
-        active_requests_mask = torch.tensor([1, 1], device='cuda')
-        new_tokens = torch.tensor([99, 100], device='cuda')  # Sampled
+        active_requests_mask = torch.tensor([1, 1], device='cpu')
+        new_tokens = torch.tensor([99, 100], device='cpu')  # Sampled
         new_speculative_tokens = torch.tensor(
-            [[991, 1001], [992, 1002]], device='cuda'
+            [[991, 1001], [992, 1002]], device='cpu'
         )  # Speculative
 
         # In update_requests, request 0 will be paused to allocate a new block.
@@ -2004,7 +2014,7 @@ class TestDynamicContext:
 
         assert ctx.paused_tokens[0].item() == 99
         assert torch.equal(
-            ctx.paused_speculative_tokens[:, 0], torch.tensor([991, 992], device='cuda')
+            ctx.paused_speculative_tokens[:, 0], torch.tensor([991, 992], device='cpu')
         )
 
     @pytest.mark.internal
@@ -2043,8 +2053,8 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         ctx.request_ids[:2] = torch.tensor([10, 11])
-        next_tokens = torch.tensor([99, 100], device='cuda')
-        new_speculative_tokens = torch.tensor([[991, 1001], [992, 1002]], device='cuda')
+        next_tokens = torch.tensor([99, 100], device='cpu')
+        new_speculative_tokens = torch.tensor([[991, 1001], [992, 1002]], device='cpu')
 
         ctx._swap_book_keeping_tensors(
             src_idxs=torch.tensor([0]),
@@ -2053,10 +2063,10 @@ class TestDynamicContext:
             new_speculative_tokens=new_speculative_tokens,
         )
 
-        assert torch.equal(ctx.request_ids[:2], torch.tensor([11, 10], device='cuda'))
-        assert torch.equal(next_tokens[:2], torch.tensor([100, 99], device='cuda'))
+        assert torch.equal(ctx.request_ids[:2], torch.tensor([11, 10], device='cpu'))
+        assert torch.equal(next_tokens[:2], torch.tensor([100, 99], device='cpu'))
         assert torch.equal(
-            new_speculative_tokens[:, :2], torch.tensor([[1001, 991], [1002, 992]], device='cuda')
+            new_speculative_tokens[:, :2], torch.tensor([[1001, 991], [1002, 992]], device='cpu')
         )
 
     @pytest.mark.internal
@@ -2087,9 +2097,9 @@ class TestDynamicContext:
         ctx.request_last_kv_block_id[:3] = torch.tensor([0, 1, 2])
         ctx.request_kv_block_counts[:3] = 1
 
-        active_requests_mask = torch.tensor([1, 0, 1], device='cuda')
-        new_tokens = torch.tensor([99, 100, 101], device='cuda')
-        new_speculative_tokens = torch.tensor([[991, 1001, 1011], [992, 1002, 1012]], device='cuda')
+        active_requests_mask = torch.tensor([1, 0, 1], device='cpu')
+        new_tokens = torch.tensor([99, 100, 101], device='cpu')
+        new_speculative_tokens = torch.tensor([[991, 1001, 1011], [992, 1002, 1012]], device='cpu')
 
         ctx.update_requests(
             active_requests_mask=active_requests_mask,
@@ -2100,13 +2110,13 @@ class TestDynamicContext:
         # req1 is finished. req2 moves to req1's position.
         assert ctx.total_request_count == 2
         assert torch.equal(
-            ctx.request_ids[:2], torch.tensor([10, 12], device='cuda', dtype=torch.int32)
+            ctx.request_ids[:2], torch.tensor([10, 12], device='cpu', dtype=torch.int32)
         )
 
         # Check interleaving for req0 and req2
         # req0: [99, 991, 992]
         # req2: [101, 1011, 1012]
-        expected_tokens = torch.tensor([99, 991, 992, 101, 1011, 1012], device='cuda')
+        expected_tokens = torch.tensor([99, 991, 992, 101, 1011, 1012], device='cpu')
         assert torch.equal(ctx.token_to_input_ids[:6], expected_tokens)
 
     @pytest.mark.internal
@@ -2137,7 +2147,7 @@ class TestDynamicContext:
         # 1. Add a standard decode request
         req_decode = DynamicInferenceRequest(
             request_id=10,
-            prompt_tokens=torch.arange(0, 10, device='cuda'),
+            prompt_tokens=torch.arange(0, 10, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=10),
         )
         ctx.add_request(req_decode)
@@ -2145,7 +2155,7 @@ class TestDynamicContext:
         # 2. Add chunk 1 of a chunked prefill request
         req_chunked = DynamicInferenceRequest(
             request_id=42,
-            prompt_tokens=torch.arange(0, 100, device='cuda'),
+            prompt_tokens=torch.arange(0, 100, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=10),
         )
         ctx.chunked_prefill_request_id = 42
@@ -2155,10 +2165,10 @@ class TestDynamicContext:
         assert ctx.active_token_count == 60
 
         # 3. Call update_requests
-        active_requests_mask = torch.tensor([1, 1], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([99, 199], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([1, 1], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([99, 199], dtype=torch.int32, device='cpu')
         new_spec = torch.tensor(
-            [[100, 200], [101, 201], [102, 202]], dtype=torch.int32, device='cuda'
+            [[100, 200], [101, 201], [102, 202]], dtype=torch.int32, device='cpu'
         )
 
         ctx.update_requests(
@@ -2223,13 +2233,13 @@ class TestDynamicContext:
         ctx.request_last_kv_block_id[:2] = torch.tensor([0, 1])
         ctx.request_kv_block_counts[:2] = 1
 
-        active_requests_mask = torch.tensor([1, 1], device='cuda')
+        active_requests_mask = torch.tensor([1, 1], device='cpu')
 
         # New base tokens: [100 (for prefill), 200 (for decode)]
-        new_tokens = torch.tensor([100, 200], device='cuda')
+        new_tokens = torch.tensor([100, 200], device='cpu')
 
         # New spec tokens: Col 0 for prefill (dummy), Col 1 for decode (real draft tokens)
-        new_speculative_tokens = torch.tensor([[101, 201], [102, 202]], device='cuda')
+        new_speculative_tokens = torch.tensor([[101, 201], [102, 202]], device='cpu')
 
         # Trigger update_requests.
         # It must detect ID 42 is at index 0, and swap it with index 1.
@@ -2241,7 +2251,7 @@ class TestDynamicContext:
 
         # 1. Verify the IDs were swapped successfully
         assert torch.equal(
-            ctx.request_ids[:2], torch.tensor([99, 42], dtype=torch.int32, device='cuda')
+            ctx.request_ids[:2], torch.tensor([99, 42], dtype=torch.int32, device='cpu')
         )
 
         # 2. Verify the Decode request (now at Index 0) correctly flattened its
@@ -2249,7 +2259,7 @@ class TestDynamicContext:
         # 3. Verify the Prefill request (now at Index 1) is hidden and does NOT
         #    flatten its dummy tokens.
         expected_flattened_tokens = torch.tensor(
-            [200, 201, 202], device='cuda'  # Decode request (ID 99)
+            [200, 201, 202], device='cpu'  # Decode request (ID 99)
         )
 
         assert ctx.active_token_count == 3
@@ -2259,7 +2269,7 @@ class TestDynamicContext:
 
         # 4. Verify that the new_speculative_tokens tensor itself was swapped so that
         # the hidden state perfectly preserves the alignment for subsequent steps.
-        expected_swapped_spec_tokens = torch.tensor([[201, 101], [202, 102]], device='cuda')
+        expected_swapped_spec_tokens = torch.tensor([[201, 101], [202, 102]], device='cpu')
         assert torch.equal(
             new_speculative_tokens, expected_swapped_spec_tokens
         ), "new_speculative_tokens was not swapped in-place alongside the request metadata!"
@@ -2287,7 +2297,7 @@ class TestDynamicContext:
         # This avoids the single-token-chunk clamp (effective_prefill >= 2) and
         # verifies that the prefix skip actually works.
         tail = 5
-        prompt = torch.arange(bs * 3 + tail, device='cuda')
+        prompt = torch.arange(bs * 3 + tail, device='cpu')
 
         # First request registers blocks.
         req1 = DynamicInferenceRequest(
@@ -2349,7 +2359,7 @@ class TestDynamicContext:
         # Use bs * 2 + 5 tokens so the prompt extends past the last full block,
         # avoiding the single-token-chunk clamp while still testing the skip.
         tail = 5
-        prompt = torch.arange(bs * 2 + tail, device='cuda')
+        prompt = torch.arange(bs * 2 + tail, device='cpu')
 
         # First request.
         req1 = DynamicInferenceRequest(
@@ -2397,7 +2407,7 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         bs = ctx.block_size_tokens
-        prompt = torch.arange(bs * 2, device='cuda')
+        prompt = torch.arange(bs * 2, device='cpu')
 
         # Two requests sharing the same prefix.
         req1 = DynamicInferenceRequest(
@@ -2454,7 +2464,7 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         bs = ctx.block_size_tokens
-        prompt = torch.arange(bs * 2, device='cuda')
+        prompt = torch.arange(bs * 2, device='cpu')
 
         # Request 1: adds prefix blocks.
         req1 = DynamicInferenceRequest(
@@ -2491,9 +2501,9 @@ class TestDynamicContext:
         ctx.request_in_prefill_status_tensor[0] = 0
         ctx.active_token_count = 2
 
-        active_mask = torch.tensor([1, 1], device='cuda', dtype=torch.int32)
-        new_tokens = torch.tensor([50, 50], device='cuda')
-        new_spec = torch.tensor([[51, 51], [52, 52]], device='cuda')
+        active_mask = torch.tensor([1, 1], device='cpu', dtype=torch.int32)
+        new_tokens = torch.tensor([50, 50], device='cpu')
+        new_spec = torch.tensor([[51, 51], [52, 52]], device='cpu')
 
         ctx.update_requests(
             active_requests_mask=active_mask, new_tokens=new_tokens, new_speculative_tokens=new_spec
@@ -2535,7 +2545,7 @@ class TestDynamicContext:
         bs = ctx.block_size_tokens
 
         # First request: register prefix blocks (bs * 3 tokens = 3 complete blocks).
-        first_prompt = torch.arange(bs * 3, device='cuda')
+        first_prompt = torch.arange(bs * 3, device='cpu')
         req_first = DynamicInferenceRequest(
             request_id=1,
             prompt_tokens=first_prompt.clone(),
@@ -2560,9 +2570,9 @@ class TestDynamicContext:
         ctx.add_request(req2, prefill_chunk_length=bs)
 
         # Call update_requests to move req2 to the hidden state
-        active_requests_mask = torch.tensor([1, 1], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([99, 199], dtype=torch.int32, device='cuda')
-        new_spec = torch.tensor([[100, 200], [101, 201]], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([1, 1], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([99, 199], dtype=torch.int32, device='cpu')
+        new_spec = torch.tensor([[100, 200], [101, 201]], dtype=torch.int32, device='cpu')
         ctx.update_requests(active_requests_mask, new_tokens, new_speculative_tokens=new_spec)
 
         # Capture active tokens before chunk 2 (which should just be the 3 tokens of req_first)
@@ -2604,7 +2614,7 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         bs = ctx.block_size_tokens
-        prompt = torch.arange(bs * 2, device='cuda')
+        prompt = torch.arange(bs * 2, device='cpu')
 
         # First request registers blocks.
         req1 = DynamicInferenceRequest(
@@ -2654,7 +2664,7 @@ class TestDynamicContext:
         bs = ctx.block_size_tokens
 
         # req1: 32 tokens (exactly 2 complete blocks)
-        prompt1 = torch.arange(bs * 2, device='cuda')
+        prompt1 = torch.arange(bs * 2, device='cpu')
         req1 = DynamicInferenceRequest(
             request_id=1,
             prompt_tokens=prompt1,
@@ -2665,7 +2675,7 @@ class TestDynamicContext:
         ctx.add_request(req1)
 
         # req2: 35 tokens (first 32 tokens match req1)
-        prompt2 = torch.arange(bs * 2 + 3, device='cuda')
+        prompt2 = torch.arange(bs * 2 + 3, device='cpu')
         req2 = DynamicInferenceRequest(
             request_id=2,
             prompt_tokens=prompt2,
@@ -2712,7 +2722,7 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         bs = ctx.block_size_tokens
-        prompt = torch.arange(bs * 2, device='cuda')
+        prompt = torch.arange(bs * 2, device='cpu')
 
         # Add req1 and req2 with identical prompts
         req1 = DynamicInferenceRequest(
@@ -2752,7 +2762,7 @@ class TestDynamicContext:
 
         # Trigger the eviction logic
         # next_tokens must be sized to total_request_count (1 paused + 1 active = 2)
-        next_tokens = torch.tensor([50, 51], device='cuda')
+        next_tokens = torch.tensor([50, 51], device='cpu')
         evicted_ids = ctx.evict_overflow_paused_requests(
             active_request_count=1, next_tokens=next_tokens
         )
@@ -2792,17 +2802,17 @@ class TestDynamicContext:
         ctx.paused_request_count = 0
         ctx.active_token_count = 2
 
-        ctx.request_ids[:2] = torch.tensor([10, 11], device='cuda')
+        ctx.request_ids[:2] = torch.tensor([10, 11], device='cpu')
         ctx.request_query_lengths[:2] = 1
         ctx.request_kv_block_counts[:2] = 1
 
         # Request 0 offset is 15. Adding 1 sampled + 2 spec = 3 tokens crosses the boundary (16).
         # Request 1 offset is 5. Adding 3 tokens = 8 (does not cross).
         ctx.request_kv_length_offsets[:2] = torch.tensor(
-            [bs - 1, 5], device='cuda', dtype=torch.int32
+            [bs - 1, 5], device='cpu', dtype=torch.int32
         )
         ctx.request_last_kv_block_offset[:2] = torch.tensor(
-            [bs - 1, 5], device='cuda', dtype=torch.int32
+            [bs - 1, 5], device='cpu', dtype=torch.int32
         )
 
         blocks = ctx.kv_block_allocator.allocate_memory_blocks(2)
@@ -2814,9 +2824,9 @@ class TestDynamicContext:
         ctx.kv_block_allocator.total_avail = 0
         ctx.kv_block_allocator.paused_count = 100  # Prevent immediate eviction out of the system
 
-        active_mask = torch.tensor([1, 1], device='cuda', dtype=torch.int32)
-        new_tokens = torch.tensor([99, 88], device='cuda')
-        new_spec = torch.tensor([[100, 200], [101, 201]], device='cuda')
+        active_mask = torch.tensor([1, 1], device='cpu', dtype=torch.int32)
+        new_tokens = torch.tensor([99, 88], device='cpu')
+        new_spec = torch.tensor([[100, 200], [101, 201]], device='cpu')
 
         # Run update requests
         ctx.update_requests(
@@ -2880,9 +2890,9 @@ class TestDynamicContext:
         ctx.request_to_kv_block_ids[0, 1] = blocks[1]
         ctx.request_last_kv_block_id[0] = blocks[1]
 
-        active_requests_mask = torch.tensor([1], device='cuda')
-        new_tokens = torch.tensor([50], device='cuda')
-        new_speculative_tokens = torch.tensor([[51], [52]], device='cuda')
+        active_requests_mask = torch.tensor([1], device='cpu')
+        new_tokens = torch.tensor([50], device='cpu')
+        new_speculative_tokens = torch.tensor([[51], [52]], device='cpu')
 
         # This will pause the request (offset 13 >= 13), then resume it by
         # allocating a 3rd block at col_idx=2. Without the fix, this raises
@@ -2921,7 +2931,7 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         bs = ctx.block_size_tokens
-        prompt = torch.arange(128, device='cuda')
+        prompt = torch.arange(128, device='cpu')
 
         # Cache req1 (fully processed)
         req1 = DynamicInferenceRequest(

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -793,6 +793,9 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         req3 = self._req(ctx3, p3.clone(), request_id=2)
         req3._mamba_num_matched_blocks = 0
         ctx3.add_request(req3)
+        # Deferred Mamba ops execute during transfer.
+        ctx3.initialize_attention_state()
+        ctx3.transfer_bookkeeping_to_gpu()
         assert ctx3.mamba_slot_allocator._eos_cache_block_id_gpu[1].item() >= 0
 
         # intermediate output buffers are pre-allocated

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -762,12 +762,12 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
             overall,
         )
         # Penultimate block offset (block 2 boundary) is a valid intermediate
-        count = msa._intermediate_counts_gpu[1].item()
+        count = msa._intermediate_counts_cpu[1].item()
         if count > 0:
-            offsets = msa._intermediate_offsets_gpu[1, :count].tolist()
+            offsets = msa._intermediate_offsets_cpu[1, :count].tolist()
             for o in offsets:
                 assert o > 0 and o % 128 == 0
-        assert msa._eos_cache_block_id_gpu[1].item() >= 0
+        assert msa._eos_cache_block_id_cpu[1].item() >= 0
 
         # non-aligned prompt produces last_aligned intermediate offset
         ctx2 = self._mctx(block_size_tokens=bs)
@@ -779,12 +779,12 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         req2b = self._req(ctx2, p2.clone(), request_id=2)
         req2b._mamba_num_matched_blocks = 2
         ctx2.add_request(req2b)
-        count2 = msa2._intermediate_counts_gpu[1].item()
+        count2 = msa2._intermediate_counts_cpu[1].item()
         if count2 > 0:
-            offsets = msa2._intermediate_offsets_gpu[1, :count2].tolist()
+            offsets = msa2._intermediate_offsets_cpu[1, :count2].tolist()
             for o in offsets:
                 assert o > 0 and o % 128 == 0
-        assert msa2._eos_cache_block_id_gpu[1].item() < 0
+        assert msa2._eos_cache_block_id_cpu[1].item() < 0
 
         # block-aligned prompts set EOS cache block ID
         ctx3 = self._mctx(block_size_tokens=bs)
@@ -796,7 +796,7 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         # Deferred Mamba ops execute during transfer.
         ctx3.initialize_attention_state()
         ctx3.transfer_bookkeeping_to_gpu()
-        assert ctx3.mamba_slot_allocator._eos_cache_block_id_gpu[1].item() >= 0
+        assert ctx3.mamba_slot_allocator._eos_cache_block_id_cpu[1].item() >= 0
 
         # intermediate output buffers are pre-allocated
         ctx4 = self._mctx()
@@ -1030,9 +1030,9 @@ class TestMambaSlotAllocator(PrefixCachingTestBase):
 
         # Set up intermediate offsets: 1 intermediate at src_offset=0
         bid0 = ctx.request_to_kv_block_ids[ctx_idx][0].item()
-        msa._intermediate_block_ids_gpu[ctx_idx, 0] = bid0
-        msa._intermediate_offsets_gpu[ctx_idx, 0] = 128
-        msa._intermediate_counts_gpu[ctx_idx] = 1
+        msa._intermediate_block_ids_cpu[ctx_idx, 0] = bid0
+        msa._intermediate_offsets_cpu[ctx_idx, 0] = 128
+        msa._intermediate_counts_cpu[ctx_idx] = 1
         msa._has_intermediates = True
 
         # Set metadata fields that would normally be set by _update_intermediate_offsets
@@ -1041,7 +1041,7 @@ class TestMambaSlotAllocator(PrefixCachingTestBase):
 
         # Set up EOS block (block-aligned prompt)
         eos_bid = ctx.request_to_kv_block_ids[ctx_idx][2].item()
-        msa._eos_cache_block_id_gpu[ctx_idx] = eos_bid
+        msa._eos_cache_block_id_cpu[ctx_idx] = eos_bid
 
         # Write known patterns to live mamba state for EOS copy
         mamba_idx = metadata.request_to_mamba_state_idx[ctx_idx].item()

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -901,6 +901,7 @@ class TestMixedCachedAndFreshPrefill(PrefixCachingTestBase):
 
         # last_token_logits
         ctx.initialize_attention_state()
+        ctx.transfer_bookkeeping_to_gpu()
         logits = torch.randn(
             1, ctx.padded_active_token_count, vocab_size, device=torch.cuda.current_device()
         )

--- a/tools/run_dynamic_text_generation_server.py
+++ b/tools/run_dynamic_text_generation_server.py
@@ -10,7 +10,7 @@ from megatron.core.inference.text_generation_server.dynamic_text_gen_server impo
     start_text_gen_server,
     stop_text_gen_server,
 )
-from megatron.core.utils import trace_async_exceptions
+from megatron.core.utils import configure_nvtx_profiling, trace_async_exceptions
 from megatron.inference.utils import add_inference_args, get_dynamic_inference_engine
 from megatron.post_training.arguments import add_modelopt_args
 from megatron.training.arguments import parse_and_validate_args
@@ -81,6 +81,13 @@ if __name__ == "__main__":
             args_defaults={'no_load_rng': True, 'no_load_optim': True},
         )
         initialize_megatron()
+
+        # Match training's NVTX gating (training.py only flips this when both
+        # --profile and --nvtx-ranges are set). Otherwise the engine-side
+        # nvtx_range_push labels (bookkeeping, Decode, _ep_establish_consensus,
+        # etc.) are no-ops and the inter-step gap is unattributable in nsys.
+        if args.profile and args.nvtx_ranges:
+            configure_nvtx_profiling(True)
 
         # Enable return_log_probs to allow prompt logprobs computation for echo=True requests
         # This sets materialize_only_last_token_logits=False in the inference context,

--- a/tools/run_dynamic_text_generation_server.py
+++ b/tools/run_dynamic_text_generation_server.py
@@ -13,7 +13,7 @@ from megatron.core.inference.text_generation_server.dynamic_text_gen_server impo
 from megatron.core.utils import trace_async_exceptions
 from megatron.inference.utils import add_inference_args, get_dynamic_inference_engine
 from megatron.post_training.arguments import add_modelopt_args
-from megatron.training import get_args
+from megatron.training.arguments import parse_and_validate_args
 from megatron.training.initialize import initialize_megatron
 
 
@@ -76,15 +76,15 @@ async def run_text_generation_server(
 
 if __name__ == "__main__":
     with torch.inference_mode():
-        initialize_megatron(
+        args = parse_and_validate_args(
             extra_args_provider=add_text_generation_server_args,
             args_defaults={'no_load_rng': True, 'no_load_optim': True},
         )
+        initialize_megatron()
 
         # Enable return_log_probs to allow prompt logprobs computation for echo=True requests
         # This sets materialize_only_last_token_logits=False in the inference context,
         # which is required for lm-eval compatibility (loglikelihood evaluation tasks)
-        args = get_args()
         args.return_log_probs = True
 
         engine = get_dynamic_inference_engine()


### PR DESCRIPTION
> [!NOTE]
> **Builds on and depends on #4306** ("Move inference context bookkeeping to CPU with ContextGPUView"). #4306 must land first; the async-scheduling commits in this PR sit directly on top of that branch's tip.

## Summary

- Speculative forward passes for the dynamic inference engine: on pure-decode chains the engine pre-launches step N+1's `H2D → forward → sample` while CPU bookkeeping for step N runs in parallel, so the GPU stream stays continuously busy with `forward → sample → forward → sample`.
- Correct under rejection: the speculative pre-launch is rolled back when CPU bookkeeping detects a finish, pause, evict, or new-request event. Rollback restores the sampling RNG state and (for hybrid models) the per-active-request Mamba `conv_states` / `ssm_states` slices via a stream-ordered shadow-buffer copy. Attention KV writes are idempotent and need no rollback.
- Configurable via `--inference-dynamic-batching-async-scheduling` (default on) and `--inference-dynamic-batching-finished-sync-period`. Falls back transparently to today's serial path when the speculation predicate (`is_decode_only`, no boundary crossing, no waiting requests, no spec-decoding interaction) is not satisfied.

## Commits

- `C1` GPU-resident token flow: sampling kernel mirrors into `gpu_view.token_to_input_ids` so the next forward's CUDA graph reads the sample directly.
- `C2` Lookahead predicates (`predict_decode_blocks_needed`, `can_speculate_decode_step`).
- `C3` Async-scheduling configuration + engine gating predicate.
- `C3.5` Structural split of `async_step` into serial and speculative paths.
- `C4` Rejection detection + periodic finished-sync gating.
- `C5.1` Split controller decode step into `_launch_decode_step` and `_bookkeep_decode_step`.
- `C5.2` Speculative state advance/restore (`speculatively_advance_for_next_decode_step`).
- `C5.3` Async-scheduling launch-ahead infrastructure (sample buffer, events, drain helper, sample override).
- `C5.4` Speculative launch-ahead loop with RNG snapshot/restore.
- `C5.5` Mamba SSM rollback for hybrid speculation.
- `C5.6` Switch mamba speculative save to contiguous full-pool copy (avoids slow scatter access).

## Test plan

- [x] `tests/unit_tests/inference/engines/test_dynamic_engine.py` — 140 passed (3× consecutive runs across all configurations).
- [x] `tests/unit_tests/inference/engines/test_dynamic_events.py` — 10 passed.
- [x] `tests/unit_tests/inference/contexts/test_dynamic_context.py` — added round-trip and gating tests for `speculatively_advance_for_next_decode_step` and `can_speculate_decode_step`.
- [x] `tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py` — 18 passed.
- [x] `tests/unit_tests/inference/test_dynamic_prefix_caching_coordinator.py` — 35 passed.
- [x] `tests/unit_tests/inference/engines/test_prefix_caching_cuda_graphs.py` — 7 passed.
- [x] `tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py` — 12 passed.
- [x] End-to-end nanov3 hybrid+MoE benchmark via `lawrence/siddharth/run_full_benchmark.sh` — output tokens identical to baseline; throughput within run-to-run variance on this prefill-dominated workload (decode is ~7% of wall time, so per-decode-step gains do not move overall throughput much; the trace-level `Decode` NVTX range is the more direct metric).
- [ ] Decode-heavy benchmark configuration (smaller prompts, longer generation, no chunked prefill) to make the per-decode-step gain visible in throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)