### PR TITLE
Support YAML quant recipe in PTQ and remove first/last layer modifier code

### DIFF
--- a/examples/post_training/modelopt/quantize.py
+++ b/examples/post_training/modelopt/quantize.py
@@ -167,9 +167,8 @@ def get_modelopt_torch_quantization_config():
         # cache override; the recipe encodes quant_cfg + algorithm + KV cache directly.
         print_rank_0(f"Use recipe {args.recipe} for quantization")
         recipe = load_recipe(args.recipe)
-        assert isinstance(recipe, ModelOptPTQRecipe), (
-            f"Expected PTQ recipe, but got {type(recipe).__name__} from {args.recipe}"
-        )
+        if not isinstance(recipe, ModelOptPTQRecipe), 
+            raise TypeError(f"Expected PTQ recipe, but got {type(recipe).__name__} from {args.recipe}")
         if args.export_kv_cache_quant != "none":
             print_rank_0(f"Ignoring --export-kv-cache-quant={args.export_kv_cache_quant} since you passed in a YAML recipe.")
         return recipe.quantize.model_dump()
@@ -218,19 +217,6 @@ def get_modelopt_torch_quantization_config():
     # Weight Only Quantization
     if args.weight_only:
         mtq_config["quant_cfg"].append({"quantizer_name": "*input_quantizer", "enable": False})
-    if args.num_first_layers_to_skip_quant is not None:
-        mtq_config = get_first_layers_disabled_config(
-            mtq_config,
-            num_layers=args.num_layers,
-            num_layers_to_disable=args.num_first_layers_to_skip_quant,
-        )
-    if args.num_last_layers_to_skip_quant is not None:
-        mtq_config = get_last_layers_disabled_config(
-            mtq_config,
-            num_layers=args.num_layers,
-            num_layers_to_disable=args.num_last_layers_to_skip_quant,
-        )
-
     return mtq_config
 
 

--- a/examples/post_training/modelopt/quantize.py
+++ b/examples/post_training/modelopt/quantize.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
-"""Sample Generate GPT."""
+"""Script for quantizing a HuggingFace or Megatron-LM checkpoint using ModelOpt."""
 
 import copy
 import functools
@@ -19,6 +19,7 @@ from tqdm import tqdm
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
 
 import modelopt.torch.quantization as mtq
+from modelopt.recipe import ModelOptPTQRecipe, load_recipe
 from modelopt.torch.export import import_mcore_gpt_from_hf
 from modelopt.torch.utils.dataset_utils import get_dataset_dataloader
 
@@ -130,21 +131,16 @@ def add_text_generate_ptq_args(parser):
     )
     group.add_argument("--weight-only", action="store_true", help="Disable input quantization.")
     group.add_argument(
-        "--force-all-expert-routing",
-        action="store_true",
-        help="Forcing all experts to be routed during the calibration.",
-    )
-    group.add_argument(
-        "--num-first-layers-to-skip-quant",
-        type=int,
+        "--recipe",
+        type=str,
         default=None,
-        help="Number of first layers to skip quantization.",
-    )
-    group.add_argument(
-        "--num-last-layers-to-skip-quant",
-        type=int,
-        default=None,
-        help="Number of last layers to skip quantization.",
+        help=(
+            "PTQ recipe YAML file or name without suffix (e.g. "
+            "'general/ptq/nvfp4_default-fp8_kv', "
+            "'models/Nemotron-3-Super-120B-A12B/super-nvfp4'). "
+            "When set, --export-quant-cfg / --export-kv-cache-quant are ignored; "
+            "the recipe is authoritative for quant_cfg, algorithm, and KV cache config."
+        ),
     )
     add_modelopt_args(parser)
     return parser
@@ -162,59 +158,22 @@ def check_arguments():
         args.moe_grouped_gemm = False
 
 
-def _is_first_layers(name: str, num_layers: int = 1, num_layers_to_disable: int = 1) -> bool:
-    if "layers." not in name:
-        return False
-    try:
-        layer_idx = int(name.split("layers.")[-1].split(".")[0])
-    except ValueError:
-        return False
-    return layer_idx < num_layers_to_disable
-
-
-def _is_last_layers(name: str, num_layers: int = 1, num_layers_to_disable: int = 1) -> bool:
-    if "layers." not in name:
-        return False
-    try:
-        layer_idx = int(name.split("layers.")[-1].split(".")[0])
-    except ValueError:
-        return False
-    return layer_idx >= num_layers - num_layers_to_disable
-
-
-def get_first_layers_disabled_config(config, num_layers: int = 1, num_layers_to_disable: int = 1):
-    """Get a config for `mtq.quantize` with first & last `num_layers_to_disable` layers disabled.
-
-    The layers to disable are the first & last `num_layers_to_disable` layers.
-    """
-    config = copy.deepcopy(config)
-    quant_cfg = config.get("quant_cfg", {})
-    predicate = functools.partial(
-        _is_first_layers, num_layers=num_layers, num_layers_to_disable=num_layers_to_disable
-    )
-    quant_cfg.append({"quantizer_name": predicate, "enable": False})
-    config["quant_cfg"] = quant_cfg
-    return config
-
-
-def get_last_layers_disabled_config(config, num_layers: int = 1, num_layers_to_disable: int = 1):
-    """Get a config for `mtq.quantize` with last `num_layers_to_disable` layers disabled.
-
-    The layers to disable are the last `num_layers_to_disable` layers.
-    """
-    config = copy.deepcopy(config)
-    quant_cfg = config.get("quant_cfg", {})
-    predicate = functools.partial(
-        _is_last_layers, num_layers=num_layers, num_layers_to_disable=num_layers_to_disable
-    )
-    quant_cfg.append({"quantizer_name": predicate, "enable": False})
-    config["quant_cfg"] = quant_cfg
-    return config
-
-
 def get_modelopt_torch_quantization_config():
     """Return a quantization config."""
     args = get_args()
+
+    if args.recipe is not None:
+        # YAML recipe is authoritative: skip predefined-config customizations and KV
+        # cache override; the recipe encodes quant_cfg + algorithm + KV cache directly.
+        print_rank_0(f"Use recipe {args.recipe} for quantization")
+        recipe = load_recipe(args.recipe)
+        assert isinstance(recipe, ModelOptPTQRecipe), (
+            f"Expected PTQ recipe, but got {type(recipe).__name__} from {args.recipe}"
+        )
+        if args.export_kv_cache_quant != "none":
+            print_rank_0(f"Ignoring --export-kv-cache-quant={args.export_kv_cache_quant} since you passed in a YAML recipe.")
+        return recipe.quantize.model_dump()
+
     if args.export_quant_cfg not in QUANT_CFG_CHOICES:
         raise ValueError(f"Unsupported quantization config {args.export_quant_cfg}.")
     mtq_config = QUANT_CFG_CHOICES[args.export_quant_cfg]
@@ -414,12 +373,7 @@ if __name__ == "__main__":
 
     unwrapped_model = unwrap_model(model)[0]
 
-    if args.force_all_expert_routing:
-        warnings.warn(
-            "--force-all-expert-routing will be deprecated in the next release and is no longer needed."
-        )
-
-    if args.export_quant_cfg is not None:
+    if args.export_quant_cfg is not None or args.recipe is not None:
         print_rank_0("Quantizing the model...")
         mtq_config = get_modelopt_torch_quantization_config()
 

--- a/examples/post_training/modelopt/quantize.py
+++ b/examples/post_training/modelopt/quantize.py
@@ -167,7 +167,7 @@ def get_modelopt_torch_quantization_config():
         # cache override; the recipe encodes quant_cfg + algorithm + KV cache directly.
         print_rank_0(f"Use recipe {args.recipe} for quantization")
         recipe = load_recipe(args.recipe)
-        if not isinstance(recipe, ModelOptPTQRecipe), 
+        if not isinstance(recipe, ModelOptPTQRecipe):
             raise TypeError(f"Expected PTQ recipe, but got {type(recipe).__name__} from {args.recipe}")
         if args.export_kv_cache_quant != "none":
             print_rank_0(f"Ignoring --export-kv-cache-quant={args.export_kv_cache_quant} since you passed in a YAML recipe.")

--- a/examples/post_training/modelopt/quantize.py
+++ b/examples/post_training/modelopt/quantize.py
@@ -2,7 +2,6 @@
 
 """Script for quantizing a HuggingFace or Megatron-LM checkpoint using ModelOpt."""
 
-import copy
 import functools
 import inspect
 import json

--- a/examples/post_training/modelopt/quantize.sh
+++ b/examples/post_training/modelopt/quantize.sh
@@ -20,6 +20,18 @@ if [ -z ${QUANT_CFG} ]; then
     printf "${MLM_WARNING} Variable ${PURPLE}QUANT_CFG${WHITE} is not set (default: ${QUANT_CFG})!\n"
 fi
 
+# If the 2nd positional arg looks like a recipe path (contains '/' or ends in
+# '.yaml'/'.yml') pass it via --recipe; otherwise treat it as a built-in
+# config name and pass it via --export-quant-cfg.
+case "${QUANT_CFG}" in
+    */*|*.yaml|*.yml)
+        QUANT_CFG_ARGS=(--recipe "${QUANT_CFG}")
+        ;;
+    *)
+        QUANT_CFG_ARGS=(--export-quant-cfg "${QUANT_CFG}")
+        ;;
+esac
+
 if [ -z ${MLM_MODEL_SAVE} ]; then
     MLM_MODEL_SAVE=${MLM_WORK_DIR}/${MLM_MODEL_CFG}_quant
     printf "${MLM_WARNING} Variable ${PURPLE}MLM_MODEL_SAVE${WHITE} is not set (default: ${MLM_MODEL_SAVE})!\n"
@@ -41,7 +53,7 @@ if [ -z ${MLM_MODEL_CKPT} ]; then
         --tokenizer-model ${TOKENIZER_MODEL} \
         --pretrained-model-path ${HF_MODEL_CKPT} \
         --save ${MLM_MODEL_SAVE} \
-        --export-quant-cfg ${QUANT_CFG} \
+        "${QUANT_CFG_ARGS[@]}" \
         --references "${MLM_REF_LABEL}" \
         "${EXTRA_ARGS[@]}"
 else
@@ -55,7 +67,7 @@ else
         --tokenizer-model ${TOKENIZER_MODEL} \
         --load ${MLM_MODEL_CKPT} \
         --save ${MLM_MODEL_SAVE} \
-        --export-quant-cfg ${QUANT_CFG} \
+        "${QUANT_CFG_ARGS[@]}" \
         --references "${MLM_REF_LABEL}" \
         "${EXTRA_ARGS[@]}"
 fi


### PR DESCRIPTION
# What does this PR do ?
Support YAML quant recipe in PTQ, which eliminates the need of the code to modify first/last layers in quant config. User can now skip layers directly in the yaml, e.g. 
```
Disable one layer entirely                                                                                              
                                                                                                                          
  - quantizer_name: '*layers.42.*'                                                                               
    enable: false
    
    Disable one module on one layer                                                                                         
                                                         
  - quantizer_name: '*layers.42.mixer.o_proj*'
    enable: false                                                                                                         
  
  Disable a few specific layers                                                                                           
                                                         
  - quantizer_name: '*layers.42.mixer.o_proj*'                                                                   
    enable: false
  - quantizer_name: '*layers.43.mixer.o_proj*'                                                                   
    enable: false
```

- quantize.py has new `--recipe` flag
- quantize.sh works with quant config or recipe, e.g. `... quantize.sh <model> NVFP4_DEFAULT_CONFIG` or `...quantize.sh <model> /path/to/modelopt_recipe` 
- remove `--force-all-expert-routing` which is a no-op

## Deprecation
Deprecating these flags in `quantize.py`: `--num-first-layers-to-skip-quant, --num-last-layers-to-skip-quant, --force-all-expert-routing`
-  `--force-all-expert-routing` was already a no-op in the process of deprecation
- use YAML instead of  `--num-first-layers-to-skip-quant, --num-last-layers-to-skip-quant` to skip layers
:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
