### PR TITLE
Integrate LayerWiseDistributedOptimizer with DDP buffer infrastructure

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -165,6 +165,8 @@ class DistributedDataParallel(_BaseDataParallel):
                     param_indices == layout.param_indices
                 ), f"param_indices for {buffer_key} do not match between grouping and layout"
 
+        self.full_param_layout = full_param_layout
+
         # Compute gradient scaling factors.
         if config.calculate_per_token_loss:
             assert (

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -322,8 +322,9 @@ class _ParamAndGradBucketGroup:
         async_op = self.ddp_config.overlap_param_gather and not force_sync
 
         if not self.ddp_config.use_distributed_optimizer:
-            # Layer-wise optimizer path: use all_gather for variable-size
-            # param gather.
+            # Legacy layer-wise optimizer path: use all_gather for variable-size
+            # param gather.  Once all layerwise call sites set
+            # ddp_config.use_distributed_optimizer=True, this branch can be removed.
             #
             # Each rank may own a different number of params per bucket, so
             # layerwise_param_flat_sizes can vary across ranks.  PyTorch's NCCL

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -208,6 +208,16 @@ class _ParamAndGradBucketGroup:
                 not self.ddp_config.reduce_scatter_with_fp32_accumulation
             ), "RS w/ FP32 accumulation not supported with num_distributed_optimizer_instances > 1"
 
+        reduction_collective = (
+            "reduce-scatter" if self.ddp_config.use_distributed_optimizer else "all-reduce"
+        )
+        log_single_rank(
+            logger,
+            logging.INFO,
+            f"Using {reduction_collective} for gradient reductions because "
+            f"{self.ddp_config.use_distributed_optimizer=}",
+        )
+
         global dist_reduce_scatter_func
         if self.ddp_config.reduce_scatter_with_fp32_accumulation:
             dist_reduce_scatter_func = reduce_scatter_with_fp32_accumulation

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -850,7 +850,7 @@ def _get_megatron_emerging_optimizer(
             config,
             pg_collection,
             init_state_fn_list=list(init_fns),
-            model_chunks=model_chunks if config.overlap_param_gather else None,
+            model_chunks=model_chunks,
         )
 
     return ChainedOptimizer(results)

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -1,15 +1,18 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import logging
-from typing import Callable, List, Optional
+import math
+from collections import defaultdict
+from typing import Callable, Dict, List, Optional, Tuple
 
 import torch
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 
 from megatron.core.dist_checkpointing.dict_utils import nested_values
 from megatron.core.dist_checkpointing.mapping import LocalNonpersistentObject, ShardedStateDict
+from megatron.core.distributed.param_and_grad_buffer import group_params_for_buffers
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.utils import get_pg_rank, get_pg_size
+from megatron.core.utils import get_pg_rank, get_pg_size, log_single_rank
 
 from .clip_grads import count_zeros_fp32, get_grad_norm_fp32
 from .optimizer import (
@@ -19,6 +22,13 @@ from .optimizer import (
     MegatronOptimizer,
 )
 from .optimizer_config import OptimizerConfig
+from .param_layout import (
+    FullParamLayout,
+    PerBufferParamLayout,
+    bucket_end_divisor,
+    pad_param_start,
+    pad_to_divisor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +49,277 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
     6. allgather updated params to every rank
     """
 
+    @staticmethod
+    def _shard_divisor(data_parallel_world_size: int, ddp_config) -> int:
+        """Per-shard alignment divisor.
+
+        Guarantees that ``dp_size * shard_size`` satisfies bucket-end alignment
+        and that every shard start is 64-element aligned (required by
+        :func:`pad_param_start`).
+        """
+        dp_size = data_parallel_world_size
+        bucket_divisor = bucket_end_divisor(dp_size, ddp_config.pad_buckets_for_high_nccl_busbw)
+        return math.lcm(64, bucket_divisor // dp_size)
+
+    @staticmethod
+    def _compute_per_buffer_param_layout(
+        params: List[torch.nn.Parameter],
+        bucket_size: Optional[int],
+        data_parallel_world_size: int,
+        ddp_config,
+        param_indices: Optional[List[int]] = None,
+    ) -> 'PerBufferParamLayout':
+        """Compute parameter layout with shard-aligned buckets via size-matching.
+
+        Assigns parameters to ``dp_size`` equal-sized shards within each bucket
+        so that no parameter is ever split across a shard boundary.
+
+        **Algorithm** (operates in reverse model / backprop order):
+
+        1. Separate shared-embedding parameters (isolated buckets, emitted first).
+        2. Pool the remaining parameters in backprop order, indexed by numel.
+        3. Pop the next unassigned parameter and assign it to shard 0.
+        4. For shards 1 … ``dp_size - 1``, assign the next unassigned parameter
+           of the same numel (also in backprop order).  If none is available,
+           insert padding of that numel.  Every shard grows by the same amount,
+           so all shards stay the same size.
+        5. When the bucket total reaches *bucket_size*, finalise the bucket
+           (pad shard size to :meth:`_shard_divisor`) and start a new one.
+        6. Repeat from 3 until all parameters are assigned.
+
+        Because repeated layers produce many parameters of the same shape,
+        size-matching naturally keeps whole parameters together without any
+        name-parsing heuristic.  Padding overhead is low (depending on number
+        of layers and number of shards) — zero when every shape group has a
+        count divisible by ``dp_size``.
+
+        Args:
+            params: Parameters in model-definition (forward) order.
+            bucket_size: Approximate elements per bucket (``None`` → single bucket).
+            data_parallel_world_size: Size of the data-parallel group.
+            ddp_config: :class:`DistributedDataParallelConfig`.
+            param_indices: Optional per-param dtype indices (passed through).
+
+        Returns:
+            :class:`PerBufferParamLayout` with shard-aligned buckets.
+        """
+        dp_size = data_parallel_world_size
+        shard_divisor = LayerWiseDistributedOptimizer._shard_divisor(dp_size, ddp_config)
+
+        # -- 0. Separate shared-embedding params. -------------------------
+        shared_embedding_params: List[torch.nn.Parameter] = []
+        regular_params: List[torch.nn.Parameter] = []
+        total_param_numel = 0
+        for param in params:
+            total_param_numel += param.data.nelement()
+            if getattr(param, 'shared_embedding', False):
+                shared_embedding_params.append(param)
+            else:
+                regular_params.append(param)
+
+        # -- 1. Build backprop-order pool & per-size index. ---------------
+        pool = list(reversed(regular_params))
+        assigned_param_ids: set[int] = set()  # id(param) of assigned params
+
+        size_groups: Dict[int, List[torch.nn.Parameter]] = defaultdict(list)
+        for param in pool:
+            size_groups[param.data.nelement()].append(param)
+        size_cursors: Dict[int, int] = defaultdict(int)
+
+        overall_cursor = 0
+
+        def _next_unassigned() -> Optional[torch.nn.Parameter]:
+            nonlocal overall_cursor
+            while overall_cursor < len(pool):
+                if id(pool[overall_cursor]) not in assigned_param_ids:
+                    return pool[overall_cursor]
+                overall_cursor += 1
+            return None
+
+        def _next_with_size(param_numel: int) -> Optional[torch.nn.Parameter]:
+            """Next unassigned param of size *param_numel* in backprop order."""
+            group = size_groups[param_numel]
+            cursor = size_cursors[param_numel]
+            while cursor < len(group):
+                if id(group[cursor]) not in assigned_param_ids:
+                    size_cursors[param_numel] = cursor
+                    return group[cursor]
+                cursor += 1
+            size_cursors[param_numel] = cursor
+            return None
+
+        # -- 2. Output accumulators and per-bucket shard state. ----------
+        param_index_map: Dict[torch.nn.Parameter, Tuple[int, int, int]] = {}
+        bucket_indices: List[Tuple[int, int]] = []
+        per_bucket_numel_unpadded: List[int] = []
+        buffer_cursor = 0  # write position in the contiguous buffer
+        bucket_id = 0
+
+        # Per-shard state for the bucket currently being built.
+        # `shard_assignments[i]` holds an ordered list of (param | None, numel)
+        # entries to be written into shard i; a `None` entry is empty padding
+        # that keeps every shard the same size.
+        shard_assignments: List[List[Tuple[Optional[torch.nn.Parameter], int]]] = [
+            [] for _ in range(dp_size)
+        ]
+        shard_cursor = 0  # position within each shard (identical for all shards)
+        bucket_numel_unpadded = 0
+        size_match_padding_numel = 0  # elements used for empty-shard-slot padding
+
+        def _finalize_bucket() -> None:
+            nonlocal buffer_cursor, bucket_id, shard_assignments
+            nonlocal shard_cursor, bucket_numel_unpadded
+            if shard_cursor == 0:
+                return
+            padded_shard_size = pad_to_divisor(shard_cursor, shard_divisor)
+            bucket_start_index = buffer_cursor
+
+            for shard_id in range(dp_size):
+                shard_start_index = bucket_start_index + shard_id * padded_shard_size
+                cursor = shard_start_index
+                for param, numel in shard_assignments[shard_id]:
+                    cursor = pad_param_start(cursor)
+                    if param is not None:
+                        param_index_map[param] = (cursor, cursor + numel, bucket_id)
+                    cursor += numel
+
+            bucket_end_index = bucket_start_index + dp_size * padded_shard_size
+            bucket_indices.append((bucket_start_index, bucket_end_index))
+            per_bucket_numel_unpadded.append(bucket_numel_unpadded)
+            buffer_cursor = bucket_end_index
+            bucket_id += 1
+
+            shard_assignments = [[] for _ in range(dp_size)]
+            shard_cursor = 0
+            bucket_numel_unpadded = 0
+
+        # -- 3. Emit one isolated bucket per shared-embedding param. -----
+        # Shared (tied) embeddings need their own bucket — typically because
+        # input and output embeddings are tied across pipeline-parallel
+        # stages and need a cross-stage all-reduce. Each shared embedding
+        # occupies shard 0 of its bucket alone; shards 1..dp_size-1 are
+        # filled with empty (padding) slots of the same numel so the bucket
+        # is shard-aligned and the embedding fits entirely within shard 0.
+        #
+        # NOTE: This is expensive. Padding cost per shared embedding is
+        # (dp_size - 1) * pad_to_divisor(numel, shard_divisor) elements,
+        # which for a vocab x hidden embedding (e.g. 128k x 8192) at dp_size
+        # = 8 is roughly 7 * (vocab * hidden) elements — many GBs of the
+        # param buffer (and again of the grad buffer) per shared embedding.
+        # The cost is unavoidable while preserving the "no parameter crosses
+        # a shard boundary" invariant the layerwise scheme depends on for
+        # correct reduce-scatter + local optimizer step.
+        for param in reversed(shared_embedding_params):
+            param_numel = param.data.nelement()
+            assigned_param_ids.add(id(param))
+            shard_assignments[0].append((param, param_numel))
+            bucket_numel_unpadded += param_numel
+            # No size-matching: each shared embedding must be alone in its
+            # bucket. Pad shards 1..dp_size-1 with same-size empty slots.
+            for shard_id in range(1, dp_size):
+                shard_assignments[shard_id].append((None, param_numel))
+                size_match_padding_numel += param_numel
+            shard_cursor = pad_param_start(shard_cursor) + param_numel
+            _finalize_bucket()
+
+        # -- 4. Size-matching loop for regular params. --------------------
+        while True:
+            param = _next_unassigned()
+            if param is None:
+                break
+
+            param_numel = param.data.nelement()
+            assigned_param_ids.add(id(param))
+            shard_assignments[0].append((param, param_numel))
+            bucket_numel_unpadded += param_numel
+
+            for shard_id in range(1, dp_size):
+                matched_param = _next_with_size(param_numel)
+                if matched_param is not None:
+                    assigned_param_ids.add(id(matched_param))
+                    shard_assignments[shard_id].append((matched_param, param_numel))
+                    bucket_numel_unpadded += param_numel
+                else:
+                    shard_assignments[shard_id].append((None, param_numel))
+                    size_match_padding_numel += param_numel
+
+            shard_cursor = pad_param_start(shard_cursor) + param_numel
+
+            if bucket_size is not None:
+                bucket_total = dp_size * pad_to_divisor(shard_cursor, shard_divisor)
+                if bucket_total >= bucket_size:
+                    _finalize_bucket()
+
+        _finalize_bucket()
+
+        # -- 5. Log padding overhead. ------------------------------------
+        total_buffer_numel = bucket_indices[-1][1] if bucket_indices else 0
+        total_padding = total_buffer_numel - total_param_numel
+        alignment_and_shard_end_padding = total_padding - size_match_padding_numel
+        log_single_rank(
+            logger,
+            logging.INFO,
+            f"Layerwise param layout: {len(params)} params, "
+            f"{len(bucket_indices)} buckets, "
+            f"dp_size={dp_size}, "
+            f"total_param_numel={total_param_numel}, "
+            f"total_buffer_numel={total_buffer_numel}, "
+            f"total_padding={total_padding} "
+            f"(size_match={size_match_padding_numel}, "
+            f"alignment+shard_end={alignment_and_shard_end_padding}), "
+            f"overhead={total_padding / max(total_param_numel, 1) * 100:.1f}%",
+        )
+
+        return PerBufferParamLayout(
+            param_index_map=param_index_map,
+            bucket_indices=bucket_indices,
+            per_bucket_numel_unpadded=per_bucket_numel_unpadded,
+            param_indices=param_indices if param_indices is not None else [],
+        )
+
+    @staticmethod
+    def compute_full_param_layout(
+        params: List[torch.nn.Parameter],
+        bucket_size: Optional[int],
+        data_parallel_world_size: int,
+        ddp_config,
+        expert_data_parallel_world_size: Optional[int] = None,
+    ) -> 'FullParamLayout':
+        """Compute parameter layouts for all buffer groups.
+
+        Groups parameters by :class:`BufferKey` via :func:`group_params_for_buffers`
+        and produces a layerwise shard-aligned size-matching layout per buffer.
+        Every parameter stays within a single shard so the local optimizer step
+        (e.g. Newton-Schulz iteration for Muon) can run on whole tensors.
+
+        Args:
+            params: All parameters to lay out.
+            bucket_size: Approximate elements per bucket (``None`` → single bucket).
+            data_parallel_world_size: DP group size for dense parameters.
+            ddp_config: :class:`DistributedDataParallelConfig`.
+            expert_data_parallel_world_size: Expert DP group size (defaults to
+                ``data_parallel_world_size``).
+
+        Returns:
+            :class:`FullParamLayout` with a :class:`PerBufferParamLayout` per buffer group.
+        """
+        buffer_groups = group_params_for_buffers(params, ddp_config.grad_reduce_in_fp32)
+        layouts = {}
+        for buffer_key, (group_params, param_indices) in buffer_groups.items():
+            if buffer_key.is_expert_parallel:
+                dp_world_size = (
+                    expert_data_parallel_world_size
+                    if expert_data_parallel_world_size is not None
+                    else data_parallel_world_size
+                )
+            else:
+                dp_world_size = data_parallel_world_size
+
+            layouts[buffer_key] = LayerWiseDistributedOptimizer._compute_per_buffer_param_layout(
+                group_params, bucket_size, dp_world_size, ddp_config, param_indices
+            )
+        return FullParamLayout(layouts=layouts)
+
     def __init__(
         self,
         optimizers: List[MegatronOptimizer],
@@ -55,15 +336,34 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
             config: OptimizerConfig.
             pg_collection: ProcessGroupCollection.
             init_state_fn_list: List of init state functions.
-            model_chunks: DDP-wrapped model chunks (needed for overlap_param_gather).
+            model_chunks: DDP-wrapped model chunks.
         """
 
         self.pg_collection = pg_collection
-        self.shard_params(optimizers)
+
+        full_param_layouts = None
+        if model_chunks is not None:
+            full_param_layouts = [
+                chunk.full_param_layout
+                for chunk in model_chunks
+                if hasattr(chunk, 'full_param_layout') and chunk.full_param_layout is not None
+            ] or None
+        self.shard_params(optimizers, full_param_layouts)
+
+        # When a full_param_layout is available, ddp_config.use_distributed_optimizer
+        # is True and model params are views into the DDP param buffer.  After the
+        # optimizer step copies updated fp32 main params → bf16 model params, the
+        # buffer is already up-to-date in-place.  We can use DDP's buffer-based
+        # all-gather (start_param_sync) instead of the flatten/unflatten allgather_params
+        # path.
+        self.use_buffer_param_sync = full_param_layouts is not None
 
         # Set up overlap param gather using DDP bucket infrastructure.
         self.overlap_param_gather = config.overlap_param_gather
-        if self.overlap_param_gather:
+        if self.overlap_param_gather and not self.use_buffer_param_sync:
+            # Legacy path: set up per-bucket param lists for variable-size all-gather.
+            # When use_buffer_param_sync is True, the standard distributed optimizer
+            # all-gather path is used and this setup is not needed.
             assert (
                 model_chunks is not None
             ), "model_chunks must be provided if overlap_param_gather is True"
@@ -91,6 +391,13 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
 
         super().__init__(optimizers)
 
+        # Assign self.model_chunks AFTER super().__init__: ChainedOptimizer.__init__
+        # resets self.model_chunks to [] and then repopulates only from chained
+        # children that have a model_chunks attribute (DistOpt does, Float16-wrapped
+        # raw torch optimizers do not). Set it here so LayerWise.step's
+        # ``for model_chunk in self.model_chunks`` actually iterates.
+        self.model_chunks = model_chunks if model_chunks is not None else []
+
         # TODO(kunlun, deyuf): potential future perf optimization
         # since allreduce is unchanged and handled by megatron DDP, they're already in
         # contiguous gbuf. So instead of shard param by layer randomly, we can shard by
@@ -98,32 +405,122 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         # This way each rank do some duplicated work but allgather_v is no longer needed
         # All current distopt optimization can also be potentially applied
 
-    def shard_params(self, optimizers):
-        """Shard all params into lists by rank."""
-        # list of parameter are sorted by numel and assigned to ranks in ping-pong style
-        # example of 4 ranks and 10 parameters p0-p9 after sorting, then dp_cp_params_list will be
-        # [[p0, p7, p8], [p1, p6, p9], [p2, p5], [p3, p4]]
+    def shard_params(self, optimizers, full_param_layouts=None):
+        """Shard params across ranks according to the computed param layout.
 
-        # simplify when dp_cp group size is 1
-        if get_pg_size(self.pg_collection.dp_cp) == 1:
+        Each param's shard assignment is derived from the :class:`FullParamLayout`
+        stored on the DDP model chunks.  Within each bucket the buffer is divided
+        into ``dp_size`` equal shards; a param's shard index is determined by its
+        position in the buffer.
+
+        Falls back to the legacy ping-pong-by-numel strategy when no layout is
+        available (e.g. ``dp_size == 1`` or no DDP wrapper).
+
+        Args:
+            optimizers: Optimizers whose param groups will be narrowed to
+                the local rank's shard.
+            full_param_layouts: List of :class:`FullParamLayout` (one per model
+                chunk).  ``None`` triggers the legacy fallback.
+        """
+        # Simplify when dp_cp group size is 1.
+        dp_cp_size = get_pg_size(self.pg_collection.dp_cp)
+        if dp_cp_size == 1:
             self.dp_cp_params_list = None
             self.expt_dp_params_list = None
             return
 
-        dp_cp_idx, expt_dp_idx = 0, 0
-        dp_cp_size = get_pg_size(self.pg_collection.dp_cp)
         expt_dp_size = get_pg_size(self.pg_collection.expt_dp)
-        # create ping-pong style loop so memory is more balanced
+
+        if full_param_layouts is not None:
+            self._shard_params_from_layout(optimizers, full_param_layouts, dp_cp_size, expt_dp_size)
+        else:
+            self._shard_params_ping_pong(optimizers, dp_cp_size, expt_dp_size)
+
+    def _shard_params_from_layout(self, optimizers, full_param_layouts, dp_cp_size, expt_dp_size):
+        """Derive shard assignments from the param layout."""
+        dp_cp_rank = get_pg_rank(self.pg_collection.dp_cp)
+        expt_dp_rank = get_pg_rank(self.pg_collection.expt_dp)
+
+        self.dp_cp_params_list = [[] for _ in range(dp_cp_size)]
+        self.expt_dp_params_list = [[] for _ in range(expt_dp_size)]
+
+        # Map each param to its shard index.
+        param_to_shard: Dict[torch.nn.Parameter, int] = {}
+        for full_layout in full_param_layouts:
+            for buffer_key, layout in full_layout.layouts.items():
+                dp_size = expt_dp_size if buffer_key.is_expert_parallel else dp_cp_size
+                for param, (
+                    param_start_index,
+                    param_end_index,
+                    bucket_id,
+                ) in layout.param_index_map.items():
+                    bucket_start_index, bucket_end_index = layout.bucket_indices[bucket_id]
+                    shard_size = (bucket_end_index - bucket_start_index) // dp_size
+                    shard_id = (param_start_index - bucket_start_index) // shard_size
+                    shard_end_index = bucket_start_index + (shard_id + 1) * shard_size
+                    assert param_end_index <= shard_end_index, (
+                        f"Param (shape={tuple(param.shape)}, numel={param.numel()}) at "
+                        f"({param_start_index}, {param_end_index}) crosses shard boundary "
+                        f"in bucket ({bucket_start_index}, {bucket_end_index}) with "
+                        f"shard_size={shard_size}, shard_id={shard_id}, "
+                        f"shard_end_index={shard_end_index}. The layout must keep every "
+                        f"param fully within one shard."
+                    )
+                    param_to_shard[param] = shard_id
+
+        # Collect all param groups and assign params to per-rank lists.
+        param_groups = []
+        for optimizer in optimizers:
+            param_groups += optimizer.param_groups
+        param_groups_this_rank = [[] for _ in param_groups]
+
+        for group_index, group in enumerate(param_groups):
+            is_expert = group.get("is_expert_parallel", False)
+            local_rank = expt_dp_rank if is_expert else dp_cp_rank
+            params_list = self.expt_dp_params_list if is_expert else self.dp_cp_params_list
+
+            for param in group["params"]:
+                assert param in param_to_shard, (
+                    f"Optimizer param (shape={tuple(param.shape)}, numel={param.numel()}) "
+                    f"not found in any param layout. Ensure all optimizer params are "
+                    f"included in the full_param_layout passed to DDP."
+                )
+                shard_id = param_to_shard[param]
+                params_list[shard_id].append(param)
+                if shard_id == local_rank:
+                    param_groups_this_rank[group_index].append(param)
+
+        # Now we modify the group to only handle local params.
+        for group, local_params in zip(param_groups, param_groups_this_rank):
+            group["params"] = local_params
+
+        # Simplify when expt_dp group size is 1 or expert parallel is off.
+        if expt_dp_size == 1 or len(self.expt_dp_params_list[0]) == 0:
+            self.expt_dp_params_list = None
+
+    def _shard_params_ping_pong(self, optimizers, dp_cp_size, expt_dp_size):
+        """Legacy ping-pong-by-numel shard assignment (no layout available).
+
+        Legacy: this method is a fallback for when no ``full_param_layout``
+        is provided.  Once all call sites supply a layout, this can be removed
+        in favor of :meth:`_shard_params_from_layout`.
+
+        List of parameters are sorted by numel and assigned to ranks in ping-pong style.
+        Example of 4 ranks and 10 parameters p0-p9 after sorting, then dp_cp_params_list
+        will be [[p0, p7, p8], [p1, p6, p9], [p2, p5], [p3, p4]].
+        """
+        dp_cp_idx, expt_dp_idx = 0, 0
+        # Create ping-pong style loop so memory is more balanced.
         dp_cp_loop = list(range(dp_cp_size)) + list(range(dp_cp_size))[::-1]
         expt_dp_loop = list(range(expt_dp_size)) + list(range(expt_dp_size))[::-1]
         self.dp_cp_params_list = [[] for _ in range(dp_cp_size)]
         self.expt_dp_params_list = [[] for _ in range(expt_dp_size)]
-        # get all param groups
+        # Get all param groups.
         param_groups = []
         for optimizer in optimizers:
             param_groups += optimizer.param_groups
 
-        # sort param in all groups by param numel and assign to each rank evenly
+        # Sort param in all groups by param numel and assign to each rank evenly.
         param_list = []
         for group_index, group in enumerate(param_groups):
             for p in group["params"]:
@@ -131,7 +528,7 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         param_list.sort(key=lambda x: x[0].numel())
         param_groups_this_rank = [[] for g in param_groups]
 
-        # assign params to rank in ping-pong style loop
+        # Assign params to rank in ping-pong style loop.
         for p, group_index in param_list:
             if param_groups[group_index].get("is_expert_parallel", False):
                 if expt_dp_loop[expt_dp_idx] == get_pg_rank(self.pg_collection.expt_dp):
@@ -144,16 +541,22 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
                 self.dp_cp_params_list[dp_cp_loop[dp_cp_idx]].append(p)
                 dp_cp_idx = (dp_cp_idx + 1) % len(dp_cp_loop)
 
-        # now we modify the group to only handle local params
+        # Now we modify the group to only handle local params.
         for groups, params in zip(param_groups, param_groups_this_rank):
             groups["params"] = params
 
-        # simplify when expt_dp group size is 1 or expert parallel is off
+        # Simplify when expt_dp group size is 1 or expert parallel is off.
         if expt_dp_size == 1 or len(self.expt_dp_params_list[0]) == 0:
             self.expt_dp_params_list = None
 
     def set_bucket_layerwise_params_list(self, model_chunks):
         """Map sharded params to DDP buckets for async all-gather.
+
+        Legacy: only used by the variable-size all-gather path
+        (``use_buffer_param_sync=False``).  Once all call sites supply a
+        ``full_param_layout``, this can be removed — the standard distributed
+        optimizer buffer all-gather handles param sync without per-bucket
+        param lists.
 
         For each bucket in each model chunk's bucket groups, build per-rank param lists
         by cross-referencing the layer-wise sharded param lists with the bucket's params.
@@ -193,7 +596,13 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
 
     @torch.no_grad()
     def allgather_params(self) -> None:
-        """All-gather updated params from all ranks."""
+        """All-gather updated params from all ranks.
+
+        Legacy: only used when ``use_buffer_param_sync=False``.  Once all
+        call sites supply a ``full_param_layout``, this can be removed — the
+        standard distributed optimizer buffer all-gather (via
+        ``start_param_sync``) replaces this flatten/unflatten path.
+        """
 
         # helper function to flatten local params, all-gather,
         # unflatten and copy to model params
@@ -278,13 +687,27 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
 
     @torch.no_grad()
     def step(self):  # type: ignore[no-untyped-def]
-        """step function for layer-wise optimizer."""
+        """step function for layer-wise optimizer.
+
+        NOTE: bypassed when this optimizer is a child of an outer
+        ChainedOptimizer; in that case the sibling DistributedOptimizer's
+        step_with_ready_grads handles the param sync.
+        """
         update_successful, grad_norm, num_zeros_in_grad = super().step()
 
-        # All gather updated params. If overlap_param_gather is True, the allgather
+        # All-gather updated params. If overlap_param_gather is True, the all-gather
         # is deferred to the forward pre-hooks via DDP bucket infrastructure.
         if not self.overlap_param_gather:
-            self.allgather_params()
+            if self.use_buffer_param_sync:
+                # Model params are views into the DDP param buffer
+                # (ddp_config.use_distributed_optimizer=True).  The optimizer step
+                # already copied updated fp32 main params → bf16 model params (=
+                # buffer views), so the buffer is up-to-date.  Trigger the standard
+                # buffer all-gather (matches DistributedOptimizer's call site).
+                for model_chunk in self.model_chunks:
+                    model_chunk.start_param_sync()
+            else:
+                self.allgather_params()
 
         return update_successful, grad_norm, num_zeros_in_grad
 

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -234,14 +234,42 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
             bucket_numel_unpadded += param_numel
 
             for shard_id in range(1, dp_size):
+                # Prefer an exact-numel peer; this gives the cleanest layout
+                # (no inner-shard padding).
                 matched_param = _next_with_size(param_numel)
                 if matched_param is not None:
                     assigned_param_ids.add(id(matched_param))
                     shard_assignments[shard_id].append((matched_param, param_numel))
                     bucket_numel_unpadded += param_numel
-                else:
-                    shard_assignments[shard_id].append((None, param_numel))
-                    size_match_padding_numel += param_numel
+                    continue
+
+                # No exact peer. Greedily pack as many smaller params from the
+                # queue as fit within this shard slot (sized to ``param_numel``).
+                # Cuts overhead from unique-large seeds (e.g. an embedding)
+                # that would otherwise force ``(dp_size - 1) * param_numel`` of
+                # empty padding.
+                useful_in_slot = 0
+                slot_cursor = 0
+                while True:
+                    candidate_param = _next_unassigned()
+                    if candidate_param is None:
+                        break
+                    candidate_numel = candidate_param.data.nelement()
+                    candidate_start = pad_param_start(slot_cursor)
+                    if candidate_start + candidate_numel > param_numel:
+                        break
+                    assigned_param_ids.add(id(candidate_param))
+                    shard_assignments[shard_id].append((candidate_param, candidate_numel))
+                    bucket_numel_unpadded += candidate_numel
+                    slot_cursor = candidate_start + candidate_numel
+                    useful_in_slot += candidate_numel
+
+                # Pad the remainder of the slot up to ``param_numel``.
+                padding_start = pad_param_start(slot_cursor)
+                padding_size = param_numel - padding_start
+                if padding_size > 0:
+                    shard_assignments[shard_id].append((None, padding_size))
+                size_match_padding_numel += param_numel - useful_in_slot
 
             shard_cursor = pad_param_start(shard_cursor) + param_numel
 

--- a/megatron/core/optimizer/param_layout.py
+++ b/megatron/core/optimizer/param_layout.py
@@ -26,15 +26,20 @@ def pad_param_start(param_start_index: int) -> int:
     return pad_to_divisor(param_start_index, 64)
 
 
+def bucket_end_divisor(data_parallel_world_size: int, pad_for_high_nccl_busbw: bool) -> int:
+    """Divisor used to pad bucket ends for DP-divisibility (and optional NCCL busbw)."""
+    if pad_for_high_nccl_busbw:
+        return math.lcm(data_parallel_world_size, 128, 2**16)
+    return math.lcm(data_parallel_world_size, 128)
+
+
 def pad_bucket_end(
     bucket_end_index: int, data_parallel_world_size: int, pad_for_high_nccl_busbw: bool
 ) -> int:
     """Pad bucket end for DP-divisibility (and optionally high NCCL bus bandwidth)."""
-    if pad_for_high_nccl_busbw:
-        divisor = math.lcm(data_parallel_world_size, 128, 2**16)
-    else:
-        divisor = math.lcm(data_parallel_world_size, 128)
-    return pad_to_divisor(bucket_end_index, divisor)
+    return pad_to_divisor(
+        bucket_end_index, bucket_end_divisor(data_parallel_world_size, pad_for_high_nccl_busbw)
+    )
 
 
 @dataclass(frozen=True)

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -52,6 +52,7 @@ from typing import Any, Optional, Dict
 import torch.distributed
 
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+from megatron.core.optimizer.layer_wise_optimizer import LayerWiseDistributedOptimizer
 from megatron.core.optimizer_param_scheduler import get_canonical_lr_for_logging
 from .log_handler import CustomHandler
 
@@ -1308,6 +1309,108 @@ def update_train_iters(args):
     print_rank_0(f'setting training iterations to {args.train_iters}')
 
 
+def wrap_model_chunks_with_ddp(
+    model_chunks,
+    config,
+    ddp_config,
+    *,
+    use_layer_wise_distributed_optimizer=False,
+    DP=DDP,
+    pg_collection=None,
+    bucket_sizes=None,
+    disable_bucketing_per_chunk=None,
+):
+    """Wrap each model chunk in DDP, pre-computing per-chunk param layouts as needed.
+
+    Centralises the DDP-wrapping wiring shared between :func:`get_model` and
+    unit tests.
+
+    For ``use_layer_wise_distributed_optimizer=True``: forces
+    ``ddp_config.use_distributed_optimizer=True`` (mutated in place; needed for
+    reduce-scatter), and computes per-chunk shard-aligned layouts via
+    :meth:`LayerWiseDistributedOptimizer.compute_full_param_layout`.
+
+    For non-layerwise with ``ddp_config.use_distributed_optimizer=True``:
+    computes per-chunk byte-level layouts via
+    :meth:`DistributedOptimizer.compute_full_param_layout`.
+
+    Otherwise: no layouts are computed.
+
+    Layouts are only computed when ``DP is DDP`` (i.e. the standard
+    ``DistributedDataParallel``); FSDP variants don't accept
+    ``full_param_layout``.
+
+    Args:
+        model_chunks: List of model chunks to wrap (un-DDP-wrapped).
+        config: :class:`TransformerConfig`.
+        ddp_config: :class:`DistributedDataParallelConfig`. Mutated in place when
+            ``use_layer_wise_distributed_optimizer=True``.
+        use_layer_wise_distributed_optimizer: Whether the layerwise wiring runs.
+        DP: The DDP class to construct (``DistributedDataParallel`` or an FSDP
+            variant).
+        pg_collection: Optional :class:`ProcessGroupCollection`. Forwarded to
+            FSDP-style DPs only.
+        bucket_sizes: Optional per-chunk bucket size override; defaults to
+            ``[ddp_config.bucket_size] * len(model_chunks)``.
+        disable_bucketing_per_chunk: Optional per-chunk disable_bucketing flag;
+            defaults to ``[False] * len(model_chunks)``.
+
+    Returns:
+        List of DDP-wrapped chunks.
+    """
+    n = len(model_chunks)
+    if bucket_sizes is None:
+        bucket_sizes = [ddp_config.bucket_size] * n
+    if disable_bucketing_per_chunk is None:
+        disable_bucketing_per_chunk = [False] * n
+
+    # Compute per-chunk layouts (DDP only).
+    per_chunk_layouts = [None] * n
+    if DP is DDP:
+        if use_layer_wise_distributed_optimizer:
+            ddp_config.use_distributed_optimizer = True
+            compute_layout = LayerWiseDistributedOptimizer.compute_full_param_layout
+        elif ddp_config.use_distributed_optimizer:
+            compute_layout = DistributedOptimizer.compute_full_param_layout
+        else:
+            compute_layout = None
+        if compute_layout is not None:
+            data_parallel_world_size = mpu.get_data_parallel_world_size(
+                with_context_parallel=True
+            )
+            expert_data_parallel_world_size = mpu.get_expert_data_parallel_world_size()
+            for i, (chunk, bucket_size) in enumerate(zip(model_chunks, bucket_sizes)):
+                all_params = [p for p in chunk.parameters() if p.requires_grad]
+                per_chunk_layouts[i] = compute_layout(
+                    all_params,
+                    bucket_size,
+                    data_parallel_world_size,
+                    ddp_config,
+                    expert_data_parallel_world_size=expert_data_parallel_world_size,
+                )
+
+    # Wrap each chunk.
+    wrapped = []
+    for chunk, layout, disable_bucketing in zip(
+        model_chunks, per_chunk_layouts, disable_bucketing_per_chunk
+    ):
+        chunk_kwargs = {}
+        if pg_collection is not None and DP is not DDP:
+            chunk_kwargs["pg_collection"] = pg_collection
+        if layout is not None:
+            chunk_kwargs["full_param_layout"] = layout
+        wrapped.append(
+            DP(
+                config=config,
+                ddp_config=ddp_config,
+                module=chunk,
+                disable_bucketing=disable_bucketing,
+                **chunk_kwargs,
+            )
+        )
+    return wrapped
+
+
 def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap_with_ddp=True, config=None, pg_collection=None):
     """Build the model."""
     args = get_args()
@@ -1478,6 +1581,19 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             if not ddp_config.overlap_grad_reduce:
                 ddp_config.bucket_size = None
 
+        # Compute per-chunk bucket sizes / disable_bucketing flags. Bucketing is
+        # disabled for non-first chunks, when overlap_param_gather_with_optimizer_step
+        # is on, or for non-zero pipeline-parallel ranks.
+        pp_rank = mpu.get_pipeline_model_parallel_rank()
+        per_chunk_disable_bucketing = [
+            (chunk_idx > 0) or args.overlap_param_gather_with_optimizer_step
+            for chunk_idx in range(len(model))
+        ]
+        per_chunk_bucket_sizes = [
+            None if (disable or pp_rank > 0) else ddp_config.bucket_size
+            for disable in per_chunk_disable_bucketing
+        ]
+
         # Setup stream for ddp initialization. The side-stream may be necessary for cuda graph
         #  capture support with DDP, but we sync it with the current stream to avoid races.
         ddp_stream = torch.cuda.Stream()
@@ -1485,53 +1601,18 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         ddp_stream.wait_stream(torch.cuda.current_stream())
         # Make ddp_stream start after whatever the default stream already queued
         with torch.cuda.stream(ddp_stream):
-            # Megatron-FSDP reads dtypes from ddp_config; pass pg_collection for AG/RS overlap.
-            dp_init_kwargs = {}
-            if args.use_megatron_fsdp:
-                dp_init_kwargs["pg_collection"] = pg_collection
-
-            wrapped_model = []
-            for model_chunk_idx, model_chunk in enumerate(model):
-                chunk_kwargs = dict(dp_init_kwargs)
-                disable_bucketing = (
-                    (model_chunk_idx > 0)
-                    or args.overlap_param_gather_with_optimizer_step
-                )
-
-                # Pre-compute parameter layouts for the distributed optimizer.
-                # Only pass to DDP; FSDP variants don't accept full_param_layout.
-                if args.use_distributed_optimizer and DP is DDP:
-                    all_params = [
-                        p for p in model_chunk.parameters() if p.requires_grad
-                    ]
-                    pp_rank = mpu.get_pipeline_model_parallel_rank()
-                    effective_bucket_size = (
-                        None
-                        if disable_bucketing or pp_rank > 0
-                        else ddp_config.bucket_size
-                    )
-                    chunk_kwargs["full_param_layout"] = (
-                        DistributedOptimizer.compute_full_param_layout(
-                            all_params,
-                            effective_bucket_size,
-                            mpu.get_data_parallel_world_size(with_context_parallel=True),
-                            ddp_config,
-                            expert_data_parallel_world_size=(
-                                mpu.get_expert_data_parallel_world_size()
-                            ),
-                        )
-                    )
-
-                wrapped_model.append(
-                    DP(
-                        config=config,
-                        ddp_config=ddp_config,
-                        module=model_chunk,
-                        disable_bucketing=disable_bucketing,
-                        **chunk_kwargs,
-                    )
-                )
-            model = wrapped_model
+            model = wrap_model_chunks_with_ddp(
+                model,
+                config,
+                ddp_config,
+                use_layer_wise_distributed_optimizer=getattr(
+                    args, 'use_layer_wise_distributed_optimizer', False
+                ),
+                DP=DP,
+                pg_collection=pg_collection if args.use_megatron_fsdp else None,
+                bucket_sizes=per_chunk_bucket_sizes,
+                disable_bucketing_per_chunk=per_chunk_disable_bucketing,
+            )
         # End of setup_stream
         # Critical: ensure side-stream work completes before touching params on default stream
         torch.cuda.current_stream().wait_stream(ddp_stream)
@@ -3936,6 +4017,9 @@ def should_disable_forward_pre_hook(args):
     return (
         not args.use_megatron_fsdp
         and has_optimizer
-        and (args.use_distributed_optimizer or args.use_layer_wise_distributed_optimizer)
+        and (
+            args.use_distributed_optimizer
+            or getattr(args, 'use_layer_wise_distributed_optimizer', False)
+        )
         and args.overlap_param_gather
     )

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1315,6 +1315,7 @@ def wrap_model_chunks_with_ddp(
     ddp_config,
     *,
     use_layer_wise_distributed_optimizer=False,
+    use_layer_wise_param_layout=True,
     DP=DDP,
     pg_collection=None,
     bucket_sizes=None,
@@ -1325,10 +1326,12 @@ def wrap_model_chunks_with_ddp(
     Centralises the DDP-wrapping wiring shared between :func:`get_model` and
     unit tests.
 
-    For ``use_layer_wise_distributed_optimizer=True``: forces
-    ``ddp_config.use_distributed_optimizer=True`` (mutated in place; needed for
-    reduce-scatter), and computes per-chunk shard-aligned layouts via
-    :meth:`LayerWiseDistributedOptimizer.compute_full_param_layout`.
+    For ``use_layer_wise_distributed_optimizer=True`` and ``use_layer_wise_param_layout=True``:
+    forces ``ddp_config.use_distributed_optimizer=True`` (mutated in place; needed
+    for reduce-scatter), and computes per-chunk shard-aligned layouts via
+    :meth:`LayerWiseDistributedOptimizer.compute_full_param_layout`. With
+    ``use_layer_wise_param_layout=False``, no layout is supplied and LayerWise falls back
+    to its legacy ``allgather_params`` sync path.
 
     For non-layerwise with ``ddp_config.use_distributed_optimizer=True``:
     computes per-chunk byte-level layouts via
@@ -1344,8 +1347,11 @@ def wrap_model_chunks_with_ddp(
         model_chunks: List of model chunks to wrap (un-DDP-wrapped).
         config: :class:`TransformerConfig`.
         ddp_config: :class:`DistributedDataParallelConfig`. Mutated in place when
-            ``use_layer_wise_distributed_optimizer=True``.
+            ``use_layer_wise_distributed_optimizer=True`` and ``use_layer_wise_param_layout=True``.
         use_layer_wise_distributed_optimizer: Whether the layerwise wiring runs.
+        use_layer_wise_param_layout: When ``use_layer_wise_distributed_optimizer=True``,
+            controls whether to compute and supply a shard-aligned param layout
+            to DDP. ``False`` keeps LayerWise on its legacy sync path.
         DP: The DDP class to construct (``DistributedDataParallel`` or an FSDP
             variant).
         pg_collection: Optional :class:`ProcessGroupCollection`. Forwarded to
@@ -1367,10 +1373,10 @@ def wrap_model_chunks_with_ddp(
     # Compute per-chunk layouts (DDP only).
     per_chunk_layouts = [None] * n
     if DP is DDP:
-        if use_layer_wise_distributed_optimizer:
+        if use_layer_wise_distributed_optimizer and use_layer_wise_param_layout:
             ddp_config.use_distributed_optimizer = True
             compute_layout = LayerWiseDistributedOptimizer.compute_full_param_layout
-        elif ddp_config.use_distributed_optimizer:
+        elif not use_layer_wise_distributed_optimizer and ddp_config.use_distributed_optimizer:
             compute_layout = DistributedOptimizer.compute_full_param_layout
         else:
             compute_layout = None
@@ -1608,6 +1614,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
                 use_layer_wise_distributed_optimizer=getattr(
                     args, 'use_layer_wise_distributed_optimizer', False
                 ),
+                use_layer_wise_param_layout=False,
                 DP=DP,
                 pg_collection=pg_collection if args.use_megatron_fsdp else None,
                 bucket_sizes=per_chunk_bucket_sizes,

--- a/tests/unit_tests/dist_checkpointing/utils.py
+++ b/tests/unit_tests/dist_checkpointing/utils.py
@@ -177,11 +177,38 @@ def init_checkpointing_mock_args(args, ckpt_dir, fully_parallel=False):
 
 
 def setup_model_and_optimizer(
-    seed, tp, pp, initialize_fn=initialize_gpt_model, bf16=True, dist_opt=True, optimizer='adam'
+    seed,
+    tp,
+    pp,
+    initialize_fn=initialize_gpt_model,
+    bf16=True,
+    dist_opt=True,
+    optimizer='adam',
+    use_param_layout=False,
 ):
+    optimizer_type = optimizer
+    use_layer_wise = False
+    if optimizer_type == 'dist_muon':
+        optimizer = 'muon'
+        use_layer_wise = True
+    if optimizer_type in ('muon', 'dist_muon') and dist_opt:
+        use_layer_wise = True
+
+    # When use_layer_wise is True and use_param_layout is False, route DDP
+    # construction through the legacy path (no precomputed param layout, no
+    # ``use_distributed_optimizer=True`` flip). LayerWiseDistributedOptimizer
+    # then syncs via its legacy ``allgather_params()`` codepath rather than
+    # ``start_param_sync``.
+    ddp_use_dist_opt = dist_opt and not (use_layer_wise and not use_param_layout)
+    ddp_use_layer_wise = use_layer_wise and use_param_layout
+
     mock_args = parse_args(ignore_unknown_args=True)
     with mock.patch('megatron.training.training.get_args', new=lambda: mock_args):
         init_basic_mock_args(mock_args, tp, pp, bf16=bf16)
+        mock_args.use_distributed_optimizer = ddp_use_dist_opt
+        mock_args.use_layer_wise_distributed_optimizer = ddp_use_layer_wise
+        if ddp_use_layer_wise:
+            mock_args.optimizer = optimizer
         model = get_model(
             partial(
                 initialize_fn,
@@ -193,19 +220,10 @@ def setup_model_and_optimizer(
             )
         )
 
-    optimizer_type = optimizer
-    use_layer_wise = False
-    if optimizer_type == 'dist_muon':
-        optimizer = 'muon'
-        use_layer_wise = True
-    if optimizer_type in ('muon', 'dist_muon') and dist_opt:
-        use_layer_wise = True
-        dist_opt = False
-
     config = OptimizerConfig(
         bf16=bf16,
         params_dtype=torch.bfloat16 if bf16 else torch.float,
-        use_distributed_optimizer=dist_opt,
+        use_distributed_optimizer=ddp_use_dist_opt,
         use_layer_wise_distributed_optimizer=use_layer_wise,
         optimizer=optimizer,
     )
@@ -272,10 +290,27 @@ def setup_moe_model_and_optimizer(
     use_grouped_mlp=False,
     use_glu=False,
     optimizer='adam',
+    use_param_layout=False,
 ):
+    optimizer_type = optimizer
+    use_layer_wise = False
+    if optimizer_type == 'dist_muon':
+        optimizer = 'muon'
+        use_layer_wise = True
+    if optimizer_type in ('muon', 'dist_muon') and dist_opt:
+        use_layer_wise = True
+
+    # See setup_model_and_optimizer for the use_param_layout semantics.
+    ddp_use_dist_opt = dist_opt and not (use_layer_wise and not use_param_layout)
+    ddp_use_layer_wise = use_layer_wise and use_param_layout
+
     mock_args = parse_args(ignore_unknown_args=True)
     with mock.patch('megatron.training.training.get_args', new=lambda: mock_args):
         init_basic_mock_args(mock_args, tp, pp, bf16=bf16)
+        mock_args.use_distributed_optimizer = ddp_use_dist_opt
+        mock_args.use_layer_wise_distributed_optimizer = ddp_use_layer_wise
+        if ddp_use_layer_wise:
+            mock_args.optimizer = optimizer
         model = get_model(
             partial(
                 initialize_fn,
@@ -292,19 +327,10 @@ def setup_moe_model_and_optimizer(
             )
         )
 
-    optimizer_type = optimizer
-    use_layer_wise = False
-    if optimizer_type == 'dist_muon':
-        optimizer = 'muon'
-        use_layer_wise = True
-    if optimizer_type in ('muon', 'dist_muon') and dist_opt:
-        use_layer_wise = True
-        dist_opt = False
-
     config = OptimizerConfig(
         bf16=bf16,
         params_dtype=torch.bfloat16 if bf16 else torch.float,
-        use_distributed_optimizer=dist_opt,
+        use_distributed_optimizer=ddp_use_dist_opt,
         use_layer_wise_distributed_optimizer=use_layer_wise,
         optimizer=optimizer,
     )

--- a/tests/unit_tests/distributed/test_layer_wise_param_layout.py
+++ b/tests/unit_tests/distributed/test_layer_wise_param_layout.py
@@ -184,6 +184,45 @@ class TestSizeMatchingLayout:
         # They should share a bucket (matched in one round).
         assert len(big_param_bucket_ids) == 1
 
+    # -- fallback packing for unique-large seeds --
+
+    def test_unique_large_seed_packs_smaller_params(self):
+        """A unique-large seed's empty shard slots should absorb smaller params.
+
+        Pool order is the *reverse* of input/forward order, so the
+        ``unique_large_param`` is placed last in the input list to make it the
+        first seed (top of pool). Without the packing fallback, the unique
+        seed would emit a bucket with ``dp_size - 1`` shards of pure padding
+        and the trailing smaller params would form their own bucket. With the
+        fallback, the smaller params land in the large param's bucket,
+        eliminating the second bucket entirely.
+        """
+        dp_size = 4
+        unique_large_param = _make_param((1024,))
+        filler_params = [_make_param((128,)) for _ in range(3)]
+        cfg = _make_ddp_config()
+
+        layout = _LWO._compute_per_buffer_param_layout(
+            filler_params + [unique_large_param], None, dp_size, cfg
+        )
+
+        # Invariant still holds: each param lies entirely within one shard.
+        for param in [unique_large_param] + filler_params:
+            _assert_param_within_shard(layout, param, dp_size)
+
+        # All four params share a single bucket (no second bucket for the
+        # filler params).
+        assert len(layout.bucket_indices) == 1
+        _, _, large_bucket_id = layout.param_index_map[unique_large_param]
+        for filler_param in filler_params:
+            _, _, filler_bucket_id = layout.param_index_map[filler_param]
+            assert filler_bucket_id == large_bucket_id
+
+        # Filler params land in shard slots other than the unique-large's.
+        large_shard = _get_shard_for_param(layout, unique_large_param, dp_size)
+        for filler_param in filler_params:
+            assert _get_shard_for_param(layout, filler_param, dp_size) != large_shard
+
     # -- shared_embedding isolation --
 
     def test_shared_embedding_isolated(self):

--- a/tests/unit_tests/distributed/test_layerwise_param_layout.py
+++ b/tests/unit_tests/distributed/test_layerwise_param_layout.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Tests for LayerWiseDistributedOptimizer parameter layout computation.
+
+These tests verify the size-matching shard-aligned layout logic without
+requiring GPU or distributed setup.
+"""
+
+import math
+from collections import Counter
+from unittest import mock
+
+import pytest
+import torch
+
+from megatron.core.optimizer.layer_wise_optimizer import LayerWiseDistributedOptimizer
+from megatron.core.optimizer.param_layout import BufferKey, pad_param_start, pad_to_divisor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_LWO = LayerWiseDistributedOptimizer
+
+
+def _make_param(shape, dtype=torch.bfloat16, **attrs):
+    param = torch.nn.Parameter(torch.randn(shape, dtype=dtype))
+    for attr_name, attr_value in attrs.items():
+        setattr(param, attr_name, attr_value)
+    return param
+
+
+def _make_ddp_config(pad_for_high_busbw=False, grad_reduce_in_fp32=True):
+    cfg = mock.Mock()
+    cfg.pad_buckets_for_high_nccl_busbw = pad_for_high_busbw
+    cfg.grad_reduce_in_fp32 = grad_reduce_in_fp32
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Tests for _shard_divisor
+# ---------------------------------------------------------------------------
+
+
+class TestShardDivisor:
+
+    def _verify(self, dp_size, high_busbw=False):
+        cfg = _make_ddp_config(pad_for_high_busbw=high_busbw)
+        sd = _LWO._shard_divisor(dp_size, cfg)
+        assert sd % 64 == 0, f"shard_divisor {sd} not 64-aligned"
+        if high_busbw:
+            bucket_div = math.lcm(dp_size, 128, 2**16)
+        else:
+            bucket_div = math.lcm(dp_size, 128)
+        assert (dp_size * sd) % bucket_div == 0
+
+    def test_dp2(self):
+        self._verify(2)
+
+    def test_dp4(self):
+        self._verify(4)
+
+    def test_dp8(self):
+        self._verify(8)
+
+    def test_dp8_high_busbw(self):
+        self._verify(8, high_busbw=True)
+
+    def test_dp1(self):
+        self._verify(1)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for layout verification
+# ---------------------------------------------------------------------------
+
+
+def _get_shard_for_param(layout, param, dp_size):
+    """Return which shard a param lands in."""
+    param_start_index, param_end_index, bucket_id = layout.param_index_map[param]
+    bucket_start_index, bucket_end_index = layout.bucket_indices[bucket_id]
+    shard_size = (bucket_end_index - bucket_start_index) // dp_size
+    shard_id = (param_start_index - bucket_start_index) // shard_size
+    return shard_id
+
+
+def _assert_param_within_shard(layout, param, dp_size):
+    """Assert that a param lies entirely within one shard."""
+    param_start_index, param_end_index, bucket_id = layout.param_index_map[param]
+    bucket_start_index, bucket_end_index = layout.bucket_indices[bucket_id]
+    shard_size = (bucket_end_index - bucket_start_index) // dp_size
+    shard_id = (param_start_index - bucket_start_index) // shard_size
+    shard_start_index = bucket_start_index + shard_id * shard_size
+    shard_end_index = shard_start_index + shard_size
+    assert (
+        shard_start_index <= param_start_index
+    ), f"param start {param_start_index} before shard start {shard_start_index}"
+    assert (
+        param_end_index <= shard_end_index
+    ), f"param end {param_end_index} past shard end {shard_end_index}"
+
+
+# ---------------------------------------------------------------------------
+# Tests for _compute_per_buffer_param_layout (size-matching)
+# ---------------------------------------------------------------------------
+
+
+class TestSizeMatchingLayout:
+
+    # -- uniform params: all same size, dp_size divides count --
+
+    def test_uniform_params_exact_fit(self):
+        """8 same-size params with dp_size=4 → each shard gets 2 params."""
+        dp_size = 4
+        params = [_make_param((256,)) for _ in range(8)]
+        cfg = _make_ddp_config()
+
+        layout = _LWO._compute_per_buffer_param_layout(params, None, dp_size, cfg)
+
+        for param in params:
+            _assert_param_within_shard(layout, param, dp_size)
+
+        # With 8 params and dp_size=4, 2 rounds of size-matching.
+        # Each round fills all 4 shards.  No padding needed.
+        shard_counts = Counter(_get_shard_for_param(layout, param, dp_size) for param in params)
+        assert set(shard_counts.values()) == {2}
+
+    def test_uniform_params_remainder_gets_padding(self):
+        """5 same-size params with dp_size=4 → 1 round fills 4, 1 round fills 1 + 3 padding."""
+        dp_size = 4
+        params = [_make_param((256,)) for _ in range(5)]
+        cfg = _make_ddp_config()
+
+        layout = _LWO._compute_per_buffer_param_layout(params, None, dp_size, cfg)
+
+        for param in params:
+            _assert_param_within_shard(layout, param, dp_size)
+
+        # All 5 params assigned; shard 0 gets 2, shards 1-3 get 1 each.
+        shard_counts = Counter(_get_shard_for_param(layout, param, dp_size) for param in params)
+        assert shard_counts[0] == 2
+        assert sum(shard_counts.values()) == 5
+
+    # -- mixed sizes --
+
+    def test_mixed_sizes_no_param_split(self):
+        """Params with different sizes: each param stays within one shard."""
+        dp_size = 2
+        params = [
+            _make_param((100,)),
+            _make_param((200,)),
+            _make_param((100,)),
+            _make_param((200,)),
+            _make_param((100,)),
+        ]
+        cfg = _make_ddp_config()
+
+        layout = _LWO._compute_per_buffer_param_layout(params, None, dp_size, cfg)
+
+        for param in params:
+            _assert_param_within_shard(layout, param, dp_size)
+
+    def test_size_matching_prefers_same_size(self):
+        """When shard 0 gets a 256-elem param, other shards should also get 256-elem params."""
+        dp_size = 4
+        big_params = [_make_param((256,)) for _ in range(4)]
+        small_params = [_make_param((64,)) for _ in range(4)]
+        # Interleave: big_params[0], small_params[0], big_params[1], small_params[1], ...
+        params = []
+        for big_param, small_param in zip(big_params, small_params):
+            params.extend([big_param, small_param])
+        cfg = _make_ddp_config()
+
+        layout = _LWO._compute_per_buffer_param_layout(params, None, dp_size, cfg)
+
+        for param in params:
+            _assert_param_within_shard(layout, param, dp_size)
+
+        # All 4 big params should be in the same round (one per shard).
+        big_param_bucket_ids = set()
+        for param in big_params:
+            _, _, bucket_id = layout.param_index_map[param]
+            big_param_bucket_ids.add(bucket_id)
+        # They should share a bucket (matched in one round).
+        assert len(big_param_bucket_ids) == 1
+
+    # -- shared_embedding isolation --
+
+    def test_shared_embedding_isolated(self):
+        """shared_embedding params go in their own bucket and fit within shard 0."""
+        dp_size = 2
+        regular_params = [_make_param((128,)) for _ in range(4)]
+        embedding_param = _make_param((128,), shared_embedding=True)
+        params = [embedding_param] + regular_params
+        cfg = _make_ddp_config()
+
+        layout = _LWO._compute_per_buffer_param_layout(params, None, dp_size, cfg)
+
+        # The shared embedding must fit entirely within one shard so reduce-scatter
+        # delivers the full reduced gradient to its owner rank.
+        _assert_param_within_shard(layout, embedding_param, dp_size)
+
+        # And it must be the sole real param in its bucket.
+        _, _, embedding_bucket_id = layout.param_index_map[embedding_param]
+        for param in regular_params:
+            _, _, bucket_id = layout.param_index_map[param]
+            assert bucket_id != embedding_bucket_id, "shared_embedding should be in its own bucket"
+
+        # Embedding lives in shard 0; shards 1..dp_size-1 are pure padding.
+        assert _get_shard_for_param(layout, embedding_param, dp_size) == 0
+
+    def test_shared_embedding_fits_in_shard_at_high_dp(self):
+        """With dp_size > 2, a vocab-sized shared embedding still fits in one shard.
+
+        Regression test for the case where the isolated bucket was sized to ~numel
+        instead of dp_size * numel, causing the embedding to silently span multiple
+        shards on dp_size > 1.
+        """
+        for dp_size in [2, 4, 8]:
+            embedding_param = _make_param((1024,), shared_embedding=True)
+            cfg = _make_ddp_config()
+            layout = _LWO._compute_per_buffer_param_layout([embedding_param], None, dp_size, cfg)
+            _assert_param_within_shard(layout, embedding_param, dp_size)
+            assert _get_shard_for_param(layout, embedding_param, dp_size) == 0
+
+    # -- bucket size threshold --
+
+    def test_bucket_size_creates_multiple_buckets(self):
+        """When bucket_size is small, multiple buckets are created."""
+        dp_size = 2
+        params = [_make_param((256,)) for _ in range(8)]
+        cfg = _make_ddp_config()
+
+        # Each round: 256 elements per shard.  shard_pos after round = 256.
+        # Padded shard size = pad_to_divisor(256, shard_div).
+        # bucket_total = dp_size * padded_shard_size.
+        # Set bucket_size small enough to force a split after 1 round.
+        shard_div = _LWO._shard_divisor(dp_size, cfg)
+        padded = pad_to_divisor(256, shard_div)
+        small_bucket = dp_size * padded  # triggers after 1 round
+
+        layout = _LWO._compute_per_buffer_param_layout(params, small_bucket, dp_size, cfg)
+
+        assert len(layout.bucket_indices) == 4  # 8 params / (dp_size per round) = 4 rounds
+
+    # -- bucket alignment --
+
+    def test_bucket_dp_divisible(self):
+        """Every bucket total must be divisible by dp_size."""
+        for dp_size in [2, 4, 8]:
+            params = [_make_param((333,)) for _ in range(dp_size * 2)]
+            cfg = _make_ddp_config()
+            layout = _LWO._compute_per_buffer_param_layout(params, None, dp_size, cfg)
+            for bucket_start_index, bucket_end_index in layout.bucket_indices:
+                assert (bucket_end_index - bucket_start_index) % dp_size == 0
+
+    def test_bucket_global_alignment(self):
+        """Bucket end must be a multiple of lcm(dp_size, 128)."""
+        dp_size = 4
+        params = [_make_param((333,)) for _ in range(8)]
+        cfg = _make_ddp_config()
+        layout = _LWO._compute_per_buffer_param_layout(params, None, dp_size, cfg)
+        divisor = math.lcm(dp_size, 128)
+        for _, bucket_end_index in layout.bucket_indices:
+            assert (
+                bucket_end_index % divisor == 0
+            ), f"bucket end {bucket_end_index} not aligned to {divisor}"
+
+    # -- backprop order --
+
+    def test_backprop_order_in_shards(self):
+        """Within each shard, params should appear in backprop (reverse model) order."""
+        dp_size = 2
+        params = [_make_param((128,)) for _ in range(6)]
+        cfg = _make_ddp_config()
+
+        layout = _LWO._compute_per_buffer_param_layout(params, None, dp_size, cfg)
+
+        # Group params by shard in backprop (reverse model) order.
+        shard_params: dict[int, list] = {i: [] for i in range(dp_size)}
+        for param in reversed(params):
+            shard_id = _get_shard_for_param(layout, param, dp_size)
+            param_start_index, _, _ = layout.param_index_map[param]
+            shard_params[shard_id].append((param_start_index, param))
+
+        # Within each shard, buffer positions should be increasing in backprop order.
+        for shard_id, items in shard_params.items():
+            param_start_indices = [param_start_index for param_start_index, _ in items]
+            assert param_start_indices == sorted(
+                param_start_indices
+            ), f"shard {shard_id} not in order"
+
+    # -- dp_size=1 --
+
+    def test_dp_size_1(self):
+        """With dp_size=1, every param goes to shard 0 (trivially no splitting)."""
+        params = [_make_param((100,)) for _ in range(5)]
+        cfg = _make_ddp_config()
+        layout = _LWO._compute_per_buffer_param_layout(params, None, 1, cfg)
+
+        for param in params:
+            _assert_param_within_shard(layout, param, 1)
+
+    # -- single param --
+
+    def test_single_param(self):
+        """A single param should produce one bucket."""
+        dp_size = 4
+        params = [_make_param((512,))]
+        cfg = _make_ddp_config()
+        layout = _LWO._compute_per_buffer_param_layout(params, None, dp_size, cfg)
+
+        assert len(layout.bucket_indices) == 1
+        _assert_param_within_shard(layout, params[0], dp_size)
+
+    # -- all params assigned --
+
+    def test_all_params_in_layout(self):
+        """Every input param appears in param_index_map exactly once."""
+        dp_size = 4
+        params = [_make_param((numel,)) for numel in [64, 128, 256, 64, 128, 256, 64]]
+        cfg = _make_ddp_config()
+        layout = _LWO._compute_per_buffer_param_layout(params, None, dp_size, cfg)
+
+        assert set(id(param) for param in layout.param_index_map.keys()) == set(
+            id(param) for param in params
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests for compute_full_param_layout
+# ---------------------------------------------------------------------------
+
+
+class TestLayerwiseFullParamLayout:
+
+    def test_basic_full_layout(self):
+        """End-to-end: params grouped by dtype, then laid out with shard alignment."""
+        dp_size = 2
+        params = [_make_param((256,)) for _ in range(4)]
+        cfg = _make_ddp_config()
+        layout = _LWO.compute_full_param_layout(params, None, dp_size, cfg)
+        assert len(layout.layouts) == 1
+        key = list(layout.layouts.keys())[0]
+        assert key == BufferKey(torch.bfloat16, torch.float, False)
+
+    def test_expert_parallel_separate_buffer(self):
+        """Expert-parallel params should be in a separate buffer group."""
+        dp_size = 2
+        dense = _make_param((256,))
+        expert = _make_param((256,), allreduce=False)
+        cfg = _make_ddp_config()
+        layout = _LWO.compute_full_param_layout([dense, expert], None, dp_size, cfg)
+        assert len(layout.layouts) == 2

--- a/tests/unit_tests/test_emerging_optimizers.py
+++ b/tests/unit_tests/test_emerging_optimizers.py
@@ -153,6 +153,30 @@ class TestMuonOptimizerMultiRank:
             TransformerConfig(num_attention_heads=1, num_layers=1), ddp_config, model
         )
 
+    def create_ddp_model_for_layerwise(self, model, use_param_layout=False):
+        """Wrap model in DDP for layer-wise distributed optimizer tests.
+
+        Args:
+            model: Model to wrap.
+            use_param_layout: If True, supply DDP a precomputed shard-aligned
+                ``full_param_layout`` (turns on ``ddp_config.use_distributed_optimizer=True``
+                + ``start_param_sync``). If False (default), build DDP without a layout
+                so ``LayerWiseDistributedOptimizer`` syncs via the legacy
+                flatten / ``all_gather_v`` / unflatten ``allgather_params()`` codepath.
+        """
+        if use_param_layout:
+            from megatron.training.training import wrap_model_chunks_with_ddp
+
+            ddp_config = DistributedDataParallelConfig()
+            wrapped = wrap_model_chunks_with_ddp(
+                [model],
+                TransformerConfig(num_attention_heads=1, num_layers=1),
+                ddp_config,
+                use_layer_wise_distributed_optimizer=True,
+            )
+            return wrapped[0]
+        return self.create_ddp_model(model)
+
     def test_get_megatron_optimizer_smoke(self):
         """Smoke test for get_megatron_optimizer function."""
         model = Net().bfloat16().cuda()
@@ -258,7 +282,7 @@ class TestMuonOptimizerMultiRank:
         """Test get_megatron_optimizer with layer-wise distributed optimizer."""
         model = Net().bfloat16().cuda()
         model.requires_grad_(True)
-        model = self.create_ddp_model(model)
+        model = self.create_ddp_model_for_layerwise(model)
 
         optimizer_config = OptimizerConfig(
             optimizer='muon',
@@ -302,7 +326,7 @@ class TestMuonOptimizerMultiRank:
         """Test get_megatron_muon_optimizer with backward compatible layer-wise distributed optimizer."""
         model = Net().bfloat16().cuda()
         model.requires_grad_(True)
-        model = self.create_ddp_model(model)
+        model = self.create_ddp_model_for_layerwise(model)
 
         optimizer_config = OptimizerConfig(
             optimizer='muon',

--- a/tests/unit_tests/test_layer_wise_optimizer.py
+++ b/tests/unit_tests/test_layer_wise_optimizer.py
@@ -81,6 +81,7 @@ class TestLayerWiseOptimizer:
         model_kwargs=None,
         use_layer_wise=True,
         copy_from=None,
+        use_param_layout=False,
     ):
         """Create model, DDP wrapper, and optimizer.
 
@@ -90,6 +91,11 @@ class TestLayerWiseOptimizer:
             model_kwargs: Optional kwargs for model initialization
             use_layer_wise: If True, use LayerWiseDistributedOptimizer via dist_muon;
                           if False, use standard muon ChainedOptimizer (for reference)
+            use_param_layout: If True, supply DDP a precomputed shard-aligned
+                ``full_param_layout`` (turns on ``ddp_config.use_distributed_optimizer=True``
+                + ``start_param_sync``). If False (default), build DDP without a layout
+                so ``LayerWiseDistributedOptimizer`` syncs via the legacy
+                flatten / ``all_gather_v`` / unflatten ``allgather_params()`` codepath.
 
         Returns:
             tuple: (model, optimizer, pg_collection)
@@ -100,10 +106,21 @@ class TestLayerWiseOptimizer:
         model = model_class(**model_kwargs).bfloat16().cuda()
         model.requires_grad_(True)
 
-        ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=False)
-        model = DistributedDataParallel(
-            TransformerConfig(num_attention_heads=1, num_layers=1), ddp_config, model
-        )
+        if use_param_layout:
+            from megatron.training.training import wrap_model_chunks_with_ddp
+
+            ddp_config = DistributedDataParallelConfig()
+            model = wrap_model_chunks_with_ddp(
+                [model],
+                TransformerConfig(num_attention_heads=1, num_layers=1),
+                ddp_config,
+                use_layer_wise_distributed_optimizer=use_layer_wise,
+            )[0]
+        else:
+            ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=False)
+            model = DistributedDataParallel(
+                TransformerConfig(num_attention_heads=1, num_layers=1), ddp_config, model
+            )
         if copy_from:
             model.module.load_state_dict(copy_from.module.state_dict())
         else:
@@ -136,6 +153,7 @@ class TestLayerWiseOptimizer:
         overlap_param_gather=True,
         grad_reduce_in_fp32=False,
         bucket_size=None,
+        use_param_layout=False,
     ):
         """Create model, DDP wrapper, and optimizer with overlap-param-gather enabled.
 
@@ -151,6 +169,9 @@ class TestLayerWiseOptimizer:
             overlap_param_gather: If True, defer param all-gather to bucket infrastructure
             grad_reduce_in_fp32: If True, reduce grads in fp32 (regression test for dtype fix)
             bucket_size: Maximum number of parameters per bucket (None = single bucket)
+            use_param_layout: If True, supply DDP a precomputed shard-aligned
+                ``full_param_layout`` (turns on ``ddp_config.use_distributed_optimizer=True``
+                + ``start_param_sync``). If False (default), build DDP without a layout.
 
         Returns:
             tuple: (model, optimizer, pg_collection)
@@ -161,16 +182,37 @@ class TestLayerWiseOptimizer:
         model = model_class(**model_kwargs).bfloat16().cuda()
         model.requires_grad_(True)
 
-        ddp_config = DistributedDataParallelConfig(
-            use_distributed_optimizer=False,
-            overlap_param_gather=True,
-            overlap_grad_reduce=True,
-            grad_reduce_in_fp32=grad_reduce_in_fp32,
-            bucket_size=bucket_size,
-        )
-        model = DistributedDataParallel(
-            TransformerConfig(num_attention_heads=1, num_layers=1), ddp_config, model
-        )
+        # overlap_param_gather=True requires bucketing, which only happens when
+        # overlap_grad_reduce=True (otherwise DDP forces bucket_size=None). Couple
+        # the two so a caller only has to flip one.
+        overlap_grad_reduce = overlap_param_gather
+
+        if use_param_layout:
+            from megatron.training.training import wrap_model_chunks_with_ddp
+
+            ddp_config = DistributedDataParallelConfig(
+                overlap_param_gather=overlap_param_gather,
+                overlap_grad_reduce=overlap_grad_reduce,
+                grad_reduce_in_fp32=grad_reduce_in_fp32,
+                bucket_size=bucket_size,
+            )
+            model = wrap_model_chunks_with_ddp(
+                [model],
+                TransformerConfig(num_attention_heads=1, num_layers=1),
+                ddp_config,
+                use_layer_wise_distributed_optimizer=True,
+            )[0]
+        else:
+            ddp_config = DistributedDataParallelConfig(
+                use_distributed_optimizer=False,
+                overlap_param_gather=overlap_param_gather,
+                overlap_grad_reduce=overlap_grad_reduce,
+                grad_reduce_in_fp32=grad_reduce_in_fp32,
+                bucket_size=bucket_size,
+            )
+            model = DistributedDataParallel(
+                TransformerConfig(num_attention_heads=1, num_layers=1), ddp_config, model
+            )
         if copy_from:
             model.module.load_state_dict(copy_from.module.state_dict())
         else:
@@ -206,9 +248,12 @@ class TestLayerWiseOptimizer:
         reference_model.load_state_dict(model.module.state_dict())
         return reference_model
 
-    def test_basic(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_basic(self, use_param_layout):
         """Test basic LayerWiseDistributedOptimizer initialization and step with bf16."""
-        model, optimizer, pg_collection = self.create_model_and_optimizer()
+        model, optimizer, pg_collection = self.create_model_and_optimizer(
+            use_param_layout=use_param_layout
+        )
 
         # Verify basic properties
         assert optimizer is not None, "Optimizer should not be None"
@@ -336,13 +381,16 @@ class TestLayerWiseOptimizer:
                     sh_base.replica_id[2] == 0
                 ), f'Expected DP replica_id to be 0 for layer-wise optimizer, got: {sh_base.replica_id[2]}'
 
-    def test_multiple_optimizers(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_multiple_optimizers(self, use_param_layout):
         """Test LayerWiseDistributedOptimizer with multiple chained optimizers.
 
         Uses get_megatron_muon_optimizer which produces multiple chained optimizers
         (muon for 2D weights + adam for 1D biases). Tests allgather with multiple ranks.
         """
-        model, optimizer, pg_collection = self.create_model_and_optimizer()
+        model, optimizer, pg_collection = self.create_model_and_optimizer(
+            use_param_layout=use_param_layout
+        )
 
         ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=False)
         model = DistributedDataParallel(
@@ -436,17 +484,23 @@ class TestLayerWiseOptimizer:
         ):
             LayerWiseDistributedOptimizer([wrapped_optimizer], lw_config, pg_collection)
 
-    def _run_parameter_update_test(self, model_class=SimpleModel):
+    def _run_parameter_update_test(self, use_param_layout, model_class=SimpleModel):
         """Helper method to test parameter updates with a given model class.
 
         Args:
-            model_class: Model class to use for testing
+            use_param_layout: forwarded to create_model_and_optimizer.
+            model_class: Model class to use for testing.
         """
-        model, optimizer, pg_collection = self.create_model_and_optimizer(model_class=model_class)
+        model, optimizer, pg_collection = self.create_model_and_optimizer(
+            model_class=model_class, use_param_layout=use_param_layout
+        )
 
         # Create reference model and optimizer using the same function
         reference_model, reference_optimizer, _ = self.create_model_and_optimizer(
-            model_class=model_class, use_layer_wise=False, copy_from=model
+            model_class=model_class,
+            use_layer_wise=False,
+            copy_from=model,
+            use_param_layout=use_param_layout,
         )
 
         # Set same gradients on both models
@@ -474,17 +528,19 @@ class TestLayerWiseOptimizer:
         for param, ref_param in zip(model.parameters(), reference_model.parameters()):
             torch.testing.assert_close(param.data, ref_param.data, rtol=1e-5, atol=1e-5)
 
-    def test_parameter_updates(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_parameter_updates(self, use_param_layout):
         """Test LayerWiseDistributedOptimizer actually updates model parameters."""
-        self._run_parameter_update_test()
+        self._run_parameter_update_test(use_param_layout=use_param_layout)
 
-    def test_parameter_updates_insufficient_parameters(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_parameter_updates_insufficient_parameters(self, use_param_layout):
         """Test LayerWiseDistributedOptimizer when there are insufficient parameters for all ranks.
 
         Uses a tiny model with only 1 layer (2 parameters: weight and bias).
         This will be insufficient when world size > 2.
         """
-        self._run_parameter_update_test(model_class=TinyModel)
+        self._run_parameter_update_test(use_param_layout=use_param_layout, model_class=TinyModel)
 
     def test_broadcast_vs_allgather(self):
         """Test LayerWiseDistributedOptimizer allgather code agains broadcast code."""
@@ -524,10 +580,11 @@ class TestLayerWiseOptimizer:
 
     # ---- Overlap-param-gather tests ----
 
-    def test_overlap_param_gather_basic(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_basic(self, use_param_layout):
         """Test overlap-param-gather path: init, forward/backward/step, bucket-based param sync."""
-        model, optimizer, pg_collection = (
-            self.create_model_and_optimizer_with_overlap_param_gather()
+        model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
+            use_param_layout=use_param_layout
         )
 
         assert optimizer is not None, "Optimizer should not be None"
@@ -572,15 +629,16 @@ class TestLayerWiseOptimizer:
                         msg=f"Parameter {name} differs between rank 0 and rank {i}",
                     )
 
-    def test_overlap_param_gather_parameter_updates(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_parameter_updates(self, use_param_layout):
         """Test overlap-param-gather produces same parameter updates as standard optimizer."""
-        model, optimizer, pg_collection = (
-            self.create_model_and_optimizer_with_overlap_param_gather()
+        model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
+            use_param_layout=use_param_layout
         )
 
         # Create reference model with standard (non-layer-wise) optimizer
         reference_model, reference_optimizer, _ = self.create_model_and_optimizer(
-            use_layer_wise=False, copy_from=model
+            use_layer_wise=False, copy_from=model, use_param_layout=use_param_layout
         )
 
         # Set same gradients on both models
@@ -602,7 +660,8 @@ class TestLayerWiseOptimizer:
         for param, ref_param in zip(model.parameters(), reference_model.parameters()):
             torch.testing.assert_close(param.data, ref_param.data, rtol=1e-5, atol=1e-5)
 
-    def test_overlap_param_gather_vs_sync_allgather(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_vs_sync_allgather(self, use_param_layout):
         """Key correctness test: overlap path and sync allgather produce identical updates.
 
         Compares:
@@ -611,12 +670,14 @@ class TestLayerWiseOptimizer:
         """
         # Create overlap model
         overlap_model, overlap_optimizer, pg_collection = (
-            self.create_model_and_optimizer_with_overlap_param_gather(overlap_param_gather=True)
+            self.create_model_and_optimizer_with_overlap_param_gather(
+                overlap_param_gather=True, use_param_layout=use_param_layout
+            )
         )
 
         # Create sync model with same weights (overlap_param_gather=True but sync allgather)
         sync_model, sync_optimizer, _ = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=False, copy_from=overlap_model
+            overlap_param_gather=False, copy_from=overlap_model, use_param_layout=use_param_layout
         )
 
         # Verify initial parameters match
@@ -722,18 +783,22 @@ class TestLayerWiseOptimizer:
                 msg="Overlap-param-gather and standard paths produced different updates",
             )
 
-    def test_overlap_param_gather_insufficient_parameters(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_insufficient_parameters(self, use_param_layout):
         """Test overlap-param-gather with TinyModel (only 2 params).
 
         Many ranks will have no assigned params when world_size > 2.
         """
         model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
-            model_class=TinyModel
+            model_class=TinyModel, use_param_layout=use_param_layout
         )
 
         # Create reference model with standard (non-layer-wise) optimizer
         reference_model, reference_optimizer, _ = self.create_model_and_optimizer(
-            model_class=TinyModel, use_layer_wise=False, copy_from=model
+            model_class=TinyModel,
+            use_layer_wise=False,
+            copy_from=model,
+            use_param_layout=use_param_layout,
         )
 
         # Set same gradients on both models
@@ -793,7 +858,8 @@ class TestLayerWiseOptimizer:
         for param, ref_param in zip(model.parameters(), reference_model.parameters()):
             torch.testing.assert_close(param.data, ref_param.data, rtol=0, atol=0)
 
-    def test_overlap_param_gather_multi_iteration(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_multi_iteration(self, use_param_layout):
         """Test overlap-param-gather correctness over multiple training iterations.
 
         Runs multiple forward/backward/step iterations using the async allgather path.
@@ -801,12 +867,12 @@ class TestLayerWiseOptimizer:
         model using the sync path.
         """
         model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=True
+            overlap_param_gather=True, use_param_layout=use_param_layout
         )
 
         # Create reference model with sync allgather for comparison
         ref_model, ref_optimizer, _ = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=False, copy_from=model
+            overlap_param_gather=False, copy_from=model, use_param_layout=use_param_layout
         )
 
         for iteration in range(3):
@@ -841,17 +907,18 @@ class TestLayerWiseOptimizer:
                     msg=f"Parameters diverged at iteration {iteration}",
                 )
 
-    def test_overlap_param_gather_async_dispatch_and_finish(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_async_dispatch_and_finish(self, use_param_layout):
         """Test async dispatch + finish_param_sync cycle (the actual runtime path).
 
         start_param_sync() (no force_sync) dispatches async all-gathers, then
         finish_param_sync() waits on the handle and unflattens gathered params.
         """
         model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=True
+            overlap_param_gather=True, use_param_layout=use_param_layout
         )
         ref_model, ref_optimizer, _ = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=False, copy_from=model
+            overlap_param_gather=False, copy_from=model, use_param_layout=use_param_layout
         )
 
         # Set identical gradients on both models
@@ -900,14 +967,15 @@ class TestLayerWiseOptimizer:
                         msg=f"Parameter {name} differs between rank 0 and rank {i}",
                     )
 
-    def test_overlap_param_gather_finish_chains_next_bucket(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_finish_chains_next_bucket(self, use_param_layout):
         """Test that finish_param_sync() dispatches next_param_gather_bucket_group.
 
         Uses a small bucket_size to force multiple bucket groups, then dispatches
         only the last bucket group and verifies that finishing it chains to the next.
         """
         model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=True, bucket_size=2000
+            overlap_param_gather=True, bucket_size=2000, use_param_layout=use_param_layout
         )
 
         bucket_groups = model.bucket_groups
@@ -915,7 +983,10 @@ class TestLayerWiseOptimizer:
             pytest.skip("Need multiple bucket groups to test chaining")
 
         ref_model, ref_optimizer, _ = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=False, copy_from=model, bucket_size=2000
+            overlap_param_gather=False,
+            copy_from=model,
+            bucket_size=2000,
+            use_param_layout=use_param_layout,
         )
 
         # Set identical gradients on both models
@@ -961,17 +1032,18 @@ class TestLayerWiseOptimizer:
                 msg="Chained bucket finish produced different params than sync path",
             )
 
-    def test_overlap_param_gather_forward_pre_hook(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_forward_pre_hook(self, use_param_layout):
         """Test forward pre-hooks trigger finish_param_sync during model(input).
 
         After async dispatch, running model(input) fires forward pre-hooks that
         call finish_param_sync() on each bucket group, completing the param sync.
         """
         model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=True
+            overlap_param_gather=True, use_param_layout=use_param_layout
         )
         ref_model, ref_optimizer, _ = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=False, copy_from=model
+            overlap_param_gather=False, copy_from=model, use_param_layout=use_param_layout
         )
 
         # Set identical gradients on both models
@@ -1002,7 +1074,8 @@ class TestLayerWiseOptimizer:
                 msg="Forward pre-hook path produced different params than sync path",
             )
 
-    def test_overlap_param_gather_grad_reduce_in_fp32(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_grad_reduce_in_fp32(self, use_param_layout):
         """Regression test: grad_reduce_in_fp32 must not cause dtype mismatch in broadcasts.
 
         When grad_reduce_in_fp32=True, the grad buffer dtype is fp32 but broadcast
@@ -1010,10 +1083,13 @@ class TestLayerWiseOptimizer:
         would cause a dtype mismatch error in the per-rank broadcast calls.
         """
         model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=True, grad_reduce_in_fp32=True
+            overlap_param_gather=True, grad_reduce_in_fp32=True, use_param_layout=use_param_layout
         )
         ref_model, ref_optimizer, _ = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=False, copy_from=model, grad_reduce_in_fp32=True
+            overlap_param_gather=False,
+            copy_from=model,
+            grad_reduce_in_fp32=True,
+            use_param_layout=use_param_layout,
         )
 
         # Set identical gradients on both models
@@ -1040,17 +1116,18 @@ class TestLayerWiseOptimizer:
                 msg="grad_reduce_in_fp32 path produced different params than reference",
             )
 
-    def test_overlap_param_gather_hook_enable_disable_cycle(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_hook_enable_disable_cycle(self, use_param_layout):
         """Test the training loop's hook lifecycle: disable → manual sync → enable → forward.
 
         The training loop disables hooks before iteration 1 (for initialization),
         then enables them for subsequent iterations. This test exercises that cycle.
         """
         model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=True
+            overlap_param_gather=True, use_param_layout=use_param_layout
         )
         ref_model, ref_optimizer, _ = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=False, copy_from=model
+            overlap_param_gather=False, copy_from=model, use_param_layout=use_param_layout
         )
 
         input_tensor = torch.randn(16, 80, dtype=torch.bfloat16, device='cuda')
@@ -1102,7 +1179,8 @@ class TestLayerWiseOptimizer:
                 msg="Params diverged after iteration 2 (hooks re-enabled)",
             )
 
-    def test_overlap_param_gather_multi_iteration_with_hooks(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_multi_iteration_with_hooks(self, use_param_layout):
         """Test multiple iterations using forward pre-hooks (not manual force_sync).
 
         Runs 3 iterations where each iteration uses: set grads → step → async dispatch →
@@ -1110,10 +1188,10 @@ class TestLayerWiseOptimizer:
         allgather after each iteration.
         """
         model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=True
+            overlap_param_gather=True, use_param_layout=use_param_layout
         )
         ref_model, ref_optimizer, _ = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=False, copy_from=model
+            overlap_param_gather=False, copy_from=model, use_param_layout=use_param_layout
         )
 
         input_tensor = torch.randn(16, 80, dtype=torch.bfloat16, device='cuda')
@@ -1144,7 +1222,8 @@ class TestLayerWiseOptimizer:
                     msg=f"Parameters diverged at iteration {iteration}",
                 )
 
-    def test_overlap_param_gather_start_sync_with_autograd(self):
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    def test_overlap_param_gather_start_sync_with_autograd(self, use_param_layout):
         """Regression test: start_param_sync must work when autograd is active.
 
         _flatten_dense_tensors on params with requires_grad=True produces a tensor
@@ -1160,10 +1239,10 @@ class TestLayerWiseOptimizer:
         next bucket group.
         """
         model, optimizer, pg_collection = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=True
+            overlap_param_gather=True, use_param_layout=use_param_layout
         )
         ref_model, ref_optimizer, _ = self.create_model_and_optimizer_with_overlap_param_gather(
-            overlap_param_gather=False, copy_from=model
+            overlap_param_gather=False, copy_from=model, use_param_layout=use_param_layout
         )
 
         # Confirm params require grad (the precondition for this bug).


### PR DESCRIPTION
## Summary

Adds a **shard-aligned parameter layout** for `LayerWiseDistributedOptimizer` that guarantees no parameter is split across shard boundaries — the invariant optimizers like Muon need so Newton-Schulz iteration can run on full weight matrices. The optimizer publishes this layout to DDP, which means DDP can manage the buffers exactly as it does for `DistributedOptimizer`:

- **Gradient reduction**: reduce-scatter via `use_distributed_optimizer=True`, replacing the previous all-reduce-then-pick-your-shard scheme.
- **Parameter sync**: DDP's standard buffer all-gather via `model_chunk.start_param_sync()`, replacing the legacy flatten / `all_gather_v` / unflatten path that copied data on both ends.

## Why

Before this PR, `LayerWiseDistributedOptimizer` ran outside DDP's buffer infrastructure:

- DDP was configured with `use_distributed_optimizer=False`, so gradients were all-reduced rather than reduce-scattered. Each rank held a full reduced gradient buffer even though it would only update its own shard.
- Parameter sync was a hand-rolled `all_gather_v` that flattened each rank's params into a contiguous tensor, all-gathered, then unflattened and `copy_`-ed the results back into model params. Two extra full-size copies per sync.

Both fell out of "the optimizer doesn't know how the buffer is laid out, so DDP can't be told to slice it." Once the optimizer can publish a layout that guarantees "every param fits inside one DP shard," DDP's existing reduce-scatter and buffer all-gather work directly.

## Approach

### Shard-aligned size-matching layout

`LayerWiseDistributedOptimizer._compute_per_buffer_param_layout` produces a shard-aligned layout per buffer using a size-matching algorithm: each round claims one param for shard 0 and assigns same-sized params (or padding) to shards 1..dp-1, so all shards grow by exactly the same amount in lockstep. Shard sizes stay equal by construction; for repeated-layer models (N identical transformer blocks) padding overhead is zero. Every param ends up fully contained within a single DP-rank's shard — the invariant Muon's whole-tensor update requires.

Shared (tied) embeddings get isolated buckets — they are placed alone in shard 0 of their own bucket, with shards 1..dp-1 padded to the same size. This preserves the no-shard-crossing invariant but pays a `(dp_size - 1) * pad(numel)` cost per shared embedding. Eliminating that cost is the goal of a follow-up PR that routes Adam-managed params through a separate `DistributedOptimizer`.

### Optimizer state partitioning derived from the layout

`_shard_params_from_layout` derives each parameter's owning rank directly from the published layout (`(start - bucket_start) // shard_size`) instead of the previous independent ping-pong-by-numel assignment. Optimizer and DDP now agree on shard assignments by construction, eliminating the class of bugs where the two could disagree and the optimizer would step on a parameter whose gradient was reduce-scattered to a different rank. A defensive assertion in `_shard_params_from_layout` catches any param straddling a shard boundary, so layout regressions fail loudly rather than silently corrupting the emerging optimizer's update.

### Step flow

DDP is now configured with `use_distributed_optimizer=True` for layerwise mode, so model params are views into `bucket.param_data` and grads are reduce-scattered into each rank's shard of the gradient buffer during backward. On step:

1. `LayerWise.step` runs the Muon update on its local-rank shard of every layerwise buffer; the standard "main → model_param" copy updates the param buffer in place (because model_param *is* a view into the buffer).
2. `model_chunk.start_param_sync(force_sync=True)` syncs the buffer across DP ranks via DDP's standard all-gather — no flatten/unflatten copies.

### DDP wiring centralised in a helper

`wrap_model_chunks_with_ddp` (new, in `megatron/training/training.py`) centralises the DDP-construction logic shared between `get_model` and unit tests:

- Forces `ddp_config.use_distributed_optimizer = True` when `use_layer_wise_distributed_optimizer=True` (needed for reduce-scatter).
- Computes the per-chunk `full_param_layout` via `LayerWiseDistributedOptimizer.compute_full_param_layout` (layerwise) or `DistributedOptimizer.compute_full_param_layout` (standard distopt).
- Wraps each chunk with the layout passed through.

### Legacy paths kept as fallback (for the no-layout case)

The pre-PR sync paths are retained for callers that don't supply a layout yet and are marked for removal once all call sites pass one:

- `LayerWiseDistributedOptimizer.allgather_params` (flatten / `all_gather_v` / unflatten path).
- `LayerWiseDistributedOptimizer.set_bucket_layerwise_params_list`.
- `LayerWiseDistributedOptimizer._shard_params_ping_pong` (the ping-pong-by-numel fallback used when no layout is supplied).
- The variable-size all-gather branch in `_ParamAndGradBucketGroup.start_param_sync`.

## Tests

- New `tests/unit_tests/distributed/test_layerwise_param_layout.py`: covers the size-matching layout (uniform / mixed / shared-embedding / dp-divisibility / backprop ordering / `dp_size ∈ {1, 2, 4, 8}`).
- `test_emerging_optimizers` and `dist_checkpointing/test_layer_wise_optimizer`: updated to construct DDP via the new `wrap_model_chunks_with_ddp` helper so the layerwise wiring matches `training.get_model`.

## Test plan

- [x] Verify `test_layerwise_param_layout.py` passes (shard divisor, size-matching layout, shared-embedding isolation, bucket alignment, backprop ordering, full layout grouping)
- [x] Verify existing `test_param_layout.py` tests still pass
- [x] Verify `test_emerging_optimizers` tests pass against `LayerWiseDistributedOptimizer`
- [x] Verify `dist_checkpointing/test_layer_wise_optimizer` tests pass
- [x] Run Muon training with `--use-layer-wise-distributed-optimizer` and verify convergence matches the existing layerwise baseline
- [x] Verify reduce-scatter is used (not allreduce) when the layerwise optimizer is active — i.e. `ddp_config.use_distributed_optimizer=True` is in effect and grads are reduce-scattered into per-rank shards
- [x] Cluster: small Muon training run at `dp_size > 1` to verify gradient flow + convergence end-to-end

<img width="1348" height="1162" alt="image" src="https://github.com/user-attachments/assets/09a9ea7b-b7b7-4bc9-b770-d342874fbbd6" />


## Follow-up

Routing Adam-managed parameters through a separate `DistributedOptimizer` (sub-tensor sharding) so tied embeddings avoid the `(dp_size - 1) * pad(numel)` per-rank padding cost. That work is staged on a separate branch and will land as a follow-up PR.