### PR TITLE
[Dev] remove dead manual_release_grads code path in 1F1B overlap schedule

### DIFF
--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -316,12 +316,6 @@ class TransformerLayerNode(ScheduleNode):
         detached_grad = tuple([e.grad for e in self.detached])
         grads = output_grad + detached_grad
         self.default_backward_func(outputs + self.before_detached, grads)
-        # release the output grad memory after backward finishes,
-        # except when delay_wgrad_comptue is enabled, the grad should be
-        # kept until all modules' backward_dw has been invoked.
-        if self.delay_wgrad_compute:
-            self.output_grads = grads
-            self.delay_grads_release = len(self.bwd_dw_callables) > 0
 
         # return grads for record stream
         return grads
@@ -338,13 +332,6 @@ class TransformerLayerNode(ScheduleNode):
             for module in self.bwd_dw_callables:
                 module.backward_dw()
             nvtx_range_pop(nvtx_msg)
-
-        # the output grad memory is last used in wgrad compute, should be safe to release.
-        assert self.delay_grads_release, "output grad memory should be valid before wgrad."
-        if self.manual_release_grads:
-            for tensor in self.output_grads:
-                tensor.untyped_storage().resize_(0)
-        self.output_grads = None
 
         self.bwd_dw_callables = None
 

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -182,8 +182,6 @@ class ScheduleNode:
         self.free_input = free_input
         self.inputs = None
         self.outputs = None
-        self.delay_grads_release = False
-        self.manual_release_grads = False
 
     def default_backward_func(self, outputs, output_grad):
         """Default backward function"""
@@ -263,12 +261,6 @@ class ScheduleNode:
             for g in output_grad:
                 if g is not None:
                     g.record_stream(self.stream)
-                    # Manually trigger the memory release of dgrad tensor
-                    # to avoid delayed garbage collection. If
-                    # delay_grads_release is True, dgrad is last used in
-                    # wgrad compute and skip the release here.
-                    if self.manual_release_grads and not self.delay_grads_release:
-                        g.untyped_storage().resize_(0)
 
         grads = self.get_grad()
         self._release_state()


### PR DESCRIPTION
# What does this PR do ?

Removes dead code in the 1F1B overlap schedule. `ScheduleNode.manual_release_grads` was hardcoded to `False` at construction in `pipeline_parallel/utils.py` and never reassigned anywhere in the codebase, so both `if self.manual_release_grads:` branches were unreachable. The supporting bookkeeping (`delay_grads_release`, `output_grads`) existed only to feed those unreachable branches.

Removed:
- `pipeline_parallel/utils.py`: `self.manual_release_grads = False` and `self.delay_grads_release = False` fields on `ScheduleNode`; the unreachable `g.untyped_storage().resize_(0)` branch in `_backward`.
- `models/gpt/fine_grained_callables.py`: in `backward_impl`, the `if self.delay_wgrad_compute: self.output_grads = grads; self.delay_grads_release = ...` block (only consumed by the dead release path); in `backward_dw`, the unreachable `tensor.untyped_storage().resize_(0)` loop, the now-meaningless `assert self.delay_grads_release`, and the explicit `self.output_grads = None` clearing.

PyTorch's caching allocator already reclaims the dgrad tensors when the last Python reference drops at the end of `_backward` / `backward_dw`, so this whole machinery was a no-op. Same scope as #4122.

### Why this is safe

A/B comparison was run with the flag temporarily exposed as a `TransformerConfig` field, on `qwen3_moe_proxy` (PP=1 EP=8, `overlap_moe_expert_parallel_comm` + `delay_wgrad_compute` enabled, 100 iters on real 8×H100, EOS):

| `manual_release_grads` | Peak max-allocated (MB) |
|------------------------|-------------------------|
| `False` (status quo)   | 12479.13                |
| `True` (release on)    | 12479.13                |

Peak allocated memory is identical to two decimals.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

Companion main PR: https://github.com/NVIDIA/Megatron-LM/pull/4511

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

(Pure deletion of unreachable code; existing 1F1B-overlap functional tests cover the surrounding paths.)

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>