### PR TITLE
Async GPU/CPU overlap for dynamic inference scheduling

### DIFF
--- a/docs/api-guide/dynamic-inference-async-overlap.md
+++ b/docs/api-guide/dynamic-inference-async-overlap.md
@@ -1,0 +1,44 @@
+<!---
+   Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+   NVIDIA CORPORATION and its licensors retain all intellectual property
+   and proprietary rights in and to this software, related documentation
+   and any modifications thereto. Any use, reproduction, disclosure or
+   distribution of this software and related documentation without an express
+   license agreement from NVIDIA CORPORATION is strictly prohibited.
+-->
+
+# Dynamic Inference Async Overlap
+
+Dynamic inference uses a queue-depth-limited pipeline to overlap GPU forward and
+sampling work with CPU-owned bookkeeping and ordered output retirement.
+`async_overlap_queue_depth=2` is the default validated mode. Queue depth one uses
+the same architecture and remains the debug and correctness fallback.
+
+## Invariants
+
+- Every dynamic step has a monotonic step id, a step journal entry, and an owned
+  snapshot slot before the forward launches.
+- The scheduler updates CPU-resident request state first, then transfers one
+  coalesced metadata snapshot to a fixed-address GPU snapshot slot.
+- Output retirement is ordered by step id, not by launch completion order.
+- Lookahead may be disabled for a step, but the engine does not switch to a
+  second serial implementation.
+- Distributed ranks must agree on prepare metadata before launching a forward.
+  Repeated divergence downgrades the live pipeline to queue depth one and records
+  the reason in metrics.
+
+## Observability
+
+Inference metrics include the active queue depth, queue-depth distribution,
+maximum in-flight launches observed, snapshot-slot waits, output-event waits,
+lookahead-token discards, rollback counts, graph-cache hit/miss counts by
+snapshot slot, host-observed inter-step gap, and CPU time retired while another
+launch remains in flight.
+
+## Tuning
+
+Depth-two mode allocates one spare snapshot slot beyond the launch queue depth so
+retiring snapshots and CUDA graph capture reuse do not force avoidable host-side
+stalls. The pinned output-copy pool also keeps one spare slot beyond the queue
+depth, allowing public output retirement to lag the next launch without reusing a
+buffer that still has an outstanding D2H event.

--- a/docs/api-guide/index.md
+++ b/docs/api-guide/index.md
@@ -17,4 +17,5 @@ API reference documentation for Megatron Core components.
 models/index
 core/index
 internal/index
+dynamic-inference-async-overlap
 ```

--- a/examples/inference/gpt/gpt_dynamic_inference.py
+++ b/examples/inference/gpt/gpt_dynamic_inference.py
@@ -491,7 +491,7 @@ def main():
         p_count = len(p_times)
         d_count = len(d_times)
 
-        p_mean = p_total / p_count
+        p_mean = p_total / p_count if p_count != 0 else 0.0
         d_mean = d_total / d_count if d_count != 0 else 0.0
 
         # Commented out for now as the step/add/output times are not calculated correctly.

--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -143,6 +143,7 @@ class InferenceBatchDimensions:
         smallest_non_decode_cuda_graph_size: int,
         ep_group: Optional[torch.distributed.ProcessGroup] = None,
         num_speculative_tokens: int = 0,
+        ep_zmq_communicator=None,
     ) -> Optional["InferenceBatchDimensions"]:
         """Adjusted cuda graph batch dimensions for expert parallelism.
             We take the max token count across expert model parallel group.
@@ -154,6 +155,11 @@ class InferenceBatchDimensions:
             ep_group: Optional expert parallel process group. If None, uses global parallel state.
                       When using different EP sizes for inference vs training, pass the
                       inference EP group explicitly.
+            ep_zmq_communicator: Optional AsyncZMQCommunicator over the EP group. When
+                      provided, the cross-rank MAX reduction runs on the CPU via ZMQ
+                      (no GPU kernel, no H2D/D2H), avoiding a per-step NCCL AllReduce
+                      on the compute stream. When absent, falls back to
+                      torch.distributed.all_reduce on a GPU tensor.
 
         Return:
             (InferenceBatchDimensions) A new InferenceBatchDimensions object with
@@ -166,21 +172,41 @@ class InferenceBatchDimensions:
 
         is_non_decode = local_batch_dims.prefill_req_count > 0
 
-        sync_tensor = torch.tensor(
-            [
+        if ep_zmq_communicator is not None:
+            # CPU-only sync via ZMQ: avoids a NCCL AllReduce kernel on the
+            # compute stream plus the H2D/D2H pair that sandwiches it.
+            (
+                max_token_count,
+                max_is_non_decode,
+                max_prefill_count,
+                max_decode_count,
+            ) = ep_zmq_communicator.sync_all_reduce_max(
                 local_batch_dims.token_count,
                 int(is_non_decode),
                 local_batch_dims.prefill_req_count,
                 local_batch_dims.decode_req_count,
-            ],
-            dtype=torch.int32,
-            device=torch.cuda.current_device(),
-        )
+            )
+        else:
+            sync_tensor = torch.tensor(
+                [
+                    local_batch_dims.token_count,
+                    int(is_non_decode),
+                    local_batch_dims.prefill_req_count,
+                    local_batch_dims.decode_req_count,
+                ],
+                dtype=torch.int32,
+                device=torch.cuda.current_device(),
+            )
+            torch.distributed.all_reduce(
+                sync_tensor, op=torch.distributed.ReduceOp.MAX, group=ep_group
+            )
+            sync_tensor = sync_tensor.cpu()
+            max_token_count = int(sync_tensor[0].item())
+            max_is_non_decode = int(sync_tensor[1].item())
+            max_prefill_count = int(sync_tensor[2].item())
+            max_decode_count = int(sync_tensor[3].item())
 
-        torch.distributed.all_reduce(sync_tensor, op=torch.distributed.ReduceOp.MAX, group=ep_group)
-
-        sync_tensor = sync_tensor.cpu()
-        is_any_ep_rank_in_non_decode = sync_tensor[1].item() == 1
+        is_any_ep_rank_in_non_decode = max_is_non_decode == 1
 
         # We force eager mode for scenarios where some ranks will run with CUDA graphs
         # while others will not. Without this check, communication in the
@@ -191,7 +217,7 @@ class InferenceBatchDimensions:
         if is_any_ep_rank_in_non_decode and decode_only_cuda_graphs:
             return None  # indicate no match, run in eager mode
 
-        adjusted_token_count = int(sync_tensor[0].item())
+        adjusted_token_count = max_token_count
 
         # Sync request counts across EP ranks when strict matching is enabled
         # or when speculative tokens are used.  With speculative tokens,
@@ -203,12 +229,10 @@ class InferenceBatchDimensions:
             is_any_ep_rank_in_non_decode and num_speculative_tokens > 0
         )
         adjusted_prefill_req_count = (
-            int(sync_tensor[2].item())
-            if sync_request_counts
-            else local_batch_dims.prefill_req_count
+            max_prefill_count if sync_request_counts else local_batch_dims.prefill_req_count
         )
         adjusted_decode_req_count = (
-            int(sync_tensor[3].item()) if sync_request_counts else local_batch_dims.decode_req_count
+            max_decode_count if sync_request_counts else local_batch_dims.decode_req_count
         )
 
         # When any EP rank has prefill requests (non-strict mode), elevate
@@ -511,6 +535,7 @@ class CUDAGraphBatchDimensionBuilder:
         decode_only_cuda_graphs: bool = False,
         ep_group: Optional[torch.distributed.ProcessGroup] = None,
         num_speculative_tokens: int = 0,
+        ep_zmq_communicator=None,
     ) -> Optional[InferenceBatchDimensions]:
         """
         Matches the best CUDA graph batch dimension for the given real batch dimension.
@@ -526,6 +551,10 @@ class CUDAGraphBatchDimensionBuilder:
             ep_group: Optional expert parallel process group. If None, uses global parallel state.
                       When using different EP sizes for inference vs training, pass the
                       inference EP group explicitly.
+            ep_zmq_communicator: Optional AsyncZMQCommunicator over the EP group. When
+                      provided, batch-dimension MAX reduction uses a CPU-only ZMQ sync
+                      instead of a GPU NCCL AllReduce. Forwarded to
+                      adjust_batch_dims_for_expert_parallelism.
         Returns:
             The best matching CUDA graph batch dimension, or None if no applicable match is found
         """
@@ -541,6 +570,7 @@ class CUDAGraphBatchDimensionBuilder:
             ep_group=ep_group,
             smallest_non_decode_cuda_graph_size=smallest_non_decode_cuda_graph_size,
             num_speculative_tokens=num_speculative_tokens,
+            ep_zmq_communicator=ep_zmq_communicator,
         )
 
         if adjusted_batch_dim is None:

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -304,21 +304,20 @@ class InferenceConfig:
     """
 
     # =================================
-    # Temporary async-overlap rollout config
+    # Async-overlap config
     # =================================
-    enable_async_overlap_architecture: bool = False
-    """Enable the async-overlap architecture rollout path.
+    enable_async_overlap_architecture: bool = True
+    """Deprecated compatibility flag for async-overlap architecture rollout.
 
-    This is temporary scaffolding. Queue depth one is the serial correctness/debug mode;
-    later commits replace the old direct serial path with the new queue-depth-one path
-    before queue-depth-two overlap is enabled.
+    The dynamic engine now always uses the async-overlap architecture. This flag is
+    retained only so older configs continue to load until the rollout cleanup removes it.
     """
 
-    async_overlap_queue_depth: int = 1
-    """Maximum async-overlap pipeline depth. ``1`` is serial debug/correctness mode."""
+    async_overlap_queue_depth: int = 2
+    """Maximum async-overlap pipeline depth. ``1`` is debug/correctness mode."""
 
     async_overlap_debug_checks: bool = False
-    """Enable expensive async-overlap invariant checks while the rollout flag exists."""
+    """Enable expensive async-overlap invariant checks."""
 
     use_synchronous_zmq_collectives: bool = False
     """Whether to use synchronous ZMQ collectives for inference. If True, the
@@ -340,4 +339,9 @@ class InferenceConfig:
         if self.async_overlap_queue_depth < 1:
             raise ValueError(
                 f"async_overlap_queue_depth must be >= 1, got {self.async_overlap_queue_depth}"
+            )
+        if self.async_overlap_queue_depth > 2:
+            raise ValueError(
+                "async_overlap_queue_depth > 2 is not available until wider async-overlap "
+                "pipeline depths are validated"
             )

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -306,13 +306,6 @@ class InferenceConfig:
     # =================================
     # Async-overlap config
     # =================================
-    enable_async_overlap_architecture: bool = True
-    """Deprecated compatibility flag for async-overlap architecture rollout.
-
-    The dynamic engine now always uses the async-overlap architecture. This flag is
-    retained only so older configs continue to load until the rollout cleanup removes it.
-    """
-
     async_overlap_queue_depth: int = 2
     """Maximum async-overlap pipeline depth. ``1`` is debug/correctness mode."""
 

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -303,6 +303,23 @@ class InferenceConfig:
     consisting of the string label, the target dtype, and whether to store the data on GPU.
     """
 
+    # =================================
+    # Temporary async-overlap rollout config
+    # =================================
+    enable_async_overlap_architecture: bool = False
+    """Enable the async-overlap architecture rollout path.
+
+    This is temporary scaffolding. Queue depth one is the serial correctness/debug mode;
+    later commits replace the old direct serial path with the new queue-depth-one path
+    before queue-depth-two overlap is enabled.
+    """
+
+    async_overlap_queue_depth: int = 1
+    """Maximum async-overlap pipeline depth. ``1`` is serial debug/correctness mode."""
+
+    async_overlap_debug_checks: bool = False
+    """Enable expensive async-overlap invariant checks while the rollout flag exists."""
+
     use_synchronous_zmq_collectives: bool = False
     """Whether to use synchronous ZMQ collectives for inference. If True, the
     all_reduce_max operation will be performed synchronously, which can help reduce
@@ -319,4 +336,8 @@ class InferenceConfig:
             raise ValueError(
                 f"prefix_caching_routing_alpha must be in [0, 1], "
                 f"got {self.prefix_caching_routing_alpha}"
+            )
+        if self.async_overlap_queue_depth < 1:
+            raise ValueError(
+                f"async_overlap_queue_depth must be >= 1, got {self.async_overlap_queue_depth}"
             )

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -357,9 +357,19 @@ class MambaMetadata:
         max_count = self.max_intermediate_count
 
         if intermediate_offsets_gpu is not None and real_prefill_count > 0:
-            # Transfer counts to CPU (single sync) for per_request_counts and total check
+            # counts_list is CPU-cheap (source is already CPU from MambaSlotAllocator).
             counts_list = intermediate_counts_gpu.tolist()
             total = sum(counts_list)
+
+            # Ensure GPU copies for vectorized GPU ops below.
+            if not intermediate_offsets_gpu.is_cuda:
+                intermediate_offsets_gpu = intermediate_offsets_gpu.to(
+                    self.device, non_blocking=True,
+                )
+            if not intermediate_counts_gpu.is_cuda:
+                intermediate_counts_gpu = intermediate_counts_gpu.to(
+                    self.device, non_blocking=True,
+                )
 
             if total > 0:
                 # Compute cumulative chunk counts from cu_seqlens (already on GPU)

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -9,7 +9,7 @@ from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensi
 from megatron.core.inference.contexts.mamba_slot_allocator import (
     MAX_INTERMEDIATE_OFFSETS_PER_REQUEST,
 )
-from megatron.core.inference.contexts.step_journal import ResourceReservation
+from megatron.core.inference.contexts.step_journal import ResourceReservation, RollbackStatus
 
 
 @dataclass(frozen=True)
@@ -931,20 +931,32 @@ class MambaMetadata:
             raise RuntimeError(f"Mamba reservation {reservation.reservation_id} is not open")
         self._committed_reservations[reservation.reservation_id] = open_reservation
 
-    def rollback_reservation(self, reservation: ResourceReservation) -> None:
+    def rollback_reservation(
+        self, reservation: ResourceReservation, *, defer_until_snapshot_retired: bool = False
+    ) -> RollbackStatus:
         """Roll back a Mamba slot reservation and return its slots to the pool."""
         open_reservation = self._open_reservations.pop(reservation.reservation_id, None)
         if open_reservation is None:
             if reservation.reservation_id in self._rolled_back_reservations:
-                return
-            raise RuntimeError(f"Mamba reservation {reservation.reservation_id} is not open")
-        self._release_slot_ids(open_reservation.mamba_slot_ids)
+                return RollbackStatus.ALREADY_ROLLED_BACK
+            if reservation.reservation_id in self._committed_reservations:
+                return RollbackStatus.ALREADY_COMMITTED
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
         request_slot = int(open_reservation.request_slot)
         if 0 <= request_slot < self.max_requests:
             current_slot = int(self.request_to_mamba_state_idx[request_slot].item())
             if current_slot in set(open_reservation.mamba_slot_ids):
                 self.request_to_mamba_state_idx[request_slot] = -1
+        if defer_until_snapshot_retired:
+            self.defer_release_until_snapshot_retired(
+                torch.tensor(open_reservation.mamba_slot_ids, dtype=torch.int32, device='cpu'),
+                open_reservation.snapshot_slot_id,
+            )
+            status = RollbackStatus.DEFERRED_UNTIL_SNAPSHOT_RETIRED
+        else:
+            status = self._release_slot_ids(open_reservation.mamba_slot_ids)
         self._rolled_back_reservations[reservation.reservation_id] = open_reservation
+        return status
 
     def batch_allocate_slots(self, num_slots: int) -> Optional[torch.Tensor]:
         """
@@ -1002,16 +1014,33 @@ class MambaMetadata:
         for slot_ids in deferred:
             self._release_slot_ids(slot_ids.tolist())
 
-    def _release_slot_ids(self, slot_ids) -> None:
+    def _release_slot_ids(self, slot_ids) -> RollbackStatus:
         """Return live Mamba state slots to the free pool."""
-        slot_ids = tuple(int(slot_id) for slot_id in slot_ids)
+        slot_ids = tuple(dict.fromkeys(int(slot_id) for slot_id in slot_ids))
         if not slot_ids:
-            return
+            return RollbackStatus.FULLY_RELEASED
+        valid_slot_ids = tuple(slot_id for slot_id in slot_ids if 0 <= slot_id < self.max_requests)
+        if not valid_slot_ids:
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
+        free_ids = set(
+            int(slot_id)
+            for slot_id in self.mamba_state_free_slots[
+                : self.mamba_state_free_slot_count
+            ].tolist()
+        )
+        releasable_slot_ids = tuple(slot_id for slot_id in valid_slot_ids if slot_id not in free_ids)
+        if not releasable_slot_ids:
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
         start_idx = self.mamba_state_free_slot_count
-        end_idx = start_idx + len(slot_ids)
-        if end_idx > self.max_requests:
-            raise RuntimeError("Mamba state free slot pool overflow")
+        capacity = max(0, self.max_requests - start_idx)
+        if capacity == 0:
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
+        releasable_slot_ids = releasable_slot_ids[:capacity]
+        end_idx = start_idx + len(releasable_slot_ids)
         self.mamba_state_free_slots[start_idx:end_idx] = torch.tensor(
-            slot_ids, dtype=torch.int32, device='cpu'
+            releasable_slot_ids, dtype=torch.int32, device='cpu'
         )
         self.mamba_state_free_slot_count = end_idx
+        if len(releasable_slot_ids) < len(valid_slot_ids) or len(valid_slot_ids) < len(slot_ids):
+            return RollbackStatus.PARTIALLY_RELEASED
+        return RollbackStatus.FULLY_RELEASED

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-from typing import Dict, Optional, Sequence
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence
 
 import torch
 
@@ -9,6 +10,29 @@ from megatron.core.inference.contexts.mamba_slot_allocator import (
     MAX_INTERMEDIATE_OFFSETS_PER_REQUEST,
 )
 from megatron.core.inference.contexts.step_journal import ResourceReservation
+
+
+@dataclass(frozen=True)
+class MambaMetadataSnapshot:
+    """Per-snapshot Mamba metadata views bound to one GPU view."""
+
+    gpu_view: Any
+    batch_indices_decode: Optional[torch.Tensor] = None
+    batch_indices_prefill: Optional[torch.Tensor] = None
+    cu_seqlens: Optional[torch.Tensor] = None
+    seq_idx: Optional[torch.Tensor] = None
+    device_decode_prefill: Optional[torch.Tensor] = None
+    cu_chunk_seqlens: Optional[torch.Tensor] = None
+    last_chunk_indices: Optional[torch.Tensor] = None
+    seq_idx_for_varlen: Optional[torch.Tensor] = None
+    conv_seq_idx: Optional[torch.Tensor] = None
+    conv_seq_start: Optional[torch.Tensor] = None
+    real_prefill_token_count: int = 0
+    cu_seqlens_list: Sequence[int] = (0,)
+    intermediate_chunk_indices: Optional[torch.Tensor] = None
+    intermediate_abs_positions: Optional[torch.Tensor] = None
+    intermediate_count: int = 0
+    per_request_intermediate_counts: Sequence[int] = ()
 
 
 class MambaMetadata:
@@ -121,6 +145,11 @@ class MambaMetadata:
         # without a context).
         self._cpu_bufs = None
         self._gpu_view = None
+        self.snapshot_state = None
+        self._snapshot_states: Dict[int, MambaMetadataSnapshot] = {}
+        self._snapshot_device_decode_prefill_buffers: Dict[int, torch.Tensor] = {}
+        self._snapshot_intermediate_chunk_indices_buffers: Dict[int, torch.Tensor] = {}
+        self._snapshot_intermediate_abs_positions_buffers: Dict[int, torch.Tensor] = {}
 
         self.reset_varlen_metadata()
 
@@ -137,6 +166,34 @@ class MambaMetadata:
     def bind_gpu_buffers(self, gpu_view) -> None:
         """Attach shared GPU views from the context's :class:`ContextGPUView`."""
         self._gpu_view = gpu_view
+
+    def _device_decode_prefill_buffer_for_snapshot(
+        self, snapshot_slot_id: Optional[int]
+    ) -> torch.Tensor:
+        if snapshot_slot_id is None:
+            return self._device_decode_prefill_buffer
+        slot_id = int(snapshot_slot_id)
+        if slot_id not in self._snapshot_device_decode_prefill_buffers:
+            self._snapshot_device_decode_prefill_buffers[slot_id] = torch.zeros_like(
+                self._device_decode_prefill_buffer
+            )
+        return self._snapshot_device_decode_prefill_buffers[slot_id]
+
+    def _intermediate_buffers_for_snapshot(self, snapshot_slot_id: Optional[int]):
+        if snapshot_slot_id is None:
+            return self._intermediate_chunk_indices_buffer, self._intermediate_abs_positions_buffer
+        slot_id = int(snapshot_slot_id)
+        if slot_id not in self._snapshot_intermediate_chunk_indices_buffers:
+            self._snapshot_intermediate_chunk_indices_buffers[slot_id] = torch.zeros_like(
+                self._intermediate_chunk_indices_buffer
+            )
+            self._snapshot_intermediate_abs_positions_buffers[slot_id] = torch.full_like(
+                self._intermediate_abs_positions_buffer, self.d_conv
+            )
+        return (
+            self._snapshot_intermediate_chunk_indices_buffers[slot_id],
+            self._snapshot_intermediate_abs_positions_buffers[slot_id],
+        )
 
     def reset(self) -> None:
         """
@@ -155,6 +212,7 @@ class MambaMetadata:
         self._committed_reservations.clear()
         self._rolled_back_reservations.clear()
         self._deferred_snapshot_slot_releases.clear()
+        self._snapshot_states.clear()
         self._next_reservation_id = 0
 
     def reset_varlen_metadata(self) -> None:
@@ -181,6 +239,7 @@ class MambaMetadata:
         self.intermediate_abs_positions = None
         self.intermediate_count = 0
         self.per_request_intermediate_counts = []
+        self.snapshot_state = None
 
     def update(
         self,
@@ -374,7 +433,9 @@ class MambaMetadata:
         intermediate_counts_gpu: Optional[torch.Tensor],
         real_prefill_count: int,
         cu_seqlens_gpu: Optional[torch.Tensor] = None,
-    ) -> None:
+        chunk_indices_buffer: Optional[torch.Tensor] = None,
+        abs_positions_buffer: Optional[torch.Tensor] = None,
+    ) -> Dict[str, Any]:
         """Precompute intermediate extraction metadata for CUDA graph compatibility.
 
         Converts per-request token offsets to chunk indices and absolute
@@ -396,6 +457,10 @@ class MambaMetadata:
         max_count = self.max_intermediate_count
         if cu_seqlens_gpu is None:
             cu_seqlens_gpu = self._cu_seqlens_buffer
+        if chunk_indices_buffer is None:
+            chunk_indices_buffer = self._intermediate_chunk_indices_buffer
+        if abs_positions_buffer is None:
+            abs_positions_buffer = self._intermediate_abs_positions_buffer
 
         if intermediate_offsets_gpu is not None and real_prefill_count > 0:
             # counts_list is CPU-cheap (source is already CPU from MambaSlotAllocator).
@@ -446,39 +511,44 @@ class MambaMetadata:
                 valid_abs_positions = abs_positions_2d[valid_mask]
 
                 real_count = valid_chunk_indices.numel()
-                self._intermediate_chunk_indices_buffer[:real_count] = valid_chunk_indices
-                self._intermediate_abs_positions_buffer[:real_count] = valid_abs_positions.to(
-                    torch.int32
-                )
+                chunk_indices_buffer[:real_count] = valid_chunk_indices
+                abs_positions_buffer[:real_count] = valid_abs_positions.to(torch.int32)
 
                 # Pad unused slots with safe defaults for CUDA graph replay:
                 # - chunk_indices=0: reads from chunk 0 (always exists), output ignored
                 # - abs_positions=d_conv: conv gather reads tokens [0..d_conv-1],
                 #   which are within bounds and produce a valid but unused state
                 if real_count < max_count:
-                    self._intermediate_chunk_indices_buffer[real_count:].fill_(0)
-                    self._intermediate_abs_positions_buffer[real_count:].fill_(self.d_conv)
+                    chunk_indices_buffer[real_count:].fill_(0)
+                    abs_positions_buffer[real_count:].fill_(self.d_conv)
 
                 self.intermediate_count = real_count
                 self.per_request_intermediate_counts = counts_list
             else:
                 # All counts are 0
-                self._intermediate_chunk_indices_buffer.fill_(0)
-                self._intermediate_abs_positions_buffer.fill_(self.d_conv)
+                chunk_indices_buffer.fill_(0)
+                abs_positions_buffer.fill_(self.d_conv)
                 self.intermediate_count = 0
                 self.per_request_intermediate_counts = counts_list
 
-            self.intermediate_chunk_indices = self._intermediate_chunk_indices_buffer[:max_count]
-            self.intermediate_abs_positions = self._intermediate_abs_positions_buffer[:max_count]
+            self.intermediate_chunk_indices = chunk_indices_buffer[:max_count]
+            self.intermediate_abs_positions = abs_positions_buffer[:max_count]
         else:
             # No extraction: fill with safe defaults for CUDA graph warmup
             # (same rationale as padding comment above)
-            self._intermediate_chunk_indices_buffer.fill_(0)
-            self._intermediate_abs_positions_buffer.fill_(self.d_conv)
+            chunk_indices_buffer.fill_(0)
+            abs_positions_buffer.fill_(self.d_conv)
             self.intermediate_count = 0
             self.per_request_intermediate_counts = []
-            self.intermediate_chunk_indices = self._intermediate_chunk_indices_buffer[:max_count]
-            self.intermediate_abs_positions = self._intermediate_abs_positions_buffer[:max_count]
+            self.intermediate_chunk_indices = chunk_indices_buffer[:max_count]
+            self.intermediate_abs_positions = abs_positions_buffer[:max_count]
+
+        return {
+            "intermediate_chunk_indices": self.intermediate_chunk_indices,
+            "intermediate_abs_positions": self.intermediate_abs_positions,
+            "intermediate_count": self.intermediate_count,
+            "per_request_intermediate_counts": tuple(self.per_request_intermediate_counts),
+        }
 
     def compute_cpu_metadata(
         self,
@@ -645,7 +715,36 @@ class MambaMetadata:
 
         return result
 
-    def load_from_cpu(self, d: dict) -> None:
+    def activate_snapshot_state(self, snapshot_or_slot_id) -> MambaMetadataSnapshot:
+        """Install one stored Mamba metadata snapshot as the active layer view."""
+        if isinstance(snapshot_or_slot_id, MambaMetadataSnapshot):
+            snapshot = snapshot_or_slot_id
+        else:
+            snapshot = self._snapshot_states[int(snapshot_or_slot_id)]
+
+        self._gpu_view = snapshot.gpu_view
+        self.batch_indices_decode = snapshot.batch_indices_decode
+        self.batch_indices_prefill = snapshot.batch_indices_prefill
+        self.cu_seqlens = snapshot.cu_seqlens
+        self.seq_idx = snapshot.seq_idx
+        self.device_decode_prefill = snapshot.device_decode_prefill
+        self.cu_chunk_seqlens = snapshot.cu_chunk_seqlens
+        self.last_chunk_indices = snapshot.last_chunk_indices
+        self.seq_idx_for_varlen = snapshot.seq_idx_for_varlen
+        self.conv_seq_idx = snapshot.conv_seq_idx
+        self.conv_seq_start = snapshot.conv_seq_start
+        self.real_prefill_token_count = snapshot.real_prefill_token_count
+        self.cu_seqlens_list = list(snapshot.cu_seqlens_list)
+        self.intermediate_chunk_indices = snapshot.intermediate_chunk_indices
+        self.intermediate_abs_positions = snapshot.intermediate_abs_positions
+        self.intermediate_count = snapshot.intermediate_count
+        self.per_request_intermediate_counts = list(snapshot.per_request_intermediate_counts)
+        self.snapshot_state = snapshot
+        return snapshot
+
+    def load_from_cpu(
+        self, d: dict, *, gpu_view=None, snapshot_slot_id: Optional[int] = None
+    ) -> MambaMetadataSnapshot:
         """Point state attributes at the freshly-transferred shared GPU views.
 
         No H2D copies happen here: the 9 Mamba fields were transferred as
@@ -656,44 +755,97 @@ class MambaMetadata:
         Args:
             d: Dict returned by compute_cpu_metadata().
         """
-        assert self._gpu_view is not None, "bind_gpu_buffers() must be called first"
-        v = self._gpu_view
+        v = gpu_view if gpu_view is not None else self._gpu_view
+        assert v is not None, "bind_gpu_buffers() must be called first"
 
         padded_decode_count = d["padded_decode_count"]
         padded_prefill_count = d["padded_prefill_count"]
         padded_token_count = d["padded_token_count"]
         real_prefill_count = d["real_prefill_count"]
 
+        batch_indices_decode = None
+        batch_indices_prefill = None
+        cu_seqlens = None
+        seq_idx = None
+        device_decode_prefill = None
+        cu_chunk_seqlens = None
+        last_chunk_indices = None
+        seq_idx_for_varlen = None
+        conv_seq_idx = None
+        conv_seq_start = None
+        real_prefill_token_count = 0
+        cu_seqlens_list = (0,)
+        intermediate_state = {
+            "intermediate_chunk_indices": None,
+            "intermediate_abs_positions": None,
+            "intermediate_count": 0,
+            "per_request_intermediate_counts": (),
+        }
+
         if padded_decode_count > 0:
-            self.batch_indices_decode = v.mamba_batch_indices_decode[:padded_decode_count]
+            batch_indices_decode = v.mamba_batch_indices_decode[:padded_decode_count]
 
         if padded_prefill_count > 0:
-            self.batch_indices_prefill = v.mamba_batch_indices_prefill[:padded_prefill_count]
-            self.seq_idx = v.mamba_seq_idx[:, :padded_token_count]
-            self.cu_seqlens = v.mamba_cu_seqlens[: padded_prefill_count + 1]
-            self.cu_seqlens_list = d["cu_seqlens_list"]
-            self.real_prefill_token_count = d["real_prefill_token_count"]
+            batch_indices_prefill = v.mamba_batch_indices_prefill[:padded_prefill_count]
+            seq_idx = v.mamba_seq_idx[:, :padded_token_count]
+            cu_seqlens = v.mamba_cu_seqlens[: padded_prefill_count + 1]
+            cu_seqlens_list = tuple(d["cu_seqlens_list"])
+            real_prefill_token_count = d["real_prefill_token_count"]
 
             padded_max_chunks = d["padded_max_chunks"]
-            self.cu_chunk_seqlens = v.mamba_cu_chunk_seqlens[: padded_max_chunks + 1]
-            self.last_chunk_indices = v.mamba_last_chunk_indices[:padded_prefill_count]
-            self.seq_idx_for_varlen = v.mamba_seq_idx_for_varlen[:padded_max_chunks]
-            self.conv_seq_idx = v.mamba_conv_seq_idx[:padded_token_count]
-            self.conv_seq_start = v.mamba_conv_seq_start[:padded_token_count]
+            cu_chunk_seqlens = v.mamba_cu_chunk_seqlens[: padded_max_chunks + 1]
+            last_chunk_indices = v.mamba_last_chunk_indices[:padded_prefill_count]
+            seq_idx_for_varlen = v.mamba_seq_idx_for_varlen[:padded_max_chunks]
+            conv_seq_idx = v.mamba_conv_seq_idx[:padded_token_count]
+            conv_seq_start = v.mamba_conv_seq_start[:padded_token_count]
 
             # Intermediate metadata reads from the just-transferred cu_seqlens
             # to compute chunk indices & absolute positions for state extraction.
-            self._update_intermediate_metadata(
+            chunk_indices_buffer, abs_positions_buffer = self._intermediate_buffers_for_snapshot(
+                snapshot_slot_id
+            )
+            intermediate_state = self._update_intermediate_metadata(
                 d["intermediate_offsets_gpu"],
                 d["intermediate_counts_gpu"],
                 real_prefill_count,
                 cu_seqlens_gpu=v.mamba_cu_seqlens,
+                chunk_indices_buffer=chunk_indices_buffer,
+                abs_positions_buffer=abs_positions_buffer,
             )
 
         if padded_decode_count > 0 and padded_prefill_count > 0:
-            self._device_decode_prefill_buffer[0] = d["decode_prefill_0"]
-            self._device_decode_prefill_buffer[1] = d["decode_prefill_1"]
-            self.device_decode_prefill = self._device_decode_prefill_buffer
+            device_decode_prefill_buffer = self._device_decode_prefill_buffer_for_snapshot(
+                snapshot_slot_id
+            )
+            device_decode_prefill_buffer[0] = d["decode_prefill_0"]
+            device_decode_prefill_buffer[1] = d["decode_prefill_1"]
+            device_decode_prefill = device_decode_prefill_buffer
+
+        snapshot = MambaMetadataSnapshot(
+            gpu_view=v,
+            batch_indices_decode=batch_indices_decode,
+            batch_indices_prefill=batch_indices_prefill,
+            cu_seqlens=cu_seqlens,
+            seq_idx=seq_idx,
+            device_decode_prefill=device_decode_prefill,
+            cu_chunk_seqlens=cu_chunk_seqlens,
+            last_chunk_indices=last_chunk_indices,
+            seq_idx_for_varlen=seq_idx_for_varlen,
+            conv_seq_idx=conv_seq_idx,
+            conv_seq_start=conv_seq_start,
+            real_prefill_token_count=real_prefill_token_count,
+            cu_seqlens_list=cu_seqlens_list,
+            intermediate_chunk_indices=intermediate_state["intermediate_chunk_indices"],
+            intermediate_abs_positions=intermediate_state["intermediate_abs_positions"],
+            intermediate_count=intermediate_state["intermediate_count"],
+            per_request_intermediate_counts=intermediate_state[
+                "per_request_intermediate_counts"
+            ],
+        )
+        if snapshot_slot_id is not None:
+            self._snapshot_states[int(snapshot_slot_id)] = snapshot
+        self.activate_snapshot_state(snapshot)
+        return snapshot
 
     def allocate_slot(self) -> Optional[int]:
         """

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -35,9 +35,9 @@ class MambaMetadata:
         # Maximum possible chunks across all batch configurations
         self.max_chunks = max_tokens // mamba_chunk_size + max_requests
 
-        # Map from requests to slots in the static Mamba state buffer
+        # Map from requests to slots in the static Mamba state buffer (CPU for bookkeeping).
         self.request_to_mamba_state_idx = torch.full(
-            (self.max_requests,), -1, dtype=torch.int32, device=torch.cuda.current_device()
+            (self.max_requests,), -1, dtype=torch.int32, device='cpu',
         )
 
         # Map from requests to slots in the static Mamba state buffer for active decode requests
@@ -84,9 +84,9 @@ class MambaMetadata:
         self._conv_seq_idx_buffer = torch.zeros(max_tokens, dtype=torch.int32, device=self.device)
         self._conv_seq_start_buffer = torch.zeros(max_tokens, dtype=torch.int32, device=self.device)
 
-        # Allocator for Mamba state slots
+        # Allocator for Mamba state slots (CPU for bookkeeping).
         self.mamba_state_free_slots = torch.arange(
-            self.max_requests, dtype=torch.int32, device=torch.cuda.current_device()
+            self.max_requests, dtype=torch.int32, device='cpu',
         )
         self.mamba_state_free_slot_count = self.max_requests
 
@@ -119,7 +119,7 @@ class MambaMetadata:
 
         # Re-initialize the free slot pool
         self.mamba_state_free_slots = torch.arange(
-            self.max_requests, dtype=torch.int32, device=torch.cuda.current_device()
+            self.max_requests, dtype=torch.int32, device='cpu',
         )
         self.mamba_state_free_slot_count = self.max_requests
 

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -107,7 +107,30 @@ class MambaMetadata:
         else:
             self.conv_gather_offsets = None
 
+        # Coalesced production path: pinned CPU views + shared GPU views bound
+        # by DynamicInferenceContext so that the 9 per-step Mamba fields ride
+        # along with the single coalesced H2D in transfer_bookkeeping_to_gpu.
+        # The legacy update() path above keeps using the standalone _*_buffer
+        # tensors (exercised only by unit tests that construct MambaMetadata
+        # without a context).
+        self._cpu_bufs = None
+        self._gpu_view = None
+
         self.reset_varlen_metadata()
+
+    def bind_cpu_buffers(self, bufs: dict) -> None:
+        """Attach pinned CPU views from DynamicInferenceContext._cpu_bookkeeping_buf.
+
+        ``bufs`` maps field names to 1D (or (1, max_tokens) for ``seq_idx``)
+        pinned CPU views that compute_cpu_metadata writes into. The matching
+        GPU views on the other side of the H2D are exposed via
+        :meth:`bind_gpu_buffers`.
+        """
+        self._cpu_bufs = bufs
+
+    def bind_gpu_buffers(self, gpu_view) -> None:
+        """Attach shared GPU views from the context's :class:`ContextGPUView`."""
+        self._gpu_view = gpu_view
 
     def reset(self) -> None:
         """
@@ -339,6 +362,7 @@ class MambaMetadata:
         intermediate_offsets_gpu: Optional[torch.Tensor],
         intermediate_counts_gpu: Optional[torch.Tensor],
         real_prefill_count: int,
+        cu_seqlens_gpu: Optional[torch.Tensor] = None,
     ) -> None:
         """Precompute intermediate extraction metadata for CUDA graph compatibility.
 
@@ -352,9 +376,15 @@ class MambaMetadata:
             intermediate_counts_gpu: [real_prefill_count] int32 GPU tensor of
                 per-request offset counts (0-3), or None.
             real_prefill_count: Number of real (non-padding) prefill requests.
+            cu_seqlens_gpu: GPU cu_seqlens tensor to read from. Defaults to
+                the legacy standalone ``_cu_seqlens_buffer`` used by
+                :meth:`update`; the coalesced production path passes the
+                shared ``ContextGPUView.mamba_cu_seqlens`` view.
         """
         chunk_size = self.mamba_chunk_size
         max_count = self.max_intermediate_count
+        if cu_seqlens_gpu is None:
+            cu_seqlens_gpu = self._cu_seqlens_buffer
 
         if intermediate_offsets_gpu is not None and real_prefill_count > 0:
             # counts_list is CPU-cheap (source is already CPU from MambaSlotAllocator).
@@ -373,7 +403,7 @@ class MambaMetadata:
 
             if total > 0:
                 # Compute cumulative chunk counts from cu_seqlens (already on GPU)
-                cu = self._cu_seqlens_buffer[: real_prefill_count + 1]
+                cu = cu_seqlens_gpu[: real_prefill_count + 1]
                 seq_lens = (cu[1 : real_prefill_count + 1] - cu[:real_prefill_count]).to(
                     torch.int64
                 )
@@ -450,10 +480,13 @@ class MambaMetadata:
         intermediate_offsets_gpu: Optional[torch.Tensor] = None,
         intermediate_counts_gpu: Optional[torch.Tensor] = None,
     ) -> dict:
-        """Compute all Mamba metadata on CPU. Returns dict for load_from_cpu().
+        """Compute all Mamba metadata on CPU, writing directly into the bound
+        pinned CPU views.
 
-        This performs the same computation as update() but entirely on CPU,
-        producing CPU tensors that are later copied to GPU buffers.
+        The values written here are transferred to GPU by the single coalesced
+        H2D in :meth:`DynamicInferenceContext.transfer_bookkeeping_to_gpu`.
+        The returned dict contains only Python scalars + the intermediate GPU
+        tensors, which :meth:`load_from_cpu` consumes after the H2D.
 
         Args:
             active_mamba_indices: CPU tensor of Mamba slot indices for active requests.
@@ -465,6 +498,9 @@ class MambaMetadata:
             intermediate_offsets_gpu: GPU tensor of per-request intermediate offsets, or None.
             intermediate_counts_gpu: GPU tensor of per-request intermediate counts, or None.
         """
+        assert self._cpu_bufs is not None, "bind_cpu_buffers() must be called first"
+        bufs = self._cpu_bufs
+
         real_decode_count = batch_dimensions.decode_req_count
         real_prefill_count = batch_dimensions.prefill_req_count
         padded_decode_count = padded_batch_dimensions.decode_req_count
@@ -480,21 +516,23 @@ class MambaMetadata:
             "real_prefill_count": real_prefill_count,
         }
 
-        # Decode batch indices.
+        # Decode batch indices (write into pinned view; padded slots = -1).
         if padded_decode_count > 0:
-            cpu_decode = torch.full((padded_decode_count,), -1, dtype=torch.int32)
-            cpu_decode[:real_decode_count] = active_mamba_indices[:real_decode_count]
-            result["batch_indices_decode"] = cpu_decode
+            bufs['batch_indices_decode'][:real_decode_count] = active_mamba_indices[
+                :real_decode_count
+            ]
+            if padded_decode_count > real_decode_count:
+                bufs['batch_indices_decode'][real_decode_count:padded_decode_count] = -1
 
-        # Prefill batch indices.
+        # Prefill batch indices, seq_idx, cu_seqlens, chunk/conv metadata.
         if padded_prefill_count > 0:
-            cpu_prefill = torch.full((padded_prefill_count,), -1, dtype=torch.int32)
             if real_prefill_count > 0:
                 start = real_decode_count
-                cpu_prefill[:real_prefill_count] = active_mamba_indices[
+                bufs['batch_indices_prefill'][:real_prefill_count] = active_mamba_indices[
                     start : start + real_prefill_count
                 ]
-            result["batch_indices_prefill"] = cpu_prefill
+            if padded_prefill_count > real_prefill_count:
+                bufs['batch_indices_prefill'][real_prefill_count:padded_prefill_count] = -1
 
             # seq_idx: normalized token-to-request mapping for prefill tokens.
             prefill_start_req = real_decode_count
@@ -503,32 +541,32 @@ class MambaMetadata:
             end_token = cpu_cu_query[end_prefill_req].item()
             seq_len = end_token - start_token
 
-            cpu_seq_idx = torch.full((padded_token_count,), -1, dtype=torch.int32)
             if seq_len > 0:
                 raw = token_to_request_idx[start_token:end_token]
-                cpu_seq_idx[:seq_len] = raw - raw[0]
-            result["seq_idx"] = cpu_seq_idx
+                bufs['seq_idx'][0, :seq_len] = raw - raw[0]
+            if padded_token_count > seq_len:
+                bufs['seq_idx'][0, seq_len:padded_token_count] = -1
             result["seq_len"] = seq_len
 
             # cu_seqlens for prefill.
-            cpu_cu_seqlens = torch.zeros(padded_prefill_count + 1, dtype=torch.int32)
+            cu_seqlens_view = bufs['cu_seqlens']
+            cu_seqlens_view[0] = 0
             if real_prefill_count > 0:
-                cpu_cu_seqlens[1 : real_prefill_count + 1] = (
+                cu_seqlens_view[1 : real_prefill_count + 1] = (
                     cpu_cu_query[prefill_start_req + 1 : end_prefill_req + 1]
                     - cpu_cu_query[prefill_start_req]
                 )
             if real_prefill_count < padded_prefill_count:
-                last_val = cpu_cu_seqlens[real_prefill_count].item()
-                cpu_cu_seqlens[real_prefill_count + 1 :] = last_val
-            result["cu_seqlens"] = cpu_cu_seqlens
+                last_val = cu_seqlens_view[real_prefill_count].item()
+                cu_seqlens_view[real_prefill_count + 1 : padded_prefill_count + 1] = last_val
 
-            cu_seqlens_list = cpu_cu_seqlens[: real_prefill_count + 1].tolist()
+            cu_seqlens_list = cu_seqlens_view[: real_prefill_count + 1].tolist()
             real_prefill_tokens = cu_seqlens_list[real_prefill_count] if real_prefill_count > 0 else 0
             result["cu_seqlens_list"] = cu_seqlens_list
             result["real_prefill_token_count"] = real_prefill_tokens
 
             # Chunk metadata (Python loop, pure CPU).
-            cu_seqlens_all = cpu_cu_seqlens[: padded_prefill_count + 1].tolist()
+            cu_seqlens_all = cu_seqlens_view[: padded_prefill_count + 1].tolist()
             chunk_boundaries = [0]
             last_chunk_idx_list = []
             chunk_to_seq_list = []
@@ -553,38 +591,36 @@ class MambaMetadata:
                 chunk_to_seq_list.extend([0] * pad_s)
 
             n_cu = padded_max_chunks + 1
-            result["cu_chunk_seqlens"] = torch.tensor(
+            bufs['cu_chunk_seqlens'][:n_cu] = torch.tensor(
                 chunk_boundaries[:n_cu], dtype=torch.int32,
             )
-            result["last_chunk_indices"] = torch.tensor(
+            bufs['last_chunk_indices'][:padded_prefill_count] = torch.tensor(
                 last_chunk_idx_list, dtype=torch.int32,
             )
-            result["seq_idx_for_varlen"] = torch.tensor(
+            bufs['seq_idx_for_varlen'][:padded_max_chunks] = torch.tensor(
                 chunk_to_seq_list[:padded_max_chunks], dtype=torch.int32,
             )
             result["padded_max_chunks"] = padded_max_chunks
 
             # Conv1d per-token metadata (CPU repeat_interleave).
+            conv_seq_idx_view = bufs['conv_seq_idx']
+            conv_seq_start_view = bufs['conv_seq_start']
             if real_prefill_tokens > 0:
-                cu_t = cpu_cu_seqlens[: real_prefill_count + 1]
+                cu_t = cu_seqlens_view[: real_prefill_count + 1]
                 lengths = (cu_t[1:] - cu_t[:-1]).to(torch.int64)
                 seq_indices = torch.arange(real_prefill_count, dtype=torch.int32)
                 seq_starts = cu_t[:real_prefill_count].to(torch.int32)
-                cpu_conv_seq_idx = torch.zeros(padded_token_count, dtype=torch.int32)
-                cpu_conv_seq_start = torch.zeros(padded_token_count, dtype=torch.int32)
-                cpu_conv_seq_idx[:real_prefill_tokens] = torch.repeat_interleave(
+                conv_seq_idx_view[:real_prefill_tokens] = torch.repeat_interleave(
                     seq_indices, lengths,
                 )
-                cpu_conv_seq_start[:real_prefill_tokens] = torch.repeat_interleave(
+                conv_seq_start_view[:real_prefill_tokens] = torch.repeat_interleave(
                     seq_starts, lengths,
                 )
-            else:
-                cpu_conv_seq_idx = torch.zeros(padded_token_count, dtype=torch.int32)
-                cpu_conv_seq_start = torch.zeros(padded_token_count, dtype=torch.int32)
-            result["conv_seq_idx"] = cpu_conv_seq_idx
-            result["conv_seq_start"] = cpu_conv_seq_start
+            if padded_token_count > real_prefill_tokens:
+                conv_seq_idx_view[real_prefill_tokens:padded_token_count] = 0
+                conv_seq_start_view[real_prefill_tokens:padded_token_count] = 0
 
-            # Intermediate metadata (needs GPU data -- defer to load_from_cpu).
+            # Intermediate metadata still requires GPU data: defer to load_from_cpu.
             result["intermediate_offsets_gpu"] = intermediate_offsets_gpu
             result["intermediate_counts_gpu"] = intermediate_counts_gpu
 
@@ -599,73 +635,48 @@ class MambaMetadata:
         return result
 
     def load_from_cpu(self, d: dict) -> None:
-        """Copy pre-computed CPU metadata into GPU buffers.
+        """Point state attributes at the freshly-transferred shared GPU views.
+
+        No H2D copies happen here: the 9 Mamba fields were transferred as
+        part of the coalesced bookkeeping H2D. This method just slices the
+        bound GPU views to the per-step sizes and runs the intermediate
+        metadata computation (which reads from the now-valid GPU cu_seqlens).
 
         Args:
             d: Dict returned by compute_cpu_metadata().
         """
+        assert self._gpu_view is not None, "bind_gpu_buffers() must be called first"
+        v = self._gpu_view
+
         padded_decode_count = d["padded_decode_count"]
         padded_prefill_count = d["padded_prefill_count"]
         padded_token_count = d["padded_token_count"]
         real_prefill_count = d["real_prefill_count"]
 
         if padded_decode_count > 0:
-            self._batch_indices_decode_buffer[:padded_decode_count].copy_(
-                d["batch_indices_decode"], non_blocking=True,
-            )
-            self.batch_indices_decode = self._batch_indices_decode_buffer[:padded_decode_count]
+            self.batch_indices_decode = v.mamba_batch_indices_decode[:padded_decode_count]
 
         if padded_prefill_count > 0:
-            self._batch_indices_prefill_buffer[:padded_prefill_count].copy_(
-                d["batch_indices_prefill"], non_blocking=True,
-            )
-            self.batch_indices_prefill = self._batch_indices_prefill_buffer[:padded_prefill_count]
-
-            seq_len = d["seq_len"]
-            self._seq_idx_buffer[:, :padded_token_count].copy_(
-                d["seq_idx"][:padded_token_count].unsqueeze(0), non_blocking=True,
-            )
-            self.seq_idx = self._seq_idx_buffer[:, :padded_token_count]
-
-            self._cu_seqlens_buffer[: padded_prefill_count + 1].copy_(
-                d["cu_seqlens"], non_blocking=True,
-            )
-            self.cu_seqlens = self._cu_seqlens_buffer[: padded_prefill_count + 1]
+            self.batch_indices_prefill = v.mamba_batch_indices_prefill[:padded_prefill_count]
+            self.seq_idx = v.mamba_seq_idx[:, :padded_token_count]
+            self.cu_seqlens = v.mamba_cu_seqlens[: padded_prefill_count + 1]
             self.cu_seqlens_list = d["cu_seqlens_list"]
             self.real_prefill_token_count = d["real_prefill_token_count"]
 
             padded_max_chunks = d["padded_max_chunks"]
-            n_cu = padded_max_chunks + 1
-            self._cu_chunk_seqlens_buffer[:n_cu].copy_(
-                d["cu_chunk_seqlens"], non_blocking=True,
-            )
-            self.cu_chunk_seqlens = self._cu_chunk_seqlens_buffer[:n_cu]
+            self.cu_chunk_seqlens = v.mamba_cu_chunk_seqlens[: padded_max_chunks + 1]
+            self.last_chunk_indices = v.mamba_last_chunk_indices[:padded_prefill_count]
+            self.seq_idx_for_varlen = v.mamba_seq_idx_for_varlen[:padded_max_chunks]
+            self.conv_seq_idx = v.mamba_conv_seq_idx[:padded_token_count]
+            self.conv_seq_start = v.mamba_conv_seq_start[:padded_token_count]
 
-            self._last_chunk_indices_buffer[:padded_prefill_count].copy_(
-                d["last_chunk_indices"], non_blocking=True,
-            )
-            self.last_chunk_indices = self._last_chunk_indices_buffer[:padded_prefill_count]
-
-            self._seq_idx_for_varlen_buffer[:padded_max_chunks].copy_(
-                d["seq_idx_for_varlen"], non_blocking=True,
-            )
-            self.seq_idx_for_varlen = self._seq_idx_for_varlen_buffer[:padded_max_chunks]
-
-            self._conv_seq_idx_buffer[:padded_token_count].copy_(
-                d["conv_seq_idx"][:padded_token_count], non_blocking=True,
-            )
-            self.conv_seq_idx = self._conv_seq_idx_buffer[:padded_token_count]
-
-            self._conv_seq_start_buffer[:padded_token_count].copy_(
-                d["conv_seq_start"][:padded_token_count], non_blocking=True,
-            )
-            self.conv_seq_start = self._conv_seq_start_buffer[:padded_token_count]
-
-            # Intermediate metadata still requires GPU computation.
+            # Intermediate metadata reads from the just-transferred cu_seqlens
+            # to compute chunk indices & absolute positions for state extraction.
             self._update_intermediate_metadata(
                 d["intermediate_offsets_gpu"],
                 d["intermediate_counts_gpu"],
                 real_prefill_count,
+                cu_seqlens_gpu=v.mamba_cu_seqlens,
             )
 
         if padded_decode_count > 0 and padded_prefill_count > 0:

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-from typing import Optional
+from typing import Dict, Optional, Sequence
 
 import torch
 
@@ -8,6 +8,7 @@ from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensi
 from megatron.core.inference.contexts.mamba_slot_allocator import (
     MAX_INTERMEDIATE_OFFSETS_PER_REQUEST,
 )
+from megatron.core.inference.contexts.step_journal import ResourceReservation
 
 
 class MambaMetadata:
@@ -89,6 +90,11 @@ class MambaMetadata:
             self.max_requests, dtype=torch.int32, device='cpu',
         )
         self.mamba_state_free_slot_count = self.max_requests
+        self._next_reservation_id = 0
+        self._open_reservations: Dict[int, ResourceReservation] = {}
+        self._committed_reservations: Dict[int, ResourceReservation] = {}
+        self._rolled_back_reservations: Dict[int, ResourceReservation] = {}
+        self._deferred_snapshot_slot_releases: Dict[int, list[torch.Tensor]] = {}
 
         # Intermediate state extraction buffers (CUDA graph compatible)
         # Each prefill request can produce up to 3 intermediate offsets
@@ -145,6 +151,11 @@ class MambaMetadata:
             self.max_requests, dtype=torch.int32, device='cpu',
         )
         self.mamba_state_free_slot_count = self.max_requests
+        self._open_reservations.clear()
+        self._committed_reservations.clear()
+        self._rolled_back_reservations.clear()
+        self._deferred_snapshot_slot_releases.clear()
+        self._next_reservation_id = 0
 
     def reset_varlen_metadata(self) -> None:
         """Resets varlen metadata."""
@@ -701,6 +712,88 @@ class MambaMetadata:
 
         return mamba_idx
 
+    def reserve_slot(
+        self,
+        request_slot: int,
+        step_id: int,
+        snapshot_slot_id: int = 0,
+        *,
+        zero_state: bool = False,
+        restore_block_id: Optional[int] = None,
+    ) -> Optional[ResourceReservation]:
+        """Reserve one live Mamba state slot for a scheduled step."""
+        mamba_idx = self.allocate_slot()
+        if mamba_idx is None:
+            return None
+        slot_id = int(mamba_idx.item() if isinstance(mamba_idx, torch.Tensor) else mamba_idx)
+        reservation = ResourceReservation(
+            step_id=int(step_id),
+            request_slot=int(request_slot),
+            snapshot_slot_id=int(snapshot_slot_id),
+            reservation_id=self._next_reservation_id,
+            mamba_slot_ids=(slot_id,),
+            mamba_zero_slot_ids=(slot_id,) if zero_state else (),
+            mamba_restore_block_ids={slot_id: int(restore_block_id)}
+            if restore_block_id is not None
+            else {},
+        )
+        self._next_reservation_id += 1
+        self._open_reservations[reservation.reservation_id] = reservation
+        return reservation
+
+    def reserve_slots(
+        self,
+        request_slots: Sequence[int],
+        step_id: int,
+        snapshot_slot_id: int = 0,
+        *,
+        zero_state: bool = False,
+    ) -> Optional[ResourceReservation]:
+        """Reserve multiple live Mamba state slots for a scheduled step."""
+        request_slots = tuple(int(slot) for slot in request_slots)
+        if not request_slots:
+            slot_ids = ()
+        else:
+            allocated = self.batch_allocate_slots(len(request_slots))
+            if allocated is None:
+                return None
+            slot_ids = tuple(int(slot) for slot in allocated.tolist())
+        reservation = ResourceReservation(
+            step_id=int(step_id),
+            request_slot=request_slots[0] if request_slots else -1,
+            snapshot_slot_id=int(snapshot_slot_id),
+            reservation_id=self._next_reservation_id,
+            mamba_slot_ids=slot_ids,
+            mamba_zero_slot_ids=slot_ids if zero_state else (),
+        )
+        self._next_reservation_id += 1
+        self._open_reservations[reservation.reservation_id] = reservation
+        return reservation
+
+    def commit_reservation(self, reservation: ResourceReservation) -> None:
+        """Commit a Mamba slot reservation into durable request ownership."""
+        open_reservation = self._open_reservations.pop(reservation.reservation_id, None)
+        if open_reservation is None:
+            if reservation.reservation_id in self._committed_reservations:
+                return
+            raise RuntimeError(f"Mamba reservation {reservation.reservation_id} is not open")
+        self._committed_reservations[reservation.reservation_id] = open_reservation
+
+    def rollback_reservation(self, reservation: ResourceReservation) -> None:
+        """Roll back a Mamba slot reservation and return its slots to the pool."""
+        open_reservation = self._open_reservations.pop(reservation.reservation_id, None)
+        if open_reservation is None:
+            if reservation.reservation_id in self._rolled_back_reservations:
+                return
+            raise RuntimeError(f"Mamba reservation {reservation.reservation_id} is not open")
+        self._release_slot_ids(open_reservation.mamba_slot_ids)
+        request_slot = int(open_reservation.request_slot)
+        if 0 <= request_slot < self.max_requests:
+            current_slot = int(self.request_to_mamba_state_idx[request_slot].item())
+            if current_slot in set(open_reservation.mamba_slot_ids):
+                self.request_to_mamba_state_idx[request_slot] = -1
+        self._rolled_back_reservations[reservation.reservation_id] = open_reservation
+
     def batch_allocate_slots(self, num_slots: int) -> Optional[torch.Tensor]:
         """
         Allocates new slots for the given number of requests in the Mamba state buffers.
@@ -735,11 +828,38 @@ class MambaMetadata:
         num_to_free = len(mamba_indices_to_free)
 
         if num_to_free > 0:
-            # Add the freed indices back to the free slot pool
-            start_idx = self.mamba_state_free_slot_count
-            end_idx = start_idx + num_to_free
-            self.mamba_state_free_slots[start_idx:end_idx] = mamba_indices_to_free
-            self.mamba_state_free_slot_count = end_idx
+            self._release_slot_ids(mamba_indices_to_free.tolist())
 
         # Invalidate the Mamba state index for the finished requests
         self.request_to_mamba_state_idx[request_indices] = -1
+
+    def defer_release_until_snapshot_retired(
+        self, slot_ids: torch.Tensor, snapshot_slot_id: int
+    ) -> None:
+        """Defer live Mamba slot reuse until a snapshot no longer reads it."""
+        if slot_ids.numel() == 0:
+            return
+        slot_ids = slot_ids.to(dtype=torch.int32, device='cpu')
+        self._deferred_snapshot_slot_releases.setdefault(int(snapshot_slot_id), []).append(
+            slot_ids.clone()
+        )
+
+    def release_deferred_slots_for_snapshot(self, snapshot_slot_id: int) -> None:
+        """Release live Mamba slots whose snapshot-read dependency has retired."""
+        deferred = self._deferred_snapshot_slot_releases.pop(int(snapshot_slot_id), [])
+        for slot_ids in deferred:
+            self._release_slot_ids(slot_ids.tolist())
+
+    def _release_slot_ids(self, slot_ids) -> None:
+        """Return live Mamba state slots to the free pool."""
+        slot_ids = tuple(int(slot_id) for slot_id in slot_ids)
+        if not slot_ids:
+            return
+        start_idx = self.mamba_state_free_slot_count
+        end_idx = start_idx + len(slot_ids)
+        if end_idx > self.max_requests:
+            raise RuntimeError("Mamba state free slot pool overflow")
+        self.mamba_state_free_slots[start_idx:end_idx] = torch.tensor(
+            slot_ids, dtype=torch.int32, device='cpu'
+        )
+        self.mamba_state_free_slot_count = end_idx

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -429,6 +429,240 @@ class MambaMetadata:
             self.intermediate_chunk_indices = self._intermediate_chunk_indices_buffer[:max_count]
             self.intermediate_abs_positions = self._intermediate_abs_positions_buffer[:max_count]
 
+    def compute_cpu_metadata(
+        self,
+        active_mamba_indices: torch.Tensor,
+        token_to_request_idx: torch.Tensor,
+        cpu_cu_query: torch.Tensor,
+        batch_dimensions: InferenceBatchDimensions,
+        padded_batch_dimensions: InferenceBatchDimensions,
+        enable_chunked_prefill: bool,
+        intermediate_offsets_gpu: Optional[torch.Tensor] = None,
+        intermediate_counts_gpu: Optional[torch.Tensor] = None,
+    ) -> dict:
+        """Compute all Mamba metadata on CPU. Returns dict for load_from_cpu().
+
+        This performs the same computation as update() but entirely on CPU,
+        producing CPU tensors that are later copied to GPU buffers.
+
+        Args:
+            active_mamba_indices: CPU tensor of Mamba slot indices for active requests.
+            token_to_request_idx: CPU tensor mapping tokens to request indices.
+            cpu_cu_query: CPU cumulative query lengths from MHA metadata computation.
+            batch_dimensions: Dimensions of the current batch.
+            padded_batch_dimensions: Dimensions of the padded batch.
+            enable_chunked_prefill: Whether chunked prefill is enabled.
+            intermediate_offsets_gpu: GPU tensor of per-request intermediate offsets, or None.
+            intermediate_counts_gpu: GPU tensor of per-request intermediate counts, or None.
+        """
+        real_decode_count = batch_dimensions.decode_req_count
+        real_prefill_count = batch_dimensions.prefill_req_count
+        padded_decode_count = padded_batch_dimensions.decode_req_count
+        padded_prefill_count = padded_batch_dimensions.prefill_req_count
+        padded_token_count = padded_batch_dimensions.token_count
+        chunk_size = self.mamba_chunk_size
+
+        result = {
+            "padded_decode_count": padded_decode_count,
+            "padded_prefill_count": padded_prefill_count,
+            "padded_token_count": padded_token_count,
+            "real_decode_count": real_decode_count,
+            "real_prefill_count": real_prefill_count,
+        }
+
+        # Decode batch indices.
+        if padded_decode_count > 0:
+            cpu_decode = torch.full((padded_decode_count,), -1, dtype=torch.int32)
+            cpu_decode[:real_decode_count] = active_mamba_indices[:real_decode_count]
+            result["batch_indices_decode"] = cpu_decode
+
+        # Prefill batch indices.
+        if padded_prefill_count > 0:
+            cpu_prefill = torch.full((padded_prefill_count,), -1, dtype=torch.int32)
+            if real_prefill_count > 0:
+                start = real_decode_count
+                cpu_prefill[:real_prefill_count] = active_mamba_indices[
+                    start : start + real_prefill_count
+                ]
+            result["batch_indices_prefill"] = cpu_prefill
+
+            # seq_idx: normalized token-to-request mapping for prefill tokens.
+            prefill_start_req = real_decode_count
+            end_prefill_req = real_decode_count + real_prefill_count
+            start_token = cpu_cu_query[prefill_start_req].item()
+            end_token = cpu_cu_query[end_prefill_req].item()
+            seq_len = end_token - start_token
+
+            cpu_seq_idx = torch.full((padded_token_count,), -1, dtype=torch.int32)
+            if seq_len > 0:
+                raw = token_to_request_idx[start_token:end_token]
+                cpu_seq_idx[:seq_len] = raw - raw[0]
+            result["seq_idx"] = cpu_seq_idx
+            result["seq_len"] = seq_len
+
+            # cu_seqlens for prefill.
+            cpu_cu_seqlens = torch.zeros(padded_prefill_count + 1, dtype=torch.int32)
+            if real_prefill_count > 0:
+                cpu_cu_seqlens[1 : real_prefill_count + 1] = (
+                    cpu_cu_query[prefill_start_req + 1 : end_prefill_req + 1]
+                    - cpu_cu_query[prefill_start_req]
+                )
+            if real_prefill_count < padded_prefill_count:
+                last_val = cpu_cu_seqlens[real_prefill_count].item()
+                cpu_cu_seqlens[real_prefill_count + 1 :] = last_val
+            result["cu_seqlens"] = cpu_cu_seqlens
+
+            cu_seqlens_list = cpu_cu_seqlens[: real_prefill_count + 1].tolist()
+            real_prefill_tokens = cu_seqlens_list[real_prefill_count] if real_prefill_count > 0 else 0
+            result["cu_seqlens_list"] = cu_seqlens_list
+            result["real_prefill_token_count"] = real_prefill_tokens
+
+            # Chunk metadata (Python loop, pure CPU).
+            cu_seqlens_all = cpu_cu_seqlens[: padded_prefill_count + 1].tolist()
+            chunk_boundaries = [0]
+            last_chunk_idx_list = []
+            chunk_to_seq_list = []
+
+            for i in range(padded_prefill_count):
+                start = cu_seqlens_all[i]
+                end = cu_seqlens_all[i + 1]
+                s_len = end - start
+                n_chunks = max(1, (s_len + chunk_size - 1) // chunk_size)
+                boundaries = [min(start + (k + 1) * chunk_size, end) for k in range(n_chunks)]
+                chunk_boundaries.extend(boundaries)
+                chunk_to_seq_list.extend([i] * n_chunks)
+                last_chunk_idx_list.append(len(chunk_boundaries) - 2)
+
+            padded_max_chunks = padded_token_count // chunk_size + padded_prefill_count
+            last_boundary = chunk_boundaries[-1]
+            pad_b = padded_max_chunks + 1 - len(chunk_boundaries)
+            if pad_b > 0:
+                chunk_boundaries.extend([last_boundary] * pad_b)
+            pad_s = padded_max_chunks - len(chunk_to_seq_list)
+            if pad_s > 0:
+                chunk_to_seq_list.extend([0] * pad_s)
+
+            n_cu = padded_max_chunks + 1
+            result["cu_chunk_seqlens"] = torch.tensor(
+                chunk_boundaries[:n_cu], dtype=torch.int32,
+            )
+            result["last_chunk_indices"] = torch.tensor(
+                last_chunk_idx_list, dtype=torch.int32,
+            )
+            result["seq_idx_for_varlen"] = torch.tensor(
+                chunk_to_seq_list[:padded_max_chunks], dtype=torch.int32,
+            )
+            result["padded_max_chunks"] = padded_max_chunks
+
+            # Conv1d per-token metadata (CPU repeat_interleave).
+            if real_prefill_tokens > 0:
+                cu_t = cpu_cu_seqlens[: real_prefill_count + 1]
+                lengths = (cu_t[1:] - cu_t[:-1]).to(torch.int64)
+                seq_indices = torch.arange(real_prefill_count, dtype=torch.int32)
+                seq_starts = cu_t[:real_prefill_count].to(torch.int32)
+                cpu_conv_seq_idx = torch.zeros(padded_token_count, dtype=torch.int32)
+                cpu_conv_seq_start = torch.zeros(padded_token_count, dtype=torch.int32)
+                cpu_conv_seq_idx[:real_prefill_tokens] = torch.repeat_interleave(
+                    seq_indices, lengths,
+                )
+                cpu_conv_seq_start[:real_prefill_tokens] = torch.repeat_interleave(
+                    seq_starts, lengths,
+                )
+            else:
+                cpu_conv_seq_idx = torch.zeros(padded_token_count, dtype=torch.int32)
+                cpu_conv_seq_start = torch.zeros(padded_token_count, dtype=torch.int32)
+            result["conv_seq_idx"] = cpu_conv_seq_idx
+            result["conv_seq_start"] = cpu_conv_seq_start
+
+            # Intermediate metadata (needs GPU data -- defer to load_from_cpu).
+            result["intermediate_offsets_gpu"] = intermediate_offsets_gpu
+            result["intermediate_counts_gpu"] = intermediate_counts_gpu
+
+        # device_decode_prefill scalars.
+        if padded_decode_count > 0 and padded_prefill_count > 0:
+            result["decode_prefill_0"] = cpu_cu_query[real_decode_count].item()
+            result["decode_prefill_1"] = (
+                cpu_cu_query[real_decode_count + real_prefill_count].item()
+                - cpu_cu_query[real_decode_count].item()
+            )
+
+        return result
+
+    def load_from_cpu(self, d: dict) -> None:
+        """Copy pre-computed CPU metadata into GPU buffers.
+
+        Args:
+            d: Dict returned by compute_cpu_metadata().
+        """
+        padded_decode_count = d["padded_decode_count"]
+        padded_prefill_count = d["padded_prefill_count"]
+        padded_token_count = d["padded_token_count"]
+        real_prefill_count = d["real_prefill_count"]
+
+        if padded_decode_count > 0:
+            self._batch_indices_decode_buffer[:padded_decode_count].copy_(
+                d["batch_indices_decode"], non_blocking=True,
+            )
+            self.batch_indices_decode = self._batch_indices_decode_buffer[:padded_decode_count]
+
+        if padded_prefill_count > 0:
+            self._batch_indices_prefill_buffer[:padded_prefill_count].copy_(
+                d["batch_indices_prefill"], non_blocking=True,
+            )
+            self.batch_indices_prefill = self._batch_indices_prefill_buffer[:padded_prefill_count]
+
+            seq_len = d["seq_len"]
+            self._seq_idx_buffer[:, :padded_token_count].copy_(
+                d["seq_idx"][:padded_token_count].unsqueeze(0), non_blocking=True,
+            )
+            self.seq_idx = self._seq_idx_buffer[:, :padded_token_count]
+
+            self._cu_seqlens_buffer[: padded_prefill_count + 1].copy_(
+                d["cu_seqlens"], non_blocking=True,
+            )
+            self.cu_seqlens = self._cu_seqlens_buffer[: padded_prefill_count + 1]
+            self.cu_seqlens_list = d["cu_seqlens_list"]
+            self.real_prefill_token_count = d["real_prefill_token_count"]
+
+            padded_max_chunks = d["padded_max_chunks"]
+            n_cu = padded_max_chunks + 1
+            self._cu_chunk_seqlens_buffer[:n_cu].copy_(
+                d["cu_chunk_seqlens"], non_blocking=True,
+            )
+            self.cu_chunk_seqlens = self._cu_chunk_seqlens_buffer[:n_cu]
+
+            self._last_chunk_indices_buffer[:padded_prefill_count].copy_(
+                d["last_chunk_indices"], non_blocking=True,
+            )
+            self.last_chunk_indices = self._last_chunk_indices_buffer[:padded_prefill_count]
+
+            self._seq_idx_for_varlen_buffer[:padded_max_chunks].copy_(
+                d["seq_idx_for_varlen"], non_blocking=True,
+            )
+            self.seq_idx_for_varlen = self._seq_idx_for_varlen_buffer[:padded_max_chunks]
+
+            self._conv_seq_idx_buffer[:padded_token_count].copy_(
+                d["conv_seq_idx"][:padded_token_count], non_blocking=True,
+            )
+            self.conv_seq_idx = self._conv_seq_idx_buffer[:padded_token_count]
+
+            self._conv_seq_start_buffer[:padded_token_count].copy_(
+                d["conv_seq_start"][:padded_token_count], non_blocking=True,
+            )
+            self.conv_seq_start = self._conv_seq_start_buffer[:padded_token_count]
+
+            # Intermediate metadata still requires GPU computation.
+            self._update_intermediate_metadata(
+                d["intermediate_offsets_gpu"],
+                d["intermediate_counts_gpu"],
+                real_prefill_count,
+            )
+
+        if padded_decode_count > 0 and padded_prefill_count > 0:
+            self._device_decode_prefill_buffer[0] = d["decode_prefill_0"]
+            self._device_decode_prefill_buffer[1] = d["decode_prefill_1"]
+            self.device_decode_prefill = self._device_decode_prefill_buffer
+
     def allocate_slot(self) -> Optional[int]:
         """
         Allocates a new slot for a request in the Mamba state buffers.

--- a/megatron/core/inference/contexts/attention_context/mha_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mha_metadata.py
@@ -168,12 +168,13 @@ class MHAMetadata(MetadataBase):
     def reset(self):
         """
         Reset the metadata for the next batch.
+
+        The GPU buffers (query_lengths, cu_query_seq_lengths, cu_kv_seq_lengths,
+        kv_seq_lengths, block_table) are fully overwritten by the next update()
+        or load_from_cpu() call, and state_data slices them to exactly the range
+        that will be re-written. Clearing them here would launch 5 redundant
+        CUDA kernels per step with no correctness benefit.
         """
-        self._query_lengths_buf.fill_(0)
-        self._cu_query_seq_lengths_buf.fill_(0)
-        self._cu_kv_seq_lengths_buf.fill_(0)
-        self._kv_seq_lengths_buf.fill_(0)
-        self._block_table_buf.fill_(0)
         self._max_seqlen_q = 0
         self._max_seqlen_k = 0
 

--- a/megatron/core/inference/contexts/attention_context/mha_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mha_metadata.py
@@ -1,261 +1,84 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 import torch
 
-from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensions
-
 from .metadata_base import MetadataBase
 
 
 class MHAMetadata(MetadataBase):
     """
     Metadata for MHA layer using flash-attention.
+
+    GPU storage for the per-step fields (``query_lengths``,
+    ``cu_query_seq_lengths``, ``kv_seq_lengths``, ``cu_kv_seq_lengths``,
+    ``block_table``) lives inside the context's :class:`ContextGPUView`
+    unified buffer. Both :class:`GraphedMHAMetadata` and
+    :class:`NonGraphedMHAMetadata` bind to the same GPU views (only one is
+    active per step), so the single coalesced H2D in
+    :meth:`DynamicInferenceContext.transfer_bookkeeping_to_gpu` covers the
+    MHA fields along with the rest of the bookkeeping state.
     """
 
     def __init__(
         self, block_count_total, max_kv_block_count, max_requests, block_size_tokens, max_seqlen
     ):
         super().__init__()
-        device = torch.cuda.current_device()
-        self.device = device
+        self.device = torch.cuda.current_device()
         self.max_blocks = block_count_total
         self.max_kv_blocks = max_kv_block_count
         self.max_bs = max_requests
         self.max_seqlen = max_seqlen
-        self._query_lengths_buf = torch.zeros(self.max_bs, dtype=torch.int32, device=device)
-        self._cu_query_seq_lengths_buf = torch.zeros(
-            self.max_bs + 1, dtype=torch.int32, device=device
-        )
-        self._cu_kv_seq_lengths_buf = torch.zeros(self.max_bs + 1, dtype=torch.int32, device=device)
-        self._kv_seq_lengths_buf = torch.zeros(self.max_bs, dtype=torch.int32, device=device)
-        self._block_table_buf = torch.zeros(
-            (self.max_bs, self.max_kv_blocks), dtype=torch.int32, device=device
-        )
         self._max_seqlen_q = 0
         self._max_seqlen_k = 0
         self.state_data = {}
+        # Set by bind_gpu_buffers(); references shared views in ContextGPUView._buf.
+        self._gpu_view = None
 
-    def update(
-        self,
-        request_query_lengths: torch.Tensor,
-        request_kv_length_offsets: torch.Tensor,
-        request_to_kv_block_ids: torch.Tensor,
-        batch_dimensions: InferenceBatchDimensions,
-        padded_batch_dimensions: InferenceBatchDimensions,
-        num_speculative_tokens: int = 0,
-    ):
+    def bind_gpu_buffers(self, gpu_view) -> None:
+        """Attach shared GPU buffer views from the context's ContextGPUView.
+
+        Called by :class:`DynamicInferenceContext` after ``self.gpu_view`` is
+        constructed. Both graphed and non-graphed MHA metadata bind to the
+        same views; only one is active per step, so sharing storage is safe.
         """
-        Args:
-            request_query_lengths: (>real_batch_size,)
-            request_kv_length_offsets: (>real_batch_size,)
-            request_to_kv_block_ids: (>real_batch_size, max_kv_blocks)
-            batch_dimensions: Configuration object containing real batch settings
-            padded_batch_dimensions: Configuration object containing padded batch settings
-            num_speculative_tokens: Number of speculative tokens
+        self._gpu_view = gpu_view
+
+    def set_state_data(
+        self, padded_active_request_count: int, max_seqlen_q: int, max_seqlen_k: int
+    ) -> None:
+        """Build ``state_data`` slices into the bound GPU buffers.
+
+        Called once per step from ``transfer_bookkeeping_to_gpu`` after the
+        coalesced H2D copy. No ``.copy_()`` calls, no kernel launches.
         """
-        # Extract values from configs
-        real_batch_size = batch_dimensions.req_count
-        padded_active_token_count = padded_batch_dimensions.token_count
-        padded_active_request_count = padded_batch_dimensions.req_count
-
-        assert real_batch_size <= padded_active_request_count <= self.max_bs
-        assert request_query_lengths.shape[0] == real_batch_size
-        assert request_kv_length_offsets.shape[0] == real_batch_size
-        assert request_to_kv_block_ids.shape[0] == real_batch_size
-
-        self.tensor_copy_and_pad(
-            self._query_lengths_buf,
-            request_query_lengths,
-            real_batch_size,
-            padded_active_request_count,
-        )
-        self._cu_query_seq_lengths_buf[0] = 0
-        self.tensor_copy_and_pad(
-            self._cu_query_seq_lengths_buf[1:],
-            torch.cumsum(request_query_lengths, dim=0),
-            real_batch_size,
-            padded_active_request_count,
-            is_cumulative_tensor=True,
-        )
-        self.tensor_copy_and_pad(
-            self._kv_seq_lengths_buf,
-            request_kv_length_offsets + request_query_lengths,
-            real_batch_size,
-            padded_active_request_count,
-        )
-        self.tensor_copy_and_pad(
-            self._block_table_buf,
-            request_to_kv_block_ids,
-            real_batch_size,
-            padded_active_request_count,
-            pad_value=torch.tensor(self.max_kv_blocks, dtype=torch.int32, device=self.device).fill_(
-                -1
-            ),
-        )
-        self._cu_kv_seq_lengths_buf[0] = 0
-        self.tensor_copy_and_pad(
-            self._cu_kv_seq_lengths_buf[1:],
-            torch.cumsum(self._kv_seq_lengths_buf, dim=0),
-            real_batch_size,
-            padded_active_request_count,
-            is_cumulative_tensor=True,
-        )
-
-        if padded_batch_dimensions.prefill_req_count == 0:
-            self._max_seqlen_q = num_speculative_tokens + 1
-        else:
-            # Make sure we will launch the prefill kernel for prefill graphs
-            self._max_seqlen_q = max(2, padded_batch_dimensions.token_count)
-
-        self._max_seqlen_k = self.max_seqlen
-
-        self.state_data = {
-            "query_lengths": self._query_lengths_buf[:padded_active_request_count],
-            "cu_query_seq_lengths": self._cu_query_seq_lengths_buf[
-                : padded_active_request_count + 1
-            ],
-            "cu_kv_seq_lengths": self._cu_kv_seq_lengths_buf[: padded_active_request_count + 1],
-            "kv_seq_lengths": self._kv_seq_lengths_buf[:padded_active_request_count],
-            "block_table": self._block_table_buf[0:padded_active_request_count, :],
-            "max_seqlen_q": self._max_seqlen_q,
-            "max_seqlen_k": self._max_seqlen_k,
-        }
-
-    def load_from_cpu(
-        self,
-        query_lengths: torch.Tensor,
-        cu_query_seq_lengths: torch.Tensor,
-        kv_seq_lengths: torch.Tensor,
-        cu_kv_seq_lengths: torch.Tensor,
-        block_table: torch.Tensor,
-        max_seqlen_q: int,
-        max_seqlen_k: int,
-        padded_active_request_count: int,
-    ):
-        """Load pre-computed CPU metadata into GPU buffers.
-
-        All computation (cumsum, padding) has already been done on CPU.
-        This method only performs H2D copies into the fixed-address GPU buffers.
-
-        Args:
-            query_lengths: Padded query lengths, shape (padded_active_request_count,).
-            cu_query_seq_lengths: Padded cumulative query lengths, shape (padded_active_request_count + 1,).
-            kv_seq_lengths: Padded KV lengths, shape (padded_active_request_count,).
-            cu_kv_seq_lengths: Padded cumulative KV lengths, shape (padded_active_request_count + 1,).
-            block_table: Padded block table, shape (padded_active_request_count, max_kv_blocks).
-            max_seqlen_q: Maximum query sequence length.
-            max_seqlen_k: Maximum KV sequence length.
-            padded_active_request_count: Number of padded active requests.
-        """
+        assert self._gpu_view is not None, "bind_gpu_buffers() must be called first"
         n = padded_active_request_count
-        self._query_lengths_buf[:n].copy_(query_lengths[:n], non_blocking=True)
-        self._cu_query_seq_lengths_buf[: n + 1].copy_(cu_query_seq_lengths[: n + 1], non_blocking=True)
-        self._kv_seq_lengths_buf[:n].copy_(kv_seq_lengths[:n], non_blocking=True)
-        self._cu_kv_seq_lengths_buf[: n + 1].copy_(cu_kv_seq_lengths[: n + 1], non_blocking=True)
-        self._block_table_buf[:n].copy_(block_table[:n], non_blocking=True)
+        v = self._gpu_view
         self._max_seqlen_q = max_seqlen_q
         self._max_seqlen_k = max_seqlen_k
-
         self.state_data = {
-            "query_lengths": self._query_lengths_buf[:n],
-            "cu_query_seq_lengths": self._cu_query_seq_lengths_buf[: n + 1],
-            "cu_kv_seq_lengths": self._cu_kv_seq_lengths_buf[: n + 1],
-            "kv_seq_lengths": self._kv_seq_lengths_buf[:n],
-            "block_table": self._block_table_buf[:n, :],
-            "max_seqlen_q": self._max_seqlen_q,
-            "max_seqlen_k": self._max_seqlen_k,
+            "query_lengths": v.mha_query_lengths[:n],
+            "cu_query_seq_lengths": v.mha_cu_query_seq_lengths[: n + 1],
+            "cu_kv_seq_lengths": v.mha_cu_kv_seq_lengths[: n + 1],
+            "kv_seq_lengths": v.mha_kv_seq_lengths[:n],
+            "block_table": v.mha_block_table[:n, :],
+            "max_seqlen_q": max_seqlen_q,
+            "max_seqlen_k": max_seqlen_k,
         }
 
     def reset(self):
-        """
-        Reset the metadata for the next batch.
+        """Reset the metadata for the next batch.
 
-        The GPU buffers (query_lengths, cu_query_seq_lengths, cu_kv_seq_lengths,
-        kv_seq_lengths, block_table) are fully overwritten by the next update()
-        or load_from_cpu() call, and state_data slices them to exactly the range
-        that will be re-written. Clearing them here would launch 5 redundant
-        CUDA kernels per step with no correctness benefit.
+        The GPU buffers live in the context's unified buffer and are fully
+        overwritten by the next H2D copy; clearing them here would launch
+        redundant CUDA kernels with no correctness benefit.
         """
         self._max_seqlen_q = 0
         self._max_seqlen_k = 0
 
 
 class GraphedMHAMetadata(MHAMetadata):
-    """
-    Metadata for MHA layer using flash-attention with CUDA graphs.
-    """
-
-    def __init__(
-        self, block_count_total, max_kv_block_count, max_requests, block_size_tokens, max_seqlen
-    ):
-        super().__init__(
-            block_count_total, max_kv_block_count, max_requests, block_size_tokens, max_seqlen
-        )
-
-    def update(
-        self,
-        request_query_lengths: torch.Tensor,
-        request_kv_length_offsets: torch.Tensor,
-        request_to_kv_block_ids: torch.Tensor,
-        batch_dimensions: InferenceBatchDimensions,
-        padded_batch_dimensions: InferenceBatchDimensions,
-        num_speculative_tokens: int = 0,
-    ):
-        """
-        Args:
-            request_query_lengths: (>real_batch_size,)
-            request_kv_length_offsets: (>real_batch_size,)
-            request_to_kv_block_ids: (>real_batch_size, max_kv_blocks)
-            batch_dimensions: Configuration object containing real batch settings
-            padded_batch_dimensions: Configuration object containing padded batch settings
-            num_speculative_tokens: Number of speculative tokens
-        """
-        super().update(
-            request_query_lengths,
-            request_kv_length_offsets,
-            request_to_kv_block_ids,
-            batch_dimensions,
-            padded_batch_dimensions,
-            num_speculative_tokens,
-        )
-
-    def reset(self):
-        super().reset()
+    """MHA metadata for CUDA-graphed execution."""
 
 
 class NonGraphedMHAMetadata(MHAMetadata):
-    """
-    Metadata for MHA layer using flash-attention without CUDA graphs.
-    """
-
-    def update(
-        self,
-        request_query_lengths: torch.Tensor,
-        request_kv_length_offsets: torch.Tensor,
-        request_to_kv_block_ids: torch.Tensor,
-        batch_dimensions: InferenceBatchDimensions,
-        padded_batch_dimensions: InferenceBatchDimensions,
-        num_speculative_tokens: int = 0,
-    ):
-        """
-        Args:
-            request_query_lengths: (>real_batch_size,)
-            request_kv_length_offsets: (>real_batch_size,)
-            request_to_kv_block_ids: (>real_batch_size, max_kv_blocks)
-            batch_dimensions: Configuration object containing real batch settings
-            padded_batch_dimensions: Configuration object containing padded batch settings
-            num_speculative_tokens: Number of speculative tokens
-        """
-        super().update(
-            request_query_lengths,
-            request_kv_length_offsets,
-            request_to_kv_block_ids,
-            batch_dimensions,
-            padded_batch_dimensions,
-            num_speculative_tokens,
-        )
-        if len(self.state_data["query_lengths"]) > 0:
-            self.state_data["max_seqlen_q"] = torch.max(self.state_data["query_lengths"]).item()
-            self.state_data["max_seqlen_k"] = torch.max(self.state_data["kv_seq_lengths"]).item()
-        else:
-            self.state_data["max_seqlen_q"] = num_speculative_tokens + 1
-            self.state_data["max_seqlen_k"] = 1
+    """MHA metadata for non-graphed (eager) execution."""

--- a/megatron/core/inference/contexts/attention_context/mha_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mha_metadata.py
@@ -1,7 +1,22 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
 import torch
 
 from .metadata_base import MetadataBase
+
+
+@dataclass(frozen=True)
+class MHAMetadataSnapshot:
+    """Per-snapshot MHA launch metadata bound to one GPU view."""
+
+    gpu_view: Any
+    state_data: Dict[str, Any]
+    padded_active_request_count: int
+    max_seqlen_q: int
+    max_seqlen_k: int
+    padded_batch_dimensions: Optional[Any] = None
 
 
 class MHAMetadata(MetadataBase):
@@ -30,6 +45,8 @@ class MHAMetadata(MetadataBase):
         self._max_seqlen_q = 0
         self._max_seqlen_k = 0
         self.state_data = {}
+        self.snapshot_state = None
+        self._snapshot_states = {}
         # Set by bind_gpu_buffers(); references shared views in ContextGPUView._buf.
         self._gpu_view = None
 
@@ -42,20 +59,20 @@ class MHAMetadata(MetadataBase):
         """
         self._gpu_view = gpu_view
 
-    def set_state_data(
-        self, padded_active_request_count: int, max_seqlen_q: int, max_seqlen_k: int
-    ) -> None:
-        """Build ``state_data`` slices into the bound GPU buffers.
-
-        Called once per step from ``transfer_bookkeeping_to_gpu`` after the
-        coalesced H2D copy. No ``.copy_()`` calls, no kernel launches.
-        """
-        assert self._gpu_view is not None, "bind_gpu_buffers() must be called first"
+    def make_snapshot_state(
+        self,
+        padded_active_request_count: int,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        *,
+        gpu_view=None,
+        padded_batch_dimensions=None,
+    ) -> MHAMetadataSnapshot:
+        """Build immutable per-step slices into one snapshot GPU view."""
+        v = gpu_view if gpu_view is not None else self._gpu_view
+        assert v is not None, "bind_gpu_buffers() must be called first"
         n = padded_active_request_count
-        v = self._gpu_view
-        self._max_seqlen_q = max_seqlen_q
-        self._max_seqlen_k = max_seqlen_k
-        self.state_data = {
+        state_data = {
             "query_lengths": v.mha_query_lengths[:n],
             "cu_query_seq_lengths": v.mha_cu_query_seq_lengths[: n + 1],
             "cu_kv_seq_lengths": v.mha_cu_kv_seq_lengths[: n + 1],
@@ -64,6 +81,55 @@ class MHAMetadata(MetadataBase):
             "max_seqlen_q": max_seqlen_q,
             "max_seqlen_k": max_seqlen_k,
         }
+        return MHAMetadataSnapshot(
+            gpu_view=v,
+            state_data=state_data,
+            padded_active_request_count=n,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            padded_batch_dimensions=padded_batch_dimensions,
+        )
+
+    def activate_snapshot_state(self, snapshot_or_slot_id) -> MHAMetadataSnapshot:
+        """Install a stored MHA snapshot state as the active layer-facing view."""
+        if isinstance(snapshot_or_slot_id, MHAMetadataSnapshot):
+            snapshot = snapshot_or_slot_id
+        else:
+            snapshot = self._snapshot_states[int(snapshot_or_slot_id)]
+
+        self._gpu_view = snapshot.gpu_view
+        self._max_seqlen_q = snapshot.max_seqlen_q
+        self._max_seqlen_k = snapshot.max_seqlen_k
+        self.state_data = snapshot.state_data
+        self.snapshot_state = snapshot
+        return snapshot
+
+    def set_state_data(
+        self,
+        padded_active_request_count: int,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        *,
+        gpu_view=None,
+        snapshot_slot_id: Optional[int] = None,
+        padded_batch_dimensions=None,
+    ) -> MHAMetadataSnapshot:
+        """Build ``state_data`` slices into the bound GPU buffers.
+
+        Called once per step from ``transfer_bookkeeping_to_gpu`` after the
+        coalesced H2D copy. No ``.copy_()`` calls, no kernel launches.
+        """
+        snapshot = self.make_snapshot_state(
+            padded_active_request_count,
+            max_seqlen_q,
+            max_seqlen_k,
+            gpu_view=gpu_view,
+            padded_batch_dimensions=padded_batch_dimensions,
+        )
+        if snapshot_slot_id is not None:
+            self._snapshot_states[int(snapshot_slot_id)] = snapshot
+        self.activate_snapshot_state(snapshot)
+        return snapshot
 
     def reset(self):
         """Reset the metadata for the next batch.
@@ -74,6 +140,9 @@ class MHAMetadata(MetadataBase):
         """
         self._max_seqlen_q = 0
         self._max_seqlen_k = 0
+        self.state_data = {}
+        self.snapshot_state = None
+        self._snapshot_states.clear()
 
 
 class GraphedMHAMetadata(MHAMetadata):

--- a/megatron/core/inference/contexts/attention_context/mha_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mha_metadata.py
@@ -120,6 +120,51 @@ class MHAMetadata(MetadataBase):
             "max_seqlen_k": self._max_seqlen_k,
         }
 
+    def load_from_cpu(
+        self,
+        query_lengths: torch.Tensor,
+        cu_query_seq_lengths: torch.Tensor,
+        kv_seq_lengths: torch.Tensor,
+        cu_kv_seq_lengths: torch.Tensor,
+        block_table: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        padded_active_request_count: int,
+    ):
+        """Load pre-computed CPU metadata into GPU buffers.
+
+        All computation (cumsum, padding) has already been done on CPU.
+        This method only performs H2D copies into the fixed-address GPU buffers.
+
+        Args:
+            query_lengths: Padded query lengths, shape (padded_active_request_count,).
+            cu_query_seq_lengths: Padded cumulative query lengths, shape (padded_active_request_count + 1,).
+            kv_seq_lengths: Padded KV lengths, shape (padded_active_request_count,).
+            cu_kv_seq_lengths: Padded cumulative KV lengths, shape (padded_active_request_count + 1,).
+            block_table: Padded block table, shape (padded_active_request_count, max_kv_blocks).
+            max_seqlen_q: Maximum query sequence length.
+            max_seqlen_k: Maximum KV sequence length.
+            padded_active_request_count: Number of padded active requests.
+        """
+        n = padded_active_request_count
+        self._query_lengths_buf[:n].copy_(query_lengths[:n], non_blocking=True)
+        self._cu_query_seq_lengths_buf[: n + 1].copy_(cu_query_seq_lengths[: n + 1], non_blocking=True)
+        self._kv_seq_lengths_buf[:n].copy_(kv_seq_lengths[:n], non_blocking=True)
+        self._cu_kv_seq_lengths_buf[: n + 1].copy_(cu_kv_seq_lengths[: n + 1], non_blocking=True)
+        self._block_table_buf[:n].copy_(block_table[:n], non_blocking=True)
+        self._max_seqlen_q = max_seqlen_q
+        self._max_seqlen_k = max_seqlen_k
+
+        self.state_data = {
+            "query_lengths": self._query_lengths_buf[:n],
+            "cu_query_seq_lengths": self._cu_query_seq_lengths_buf[: n + 1],
+            "cu_kv_seq_lengths": self._cu_kv_seq_lengths_buf[: n + 1],
+            "kv_seq_lengths": self._kv_seq_lengths_buf[:n],
+            "block_table": self._block_table_buf[:n, :],
+            "max_seqlen_q": self._max_seqlen_q,
+            "max_seqlen_k": self._max_seqlen_k,
+        }
+
     def reset(self):
         """
         Reset the metadata for the next batch.

--- a/megatron/core/inference/contexts/decode_metadata_kernels.py
+++ b/megatron/core/inference/contexts/decode_metadata_kernels.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""GPU-side metadata preparation for steady-state dynamic decode rows."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+
+
+def prepare_decode_metadata(
+    gpu_view,
+    *,
+    decode_request_slots: Sequence[int],
+    decode_input_destination_indices: Sequence[int],
+    speculative_width: int,
+    block_size_tokens: int,
+) -> None:
+    """Populate decode token metadata directly in a snapshot-bound GPU view."""
+    decode_count = len(decode_input_destination_indices)
+    if decode_count == 0:
+        return
+    if len(decode_request_slots) != decode_count:
+        raise ValueError("decode request slots and destination indices must have equal length")
+
+    tokens_per_request = int(speculative_width) + 1
+    if tokens_per_request <= 0:
+        raise ValueError(f"tokens_per_request must be positive, got {tokens_per_request}")
+
+    device = gpu_view.token_to_pos_ids.device
+    request_slots = torch.tensor(decode_request_slots, dtype=torch.long, device=device)
+    destinations = torch.tensor(
+        decode_input_destination_indices, dtype=torch.long, device=device
+    )
+    token_offsets = torch.arange(tokens_per_request, dtype=torch.long, device=device)
+    token_indices = (destinations[:, None] + token_offsets[None, :]).reshape(-1)
+
+    request_kv_offsets = gpu_view.request_kv_length_offsets[request_slots].to(torch.long)
+    positions = (request_kv_offsets[:, None] + token_offsets[None, :]).reshape(-1)
+    positions_i32 = positions.to(torch.int32)
+
+    gpu_view.token_to_pos_ids.index_copy_(0, token_indices, positions)
+    gpu_view.token_to_position_in_request.index_copy_(0, token_indices, positions_i32)
+    gpu_view.token_to_local_position_within_kv_block.index_copy_(
+        0, token_indices, torch.remainder(positions_i32, int(block_size_tokens))
+    )
+    gpu_view.token_to_request_idx.index_copy_(
+        0,
+        token_indices,
+        request_slots.to(torch.int32).repeat_interleave(tokens_per_request),
+    )
+
+    block_columns = torch.div(
+        positions, int(block_size_tokens), rounding_mode="floor"
+    ).to(torch.long)
+    request_slots_per_token = request_slots.repeat_interleave(tokens_per_request)
+    block_ids = gpu_view.mha_block_table[request_slots_per_token, block_columns]
+    gpu_view.token_to_block_idx.index_copy_(0, token_indices, block_ids)
+
+    query_lengths = torch.full(
+        (decode_count,), tokens_per_request, dtype=torch.int32, device=device
+    )
+    gpu_view.request_query_lengths.index_copy_(0, request_slots, query_lengths)
+    gpu_view.mha_query_lengths.index_copy_(0, request_slots, query_lengths)
+    kv_seq_lengths = gpu_view.request_kv_length_offsets[request_slots] + query_lengths
+    gpu_view.mha_kv_seq_lengths.index_copy_(0, request_slots, kv_seq_lengths)
+
+    cu_query = torch.arange(
+        decode_count + 1, dtype=torch.int32, device=device
+    ) * tokens_per_request
+    gpu_view.mha_cu_query_seq_lengths[: decode_count + 1].copy_(cu_query)
+    gpu_view.mha_cu_kv_seq_lengths[0].zero_()
+    gpu_view.mha_cu_kv_seq_lengths[1 : decode_count + 1].copy_(
+        torch.cumsum(kv_seq_lengths, dim=0)
+    )

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2758,9 +2758,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         *,
         record_journal: bool = True,
     ):
-        """Prepare the optimistic request plan for one serial dynamic step.
+        """Prepare the optimistic request plan for one dynamic step.
 
-        Queue depth one still executes this in serial order. Later commits can run this
+        Queue depth one executes this in retirement order. Larger queue depths can run this
         before the previous step retires, then reconcile through the journal.
         """
         step_id = self._coerce_dynamic_step_id(step_id)
@@ -2977,7 +2977,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         return f"{name}[step={step_id}]"
 
     def sync_optimistic_to_committed_for_queue_depth_one(self) -> None:
-        """Synchronize committed and optimistic ledgers to the live serial context."""
+        """Synchronize committed and optimistic ledgers in queue-depth-one mode."""
         self.request_ledgers.sync_from_context_for_queue_depth_one(self)
         if self.config.async_overlap_debug_checks:
             self.request_ledgers.assert_committed_matches_optimistic()
@@ -3073,7 +3073,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
 
     def commit_step_journal(self, step_id: int):
-        """Commit the journal entry for one serial dynamic step."""
+        """Commit the journal entry for one dynamic step."""
         if self.step_journal.get_open_entry(step_id) is None:
             return None
         return self.step_journal.commit_step_journal(

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -43,6 +43,7 @@ from .gpu_view import ContextGPUView
 from .kv_block_allocator import KVBlockAllocator
 from .mamba_slot_allocator import MambaSlotAllocator
 from .routing_metadata import RoutingMetadata
+from .snapshot_pool import GpuSnapshotBufferPool
 from .step_journal import StepJournal
 
 try:
@@ -663,6 +664,16 @@ class DynamicInferenceContext(BaseInferenceContext):
             f"    total_blocks:          {total_blocks} ({get_mem_size_str(total_kv_bytes)})",
         ]
 
+        snapshot_accounting = self.snapshot_pool.memory_accounting()
+        log_lines += [
+            f"  GPU bookkeeping snapshots:",
+            f"    slots:                 {snapshot_accounting['snapshot_slot_count']}",
+            f"    metadata_buffers:      {get_mem_size_str(snapshot_accounting['metadata_buffer_bytes'])}",
+            f"    pinned_mirrors:        {get_mem_size_str(snapshot_accounting['pinned_mirror_bytes'])}",
+            f"    graph_captures:        {snapshot_accounting['graph_capture_count']} "
+            f"({get_mem_size_str(snapshot_accounting['graph_capture_bytes'])})",
+        ]
+
         if self.is_hybrid_model:
             mamba_conv_bytes = (
                 math.prod(self.mamba_conv_states_shape)
@@ -1115,6 +1126,14 @@ class DynamicInferenceContext(BaseInferenceContext):
             max_mamba_chunks=self._max_mamba_chunks,
         )
         self.gpu_view.current_dynamic_step_id = self.current_dynamic_step_id
+        self.snapshot_pool = GpuSnapshotBufferPool(
+            slot_count=max(1, int(self.config.async_overlap_queue_depth)),
+            max_requests=self.max_requests,
+            max_tokens=self.max_tokens,
+            max_kv_blocks=self.max_kv_block_count,
+            device=torch.cuda.current_device(),
+            max_mamba_chunks=self._max_mamba_chunks,
+        )
 
         # Bind the shared MHA GPU views to both graph and non-graph metadata;
         # only one is active per step, so sharing storage is safe.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -863,28 +863,89 @@ class DynamicInferenceContext(BaseInferenceContext):
             for label, dtype, _ in self.request_metadata_types
         }
 
-        # Per-token state (CPU, pinned memory for fast H2D transfer).
-        self.token_to_input_ids = torch.full(
-            (self.max_tokens,), 0, dtype=torch.long, device='cpu', pin_memory=True,
+        # Coalesced pinned CPU buffer for the 9 bookkeeping fields that get
+        # transferred to GPU each step via transfer_bookkeeping_to_gpu().
+        # Layout matches ContextGPUView._buf so a single cudaMemcpyAsync
+        # suffices. Int64 token fields come first (8-byte aligned automatically),
+        # then int32 token fields, then int32 request-staging fields.
+        #   token_to_input_ids                         (int64, max_tokens)
+        #   token_to_pos_ids                           (int64, max_tokens)
+        #   token_to_block_idx                         (int32, max_tokens)
+        #   token_to_local_position_within_kv_block    (int32, max_tokens)
+        #   token_to_request_idx                       (int32, max_tokens)
+        #   token_to_position_in_request               (int32, max_tokens)
+        #   request_in_prefill_status  (staging)       (int32, max_requests)
+        #   request_query_lengths      (staging)       (int32, max_requests)
+        #   request_kv_length_offsets  (staging)       (int32, max_requests)
+        #
+        # Token fields are aliased with the source-of-truth attributes
+        # (`self.token_to_input_ids`, etc.) because the forward pass reads
+        # `gpu_view.token_to_input_ids[:n_tok]` which matches the CPU slot
+        # layout `[0, n_tok)`. Request fields, however, are read on GPU at
+        # `[:n_active]` but on CPU at `[paused_count:total_count)` — so the
+        # staging slots here are refreshed each step by copying the active
+        # slice from the persistent `request_*` tensors above.
+        _tok_int64_bytes = self.max_tokens * 8
+        _tok_int32_bytes = self.max_tokens * 4
+        _req_int32_bytes = self.max_requests * 4
+        _total_bytes = 2 * _tok_int64_bytes + 4 * _tok_int32_bytes + 3 * _req_int32_bytes
+        self._cpu_bookkeeping_buf = torch.empty(
+            _total_bytes, dtype=torch.uint8, device='cpu', pin_memory=True,
         )
-        self.token_to_pos_ids = torch.full(
-            (self.max_tokens,), 0, dtype=torch.long, device='cpu', pin_memory=True,
+        # token_to_input_ids and token_to_pos_ids were previously torch.full(0);
+        # zero the whole buffer so their views start at 0 too, and so the
+        # request staging slots start with a deterministic value.
+        self._cpu_bookkeeping_buf.fill_(0)
+
+        _off = 0
+        # Per-token state (source-of-truth lives in the coalesced buffer since
+        # the CPU-side bookkeeping and the GPU forward pass use the same
+        # `[:n_tok]` slice).
+        self.token_to_input_ids = self._cpu_bookkeeping_buf[_off : _off + _tok_int64_bytes].view(
+            torch.long
         )
-        self.token_to_request_idx = torch.empty(
-            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        _off += _tok_int64_bytes
+        self.token_to_pos_ids = self._cpu_bookkeeping_buf[_off : _off + _tok_int64_bytes].view(
+            torch.long
         )
-        self.token_to_block_idx = torch.empty(
-            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        _off += _tok_int64_bytes
+        self.token_to_block_idx = self._cpu_bookkeeping_buf[_off : _off + _tok_int32_bytes].view(
+            torch.int32
         )
+        _off += _tok_int32_bytes
         # i.e For a set of tokens A B C D E F ..  and block_size 4:
         # token_to_position_in_request is  [0, 1, 2, 3, 4, 5]
         # token_to_local_position_within_kv_block is [0 , 1, 2, 3, 0, 1, 2]
-        self.token_to_position_in_request = torch.empty(
-            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
-        )
-        self.token_to_local_position_within_kv_block = torch.empty(
-            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
-        )
+        self.token_to_local_position_within_kv_block = self._cpu_bookkeeping_buf[
+            _off : _off + _tok_int32_bytes
+        ].view(torch.int32)
+        _off += _tok_int32_bytes
+        self.token_to_request_idx = self._cpu_bookkeeping_buf[
+            _off : _off + _tok_int32_bytes
+        ].view(torch.int32)
+        _off += _tok_int32_bytes
+        self.token_to_position_in_request = self._cpu_bookkeeping_buf[
+            _off : _off + _tok_int32_bytes
+        ].view(torch.int32)
+        _off += _tok_int32_bytes
+
+        # Request-level staging views into the coalesced buffer. Write-only on
+        # CPU (refreshed from persistent tensors in transfer_bookkeeping_to_gpu);
+        # read-only on GPU via matching slots in ContextGPUView._buf.
+        self._staging_request_in_prefill_status = self._cpu_bookkeeping_buf[
+            _off : _off + _req_int32_bytes
+        ].view(torch.int32)
+        _off += _req_int32_bytes
+        self._staging_request_query_lengths = self._cpu_bookkeeping_buf[
+            _off : _off + _req_int32_bytes
+        ].view(torch.int32)
+        _off += _req_int32_bytes
+        self._staging_request_kv_length_offsets = self._cpu_bookkeeping_buf[
+            _off : _off + _req_int32_bytes
+        ].view(torch.int32)
+        _off += _req_int32_bytes
+
+        assert _off == _total_bytes, f"layout bug: wrote {_off} of {_total_bytes} bytes"
 
         # GPU view: the single interface for GPU code to read context state.
         # Populated per-step by transfer_bookkeeping_to_gpu().
@@ -1920,41 +1981,33 @@ class DynamicInferenceContext(BaseInferenceContext):
         Called after initialize_attention_state() and before the forward pass.
         All copies use non_blocking=True with pinned CPU memory. CUDA stream
         ordering guarantees the forward pass sees completed transfers.
+
+        The 9 bookkeeping fields are backed by one contiguous pinned CPU buffer
+        and one contiguous GPU buffer; a single cudaMemcpyAsync suffices.
+        Request-level staging slots are refreshed from the persistent CPU
+        tensors immediately before the H2D (GPU reads them at `[:n_active]`
+        while CPU bookkeeping keeps them at `[paused_count:total_count)`).
         """
-        n_tok = self.padded_active_token_count
-
-        # Token-level transfers.
-        self.gpu_view.token_to_input_ids[:n_tok].copy_(
-            self.token_to_input_ids[:n_tok], non_blocking=True,
-        )
-        self.gpu_view.token_to_pos_ids[:n_tok].copy_(
-            self.token_to_pos_ids[:n_tok], non_blocking=True,
-        )
-        self.gpu_view.token_to_block_idx[:n_tok].copy_(
-            self.token_to_block_idx[:n_tok], non_blocking=True,
-        )
-        self.gpu_view.token_to_local_position_within_kv_block[:n_tok].copy_(
-            self.token_to_local_position_within_kv_block[:n_tok], non_blocking=True,
-        )
-        self.gpu_view.token_to_request_idx[:n_tok].copy_(
-            self.token_to_request_idx[:n_tok], non_blocking=True,
-        )
-        self.gpu_view.token_to_position_in_request[:n_tok].copy_(
-            self.token_to_position_in_request[:n_tok], non_blocking=True,
-        )
-
-        # Request-level transfers (consumed by sampling, log-probs, speculative verification).
-        active_slice = slice(self.paused_request_count, self.total_request_count)
         n_active = self.total_request_count - self.paused_request_count
-        self.gpu_view.request_in_prefill_status[:n_active].copy_(
-            self.request_in_prefill_status_tensor[active_slice], non_blocking=True,
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+
+        # Refresh request-level staging slots from the persistent CPU source.
+        # CPU-to-CPU slice assignment on pinned memory (~7.5 KB total for 3
+        # int32 fields at max_requests=624). Negligible vs. the launch overhead
+        # we save by merging 9 H2D memcpys into 1.
+        self._staging_request_in_prefill_status[:n_active] = (
+            self.request_in_prefill_status_tensor[active_slice]
         )
-        self.gpu_view.request_query_lengths[:n_active].copy_(
-            self.request_query_lengths[active_slice], non_blocking=True,
-        )
-        self.gpu_view.request_kv_length_offsets[:n_active].copy_(
-            self.request_kv_length_offsets[active_slice], non_blocking=True,
-        )
+        self._staging_request_query_lengths[:n_active] = self.request_query_lengths[active_slice]
+        self._staging_request_kv_length_offsets[:n_active] = self.request_kv_length_offsets[
+            active_slice
+        ]
+
+        # Coalesced H2D: one cudaMemcpyAsync for the entire bookkeeping buffer.
+        # Copying the whole (max_tokens + max_requests)-sized buffer including
+        # unused slots is cheap (~71 KB total, ~3-5 us on PCIe Gen4) and saves
+        # 8 redundant launch overheads vs. the prior per-field copies.
+        self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
 
         # MHA metadata transfer.
         if hasattr(self, '_pending_mha_transfer') and self._pending_mha_transfer is not None:

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2803,21 +2803,6 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Slice tokens to skip matched prefix
         this_round_tokens = req.remaining_prompt_tokens[prefix_skip_tokens:prefill_chunk_length]
 
-        new_block_ids = None
-        if num_blocks_from_pool > 0:
-            new_block_ids = self.kv_block_allocator.allocate_memory_blocks(num_blocks_from_pool)
-            if new_block_ids is None or len(new_block_ids) != num_blocks_from_pool:
-                raise BlockOverflowError(req.request_id)
-
-        # Increment ref counts and update timestamps for matched (shared) blocks
-        if num_matched_blocks > 0:
-            matched_tensor = torch.tensor(
-                matched_block_ids, dtype=torch.int32, device='cpu',
-            )
-            self.kv_block_allocator.block_ref_counts[matched_tensor] += 1
-            if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
-                self.kv_block_allocator.update_timestamps(matched_tensor)
-
         # Note that we decremented the total_request_count for the chunked prefill request
         # in update_requests, so setting current_id to the total_request_count will again
         # make the last request the continuing chunked prefill request if one exists.
@@ -2831,6 +2816,29 @@ class DynamicInferenceContext(BaseInferenceContext):
             > self.max_tokens
         ):
             raise TokenOverflowError(req.request_id)
+
+        new_block_ids = None
+        new_block_reservation = None
+        if num_blocks_from_pool > 0:
+            step_id = max(0, int(self.current_dynamic_step_id))
+            new_block_reservation = self.kv_block_allocator.reserve_blocks(
+                current_id, num_blocks_from_pool, step_id
+            )
+            if new_block_reservation is None:
+                raise BlockOverflowError(req.request_id)
+            self.record_resource_reservation(step_id, new_block_reservation)
+            new_block_ids = torch.tensor(
+                new_block_reservation.kv_block_ids, dtype=torch.int32, device='cpu'
+            )
+
+        # Increment ref counts and update timestamps for matched (shared) blocks
+        if num_matched_blocks > 0:
+            matched_tensor = torch.tensor(
+                matched_block_ids, dtype=torch.int32, device='cpu',
+            )
+            self.kv_block_allocator.block_ref_counts[matched_tensor] += 1
+            if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
+                self.kv_block_allocator.update_timestamps(matched_tensor)
 
         self.request_ids[current_id] = req.request_id
 
@@ -2873,6 +2881,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.request_to_kv_block_ids[current_id][
                 new_block_start : new_block_start + len(new_block_ids)
             ] = new_block_ids
+            self.kv_block_allocator.commit_reservation(new_block_reservation)
 
         self.request_kv_length_offsets[current_id] = effective_kv_offset
         self.request_kv_block_counts[current_id] = overall_required_blocks
@@ -3167,7 +3176,14 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             if num_new_blocks > 0:
                 assert num_new_blocks <= self.kv_block_allocator.total_avail
-                block_ids = self.kv_block_allocator.allocate_memory_blocks(num_new_blocks)
+                step_id = max(0, int(self.current_dynamic_step_id))
+                reservation = self.kv_block_allocator.reserve_blocks(
+                    resume_start, num_new_blocks, step_id
+                )
+                if reservation is None:
+                    raise BlockOverflowError(int(self.request_ids[resume_start].item()))
+                self.record_resource_reservation(step_id, reservation)
+                block_ids = torch.tensor(reservation.kv_block_ids, dtype=torch.int32, device='cpu')
 
                 # Apply updates only to the requests that required a new block
                 relative_row_idx = torch.nonzero(needs_new_block).squeeze(1)
@@ -3177,6 +3193,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                 self.request_to_kv_block_ids[row_idx, col_idx] = block_ids
                 self.request_kv_block_counts[row_idx] += 1
                 self.request_last_kv_block_id[row_idx] = block_ids
+                self.kv_block_allocator.commit_reservation(reservation)
 
         # Remove resumed requests from newly_paused_request_ids. We do this by
         # truncating the end of newly_paused_request_ids, which works because we

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -46,7 +46,7 @@ from .kv_block_allocator import KVBlockAllocator
 from .mamba_slot_allocator import MambaSlotAllocator
 from .routing_metadata import RoutingMetadata
 from .snapshot_pool import GpuSnapshotBufferPool
-from .step_journal import StepJournal
+from .step_journal import RollbackStatus, StepJournal
 
 try:
     from .fused_kv_append_kernel import triton_append_key_value_cache
@@ -287,6 +287,10 @@ class DynamicInferenceContext(BaseInferenceContext):
             "placeholder_count": 0,
             "reservation_commits": 0,
             "reservation_rollbacks": 0,
+            "rollback_status_counts": {},
+            "partial_reservation_rollbacks": 0,
+            "resource_already_evicted_rollbacks": 0,
+            "deferred_reservation_rollbacks": 0,
         }
 
         self.cache_mla_latent = (
@@ -2495,6 +2499,10 @@ class DynamicInferenceContext(BaseInferenceContext):
                 "reservation_rollbacks": 0,
                 "mamba_reservation_commits": 0,
                 "mamba_reservation_rollbacks": 0,
+                "rollback_status_counts": {},
+                "partial_reservation_rollbacks": 0,
+                "resource_already_evicted_rollbacks": 0,
+                "deferred_reservation_rollbacks": 0,
             }
         )
 
@@ -2598,16 +2606,16 @@ class DynamicInferenceContext(BaseInferenceContext):
         self._clear_pending_gpu_decode_input()
 
     def _release_deferred_mamba_slots_for_free_snapshots(self) -> None:
-        """Release deferred Mamba slots only after their snapshot slot is reusable."""
-        if not self.is_hybrid_model:
-            return
+        """Release deferred resources only after their snapshot slot is reusable."""
         for slot in self.snapshot_pool.slots:
             if not slot.is_free:
                 continue
-            if self.mamba_metadata is not None:
-                self.mamba_metadata.release_deferred_slots_for_snapshot(slot.slot_id)
-            if self.mamba_slot_allocator is not None:
-                self.mamba_slot_allocator.release_deferred_slots_for_snapshot(slot.slot_id)
+            self.kv_block_allocator.release_deferred_blocks_for_snapshot(slot.slot_id)
+            if self.is_hybrid_model:
+                if self.mamba_metadata is not None:
+                    self.mamba_metadata.release_deferred_slots_for_snapshot(slot.slot_id)
+                if self.mamba_slot_allocator is not None:
+                    self.mamba_slot_allocator.release_deferred_slots_for_snapshot(slot.slot_id)
 
     @property
     def cuda_graph_capture_slot_ids(self) -> Tuple[int, ...]:
@@ -3076,13 +3084,108 @@ class DynamicInferenceContext(BaseInferenceContext):
 
     def rollback_step_journal(self, step_id: int, reason: Optional[str] = None):
         """Roll back the journal entry for one dynamic step."""
-        if self.step_journal.get_open_entry(step_id) is None:
-            return None
-        return self.step_journal.rollback_step_journal(step_id, reason=reason)
+        result = self.step_journal.rollback_step_journal(step_id, reason=reason)
+        if result.entry is None or result.status != RollbackStatus.FULLY_RELEASED:
+            self._record_rollback_status(result.status)
+            return result
+
+        resource_statuses = []
+        for reservation in result.entry.resources_waiting_on_snapshot:
+            resource_statuses.append(self._rollback_resource_reservation(reservation))
+        if resource_statuses:
+            result = result.with_resource_statuses(tuple(resource_statuses))
+            for status in resource_statuses:
+                self._record_rollback_status(status)
+        self._record_rollback_status(result.status)
+        return result
 
     def rollback_all_open_step_journals(self, reason: Optional[str] = None):
         """Roll back every open dynamic-step journal entry."""
-        return self.step_journal.rollback_all_open(reason=reason)
+        return tuple(
+            self.rollback_step_journal(step_id, reason=reason)
+            for step_id in self.step_journal.open_step_ids
+        )
+
+    def _rollback_resource_reservation(self, reservation) -> RollbackStatus:
+        """Roll back one allocator reservation recorded in a step journal."""
+        statuses = []
+        if getattr(reservation, "kv_block_ids", ()) or getattr(
+            reservation, "prefix_cache_refcount_deltas", {}
+        ):
+            statuses.append(self.kv_block_allocator.rollback_reservation(reservation))
+        if (
+            getattr(reservation, "mamba_slot_ids", ())
+            or getattr(reservation, "mamba_zero_slot_ids", ())
+            or getattr(reservation, "mamba_restore_block_ids", {})
+        ):
+            if self.mamba_metadata is None:
+                statuses.append(RollbackStatus.RESOURCE_ALREADY_EVICTED)
+            else:
+                statuses.append(
+                    self.mamba_metadata.rollback_reservation(
+                        reservation,
+                        defer_until_snapshot_retired=not self._snapshot_slot_is_free(
+                            reservation.snapshot_slot_id
+                        ),
+                    )
+                )
+                self.async_overlap_debug_counters["mamba_reservation_rollbacks"] = (
+                    self.async_overlap_debug_counters.get("mamba_reservation_rollbacks", 0) + 1
+                )
+        return self._merge_rollback_statuses(statuses)
+
+    def _snapshot_slot_is_free(self, snapshot_slot_id: int) -> bool:
+        """Return whether a snapshot slot can no longer be read by GPU work."""
+        if not hasattr(self, "snapshot_pool"):
+            return True
+        try:
+            return bool(self.snapshot_pool.get_slot(int(snapshot_slot_id)).is_free)
+        except (AttributeError, IndexError):
+            return True
+
+    def _record_rollback_status(self, status: RollbackStatus) -> None:
+        """Record rollback outcome counters for diagnostics and metrics."""
+        if not hasattr(self, "async_overlap_debug_counters"):
+            return
+        status = RollbackStatus(status)
+        status_counts = self.async_overlap_debug_counters.setdefault("rollback_status_counts", {})
+        status_counts[status.value] = status_counts.get(status.value, 0) + 1
+        if status == RollbackStatus.PARTIALLY_RELEASED:
+            self.async_overlap_debug_counters["partial_reservation_rollbacks"] = (
+                self.async_overlap_debug_counters.get("partial_reservation_rollbacks", 0) + 1
+            )
+        elif status == RollbackStatus.RESOURCE_ALREADY_EVICTED:
+            self.async_overlap_debug_counters["resource_already_evicted_rollbacks"] = (
+                self.async_overlap_debug_counters.get(
+                    "resource_already_evicted_rollbacks", 0
+                )
+                + 1
+            )
+        elif status == RollbackStatus.DEFERRED_UNTIL_SNAPSHOT_RETIRED:
+            self.async_overlap_debug_counters["deferred_reservation_rollbacks"] = (
+                self.async_overlap_debug_counters.get("deferred_reservation_rollbacks", 0) + 1
+            )
+
+    @staticmethod
+    def _merge_rollback_statuses(statuses) -> RollbackStatus:
+        """Merge per-resource rollback outcomes into one journal-facing status."""
+        statuses = tuple(status for status in statuses if status is not None)
+        if not statuses:
+            return RollbackStatus.FULLY_RELEASED
+        if all(status == RollbackStatus.FULLY_RELEASED for status in statuses):
+            return RollbackStatus.FULLY_RELEASED
+        if all(status == RollbackStatus.RESOURCE_ALREADY_EVICTED for status in statuses):
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
+        if (
+            RollbackStatus.PARTIALLY_RELEASED in statuses
+            or RollbackStatus.RESOURCE_ALREADY_EVICTED in statuses
+        ):
+            return RollbackStatus.PARTIALLY_RELEASED
+        if RollbackStatus.DEFERRED_UNTIL_SNAPSHOT_RETIRED in statuses:
+            return RollbackStatus.DEFERRED_UNTIL_SNAPSHOT_RETIRED
+        if RollbackStatus.ALREADY_COMMITTED in statuses:
+            return RollbackStatus.ALREADY_COMMITTED
+        return RollbackStatus.ALREADY_ROLLED_BACK
 
     def reset(self) -> None:
         """Reset entire context.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -279,10 +279,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_ledgers = DynamicRequestLedgers()
         self.step_journal = StepJournal()
         self.async_overlap_debug_counters = {
-            "queue_depth": 1,
+            "queue_depth": int(inference_config.async_overlap_queue_depth),
             "snapshot_slot_waits": 0,
             "output_event_waits": 0,
             "fallback_or_queue_depth_one_reasons": {},
+            "downgrade_reasons": {},
             "discarded_lookahead_tokens": 0,
             "placeholder_count": 0,
             "reservation_commits": 0,
@@ -2489,10 +2490,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.set_current_dynamic_step_id(-1)
         self.async_overlap_debug_counters.update(
             {
-                "queue_depth": 1,
+                "queue_depth": int(self.config.async_overlap_queue_depth),
                 "snapshot_slot_waits": 0,
                 "output_event_waits": 0,
                 "fallback_or_queue_depth_one_reasons": {},
+                "downgrade_reasons": {},
                 "discarded_lookahead_tokens": 0,
                 "placeholder_count": 0,
                 "reservation_commits": 0,

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -4,7 +4,7 @@ import logging
 import math
 import warnings
 from contextlib import nullcontext
-from typing import List, Mapping, Optional, Sequence, Tuple
+from typing import Any, List, Mapping, Optional, Sequence, Tuple
 
 import torch  # type: ignore
 import torch.nn.functional as F  # type: ignore
@@ -2608,6 +2608,161 @@ class DynamicInferenceContext(BaseInferenceContext):
             accepted_token_counts_cpu=accepted_token_counts_cpu,
         )
 
+    def _coerce_dynamic_step_id(self, step_id):
+        """Return a DynamicStepId for public split-step APIs."""
+        from megatron.core.inference.engines.dynamic_step import DynamicStepId
+
+        if isinstance(step_id, DynamicStepId):
+            return step_id
+        return DynamicStepId(int(step_id))
+
+    def _build_dynamic_step_request_plan(self, step_id):
+        """Build the scheduler-visible request plan for the current context state."""
+        from megatron.core.inference.engines.dynamic_step import DynamicStepRequestPlan
+
+        step_id = self._coerce_dynamic_step_id(step_id)
+        active_request_count = int(self.total_request_count) - int(self.paused_request_count)
+        active_slice = slice(int(self.paused_request_count), int(self.total_request_count))
+
+        if active_request_count == 0:
+            return DynamicStepRequestPlan(step_id=step_id)
+
+        active_request_ids = tuple(
+            str(int(request_id)) for request_id in self.request_ids[active_slice].tolist()
+        )
+        request_in_prefill = self.request_in_prefill_status_tensor[active_slice].tolist()
+        prefill_request_ids = tuple(
+            request_id
+            for request_id, is_prefill in zip(active_request_ids, request_in_prefill)
+            if is_prefill
+        )
+        decode_request_ids = tuple(
+            request_id
+            for request_id, is_prefill in zip(active_request_ids, request_in_prefill)
+            if not is_prefill
+        )
+        speculative_request_ids = (
+            decode_request_ids if int(self.num_speculative_tokens) > 0 else ()
+        )
+        placeholder_token_counts = (
+            {request_id: int(self.num_speculative_tokens) for request_id in speculative_request_ids}
+            if int(self.num_speculative_tokens) > 0
+            else {}
+        )
+
+        return DynamicStepRequestPlan(
+            step_id=step_id,
+            active_request_ids=active_request_ids,
+            decode_request_ids=decode_request_ids,
+            prefill_request_ids=prefill_request_ids,
+            speculative_request_ids=speculative_request_ids,
+            placeholder_token_counts=placeholder_token_counts,
+        )
+
+    def prepare_next_step_optimistic(
+        self,
+        step_id,
+        request_plan=None,
+        *,
+        record_journal: bool = True,
+    ):
+        """Prepare the optimistic request plan for one serial dynamic step.
+
+        Queue depth one still executes this in serial order. Later commits can run this
+        before the previous step retires, then reconcile through the journal.
+        """
+        step_id = self._coerce_dynamic_step_id(step_id)
+        if request_plan is None:
+            request_plan = self._build_dynamic_step_request_plan(step_id)
+
+        if record_journal and not self.step_journal.has_terminal_entry(step_id):
+            if self.step_journal.get_open_entry(step_id) is None:
+                self.begin_step_journal(step_id.value)
+            self.record_request_slot_transition(
+                step_id.value,
+                request_slots_after=tuple(range(int(self.total_request_count))),
+                active_request_ids=request_plan.active_request_ids,
+            )
+
+        return request_plan
+
+    def _extract_step_output_attr(self, output: Any, name: str, default: Any = None) -> Any:
+        """Read a field from either a dataclass-like output or a mapping."""
+        if isinstance(output, Mapping):
+            return output.get(name, default)
+        return getattr(output, name, default)
+
+    def commit_step_output(
+        self,
+        step_id,
+        output,
+        *,
+        active_requests_mask: Optional[Tensor] = None,
+        new_speculative_tokens: Optional[Tensor] = None,
+        defer_decode_input_tokens: bool = False,
+        commit_journal: bool = True,
+    ):
+        """Commit a dynamic step output into the context's ordered ledger."""
+        from megatron.core.inference.engines.dynamic_step import StepRetirementResult
+
+        step_id = self._coerce_dynamic_step_id(step_id)
+        if hasattr(output, "result") and callable(output.result):
+            output = output.result()
+
+        if active_requests_mask is None:
+            active_requests_mask = self._extract_step_output_attr(output, "active_requests_mask")
+        if active_requests_mask is None:
+            raise ValueError("commit_step_output requires active_requests_mask")
+
+        new_tokens = self._extract_step_output_attr(output, "sampled_tokens_cpu")
+        if new_tokens is None:
+            new_tokens = self._extract_step_output_attr(output, "new_tokens")
+        if new_tokens is None:
+            raise ValueError("commit_step_output requires sampled_tokens_cpu or new_tokens")
+
+        if new_speculative_tokens is None:
+            new_speculative_tokens = self._extract_step_output_attr(
+                output, "sampled_mtp_tokens_cpu"
+            )
+        if new_speculative_tokens is None:
+            new_speculative_tokens = self._extract_step_output_attr(
+                output, "new_speculative_tokens"
+            )
+
+        active_request_slice = slice(int(self.paused_request_count), int(self.total_request_count))
+        step_request_ids = self.request_ids[active_request_slice].long().clone()
+        active_mask_cpu = active_requests_mask.cpu() if active_requests_mask.is_cuda else active_requests_mask
+        completed_request_ids = tuple(
+            str(int(request_id))
+            for request_id in step_request_ids[active_mask_cpu == 0].tolist()
+        )
+        committed_request_ids = tuple(str(int(request_id)) for request_id in step_request_ids.tolist())
+
+        update_result = self._update_requests_serial_impl(
+            active_mask_cpu,
+            new_tokens,
+            new_speculative_tokens,
+            defer_decode_input_tokens=defer_decode_input_tokens,
+        )
+
+        open_entry = self.step_journal.get_open_entry(step_id)
+        snapshot_slot_id = (
+            int(open_entry.snapshot_slot_id)
+            if open_entry is not None
+            else int(getattr(self.gpu_view, "current_snapshot_slot_id", 0))
+        )
+        if commit_journal:
+            self.commit_step_journal(step_id.value)
+
+        return StepRetirementResult(
+            step_id=step_id,
+            snapshot_slot_id=snapshot_slot_id,
+            output_ready_event=self._extract_step_output_attr(output, "output_ready_event"),
+            committed_request_ids=committed_request_ids,
+            completed_request_ids=completed_request_ids,
+            context_update_result=update_result,
+        )
+
     def build_step_input_plan(
         self,
         *,
@@ -3670,6 +3825,34 @@ class DynamicInferenceContext(BaseInferenceContext):
         return evict_request_ids
 
     def update_requests(
+        self,
+        active_requests_mask: Tensor,
+        new_tokens: Tensor,
+        new_speculative_tokens: Tensor = None,
+        defer_decode_input_tokens: bool = False,
+    ) -> Tensor:
+        """Compatibility wrapper for the split optimistic-prepare/ordered-commit path."""
+        current_step_id = int(getattr(self, "current_dynamic_step_id", -1))
+        record_journal = current_step_id >= 0
+        step_id = current_step_id if record_journal else 0
+        request_plan = self.prepare_next_step_optimistic(
+            step_id,
+            record_journal=record_journal,
+        )
+        output = {
+            "active_requests_mask": active_requests_mask,
+            "sampled_tokens_cpu": new_tokens,
+            "sampled_mtp_tokens_cpu": new_speculative_tokens,
+        }
+        retirement = self.commit_step_output(
+            request_plan.step_id,
+            output,
+            defer_decode_input_tokens=defer_decode_input_tokens,
+            commit_journal=record_journal,
+        )
+        return retirement.context_update_result
+
+    def _update_requests_serial_impl(
         self,
         active_requests_mask: Tensor,
         new_tokens: Tensor,

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1375,6 +1375,25 @@ class DynamicInferenceContext(BaseInferenceContext):
         """Returns the current number of active requests."""
         return self.total_request_count - self.paused_request_count
 
+    def is_async_overlap_steady_state_decode_ready(self) -> bool:
+        """Return whether the current context can safely launch one decode lookahead."""
+        if self.get_active_request_count() <= 0:
+            return False
+        if self.paused_request_count != 0:
+            return False
+        if not self.is_decode_only():
+            return False
+        if self.get_index_of_chunked_prefill_request(safe=False) != -1:
+            return False
+
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        if torch.any(self.num_output_placeholders[active_slice] != 0):
+            return False
+
+        tokens_per_decode_request = int(self.num_speculative_tokens) + 1
+        last_offsets = self.request_last_kv_block_offset[active_slice]
+        return bool(torch.all(last_offsets + tokens_per_decode_request < self.block_size_tokens))
+
     def _placeholder_request_slots_tensor(self, request_slots) -> Tensor:
         """Return request slots as a CPU int64 tensor."""
         if isinstance(request_slots, slice):

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2544,6 +2544,30 @@ class DynamicInferenceContext(BaseInferenceContext):
         slot.cpu_view.current_dynamic_step_id = self.current_dynamic_step_id
         return slot
 
+    def acquire_snapshot_slot(self, step_id: int):
+        """Acquire a snapshot slot after releasing Mamba slots from reusable snapshots."""
+        self.snapshot_pool.poll_retired()
+        self._release_deferred_mamba_slots_for_free_snapshots()
+        return self.snapshot_pool.acquire(step_id)
+
+    def release_snapshot_slot(self, snapshot_slot_id: int):
+        """Release a snapshot slot and any Mamba slots whose snapshot dependency is done."""
+        slot = self.snapshot_pool.release(snapshot_slot_id)
+        self._release_deferred_mamba_slots_for_free_snapshots()
+        return slot
+
+    def _release_deferred_mamba_slots_for_free_snapshots(self) -> None:
+        """Release deferred Mamba slots only after their snapshot slot is reusable."""
+        if not self.is_hybrid_model:
+            return
+        for slot in self.snapshot_pool.slots:
+            if not slot.is_free:
+                continue
+            if self.mamba_metadata is not None:
+                self.mamba_metadata.release_deferred_slots_for_snapshot(slot.slot_id)
+            if self.mamba_slot_allocator is not None:
+                self.mamba_slot_allocator.release_deferred_slots_for_snapshot(slot.slot_id)
+
     @property
     def cuda_graph_capture_slot_ids(self) -> Tuple[int, ...]:
         """Return snapshot slot IDs that need CUDA graph captures."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -4,7 +4,7 @@ import logging
 import math
 import warnings
 from contextlib import nullcontext
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Mapping, Optional, Sequence, Tuple
 
 import torch  # type: ignore
 import torch.nn.functional as F  # type: ignore
@@ -866,6 +866,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_output_lengths = torch.empty(
             self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
         )
+        # Output tokens scheduled but not yet retired by the committed ledger.
+        self.num_output_placeholders = torch.zeros(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # request_kv_length_offsets is the same as query length during prefill phase (1st step) and then 1 for the decode phase (i.e During generation)
         self.request_kv_length_offsets = torch.empty(
             self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
@@ -1307,6 +1311,22 @@ class DynamicInferenceContext(BaseInferenceContext):
         lengths = lengths[self.paused_request_count : self.total_request_count]
         return lengths
 
+    def get_placeholder_adjusted_active_sequence_lengths(self) -> Tensor:
+        """Total active sequence lengths including scheduled output placeholders."""
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        return (
+            self.request_kv_length_offsets[active_slice]
+            + self.request_query_lengths[active_slice]
+            + self.num_output_placeholders[active_slice]
+        )
+
+    def get_placeholder_adjusted_active_token_count(self) -> int:
+        """Active token count including scheduled output placeholders."""
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        return int(
+            self.active_token_count + self.num_output_placeholders[active_slice].sum().item()
+        )
+
     def get_max_sequence_lengths(self) -> Tensor:
         """Maximum sequence length for active requests."""
         return self.request_output_lengths[self.paused_request_count : self.total_request_count]
@@ -1314,6 +1334,94 @@ class DynamicInferenceContext(BaseInferenceContext):
     def get_active_request_count(self):
         """Returns the current number of active requests."""
         return self.total_request_count - self.paused_request_count
+
+    def _placeholder_request_slots_tensor(self, request_slots) -> Tensor:
+        """Return request slots as a CPU int64 tensor."""
+        if isinstance(request_slots, slice):
+            start = 0 if request_slots.start is None else request_slots.start
+            stop = self.total_request_count if request_slots.stop is None else request_slots.stop
+            step = 1 if request_slots.step is None else request_slots.step
+            return torch.arange(start, stop, step, dtype=torch.long, device='cpu')
+        if isinstance(request_slots, torch.Tensor):
+            return request_slots.to(device='cpu', dtype=torch.long)
+        return torch.as_tensor(request_slots, dtype=torch.long, device='cpu')
+
+    def _placeholder_counts_tensor(self, request_slots: Tensor, count_by_request) -> Tensor:
+        """Return placeholder counts aligned with request slots."""
+        if isinstance(count_by_request, Mapping):
+            counts = []
+            for slot in request_slots.tolist():
+                request_id = int(self.request_ids[slot].item())
+                counts.append(
+                    int(
+                        count_by_request.get(
+                            request_id, count_by_request.get(str(request_id), 0)
+                        )
+                    )
+                )
+            return torch.tensor(counts, dtype=self.num_output_placeholders.dtype, device='cpu')
+        if isinstance(count_by_request, torch.Tensor):
+            counts = count_by_request.to(device='cpu', dtype=self.num_output_placeholders.dtype)
+        else:
+            counts = torch.as_tensor(
+                count_by_request, dtype=self.num_output_placeholders.dtype, device='cpu'
+            )
+        if counts.dim() == 0:
+            counts = counts.expand(request_slots.numel()).clone()
+        return counts.reshape(-1)
+
+    def _update_placeholder_debug_count(self) -> None:
+        """Update the aggregate placeholder debug counter."""
+        if not hasattr(self, "async_overlap_debug_counters"):
+            return
+        self.async_overlap_debug_counters["placeholder_count"] = int(
+            self.num_output_placeholders[: self.total_request_count].sum().item()
+        )
+
+    def add_output_placeholders(self, request_slots, count_by_request) -> None:
+        """Add scheduled output placeholders for the provided request slots."""
+        slots = self._placeholder_request_slots_tensor(request_slots)
+        if slots.numel() == 0:
+            return
+        counts = self._placeholder_counts_tensor(slots, count_by_request)
+        self.num_output_placeholders[slots] += counts
+        for slot, count in zip(slots.tolist(), counts.tolist()):
+            if count:
+                self.record_placeholder_delta(
+                    self.current_dynamic_step_id, int(self.request_ids[slot].item()), int(count)
+                )
+        self._update_placeholder_debug_count()
+
+    def consume_output_placeholders(self, request_slots, accepted_count_by_request) -> None:
+        """Consume retired output placeholders for the provided request slots."""
+        slots = self._placeholder_request_slots_tensor(request_slots)
+        if slots.numel() == 0:
+            return
+        counts = self._placeholder_counts_tensor(slots, accepted_count_by_request)
+        updated_counts = self.num_output_placeholders[slots] - counts
+        if torch.any(updated_counts < 0):
+            raise AssertionError("Output placeholder accounting underflow")
+        self.num_output_placeholders[slots] = updated_counts
+        for slot, count in zip(slots.tolist(), counts.tolist()):
+            if count:
+                self.record_placeholder_delta(
+                    self.current_dynamic_step_id, int(self.request_ids[slot].item()), -int(count)
+                )
+        self._update_placeholder_debug_count()
+
+    def placeholder_adjusted_sequence_length(self, request_slot: int) -> int:
+        """Return request sequence length including output placeholders."""
+        return int(
+            (
+                self.request_kv_length_offsets[request_slot]
+                + self.request_query_lengths[request_slot]
+                + self.num_output_placeholders[request_slot]
+            ).item()
+        )
+
+    def placeholder_adjusted_kv_length(self, request_slot: int) -> int:
+        """Return request KV length including output placeholders."""
+        return self.placeholder_adjusted_sequence_length(request_slot)
 
     def append_key_value_cache(self, layer_number: int, key: Tensor, value: Tensor) -> None:
         """Append to KV cache.
@@ -1630,7 +1738,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                 metadata_cols[i].append(m)
 
         total_new_tokens = sum(lengths)
-        if self.active_token_count + total_new_tokens > self.max_tokens:
+        if self.get_placeholder_adjusted_active_token_count() + total_new_tokens > self.max_tokens:
             raise TokenOverflowError(requests[-1].request_id)
 
         device = self.request_ids.device
@@ -1656,6 +1764,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_query_lengths[request_slice] = lengths_tensor
         self.request_in_prefill_status_tensor[request_slice] = 1
         self.request_output_lengths[request_slice] = lengths_tensor + tokens_to_generate_tensor
+        self.num_output_placeholders[request_slice] = 0
         self.request_kv_length_offsets[request_slice] = 0
         self.request_kv_block_counts[request_slice] = block_counts
         for i, (label, dtype, _) in enumerate(self.request_metadata_types):
@@ -2248,6 +2357,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.reset_mamba_state()
         self.kv_block_allocator.reset()
         self.request_to_kv_block_ids.fill_(-1)
+        self.num_output_placeholders.fill_(0)
 
         # Reset step counter and LRU clock
         self.step_count = 0
@@ -2593,7 +2703,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
 
         request_tokens_can_be_added = (
-            self.active_token_count + effective_prefill_chunk_length <= self.max_tokens
+            self.get_placeholder_adjusted_active_token_count() + effective_prefill_chunk_length
+            <= self.max_tokens
         )
         kv_cache_available = self.kv_block_allocator.is_memory_available(num_blocks_from_pool)
         return request_can_be_added, request_tokens_can_be_added, kv_cache_available
@@ -2715,7 +2826,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         if current_id >= self.max_requests:
             raise RequestOverflowError(req.request_id)
 
-        if self.active_token_count + effective_prefill_chunk_length > self.max_tokens:
+        if (
+            self.get_placeholder_adjusted_active_token_count() + effective_prefill_chunk_length
+            > self.max_tokens
+        ):
             raise TokenOverflowError(req.request_id)
 
         self.request_ids[current_id] = req.request_id
@@ -2740,6 +2854,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Handle length and block assignments.
         self.request_query_lengths[current_id] = effective_prefill_chunk_length
         self.request_in_prefill_status_tensor[current_id] = 1
+        self.num_output_placeholders[current_id] = 0
         self.request_output_lengths[current_id] = (
             req.finished_chunk_token_count
             + prefill_chunk_length
@@ -2867,6 +2982,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         ]
         self.request_query_lengths[dst_idxs] = self.request_query_lengths[src_idxs]
         self.request_output_lengths[dst_idxs] = self.request_output_lengths[src_idxs]
+        self.num_output_placeholders[dst_idxs] = self.num_output_placeholders[src_idxs]
         self.request_ids[dst_idxs] = self.request_ids[src_idxs]
         next_tokens[dst_idxs] = next_tokens[src_idxs]  # num tokens sames as num samples
         if new_speculative_tokens is not None:
@@ -2894,6 +3010,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         tensor_swap(self.request_query_lengths, src_idxs, dst_idxs)
         tensor_swap(self.request_in_prefill_status_tensor, src_idxs, dst_idxs)
         tensor_swap(self.request_output_lengths, src_idxs, dst_idxs)
+        tensor_swap(self.num_output_placeholders, src_idxs, dst_idxs)
         tensor_swap(self.request_ids, src_idxs, dst_idxs)
         tensor_swap(self.request_to_kv_block_ids, src_idxs, dst_idxs)
         tensor_swap(self.request_kv_block_counts, src_idxs, dst_idxs)
@@ -2957,6 +3074,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         # fill_()/add_() creates a clone and updates it instead of the original
         # tensor.
         self.request_to_kv_block_ids[request_indexes] = -1
+        self.num_output_placeholders[request_indexes] = 0
+        self._update_placeholder_debug_count()
 
         # Free Mamba slots.
         if self.is_hybrid_model:
@@ -2998,8 +3117,10 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             # Check which paused requests will actually need a new block upon resuming
             offsets = self.request_last_kv_block_offset[: self.paused_request_count]
+            paused_placeholder_counts = self.num_output_placeholders[: self.paused_request_count]
             needs_new_block = (
-                offsets >= self.block_size_tokens - 1 - self.num_speculative_tokens
+                offsets + self.num_speculative_tokens + 1 + paused_placeholder_counts
+                >= self.block_size_tokens
             ).to(paused_block_counts.dtype)
             needs_new_block = needs_new_block.flip(dims=[0])
 
@@ -3012,8 +3133,17 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
 
             # Constrain resumptions by the maximum allowed active requests and tokens
+            active_placeholder_count = int(
+                self.num_output_placeholders[
+                    self.paused_request_count : self.total_request_count
+                ]
+                .sum()
+                .item()
+            )
+            placeholder_adjusted_max_tokens = max(0, self.max_tokens - active_placeholder_count)
             max_allowed_active = min(
-                self.max_requests, self.max_tokens // (self.num_speculative_tokens + 1)
+                self.max_requests,
+                placeholder_adjusted_max_tokens // (self.num_speculative_tokens + 1),
             )
             allowed_to_resume = max(0, max_allowed_active - active_request_count)
             resume_request_count = min(resume_request_count, allowed_to_resume)
@@ -3028,7 +3158,11 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             # Check which resumed requests actually need a new block
             offsets = self.request_last_kv_block_offset[resume_start:resume_end]
-            needs_new_block = offsets >= (self.block_size_tokens - 1 - self.num_speculative_tokens)
+            resumed_placeholder_counts = self.num_output_placeholders[resume_start:resume_end]
+            needs_new_block = (
+                offsets + self.num_speculative_tokens + 1 + resumed_placeholder_counts
+                >= self.block_size_tokens
+            )
             num_new_blocks = needs_new_block.sum().item()
 
             if num_new_blocks > 0:
@@ -3164,6 +3298,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.total_request_count, self.total_request_count + evict_request_count
         )
         self.request_to_kv_block_ids[evict_slice] = -1
+        self.num_output_placeholders[evict_slice] = 0
+        self._update_placeholder_debug_count()
         if self.is_hybrid_model:
             self.mamba_metadata.request_to_mamba_state_idx[evict_slice] = -1
 
@@ -3227,6 +3363,13 @@ class DynamicInferenceContext(BaseInferenceContext):
             new_tokens = new_tokens.cpu()
         if new_speculative_tokens is not None and new_speculative_tokens.is_cuda:
             new_speculative_tokens = new_speculative_tokens.cpu()
+
+        step_request_slots = torch.arange(
+            self.paused_request_count, self.total_request_count, dtype=torch.long, device='cpu'
+        )
+        step_placeholder_counts = self.num_output_placeholders[step_request_slots].clone()
+        if torch.any(step_placeholder_counts > 0):
+            self.consume_output_placeholders(step_request_slots, step_placeholder_counts)
 
         self.num_prefill_requests = 0  # all turns to decode
         # All request that were in prefill become decode requests.
@@ -3320,6 +3463,8 @@ class DynamicInferenceContext(BaseInferenceContext):
 
                 # Reset chunk ids for recently moved requests.
                 self.request_to_kv_block_ids[active_idxs_on_right] = -1
+                self.num_output_placeholders[active_idxs_on_right] = 0
+                self._update_placeholder_debug_count()
                 if self.is_hybrid_model:
                     self.mamba_metadata.request_to_mamba_state_idx[active_idxs_on_right] = -1
 
@@ -3332,8 +3477,15 @@ class DynamicInferenceContext(BaseInferenceContext):
             num_tokens_in_last_block = self.request_last_kv_block_offset[
                 self.paused_request_count : (active_request_count + self.paused_request_count)
             ]
+            active_placeholder_counts = self.num_output_placeholders[
+                self.paused_request_count : (active_request_count + self.paused_request_count)
+            ]
+            tokens_reserved_for_next_step = (
+                self.num_speculative_tokens + 1 + active_placeholder_counts
+            )
             active_requests_requiring_new_block = (
-                num_tokens_in_last_block >= self.block_size_tokens - 1 - self.num_speculative_tokens
+                num_tokens_in_last_block + tokens_reserved_for_next_step
+                >= self.block_size_tokens
             ).byte()
 
             # Find the id in request_ids that is the chunked_prefill_request_id. Only one request should be chunked.
@@ -3344,8 +3496,19 @@ class DynamicInferenceContext(BaseInferenceContext):
                     chunked_prefill_request_idx - self.paused_request_count
                 ] = 0  # chunked prefill should not be paused
             else:
+                active_placeholder_count = int(
+                    self.num_output_placeholders[
+                        self.paused_request_count : self.total_request_count
+                    ]
+                    .sum()
+                    .item()
+                )
+                placeholder_adjusted_max_tokens = max(
+                    0, self.max_tokens - active_placeholder_count
+                )
                 max_allowed_active = min(
-                    self.max_requests, self.max_tokens // (self.num_speculative_tokens + 1)
+                    self.max_requests,
+                    placeholder_adjusted_max_tokens // (self.num_speculative_tokens + 1),
                 )
                 if active_request_count > max_allowed_active:
                     # Force-pause excess requests in a decode-only batch

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2005,6 +2005,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         *,
         construct_graph_dimensions: Optional[InferenceBatchDimensions] = None,
         is_expert_parallel_dummy_cuda_graph_step: bool = False,
+        snapshot_slot_handle=None,
     ) -> None:
         """Initialize attention state so that every layer can use it.
 
@@ -2016,6 +2017,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         Return:
             None.
         """
+        if snapshot_slot_handle is not None:
+            self.bind_snapshot_slot(snapshot_slot_handle)
+
         # Launch deferred Mamba GPU ops first (state zeroing/restore) so they
         # overlap with the CPU work below.  These are non-blocking GPU kernels.
         self._execute_pending_mamba_ops()
@@ -2253,6 +2257,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             else:
                 self.moe_routing_metadata.disable_static_buffer_recording()
 
+        if snapshot_slot_handle is not None:
+            self._populate_snapshot_cpu_mirror(snapshot_slot_handle)
+
     def _execute_pending_mamba_ops(self) -> None:
         """Execute Mamba GPU operations deferred from add_request() / update_requests().
 
@@ -2280,7 +2287,30 @@ class DynamicInferenceContext(BaseInferenceContext):
                 self.mamba_ssm_states[:, indices] = 0.0
                 self._pending_mamba_zeros.clear()
 
-    def transfer_bookkeeping_to_gpu(self) -> None:
+    def _refresh_request_staging_fields(self) -> None:
+        """Refresh request-level staging slots from persistent CPU tensors."""
+        n_active = self.total_request_count - self.paused_request_count
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+
+        # CPU-to-CPU slice assignment on pinned memory (~7.5 KB total for 3
+        # int32 fields at max_requests=624). Negligible vs. the launch overhead
+        # we save by merging 9 H2D memcpys into 1.
+        self._staging_request_in_prefill_status[:n_active] = (
+            self.request_in_prefill_status_tensor[active_slice]
+        )
+        self._staging_request_query_lengths[:n_active] = self.request_query_lengths[active_slice]
+        self._staging_request_kv_length_offsets[:n_active] = self.request_kv_length_offsets[
+            active_slice
+        ]
+
+    def _populate_snapshot_cpu_mirror(self, snapshot_slot_handle):
+        """Copy the populated pinned CPU bookkeeping buffer into a snapshot mirror."""
+        slot = self._snapshot_slot_from_handle(snapshot_slot_handle)
+        self._refresh_request_staging_fields()
+        slot.cpu_mirror.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+        return slot
+
+    def transfer_bookkeeping_to_gpu(self, snapshot_slot_handle=None):
         """Batch transfer CPU bookkeeping state to GPU staging buffers.
 
         Called after initialize_attention_state() and before the forward pass.
@@ -2293,20 +2323,15 @@ class DynamicInferenceContext(BaseInferenceContext):
         tensors immediately before the H2D (GPU reads them at `[:n_active]`
         while CPU bookkeeping keeps them at `[paused_count:total_count)`).
         """
-        n_active = self.total_request_count - self.paused_request_count
-        active_slice = slice(self.paused_request_count, self.total_request_count)
-
-        # Refresh request-level staging slots from the persistent CPU source.
-        # CPU-to-CPU slice assignment on pinned memory (~7.5 KB total for 3
-        # int32 fields at max_requests=624). Negligible vs. the launch overhead
-        # we save by merging 9 H2D memcpys into 1.
-        self._staging_request_in_prefill_status[:n_active] = (
-            self.request_in_prefill_status_tensor[active_slice]
-        )
-        self._staging_request_query_lengths[:n_active] = self.request_query_lengths[active_slice]
-        self._staging_request_kv_length_offsets[:n_active] = self.request_kv_length_offsets[
-            active_slice
-        ]
+        snapshot_slot = self._snapshot_slot_from_handle(snapshot_slot_handle)
+        if snapshot_slot is not None:
+            self._bind_gpu_view(snapshot_slot.gpu_view)
+            source_buffer = snapshot_slot.cpu_mirror
+            ready_event = snapshot_slot.metadata_ready_event
+        else:
+            self._refresh_request_staging_fields()
+            source_buffer = self._cpu_bookkeeping_buf
+            ready_event = self._gpu_bookkeeping_complete_event
 
         pending_mamba_transfer = getattr(self, '_pending_mamba_transfer', None)
 
@@ -2315,11 +2340,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         # unused slots is cheap (~71 KB total, ~3-5 us on PCIe Gen4) and saves
         # 8 redundant launch overheads vs. the prior per-field copies.
         with torch.cuda.stream(self.gpu_bookkeeping_stream):
-            self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+            self.gpu_view._buf.copy_(source_buffer, non_blocking=True)
             if pending_mamba_transfer is not None:
                 self.mamba_metadata.load_from_cpu(pending_mamba_transfer)
-            self._gpu_bookkeeping_complete_event.record(self.gpu_bookkeeping_stream)
-        torch.cuda.current_stream().wait_event(self._gpu_bookkeeping_complete_event)
+            ready_event.record(self.gpu_bookkeeping_stream)
+        torch.cuda.current_stream().wait_event(ready_event)
+
+        if snapshot_slot is not None:
+            self.snapshot_pool.mark_ready(snapshot_slot, ready_event)
 
         # MHA metadata: buffers already covered by the coalesced H2D above.
         # All that's left is pointing state_data at the correct GPU slices and
@@ -2337,6 +2365,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Mamba metadata: GPU-side views were loaded on gpu_bookkeeping_stream.
         if pending_mamba_transfer is not None:
             self._pending_mamba_transfer = None
+
+        return ready_event
 
     def reset_tensors(self) -> None:
         """Fill all bookkeeping tensors with sentinel values."""
@@ -2428,6 +2458,35 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.current_dynamic_step_id = step_id
         if hasattr(self, "gpu_view"):
             self.gpu_view.current_dynamic_step_id = step_id
+
+    def _bind_gpu_view(self, gpu_view) -> None:
+        """Bind metadata helpers to the GPU view for the active step snapshot."""
+        self.gpu_view = gpu_view
+        self.gpu_view.current_dynamic_step_id = self.current_dynamic_step_id
+        self.graph_attn_metadata["mha_metadata"].bind_gpu_buffers(self.gpu_view)
+        self.non_graph_attn_metadata["mha_metadata"].bind_gpu_buffers(self.gpu_view)
+        if self.is_hybrid_model and self.mamba_metadata is not None:
+            self.mamba_metadata.bind_gpu_buffers(self.gpu_view)
+
+    def _snapshot_slot_from_handle(self, snapshot_slot_handle):
+        """Return the snapshot slot described by a handle-like object."""
+        if snapshot_slot_handle is None:
+            return None
+        slot = self.snapshot_pool.get_slot(snapshot_slot_handle.snapshot_slot_id)
+        step_id = getattr(snapshot_slot_handle.step_id, "value", snapshot_slot_handle.step_id)
+        if slot.owning_step_id != int(step_id):
+            raise RuntimeError(
+                f"Snapshot slot {slot.slot_id} is owned by step {slot.owning_step_id}, "
+                f"not step {step_id}"
+            )
+        return slot
+
+    def bind_snapshot_slot(self, snapshot_slot_handle):
+        """Make a snapshot slot's fixed-address GPU view the active launch view."""
+        slot = self._snapshot_slot_from_handle(snapshot_slot_handle)
+        self._bind_gpu_view(slot.gpu_view)
+        slot.cpu_view.current_dynamic_step_id = self.current_dynamic_step_id
+        return slot
 
     def dynamic_step_nvtx_label(self, name: str, step_id: Optional[int] = None) -> str:
         """Return an NVTX range name with the current dynamic step id."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -39,6 +39,7 @@ from .attention_context.mamba_metadata import MambaMetadata
 from .attention_context.mha_metadata import GraphedMHAMetadata, NonGraphedMHAMetadata
 from .base_context import BaseInferenceContext
 from .dynamic_ledgers import DynamicRequestLedgers
+from .gpu_input_state import GpuSampledTokenState
 from .gpu_view import ContextGPUView
 from .kv_block_allocator import KVBlockAllocator
 from .mamba_slot_allocator import MambaSlotAllocator
@@ -1149,6 +1150,12 @@ class DynamicInferenceContext(BaseInferenceContext):
         self._pending_mamba_restores: list = []
         self.gpu_bookkeeping_stream = torch.cuda.Stream(device=torch.cuda.current_device())
         self._gpu_bookkeeping_complete_event = torch.cuda.Event()
+        self.gpu_sampled_token_state = GpuSampledTokenState(
+            max_requests=self.max_requests,
+            num_speculative_tokens=self.num_speculative_tokens,
+            device=torch.cuda.current_device(),
+            stream=self.gpu_bookkeeping_stream,
+        )
 
         # Allocate large non-graphed buffers.
         need_static_addr = (
@@ -2548,6 +2555,47 @@ class DynamicInferenceContext(BaseInferenceContext):
             byte_count=byte_count,
             cache_key=cache_key,
             max_captures=max(1, len(self.cuda_graph_batch_dimensions_list)),
+        )
+
+    def record_sampled_tokens_gpu_state(
+        self,
+        *,
+        sampled_tokens,
+        active_request_count: int,
+        source_stream: Optional[torch.cuda.Stream] = None,
+        sampled_mtp_tokens=None,
+        accepted_token_counts=None,
+    ) -> torch.cuda.Event:
+        """Record GPU-resident sampled tokens for the next input-preparation phase."""
+        return self.gpu_sampled_token_state.record(
+            sampled_tokens=sampled_tokens,
+            active_request_count=active_request_count,
+            source_stream=source_stream,
+            sampled_mtp_tokens=sampled_mtp_tokens,
+            accepted_token_counts=accepted_token_counts,
+        )
+
+    @property
+    def sample_gpu_ready_event(self) -> torch.cuda.Event:
+        """Event recorded when GPU-resident sampled-token state is ready."""
+        return self.gpu_sampled_token_state.sample_gpu_ready_event
+
+    def debug_compare_sampled_tokens_gpu_state(
+        self,
+        *,
+        sampled_tokens_cpu,
+        active_request_count: int,
+        sampled_mtp_tokens_cpu=None,
+        accepted_token_counts_cpu=None,
+    ) -> None:
+        """Compare GPU sampled-token state with CPU output copies in debug mode."""
+        if not self.config.async_overlap_debug_checks:
+            return
+        self.gpu_sampled_token_state.debug_compare_cpu(
+            sampled_tokens_cpu=sampled_tokens_cpu,
+            active_request_count=active_request_count,
+            sampled_mtp_tokens_cpu=sampled_mtp_tokens_cpu,
+            accepted_token_counts_cpu=accepted_token_counts_cpu,
         )
 
     def dynamic_step_nvtx_label(self, name: str, step_id: Optional[int] = None) -> str:

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -43,6 +43,7 @@ from .gpu_view import ContextGPUView
 from .kv_block_allocator import KVBlockAllocator
 from .mamba_slot_allocator import MambaSlotAllocator
 from .routing_metadata import RoutingMetadata
+from .step_journal import StepJournal
 
 try:
     from .fused_kv_append_kernel import triton_append_key_value_cache
@@ -273,6 +274,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.step_count = 0
         self.current_dynamic_step_id = -1
         self.request_ledgers = DynamicRequestLedgers()
+        self.step_journal = StepJournal()
         self.async_overlap_debug_counters = {
             "queue_depth": 1,
             "snapshot_slot_waits": 0,
@@ -2300,6 +2302,92 @@ class DynamicInferenceContext(BaseInferenceContext):
         """Return optimistic request-ledger state."""
         return self.request_ledgers.get_optimistic_request_state(request_id)
 
+    def _journal_request_slots(self) -> Tuple[int, ...]:
+        """Return request slots currently visible to the scheduler."""
+        return tuple(range(int(self.total_request_count)))
+
+    def _journal_active_request_ids(self) -> Tuple[str, ...]:
+        """Return active request IDs currently visible to the scheduler."""
+        active_slice = slice(int(self.paused_request_count), int(self.total_request_count))
+        return tuple(str(int(request_id)) for request_id in self.request_ids[active_slice].tolist())
+
+    def begin_step_journal(self, step_id: int):
+        """Open the transaction journal entry for one dynamic step."""
+        return self.step_journal.begin_step_journal(
+            step_id,
+            snapshot_slot_id=getattr(self.gpu_view, "current_snapshot_slot_id", 0),
+            request_slots_before=self._journal_request_slots(),
+            active_request_ids=self._journal_active_request_ids(),
+        )
+
+    def record_placeholder_delta(self, step_id: int, request_id, token_count_delta: int):
+        """Record placeholder-token accounting for the step journal."""
+        if self.step_journal.get_open_entry(step_id) is None:
+            return None
+        return self.step_journal.record_placeholder_delta(
+            step_id, request_id, token_count_delta
+        )
+
+    def record_resource_reservation(self, step_id: int, reservation):
+        """Record a resource reservation in the step journal."""
+        if self.step_journal.get_open_entry(step_id) is None:
+            return None
+        return self.step_journal.record_resource_reservation(step_id, reservation)
+
+    def record_snapshot_slot(
+        self, step_id: int, snapshot_slot_id: int, cuda_graph_batch_dimensions=None
+    ):
+        """Record the snapshot slot bound to this step."""
+        if self.step_journal.get_open_entry(step_id) is None:
+            return None
+        return self.step_journal.record_snapshot_slot(
+            step_id,
+            snapshot_slot_id,
+            cuda_graph_batch_dimensions=cuda_graph_batch_dimensions,
+        )
+
+    def record_request_slot_transition(
+        self,
+        step_id: int,
+        *,
+        request_slots_before: Optional[Sequence[int]] = None,
+        request_slots_after: Optional[Sequence[int]] = None,
+        active_request_ids: Optional[Sequence[int]] = None,
+        pause_resume_evictions: Optional[Sequence[int]] = None,
+        decode_input_destination_indices: Optional[Sequence[int]] = None,
+    ):
+        """Record request-slot movement for this step."""
+        if self.step_journal.get_open_entry(step_id) is None:
+            return None
+        return self.step_journal.record_request_slot_transition(
+            step_id,
+            request_slots_before=request_slots_before,
+            request_slots_after=request_slots_after,
+            active_request_ids=active_request_ids,
+            pause_resume_evictions=pause_resume_evictions,
+            decode_input_destination_indices=decode_input_destination_indices,
+        )
+
+    def commit_step_journal(self, step_id: int):
+        """Commit the journal entry for one serial dynamic step."""
+        if self.step_journal.get_open_entry(step_id) is None:
+            return None
+        return self.step_journal.commit_step_journal(
+            step_id,
+            request_slots_after=self._journal_request_slots(),
+            active_request_ids=self._journal_active_request_ids(),
+        )
+
+    def rollback_step_journal(self, step_id: int, reason: Optional[str] = None):
+        """Roll back the journal entry for one dynamic step."""
+        if self.step_journal.get_open_entry(step_id) is None:
+            return None
+        return self.step_journal.rollback_step_journal(step_id, reason=reason)
+
+    def rollback_all_open_step_journals(self, reason: Optional[str] = None):
+        """Roll back every open dynamic-step journal entry."""
+        return self.step_journal.rollback_all_open(reason=reason)
+
     def reset(self) -> None:
         """Reset entire context.
 
@@ -2312,6 +2400,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         context's memory buffer is referenced by the cuda graph system and
         cannot be deallocated.
         """
+        self.rollback_all_open_step_journals(reason="context_reset")
         self.reset_tensors()
         self.reset_metadata()
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -39,6 +39,7 @@ from .attention_context.mamba_metadata import MambaMetadata
 from .attention_context.mha_metadata import GraphedMHAMetadata, NonGraphedMHAMetadata
 from .base_context import BaseInferenceContext
 from .dynamic_ledgers import DynamicRequestLedgers
+from .gpu_input_preparer import GpuInputPreparer
 from .gpu_input_state import GpuSampledTokenState
 from .gpu_view import ContextGPUView
 from .kv_block_allocator import KVBlockAllocator
@@ -1155,6 +1156,10 @@ class DynamicInferenceContext(BaseInferenceContext):
             num_speculative_tokens=self.num_speculative_tokens,
             device=torch.cuda.current_device(),
             stream=self.gpu_bookkeeping_stream,
+        )
+        self.gpu_input_preparer = GpuInputPreparer(
+            stream=self.gpu_bookkeeping_stream,
+            debug_enabled=self.config.async_overlap_debug_checks,
         )
 
         # Allocate large non-graphed buffers.
@@ -2597,6 +2602,72 @@ class DynamicInferenceContext(BaseInferenceContext):
             sampled_mtp_tokens_cpu=sampled_mtp_tokens_cpu,
             accepted_token_counts_cpu=accepted_token_counts_cpu,
         )
+
+    def build_step_input_plan(
+        self,
+        *,
+        step_id,
+        snapshot_slot_id: int,
+        source_step_id=None,
+    ):
+        """Build a GPU input-preparation plan for the current context state."""
+        from megatron.core.inference.engines.dynamic_step import StepInputPlan
+
+        active_slots = tuple(range(int(self.paused_request_count), int(self.total_request_count)))
+        active_slice = slice(int(self.paused_request_count), int(self.total_request_count))
+        request_ids = tuple(str(int(request_id)) for request_id in self.request_ids[active_slice])
+        prefill_status = self.request_in_prefill_status_tensor[active_slice].tolist()
+        decode_request_slots = tuple(
+            slot for slot, is_prefill in zip(active_slots, prefill_status) if not is_prefill
+        )
+        decode_request_ids = tuple(
+            request_id
+            for request_id, is_prefill in zip(request_ids, prefill_status)
+            if not is_prefill
+        )
+        prefill_request_ids = tuple(
+            request_id
+            for request_id, is_prefill in zip(request_ids, prefill_status)
+            if is_prefill
+        )
+
+        tokens_per_decode_request = self.num_speculative_tokens + 1
+        decode_input_destination_indices = tuple(
+            idx * tokens_per_decode_request for idx in range(len(decode_request_slots))
+        )
+
+        cursor = len(decode_request_slots) * tokens_per_decode_request
+        prefill_prompt_token_ranges = []
+        for slot, is_prefill in zip(active_slots, prefill_status):
+            if not is_prefill:
+                continue
+            query_length = int(self.request_query_lengths[slot])
+            prefill_prompt_token_ranges.append((cursor, cursor + query_length))
+            cursor += query_length
+
+        debug_expected_input_ids = None
+        if self.config.async_overlap_debug_checks:
+            debug_expected_input_ids = self.token_to_input_ids[: self.active_token_count].clone()
+
+        return StepInputPlan(
+            step_id=step_id,
+            snapshot_slot_id=snapshot_slot_id,
+            source_step_id=source_step_id,
+            request_ids=request_ids,
+            decode_request_slots=decode_request_slots,
+            decode_request_ids=decode_request_ids,
+            prefill_request_ids=prefill_request_ids,
+            decode_input_destination_indices=decode_input_destination_indices,
+            prefill_prompt_token_ranges=tuple(prefill_prompt_token_ranges),
+            speculative_width=self.num_speculative_tokens,
+            debug_expected_input_ids=debug_expected_input_ids,
+        )
+
+    def prepare_gpu_inputs(self, snapshot, input_plan, previous_sample_state=None):
+        """Prepare snapshot-bound GPU inputs from a StepInputPlan."""
+        if previous_sample_state is None:
+            previous_sample_state = self.gpu_sampled_token_state
+        return self.gpu_input_preparer.prepare(snapshot, input_plan, previous_sample_state)
 
     def dynamic_step_nvtx_label(self, name: str, step_id: Optional[int] = None) -> str:
         """Return an NVTX range name with the current dynamic step id."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2836,9 +2836,12 @@ class DynamicInferenceContext(BaseInferenceContext):
             matched_tensor = torch.tensor(
                 matched_block_ids, dtype=torch.int32, device='cpu',
             )
-            self.kv_block_allocator.block_ref_counts[matched_tensor] += 1
-            if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
-                self.kv_block_allocator.update_timestamps(matched_tensor)
+            step_id = max(0, int(self.current_dynamic_step_id))
+            prefix_ref_reservation = self.kv_block_allocator.reserve_prefix_refcounts(
+                current_id, matched_tensor, step_id
+            )
+            self.record_resource_reservation(step_id, prefix_ref_reservation)
+            self.kv_block_allocator.commit_reservation(prefix_ref_reservation)
 
         self.request_ids[current_id] = req.request_id
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -888,6 +888,11 @@ class DynamicInferenceContext(BaseInferenceContext):
             device=torch.cuda.current_device(),
         )
 
+        # Deferred Mamba GPU operations.  Populated by add_request() /
+        # update_requests() (CPU phase), executed by transfer_bookkeeping_to_gpu().
+        self._pending_mamba_zeros: list = []
+        self._pending_mamba_restores: list = []
+
         # NOTE: Need to build this outside the UVM / TMS context to avoid IMA.
         if self.is_hybrid_model:
             self.mamba_metadata = MambaMetadata(
@@ -1480,8 +1485,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                     raise ContextOverflowError(
                         requests[logical_idx].request_id, "No Mamba slots available"
                     )
-                self.mamba_conv_states[:, mamba_idx] = 0.0
-                self.mamba_ssm_states[:, mamba_idx] = 0.0
+                self._pending_mamba_zeros.append(mamba_idx)
                 self.mamba_metadata.request_to_mamba_state_idx[request_idx] = mamba_idx
 
         self.active_token_count = token_end
@@ -1857,6 +1861,32 @@ class DynamicInferenceContext(BaseInferenceContext):
             else:
                 self.moe_routing_metadata.disable_static_buffer_recording()
 
+    def _execute_pending_mamba_ops(self) -> None:
+        """Execute Mamba GPU operations deferred from add_request() / update_requests().
+
+        This runs at the start of transfer_bookkeeping_to_gpu() so that all GPU
+        Mamba state is correct before the forward pass.
+        """
+        if not (self._pending_mamba_restores or self._pending_mamba_zeros):
+            return
+
+        # Restore cached Mamba state to live buffers.  On failure, fall back to zeroing.
+        for request_idx, block_id, mamba_idx in self._pending_mamba_restores:
+            restored = self.mamba_slot_allocator.restore_to_live(request_idx, block_id)
+            if not restored:
+                self._pending_mamba_zeros.append(mamba_idx)
+        self._pending_mamba_restores.clear()
+
+        # Batch-zero newly allocated Mamba slots.
+        if self._pending_mamba_zeros:
+            device = self.mamba_conv_states.device
+            indices = torch.tensor(
+                self._pending_mamba_zeros, dtype=torch.long, device=device,
+            )
+            self.mamba_conv_states[:, indices] = 0.0
+            self.mamba_ssm_states[:, indices] = 0.0
+            self._pending_mamba_zeros.clear()
+
     def transfer_bookkeeping_to_gpu(self) -> None:
         """Batch transfer CPU bookkeeping state to GPU staging buffers.
 
@@ -1864,6 +1894,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         All copies use non_blocking=True with pinned CPU memory. CUDA stream
         ordering guarantees the forward pass sees completed transfers.
         """
+        # Execute deferred Mamba GPU operations first (state zeroing, restore, offsets).
+        self._execute_pending_mamba_ops()
+
         n_tok = self.padded_active_token_count
 
         # Token-level transfers.
@@ -2439,17 +2472,18 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             # Restore Mamba state from the block corresponding to prefix_skip_tokens
             restore_block_count = prefix_skip_tokens // self.block_size_tokens
-            restored = False
             if restore_block_count > 0 and self.mamba_slot_allocator is not None:
                 restore_block_id = matched_block_ids[restore_block_count - 1]
-                restored = self.mamba_slot_allocator.restore_to_live(
-                    self.total_request_count, restore_block_id
+                self._pending_mamba_restores.append(
+                    (self.total_request_count, restore_block_id, mamba_idx)
                 )
-            if not restored:
-                self.mamba_conv_states[:, mamba_idx] = 0.0
-                self.mamba_ssm_states[:, mamba_idx] = 0.0
+            else:
+                self._pending_mamba_zeros.append(mamba_idx)
 
-            # Compute intermediate offsets for state extraction during forward pass
+            # compute_and_store_offsets sets both CPU state (hash_to_block_id,
+            # _eos_cache_block_id_gpu) and GPU staging buffers.  Runs immediately
+            # because commit_intermediate_states() reads the CPU state after the
+            # forward pass.
             if self.mamba_slot_allocator is not None:
                 self.mamba_slot_allocator.compute_and_store_offsets(
                     req,

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1136,7 +1136,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
         self.gpu_view.current_dynamic_step_id = self.current_dynamic_step_id
         self.snapshot_pool = GpuSnapshotBufferPool(
-            slot_count=max(1, int(self.config.async_overlap_queue_depth)),
+            slot_count=self._async_overlap_snapshot_slot_count(),
             max_requests=self.max_requests,
             max_tokens=self.max_tokens,
             max_kv_blocks=self.max_kv_block_count,
@@ -2519,6 +2519,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         self._clear_pending_gpu_decode_input()
         self.sync_optimistic_to_committed_for_queue_depth_one()
 
+    def _async_overlap_snapshot_slot_count(self) -> int:
+        """Return snapshot slots needed for the configured queue depth plus one spare."""
+        queue_depth = max(1, int(self.config.async_overlap_queue_depth))
+        return queue_depth + (1 if queue_depth > 1 else 0)
+
     def set_current_dynamic_step_id(self, step_id: int) -> None:
         """Set the CPU/GPU debug step identity used for trace labels."""
         self.current_dynamic_step_id = step_id
@@ -2584,7 +2589,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.gpu_bookkeeping_stream = torch.cuda.Stream(device=torch.cuda.current_device())
         self._gpu_bookkeeping_complete_event = torch.cuda.Event()
         self.snapshot_pool = GpuSnapshotBufferPool(
-            slot_count=max(1, int(self.config.async_overlap_queue_depth)),
+            slot_count=self._async_overlap_snapshot_slot_count(),
             max_requests=self.max_requests,
             max_tokens=self.max_tokens,
             max_kv_blocks=self.max_kv_block_count,

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2949,6 +2949,22 @@ class DynamicInferenceContext(BaseInferenceContext):
             return None
         return self.step_journal.record_resource_reservation(step_id, reservation)
 
+    def record_speculative_acceptance(
+        self,
+        step_id: int,
+        *,
+        accepted_token_counts: Optional[Mapping[int, int]] = None,
+        kv_rewind_token_counts: Optional[Mapping[int, int]] = None,
+    ):
+        """Record speculative acceptance and KV rewind counts in the step journal."""
+        if self.step_journal.get_open_entry(step_id) is None:
+            return None
+        return self.step_journal.record_speculative_acceptance(
+            step_id,
+            accepted_token_counts=accepted_token_counts,
+            kv_rewind_token_counts=kv_rewind_token_counts,
+        )
+
     def record_snapshot_slot(
         self, step_id: int, snapshot_slot_id: int, cuda_graph_batch_dimensions=None
     ):

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2556,6 +2556,47 @@ class DynamicInferenceContext(BaseInferenceContext):
         self._release_deferred_mamba_slots_for_free_snapshots()
         return slot
 
+    def suspend_async_overlap_runtime_state(self) -> None:
+        """Drain transient async-overlap state before inference tensors are suspended."""
+        if hasattr(self, "gpu_bookkeeping_stream"):
+            self.gpu_bookkeeping_stream.synchronize()
+        self.rollback_all_open_step_journals(reason="suspend_runtime")
+        if hasattr(self, "snapshot_pool"):
+            self.snapshot_pool.reset_for_suspend()
+        self._snapshot_metadata_by_slot.clear()
+        self._release_deferred_mamba_slots_for_free_snapshots()
+        if hasattr(self, "gpu_sampled_token_state"):
+            self.gpu_sampled_token_state.last_active_request_count = 0
+        self._clear_pending_gpu_decode_input()
+
+    def rebuild_async_overlap_runtime_state(self) -> None:
+        """Recreate snapshot, stream, and GPU-input runtime objects after resume."""
+        self.gpu_bookkeeping_stream = torch.cuda.Stream(device=torch.cuda.current_device())
+        self._gpu_bookkeeping_complete_event = torch.cuda.Event()
+        self.snapshot_pool = GpuSnapshotBufferPool(
+            slot_count=max(1, int(self.config.async_overlap_queue_depth)),
+            max_requests=self.max_requests,
+            max_tokens=self.max_tokens,
+            max_kv_blocks=self.max_kv_block_count,
+            device=torch.cuda.current_device(),
+            max_mamba_chunks=self._max_mamba_chunks,
+        )
+        self._snapshot_metadata_by_slot = {}
+        self.gpu_sampled_token_state = GpuSampledTokenState(
+            max_requests=self.max_requests,
+            num_speculative_tokens=self.num_speculative_tokens,
+            device=torch.cuda.current_device(),
+            stream=self.gpu_bookkeeping_stream,
+        )
+        self.gpu_input_preparer = GpuInputPreparer(
+            stream=self.gpu_bookkeeping_stream,
+            block_size_tokens=self.block_size_tokens,
+            debug_enabled=self.config.async_overlap_debug_checks,
+        )
+        self._pending_mamba_zeros = []
+        self._pending_mamba_restores = []
+        self._clear_pending_gpu_decode_input()
+
     def _release_deferred_mamba_slots_for_free_snapshots(self) -> None:
         """Release deferred Mamba slots only after their snapshot slot is reusable."""
         if not self.is_hybrid_model:

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -888,7 +888,23 @@ class DynamicInferenceContext(BaseInferenceContext):
         _tok_int64_bytes = self.max_tokens * 8
         _tok_int32_bytes = self.max_tokens * 4
         _req_int32_bytes = self.max_requests * 4
-        _total_bytes = 2 * _tok_int64_bytes + 4 * _tok_int32_bytes + 3 * _req_int32_bytes
+        # MHA section: 5 fields (int32) shared between GraphedMHAMetadata and
+        # NonGraphedMHAMetadata. max_bs == max_requests.
+        _mha_query_lengths_bytes = self.max_requests * 4
+        _mha_cu_query_seq_lengths_bytes = (self.max_requests + 1) * 4
+        _mha_kv_seq_lengths_bytes = self.max_requests * 4
+        _mha_cu_kv_seq_lengths_bytes = (self.max_requests + 1) * 4
+        _mha_block_table_bytes = self.max_requests * self.max_kv_block_count * 4
+        _total_bytes = (
+            2 * _tok_int64_bytes
+            + 4 * _tok_int32_bytes
+            + 3 * _req_int32_bytes
+            + _mha_query_lengths_bytes
+            + _mha_cu_query_seq_lengths_bytes
+            + _mha_kv_seq_lengths_bytes
+            + _mha_cu_kv_seq_lengths_bytes
+            + _mha_block_table_bytes
+        )
         self._cpu_bookkeeping_buf = torch.empty(
             _total_bytes, dtype=torch.uint8, device='cpu', pin_memory=True,
         )
@@ -945,6 +961,33 @@ class DynamicInferenceContext(BaseInferenceContext):
         ].view(torch.int32)
         _off += _req_int32_bytes
 
+        # MHA flash-attention metadata views (write-only on CPU, read-only on
+        # GPU via the matching region of ContextGPUView._buf). Populated per
+        # step by initialize_attention_state(); transferred as part of the
+        # single coalesced H2D in transfer_bookkeeping_to_gpu().
+        self._cpu_mha_query_lengths = self._cpu_bookkeeping_buf[
+            _off : _off + _mha_query_lengths_bytes
+        ].view(torch.int32)
+        _off += _mha_query_lengths_bytes
+        self._cpu_mha_cu_query_seq_lengths = self._cpu_bookkeeping_buf[
+            _off : _off + _mha_cu_query_seq_lengths_bytes
+        ].view(torch.int32)
+        _off += _mha_cu_query_seq_lengths_bytes
+        self._cpu_mha_kv_seq_lengths = self._cpu_bookkeeping_buf[
+            _off : _off + _mha_kv_seq_lengths_bytes
+        ].view(torch.int32)
+        _off += _mha_kv_seq_lengths_bytes
+        self._cpu_mha_cu_kv_seq_lengths = self._cpu_bookkeeping_buf[
+            _off : _off + _mha_cu_kv_seq_lengths_bytes
+        ].view(torch.int32)
+        _off += _mha_cu_kv_seq_lengths_bytes
+        self._cpu_mha_block_table = (
+            self._cpu_bookkeeping_buf[_off : _off + _mha_block_table_bytes]
+            .view(torch.int32)
+            .view(self.max_requests, self.max_kv_block_count)
+        )
+        _off += _mha_block_table_bytes
+
         assert _off == _total_bytes, f"layout bug: wrote {_off} of {_total_bytes} bytes"
 
         # GPU view: the single interface for GPU code to read context state.
@@ -952,8 +995,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.gpu_view = ContextGPUView(
             max_requests=self.max_requests,
             max_tokens=self.max_tokens,
+            max_kv_blocks=self.max_kv_block_count,
             device=torch.cuda.current_device(),
         )
+
+        # Bind the shared MHA GPU views to both graph and non-graph metadata;
+        # only one is active per step, so sharing storage is safe.
+        self.graph_attn_metadata["mha_metadata"].bind_gpu_buffers(self.gpu_view)
+        self.non_graph_attn_metadata["mha_metadata"].bind_gpu_buffers(self.gpu_view)
 
         # Deferred Mamba GPU operations.  Populated by add_request() /
         # update_requests() (CPU phase), executed by transfer_bookkeeping_to_gpu().
@@ -1666,7 +1715,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.active_token_count = T
         self.num_prefill_requests = N_prefill
 
-        # 2. Per-request state consumed by mha_metadata.update().
+        # 2. Per-request state consumed by initialize_attention_state().
         #    Decode requests come first, followed by prefill requests.
         self.request_query_lengths[0:N_decode].fill_(tokens_per_decode_request)
         if N_prefill > 0:
@@ -1858,46 +1907,59 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         assert self.active_attn_metadata is not None
 
-        # Compute MHA metadata on CPU (ephemeral locals, not persistent attributes).
+        # Compute MHA metadata directly into the pinned CPU section of
+        # _cpu_bookkeeping_buf. The single coalesced H2D in
+        # transfer_bookkeeping_to_gpu() covers these fields along with the rest
+        # of the bookkeeping state, so no ephemeral tensors and no per-field
+        # cudaMemcpyAsyncs.
         real_bs = attn_dimensions.req_count
         padded_bs = self.padded_batch_dimensions.req_count
         mha = self.active_attn_metadata["mha_metadata"]
 
-        # Query lengths (padded).
-        cpu_query_lengths = torch.zeros(padded_bs, dtype=torch.int32)
-        cpu_query_lengths[:real_bs] = query_lengths_view[:real_bs]
-
-        # Cumulative query lengths (padded).
-        cpu_cu_query = torch.zeros(padded_bs + 1, dtype=torch.int32)
-        if real_bs > 0:
-            cpu_cu_query[1 : real_bs + 1] = torch.cumsum(query_lengths_view[:real_bs], dim=0)
+        # Query lengths: [0:real_bs] real data, [real_bs:padded_bs] zero pad.
+        self._cpu_mha_query_lengths[:real_bs] = query_lengths_view[:real_bs]
         if real_bs < padded_bs:
-            cpu_cu_query[real_bs + 1 : padded_bs + 1] = cpu_cu_query[real_bs]
+            self._cpu_mha_query_lengths[real_bs:padded_bs] = 0
 
-        # KV sequence lengths (padded).
-        cpu_kv_lengths = torch.zeros(padded_bs, dtype=torch.int32)
-        cpu_kv_lengths[:real_bs] = (
+        # Cumulative query lengths (padded slots repeat cu[real_bs]).
+        self._cpu_mha_cu_query_seq_lengths[0] = 0
+        if real_bs > 0:
+            self._cpu_mha_cu_query_seq_lengths[1 : real_bs + 1] = torch.cumsum(
+                query_lengths_view[:real_bs], dim=0
+            )
+        if real_bs < padded_bs:
+            self._cpu_mha_cu_query_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                self._cpu_mha_cu_query_seq_lengths[real_bs]
+            )
+
+        # KV sequence lengths: [0:real_bs] = kv_offsets + query_lengths.
+        self._cpu_mha_kv_seq_lengths[:real_bs] = (
             request_kv_length_offsets_view[:real_bs] + query_lengths_view[:real_bs]
         )
-
-        # Cumulative KV lengths (padded).
-        cpu_cu_kv = torch.zeros(padded_bs + 1, dtype=torch.int32)
-        if real_bs > 0:
-            cpu_cu_kv[1 : real_bs + 1] = torch.cumsum(cpu_kv_lengths[:real_bs], dim=0)
         if real_bs < padded_bs:
-            cpu_cu_kv[real_bs + 1 : padded_bs + 1] = cpu_cu_kv[real_bs]
+            self._cpu_mha_kv_seq_lengths[real_bs:padded_bs] = 0
 
-        # Block table (padded).
-        cpu_block_table = torch.full(
-            (padded_bs, mha.max_kv_blocks), -1, dtype=torch.int32,
-        )
-        cpu_block_table[:real_bs] = request_to_kv_block_ids_view[:real_bs]
+        # Cumulative KV lengths.
+        self._cpu_mha_cu_kv_seq_lengths[0] = 0
+        if real_bs > 0:
+            self._cpu_mha_cu_kv_seq_lengths[1 : real_bs + 1] = torch.cumsum(
+                self._cpu_mha_kv_seq_lengths[:real_bs], dim=0
+            )
+        if real_bs < padded_bs:
+            self._cpu_mha_cu_kv_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                self._cpu_mha_cu_kv_seq_lengths[real_bs]
+            )
 
-        # Max sequence lengths.
+        # Block table: [0:real_bs] real, [real_bs:padded_bs] = -1 sentinel.
+        self._cpu_mha_block_table[:real_bs] = request_to_kv_block_ids_view[:real_bs]
+        if real_bs < padded_bs:
+            self._cpu_mha_block_table[real_bs:padded_bs] = -1
+
+        # Max sequence lengths (Python scalars; consumed as kernel launch args).
         if not self.using_cuda_graph_this_step() and real_bs > 0:
             # NonGraphedMHAMetadata: use actual max values.
-            max_seqlen_q = cpu_query_lengths[:real_bs].max().item()
-            max_seqlen_k = cpu_kv_lengths[:real_bs].max().item()
+            max_seqlen_q = self._cpu_mha_query_lengths[:real_bs].max().item()
+            max_seqlen_k = self._cpu_mha_kv_seq_lengths[:real_bs].max().item()
         else:
             # GraphedMHAMetadata: use conservative bounds.
             if self.padded_batch_dimensions.prefill_req_count == 0:
@@ -1909,16 +1971,11 @@ class DynamicInferenceContext(BaseInferenceContext):
             max_seqlen_q = self.num_speculative_tokens + 1
             max_seqlen_k = 1
 
-        # Store for transfer_bookkeeping_to_gpu().
+        # Scalars consumed by set_state_data() after the single H2D completes.
         self._pending_mha_transfer = {
-            "query_lengths": cpu_query_lengths,
-            "cu_query_seq_lengths": cpu_cu_query,
-            "kv_seq_lengths": cpu_kv_lengths,
-            "cu_kv_seq_lengths": cpu_cu_kv,
-            "block_table": cpu_block_table,
+            "padded_active_request_count": padded_bs,
             "max_seqlen_q": max_seqlen_q,
             "max_seqlen_k": max_seqlen_k,
-            "padded_active_request_count": padded_bs,
         }
 
         if self.is_hybrid_model:
@@ -1935,7 +1992,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self._pending_mamba_transfer = self.mamba_metadata.compute_cpu_metadata(
                 active_mamba_indices=self.mamba_metadata.request_to_mamba_state_idx[active_slice],
                 token_to_request_idx=self.token_to_request_idx[: self.active_token_count],
-                cpu_cu_query=cpu_cu_query,
+                cpu_cu_query=self._cpu_mha_cu_query_seq_lengths,
                 batch_dimensions=attn_dimensions,
                 padded_batch_dimensions=self.padded_batch_dimensions,
                 enable_chunked_prefill=self.is_chunked_prefill_enabled(),
@@ -2009,19 +2066,16 @@ class DynamicInferenceContext(BaseInferenceContext):
         # 8 redundant launch overheads vs. the prior per-field copies.
         self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
 
-        # MHA metadata transfer.
+        # MHA metadata: buffers already covered by the coalesced H2D above.
+        # All that's left is pointing state_data at the correct GPU slices and
+        # stashing the per-step max_seqlen scalars.
         if hasattr(self, '_pending_mha_transfer') and self._pending_mha_transfer is not None:
             mha = self.active_attn_metadata["mha_metadata"]
             d = self._pending_mha_transfer
-            mha.load_from_cpu(
-                query_lengths=d["query_lengths"],
-                cu_query_seq_lengths=d["cu_query_seq_lengths"],
-                kv_seq_lengths=d["kv_seq_lengths"],
-                cu_kv_seq_lengths=d["cu_kv_seq_lengths"],
-                block_table=d["block_table"],
+            mha.set_state_data(
+                padded_active_request_count=d["padded_active_request_count"],
                 max_seqlen_q=d["max_seqlen_q"],
                 max_seqlen_k=d["max_seqlen_k"],
-                padded_active_request_count=d["padded_active_request_count"],
             )
             self._pending_mha_transfer = None
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -33,7 +33,7 @@ from megatron.core.ssm.mamba_hybrid_layer_allocation import get_layer_maps_from_
 from megatron.core.transformer import MLATransformerConfig, TransformerConfig
 from megatron.core.utils import deprecate_args
 from megatron.core.utils import divide as core_divide
-from megatron.core.utils import get_pg_size, internal_api
+from megatron.core.utils import get_pg_size, internal_api, nvtx_range_pop, nvtx_range_push
 
 from .attention_context.mamba_metadata import MambaMetadata
 from .attention_context.mha_metadata import GraphedMHAMetadata, NonGraphedMHAMetadata
@@ -270,6 +270,17 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # Engine step counter (used for logging, metrics, and event tracking)
         self.step_count = 0
+        self.current_dynamic_step_id = -1
+        self.async_overlap_debug_counters = {
+            "queue_depth": 1,
+            "snapshot_slot_waits": 0,
+            "output_event_waits": 0,
+            "fallback_or_queue_depth_one_reasons": {},
+            "discarded_lookahead_tokens": 0,
+            "placeholder_count": 0,
+            "reservation_commits": 0,
+            "reservation_rollbacks": 0,
+        }
 
         self.cache_mla_latent = (
             isinstance(model_config, MLATransformerConfig) and model_config.cache_mla_latents
@@ -1095,6 +1106,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             device=torch.cuda.current_device(),
             max_mamba_chunks=self._max_mamba_chunks,
         )
+        self.gpu_view.current_dynamic_step_id = self.current_dynamic_step_id
 
         # Bind the shared MHA GPU views to both graph and non-graph metadata;
         # only one is active per step, so sharing storage is safe.
@@ -1995,6 +2007,9 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         assert self.active_attn_metadata is not None
 
+        metadata_range = self.dynamic_step_nvtx_label("attention_metadata_build")
+        nvtx_range_push(metadata_range)
+
         # Compute MHA metadata directly into the pinned CPU section of
         # _cpu_bookkeeping_buf. The single coalesced H2D in
         # transfer_bookkeeping_to_gpu() covers these fields along with the rest
@@ -2087,6 +2102,8 @@ class DynamicInferenceContext(BaseInferenceContext):
                 intermediate_offsets_gpu=intermediate_offsets_gpu,
                 intermediate_counts_gpu=intermediate_counts_gpu,
             )
+
+        nvtx_range_pop(metadata_range)
 
         if self.moe_enable_routing_replay:
             if self.using_cuda_graph_this_step():
@@ -2230,6 +2247,19 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Reset step counter and LRU clock
         self.step_count = 0
         self.prefix_cache_lru_clock = 0
+        self.set_current_dynamic_step_id(-1)
+        self.async_overlap_debug_counters.update(
+            {
+                "queue_depth": 1,
+                "snapshot_slot_waits": 0,
+                "output_event_waits": 0,
+                "fallback_or_queue_depth_one_reasons": {},
+                "discarded_lookahead_tokens": 0,
+                "placeholder_count": 0,
+                "reservation_commits": 0,
+                "reservation_rollbacks": 0,
+            }
+        )
 
         # Reset chunked prefill state
         self.chunked_prefill_request_id = -1
@@ -2239,6 +2269,18 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.padded_batch_dimensions = InferenceBatchDimensions(
             token_count=0, prefill_req_count=0, decode_req_count=0
         )
+
+    def set_current_dynamic_step_id(self, step_id: int) -> None:
+        """Set the CPU/GPU debug step identity used for trace labels."""
+        self.current_dynamic_step_id = step_id
+        if hasattr(self, "gpu_view"):
+            self.gpu_view.current_dynamic_step_id = step_id
+
+    def dynamic_step_nvtx_label(self, name: str, step_id: Optional[int] = None) -> str:
+        """Return an NVTX range name with the current dynamic step id."""
+        if step_id is None:
+            step_id = self.current_dynamic_step_id
+        return f"{name}[step={step_id}]"
 
     def reset(self) -> None:
         """Reset entire context.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -672,6 +672,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             f"    pinned_mirrors:        {get_mem_size_str(snapshot_accounting['pinned_mirror_bytes'])}",
             f"    graph_captures:        {snapshot_accounting['graph_capture_count']} "
             f"({get_mem_size_str(snapshot_accounting['graph_capture_bytes'])})",
+            f"    graph_cache:           {snapshot_accounting['graph_cache_hits']} hit / "
+            f"{snapshot_accounting['graph_cache_misses']} miss",
         ]
 
         if self.is_hybrid_model:
@@ -2505,6 +2507,48 @@ class DynamicInferenceContext(BaseInferenceContext):
         self._bind_gpu_view(slot.gpu_view)
         slot.cpu_view.current_dynamic_step_id = self.current_dynamic_step_id
         return slot
+
+    @property
+    def cuda_graph_capture_slot_ids(self) -> Tuple[int, ...]:
+        """Return snapshot slot IDs that need CUDA graph captures."""
+        return tuple(slot.slot_id for slot in self.snapshot_pool.slots)
+
+    def cuda_graph_max_cache_entries(self) -> int:
+        """Maximum dynamic CUDA graph cache entries per graph-managed module."""
+        return max(1, len(self.cuda_graph_batch_dimensions_list)) * max(
+            1, self.snapshot_pool.slot_count
+        )
+
+    def cuda_graph_cache_key(
+        self,
+        padded_batch_dimensions: Optional[InferenceBatchDimensions] = None,
+        snapshot_slot_id: Optional[int] = None,
+    ):
+        """Return the dynamic CUDA graph cache key for the active snapshot binding."""
+        if padded_batch_dimensions is None:
+            padded_batch_dimensions = self.padded_batch_dimensions
+        if snapshot_slot_id is None:
+            snapshot_slot_id = getattr(self.gpu_view, "current_snapshot_slot_id", 0)
+        return (padded_batch_dimensions, int(snapshot_slot_id))
+
+    def record_cuda_graph_cache_lookup(self, cache_key, *, hit: bool) -> None:
+        """Record CUDA graph cache lookup metrics for a snapshot slot."""
+        if cache_key is None:
+            return
+        _, snapshot_slot_id = cache_key
+        self.snapshot_pool.record_graph_cache_lookup(snapshot_slot_id, hit=hit)
+
+    def record_cuda_graph_capture(self, cache_key, *, byte_count: int = 0) -> None:
+        """Record CUDA graph capture memory for a snapshot slot."""
+        if cache_key is None:
+            return
+        _, snapshot_slot_id = cache_key
+        self.snapshot_pool.register_graph_capture(
+            snapshot_slot_id,
+            byte_count=byte_count,
+            cache_key=cache_key,
+            max_captures=max(1, len(self.cuda_graph_batch_dimensions_list)),
+        )
 
     def dynamic_step_nvtx_label(self, name: str, step_id: Optional[int] = None) -> str:
         """Return an NVTX range name with the current dynamic step id."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -38,6 +38,7 @@ from megatron.core.utils import get_pg_size, internal_api, nvtx_range_pop, nvtx_
 from .attention_context.mamba_metadata import MambaMetadata
 from .attention_context.mha_metadata import GraphedMHAMetadata, NonGraphedMHAMetadata
 from .base_context import BaseInferenceContext
+from .dynamic_ledgers import DynamicRequestLedgers
 from .gpu_view import ContextGPUView
 from .kv_block_allocator import KVBlockAllocator
 from .mamba_slot_allocator import MambaSlotAllocator
@@ -271,6 +272,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Engine step counter (used for logging, metrics, and event tracking)
         self.step_count = 0
         self.current_dynamic_step_id = -1
+        self.request_ledgers = DynamicRequestLedgers()
         self.async_overlap_debug_counters = {
             "queue_depth": 1,
             "snapshot_slot_waits": 0,
@@ -1722,6 +1724,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.total_request_count = end_request_idx
         if count_as_prefill:
             self.num_prefill_requests += num_new_requests
+        self.sync_optimistic_to_committed_for_queue_depth_one()
 
     def add_dummy_requests_for_cudagraph_capture(
         self, graph_dimensions: InferenceBatchDimensions
@@ -2269,6 +2272,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.padded_batch_dimensions = InferenceBatchDimensions(
             token_count=0, prefill_req_count=0, decode_req_count=0
         )
+        self.sync_optimistic_to_committed_for_queue_depth_one()
 
     def set_current_dynamic_step_id(self, step_id: int) -> None:
         """Set the CPU/GPU debug step identity used for trace labels."""
@@ -2281,6 +2285,20 @@ class DynamicInferenceContext(BaseInferenceContext):
         if step_id is None:
             step_id = self.current_dynamic_step_id
         return f"{name}[step={step_id}]"
+
+    def sync_optimistic_to_committed_for_queue_depth_one(self) -> None:
+        """Synchronize committed and optimistic ledgers to the live serial context."""
+        self.request_ledgers.sync_from_context_for_queue_depth_one(self)
+        if self.config.async_overlap_debug_checks:
+            self.request_ledgers.assert_committed_matches_optimistic()
+
+    def get_committed_request_state(self, request_id: Optional[int] = None):
+        """Return committed request-ledger state."""
+        return self.request_ledgers.get_committed_request_state(request_id)
+
+    def get_optimistic_request_state(self, request_id: Optional[int] = None):
+        """Return optimistic request-ledger state."""
+        return self.request_ledgers.get_optimistic_request_state(request_id)
 
     def reset(self) -> None:
         """Reset entire context.
@@ -2746,6 +2764,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.lifetime_prefill_token_count += effective_prefill_chunk_length
         self.total_request_count += 1
         self.num_prefill_requests += 1
+        self.sync_optimistic_to_committed_for_queue_depth_one()
 
     def _move_book_keeping_tensors(
         self, src_idxs, dst_idxs, next_tokens, new_speculative_tokens=None
@@ -3166,6 +3185,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             # Reset Mamba state.
             self.reset_mamba_state()
+            self.sync_optimistic_to_committed_for_queue_depth_one()
             return
 
         # 3. Concatenate the paused tokens to the active tokens if present.
@@ -3513,6 +3533,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             # Convert back to 1d tensor
             self.token_to_block_idx[: self.active_token_count] = block_idx.flatten()
 
+        self.sync_optimistic_to_committed_for_queue_depth_one()
         return {
             "newly_paused_request_ids": newly_paused_request_ids,
             "evict_request_ids": evict_request_ids,

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1134,6 +1134,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             device=torch.cuda.current_device(),
             max_mamba_chunks=self._max_mamba_chunks,
         )
+        self._snapshot_metadata_by_slot = {}
 
         # Bind the shared MHA GPU views to both graph and non-graph metadata;
         # only one is active per step, so sharing storage is safe.
@@ -2324,6 +2325,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         while CPU bookkeeping keeps them at `[paused_count:total_count)`).
         """
         snapshot_slot = self._snapshot_slot_from_handle(snapshot_slot_handle)
+        snapshot_slot_id = snapshot_slot.slot_id if snapshot_slot is not None else None
         if snapshot_slot is not None:
             self._bind_gpu_view(snapshot_slot.gpu_view)
             source_buffer = snapshot_slot.cpu_mirror
@@ -2342,7 +2344,13 @@ class DynamicInferenceContext(BaseInferenceContext):
         with torch.cuda.stream(self.gpu_bookkeeping_stream):
             self.gpu_view._buf.copy_(source_buffer, non_blocking=True)
             if pending_mamba_transfer is not None:
-                self.mamba_metadata.load_from_cpu(pending_mamba_transfer)
+                mamba_snapshot_state = self.mamba_metadata.load_from_cpu(
+                    pending_mamba_transfer,
+                    gpu_view=self.gpu_view,
+                    snapshot_slot_id=snapshot_slot_id,
+                )
+            else:
+                mamba_snapshot_state = None
             ready_event.record(self.gpu_bookkeeping_stream)
         torch.cuda.current_stream().wait_event(ready_event)
 
@@ -2355,11 +2363,21 @@ class DynamicInferenceContext(BaseInferenceContext):
         if hasattr(self, '_pending_mha_transfer') and self._pending_mha_transfer is not None:
             mha = self.active_attn_metadata["mha_metadata"]
             d = self._pending_mha_transfer
-            mha.set_state_data(
+            mha_snapshot_state = mha.set_state_data(
                 padded_active_request_count=d["padded_active_request_count"],
                 max_seqlen_q=d["max_seqlen_q"],
                 max_seqlen_k=d["max_seqlen_k"],
+                gpu_view=self.gpu_view,
+                snapshot_slot_id=snapshot_slot_id,
+                padded_batch_dimensions=self.padded_batch_dimensions,
             )
+            if snapshot_slot is not None:
+                self._snapshot_metadata_by_slot[snapshot_slot.slot_id] = {
+                    "mha_metadata": mha_snapshot_state,
+                    "mamba_metadata": mamba_snapshot_state,
+                    "padded_batch_dimensions": self.padded_batch_dimensions,
+                    "padded_active_request_count": self.padded_active_request_count,
+                }
             self._pending_mha_transfer = None
 
         # Mamba metadata: GPU-side views were loaded on gpu_bookkeeping_stream.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -38,6 +38,7 @@ from megatron.core.utils import get_pg_size, internal_api
 from .attention_context.mamba_metadata import MambaMetadata
 from .attention_context.mha_metadata import GraphedMHAMetadata, NonGraphedMHAMetadata
 from .base_context import BaseInferenceContext
+from .gpu_view import ContextGPUView
 from .kv_block_allocator import KVBlockAllocator
 from .mamba_slot_allocator import MambaSlotAllocator
 from .routing_metadata import RoutingMetadata
@@ -810,49 +811,82 @@ class DynamicInferenceContext(BaseInferenceContext):
                 f"Please move tensor '{key}'."
             )
 
-        # Per-request state.
+        # Per-request state (CPU, pinned memory for fast H2D transfer).
         self.request_ids = torch.full(
-            (self.max_requests,), -1, dtype=torch.int32, device=torch.cuda.current_device()
+            (self.max_requests,), -1, dtype=torch.int32, device='cpu', pin_memory=True,
         )
         # request_query_lengths is the input prompt tokens length during prefill phase (1st step) and then 1 for the decode phase (i.e During generation)
-        self.request_query_lengths = torch.empty_like(self.request_ids)
+        self.request_query_lengths = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # True only for a new request , then after a forward pass it is set to False
-        self.request_in_prefill_status_tensor = torch.empty_like(self.request_ids)
+        self.request_in_prefill_status_tensor = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # request_output_lengths is len(input_prompt_tokens) + num_tokens_to_generate
-        self.request_output_lengths = torch.empty_like(self.request_ids)
+        self.request_output_lengths = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # request_kv_length_offsets is the same as query length during prefill phase (1st step) and then 1 for the decode phase (i.e During generation)
-        self.request_kv_length_offsets = torch.empty_like(self.request_ids)
-        self.request_kv_block_counts = torch.empty_like(self.request_ids)
-        self.request_last_kv_block_id = torch.empty_like(self.request_ids)
+        self.request_kv_length_offsets = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
+        self.request_kv_block_counts = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
+        self.request_last_kv_block_id = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # request_last_kv_block_offset represents number of tokens in the last kv block
-        self.request_last_kv_block_offset = torch.empty_like(self.request_ids)
+        self.request_last_kv_block_offset = torch.empty(
+            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         self.request_to_kv_block_ids = torch.full(
             (self.max_requests, self.max_kv_block_count),
             -1,
             dtype=torch.int,
-            device=torch.cuda.current_device(),
+            device='cpu',
+            pin_memory=True,
         )
 
         # Track request metadata.
         self.request_metadata = {
             label: torch.empty(
-                (self.max_requests,), dtype=dtype, device=torch.cuda.current_device()
+                (self.max_requests,), dtype=dtype, device='cpu', pin_memory=True,
             )
             for label, dtype, _ in self.request_metadata_types
         }
 
-        # Per-token state.
+        # Per-token state (CPU, pinned memory for fast H2D transfer).
         self.token_to_input_ids = torch.full(
-            (self.max_tokens,), 0, dtype=torch.long, device=torch.cuda.current_device()
+            (self.max_tokens,), 0, dtype=torch.long, device='cpu', pin_memory=True,
         )
-        self.token_to_pos_ids = torch.full_like(self.token_to_input_ids, 0)
-        self.token_to_request_idx = torch.empty_like(self.token_to_input_ids)
-        self.token_to_block_idx = torch.empty_like(self.token_to_input_ids)
+        self.token_to_pos_ids = torch.full(
+            (self.max_tokens,), 0, dtype=torch.long, device='cpu', pin_memory=True,
+        )
+        self.token_to_request_idx = torch.empty(
+            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
+        self.token_to_block_idx = torch.empty(
+            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
         # i.e For a set of tokens A B C D E F ..  and block_size 4:
         # token_to_position_in_request is  [0, 1, 2, 3, 4, 5]
         # token_to_local_position_within_kv_block is [0 , 1, 2, 3, 0, 1, 2]
-        self.token_to_position_in_request = torch.empty_like(self.token_to_input_ids)
-        self.token_to_local_position_within_kv_block = torch.empty_like(self.token_to_input_ids)
+        self.token_to_position_in_request = torch.empty(
+            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
+        self.token_to_local_position_within_kv_block = torch.empty(
+            self.max_tokens, dtype=torch.int32, device='cpu', pin_memory=True,
+        )
+
+        # GPU view: the single interface for GPU code to read context state.
+        # Populated per-step by transfer_bookkeeping_to_gpu().
+        self.gpu_view = ContextGPUView(
+            max_requests=self.max_requests,
+            max_tokens=self.max_tokens,
+            device=torch.cuda.current_device(),
+        )
 
         # NOTE: Need to build this outside the UVM / TMS context to avoid IMA.
         if self.is_hybrid_model:
@@ -1074,12 +1108,12 @@ class DynamicInferenceContext(BaseInferenceContext):
                 value=value,
                 memory_buffer=self.memory_buffer,
                 padded_active_token_count=self.padded_active_token_count,
-                token_to_block_idx=self.token_to_block_idx,
-                token_to_local_position_within_kv_block=self.token_to_local_position_within_kv_block,
+                token_to_block_idx=self.gpu_view.token_to_block_idx,
+                token_to_local_position_within_kv_block=self.gpu_view.token_to_local_position_within_kv_block,
             )
 
-        block_idx = self.token_to_block_idx[: self.padded_active_token_count]
-        local_kv_seq_idx = self.token_to_local_position_within_kv_block[
+        block_idx = self.gpu_view.token_to_block_idx[: self.padded_active_token_count]
+        local_kv_seq_idx = self.gpu_view.token_to_local_position_within_kv_block[
             : self.padded_active_token_count
         ]
 
@@ -1215,7 +1249,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # use .view instead of .reshape to avoid extra transpose operations
         query_rope, key_rope = flashinfer.rope.apply_rope_with_cos_sin_cache(
-            positions=self.token_to_pos_ids[:n],
+            positions=self.gpu_view.token_to_pos_ids[:n],
             query=query[:n].reshape(n, num_q_heads * head_size),
             key=key[:n].reshape(n, num_k_heads * head_size),
             head_size=head_size,
@@ -1248,7 +1282,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             (Tensor) Query tensor after applying rotary embeddings.
         """
         n = self.padded_active_token_count
-        query_seq_idx = self.token_to_pos_ids[:n]
+        query_seq_idx = self.gpu_view.token_to_pos_ids[:n]
         query_emb = query_emb[query_seq_idx]
         query[:n] = apply_rotary_pos_emb(
             t=query[:n],
@@ -1280,7 +1314,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             (Tensor) Key tensor after applying rotary embeddings.
         """
         n = self.padded_active_token_count
-        key_seq_idx = self.token_to_position_in_request[:n]
+        key_seq_idx = self.gpu_view.token_to_position_in_request[:n]
         key_emb = key_emb[key_seq_idx]
         if self.is_decode_only():
             if key.shape[0] != n:
@@ -1387,7 +1421,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_kv_block_counts[request_slice] = block_counts
         for i, (label, dtype, _) in enumerate(self.request_metadata_types):
             self.request_metadata[label][request_slice] = torch.tensor(
-                metadata_cols[i], dtype=dtype, device=torch.cuda.current_device()
+                metadata_cols[i], dtype=dtype, device='cpu',
             )
 
         dummy_block_idx = self.kv_block_allocator.dummy_block_idx
@@ -1469,7 +1503,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Pre-construct shared objects (safe due to deep copy in DynamicInferenceRequest.__post_init__)
         shared_sampling_params = SamplingParams(num_tokens_to_generate=1, termination_id=-1)
         shared_decode_tokens = torch.zeros(
-            self.num_speculative_tokens + 1, dtype=torch.long, device=torch.cuda.current_device()
+            self.num_speculative_tokens + 1, dtype=torch.long, device='cpu',
         )
 
         decode_requests = [
@@ -1500,7 +1534,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Create a single large tensor and slice from it for each prefill request
         max_prefill_tokens = per_prefill_tokens + (1 if rem_prefill_tokens > 0 else 0)
         shared_prefill_tokens = torch.zeros(
-            max_prefill_tokens, dtype=torch.long, device=torch.cuda.current_device()
+            max_prefill_tokens, dtype=torch.long, device='cpu',
         )
 
         prefill_requests = [
@@ -1733,37 +1767,89 @@ class DynamicInferenceContext(BaseInferenceContext):
                 )
 
         assert self.active_attn_metadata is not None
-        self.active_attn_metadata["mha_metadata"].update(
-            request_query_lengths=query_lengths_view,
-            request_kv_length_offsets=request_kv_length_offsets_view,
-            request_to_kv_block_ids=request_to_kv_block_ids_view,
-            batch_dimensions=attn_dimensions,
-            padded_batch_dimensions=self.padded_batch_dimensions,
-            num_speculative_tokens=self.num_speculative_tokens,
+
+        # Compute MHA metadata on CPU (ephemeral locals, not persistent attributes).
+        real_bs = attn_dimensions.req_count
+        padded_bs = self.padded_batch_dimensions.req_count
+        mha = self.active_attn_metadata["mha_metadata"]
+
+        # Query lengths (padded).
+        cpu_query_lengths = torch.zeros(padded_bs, dtype=torch.int32)
+        cpu_query_lengths[:real_bs] = query_lengths_view[:real_bs]
+
+        # Cumulative query lengths (padded).
+        cpu_cu_query = torch.zeros(padded_bs + 1, dtype=torch.int32)
+        if real_bs > 0:
+            cpu_cu_query[1 : real_bs + 1] = torch.cumsum(query_lengths_view[:real_bs], dim=0)
+        if real_bs < padded_bs:
+            cpu_cu_query[real_bs + 1 : padded_bs + 1] = cpu_cu_query[real_bs]
+
+        # KV sequence lengths (padded).
+        cpu_kv_lengths = torch.zeros(padded_bs, dtype=torch.int32)
+        cpu_kv_lengths[:real_bs] = (
+            request_kv_length_offsets_view[:real_bs] + query_lengths_view[:real_bs]
         )
 
+        # Cumulative KV lengths (padded).
+        cpu_cu_kv = torch.zeros(padded_bs + 1, dtype=torch.int32)
+        if real_bs > 0:
+            cpu_cu_kv[1 : real_bs + 1] = torch.cumsum(cpu_kv_lengths[:real_bs], dim=0)
+        if real_bs < padded_bs:
+            cpu_cu_kv[real_bs + 1 : padded_bs + 1] = cpu_cu_kv[real_bs]
+
+        # Block table (padded).
+        cpu_block_table = torch.full(
+            (padded_bs, mha.max_kv_blocks), -1, dtype=torch.int32,
+        )
+        cpu_block_table[:real_bs] = request_to_kv_block_ids_view[:real_bs]
+
+        # Max sequence lengths.
+        if not self.using_cuda_graph_this_step() and real_bs > 0:
+            # NonGraphedMHAMetadata: use actual max values.
+            max_seqlen_q = cpu_query_lengths[:real_bs].max().item()
+            max_seqlen_k = cpu_kv_lengths[:real_bs].max().item()
+        else:
+            # GraphedMHAMetadata: use conservative bounds.
+            if self.padded_batch_dimensions.prefill_req_count == 0:
+                max_seqlen_q = self.num_speculative_tokens + 1
+            else:
+                max_seqlen_q = max(2, self.padded_batch_dimensions.token_count)
+            max_seqlen_k = mha.max_seqlen
+        if not self.using_cuda_graph_this_step() and real_bs == 0:
+            max_seqlen_q = self.num_speculative_tokens + 1
+            max_seqlen_k = 1
+
+        # Store for transfer_bookkeeping_to_gpu().
+        self._pending_mha_transfer = {
+            "query_lengths": cpu_query_lengths,
+            "cu_query_seq_lengths": cpu_cu_query,
+            "kv_seq_lengths": cpu_kv_lengths,
+            "cu_kv_seq_lengths": cpu_cu_kv,
+            "block_table": cpu_block_table,
+            "max_seqlen_q": max_seqlen_q,
+            "max_seqlen_k": max_seqlen_k,
+            "padded_active_request_count": padded_bs,
+        }
+
         if self.is_hybrid_model:
-            active_mamba_indices_view = self.mamba_metadata.request_to_mamba_state_idx[active_slice]
-            token_to_request_idx_view = self.token_to_request_idx[: self.active_token_count]
-            cu_seqlens = self.active_attn_metadata["mha_metadata"].state_data[
-                "cu_query_seq_lengths"
-            ]
+            # Mamba metadata update is deferred to transfer_bookkeeping_to_gpu()
+            # because it writes to GPU buffers. Store the parameters here.
             intermediate_offsets_gpu = None
             intermediate_counts_gpu = None
             if self.mamba_slot_allocator is not None:
                 intermediate_offsets_gpu, intermediate_counts_gpu = (
                     self.mamba_slot_allocator.get_intermediate_gpu_data()
                 )
-            self.mamba_metadata.update(
-                active_mamba_indices_view,
-                token_to_request_idx_view,
-                cu_seqlens,
-                batch_dimensions=attn_dimensions,
-                padded_batch_dimensions=self.padded_batch_dimensions,
-                enable_chunked_prefill=self.is_chunked_prefill_enabled(),
-                intermediate_offsets_gpu=intermediate_offsets_gpu,
-                intermediate_counts_gpu=intermediate_counts_gpu,
-            )
+            self._pending_mamba_transfer = {
+                "active_mamba_indices": self.mamba_metadata.request_to_mamba_state_idx[active_slice],
+                "token_to_request_idx": self.token_to_request_idx[: self.active_token_count],
+                "cu_seqlens": cpu_cu_query,
+                "batch_dimensions": attn_dimensions,
+                "padded_batch_dimensions": self.padded_batch_dimensions,
+                "enable_chunked_prefill": self.is_chunked_prefill_enabled(),
+                "intermediate_offsets_gpu": intermediate_offsets_gpu,
+                "intermediate_counts_gpu": intermediate_counts_gpu,
+            }
 
         if self.moe_enable_routing_replay:
             if self.using_cuda_graph_this_step():
@@ -1771,8 +1857,85 @@ class DynamicInferenceContext(BaseInferenceContext):
             else:
                 self.moe_routing_metadata.disable_static_buffer_recording()
 
+    def transfer_bookkeeping_to_gpu(self) -> None:
+        """Batch transfer CPU bookkeeping state to GPU staging buffers.
+
+        Called after initialize_attention_state() and before the forward pass.
+        All copies use non_blocking=True with pinned CPU memory. CUDA stream
+        ordering guarantees the forward pass sees completed transfers.
+        """
+        n_tok = self.padded_active_token_count
+
+        # Token-level transfers.
+        self.gpu_view.token_to_input_ids[:n_tok].copy_(
+            self.token_to_input_ids[:n_tok], non_blocking=True,
+        )
+        self.gpu_view.token_to_pos_ids[:n_tok].copy_(
+            self.token_to_pos_ids[:n_tok], non_blocking=True,
+        )
+        self.gpu_view.token_to_block_idx[:n_tok].copy_(
+            self.token_to_block_idx[:n_tok], non_blocking=True,
+        )
+        self.gpu_view.token_to_local_position_within_kv_block[:n_tok].copy_(
+            self.token_to_local_position_within_kv_block[:n_tok], non_blocking=True,
+        )
+        self.gpu_view.token_to_request_idx[:n_tok].copy_(
+            self.token_to_request_idx[:n_tok], non_blocking=True,
+        )
+        self.gpu_view.token_to_position_in_request[:n_tok].copy_(
+            self.token_to_position_in_request[:n_tok], non_blocking=True,
+        )
+
+        # Request-level transfers (consumed by sampling, log-probs, speculative verification).
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        n_active = self.total_request_count - self.paused_request_count
+        self.gpu_view.request_in_prefill_status[:n_active].copy_(
+            self.request_in_prefill_status_tensor[active_slice], non_blocking=True,
+        )
+        self.gpu_view.request_query_lengths[:n_active].copy_(
+            self.request_query_lengths[active_slice], non_blocking=True,
+        )
+        self.gpu_view.request_kv_length_offsets[:n_active].copy_(
+            self.request_kv_length_offsets[active_slice], non_blocking=True,
+        )
+
+        # MHA metadata transfer.
+        if hasattr(self, '_pending_mha_transfer') and self._pending_mha_transfer is not None:
+            mha = self.active_attn_metadata["mha_metadata"]
+            d = self._pending_mha_transfer
+            mha.load_from_cpu(
+                query_lengths=d["query_lengths"],
+                cu_query_seq_lengths=d["cu_query_seq_lengths"],
+                kv_seq_lengths=d["kv_seq_lengths"],
+                cu_kv_seq_lengths=d["cu_kv_seq_lengths"],
+                block_table=d["block_table"],
+                max_seqlen_q=d["max_seqlen_q"],
+                max_seqlen_k=d["max_seqlen_k"],
+                padded_active_request_count=d["padded_active_request_count"],
+            )
+            self._pending_mha_transfer = None
+
+        # Mamba metadata transfer (update writes to GPU buffers).
+        if hasattr(self, '_pending_mamba_transfer') and self._pending_mamba_transfer is not None:
+            d = self._pending_mamba_transfer
+            # cu_seqlens needs to be on GPU for the Mamba metadata update.
+            cu_seqlens_gpu = self.active_attn_metadata["mha_metadata"].state_data[
+                "cu_query_seq_lengths"
+            ]
+            self.mamba_metadata.update(
+                d["active_mamba_indices"],
+                d["token_to_request_idx"],
+                cu_seqlens_gpu,
+                batch_dimensions=d["batch_dimensions"],
+                padded_batch_dimensions=d["padded_batch_dimensions"],
+                enable_chunked_prefill=d["enable_chunked_prefill"],
+                intermediate_offsets_gpu=d["intermediate_offsets_gpu"],
+                intermediate_counts_gpu=d["intermediate_counts_gpu"],
+            )
+            self._pending_mamba_transfer = None
+
     def reset_tensors(self) -> None:
-        """Fill all GPU tensors with sentinel values."""
+        """Fill all bookkeeping tensors with sentinel values."""
 
         # Reset request indexes.
         self.request_ids.fill_(-1)
@@ -1876,8 +2039,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.num_speculative_tokens + 1
         )
         return (
-            self.token_to_input_ids[:num_tokens].unsqueeze(0),
-            self.token_to_pos_ids[:num_tokens].unsqueeze(0),
+            self.gpu_view.token_to_input_ids[:num_tokens].unsqueeze(0),
+            self.gpu_view.token_to_pos_ids[:num_tokens].unsqueeze(0),
         )
 
     def speculative_required_logit_indices(self, device: torch.device) -> Tensor:
@@ -1899,12 +2062,12 @@ class DynamicInferenceContext(BaseInferenceContext):
         num_decode = self.num_decode_requests
 
         decode_token_count = num_decode * (self.num_speculative_tokens + 1)
-        decode_indices = torch.arange(decode_token_count, device=device)
+        decode_indices = torch.arange(decode_token_count, device='cpu')
 
         cumsum = torch.cumsum(query_lengths, dim=0)
         prefill_last_indices = cumsum[num_decode:] - 1
 
-        return torch.cat([decode_indices, prefill_last_indices])
+        return torch.cat([decode_indices, prefill_last_indices]).to(device, non_blocking=True)
 
     def last_token_logits(self, logits: Tensor) -> Tensor:
         """Select the logit positions needed for token generation.
@@ -1937,7 +2100,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         total = self.total_request_count
         query_lengths = self.request_query_lengths[paused:total]
         last_token_idxs = torch.cumsum(query_lengths, dim=0) - 1
-        return logits_2d[last_token_idxs, :]
+        return logits_2d[last_token_idxs.to(logits.device, non_blocking=True), :]
 
     def _compute_prefix_match(
         self, req: DynamicInferenceRequest, prefill_chunk_length: int
@@ -2151,7 +2314,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Increment ref counts and update timestamps for matched (shared) blocks
         if num_matched_blocks > 0:
             matched_tensor = torch.tensor(
-                matched_block_ids, dtype=torch.int32, device=torch.cuda.current_device()
+                matched_block_ids, dtype=torch.int32, device='cpu',
             )
             self.kv_block_allocator.block_ref_counts[matched_tensor] += 1
             if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
@@ -2550,7 +2713,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             -1,
             -1,
             dtype=paused_block_counts_cumsum.dtype,
-            device=torch.cuda.current_device(),
+            device='cpu',
         )
         net_block_counts = paused_block_counts_cumsum - remaining_paused_request_counts
         evict_request_count = torch.nonzero(net_block_counts >= 0)[0].item() + 1
@@ -2559,7 +2722,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         evict_start_idx = self.paused_request_count - evict_request_count
         evict_end_idx = self.paused_request_count
         evict_request_idxs = torch.arange(
-            evict_start_idx, evict_end_idx, device=torch.cuda.current_device()
+            evict_start_idx, evict_end_idx, device='cpu',
         )
         # Clone needed: subsequent release_memory_blocks_from_request_indexes and
         # _swap_book_keeping_tensors calls mutate self.request_ids in place.
@@ -2575,24 +2738,24 @@ class DynamicInferenceContext(BaseInferenceContext):
             src_idxs = torch.arange(
                 self.paused_request_count - evict_request_count,
                 self.paused_request_count,
-                device=torch.cuda.current_device(),
+                device='cpu',
             )
             dst_idxs = torch.arange(
                 self.total_request_count - evict_request_count,
                 self.total_request_count,
-                device=torch.cuda.current_device(),
+                device='cpu',
             )
         else:
             # Swap all active requests with left-most evicted requests.
             src_idxs = torch.arange(
                 self.paused_request_count - evict_request_count,
                 self.paused_request_count - evict_request_count + active_request_count,
-                device=torch.cuda.current_device(),
+                device='cpu',
             )
             dst_idxs = torch.arange(
                 self.paused_request_count,
                 self.paused_request_count + active_request_count,
-                device=torch.cuda.current_device(),
+                device='cpu',
             )
 
         # Swap evicted and active requests.
@@ -2667,6 +2830,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         # 1. The active token mask tells us which requests are still active and which are completed
         # active_request_count -> This corresponds to requests that have not reached EOD or max length
         # finished_request_count are requests that have reached the termination criterion
+
+        # Ensure all inputs are on CPU for bookkeeping operations.
+        if active_requests_mask.is_cuda:
+            active_requests_mask = active_requests_mask.cpu()
+        if new_tokens.is_cuda:
+            new_tokens = new_tokens.cpu()
+        if new_speculative_tokens is not None and new_speculative_tokens.is_cuda:
+            new_speculative_tokens = new_speculative_tokens.cpu()
 
         self.num_prefill_requests = 0  # all turns to decode
         # All request that were in prefill become decode requests.
@@ -2972,14 +3143,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.token_to_pos_ids[: self.active_token_count] = self.request_kv_length_offsets[
             self.paused_request_count : self.total_request_count
         ].repeat_interleave(num_generated_tokens) + torch.arange(
-            num_generated_tokens, device=torch.cuda.current_device()
+            num_generated_tokens, device='cpu'
         ).repeat(
             active_request_count
         )
         #
         # Token to request idx : [0, 0, 0, 1, 1, 1, 2, 2, 2 ...]
         self.token_to_request_idx[: self.active_token_count] = torch.arange(
-            self.paused_request_count, self.total_request_count, device=torch.cuda.current_device()
+            self.paused_request_count, self.total_request_count, device='cpu'
         ).repeat_interleave(num_generated_tokens)
 
         self.token_to_position_in_request[: self.active_token_count] = self.token_to_pos_ids[
@@ -3001,7 +3172,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         raw_positions = (
             old_offsets[:, None]
             + 1  # Offset by 1 because old_offsets points to the LAST token
-            + torch.arange(num_generated_tokens, device=torch.cuda.current_device())[None, :]
+            + torch.arange(num_generated_tokens, device='cpu')[None, :]
         )
         #
         # A token crosses to the next block if its raw_position >= block_size
@@ -3117,10 +3288,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         #
         #   active_token_ids[new_token_idx] = new_tokens
         #                       : [ 52 | 12 | 16  3 | 12 72 24 88 86 ]
-        active_token_ids = self.token_to_input_ids[: self.active_token_count].roll(-1, 0)
-        active_query_lengths = self.request_query_lengths[
-            self.paused_request_count : self.total_request_count
-        ]
+        n_active = self.total_request_count - self.paused_request_count
+        active_token_ids = self.gpu_view.token_to_input_ids[: self.active_token_count].roll(-1, 0)
+        active_query_lengths = self.gpu_view.request_query_lengths[:n_active]
 
         new_token_idx = active_query_lengths.cumsum(0) - 1
         active_token_ids[new_token_idx] = new_tokens

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1644,6 +1644,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         Return:
             None.
         """
+        # Launch deferred Mamba GPU ops first (state zeroing/restore) so they
+        # overlap with the CPU work below.  These are non-blocking GPU kernels.
+        self._execute_pending_mamba_ops()
+
         self.is_creating_cuda_graphs = construct_graph_dimensions is not None
         assert not (
             self.is_creating_cuda_graphs and is_expert_parallel_dummy_cuda_graph_step
@@ -1894,9 +1898,6 @@ class DynamicInferenceContext(BaseInferenceContext):
         All copies use non_blocking=True with pinned CPU memory. CUDA stream
         ordering guarantees the forward pass sees completed transfers.
         """
-        # Execute deferred Mamba GPU operations first (state zeroing, restore, offsets).
-        self._execute_pending_mamba_ops()
-
         n_tok = self.padded_active_token_count
 
         # Token-level transfers.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1161,6 +1161,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             stream=self.gpu_bookkeeping_stream,
             debug_enabled=self.config.async_overlap_debug_checks,
         )
+        self._gpu_decode_input_pending = False
+        self._gpu_decode_input_source_step_id = None
+        self._gpu_decode_input_debug_expected_input_ids = None
 
         # Allocate large non-graphed buffers.
         need_static_addr = (
@@ -2483,6 +2486,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.padded_batch_dimensions = InferenceBatchDimensions(
             token_count=0, prefill_req_count=0, decode_req_count=0
         )
+        self._clear_pending_gpu_decode_input()
         self.sync_optimistic_to_committed_for_queue_depth_one()
 
     def set_current_dynamic_step_id(self, step_id: int) -> None:
@@ -2611,7 +2615,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         source_step_id=None,
     ):
         """Build a GPU input-preparation plan for the current context state."""
-        from megatron.core.inference.engines.dynamic_step import StepInputPlan
+        from megatron.core.inference.engines.dynamic_step import DynamicStepId, StepInputPlan
+
+        if not isinstance(step_id, DynamicStepId):
+            step_id = DynamicStepId(int(step_id))
+        if source_step_id is None:
+            source_step_id = self._gpu_decode_input_source_step_id
+        if source_step_id is not None and not isinstance(source_step_id, DynamicStepId):
+            source_step_id = DynamicStepId(int(source_step_id))
 
         active_slots = tuple(range(int(self.paused_request_count), int(self.total_request_count)))
         active_slice = slice(int(self.paused_request_count), int(self.total_request_count))
@@ -2647,7 +2658,12 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         debug_expected_input_ids = None
         if self.config.async_overlap_debug_checks:
-            debug_expected_input_ids = self.token_to_input_ids[: self.active_token_count].clone()
+            if self._gpu_decode_input_debug_expected_input_ids is not None:
+                debug_expected_input_ids = self._gpu_decode_input_debug_expected_input_ids.clone()
+            else:
+                debug_expected_input_ids = self.token_to_input_ids[
+                    : self.active_token_count
+                ].clone()
 
         return StepInputPlan(
             step_id=step_id,
@@ -2665,9 +2681,46 @@ class DynamicInferenceContext(BaseInferenceContext):
 
     def prepare_gpu_inputs(self, snapshot, input_plan, previous_sample_state=None):
         """Prepare snapshot-bound GPU inputs from a StepInputPlan."""
+        if not self._gpu_decode_input_pending:
+            return None
+        if not input_plan.decode_input_destination_indices:
+            self._clear_pending_gpu_decode_input()
+            return None
         if previous_sample_state is None:
             previous_sample_state = self.gpu_sampled_token_state
-        return self.gpu_input_preparer.prepare(snapshot, input_plan, previous_sample_state)
+        decode_count = len(input_plan.decode_input_destination_indices)
+        if previous_sample_state.last_active_request_count < decode_count:
+            raise RuntimeError(
+                "GPU decode input preparation needs sampled-token state for "
+                f"{decode_count} decode requests, but only "
+                f"{previous_sample_state.last_active_request_count} are available"
+            )
+        input_ready_event = self.gpu_input_preparer.prepare(
+            snapshot, input_plan, previous_sample_state
+        )
+        self._clear_pending_gpu_decode_input()
+        return input_ready_event
+
+    def _clear_pending_gpu_decode_input(self) -> None:
+        """Clear deferred decode-token input state."""
+        self._gpu_decode_input_pending = False
+        self._gpu_decode_input_source_step_id = None
+        self._gpu_decode_input_debug_expected_input_ids = None
+
+    def _record_pending_gpu_decode_input(self, next_tokens: Tensor) -> None:
+        """Record that decode input IDs will be populated from GPU sampled state."""
+        self._gpu_decode_input_pending = True
+        current_step_id = int(getattr(self, "current_dynamic_step_id", -1))
+        self._gpu_decode_input_source_step_id = (
+            current_step_id if current_step_id >= 0 else None
+        )
+        if self.config.async_overlap_debug_checks:
+            self._gpu_decode_input_debug_expected_input_ids = next_tokens.to(
+                dtype=self.token_to_input_ids.dtype
+            ).clone()
+        else:
+            self._gpu_decode_input_debug_expected_input_ids = None
+        self.token_to_input_ids[: self.active_token_count].fill_(0)
 
     def dynamic_step_nvtx_label(self, name: str, step_id: Optional[int] = None) -> str:
         """Return an NVTX range name with the current dynamic step id."""
@@ -3620,6 +3673,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         active_requests_mask: Tensor,
         new_tokens: Tensor,
         new_speculative_tokens: Tensor = None,
+        defer_decode_input_tokens: bool = False,
     ) -> Tensor:
         """Update context state after calling engine.step().
 
@@ -3658,10 +3712,17 @@ class DynamicInferenceContext(BaseInferenceContext):
             new_speculative_tokens (Tensor): Newly sampled speculative tokens,
                 with num_speculative tokens per active request.
                 (num_speculative_tokens, active_request_length)
+            defer_decode_input_tokens (bool): If true, leave supported decode input IDs for
+                the GPU input preparer instead of copying CPU sampled-token values into
+                token_to_input_ids.
 
         Return:
             (Tensor) Newly paused request IDs.
         """
+        initial_paused_request_count = int(self.paused_request_count)
+        initial_total_request_count = int(self.total_request_count)
+        initial_chunked_prefill_idx = self.get_index_of_chunked_prefill_request(safe=False)
+
         # 1. The active token mask tells us which requests are still active and which are completed
         # active_request_count -> This corresponds to requests that have not reached EOD or max length
         # finished_request_count are requests that have reached the termination criterion
@@ -3727,6 +3788,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             # Reset Mamba state.
             self.reset_mamba_state()
+            self._clear_pending_gpu_decode_input()
             self.sync_optimistic_to_committed_for_queue_depth_one()
             return
 
@@ -3783,6 +3845,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         #       b) Move the paused requests to the left, and active requets to the right
         #       c) Update the paused request count and active_request_count appropriately
         newly_paused_request_ids = None
+        active_requests_requiring_new_block_count = 0
         if active_request_count > 0:
             num_tokens_in_last_block = self.request_last_kv_block_offset[
                 self.paused_request_count : (active_request_count + self.paused_request_count)
@@ -3999,7 +4062,25 @@ class DynamicInferenceContext(BaseInferenceContext):
         else:
             next_tokens = sampled_tokens
 
-        self.token_to_input_ids[: self.active_token_count] = next_tokens
+        can_defer_decode_input_tokens = (
+            defer_decode_input_tokens
+            and self.active_token_count > 0
+            and active_request_count > 0
+            and initial_paused_request_count == 0
+            and self.paused_request_count == 0
+            and initial_total_request_count == active_request_count
+            and finished_request_count == 0
+            and active_requests_requiring_new_block_count == 0
+            and newly_paused_request_ids is None
+            and evict_request_ids is None
+            and initial_chunked_prefill_idx == -1
+            and self.get_index_of_chunked_prefill_request(safe=False) == -1
+        )
+        if can_defer_decode_input_tokens:
+            self._record_pending_gpu_decode_input(next_tokens)
+        else:
+            self._clear_pending_gpu_decode_input()
+            self.token_to_input_ids[: self.active_token_count] = next_tokens
 
         # Req kv length offsets : [0, 5, 10 ... ]
         # For num spec tokens = 2 , this will become [0, 1, 2, 5, 6, 7 10, 11, 12 ...]

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -320,6 +320,12 @@ class DynamicInferenceContext(BaseInferenceContext):
         else:
             self.expert_model_parallel_group = None
 
+        # Optional CPU-side collective for EP batch-dimension sync. Populated by
+        # the engine via set_ep_zmq_communicator() when available. When set,
+        # match_graph_config() uses this to perform the MAX reduction on the
+        # CPU, avoiding a per-step NCCL AllReduce kernel on the compute stream.
+        self._ep_zmq_communicator = None
+
         # Mamba states.
         mamba_inference_state_config = inference_config.mamba_inference_state_config
         self.is_hybrid_model = mamba_inference_state_config is not None
@@ -1338,6 +1344,20 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
         return key
 
+    def set_ep_zmq_communicator(self, communicator) -> None:
+        """Attach an EP-group ZMQ communicator for CPU-side sync collectives.
+
+        When set, match_graph_config() uses this communicator's
+        sync_all_reduce_max() to perform the EP batch-dimension MAX reduction on
+        the CPU instead of launching a NCCL AllReduce kernel on the compute
+        stream. Expected to be called once by the inference engine after both
+        the context and the communicator have been created.
+
+        Args:
+            communicator: AsyncZMQCommunicator over the EP process group.
+        """
+        self._ep_zmq_communicator = communicator
+
     def reset_attention_state(self) -> None:
         """Reset state used within attention, after each step."""
         # Attention metadata reset is now handled by MHAMetadata.reset()
@@ -1681,6 +1701,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             decode_only_cuda_graphs=(not self.use_cuda_graphs_for_non_decode_steps),
             ep_group=self.expert_model_parallel_group,
             num_speculative_tokens=self.num_speculative_tokens,
+            ep_zmq_communicator=self._ep_zmq_communicator,
         )
         self._using_cuda_graph_this_step = best_graph is not None
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -740,8 +740,26 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata = MambaMetadata(
                 max_requests=self.max_requests,
                 max_tokens=self.max_tokens,
+                mamba_chunk_size=self.mamba_chunk_size,
                 d_conv=self.mamba_conv_states_shape[-1],
             )
+            # Bind the unified CPU/GPU buffers so the 9 per-step Mamba fields
+            # ride along with the single coalesced H2D in
+            # transfer_bookkeeping_to_gpu().
+            self.mamba_metadata.bind_cpu_buffers(
+                {
+                    "batch_indices_decode": self._cpu_mamba_batch_indices_decode,
+                    "batch_indices_prefill": self._cpu_mamba_batch_indices_prefill,
+                    "seq_idx": self._cpu_mamba_seq_idx,
+                    "cu_seqlens": self._cpu_mamba_cu_seqlens,
+                    "cu_chunk_seqlens": self._cpu_mamba_cu_chunk_seqlens,
+                    "last_chunk_indices": self._cpu_mamba_last_chunk_indices,
+                    "seq_idx_for_varlen": self._cpu_mamba_seq_idx_for_varlen,
+                    "conv_seq_idx": self._cpu_mamba_conv_seq_idx,
+                    "conv_seq_start": self._cpu_mamba_conv_seq_start,
+                }
+            )
+            self.mamba_metadata.bind_gpu_buffers(self.gpu_view)
             self.mamba_conv_states = torch.empty(
                 (self.num_mamba_layers, self.max_requests) + self.mamba_conv_states_shape,
                 dtype=self.mamba_conv_states_dtype,
@@ -895,6 +913,32 @@ class DynamicInferenceContext(BaseInferenceContext):
         _mha_kv_seq_lengths_bytes = self.max_requests * 4
         _mha_cu_kv_seq_lengths_bytes = (self.max_requests + 1) * 4
         _mha_block_table_bytes = self.max_requests * self.max_kv_block_count * 4
+        # Mamba section: 9 int32 fields (hybrid models only). Must match the
+        # MambaMetadata shapes (mirrors the layout documented in ContextGPUView).
+        if self.is_hybrid_model:
+            self._max_mamba_chunks = (
+                self.max_tokens // self.mamba_chunk_size + self.max_requests
+            )
+            _mamba_batch_indices_decode_bytes = self.max_requests * 4
+            _mamba_batch_indices_prefill_bytes = self.max_requests * 4
+            _mamba_seq_idx_bytes = self.max_tokens * 4
+            _mamba_cu_seqlens_bytes = (self.max_requests + 1) * 4
+            _mamba_cu_chunk_seqlens_bytes = (self._max_mamba_chunks + 1) * 4
+            _mamba_last_chunk_indices_bytes = self.max_requests * 4
+            _mamba_seq_idx_for_varlen_bytes = self._max_mamba_chunks * 4
+            _mamba_conv_seq_idx_bytes = self.max_tokens * 4
+            _mamba_conv_seq_start_bytes = self.max_tokens * 4
+        else:
+            self._max_mamba_chunks = 0
+            _mamba_batch_indices_decode_bytes = 0
+            _mamba_batch_indices_prefill_bytes = 0
+            _mamba_seq_idx_bytes = 0
+            _mamba_cu_seqlens_bytes = 0
+            _mamba_cu_chunk_seqlens_bytes = 0
+            _mamba_last_chunk_indices_bytes = 0
+            _mamba_seq_idx_for_varlen_bytes = 0
+            _mamba_conv_seq_idx_bytes = 0
+            _mamba_conv_seq_start_bytes = 0
         _total_bytes = (
             2 * _tok_int64_bytes
             + 4 * _tok_int32_bytes
@@ -904,6 +948,15 @@ class DynamicInferenceContext(BaseInferenceContext):
             + _mha_kv_seq_lengths_bytes
             + _mha_cu_kv_seq_lengths_bytes
             + _mha_block_table_bytes
+            + _mamba_batch_indices_decode_bytes
+            + _mamba_batch_indices_prefill_bytes
+            + _mamba_seq_idx_bytes
+            + _mamba_cu_seqlens_bytes
+            + _mamba_cu_chunk_seqlens_bytes
+            + _mamba_last_chunk_indices_bytes
+            + _mamba_seq_idx_for_varlen_bytes
+            + _mamba_conv_seq_idx_bytes
+            + _mamba_conv_seq_start_bytes
         )
         self._cpu_bookkeeping_buf = torch.empty(
             _total_bytes, dtype=torch.uint8, device='cpu', pin_memory=True,
@@ -988,6 +1041,49 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
         _off += _mha_block_table_bytes
 
+        # Mamba varlen metadata views (hybrid models only). Populated per step
+        # by MambaMetadata.compute_cpu_metadata(); transferred as part of the
+        # single coalesced H2D in transfer_bookkeeping_to_gpu().
+        if self.is_hybrid_model:
+            self._cpu_mamba_batch_indices_decode = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_batch_indices_decode_bytes
+            ].view(torch.int32)
+            _off += _mamba_batch_indices_decode_bytes
+            self._cpu_mamba_batch_indices_prefill = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_batch_indices_prefill_bytes
+            ].view(torch.int32)
+            _off += _mamba_batch_indices_prefill_bytes
+            self._cpu_mamba_seq_idx = (
+                self._cpu_bookkeeping_buf[_off : _off + _mamba_seq_idx_bytes]
+                .view(torch.int32)
+                .view(1, self.max_tokens)
+            )
+            _off += _mamba_seq_idx_bytes
+            self._cpu_mamba_cu_seqlens = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_cu_seqlens_bytes
+            ].view(torch.int32)
+            _off += _mamba_cu_seqlens_bytes
+            self._cpu_mamba_cu_chunk_seqlens = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_cu_chunk_seqlens_bytes
+            ].view(torch.int32)
+            _off += _mamba_cu_chunk_seqlens_bytes
+            self._cpu_mamba_last_chunk_indices = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_last_chunk_indices_bytes
+            ].view(torch.int32)
+            _off += _mamba_last_chunk_indices_bytes
+            self._cpu_mamba_seq_idx_for_varlen = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_seq_idx_for_varlen_bytes
+            ].view(torch.int32)
+            _off += _mamba_seq_idx_for_varlen_bytes
+            self._cpu_mamba_conv_seq_idx = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_conv_seq_idx_bytes
+            ].view(torch.int32)
+            _off += _mamba_conv_seq_idx_bytes
+            self._cpu_mamba_conv_seq_start = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_conv_seq_start_bytes
+            ].view(torch.int32)
+            _off += _mamba_conv_seq_start_bytes
+
         assert _off == _total_bytes, f"layout bug: wrote {_off} of {_total_bytes} bytes"
 
         # GPU view: the single interface for GPU code to read context state.
@@ -997,6 +1093,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             max_tokens=self.max_tokens,
             max_kv_blocks=self.max_kv_block_count,
             device=torch.cuda.current_device(),
+            max_mamba_chunks=self._max_mamba_chunks,
         )
 
         # Bind the shared MHA GPU views to both graph and non-graph metadata;
@@ -1008,15 +1105,6 @@ class DynamicInferenceContext(BaseInferenceContext):
         # update_requests() (CPU phase), executed by transfer_bookkeeping_to_gpu().
         self._pending_mamba_zeros: list = []
         self._pending_mamba_restores: list = []
-
-        # NOTE: Need to build this outside the UVM / TMS context to avoid IMA.
-        if self.is_hybrid_model:
-            self.mamba_metadata = MambaMetadata(
-                max_requests=self.max_requests,
-                max_tokens=self.max_tokens,
-                mamba_chunk_size=self.mamba_chunk_size,
-                d_conv=self.mamba_conv_states_shape[-1],
-            )
 
         # Allocate large non-graphed buffers.
         need_static_addr = (

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1842,11 +1842,13 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.is_hybrid_model:
             # Mamba metadata update is deferred to transfer_bookkeeping_to_gpu()
             # because it writes to GPU buffers. Store the parameters here.
+            # intermediate_offsets_gpu / intermediate_counts_gpu get the CPU-side
+            # slices here; H2D transfer happens in transfer_bookkeeping_to_gpu().
             intermediate_offsets_gpu = None
             intermediate_counts_gpu = None
             if self.mamba_slot_allocator is not None:
                 intermediate_offsets_gpu, intermediate_counts_gpu = (
-                    self.mamba_slot_allocator.get_intermediate_gpu_data()
+                    self.mamba_slot_allocator.get_intermediate_cpu_data()
                 )
             self._pending_mamba_transfer = self.mamba_metadata.compute_cpu_metadata(
                 active_mamba_indices=self.mamba_metadata.request_to_mamba_state_idx[active_slice],
@@ -2594,13 +2596,13 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.is_hybrid_model:
             self.mamba_metadata.free_slots(request_indexes)
 
-        # Clear intermediate offset entries for released requests
+        # Clear intermediate offset entries for released requests (CPU writes).
         if self.mamba_slot_allocator is not None:
             sa = self.mamba_slot_allocator
-            sa._intermediate_counts_gpu[request_indexes] = 0
-            sa._intermediate_offsets_gpu[request_indexes] = 0
-            sa._intermediate_block_ids_gpu[request_indexes] = -1
-            sa._eos_cache_block_id_gpu[request_indexes] = -1
+            sa._intermediate_counts_cpu[request_indexes] = 0
+            sa._intermediate_offsets_cpu[request_indexes] = 0
+            sa._intermediate_block_ids_cpu[request_indexes] = -1
+            sa._eos_cache_block_id_cpu[request_indexes] = -1
 
     def resume_paused_requests(
         self, active_request_count: int, newly_paused_request_ids: torch.Tensor

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1125,6 +1125,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         # update_requests() (CPU phase), executed by transfer_bookkeeping_to_gpu().
         self._pending_mamba_zeros: list = []
         self._pending_mamba_restores: list = []
+        self.gpu_bookkeeping_stream = torch.cuda.Stream(device=torch.cuda.current_device())
+        self._gpu_bookkeeping_complete_event = torch.cuda.Event()
 
         # Allocate large non-graphed buffers.
         need_static_addr = (
@@ -1823,13 +1825,20 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         if self.is_hybrid_model:
             for logical_idx, request_idx in enumerate(range(start_request_idx, end_request_idx)):
-                mamba_idx = self.mamba_metadata.allocate_slot()
-                if mamba_idx is None:
+                step_id = max(0, int(self.current_dynamic_step_id))
+                mamba_reservation = self.mamba_metadata.reserve_slot(
+                    request_idx, step_id, zero_state=True
+                )
+                if mamba_reservation is None:
                     raise ContextOverflowError(
                         requests[logical_idx].request_id, "No Mamba slots available"
                     )
+                mamba_idx = mamba_reservation.mamba_slot_ids[0]
                 self._pending_mamba_zeros.append(mamba_idx)
+                self.record_resource_reservation(step_id, mamba_reservation)
                 self.mamba_metadata.request_to_mamba_state_idx[request_idx] = mamba_idx
+                self.mamba_metadata.commit_reservation(mamba_reservation)
+                self.async_overlap_debug_counters["mamba_reservation_commits"] += 1
 
         self.active_token_count = token_end
         self.total_request_count = end_request_idx
@@ -2228,28 +2237,29 @@ class DynamicInferenceContext(BaseInferenceContext):
     def _execute_pending_mamba_ops(self) -> None:
         """Execute Mamba GPU operations deferred from add_request() / update_requests().
 
-        This runs at the start of transfer_bookkeeping_to_gpu() so that all GPU
-        Mamba state is correct before the forward pass.
+        These kernels are always enqueued on ``gpu_bookkeeping_stream`` so their
+        ordering does not depend on whatever CUDA stream the caller made current.
         """
         if not (self._pending_mamba_restores or self._pending_mamba_zeros):
             return
 
-        # Restore cached Mamba state to live buffers.  On failure, fall back to zeroing.
-        for request_idx, block_id, mamba_idx in self._pending_mamba_restores:
-            restored = self.mamba_slot_allocator.restore_to_live(request_idx, block_id)
-            if not restored:
-                self._pending_mamba_zeros.append(mamba_idx)
-        self._pending_mamba_restores.clear()
+        with torch.cuda.stream(self.gpu_bookkeeping_stream):
+            # Restore cached Mamba state to live buffers.  On failure, fall back to zeroing.
+            for request_idx, block_id, mamba_idx in self._pending_mamba_restores:
+                restored = self.mamba_slot_allocator.restore_to_live(request_idx, block_id)
+                if not restored:
+                    self._pending_mamba_zeros.append(mamba_idx)
+            self._pending_mamba_restores.clear()
 
-        # Batch-zero newly allocated Mamba slots.
-        if self._pending_mamba_zeros:
-            device = self.mamba_conv_states.device
-            indices = torch.tensor(
-                self._pending_mamba_zeros, dtype=torch.long, device=device,
-            )
-            self.mamba_conv_states[:, indices] = 0.0
-            self.mamba_ssm_states[:, indices] = 0.0
-            self._pending_mamba_zeros.clear()
+            # Batch-zero newly allocated Mamba slots.
+            if self._pending_mamba_zeros:
+                device = self.mamba_conv_states.device
+                indices = torch.tensor(
+                    self._pending_mamba_zeros, dtype=torch.long, device=device,
+                )
+                self.mamba_conv_states[:, indices] = 0.0
+                self.mamba_ssm_states[:, indices] = 0.0
+                self._pending_mamba_zeros.clear()
 
     def transfer_bookkeeping_to_gpu(self) -> None:
         """Batch transfer CPU bookkeeping state to GPU staging buffers.
@@ -2279,11 +2289,18 @@ class DynamicInferenceContext(BaseInferenceContext):
             active_slice
         ]
 
+        pending_mamba_transfer = getattr(self, '_pending_mamba_transfer', None)
+
         # Coalesced H2D: one cudaMemcpyAsync for the entire bookkeeping buffer.
         # Copying the whole (max_tokens + max_requests)-sized buffer including
         # unused slots is cheap (~71 KB total, ~3-5 us on PCIe Gen4) and saves
         # 8 redundant launch overheads vs. the prior per-field copies.
-        self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+        with torch.cuda.stream(self.gpu_bookkeeping_stream):
+            self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+            if pending_mamba_transfer is not None:
+                self.mamba_metadata.load_from_cpu(pending_mamba_transfer)
+            self._gpu_bookkeeping_complete_event.record(self.gpu_bookkeeping_stream)
+        torch.cuda.current_stream().wait_event(self._gpu_bookkeeping_complete_event)
 
         # MHA metadata: buffers already covered by the coalesced H2D above.
         # All that's left is pointing state_data at the correct GPU slices and
@@ -2298,9 +2315,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
             self._pending_mha_transfer = None
 
-        # Mamba metadata: copy pre-computed CPU tensors to GPU buffers.
-        if hasattr(self, '_pending_mamba_transfer') and self._pending_mamba_transfer is not None:
-            self.mamba_metadata.load_from_cpu(self._pending_mamba_transfer)
+        # Mamba metadata: GPU-side views were loaded on gpu_bookkeeping_stream.
+        if pending_mamba_transfer is not None:
             self._pending_mamba_transfer = None
 
     def reset_tensors(self) -> None:
@@ -2373,6 +2389,8 @@ class DynamicInferenceContext(BaseInferenceContext):
                 "placeholder_count": 0,
                 "reservation_commits": 0,
                 "reservation_rollbacks": 0,
+                "mamba_reservation_commits": 0,
+                "mamba_reservation_rollbacks": 0,
             }
         )
 
@@ -2945,16 +2963,29 @@ class DynamicInferenceContext(BaseInferenceContext):
             _register_range(already_allocated_blocks + num_matched_blocks, num_complete_blocks)
 
         if self.is_hybrid_model and req.finished_chunk_token_count == 0:
-            # Allocate a slot for Mamba states
-            mamba_idx = self.mamba_metadata.allocate_slot()
-            if mamba_idx is None:
-                raise ContextOverflowError(req.request_id, "No Mamba slots available")
-            self.mamba_metadata.request_to_mamba_state_idx[self.total_request_count] = mamba_idx
-
             # Restore Mamba state from the block corresponding to prefix_skip_tokens
             restore_block_count = prefix_skip_tokens // self.block_size_tokens
+            restore_block_id = None
             if restore_block_count > 0 and self.mamba_slot_allocator is not None:
                 restore_block_id = matched_block_ids[restore_block_count - 1]
+
+            # Allocate a slot for Mamba states through the reservation lifecycle.
+            step_id = max(0, int(self.current_dynamic_step_id))
+            mamba_reservation = self.mamba_metadata.reserve_slot(
+                self.total_request_count,
+                step_id,
+                zero_state=restore_block_id is None,
+                restore_block_id=restore_block_id,
+            )
+            if mamba_reservation is None:
+                raise ContextOverflowError(req.request_id, "No Mamba slots available")
+            mamba_idx = mamba_reservation.mamba_slot_ids[0]
+            self.mamba_metadata.request_to_mamba_state_idx[self.total_request_count] = mamba_idx
+            self.record_resource_reservation(step_id, mamba_reservation)
+            self.mamba_metadata.commit_reservation(mamba_reservation)
+            self.async_overlap_debug_counters["mamba_reservation_commits"] += 1
+
+            if restore_block_id is not None:
                 self._pending_mamba_restores.append(
                     (self.total_request_count, restore_block_id, mamba_idx)
                 )

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1848,16 +1848,16 @@ class DynamicInferenceContext(BaseInferenceContext):
                 intermediate_offsets_gpu, intermediate_counts_gpu = (
                     self.mamba_slot_allocator.get_intermediate_gpu_data()
                 )
-            self._pending_mamba_transfer = {
-                "active_mamba_indices": self.mamba_metadata.request_to_mamba_state_idx[active_slice],
-                "token_to_request_idx": self.token_to_request_idx[: self.active_token_count],
-                "cu_seqlens": cpu_cu_query,
-                "batch_dimensions": attn_dimensions,
-                "padded_batch_dimensions": self.padded_batch_dimensions,
-                "enable_chunked_prefill": self.is_chunked_prefill_enabled(),
-                "intermediate_offsets_gpu": intermediate_offsets_gpu,
-                "intermediate_counts_gpu": intermediate_counts_gpu,
-            }
+            self._pending_mamba_transfer = self.mamba_metadata.compute_cpu_metadata(
+                active_mamba_indices=self.mamba_metadata.request_to_mamba_state_idx[active_slice],
+                token_to_request_idx=self.token_to_request_idx[: self.active_token_count],
+                cpu_cu_query=cpu_cu_query,
+                batch_dimensions=attn_dimensions,
+                padded_batch_dimensions=self.padded_batch_dimensions,
+                enable_chunked_prefill=self.is_chunked_prefill_enabled(),
+                intermediate_offsets_gpu=intermediate_offsets_gpu,
+                intermediate_counts_gpu=intermediate_counts_gpu,
+            )
 
         if self.moe_enable_routing_replay:
             if self.using_cuda_graph_this_step():
@@ -1949,23 +1949,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
             self._pending_mha_transfer = None
 
-        # Mamba metadata transfer (update writes to GPU buffers).
+        # Mamba metadata: copy pre-computed CPU tensors to GPU buffers.
         if hasattr(self, '_pending_mamba_transfer') and self._pending_mamba_transfer is not None:
-            d = self._pending_mamba_transfer
-            # cu_seqlens needs to be on GPU for the Mamba metadata update.
-            cu_seqlens_gpu = self.active_attn_metadata["mha_metadata"].state_data[
-                "cu_query_seq_lengths"
-            ]
-            self.mamba_metadata.update(
-                d["active_mamba_indices"],
-                d["token_to_request_idx"],
-                cu_seqlens_gpu,
-                batch_dimensions=d["batch_dimensions"],
-                padded_batch_dimensions=d["padded_batch_dimensions"],
-                enable_chunked_prefill=d["enable_chunked_prefill"],
-                intermediate_offsets_gpu=d["intermediate_offsets_gpu"],
-                intermediate_counts_gpu=d["intermediate_counts_gpu"],
-            )
+            self.mamba_metadata.load_from_cpu(self._pending_mamba_transfer)
             self._pending_mamba_transfer = None
 
     def reset_tensors(self) -> None:

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1159,6 +1159,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
         self.gpu_input_preparer = GpuInputPreparer(
             stream=self.gpu_bookkeeping_stream,
+            block_size_tokens=self.block_size_tokens,
             debug_enabled=self.config.async_overlap_debug_checks,
         )
         self._gpu_decode_input_pending = False

--- a/megatron/core/inference/contexts/dynamic_ledgers.py
+++ b/megatron/core/inference/contexts/dynamic_ledgers.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Committed and optimistic request ledgers for dynamic inference."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class RequestLedgerRequestState:
+    """Per-request view inside a dynamic request ledger."""
+
+    request_id: int
+    slot: int
+    is_paused: bool
+    query_length: int
+    in_prefill: bool
+
+
+@dataclass(frozen=True)
+class RequestLedgerState:
+    """Snapshot of scheduler-visible dynamic request state."""
+
+    total_request_count: int = 0
+    paused_request_count: int = 0
+    active_token_count: int = 0
+    chunked_prefill_request_id: int = -1
+    request_ids: Tuple[int, ...] = field(default_factory=tuple)
+    request_query_lengths: Tuple[int, ...] = field(default_factory=tuple)
+    request_in_prefill_status: Tuple[int, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_context(cls, context) -> "RequestLedgerState":
+        """Capture the current request state from a DynamicInferenceContext."""
+        total_request_count = int(context.total_request_count)
+        active_slice = slice(0, total_request_count)
+        return cls(
+            total_request_count=total_request_count,
+            paused_request_count=int(context.paused_request_count),
+            active_token_count=int(context.active_token_count),
+            chunked_prefill_request_id=int(context.chunked_prefill_request_id),
+            request_ids=tuple(int(v) for v in context.request_ids[active_slice].tolist()),
+            request_query_lengths=tuple(
+                int(v) for v in context.request_query_lengths[active_slice].tolist()
+            ),
+            request_in_prefill_status=tuple(
+                int(v)
+                for v in context.request_in_prefill_status_tensor[active_slice].tolist()
+            ),
+        )
+
+    def get_request_state(self, request_id: int) -> Optional[RequestLedgerRequestState]:
+        """Return per-request state if the request is present in this ledger."""
+        for slot, current_request_id in enumerate(self.request_ids):
+            if current_request_id == request_id:
+                return RequestLedgerRequestState(
+                    request_id=request_id,
+                    slot=slot,
+                    is_paused=slot < self.paused_request_count,
+                    query_length=self.request_query_lengths[slot],
+                    in_prefill=bool(self.request_in_prefill_status[slot]),
+                )
+        return None
+
+
+class DynamicRequestLedgers:
+    """Pair of committed and optimistic request ledgers."""
+
+    def __init__(self):
+        empty_state = RequestLedgerState()
+        self.committed = empty_state
+        self.optimistic = empty_state
+
+    def sync_from_context_for_queue_depth_one(self, context) -> None:
+        """Keep both ledgers identical to the live context in serial mode."""
+        snapshot = RequestLedgerState.from_context(context)
+        self.committed = snapshot
+        self.optimistic = snapshot
+
+    def assert_committed_matches_optimistic(self) -> None:
+        """Assert the queue-depth-one invariant."""
+        if self.committed != self.optimistic:
+            raise AssertionError(
+                "Committed and optimistic request ledgers diverged: "
+                f"committed={self.committed}, optimistic={self.optimistic}"
+            )
+
+    def get_committed_request_state(
+        self, request_id: Optional[int] = None
+    ) -> RequestLedgerState | Optional[RequestLedgerRequestState]:
+        """Return the committed ledger or one committed request state."""
+        if request_id is None:
+            return self.committed
+        return self.committed.get_request_state(request_id)
+
+    def get_optimistic_request_state(
+        self, request_id: Optional[int] = None
+    ) -> RequestLedgerState | Optional[RequestLedgerRequestState]:
+        """Return the optimistic ledger or one optimistic request state."""
+        if request_id is None:
+            return self.optimistic
+        return self.optimistic.get_request_state(request_id)

--- a/megatron/core/inference/contexts/gpu_input_preparer.py
+++ b/megatron/core/inference/contexts/gpu_input_preparer.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""GPU-side input preparation helpers for dynamic inference snapshots."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from .gpu_input_state import GpuSampledTokenState
+
+if TYPE_CHECKING:
+    from megatron.core.inference.engines.dynamic_step import (
+        DynamicStepContextSnapshot,
+        StepInputPlan,
+    )
+
+
+class GpuInputPreparer:
+    """Scatters GPU-resident sampled tokens into a prepared snapshot."""
+
+    def __init__(self, *, stream: torch.cuda.Stream, debug_enabled: bool = False):
+        self.stream = stream
+        self.debug_enabled = bool(debug_enabled)
+        self._last_input_ready_event: Optional[torch.cuda.Event] = None
+
+    def prepare(
+        self,
+        snapshot: "DynamicStepContextSnapshot",
+        input_plan: "StepInputPlan",
+        previous_sample_state: Optional[GpuSampledTokenState],
+    ) -> torch.cuda.Event:
+        """Prepare GPU inputs for ``snapshot`` and return an input-ready event."""
+        if snapshot.snapshot_slot_id != input_plan.snapshot_slot_id:
+            raise RuntimeError(
+                f"Input plan targets snapshot slot {input_plan.snapshot_slot_id}, "
+                f"but snapshot slot is {snapshot.snapshot_slot_id}"
+            )
+        if snapshot.gpu_view is None:
+            raise RuntimeError("GPU input preparation requires a snapshot gpu_view")
+        bound_slot_id = getattr(snapshot.gpu_view, "current_snapshot_slot_id", None)
+        if bound_slot_id != snapshot.snapshot_slot_id:
+            raise RuntimeError(
+                f"Snapshot gpu_view is bound to slot {bound_slot_id}, "
+                f"not slot {snapshot.snapshot_slot_id}"
+            )
+
+        decode_count = len(input_plan.decode_input_destination_indices)
+        if decode_count and previous_sample_state is None:
+            raise RuntimeError("Decode input preparation requires previous sampled-token state")
+
+        token_buffer = snapshot.gpu_view.token_to_input_ids
+        input_ready_event = torch.cuda.Event()
+        with torch.cuda.stream(self.stream):
+            if decode_count:
+                self.stream.wait_event(previous_sample_state.sample_gpu_ready_event)
+                destinations = torch.tensor(
+                    input_plan.decode_input_destination_indices,
+                    dtype=torch.long,
+                    device=token_buffer.device,
+                )
+                token_buffer.index_copy_(
+                    0, destinations, previous_sample_state.sampled_tokens[:decode_count]
+                )
+                if input_plan.speculative_width > 0:
+                    if previous_sample_state.sampled_mtp_tokens is None:
+                        raise RuntimeError(
+                            "Speculative input preparation requested without sampled MTP state"
+                        )
+                    if input_plan.speculative_width > previous_sample_state.num_speculative_tokens:
+                        raise RuntimeError(
+                            "Input plan speculative width exceeds sampled-token state width"
+                        )
+                    for depth in range(input_plan.speculative_width):
+                        token_buffer.index_copy_(
+                            0,
+                            destinations + depth + 1,
+                            previous_sample_state.sampled_mtp_tokens[depth, :decode_count],
+                        )
+            input_ready_event.record(self.stream)
+
+        self._last_input_ready_event = input_ready_event
+        if self.debug_enabled and input_plan.debug_expected_input_ids is not None:
+            self._debug_compare(snapshot, input_plan, input_ready_event)
+
+        return input_ready_event
+
+    def _debug_compare(
+        self,
+        snapshot: "DynamicStepContextSnapshot",
+        input_plan: "StepInputPlan",
+        input_ready_event: torch.cuda.Event,
+    ) -> None:
+        """Synchronize in debug mode and compare scatter destinations."""
+        input_ready_event.synchronize()
+        if not input_plan.decode_input_destination_indices:
+            return
+
+        compare_indices = []
+        for base_idx in input_plan.decode_input_destination_indices:
+            compare_indices.extend(
+                int(base_idx) + offset for offset in range(input_plan.speculative_width + 1)
+            )
+
+        index_cpu = torch.tensor(compare_indices, dtype=torch.long, device="cpu")
+        index_gpu = index_cpu.to(snapshot.gpu_view.token_to_input_ids.device, non_blocking=True)
+        actual = snapshot.gpu_view.token_to_input_ids.index_select(0, index_gpu).cpu()
+        expected_source = input_plan.debug_expected_input_ids
+        if torch.is_tensor(expected_source):
+            expected = expected_source.to(device="cpu").index_select(0, index_cpu)
+        else:
+            expected = torch.tensor(
+                [expected_source[int(idx)] for idx in index_cpu.tolist()],
+                dtype=actual.dtype,
+                device="cpu",
+            )
+        if not torch.equal(actual, expected):
+            raise RuntimeError("GPU input scatter destinations diverged from CPU input IDs")

--- a/megatron/core/inference/contexts/gpu_input_preparer.py
+++ b/megatron/core/inference/contexts/gpu_input_preparer.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
+from .decode_metadata_kernels import prepare_decode_metadata
 from .gpu_input_state import GpuSampledTokenState
 
 if TYPE_CHECKING:
@@ -20,8 +21,15 @@ if TYPE_CHECKING:
 class GpuInputPreparer:
     """Scatters GPU-resident sampled tokens into a prepared snapshot."""
 
-    def __init__(self, *, stream: torch.cuda.Stream, debug_enabled: bool = False):
+    def __init__(
+        self,
+        *,
+        stream: torch.cuda.Stream,
+        block_size_tokens: int,
+        debug_enabled: bool = False,
+    ):
         self.stream = stream
+        self.block_size_tokens = int(block_size_tokens)
         self.debug_enabled = bool(debug_enabled)
         self._last_input_ready_event: Optional[torch.cuda.Event] = None
 
@@ -51,8 +59,11 @@ class GpuInputPreparer:
             raise RuntimeError("Decode input preparation requires previous sampled-token state")
 
         token_buffer = snapshot.gpu_view.token_to_input_ids
+        debug_expected_metadata = None
         input_ready_event = torch.cuda.Event()
         with torch.cuda.stream(self.stream):
+            if self.debug_enabled and decode_count:
+                debug_expected_metadata = self._capture_decode_metadata(snapshot, input_plan)
             if decode_count:
                 self.stream.wait_event(previous_sample_state.sample_gpu_ready_event)
                 destinations = torch.tensor(
@@ -78,32 +89,98 @@ class GpuInputPreparer:
                             destinations + depth + 1,
                             previous_sample_state.sampled_mtp_tokens[depth, :decode_count],
                         )
+                prepare_decode_metadata(
+                    snapshot.gpu_view,
+                    decode_request_slots=input_plan.decode_request_slots,
+                    decode_input_destination_indices=input_plan.decode_input_destination_indices,
+                    speculative_width=input_plan.speculative_width,
+                    block_size_tokens=self.block_size_tokens,
+                )
             input_ready_event.record(self.stream)
 
         self._last_input_ready_event = input_ready_event
         if self.debug_enabled and input_plan.debug_expected_input_ids is not None:
-            self._debug_compare(snapshot, input_plan, input_ready_event)
+            self._debug_compare(
+                snapshot,
+                input_plan,
+                input_ready_event,
+                debug_expected_metadata=debug_expected_metadata,
+            )
 
         return input_ready_event
+
+    def _decode_token_indices(self, input_plan: "StepInputPlan") -> torch.Tensor:
+        """Return CPU token indices covered by decode input preparation."""
+        compare_indices = []
+        for base_idx in input_plan.decode_input_destination_indices:
+            compare_indices.extend(
+                int(base_idx) + offset for offset in range(input_plan.speculative_width + 1)
+            )
+        return torch.tensor(compare_indices, dtype=torch.long, device="cpu")
+
+    def _capture_decode_metadata(
+        self, snapshot: "DynamicStepContextSnapshot", input_plan: "StepInputPlan"
+    ) -> dict:
+        """Capture CPU-prepared GPU metadata before the GPU decode helper overwrites it."""
+        gpu_view = snapshot.gpu_view
+        token_indices_cpu = self._decode_token_indices(input_plan)
+        token_indices_gpu = token_indices_cpu.to(gpu_view.token_to_pos_ids.device)
+        request_slots_cpu = torch.tensor(
+            input_plan.decode_request_slots, dtype=torch.long, device="cpu"
+        )
+        request_slots_gpu = request_slots_cpu.to(gpu_view.token_to_pos_ids.device)
+        decode_count = len(input_plan.decode_request_slots)
+        return {
+            "token_indices_cpu": token_indices_cpu,
+            "request_slots_cpu": request_slots_cpu,
+            "token_to_pos_ids": gpu_view.token_to_pos_ids.index_select(
+                0, token_indices_gpu
+            ).clone(),
+            "token_to_request_idx": gpu_view.token_to_request_idx.index_select(
+                0, token_indices_gpu
+            ).clone(),
+            "token_to_position_in_request": gpu_view.token_to_position_in_request.index_select(
+                0, token_indices_gpu
+            ).clone(),
+            "token_to_local_position_within_kv_block": (
+                gpu_view.token_to_local_position_within_kv_block.index_select(
+                    0, token_indices_gpu
+                ).clone()
+            ),
+            "token_to_block_idx": gpu_view.token_to_block_idx.index_select(
+                0, token_indices_gpu
+            ).clone(),
+            "request_query_lengths": gpu_view.request_query_lengths.index_select(
+                0, request_slots_gpu
+            ).clone(),
+            "mha_query_lengths": gpu_view.mha_query_lengths.index_select(
+                0, request_slots_gpu
+            ).clone(),
+            "mha_kv_seq_lengths": gpu_view.mha_kv_seq_lengths.index_select(
+                0, request_slots_gpu
+            ).clone(),
+            "mha_cu_query_seq_lengths": gpu_view.mha_cu_query_seq_lengths[
+                : decode_count + 1
+            ].clone(),
+            "mha_cu_kv_seq_lengths": gpu_view.mha_cu_kv_seq_lengths[
+                : decode_count + 1
+            ].clone(),
+        }
 
     def _debug_compare(
         self,
         snapshot: "DynamicStepContextSnapshot",
         input_plan: "StepInputPlan",
         input_ready_event: torch.cuda.Event,
+        *,
+        debug_expected_metadata: Optional[dict] = None,
     ) -> None:
         """Synchronize in debug mode and compare scatter destinations."""
         input_ready_event.synchronize()
         if not input_plan.decode_input_destination_indices:
             return
 
-        compare_indices = []
-        for base_idx in input_plan.decode_input_destination_indices:
-            compare_indices.extend(
-                int(base_idx) + offset for offset in range(input_plan.speculative_width + 1)
-            )
-
-        index_cpu = torch.tensor(compare_indices, dtype=torch.long, device="cpu")
+        index_cpu = self._decode_token_indices(input_plan)
         index_gpu = index_cpu.to(snapshot.gpu_view.token_to_input_ids.device, non_blocking=True)
         actual = snapshot.gpu_view.token_to_input_ids.index_select(0, index_gpu).cpu()
         expected_source = input_plan.debug_expected_input_ids
@@ -114,6 +191,55 @@ class GpuInputPreparer:
                 [expected_source[int(idx)] for idx in index_cpu.tolist()],
                 dtype=actual.dtype,
                 device="cpu",
-            )
+        )
         if not torch.equal(actual, expected):
             raise RuntimeError("GPU input scatter destinations diverged from CPU input IDs")
+        if debug_expected_metadata is not None:
+            self._debug_compare_metadata(snapshot, debug_expected_metadata)
+
+    def _debug_compare_metadata(
+        self, snapshot: "DynamicStepContextSnapshot", expected_metadata: dict
+    ) -> None:
+        """Compare GPU-prepared decode metadata against the CPU-prepared H2D snapshot."""
+        gpu_view = snapshot.gpu_view
+        token_indices_gpu = expected_metadata["token_indices_cpu"].to(
+            gpu_view.token_to_pos_ids.device
+        )
+        request_slots_gpu = expected_metadata["request_slots_cpu"].to(
+            gpu_view.token_to_pos_ids.device
+        )
+        comparisons = {
+            "token_to_pos_ids": gpu_view.token_to_pos_ids.index_select(0, token_indices_gpu),
+            "token_to_request_idx": gpu_view.token_to_request_idx.index_select(
+                0, token_indices_gpu
+            ),
+            "token_to_position_in_request": gpu_view.token_to_position_in_request.index_select(
+                0, token_indices_gpu
+            ),
+            "token_to_local_position_within_kv_block": (
+                gpu_view.token_to_local_position_within_kv_block.index_select(
+                    0, token_indices_gpu
+                )
+            ),
+            "token_to_block_idx": gpu_view.token_to_block_idx.index_select(
+                0, token_indices_gpu
+            ),
+            "request_query_lengths": gpu_view.request_query_lengths.index_select(
+                0, request_slots_gpu
+            ),
+            "mha_query_lengths": gpu_view.mha_query_lengths.index_select(0, request_slots_gpu),
+            "mha_kv_seq_lengths": gpu_view.mha_kv_seq_lengths.index_select(
+                0, request_slots_gpu
+            ),
+            "mha_cu_query_seq_lengths": gpu_view.mha_cu_query_seq_lengths[
+                : expected_metadata["mha_cu_query_seq_lengths"].numel()
+            ],
+            "mha_cu_kv_seq_lengths": gpu_view.mha_cu_kv_seq_lengths[
+                : expected_metadata["mha_cu_kv_seq_lengths"].numel()
+            ],
+        }
+        for name, actual_gpu in comparisons.items():
+            actual = actual_gpu.cpu()
+            expected = expected_metadata[name].cpu()
+            if not torch.equal(actual, expected):
+                raise RuntimeError(f"GPU-prepared decode metadata diverged for {name}")

--- a/megatron/core/inference/contexts/gpu_input_preparer.py
+++ b/megatron/core/inference/contexts/gpu_input_preparer.py
@@ -57,6 +57,7 @@ class GpuInputPreparer:
         decode_count = len(input_plan.decode_input_destination_indices)
         if decode_count and previous_sample_state is None:
             raise RuntimeError("Decode input preparation requires previous sampled-token state")
+        self._validate_decode_prefill_ranges_are_disjoint(input_plan)
 
         token_buffer = snapshot.gpu_view.token_to_input_ids
         debug_expected_metadata = None
@@ -108,6 +109,25 @@ class GpuInputPreparer:
             )
 
         return input_ready_event
+
+    def _validate_decode_prefill_ranges_are_disjoint(self, input_plan: "StepInputPlan") -> None:
+        """Validate decode GPU handoff indices do not overlap CPU prefill ranges."""
+        if not input_plan.decode_input_destination_indices or not input_plan.prefill_prompt_token_ranges:
+            return
+
+        decode_indices = set()
+        for base_idx in input_plan.decode_input_destination_indices:
+            decode_indices.update(
+                int(base_idx) + offset for offset in range(input_plan.speculative_width + 1)
+            )
+
+        for start, end in input_plan.prefill_prompt_token_ranges:
+            prefill_indices = range(int(start), int(end))
+            if any(index in decode_indices for index in prefill_indices):
+                raise RuntimeError(
+                    "Decode GPU input handoff overlaps prefill CPU input range "
+                    f"({start}, {end})"
+                )
 
     def _decode_token_indices(self, input_plan: "StepInputPlan") -> torch.Tensor:
         """Return CPU token indices covered by decode input preparation."""

--- a/megatron/core/inference/contexts/gpu_input_state.py
+++ b/megatron/core/inference/contexts/gpu_input_state.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""GPU-resident sampled-token state for async dynamic input preparation."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+class GpuSampledTokenState:
+    """Owns GPU-side sampled-token buffers and the event that makes them usable."""
+
+    def __init__(
+        self,
+        *,
+        max_requests: int,
+        num_speculative_tokens: int,
+        device,
+        stream: torch.cuda.Stream,
+    ):
+        if max_requests <= 0:
+            raise ValueError(f"max_requests must be > 0, got {max_requests}")
+        if num_speculative_tokens < 0:
+            raise ValueError(
+                f"num_speculative_tokens must be >= 0, got {num_speculative_tokens}"
+            )
+
+        self.max_requests = int(max_requests)
+        self.num_speculative_tokens = int(num_speculative_tokens)
+        self.stream = stream
+        self.sampled_tokens = torch.empty(self.max_requests, dtype=torch.int64, device=device)
+        self.sampled_mtp_tokens = (
+            torch.empty(
+                (self.num_speculative_tokens, self.max_requests),
+                dtype=torch.int64,
+                device=device,
+            )
+            if self.num_speculative_tokens > 0
+            else None
+        )
+        self.accepted_token_counts = torch.empty(
+            self.max_requests, dtype=torch.int64, device=device
+        )
+        self.sample_gpu_ready_event = torch.cuda.Event()
+        self.last_active_request_count = 0
+
+    def record(
+        self,
+        *,
+        sampled_tokens: torch.Tensor,
+        active_request_count: int,
+        source_stream: Optional[torch.cuda.Stream] = None,
+        sampled_mtp_tokens: Optional[torch.Tensor] = None,
+        accepted_token_counts: Optional[torch.Tensor] = None,
+    ) -> torch.cuda.Event:
+        """Enqueue GPU-to-GPU sampled-token handoff and record a ready event."""
+        active_request_count = int(active_request_count)
+        if active_request_count < 0:
+            raise ValueError(
+                f"active_request_count must be >= 0, got {active_request_count}"
+            )
+        if active_request_count > self.max_requests:
+            raise ValueError(
+                f"active_request_count {active_request_count} exceeds max_requests "
+                f"{self.max_requests}"
+            )
+
+        if source_stream is None:
+            source_stream = torch.cuda.current_stream()
+        self.stream.wait_stream(source_stream)
+
+        active_slice = slice(0, active_request_count)
+        with torch.cuda.stream(self.stream):
+            self.sampled_tokens[active_slice].copy_(
+                sampled_tokens[active_slice], non_blocking=True
+            )
+            if self.sampled_mtp_tokens is not None:
+                if sampled_mtp_tokens is None:
+                    self.sampled_mtp_tokens[:, active_slice].fill_(-1)
+                else:
+                    self.sampled_mtp_tokens[:, active_slice].copy_(
+                        sampled_mtp_tokens[:, active_slice], non_blocking=True
+                    )
+            if accepted_token_counts is None:
+                self.accepted_token_counts[active_slice].fill_(1)
+            else:
+                self.accepted_token_counts[active_slice].copy_(
+                    accepted_token_counts[active_slice], non_blocking=True
+                )
+            self.sample_gpu_ready_event.record(self.stream)
+
+        self.last_active_request_count = active_request_count
+        return self.sample_gpu_ready_event
+
+    def debug_compare_cpu(
+        self,
+        *,
+        sampled_tokens_cpu: torch.Tensor,
+        active_request_count: int,
+        sampled_mtp_tokens_cpu: Optional[torch.Tensor] = None,
+        accepted_token_counts_cpu: Optional[torch.Tensor] = None,
+    ) -> None:
+        """Synchronize in debug mode and compare GPU state with CPU output copies."""
+        active_request_count = int(active_request_count)
+        active_slice = slice(0, active_request_count)
+        self.sample_gpu_ready_event.synchronize()
+
+        sampled_tokens = self.sampled_tokens[active_slice].cpu()
+        if not torch.equal(sampled_tokens, sampled_tokens_cpu[active_slice]):
+            raise RuntimeError("GPU sampled-token state diverged from CPU sampled output")
+
+        if sampled_mtp_tokens_cpu is not None:
+            if self.sampled_mtp_tokens is None:
+                raise RuntimeError("CPU sampled MTP output exists without GPU MTP state")
+            sampled_mtp_tokens = self.sampled_mtp_tokens[:, active_slice].cpu()
+            if not torch.equal(sampled_mtp_tokens, sampled_mtp_tokens_cpu[:, active_slice]):
+                raise RuntimeError("GPU sampled-MTP state diverged from CPU sampled output")
+
+        if accepted_token_counts_cpu is not None:
+            accepted_counts = self.accepted_token_counts[active_slice].cpu()
+            if not torch.equal(accepted_counts, accepted_token_counts_cpu[active_slice]):
+                raise RuntimeError("GPU accepted-token counts diverged from CPU output")

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -30,10 +30,13 @@ class ContextGPUView:
         max_tokens: int,
         max_kv_blocks: int,
         device: torch.device,
+        max_mamba_chunks: int = 0,
     ):
         # Field layout (must match DynamicInferenceContext's CPU buffer layout):
         #   int64 token fields first (auto 8-byte alignment), then int32 token
-        #   fields, then int32 request fields, then int32 MHA fields.
+        #   fields, then int32 request fields, then int32 MHA fields, then
+        #   int32 Mamba fields (hybrid models only; omitted when
+        #   max_mamba_chunks == 0).
         tok_int64_bytes = max_tokens * 8  # 2 fields of int64 = 8 bytes/elem
         tok_int32_bytes = max_tokens * 4  # 4 fields of int32 = 4 bytes/elem
         req_int32_bytes = max_requests * 4  # 3 fields of int32
@@ -53,6 +56,37 @@ class ContextGPUView:
         mha_cu_kv_seq_lengths_bytes = (max_bs + 1) * 4
         mha_block_table_bytes = max_bs * max_kv_blocks * 4
 
+        # Mamba section: 9 int32 fields, only present for hybrid models.
+        #   mamba_batch_indices_decode    int32 (max_bs,)
+        #   mamba_batch_indices_prefill   int32 (max_bs,)
+        #   mamba_seq_idx                 int32 (1, max_tokens)
+        #   mamba_cu_seqlens              int32 (max_bs + 1,)
+        #   mamba_cu_chunk_seqlens        int32 (max_mamba_chunks + 1,)
+        #   mamba_last_chunk_indices      int32 (max_bs,)
+        #   mamba_seq_idx_for_varlen      int32 (max_mamba_chunks,)
+        #   mamba_conv_seq_idx            int32 (max_tokens,)
+        #   mamba_conv_seq_start          int32 (max_tokens,)
+        if max_mamba_chunks > 0:
+            mamba_batch_indices_decode_bytes = max_bs * 4
+            mamba_batch_indices_prefill_bytes = max_bs * 4
+            mamba_seq_idx_bytes = max_tokens * 4
+            mamba_cu_seqlens_bytes = (max_bs + 1) * 4
+            mamba_cu_chunk_seqlens_bytes = (max_mamba_chunks + 1) * 4
+            mamba_last_chunk_indices_bytes = max_bs * 4
+            mamba_seq_idx_for_varlen_bytes = max_mamba_chunks * 4
+            mamba_conv_seq_idx_bytes = max_tokens * 4
+            mamba_conv_seq_start_bytes = max_tokens * 4
+        else:
+            mamba_batch_indices_decode_bytes = 0
+            mamba_batch_indices_prefill_bytes = 0
+            mamba_seq_idx_bytes = 0
+            mamba_cu_seqlens_bytes = 0
+            mamba_cu_chunk_seqlens_bytes = 0
+            mamba_last_chunk_indices_bytes = 0
+            mamba_seq_idx_for_varlen_bytes = 0
+            mamba_conv_seq_idx_bytes = 0
+            mamba_conv_seq_start_bytes = 0
+
         total_bytes = (
             2 * tok_int64_bytes
             + 4 * tok_int32_bytes
@@ -62,6 +96,15 @@ class ContextGPUView:
             + mha_kv_seq_lengths_bytes
             + mha_cu_kv_seq_lengths_bytes
             + mha_block_table_bytes
+            + mamba_batch_indices_decode_bytes
+            + mamba_batch_indices_prefill_bytes
+            + mamba_seq_idx_bytes
+            + mamba_cu_seqlens_bytes
+            + mamba_cu_chunk_seqlens_bytes
+            + mamba_last_chunk_indices_bytes
+            + mamba_seq_idx_for_varlen_bytes
+            + mamba_conv_seq_idx_bytes
+            + mamba_conv_seq_start_bytes
         )
 
         # Zero-initialized so pre-transfer reads see zeros (matches prior semantics).
@@ -114,5 +157,59 @@ class ContextGPUView:
             .view(max_bs, max_kv_blocks)
         )
         off += mha_block_table_bytes
+
+        # Mamba varlen metadata (hybrid models only). Each GPU view matches a
+        # pinned CPU view in DynamicInferenceContext._cpu_bookkeeping_buf; the
+        # per-step coalesced H2D copy covers both MHA and Mamba alongside the
+        # token/request bookkeeping.
+        if max_mamba_chunks > 0:
+            self.mamba_batch_indices_decode = self._buf[
+                off : off + mamba_batch_indices_decode_bytes
+            ].view(torch.int32)
+            off += mamba_batch_indices_decode_bytes
+            self.mamba_batch_indices_prefill = self._buf[
+                off : off + mamba_batch_indices_prefill_bytes
+            ].view(torch.int32)
+            off += mamba_batch_indices_prefill_bytes
+            self.mamba_seq_idx = (
+                self._buf[off : off + mamba_seq_idx_bytes]
+                .view(torch.int32)
+                .view(1, max_tokens)
+            )
+            off += mamba_seq_idx_bytes
+            self.mamba_cu_seqlens = self._buf[off : off + mamba_cu_seqlens_bytes].view(
+                torch.int32
+            )
+            off += mamba_cu_seqlens_bytes
+            self.mamba_cu_chunk_seqlens = self._buf[
+                off : off + mamba_cu_chunk_seqlens_bytes
+            ].view(torch.int32)
+            off += mamba_cu_chunk_seqlens_bytes
+            self.mamba_last_chunk_indices = self._buf[
+                off : off + mamba_last_chunk_indices_bytes
+            ].view(torch.int32)
+            off += mamba_last_chunk_indices_bytes
+            self.mamba_seq_idx_for_varlen = self._buf[
+                off : off + mamba_seq_idx_for_varlen_bytes
+            ].view(torch.int32)
+            off += mamba_seq_idx_for_varlen_bytes
+            self.mamba_conv_seq_idx = self._buf[
+                off : off + mamba_conv_seq_idx_bytes
+            ].view(torch.int32)
+            off += mamba_conv_seq_idx_bytes
+            self.mamba_conv_seq_start = self._buf[
+                off : off + mamba_conv_seq_start_bytes
+            ].view(torch.int32)
+            off += mamba_conv_seq_start_bytes
+        else:
+            self.mamba_batch_indices_decode = None
+            self.mamba_batch_indices_prefill = None
+            self.mamba_seq_idx = None
+            self.mamba_cu_seqlens = None
+            self.mamba_cu_chunk_seqlens = None
+            self.mamba_last_chunk_indices = None
+            self.mamba_seq_idx_for_varlen = None
+            self.mamba_conv_seq_idx = None
+            self.mamba_conv_seq_start = None
 
         assert off == total_bytes, f"layout bug: wrote {off} of {total_bytes} bytes"

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -32,6 +32,11 @@ class ContextGPUView:
         device: torch.device,
         max_mamba_chunks: int = 0,
     ):
+        # CPU-side debug identity for trace correlation. Later snapshot-pool
+        # work will replace this singleton identity with per-slot handles.
+        self.current_dynamic_step_id = -1
+        self.current_snapshot_slot_id = 0
+
         # Field layout (must match DynamicInferenceContext's CPU buffer layout):
         #   int64 token fields first (auto 8-byte alignment), then int32 token
         #   fields, then int32 request fields, then int32 MHA fields, then

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -24,15 +24,45 @@ class ContextGPUView:
     single ``cudaMemcpyAsync`` instead of nine small ones.
     """
 
-    def __init__(self, max_requests: int, max_tokens: int, device: torch.device):
+    def __init__(
+        self,
+        max_requests: int,
+        max_tokens: int,
+        max_kv_blocks: int,
+        device: torch.device,
+    ):
         # Field layout (must match DynamicInferenceContext's CPU buffer layout):
         #   int64 token fields first (auto 8-byte alignment), then int32 token
-        #   fields, then int32 request fields.
+        #   fields, then int32 request fields, then int32 MHA fields.
         tok_int64_bytes = max_tokens * 8  # 2 fields of int64 = 8 bytes/elem
         tok_int32_bytes = max_tokens * 4  # 4 fields of int32 = 4 bytes/elem
         req_int32_bytes = max_requests * 4  # 3 fields of int32
 
-        total_bytes = 2 * tok_int64_bytes + 4 * tok_int32_bytes + 3 * req_int32_bytes
+        # MHA section: 5 fields shared by both graphed and non-graphed MHAMetadata
+        # (only one is active per step, so sharing storage is fine).
+        #   mha_query_lengths          int32 (max_bs,)         = max_bs   * 4
+        #   mha_cu_query_seq_lengths   int32 (max_bs + 1,)     = (max_bs+1) * 4
+        #   mha_kv_seq_lengths         int32 (max_bs,)         = max_bs   * 4
+        #   mha_cu_kv_seq_lengths      int32 (max_bs + 1,)     = (max_bs+1) * 4
+        #   mha_block_table            int32 (max_bs, max_kv_blocks)
+        # max_bs == max_requests in DynamicInferenceContext.
+        max_bs = max_requests
+        mha_query_lengths_bytes = max_bs * 4
+        mha_cu_query_seq_lengths_bytes = (max_bs + 1) * 4
+        mha_kv_seq_lengths_bytes = max_bs * 4
+        mha_cu_kv_seq_lengths_bytes = (max_bs + 1) * 4
+        mha_block_table_bytes = max_bs * max_kv_blocks * 4
+
+        total_bytes = (
+            2 * tok_int64_bytes
+            + 4 * tok_int32_bytes
+            + 3 * req_int32_bytes
+            + mha_query_lengths_bytes
+            + mha_cu_query_seq_lengths_bytes
+            + mha_kv_seq_lengths_bytes
+            + mha_cu_kv_seq_lengths_bytes
+            + mha_block_table_bytes
+        )
 
         # Zero-initialized so pre-transfer reads see zeros (matches prior semantics).
         self._buf = torch.zeros(total_bytes, dtype=torch.uint8, device=device)
@@ -63,5 +93,26 @@ class ContextGPUView:
         off += req_int32_bytes
         self.request_kv_length_offsets = self._buf[off : off + req_int32_bytes].view(torch.int32)
         off += req_int32_bytes
+
+        # MHA flash-attention metadata (shared between GraphedMHAMetadata and
+        # NonGraphedMHAMetadata — only one is active per step).
+        self.mha_query_lengths = self._buf[off : off + mha_query_lengths_bytes].view(torch.int32)
+        off += mha_query_lengths_bytes
+        self.mha_cu_query_seq_lengths = self._buf[
+            off : off + mha_cu_query_seq_lengths_bytes
+        ].view(torch.int32)
+        off += mha_cu_query_seq_lengths_bytes
+        self.mha_kv_seq_lengths = self._buf[off : off + mha_kv_seq_lengths_bytes].view(torch.int32)
+        off += mha_kv_seq_lengths_bytes
+        self.mha_cu_kv_seq_lengths = self._buf[
+            off : off + mha_cu_kv_seq_lengths_bytes
+        ].view(torch.int32)
+        off += mha_cu_kv_seq_lengths_bytes
+        self.mha_block_table = (
+            self._buf[off : off + mha_block_table_bytes]
+            .view(torch.int32)
+            .view(max_bs, max_kv_blocks)
+        )
+        off += mha_block_table_bytes
 
         assert off == total_bytes, f"layout bug: wrote {off} of {total_bytes} bytes"

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -16,28 +16,52 @@ class ContextGPUView:
     Convention:
         ``context.foo``      -> CPU (source of truth, used by bookkeeping)
         ``context.gpu_view.foo`` -> GPU (snapshot, used by forward pass)
+
+    Layout note: the 9 bookkeeping fields are backed by a single contiguous
+    ``uint8`` buffer (``self._buf``). Each field is a ``view(dtype)`` onto a
+    slice of that buffer. This matches the pinned-CPU-buffer layout in
+    :class:`DynamicInferenceContext` so that the per-step H2D transfer is a
+    single ``cudaMemcpyAsync`` instead of nine small ones.
     """
 
     def __init__(self, max_requests: int, max_tokens: int, device: torch.device):
+        # Field layout (must match DynamicInferenceContext's CPU buffer layout):
+        #   int64 token fields first (auto 8-byte alignment), then int32 token
+        #   fields, then int32 request fields.
+        tok_int64_bytes = max_tokens * 8  # 2 fields of int64 = 8 bytes/elem
+        tok_int32_bytes = max_tokens * 4  # 4 fields of int32 = 4 bytes/elem
+        req_int32_bytes = max_requests * 4  # 3 fields of int32
+
+        total_bytes = 2 * tok_int64_bytes + 4 * tok_int32_bytes + 3 * req_int32_bytes
+
+        # Zero-initialized so pre-transfer reads see zeros (matches prior semantics).
+        self._buf = torch.zeros(total_bytes, dtype=torch.uint8, device=device)
+
         # Token-level tensors (consumed by embedding, RoPE, KV append, Mamba).
-        self.token_to_input_ids = torch.zeros(max_tokens, dtype=torch.long, device=device)
-        self.token_to_pos_ids = torch.zeros(max_tokens, dtype=torch.long, device=device)
-        self.token_to_block_idx = torch.zeros(max_tokens, dtype=torch.int32, device=device)
-        self.token_to_local_position_within_kv_block = torch.zeros(
-            max_tokens, dtype=torch.int32, device=device,
+        off = 0
+        self.token_to_input_ids = self._buf[off : off + tok_int64_bytes].view(torch.long)
+        off += tok_int64_bytes
+        self.token_to_pos_ids = self._buf[off : off + tok_int64_bytes].view(torch.long)
+        off += tok_int64_bytes
+        self.token_to_block_idx = self._buf[off : off + tok_int32_bytes].view(torch.int32)
+        off += tok_int32_bytes
+        self.token_to_local_position_within_kv_block = self._buf[
+            off : off + tok_int32_bytes
+        ].view(torch.int32)
+        off += tok_int32_bytes
+        self.token_to_request_idx = self._buf[off : off + tok_int32_bytes].view(torch.int32)
+        off += tok_int32_bytes
+        self.token_to_position_in_request = self._buf[off : off + tok_int32_bytes].view(
+            torch.int32
         )
-        self.token_to_request_idx = torch.zeros(max_tokens, dtype=torch.int32, device=device)
-        self.token_to_position_in_request = torch.zeros(
-            max_tokens, dtype=torch.int32, device=device,
-        )
+        off += tok_int32_bytes
 
         # Request-level tensors (consumed by sampling, log-probs, speculative verification, MTP).
-        self.request_in_prefill_status = torch.zeros(
-            max_requests, dtype=torch.int32, device=device,
-        )
-        self.request_query_lengths = torch.zeros(
-            max_requests, dtype=torch.int32, device=device,
-        )
-        self.request_kv_length_offsets = torch.zeros(
-            max_requests, dtype=torch.int32, device=device,
-        )
+        self.request_in_prefill_status = self._buf[off : off + req_int32_bytes].view(torch.int32)
+        off += req_int32_bytes
+        self.request_query_lengths = self._buf[off : off + req_int32_bytes].view(torch.int32)
+        off += req_int32_bytes
+        self.request_kv_length_offsets = self._buf[off : off + req_int32_bytes].view(torch.int32)
+        off += req_int32_bytes
+
+        assert off == total_bytes, f"layout bug: wrote {off} of {total_bytes} bytes"

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import torch
+
+
+class ContextGPUView:
+    """GPU-resident snapshot of context bookkeeping data for the forward pass.
+
+    This is the ONLY interface GPU code (attention kernels, KV append, RoPE,
+    sampling, log-probs, speculative verification) uses to read context state.
+    CPU bookkeeping code accesses context tensors directly.
+
+    Populated once per step by ``DynamicInferenceContext.transfer_bookkeeping_to_gpu()``.
+    All tensors have fixed addresses for CUDA graph compatibility.
+
+    Convention:
+        ``context.foo``      -> CPU (source of truth, used by bookkeeping)
+        ``context.gpu_view.foo`` -> GPU (snapshot, used by forward pass)
+    """
+
+    def __init__(self, max_requests: int, max_tokens: int, device: torch.device):
+        # Token-level tensors (consumed by embedding, RoPE, KV append, Mamba).
+        self.token_to_input_ids = torch.zeros(max_tokens, dtype=torch.long, device=device)
+        self.token_to_pos_ids = torch.zeros(max_tokens, dtype=torch.long, device=device)
+        self.token_to_block_idx = torch.zeros(max_tokens, dtype=torch.int32, device=device)
+        self.token_to_local_position_within_kv_block = torch.zeros(
+            max_tokens, dtype=torch.int32, device=device,
+        )
+        self.token_to_request_idx = torch.zeros(max_tokens, dtype=torch.int32, device=device)
+        self.token_to_position_in_request = torch.zeros(
+            max_tokens, dtype=torch.int32, device=device,
+        )
+
+        # Request-level tensors (consumed by sampling, log-probs, speculative verification, MTP).
+        self.request_in_prefill_status = torch.zeros(
+            max_requests, dtype=torch.int32, device=device,
+        )
+        self.request_query_lengths = torch.zeros(
+            max_requests, dtype=torch.int32, device=device,
+        )
+        self.request_kv_length_offsets = torch.zeros(
+            max_requests, dtype=torch.int32, device=device,
+        )

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -31,6 +31,8 @@ class ContextGPUView:
         max_kv_blocks: int,
         device: torch.device,
         max_mamba_chunks: int = 0,
+        backing_buffer: torch.Tensor = None,
+        zero_initialize: bool = True,
     ):
         # CPU-side debug identity for trace correlation. Later snapshot-pool
         # work will replace this singleton identity with per-slot handles.
@@ -112,8 +114,21 @@ class ContextGPUView:
             + mamba_conv_seq_start_bytes
         )
 
-        # Zero-initialized so pre-transfer reads see zeros (matches prior semantics).
-        self._buf = torch.zeros(total_bytes, dtype=torch.uint8, device=device)
+        self.total_bytes = total_bytes
+        if backing_buffer is None:
+            # Zero-initialized so pre-transfer reads see zeros (matches prior semantics).
+            self._buf = torch.zeros(total_bytes, dtype=torch.uint8, device=device)
+        else:
+            if backing_buffer.dtype != torch.uint8:
+                raise TypeError("ContextGPUView backing_buffer must have dtype torch.uint8")
+            if backing_buffer.numel() != total_bytes:
+                raise ValueError(
+                    f"ContextGPUView backing_buffer has {backing_buffer.numel()} bytes, "
+                    f"expected {total_bytes}"
+                )
+            self._buf = backing_buffer
+            if zero_initialize:
+                self._buf.zero_()
 
         # Token-level tensors (consumed by embedding, RoPE, KV append, Mamba).
         off = 0

--- a/megatron/core/inference/contexts/kv_block_allocator.py
+++ b/megatron/core/inference/contexts/kv_block_allocator.py
@@ -8,6 +8,8 @@ from torch import Tensor
 
 from megatron.core.inference.config import PrefixCachingEvictionPolicy
 
+from .step_journal import ResourceReservation
+
 
 class KVBlockAllocator:
     """Allocator that manages blocks of memory for the KV cache.
@@ -39,6 +41,11 @@ class KVBlockAllocator:
         self.enable_prefix_caching = enable_prefix_caching
         self.prefix_caching_eviction_policy = prefix_caching_eviction_policy
         self.on_blocks_deregistered: Optional[Callable] = None
+        self._next_reservation_id = 0
+        self._open_reservations: Dict[int, ResourceReservation] = {}
+        self._committed_reservations: Dict[int, ResourceReservation] = {}
+        self._rolled_back_reservations: Dict[int, ResourceReservation] = {}
+        self._deferred_snapshot_block_releases: Dict[int, list[Tensor]] = {}
 
         self.total_count = total_count
         self.total_avail = total_count - 1  # -1 for dummy_block_idx (see below)
@@ -185,6 +192,67 @@ class KVBlockAllocator:
 
         return block_ids
 
+    def reserve_blocks(
+        self, request_slot: int, count: int, step_id: int, snapshot_slot_id: int = 0
+    ) -> Optional[ResourceReservation]:
+        """Reserve KV blocks for a scheduled-but-not-retired step."""
+        if count == 0:
+            block_ids = torch.empty(0, dtype=torch.int32, device='cpu')
+        else:
+            block_ids = self.allocate_memory_blocks(count)
+            if block_ids is None:
+                return None
+        reservation = ResourceReservation(
+            step_id=int(step_id),
+            request_slot=int(request_slot),
+            snapshot_slot_id=int(snapshot_slot_id),
+            reservation_id=self._next_reservation_id,
+            kv_block_ids=tuple(int(block_id) for block_id in block_ids.tolist()),
+        )
+        self._next_reservation_id += 1
+        self._open_reservations[reservation.reservation_id] = reservation
+        return reservation
+
+    def commit_reservation(self, reservation: ResourceReservation) -> None:
+        """Commit a KV reservation into durable request ownership."""
+        open_reservation = self._open_reservations.pop(reservation.reservation_id, None)
+        if open_reservation is None:
+            if reservation.reservation_id in self._committed_reservations:
+                return
+            raise RuntimeError(f"KV reservation {reservation.reservation_id} is not open")
+        self._committed_reservations[reservation.reservation_id] = open_reservation
+        if hasattr(self.context, "async_overlap_debug_counters"):
+            self.context.async_overlap_debug_counters["reservation_commits"] += 1
+
+    def rollback_reservation(self, reservation: ResourceReservation) -> None:
+        """Roll back a KV reservation and return its blocks to the allocator."""
+        open_reservation = self._open_reservations.pop(reservation.reservation_id, None)
+        if open_reservation is None:
+            if reservation.reservation_id in self._rolled_back_reservations:
+                return
+            raise RuntimeError(f"KV reservation {reservation.reservation_id} is not open")
+        block_ids = torch.tensor(open_reservation.kv_block_ids, dtype=torch.int32, device='cpu')
+        self.release_memory_blocks(block_ids)
+        self._rolled_back_reservations[reservation.reservation_id] = open_reservation
+        if hasattr(self.context, "async_overlap_debug_counters"):
+            self.context.async_overlap_debug_counters["reservation_rollbacks"] += 1
+
+    def defer_release_until_snapshot_retired(
+        self, block_ids: Tensor, snapshot_slot_id: int
+    ) -> None:
+        """Defer block release until the owning snapshot can no longer read them."""
+        if block_ids.numel() == 0:
+            return
+        self._deferred_snapshot_block_releases.setdefault(int(snapshot_slot_id), []).append(
+            block_ids.to(dtype=torch.int32, device='cpu').clone()
+        )
+
+    def release_deferred_blocks_for_snapshot(self, snapshot_slot_id: int) -> None:
+        """Release blocks whose snapshot-read dependency has retired."""
+        deferred = self._deferred_snapshot_block_releases.pop(int(snapshot_slot_id), [])
+        for block_ids in deferred:
+            self.release_memory_blocks(block_ids)
+
     def release_memory_blocks(self, blocks: Tensor) -> None:
         """Release memory blocks by decrementing reference counts.
 
@@ -244,6 +312,11 @@ class KVBlockAllocator:
         )
 
         self.total_avail = self.total_count - 1
+        self._open_reservations.clear()
+        self._committed_reservations.clear()
+        self._rolled_back_reservations.clear()
+        self._deferred_snapshot_block_releases.clear()
+        self._next_reservation_id = 0
 
         if self.enable_prefix_caching:
             # Reset all block hashes

--- a/megatron/core/inference/contexts/kv_block_allocator.py
+++ b/megatron/core/inference/contexts/kv_block_allocator.py
@@ -213,6 +213,30 @@ class KVBlockAllocator:
         self._open_reservations[reservation.reservation_id] = reservation
         return reservation
 
+    def reserve_prefix_refcounts(
+        self,
+        request_slot: int,
+        block_ids: Tensor,
+        step_id: int,
+        snapshot_slot_id: int = 0,
+        refcount_delta: int = 1,
+    ) -> ResourceReservation:
+        """Reserve prefix-cache refcount deltas for matched KV blocks."""
+        block_ids = block_ids.to(dtype=torch.int32, device='cpu')
+        unique_block_ids = torch.unique(block_ids)
+        deltas = {int(block_id): int(refcount_delta) for block_id in unique_block_ids.tolist()}
+        self._apply_prefix_refcount_deltas(deltas)
+        reservation = ResourceReservation(
+            step_id=int(step_id),
+            request_slot=int(request_slot),
+            snapshot_slot_id=int(snapshot_slot_id),
+            reservation_id=self._next_reservation_id,
+            prefix_cache_refcount_deltas=deltas,
+        )
+        self._next_reservation_id += 1
+        self._open_reservations[reservation.reservation_id] = reservation
+        return reservation
+
     def commit_reservation(self, reservation: ResourceReservation) -> None:
         """Commit a KV reservation into durable request ownership."""
         open_reservation = self._open_reservations.pop(reservation.reservation_id, None)
@@ -233,9 +257,31 @@ class KVBlockAllocator:
             raise RuntimeError(f"KV reservation {reservation.reservation_id} is not open")
         block_ids = torch.tensor(open_reservation.kv_block_ids, dtype=torch.int32, device='cpu')
         self.release_memory_blocks(block_ids)
+        self._apply_prefix_refcount_deltas(
+            {
+                block_id: -delta
+                for block_id, delta in open_reservation.prefix_cache_refcount_deltas.items()
+            }
+        )
         self._rolled_back_reservations[reservation.reservation_id] = open_reservation
         if hasattr(self.context, "async_overlap_debug_counters"):
             self.context.async_overlap_debug_counters["reservation_rollbacks"] += 1
+
+    def _apply_prefix_refcount_deltas(self, deltas: Dict[int, int]) -> None:
+        """Apply prefix-cache refcount deltas with normal cache-release semantics."""
+        if not deltas:
+            return
+        if not self.enable_prefix_caching:
+            raise RuntimeError("Prefix-cache refcount deltas require prefix caching")
+        for block_id, delta in deltas.items():
+            block_tensor = torch.tensor([int(block_id)], dtype=torch.int32, device='cpu')
+            if delta > 0:
+                self.block_ref_counts[block_tensor] += int(delta)
+                if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
+                    self.update_timestamps(block_tensor)
+            elif delta < 0:
+                for _ in range(-int(delta)):
+                    self.release_memory_blocks(block_tensor)
 
     def defer_release_until_snapshot_retired(
         self, block_ids: Tensor, snapshot_slot_id: int

--- a/megatron/core/inference/contexts/kv_block_allocator.py
+++ b/megatron/core/inference/contexts/kv_block_allocator.py
@@ -47,15 +47,15 @@ class KVBlockAllocator:
         assert self.active_count >= 1  # ensures paused_count < total_count - 1
         self.dummy_block_idx = self.total_count - 1
 
-        # Initialize block pool as a "stack" data structure
+        # Initialize block pool as a "stack" data structure (CPU for bookkeeping).
         self.block_bag = torch.arange(
-            self.total_count, dtype=torch.int32, device=torch.cuda.current_device()
+            self.total_count, dtype=torch.int32, device='cpu',
         )
 
         if self.enable_prefix_caching:
             # Block hash tracking for prefix caching: -1 = uncomputed, positive = valid hash
             self.block_hashes = torch.full(
-                (self.total_count,), -1, dtype=torch.int64, device=torch.cuda.current_device()
+                (self.total_count,), -1, dtype=torch.int64, device='cpu',
             )
 
             # Hash-to-block mapping for O(1) prefix lookup
@@ -63,14 +63,14 @@ class KVBlockAllocator:
 
             # Reference count per block: 0 = cached (evictable), >0 = actively used
             self.block_ref_counts = torch.zeros(
-                (self.total_count,), dtype=torch.int32, device=torch.cuda.current_device()
+                (self.total_count,), dtype=torch.int32, device='cpu',
             )
 
             # LRU timestamps for eviction ordering (higher = more recently used)
             # Only needed in LRU mode; RZ mode evicts immediately on ref_count==0
             if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
                 self.block_timestamps = torch.zeros(
-                    (self.total_count,), dtype=torch.int64, device=torch.cuda.current_device()
+                    (self.total_count,), dtype=torch.int64, device='cpu',
                 )
 
     def __str__(self):
@@ -240,7 +240,7 @@ class KVBlockAllocator:
         # requests will point to each other's memory blocks, resulting in faulty
         # generations.
         self.block_bag = torch.arange(
-            self.total_count, dtype=torch.int32, device=torch.cuda.current_device()
+            self.total_count, dtype=torch.int32, device='cpu',
         )
 
         self.total_avail = self.total_count - 1

--- a/megatron/core/inference/contexts/kv_block_allocator.py
+++ b/megatron/core/inference/contexts/kv_block_allocator.py
@@ -8,7 +8,47 @@ from torch import Tensor
 
 from megatron.core.inference.config import PrefixCachingEvictionPolicy
 
-from .step_journal import ResourceReservation
+from .step_journal import ResourceReservation, RollbackStatus
+
+
+def _merge_rollback_statuses(statuses) -> RollbackStatus:
+    """Merge per-resource rollback outcomes into one reservation status."""
+    statuses = tuple(status for status in statuses if status is not None)
+    if not statuses:
+        return RollbackStatus.FULLY_RELEASED
+    if all(status == RollbackStatus.FULLY_RELEASED for status in statuses):
+        return RollbackStatus.FULLY_RELEASED
+    if all(status == RollbackStatus.RESOURCE_ALREADY_EVICTED for status in statuses):
+        return RollbackStatus.RESOURCE_ALREADY_EVICTED
+    if (
+        RollbackStatus.PARTIALLY_RELEASED in statuses
+        or RollbackStatus.RESOURCE_ALREADY_EVICTED in statuses
+    ):
+        return RollbackStatus.PARTIALLY_RELEASED
+    if RollbackStatus.DEFERRED_UNTIL_SNAPSHOT_RETIRED in statuses:
+        return RollbackStatus.DEFERRED_UNTIL_SNAPSHOT_RETIRED
+    if RollbackStatus.ALREADY_COMMITTED in statuses:
+        return RollbackStatus.ALREADY_COMMITTED
+    return RollbackStatus.ALREADY_ROLLED_BACK
+
+
+def _record_rollback_status(counters: Dict, status: RollbackStatus) -> None:
+    """Record allocator rollback status in a debug-counter mapping."""
+    status_value = RollbackStatus(status).value
+    status_counts = counters.setdefault("rollback_status_counts", {})
+    status_counts[status_value] = status_counts.get(status_value, 0) + 1
+    if status == RollbackStatus.PARTIALLY_RELEASED:
+        counters["partial_reservation_rollbacks"] = (
+            counters.get("partial_reservation_rollbacks", 0) + 1
+        )
+    elif status == RollbackStatus.RESOURCE_ALREADY_EVICTED:
+        counters["resource_already_evicted_rollbacks"] = (
+            counters.get("resource_already_evicted_rollbacks", 0) + 1
+        )
+    elif status == RollbackStatus.DEFERRED_UNTIL_SNAPSHOT_RETIRED:
+        counters["deferred_reservation_rollbacks"] = (
+            counters.get("deferred_reservation_rollbacks", 0) + 1
+        )
 
 
 class KVBlockAllocator:
@@ -46,6 +86,7 @@ class KVBlockAllocator:
         self._committed_reservations: Dict[int, ResourceReservation] = {}
         self._rolled_back_reservations: Dict[int, ResourceReservation] = {}
         self._deferred_snapshot_block_releases: Dict[int, list[Tensor]] = {}
+        self._deferred_snapshot_prefix_refcount_deltas: Dict[int, list[Dict[int, int]]] = {}
 
         self.total_count = total_count
         self.total_avail = total_count - 1  # -1 for dummy_block_idx (see below)
@@ -248,24 +289,48 @@ class KVBlockAllocator:
         if hasattr(self.context, "async_overlap_debug_counters"):
             self.context.async_overlap_debug_counters["reservation_commits"] += 1
 
-    def rollback_reservation(self, reservation: ResourceReservation) -> None:
+    def rollback_reservation(self, reservation: ResourceReservation) -> RollbackStatus:
         """Roll back a KV reservation and return its blocks to the allocator."""
         open_reservation = self._open_reservations.pop(reservation.reservation_id, None)
         if open_reservation is None:
             if reservation.reservation_id in self._rolled_back_reservations:
-                return
-            raise RuntimeError(f"KV reservation {reservation.reservation_id} is not open")
+                return RollbackStatus.ALREADY_ROLLED_BACK
+            if reservation.reservation_id in self._committed_reservations:
+                return RollbackStatus.ALREADY_COMMITTED
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
         block_ids = torch.tensor(open_reservation.kv_block_ids, dtype=torch.int32, device='cpu')
-        self.release_memory_blocks(block_ids)
-        self._apply_prefix_refcount_deltas(
-            {
-                block_id: -delta
-                for block_id, delta in open_reservation.prefix_cache_refcount_deltas.items()
-            }
+        has_resources = bool(open_reservation.kv_block_ids) or bool(
+            open_reservation.prefix_cache_refcount_deltas
         )
+        if has_resources and self._should_defer_for_snapshot(open_reservation):
+            self.defer_release_until_snapshot_retired(
+                block_ids, open_reservation.snapshot_slot_id
+            )
+            self.defer_prefix_refcount_deltas_until_snapshot_retired(
+                {
+                    block_id: -delta
+                    for block_id, delta in open_reservation.prefix_cache_refcount_deltas.items()
+                },
+                open_reservation.snapshot_slot_id,
+            )
+            status = RollbackStatus.DEFERRED_UNTIL_SNAPSHOT_RETIRED
+        else:
+            statuses = []
+            if open_reservation.kv_block_ids:
+                statuses.append(self.release_memory_blocks(block_ids))
+            if open_reservation.prefix_cache_refcount_deltas:
+                statuses.append(
+                    self._rollback_prefix_refcount_deltas(
+                        open_reservation.prefix_cache_refcount_deltas
+                    )
+                )
+            status = _merge_rollback_statuses(statuses)
         self._rolled_back_reservations[reservation.reservation_id] = open_reservation
         if hasattr(self.context, "async_overlap_debug_counters"):
-            self.context.async_overlap_debug_counters["reservation_rollbacks"] += 1
+            counters = self.context.async_overlap_debug_counters
+            counters["reservation_rollbacks"] = counters.get("reservation_rollbacks", 0) + 1
+            _record_rollback_status(counters, status)
+        return status
 
     def _apply_prefix_refcount_deltas(self, deltas: Dict[int, int]) -> None:
         """Apply prefix-cache refcount deltas with normal cache-release semantics."""
@@ -280,8 +345,82 @@ class KVBlockAllocator:
                 if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
                     self.update_timestamps(block_tensor)
             elif delta < 0:
-                for _ in range(-int(delta)):
+                release_count = min(-int(delta), int(self.block_ref_counts[block_tensor].item()))
+                for _ in range(release_count):
                     self.release_memory_blocks(block_tensor)
+
+    def _rollback_prefix_refcount_deltas(self, deltas: Dict[int, int]) -> RollbackStatus:
+        """Undo prefix-cache refcount deltas without underflowing shared refs."""
+        if not deltas:
+            return RollbackStatus.FULLY_RELEASED
+        if not self.enable_prefix_caching:
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
+
+        expected_release_count = 0
+        released_count = 0
+        for block_id, delta in deltas.items():
+            release_count = max(0, int(delta))
+            if release_count == 0:
+                continue
+            expected_release_count += release_count
+            block_id = int(block_id)
+            if block_id < 0 or block_id >= self.dummy_block_idx:
+                continue
+            block_tensor = torch.tensor([block_id], dtype=torch.int32, device='cpu')
+            current_ref_count = int(self.block_ref_counts[block_tensor].item())
+            safe_release_count = min(release_count, current_ref_count)
+            for _ in range(safe_release_count):
+                self.release_memory_blocks(block_tensor)
+            released_count += safe_release_count
+
+        if expected_release_count == 0:
+            return RollbackStatus.FULLY_RELEASED
+        if released_count == 0:
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
+        if released_count < expected_release_count:
+            return RollbackStatus.PARTIALLY_RELEASED
+        return RollbackStatus.FULLY_RELEASED
+
+    def _should_defer_for_snapshot(self, reservation: ResourceReservation) -> bool:
+        """Return whether a reservation's snapshot can still read its blocks."""
+        snapshot_pool = getattr(self.context, "snapshot_pool", None)
+        if snapshot_pool is None:
+            return False
+        try:
+            slot = snapshot_pool.get_slot(int(reservation.snapshot_slot_id))
+        except (AttributeError, IndexError):
+            return False
+        return not getattr(slot, "is_free", True)
+
+    def _valid_unique_blocks(self, blocks: Tensor) -> tuple[Tensor, int]:
+        """Return valid unique non-dummy block IDs and the expected unique count."""
+        if blocks.numel() == 0:
+            return torch.empty(0, dtype=torch.int32, device='cpu'), 0
+        block_ids = torch.unique(blocks.to(dtype=torch.int32, device='cpu').flatten())
+        expected_count = int(block_ids.numel())
+        valid_mask = (block_ids >= 0) & (block_ids < self.dummy_block_idx)
+        return block_ids[valid_mask], expected_count
+
+    def _return_blocks_to_free_pool(self, blocks: Tensor) -> int:
+        """Return blocks to the free pool, skipping blocks already present there."""
+        valid_blocks, _ = self._valid_unique_blocks(blocks)
+        if valid_blocks.numel() == 0:
+            return 0
+        free_ids = set(int(block_id) for block_id in self.block_bag[: self.total_avail].tolist())
+        block_ids = [
+            int(block_id) for block_id in valid_blocks.tolist() if int(block_id) not in free_ids
+        ]
+        if not block_ids:
+            return 0
+        capacity = max(0, self.total_count - 1 - self.total_avail)
+        if capacity == 0:
+            return 0
+        block_ids = block_ids[:capacity]
+        block_tensor = torch.tensor(block_ids, dtype=torch.int32, device='cpu')
+        num_blocks = int(block_tensor.numel())
+        self.block_bag[self.total_avail : self.total_avail + num_blocks] = block_tensor
+        self.total_avail += num_blocks
+        return num_blocks
 
     def defer_release_until_snapshot_retired(
         self, block_ids: Tensor, snapshot_slot_id: int
@@ -293,13 +432,28 @@ class KVBlockAllocator:
             block_ids.to(dtype=torch.int32, device='cpu').clone()
         )
 
+    def defer_prefix_refcount_deltas_until_snapshot_retired(
+        self, deltas: Dict[int, int], snapshot_slot_id: int
+    ) -> None:
+        """Defer prefix-cache refcount cleanup until a snapshot no longer reads blocks."""
+        if not deltas:
+            return
+        self._deferred_snapshot_prefix_refcount_deltas.setdefault(int(snapshot_slot_id), []).append(
+            {int(block_id): int(delta) for block_id, delta in deltas.items()}
+        )
+
     def release_deferred_blocks_for_snapshot(self, snapshot_slot_id: int) -> None:
         """Release blocks whose snapshot-read dependency has retired."""
         deferred = self._deferred_snapshot_block_releases.pop(int(snapshot_slot_id), [])
         for block_ids in deferred:
             self.release_memory_blocks(block_ids)
+        deferred_deltas = self._deferred_snapshot_prefix_refcount_deltas.pop(
+            int(snapshot_slot_id), []
+        )
+        for deltas in deferred_deltas:
+            self._apply_prefix_refcount_deltas(deltas)
 
-    def release_memory_blocks(self, blocks: Tensor) -> None:
+    def release_memory_blocks(self, blocks: Tensor) -> RollbackStatus:
         """Release memory blocks by decrementing reference counts.
 
         Blocks with ref_count == 0 remain cached (in hash map) for potential reuse.
@@ -312,31 +466,52 @@ class KVBlockAllocator:
             None
         """
         if blocks.numel() == 0:
-            return
+            return RollbackStatus.FULLY_RELEASED
 
         if self.enable_prefix_caching:
-            self.block_ref_counts[blocks] -= 1
+            block_ids = blocks.to(dtype=torch.int32, device='cpu').flatten()
+            expected_count = int(block_ids.numel())
+            valid_mask = (block_ids >= 0) & (block_ids < self.dummy_block_idx)
+            valid_blocks = block_ids[valid_mask]
+            if valid_blocks.numel() == 0:
+                return RollbackStatus.RESOURCE_ALREADY_EVICTED
+            unique_blocks, release_counts = torch.unique(valid_blocks, return_counts=True)
+            current_ref_counts = self.block_ref_counts[unique_blocks]
+            safe_release_counts = torch.minimum(
+                release_counts.to(dtype=torch.int32), current_ref_counts
+            )
+            releasable_mask = safe_release_counts > 0
+            releasable_blocks = unique_blocks[releasable_mask]
+            if releasable_blocks.numel() == 0:
+                return RollbackStatus.RESOURCE_ALREADY_EVICTED
+            self.block_ref_counts[releasable_blocks] -= safe_release_counts[releasable_mask]
             if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.REF_ZERO:
-                zero_mask = self.block_ref_counts[blocks] == 0
+                zero_mask = self.block_ref_counts[releasable_blocks] == 0
                 if zero_mask.any():
-                    self._deregister_blocks(blocks[zero_mask])
+                    self._deregister_blocks(releasable_blocks[zero_mask])
             elif self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
                 # Unregistered blocks (hash == -1, ref_count == 0) have no hash
                 # entry to preserve for reuse (e.g., partial blocks at the end of
                 # a request). Return them directly to the free pool so they are not
                 # leaked.
-                unreg_mask = (self.block_ref_counts[blocks] == 0) & (
-                    self.block_hashes[blocks] == -1
+                unreg_mask = (self.block_ref_counts[releasable_blocks] == 0) & (
+                    self.block_hashes[releasable_blocks] == -1
                 )
                 if unreg_mask.any():
-                    unreg_blocks = blocks[unreg_mask]
-                    num_unreg = unreg_blocks.numel()
-                    self.block_bag[self.total_avail : self.total_avail + num_unreg] = unreg_blocks
-                    self.total_avail += num_unreg
+                    self._return_blocks_to_free_pool(releasable_blocks[unreg_mask])
+            released_count = int(safe_release_counts[releasable_mask].sum().item())
         else:
-            num_blocks = blocks.numel()
-            self.block_bag[self.total_avail : self.total_avail + num_blocks] = blocks
-            self.total_avail += num_blocks
+            valid_blocks, expected_count = self._valid_unique_blocks(blocks)
+            if expected_count == 0:
+                return RollbackStatus.FULLY_RELEASED
+            if valid_blocks.numel() == 0:
+                return RollbackStatus.RESOURCE_ALREADY_EVICTED
+            released_count = self._return_blocks_to_free_pool(valid_blocks)
+        if released_count == 0:
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
+        if released_count < expected_count:
+            return RollbackStatus.PARTIALLY_RELEASED
+        return RollbackStatus.FULLY_RELEASED
 
     def reset(self) -> None:
         """Reset the allocator to initial state.
@@ -362,6 +537,7 @@ class KVBlockAllocator:
         self._committed_reservations.clear()
         self._rolled_back_reservations.clear()
         self._deferred_snapshot_block_releases.clear()
+        self._deferred_snapshot_prefix_refcount_deltas.clear()
         self._next_reservation_id = 0
 
         if self.enable_prefix_caching:
@@ -426,8 +602,7 @@ class KVBlockAllocator:
             self.block_timestamps[block_ids] = 0
 
         # Return blocks to free pool
-        self.block_bag[self.total_avail : self.total_avail + num_blocks] = block_ids
-        self.total_avail += num_blocks
+        self._return_blocks_to_free_pool(block_ids)
 
     def update_timestamps(self, block_ids: Tensor) -> None:
         """Update LRU timestamps for accessed blocks. No-op in RZ mode.

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -73,21 +73,29 @@ class MambaSlotAllocator:
         # Hash-to-block mapping: only blocks with cached Mamba state
         self.hash_to_block_id: Dict[int, int] = {}
 
-        # Per-request intermediate state storage (GPU tensors, fixed-size per request).
-        # These are consumed by Triton kernels during the forward pass.
-        # 0 = no offset, -1 = no block
+        # Per-request intermediate state storage.
+        # offsets_cpu and counts_cpu: CPU source of truth.  GPU copies are
+        # populated by transfer_bookkeeping_to_gpu() since Triton kernels read them.
+        # block_ids and eos_cache_block_id: CPU only (consumed by CPU code).
         k = MAX_INTERMEDIATE_OFFSETS_PER_REQUEST
+        self._intermediate_offsets_cpu = torch.zeros(
+            (context.max_requests, k), dtype=torch.int32, device='cpu',
+        )
+        self._intermediate_counts_cpu = torch.zeros(
+            context.max_requests, dtype=torch.int32, device='cpu',
+        )
         self._intermediate_offsets_gpu = torch.zeros(
             (context.max_requests, k), dtype=torch.int32, device=gpu_device,
-        )
-        self._intermediate_block_ids_gpu = torch.full(
-            (context.max_requests, k), -1, dtype=torch.int32, device=gpu_device,
         )
         self._intermediate_counts_gpu = torch.zeros(
             context.max_requests, dtype=torch.int32, device=gpu_device,
         )
-        self._eos_cache_block_id_gpu = torch.full(
-            (context.max_requests,), -1, dtype=torch.int32, device=gpu_device,
+        # CPU-only: consumed by _collect_commit_data() which needs .tolist() anyway.
+        self._intermediate_block_ids_cpu = torch.full(
+            (context.max_requests, k), -1, dtype=torch.int32, device='cpu',
+        )
+        self._eos_cache_block_id_cpu = torch.full(
+            (context.max_requests,), -1, dtype=torch.int32, device='cpu',
         )
         # CPU flag to skip GPU sync when no intermediates exist
         self._has_intermediates = False
@@ -418,42 +426,41 @@ class MambaSlotAllocator:
         offsets = sorted(offsets_set)
         count = len(offsets)
 
-        # Vectorized block ID lookup: GPU gather avoids per-block .item() syncs
+        # CPU bookkeeping writes (no GPU kernel launches).
         if count > 0:
-            device = self._intermediate_offsets_gpu.device
-            abs_tokens = torch.tensor(
-                [skip_tokens + o for o in offsets], dtype=torch.int64, device=device
+            abs_tokens_cpu = torch.tensor(
+                [skip_tokens + o for o in offsets], dtype=torch.int64,
             )
-            block_indices = abs_tokens // ctx.block_size_tokens - 1
-            bids = ctx.request_to_kv_block_ids[current_id][block_indices.cpu()].to(device)
+            block_indices_cpu = abs_tokens_cpu // ctx.block_size_tokens - 1
+            bids_cpu = ctx.request_to_kv_block_ids[current_id][block_indices_cpu]
 
-            self._intermediate_offsets_gpu[current_id, :count] = torch.tensor(
-                offsets, dtype=torch.int32, device=device
+            self._intermediate_offsets_cpu[current_id, :count] = torch.tensor(
+                offsets, dtype=torch.int32,
             )
-            self._intermediate_block_ids_gpu[current_id, :count] = bids.to(torch.int32)
+            self._intermediate_block_ids_cpu[current_id, :count] = bids_cpu.to(torch.int32)
             self._has_intermediates = True
-        self._intermediate_counts_gpu[current_id] = count
+        self._intermediate_counts_cpu[current_id] = count
 
         # Block-aligned EOS: prompt_len is exactly block-aligned
         if last_aligned_abs == prompt_len and prompt_len > 0:
             last_block_idx = prompt_len // ctx.block_size_tokens - 1
             if last_block_idx >= 0:
-                self._eos_cache_block_id_gpu[current_id] = ctx.request_to_kv_block_ids[current_id][
+                self._eos_cache_block_id_cpu[current_id] = ctx.request_to_kv_block_ids[current_id][
                     last_block_idx
                 ]
                 self._has_intermediates = True
             else:
-                self._eos_cache_block_id_gpu[current_id] = -1
+                self._eos_cache_block_id_cpu[current_id] = -1
         else:
-            self._eos_cache_block_id_gpu[current_id] = -1
+            self._eos_cache_block_id_cpu[current_id] = -1
 
-    def get_intermediate_gpu_data(self):
-        """Get intermediate offsets and counts as GPU tensor slices for current prefill batch.
+    def get_intermediate_cpu_data(self):
+        """Get intermediate offsets and counts as CPU tensor slices for current prefill batch.
 
         Returns:
-            Tuple of (offsets_gpu, counts_gpu) where:
-                offsets_gpu: [prefill_count, 3] int32 GPU tensor
-                counts_gpu: [prefill_count] int32 GPU tensor
+            Tuple of (offsets_cpu, counts_cpu) where:
+                offsets_cpu: [prefill_count, 3] int32 CPU tensor
+                counts_cpu: [prefill_count] int32 CPU tensor
             Returns (None, None) if no prefill requests or no intermediates.
         """
         if not self._has_intermediates:
@@ -468,9 +475,32 @@ class MambaSlotAllocator:
         decode_count = ctx.batch_dimensions.decode_req_count
         prefill_start = active_start + decode_count
 
-        offsets = self._intermediate_offsets_gpu[prefill_start : prefill_start + prefill_count]
-        counts = self._intermediate_counts_gpu[prefill_start : prefill_start + prefill_count]
+        offsets = self._intermediate_offsets_cpu[prefill_start : prefill_start + prefill_count]
+        counts = self._intermediate_counts_cpu[prefill_start : prefill_start + prefill_count]
         return offsets, counts
+
+    def transfer_intermediate_to_gpu(self, prefill_start: int, prefill_count: int):
+        """Copy intermediate offsets/counts slice from CPU to GPU for Mamba kernels.
+
+        Returns the GPU tensor views for the forward-pass kernels to consume.
+        """
+        if prefill_count == 0:
+            return None, None
+        offsets_cpu = self._intermediate_offsets_cpu[
+            prefill_start : prefill_start + prefill_count
+        ]
+        counts_cpu = self._intermediate_counts_cpu[
+            prefill_start : prefill_start + prefill_count
+        ]
+        offsets_gpu = self._intermediate_offsets_gpu[
+            prefill_start : prefill_start + prefill_count
+        ]
+        counts_gpu = self._intermediate_counts_gpu[
+            prefill_start : prefill_start + prefill_count
+        ]
+        offsets_gpu.copy_(offsets_cpu, non_blocking=True)
+        counts_gpu.copy_(counts_cpu, non_blocking=True)
+        return offsets_gpu, counts_gpu
 
     # =========================================================================
     # Intermediate state commit
@@ -522,14 +552,14 @@ class MambaSlotAllocator:
         decode_count = ctx.batch_dimensions.decode_req_count
         prefill_start = active_start + decode_count
 
-        # Batch-transfer block IDs and EOS block IDs from GPU (2 GPU syncs)
+        # Block IDs and EOS block IDs live on CPU (no GPU sync needed).
         intermediate_count = metadata.intermediate_count
         per_request_counts = metadata.per_request_intermediate_counts
 
-        all_block_ids_cpu = self._intermediate_block_ids_gpu[
+        all_block_ids_cpu = self._intermediate_block_ids_cpu[
             prefill_start : prefill_start + prefill_count
         ].tolist()
-        eos_bids_cpu = self._eos_cache_block_id_gpu[
+        eos_bids_cpu = self._eos_cache_block_id_cpu[
             prefill_start : prefill_start + prefill_count
         ].tolist()
 
@@ -591,10 +621,10 @@ class MambaSlotAllocator:
             decode_count = ctx.batch_dimensions.decode_req_count
             prefill_start = active_start + decode_count
             end = prefill_start + prefill_count
-            self._intermediate_counts_gpu[prefill_start:end].fill_(0)
-            self._intermediate_offsets_gpu[prefill_start:end].fill_(0)
-            self._intermediate_block_ids_gpu[prefill_start:end].fill_(-1)
-            self._eos_cache_block_id_gpu[prefill_start:end].fill_(-1)
+            self._intermediate_counts_cpu[prefill_start:end].fill_(0)
+            self._intermediate_offsets_cpu[prefill_start:end].fill_(0)
+            self._intermediate_block_ids_cpu[prefill_start:end].fill_(-1)
+            self._eos_cache_block_id_cpu[prefill_start:end].fill_(-1)
         self._has_intermediates = False
 
     # =========================================================================
@@ -612,8 +642,8 @@ class MambaSlotAllocator:
         self.hash_to_block_id.clear()
         self.intermediate_ssm_out.zero_()
         self.intermediate_conv_out.zero_()
-        self._intermediate_offsets_gpu.fill_(0)
-        self._intermediate_block_ids_gpu.fill_(-1)
-        self._intermediate_counts_gpu.fill_(0)
-        self._eos_cache_block_id_gpu.fill_(-1)
+        self._intermediate_offsets_cpu.fill_(0)
+        self._intermediate_counts_cpu.fill_(0)
+        self._intermediate_block_ids_cpu.fill_(-1)
+        self._eos_cache_block_id_cpu.fill_(-1)
         self._has_intermediates = False

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -6,6 +6,7 @@ import torch
 from torch import Tensor
 
 from megatron.core.inference.config import PrefixCachingEvictionPolicy
+from megatron.core.inference.contexts.step_journal import RollbackStatus
 
 if TYPE_CHECKING:
     from .dynamic_context import DynamicInferenceContext
@@ -296,16 +297,34 @@ class MambaSlotAllocator:
         for slot_ids in deferred:
             self._return_slots_to_free_pool(slot_ids)
 
-    def _return_slots_to_free_pool(self, slot_ids: Tensor) -> None:
+    def _return_slots_to_free_pool(self, slot_ids: Tensor) -> RollbackStatus:
         """Return cache slots to the free pool."""
         if slot_ids.numel() == 0:
-            return
-        n = slot_ids.numel()
+            return RollbackStatus.FULLY_RELEASED
+        slot_ids = torch.unique(slot_ids.to(dtype=torch.int32, device='cpu').flatten())
+        requested_count = int(slot_ids.numel())
+        valid_mask = (slot_ids >= 0) & (slot_ids < self.max_slots)
+        valid_slot_ids = slot_ids[valid_mask]
+        if valid_slot_ids.numel() == 0:
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
+        free_ids = set(int(slot_id) for slot_id in self.free_slots[: self.free_count].tolist())
+        releasable_slot_ids = [
+            int(slot_id) for slot_id in valid_slot_ids.tolist() if int(slot_id) not in free_ids
+        ]
+        if not releasable_slot_ids:
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
+        capacity = max(0, self.max_slots - self.free_count)
+        if capacity == 0:
+            return RollbackStatus.RESOURCE_ALREADY_EVICTED
+        releasable_slot_ids = releasable_slot_ids[:capacity]
+        slot_ids = torch.tensor(releasable_slot_ids, dtype=torch.int32, device='cpu')
+        n = int(slot_ids.numel())
         end = self.free_count + n
-        if end > self.max_slots:
-            raise RuntimeError("Mamba cache free slot pool overflow")
         self.free_slots[self.free_count : end] = slot_ids.to(torch.int32)
         self.free_count = end
+        if n < int(valid_slot_ids.numel()) or int(valid_slot_ids.numel()) < requested_count:
+            return RollbackStatus.PARTIALLY_RELEASED
+        return RollbackStatus.FULLY_RELEASED
 
     def on_kv_blocks_deregistered(self, block_ids_list: list, hashes_to_delete: set) -> None:
         """Handle KV block deregistration by cleaning up Mamba state.

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -47,59 +47,62 @@ class MambaSlotAllocator:
         self.max_slots = max_slots
         self.num_mamba_layers = num_mamba_layers
 
-        device = torch.cuda.current_device()
+        gpu_device = torch.cuda.current_device()
         num_blocks = context.kv_block_allocator.total_count
 
-        # Block <-> slot mappings
-        self.block_to_slot = torch.full((num_blocks,), -1, dtype=torch.int32, device=device)
-        self.slot_to_block = torch.full((max_slots,), -1, dtype=torch.int32, device=device)
+        # Block <-> slot mappings (CPU for bookkeeping).
+        self.block_to_slot = torch.full((num_blocks,), -1, dtype=torch.int32, device='cpu')
+        self.slot_to_block = torch.full((max_slots,), -1, dtype=torch.int32, device='cpu')
 
-        # Free slot pool (stack)
-        self.free_slots = torch.arange(max_slots, dtype=torch.int32, device=device)
+        # Free slot pool (stack, CPU).
+        self.free_slots = torch.arange(max_slots, dtype=torch.int32, device='cpu')
         self.free_count = max_slots
 
-        # State tensors
+        # State tensors (GPU - accessed by Mamba CUDA kernels).
         self.conv_states = torch.zeros(
             (num_mamba_layers, max_slots) + conv_states_shape,
             dtype=conv_states_dtype,
-            device=device,
+            device=gpu_device,
         )
         self.ssm_states = torch.zeros(
-            (num_mamba_layers, max_slots) + ssm_states_shape, dtype=ssm_states_dtype, device=device
+            (num_mamba_layers, max_slots) + ssm_states_shape,
+            dtype=ssm_states_dtype,
+            device=gpu_device,
         )
 
         # Hash-to-block mapping: only blocks with cached Mamba state
         self.hash_to_block_id: Dict[int, int] = {}
 
-        # Per-request intermediate state storage (GPU tensors, fixed-size per request)
+        # Per-request intermediate state storage (GPU tensors, fixed-size per request).
+        # These are consumed by Triton kernels during the forward pass.
         # 0 = no offset, -1 = no block
         k = MAX_INTERMEDIATE_OFFSETS_PER_REQUEST
         self._intermediate_offsets_gpu = torch.zeros(
-            (context.max_requests, k), dtype=torch.int32, device=device
+            (context.max_requests, k), dtype=torch.int32, device=gpu_device,
         )
         self._intermediate_block_ids_gpu = torch.full(
-            (context.max_requests, k), -1, dtype=torch.int32, device=device
+            (context.max_requests, k), -1, dtype=torch.int32, device=gpu_device,
         )
         self._intermediate_counts_gpu = torch.zeros(
-            context.max_requests, dtype=torch.int32, device=device
+            context.max_requests, dtype=torch.int32, device=gpu_device,
         )
         self._eos_cache_block_id_gpu = torch.full(
-            (context.max_requests,), -1, dtype=torch.int32, device=device
+            (context.max_requests,), -1, dtype=torch.int32, device=gpu_device,
         )
         # CPU flag to skip GPU sync when no intermediates exist
         self._has_intermediates = False
 
-        # Pre-allocated output buffers for CUDA graph compatible extraction
+        # Pre-allocated output buffers for CUDA graph compatible extraction (GPU).
         self.max_intermediate_count = MAX_INTERMEDIATE_OFFSETS_PER_REQUEST * context.max_requests
         self.intermediate_ssm_out = torch.zeros(
             (num_mamba_layers, self.max_intermediate_count) + ssm_states_shape,
             dtype=ssm_states_dtype,
-            device=device,
+            device=gpu_device,
         )
         self.intermediate_conv_out = torch.zeros(
             (num_mamba_layers, self.max_intermediate_count) + conv_states_shape,
             dtype=conv_states_dtype,
-            device=device,
+            device=gpu_device,
         )
 
     # =========================================================================
@@ -320,9 +323,11 @@ class MambaSlotAllocator:
             return
         device = self.conv_states.device
         slot_tensor = torch.tensor(slots, dtype=torch.int64, device=device)
-        req_tensor = torch.tensor(request_indices, dtype=torch.int64, device=device)
-        # Batch lookup mamba state indices (1 GPU sync)
-        mamba_indices = self.context.mamba_metadata.request_to_mamba_state_idx[req_tensor].tolist()
+        # Lookup mamba indices from CPU bookkeeping, then move to GPU for state copy.
+        req_tensor_cpu = torch.tensor(request_indices, dtype=torch.int64)
+        mamba_indices = self.context.mamba_metadata.request_to_mamba_state_idx[
+            req_tensor_cpu
+        ].tolist()
         mamba_idx_tensor = torch.tensor(mamba_indices, dtype=torch.int64, device=device)
         # Fancy-indexed copy (2 kernel launches instead of 2E)
         self.conv_states[:, slot_tensor] = self.context.mamba_conv_states[:, mamba_idx_tensor]
@@ -420,7 +425,7 @@ class MambaSlotAllocator:
                 [skip_tokens + o for o in offsets], dtype=torch.int64, device=device
             )
             block_indices = abs_tokens // ctx.block_size_tokens - 1
-            bids = ctx.request_to_kv_block_ids[current_id][block_indices]
+            bids = ctx.request_to_kv_block_ids[current_id][block_indices.cpu()].to(device)
 
             self._intermediate_offsets_gpu[current_id, :count] = torch.tensor(
                 offsets, dtype=torch.int32, device=device
@@ -601,7 +606,7 @@ class MambaSlotAllocator:
         self.block_to_slot.fill_(-1)
         self.slot_to_block.fill_(-1)
         self.free_slots = torch.arange(
-            self.max_slots, dtype=torch.int32, device=torch.cuda.current_device()
+            self.max_slots, dtype=torch.int32, device='cpu',
         )
         self.free_count = self.max_slots
         self.hash_to_block_id.clear()

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -72,6 +72,7 @@ class MambaSlotAllocator:
 
         # Hash-to-block mapping: only blocks with cached Mamba state
         self.hash_to_block_id: Dict[int, int] = {}
+        self._deferred_snapshot_slot_releases: Dict[int, list[Tensor]] = {}
 
         # Per-request intermediate state storage.
         # offsets_cpu and counts_cpu: CPU source of truth.  GPU copies are
@@ -255,9 +256,7 @@ class MambaSlotAllocator:
             return
         self.block_to_slot[block_id] = -1
         self.slot_to_block[slot] = -1
-        # Return slot to free pool
-        self.free_slots[self.free_count] = slot
-        self.free_count += 1
+        self._return_slots_to_free_pool(torch.tensor([slot], dtype=torch.int32, device='cpu'))
 
     def _invalidate_blocks_batch(self, block_ids_list: list) -> None:
         """Free cache slots and clear mappings for multiple blocks at once.
@@ -279,9 +278,34 @@ class MambaSlotAllocator:
         valid_bids = bid_t[valid_mask]
         self.block_to_slot[valid_bids] = -1
         self.slot_to_block[valid_slots] = -1
-        n = valid_slots.numel()
-        self.free_slots[self.free_count : self.free_count + n] = valid_slots.to(torch.int32)
-        self.free_count += n
+        self._return_slots_to_free_pool(valid_slots.to(torch.int32))
+
+    def defer_release_until_snapshot_retired(
+        self, slot_ids: Tensor, snapshot_slot_id: int
+    ) -> None:
+        """Defer Mamba cache slot reuse until a snapshot no longer reads it."""
+        if slot_ids.numel() == 0:
+            return
+        self._deferred_snapshot_slot_releases.setdefault(int(snapshot_slot_id), []).append(
+            slot_ids.to(dtype=torch.int32, device='cpu').clone()
+        )
+
+    def release_deferred_slots_for_snapshot(self, snapshot_slot_id: int) -> None:
+        """Return deferred Mamba cache slots once the owning snapshot retires."""
+        deferred = self._deferred_snapshot_slot_releases.pop(int(snapshot_slot_id), [])
+        for slot_ids in deferred:
+            self._return_slots_to_free_pool(slot_ids)
+
+    def _return_slots_to_free_pool(self, slot_ids: Tensor) -> None:
+        """Return cache slots to the free pool."""
+        if slot_ids.numel() == 0:
+            return
+        n = slot_ids.numel()
+        end = self.free_count + n
+        if end > self.max_slots:
+            raise RuntimeError("Mamba cache free slot pool overflow")
+        self.free_slots[self.free_count : end] = slot_ids.to(torch.int32)
+        self.free_count = end
 
     def on_kv_blocks_deregistered(self, block_ids_list: list, hashes_to_delete: set) -> None:
         """Handle KV block deregistration by cleaning up Mamba state.
@@ -640,6 +664,7 @@ class MambaSlotAllocator:
         )
         self.free_count = self.max_slots
         self.hash_to_block_id.clear()
+        self._deferred_snapshot_slot_releases.clear()
         self.intermediate_ssm_out.zero_()
         self.intermediate_conv_out.zero_()
         self._intermediate_offsets_cpu.fill_(0)

--- a/megatron/core/inference/contexts/snapshot_pool.py
+++ b/megatron/core/inference/contexts/snapshot_pool.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Sequence
 
 import torch
@@ -33,6 +33,9 @@ class GpuSnapshotSlot:
     journal_retired: bool = True
     graph_capture_count: int = 0
     graph_capture_bytes: int = 0
+    graph_capture_keys: set = field(default_factory=set)
+    graph_cache_hits: int = 0
+    graph_cache_misses: int = 0
 
     @property
     def is_free(self) -> bool:
@@ -101,14 +104,16 @@ class GpuSnapshotBufferPool:
         self.poll_retired()
         for slot in self.slots:
             if slot.is_free:
-                slot.state = SNAPSHOT_POPULATING
-                slot.owning_step_id = int(step_id)
-                slot.journal_retired = False
-                slot.last_gpu_read_event = None
-                slot.gpu_view.current_dynamic_step_id = int(step_id)
-                slot.cpu_view.current_dynamic_step_id = int(step_id)
-                return slot
+                return self._acquire_slot(slot, step_id)
         raise RuntimeError("No reusable GPU snapshot slots are available")
+
+    def acquire_specific(self, slot_or_id, step_id: int) -> GpuSnapshotSlot:
+        """Acquire a specific free snapshot slot for CUDA graph capture."""
+        self.poll_retired()
+        slot = self.get_slot(slot_or_id)
+        if not slot.is_free:
+            raise RuntimeError(f"Snapshot slot {slot.slot_id} is not reusable")
+        return self._acquire_slot(slot, step_id)
 
     def mark_ready(
         self, slot_or_id, metadata_ready_event: Optional[torch.cuda.Event] = None
@@ -161,22 +166,51 @@ class GpuSnapshotBufferPool:
             raise IndexError(f"snapshot slot id {slot_id} out of range")
         return self.slots[slot_id]
 
-    def register_graph_capture(self, slot_or_id, byte_count: int = 0) -> None:
+    def register_graph_capture(
+        self,
+        slot_or_id,
+        byte_count: int = 0,
+        *,
+        cache_key=None,
+        max_captures: Optional[int] = None,
+    ) -> None:
         """Record CUDA graph capture accounting associated with a slot."""
         slot = self.get_slot(slot_or_id)
+        if cache_key is not None:
+            if cache_key in slot.graph_capture_keys:
+                return
+            if max_captures is not None and len(slot.graph_capture_keys) >= int(max_captures):
+                raise RuntimeError(
+                    f"Snapshot slot {slot.slot_id} exceeded CUDA graph capture budget "
+                    f"({max_captures})"
+                )
+            slot.graph_capture_keys.add(cache_key)
         slot.graph_capture_count += 1
         slot.graph_capture_bytes += int(byte_count)
+
+    def record_graph_cache_lookup(self, slot_or_id, *, hit: bool) -> None:
+        """Record one CUDA graph cache lookup for a snapshot slot."""
+        slot = self.get_slot(slot_or_id)
+        if hit:
+            slot.graph_cache_hits += 1
+        else:
+            slot.graph_cache_misses += 1
 
     def memory_accounting(self) -> Dict[str, int]:
         """Return memory accounting for snapshot metadata and graph captures."""
         graph_capture_count = sum(slot.graph_capture_count for slot in self.slots)
         graph_capture_bytes = sum(slot.graph_capture_bytes for slot in self.slots)
+        graph_cache_hits = sum(slot.graph_cache_hits for slot in self.slots)
+        graph_cache_misses = sum(slot.graph_cache_misses for slot in self.slots)
         return {
             "snapshot_slot_count": self.slot_count,
             "metadata_buffer_bytes": sum(slot.gpu_view.total_bytes for slot in self.slots),
             "pinned_mirror_bytes": sum(slot.cpu_mirror.numel() for slot in self.slots),
             "graph_capture_count": graph_capture_count,
             "graph_capture_bytes": graph_capture_bytes,
+            "graph_cache_hits": graph_cache_hits,
+            "graph_cache_misses": graph_cache_misses,
+            "graph_capture_key_count": sum(len(slot.graph_capture_keys) for slot in self.slots),
         }
 
     @property
@@ -189,6 +223,15 @@ class GpuSnapshotBufferPool:
             return False
         event = slot.last_gpu_read_event
         return event is None or bool(event.query())
+
+    def _acquire_slot(self, slot: GpuSnapshotSlot, step_id: int) -> GpuSnapshotSlot:
+        slot.state = SNAPSHOT_POPULATING
+        slot.owning_step_id = int(step_id)
+        slot.journal_retired = False
+        slot.last_gpu_read_event = None
+        slot.gpu_view.current_dynamic_step_id = int(step_id)
+        slot.cpu_view.current_dynamic_step_id = int(step_id)
+        return slot
 
     def _mark_free(self, slot: GpuSnapshotSlot) -> None:
         slot.state = SNAPSHOT_FREE

--- a/megatron/core/inference/contexts/snapshot_pool.py
+++ b/megatron/core/inference/contexts/snapshot_pool.py
@@ -157,6 +157,21 @@ class GpuSnapshotBufferPool:
             if slot.state == SNAPSHOT_RETIRING and self._can_reuse(slot):
                 self._mark_free(slot)
 
+    def reset_for_suspend(self, *, clear_graph_captures: bool = True) -> None:
+        """Synchronize active slots and return the pool to a fully reusable state."""
+        for slot in self.slots:
+            if slot.state != SNAPSHOT_FREE and slot.metadata_ready_event is not None:
+                slot.metadata_ready_event.synchronize()
+            if slot.last_gpu_read_event is not None:
+                slot.last_gpu_read_event.synchronize()
+            self._mark_free(slot)
+            if clear_graph_captures:
+                slot.graph_capture_count = 0
+                slot.graph_capture_bytes = 0
+                slot.graph_capture_keys.clear()
+                slot.graph_cache_hits = 0
+                slot.graph_cache_misses = 0
+
     def get_slot(self, slot_or_id) -> GpuSnapshotSlot:
         """Return a snapshot slot by handle or slot id."""
         if isinstance(slot_or_id, GpuSnapshotSlot):

--- a/megatron/core/inference/contexts/snapshot_pool.py
+++ b/megatron/core/inference/contexts/snapshot_pool.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Fixed-address GPU snapshot buffers for async dynamic inference."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence
+
+import torch
+
+from .gpu_view import ContextGPUView
+
+SNAPSHOT_FREE = "free"
+SNAPSHOT_POPULATING = "populating"
+SNAPSHOT_READY = "ready"
+SNAPSHOT_FORWARD_IN_FLIGHT = "forward_in_flight"
+SNAPSHOT_RETIRING = "retiring"
+
+
+@dataclass
+class GpuSnapshotSlot:
+    """One fixed-address CPU/GPU bookkeeping snapshot slot."""
+
+    slot_id: int
+    gpu_view: ContextGPUView
+    cpu_mirror: torch.Tensor
+    cpu_view: ContextGPUView
+    metadata_ready_event: torch.cuda.Event
+    state: str = SNAPSHOT_FREE
+    owning_step_id: Optional[int] = None
+    last_gpu_read_event: Optional[Any] = None
+    journal_retired: bool = True
+    graph_capture_count: int = 0
+    graph_capture_bytes: int = 0
+
+    @property
+    def is_free(self) -> bool:
+        """Return whether this slot can be acquired immediately."""
+        return self.state == SNAPSHOT_FREE
+
+
+class GpuSnapshotBufferPool:
+    """Owns fixed-address GPU snapshot slots and pinned CPU mirrors."""
+
+    def __init__(
+        self,
+        *,
+        slot_count: int,
+        max_requests: int,
+        max_tokens: int,
+        max_kv_blocks: int,
+        device,
+        max_mamba_chunks: int = 0,
+    ):
+        if slot_count < 1:
+            raise ValueError(f"slot_count must be >= 1, got {slot_count}")
+        self.slot_count = int(slot_count)
+        self.max_requests = int(max_requests)
+        self.max_tokens = int(max_tokens)
+        self.max_kv_blocks = int(max_kv_blocks)
+        self.device = device
+        self.max_mamba_chunks = int(max_mamba_chunks)
+        self.slots = tuple(self._make_slot(slot_id) for slot_id in range(self.slot_count))
+
+    def _make_slot(self, slot_id: int) -> GpuSnapshotSlot:
+        gpu_view = ContextGPUView(
+            max_requests=self.max_requests,
+            max_tokens=self.max_tokens,
+            max_kv_blocks=self.max_kv_blocks,
+            device=self.device,
+            max_mamba_chunks=self.max_mamba_chunks,
+        )
+        gpu_view.current_snapshot_slot_id = slot_id
+
+        cpu_mirror = torch.empty(
+            gpu_view.total_bytes, dtype=torch.uint8, device='cpu', pin_memory=True,
+        )
+        cpu_mirror.zero_()
+        cpu_view = ContextGPUView(
+            max_requests=self.max_requests,
+            max_tokens=self.max_tokens,
+            max_kv_blocks=self.max_kv_blocks,
+            device=torch.device('cpu'),
+            max_mamba_chunks=self.max_mamba_chunks,
+            backing_buffer=cpu_mirror,
+            zero_initialize=False,
+        )
+        cpu_view.current_snapshot_slot_id = slot_id
+
+        return GpuSnapshotSlot(
+            slot_id=slot_id,
+            gpu_view=gpu_view,
+            cpu_mirror=cpu_mirror,
+            cpu_view=cpu_view,
+            metadata_ready_event=torch.cuda.Event(),
+        )
+
+    def acquire(self, step_id: int) -> GpuSnapshotSlot:
+        """Acquire a free snapshot slot for a scheduled step."""
+        self.poll_retired()
+        for slot in self.slots:
+            if slot.is_free:
+                slot.state = SNAPSHOT_POPULATING
+                slot.owning_step_id = int(step_id)
+                slot.journal_retired = False
+                slot.last_gpu_read_event = None
+                slot.gpu_view.current_dynamic_step_id = int(step_id)
+                slot.cpu_view.current_dynamic_step_id = int(step_id)
+                return slot
+        raise RuntimeError("No reusable GPU snapshot slots are available")
+
+    def mark_ready(
+        self, slot_or_id, metadata_ready_event: Optional[torch.cuda.Event] = None
+    ) -> GpuSnapshotSlot:
+        """Mark a populated snapshot ready for the forward pass."""
+        slot = self.get_slot(slot_or_id)
+        if slot.state != SNAPSHOT_POPULATING:
+            raise RuntimeError(f"Snapshot slot {slot.slot_id} is not being populated")
+        if metadata_ready_event is not None:
+            slot.metadata_ready_event = metadata_ready_event
+        slot.state = SNAPSHOT_READY
+        return slot
+
+    def mark_forward_in_flight(
+        self, slot_or_id, gpu_read_event: Optional[Any] = None
+    ) -> GpuSnapshotSlot:
+        """Mark a ready snapshot as being read by a GPU forward pass."""
+        slot = self.get_slot(slot_or_id)
+        if slot.state not in (SNAPSHOT_POPULATING, SNAPSHOT_READY):
+            raise RuntimeError(f"Snapshot slot {slot.slot_id} cannot enter forward_in_flight")
+        if gpu_read_event is None:
+            gpu_read_event = torch.cuda.Event()
+            gpu_read_event.record(torch.cuda.current_stream())
+        slot.last_gpu_read_event = gpu_read_event
+        slot.state = SNAPSHOT_FORWARD_IN_FLIGHT
+        return slot
+
+    def release(self, slot_or_id) -> GpuSnapshotSlot:
+        """Mark the slot's journal retired and free it once GPU reads are done."""
+        slot = self.get_slot(slot_or_id)
+        slot.journal_retired = True
+        if self._can_reuse(slot):
+            self._mark_free(slot)
+        else:
+            slot.state = SNAPSHOT_RETIRING
+        return slot
+
+    def poll_retired(self) -> None:
+        """Free retiring slots whose GPU-read event has completed."""
+        for slot in self.slots:
+            if slot.state == SNAPSHOT_RETIRING and self._can_reuse(slot):
+                self._mark_free(slot)
+
+    def get_slot(self, slot_or_id) -> GpuSnapshotSlot:
+        """Return a snapshot slot by handle or slot id."""
+        if isinstance(slot_or_id, GpuSnapshotSlot):
+            return slot_or_id
+        slot_id = int(slot_or_id)
+        if slot_id < 0 or slot_id >= self.slot_count:
+            raise IndexError(f"snapshot slot id {slot_id} out of range")
+        return self.slots[slot_id]
+
+    def register_graph_capture(self, slot_or_id, byte_count: int = 0) -> None:
+        """Record CUDA graph capture accounting associated with a slot."""
+        slot = self.get_slot(slot_or_id)
+        slot.graph_capture_count += 1
+        slot.graph_capture_bytes += int(byte_count)
+
+    def memory_accounting(self) -> Dict[str, int]:
+        """Return memory accounting for snapshot metadata and graph captures."""
+        graph_capture_count = sum(slot.graph_capture_count for slot in self.slots)
+        graph_capture_bytes = sum(slot.graph_capture_bytes for slot in self.slots)
+        return {
+            "snapshot_slot_count": self.slot_count,
+            "metadata_buffer_bytes": sum(slot.gpu_view.total_bytes for slot in self.slots),
+            "pinned_mirror_bytes": sum(slot.cpu_mirror.numel() for slot in self.slots),
+            "graph_capture_count": graph_capture_count,
+            "graph_capture_bytes": graph_capture_bytes,
+        }
+
+    @property
+    def active_slot_ids(self) -> Sequence[int]:
+        """Return slot IDs not currently free."""
+        return tuple(slot.slot_id for slot in self.slots if not slot.is_free)
+
+    def _can_reuse(self, slot: GpuSnapshotSlot) -> bool:
+        if not slot.journal_retired:
+            return False
+        event = slot.last_gpu_read_event
+        return event is None or bool(event.query())
+
+    def _mark_free(self, slot: GpuSnapshotSlot) -> None:
+        slot.state = SNAPSHOT_FREE
+        slot.owning_step_id = None
+        slot.last_gpu_read_event = None
+        slot.journal_retired = True

--- a/megatron/core/inference/contexts/step_journal.py
+++ b/megatron/core/inference/contexts/step_journal.py
@@ -81,6 +81,8 @@ class StepJournalEntry:
     request_slots_after: Sequence[int] = field(default_factory=tuple)
     active_request_ids: Sequence[str] = field(default_factory=tuple)
     placeholder_token_counts: Mapping[str, int] = field(default_factory=dict)
+    speculative_accepted_token_counts: Mapping[str, int] = field(default_factory=dict)
+    kv_rewind_token_counts: Mapping[str, int] = field(default_factory=dict)
     reserved_kv_blocks: Sequence[int] = field(default_factory=tuple)
     reserved_mamba_slots: Sequence[int] = field(default_factory=tuple)
     prefix_cache_refcount_deltas: Mapping[Any, int] = field(default_factory=dict)
@@ -101,6 +103,14 @@ class StepJournalEntry:
         object.__setattr__(self, "active_request_ids", _str_tuple(self.active_request_ids))
         object.__setattr__(
             self, "placeholder_token_counts", _freeze_mapping(self.placeholder_token_counts)
+        )
+        object.__setattr__(
+            self,
+            "speculative_accepted_token_counts",
+            _freeze_mapping(self.speculative_accepted_token_counts),
+        )
+        object.__setattr__(
+            self, "kv_rewind_token_counts", _freeze_mapping(self.kv_rewind_token_counts)
         )
         object.__setattr__(self, "reserved_kv_blocks", _int_tuple(self.reserved_kv_blocks))
         object.__setattr__(self, "reserved_mamba_slots", _int_tuple(self.reserved_mamba_slots))
@@ -136,6 +146,8 @@ class _MutableStepJournalEntry:
     request_slots_after: Tuple[int, ...] = field(default_factory=tuple)
     active_request_ids: Tuple[str, ...] = field(default_factory=tuple)
     placeholder_token_counts: Dict[str, int] = field(default_factory=dict)
+    speculative_accepted_token_counts: Dict[str, int] = field(default_factory=dict)
+    kv_rewind_token_counts: Dict[str, int] = field(default_factory=dict)
     reserved_kv_blocks: list[int] = field(default_factory=list)
     reserved_mamba_slots: list[int] = field(default_factory=list)
     prefix_cache_refcount_deltas: Dict[Any, int] = field(default_factory=dict)
@@ -155,6 +167,8 @@ class _MutableStepJournalEntry:
             request_slots_after=self.request_slots_after,
             active_request_ids=self.active_request_ids,
             placeholder_token_counts=self.placeholder_token_counts,
+            speculative_accepted_token_counts=self.speculative_accepted_token_counts,
+            kv_rewind_token_counts=self.kv_rewind_token_counts,
             reserved_kv_blocks=self.reserved_kv_blocks,
             reserved_mamba_slots=self.reserved_mamba_slots,
             prefix_cache_refcount_deltas=self.prefix_cache_refcount_deltas,
@@ -250,6 +264,23 @@ class StepJournal:
         )
         for key, block_id in getattr(reservation, "mamba_restore_block_ids", {}).items():
             entry.mamba_restore_block_ids[key] = int(block_id)
+        return entry.freeze()
+
+    def record_speculative_acceptance(
+        self,
+        step_id,
+        *,
+        accepted_token_counts: Optional[Mapping[Any, int]] = None,
+        kv_rewind_token_counts: Optional[Mapping[Any, int]] = None,
+    ) -> StepJournalEntry:
+        """Record speculative acceptance and rejected-token KV rewind counts."""
+        entry = self._require_open_entry(step_id)
+        if accepted_token_counts is not None:
+            for request_id, token_count in accepted_token_counts.items():
+                entry.speculative_accepted_token_counts[str(request_id)] = int(token_count)
+        if kv_rewind_token_counts is not None:
+            for request_id, token_count in kv_rewind_token_counts.items():
+                entry.kv_rewind_token_counts[str(request_id)] = int(token_count)
         return entry.freeze()
 
     def record_snapshot_slot(

--- a/megatron/core/inference/contexts/step_journal.py
+++ b/megatron/core/inference/contexts/step_journal.py
@@ -50,6 +50,8 @@ class ResourceReservation:
     kv_block_ids: Sequence[int] = field(default_factory=tuple)
     mamba_slot_ids: Sequence[int] = field(default_factory=tuple)
     prefix_cache_refcount_deltas: Mapping[Any, int] = field(default_factory=dict)
+    mamba_zero_slot_ids: Sequence[int] = field(default_factory=tuple)
+    mamba_restore_block_ids: Mapping[Any, int] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.step_id < 0:
@@ -62,6 +64,10 @@ class ResourceReservation:
             self,
             "prefix_cache_refcount_deltas",
             _freeze_mapping(self.prefix_cache_refcount_deltas),
+        )
+        object.__setattr__(self, "mamba_zero_slot_ids", _int_tuple(self.mamba_zero_slot_ids))
+        object.__setattr__(
+            self, "mamba_restore_block_ids", _freeze_mapping(self.mamba_restore_block_ids)
         )
 
 
@@ -78,6 +84,8 @@ class StepJournalEntry:
     reserved_kv_blocks: Sequence[int] = field(default_factory=tuple)
     reserved_mamba_slots: Sequence[int] = field(default_factory=tuple)
     prefix_cache_refcount_deltas: Mapping[Any, int] = field(default_factory=dict)
+    mamba_zero_slot_ids: Sequence[int] = field(default_factory=tuple)
+    mamba_restore_block_ids: Mapping[Any, int] = field(default_factory=dict)
     pause_resume_evictions: Sequence[str] = field(default_factory=tuple)
     decode_input_destination_indices: Sequence[int] = field(default_factory=tuple)
     cuda_graph_batch_dimensions: Optional[Any] = None
@@ -100,6 +108,10 @@ class StepJournalEntry:
             self,
             "prefix_cache_refcount_deltas",
             _freeze_mapping(self.prefix_cache_refcount_deltas),
+        )
+        object.__setattr__(self, "mamba_zero_slot_ids", _int_tuple(self.mamba_zero_slot_ids))
+        object.__setattr__(
+            self, "mamba_restore_block_ids", _freeze_mapping(self.mamba_restore_block_ids)
         )
         object.__setattr__(
             self, "pause_resume_evictions", _str_tuple(self.pause_resume_evictions)
@@ -127,6 +139,8 @@ class _MutableStepJournalEntry:
     reserved_kv_blocks: list[int] = field(default_factory=list)
     reserved_mamba_slots: list[int] = field(default_factory=list)
     prefix_cache_refcount_deltas: Dict[Any, int] = field(default_factory=dict)
+    mamba_zero_slot_ids: list[int] = field(default_factory=list)
+    mamba_restore_block_ids: Dict[Any, int] = field(default_factory=dict)
     pause_resume_evictions: list[str] = field(default_factory=list)
     decode_input_destination_indices: Tuple[int, ...] = field(default_factory=tuple)
     cuda_graph_batch_dimensions: Optional[Any] = None
@@ -144,6 +158,8 @@ class _MutableStepJournalEntry:
             reserved_kv_blocks=self.reserved_kv_blocks,
             reserved_mamba_slots=self.reserved_mamba_slots,
             prefix_cache_refcount_deltas=self.prefix_cache_refcount_deltas,
+            mamba_zero_slot_ids=self.mamba_zero_slot_ids,
+            mamba_restore_block_ids=self.mamba_restore_block_ids,
             pause_resume_evictions=self.pause_resume_evictions,
             decode_input_destination_indices=self.decode_input_destination_indices,
             cuda_graph_batch_dimensions=self.cuda_graph_batch_dimensions,
@@ -224,6 +240,11 @@ class StepJournal:
             entry.prefix_cache_refcount_deltas[key] = (
                 entry.prefix_cache_refcount_deltas.get(key, 0) + int(delta)
             )
+        entry.mamba_zero_slot_ids.extend(
+            int(slot_id) for slot_id in getattr(reservation, "mamba_zero_slot_ids", ())
+        )
+        for key, block_id in getattr(reservation, "mamba_restore_block_ids", {}).items():
+            entry.mamba_restore_block_ids[key] = int(block_id)
         return entry.freeze()
 
     def record_snapshot_slot(

--- a/megatron/core/inference/contexts/step_journal.py
+++ b/megatron/core/inference/contexts/step_journal.py
@@ -1,0 +1,301 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Transaction journal scaffolding for dynamic inference steps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Tuple
+
+
+def _step_id_value(step_id) -> int:
+    """Return the integer value for a dynamic step ID."""
+    if hasattr(step_id, "value"):
+        return int(step_id.value)
+    if step_id < 0:
+        raise ValueError(f"step_id must be >= 0, got {step_id}")
+    return int(step_id)
+
+
+def _int_tuple(values: Optional[Iterable[int]]) -> Tuple[int, ...]:
+    """Return an immutable tuple of ints."""
+    if values is None:
+        return ()
+    return tuple(int(value) for value in values)
+
+
+def _str_tuple(values: Optional[Iterable[Any]]) -> Tuple[str, ...]:
+    """Return an immutable tuple of strings."""
+    if values is None:
+        return ()
+    return tuple(str(value) for value in values)
+
+
+def _freeze_mapping(value: Optional[Mapping[Any, Any]]) -> Mapping[Any, Any]:
+    """Return an immutable mapping copy."""
+    if value is None:
+        return MappingProxyType({})
+    return MappingProxyType(dict(value))
+
+
+@dataclass(frozen=True, kw_only=True)
+class StepJournalEntry:
+    """Immutable journal record for one dynamic step."""
+
+    step_id: int
+    snapshot_slot_id: int = 0
+    request_slots_before: Sequence[int] = field(default_factory=tuple)
+    request_slots_after: Sequence[int] = field(default_factory=tuple)
+    active_request_ids: Sequence[str] = field(default_factory=tuple)
+    placeholder_token_counts: Mapping[str, int] = field(default_factory=dict)
+    reserved_kv_blocks: Sequence[int] = field(default_factory=tuple)
+    reserved_mamba_slots: Sequence[int] = field(default_factory=tuple)
+    prefix_cache_refcount_deltas: Mapping[Any, int] = field(default_factory=dict)
+    pause_resume_evictions: Sequence[str] = field(default_factory=tuple)
+    decode_input_destination_indices: Sequence[int] = field(default_factory=tuple)
+    cuda_graph_batch_dimensions: Optional[Any] = None
+    resources_waiting_on_snapshot: Sequence[Any] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.step_id < 0:
+            raise ValueError(f"step_id must be >= 0, got {self.step_id}")
+        if self.snapshot_slot_id < 0:
+            raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+        object.__setattr__(self, "request_slots_before", _int_tuple(self.request_slots_before))
+        object.__setattr__(self, "request_slots_after", _int_tuple(self.request_slots_after))
+        object.__setattr__(self, "active_request_ids", _str_tuple(self.active_request_ids))
+        object.__setattr__(
+            self, "placeholder_token_counts", _freeze_mapping(self.placeholder_token_counts)
+        )
+        object.__setattr__(self, "reserved_kv_blocks", _int_tuple(self.reserved_kv_blocks))
+        object.__setattr__(self, "reserved_mamba_slots", _int_tuple(self.reserved_mamba_slots))
+        object.__setattr__(
+            self,
+            "prefix_cache_refcount_deltas",
+            _freeze_mapping(self.prefix_cache_refcount_deltas),
+        )
+        object.__setattr__(
+            self, "pause_resume_evictions", _str_tuple(self.pause_resume_evictions)
+        )
+        object.__setattr__(
+            self,
+            "decode_input_destination_indices",
+            _int_tuple(self.decode_input_destination_indices),
+        )
+        object.__setattr__(
+            self, "resources_waiting_on_snapshot", tuple(self.resources_waiting_on_snapshot)
+        )
+
+
+@dataclass
+class _MutableStepJournalEntry:
+    """Mutable journal entry used while a step is open."""
+
+    step_id: int
+    snapshot_slot_id: int = 0
+    request_slots_before: Tuple[int, ...] = field(default_factory=tuple)
+    request_slots_after: Tuple[int, ...] = field(default_factory=tuple)
+    active_request_ids: Tuple[str, ...] = field(default_factory=tuple)
+    placeholder_token_counts: Dict[str, int] = field(default_factory=dict)
+    reserved_kv_blocks: list[int] = field(default_factory=list)
+    reserved_mamba_slots: list[int] = field(default_factory=list)
+    prefix_cache_refcount_deltas: Dict[Any, int] = field(default_factory=dict)
+    pause_resume_evictions: list[str] = field(default_factory=list)
+    decode_input_destination_indices: Tuple[int, ...] = field(default_factory=tuple)
+    cuda_graph_batch_dimensions: Optional[Any] = None
+    resources_waiting_on_snapshot: list[Any] = field(default_factory=list)
+
+    def freeze(self) -> StepJournalEntry:
+        """Return an immutable public view of this journal entry."""
+        return StepJournalEntry(
+            step_id=self.step_id,
+            snapshot_slot_id=self.snapshot_slot_id,
+            request_slots_before=self.request_slots_before,
+            request_slots_after=self.request_slots_after,
+            active_request_ids=self.active_request_ids,
+            placeholder_token_counts=self.placeholder_token_counts,
+            reserved_kv_blocks=self.reserved_kv_blocks,
+            reserved_mamba_slots=self.reserved_mamba_slots,
+            prefix_cache_refcount_deltas=self.prefix_cache_refcount_deltas,
+            pause_resume_evictions=self.pause_resume_evictions,
+            decode_input_destination_indices=self.decode_input_destination_indices,
+            cuda_graph_batch_dimensions=self.cuda_graph_batch_dimensions,
+            resources_waiting_on_snapshot=self.resources_waiting_on_snapshot,
+        )
+
+
+class StepJournal:
+    """Ordered transaction journal for scheduled dynamic steps."""
+
+    def __init__(self):
+        self._open_entries: Dict[int, _MutableStepJournalEntry] = {}
+        self._committed_entries: Dict[int, StepJournalEntry] = {}
+        self._rolled_back_entries: Dict[int, StepJournalEntry] = {}
+
+    @property
+    def open_step_ids(self) -> Tuple[int, ...]:
+        """Step IDs with open journal entries."""
+        return tuple(sorted(self._open_entries))
+
+    @property
+    def open_entry_count(self) -> int:
+        """Number of open journal entries."""
+        return len(self._open_entries)
+
+    def has_open_entries(self) -> bool:
+        """Return whether any journal entry is still open."""
+        return bool(self._open_entries)
+
+    def begin_step_journal(
+        self,
+        step_id,
+        *,
+        snapshot_slot_id: int = 0,
+        request_slots_before: Optional[Sequence[int]] = None,
+        active_request_ids: Optional[Sequence[Any]] = None,
+    ) -> StepJournalEntry:
+        """Open a journal entry for one dynamic step."""
+        step_value = _step_id_value(step_id)
+        if step_value in self._open_entries:
+            raise RuntimeError(f"Step journal entry {step_value} is already open")
+        if step_value in self._committed_entries or step_value in self._rolled_back_entries:
+            raise RuntimeError(f"Step journal entry {step_value} is already terminal")
+
+        entry = _MutableStepJournalEntry(
+            step_id=step_value,
+            snapshot_slot_id=int(snapshot_slot_id),
+            request_slots_before=_int_tuple(request_slots_before),
+            active_request_ids=_str_tuple(active_request_ids),
+        )
+        self._open_entries[step_value] = entry
+        return entry.freeze()
+
+    def record_placeholder_delta(
+        self, step_id, request_id: Any, token_count_delta: int
+    ) -> StepJournalEntry:
+        """Record placeholder-token accounting for a request."""
+        entry = self._require_open_entry(step_id)
+        request_key = str(request_id)
+        new_count = entry.placeholder_token_counts.get(request_key, 0) + int(token_count_delta)
+        if new_count == 0:
+            entry.placeholder_token_counts.pop(request_key, None)
+        else:
+            entry.placeholder_token_counts[request_key] = new_count
+        return entry.freeze()
+
+    def record_resource_reservation(self, step_id, reservation) -> StepJournalEntry:
+        """Record resources reserved for the step."""
+        entry = self._require_open_entry(step_id)
+        entry.resources_waiting_on_snapshot.append(reservation)
+        entry.reserved_kv_blocks.extend(
+            int(block_id) for block_id in getattr(reservation, "kv_block_ids", ())
+        )
+        entry.reserved_mamba_slots.extend(
+            int(slot_id) for slot_id in getattr(reservation, "mamba_slot_ids", ())
+        )
+        for key, delta in getattr(reservation, "prefix_cache_refcount_deltas", {}).items():
+            entry.prefix_cache_refcount_deltas[key] = (
+                entry.prefix_cache_refcount_deltas.get(key, 0) + int(delta)
+            )
+        return entry.freeze()
+
+    def record_snapshot_slot(
+        self,
+        step_id,
+        snapshot_slot_id: int,
+        *,
+        cuda_graph_batch_dimensions: Optional[Any] = None,
+    ) -> StepJournalEntry:
+        """Record the snapshot slot bound to this step."""
+        entry = self._require_open_entry(step_id)
+        entry.snapshot_slot_id = int(snapshot_slot_id)
+        if cuda_graph_batch_dimensions is not None:
+            entry.cuda_graph_batch_dimensions = cuda_graph_batch_dimensions
+        return entry.freeze()
+
+    def record_request_slot_transition(
+        self,
+        step_id,
+        *,
+        request_slots_before: Optional[Sequence[int]] = None,
+        request_slots_after: Optional[Sequence[int]] = None,
+        active_request_ids: Optional[Sequence[Any]] = None,
+        pause_resume_evictions: Optional[Sequence[Any]] = None,
+        decode_input_destination_indices: Optional[Sequence[int]] = None,
+    ) -> StepJournalEntry:
+        """Record request-slot movement for this step."""
+        entry = self._require_open_entry(step_id)
+        if request_slots_before is not None:
+            entry.request_slots_before = _int_tuple(request_slots_before)
+        if request_slots_after is not None:
+            entry.request_slots_after = _int_tuple(request_slots_after)
+        if active_request_ids is not None:
+            entry.active_request_ids = _str_tuple(active_request_ids)
+        if pause_resume_evictions is not None:
+            entry.pause_resume_evictions = list(_str_tuple(pause_resume_evictions))
+        if decode_input_destination_indices is not None:
+            entry.decode_input_destination_indices = _int_tuple(
+                decode_input_destination_indices
+            )
+        return entry.freeze()
+
+    def commit_step_journal(
+        self,
+        step_id,
+        *,
+        request_slots_after: Optional[Sequence[int]] = None,
+        active_request_ids: Optional[Sequence[Any]] = None,
+    ) -> StepJournalEntry:
+        """Commit an open journal entry."""
+        step_value = _step_id_value(step_id)
+        entry = self._open_entries.pop(step_value)
+        if request_slots_after is not None:
+            entry.request_slots_after = _int_tuple(request_slots_after)
+        if active_request_ids is not None:
+            entry.active_request_ids = _str_tuple(active_request_ids)
+        frozen_entry = entry.freeze()
+        self._committed_entries[step_value] = frozen_entry
+        return frozen_entry
+
+    def rollback_step_journal(
+        self, step_id, *, reason: Optional[str] = None
+    ) -> StepJournalEntry:
+        """Roll back an open journal entry."""
+        del reason
+        step_value = _step_id_value(step_id)
+        entry = self._open_entries.pop(step_value)
+        frozen_entry = entry.freeze()
+        self._rolled_back_entries[step_value] = frozen_entry
+        return frozen_entry
+
+    def rollback_all_open(self, *, reason: Optional[str] = None) -> Tuple[StepJournalEntry, ...]:
+        """Roll back every open entry in step order."""
+        return tuple(
+            self.rollback_step_journal(step_id, reason=reason) for step_id in self.open_step_ids
+        )
+
+    def get_open_entry(self, step_id) -> Optional[StepJournalEntry]:
+        """Return an immutable view of an open entry."""
+        entry = self._open_entries.get(_step_id_value(step_id))
+        return None if entry is None else entry.freeze()
+
+    def get_committed_entry(self, step_id) -> Optional[StepJournalEntry]:
+        """Return a committed entry."""
+        return self._committed_entries.get(_step_id_value(step_id))
+
+    def get_rolled_back_entry(self, step_id) -> Optional[StepJournalEntry]:
+        """Return a rolled-back entry."""
+        return self._rolled_back_entries.get(_step_id_value(step_id))
+
+    def debug_dump_open_entries(self) -> Mapping[int, StepJournalEntry]:
+        """Return immutable open-entry views keyed by step ID."""
+        return {step_id: entry.freeze() for step_id, entry in self._open_entries.items()}
+
+    def _require_open_entry(self, step_id) -> _MutableStepJournalEntry:
+        """Return an open mutable entry or raise a targeted error."""
+        step_value = _step_id_value(step_id)
+        try:
+            return self._open_entries[step_value]
+        except KeyError as exc:
+            raise RuntimeError(f"Step journal entry {step_value} is not open") from exc

--- a/megatron/core/inference/contexts/step_journal.py
+++ b/megatron/core/inference/contexts/step_journal.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from types import MappingProxyType
 from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Tuple
 
@@ -37,6 +38,48 @@ def _freeze_mapping(value: Optional[Mapping[Any, Any]]) -> Mapping[Any, Any]:
     if value is None:
         return MappingProxyType({})
     return MappingProxyType(dict(value))
+
+
+class RollbackStatus(str, Enum):
+    """Terminal cleanup status for a journal or resource rollback."""
+
+    FULLY_RELEASED = "fully_released"
+    ALREADY_COMMITTED = "already_committed"
+    ALREADY_ROLLED_BACK = "already_rolled_back"
+    RESOURCE_ALREADY_EVICTED = "resource_already_evicted"
+    PARTIALLY_RELEASED = "partially_released"
+    DEFERRED_UNTIL_SNAPSHOT_RETIRED = "deferred_until_snapshot_retired"
+
+
+@dataclass(frozen=True, kw_only=True)
+class RollbackResult:
+    """Result returned by an idempotent dynamic-step rollback."""
+
+    step_id: int
+    status: RollbackStatus
+    entry: Optional["StepJournalEntry"] = None
+    reason: Optional[str] = None
+    resource_statuses: Sequence[RollbackStatus] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.step_id < 0:
+            raise ValueError(f"step_id must be >= 0, got {self.step_id}")
+        object.__setattr__(self, "status", RollbackStatus(self.status))
+        object.__setattr__(
+            self,
+            "resource_statuses",
+            tuple(RollbackStatus(status) for status in self.resource_statuses),
+        )
+
+    def with_resource_statuses(self, statuses: Sequence[RollbackStatus]) -> "RollbackResult":
+        """Return a copy with allocator rollback statuses attached."""
+        return RollbackResult(
+            step_id=self.step_id,
+            status=self.status,
+            entry=self.entry,
+            reason=self.reason,
+            resource_statuses=statuses,
+        )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -341,18 +384,36 @@ class StepJournal:
         self._committed_entries[step_value] = frozen_entry
         return frozen_entry
 
-    def rollback_step_journal(
-        self, step_id, *, reason: Optional[str] = None
-    ) -> StepJournalEntry:
-        """Roll back an open journal entry."""
-        del reason
+    def rollback_step_journal(self, step_id, *, reason: Optional[str] = None) -> RollbackResult:
+        """Roll back an open journal entry, idempotently."""
         step_value = _step_id_value(step_id)
-        entry = self._open_entries.pop(step_value)
-        frozen_entry = entry.freeze()
-        self._rolled_back_entries[step_value] = frozen_entry
-        return frozen_entry
+        entry = self._open_entries.pop(step_value, None)
+        if entry is not None:
+            frozen_entry = entry.freeze()
+            self._rolled_back_entries[step_value] = frozen_entry
+            return RollbackResult(
+                step_id=step_value,
+                status=RollbackStatus.FULLY_RELEASED,
+                entry=frozen_entry,
+                reason=reason,
+            )
+        committed_entry = self._committed_entries.get(step_value)
+        if committed_entry is not None:
+            return RollbackResult(
+                step_id=step_value,
+                status=RollbackStatus.ALREADY_COMMITTED,
+                entry=committed_entry,
+                reason=reason,
+            )
+        rolled_back_entry = self._rolled_back_entries.get(step_value)
+        return RollbackResult(
+            step_id=step_value,
+            status=RollbackStatus.ALREADY_ROLLED_BACK,
+            entry=rolled_back_entry,
+            reason=reason,
+        )
 
-    def rollback_all_open(self, *, reason: Optional[str] = None) -> Tuple[StepJournalEntry, ...]:
+    def rollback_all_open(self, *, reason: Optional[str] = None) -> Tuple[RollbackResult, ...]:
         """Roll back every open entry in step order."""
         return tuple(
             self.rollback_step_journal(step_id, reason=reason) for step_id in self.open_step_ids

--- a/megatron/core/inference/contexts/step_journal.py
+++ b/megatron/core/inference/contexts/step_journal.py
@@ -189,6 +189,11 @@ class StepJournal:
         """Return whether any journal entry is still open."""
         return bool(self._open_entries)
 
+    def has_terminal_entry(self, step_id) -> bool:
+        """Return whether a step already reached commit or rollback."""
+        step_value = _step_id_value(step_id)
+        return step_value in self._committed_entries or step_value in self._rolled_back_entries
+
     def begin_step_journal(
         self,
         step_id,

--- a/megatron/core/inference/contexts/step_journal.py
+++ b/megatron/core/inference/contexts/step_journal.py
@@ -40,6 +40,32 @@ def _freeze_mapping(value: Optional[Mapping[Any, Any]]) -> Mapping[Any, Any]:
 
 
 @dataclass(frozen=True, kw_only=True)
+class ResourceReservation:
+    """Allocator resources reserved for a scheduled step."""
+
+    step_id: int
+    request_slot: int
+    snapshot_slot_id: int = 0
+    reservation_id: int = -1
+    kv_block_ids: Sequence[int] = field(default_factory=tuple)
+    mamba_slot_ids: Sequence[int] = field(default_factory=tuple)
+    prefix_cache_refcount_deltas: Mapping[Any, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.step_id < 0:
+            raise ValueError(f"step_id must be >= 0, got {self.step_id}")
+        if self.snapshot_slot_id < 0:
+            raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+        object.__setattr__(self, "kv_block_ids", _int_tuple(self.kv_block_ids))
+        object.__setattr__(self, "mamba_slot_ids", _int_tuple(self.mamba_slot_ids))
+        object.__setattr__(
+            self,
+            "prefix_cache_refcount_deltas",
+            _freeze_mapping(self.prefix_cache_refcount_deltas),
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
 class StepJournalEntry:
     """Immutable journal record for one dynamic step."""
 

--- a/megatron/core/inference/data_parallel_inference_coordinator.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator.py
@@ -17,9 +17,7 @@ import torch
 from megatron.core.inference.config import PrefixCachingCoordinatorPolicy
 from megatron.core.inference.headers import Headers, UnknownHeaderError
 from megatron.core.inference.inference_request import compute_block_hashes_batched
-from megatron.core.inference.text_generation_controllers.text_generation_controller import (
-    TextGenerationController,
-)
+from megatron.core.utils import accepts_parameter
 
 try:
     import zmq
@@ -587,17 +585,30 @@ class DataParallelInferenceCoordinator:
                 generated tokens to be detokenized. It is modified in place.
         """
         if finished_request["prompt"] is None:
-            finished_request["prompt"] = TextGenerationController.detokenize(
+            finished_request["prompt"] = self._detokenize(
                 self.tokenizer, finished_request["prompt_tokens"][1], remove_EOD=False
             )
         detokenize_stop_sequence = (finished_request.get("sampling_params", {}) or {}).get(
             "detokenize_stop_sequence", False
         )
-        finished_request["generated_text"] = TextGenerationController.detokenize(
+        finished_request["generated_text"] = self._detokenize(
             self.tokenizer,
             finished_request["generated_tokens"],
             remove_EOD=not detokenize_stop_sequence,
         )
+
+    @staticmethod
+    def _detokenize(
+        tokenizer, tokens: list[int], remove_EOD: bool = True, skip_special_tokens: bool = True
+    ) -> str:
+        """Detokenize without importing the full text generation controller."""
+        if remove_EOD and getattr(tokenizer, "eod", None) is not None:
+            while tokens and tokens[-1] == tokenizer.eod:
+                tokens = tokens[:-1]
+
+        if accepts_parameter(tokenizer.detokenize, "skip_special_tokens"):
+            return tokenizer.detokenize(tokens, skip_special_tokens=skip_special_tokens)
+        return tokenizer.detokenize(tokens)
 
     @classmethod
     def entrypoint(

--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -131,6 +131,45 @@ class AsyncZMQCommunicator:
                 except zmq.Again:
                     await asyncio.sleep(0.001)
 
+    def sync_all_reduce_max(self, *local_vals: int) -> int | tuple[int, ...]:
+        """Synchronous (non-asyncio) variant of all_reduce_max.
+
+        Uses blocking ZMQ sends/recvs so it can be called from synchronous
+        call sites that need a CPU-only MAX reduction across the process
+        group. Intended for tiny payloads (e.g. a few integers) that would
+        otherwise force a NCCL AllReduce kernel on the compute stream.
+
+        Note: when called from inside a running asyncio event loop, the
+        blocking recv will pause other coroutines on this rank until all
+        peers respond. This is acceptable here because every rank reaches
+        the call simultaneously and the message size is trivial.
+
+        Returns a single int when called with one argument, otherwise a tuple.
+        """
+        n = len(local_vals)
+        if n == 0:
+            raise ValueError("sync_all_reduce_max requires at least one value")
+
+        if self.world_size <= 1:
+            return local_vals[0] if n == 1 else local_vals
+
+        fmt = f'!{n}i'
+        payload = struct.pack(fmt, *local_vals)
+
+        if self.is_leader:
+            rows = [local_vals]
+            while len(rows) < self.world_size:
+                msg = self.gather_sock.recv()
+                rows.append(struct.unpack(fmt, msg))
+            maxes = tuple(max(row[i] for row in rows) for i in range(n))
+            self.bcast_sock.send(struct.pack(fmt, *maxes))
+            return maxes[0] if n == 1 else maxes
+        else:
+            self.gather_sock.send(payload)
+            msg = self.bcast_sock.recv()
+            result = struct.unpack(fmt, msg)
+            return result[0] if n == 1 else result
+
     def close(self):
         """
         Close the ZMQ sockets.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -251,10 +251,10 @@ class DynamicInferenceEngine(AbstractEngine):
         )
         self.async_overlap_queue_depth = inference_config.async_overlap_queue_depth
         self.async_overlap_debug_checks = inference_config.async_overlap_debug_checks
-        if self.enable_async_overlap_architecture and self.async_overlap_queue_depth != 1:
+        if self.enable_async_overlap_architecture and self.async_overlap_queue_depth > 2:
             raise ValueError(
-                "async_overlap_queue_depth > 1 is not available until the "
-                "queue-depth-two async-overlap pipeline commit"
+                "async_overlap_queue_depth > 2 is not available until wider async-overlap "
+                "pipeline depths are validated"
             )
         self.cuda_graph_impl = model_config.cuda_graph_impl
         self.cuda_graph_scope = model_config.cuda_graph_scope
@@ -948,7 +948,73 @@ class DynamicInferenceEngine(AbstractEngine):
 
     def has_unfinished_requests(self) -> bool:
         """Test if context contains unfinished requests."""
-        return self.context.has_unfinished_requests() or len(self.waiting_request_ids) > 0
+        return (
+            self.context.has_unfinished_requests()
+            or len(self.waiting_request_ids) > 0
+            or self.has_async_overlap_pending_work()
+        )
+
+    def has_async_overlap_pending_work(self) -> bool:
+        """Return whether the async-overlap pipeline has work left to retire."""
+        if not hasattr(self, "async_pipeline"):
+            return False
+        return (
+            self.async_pipeline.pending_launch_count > 0
+            or self.step_retirement_service.pending_count > 0
+        )
+
+    def has_async_overlap_launch_work(self) -> bool:
+        """Return whether another real dynamic step can be launched."""
+        if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING, EngineState.STOPPED):
+            return False
+        return self.context.get_active_request_count() > 0 or len(self.waiting_request_ids) > 0
+
+    def can_launch_async_overlap_lookahead(self) -> bool:
+        """Return whether queue-depth-two lookahead is safe for the current step."""
+        if not self.enable_async_overlap_architecture or self.async_overlap_queue_depth < 2:
+            return False
+        reason = self._async_overlap_lookahead_blocker()
+        if reason is not None:
+            self.async_overlap_debug_counters.fallback_or_queue_depth_one_reasons[reason] = (
+                self.async_overlap_debug_counters.fallback_or_queue_depth_one_reasons.get(
+                    reason, 0
+                )
+                + 1
+            )
+            return False
+        return True
+
+    def _async_overlap_lookahead_blocker(self) -> Optional[str]:
+        """Return the conservative queue-depth-two blocker, or None if eligible."""
+        if self.context.get_active_request_count() <= 0:
+            return "no_active_requests"
+        if len(self.waiting_request_ids) > 0:
+            return "waiting_requests"
+        if self.use_coordinator:
+            return "coordinator"
+        if self.controller.model_is_pipeline_parallel:
+            return "pipeline_parallel"
+        if getattr(self, "ep_world_size", 1) > 1:
+            return "expert_parallel"
+        if self.num_speculative_tokens > 0:
+            return "speculative"
+        if self.context.is_hybrid_model:
+            return "hybrid_mamba"
+        if self.enable_chunked_prefill or self.context.get_index_of_chunked_prefill_request(
+            safe=False
+        ) != -1:
+            return "chunked_prefill"
+        if not self.context.is_async_overlap_steady_state_decode_ready():
+            return "not_steady_state_decode"
+        active_slice = slice(self.context.paused_request_count, self.context.total_request_count)
+        for request_id in self.context.request_ids[active_slice].tolist():
+            request = self.get_request(int(request_id))
+            sampling_params = request.sampling_params
+            if request.stop_word_ids:
+                return "stop_words"
+            if sampling_params.return_log_probs or sampling_params.top_n_logprobs > 0:
+                return "logprobs"
+        return None
 
     def get_request(self, request_id: int) -> DynamicInferenceRequest:
         """Get most recent request from a request record.
@@ -2136,6 +2202,7 @@ class DynamicInferenceEngine(AbstractEngine):
                             and (
                                 self.context.get_active_request_count() > 0
                                 or self.waiting_request_ids
+                                or self.has_async_overlap_pending_work()
                             )
                         )
                     )
@@ -2233,7 +2300,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 if self.state in (EngineState.RUNNING, EngineState.PAUSING):
                     local_pending = self.context.get_active_request_count() + len(
                         self.waiting_request_ids
-                    )
+                    ) + int(self.has_async_overlap_pending_work())
                     global_work, all_pausing = await self._ep_establish_consensus(
                         local_pending, signal_consensus=(self.state == EngineState.PAUSING)
                     )

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -11,7 +11,7 @@ import time
 import warnings
 from collections import deque
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
 from itertools import repeat
@@ -150,6 +150,20 @@ class RequestEntry:
 
     record: DynamicInferenceRequestRecord
     future: asyncio.Future
+
+
+@dataclass
+class AsyncOverlapDebugCounters:
+    """Debug counters used by the async-overlap rollout path."""
+
+    queue_depth: int = 1
+    snapshot_slot_waits: int = 0
+    output_event_waits: int = 0
+    fallback_or_queue_depth_one_reasons: Dict[str, int] = field(default_factory=dict)
+    discarded_lookahead_tokens: int = 0
+    placeholder_count: int = 0
+    reservation_commits: int = 0
+    reservation_rollbacks: int = 0
 
 
 # pylint: disable=line-too-long
@@ -307,9 +321,26 @@ class DynamicInferenceEngine(AbstractEngine):
         self._prefix_cache_hits = 0
         self._prefix_cache_blocks_matched = 0
         self._prefix_coordination_waits = 0
+        self._next_dynamic_step_id = 0
+        self._current_dynamic_step_id = -1
+        self.async_overlap_debug_counters = AsyncOverlapDebugCounters()
 
         # Coordinator state.
         self.use_coordinator = False
+
+    def _step_nvtx_label(self, name: str, step_id: Optional[int] = None) -> str:
+        """Return an NVTX range name with a dynamic step id."""
+        if step_id is None:
+            step_id = self._current_dynamic_step_id
+        return f"{name}[step={step_id}]"
+
+    def _begin_dynamic_step(self) -> int:
+        """Allocate and publish the next monotonic dynamic step id."""
+        step_id = self._next_dynamic_step_id
+        self._next_dynamic_step_id += 1
+        self._current_dynamic_step_id = step_id
+        self.context.set_current_dynamic_step_id(step_id)
+        return step_id
 
     async def wait_until(self, state: EngineState):
         """Wait until the engine reaches the given state.
@@ -1651,8 +1682,13 @@ class DynamicInferenceEngine(AbstractEngine):
         if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
             raise EngineSuspendedError(self.context.step_count)
 
+        step_id = self._begin_dynamic_step()
+
         # schedule requests
+        scheduling_range = self._step_nvtx_label("scheduling", step_id)
+        nvtx_range_push(scheduling_range)
         self.schedule_waiting_requests()
+        nvtx_range_pop(scheduling_range)
 
         # The print block (async_bookkeep) and metrics block both fire on this
         # condition after step_count is incremented. Predict it up-front so we
@@ -1672,6 +1708,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 "paused_request_count": self.context.paused_request_count,
                 "active_token_count": self.context.active_token_count,
                 "step_count": self.context.step_count,
+                "dynamic_step_id": step_id,
             }
         else:
             # active_token_count and step_count are still consumed by
@@ -1680,10 +1717,14 @@ class DynamicInferenceEngine(AbstractEngine):
             pre_step_context_state = {
                 "active_token_count": self.context.active_token_count,
                 "step_count": self.context.step_count,
+                "dynamic_step_id": step_id,
             }
 
         # Generate tokens.
-        nvtx_range_push("Prefill" if not is_decode_only else "Decode")
+        step_type_range = self._step_nvtx_label(
+            "Prefill" if not is_decode_only else "Decode", step_id
+        )
+        nvtx_range_push(step_type_range)
         # TODO @TDE: Account for this line when overlapping forward and bookkeep.
         self.is_decode_only = is_decode_only
 
@@ -1699,7 +1740,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self.context.step_count += 1
         self.context.prefix_cache_lru_clock += 1
 
-        nvtx_range_pop("Prefill" if not is_decode_only else "Decode")
+        nvtx_range_pop(step_type_range)
 
         if will_log_this_step:
             kvcache_util_stats = (
@@ -1743,7 +1784,9 @@ class DynamicInferenceEngine(AbstractEngine):
                 cuda_graph_request_count (int): The CUDA graph batch size matching this step.
         """
         # Increment finished_request_count.
-        nvtx_range_push("bookkeeping")
+        step_id = context_state.get("dynamic_step_id", self._current_dynamic_step_id)
+        output_retirement_range = self._step_nvtx_label("output_retirement", step_id)
+        nvtx_range_push(output_retirement_range)
         cuda_graph_request_count = None
 
         if step_result is not None:
@@ -1764,6 +1807,8 @@ class DynamicInferenceEngine(AbstractEngine):
                 [self.get_request(i).add_event_pause() for i in newly_paused_request_ids]
 
             # Process finished requests (adds FINISH events and returns records).
+            post_process_range = self._step_nvtx_label("post_process_requests", step_id)
+            nvtx_range_push(post_process_range)
             (active_request_ids, finished_request_records) = self.post_process_requests(
                 active_request_ids,
                 finished_request_ids,
@@ -1777,6 +1822,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 pre_fwd_active_token_count=context_state.get("active_token_count"),
                 pre_fwd_step_count=context_state.get("step_count"),
             )
+            nvtx_range_pop(post_process_range)
 
         else:
             active_request_ids: list[int] = []
@@ -1792,13 +1838,14 @@ class DynamicInferenceEngine(AbstractEngine):
             ), f"Failed request {failed_request_id} future has not been properly resolved."
         self.failed_request_ids.clear()
 
-        nvtx_range_pop("bookkeeping")
+        nvtx_range_pop(output_retirement_range)
 
         # Detokenize all finished requests if not using
         # the coordinator. Otherwise, the coordinator will
         # overlap detokenization with the engine.
         if not self.use_coordinator:
-            nvtx_range_push("detokenization")
+            detokenization_range = self._step_nvtx_label("detokenization", step_id)
+            nvtx_range_push(detokenization_range)
             for record in finished_request_records:
                 for request in record.requests:
                     if request.prompt is None:
@@ -1812,7 +1859,7 @@ class DynamicInferenceEngine(AbstractEngine):
                         request.generated_tokens,
                         remove_EOD=not request.sampling_params.detokenize_stop_sequence,
                     )
-            nvtx_range_pop("detokenization")
+            nvtx_range_pop(detokenization_range)
 
         # Handle necessary ZMQ DP coordinator communication.
         # Failed request replies were already sent in _handle_failed_request,
@@ -1822,13 +1869,14 @@ class DynamicInferenceEngine(AbstractEngine):
                 r for r in finished_request_records if r.requests[-1].status != Status.FAILED
             ]
             if records_to_send:
-                nvtx_range_push("coordinator_communication")
+                coordinator_range = self._step_nvtx_label("coordinator_send", step_id)
+                nvtx_range_push(coordinator_range)
                 payload = msgpack.packb(
                     [Headers.ENGINE_REPLY.value, [r.merge().serialize() for r in records_to_send]],
                     use_bin_type=True,
                 )
                 self.socket_for_receiving_requests.send(payload)
-                nvtx_range_pop("coordinator_communication")
+                nvtx_range_pop(coordinator_range)
 
         # Drain prefix cache hit counters from context into engine accumulators.
         if self.context.enable_prefix_caching:
@@ -2068,7 +2116,8 @@ class DynamicInferenceEngine(AbstractEngine):
             int: The number of messages that were received and processed in this batch.
         """
 
-        nvtx_range_push("drain_zmq_socket")
+        drain_range = self._step_nvtx_label("event_polling.drain_zmq_socket")
+        nvtx_range_push(drain_range)
         all_messages = []
         if self.is_mp_coordinator:
             while True:
@@ -2101,7 +2150,7 @@ class DynamicInferenceEngine(AbstractEngine):
             else:
                 all_messages = []
 
-        nvtx_range_pop("drain_zmq_socket")
+        nvtx_range_pop(drain_range)
 
         # First pass: add requests.
         # Control signals are queued for the second pass.
@@ -2112,9 +2161,10 @@ class DynamicInferenceEngine(AbstractEngine):
             if header == Headers.SUBMIT_REQUEST:
                 request_id, prompt, sampling_params = data[1:]
                 sampling_params = SamplingParams.deserialize(sampling_params)
-                nvtx_range_push("add_request")
+                add_request_range = self._step_nvtx_label("scheduling.add_request")
+                nvtx_range_push(add_request_range)
                 self.add_request(request_id, prompt, sampling_params)
-                nvtx_range_pop("add_request")
+                nvtx_range_pop(add_request_range)
             elif header == Headers.SET_GENERATION_EPOCH:
                 new_generation_epoch = data[1]
             else:
@@ -2258,7 +2308,8 @@ class DynamicInferenceEngine(AbstractEngine):
             (global_work, all_pausing): max work across EP, and whether
             all peers signaled consensus.
         """
-        nvtx_range_push("_ep_establish_consensus")
+        consensus_range = self._step_nvtx_label("event_polling.ep_consensus")
+        nvtx_range_push(consensus_range)
 
         consensus_val = -1 if signal_consensus else 0
 
@@ -2283,7 +2334,7 @@ class DynamicInferenceEngine(AbstractEngine):
         else:
             global_work, global_consensus = local_work, consensus_val
 
-        nvtx_range_pop("_ep_establish_consensus")
+        nvtx_range_pop(consensus_range)
         return global_work, global_consensus == -1
 
     async def _world_barrier(self):
@@ -2295,12 +2346,13 @@ class DynamicInferenceEngine(AbstractEngine):
 
         No-op when world_size == 1 (communicator is not created).
         """
-        nvtx_range_push("world_barrier")
+        barrier_range = self._step_nvtx_label("event_polling.world_barrier")
+        nvtx_range_push(barrier_range)
         if hasattr(self, 'world_zmq_communicator'):
             await self.world_zmq_communicator.all_reduce_max(
                 1, async_op=(not self.use_synchronous_zmq_collectives)
             )
-        nvtx_range_pop("world_barrier")
+        nvtx_range_pop(barrier_range)
 
     @trace_async_exceptions
     async def run_engine_with_coordinator(

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -30,7 +30,11 @@ from megatron.core.inference.data_parallel_inference_coordinator import (
     DataParallelInferenceCoordinator,
 )
 from megatron.core.inference.engines.abstract_engine import AbstractEngine
-from megatron.core.inference.engines.dynamic_step import DynamicStepId, SnapshotSlotHandle
+from megatron.core.inference.engines.dynamic_step import (
+    DynamicAsyncPipeline,
+    DynamicStepId,
+    SnapshotSlotHandle,
+)
 from megatron.core.inference.headers import Headers, UnknownHeaderError
 from megatron.core.inference.inference_request import (
     DynamicInferenceEvent,
@@ -340,6 +344,11 @@ class DynamicInferenceEngine(AbstractEngine):
             queue_depth=getattr(self, "async_overlap_queue_depth", 1)
         )
         self.step_retirement_service = StepRetirementService(self)
+        self.async_pipeline = DynamicAsyncPipeline(
+            engine=self,
+            retirement_service=self.step_retirement_service,
+            queue_depth=self.async_overlap_queue_depth,
+        )
 
         # Coordinator state.
         self.use_coordinator = False
@@ -784,7 +793,7 @@ class DynamicInferenceEngine(AbstractEngine):
         if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
             return
 
-        self.step_retirement_service.drain_for_suspend()
+        self.async_pipeline.drain_for_suspend()
 
         # Deallocate context tensors.
         with self.__class__.suspend_resume_ctx(
@@ -957,7 +966,7 @@ class DynamicInferenceEngine(AbstractEngine):
     ) -> asyncio.Future[DynamicInferenceRequest]:
 
         request_id = request.request_id
-        self.step_retirement_service.drain_for_request_reuse(request_id)
+        self.async_pipeline.drain_for_request_reuse(request_id)
 
         # Add request to self.requests. If the engine has previously been
         # suspended, then the request may already exist.
@@ -1856,17 +1865,12 @@ class DynamicInferenceEngine(AbstractEngine):
                 2. Requests that ran in the last step and have now finished.
                 3. The step time in seconds.
         """
-        if self.enable_async_overlap_architecture and self.async_overlap_queue_depth == 1:
-            # TODO(async-overlap commit 23): route queue-depth-one through the
-            # new DynamicAsyncPipeline once its phase contract exists. Until
-            # then this rollout flag is configuration plumbing only.
-            reasons = self.async_overlap_debug_counters.fallback_or_queue_depth_one_reasons
-            reasons["queue_depth_one_debug_mode_pending_pipeline"] = (
-                reasons.get("queue_depth_one_debug_mode_pending_pipeline", 0) + 1
-            )
         try:
-            last_step_data = await self.async_forward()
-            ret = await self.async_bookkeep(*last_step_data)
+            if self.enable_async_overlap_architecture:
+                ret = await self.async_pipeline.step()
+            else:
+                last_step_data = await self.async_forward()
+                ret = await self.async_bookkeep(*last_step_data)
         except BaseException:
             self.context.rollback_step_journal(
                 self._current_dynamic_step_id, reason="async_step_exception"
@@ -2089,7 +2093,7 @@ class DynamicInferenceEngine(AbstractEngine):
         Called from the engine loop's finally block after the loop exits.
         """
         self.state = EngineState.STOPPED
-        self.step_retirement_service.drain_for_shutdown()
+        self.async_pipeline.drain_for_shutdown()
 
         # Cleanup the request futures.
         for entry in self.requests.values():

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1164,10 +1164,15 @@ class DynamicInferenceEngine(AbstractEngine):
                         request.ttft = (
                             first_token_event.timestamp - request.event_add_engine.timestamp
                         )
-                    if request.tpot is None:
-                        request.tpot = []
-                    per_token_step_time = step_time / len(tokens)
-                    request.tpot.extend([per_token_step_time] * len(tokens))
+                    # TPOT is observability-only. step_time is 0.0 on
+                    # non-logging steps (async_forward skips the event sync),
+                    # so gate the update to keep the metric a truthful sparse
+                    # sample instead of polluting it with zeros.
+                    if step_time > 0:
+                        if request.tpot is None:
+                            request.tpot = []
+                        per_token_step_time = step_time / len(tokens)
+                        request.tpot.extend([per_token_step_time] * len(tokens))
 
                 # Check for stop words (after token is appended).
                 # With speculative decoding, a stop word may end before the last
@@ -1649,56 +1654,74 @@ class DynamicInferenceEngine(AbstractEngine):
         # schedule requests
         self.schedule_waiting_requests()
 
-        # Saving pre-step state, for printing output below.
+        # The print block (async_bookkeep) and metrics block both fire on this
+        # condition after step_count is incremented. Predict it up-front so we
+        # can skip the GPU-timing sync and the context_state dict builds that
+        # only exist to feed those logging/metrics blocks.
+        will_log_this_step = (
+            self.logging_step_interval > 0
+            and (self.context.step_count + 1) % self.logging_step_interval == 0
+        )
+
         is_decode_only = self.context.is_decode_only()
-        pre_step_context_state = {
-            "is_decode_only": is_decode_only,
-            "max_requests": self.context.max_requests,
-            "total_request_count": self.context.total_request_count,
-            "paused_request_count": self.context.paused_request_count,
-            "active_token_count": self.context.active_token_count,
-            "step_count": self.context.step_count,
-        }
+        if will_log_this_step:
+            pre_step_context_state = {
+                "is_decode_only": is_decode_only,
+                "max_requests": self.context.max_requests,
+                "total_request_count": self.context.total_request_count,
+                "paused_request_count": self.context.paused_request_count,
+                "active_token_count": self.context.active_token_count,
+                "step_count": self.context.step_count,
+            }
+        else:
+            # active_token_count and step_count are still consumed by
+            # post_process_requests' pre_fwd_* args (for add_event_generated_token);
+            # the other four fields are only read in the gated print block.
+            pre_step_context_state = {
+                "active_token_count": self.context.active_token_count,
+                "step_count": self.context.step_count,
+            }
 
         # Generate tokens.
         nvtx_range_push("Prefill" if not is_decode_only else "Decode")
         # TODO @TDE: Account for this line when overlapping forward and bookkeep.
         self.is_decode_only = is_decode_only
 
-        self.step_start_event.record()
+        if will_log_this_step:
+            self.step_start_event.record()
         result = await self.controller.async_generate_output_tokens_dynamic_batch()
-        self.step_end_event.record()
-        self.step_end_event.synchronize()
-        step_time = self.step_start_event.elapsed_time(self.step_end_event) / 1e3
+        if will_log_this_step:
+            self.step_end_event.record()
+            self.step_end_event.synchronize()
+            step_time = self.step_start_event.elapsed_time(self.step_end_event) / 1e3
+        else:
+            step_time = 0.0
         self.context.step_count += 1
         self.context.prefix_cache_lru_clock += 1
 
         nvtx_range_pop("Prefill" if not is_decode_only else "Decode")
 
-        if (
-            self.logging_step_interval > 0
-            and self.context.step_count > 0
-            and self.context.step_count % self.logging_step_interval == 0
-            and self.metrics_writer is not None
-        ):
-            kvcache_util_stats = self.context.get_kvcache_utilization_stats()
+        if will_log_this_step:
+            kvcache_util_stats = (
+                self.context.get_kvcache_utilization_stats()
+                if self.metrics_writer is not None
+                else None
+            )
+            post_step_context_state = {
+                "waiting_request_count": len(self.waiting_request_ids),
+                "finished_request_count": self.finished_request_count,
+                "evicted_request_count": self.evicted_request_count,
+                "kv_stats": kvcache_util_stats,
+                "total_active_block_count": self.context.kv_block_allocator.active_count,
+                "total_paused_block_count": self.context.kv_block_allocator.paused_count,
+                "total_active_used_blocks": self.context.kv_block_allocator.get_active_used(),
+                "total_paused_used_blocks": self.context.kv_block_allocator.get_paused_used(),
+            }
+            context_state = {**pre_step_context_state, **post_step_context_state}
         else:
-            kvcache_util_stats = None
-
-        post_step_context_state = {
-            "waiting_request_count": len(self.waiting_request_ids),
-            "finished_request_count": self.finished_request_count,
-            "evicted_request_count": self.evicted_request_count,
-            "kv_stats": kvcache_util_stats,
-            "padded_active_token_count": self.context.padded_active_token_count,
-            "using_cuda_graph_this_step": self.context.using_cuda_graph_this_step(),
-            "total_active_block_count": self.context.kv_block_allocator.active_count,
-            "total_paused_block_count": self.context.kv_block_allocator.paused_count,
-            "total_active_used_blocks": self.context.kv_block_allocator.get_active_used(),
-            "total_paused_used_blocks": self.context.kv_block_allocator.get_paused_used(),
-        }
-
-        context_state = {**pre_step_context_state, **post_step_context_state}
+            # Keep kv_stats=None so the metrics-block gate at `async_bookkeep`
+            # (`if context_state["kv_stats"] is not None`) remains well-typed.
+            context_state = {**pre_step_context_state, "kv_stats": None}
 
         return result, context_state, step_time
 

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -239,6 +239,16 @@ class DynamicInferenceEngine(AbstractEngine):
         self.logging_step_interval = inference_config.logging_step_interval
         self.unified_memory_level = inference_config.unified_memory_level
         self.use_synchronous_zmq_collectives = inference_config.use_synchronous_zmq_collectives
+        self.enable_async_overlap_architecture = (
+            inference_config.enable_async_overlap_architecture
+        )
+        self.async_overlap_queue_depth = inference_config.async_overlap_queue_depth
+        self.async_overlap_debug_checks = inference_config.async_overlap_debug_checks
+        if self.enable_async_overlap_architecture and self.async_overlap_queue_depth != 1:
+            raise ValueError(
+                "async_overlap_queue_depth > 1 is not available until the "
+                "queue-depth-two async-overlap pipeline commit"
+            )
         self.cuda_graph_impl = model_config.cuda_graph_impl
         self.cuda_graph_scope = model_config.cuda_graph_scope
         # Initialize engine.
@@ -323,7 +333,9 @@ class DynamicInferenceEngine(AbstractEngine):
         self._prefix_coordination_waits = 0
         self._next_dynamic_step_id = 0
         self._current_dynamic_step_id = -1
-        self.async_overlap_debug_counters = AsyncOverlapDebugCounters()
+        self.async_overlap_debug_counters = AsyncOverlapDebugCounters(
+            queue_depth=getattr(self, "async_overlap_queue_depth", 1)
+        )
 
         # Coordinator state.
         self.use_coordinator = False
@@ -2019,6 +2031,14 @@ class DynamicInferenceEngine(AbstractEngine):
                 2. Requests that ran in the last step and have now finished.
                 3. The step time in seconds.
         """
+        if self.enable_async_overlap_architecture and self.async_overlap_queue_depth == 1:
+            # TODO(async-overlap commit 23): route queue-depth-one through the
+            # new DynamicAsyncPipeline once its phase contract exists. Until
+            # then this rollout flag is configuration plumbing only.
+            reasons = self.async_overlap_debug_counters.fallback_or_queue_depth_one_reasons
+            reasons["queue_depth_one_debug_mode_pending_pipeline"] = (
+                reasons.get("queue_depth_one_debug_mode_pending_pipeline", 0) + 1
+            )
         last_step_data = await self.async_forward()
         ret = await self.async_bookkeep(*last_step_data)
         # Keep for compatibility with current test suite.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -12,7 +12,6 @@ import warnings
 from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime
 from enum import Enum, auto
 from itertools import repeat
 from typing import Dict, List, Optional, Tuple, Union
@@ -67,6 +66,7 @@ from megatron.core.utils import (
 )
 
 from .async_zmq_communicator import AsyncZMQCommunicator
+from .step_retirement import StepRetirementService
 
 try:
     from tqdm import tqdm
@@ -336,6 +336,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self.async_overlap_debug_counters = AsyncOverlapDebugCounters(
             queue_depth=getattr(self, "async_overlap_queue_depth", 1)
         )
+        self.step_retirement_service = StepRetirementService(self)
 
         # Coordinator state.
         self.use_coordinator = False
@@ -748,6 +749,8 @@ class DynamicInferenceEngine(AbstractEngine):
         if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
             return
 
+        self.step_retirement_service.drain_for_suspend()
+
         # Deallocate context tensors.
         with self.__class__.suspend_resume_ctx(
             "suspended", unified_memory_level=self.unified_memory_level
@@ -919,6 +922,7 @@ class DynamicInferenceEngine(AbstractEngine):
     ) -> asyncio.Future[DynamicInferenceRequest]:
 
         request_id = request.request_id
+        self.step_retirement_service.drain_for_request_reuse(request_id)
 
         # Add request to self.requests. If the engine has previously been
         # suspended, then the request may already exist.
@@ -1795,227 +1799,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 step_time (float): The step time in seconds.
                 cuda_graph_request_count (int): The CUDA graph batch size matching this step.
         """
-        # Increment finished_request_count.
-        step_id = context_state.get("dynamic_step_id", self._current_dynamic_step_id)
-        output_retirement_range = self._step_nvtx_label("output_retirement", step_id)
-        nvtx_range_push(output_retirement_range)
-        cuda_graph_request_count = None
-
-        if step_result is not None:
-            active_request_ids = step_result["active_request_ids"]
-            finished_request_ids = step_result["finished_request_ids"]
-            newly_paused_request_ids = step_result.get("newly_paused_request_ids")
-            evict_request_ids = step_result.get("evict_request_ids")
-            sample = step_result["sample"]
-            accepted_tokens = step_result["accepted_tokens"]
-            log_probs = step_result["log_probs"]
-            top_n_logprobs = step_result.get("top_n_logprobs", None)
-            routing_indices_per_request = step_result.get("routing_indices_per_request", None)
-            cuda_graph_request_count = step_result["cuda_graph_request_count"]
-
-            # Add paused events.
-            if newly_paused_request_ids is not None and self.track_paused_request_events:
-                newly_paused_request_ids = newly_paused_request_ids.tolist()
-                [self.get_request(i).add_event_pause() for i in newly_paused_request_ids]
-
-            # Process finished requests (adds FINISH events and returns records).
-            post_process_range = self._step_nvtx_label("post_process_requests", step_id)
-            nvtx_range_push(post_process_range)
-            (active_request_ids, finished_request_records) = self.post_process_requests(
-                active_request_ids,
-                finished_request_ids,
-                evict_request_ids,
-                step_time,
-                sample,
-                accepted_tokens,
-                log_probs,
-                top_n_logprobs,
-                routing_indices_per_request,
-                pre_fwd_active_token_count=context_state.get("active_token_count"),
-                pre_fwd_step_count=context_state.get("step_count"),
-            )
-            nvtx_range_pop(post_process_range)
-
-        else:
-            active_request_ids: list[int] = []
-            finished_request_records: list[DynamicInferenceRequestRecord] = []
-
-        # Failed requests. Status and events were already set in _handle_failed_request;
-        # here we just clean up the entry and include it in finished_request_records.
-        for failed_request_id in self.failed_request_ids:
-            failed_entry = self.requests.pop(failed_request_id)
-            finished_request_records.append(failed_entry.record)
-            assert (
-                failed_entry.future.done()
-            ), f"Failed request {failed_request_id} future has not been properly resolved."
-        self.failed_request_ids.clear()
-
-        nvtx_range_pop(output_retirement_range)
-
-        # Detokenize all finished requests if not using
-        # the coordinator. Otherwise, the coordinator will
-        # overlap detokenization with the engine.
-        if not self.use_coordinator:
-            detokenization_range = self._step_nvtx_label("detokenization", step_id)
-            nvtx_range_push(detokenization_range)
-            for record in finished_request_records:
-                for request in record.requests:
-                    if request.prompt is None:
-                        request.prompt = self.controller.detokenize(
-                            self.controller.tokenizer,
-                            request.prompt_tokens.tolist(),
-                            remove_EOD=False,
-                        )
-                    request.generated_text = self.controller.detokenize(
-                        self.controller.tokenizer,
-                        request.generated_tokens,
-                        remove_EOD=not request.sampling_params.detokenize_stop_sequence,
-                    )
-            nvtx_range_pop(detokenization_range)
-
-        # Handle necessary ZMQ DP coordinator communication.
-        # Failed request replies were already sent in _handle_failed_request,
-        # so only send completed records here.
-        if self.use_coordinator and self.is_mp_coordinator:
-            records_to_send = [
-                r for r in finished_request_records if r.requests[-1].status != Status.FAILED
-            ]
-            if records_to_send:
-                coordinator_range = self._step_nvtx_label("coordinator_send", step_id)
-                nvtx_range_push(coordinator_range)
-                payload = msgpack.packb(
-                    [Headers.ENGINE_REPLY.value, [r.merge().serialize() for r in records_to_send]],
-                    use_bin_type=True,
-                )
-                self.socket_for_receiving_requests.send(payload)
-                nvtx_range_pop(coordinator_range)
-
-        # Drain prefix cache hit counters from context into engine accumulators.
-        if self.context.enable_prefix_caching:
-            self._prefix_cache_hits += self.context.prefix_cache_hits
-            self._prefix_cache_blocks_matched += self.context.prefix_cache_blocks_matched
-            self.context.prefix_cache_hits = 0
-            self.context.prefix_cache_blocks_matched = 0
-
-        # Log KV cache utilization stats to W&B
-        if context_state["kv_stats"] is not None:
-            # Prepare metrics dictionary with all stats
-            # Use 'inference/' prefix for all metrics to separate from training metrics
-            metrics = {
-                'inference/inference_step': int(
-                    self.inference_step_offset + int(self.context.step_count)
-                ),
-                'inference/step_time_s': float(step_time),
-                'inference/waiting_queue_len': int(len(self.waiting_request_ids)),
-                'inference/total_requests_dict_size': int(len(self.requests)),
-            }
-            # Add KV stats with inference/ prefix
-            # Convert utilization metrics from 0-1 range to 0-100 percentage range for better visualization
-            for key, value in context_state["kv_stats"].items():
-                if 'utilization' in key:
-                    # Convert to percentage (0-100) and group under kvcache_utilization
-                    metrics[f'inference/{key}'] = float(value * 100.0)
-                else:
-                    metrics[f'inference/{key}'] = value
-
-            # Add speculative decoding acceptance metrics.
-            if self.num_speculative_tokens > 0 and self._spec_tokens_proposed > 0:
-                acceptance_rate = self._spec_tokens_accepted / self._spec_tokens_proposed
-                metrics['inference/spec_decode_acceptance_rate'] = float(acceptance_rate * 100.0)
-                metrics['inference/spec_decode_tokens_proposed'] = int(self._spec_tokens_proposed)
-                metrics['inference/spec_decode_tokens_accepted'] = int(self._spec_tokens_accepted)
-                metrics['inference/spec_decode_num_steps'] = int(self._spec_steps)
-
-            # Add prefix caching metrics.
-            if self.context.enable_prefix_caching and self._prefix_cache_hits > 0:
-                metrics['inference/prefix_cache_hits'] = int(self._prefix_cache_hits)
-                metrics['inference/prefix_cache_blocks_matched'] = int(
-                    self._prefix_cache_blocks_matched
-                )
-
-            if HAVE_WANDB and self.metrics_writer.__name__ == "wandb":
-                self.metrics_writer.log(metrics, commit=True)
-            else:
-                raise ValueError(f"Unsupported metrics writer type: {type(self.metrics_writer)}")
-
-        # Print context state.
-        if (
-            self.logging_step_interval > 0
-            and self.context.step_count % self.logging_step_interval == 0
-        ):
-            mem = torch.cuda.memory_stats()
-            step_type = "decode" if context_state["is_decode_only"] else "non-decode"
-            output_str = (
-                "* rank %d | step %d | %s ... time: %.3f ms%s ... "
-                "reqs: a %d/%d, p %d, w %d, f %d, e %d ... "
-                "blocks: a %d/%d, p %d/%d ... "
-                "mem: tensors %d, alloc %.1f gb, res %.1f gb."
-                % (
-                    self.rank,
-                    self.context.step_count,
-                    datetime.now().strftime("%H:%M:%S"),
-                    step_time * 1000,
-                    (
-                        " [%s + real config %s + cuda graph %s]"
-                        % (
-                            step_type,
-                            self.context.batch_dimensions,
-                            (
-                                "OFF"
-                                if not self.context.using_cuda_graph_this_step()
-                                else self.context.padded_batch_dimensions
-                            ),
-                        )
-                    ),
-                    context_state["total_request_count"] - context_state["paused_request_count"],
-                    context_state["max_requests"],
-                    context_state["paused_request_count"],
-                    context_state["waiting_request_count"],
-                    context_state["finished_request_count"],
-                    context_state["evicted_request_count"],
-                    context_state["total_active_used_blocks"],
-                    context_state["total_active_block_count"],
-                    context_state["total_paused_used_blocks"],
-                    context_state["total_paused_block_count"],
-                    mem["allocation.all.current"],
-                    mem["allocated_bytes.all.current"] / (1024**3),
-                    mem["reserved_bytes.all.current"] / (1024**3),
-                )
-            )
-            if self.num_speculative_tokens > 0 and self._spec_tokens_proposed > 0:
-                spec_rate = self._spec_tokens_accepted / self._spec_tokens_proposed * 100.0
-                output_str += " ... spec: accept %.1f%% (%d/%d in %d steps)" % (
-                    spec_rate,
-                    self._spec_tokens_accepted,
-                    self._spec_tokens_proposed,
-                    self._spec_steps,
-                )
-            if self.context.enable_prefix_caching and self._prefix_cache_hits > 0:
-                output_str += " ... prefix cache: %d hits, %d blocks matched" % (
-                    self._prefix_cache_hits,
-                    self._prefix_cache_blocks_matched,
-                )
-            if context_state["is_decode_only"]:
-                output_str = f"\033[94m{output_str}\033[0m"
-            logging.info(output_str)
-
-            # Reset speculative decoding accumulators after both wandb and console logging.
-            if self.num_speculative_tokens > 0:
-                self._spec_tokens_proposed = 0
-                self._spec_tokens_accepted = 0
-                self._spec_steps = 0
-
-            # Reset prefix caching accumulators after both wandb and console logging.
-            if self.context.enable_prefix_caching:
-                self._prefix_cache_hits = 0
-                self._prefix_cache_blocks_matched = 0
-
-        return {
-            "active_request_ids": active_request_ids,
-            "finished_request_records": finished_request_records,
-            "step_time": step_time,
-            "cuda_graph_request_count": cuda_graph_request_count,
-        }
+        return self.step_retirement_service.retire_step(step_result, context_state, step_time)
 
     async def async_step(
         self,
@@ -2258,6 +2042,7 @@ class DynamicInferenceEngine(AbstractEngine):
         Called from the engine loop's finally block after the loop exits.
         """
         self.state = EngineState.STOPPED
+        self.step_retirement_service.drain_for_shutdown()
 
         # Cleanup the request futures.
         for entry in self.requests.values():

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -790,14 +790,34 @@ class DynamicInferenceEngine(AbstractEngine):
                 f"abs mem usage: {total_mem_str}"
             )
 
-    def suspend(self):
-        """Suspend engine by deallocating context's GPU state."""
+    def _rebuild_async_overlap_pipeline(self) -> None:
+        """Recreate runtime pipeline helpers after suspend/resume."""
+        self.step_retirement_service = StepRetirementService(self)
+        self.async_pipeline = DynamicAsyncPipeline(
+            engine=self,
+            retirement_service=self.step_retirement_service,
+            queue_depth=self.async_overlap_queue_depth,
+        )
+        self._current_dynamic_step_id = -1
+        if hasattr(self.context, "set_current_dynamic_step_id"):
+            self.context.set_current_dynamic_step_id(-1)
 
-        # Skip if already suspended or in the process of suspending.
-        if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
+    def suspend(self):
+        """Suspend engine by draining the async pipeline and deallocating GPU state."""
+
+        # Skip if already suspended. If the coordinator has already moved the
+        # state to SUSPENDING, this call owns the actual drain barrier.
+        if self.state == EngineState.SUSPENDED:
             return
 
-        self.async_pipeline.drain_for_suspend()
+        if self.state != EngineState.SUSPENDING:
+            self.state = EngineState.SUSPENDING
+        if hasattr(self, "async_pipeline"):
+            self._run_coroutine_sync(self.async_pipeline.drain_for_suspend_barrier())
+        elif hasattr(self, "step_retirement_service"):
+            self.step_retirement_service.drain_for_suspend()
+        if hasattr(self.context, "suspend_async_overlap_runtime_state"):
+            self.context.suspend_async_overlap_runtime_state()
 
         # Deallocate context tensors.
         with self.__class__.suspend_resume_ctx(
@@ -857,6 +877,8 @@ class DynamicInferenceEngine(AbstractEngine):
             alloc_time = time.time()
             torch.cuda.synchronize()
             self.context.reinitialize_inference_state_buffers()
+            self.context.rebuild_async_overlap_runtime_state()
+            self._rebuild_async_overlap_pipeline()
             torch.cuda.synchronize()
             alloc_time = time.time() - alloc_time
 

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -170,7 +170,7 @@ class RequestEntry:
 
 @dataclass
 class AsyncOverlapDebugCounters:
-    """Debug counters used by the async-overlap rollout path."""
+    """Debug counters used by the async-overlap architecture."""
 
     queue_depth: int = 1
     snapshot_slot_waits: int = 0
@@ -182,6 +182,8 @@ class AsyncOverlapDebugCounters:
     distributed_consensus_mismatches: int = 0
     distributed_prepare_reconciliations: int = 0
     distributed_prepare_downgrades: int = 0
+    queue_depth_one_downgrades: int = 0
+    downgrade_reasons: Dict[str, int] = field(default_factory=dict)
     speculative_rejected_tokens: int = 0
     placeholder_count: int = 0
     reservation_commits: int = 0
@@ -363,6 +365,10 @@ class DynamicInferenceEngine(AbstractEngine):
         self.async_overlap_debug_counters = AsyncOverlapDebugCounters(
             queue_depth=getattr(self, "async_overlap_queue_depth", 1)
         )
+        if self.async_overlap_queue_depth == 1:
+            self.async_overlap_debug_counters.fallback_or_queue_depth_one_reasons[
+                "explicit_queue_depth_one"
+            ] = 1
         self.step_retirement_service = StepRetirementService(self)
         self.async_pipeline = DynamicAsyncPipeline(
             engine=self,
@@ -2495,19 +2501,31 @@ class DynamicInferenceEngine(AbstractEngine):
 
     def _downgrade_async_overlap_queue_depth_one(self, reason: str) -> None:
         """Downgrade the new architecture to queue depth one after unsafe divergence."""
-        self.async_overlap_queue_depth = 1
-        if hasattr(self, "async_pipeline"):
-            self.async_pipeline.queue_depth = 1
-        if hasattr(self, "step_retirement_service"):
-            self.step_retirement_service.max_retirement_backlog = 1
-            self.step_retirement_service._update_backlog_counters()
-        counters = getattr(self, "async_overlap_debug_counters", None)
-        if counters is not None:
-            counters.queue_depth = 1
-            counters.distributed_prepare_downgrades += 1
-            counters.fallback_or_queue_depth_one_reasons[reason] = (
-                counters.fallback_or_queue_depth_one_reasons.get(reason, 0) + 1
-            )
+        already_queue_depth_one = int(getattr(self, "async_overlap_queue_depth", 1)) <= 1
+        downgrade_range = self._step_nvtx_label(f"downgrade_async_overlap.{reason}")
+        nvtx_range_push(downgrade_range)
+        try:
+            self.async_overlap_queue_depth = 1
+            if hasattr(self, "async_pipeline"):
+                self.async_pipeline.queue_depth = 1
+            if hasattr(self, "step_retirement_service"):
+                self.step_retirement_service.max_retirement_backlog = 1
+                self.step_retirement_service._update_backlog_counters()
+            counters = getattr(self, "async_overlap_debug_counters", None)
+            if counters is not None:
+                counters.queue_depth = 1
+                counters.fallback_or_queue_depth_one_reasons[reason] = (
+                    counters.fallback_or_queue_depth_one_reasons.get(reason, 0) + 1
+                )
+                if not already_queue_depth_one:
+                    counters.queue_depth_one_downgrades += 1
+                    counters.downgrade_reasons[reason] = (
+                        counters.downgrade_reasons.get(reason, 0) + 1
+                    )
+                    if reason == "distributed_prepare_divergence":
+                        counters.distributed_prepare_downgrades += 1
+        finally:
+            nvtx_range_pop(downgrade_range)
 
     def _run_dummy_forward_launches(self, count: int) -> None:
         """Run dummy forwards so ranks without real work match distributed launches."""

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1004,8 +1004,6 @@ class DynamicInferenceEngine(AbstractEngine):
             return "pipeline_parallel"
         if getattr(self, "ep_world_size", 1) > 1:
             return "expert_parallel"
-        if self.context.is_hybrid_model:
-            return "hybrid_mamba"
         if self.waiting_request_ids and self.context.enable_prefix_caching:
             return "prefix_caching_waiting_prefill"
         if has_chunked_prefill_work:

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -165,7 +165,9 @@ class AsyncOverlapDebugCounters:
     snapshot_slot_waits: int = 0
     output_event_waits: int = 0
     fallback_or_queue_depth_one_reasons: Dict[str, int] = field(default_factory=dict)
+    accepted_output_tokens: int = 0
     discarded_lookahead_tokens: int = 0
+    speculative_rejected_tokens: int = 0
     placeholder_count: int = 0
     reservation_commits: int = 0
     reservation_rollbacks: int = 0
@@ -1032,11 +1034,8 @@ class DynamicInferenceEngine(AbstractEngine):
         )
         for request_id in request_ids:
             request = self.get_request(int(request_id))
-            sampling_params = request.sampling_params
             if request.stop_word_ids:
                 return "stop_words"
-            if sampling_params.return_log_probs or sampling_params.top_n_logprobs > 0:
-                return "logprobs"
         return None
 
     def get_request(self, request_id: int) -> DynamicInferenceRequest:
@@ -1254,6 +1253,13 @@ class DynamicInferenceEngine(AbstractEngine):
 
         log_probs_iter = log_probs if log_probs else repeat(None)
         block_allocator = self.context.kv_block_allocator
+        if (
+            isinstance(routing_indices_per_request, dict)
+            and "by_request_id" in routing_indices_per_request
+        ):
+            routing_indices_by_request = routing_indices_per_request["by_request_id"]
+        else:
+            routing_indices_by_request = routing_indices_per_request
 
         # Pre-compute step-level block stats (before the per-request loop)
         if self.track_generated_token_events:
@@ -1292,6 +1298,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 # Therefore, the newly sampled token must go at the end of the sequence.
                 tokens = accepted_tokens + tokens
 
+            original_token_count = len(tokens)
             num_stop_word_trim = 0
             if request_id not in chunked_prefill_no_output_request_ids:
                 # Skip appending token for requests being finished due to stop words
@@ -1308,8 +1315,9 @@ class DynamicInferenceEngine(AbstractEngine):
                     # Trim log probs / top-n to match so the counts stay in sync.
                     if request_log_probs is not None:
                         request_log_probs = request_log_probs[:keep]
-                    if top_n_logprobs is not None and req_idx in top_n_logprobs:
-                        top_n_logprobs[req_idx] = top_n_logprobs[req_idx][:keep]
+                    top_n_key = self._top_n_payload_key(top_n_logprobs, request_id, req_idx)
+                    if top_n_key is not None:
+                        top_n_logprobs[top_n_key] = top_n_logprobs[top_n_key][:keep]
                 if request_id not in self.stop_word_being_finished_ids:
                     is_first_token = len(request.generated_tokens) == 0
                     request.generated_tokens += tokens
@@ -1372,6 +1380,17 @@ class DynamicInferenceEngine(AbstractEngine):
 
                     self._spec_tokens_proposed += actual_proposed
                     self._spec_tokens_accepted += actual_accepted
+                    self.async_overlap_debug_counters.speculative_rejected_tokens += max(
+                        0, actual_proposed - actual_accepted
+                    )
+
+                accepted_output_token_count = max(0, len(tokens) - num_stop_word_trim)
+                self.async_overlap_debug_counters.accepted_output_tokens += (
+                    accepted_output_token_count
+                )
+                self.async_overlap_debug_counters.discarded_lookahead_tokens += max(
+                    0, original_token_count - accepted_output_token_count
+                )
 
                 if request_id in finished_request_ids:
                     # Request finished by normal means (termination_id, max_length, or stop word from previous step)
@@ -1394,6 +1413,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 # A non-final chunked prefill produces useless tokens
                 # so we are not appending them to the generated tokens.
                 # Additionally, chunked prefill requests do not finish.
+                self.async_overlap_debug_counters.discarded_lookahead_tokens += len(tokens)
                 active_request_ids.append(request_id)
 
             # When a stop word was found mid-speculative-batch, trim log probs
@@ -1401,8 +1421,11 @@ class DynamicInferenceEngine(AbstractEngine):
             if num_stop_word_trim > 0:
                 if request_log_probs is not None:
                     request_log_probs = request_log_probs[:-num_stop_word_trim]
-                if top_n_logprobs is not None and req_idx in top_n_logprobs:
-                    top_n_logprobs[req_idx] = top_n_logprobs[req_idx][:-num_stop_word_trim]
+                top_n_key = self._top_n_payload_key(top_n_logprobs, request_id, req_idx)
+                if top_n_key is not None:
+                    top_n_logprobs[top_n_key] = top_n_logprobs[top_n_key][
+                        :-num_stop_word_trim
+                    ]
 
             # Process log_probs if available (unified for both regular and chunked prefill)
             # Skip for requests being finished due to stop words — tokens are not
@@ -1445,9 +1468,10 @@ class DynamicInferenceEngine(AbstractEngine):
 
             # Process top_n_logprobs if available (unified for both regular and chunked prefill)
             # Same stop-word guard as log probs above.
+            top_n_key = self._top_n_payload_key(top_n_logprobs, request_id, req_idx)
             if (
                 top_n_logprobs is not None
-                and req_idx in top_n_logprobs
+                and top_n_key is not None
                 and request_id not in self.stop_word_being_finished_ids
             ):
                 # Initialize lists if they don't exist
@@ -1456,7 +1480,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 if request.generated_top_n_logprobs is None:
                     request.generated_top_n_logprobs = []
 
-                top_n_data_list = top_n_logprobs[req_idx]
+                top_n_data_list = top_n_logprobs[top_n_key]
                 prompt_length = len(request.prompt_tokens)
 
                 # Process each token's top-n logprobs
@@ -1487,10 +1511,10 @@ class DynamicInferenceEngine(AbstractEngine):
             # Each step's routing is a tensor of shape [num_tokens_this_step, num_layers, topk]
             # We concatenate along dim=0 to accumulate: [total_tokens, num_layers, topk]
             if (
-                routing_indices_per_request is not None
-                and request_id in routing_indices_per_request
+                routing_indices_by_request is not None
+                and request_id in routing_indices_by_request
             ):
-                step_routing = routing_indices_per_request[
+                step_routing = routing_indices_by_request[
                     request_id
                 ]  # [num_tokens, num_layers, topk]
                 if request.routing_indices is None:
@@ -1521,6 +1545,17 @@ class DynamicInferenceEngine(AbstractEngine):
         self.stop_word_being_finished_ids.clear()
 
         return active_request_ids, finished_request_records
+
+    @staticmethod
+    def _top_n_payload_key(top_n_logprobs, request_id: int, request_index: int):
+        """Return the top-n payload key for a request in one retired step."""
+        if top_n_logprobs is None:
+            return None
+        if request_id in top_n_logprobs:
+            return request_id
+        if request_index in top_n_logprobs:
+            return request_index
+        return None
 
     def _get_and_clear_stop_word_finished_ids(self, active_request_ids: list[int]) -> set[int]:
         """Get and clear the set of request IDs that should be finished due to stop words.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -165,6 +165,8 @@ class AsyncOverlapDebugCounters:
     placeholder_count: int = 0
     reservation_commits: int = 0
     reservation_rollbacks: int = 0
+    retirement_backlog: int = 0
+    max_retirement_backlog: int = 1
 
 
 # pylint: disable=line-too-long
@@ -1838,7 +1840,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 step_time (float): The step time in seconds.
                 cuda_graph_request_count (int): The CUDA graph batch size matching this step.
         """
-        return self.step_retirement_service.retire_step(step_result, context_state, step_time)
+        return self.step_retirement_service.submit_step(step_result, context_state, step_time)
 
     async def async_step(
         self,

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -988,8 +988,6 @@ class DynamicInferenceEngine(AbstractEngine):
         """Return the conservative queue-depth-two blocker, or None if eligible."""
         if self.context.get_active_request_count() <= 0:
             return "no_active_requests"
-        if len(self.waiting_request_ids) > 0:
-            return "waiting_requests"
         if self.use_coordinator:
             return "coordinator"
         if self.controller.model_is_pipeline_parallel:
@@ -1004,10 +1002,15 @@ class DynamicInferenceEngine(AbstractEngine):
             safe=False
         ) != -1:
             return "chunked_prefill"
+        if self.waiting_request_ids and self.context.enable_prefix_caching:
+            return "prefix_caching_waiting_prefill"
         if not self.context.is_async_overlap_steady_state_decode_ready():
             return "not_steady_state_decode"
         active_slice = slice(self.context.paused_request_count, self.context.total_request_count)
-        for request_id in self.context.request_ids[active_slice].tolist():
+        request_ids = list(self.context.request_ids[active_slice].tolist()) + list(
+            self.waiting_request_ids
+        )
+        for request_id in request_ids:
             request = self.get_request(int(request_id))
             sampling_params = request.sampling_params
             if request.stop_word_ids:

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -170,6 +170,10 @@ class AsyncOverlapDebugCounters:
     placeholder_count: int = 0
     reservation_commits: int = 0
     reservation_rollbacks: int = 0
+    rollback_status_counts: Dict[str, int] = field(default_factory=dict)
+    partial_reservation_rollbacks: int = 0
+    resource_already_evicted_rollbacks: int = 0
+    deferred_reservation_rollbacks: int = 0
     retirement_backlog: int = 0
     max_retirement_backlog: int = 1
 

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1699,6 +1699,7 @@ class DynamicInferenceEngine(AbstractEngine):
             raise EngineSuspendedError(self.context.step_count)
 
         step_id = self._begin_dynamic_step()
+        self.context.begin_step_journal(step_id)
 
         # schedule requests
         scheduling_range = self._step_nvtx_label("scheduling", step_id)
@@ -1823,8 +1824,14 @@ class DynamicInferenceEngine(AbstractEngine):
             reasons["queue_depth_one_debug_mode_pending_pipeline"] = (
                 reasons.get("queue_depth_one_debug_mode_pending_pipeline", 0) + 1
             )
-        last_step_data = await self.async_forward()
-        ret = await self.async_bookkeep(*last_step_data)
+        try:
+            last_step_data = await self.async_forward()
+            ret = await self.async_bookkeep(*last_step_data)
+        except BaseException:
+            self.context.rollback_step_journal(
+                self._current_dynamic_step_id, reason="async_step_exception"
+            )
+            raise
         # Keep for compatibility with current test suite.
         return ret
 

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -267,12 +267,9 @@ class DynamicInferenceEngine(AbstractEngine):
         self.logging_step_interval = inference_config.logging_step_interval
         self.unified_memory_level = inference_config.unified_memory_level
         self.use_synchronous_zmq_collectives = inference_config.use_synchronous_zmq_collectives
-        self.enable_async_overlap_architecture = (
-            inference_config.enable_async_overlap_architecture
-        )
         self.async_overlap_queue_depth = inference_config.async_overlap_queue_depth
         self.async_overlap_debug_checks = inference_config.async_overlap_debug_checks
-        if self.enable_async_overlap_architecture and self.async_overlap_queue_depth > 2:
+        if self.async_overlap_queue_depth > 2:
             raise ValueError(
                 "async_overlap_queue_depth > 2 is not available until wider async-overlap "
                 "pipeline depths are validated"
@@ -834,10 +831,7 @@ class DynamicInferenceEngine(AbstractEngine):
 
         if self.state != EngineState.SUSPENDING:
             self.state = EngineState.SUSPENDING
-        if hasattr(self, "async_pipeline"):
-            self._run_coroutine_sync(self.async_pipeline.drain_for_suspend_barrier())
-        elif hasattr(self, "step_retirement_service"):
-            self.step_retirement_service.drain_for_suspend()
+        self._run_coroutine_sync(self.async_pipeline.drain_for_suspend_barrier())
         if hasattr(self.context, "suspend_async_overlap_runtime_state"):
             self.context.suspend_async_overlap_runtime_state()
 
@@ -1019,7 +1013,7 @@ class DynamicInferenceEngine(AbstractEngine):
 
     def can_launch_async_overlap_lookahead(self) -> bool:
         """Return whether queue-depth-two lookahead is safe for the current step."""
-        if not self.enable_async_overlap_architecture or self.async_overlap_queue_depth < 2:
+        if self.async_overlap_queue_depth < 2:
             return False
         reason = self._async_overlap_lookahead_blocker()
         if reason is not None:
@@ -1034,7 +1028,7 @@ class DynamicInferenceEngine(AbstractEngine):
 
     def can_plan_async_overlap_lookahead(self) -> bool:
         """Return queue-depth-two eligibility without mutating debug counters."""
-        if not self.enable_async_overlap_architecture or self.async_overlap_queue_depth < 2:
+        if self.async_overlap_queue_depth < 2:
             return False
         return self._async_overlap_lookahead_blocker() is None
 
@@ -1042,13 +1036,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self, *, max_forward_launches: Optional[int] = None
     ) -> int:
         """Return how many real dynamic forwards the next async step can launch."""
-        if getattr(self, "enable_async_overlap_architecture", False):
-            return self.async_pipeline.planned_launch_count(
-                max_forward_launches=max_forward_launches
-            )
-        if max_forward_launches is not None and max_forward_launches <= 0:
-            return 0
-        return 1 if self.has_async_overlap_launch_work() else 0
+        return self.async_pipeline.planned_launch_count(max_forward_launches=max_forward_launches)
 
     def _async_overlap_lookahead_blocker(self) -> Optional[str]:
         """Return the conservative queue-depth-two blocker, or None if eligible."""
@@ -2048,13 +2036,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 3. The step time in seconds.
         """
         try:
-            if self.enable_async_overlap_architecture:
-                ret = await self.async_pipeline.step(
-                    max_forward_launches=max_forward_launches
-                )
-            else:
-                last_step_data = await self.async_forward()
-                ret = await self.async_bookkeep(*last_step_data)
+            ret = await self.async_pipeline.step(max_forward_launches=max_forward_launches)
         except BaseException:
             self.context.rollback_step_journal(
                 self._current_dynamic_step_id, reason="async_step_exception"
@@ -2615,12 +2597,7 @@ class DynamicInferenceEngine(AbstractEngine):
                             missing_dummy_launches = max(0, global_launches - local_launches)
                             if missing_dummy_launches:
                                 self._run_dummy_forward_launches(missing_dummy_launches)
-                            if getattr(self, "enable_async_overlap_architecture", False):
-                                await self.async_step(
-                                    max_forward_launches=max_launches_per_tick
-                                )
-                            else:
-                                await self.async_step()
+                            await self.async_step(max_forward_launches=max_launches_per_tick)
                         else:
                             self._run_dummy_forward_launches(global_launches)
                     else:

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -610,6 +610,10 @@ class DynamicInferenceEngine(AbstractEngine):
             self.expert_parallel_zmq_communicator = AsyncZMQCommunicator(
                 self.zmq_context, process_group=self.pg_collection.ep, hostname=hostname
             )
+            # Give the context a CPU-side MAX-reduction primitive so
+            # match_graph_config() can avoid a per-step NCCL AllReduce kernel.
+            if hasattr(self.context, "set_ep_zmq_communicator"):
+                self.context.set_ep_zmq_communicator(self.expert_parallel_zmq_communicator)
 
         # initialize zmq-based world communicator for consensus barriers
         total_world_size = torch.distributed.get_world_size()

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1608,10 +1608,15 @@ class DynamicInferenceEngine(AbstractEngine):
 
             # Use remaining prompt tokens for scheduling decisions
             remaining_len = len(req.remaining_prompt_tokens)
-            token_fully_can_be_added = (
-                self.context.active_token_count + remaining_len <= self.context.max_tokens
+            placeholder_adjusted_token_count = (
+                self.context.get_placeholder_adjusted_active_token_count()
             )
-            token_partially_can_be_added = self.context.active_token_count < self.context.max_tokens
+            token_fully_can_be_added = (
+                placeholder_adjusted_token_count + remaining_len <= self.context.max_tokens
+            )
+            token_partially_can_be_added = (
+                placeholder_adjusted_token_count < self.context.max_tokens
+            )
             request_can_be_added, _, kv_cache_available = self.context.check_availability(req)
             request_can_be_added = is_continuing_chunked_prefill or request_can_be_added
 

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -30,6 +30,7 @@ from megatron.core.inference.data_parallel_inference_coordinator import (
     DataParallelInferenceCoordinator,
 )
 from megatron.core.inference.engines.abstract_engine import AbstractEngine
+from megatron.core.inference.engines.dynamic_step import DynamicStepId, SnapshotSlotHandle
 from megatron.core.inference.headers import Headers, UnknownHeaderError
 from megatron.core.inference.inference_request import (
     DynamicInferenceEvent,
@@ -409,32 +410,64 @@ class DynamicInferenceEngine(AbstractEngine):
             unwrapped_model = controller.inference_wrapped_model.model
             set_inference_cuda_graphed_iteration_for_ep_inference(unwrapped_model)
 
-        tbar = enumerate(context.cuda_graph_batch_dimensions_list)
+        capture_items = [
+            (cuda_graph_batch_dimension, snapshot_slot_id)
+            for cuda_graph_batch_dimension in context.cuda_graph_batch_dimensions_list
+            for snapshot_slot_id in context.cuda_graph_capture_slot_ids
+        ]
+        tbar = enumerate(capture_items)
         if HAVE_TQDM:
-            tbar = tqdm(tbar, total=len(context.cuda_graph_batch_dimensions_list))
-        for tbar_idx, cuda_graph_batch_dimension in tbar:
-            input_ids, position_ids = self.controller._dynamic_step_context_init(
-                construct_graph_dimensions=cuda_graph_batch_dimension
+            tbar = tqdm(tbar, total=len(capture_items))
+        for tbar_idx, (cuda_graph_batch_dimension, snapshot_slot_id) in tbar:
+            capture_step_id = DynamicStepId(tbar_idx)
+            context.set_current_dynamic_step_id(capture_step_id.value)
+            snapshot_slot = context.snapshot_pool.acquire_specific(
+                snapshot_slot_id, capture_step_id.value
             )
-            # Progress.
-            tbar_str = f"cuda graph warmup - {cuda_graph_batch_dimension}"
-            if HAVE_TQDM:
-                tbar.set_description(tbar_str)
-            else:
-                logging.info(
-                    f"{tbar_idx}/{len(context.cuda_graph_batch_dimensions_list)}. {tbar_str}"
+            snapshot_handle = SnapshotSlotHandle(
+                step_id=capture_step_id, snapshot_slot_id=snapshot_slot.slot_id
+            )
+            try:
+                input_ids, position_ids = self.controller._dynamic_step_context_init(
+                    construct_graph_dimensions=cuda_graph_batch_dimension,
+                    snapshot_slot_handle=snapshot_handle,
                 )
+                cache_key = context.cuda_graph_cache_key(snapshot_slot_id=snapshot_slot.slot_id)
+                # Progress.
+                tbar_str = (
+                    f"cuda graph warmup - {cuda_graph_batch_dimension} "
+                    f"slot={snapshot_slot.slot_id}"
+                )
+                if HAVE_TQDM:
+                    tbar.set_description(tbar_str)
+                else:
+                    logging.info(f"{tbar_idx}/{len(capture_items)}. {tbar_str}")
 
-            # Enable routing recording during warmup if routing replay is enabled.
-            # This ensures the record_indices copy operation is captured in the CUDA graph.
-            model_config = controller.inference_wrapped_model.model.config
-            if model_config.moe_enable_routing_replay:
-                RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+                # Enable routing recording during warmup if routing replay is enabled.
+                # This ensures the record_indices copy operation is captured in the CUDA graph.
+                model_config = controller.inference_wrapped_model.model.config
+                if model_config.moe_enable_routing_replay:
+                    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
 
-            # Forward pass -> logits.
-            controller._dynamic_step_forward_logits(input_ids, position_ids)
+                mem_stats_before_graph = torch.cuda.memory_stats()
 
-            context.reset()
+                # Forward pass -> logits.
+                controller._dynamic_step_forward_logits(input_ids, position_ids)
+
+                mem_stats_after_graph = torch.cuda.memory_stats()
+                graph_capture_bytes = max(
+                    0,
+                    mem_stats_after_graph["allocated_bytes.all.current"]
+                    - mem_stats_before_graph["allocated_bytes.all.current"],
+                    mem_stats_after_graph["reserved_bytes.all.current"]
+                    - mem_stats_before_graph["reserved_bytes.all.current"],
+                )
+                context.record_cuda_graph_capture(
+                    cache_key, byte_count=int(graph_capture_bytes)
+                )
+            finally:
+                context.snapshot_pool.release(snapshot_slot)
+                context.reset()
 
         # Disable inference dispatcher after graph capture
         if is_inference_optimized_ep:

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import concurrent.futures
+import hashlib
 import logging
 import math
 import multiprocessing
@@ -131,6 +132,19 @@ class EngineState(Enum):
     STOPPED = auto()  # All ranks confirmed; teardown complete
 
 
+DISTRIBUTED_PREPARE_CONSENSUS_FIELDS = (
+    "step_id",
+    "queue_depth",
+    "optimistic_ledger_version",
+    "committed_ledger_version",
+    "request_plan_digest",
+    "placeholder_token_count",
+    "placeholder_prefill_count",
+    "placeholder_decode_count",
+    "snapshot_slot_generation",
+)
+
+
 class EngineSuspendedError(Exception):
     """Engine is currently suspended and not performing steps."""
 
@@ -166,6 +180,8 @@ class AsyncOverlapDebugCounters:
     discarded_lookahead_tokens: int = 0
     dummy_forward_launches: int = 0
     distributed_consensus_mismatches: int = 0
+    distributed_prepare_reconciliations: int = 0
+    distributed_prepare_downgrades: int = 0
     speculative_rejected_tokens: int = 0
     placeholder_count: int = 0
     reservation_commits: int = 0
@@ -345,6 +361,8 @@ class DynamicInferenceEngine(AbstractEngine):
         self._prefix_coordination_waits = 0
         self._next_dynamic_step_id = 0
         self._current_dynamic_step_id = -1
+        self._distributed_prepare_mismatch_streak = 0
+        self._distributed_prepare_reconcile_retry_limit = 2
         self.async_overlap_debug_counters = AsyncOverlapDebugCounters(
             queue_depth=getattr(self, "async_overlap_queue_depth", 1)
         )
@@ -2320,6 +2338,7 @@ class DynamicInferenceEngine(AbstractEngine):
         local_launches: int = 0,
         local_queue_depth: Optional[int] = None,
         local_step_id: Optional[int] = None,
+        local_prepare_metadata: Optional[Dict[str, int]] = None,
     ) -> tuple[int, bool, int, bool]:
         """EP all-reduce to share work counts and pause consensus.
 
@@ -2327,7 +2346,7 @@ class DynamicInferenceEngine(AbstractEngine):
         - local_work: actual pending request count (always >= 0).
         - consensus flag: -1 if this rank wants to pause, 0 otherwise.
         - local_launches: number of real forwards this rank will launch this tick.
-        - queue depth and next step ID: debug consensus fields that detect drift.
+        - optimistic-prepare metadata fields that detect distributed drift.
 
         Using max for both:
         - max(work) > 0 means at least one EP peer has real work.
@@ -2340,22 +2359,29 @@ class DynamicInferenceEngine(AbstractEngine):
         Returns:
             (global_work, all_pausing, global_launches, metadata_agrees): max work
             across EP, whether all peers signaled consensus, the forward-launch
-            count all ranks must participate in, and whether queue-depth/step-ID
-            debug metadata agrees.
+            count all ranks must participate in, and whether prepare metadata agrees.
         """
         consensus_range = self._step_nvtx_label("event_polling.ep_consensus")
         nvtx_range_push(consensus_range)
 
         consensus_val = -1 if signal_consensus else 0
-        queue_depth = (
-            int(getattr(self, "async_overlap_queue_depth", 1))
-            if local_queue_depth is None
-            else int(local_queue_depth)
+        prepare_metadata = dict(
+            local_prepare_metadata
+            if local_prepare_metadata is not None
+            else self._distributed_prepare_consensus_metadata()
         )
-        step_id = (
-            int(getattr(self, "_next_dynamic_step_id", 0))
-            if local_step_id is None
-            else int(local_step_id)
+        if local_queue_depth is not None:
+            prepare_metadata["queue_depth"] = int(local_queue_depth)
+        if local_step_id is not None:
+            prepare_metadata["step_id"] = int(local_step_id)
+        metadata_values = tuple(
+            int(prepare_metadata.get(field, 0))
+            for field in DISTRIBUTED_PREPARE_CONSENSUS_FIELDS
+        )
+        metadata_reduce_values = tuple(
+            value
+            for metadata_value in metadata_values
+            for value in (metadata_value, -metadata_value)
         )
 
         # Signals can be received asynchronously on EP ranks.
@@ -2375,19 +2401,13 @@ class DynamicInferenceEngine(AbstractEngine):
                 global_work,
                 global_consensus,
                 global_launches,
-                max_queue_depth,
-                neg_min_queue_depth,
-                max_step_id,
-                neg_min_step_id,
+                *global_metadata_values,
             ) = (
                 await self.expert_parallel_zmq_communicator.all_reduce_max(
                     local_work,
                     consensus_val,
                     int(local_launches),
-                    queue_depth,
-                    -queue_depth,
-                    step_id,
-                    -step_id,
+                    *metadata_reduce_values,
                     async_op=(not self.use_synchronous_zmq_collectives),
                 )
             )
@@ -2395,16 +2415,117 @@ class DynamicInferenceEngine(AbstractEngine):
             global_work = local_work
             global_consensus = consensus_val
             global_launches = int(local_launches)
-            max_queue_depth = queue_depth
-            neg_min_queue_depth = -queue_depth
-            max_step_id = step_id
-            neg_min_step_id = -step_id
+            global_metadata_values = metadata_reduce_values
 
         nvtx_range_pop(consensus_range)
-        metadata_agrees = (
-            max_queue_depth == -neg_min_queue_depth and max_step_id == -neg_min_step_id
+        metadata_agrees = all(
+            global_metadata_values[idx] == -global_metadata_values[idx + 1]
+            for idx in range(0, len(global_metadata_values), 2)
         )
         return global_work, global_consensus == -1, global_launches, metadata_agrees
+
+    @staticmethod
+    def _stable_consensus_digest(value) -> int:
+        """Return a stable positive 31-bit digest for distributed consensus."""
+        payload = repr(value).encode("utf-8")
+        digest = hashlib.blake2b(payload, digest_size=4).digest()
+        return int.from_bytes(digest, byteorder="big", signed=False) & 0x7FFFFFFF
+
+    def _distributed_prepare_consensus_metadata(self) -> Dict[str, int]:
+        """Build drift-detection metadata for distributed optimistic prepare."""
+        step_id = int(getattr(self, "_next_dynamic_step_id", 0))
+        request_plan = self.context._build_dynamic_step_request_plan(step_id)
+        batch_dimensions = getattr(self.context, "batch_dimensions", None)
+        placeholder_token_count = int(self.context.get_placeholder_adjusted_active_token_count())
+        placeholder_prefill_count = (
+            int(getattr(batch_dimensions, "prefill_req_count", 0))
+            if batch_dimensions is not None
+            else 0
+        )
+        placeholder_decode_count = (
+            int(getattr(batch_dimensions, "decode_req_count", 0))
+            if batch_dimensions is not None
+            else 0
+        )
+        waiting_request_ids = tuple(int(request_id) for request_id in self.waiting_request_ids)
+        request_plan_digest = self._stable_consensus_digest(
+            (
+                tuple(request_plan.active_request_ids),
+                tuple(request_plan.decode_request_ids),
+                tuple(request_plan.prefill_request_ids),
+                tuple(request_plan.speculative_request_ids),
+                tuple(sorted(request_plan.placeholder_token_counts.items())),
+                waiting_request_ids,
+                int(self.context.total_request_count),
+                int(self.context.paused_request_count),
+                int(self.context.active_token_count),
+            )
+        )
+        return {
+            "step_id": step_id,
+            "queue_depth": int(getattr(self, "async_overlap_queue_depth", 1)),
+            "optimistic_ledger_version": self._stable_consensus_digest(
+                self.context.get_optimistic_request_state()
+            ),
+            "committed_ledger_version": self._stable_consensus_digest(
+                self.context.get_committed_request_state()
+            ),
+            "request_plan_digest": request_plan_digest,
+            "placeholder_token_count": placeholder_token_count,
+            "placeholder_prefill_count": placeholder_prefill_count,
+            "placeholder_decode_count": placeholder_decode_count,
+            "snapshot_slot_generation": self._snapshot_slot_generation_digest(),
+        }
+
+    def _snapshot_slot_generation_digest(self) -> int:
+        """Return a stable digest of snapshot-slot ownership generations."""
+        snapshot_pool = getattr(self.context, "snapshot_pool", None)
+        if snapshot_pool is None:
+            return 0
+        slot_state = tuple(
+            (
+                int(slot.slot_id),
+                str(slot.state),
+                -1 if slot.owning_step_id is None else int(slot.owning_step_id),
+                int(bool(slot.journal_retired)),
+                int(slot.graph_capture_count),
+            )
+            for slot in snapshot_pool.slots
+        )
+        return self._stable_consensus_digest(slot_state)
+
+    def _record_distributed_prepare_convergence(self) -> None:
+        """Reset mismatch streak after all ranks agree on prepare metadata."""
+        self._distributed_prepare_mismatch_streak = 0
+
+    def _handle_distributed_prepare_divergence(self) -> None:
+        """Record a prepare mismatch and downgrade after bounded retries."""
+        counters = getattr(self, "async_overlap_debug_counters", None)
+        if counters is not None:
+            counters.distributed_consensus_mismatches += 1
+            counters.distributed_prepare_reconciliations += 1
+        self._distributed_prepare_mismatch_streak = (
+            getattr(self, "_distributed_prepare_mismatch_streak", 0) + 1
+        )
+        retry_limit = max(1, int(getattr(self, "_distributed_prepare_reconcile_retry_limit", 2)))
+        if self._distributed_prepare_mismatch_streak >= retry_limit:
+            self._downgrade_async_overlap_queue_depth_one("distributed_prepare_divergence")
+
+    def _downgrade_async_overlap_queue_depth_one(self, reason: str) -> None:
+        """Downgrade the new architecture to queue depth one after unsafe divergence."""
+        self.async_overlap_queue_depth = 1
+        if hasattr(self, "async_pipeline"):
+            self.async_pipeline.queue_depth = 1
+        if hasattr(self, "step_retirement_service"):
+            self.step_retirement_service.max_retirement_backlog = 1
+            self.step_retirement_service._update_backlog_counters()
+        counters = getattr(self, "async_overlap_debug_counters", None)
+        if counters is not None:
+            counters.queue_depth = 1
+            counters.distributed_prepare_downgrades += 1
+            counters.fallback_or_queue_depth_one_reasons[reason] = (
+                counters.fallback_or_queue_depth_one_reasons.get(reason, 0) + 1
+            )
 
     def _run_dummy_forward_launches(self, count: int) -> None:
         """Run dummy forwards so ranks without real work match distributed launches."""
@@ -2478,8 +2599,10 @@ class DynamicInferenceEngine(AbstractEngine):
                         local_step_id=getattr(self, "_next_dynamic_step_id", 0),
                     )
                     if not metadata_agrees:
-                        if hasattr(self, "async_overlap_debug_counters"):
-                            self.async_overlap_debug_counters.distributed_consensus_mismatches += 1
+                        self._handle_distributed_prepare_divergence()
+                        await asyncio.sleep(0)
+                        continue
+                    self._record_distributed_prepare_convergence()
 
                     if all_pausing:
                         # All EP peers are PAUSING: pause immediately.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -26,9 +26,6 @@ from megatron.core.inference.contexts.dynamic_context import (
     MaxSequenceLengthOverflowError,
     TokenOverflowError,
 )
-from megatron.core.inference.data_parallel_inference_coordinator import (
-    DataParallelInferenceCoordinator,
-)
 from megatron.core.inference.engines.abstract_engine import AbstractEngine
 from megatron.core.inference.engines.dynamic_step import (
     DynamicAsyncPipeline,
@@ -167,6 +164,8 @@ class AsyncOverlapDebugCounters:
     fallback_or_queue_depth_one_reasons: Dict[str, int] = field(default_factory=dict)
     accepted_output_tokens: int = 0
     discarded_lookahead_tokens: int = 0
+    dummy_forward_launches: int = 0
+    distributed_consensus_mismatches: int = 0
     speculative_rejected_tokens: int = 0
     placeholder_count: int = 0
     reservation_commits: int = 0
@@ -358,7 +357,7 @@ class DynamicInferenceEngine(AbstractEngine):
     def _step_nvtx_label(self, name: str, step_id: Optional[int] = None) -> str:
         """Return an NVTX range name with a dynamic step id."""
         if step_id is None:
-            step_id = self._current_dynamic_step_id
+            step_id = getattr(self, "_current_dynamic_step_id", -1)
         return f"{name}[step={step_id}]"
 
     def _begin_dynamic_step(self) -> int:
@@ -570,6 +569,9 @@ class DynamicInferenceEngine(AbstractEngine):
         assert HAVE_MSGPACK, (
             "please install the messagepack library to use InferenceCoordinator\n"
             "pip install msgpack"
+        )
+        from megatron.core.inference.data_parallel_inference_coordinator import (
+            DataParallelInferenceCoordinator,
         )
 
         self.zmq_context = zmq.Context.instance()
@@ -986,6 +988,24 @@ class DynamicInferenceEngine(AbstractEngine):
             return False
         return True
 
+    def can_plan_async_overlap_lookahead(self) -> bool:
+        """Return queue-depth-two eligibility without mutating debug counters."""
+        if not self.enable_async_overlap_architecture or self.async_overlap_queue_depth < 2:
+            return False
+        return self._async_overlap_lookahead_blocker() is None
+
+    def planned_async_overlap_forward_launches(
+        self, *, max_forward_launches: Optional[int] = None
+    ) -> int:
+        """Return how many real dynamic forwards the next async step can launch."""
+        if getattr(self, "enable_async_overlap_architecture", False):
+            return self.async_pipeline.planned_launch_count(
+                max_forward_launches=max_forward_launches
+            )
+        if max_forward_launches is not None and max_forward_launches <= 0:
+            return 0
+        return 1 if self.has_async_overlap_launch_work() else 0
+
     def _async_overlap_lookahead_blocker(self) -> Optional[str]:
         """Return the conservative queue-depth-two blocker, or None if eligible."""
         active_request_count = self.context.get_active_request_count()
@@ -998,12 +1018,6 @@ class DynamicInferenceEngine(AbstractEngine):
         )
         if active_request_count <= 0 and not has_chunked_prefill_work:
             return "no_active_requests"
-        if self.use_coordinator:
-            return "coordinator"
-        if self.controller.model_is_pipeline_parallel:
-            return "pipeline_parallel"
-        if getattr(self, "ep_world_size", 1) > 1:
-            return "expert_parallel"
         if self.waiting_request_ids and self.context.enable_prefix_caching:
             return "prefix_caching_waiting_prefill"
         if has_chunked_prefill_work:
@@ -1975,6 +1989,8 @@ class DynamicInferenceEngine(AbstractEngine):
 
     async def async_step(
         self,
+        *,
+        max_forward_launches: Optional[int] = None,
     ) -> Tuple[List[DynamicInferenceRequest], List[DynamicInferenceRequest], float]:
         """
         Wrapper for controller.generate_output_tokens_dynamic_batch(), to
@@ -1989,7 +2005,9 @@ class DynamicInferenceEngine(AbstractEngine):
         """
         try:
             if self.enable_async_overlap_architecture:
-                ret = await self.async_pipeline.step()
+                ret = await self.async_pipeline.step(
+                    max_forward_launches=max_forward_launches
+                )
             else:
                 last_step_data = await self.async_forward()
                 ret = await self.async_bookkeep(*last_step_data)
@@ -2215,7 +2233,9 @@ class DynamicInferenceEngine(AbstractEngine):
         Called from the engine loop's finally block after the loop exits.
         """
         self.state = EngineState.STOPPED
-        self.async_pipeline.drain_for_shutdown()
+        async_pipeline = getattr(self, "async_pipeline", None)
+        if async_pipeline is not None:
+            async_pipeline.drain_for_shutdown()
 
         # Cleanup the request futures.
         for entry in self.requests.values():
@@ -2267,13 +2287,21 @@ class DynamicInferenceEngine(AbstractEngine):
             pass
 
     async def _ep_establish_consensus(
-        self, local_work: int, signal_consensus: bool
-    ) -> tuple[int, bool]:
+        self,
+        local_work: int,
+        signal_consensus: bool,
+        *,
+        local_launches: int = 0,
+        local_queue_depth: Optional[int] = None,
+        local_step_id: Optional[int] = None,
+    ) -> tuple[int, bool, int, bool]:
         """EP all-reduce to share work counts and pause consensus.
 
         All-reduces two integers at once:
         - local_work: actual pending request count (always >= 0).
         - consensus flag: -1 if this rank wants to pause, 0 otherwise.
+        - local_launches: number of real forwards this rank will launch this tick.
+        - queue depth and next step ID: debug consensus fields that detect drift.
 
         Using max for both:
         - max(work) > 0 means at least one EP peer has real work.
@@ -2284,13 +2312,25 @@ class DynamicInferenceEngine(AbstractEngine):
             local_work: Pending request count for this rank.
             signal_consensus: True if this rank is ready to pause.
         Returns:
-            (global_work, all_pausing): max work across EP, and whether
-            all peers signaled consensus.
+            (global_work, all_pausing, global_launches, metadata_agrees): max work
+            across EP, whether all peers signaled consensus, the forward-launch
+            count all ranks must participate in, and whether queue-depth/step-ID
+            debug metadata agrees.
         """
         consensus_range = self._step_nvtx_label("event_polling.ep_consensus")
         nvtx_range_push(consensus_range)
 
         consensus_val = -1 if signal_consensus else 0
+        queue_depth = (
+            int(getattr(self, "async_overlap_queue_depth", 1))
+            if local_queue_depth is None
+            else int(local_queue_depth)
+        )
+        step_id = (
+            int(getattr(self, "_next_dynamic_step_id", 0))
+            if local_step_id is None
+            else int(local_step_id)
+        )
 
         # Signals can be received asynchronously on EP ranks.
         # We do not want a rank to pause prematurely if its peers have yet to receive the signal.
@@ -2305,16 +2345,54 @@ class DynamicInferenceEngine(AbstractEngine):
             # The user may have other tasks running in the event loop that need to be serviced.
             # Do not using a torch.distributed blocking all-reduce here using nccl/gloo.
             # We have tried that and it blocks the event loop in megatron-rl.
-            global_work, global_consensus = (
+            (
+                global_work,
+                global_consensus,
+                global_launches,
+                max_queue_depth,
+                neg_min_queue_depth,
+                max_step_id,
+                neg_min_step_id,
+            ) = (
                 await self.expert_parallel_zmq_communicator.all_reduce_max(
-                    local_work, consensus_val, async_op=(not self.use_synchronous_zmq_collectives)
+                    local_work,
+                    consensus_val,
+                    int(local_launches),
+                    queue_depth,
+                    -queue_depth,
+                    step_id,
+                    -step_id,
+                    async_op=(not self.use_synchronous_zmq_collectives),
                 )
             )
         else:
-            global_work, global_consensus = local_work, consensus_val
+            global_work = local_work
+            global_consensus = consensus_val
+            global_launches = int(local_launches)
+            max_queue_depth = queue_depth
+            neg_min_queue_depth = -queue_depth
+            max_step_id = step_id
+            neg_min_step_id = -step_id
 
         nvtx_range_pop(consensus_range)
-        return global_work, global_consensus == -1
+        metadata_agrees = (
+            max_queue_depth == -neg_min_queue_depth and max_step_id == -neg_min_step_id
+        )
+        return global_work, global_consensus == -1, global_launches, metadata_agrees
+
+    def _run_dummy_forward_launches(self, count: int) -> None:
+        """Run dummy forwards so ranks without real work match distributed launches."""
+        for _ in range(int(count)):
+            if hasattr(self, "_next_dynamic_step_id"):
+                self._begin_dynamic_step()
+            self.step_start_event.record()
+            self.controller.dummy_forward()
+            self.step_end_event.record()
+            self.step_end_event.synchronize()
+            self.context.step_count += 1
+            self.context.prefix_cache_lru_clock += 1
+            if hasattr(self, "async_overlap_debug_counters"):
+                self.async_overlap_debug_counters.dummy_forward_launches += 1
 
     async def _world_barrier(self):
         """World-wide ZMQ all-reduce barrier for global rank consensus.
@@ -2357,9 +2435,25 @@ class DynamicInferenceEngine(AbstractEngine):
                     local_pending = self.context.get_active_request_count() + len(
                         self.waiting_request_ids
                     ) + int(self.has_async_overlap_pending_work())
-                    global_work, all_pausing = await self._ep_establish_consensus(
-                        local_pending, signal_consensus=(self.state == EngineState.PAUSING)
+                    max_launches_per_tick = 1 if self.use_coordinator else None
+                    local_launches = self.planned_async_overlap_forward_launches(
+                        max_forward_launches=max_launches_per_tick
                     )
+                    (
+                        global_work,
+                        all_pausing,
+                        global_launches,
+                        metadata_agrees,
+                    ) = await self._ep_establish_consensus(
+                        local_pending,
+                        signal_consensus=(self.state == EngineState.PAUSING),
+                        local_launches=local_launches,
+                        local_queue_depth=getattr(self, "async_overlap_queue_depth", 1),
+                        local_step_id=getattr(self, "_next_dynamic_step_id", 0),
+                    )
+                    if not metadata_agrees:
+                        if hasattr(self, "async_overlap_debug_counters"):
+                            self.async_overlap_debug_counters.distributed_consensus_mismatches += 1
 
                     if all_pausing:
                         # All EP peers are PAUSING: pause immediately.
@@ -2369,15 +2463,17 @@ class DynamicInferenceEngine(AbstractEngine):
                     elif global_work > 0:
                         # At least one EP peer has work: all must participate.
                         if local_pending > 0:
-                            await self.async_step()
+                            missing_dummy_launches = max(0, global_launches - local_launches)
+                            if missing_dummy_launches:
+                                self._run_dummy_forward_launches(missing_dummy_launches)
+                            if getattr(self, "enable_async_overlap_architecture", False):
+                                await self.async_step(
+                                    max_forward_launches=max_launches_per_tick
+                                )
+                            else:
+                                await self.async_step()
                         else:
-                            # Dummy forward to participate in the EP collective.
-                            self.step_start_event.record()
-                            self.controller.dummy_forward()
-                            self.step_end_event.record()
-                            self.step_end_event.synchronize()
-                            self.context.step_count += 1
-                            self.context.prefix_cache_lru_clock += 1
+                            self._run_dummy_forward_launches(global_launches)
                     else:
                         # No work, but not all pausing: idle.
                         await asyncio.sleep(0.02)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -986,7 +986,15 @@ class DynamicInferenceEngine(AbstractEngine):
 
     def _async_overlap_lookahead_blocker(self) -> Optional[str]:
         """Return the conservative queue-depth-two blocker, or None if eligible."""
-        if self.context.get_active_request_count() <= 0:
+        active_request_count = self.context.get_active_request_count()
+        has_chunked_prefill_work = bool(
+            self.enable_chunked_prefill
+            and (
+                self.waiting_request_ids
+                or self.context.get_index_of_chunked_prefill_request(safe=False) != -1
+            )
+        )
+        if active_request_count <= 0 and not has_chunked_prefill_work:
             return "no_active_requests"
         if self.use_coordinator:
             return "coordinator"
@@ -998,13 +1006,25 @@ class DynamicInferenceEngine(AbstractEngine):
             return "speculative"
         if self.context.is_hybrid_model:
             return "hybrid_mamba"
-        if self.enable_chunked_prefill or self.context.get_index_of_chunked_prefill_request(
-            safe=False
-        ) != -1:
-            return "chunked_prefill"
         if self.waiting_request_ids and self.context.enable_prefix_caching:
             return "prefix_caching_waiting_prefill"
-        if not self.context.is_async_overlap_steady_state_decode_ready():
+        if has_chunked_prefill_work:
+            if self.context.paused_request_count != 0:
+                return "paused_requests"
+            if active_request_count > 0 and not self.context.is_decode_only():
+                return "not_steady_state_decode"
+            active_slice = slice(
+                self.context.paused_request_count, self.context.total_request_count
+            )
+            if torch.any(self.context.num_output_placeholders[active_slice] != 0):
+                return "output_placeholders"
+            tokens_per_decode_request = int(self.num_speculative_tokens) + 1
+            last_offsets = self.context.request_last_kv_block_offset[active_slice]
+            if last_offsets.numel() and torch.any(
+                last_offsets + tokens_per_decode_request >= self.context.block_size_tokens
+            ):
+                return "block_boundary"
+        elif not self.context.is_async_overlap_steady_state_decode_ready():
             return "not_steady_state_decode"
         active_slice = slice(self.context.paused_request_count, self.context.total_request_count)
         request_ids = list(self.context.request_ids[active_slice].tolist()) + list(
@@ -1200,6 +1220,7 @@ class DynamicInferenceEngine(AbstractEngine):
         log_probs: torch.Tensor,
         top_n_logprobs: Optional[Dict[int, List[Tuple[torch.Tensor, torch.Tensor]]]] = None,
         routing_indices_per_request: Optional[Dict[int, torch.Tensor]] = None,
+        chunked_prefill_no_output_request_ids: Optional[set[int]] = None,
         pre_fwd_active_token_count: Optional[int] = None,
         pre_fwd_step_count: Optional[int] = None,
     ) -> Tuple[List[DynamicInferenceRequest], List[DynamicInferenceRequest]]:
@@ -1225,6 +1246,7 @@ class DynamicInferenceEngine(AbstractEngine):
         """
         active_request_ids: list[int] = []
         finished_request_ids = set(finished_request_ids.tolist())
+        chunked_prefill_no_output_request_ids = chunked_prefill_no_output_request_ids or set()
         finished_request_records: list[DynamicInferenceRequestRecord] = []
         self.finished_request_count += len(finished_request_ids)
         if evict_request_ids is not None:
@@ -1271,7 +1293,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 tokens = accepted_tokens + tokens
 
             num_stop_word_trim = 0
-            if request_id != self.context.chunked_prefill_request_id:
+            if request_id not in chunked_prefill_no_output_request_ids:
                 # Skip appending token for requests being finished due to stop words
                 # (they already have their final token from the previous step)
                 # If the request already has more tokens, then we only append as much as is necessary
@@ -1369,9 +1391,9 @@ class DynamicInferenceEngine(AbstractEngine):
                 else:
                     active_request_ids.append(request_id)
             else:
-                # The chunked prefill produces useless tokens
+                # A non-final chunked prefill produces useless tokens
                 # so we are not appending them to the generated tokens.
-                # Additionally, chunked prefill request do not finish.
+                # Additionally, chunked prefill requests do not finish.
                 active_request_ids.append(request_id)
 
             # When a stop word was found mid-speculative-batch, trim log probs
@@ -1396,7 +1418,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 if not request.generated_log_probs:
                     request.generated_log_probs = []
 
-                is_chunked_prefill = request_id == self.context.chunked_prefill_request_id
+                is_chunked_prefill = request_id in chunked_prefill_no_output_request_ids
                 is_prefill = len(request.generated_log_probs) == 0
 
                 if request.sampling_params.skip_prompt_log_probs:

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -144,6 +144,8 @@ DISTRIBUTED_PREPARE_CONSENSUS_FIELDS = (
     "snapshot_slot_generation",
 )
 
+ASYNC_OVERLAP_IDLE_POLL_INTERVAL_S = 0.005
+
 
 class EngineSuspendedError(Exception):
     """Engine is currently suspended and not performing steps."""
@@ -194,6 +196,12 @@ class AsyncOverlapDebugCounters:
     deferred_reservation_rollbacks: int = 0
     retirement_backlog: int = 0
     max_retirement_backlog: int = 1
+    queue_depth_one_steps: int = 0
+    queue_depth_two_steps: int = 0
+    max_pending_launches_observed: int = 0
+    cpu_time_hidden_under_gpu_s: float = 0.0
+    gpu_gap_sampling_to_next_forward_s: float = 0.0
+    gpu_gap_observations: int = 0
 
 
 # pylint: disable=line-too-long
@@ -360,6 +368,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self._prefix_coordination_waits = 0
         self._next_dynamic_step_id = 0
         self._current_dynamic_step_id = -1
+        self._last_dynamic_sampling_end_perf: Optional[float] = None
         self._distributed_prepare_mismatch_streak = 0
         self._distributed_prepare_reconcile_retry_limit = 2
         self.async_overlap_debug_counters = AsyncOverlapDebugCounters(
@@ -1970,7 +1979,13 @@ class DynamicInferenceEngine(AbstractEngine):
 
         if will_log_this_step:
             self.step_start_event.record()
+        forward_start_perf = time.perf_counter()
+        if self._last_dynamic_sampling_end_perf is not None:
+            gap_s = max(0.0, forward_start_perf - self._last_dynamic_sampling_end_perf)
+            self.async_overlap_debug_counters.gpu_gap_sampling_to_next_forward_s += gap_s
+            self.async_overlap_debug_counters.gpu_gap_observations += 1
         result = await self.controller.async_generate_output_tokens_dynamic_batch()
+        self._last_dynamic_sampling_end_perf = time.perf_counter()
         if will_log_this_step:
             self.step_end_event.record()
             self.step_end_event.synchronize()
@@ -2620,10 +2635,10 @@ class DynamicInferenceEngine(AbstractEngine):
                             self._run_dummy_forward_launches(global_launches)
                     else:
                         # No work, but not all pausing: idle.
-                        await asyncio.sleep(0.02)
+                        await asyncio.sleep(ASYNC_OVERLAP_IDLE_POLL_INTERVAL_S)
 
                 elif self.state == EngineState.PAUSED:
-                    await asyncio.sleep(0.02)
+                    await asyncio.sleep(ASYNC_OVERLAP_IDLE_POLL_INTERVAL_S)
 
                 elif self.state == EngineState.UNPAUSING:
                     await self._world_barrier()
@@ -2637,7 +2652,7 @@ class DynamicInferenceEngine(AbstractEngine):
                     self._state_events[EngineState.SUSPENDED].set()
 
                 elif self.state == EngineState.SUSPENDED:
-                    await asyncio.sleep(0.02)
+                    await asyncio.sleep(ASYNC_OVERLAP_IDLE_POLL_INTERVAL_S)
 
                 elif self.state == EngineState.RESUMING:
                     await self._world_barrier()

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1004,8 +1004,6 @@ class DynamicInferenceEngine(AbstractEngine):
             return "pipeline_parallel"
         if getattr(self, "ep_world_size", 1) > 1:
             return "expert_parallel"
-        if self.num_speculative_tokens > 0:
-            return "speculative"
         if self.context.is_hybrid_model:
             return "hybrid_mamba"
         if self.waiting_request_ids and self.context.enable_prefix_caching:

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Typed contracts for dynamic async-overlap inference steps."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Optional, Tuple
+
+
+def _as_tuple(value: Optional[Sequence[Any]]) -> Tuple[Any, ...]:
+    """Return an immutable tuple copy of a possibly missing sequence."""
+    if value is None:
+        return ()
+    return tuple(value)
+
+
+def _freeze_mapping(value: Optional[Mapping[Any, Any]]) -> Mapping[Any, Any]:
+    """Return an immutable mapping copy of a possibly missing mapping."""
+    if value is None:
+        return MappingProxyType({})
+    return MappingProxyType(dict(value))
+
+
+@dataclass(frozen=True, order=True)
+class DynamicStepId:
+    """Monotonic dynamic inference step identity."""
+
+    value: int
+
+    def __post_init__(self) -> None:
+        if self.value < 0:
+            raise ValueError(f"DynamicStepId must be >= 0, got {self.value}")
+
+
+@dataclass(frozen=True, kw_only=True)
+class DynamicStepRequestPlan:
+    """Scheduler-visible request plan for one dynamic step."""
+
+    step_id: DynamicStepId
+    active_request_ids: Sequence[str] = field(default_factory=tuple)
+    decode_request_ids: Sequence[str] = field(default_factory=tuple)
+    prefill_request_ids: Sequence[str] = field(default_factory=tuple)
+    speculative_request_ids: Sequence[str] = field(default_factory=tuple)
+    placeholder_token_counts: Mapping[str, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "active_request_ids", _as_tuple(self.active_request_ids))
+        object.__setattr__(self, "decode_request_ids", _as_tuple(self.decode_request_ids))
+        object.__setattr__(self, "prefill_request_ids", _as_tuple(self.prefill_request_ids))
+        object.__setattr__(
+            self, "speculative_request_ids", _as_tuple(self.speculative_request_ids)
+        )
+        object.__setattr__(
+            self, "placeholder_token_counts", _freeze_mapping(self.placeholder_token_counts)
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class SnapshotSlotHandle:
+    """Ownership handle for a fixed-address GPU snapshot slot."""
+
+    step_id: DynamicStepId
+    snapshot_slot_id: int
+    metadata_ready_event: Optional[Any] = None
+    input_ready_event: Optional[Any] = None
+
+    def __post_init__(self) -> None:
+        if self.snapshot_slot_id < 0:
+            raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+
+
+@dataclass(frozen=True, kw_only=True)
+class StepInputPlan:
+    """GPU input preparation plan for one dynamic step."""
+
+    step_id: DynamicStepId
+    snapshot_slot_id: int
+    request_ids: Sequence[str] = field(default_factory=tuple)
+    decode_request_ids: Sequence[str] = field(default_factory=tuple)
+    prefill_request_ids: Sequence[str] = field(default_factory=tuple)
+    decode_input_destination_indices: Sequence[int] = field(default_factory=tuple)
+    input_ready_event: Optional[Any] = None
+
+    def __post_init__(self) -> None:
+        if self.snapshot_slot_id < 0:
+            raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+        object.__setattr__(self, "request_ids", _as_tuple(self.request_ids))
+        object.__setattr__(self, "decode_request_ids", _as_tuple(self.decode_request_ids))
+        object.__setattr__(self, "prefill_request_ids", _as_tuple(self.prefill_request_ids))
+        object.__setattr__(
+            self,
+            "decode_input_destination_indices",
+            _as_tuple(self.decode_input_destination_indices),
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class DynamicStepContextSnapshot:
+    """Immutable view of the context snapshot owned by one dynamic step."""
+
+    step_id: DynamicStepId
+    snapshot_slot_id: int
+    request_plan: DynamicStepRequestPlan
+    metadata_ready_event: Optional[Any] = None
+    input_ready_event: Optional[Any] = None
+    gpu_view: Optional[Any] = None
+    cpu_staging_buffer: Optional[Any] = None
+
+    def __post_init__(self) -> None:
+        if self.snapshot_slot_id < 0:
+            raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+
+
+@dataclass(frozen=True, kw_only=True)
+class DynamicStepGpuLaunch:
+    """Forward/sampling launch contract for one dynamic step."""
+
+    step_id: DynamicStepId
+    snapshot_slot_id: int
+    metadata_ready_event: Optional[Any] = None
+    input_ready_event: Optional[Any] = None
+    compute_done_event: Optional[Any] = None
+    cuda_graph_batch_dimensions: Optional[Any] = None
+
+    def __post_init__(self) -> None:
+        if self.snapshot_slot_id < 0:
+            raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+
+
+@dataclass(frozen=True, kw_only=True)
+class AsyncStepOutput:
+    """CPU-visible output copy contract for one dynamic step."""
+
+    step_id: DynamicStepId
+    snapshot_slot_id: int
+    compute_done_event: Optional[Any] = None
+    output_ready_event: Optional[Any] = None
+    sampled_tokens: Optional[Any] = None
+    sampled_tokens_cpu: Optional[Any] = None
+    accepted_token_counts_cpu: Optional[Any] = None
+    logprob_payload_cpu: Optional[Any] = None
+    routing_payload_cpu: Optional[Any] = None
+
+    def __post_init__(self) -> None:
+        if self.snapshot_slot_id < 0:
+            raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+
+
+@dataclass(frozen=True, kw_only=True)
+class ResourceReservation:
+    """Allocator resources reserved for a scheduled-but-not-retired step."""
+
+    step_id: DynamicStepId
+    request_id: str
+    snapshot_slot_id: int
+    kv_block_ids: Sequence[int] = field(default_factory=tuple)
+    mamba_slot_ids: Sequence[int] = field(default_factory=tuple)
+    prefix_cache_refcount_deltas: Mapping[Any, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.snapshot_slot_id < 0:
+            raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+        object.__setattr__(self, "kv_block_ids", _as_tuple(self.kv_block_ids))
+        object.__setattr__(self, "mamba_slot_ids", _as_tuple(self.mamba_slot_ids))
+        object.__setattr__(
+            self,
+            "prefix_cache_refcount_deltas",
+            _freeze_mapping(self.prefix_cache_refcount_deltas),
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class StepJournalEntry:
+    """Ordered commit/rollback record for one scheduled dynamic step."""
+
+    step_id: DynamicStepId
+    snapshot_slot_id: int
+    request_slots_before: Sequence[int] = field(default_factory=tuple)
+    request_slots_after: Sequence[int] = field(default_factory=tuple)
+    active_request_ids: Sequence[str] = field(default_factory=tuple)
+    placeholder_token_counts: Mapping[str, int] = field(default_factory=dict)
+    reserved_kv_blocks: Sequence[int] = field(default_factory=tuple)
+    reserved_mamba_slots: Sequence[int] = field(default_factory=tuple)
+    prefix_cache_refcount_deltas: Mapping[Any, int] = field(default_factory=dict)
+    pause_resume_evictions: Sequence[str] = field(default_factory=tuple)
+    decode_input_destination_indices: Sequence[int] = field(default_factory=tuple)
+    cuda_graph_batch_dimensions: Optional[Any] = None
+    resources_waiting_on_snapshot: Sequence[ResourceReservation] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.snapshot_slot_id < 0:
+            raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+        object.__setattr__(self, "request_slots_before", _as_tuple(self.request_slots_before))
+        object.__setattr__(self, "request_slots_after", _as_tuple(self.request_slots_after))
+        object.__setattr__(self, "active_request_ids", _as_tuple(self.active_request_ids))
+        object.__setattr__(
+            self, "placeholder_token_counts", _freeze_mapping(self.placeholder_token_counts)
+        )
+        object.__setattr__(self, "reserved_kv_blocks", _as_tuple(self.reserved_kv_blocks))
+        object.__setattr__(self, "reserved_mamba_slots", _as_tuple(self.reserved_mamba_slots))
+        object.__setattr__(
+            self,
+            "prefix_cache_refcount_deltas",
+            _freeze_mapping(self.prefix_cache_refcount_deltas),
+        )
+        object.__setattr__(
+            self, "pause_resume_evictions", _as_tuple(self.pause_resume_evictions)
+        )
+        object.__setattr__(
+            self,
+            "decode_input_destination_indices",
+            _as_tuple(self.decode_input_destination_indices),
+        )
+        object.__setattr__(
+            self, "resources_waiting_on_snapshot", _as_tuple(self.resources_waiting_on_snapshot)
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class StepRetirementResult:
+    """Ordered retirement result for one dynamic step."""
+
+    step_id: DynamicStepId
+    snapshot_slot_id: int
+    output_ready_event: Optional[Any] = None
+    committed_request_ids: Sequence[str] = field(default_factory=tuple)
+    completed_request_ids: Sequence[str] = field(default_factory=tuple)
+    rolled_back_request_ids: Sequence[str] = field(default_factory=tuple)
+    reservation_commits: int = 0
+    reservation_rollbacks: int = 0
+
+    def __post_init__(self) -> None:
+        if self.snapshot_slot_id < 0:
+            raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+        object.__setattr__(self, "committed_request_ids", _as_tuple(self.committed_request_ids))
+        object.__setattr__(self, "completed_request_ids", _as_tuple(self.completed_request_ids))
+        object.__setattr__(
+            self, "rolled_back_request_ids", _as_tuple(self.rolled_back_request_ids)
+        )

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -24,6 +24,21 @@ def _freeze_mapping(value: Optional[Mapping[Any, Any]]) -> Mapping[Any, Any]:
     return MappingProxyType(dict(value))
 
 
+def _as_int_pair_tuple(value: Optional[Sequence[Sequence[int]]]) -> Tuple[Tuple[int, int], ...]:
+    """Return an immutable tuple of integer pairs."""
+    if value is None:
+        return ()
+    pairs = []
+    for pair in value:
+        if len(pair) != 2:
+            raise ValueError(f"expected a pair, got {pair}")
+        start, end = pair
+        if int(start) < 0 or int(end) < int(start):
+            raise ValueError(f"invalid token range ({start}, {end})")
+        pairs.append((int(start), int(end)))
+    return tuple(pairs)
+
+
 @dataclass(frozen=True, order=True)
 class DynamicStepId:
     """Monotonic dynamic inference step identity."""
@@ -78,16 +93,24 @@ class StepInputPlan:
 
     step_id: DynamicStepId
     snapshot_slot_id: int
+    source_step_id: Optional[DynamicStepId] = None
     request_ids: Sequence[str] = field(default_factory=tuple)
+    decode_request_slots: Sequence[int] = field(default_factory=tuple)
     decode_request_ids: Sequence[str] = field(default_factory=tuple)
     prefill_request_ids: Sequence[str] = field(default_factory=tuple)
     decode_input_destination_indices: Sequence[int] = field(default_factory=tuple)
+    prefill_prompt_token_ranges: Sequence[Sequence[int]] = field(default_factory=tuple)
+    speculative_width: int = 0
+    debug_expected_input_ids: Optional[Any] = None
     input_ready_event: Optional[Any] = None
 
     def __post_init__(self) -> None:
         if self.snapshot_slot_id < 0:
             raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+        if self.speculative_width < 0:
+            raise ValueError(f"speculative_width must be >= 0, got {self.speculative_width}")
         object.__setattr__(self, "request_ids", _as_tuple(self.request_ids))
+        object.__setattr__(self, "decode_request_slots", _as_tuple(self.decode_request_slots))
         object.__setattr__(self, "decode_request_ids", _as_tuple(self.decode_request_ids))
         object.__setattr__(self, "prefill_request_ids", _as_tuple(self.prefill_request_ids))
         object.__setattr__(
@@ -95,6 +118,16 @@ class StepInputPlan:
             "decode_input_destination_indices",
             _as_tuple(self.decode_input_destination_indices),
         )
+        object.__setattr__(
+            self,
+            "prefill_prompt_token_ranges",
+            _as_int_pair_tuple(self.prefill_prompt_token_ranges),
+        )
+        if len(self.decode_request_slots) != len(self.decode_input_destination_indices):
+            raise ValueError(
+                "decode_request_slots and decode_input_destination_indices must have "
+                "the same length"
+            )
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -68,30 +68,52 @@ class DynamicAsyncPipeline:
         """Number of launched steps awaiting ordered retirement."""
         return len(self.in_flight_launches)
 
-    async def step(self):
+    async def step(self, max_forward_launches: Optional[int] = None):
         """Run one queue-depth-limited pipeline step."""
         if self.queue_depth == 1:
-            return await self._step_queue_depth_one()
-        return await self._step_with_lookahead()
+            return await self._step_queue_depth_one(max_forward_launches=max_forward_launches)
+        return await self._step_with_lookahead(max_forward_launches=max_forward_launches)
 
-    async def _step_queue_depth_one(self):
+    def planned_launch_count(self, max_forward_launches: Optional[int] = None) -> int:
+        """Return how many real forwards the next :meth:`step` call can launch."""
+        if max_forward_launches is not None and max_forward_launches <= 0:
+            return 0
+        if self.pending_launch_count >= self.queue_depth:
+            return 0
+        if not self._has_launch_work():
+            return 0
+        if self.pending_launch_count > 0 and not self._can_launch_lookahead(record_blocker=False):
+            return 0
+        if max_forward_launches is None:
+            return 1
+        return min(1, int(max_forward_launches))
+
+    async def _step_queue_depth_one(self, max_forward_launches: Optional[int] = None):
         """Run the serial queue-depth-one pipeline."""
         if self.pending_launch_count >= self.queue_depth:
             await self.drain_next()
-        self.in_flight_launches.append(await self.engine.async_forward())
+        if self.planned_launch_count(max_forward_launches=max_forward_launches) > 0:
+            self.in_flight_launches.append(await self.engine.async_forward())
         return await self.drain_next()
 
-    async def _step_with_lookahead(self):
+    async def _step_with_lookahead(self, max_forward_launches: Optional[int] = None):
         """Launch one lookahead step before retiring the oldest pending step."""
         if self.pending_launch_count >= self.queue_depth:
             return await self.drain_next()
 
         launched = False
-        while self.pending_launch_count < self.queue_depth and self._has_launch_work():
+        launch_count = 0
+        launch_limit = self.queue_depth if max_forward_launches is None else max_forward_launches
+        while (
+            launch_count < launch_limit
+            and self.pending_launch_count < self.queue_depth
+            and self._has_launch_work()
+        ):
             if self.pending_launch_count > 0 and not self._can_launch_lookahead():
                 break
             self.in_flight_launches.append(await self.engine.async_forward())
             launched = True
+            launch_count += 1
             if self.pending_launch_count > 1:
                 break
 
@@ -109,8 +131,11 @@ class DynamicAsyncPipeline:
             return bool(checker())
         return True
 
-    def _can_launch_lookahead(self) -> bool:
+    def _can_launch_lookahead(self, *, record_blocker: bool = True) -> bool:
         """Return whether a pending step can safely be left for ordered retirement."""
+        planning_checker = getattr(self.engine, "can_plan_async_overlap_lookahead", None)
+        if not record_blocker and planning_checker is not None:
+            return bool(planning_checker())
         checker = getattr(self.engine, "can_launch_async_overlap_lookahead", None)
         if checker is not None:
             return bool(checker())

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -144,11 +144,48 @@ class DynamicAsyncPipeline:
 
     def drain_for_request_reuse(self, request_id: int) -> None:
         """Validate no launched step can still reference a reused request ID."""
-        if self.in_flight_launches:
+        if self._pending_launch_references_request(request_id):
             raise RuntimeError(
                 f"Cannot reuse request {request_id} with unretired launched steps"
             )
         self.retirement_service.drain_for_request_reuse(request_id)
+
+    def _pending_launch_references_request(self, request_id: int) -> bool:
+        """Return whether pending launched work references a request ID."""
+        request_id = int(request_id)
+        for step_result, _, _ in self.in_flight_launches:
+            if step_result is None:
+                continue
+            referenced_ids = (
+                step_result.get("active_request_ids"),
+                step_result.get("finished_request_ids"),
+                step_result.get("newly_paused_request_ids"),
+                step_result.get("evict_request_ids"),
+            )
+            for ids in referenced_ids:
+                if ids is None:
+                    continue
+                if request_id in self._coerce_request_id_set(ids):
+                    return True
+        return False
+
+    @staticmethod
+    def _coerce_request_id_set(ids: Any) -> set[int]:
+        """Return a flat set of integer request IDs from tensor/list/scalar data."""
+        if hasattr(ids, "tolist"):
+            ids = ids.tolist()
+        if not isinstance(ids, (list, tuple)):
+            ids = [ids]
+
+        flattened = []
+        stack = list(ids)
+        while stack:
+            value = stack.pop()
+            if isinstance(value, (list, tuple)):
+                stack.extend(value)
+            else:
+                flattened.append(int(value))
+        return set(flattened)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections import deque
 from collections.abc import Mapping, Sequence
@@ -107,19 +108,28 @@ class DynamicAsyncPipeline:
         launched = False
         launch_count = 0
         launch_limit = self.queue_depth if max_forward_launches is None else max_forward_launches
-        while (
+        if launch_limit is None:
+            launch_limit = self.queue_depth
+        launch_limit = int(launch_limit)
+
+        if (
             launch_count < launch_limit
-            and self.pending_launch_count < self.queue_depth
+            and self.pending_launch_count == 0
             and self._has_launch_work()
         ):
-            if self.pending_launch_count > 0 and not self._can_launch_lookahead():
-                break
             self.in_flight_launches.append(await self.engine.async_forward())
             self._record_pending_launch_count()
             launched = True
             launch_count += 1
-            if self.pending_launch_count > 1:
-                break
+
+        if (
+            launch_count < launch_limit
+            and self.pending_launch_count > 0
+            and self.pending_launch_count < self.queue_depth
+            and self._has_launch_work()
+            and self._can_launch_lookahead()
+        ):
+            return await self._launch_lookahead_and_drain_next()
 
         if self.pending_launch_count > 1:
             return await self.drain_next()
@@ -127,6 +137,33 @@ class DynamicAsyncPipeline:
             if not launched or not self._has_launch_work() or not self._can_launch_lookahead():
                 return await self.drain_next()
         return None
+
+    async def _launch_lookahead_and_drain_next(self):
+        """Run the next forward to its yield point, then retire older CPU output."""
+        launch_task = asyncio.create_task(self.engine.async_forward())
+
+        # ``async_forward`` yields immediately after enqueueing forward kernels.
+        # Give it one event-loop turn so retirement can run while those kernels
+        # are active instead of after the entire lookahead step has completed.
+        await asyncio.sleep(0)
+
+        if launch_task.done():
+            self.in_flight_launches.append(launch_task.result())
+            self._record_pending_launch_count()
+            return await self.drain_next()
+
+        try:
+            result = await self.drain_next(hidden_under_gpu=True)
+        except BaseException:
+            if not launch_task.done():
+                try:
+                    await launch_task
+                except BaseException:
+                    pass
+            raise
+        self.in_flight_launches.append(await launch_task)
+        self._record_pending_launch_count()
+        return result
 
     def _has_launch_work(self) -> bool:
         """Return whether the engine can launch another dynamic step."""
@@ -145,7 +182,7 @@ class DynamicAsyncPipeline:
             return bool(checker())
         return True
 
-    async def drain_next(self):
+    async def drain_next(self, *, hidden_under_gpu: bool = False):
         """Retire the oldest launched step, if one is pending."""
         if not self.in_flight_launches:
             return None
@@ -155,7 +192,7 @@ class DynamicAsyncPipeline:
             return await self.engine.async_bookkeep(step_result, context_state, step_time)
         finally:
             counters = getattr(self.engine, "async_overlap_debug_counters", None)
-            if counters is not None and self.pending_launch_count > 0:
+            if counters is not None and (hidden_under_gpu or self.pending_launch_count > 0):
                 counters.cpu_time_hidden_under_gpu_s += time.perf_counter() - hidden_start
 
     async def drain_all(self):

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -70,10 +70,51 @@ class DynamicAsyncPipeline:
 
     async def step(self):
         """Run one queue-depth-limited pipeline step."""
+        if self.queue_depth == 1:
+            return await self._step_queue_depth_one()
+        return await self._step_with_lookahead()
+
+    async def _step_queue_depth_one(self):
+        """Run the serial queue-depth-one pipeline."""
         if self.pending_launch_count >= self.queue_depth:
             await self.drain_next()
         self.in_flight_launches.append(await self.engine.async_forward())
         return await self.drain_next()
+
+    async def _step_with_lookahead(self):
+        """Launch one lookahead step before retiring the oldest pending step."""
+        if self.pending_launch_count >= self.queue_depth:
+            return await self.drain_next()
+
+        launched = False
+        while self.pending_launch_count < self.queue_depth and self._has_launch_work():
+            if self.pending_launch_count > 0 and not self._can_launch_lookahead():
+                break
+            self.in_flight_launches.append(await self.engine.async_forward())
+            launched = True
+            if self.pending_launch_count > 1:
+                break
+
+        if self.pending_launch_count > 1:
+            return await self.drain_next()
+        if self.pending_launch_count == 1:
+            if not launched or not self._has_launch_work() or not self._can_launch_lookahead():
+                return await self.drain_next()
+        return None
+
+    def _has_launch_work(self) -> bool:
+        """Return whether the engine can launch another dynamic step."""
+        checker = getattr(self.engine, "has_async_overlap_launch_work", None)
+        if checker is not None:
+            return bool(checker())
+        return True
+
+    def _can_launch_lookahead(self) -> bool:
+        """Return whether a pending step can safely be left for ordered retirement."""
+        checker = getattr(self.engine, "can_launch_async_overlap_lookahead", None)
+        if checker is not None:
+            return bool(checker())
+        return True
 
     async def drain_next(self):
         """Retire the oldest launched step, if one is pending."""

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -104,14 +104,22 @@ class DynamicStepContextSnapshot:
     step_id: DynamicStepId
     snapshot_slot_id: int
     request_plan: DynamicStepRequestPlan
+    active_request_count: int = 0
+    cuda_graph_request_count: Optional[int] = None
     metadata_ready_event: Optional[Any] = None
     input_ready_event: Optional[Any] = None
+    input_ids: Optional[Any] = None
+    position_ids: Optional[Any] = None
     gpu_view: Optional[Any] = None
     cpu_staging_buffer: Optional[Any] = None
 
     def __post_init__(self) -> None:
         if self.snapshot_slot_id < 0:
             raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+        if self.active_request_count < 0:
+            raise ValueError(
+                f"active_request_count must be >= 0, got {self.active_request_count}"
+            )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -123,6 +131,10 @@ class DynamicStepGpuLaunch:
     metadata_ready_event: Optional[Any] = None
     input_ready_event: Optional[Any] = None
     compute_done_event: Optional[Any] = None
+    input_ids: Optional[Any] = None
+    position_ids: Optional[Any] = None
+    logits: Optional[Any] = None
+    routing_indices_per_request: Optional[Any] = None
     cuda_graph_batch_dimensions: Optional[Any] = None
 
     def __post_init__(self) -> None:
@@ -136,10 +148,12 @@ class AsyncStepOutput:
 
     step_id: DynamicStepId
     snapshot_slot_id: int
+    active_request_count: int = 0
     compute_done_event: Optional[Any] = None
     output_ready_event: Optional[Any] = None
     sampled_tokens: Optional[Any] = None
     sampled_tokens_cpu: Optional[Any] = None
+    sampled_mtp_tokens_cpu: Optional[Any] = None
     accepted_token_counts_cpu: Optional[Any] = None
     logprob_payload_cpu: Optional[Any] = None
     routing_payload_cpu: Optional[Any] = None
@@ -147,6 +161,10 @@ class AsyncStepOutput:
     def __post_init__(self) -> None:
         if self.snapshot_slot_id < 0:
             raise ValueError(f"snapshot_slot_id must be >= 0, got {self.snapshot_slot_id}")
+        if self.active_request_count < 0:
+            raise ValueError(
+                f"active_request_count must be >= 0, got {self.active_request_count}"
+            )
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -200,6 +200,7 @@ class AsyncStepOutput:
     active_request_count: int = 0
     compute_done_event: Optional[Any] = None
     output_ready_event: Optional[Any] = None
+    active_requests_mask: Optional[Any] = None
     sampled_tokens: Optional[Any] = None
     sampled_tokens_cpu: Optional[Any] = None
     sampled_mtp_tokens_cpu: Optional[Any] = None
@@ -298,6 +299,7 @@ class StepRetirementResult:
     rolled_back_request_ids: Sequence[str] = field(default_factory=tuple)
     reservation_commits: int = 0
     reservation_rollbacks: int = 0
+    context_update_result: Optional[Mapping[str, Any]] = None
 
     def __post_init__(self) -> None:
         if self.snapshot_slot_id < 0:
@@ -307,3 +309,7 @@ class StepRetirementResult:
         object.__setattr__(
             self, "rolled_back_request_ids", _as_tuple(self.rolled_back_request_ids)
         )
+        if self.context_update_result is not None:
+            object.__setattr__(
+                self, "context_update_result", _freeze_mapping(self.context_update_result)
+            )

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Optional, Tuple
+from typing import Any, Deque, Optional, Tuple
 
 
 def _as_tuple(value: Optional[Sequence[Any]]) -> Tuple[Any, ...]:
@@ -48,6 +49,65 @@ class DynamicStepId:
     def __post_init__(self) -> None:
         if self.value < 0:
             raise ValueError(f"DynamicStepId must be >= 0, got {self.value}")
+
+
+class DynamicAsyncPipeline:
+    """Queue-depth-limited dynamic-step launch and retirement pipeline."""
+
+    def __init__(self, *, engine: Any, retirement_service: Any, queue_depth: int):
+        if queue_depth <= 0:
+            raise ValueError(f"queue_depth must be > 0, got {queue_depth}")
+        self.engine = engine
+        self.retirement_service = retirement_service
+        self.queue_depth = int(queue_depth)
+        self.snapshot_pool = engine.context.snapshot_pool
+        self.in_flight_launches: Deque[Tuple[Any, Any, float]] = deque()
+
+    @property
+    def pending_launch_count(self) -> int:
+        """Number of launched steps awaiting ordered retirement."""
+        return len(self.in_flight_launches)
+
+    async def step(self):
+        """Run one queue-depth-limited pipeline step."""
+        if self.pending_launch_count >= self.queue_depth:
+            await self.drain_next()
+        self.in_flight_launches.append(await self.engine.async_forward())
+        return await self.drain_next()
+
+    async def drain_next(self):
+        """Retire the oldest launched step, if one is pending."""
+        if not self.in_flight_launches:
+            return None
+        step_result, context_state, step_time = self.in_flight_launches.popleft()
+        return await self.engine.async_bookkeep(step_result, context_state, step_time)
+
+    async def drain_all(self):
+        """Retire every pending launched step."""
+        result = None
+        while self.in_flight_launches:
+            result = await self.drain_next()
+        return result
+
+    def drain_for_shutdown(self) -> None:
+        """Validate no launched step is left unretired before shutdown."""
+        if self.in_flight_launches:
+            raise RuntimeError("Cannot synchronously shutdown with unretired launched steps")
+        self.retirement_service.drain_for_shutdown()
+
+    def drain_for_suspend(self) -> None:
+        """Validate no launched step is left unretired before suspend."""
+        if self.in_flight_launches:
+            raise RuntimeError("Cannot synchronously suspend with unretired launched steps")
+        self.retirement_service.drain_for_suspend()
+
+    def drain_for_request_reuse(self, request_id: int) -> None:
+        """Validate no launched step can still reference a reused request ID."""
+        if self.in_flight_launches:
+            raise RuntimeError(
+                f"Cannot reuse request {request_id} with unretired launched steps"
+            )
+        self.retirement_service.drain_for_request_reuse(request_id)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import time
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
@@ -70,6 +71,7 @@ class DynamicAsyncPipeline:
 
     async def step(self, max_forward_launches: Optional[int] = None):
         """Run one queue-depth-limited pipeline step."""
+        self._record_queue_depth_sample()
         if self.queue_depth == 1:
             return await self._step_queue_depth_one(max_forward_launches=max_forward_launches)
         return await self._step_with_lookahead(max_forward_launches=max_forward_launches)
@@ -94,6 +96,7 @@ class DynamicAsyncPipeline:
             await self.drain_next()
         if self.planned_launch_count(max_forward_launches=max_forward_launches) > 0:
             self.in_flight_launches.append(await self.engine.async_forward())
+            self._record_pending_launch_count()
         return await self.drain_next()
 
     async def _step_with_lookahead(self, max_forward_launches: Optional[int] = None):
@@ -112,6 +115,7 @@ class DynamicAsyncPipeline:
             if self.pending_launch_count > 0 and not self._can_launch_lookahead():
                 break
             self.in_flight_launches.append(await self.engine.async_forward())
+            self._record_pending_launch_count()
             launched = True
             launch_count += 1
             if self.pending_launch_count > 1:
@@ -146,7 +150,13 @@ class DynamicAsyncPipeline:
         if not self.in_flight_launches:
             return None
         step_result, context_state, step_time = self.in_flight_launches.popleft()
-        return await self.engine.async_bookkeep(step_result, context_state, step_time)
+        hidden_start = time.perf_counter()
+        try:
+            return await self.engine.async_bookkeep(step_result, context_state, step_time)
+        finally:
+            counters = getattr(self.engine, "async_overlap_debug_counters", None)
+            if counters is not None and self.pending_launch_count > 0:
+                counters.cpu_time_hidden_under_gpu_s += time.perf_counter() - hidden_start
 
     async def drain_all(self):
         """Retire every pending launched step."""
@@ -179,6 +189,26 @@ class DynamicAsyncPipeline:
                 f"Cannot reuse request {request_id} with unretired launched steps"
             )
         self.retirement_service.drain_for_request_reuse(request_id)
+
+    def _record_queue_depth_sample(self) -> None:
+        """Update per-step queue-depth distribution counters."""
+        counters = getattr(self.engine, "async_overlap_debug_counters", None)
+        if counters is None:
+            return
+        if self.queue_depth <= 1:
+            counters.queue_depth_one_steps += 1
+        else:
+            counters.queue_depth_two_steps += 1
+        self._record_pending_launch_count()
+
+    def _record_pending_launch_count(self) -> None:
+        """Track the maximum observed in-flight launch count."""
+        counters = getattr(self.engine, "async_overlap_debug_counters", None)
+        if counters is None:
+            return
+        counters.max_pending_launches_observed = max(
+            counters.max_pending_launches_observed, self.pending_launch_count
+        )
 
     def _pending_launch_references_request(self, request_id: int) -> bool:
         """Return whether pending launched work references a request ID."""

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -122,6 +122,21 @@ class DynamicStepContextSnapshot:
             )
 
 
+def assert_snapshot_gpu_view_bound(
+    snapshot: DynamicStepContextSnapshot, live_gpu_view: Optional[Any], *, debug_enabled: bool
+) -> None:
+    """Guard that dynamic GPU work is bound to the prepared snapshot view."""
+    if not debug_enabled:
+        return
+    if snapshot.gpu_view is None:
+        raise RuntimeError("Dynamic GPU launch requires a snapshot-bound gpu_view")
+    if snapshot.gpu_view is not live_gpu_view:
+        raise RuntimeError(
+            "Dynamic GPU launch would read mutable context.gpu_view instead of the prepared "
+            "snapshot gpu_view"
+        )
+
+
 @dataclass(frozen=True, kw_only=True)
 class DynamicStepGpuLaunch:
     """Forward/sampling launch contract for one dynamic step."""
@@ -133,6 +148,7 @@ class DynamicStepGpuLaunch:
     compute_done_event: Optional[Any] = None
     input_ids: Optional[Any] = None
     position_ids: Optional[Any] = None
+    gpu_view: Optional[Any] = None
     logits: Optional[Any] = None
     routing_indices_per_request: Optional[Any] = None
     cuda_graph_batch_dimensions: Optional[Any] = None

--- a/megatron/core/inference/engines/dynamic_step.py
+++ b/megatron/core/inference/engines/dynamic_step.py
@@ -155,6 +155,11 @@ class DynamicAsyncPipeline:
             result = await self.drain_next()
         return result
 
+    async def drain_for_suspend_barrier(self):
+        """Retire launched steps and clear open retirement work before suspend."""
+        await self.drain_all()
+        self.drain_for_suspend()
+
     def drain_for_shutdown(self) -> None:
         """Validate no launched step is left unretired before shutdown."""
         if self.in_flight_launches:

--- a/megatron/core/inference/engines/step_retirement.py
+++ b/megatron/core/inference/engines/step_retirement.py
@@ -164,6 +164,10 @@ class StepRetirementService:
             log_probs = step_result["log_probs"]
             top_n_logprobs = step_result.get("top_n_logprobs", None)
             routing_indices_per_request = step_result.get("routing_indices_per_request", None)
+            chunked_prefill_no_output_request_ids = set(
+                int(request_id)
+                for request_id in step_result.get("chunked_prefill_no_output_request_ids", ())
+            )
             cuda_graph_request_count = step_result["cuda_graph_request_count"]
 
             # Add paused events.
@@ -184,6 +188,7 @@ class StepRetirementService:
                 log_probs,
                 top_n_logprobs,
                 routing_indices_per_request,
+                chunked_prefill_no_output_request_ids,
                 pre_fwd_active_token_count=context_state.get("active_token_count"),
                 pre_fwd_step_count=context_state.get("step_count"),
             )

--- a/megatron/core/inference/engines/step_retirement.py
+++ b/megatron/core/inference/engines/step_retirement.py
@@ -321,6 +321,12 @@ class StepRetirementService:
             'inference/step_time_s': float(step_time),
             'inference/waiting_queue_len': int(len(engine.waiting_request_ids)),
             'inference/total_requests_dict_size': int(len(engine.requests)),
+            'inference/async_overlap_queue_depth': int(
+                engine.async_overlap_debug_counters.queue_depth
+            ),
+            'inference/async_overlap_queue_depth_two_active': int(
+                engine.async_overlap_debug_counters.queue_depth >= 2
+            ),
             'inference/accepted_output_tokens': int(
                 engine.async_overlap_debug_counters.accepted_output_tokens
             ),
@@ -335,6 +341,9 @@ class StepRetirementService:
             ),
             'inference/distributed_prepare_downgrades': int(
                 engine.async_overlap_debug_counters.distributed_prepare_downgrades
+            ),
+            'inference/queue_depth_one_downgrades': int(
+                engine.async_overlap_debug_counters.queue_depth_one_downgrades
             ),
         }
         for key, value in context_state["kv_stats"].items():
@@ -360,6 +369,12 @@ class StepRetirementService:
             )
         for status, count in engine.async_overlap_debug_counters.rollback_status_counts.items():
             metrics[f'inference/rollback_{status}'] = int(count)
+        for reason, count in (
+            engine.async_overlap_debug_counters.fallback_or_queue_depth_one_reasons.items()
+        ):
+            metrics[f'inference/queue_depth_one_reason_{reason}'] = int(count)
+        for reason, count in engine.async_overlap_debug_counters.downgrade_reasons.items():
+            metrics[f'inference/queue_depth_one_downgrade_{reason}'] = int(count)
 
         if HAVE_WANDB and engine.metrics_writer.__name__ == "wandb":
             engine.metrics_writer.log(metrics, commit=True)

--- a/megatron/core/inference/engines/step_retirement.py
+++ b/megatron/core/inference/engines/step_retirement.py
@@ -290,6 +290,15 @@ class StepRetirementService:
             'inference/step_time_s': float(step_time),
             'inference/waiting_queue_len': int(len(engine.waiting_request_ids)),
             'inference/total_requests_dict_size': int(len(engine.requests)),
+            'inference/accepted_output_tokens': int(
+                engine.async_overlap_debug_counters.accepted_output_tokens
+            ),
+            'inference/discarded_lookahead_tokens': int(
+                engine.async_overlap_debug_counters.discarded_lookahead_tokens
+            ),
+            'inference/speculative_rejected_tokens': int(
+                engine.async_overlap_debug_counters.speculative_rejected_tokens
+            ),
         }
         for key, value in context_state["kv_stats"].items():
             if 'utilization' in key:
@@ -302,6 +311,9 @@ class StepRetirementService:
             metrics['inference/spec_decode_acceptance_rate'] = float(acceptance_rate * 100.0)
             metrics['inference/spec_decode_tokens_proposed'] = int(engine._spec_tokens_proposed)
             metrics['inference/spec_decode_tokens_accepted'] = int(engine._spec_tokens_accepted)
+            metrics['inference/spec_decode_tokens_rejected'] = int(
+                engine._spec_tokens_proposed - engine._spec_tokens_accepted
+            )
             metrics['inference/spec_decode_num_steps'] = int(engine._spec_steps)
 
         if engine.context.enable_prefix_caching and engine._prefix_cache_hits > 0:

--- a/megatron/core/inference/engines/step_retirement.py
+++ b/megatron/core/inference/engines/step_retirement.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Deque, Dict, Optional
 
 import torch
 
+from megatron.core.inference.contexts.step_journal import RollbackStatus
 from megatron.core.inference.headers import Headers
 from megatron.core.inference.inference_request import DynamicInferenceRequestRecord, Status
 from megatron.core.utils import nvtx_range_pop, nvtx_range_push
@@ -112,7 +113,7 @@ class StepRetirementService:
         can leave an open journal entry that must not survive shutdown.
         """
         self.drain_pending()
-        self.engine.context.rollback_all_open_step_journals(reason="shutdown_drain")
+        self._rollback_open_journals("shutdown_drain")
 
     def drain_for_suspend(self) -> None:
         """Drain in-flight retirement work before suspend.
@@ -121,7 +122,7 @@ class StepRetirementService:
         can leave an open journal entry that must not survive suspend.
         """
         self.drain_pending()
-        self.engine.context.rollback_all_open_step_journals(reason="suspend_drain")
+        self._rollback_open_journals("suspend_drain")
 
     def drain_for_request_reuse(self, request_id: int) -> None:
         """Drain work that could still reference a request ID before reuse.
@@ -270,6 +271,36 @@ class StepRetirementService:
         setattr(counters, "retirement_backlog", self.pending_count)
         setattr(counters, "max_retirement_backlog", self.max_retirement_backlog)
 
+    def _rollback_open_journals(self, reason: str) -> None:
+        """Roll back open journals and record the cleanup outcomes."""
+        rollback_range = self.engine._step_nvtx_label(f"rollback_{reason}")
+        nvtx_range_push(rollback_range)
+        try:
+            rollback_results = self.engine.context.rollback_all_open_step_journals(
+                reason=reason
+            )
+        finally:
+            nvtx_range_pop(rollback_range)
+        self._record_rollback_results(rollback_results or ())
+
+    def _record_rollback_results(self, rollback_results) -> None:
+        counters = getattr(self.engine, "async_overlap_debug_counters", None)
+        if counters is None:
+            return
+        for result in rollback_results:
+            statuses = (result.status,) + tuple(result.resource_statuses)
+            for status in statuses:
+                status_value = RollbackStatus(status).value
+                counters.rollback_status_counts[status_value] = (
+                    counters.rollback_status_counts.get(status_value, 0) + 1
+                )
+                if status == RollbackStatus.PARTIALLY_RELEASED:
+                    counters.partial_reservation_rollbacks += 1
+                elif status == RollbackStatus.RESOURCE_ALREADY_EVICTED:
+                    counters.resource_already_evicted_rollbacks += 1
+                elif status == RollbackStatus.DEFERRED_UNTIL_SNAPSHOT_RETIRED:
+                    counters.deferred_reservation_rollbacks += 1
+
     def _drain_prefix_cache_counters(self) -> None:
         engine = self.engine
         if engine.context.enable_prefix_caching:
@@ -321,6 +352,8 @@ class StepRetirementService:
             metrics['inference/prefix_cache_blocks_matched'] = int(
                 engine._prefix_cache_blocks_matched
             )
+        for status, count in engine.async_overlap_debug_counters.rollback_status_counts.items():
+            metrics[f'inference/rollback_{status}'] = int(count)
 
         if HAVE_WANDB and engine.metrics_writer.__name__ == "wandb":
             engine.metrics_writer.log(metrics, commit=True)

--- a/megatron/core/inference/engines/step_retirement.py
+++ b/megatron/core/inference/engines/step_retirement.py
@@ -5,8 +5,10 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
+from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Deque, Dict, Optional
 
 import torch
 
@@ -16,6 +18,16 @@ from megatron.core.utils import nvtx_range_pop, nvtx_range_push
 
 if TYPE_CHECKING:
     from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
+
+
+@dataclass(frozen=True)
+class StepRetirementWorkItem:
+    """One ordered step waiting for public output retirement."""
+
+    step_result: Optional[Dict]
+    context_state: Dict
+    step_time: float
+
 
 try:
     import msgpack
@@ -43,6 +55,54 @@ class StepRetirementService:
     def __init__(self, engine: "DynamicInferenceEngine"):
         self.engine = engine
         self._last_retired_step_id = -1
+        self._pending_retirements: Deque[StepRetirementWorkItem] = deque()
+        self.max_retirement_backlog = max(1, int(getattr(engine, "async_overlap_queue_depth", 1)))
+        self._update_backlog_counters()
+
+    @property
+    def pending_count(self) -> int:
+        """Number of step outputs waiting for ordered retirement."""
+        return len(self._pending_retirements)
+
+    def enqueue_step(
+        self, step_result: Optional[Dict], context_state: Dict, step_time: float
+    ) -> None:
+        """Queue one step for ordered retirement, enforcing the backlog limit."""
+        if self.pending_count >= self.max_retirement_backlog:
+            raise RuntimeError(
+                "Step retirement backlog is full: "
+                f"{self.pending_count}/{self.max_retirement_backlog}"
+            )
+        self._pending_retirements.append(
+            StepRetirementWorkItem(
+                step_result=step_result,
+                context_state=context_state,
+                step_time=step_time,
+            )
+        )
+        self._update_backlog_counters()
+
+    def drain_next(self) -> Optional[Dict]:
+        """Retire the next queued step, if any."""
+        if not self._pending_retirements:
+            return None
+        item = self._pending_retirements.popleft()
+        self._update_backlog_counters()
+        return self._retire_step_now(item.step_result, item.context_state, item.step_time)
+
+    def drain_pending(self) -> None:
+        """Synchronously retire every queued output in order."""
+        while self._pending_retirements:
+            self.drain_next()
+
+    def submit_step(
+        self, step_result: Optional[Dict], context_state: Dict, step_time: float
+    ) -> Dict:
+        """Queue and immediately retire one step in queue-depth-one mode."""
+        self.enqueue_step(step_result, context_state, step_time)
+        result = self.drain_next()
+        assert result is not None
+        return result
 
     def drain_for_shutdown(self) -> None:
         """Drain in-flight retirement work before shutdown.
@@ -50,6 +110,7 @@ class StepRetirementService:
         Queue depth one has no detached retirement work, but an interrupted step
         can leave an open journal entry that must not survive shutdown.
         """
+        self.drain_pending()
         self.engine.context.rollback_all_open_step_journals(reason="shutdown_drain")
 
     def drain_for_suspend(self) -> None:
@@ -58,6 +119,7 @@ class StepRetirementService:
         Queue depth one has no detached retirement work, but an interrupted step
         can leave an open journal entry that must not survive suspend.
         """
+        self.drain_pending()
         self.engine.context.rollback_all_open_step_journals(reason="suspend_drain")
 
     def drain_for_request_reuse(self, request_id: int) -> None:
@@ -66,8 +128,15 @@ class StepRetirementService:
         Queue depth one retires each step before the next request can reuse an ID.
         """
         del request_id
+        self.drain_pending()
 
     def retire_step(
+        self, step_result: Optional[Dict], context_state: Dict, step_time: float
+    ) -> Dict:
+        """Compatibility wrapper for queueing and retiring one dynamic step."""
+        return self.submit_step(step_result, context_state, step_time)
+
+    def _retire_step_now(
         self, step_result: Optional[Dict], context_state: Dict, step_time: float
     ) -> Dict:
         """Retire one dynamic step and return the engine-visible bookkeeping result."""
@@ -187,6 +256,13 @@ class StepRetirementService:
             "step_time": step_time,
             "cuda_graph_request_count": cuda_graph_request_count,
         }
+
+    def _update_backlog_counters(self) -> None:
+        counters = getattr(self.engine, "async_overlap_debug_counters", None)
+        if counters is None:
+            return
+        setattr(counters, "retirement_backlog", self.pending_count)
+        setattr(counters, "max_retirement_backlog", self.max_retirement_backlog)
 
     def _drain_prefix_cache_counters(self) -> None:
         engine = self.engine

--- a/megatron/core/inference/engines/step_retirement.py
+++ b/megatron/core/inference/engines/step_retirement.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Ordered dynamic-step retirement for async-overlap inference."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Dict, Optional
+
+import torch
+
+from megatron.core.inference.headers import Headers
+from megatron.core.inference.inference_request import DynamicInferenceRequestRecord, Status
+from megatron.core.utils import nvtx_range_pop, nvtx_range_push
+
+if TYPE_CHECKING:
+    from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
+
+try:
+    import msgpack
+
+    HAVE_MSGPACK = True
+except ImportError:
+    HAVE_MSGPACK = False
+    msgpack = None
+
+try:
+    import wandb  # pylint: disable=unused-import
+
+    HAVE_WANDB = True
+except ImportError:
+    HAVE_WANDB = False
+
+
+class StepRetirementService:
+    """Retire dynamic steps in order.
+
+    Commit 6 runs this synchronously with queue depth one. Later commits can enqueue
+    outputs and have this service drain them independently while preserving step order.
+    """
+
+    def __init__(self, engine: "DynamicInferenceEngine"):
+        self.engine = engine
+        self._last_retired_step_id = -1
+
+    def drain_for_shutdown(self) -> None:
+        """Drain in-flight retirement work before shutdown.
+
+        Queue depth one has no detached retirement work, so this is currently a no-op.
+        """
+
+    def drain_for_suspend(self) -> None:
+        """Drain in-flight retirement work before suspend.
+
+        Queue depth one has no detached retirement work, so this is currently a no-op.
+        """
+
+    def drain_for_request_reuse(self, request_id: int) -> None:
+        """Drain work that could still reference a request ID before reuse.
+
+        Queue depth one retires each step before the next request can reuse an ID.
+        """
+        del request_id
+
+    def retire_step(
+        self, step_result: Optional[Dict], context_state: Dict, step_time: float
+    ) -> Dict:
+        """Retire one dynamic step and return the engine-visible bookkeeping result."""
+        engine = self.engine
+        step_id = context_state.get("dynamic_step_id", engine._current_dynamic_step_id)
+        if step_id <= self._last_retired_step_id:
+            raise RuntimeError(
+                f"Dynamic step {step_id} retired after {self._last_retired_step_id}; "
+                "retirement must remain ordered"
+            )
+        self._last_retired_step_id = step_id
+
+        output_retirement_range = engine._step_nvtx_label("output_retirement", step_id)
+        nvtx_range_push(output_retirement_range)
+        cuda_graph_request_count = None
+
+        if step_result is not None:
+            active_request_ids = step_result["active_request_ids"]
+            finished_request_ids = step_result["finished_request_ids"]
+            newly_paused_request_ids = step_result.get("newly_paused_request_ids")
+            evict_request_ids = step_result.get("evict_request_ids")
+            sample = step_result["sample"]
+            accepted_tokens = step_result["accepted_tokens"]
+            log_probs = step_result["log_probs"]
+            top_n_logprobs = step_result.get("top_n_logprobs", None)
+            routing_indices_per_request = step_result.get("routing_indices_per_request", None)
+            cuda_graph_request_count = step_result["cuda_graph_request_count"]
+
+            # Add paused events.
+            if newly_paused_request_ids is not None and engine.track_paused_request_events:
+                newly_paused_request_ids = newly_paused_request_ids.tolist()
+                [engine.get_request(i).add_event_pause() for i in newly_paused_request_ids]
+
+            # Process finished requests (adds FINISH events and returns records).
+            post_process_range = engine._step_nvtx_label("post_process_requests", step_id)
+            nvtx_range_push(post_process_range)
+            (active_request_ids, finished_request_records) = engine.post_process_requests(
+                active_request_ids,
+                finished_request_ids,
+                evict_request_ids,
+                step_time,
+                sample,
+                accepted_tokens,
+                log_probs,
+                top_n_logprobs,
+                routing_indices_per_request,
+                pre_fwd_active_token_count=context_state.get("active_token_count"),
+                pre_fwd_step_count=context_state.get("step_count"),
+            )
+            nvtx_range_pop(post_process_range)
+
+        else:
+            active_request_ids: list[int] = []
+            finished_request_records: list[DynamicInferenceRequestRecord] = []
+
+        # Failed requests. Status and events were already set in _handle_failed_request;
+        # here we just clean up the entry and include it in finished_request_records.
+        for failed_request_id in engine.failed_request_ids:
+            failed_entry = engine.requests.pop(failed_request_id)
+            finished_request_records.append(failed_entry.record)
+            assert (
+                failed_entry.future.done()
+            ), f"Failed request {failed_request_id} future has not been properly resolved."
+        engine.failed_request_ids.clear()
+
+        nvtx_range_pop(output_retirement_range)
+
+        # Detokenize all finished requests if not using the coordinator. Otherwise, the
+        # coordinator overlaps detokenization with the engine.
+        if not engine.use_coordinator:
+            detokenization_range = engine._step_nvtx_label("detokenization", step_id)
+            nvtx_range_push(detokenization_range)
+            for record in finished_request_records:
+                for request in record.requests:
+                    if request.prompt is None:
+                        request.prompt = engine.controller.detokenize(
+                            engine.controller.tokenizer,
+                            request.prompt_tokens.tolist(),
+                            remove_EOD=False,
+                        )
+                    request.generated_text = engine.controller.detokenize(
+                        engine.controller.tokenizer,
+                        request.generated_tokens,
+                        remove_EOD=not request.sampling_params.detokenize_stop_sequence,
+                    )
+            nvtx_range_pop(detokenization_range)
+
+        # Handle necessary ZMQ DP coordinator communication. Failed request replies were
+        # already sent in _handle_failed_request, so only send completed records here.
+        if engine.use_coordinator and engine.is_mp_coordinator:
+            records_to_send = [
+                r for r in finished_request_records if r.requests[-1].status != Status.FAILED
+            ]
+            if records_to_send:
+                if not HAVE_MSGPACK:
+                    raise ImportError("msgpack is required to send coordinator replies")
+                coordinator_range = engine._step_nvtx_label("coordinator_send", step_id)
+                nvtx_range_push(coordinator_range)
+                payload = msgpack.packb(
+                    [
+                        Headers.ENGINE_REPLY.value,
+                        [r.merge().serialize() for r in records_to_send],
+                    ],
+                    use_bin_type=True,
+                )
+                engine.socket_for_receiving_requests.send(payload)
+                nvtx_range_pop(coordinator_range)
+
+        self._drain_prefix_cache_counters()
+        self._write_metrics(context_state, step_time)
+        self._log_step(context_state, step_time)
+
+        return {
+            "active_request_ids": active_request_ids,
+            "finished_request_records": finished_request_records,
+            "step_time": step_time,
+            "cuda_graph_request_count": cuda_graph_request_count,
+        }
+
+    def _drain_prefix_cache_counters(self) -> None:
+        engine = self.engine
+        if engine.context.enable_prefix_caching:
+            engine._prefix_cache_hits += engine.context.prefix_cache_hits
+            engine._prefix_cache_blocks_matched += engine.context.prefix_cache_blocks_matched
+            engine.context.prefix_cache_hits = 0
+            engine.context.prefix_cache_blocks_matched = 0
+
+    def _write_metrics(self, context_state: Dict, step_time: float) -> None:
+        engine = self.engine
+        if context_state["kv_stats"] is None:
+            return
+
+        metrics = {
+            'inference/inference_step': int(
+                engine.inference_step_offset + int(engine.context.step_count)
+            ),
+            'inference/step_time_s': float(step_time),
+            'inference/waiting_queue_len': int(len(engine.waiting_request_ids)),
+            'inference/total_requests_dict_size': int(len(engine.requests)),
+        }
+        for key, value in context_state["kv_stats"].items():
+            if 'utilization' in key:
+                metrics[f'inference/{key}'] = float(value * 100.0)
+            else:
+                metrics[f'inference/{key}'] = value
+
+        if engine.num_speculative_tokens > 0 and engine._spec_tokens_proposed > 0:
+            acceptance_rate = engine._spec_tokens_accepted / engine._spec_tokens_proposed
+            metrics['inference/spec_decode_acceptance_rate'] = float(acceptance_rate * 100.0)
+            metrics['inference/spec_decode_tokens_proposed'] = int(engine._spec_tokens_proposed)
+            metrics['inference/spec_decode_tokens_accepted'] = int(engine._spec_tokens_accepted)
+            metrics['inference/spec_decode_num_steps'] = int(engine._spec_steps)
+
+        if engine.context.enable_prefix_caching and engine._prefix_cache_hits > 0:
+            metrics['inference/prefix_cache_hits'] = int(engine._prefix_cache_hits)
+            metrics['inference/prefix_cache_blocks_matched'] = int(
+                engine._prefix_cache_blocks_matched
+            )
+
+        if HAVE_WANDB and engine.metrics_writer.__name__ == "wandb":
+            engine.metrics_writer.log(metrics, commit=True)
+        else:
+            raise ValueError(f"Unsupported metrics writer type: {type(engine.metrics_writer)}")
+
+    def _log_step(self, context_state: Dict, step_time: float) -> None:
+        engine = self.engine
+        if not (
+            engine.logging_step_interval > 0
+            and engine.context.step_count % engine.logging_step_interval == 0
+        ):
+            return
+
+        mem = torch.cuda.memory_stats()
+        step_type = "decode" if context_state["is_decode_only"] else "non-decode"
+        output_str = (
+            "* rank %d | step %d | %s ... time: %.3f ms%s ... "
+            "reqs: a %d/%d, p %d, w %d, f %d, e %d ... "
+            "blocks: a %d/%d, p %d/%d ... "
+            "mem: tensors %d, alloc %.1f gb, res %.1f gb."
+            % (
+                engine.rank,
+                engine.context.step_count,
+                datetime.now().strftime("%H:%M:%S"),
+                step_time * 1000,
+                (
+                    " [%s + real config %s + cuda graph %s]"
+                    % (
+                        step_type,
+                        engine.context.batch_dimensions,
+                        (
+                            "OFF"
+                            if not engine.context.using_cuda_graph_this_step()
+                            else engine.context.padded_batch_dimensions
+                        ),
+                    )
+                ),
+                context_state["total_request_count"] - context_state["paused_request_count"],
+                context_state["max_requests"],
+                context_state["paused_request_count"],
+                context_state["waiting_request_count"],
+                context_state["finished_request_count"],
+                context_state["evicted_request_count"],
+                context_state["total_active_used_blocks"],
+                context_state["total_active_block_count"],
+                context_state["total_paused_used_blocks"],
+                context_state["total_paused_block_count"],
+                mem["allocation.all.current"],
+                mem["allocated_bytes.all.current"] / (1024**3),
+                mem["reserved_bytes.all.current"] / (1024**3),
+            )
+        )
+        if engine.num_speculative_tokens > 0 and engine._spec_tokens_proposed > 0:
+            spec_rate = engine._spec_tokens_accepted / engine._spec_tokens_proposed * 100.0
+            output_str += " ... spec: accept %.1f%% (%d/%d in %d steps)" % (
+                spec_rate,
+                engine._spec_tokens_accepted,
+                engine._spec_tokens_proposed,
+                engine._spec_steps,
+            )
+        if engine.context.enable_prefix_caching and engine._prefix_cache_hits > 0:
+            output_str += " ... prefix cache: %d hits, %d blocks matched" % (
+                engine._prefix_cache_hits,
+                engine._prefix_cache_blocks_matched,
+            )
+        if context_state["is_decode_only"]:
+            output_str = f"\033[94m{output_str}\033[0m"
+        logging.info(output_str)
+
+        # Reset speculative decoding accumulators after both wandb and console logging.
+        if engine.num_speculative_tokens > 0:
+            engine._spec_tokens_proposed = 0
+            engine._spec_tokens_accepted = 0
+            engine._spec_steps = 0
+
+        # Reset prefix caching accumulators after both wandb and console logging.
+        if engine.context.enable_prefix_caching:
+            engine._prefix_cache_hits = 0
+            engine._prefix_cache_blocks_matched = 0

--- a/megatron/core/inference/engines/step_retirement.py
+++ b/megatron/core/inference/engines/step_retirement.py
@@ -330,6 +330,12 @@ class StepRetirementService:
             'inference/speculative_rejected_tokens': int(
                 engine.async_overlap_debug_counters.speculative_rejected_tokens
             ),
+            'inference/distributed_prepare_reconciliations': int(
+                engine.async_overlap_debug_counters.distributed_prepare_reconciliations
+            ),
+            'inference/distributed_prepare_downgrades': int(
+                engine.async_overlap_debug_counters.distributed_prepare_downgrades
+            ),
         }
         for key, value in context_state["kv_stats"].items():
             if 'utilization' in key:

--- a/megatron/core/inference/engines/step_retirement.py
+++ b/megatron/core/inference/engines/step_retirement.py
@@ -48,8 +48,9 @@ except ImportError:
 class StepRetirementService:
     """Retire dynamic steps in order.
 
-    Commit 6 runs this synchronously with queue depth one. Later commits can enqueue
-    outputs and have this service drain them independently while preserving step order.
+    Queue depth one submits and drains synchronously through DynamicAsyncPipeline.
+    Later queue-depth commits can enqueue outputs here and drain them independently
+    while preserving step order.
     """
 
     def __init__(self, engine: "DynamicInferenceEngine"):

--- a/megatron/core/inference/engines/step_retirement.py
+++ b/megatron/core/inference/engines/step_retirement.py
@@ -47,14 +47,18 @@ class StepRetirementService:
     def drain_for_shutdown(self) -> None:
         """Drain in-flight retirement work before shutdown.
 
-        Queue depth one has no detached retirement work, so this is currently a no-op.
+        Queue depth one has no detached retirement work, but an interrupted step
+        can leave an open journal entry that must not survive shutdown.
         """
+        self.engine.context.rollback_all_open_step_journals(reason="shutdown_drain")
 
     def drain_for_suspend(self) -> None:
         """Drain in-flight retirement work before suspend.
 
-        Queue depth one has no detached retirement work, so this is currently a no-op.
+        Queue depth one has no detached retirement work, but an interrupted step
+        can leave an open journal entry that must not survive suspend.
         """
+        self.engine.context.rollback_all_open_step_journals(reason="suspend_drain")
 
     def drain_for_request_reuse(self, request_id: int) -> None:
         """Drain work that could still reference a request ID before reuse.
@@ -130,6 +134,7 @@ class StepRetirementService:
         engine.failed_request_ids.clear()
 
         nvtx_range_pop(output_retirement_range)
+        engine.context.commit_step_journal(step_id)
 
         # Detokenize all finished requests if not using the coordinator. Otherwise, the
         # coordinator overlaps detokenization with the engine.

--- a/megatron/core/inference/engines/step_retirement.py
+++ b/megatron/core/inference/engines/step_retirement.py
@@ -327,6 +327,31 @@ class StepRetirementService:
             'inference/async_overlap_queue_depth_two_active': int(
                 engine.async_overlap_debug_counters.queue_depth >= 2
             ),
+            'inference/queue_depth_one_steps': int(
+                engine.async_overlap_debug_counters.queue_depth_one_steps
+            ),
+            'inference/queue_depth_two_steps': int(
+                engine.async_overlap_debug_counters.queue_depth_two_steps
+            ),
+            'inference/max_pending_launches_observed': int(
+                engine.async_overlap_debug_counters.max_pending_launches_observed
+            ),
+            'inference/cpu_time_hidden_under_gpu_s': float(
+                engine.async_overlap_debug_counters.cpu_time_hidden_under_gpu_s
+            ),
+            'inference/gpu_gap_sampling_to_next_forward_s': float(
+                engine.async_overlap_debug_counters.gpu_gap_sampling_to_next_forward_s
+            ),
+            'inference/gpu_gap_sampling_to_next_forward_avg_s': float(
+                engine.async_overlap_debug_counters.gpu_gap_sampling_to_next_forward_s
+                / max(1, engine.async_overlap_debug_counters.gpu_gap_observations)
+            ),
+            'inference/snapshot_slot_waits': int(
+                engine.async_overlap_debug_counters.snapshot_slot_waits
+            ),
+            'inference/output_event_waits': int(
+                engine.async_overlap_debug_counters.output_event_waits
+            ),
             'inference/accepted_output_tokens': int(
                 engine.async_overlap_debug_counters.accepted_output_tokens
             ),
@@ -345,7 +370,51 @@ class StepRetirementService:
             'inference/queue_depth_one_downgrades': int(
                 engine.async_overlap_debug_counters.queue_depth_one_downgrades
             ),
+            'inference/reservation_commits': int(
+                engine.async_overlap_debug_counters.reservation_commits
+            ),
+            'inference/reservation_rollbacks': int(
+                engine.async_overlap_debug_counters.reservation_rollbacks
+            ),
+            'inference/partial_reservation_rollbacks': int(
+                engine.async_overlap_debug_counters.partial_reservation_rollbacks
+            ),
+            'inference/resource_already_evicted_rollbacks': int(
+                engine.async_overlap_debug_counters.resource_already_evicted_rollbacks
+            ),
+            'inference/deferred_reservation_rollbacks': int(
+                engine.async_overlap_debug_counters.deferred_reservation_rollbacks
+            ),
         }
+        snapshot_pool = getattr(engine.context, "snapshot_pool", None)
+        if snapshot_pool is not None:
+            snapshot_accounting = snapshot_pool.memory_accounting()
+            metrics.update(
+                {
+                    'inference/snapshot_slot_count': int(
+                        snapshot_accounting["snapshot_slot_count"]
+                    ),
+                    'inference/snapshot_graph_cache_hits': int(
+                        snapshot_accounting["graph_cache_hits"]
+                    ),
+                    'inference/snapshot_graph_cache_misses': int(
+                        snapshot_accounting["graph_cache_misses"]
+                    ),
+                    'inference/snapshot_graph_capture_count': int(
+                        snapshot_accounting["graph_capture_count"]
+                    ),
+                    'inference/snapshot_graph_capture_bytes': int(
+                        snapshot_accounting["graph_capture_bytes"]
+                    ),
+                }
+            )
+            for slot in snapshot_pool.slots:
+                metrics[f'inference/snapshot_slot_{slot.slot_id}_graph_cache_hits'] = int(
+                    slot.graph_cache_hits
+                )
+                metrics[f'inference/snapshot_slot_{slot.slot_id}_graph_cache_misses'] = int(
+                    slot.graph_cache_misses
+                )
         for key, value in context_state["kv_stats"].items():
             if 'utilization' in key:
                 metrics[f'inference/{key}'] = float(value * 100.0)

--- a/megatron/core/inference/text_generation_controllers/async_output.py
+++ b/megatron/core/inference/text_generation_controllers/async_output.py
@@ -4,8 +4,9 @@
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 
@@ -18,6 +19,9 @@ class AsyncStepOutputResult:
     sampled_mtp_tokens_cpu: Optional[torch.Tensor] = None
     accepted_tokens_cpu: Optional[torch.Tensor] = None
     accepted_token_counts_cpu: Optional[torch.Tensor] = None
+    log_probs: Optional[object] = None
+    top_n_logprobs: Optional[object] = None
+    routing_indices_per_request: Optional[object] = None
     output_ready_event: Optional[torch.cuda.Event] = None
 
 
@@ -106,6 +110,10 @@ class AsyncStepOutput:
         sampled_mtp_tokens_source: Optional[torch.Tensor],
         accepted_tokens_source: Optional[torch.Tensor],
         accepted_token_counts_source: Optional[torch.Tensor],
+        log_probs: Optional[object],
+        top_n_logprobs: Optional[object],
+        routing_indices_per_request_cpu: Optional[object],
+        routing_indices_sources: Optional[Dict[int, torch.Tensor]],
     ):
         self._pool = pool
         self._slot = slot
@@ -122,6 +130,10 @@ class AsyncStepOutput:
         self._sampled_mtp_tokens_source = sampled_mtp_tokens_source
         self._accepted_tokens_source = accepted_tokens_source
         self._accepted_token_counts_source = accepted_token_counts_source
+        self._log_probs = log_probs
+        self._top_n_logprobs = top_n_logprobs
+        self._routing_indices_per_request_cpu = routing_indices_per_request_cpu
+        self._routing_indices_sources = routing_indices_sources
 
     @classmethod
     def begin_copy(
@@ -133,6 +145,10 @@ class AsyncStepOutput:
         sampled_mtp_tokens_cuda: Optional[torch.Tensor] = None,
         accepted_tokens_cuda: Optional[torch.Tensor] = None,
         accepted_token_counts_cuda: Optional[torch.Tensor] = None,
+        log_probs: Optional[object] = None,
+        top_n_logprobs: Optional[object] = None,
+        routing_indices_per_request: Optional[Dict[int, torch.Tensor]] = None,
+        routing_step_id: Optional[int] = None,
         compute_stream: Optional[torch.cuda.Stream] = None,
         compute_done_event: Optional[torch.cuda.Event] = None,
     ) -> "AsyncStepOutput":
@@ -157,6 +173,13 @@ class AsyncStepOutput:
         sampled_mtp_copied = sampled_mtp_tokens_cuda is not None
         accepted_tokens_copied = accepted_tokens_cuda is not None
         accepted_token_counts_copied = accepted_token_counts_cuda is not None
+        log_probs = copy.deepcopy(log_probs)
+        top_n_logprobs = cls._clone_top_n_payload(top_n_logprobs)
+        routing_indices_cpu = None
+        routing_indices_sources = None
+        if routing_indices_per_request is not None:
+            routing_indices_cpu = {}
+            routing_indices_sources = {}
 
         with torch.cuda.stream(output_stream):
             slot.sampled_tokens_cpu[:active_request_count].copy_(
@@ -178,12 +201,34 @@ class AsyncStepOutput:
                 if slot.accepted_token_counts_cpu is None:
                     raise RuntimeError(
                         "accepted-token-count output requested without accepted-count buffers"
-                    )
+                )
                 slot.accepted_token_counts_cpu[:active_request_count].copy_(
                     accepted_token_counts_cuda[:active_request_count], non_blocking=True
                 )
+            if routing_indices_per_request is not None:
+                for request_id, routing_indices in routing_indices_per_request.items():
+                    request_id = int(request_id)
+                    if routing_indices.is_cuda:
+                        routing_indices_sources[request_id] = routing_indices
+                        routing_indices_cpu[request_id] = torch.empty(
+                            routing_indices.shape,
+                            dtype=routing_indices.dtype,
+                            device="cpu",
+                            pin_memory=True,
+                        )
+                        routing_indices_cpu[request_id].copy_(
+                            routing_indices, non_blocking=True
+                        )
+                    else:
+                        routing_indices_cpu[request_id] = routing_indices.detach().clone()
             output_ready_event = torch.cuda.Event()
             output_ready_event.record(output_stream)
+
+        if routing_indices_cpu is not None:
+            routing_indices_cpu = {
+                "step_id": None if routing_step_id is None else int(routing_step_id),
+                "by_request_id": routing_indices_cpu,
+            }
 
         return cls(
             pool=pool,
@@ -197,7 +242,24 @@ class AsyncStepOutput:
             sampled_mtp_tokens_source=sampled_mtp_tokens_cuda,
             accepted_tokens_source=accepted_tokens_cuda,
             accepted_token_counts_source=accepted_token_counts_cuda,
+            log_probs=log_probs,
+            top_n_logprobs=top_n_logprobs,
+            routing_indices_per_request_cpu=routing_indices_cpu,
+            routing_indices_sources=routing_indices_sources,
         )
+
+    @staticmethod
+    def _clone_top_n_payload(top_n_logprobs: Optional[object]) -> Optional[object]:
+        """Clone top-n payload tensors so retirement owns stable CPU objects."""
+        if top_n_logprobs is None:
+            return None
+        cloned = {}
+        for request_id, values in top_n_logprobs.items():
+            cloned[int(request_id)] = [
+                (top_values.detach().cpu().clone(), top_indices.detach().cpu().clone())
+                for top_values, top_indices in values
+            ]
+        return cloned
 
     def is_ready(self) -> bool:
         """Return whether the output-ready event has completed."""
@@ -236,6 +298,9 @@ class AsyncStepOutput:
                 sampled_mtp_tokens_cpu=sampled_mtp_tokens_cpu,
                 accepted_tokens_cpu=accepted_tokens_cpu,
                 accepted_token_counts_cpu=accepted_token_counts_cpu,
+                log_probs=self._log_probs,
+                top_n_logprobs=self._top_n_logprobs,
+                routing_indices_per_request=self._routing_indices_per_request_cpu,
                 output_ready_event=self.output_ready_event,
             )
             self._release_slot()

--- a/megatron/core/inference/text_generation_controllers/async_output.py
+++ b/megatron/core/inference/text_generation_controllers/async_output.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Asynchronous D2H output copies for dynamic inference steps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass(frozen=True, kw_only=True)
+class AsyncStepOutputResult:
+    """CPU views produced by an event-gated dynamic-step output copy."""
+
+    sampled_tokens_cpu: torch.Tensor
+    sampled_mtp_tokens_cpu: Optional[torch.Tensor] = None
+    accepted_tokens_cpu: Optional[torch.Tensor] = None
+    accepted_token_counts_cpu: Optional[torch.Tensor] = None
+    output_ready_event: Optional[torch.cuda.Event] = None
+
+
+class _AsyncStepOutputSlot:
+    """Pinned CPU buffers owned by one output-copy slot."""
+
+    def __init__(self, max_requests: int, num_speculative_tokens: int):
+        self.in_use = False
+        self.sampled_tokens_cpu = torch.empty(
+            max_requests, dtype=torch.int64, device="cpu", pin_memory=True
+        )
+        self.sampled_mtp_tokens_cpu = (
+            torch.empty(
+                (num_speculative_tokens, max_requests),
+                dtype=torch.int64,
+                device="cpu",
+                pin_memory=True,
+            )
+            if num_speculative_tokens > 0
+            else None
+        )
+        self.accepted_tokens_cpu = (
+            torch.empty(
+                (max_requests, num_speculative_tokens),
+                dtype=torch.int64,
+                device="cpu",
+                pin_memory=True,
+            )
+            if num_speculative_tokens > 0
+            else None
+        )
+        self.accepted_token_counts_cpu = (
+            torch.empty(max_requests, dtype=torch.int64, device="cpu", pin_memory=True)
+            if num_speculative_tokens > 0
+            else None
+        )
+
+
+class AsyncStepOutputPool:
+    """Pinned CPU output buffers plus the dedicated dynamic-output D2H stream."""
+
+    def __init__(self, max_requests: int, num_speculative_tokens: int, depth: int = 2):
+        if max_requests <= 0:
+            raise ValueError(f"max_requests must be > 0, got {max_requests}")
+        if num_speculative_tokens < 0:
+            raise ValueError(
+                f"num_speculative_tokens must be >= 0, got {num_speculative_tokens}"
+            )
+        if depth <= 0:
+            raise ValueError(f"depth must be > 0, got {depth}")
+
+        self.max_requests = max_requests
+        self.num_speculative_tokens = num_speculative_tokens
+        self.output_stream = torch.cuda.Stream()
+        self._slots = [
+            _AsyncStepOutputSlot(max_requests, num_speculative_tokens) for _ in range(depth)
+        ]
+
+    def acquire(self) -> _AsyncStepOutputSlot:
+        """Acquire a free pinned-buffer slot."""
+        for slot in self._slots:
+            if not slot.in_use:
+                slot.in_use = True
+                return slot
+        raise RuntimeError("No free async output slots; retire an output before acquiring more")
+
+    def release(self, slot: _AsyncStepOutputSlot) -> None:
+        """Release a previously acquired pinned-buffer slot."""
+        slot.in_use = False
+
+
+class AsyncStepOutput:
+    """In-flight output copy for one dynamic inference step."""
+
+    def __init__(
+        self,
+        *,
+        pool: AsyncStepOutputPool,
+        slot: _AsyncStepOutputSlot,
+        active_request_count: int,
+        output_ready_event: torch.cuda.Event,
+        sampled_mtp_copied: bool,
+        accepted_tokens_copied: bool,
+        accepted_token_counts_copied: bool,
+        sampled_tokens_source: torch.Tensor,
+        sampled_mtp_tokens_source: Optional[torch.Tensor],
+        accepted_tokens_source: Optional[torch.Tensor],
+        accepted_token_counts_source: Optional[torch.Tensor],
+    ):
+        self._pool = pool
+        self._slot = slot
+        self.active_request_count = active_request_count
+        self.output_ready_event = output_ready_event
+        self._sampled_mtp_copied = sampled_mtp_copied
+        self._accepted_tokens_copied = accepted_tokens_copied
+        self._accepted_token_counts_copied = accepted_token_counts_copied
+        self._result: Optional[AsyncStepOutputResult] = None
+        self._released = False
+
+        # Keep GPU sources alive until the output-ready event has completed.
+        self._sampled_tokens_source = sampled_tokens_source
+        self._sampled_mtp_tokens_source = sampled_mtp_tokens_source
+        self._accepted_tokens_source = accepted_tokens_source
+        self._accepted_token_counts_source = accepted_token_counts_source
+
+    @classmethod
+    def begin_copy(
+        cls,
+        *,
+        pool: AsyncStepOutputPool,
+        active_request_count: int,
+        sampled_tokens_cuda: torch.Tensor,
+        sampled_mtp_tokens_cuda: Optional[torch.Tensor] = None,
+        accepted_tokens_cuda: Optional[torch.Tensor] = None,
+        accepted_token_counts_cuda: Optional[torch.Tensor] = None,
+        compute_stream: Optional[torch.cuda.Stream] = None,
+        compute_done_event: Optional[torch.cuda.Event] = None,
+    ) -> "AsyncStepOutput":
+        """Enqueue nonblocking output copies and record an output-ready event."""
+        if active_request_count < 0:
+            raise ValueError(f"active_request_count must be >= 0, got {active_request_count}")
+        if active_request_count > pool.max_requests:
+            raise ValueError(
+                f"active_request_count {active_request_count} exceeds pool max_requests "
+                f"{pool.max_requests}"
+            )
+
+        slot = pool.acquire()
+        output_stream = pool.output_stream
+        if compute_done_event is not None:
+            output_stream.wait_event(compute_done_event)
+        elif compute_stream is not None:
+            output_stream.wait_stream(compute_stream)
+        else:
+            output_stream.wait_stream(torch.cuda.current_stream())
+
+        sampled_mtp_copied = sampled_mtp_tokens_cuda is not None
+        accepted_tokens_copied = accepted_tokens_cuda is not None
+        accepted_token_counts_copied = accepted_token_counts_cuda is not None
+
+        with torch.cuda.stream(output_stream):
+            slot.sampled_tokens_cpu[:active_request_count].copy_(
+                sampled_tokens_cuda[:active_request_count], non_blocking=True
+            )
+            if sampled_mtp_copied:
+                if slot.sampled_mtp_tokens_cpu is None:
+                    raise RuntimeError("sampled MTP output requested without MTP output buffers")
+                slot.sampled_mtp_tokens_cpu[:, :active_request_count].copy_(
+                    sampled_mtp_tokens_cuda[:, :active_request_count], non_blocking=True
+                )
+            if accepted_tokens_copied:
+                if slot.accepted_tokens_cpu is None:
+                    raise RuntimeError("accepted-token output requested without accepted buffers")
+                slot.accepted_tokens_cpu[:active_request_count, :].copy_(
+                    accepted_tokens_cuda[:active_request_count, :], non_blocking=True
+                )
+            if accepted_token_counts_copied:
+                if slot.accepted_token_counts_cpu is None:
+                    raise RuntimeError(
+                        "accepted-token-count output requested without accepted-count buffers"
+                    )
+                slot.accepted_token_counts_cpu[:active_request_count].copy_(
+                    accepted_token_counts_cuda[:active_request_count], non_blocking=True
+                )
+            output_ready_event = torch.cuda.Event()
+            output_ready_event.record(output_stream)
+
+        return cls(
+            pool=pool,
+            slot=slot,
+            active_request_count=active_request_count,
+            output_ready_event=output_ready_event,
+            sampled_mtp_copied=sampled_mtp_copied,
+            accepted_tokens_copied=accepted_tokens_copied,
+            accepted_token_counts_copied=accepted_token_counts_copied,
+            sampled_tokens_source=sampled_tokens_cuda,
+            sampled_mtp_tokens_source=sampled_mtp_tokens_cuda,
+            accepted_tokens_source=accepted_tokens_cuda,
+            accepted_token_counts_source=accepted_token_counts_cuda,
+        )
+
+    def is_ready(self) -> bool:
+        """Return whether the output-ready event has completed."""
+        return self.output_ready_event.query()
+
+    @property
+    def sampled_tokens_cpu(self) -> torch.Tensor:
+        """Return sampled tokens only after ``result()`` has synchronized the event."""
+        if self._result is None:
+            raise RuntimeError("AsyncStepOutput.result() must be called before reading outputs")
+        return self._result.sampled_tokens_cpu
+
+    def result(self) -> AsyncStepOutputResult:
+        """Synchronize the output event and return CPU views."""
+        if self._result is None:
+            self.output_ready_event.synchronize()
+            active_slice = slice(0, self.active_request_count)
+            sampled_tokens_cpu = self._slot.sampled_tokens_cpu[active_slice]
+            sampled_mtp_tokens_cpu = (
+                self._slot.sampled_mtp_tokens_cpu[:, active_slice]
+                if self._sampled_mtp_copied
+                else None
+            )
+            accepted_tokens_cpu = (
+                self._slot.accepted_tokens_cpu[active_slice, :]
+                if self._accepted_tokens_copied
+                else None
+            )
+            accepted_token_counts_cpu = (
+                self._slot.accepted_token_counts_cpu[active_slice]
+                if self._accepted_token_counts_copied
+                else None
+            )
+            self._result = AsyncStepOutputResult(
+                sampled_tokens_cpu=sampled_tokens_cpu,
+                sampled_mtp_tokens_cpu=sampled_mtp_tokens_cpu,
+                accepted_tokens_cpu=accepted_tokens_cpu,
+                accepted_token_counts_cpu=accepted_token_counts_cpu,
+                output_ready_event=self.output_ready_event,
+            )
+            self._release_slot()
+        return self._result
+
+    def _release_slot(self) -> None:
+        if not self._released:
+            self._pool.release(self._slot)
+            self._released = True

--- a/megatron/core/inference/text_generation_controllers/async_output.py
+++ b/megatron/core/inference/text_generation_controllers/async_output.py
@@ -80,6 +80,11 @@ class AsyncStepOutputPool:
             _AsyncStepOutputSlot(max_requests, num_speculative_tokens) for _ in range(depth)
         ]
 
+    @property
+    def depth(self) -> int:
+        """Number of pinned output-copy slots."""
+        return len(self._slots)
+
     def acquire(self) -> _AsyncStepOutputSlot:
         """Acquire a free pinned-buffer slot."""
         for slot in self._slots:

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -25,6 +25,8 @@ from megatron.core.inference.engines.dynamic_step import (
     DynamicStepGpuLaunch,
     DynamicStepId,
     DynamicStepRequestPlan,
+    SnapshotSlotHandle,
+    assert_snapshot_gpu_view_bound,
 )
 from megatron.core.inference.inference_request import InferenceRequest, Status
 from megatron.core.inference.model_inference_wrappers.abstract_model_inference_wrapper import (
@@ -572,6 +574,7 @@ class TextGenerationController:
         self,
         construct_graph_dimensions: Optional[InferenceBatchDimensions] = None,
         is_dummy_forward: bool = False,
+        snapshot_slot_handle: Optional[SnapshotSlotHandle] = None,
     ):
         """Initializes the inference context for dynamic batching.
 
@@ -596,12 +599,13 @@ class TextGenerationController:
         context.initialize_attention_state(
             construct_graph_dimensions=construct_graph_dimensions,
             is_expert_parallel_dummy_cuda_graph_step=is_dummy_forward,
+            snapshot_slot_handle=snapshot_slot_handle,
         )
         range_pop()
 
         # Single batch CPU-to-GPU transfer of bookkeeping state.
         range_push(context.dynamic_step_nvtx_label("transfer_bookkeeping_to_gpu"))
-        context.transfer_bookkeeping_to_gpu()
+        context.transfer_bookkeeping_to_gpu(snapshot_slot_handle=snapshot_slot_handle)
         range_pop()
 
         # If using symmetric kernels and we are using using nccl
@@ -1936,15 +1940,21 @@ class TextGenerationController:
         if context.active_token_count == 0 and active_request_count == 0:
             return None
 
-        input_ids, position_ids = self._dynamic_step_context_init()
-        active_request_count = context.total_request_count - context.paused_request_count
         step_id = self._current_dynamic_step_record()
+        snapshot_slot = context.snapshot_pool.acquire(step_id.value)
+        snapshot_handle = SnapshotSlotHandle(
+            step_id=step_id, snapshot_slot_id=snapshot_slot.slot_id
+        )
+        input_ids, position_ids = self._dynamic_step_context_init(
+            snapshot_slot_handle=snapshot_handle
+        )
+        active_request_count = context.total_request_count - context.paused_request_count
         request_plan = self._dynamic_step_request_plan(step_id)
 
         cuda_graph_request_count = (
             context.padded_active_request_count if context.using_cuda_graph_this_step() else None
         )
-        snapshot_slot_id = getattr(context.gpu_view, "current_snapshot_slot_id", 0)
+        snapshot_slot_id = snapshot_slot.slot_id
         context.record_snapshot_slot(
             step_id.value,
             snapshot_slot_id,
@@ -1962,9 +1972,11 @@ class TextGenerationController:
             request_plan=request_plan,
             active_request_count=active_request_count,
             cuda_graph_request_count=cuda_graph_request_count,
+            metadata_ready_event=snapshot_slot.metadata_ready_event,
             input_ids=input_ids,
             position_ids=position_ids,
-            gpu_view=context.gpu_view,
+            gpu_view=snapshot_slot.gpu_view,
+            cpu_staging_buffer=snapshot_slot.cpu_mirror,
         )
 
     def launch_dynamic_forward(
@@ -1972,6 +1984,11 @@ class TextGenerationController:
     ) -> DynamicStepGpuLaunch:
         """Launch the dynamic forward phase for a prepared serial step."""
         context = self.inference_wrapped_model.inference_context
+        assert_snapshot_gpu_view_bound(
+            prepared_step,
+            context.gpu_view,
+            debug_enabled=getattr(context.config, "async_overlap_debug_checks", False),
+        )
 
         # Enable routing recording before forward pass if routing replay is enabled
         config = self.inference_wrapped_model.model.config
@@ -1996,6 +2013,12 @@ class TextGenerationController:
         routing_indices_per_request = self._router_record_bookkeeping()
         range_pop()
 
+        gpu_read_event = torch.cuda.Event()
+        gpu_read_event.record(torch.cuda.current_stream())
+        context.snapshot_pool.mark_forward_in_flight(
+            prepared_step.snapshot_slot_id, gpu_read_event=gpu_read_event
+        )
+
         return DynamicStepGpuLaunch(
             step_id=prepared_step.step_id,
             snapshot_slot_id=prepared_step.snapshot_slot_id,
@@ -2003,6 +2026,7 @@ class TextGenerationController:
             input_ready_event=prepared_step.input_ready_event,
             input_ids=prepared_step.input_ids,
             position_ids=prepared_step.position_ids,
+            gpu_view=prepared_step.gpu_view,
             logits=logits,
             routing_indices_per_request=routing_indices_per_request,
             cuda_graph_batch_dimensions=prepared_step.cuda_graph_request_count,
@@ -2134,6 +2158,8 @@ class TextGenerationController:
             self._accepted_tokens_per_request.fill_(-1)
             self._accepted_token_counts_per_request.fill_(0)
         ret.update(request_bookkeeping)
+        context = self.inference_wrapped_model.inference_context
+        context.snapshot_pool.release(prepared_step.snapshot_slot_id)
         return ret
 
     async def async_generate_output_tokens_dynamic_batch(

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -173,9 +173,11 @@ class TextGenerationController:
             self._torch_sampling_buckets: List[Tuple] = []
 
         self._init_mtp_sampling_tensor()
+        output_pool_depth = max(2, int(context.config.async_overlap_queue_depth) + 1)
         self._async_step_output_pool = AsyncStepOutputPool(
             max_requests=max_requests,
             num_speculative_tokens=self.num_speculative_tokens,
+            depth=output_pool_depth,
         )
 
     def _init_mtp_sampling_tensor(self):

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -21,7 +21,6 @@ from megatron.core.inference.communication_utils import (
 from megatron.core.inference.contexts.dynamic_context import MaxSequenceLengthOverflowError
 from megatron.core.inference.contexts.static_context import StaticInferenceContext
 from megatron.core.inference.engines.dynamic_step import (
-    AsyncStepOutput,
     DynamicStepContextSnapshot,
     DynamicStepGpuLaunch,
     DynamicStepId,
@@ -32,6 +31,11 @@ from megatron.core.inference.model_inference_wrappers.abstract_model_inference_w
     AbstractModelInferenceWrapper,
 )
 from megatron.core.inference.sampling_params import SamplingParams
+from megatron.core.inference.text_generation_controllers.async_output import (
+    AsyncStepOutput,
+    AsyncStepOutputPool,
+    AsyncStepOutputResult,
+)
 from megatron.core.inference.utils import get_attention_mask, set_decode_expert_padding
 from megatron.core.models.multimodal.llava_model import LLaVAModel
 from megatron.core.tensor_parallel.mappings import (
@@ -166,6 +170,10 @@ class TextGenerationController:
             self._torch_sampling_buckets: List[Tuple] = []
 
         self._init_mtp_sampling_tensor()
+        self._async_step_output_pool = AsyncStepOutputPool(
+            max_requests=max_requests,
+            num_speculative_tokens=self.num_speculative_tokens,
+        )
 
     def _init_mtp_sampling_tensor(self):
         """Initialize the MTP sampling tensor after num_speculative_tokens is set."""
@@ -1766,14 +1774,17 @@ class TextGenerationController:
             tuple: (sampled_tokens_cpu, sampled_mtp_tokens_cpu) where
                 sampled_mtp_tokens_cpu is None when speculative decoding is off.
         """
-        sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
-        if self.num_speculative_tokens > 0:
-            sampled_mtp_tokens_cpu = self._sampled_mtp_tokens_cuda[
-                :, :active_request_count
-            ].cpu()
-        else:
-            sampled_mtp_tokens_cpu = None
-        return sampled_tokens_cpu, sampled_mtp_tokens_cpu
+        step_output = AsyncStepOutput.begin_copy(
+            pool=self._async_step_output_pool,
+            active_request_count=active_request_count,
+            sampled_tokens_cuda=self._sampled_tokens_cuda,
+            sampled_mtp_tokens_cuda=(
+                self._sampled_mtp_tokens_cuda if self.num_speculative_tokens > 0 else None
+            ),
+            compute_stream=torch.cuda.current_stream(),
+        )
+        result = step_output.result()
+        return result.sampled_tokens_cpu, result.sampled_mtp_tokens_cpu
 
     def _dynamic_step_context_bookkeeping_from_cpu_samples(
         self, sampled_tokens_cpu: Tensor, sampled_mtp_tokens_cpu: Optional[Tensor]
@@ -2042,37 +2053,40 @@ class TextGenerationController:
         active_request_count = prepared_step.active_request_count
 
         range_push(context.dynamic_step_nvtx_label("sampled_output_d2h"))
-        if skip_bookkeeping:
-            # Preserve the old skip-bookkeeping path: copy only the public sample.
-            sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
-            sampled_mtp_tokens_cpu = None
-        else:
-            sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
-                active_request_count,
-            )
-        range_pop()
-
-        return AsyncStepOutput(
-            step_id=prepared_step.step_id,
-            snapshot_slot_id=prepared_step.snapshot_slot_id,
+        step_output = AsyncStepOutput.begin_copy(
+            pool=self._async_step_output_pool,
             active_request_count=active_request_count,
-            sampled_tokens=self._sampled_tokens_cuda[:active_request_count],
-            sampled_tokens_cpu=sampled_tokens_cpu,
-            sampled_mtp_tokens_cpu=sampled_mtp_tokens_cpu,
+            sampled_tokens_cuda=self._sampled_tokens_cuda,
+            sampled_mtp_tokens_cuda=(
+                self._sampled_mtp_tokens_cuda
+                if self.num_speculative_tokens > 0 and not skip_bookkeeping
+                else None
+            ),
+            accepted_tokens_cuda=(
+                self._accepted_tokens_per_request if self.num_speculative_tokens > 0 else None
+            ),
+            accepted_token_counts_cuda=(
+                self._accepted_token_counts_per_request
+                if self.num_speculative_tokens > 0
+                else None
+            ),
+            compute_stream=torch.cuda.current_stream(),
         )
+        range_pop()
+        return step_output
 
-    def collect_dynamic_output(self, step_output: AsyncStepOutput) -> AsyncStepOutput:
+    def collect_dynamic_output(self, step_output: AsyncStepOutput) -> AsyncStepOutputResult:
         """Collect a dynamic step output copy.
 
-        Commit 5 replaces this immediate serial result with an event-gated pinned-buffer result.
+        Queue depth one waits immediately; later pipeline commits defer this collection.
         """
-        return step_output
+        return step_output.result()
 
     def commit_dynamic_bookkeeping(
         self,
         prepared_step: DynamicStepContextSnapshot,
         gpu_launch: DynamicStepGpuLaunch,
-        step_output: AsyncStepOutput,
+        step_output: AsyncStepOutputResult,
         log_probs: Optional[Tensor],
         top_n_logprobs: Optional[Dict[int, List[Tuple[Tensor, Tensor]]]],
         skip_bookkeeping: Optional[bool] = False,
@@ -2089,8 +2103,8 @@ class TextGenerationController:
 
         ret = {
             "accepted_tokens": (
-                # Clone needed: .fill_(-1) below would corrupt the returned value.
-                self._accepted_tokens_per_request.clone()
+                # Pinned CPU copy; the GPU scratch buffer is reset below.
+                step_output.accepted_tokens_cpu
                 if self.num_speculative_tokens > 0
                 else None
             ),

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, OrderedDict, Tuple, Union
 import torch
 import torch.nn.functional as F
 from torch import Tensor
+from torch.cuda.nvtx import range_pop, range_push
 
 from megatron.core import parallel_state
 from megatron.core.inference.async_stream import AsyncStream
@@ -576,10 +577,12 @@ class TextGenerationController:
         model_config = get_model_config(unwrapped_model)
 
         # Initialize attention state.
+        range_push("initialize_attention_state")
         context.initialize_attention_state(
             construct_graph_dimensions=construct_graph_dimensions,
             is_expert_parallel_dummy_cuda_graph_step=is_dummy_forward,
         )
+        range_pop()
 
         # If using symmetric kernels and we are using using nccl
         # for prefill turn off symmetric kernels
@@ -1753,6 +1756,7 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
+        range_push("active_request_mask")
         # Active sequence lengths.
         active_request_ids = context.request_ids[active_request_slice].long()
         active_sequence_lengths = context.get_active_sequence_lengths()
@@ -1788,7 +1792,9 @@ class TextGenerationController:
         # Clone needed: update_requests mutates next_tokens in-place via tensor_swap,
         # which would corrupt the reused _sampled_tokens_cuda buffer.
         new_sample_copy = self._sampled_tokens_cuda[:active_request_count].clone()
+        range_pop()
 
+        range_push("update_requests")
         # Update requests.
         # _sampled_mtp_tokens_cuda has shape [num_speculative_tokens, max_requests]
         if self.num_speculative_tokens > 0:
@@ -1798,6 +1804,7 @@ class TextGenerationController:
         update_result = context.update_requests(
             active_request_mask, new_sample_copy, sampled_mtp_tokens_cuda
         )
+        range_pop()
 
         return {
             "active_request_ids": active_request_ids,
@@ -1845,6 +1852,7 @@ class TextGenerationController:
 
             # Forward pass produces only base logits. When speculative decoding is
             # active, MTP logits are computed serially after verification.
+            range_push("forward_pass")
             logits = self._dynamic_step_forward_logits(input_ids, position_ids)
 
             # Commit Mamba intermediate states before update_requests, which
@@ -1856,6 +1864,7 @@ class TextGenerationController:
 
             # Collect routing indices per request (must be done before context transitions)
             routing_indices_per_request = self._router_record_bookkeeping()
+            range_pop()
 
         # This is the best place to yield control back to event loop.
         # At this point we have enqueued FW pass GPU kernels asynchronously.
@@ -1867,6 +1876,7 @@ class TextGenerationController:
         await asyncio.sleep(0)
 
         with torch.inference_mode():
+            range_push("sampling")
             return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
 
             self._dynamic_step_sample_bookkeeping()
@@ -1904,6 +1914,7 @@ class TextGenerationController:
                         top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs(
                             logits, log_probs_tensor
                         )
+            range_pop()
 
             if skip_bookkeeping:
                 request_bookkeeping = {}

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1819,12 +1819,30 @@ class TextGenerationController:
             dtype=torch.long,
             device='cpu',
         )
+        chunked_prefill_no_output_request_ids = set()
+        if context.chunked_prefill_request_id != -1:
+            chunked_prefill_no_output_request_ids.add(int(context.chunked_prefill_request_id))
         output_placeholder_counts = torch.ones(
             active_request_count,
             dtype=context.num_output_placeholders.dtype,
             device='cpu',
         )
-        context.add_output_placeholders(active_request_slots, output_placeholder_counts)
+        if chunked_prefill_no_output_request_ids:
+            produces_output_mask = torch.tensor(
+                [
+                    int(request_id) not in chunked_prefill_no_output_request_ids
+                    for request_id in active_request_ids.tolist()
+                ],
+                dtype=torch.bool,
+                device='cpu',
+            )
+        else:
+            produces_output_mask = torch.ones(active_request_count, dtype=torch.bool, device='cpu')
+        if torch.any(produces_output_mask):
+            context.add_output_placeholders(
+                active_request_slots[produces_output_mask],
+                output_placeholder_counts[produces_output_mask],
+            )
         active_sequence_lengths = context.get_placeholder_adjusted_active_sequence_lengths()
         max_sequence_lengths = context.get_max_sequence_lengths()
 
@@ -1841,6 +1859,8 @@ class TextGenerationController:
                 for idx, request_id in enumerate(request_ids_list):
                     if request_id in stop_word_finished_ids:
                         active_request_mask[idx] = 0
+        if chunked_prefill_no_output_request_ids:
+            active_request_mask[~produces_output_mask] = 1
 
         finished_idxs = (
             torch.nonzero(active_request_mask == 0, as_tuple=True)[0] + context.paused_request_count
@@ -1871,6 +1891,9 @@ class TextGenerationController:
             # Public retirement can lag one step behind the next output copy.
             # Keep an owning CPU copy so the async output pool slot can be reused.
             "sample": sampled_tokens_cpu.clone(),
+            "chunked_prefill_no_output_request_ids": tuple(
+                sorted(chunked_prefill_no_output_request_ids)
+            ),
             **(update_result or {}),
         }
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -759,6 +759,26 @@ class TextGenerationController:
         # so there is nothing to rewind.
         request_in_prefill_status = context.request_in_prefill_status_tensor[active_request_slice]
         num_tokens_to_rewind[request_in_prefill_status == 1] = 0
+        current_step_id = int(getattr(context, "current_dynamic_step_id", -1))
+        if current_step_id >= 0:
+            active_request_ids = context.request_ids[active_request_slice].tolist()
+            accepted_counts_by_request = {}
+            rewind_counts_by_request = {}
+            for request_id, is_prefill, accepted_count, rewind_count in zip(
+                active_request_ids,
+                request_in_prefill_status.tolist(),
+                accepted_tokens_per_request.tolist(),
+                num_tokens_to_rewind.tolist(),
+            ):
+                if not is_prefill:
+                    accepted_counts_by_request[int(request_id)] = int(accepted_count)
+                    rewind_counts_by_request[int(request_id)] = int(rewind_count)
+            if accepted_counts_by_request:
+                context.record_speculative_acceptance(
+                    current_step_id,
+                    accepted_token_counts=accepted_counts_by_request,
+                    kv_rewind_token_counts=rewind_counts_by_request,
+                )
 
         # Save the original offset BEFORE modifying to correctly detect block boundary crossing
         original_offset = context.request_last_kv_block_offset[active_request_slice].clone()

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -2159,7 +2159,7 @@ class TextGenerationController:
         top_n_logprobs: Optional[Dict[int, List[Tuple[Tensor, Tensor]]]],
         skip_bookkeeping: Optional[bool] = False,
     ) -> Dict:
-        """Commit serial CPU bookkeeping and return the public dynamic-step result."""
+        """Commit context bookkeeping and return the ordered-retirement payload."""
         context = self.inference_wrapped_model.inference_context
         if isinstance(step_output, AsyncStepOutput):
             step_output = self.collect_dynamic_output(step_output)
@@ -2193,6 +2193,8 @@ class TextGenerationController:
         if self.num_speculative_tokens > 0:
             self._accepted_tokens_per_request.fill_(-1)
             self._accepted_token_counts_per_request.fill_(0)
+        # Request-object mutation is owned by StepRetirementService so public
+        # outputs are retired in strict step order.
         ret.update(request_bookkeeping)
         context.snapshot_pool.release(prepared_step.snapshot_slot_id)
         return ret

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1990,7 +1990,7 @@ class TextGenerationController:
         )
 
     def prepare_dynamic_step(self) -> Optional[DynamicStepContextSnapshot]:
-        """Prepare the dynamic context snapshot for the next serial forward."""
+        """Prepare the dynamic context snapshot for the next forward."""
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
 
@@ -2042,7 +2042,7 @@ class TextGenerationController:
     def launch_dynamic_forward(
         self, prepared_step: DynamicStepContextSnapshot
     ) -> DynamicStepGpuLaunch:
-        """Launch the dynamic forward phase for a prepared serial step."""
+        """Launch the dynamic forward phase for a prepared step."""
         context = self.inference_wrapped_model.inference_context
         assert_snapshot_gpu_view_bound(
             prepared_step,
@@ -2099,7 +2099,7 @@ class TextGenerationController:
     def launch_dynamic_sampling(
         self, gpu_launch: DynamicStepGpuLaunch
     ) -> Tuple[Optional[Tensor], Optional[Dict[int, List[Tuple[Tensor, Tensor]]]]]:
-        """Launch serial sampling and log-prob work for a completed forward."""
+        """Launch sampling and log-prob work for a completed forward."""
         context = self.inference_wrapped_model.inference_context
         logits = gpu_launch.logits
         input_ids = gpu_launch.input_ids
@@ -2170,7 +2170,7 @@ class TextGenerationController:
         routing_indices_per_request: Optional[Dict[int, Tensor]] = None,
         skip_bookkeeping: Optional[bool] = False,
     ) -> AsyncStepOutput:
-        """Begin the serial sampled-output D2H copy for one dynamic step."""
+        """Begin the sampled-output D2H copy for one dynamic step."""
         context = self.inference_wrapped_model.inference_context
         active_request_count = prepared_step.active_request_count
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1746,6 +1746,28 @@ class TextGenerationController:
                     pp_group=self.pp_group,
                 )
 
+    def _transfer_samples_to_cpu(
+        self, active_request_count: int
+    ) -> tuple:
+        """Batch GPU-to-CPU transfer of sampled tokens.
+
+        Called at the boundary between GPU sampling and CPU bookkeeping.
+        After this returns, all sampled data is on CPU and the remainder
+        of the step is 100% CPU.
+
+        Returns:
+            tuple: (sampled_tokens_cpu, sampled_mtp_tokens_cpu) where
+                sampled_mtp_tokens_cpu is None when speculative decoding is off.
+        """
+        sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
+        if self.num_speculative_tokens > 0:
+            sampled_mtp_tokens_cpu = self._sampled_mtp_tokens_cuda[
+                :, :active_request_count
+            ].cpu()
+        else:
+            sampled_mtp_tokens_cpu = None
+        return sampled_tokens_cpu, sampled_mtp_tokens_cpu
+
     def _dynamic_step_context_bookkeeping(self) -> Dict[str, Tensor]:
         """Update the dynamic inference context after sampling.
 
@@ -1765,13 +1787,15 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
-        # GPU-to-CPU transfer of sampled tokens (single batch D2H).
+        # Batch GPU-to-CPU transfer of all sampled tokens.
         range_push("transfer_samples_to_cpu")
-        sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
+        sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
+            active_request_count,
+        )
         range_pop()
 
         range_push("active_request_mask")
-        # Active sequence lengths (CPU, from context bookkeeping).
+        # Everything below is 100% CPU.
         active_request_ids = context.request_ids[active_request_slice].long()
         active_sequence_lengths = context.get_active_sequence_lengths()
 
@@ -1783,14 +1807,11 @@ class TextGenerationController:
         max_sequence_lengths = context.get_max_sequence_lengths()
 
         # Request finished if termination_id or length >= max_sequence_length.
-        # Note: termination_id tensor has per-request termination IDs from mixed sampling.
-        # All comparisons are on CPU (sampled_tokens_cpu, _request_metadata, context tensors).
         active_request_mask = (
             sampled_tokens_cpu
             != self._request_metadata["termination_id"][active_request_slice]
         ).byte() & torch.less(active_sequence_lengths, max_sequence_lengths).byte()
 
-        # Mark requests as finished if they hit stop words (detected in previous step's post_process_requests)
         if self._get_stop_word_finished_ids_callback is not None:
             request_ids_list = active_request_ids.tolist()
             stop_word_finished_ids = self._get_stop_word_finished_ids_callback(request_ids_list)
@@ -1810,12 +1831,6 @@ class TextGenerationController:
         range_pop()
 
         range_push("update_requests")
-        # Update requests (100% CPU).
-        # _sampled_mtp_tokens_cuda has shape [num_speculative_tokens, max_requests]
-        if self.num_speculative_tokens > 0:
-            sampled_mtp_tokens_cpu = self._sampled_mtp_tokens_cuda[:, :active_request_count].cpu()
-        else:
-            sampled_mtp_tokens_cpu = None
         update_result = context.update_requests(
             active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
         )

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1998,7 +1998,7 @@ class TextGenerationController:
             return None
 
         step_id = self._current_dynamic_step_record()
-        snapshot_slot = context.snapshot_pool.acquire(step_id.value)
+        snapshot_slot = context.acquire_snapshot_slot(step_id.value)
         snapshot_handle = SnapshotSlotHandle(
             step_id=step_id, snapshot_slot_id=snapshot_slot.slot_id
         )
@@ -2257,7 +2257,7 @@ class TextGenerationController:
         # Request-object mutation is owned by StepRetirementService so public
         # outputs are retired in strict step order.
         ret.update(request_bookkeeping)
-        context.snapshot_pool.release(prepared_step.snapshot_slot_id)
+        context.release_snapshot_slot(prepared_step.snapshot_slot_id)
         return ret
 
     async def async_generate_output_tokens_dynamic_batch(

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -20,6 +20,13 @@ from megatron.core.inference.communication_utils import (
 )
 from megatron.core.inference.contexts.dynamic_context import MaxSequenceLengthOverflowError
 from megatron.core.inference.contexts.static_context import StaticInferenceContext
+from megatron.core.inference.engines.dynamic_step import (
+    AsyncStepOutput,
+    DynamicStepContextSnapshot,
+    DynamicStepGpuLaunch,
+    DynamicStepId,
+    DynamicStepRequestPlan,
+)
 from megatron.core.inference.inference_request import InferenceRequest, Status
 from megatron.core.inference.model_inference_wrappers.abstract_model_inference_wrapper import (
     AbstractModelInferenceWrapper,
@@ -1768,14 +1775,14 @@ class TextGenerationController:
             sampled_mtp_tokens_cpu = None
         return sampled_tokens_cpu, sampled_mtp_tokens_cpu
 
-    def _dynamic_step_context_bookkeeping(self) -> Dict[str, Tensor]:
+    def _dynamic_step_context_bookkeeping_from_cpu_samples(
+        self, sampled_tokens_cpu: Tensor, sampled_mtp_tokens_cpu: Optional[Tensor]
+    ) -> Dict[str, Tensor]:
         """Update the dynamic inference context after sampling.
 
         Args:
-            new_sample (Tensor): The newly sampled tokens.
-            request_metadata (Optional[Dict[str, Tensor]]): An override for the tensors
-                that manage request metadata, such as sampling parameters. By default, this
-                metadata is retrieved from the context.
+            sampled_tokens_cpu (Tensor): Newly sampled base tokens on CPU.
+            sampled_mtp_tokens_cpu (Optional[Tensor]): Newly sampled speculative tokens on CPU.
 
         Return:
             Dict [str, Tensor]: A dictionary containing:
@@ -1786,13 +1793,6 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
-
-        # Batch GPU-to-CPU transfer of all sampled tokens.
-        range_push(context.dynamic_step_nvtx_label("sampled_output_d2h"))
-        sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
-            active_request_count,
-        )
-        range_pop()
 
         range_push(context.dynamic_step_nvtx_label("active_request_mask"))
         # Everything below is 100% CPU.
@@ -1847,6 +1847,264 @@ class TextGenerationController:
             **(update_result or {}),
         }
 
+    def _dynamic_step_context_bookkeeping(self) -> Dict[str, Tensor]:
+        """Update the dynamic inference context after a blocking output transfer."""
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = context.total_request_count - context.paused_request_count
+
+        # Batch GPU-to-CPU transfer of all sampled tokens.
+        range_push(context.dynamic_step_nvtx_label("sampled_output_d2h"))
+        sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
+            active_request_count,
+        )
+        range_pop()
+        return self._dynamic_step_context_bookkeeping_from_cpu_samples(
+            sampled_tokens_cpu, sampled_mtp_tokens_cpu
+        )
+
+    def _current_dynamic_step_record(self) -> DynamicStepId:
+        """Return the typed step ID currently owned by the dynamic context."""
+        context = self.inference_wrapped_model.inference_context
+        step_id = int(getattr(context, "current_dynamic_step_id", -1))
+        if step_id < 0:
+            # Direct controller tests can call the controller without the engine
+            # assigning a trace step ID first.
+            step_id = int(getattr(context, "step_count", 0))
+        return DynamicStepId(step_id)
+
+    def _dynamic_step_request_plan(self, step_id: DynamicStepId) -> DynamicStepRequestPlan:
+        """Build the typed request plan for the current dynamic context state."""
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = context.total_request_count - context.paused_request_count
+        active_request_slice = slice(context.paused_request_count, context.total_request_count)
+
+        if active_request_count == 0:
+            return DynamicStepRequestPlan(step_id=step_id)
+
+        active_request_ids = tuple(
+            str(int(request_id)) for request_id in context.request_ids[active_request_slice].tolist()
+        )
+        request_in_prefill = context.request_in_prefill_status_tensor[active_request_slice].tolist()
+        prefill_request_ids = tuple(
+            request_id
+            for request_id, is_prefill in zip(active_request_ids, request_in_prefill)
+            if is_prefill
+        )
+        decode_request_ids = tuple(
+            request_id
+            for request_id, is_prefill in zip(active_request_ids, request_in_prefill)
+            if not is_prefill
+        )
+        speculative_request_ids = decode_request_ids if self.num_speculative_tokens > 0 else ()
+        placeholder_token_counts = (
+            {request_id: self.num_speculative_tokens for request_id in speculative_request_ids}
+            if self.num_speculative_tokens > 0
+            else {}
+        )
+
+        return DynamicStepRequestPlan(
+            step_id=step_id,
+            active_request_ids=active_request_ids,
+            decode_request_ids=decode_request_ids,
+            prefill_request_ids=prefill_request_ids,
+            speculative_request_ids=speculative_request_ids,
+            placeholder_token_counts=placeholder_token_counts,
+        )
+
+    def prepare_dynamic_step(self) -> Optional[DynamicStepContextSnapshot]:
+        """Prepare the dynamic context snapshot for the next serial forward."""
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = context.total_request_count - context.paused_request_count
+
+        if context.active_token_count == 0 and active_request_count == 0:
+            return None
+
+        input_ids, position_ids = self._dynamic_step_context_init()
+        active_request_count = context.total_request_count - context.paused_request_count
+        step_id = self._current_dynamic_step_record()
+        request_plan = self._dynamic_step_request_plan(step_id)
+
+        cuda_graph_request_count = (
+            context.padded_active_request_count if context.using_cuda_graph_this_step() else None
+        )
+
+        return DynamicStepContextSnapshot(
+            step_id=step_id,
+            snapshot_slot_id=getattr(context.gpu_view, "current_snapshot_slot_id", 0),
+            request_plan=request_plan,
+            active_request_count=active_request_count,
+            cuda_graph_request_count=cuda_graph_request_count,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            gpu_view=context.gpu_view,
+        )
+
+    def launch_dynamic_forward(
+        self, prepared_step: DynamicStepContextSnapshot
+    ) -> DynamicStepGpuLaunch:
+        """Launch the dynamic forward phase for a prepared serial step."""
+        context = self.inference_wrapped_model.inference_context
+
+        # Enable routing recording before forward pass if routing replay is enabled
+        config = self.inference_wrapped_model.model.config
+        if config.moe_enable_routing_replay:
+            RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+
+        # Forward pass produces only base logits. When speculative decoding is
+        # active, MTP logits are computed serially after verification.
+        range_push(context.dynamic_step_nvtx_label("forward"))
+        logits = self._dynamic_step_forward_logits(
+            prepared_step.input_ids, prepared_step.position_ids
+        )
+
+        # Commit Mamba intermediate states before update_requests, which
+        # may swap request indices. The Python lists tracking EOS block IDs
+        # and intermediate offsets are not swapped along with tensors, so
+        # commit must run while indices are still valid.
+        if context.is_hybrid_model and context.mamba_slot_allocator is not None:
+            context.mamba_slot_allocator.commit_intermediate_states()
+
+        # Collect routing indices per request (must be done before context transitions)
+        routing_indices_per_request = self._router_record_bookkeeping()
+        range_pop()
+
+        return DynamicStepGpuLaunch(
+            step_id=prepared_step.step_id,
+            snapshot_slot_id=prepared_step.snapshot_slot_id,
+            metadata_ready_event=prepared_step.metadata_ready_event,
+            input_ready_event=prepared_step.input_ready_event,
+            input_ids=prepared_step.input_ids,
+            position_ids=prepared_step.position_ids,
+            logits=logits,
+            routing_indices_per_request=routing_indices_per_request,
+            cuda_graph_batch_dimensions=prepared_step.cuda_graph_request_count,
+        )
+
+    def launch_dynamic_sampling(
+        self, gpu_launch: DynamicStepGpuLaunch
+    ) -> Tuple[Optional[Tensor], Optional[Dict[int, List[Tuple[Tensor, Tensor]]]]]:
+        """Launch serial sampling and log-prob work for a completed forward."""
+        context = self.inference_wrapped_model.inference_context
+        logits = gpu_launch.logits
+        input_ids = gpu_launch.input_ids
+
+        range_push(context.dynamic_step_nvtx_label("sampling"))
+        return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
+
+        self._dynamic_step_sample_bookkeeping()
+
+        range_push(context.dynamic_step_nvtx_label("sampled_token_gpu_handoff"))
+        if self.num_speculative_tokens > 0:
+            # Phase 1: Verify speculative tokens using base logits only.
+            self._dynamic_step_sample_logits_and_verify_tokens(logits, input_ids)
+            # Phase 2: Rewind KV cache for rejected tokens.
+            self._rewind_kv_cache()
+
+            # Disable MoE padding for MTP computation
+            if self.model_config.moe_pad_experts_for_cuda_graph_inference:
+                unwrapped_model = unwrap_model(self.inference_wrapped_model.model)
+                set_decode_expert_padding(unwrapped_model, False)
+
+            # Phase 3: Compute MTP serially with correct (verified) inputs.
+            self._compute_serial_mtp_and_sample()
+        else:
+            self._dynamic_step_sample_logits(logits)
+        range_pop()
+
+        log_probs = None
+        top_n_logprobs = None
+        if return_log_probs or return_top_n_logprobs:
+            if self.num_speculative_tokens > 0:
+                log_probs, log_probs_tensor = self._dynamic_step_calculate_log_probs_speculative(
+                    logits
+                )
+                if return_top_n_logprobs:
+                    top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs_speculative(
+                        log_probs_tensor
+                    )
+            else:
+                log_probs, log_probs_tensor = self._dynamic_step_calculate_log_probs(logits)
+                if return_top_n_logprobs:
+                    top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs(
+                        logits, log_probs_tensor
+                    )
+        range_pop()
+
+        return log_probs, top_n_logprobs
+
+    def begin_dynamic_output_copy(
+        self,
+        prepared_step: DynamicStepContextSnapshot,
+        skip_bookkeeping: Optional[bool] = False,
+    ) -> AsyncStepOutput:
+        """Begin the serial sampled-output D2H copy for one dynamic step."""
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = prepared_step.active_request_count
+
+        range_push(context.dynamic_step_nvtx_label("sampled_output_d2h"))
+        if skip_bookkeeping:
+            # Preserve the old skip-bookkeeping path: copy only the public sample.
+            sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
+            sampled_mtp_tokens_cpu = None
+        else:
+            sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
+                active_request_count,
+            )
+        range_pop()
+
+        return AsyncStepOutput(
+            step_id=prepared_step.step_id,
+            snapshot_slot_id=prepared_step.snapshot_slot_id,
+            active_request_count=active_request_count,
+            sampled_tokens=self._sampled_tokens_cuda[:active_request_count],
+            sampled_tokens_cpu=sampled_tokens_cpu,
+            sampled_mtp_tokens_cpu=sampled_mtp_tokens_cpu,
+        )
+
+    def collect_dynamic_output(self, step_output: AsyncStepOutput) -> AsyncStepOutput:
+        """Collect a dynamic step output copy.
+
+        Commit 5 replaces this immediate serial result with an event-gated pinned-buffer result.
+        """
+        return step_output
+
+    def commit_dynamic_bookkeeping(
+        self,
+        prepared_step: DynamicStepContextSnapshot,
+        gpu_launch: DynamicStepGpuLaunch,
+        step_output: AsyncStepOutput,
+        log_probs: Optional[Tensor],
+        top_n_logprobs: Optional[Dict[int, List[Tuple[Tensor, Tensor]]]],
+        skip_bookkeeping: Optional[bool] = False,
+    ) -> Dict:
+        """Commit serial CPU bookkeeping and return the public dynamic-step result."""
+        if skip_bookkeeping:
+            request_bookkeeping = {
+                "sample": step_output.sampled_tokens_cpu,
+            }
+        else:
+            request_bookkeeping = self._dynamic_step_context_bookkeeping_from_cpu_samples(
+                step_output.sampled_tokens_cpu, step_output.sampled_mtp_tokens_cpu
+            )
+
+        ret = {
+            "accepted_tokens": (
+                # Clone needed: .fill_(-1) below would corrupt the returned value.
+                self._accepted_tokens_per_request.clone()
+                if self.num_speculative_tokens > 0
+                else None
+            ),
+            "log_probs": log_probs,
+            "top_n_logprobs": top_n_logprobs,
+            "routing_indices_per_request": gpu_launch.routing_indices_per_request,
+            "cuda_graph_request_count": prepared_step.cuda_graph_request_count,
+        }
+        if self.num_speculative_tokens > 0:
+            self._accepted_tokens_per_request.fill_(-1)
+            self._accepted_token_counts_per_request.fill_(0)
+        ret.update(request_bookkeeping)
+        return ret
+
     async def async_generate_output_tokens_dynamic_batch(
         self, skip_bookkeeping: Optional[bool] = False
     ) -> Optional[Dict]:
@@ -1864,42 +2122,11 @@ class TextGenerationController:
                 log_probs (Optional[Tensor]): Log probabilities of the new sample, if requested.
                 cuda_graph_request_count (Optional[int]): Size of cuda graph used for this step.
         """
-        context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
-
-        # No tokens and no active requests?
-        if context.active_token_count == 0 and active_request_count == 0:
-            return None
-
         with torch.inference_mode():
-            input_ids, position_ids = self._dynamic_step_context_init()
-
-            cuda_graph_request_count = (
-                context.padded_active_request_count
-                if context.using_cuda_graph_this_step()
-                else None
-            )
-
-            # Enable routing recording before forward pass if routing replay is enabled
-            config = self.inference_wrapped_model.model.config
-            if config.moe_enable_routing_replay:
-                RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
-
-            # Forward pass produces only base logits. When speculative decoding is
-            # active, MTP logits are computed serially after verification.
-            range_push(context.dynamic_step_nvtx_label("forward"))
-            logits = self._dynamic_step_forward_logits(input_ids, position_ids)
-
-            # Commit Mamba intermediate states before update_requests, which
-            # may swap request indices. The Python lists tracking EOS block IDs
-            # and intermediate offsets are not swapped along with tensors, so
-            # commit must run while indices are still valid.
-            if context.is_hybrid_model and context.mamba_slot_allocator is not None:
-                context.mamba_slot_allocator.commit_intermediate_states()
-
-            # Collect routing indices per request (must be done before context transitions)
-            routing_indices_per_request = self._router_record_bookkeeping()
-            range_pop()
+            prepared_step = self.prepare_dynamic_step()
+            if prepared_step is None:
+                return None
+            gpu_launch = self.launch_dynamic_forward(prepared_step)
 
         # This is the best place to yield control back to event loop.
         # At this point we have enqueued FW pass GPU kernels asynchronously.
@@ -1911,79 +2138,17 @@ class TextGenerationController:
         await asyncio.sleep(0)
 
         with torch.inference_mode():
-            range_push(context.dynamic_step_nvtx_label("sampling"))
-            return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
-
-            self._dynamic_step_sample_bookkeeping()
-
-            range_push(context.dynamic_step_nvtx_label("sampled_token_gpu_handoff"))
-            if self.num_speculative_tokens > 0:
-                # Phase 1: Verify speculative tokens using base logits only.
-                self._dynamic_step_sample_logits_and_verify_tokens(logits, input_ids)
-                # Phase 2: Rewind KV cache for rejected tokens.
-                self._rewind_kv_cache()
-
-                # Disable MoE padding for MTP computation
-                if self.model_config.moe_pad_experts_for_cuda_graph_inference:
-                    unwrapped_model = unwrap_model(self.inference_wrapped_model.model)
-                    set_decode_expert_padding(unwrapped_model, False)
-
-                # Phase 3: Compute MTP serially with correct (verified) inputs.
-                self._compute_serial_mtp_and_sample()
-            else:
-                self._dynamic_step_sample_logits(logits)
-            range_pop()
-
-            log_probs = None
-            top_n_logprobs = None
-            if return_log_probs or return_top_n_logprobs:
-                if self.num_speculative_tokens > 0:
-                    log_probs, log_probs_tensor = (
-                        self._dynamic_step_calculate_log_probs_speculative(logits)
-                    )
-                    if return_top_n_logprobs:
-                        top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs_speculative(
-                            log_probs_tensor
-                        )
-                else:
-                    log_probs, log_probs_tensor = self._dynamic_step_calculate_log_probs(logits)
-                    if return_top_n_logprobs:
-                        top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs(
-                            logits, log_probs_tensor
-                        )
-            range_pop()
-
-            if skip_bookkeeping:
-                # _transfer_samples_to_cpu wasn't invoked on this path, so do
-                # a one-shot D2H here to keep "sample" as a CPU tensor for
-                # downstream consumers.
-                range_push(context.dynamic_step_nvtx_label("sampled_output_d2h"))
-                request_bookkeeping = {
-                    "sample": self._sampled_tokens_cuda[:active_request_count].cpu(),
-                }
-                range_pop()
-            else:
-                # request_bookkeeping supplies "sample" as the already-CPU
-                # tensor produced by _transfer_samples_to_cpu.
-                request_bookkeeping = self._dynamic_step_context_bookkeeping()
-
-            ret = {
-                "accepted_tokens": (
-                    # Clone needed: .fill_(-1) on line 1480 would corrupt the returned value.
-                    self._accepted_tokens_per_request.clone()
-                    if self.num_speculative_tokens > 0
-                    else None
-                ),
-                "log_probs": log_probs,
-                "top_n_logprobs": top_n_logprobs,
-                "routing_indices_per_request": routing_indices_per_request,
-                "cuda_graph_request_count": cuda_graph_request_count,
-            }
-            if self.num_speculative_tokens > 0:
-                self._accepted_tokens_per_request.fill_(-1)
-                self._accepted_token_counts_per_request.fill_(0)
-            ret.update(request_bookkeeping)
-            return ret
+            log_probs, top_n_logprobs = self.launch_dynamic_sampling(gpu_launch)
+            step_output = self.begin_dynamic_output_copy(prepared_step, skip_bookkeeping)
+            step_output = self.collect_dynamic_output(step_output)
+            return self.commit_dynamic_bookkeeping(
+                prepared_step,
+                gpu_launch,
+                step_output,
+                log_probs,
+                top_n_logprobs,
+                skip_bookkeeping,
+            )
 
     @torch.inference_mode()
     def generate_output_tokens_dynamic_batch(

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1938,10 +1938,21 @@ class TextGenerationController:
         cuda_graph_request_count = (
             context.padded_active_request_count if context.using_cuda_graph_this_step() else None
         )
+        snapshot_slot_id = getattr(context.gpu_view, "current_snapshot_slot_id", 0)
+        context.record_snapshot_slot(
+            step_id.value,
+            snapshot_slot_id,
+            cuda_graph_batch_dimensions=cuda_graph_request_count,
+        )
+        context.record_request_slot_transition(
+            step_id.value,
+            request_slots_after=tuple(range(int(context.total_request_count))),
+            active_request_ids=request_plan.active_request_ids,
+        )
 
         return DynamicStepContextSnapshot(
             step_id=step_id,
-            snapshot_slot_id=getattr(context.gpu_view, "current_snapshot_slot_id", 0),
+            snapshot_slot_id=snapshot_slot_id,
             request_plan=request_plan,
             active_request_count=active_request_count,
             cuda_graph_request_count=cuda_graph_request_count,

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1465,6 +1465,7 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
+        active_request_ids = context.request_ids[active_request_slice].tolist()
 
         # Use gpu_view for data consumed by GPU top-n operations.
         request_in_prefill_status_tensor = context.gpu_view.request_in_prefill_status[
@@ -1501,7 +1502,8 @@ class TextGenerationController:
                     top_n = int(top_n_per_request[i].item())
                     if top_n > 0:
                         num_valid = accepted_counts[i].item() + 1
-                        top_n_results[i] = [
+                        request_id = int(active_request_ids[i])
+                        top_n_results[request_id] = [
                             (topk_values_cpu[i, j, :top_n], topk_indices_cpu[i, j, :top_n])
                             for j in range(num_valid)
                         ]
@@ -1530,7 +1532,8 @@ class TextGenerationController:
                         top_n = int(prefill_top_n[i])
                         if top_n > 0:
                             req_idx = num_decode_requests + i
-                            top_n_results[req_idx] = [
+                            request_id = int(active_request_ids[req_idx])
+                            top_n_results[request_id] = [
                                 (topk_vals_cpu[i, :top_n], topk_idxs_cpu[i, :top_n])
                             ]
                 else:
@@ -1548,19 +1551,20 @@ class TextGenerationController:
                         top_n = int(prefill_top_n[i])
                         if top_n > 0:
                             req_idx = num_decode_requests + i
+                            request_id = int(active_request_ids[req_idx])
                             request_lp = prefill_log_probs_per_request[i]
                             skip_prompt = bool(prefill_skip_prompt[i])
 
                             if skip_prompt and request_lp.size(0) > 1:
                                 top_n_logits = torch.topk(request_lp[-1], k=top_n)
-                                top_n_results[req_idx] = [
+                                top_n_results[request_id] = [
                                     (top_n_logits.values.cpu(), top_n_logits.indices.cpu())
                                 ]
                             else:
                                 top_n_logits = torch.topk(request_lp, k=top_n, dim=-1)
                                 top_n_values_cpu = top_n_logits.values.cpu()
                                 top_n_indices_cpu = top_n_logits.indices.cpu()
-                                top_n_results[req_idx] = [
+                                top_n_results[request_id] = [
                                     (top_n_values_cpu[t], top_n_indices_cpu[t])
                                     for t in range(request_lp.size(0))
                                 ]
@@ -1590,6 +1594,7 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
+        active_request_ids = context.request_ids[active_request_slice].tolist()
 
         # Handle decode-only mode (only last token)
         if context.config.materialize_only_last_token_logits or context.is_decode_only():
@@ -1605,7 +1610,8 @@ class TextGenerationController:
                 if top_n > 0:
                     # Get top-n logprobs and indices for this request (single token)
                     top_n_logits = torch.topk(log_probs[req_idx], k=top_n)
-                    top_n_results[req_idx] = [
+                    request_id = int(active_request_ids[req_idx])
+                    top_n_results[request_id] = [
                         (top_n_logits.values.cpu(), top_n_logits.indices.cpu())
                     ]
             return top_n_results if top_n_results else None
@@ -1636,7 +1642,8 @@ class TextGenerationController:
                 if skip_prompt and request_log_probs.size(0) > 1:
                     # Only compute top-n for the last token (first generated token)
                     top_n_logits = torch.topk(request_log_probs[-1], k=top_n)
-                    top_n_results[req_idx] = [
+                    request_id = int(active_request_ids[req_idx])
+                    top_n_results[request_id] = [
                         (top_n_logits.values.cpu(), top_n_logits.indices.cpu())
                     ]
                 else:
@@ -1647,7 +1654,8 @@ class TextGenerationController:
                         top_n_per_token.append(
                             (top_n_logits.values.cpu(), top_n_logits.indices.cpu())
                         )
-                    top_n_results[req_idx] = top_n_per_token
+                    request_id = int(active_request_ids[req_idx])
+                    top_n_results[request_id] = top_n_per_token
 
         return top_n_results if top_n_results else None
 
@@ -2137,6 +2145,9 @@ class TextGenerationController:
     def begin_dynamic_output_copy(
         self,
         prepared_step: DynamicStepContextSnapshot,
+        log_probs: Optional[object] = None,
+        top_n_logprobs: Optional[Dict[int, List[Tuple[Tensor, Tensor]]]] = None,
+        routing_indices_per_request: Optional[Dict[int, Tensor]] = None,
         skip_bookkeeping: Optional[bool] = False,
     ) -> AsyncStepOutput:
         """Begin the serial sampled-output D2H copy for one dynamic step."""
@@ -2161,6 +2172,10 @@ class TextGenerationController:
                 if self.num_speculative_tokens > 0
                 else None
             ),
+            log_probs=log_probs,
+            top_n_logprobs=top_n_logprobs,
+            routing_indices_per_request=routing_indices_per_request,
+            routing_step_id=prepared_step.step_id.value,
             compute_stream=torch.cuda.current_stream(),
         )
         range_pop()
@@ -2186,6 +2201,9 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         if isinstance(step_output, AsyncStepOutput):
             step_output = self.collect_dynamic_output(step_output)
+        log_probs = step_output.log_probs
+        top_n_logprobs = step_output.top_n_logprobs
+        routing_indices_per_request = step_output.routing_indices_per_request
         context.debug_compare_sampled_tokens_gpu_state(
             sampled_tokens_cpu=step_output.sampled_tokens_cpu,
             active_request_count=prepared_step.active_request_count,
@@ -2210,7 +2228,7 @@ class TextGenerationController:
             ),
             "log_probs": log_probs,
             "top_n_logprobs": top_n_logprobs,
-            "routing_indices_per_request": gpu_launch.routing_indices_per_request,
+            "routing_indices_per_request": routing_indices_per_request,
             "cuda_graph_request_count": prepared_step.cuda_graph_request_count,
         }
         if self.num_speculative_tokens > 0:
@@ -2256,7 +2274,13 @@ class TextGenerationController:
 
         with torch.inference_mode():
             log_probs, top_n_logprobs = self.launch_dynamic_sampling(gpu_launch)
-            step_output = self.begin_dynamic_output_copy(prepared_step, skip_bookkeeping)
+            step_output = self.begin_dynamic_output_copy(
+                prepared_step,
+                log_probs=log_probs,
+                top_n_logprobs=top_n_logprobs,
+                routing_indices_per_request=gpu_launch.routing_indices_per_request,
+                skip_bookkeeping=skip_bookkeeping,
+            )
             return self.commit_dynamic_bookkeeping(
                 prepared_step,
                 gpu_launch,

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1868,11 +1868,9 @@ class TextGenerationController:
         return {
             "active_request_ids": active_request_ids,
             "finished_request_ids": finished_request_ids,
-            # Already a CPU tensor (independent of _sampled_tokens_cuda via the
-            # .cpu() in _transfer_samples_to_cpu; update_requests only mutates
-            # the separate new_sample_copy). Returning the CPU copy avoids a
-            # D2H sync when the engine later calls sample.tolist().
-            "sample": sampled_tokens_cpu,
+            # Public retirement can lag one step behind the next output copy.
+            # Keep an owning CPU copy so the async output pool slot can be reused.
+            "sample": sampled_tokens_cpu.clone(),
             **(update_result or {}),
         }
 
@@ -2000,6 +1998,8 @@ class TextGenerationController:
             context.gpu_view,
             debug_enabled=getattr(context.config, "async_overlap_debug_checks", False),
         )
+        if prepared_step.metadata_ready_event is not None:
+            torch.cuda.current_stream().wait_event(prepared_step.metadata_ready_event)
         if prepared_step.input_ready_event is not None:
             torch.cuda.current_stream().wait_event(prepared_step.input_ready_event)
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -2061,6 +2061,20 @@ class TextGenerationController:
             self._compute_serial_mtp_and_sample()
         else:
             self._dynamic_step_sample_logits(logits)
+        active_request_count = context.total_request_count - context.paused_request_count
+        context.record_sampled_tokens_gpu_state(
+            sampled_tokens=self._sampled_tokens_cuda,
+            active_request_count=active_request_count,
+            source_stream=torch.cuda.current_stream(),
+            sampled_mtp_tokens=(
+                self._sampled_mtp_tokens_cuda if self.num_speculative_tokens > 0 else None
+            ),
+            accepted_token_counts=(
+                self._accepted_token_counts_per_request
+                if self.num_speculative_tokens > 0
+                else None
+            ),
+        )
         range_pop()
 
         log_probs = None
@@ -2133,6 +2147,13 @@ class TextGenerationController:
         skip_bookkeeping: Optional[bool] = False,
     ) -> Dict:
         """Commit serial CPU bookkeeping and return the public dynamic-step result."""
+        context = self.inference_wrapped_model.inference_context
+        context.debug_compare_sampled_tokens_gpu_state(
+            sampled_tokens_cpu=step_output.sampled_tokens_cpu,
+            active_request_count=prepared_step.active_request_count,
+            sampled_mtp_tokens_cpu=step_output.sampled_mtp_tokens_cpu,
+            accepted_token_counts_cpu=step_output.accepted_token_counts_cpu,
+        )
         if skip_bookkeeping:
             request_bookkeeping = {
                 "sample": step_output.sampled_tokens_cpu,
@@ -2158,7 +2179,6 @@ class TextGenerationController:
             self._accepted_tokens_per_request.fill_(-1)
             self._accepted_token_counts_per_request.fill_(0)
         ret.update(request_bookkeeping)
-        context = self.inference_wrapped_model.inference_context
         context.snapshot_pool.release(prepared_step.snapshot_slot_id)
         return ret
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -577,7 +577,7 @@ class TextGenerationController:
         model_config = get_model_config(unwrapped_model)
 
         # Initialize attention state (100% CPU computation).
-        range_push("initialize_attention_state")
+        range_push(context.dynamic_step_nvtx_label("context_init"))
         context.initialize_attention_state(
             construct_graph_dimensions=construct_graph_dimensions,
             is_expert_parallel_dummy_cuda_graph_step=is_dummy_forward,
@@ -585,7 +585,7 @@ class TextGenerationController:
         range_pop()
 
         # Single batch CPU-to-GPU transfer of bookkeeping state.
-        range_push("transfer_bookkeeping_to_gpu")
+        range_push(context.dynamic_step_nvtx_label("transfer_bookkeeping_to_gpu"))
         context.transfer_bookkeeping_to_gpu()
         range_pop()
 
@@ -1788,13 +1788,13 @@ class TextGenerationController:
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
         # Batch GPU-to-CPU transfer of all sampled tokens.
-        range_push("transfer_samples_to_cpu")
+        range_push(context.dynamic_step_nvtx_label("sampled_output_d2h"))
         sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
             active_request_count,
         )
         range_pop()
 
-        range_push("active_request_mask")
+        range_push(context.dynamic_step_nvtx_label("active_request_mask"))
         # Everything below is 100% CPU.
         active_request_ids = context.request_ids[active_request_slice].long()
         active_sequence_lengths = context.get_active_sequence_lengths()
@@ -1830,7 +1830,7 @@ class TextGenerationController:
         new_sample_copy = sampled_tokens_cpu.clone()
         range_pop()
 
-        range_push("update_requests")
+        range_push(context.dynamic_step_nvtx_label("update_requests"))
         update_result = context.update_requests(
             active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
         )
@@ -1887,7 +1887,7 @@ class TextGenerationController:
 
             # Forward pass produces only base logits. When speculative decoding is
             # active, MTP logits are computed serially after verification.
-            range_push("forward_pass")
+            range_push(context.dynamic_step_nvtx_label("forward"))
             logits = self._dynamic_step_forward_logits(input_ids, position_ids)
 
             # Commit Mamba intermediate states before update_requests, which
@@ -1911,11 +1911,12 @@ class TextGenerationController:
         await asyncio.sleep(0)
 
         with torch.inference_mode():
-            range_push("sampling")
+            range_push(context.dynamic_step_nvtx_label("sampling"))
             return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
 
             self._dynamic_step_sample_bookkeeping()
 
+            range_push(context.dynamic_step_nvtx_label("sampled_token_gpu_handoff"))
             if self.num_speculative_tokens > 0:
                 # Phase 1: Verify speculative tokens using base logits only.
                 self._dynamic_step_sample_logits_and_verify_tokens(logits, input_ids)
@@ -1931,6 +1932,7 @@ class TextGenerationController:
                 self._compute_serial_mtp_and_sample()
             else:
                 self._dynamic_step_sample_logits(logits)
+            range_pop()
 
             log_probs = None
             top_n_logprobs = None
@@ -1955,9 +1957,11 @@ class TextGenerationController:
                 # _transfer_samples_to_cpu wasn't invoked on this path, so do
                 # a one-shot D2H here to keep "sample" as a CPU tensor for
                 # downstream consumers.
+                range_push(context.dynamic_step_nvtx_label("sampled_output_d2h"))
                 request_bookkeeping = {
                     "sample": self._sampled_tokens_cuda[:active_request_count].cpu(),
                 }
+                range_pop()
             else:
                 # request_bookkeeping supplies "sample" as the already-CPU
                 # tensor produced by _transfer_samples_to_cpu.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1839,6 +1839,11 @@ class TextGenerationController:
         return {
             "active_request_ids": active_request_ids,
             "finished_request_ids": finished_request_ids,
+            # Already a CPU tensor (independent of _sampled_tokens_cuda via the
+            # .cpu() in _transfer_samples_to_cpu; update_requests only mutates
+            # the separate new_sample_copy). Returning the CPU copy avoids a
+            # D2H sync when the engine later calls sample.tolist().
+            "sample": sampled_tokens_cpu,
             **(update_result or {}),
         }
 
@@ -1947,13 +1952,18 @@ class TextGenerationController:
             range_pop()
 
             if skip_bookkeeping:
-                request_bookkeeping = {}
+                # _transfer_samples_to_cpu wasn't invoked on this path, so do
+                # a one-shot D2H here to keep "sample" as a CPU tensor for
+                # downstream consumers.
+                request_bookkeeping = {
+                    "sample": self._sampled_tokens_cuda[:active_request_count].cpu(),
+                }
             else:
+                # request_bookkeeping supplies "sample" as the already-CPU
+                # tensor produced by _transfer_samples_to_cpu.
                 request_bookkeeping = self._dynamic_step_context_bookkeeping()
 
             ret = {
-                # Clone needed: _sampled_tokens_cuda is a reused buffer overwritten each step.
-                "sample": self._sampled_tokens_cuda[:active_request_count].clone(),
                 "accepted_tokens": (
                     # Clone needed: .fill_(-1) on line 1480 would corrupt the returned value.
                     self._accepted_tokens_per_request.clone()

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -576,12 +576,17 @@ class TextGenerationController:
         unwrapped_model = unwrap_model(self.inference_wrapped_model.model)
         model_config = get_model_config(unwrapped_model)
 
-        # Initialize attention state.
+        # Initialize attention state (100% CPU computation).
         range_push("initialize_attention_state")
         context.initialize_attention_state(
             construct_graph_dimensions=construct_graph_dimensions,
             is_expert_parallel_dummy_cuda_graph_step=is_dummy_forward,
         )
+        range_pop()
+
+        # Single batch CPU-to-GPU transfer of bookkeeping state.
+        range_push("transfer_bookkeeping_to_gpu")
+        context.transfer_bookkeeping_to_gpu()
         range_pop()
 
         # If using symmetric kernels and we are using using nccl
@@ -614,12 +619,11 @@ class TextGenerationController:
                 unwrapped_model.set_symmetric_ar(None)
 
         # Get request metadata for this step.
+        # Context metadata is now on CPU, so copy is CPU-to-CPU (fast).
         for label, dtype, on_gpu in context.request_metadata_types:
-            if not on_gpu:
-                # We need a D2H copy from the context to the pinned memory buffer.
-                self._request_metadata[label].copy_(
-                    context.request_metadata[label], non_blocking=True
-                )
+            self._request_metadata[label].copy_(
+                context.request_metadata[label], non_blocking=True
+            )
 
         # Get flat tokens, position ids.
         # If we are running a dummy forward step we want to use the token count agreed upon
@@ -722,9 +726,11 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
-        # Get the accepted token counts for each request
+        # Get the accepted token counts for each request (move to CPU for bookkeeping ops).
         # Note: _accepted_token_counts is indexed from 0 to active_request_count-1
         accepted_tokens_per_request = self._accepted_token_counts_per_request[:active_request_count]
+        if accepted_tokens_per_request.is_cuda:
+            accepted_tokens_per_request = accepted_tokens_per_request.cpu()
 
         # Number of tokens to rewind (rejected speculative tokens)
         num_tokens_to_rewind = self.num_speculative_tokens - accepted_tokens_per_request
@@ -791,14 +797,15 @@ class TextGenerationController:
             # Release the blocks back to the allocator
             context.kv_block_allocator.release_memory_blocks(blocks_to_release)
 
-        # Mamba speculative rewind state update
+        # Mamba speculative rewind state update.
+        # Indices are computed on CPU, then moved to GPU for indexing into GPU Mamba state buffers.
         if context.is_hybrid_model:
             active_mamba_indices = context.mamba_metadata.request_to_mamba_state_idx[
                 active_request_slice
             ]
             is_decode_mask = context.request_in_prefill_status_tensor[active_request_slice] == 0
-            decode_mamba_indices = active_mamba_indices[is_decode_mask]
-            accepted_tokens_per_decode_request = accepted_tokens_per_request[is_decode_mask]
+            decode_mamba_indices = active_mamba_indices[is_decode_mask].cuda()
+            accepted_tokens_per_decode_request = accepted_tokens_per_request[is_decode_mask].cuda()
 
             if decode_mamba_indices.numel() > 0:
                 context.mamba_conv_states[:, decode_mamba_indices] = (
@@ -877,11 +884,15 @@ class TextGenerationController:
             last_accepted_hidden = None
 
         # Compute position IDs for the next tokens.
-        # After rewind, request_kv_length_offsets has been adjusted. The actual
-        # KV cache length is: adjusted_offset + processed_tokens.
-        # The next position to predict starts at that cache length.
-        adjusted_offsets = context.request_kv_length_offsets[active_slice]
-        processed_tokens = context.request_query_lengths[active_slice]
+        # After rewind, request_kv_length_offsets has been adjusted. Read from
+        # CPU context (post-rewind values), NOT gpu_view (stale pre-rewind snapshot).
+        cuda_device = torch.cuda.current_device()
+        adjusted_offsets = context.request_kv_length_offsets[active_slice].to(
+            cuda_device, non_blocking=True,
+        )
+        processed_tokens = context.request_query_lengths[active_slice].to(
+            cuda_device, non_blocking=True,
+        )
         base_position = adjusted_offsets + processed_tokens
 
         # Start with the freshly sampled base token.
@@ -972,6 +983,7 @@ class TextGenerationController:
         Returns:
             tuple: (output_tokens, repeats) where output_tokens has shape [total_required_tokens]
         """
+        # request_in_prefill_status_tensor is already on GPU (from gpu_view).
         repeats = torch.where(
             request_in_prefill_status_tensor == 0, 1 + self.num_speculative_tokens, 1
         )
@@ -1101,12 +1113,11 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
 
-        request_in_prefill_status_tensor = context.request_in_prefill_status_tensor[
-            context.paused_request_count : context.total_request_count
+        # Use gpu_view for data consumed by GPU operations (sampling, verification).
+        request_in_prefill_status_tensor = context.gpu_view.request_in_prefill_status[
+            :active_request_count
         ]
-        request_query_lengths = context.request_query_lengths[
-            context.paused_request_count : context.total_request_count
-        ]
+        request_query_lengths = context.gpu_view.request_query_lengths[:active_request_count]
 
         num_prefill_requests = request_in_prefill_status_tensor.sum().item()
         num_decode_requests = active_request_count - num_prefill_requests
@@ -1326,12 +1337,11 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
 
-        request_in_prefill_status_tensor = context.request_in_prefill_status_tensor[
-            context.paused_request_count : context.total_request_count
+        # Use gpu_view for data consumed by GPU log-probs operations.
+        request_in_prefill_status_tensor = context.gpu_view.request_in_prefill_status[
+            :active_request_count
         ]
-        request_query_lengths = context.request_query_lengths[
-            context.paused_request_count : context.total_request_count
-        ]
+        request_query_lengths = context.gpu_view.request_query_lengths[:active_request_count]
 
         num_prefill_requests = request_in_prefill_status_tensor.sum().item()
         num_decode_requests = active_request_count - num_prefill_requests
@@ -1392,7 +1402,7 @@ class TextGenerationController:
                 ]
                 log_probs_list_prefill = [[lp.item()] for lp in selected_log_probs]
             else:
-                prefill_token_ids = context.token_to_input_ids[
+                prefill_token_ids = context.gpu_view.token_to_input_ids[
                     decode_len : context.active_token_count
                 ].roll(-1, 0)
                 prefill_query_lengths = request_query_lengths[request_in_prefill_status_tensor == 1]
@@ -1436,12 +1446,11 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
-        request_in_prefill_status_tensor = context.request_in_prefill_status_tensor[
-            context.paused_request_count : context.total_request_count
+        # Use gpu_view for data consumed by GPU top-n operations.
+        request_in_prefill_status_tensor = context.gpu_view.request_in_prefill_status[
+            :active_request_count
         ]
-        request_query_lengths = context.request_query_lengths[
-            context.paused_request_count : context.total_request_count
-        ]
+        request_query_lengths = context.gpu_view.request_query_lengths[:active_request_count]
 
         num_prefill_requests = request_in_prefill_status_tensor.sum().item()
         num_decode_requests = active_request_count - num_prefill_requests
@@ -1756,8 +1765,13 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
+        # GPU-to-CPU transfer of sampled tokens (single batch D2H).
+        range_push("transfer_samples_to_cpu")
+        sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
+        range_pop()
+
         range_push("active_request_mask")
-        # Active sequence lengths.
+        # Active sequence lengths (CPU, from context bookkeeping).
         active_request_ids = context.request_ids[active_request_slice].long()
         active_sequence_lengths = context.get_active_sequence_lengths()
 
@@ -1769,9 +1783,10 @@ class TextGenerationController:
         max_sequence_lengths = context.get_max_sequence_lengths()
 
         # Request finished if termination_id or length >= max_sequence_length.
-        # Note: termination_id tensor has per-request termination IDs from mixed sampling
+        # Note: termination_id tensor has per-request termination IDs from mixed sampling.
+        # All comparisons are on CPU (sampled_tokens_cpu, _request_metadata, context tensors).
         active_request_mask = (
-            self._sampled_tokens_cuda[:active_request_count]
+            sampled_tokens_cpu
             != self._request_metadata["termination_id"][active_request_slice]
         ).byte() & torch.less(active_sequence_lengths, max_sequence_lengths).byte()
 
@@ -1790,19 +1805,19 @@ class TextGenerationController:
         finished_request_ids = context.request_ids[finished_idxs]
 
         # Clone needed: update_requests mutates next_tokens in-place via tensor_swap,
-        # which would corrupt the reused _sampled_tokens_cuda buffer.
-        new_sample_copy = self._sampled_tokens_cuda[:active_request_count].clone()
+        # which would corrupt the reused buffer.
+        new_sample_copy = sampled_tokens_cpu.clone()
         range_pop()
 
         range_push("update_requests")
-        # Update requests.
+        # Update requests (100% CPU).
         # _sampled_mtp_tokens_cuda has shape [num_speculative_tokens, max_requests]
         if self.num_speculative_tokens > 0:
-            sampled_mtp_tokens_cuda = self._sampled_mtp_tokens_cuda[:, :active_request_count]
+            sampled_mtp_tokens_cpu = self._sampled_mtp_tokens_cuda[:, :active_request_count].cpu()
         else:
-            sampled_mtp_tokens_cuda = None
+            sampled_mtp_tokens_cpu = None
         update_result = context.update_requests(
-            active_request_mask, new_sample_copy, sampled_mtp_tokens_cuda
+            active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
         )
         range_pop()
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1808,13 +1808,19 @@ class TextGenerationController:
         range_push(context.dynamic_step_nvtx_label("active_request_mask"))
         # Everything below is 100% CPU.
         active_request_ids = context.request_ids[active_request_slice].long()
-        active_sequence_lengths = context.get_active_sequence_lengths()
-
-        # After the forward pass and KV-cache rewind, get_active_sequence_lengths()
-        # returns kv_offsets + query_lengths which already includes all accepted
-        # speculative tokens (they were part of the query and survived the rewind).
-        # Only the newly sampled base token is not yet in the KV cache, so add 1.
-        active_sequence_lengths += 1
+        active_request_slots = torch.arange(
+            context.paused_request_count,
+            context.total_request_count,
+            dtype=torch.long,
+            device='cpu',
+        )
+        output_placeholder_counts = torch.ones(
+            active_request_count,
+            dtype=context.num_output_placeholders.dtype,
+            device='cpu',
+        )
+        context.add_output_placeholders(active_request_slots, output_placeholder_counts)
+        active_sequence_lengths = context.get_placeholder_adjusted_active_sequence_lengths()
         max_sequence_lengths = context.get_max_sequence_lengths()
 
         # Request finished if termination_id or length >= max_sequence_length.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1852,13 +1852,17 @@ class TextGenerationController:
         new_sample_copy = sampled_tokens_cpu.clone()
         range_pop()
 
-        range_push(context.dynamic_step_nvtx_label("update_requests"))
-        update_result = context.update_requests(
-            active_request_mask,
-            new_sample_copy,
-            sampled_mtp_tokens_cpu,
+        range_push(context.dynamic_step_nvtx_label("commit_step_output"))
+        retirement = context.commit_step_output(
+            self._current_dynamic_step_record(),
+            {
+                "active_requests_mask": active_request_mask,
+                "sampled_tokens_cpu": new_sample_copy,
+                "sampled_mtp_tokens_cpu": sampled_mtp_tokens_cpu,
+            },
             defer_decode_input_tokens=True,
         )
+        update_result = retirement.context_update_result
         range_pop()
 
         return {
@@ -1953,7 +1957,7 @@ class TextGenerationController:
             snapshot_slot_handle=snapshot_handle
         )
         active_request_count = context.total_request_count - context.paused_request_count
-        request_plan = self._dynamic_step_request_plan(step_id)
+        request_plan = context.prepare_next_step_optimistic(step_id)
 
         cuda_graph_request_count = (
             context.padded_active_request_count if context.using_cuda_graph_this_step() else None
@@ -1963,11 +1967,6 @@ class TextGenerationController:
             step_id.value,
             snapshot_slot_id,
             cuda_graph_batch_dimensions=cuda_graph_request_count,
-        )
-        context.record_request_slot_transition(
-            step_id.value,
-            request_slots_after=tuple(range(int(context.total_request_count))),
-            active_request_ids=request_plan.active_request_ids,
         )
 
         prepared_step = DynamicStepContextSnapshot(
@@ -2155,13 +2154,15 @@ class TextGenerationController:
         self,
         prepared_step: DynamicStepContextSnapshot,
         gpu_launch: DynamicStepGpuLaunch,
-        step_output: AsyncStepOutputResult,
+        step_output: Union[AsyncStepOutput, AsyncStepOutputResult],
         log_probs: Optional[Tensor],
         top_n_logprobs: Optional[Dict[int, List[Tuple[Tensor, Tensor]]]],
         skip_bookkeeping: Optional[bool] = False,
     ) -> Dict:
         """Commit serial CPU bookkeeping and return the public dynamic-step result."""
         context = self.inference_wrapped_model.inference_context
+        if isinstance(step_output, AsyncStepOutput):
+            step_output = self.collect_dynamic_output(step_output)
         context.debug_compare_sampled_tokens_gpu_state(
             sampled_tokens_cpu=step_output.sampled_tokens_cpu,
             active_request_count=prepared_step.active_request_count,
@@ -2231,7 +2232,6 @@ class TextGenerationController:
         with torch.inference_mode():
             log_probs, top_n_logprobs = self.launch_dynamic_sampling(gpu_launch)
             step_output = self.begin_dynamic_output_copy(prepared_step, skip_bookkeeping)
-            step_output = self.collect_dynamic_output(step_output)
             return self.commit_dynamic_bookkeeping(
                 prepared_step,
                 gpu_launch,

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -5,6 +5,7 @@ import concurrent
 import copy
 import functools
 from collections import defaultdict
+from dataclasses import replace
 from typing import Any, Dict, List, Optional, OrderedDict, Tuple, Union
 
 import torch
@@ -1853,7 +1854,10 @@ class TextGenerationController:
 
         range_push(context.dynamic_step_nvtx_label("update_requests"))
         update_result = context.update_requests(
-            active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
+            active_request_mask,
+            new_sample_copy,
+            sampled_mtp_tokens_cpu,
+            defer_decode_input_tokens=True,
         )
         range_pop()
 
@@ -1966,7 +1970,7 @@ class TextGenerationController:
             active_request_ids=request_plan.active_request_ids,
         )
 
-        return DynamicStepContextSnapshot(
+        prepared_step = DynamicStepContextSnapshot(
             step_id=step_id,
             snapshot_slot_id=snapshot_slot_id,
             request_plan=request_plan,
@@ -1978,6 +1982,14 @@ class TextGenerationController:
             gpu_view=snapshot_slot.gpu_view,
             cpu_staging_buffer=snapshot_slot.cpu_mirror,
         )
+        input_plan = context.build_step_input_plan(
+            step_id=step_id,
+            snapshot_slot_id=snapshot_slot_id,
+        )
+        input_ready_event = context.prepare_gpu_inputs(prepared_step, input_plan)
+        if input_ready_event is not None:
+            prepared_step = replace(prepared_step, input_ready_event=input_ready_event)
+        return prepared_step
 
     def launch_dynamic_forward(
         self, prepared_step: DynamicStepContextSnapshot
@@ -1989,6 +2001,8 @@ class TextGenerationController:
             context.gpu_view,
             debug_enabled=getattr(context.config, "async_overlap_debug_checks", False),
         )
+        if prepared_step.input_ready_event is not None:
+            torch.cuda.current_stream().wait_event(prepared_step.input_ready_event)
 
         # Enable routing recording before forward pass if routing replay is enabled
         config = self.inference_wrapped_model.model.config

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1503,14 +1503,19 @@ class CudaGraphManager(torch.nn.Module):
         if reuse_cudagraphs:
             is_inference_mode = 'inference_context' in kwargs.keys() and kwargs['inference_context']
             if is_inference_mode:
-                is_static_batching = kwargs['inference_context'].is_static_batching()
+                inference_context = kwargs['inference_context']
+                is_static_batching = inference_context.is_static_batching()
                 if is_static_batching:
                     batch_size = kwargs['hidden_states'].shape[0]
-                    is_decode_only = kwargs["inference_context"].is_decode_only()
-                    runner = self.inference_cudagraphs_lookup_table[(batch_size, is_decode_only)]
+                    is_decode_only = inference_context.is_decode_only()
+                    inference_cache_key = (batch_size, is_decode_only)
                 else:
-                    padded_batch_dimensions = kwargs['inference_context'].padded_batch_dimensions
-                    runner = self.inference_cudagraphs_lookup_table[padded_batch_dimensions]
+                    inference_cache_key = inference_context.cuda_graph_cache_key()
+                runner = self.inference_cudagraphs_lookup_table.get(inference_cache_key)
+                if not is_static_batching:
+                    inference_context.record_cuda_graph_cache_lookup(
+                        inference_cache_key, hit=runner is not None
+                    )
             else:
                 # Todo: For training, we could also cache runners based on input shape.
                 # If autograd is currently disabled, it doesnt matter if a runner was created
@@ -1536,6 +1541,16 @@ class CudaGraphManager(torch.nn.Module):
                         f"existing runners. Use `get_mismatch_errors` to debug mismatches."
                     )
                 else:
+                    if is_inference_mode and not is_static_batching:
+                        max_entries = inference_context.cuda_graph_max_cache_entries()
+                        if (
+                            inference_cache_key not in self.inference_cudagraphs_lookup_table
+                            and len(self.inference_cudagraphs_lookup_table) >= max_entries
+                        ):
+                            raise RuntimeError(
+                                "Dynamic inference CUDA graph cache exceeded its bounded "
+                                f"capacity ({max_entries}). Missing key: {inference_cache_key}"
+                            )
                     runner = _CudaGraphRunner(
                         megatron_module,
                         CudaGraphManager.global_mempool,
@@ -1546,13 +1561,9 @@ class CudaGraphManager(torch.nn.Module):
                     )
                     self.cudagraph_runners.append(runner)
                     if is_inference_mode:
+                        runner.inference_cuda_graph_cache_key = inference_cache_key
                         # Cache the newly created runner in the inference lookup table.
-                        if is_static_batching:
-                            self.inference_cudagraphs_lookup_table[(batch_size, is_decode_only)] = (
-                                runner
-                            )
-                        else:
-                            self.inference_cudagraphs_lookup_table[padded_batch_dimensions] = runner
+                        self.inference_cudagraphs_lookup_table[inference_cache_key] = runner
         else:
             # Create cudagraphs for every microbatch
             if _CudagraphGlobalRecord.cudagraph_created:

--- a/megatron/inference/utils.py
+++ b/megatron/inference/utils.py
@@ -348,6 +348,9 @@ def get_inference_config_from_model_and_args(model: MegatronModule, args):
         max_sequence_length=max_sequence_length,
         mamba_inference_state_config=mamba_inference_state_config,
         pg_collection=pg_collection,
+        async_overlap_queue_depth=getattr(
+            args, 'inference_dynamic_batching_async_overlap_queue_depth', 2
+        ),
         use_flashinfer_fused_rope=args.use_flashinfer_fused_rope,
         materialize_only_last_token_logits=(not args.return_log_probs),
         track_generated_token_events=args.inference_dynamic_batching_track_generated_token_events,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1892,6 +1892,10 @@ def _add_inference_args(parser):
     group.add_argument('--inference-dynamic-batching-max-tokens',
                        type=int, default=None,
                        help='Override the inference context\'s default `max_tokens`.')
+    group.add_argument('--inference-dynamic-batching-async-overlap-queue-depth',
+                       type=int, default=2, choices=[1, 2],
+                       help='Maximum async-overlap pipeline depth. Use 1 for '
+                       'serial/debug mode and 2 for one-step lookahead overlap.')
     group.add_argument('--inference-dynamic-batching-num-cuda-graphs',
                        type=int, default=16,
                        help='Maximum number of cuda graphs to capture, where the '

--- a/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
+++ b/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
@@ -5,6 +5,7 @@ import torch
 
 from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensions
 from megatron.core.inference.contexts.attention_context.mamba_metadata import MambaMetadata
+from megatron.core.inference.contexts.gpu_view import ContextGPUView
 
 
 class TestMambaMetadata:
@@ -541,3 +542,55 @@ class TestMambaMetadata:
 
         metadata.release_deferred_slots_for_snapshot(2)
         assert metadata.mamba_state_free_slot_count == 3
+
+    @pytest.mark.internal
+    def test_load_from_cpu_keeps_per_snapshot_gpu_views_distinct(self):
+        """Mamba load_from_cpu stores distinct snapshot-bound GPU views and scratch buffers."""
+        metadata = MambaMetadata(max_requests=4, max_tokens=16, mamba_chunk_size=4, d_conv=4)
+        first_view = ContextGPUView(
+            max_requests=4,
+            max_tokens=16,
+            max_kv_blocks=8,
+            device=torch.cuda.current_device(),
+            max_mamba_chunks=8,
+        )
+        second_view = ContextGPUView(
+            max_requests=4,
+            max_tokens=16,
+            max_kv_blocks=8,
+            device=torch.cuda.current_device(),
+            max_mamba_chunks=8,
+        )
+
+        load_args = {
+            "padded_decode_count": 2,
+            "padded_prefill_count": 1,
+            "padded_token_count": 4,
+            "real_prefill_count": 1,
+            "padded_max_chunks": 2,
+            "cu_seqlens_list": [0, 4],
+            "real_prefill_token_count": 4,
+            "intermediate_offsets_gpu": None,
+            "intermediate_counts_gpu": None,
+            "decode_prefill_0": 2,
+            "decode_prefill_1": 4,
+        }
+
+        first = metadata.load_from_cpu(load_args, gpu_view=first_view, snapshot_slot_id=0)
+        second = metadata.load_from_cpu(load_args, gpu_view=second_view, snapshot_slot_id=1)
+
+        assert first.batch_indices_decode.data_ptr() != second.batch_indices_decode.data_ptr()
+        assert first.batch_indices_prefill.data_ptr() != second.batch_indices_prefill.data_ptr()
+        assert first.device_decode_prefill.data_ptr() != second.device_decode_prefill.data_ptr()
+        assert (
+            first.intermediate_chunk_indices.data_ptr()
+            != second.intermediate_chunk_indices.data_ptr()
+        )
+
+        metadata.activate_snapshot_state(0)
+        assert metadata.batch_indices_decode is first.batch_indices_decode
+        assert metadata.device_decode_prefill is first.device_decode_prefill
+
+        metadata.activate_snapshot_state(1)
+        assert metadata.batch_indices_decode is second.batch_indices_decode
+        assert metadata.device_decode_prefill is second.device_decode_prefill

--- a/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
+++ b/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
@@ -6,6 +6,7 @@ import torch
 from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensions
 from megatron.core.inference.contexts.attention_context.mamba_metadata import MambaMetadata
 from megatron.core.inference.contexts.gpu_view import ContextGPUView
+from megatron.core.inference.contexts.step_journal import RollbackStatus
 
 
 class TestMambaMetadata:
@@ -519,10 +520,30 @@ class TestMambaMetadata:
         assert rollback is not None
         assert rollback.mamba_restore_block_ids[2] == 13
         metadata.request_to_mamba_state_idx[2] = rollback.mamba_slot_ids[0]
-        metadata.rollback_reservation(rollback)
-        metadata.rollback_reservation(rollback)
+        status = metadata.rollback_reservation(rollback)
+        assert status == RollbackStatus.FULLY_RELEASED
+        status = metadata.rollback_reservation(rollback)
+        assert status == RollbackStatus.ALREADY_ROLLED_BACK
         assert metadata.request_to_mamba_state_idx[2].item() == -1
         assert metadata.mamba_state_free_slot_count == 3
+
+        status = metadata.rollback_reservation(reservation)
+        assert status == RollbackStatus.ALREADY_COMMITTED
+
+    @pytest.mark.internal
+    def test_mamba_slot_rollback_skips_already_released_slot(self):
+        """Mamba rollback is idempotent if pressure cleanup already returned a slot."""
+        metadata = MambaMetadata(max_requests=4, max_tokens=128)
+        reservation = metadata.reserve_slot(1, step_id=7, zero_state=True)
+        assert reservation is not None
+        metadata.request_to_mamba_state_idx[1] = reservation.mamba_slot_ids[0]
+
+        metadata._release_slot_ids(reservation.mamba_slot_ids)
+        status = metadata.rollback_reservation(reservation)
+
+        assert status == RollbackStatus.RESOURCE_ALREADY_EVICTED
+        assert metadata.request_to_mamba_state_idx[1].item() == -1
+        assert metadata.mamba_state_free_slot_count == 4
 
     @pytest.mark.internal
     def test_mamba_slot_release_can_wait_for_snapshot_retirement(self):

--- a/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
+++ b/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
@@ -498,3 +498,46 @@ class TestMambaMetadata:
         expected_seq_idx = torch.cat([expected_seq_idx_0, expected_seq_idx_1], dim=1)
 
         assert torch.equal(metadata_context.seq_idx, expected_seq_idx)
+
+    @pytest.mark.internal
+    def test_mamba_slot_reservation_commit_and_rollback(self):
+        """Mamba state slots move through reserve/commit/rollback lifecycle."""
+        metadata = MambaMetadata(max_requests=4, max_tokens=128)
+
+        reservation = metadata.reserve_slot(1, step_id=7, zero_state=True)
+        assert reservation is not None
+        assert metadata.mamba_state_free_slot_count == 3
+        assert reservation.mamba_slot_ids == (3,)
+        assert reservation.mamba_zero_slot_ids == (3,)
+        metadata.request_to_mamba_state_idx[1] = reservation.mamba_slot_ids[0]
+        metadata.commit_reservation(reservation)
+        metadata.commit_reservation(reservation)
+        assert metadata.request_to_mamba_state_idx[1].item() == 3
+
+        rollback = metadata.reserve_slot(2, step_id=8, restore_block_id=13)
+        assert rollback is not None
+        assert rollback.mamba_restore_block_ids[2] == 13
+        metadata.request_to_mamba_state_idx[2] = rollback.mamba_slot_ids[0]
+        metadata.rollback_reservation(rollback)
+        metadata.rollback_reservation(rollback)
+        assert metadata.request_to_mamba_state_idx[2].item() == -1
+        assert metadata.mamba_state_free_slot_count == 3
+
+    @pytest.mark.internal
+    def test_mamba_slot_release_can_wait_for_snapshot_retirement(self):
+        """Deferred Mamba slot release prevents reuse until snapshot retirement."""
+        metadata = MambaMetadata(max_requests=4, max_tokens=128)
+        slot = metadata.allocate_slot()
+        assert slot is not None
+        assert metadata.mamba_state_free_slot_count == 3
+
+        slot_tensor = torch.tensor([int(slot.item())], dtype=torch.int32, device='cpu')
+        metadata.defer_release_until_snapshot_retired(slot_tensor, snapshot_slot_id=2)
+        assert metadata.mamba_state_free_slot_count == 3
+
+        second_slot = metadata.allocate_slot()
+        assert int(second_slot.item()) != int(slot.item())
+        assert metadata.mamba_state_free_slot_count == 2
+
+        metadata.release_deferred_slots_for_snapshot(2)
+        assert metadata.mamba_state_free_slot_count == 3

--- a/tests/unit_tests/inference/contexts/attention_metadata/test_mha_metadata.py
+++ b/tests/unit_tests/inference/contexts/attention_metadata/test_mha_metadata.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import torch
+
+from megatron.core.inference.contexts.attention_context.mha_metadata import NonGraphedMHAMetadata
+from megatron.core.inference.contexts.gpu_view import ContextGPUView
+
+
+def _gpu_view(slot_id: int) -> ContextGPUView:
+    view = ContextGPUView(
+        max_requests=4,
+        max_tokens=16,
+        max_kv_blocks=8,
+        device=torch.cuda.current_device(),
+    )
+    view.current_snapshot_slot_id = slot_id
+    return view
+
+
+def test_mha_metadata_keeps_per_snapshot_gpu_views_distinct():
+    metadata = NonGraphedMHAMetadata(
+        block_count_total=8,
+        max_kv_block_count=8,
+        max_requests=4,
+        block_size_tokens=16,
+        max_seqlen=128,
+    )
+    first_view = _gpu_view(0)
+    second_view = _gpu_view(1)
+
+    first = metadata.set_state_data(
+        padded_active_request_count=2,
+        max_seqlen_q=4,
+        max_seqlen_k=16,
+        gpu_view=first_view,
+        snapshot_slot_id=0,
+    )
+    second = metadata.set_state_data(
+        padded_active_request_count=3,
+        max_seqlen_q=8,
+        max_seqlen_k=32,
+        gpu_view=second_view,
+        snapshot_slot_id=1,
+    )
+
+    assert first.state_data["query_lengths"].data_ptr() != second.state_data[
+        "query_lengths"
+    ].data_ptr()
+    assert first.state_data["block_table"].data_ptr() != second.state_data["block_table"].data_ptr()
+
+    metadata.activate_snapshot_state(0)
+    assert metadata.state_data is first.state_data
+    assert metadata.state_data["max_seqlen_q"] == 4
+
+    metadata.activate_snapshot_state(1)
+    assert metadata.state_data is second.state_data
+    assert metadata.state_data["max_seqlen_q"] == 8

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -14,6 +14,7 @@ from megatron.core.inference.contexts.dynamic_context import (
     RequestOverflowError,
     TokenOverflowError,
 )
+from megatron.core.inference.engines.dynamic_step import DynamicStepId
 from megatron.core.inference.inference_request import DynamicInferenceRequest
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.ssm.mamba_hybrid_layer_allocation import Symbols
@@ -807,6 +808,146 @@ class TestDynamicContext:
                     ]
                 )
             )
+
+    @pytest.mark.internal
+    @rounder_override(64)
+    def test_update_requests_defers_decode_input_tokens_to_gpu_preparer(self):
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=2,
+            kv_channels=8,
+            num_attention_heads=2,
+            max_sequence_length=128,
+            buffer_size_gb=0.01,
+            block_size_tokens=128,
+            max_tokens=256,
+            max_requests=256,
+        )
+        dynamic_context.set_current_dynamic_step_id(7)
+
+        dynamic_context.total_request_count = 2
+        dynamic_context.paused_request_count = 0
+        dynamic_context.active_token_count = 2
+        dynamic_context.request_ids[:2] = torch.tensor([10, 11], device='cpu')
+        dynamic_context.request_query_lengths[:2] = 1
+        dynamic_context.request_in_prefill_status_tensor[:2] = 0
+        dynamic_context.request_kv_length_offsets[:2] = torch.tensor([5, 8], device='cpu')
+        dynamic_context.request_last_kv_block_offset[:2] = torch.tensor([5, 8], device='cpu')
+        dynamic_context.request_kv_block_counts[:2] = 1
+        blocks = dynamic_context.kv_block_allocator.allocate_memory_blocks(2)
+        dynamic_context.request_to_kv_block_ids[:2, 0] = blocks
+        dynamic_context.request_last_kv_block_id[:2] = blocks
+
+        dynamic_context.update_requests(
+            active_requests_mask=torch.tensor([1, 1], device='cpu', dtype=torch.int32),
+            new_tokens=torch.tensor([99, 100], device='cpu'),
+            defer_decode_input_tokens=True,
+        )
+
+        assert dynamic_context._gpu_decode_input_pending
+        assert dynamic_context._gpu_decode_input_source_step_id == 7
+        assert torch.equal(
+            dynamic_context.token_to_input_ids[:2],
+            torch.zeros(2, dtype=dynamic_context.token_to_input_ids.dtype, device='cpu'),
+        )
+        assert torch.equal(
+            dynamic_context.token_to_pos_ids[:2], torch.tensor([6, 9], device='cpu')
+        )
+
+        input_plan = dynamic_context.build_step_input_plan(
+            step_id=DynamicStepId(8), snapshot_slot_id=0
+        )
+        assert input_plan.source_step_id == DynamicStepId(7)
+        assert input_plan.decode_request_ids == ("10", "11")
+        assert input_plan.decode_input_destination_indices == (0, 1)
+
+        dynamic_context.reset_metadata()
+        assert not dynamic_context._gpu_decode_input_pending
+        assert dynamic_context._gpu_decode_input_source_step_id is None
+
+    @pytest.mark.internal
+    @rounder_override(64)
+    def test_update_requests_falls_back_to_cpu_decode_tokens_when_requests_finish(self):
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=2,
+            kv_channels=8,
+            num_attention_heads=2,
+            max_sequence_length=128,
+            buffer_size_gb=0.01,
+            block_size_tokens=128,
+            max_tokens=256,
+            max_requests=256,
+        )
+
+        dynamic_context.total_request_count = 3
+        dynamic_context.paused_request_count = 0
+        dynamic_context.active_token_count = 3
+        dynamic_context.request_ids[:3] = torch.tensor([10, 11, 12], device='cpu')
+        dynamic_context.request_query_lengths[:3] = 1
+        dynamic_context.request_in_prefill_status_tensor[:3] = 0
+        dynamic_context.request_kv_length_offsets[:3] = torch.tensor([5, 8, 11], device='cpu')
+        dynamic_context.request_last_kv_block_offset[:3] = torch.tensor(
+            [5, 8, 11], device='cpu'
+        )
+        dynamic_context.request_kv_block_counts[:3] = 1
+        blocks = dynamic_context.kv_block_allocator.allocate_memory_blocks(3)
+        dynamic_context.request_to_kv_block_ids[:3, 0] = blocks
+        dynamic_context.request_last_kv_block_id[:3] = blocks
+
+        dynamic_context.update_requests(
+            active_requests_mask=torch.tensor([1, 0, 1], device='cpu', dtype=torch.int32),
+            new_tokens=torch.tensor([99, 100, 101], device='cpu'),
+            defer_decode_input_tokens=True,
+        )
+
+        assert not dynamic_context._gpu_decode_input_pending
+        assert dynamic_context.total_request_count == 2
+        assert torch.equal(
+            dynamic_context.token_to_input_ids[:2],
+            torch.tensor([99, 101], dtype=dynamic_context.token_to_input_ids.dtype, device='cpu'),
+        )
+
+    @pytest.mark.internal
+    @rounder_override(64)
+    def test_update_requests_clears_deferred_decode_input_on_empty_batch(self):
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=2,
+            kv_channels=8,
+            num_attention_heads=2,
+            max_sequence_length=128,
+            buffer_size_gb=0.01,
+            block_size_tokens=128,
+            max_tokens=256,
+            max_requests=256,
+        )
+
+        dynamic_context.total_request_count = 1
+        dynamic_context.paused_request_count = 0
+        dynamic_context.active_token_count = 1
+        dynamic_context.request_ids[0] = 10
+        dynamic_context.request_query_lengths[0] = 1
+        dynamic_context.request_in_prefill_status_tensor[0] = 0
+        dynamic_context.request_kv_length_offsets[0] = 5
+        dynamic_context.request_last_kv_block_offset[0] = 5
+        dynamic_context.request_kv_block_counts[0] = 1
+        block = dynamic_context.kv_block_allocator.allocate_memory_blocks(1)
+        dynamic_context.request_to_kv_block_ids[0, 0] = block[0]
+        dynamic_context.request_last_kv_block_id[0] = block[0]
+        dynamic_context._gpu_decode_input_pending = True
+        dynamic_context._gpu_decode_input_source_step_id = 7
+
+        dynamic_context.update_requests(
+            active_requests_mask=torch.tensor([0], device='cpu', dtype=torch.int32),
+            new_tokens=torch.tensor([99], device='cpu'),
+            defer_decode_input_tokens=True,
+        )
+
+        assert dynamic_context.total_request_count == 0
+        assert dynamic_context.active_token_count == 0
+        assert not dynamic_context._gpu_decode_input_pending
+        assert dynamic_context._gpu_decode_input_source_step_id is None
 
     @pytest.mark.internal
     @rounder_override(64)

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -867,6 +867,72 @@ class TestDynamicContext:
 
     @pytest.mark.internal
     @rounder_override(64)
+    def test_split_commit_matches_serial_update_requests_for_decode(self):
+        def make_context():
+            dynamic_context = self._get_dynamic_context(
+                params_dtype=torch.float32,
+                num_layers=2,
+                kv_channels=8,
+                num_attention_heads=2,
+                max_sequence_length=128,
+                buffer_size_gb=0.01,
+                block_size_tokens=128,
+                max_tokens=256,
+                max_requests=256,
+            )
+            dynamic_context.total_request_count = 2
+            dynamic_context.paused_request_count = 0
+            dynamic_context.active_token_count = 2
+            dynamic_context.request_ids[:2] = torch.tensor([10, 11], device='cpu')
+            dynamic_context.request_query_lengths[:2] = 1
+            dynamic_context.request_in_prefill_status_tensor[:2] = 0
+            dynamic_context.request_kv_length_offsets[:2] = torch.tensor([5, 8], device='cpu')
+            dynamic_context.request_last_kv_block_offset[:2] = torch.tensor([5, 8], device='cpu')
+            dynamic_context.request_kv_block_counts[:2] = 1
+            blocks = dynamic_context.kv_block_allocator.allocate_memory_blocks(2)
+            dynamic_context.request_to_kv_block_ids[:2, 0] = blocks
+            dynamic_context.request_last_kv_block_id[:2] = blocks
+            return dynamic_context
+
+        baseline_context = make_context()
+        split_context = make_context()
+        active_requests_mask = torch.tensor([1, 1], device='cpu', dtype=torch.int32)
+        new_tokens = torch.tensor([99, 100], device='cpu')
+
+        baseline_context._update_requests_serial_impl(
+            active_requests_mask.clone(),
+            new_tokens.clone(),
+            defer_decode_input_tokens=True,
+        )
+        split_context.set_current_dynamic_step_id(21)
+        request_plan = split_context.prepare_next_step_optimistic(DynamicStepId(21))
+        retirement = split_context.commit_step_output(
+            DynamicStepId(21),
+            {
+                "active_requests_mask": active_requests_mask.clone(),
+                "sampled_tokens_cpu": new_tokens.clone(),
+            },
+            defer_decode_input_tokens=True,
+        )
+
+        assert request_plan.decode_request_ids == ("10", "11")
+        assert retirement.committed_request_ids == ("10", "11")
+        assert retirement.completed_request_ids == ()
+        assert split_context.step_journal.get_committed_entry(21) is not None
+        assert split_context.total_request_count == baseline_context.total_request_count
+        assert split_context.active_token_count == baseline_context.active_token_count
+        assert torch.equal(
+            split_context.token_to_pos_ids[:2],
+            baseline_context.token_to_pos_ids[:2],
+        )
+        assert torch.equal(
+            split_context.token_to_block_idx[:2],
+            baseline_context.token_to_block_idx[:2],
+        )
+        assert split_context._gpu_decode_input_pending == baseline_context._gpu_decode_input_pending
+
+    @pytest.mark.internal
+    @rounder_override(64)
     def test_update_requests_falls_back_to_cpu_decode_tokens_when_requests_finish(self):
         dynamic_context = self._get_dynamic_context(
             params_dtype=torch.float32,

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -577,6 +577,10 @@ class TestDynamicContext:
 
         mamba_idx = dynamic_context.mamba_metadata.request_to_mamba_state_idx[0].item()
         assert mamba_idx >= 0
+
+        # Mamba state zeroing is deferred until transfer_bookkeeping_to_gpu().
+        dynamic_context.initialize_attention_state()
+        dynamic_context.transfer_bookkeeping_to_gpu()
         assert torch.all(dynamic_context.mamba_conv_states[:, mamba_idx] == 0)
         assert torch.all(dynamic_context.mamba_ssm_states[:, mamba_idx] == 0)
 

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -221,7 +221,7 @@ class TestDynamicContext:
                 dynamic_context.add_request(
                     DynamicInferenceRequest(
                         request_id=i,
-                        prompt_tokens=torch.zeros(10, device='cuda'),
+                        prompt_tokens=torch.zeros(10, device='cpu'),
                         sampling_params=SamplingParams(
                             num_tokens_to_generate=dynamic_context.max_tokens - 10
                         ),
@@ -249,7 +249,7 @@ class TestDynamicContext:
             dynamic_context.add_request(
                 DynamicInferenceRequest(
                     request_id=1,
-                    prompt_tokens=torch.arange(0, 225, device='cuda'),
+                    prompt_tokens=torch.arange(0, 225, device='cpu'),
                     sampling_params=SamplingParams(
                         num_tokens_to_generate=dynamic_context.max_tokens - 25
                     ),
@@ -279,7 +279,7 @@ class TestDynamicContext:
         dynamic_context.paused_request_count = 5
         dynamic_context.padded_active_token_count = 10
         dynamic_context.padded_active_request_count = 5
-        dynamic_context.paused_tokens = torch.tensor([1, 2, 3], device='cuda')
+        dynamic_context.paused_tokens = torch.tensor([1, 2, 3], device='cpu')
         dynamic_context.request_ids.fill_(1)
         dynamic_context.request_query_lengths.fill_(1)
         dynamic_context.request_kv_length_offsets.fill_(1)
@@ -363,7 +363,7 @@ class TestDynamicContext:
         )
         assert dynamic_context.kv_block_allocator.total_avail == expected_block_count_avail
         dynamic_context.kv_block_allocator.release_memory_blocks(
-            torch.tensor(expected_memory_blocks[-2:], device='cuda')
+            torch.tensor(expected_memory_blocks[-2:], device='cpu')
         )
         assert dynamic_context.kv_block_allocator.total_avail == expected_block_count_avail + 2
         assert (
@@ -400,7 +400,7 @@ class TestDynamicContext:
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=0,
-                prompt_tokens=torch.arange(0, context_length, dtype=torch.long, device='cuda'),
+                prompt_tokens=torch.arange(0, context_length, dtype=torch.long, device='cpu'),
                 sampling_params=SamplingParams(
                     num_tokens_to_generate=dynamic_context.max_tokens - context_length
                 ),
@@ -419,15 +419,15 @@ class TestDynamicContext:
         assert dynamic_context.request_last_kv_block_offset[0].item() == 15
         assert torch.all(
             dynamic_context.token_to_pos_ids[0:context_length]
-            == torch.arange(0, context_length, dtype=torch.long, device='cuda')
+            == torch.arange(0, context_length, dtype=torch.long, device='cpu')
         )
         assert torch.all(
             dynamic_context.token_to_input_ids[0:context_length]
-            == torch.arange(0, context_length, dtype=torch.long, device='cuda')
+            == torch.arange(0, context_length, dtype=torch.long, device='cpu')
         )
         assert torch.all(
             dynamic_context.token_to_position_in_request[0:context_length]
-            == torch.arange(0, context_length, dtype=torch.long, device='cuda')
+            == torch.arange(0, context_length, dtype=torch.long, device='cpu')
         )
 
         # Verify token_to_block_idx and token_to_local_position_within_kv_block based on assigned blocks
@@ -448,7 +448,7 @@ class TestDynamicContext:
         )
         assert torch.all(
             dynamic_context.token_to_local_position_within_kv_block[0:context_length]
-            == torch.arange(0, context_length, dtype=torch.long, device='cuda')
+            == torch.arange(0, context_length, dtype=torch.long, device='cpu')
             % dynamic_context.block_size_tokens
         )
 
@@ -470,12 +470,12 @@ class TestDynamicContext:
         requests = [
             DynamicInferenceRequest(
                 request_id=100,
-                prompt_tokens=torch.arange(0, 3, device='cuda'),
+                prompt_tokens=torch.arange(0, 3, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=2, termination_id=7),
             ),
             DynamicInferenceRequest(
                 request_id=101,
-                prompt_tokens=torch.arange(3, 9, device='cuda'),
+                prompt_tokens=torch.arange(3, 9, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=1, termination_id=8),
             ),
         ]
@@ -492,12 +492,12 @@ class TestDynamicContext:
         assert dynamic_context.kv_block_allocator.total_avail == block_avail_before
 
         expected_tokens = torch.cat(
-            [torch.arange(0, 3, device='cuda'), torch.arange(3, 9, device='cuda')]
+            [torch.arange(0, 3, device='cpu'), torch.arange(3, 9, device='cpu')]
         )
         assert torch.equal(dynamic_context.token_to_input_ids[:total_tokens], expected_tokens)
 
         expected_positions = torch.tensor(
-            [0, 1, 2, 0, 1, 2, 3, 4, 5], device='cuda', dtype=torch.long
+            [0, 1, 2, 0, 1, 2, 3, 4, 5], device='cpu', dtype=torch.long
         )
         assert torch.equal(
             dynamic_context.token_to_position_in_request[:total_tokens], expected_positions
@@ -505,7 +505,7 @@ class TestDynamicContext:
         assert torch.equal(dynamic_context.token_to_pos_ids[:total_tokens], expected_positions)
 
         expected_request_indices = torch.tensor(
-            [0, 0, 0, 1, 1, 1, 1, 1, 1], device='cuda', dtype=torch.long
+            [0, 0, 0, 1, 1, 1, 1, 1, 1], device='cpu', dtype=torch.long
         )
         assert torch.equal(
             dynamic_context.token_to_request_idx[:total_tokens], expected_request_indices
@@ -521,15 +521,15 @@ class TestDynamicContext:
 
         assert torch.equal(
             dynamic_context.request_query_lengths[: len(requests)],
-            torch.tensor(lengths, device='cuda', dtype=torch.int32),
+            torch.tensor(lengths, device='cpu', dtype=torch.int32),
         )
         assert torch.equal(
             dynamic_context.request_output_lengths[: len(requests)],
-            torch.tensor([5, 7], device='cuda', dtype=torch.int32),
+            torch.tensor([5, 7], device='cpu', dtype=torch.int32),
         )
         assert torch.equal(
             dynamic_context.request_kv_block_counts[: len(requests)],
-            torch.tensor([1, 2], device='cuda', dtype=torch.int32),
+            torch.tensor([1, 2], device='cpu', dtype=torch.int32),
         )
         assert torch.all(
             dynamic_context.request_to_kv_block_ids[0, :1] == dummy_block_idx
@@ -542,12 +542,12 @@ class TestDynamicContext:
         assert torch.all(dynamic_context.request_last_kv_block_id[:2] == dummy_block_idx)
         assert torch.equal(
             dynamic_context.request_last_kv_block_offset[:2],
-            torch.tensor([2, 1], device='cuda', dtype=torch.int32),
+            torch.tensor([2, 1], device='cpu', dtype=torch.int32),
         )
 
         assert torch.equal(
             dynamic_context.request_metadata["termination_id"][:2],
-            torch.tensor([7.0, 8.0], device='cuda'),
+            torch.tensor([7.0, 8.0], device='cpu'),
         )
 
     @pytest.mark.internal
@@ -569,7 +569,7 @@ class TestDynamicContext:
 
         request = DynamicInferenceRequest(
             request_id=55,
-            prompt_tokens=torch.arange(0, 5, device='cuda'),
+            prompt_tokens=torch.arange(0, 5, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=4, termination_id=9),
         )
 
@@ -597,7 +597,7 @@ class TestDynamicContext:
 
         request = DynamicInferenceRequest(
             request_id=5,
-            prompt_tokens=torch.arange(0, 1, device='cuda'),
+            prompt_tokens=torch.arange(0, 1, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=1, termination_id=2),
         )
 
@@ -663,10 +663,10 @@ class TestDynamicContext:
             is_hybrid_model=is_hybrid_model,
         )
 
-        active_requests_mask = torch.Tensor([1, 0, 1, 1, 1, 0, 0, 1]).cuda().int()
-        next_tokens = torch.arange(2, 10, device='cuda').int()
+        active_requests_mask = torch.Tensor([1, 0, 1, 1, 1, 0, 0, 1]).int()
+        next_tokens = torch.arange(2, 10, device='cpu').int()
         dynamic_context.paused_request_count = 2
-        dynamic_context.paused_tokens = torch.Tensor([0, 1]).cuda().int()
+        dynamic_context.paused_tokens = torch.Tensor([0, 1]).int()
         dynamic_context.total_request_count = 5
 
         # Total req count should be equal to paused + num elements in active request mask.
@@ -723,7 +723,7 @@ class TestDynamicContext:
 
         # Then set up the test data
         dynamic_context.request_ids[0:10] = torch.tensor(
-            [0, 1, 5, 6, 4, 2, 9, 7, 8, 9], device=torch.cuda.current_device()
+            [0, 1, 5, 6, 4, 2, 9, 7, 8, 9], device='cpu'
         )
 
         # Now verify the values
@@ -850,12 +850,12 @@ class TestDynamicContext:
 
         # Create an active_requests_mask where requests 0, 2, and 4 are finished (0),
         # and requests 1 and 3 are still active (1)
-        active_requests_mask = torch.tensor([0, 1, 0, 1, 0], device=torch.cuda.current_device())
+        active_requests_mask = torch.tensor([0, 1, 0, 1, 0], device='cpu')
 
         # Call update_requests with these parameters
         dynamic_context.update_requests(
             active_requests_mask=active_requests_mask,
-            new_tokens=torch.tensor([10, 11, 12, 13, 14], device=torch.cuda.current_device()),
+            new_tokens=torch.tensor([10, 11, 12, 13, 14], device='cpu'),
         )
 
         # After the update, we should have released 3 blocks (for requests 0, 2, and 4)
@@ -939,12 +939,12 @@ class TestDynamicContext:
                 dynamic_context.mamba_metadata.mamba_state_free_slot_count -= 1
 
         # Create an active_requests_mask where all requests are finished
-        active_requests_mask = torch.tensor([0, 0, 0], device=torch.cuda.current_device())
+        active_requests_mask = torch.tensor([0, 0, 0], device='cpu')
 
         # Call update_requests with these parameters
         dynamic_context.update_requests(
             active_requests_mask=active_requests_mask,
-            new_tokens=torch.tensor([10, 11, 12], device=torch.cuda.current_device()),
+            new_tokens=torch.tensor([10, 11, 12], device='cpu'),
         )
 
         # After the update, we should have released all 6 blocks and have 0 active requests
@@ -994,7 +994,7 @@ class TestDynamicContext:
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=0,
-                prompt_tokens=torch.arange(0, context_length, dtype=torch.long, device='cuda'),
+                prompt_tokens=torch.arange(0, context_length, dtype=torch.long, device='cpu'),
                 sampling_params=SamplingParams(
                     num_tokens_to_generate=dynamic_context.max_tokens - 10
                 ),
@@ -1047,17 +1047,17 @@ class TestDynamicContext:
         # Add a few requests to the context
         request_data = {
             1001: {
-                "tokens": torch.randint(0, 100, (10,), device='cuda'),
+                "tokens": torch.randint(0, 100, (10,), device='cpu'),
                 "prefill_len": 10,
                 "initial_token_offset": 0,
             },
             1002: {
-                "tokens": torch.randint(0, 100, (5,), device='cuda'),
+                "tokens": torch.randint(0, 100, (5,), device='cpu'),
                 "prefill_len": 5,
                 "initial_token_offset": 10,
             },
             1003: {
-                "tokens": torch.randint(0, 100, (7,), device='cuda'),
+                "tokens": torch.randint(0, 100, (7,), device='cpu'),
                 "prefill_len": 7,
                 "initial_token_offset": 15,
             },
@@ -1081,7 +1081,12 @@ class TestDynamicContext:
         # Simulate prefill step
         total_active_tokens = dynamic_context.active_token_count
         vocab_size = 50000
-        # logits will have shape [1, total_active_tokens, vocab_size]
+
+        # Populate gpu_view for calculate_log_probs (which reads from gpu_view).
+        dynamic_context.initialize_attention_state()
+        dynamic_context.transfer_bookkeeping_to_gpu()
+
+        # logits and new_tokens must be on GPU (calculate_log_probs uses gpu_view).
         prefill_logits = torch.randn(
             1, total_active_tokens, vocab_size, device='cuda', dtype=torch.float32
         )
@@ -1122,11 +1127,15 @@ class TestDynamicContext:
 
         # Simulate decode step
         # All requests are active, so the mask will be all ones for the current active requests
-        active_requests_mask = torch.ones(dynamic_context.total_request_count, device='cuda').int()
+        active_requests_mask = torch.ones(dynamic_context.total_request_count, device='cpu').int()
 
         dynamic_context.update_requests(
             active_requests_mask=active_requests_mask, new_tokens=prefill_new_tokens
         )
+
+        # Populate gpu_view again after update_requests modified bookkeeping state.
+        dynamic_context.initialize_attention_state()
+        dynamic_context.transfer_bookkeeping_to_gpu()
 
         # Generate new logits for the decode step. Now each request contributes 1 token.
         decode_logits = torch.randn(
@@ -1153,7 +1162,7 @@ class TestDynamicContext:
 
         # Add a new prefill request to the existing context
         new_request_id = 1004
-        new_request_tokens = torch.randint(0, 100, (12,), device='cuda').long()
+        new_request_tokens = torch.randint(0, 100, (12,), device='cpu').long()
         new_request_prefill_len = new_request_tokens.shape[0]
         initial_token_offset_new_request = dynamic_context.active_token_count
         dynamic_context.add_request(
@@ -1175,6 +1184,7 @@ class TestDynamicContext:
         # This step will involve both prefill (for the new request) and decode (for existing requests).
 
         dynamic_context.initialize_attention_state()
+        dynamic_context.transfer_bookkeeping_to_gpu()
 
         total_active_tokens_mixed_step = dynamic_context.active_token_count
         mixed_step_logits = torch.randn(
@@ -1299,7 +1309,7 @@ class TestDynamicContext:
             ),
         )
 
-        # Collect the total block counts on each rank
+        # Collect the total block counts on each rank (CUDA needed for NCCL all_gather)
         local_total_blocks = torch.tensor(
             [context.kv_block_allocator.total_count], device='cuda', dtype=torch.long
         )
@@ -1654,14 +1664,14 @@ class TestDynamicContext:
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=10,
-                prompt_tokens=torch.arange(0, 2, device='cuda'),
+                prompt_tokens=torch.arange(0, 2, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=10),
             )
         )
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=11,
-                prompt_tokens=torch.arange(0, 2, device='cuda'),
+                prompt_tokens=torch.arange(0, 2, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=10),
             )
         )
@@ -1669,7 +1679,7 @@ class TestDynamicContext:
         # Add Chunk 1 of the chunked prefill request
         req_999 = DynamicInferenceRequest(
             request_id=999,
-            prompt_tokens=torch.arange(0, 8, device='cuda'),
+            prompt_tokens=torch.arange(0, 8, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=10),
         )
         dynamic_context.add_request(req_999, prefill_chunk_length=4)
@@ -1683,8 +1693,8 @@ class TestDynamicContext:
         assert kv_block_before != -1
 
         # Step 1: Forward pass for all 3 requests
-        active_requests_mask = torch.tensor([1, 1, 1], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([100, 101, 102], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([1, 1, 1], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([100, 101, 102], dtype=torch.int32, device='cpu')
         dynamic_context.update_requests(active_requests_mask, new_tokens)
 
         # At this point, req 999 is hidden at index 2. total_request_count is 2 (req 10, 11).
@@ -1692,8 +1702,8 @@ class TestDynamicContext:
         assert dynamic_context.request_ids[2].item() == 999
 
         # Step 2: Forward pass where req 10 finishes, req 11 continues. Req 999 is NOT scheduled.
-        active_requests_mask = torch.tensor([0, 1], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([103, 104], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([0, 1], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([103, 104], dtype=torch.int32, device='cpu')
         dynamic_context.update_requests(active_requests_mask, new_tokens)
 
         # At this point, req 10 is evicted. Req 11 shifts to index 0. total_request_count becomes 1.
@@ -1756,14 +1766,14 @@ class TestDynamicContext:
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=10,
-                prompt_tokens=torch.arange(0, 2, device='cuda'),
+                prompt_tokens=torch.arange(0, 2, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=10),
             )
         )
         dynamic_context.add_request(
             DynamicInferenceRequest(
                 request_id=11,
-                prompt_tokens=torch.arange(0, 2, device='cuda'),
+                prompt_tokens=torch.arange(0, 2, device='cpu'),
                 sampling_params=SamplingParams(num_tokens_to_generate=10),
             )
         )
@@ -1771,7 +1781,7 @@ class TestDynamicContext:
         # Add Chunk 1 of a chunked prefill request
         req_999 = DynamicInferenceRequest(
             request_id=999,
-            prompt_tokens=torch.arange(0, 8, device='cuda'),
+            prompt_tokens=torch.arange(0, 8, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=10),
         )
         dynamic_context.add_request(req_999, prefill_chunk_length=4)
@@ -1781,8 +1791,8 @@ class TestDynamicContext:
         assert kv_block_before != -1
 
         # Step 1: All 3 requests are active, process forward pass
-        active_requests_mask = torch.tensor([1, 1, 1], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([100, 101, 102], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([1, 1, 1], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([100, 101, 102], dtype=torch.int32, device='cpu')
         dynamic_context.update_requests(active_requests_mask, new_tokens)
 
         # Chunked prefill is now hidden at position 2, total_request_count = 2
@@ -1791,8 +1801,8 @@ class TestDynamicContext:
 
         # Step 2: Both decode requests finish, chunked prefill NOT scheduled this step.
         # This must NOT crash even though active_request_count becomes 0.
-        active_requests_mask = torch.tensor([0, 0], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([103, 104], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([0, 0], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([103, 104], dtype=torch.int32, device='cpu')
         dynamic_context.update_requests(active_requests_mask, new_tokens)
 
         # total_request_count should be 0 (both finished, chunked prefill hidden)
@@ -1839,10 +1849,10 @@ class TestDynamicContext:
         ctx.request_to_kv_block_ids[:2, 0] = torch.tensor([0, 1])
         ctx.request_last_kv_block_id[:2] = torch.tensor([0, 1])
 
-        active_requests_mask = torch.tensor([1, 1], device='cuda')
-        new_tokens = torch.tensor([99, 100], device='cuda')  # Sampled tokens
+        active_requests_mask = torch.tensor([1, 1], device='cpu')
+        new_tokens = torch.tensor([99, 100], device='cpu')  # Sampled tokens
         new_speculative_tokens = torch.tensor(
-            [[991, 1001], [992, 1002]], device='cuda'
+            [[991, 1001], [992, 1002]], device='cpu'
         )  # Spec tokens
 
         ctx.update_requests(
@@ -1854,15 +1864,15 @@ class TestDynamicContext:
         # Each request generates 1 (sampled) + 2 (speculative) = 3 tokens.
         assert ctx.active_token_count == 6
         assert torch.equal(
-            ctx.request_query_lengths[:2], torch.tensor([3, 3], dtype=torch.int32, device='cuda')
+            ctx.request_query_lengths[:2], torch.tensor([3, 3], dtype=torch.int32, device='cpu')
         )
         assert torch.equal(
             ctx.request_kv_length_offsets[:2],
-            torch.tensor([6, 9], dtype=torch.int32, device='cuda'),
+            torch.tensor([6, 9], dtype=torch.int32, device='cpu'),
         )
 
         # Check interleaving: [sampled_1, spec1_1, spec2_1, sampled_2, spec1_2, spec2_2]
-        expected_tokens = torch.tensor([99, 991, 992, 100, 1001, 1002], device='cuda')
+        expected_tokens = torch.tensor([99, 991, 992, 100, 1001, 1002], device='cpu')
         assert torch.equal(ctx.token_to_input_ids[:6], expected_tokens)
 
     @pytest.mark.internal
@@ -1903,9 +1913,9 @@ class TestDynamicContext:
         ctx.request_to_kv_block_ids[0, 0] = first_block
         ctx.request_last_kv_block_id[0] = first_block
 
-        active_requests_mask = torch.tensor([1], device='cuda')
-        new_tokens = torch.tensor([50], device='cuda')
-        new_speculative_tokens = torch.tensor([[51], [52]], device='cuda')
+        active_requests_mask = torch.tensor([1], device='cpu')
+        new_tokens = torch.tensor([50], device='cpu')
+        new_speculative_tokens = torch.tensor([[51], [52]], device='cpu')
 
         # Run update_requests natively. It will automatically:
         # 1. Detect the boundary crossing and pause the request.
@@ -1929,7 +1939,7 @@ class TestDynamicContext:
         # Token 1 (offset 3) -> first_block
         # Token 2 (offset 4) -> second_block
         expected_blocks = torch.tensor(
-            [first_block, first_block, second_block], dtype=torch.int, device='cuda'
+            [first_block, first_block, second_block], dtype=torch.int, device='cpu'
         )
 
         assert torch.equal(ctx.token_to_block_idx[:3], expected_blocks)
@@ -1979,10 +1989,10 @@ class TestDynamicContext:
         ctx.kv_block_allocator.total_avail = 0
         ctx.kv_block_allocator.paused_count = 100  # Ensure it doesn't get completely evicted either
 
-        active_requests_mask = torch.tensor([1, 1], device='cuda')
-        new_tokens = torch.tensor([99, 100], device='cuda')  # Sampled
+        active_requests_mask = torch.tensor([1, 1], device='cpu')
+        new_tokens = torch.tensor([99, 100], device='cpu')  # Sampled
         new_speculative_tokens = torch.tensor(
-            [[991, 1001], [992, 1002]], device='cuda'
+            [[991, 1001], [992, 1002]], device='cpu'
         )  # Speculative
 
         # In update_requests, request 0 will be paused to allocate a new block.
@@ -2004,7 +2014,7 @@ class TestDynamicContext:
 
         assert ctx.paused_tokens[0].item() == 99
         assert torch.equal(
-            ctx.paused_speculative_tokens[:, 0], torch.tensor([991, 992], device='cuda')
+            ctx.paused_speculative_tokens[:, 0], torch.tensor([991, 992], device='cpu')
         )
 
     @pytest.mark.internal
@@ -2043,8 +2053,8 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         ctx.request_ids[:2] = torch.tensor([10, 11])
-        next_tokens = torch.tensor([99, 100], device='cuda')
-        new_speculative_tokens = torch.tensor([[991, 1001], [992, 1002]], device='cuda')
+        next_tokens = torch.tensor([99, 100], device='cpu')
+        new_speculative_tokens = torch.tensor([[991, 1001], [992, 1002]], device='cpu')
 
         ctx._swap_book_keeping_tensors(
             src_idxs=torch.tensor([0]),
@@ -2053,10 +2063,10 @@ class TestDynamicContext:
             new_speculative_tokens=new_speculative_tokens,
         )
 
-        assert torch.equal(ctx.request_ids[:2], torch.tensor([11, 10], device='cuda'))
-        assert torch.equal(next_tokens[:2], torch.tensor([100, 99], device='cuda'))
+        assert torch.equal(ctx.request_ids[:2], torch.tensor([11, 10], device='cpu'))
+        assert torch.equal(next_tokens[:2], torch.tensor([100, 99], device='cpu'))
         assert torch.equal(
-            new_speculative_tokens[:, :2], torch.tensor([[1001, 991], [1002, 992]], device='cuda')
+            new_speculative_tokens[:, :2], torch.tensor([[1001, 991], [1002, 992]], device='cpu')
         )
 
     @pytest.mark.internal
@@ -2087,9 +2097,9 @@ class TestDynamicContext:
         ctx.request_last_kv_block_id[:3] = torch.tensor([0, 1, 2])
         ctx.request_kv_block_counts[:3] = 1
 
-        active_requests_mask = torch.tensor([1, 0, 1], device='cuda')
-        new_tokens = torch.tensor([99, 100, 101], device='cuda')
-        new_speculative_tokens = torch.tensor([[991, 1001, 1011], [992, 1002, 1012]], device='cuda')
+        active_requests_mask = torch.tensor([1, 0, 1], device='cpu')
+        new_tokens = torch.tensor([99, 100, 101], device='cpu')
+        new_speculative_tokens = torch.tensor([[991, 1001, 1011], [992, 1002, 1012]], device='cpu')
 
         ctx.update_requests(
             active_requests_mask=active_requests_mask,
@@ -2100,13 +2110,13 @@ class TestDynamicContext:
         # req1 is finished. req2 moves to req1's position.
         assert ctx.total_request_count == 2
         assert torch.equal(
-            ctx.request_ids[:2], torch.tensor([10, 12], device='cuda', dtype=torch.int32)
+            ctx.request_ids[:2], torch.tensor([10, 12], device='cpu', dtype=torch.int32)
         )
 
         # Check interleaving for req0 and req2
         # req0: [99, 991, 992]
         # req2: [101, 1011, 1012]
-        expected_tokens = torch.tensor([99, 991, 992, 101, 1011, 1012], device='cuda')
+        expected_tokens = torch.tensor([99, 991, 992, 101, 1011, 1012], device='cpu')
         assert torch.equal(ctx.token_to_input_ids[:6], expected_tokens)
 
     @pytest.mark.internal
@@ -2137,7 +2147,7 @@ class TestDynamicContext:
         # 1. Add a standard decode request
         req_decode = DynamicInferenceRequest(
             request_id=10,
-            prompt_tokens=torch.arange(0, 10, device='cuda'),
+            prompt_tokens=torch.arange(0, 10, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=10),
         )
         ctx.add_request(req_decode)
@@ -2145,7 +2155,7 @@ class TestDynamicContext:
         # 2. Add chunk 1 of a chunked prefill request
         req_chunked = DynamicInferenceRequest(
             request_id=42,
-            prompt_tokens=torch.arange(0, 100, device='cuda'),
+            prompt_tokens=torch.arange(0, 100, device='cpu'),
             sampling_params=SamplingParams(num_tokens_to_generate=10),
         )
         ctx.chunked_prefill_request_id = 42
@@ -2155,10 +2165,10 @@ class TestDynamicContext:
         assert ctx.active_token_count == 60
 
         # 3. Call update_requests
-        active_requests_mask = torch.tensor([1, 1], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([99, 199], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([1, 1], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([99, 199], dtype=torch.int32, device='cpu')
         new_spec = torch.tensor(
-            [[100, 200], [101, 201], [102, 202]], dtype=torch.int32, device='cuda'
+            [[100, 200], [101, 201], [102, 202]], dtype=torch.int32, device='cpu'
         )
 
         ctx.update_requests(
@@ -2223,13 +2233,13 @@ class TestDynamicContext:
         ctx.request_last_kv_block_id[:2] = torch.tensor([0, 1])
         ctx.request_kv_block_counts[:2] = 1
 
-        active_requests_mask = torch.tensor([1, 1], device='cuda')
+        active_requests_mask = torch.tensor([1, 1], device='cpu')
 
         # New base tokens: [100 (for prefill), 200 (for decode)]
-        new_tokens = torch.tensor([100, 200], device='cuda')
+        new_tokens = torch.tensor([100, 200], device='cpu')
 
         # New spec tokens: Col 0 for prefill (dummy), Col 1 for decode (real draft tokens)
-        new_speculative_tokens = torch.tensor([[101, 201], [102, 202]], device='cuda')
+        new_speculative_tokens = torch.tensor([[101, 201], [102, 202]], device='cpu')
 
         # Trigger update_requests.
         # It must detect ID 42 is at index 0, and swap it with index 1.
@@ -2241,7 +2251,7 @@ class TestDynamicContext:
 
         # 1. Verify the IDs were swapped successfully
         assert torch.equal(
-            ctx.request_ids[:2], torch.tensor([99, 42], dtype=torch.int32, device='cuda')
+            ctx.request_ids[:2], torch.tensor([99, 42], dtype=torch.int32, device='cpu')
         )
 
         # 2. Verify the Decode request (now at Index 0) correctly flattened its
@@ -2249,7 +2259,7 @@ class TestDynamicContext:
         # 3. Verify the Prefill request (now at Index 1) is hidden and does NOT
         #    flatten its dummy tokens.
         expected_flattened_tokens = torch.tensor(
-            [200, 201, 202], device='cuda'  # Decode request (ID 99)
+            [200, 201, 202], device='cpu'  # Decode request (ID 99)
         )
 
         assert ctx.active_token_count == 3
@@ -2259,7 +2269,7 @@ class TestDynamicContext:
 
         # 4. Verify that the new_speculative_tokens tensor itself was swapped so that
         # the hidden state perfectly preserves the alignment for subsequent steps.
-        expected_swapped_spec_tokens = torch.tensor([[201, 101], [202, 102]], device='cuda')
+        expected_swapped_spec_tokens = torch.tensor([[201, 101], [202, 102]], device='cpu')
         assert torch.equal(
             new_speculative_tokens, expected_swapped_spec_tokens
         ), "new_speculative_tokens was not swapped in-place alongside the request metadata!"
@@ -2287,7 +2297,7 @@ class TestDynamicContext:
         # This avoids the single-token-chunk clamp (effective_prefill >= 2) and
         # verifies that the prefix skip actually works.
         tail = 5
-        prompt = torch.arange(bs * 3 + tail, device='cuda')
+        prompt = torch.arange(bs * 3 + tail, device='cpu')
 
         # First request registers blocks.
         req1 = DynamicInferenceRequest(
@@ -2349,7 +2359,7 @@ class TestDynamicContext:
         # Use bs * 2 + 5 tokens so the prompt extends past the last full block,
         # avoiding the single-token-chunk clamp while still testing the skip.
         tail = 5
-        prompt = torch.arange(bs * 2 + tail, device='cuda')
+        prompt = torch.arange(bs * 2 + tail, device='cpu')
 
         # First request.
         req1 = DynamicInferenceRequest(
@@ -2397,7 +2407,7 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         bs = ctx.block_size_tokens
-        prompt = torch.arange(bs * 2, device='cuda')
+        prompt = torch.arange(bs * 2, device='cpu')
 
         # Two requests sharing the same prefix.
         req1 = DynamicInferenceRequest(
@@ -2454,7 +2464,7 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         bs = ctx.block_size_tokens
-        prompt = torch.arange(bs * 2, device='cuda')
+        prompt = torch.arange(bs * 2, device='cpu')
 
         # Request 1: adds prefix blocks.
         req1 = DynamicInferenceRequest(
@@ -2491,9 +2501,9 @@ class TestDynamicContext:
         ctx.request_in_prefill_status_tensor[0] = 0
         ctx.active_token_count = 2
 
-        active_mask = torch.tensor([1, 1], device='cuda', dtype=torch.int32)
-        new_tokens = torch.tensor([50, 50], device='cuda')
-        new_spec = torch.tensor([[51, 51], [52, 52]], device='cuda')
+        active_mask = torch.tensor([1, 1], device='cpu', dtype=torch.int32)
+        new_tokens = torch.tensor([50, 50], device='cpu')
+        new_spec = torch.tensor([[51, 51], [52, 52]], device='cpu')
 
         ctx.update_requests(
             active_requests_mask=active_mask, new_tokens=new_tokens, new_speculative_tokens=new_spec
@@ -2535,7 +2545,7 @@ class TestDynamicContext:
         bs = ctx.block_size_tokens
 
         # First request: register prefix blocks (bs * 3 tokens = 3 complete blocks).
-        first_prompt = torch.arange(bs * 3, device='cuda')
+        first_prompt = torch.arange(bs * 3, device='cpu')
         req_first = DynamicInferenceRequest(
             request_id=1,
             prompt_tokens=first_prompt.clone(),
@@ -2560,9 +2570,9 @@ class TestDynamicContext:
         ctx.add_request(req2, prefill_chunk_length=bs)
 
         # Call update_requests to move req2 to the hidden state
-        active_requests_mask = torch.tensor([1, 1], dtype=torch.int32, device='cuda')
-        new_tokens = torch.tensor([99, 199], dtype=torch.int32, device='cuda')
-        new_spec = torch.tensor([[100, 200], [101, 201]], dtype=torch.int32, device='cuda')
+        active_requests_mask = torch.tensor([1, 1], dtype=torch.int32, device='cpu')
+        new_tokens = torch.tensor([99, 199], dtype=torch.int32, device='cpu')
+        new_spec = torch.tensor([[100, 200], [101, 201]], dtype=torch.int32, device='cpu')
         ctx.update_requests(active_requests_mask, new_tokens, new_speculative_tokens=new_spec)
 
         # Capture active tokens before chunk 2 (which should just be the 3 tokens of req_first)
@@ -2604,7 +2614,7 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         bs = ctx.block_size_tokens
-        prompt = torch.arange(bs * 2, device='cuda')
+        prompt = torch.arange(bs * 2, device='cpu')
 
         # First request registers blocks.
         req1 = DynamicInferenceRequest(
@@ -2654,7 +2664,7 @@ class TestDynamicContext:
         bs = ctx.block_size_tokens
 
         # req1: 32 tokens (exactly 2 complete blocks)
-        prompt1 = torch.arange(bs * 2, device='cuda')
+        prompt1 = torch.arange(bs * 2, device='cpu')
         req1 = DynamicInferenceRequest(
             request_id=1,
             prompt_tokens=prompt1,
@@ -2665,7 +2675,7 @@ class TestDynamicContext:
         ctx.add_request(req1)
 
         # req2: 35 tokens (first 32 tokens match req1)
-        prompt2 = torch.arange(bs * 2 + 3, device='cuda')
+        prompt2 = torch.arange(bs * 2 + 3, device='cpu')
         req2 = DynamicInferenceRequest(
             request_id=2,
             prompt_tokens=prompt2,
@@ -2712,7 +2722,7 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         bs = ctx.block_size_tokens
-        prompt = torch.arange(bs * 2, device='cuda')
+        prompt = torch.arange(bs * 2, device='cpu')
 
         # Add req1 and req2 with identical prompts
         req1 = DynamicInferenceRequest(
@@ -2752,7 +2762,7 @@ class TestDynamicContext:
 
         # Trigger the eviction logic
         # next_tokens must be sized to total_request_count (1 paused + 1 active = 2)
-        next_tokens = torch.tensor([50, 51], device='cuda')
+        next_tokens = torch.tensor([50, 51], device='cpu')
         evicted_ids = ctx.evict_overflow_paused_requests(
             active_request_count=1, next_tokens=next_tokens
         )
@@ -2792,17 +2802,17 @@ class TestDynamicContext:
         ctx.paused_request_count = 0
         ctx.active_token_count = 2
 
-        ctx.request_ids[:2] = torch.tensor([10, 11], device='cuda')
+        ctx.request_ids[:2] = torch.tensor([10, 11], device='cpu')
         ctx.request_query_lengths[:2] = 1
         ctx.request_kv_block_counts[:2] = 1
 
         # Request 0 offset is 15. Adding 1 sampled + 2 spec = 3 tokens crosses the boundary (16).
         # Request 1 offset is 5. Adding 3 tokens = 8 (does not cross).
         ctx.request_kv_length_offsets[:2] = torch.tensor(
-            [bs - 1, 5], device='cuda', dtype=torch.int32
+            [bs - 1, 5], device='cpu', dtype=torch.int32
         )
         ctx.request_last_kv_block_offset[:2] = torch.tensor(
-            [bs - 1, 5], device='cuda', dtype=torch.int32
+            [bs - 1, 5], device='cpu', dtype=torch.int32
         )
 
         blocks = ctx.kv_block_allocator.allocate_memory_blocks(2)
@@ -2814,9 +2824,9 @@ class TestDynamicContext:
         ctx.kv_block_allocator.total_avail = 0
         ctx.kv_block_allocator.paused_count = 100  # Prevent immediate eviction out of the system
 
-        active_mask = torch.tensor([1, 1], device='cuda', dtype=torch.int32)
-        new_tokens = torch.tensor([99, 88], device='cuda')
-        new_spec = torch.tensor([[100, 200], [101, 201]], device='cuda')
+        active_mask = torch.tensor([1, 1], device='cpu', dtype=torch.int32)
+        new_tokens = torch.tensor([99, 88], device='cpu')
+        new_spec = torch.tensor([[100, 200], [101, 201]], device='cpu')
 
         # Run update requests
         ctx.update_requests(
@@ -2880,9 +2890,9 @@ class TestDynamicContext:
         ctx.request_to_kv_block_ids[0, 1] = blocks[1]
         ctx.request_last_kv_block_id[0] = blocks[1]
 
-        active_requests_mask = torch.tensor([1], device='cuda')
-        new_tokens = torch.tensor([50], device='cuda')
-        new_speculative_tokens = torch.tensor([[51], [52]], device='cuda')
+        active_requests_mask = torch.tensor([1], device='cpu')
+        new_tokens = torch.tensor([50], device='cpu')
+        new_speculative_tokens = torch.tensor([[51], [52]], device='cpu')
 
         # This will pause the request (offset 13 >= 13), then resume it by
         # allocating a 3rd block at col_idx=2. Without the fix, this raises
@@ -2921,7 +2931,7 @@ class TestDynamicContext:
         ctx = DynamicInferenceContext(model_config=model_config, inference_config=inference_config)
 
         bs = ctx.block_size_tokens
-        prompt = torch.arange(128, device='cuda')
+        prompt = torch.arange(128, device='cpu')
 
         # Cache req1 (fully processed)
         req1 = DynamicInferenceRequest(

--- a/tests/unit_tests/inference/contexts/test_dynamic_ledgers.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_ledgers.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.inference.contexts.dynamic_ledgers import (
+    DynamicRequestLedgers,
+    RequestLedgerState,
+)
+
+
+class FakeDynamicContext:
+    def __init__(self):
+        self.total_request_count = 3
+        self.paused_request_count = 1
+        self.active_token_count = 5
+        self.chunked_prefill_request_id = -1
+        self.request_ids = torch.tensor([10, 11, 12, -1], dtype=torch.int32)
+        self.request_query_lengths = torch.tensor([1, 2, 3, 0], dtype=torch.int32)
+        self.request_in_prefill_status_tensor = torch.tensor([0, 1, 0, -1], dtype=torch.int32)
+
+
+def test_request_ledger_state_snapshots_context_values():
+    context = FakeDynamicContext()
+
+    state = RequestLedgerState.from_context(context)
+
+    assert state.total_request_count == 3
+    assert state.paused_request_count == 1
+    assert state.active_token_count == 5
+    assert state.request_ids == (10, 11, 12)
+    assert state.request_query_lengths == (1, 2, 3)
+    assert state.request_in_prefill_status == (0, 1, 0)
+
+
+def test_request_ledger_returns_per_request_state():
+    state = RequestLedgerState.from_context(FakeDynamicContext())
+
+    paused = state.get_request_state(10)
+    active_prefill = state.get_request_state(11)
+
+    assert paused.slot == 0
+    assert paused.is_paused is True
+    assert paused.in_prefill is False
+    assert active_prefill.slot == 1
+    assert active_prefill.is_paused is False
+    assert active_prefill.in_prefill is True
+    assert state.get_request_state(99) is None
+
+
+def test_queue_depth_one_sync_keeps_ledgers_identical():
+    ledgers = DynamicRequestLedgers()
+    context = FakeDynamicContext()
+
+    ledgers.sync_from_context_for_queue_depth_one(context)
+
+    assert ledgers.get_committed_request_state() == ledgers.get_optimistic_request_state()
+    assert ledgers.get_committed_request_state(12).query_length == 3
+    assert ledgers.get_optimistic_request_state(12).query_length == 3
+    ledgers.assert_committed_matches_optimistic()
+
+
+def test_ledger_debug_assertion_detects_divergence():
+    ledgers = DynamicRequestLedgers()
+    context = FakeDynamicContext()
+    ledgers.sync_from_context_for_queue_depth_one(context)
+    ledgers.optimistic = RequestLedgerState()
+
+    with pytest.raises(AssertionError, match="diverged"):
+        ledgers.assert_committed_matches_optimistic()

--- a/tests/unit_tests/inference/contexts/test_dynamic_placeholders.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_placeholders.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
+from megatron.core.inference.contexts.step_journal import StepJournal
+
+
+class FakeGpuView:
+    current_snapshot_slot_id = 0
+
+
+def _fake_context():
+    context = object.__new__(DynamicInferenceContext)
+    context.total_request_count = 4
+    context.paused_request_count = 1
+    context.active_token_count = 3
+    context.current_dynamic_step_id = 0
+    context.step_journal = StepJournal()
+    context.gpu_view = FakeGpuView()
+    context.async_overlap_debug_counters = {"placeholder_count": 0}
+    context.request_ids = torch.tensor([10, 11, 12, 13], dtype=torch.int32)
+    context.request_kv_length_offsets = torch.tensor([7, 8, 9, 10], dtype=torch.int32)
+    context.request_query_lengths = torch.tensor([1, 1, 2, 3], dtype=torch.int32)
+    context.request_output_lengths = torch.tensor([16, 16, 16, 16], dtype=torch.int32)
+    context.num_output_placeholders = torch.zeros(4, dtype=torch.int32)
+    return context
+
+
+def test_output_placeholders_adjust_sequence_and_kv_lengths():
+    context = _fake_context()
+    context.begin_step_journal(0)
+
+    context.add_output_placeholders(torch.tensor([1, 2]), {11: 1, "12": 2})
+
+    assert context.placeholder_adjusted_sequence_length(1) == 10
+    assert context.placeholder_adjusted_kv_length(2) == 13
+    assert context.get_placeholder_adjusted_active_sequence_lengths().tolist() == [10, 13, 13]
+    assert context.async_overlap_debug_counters["placeholder_count"] == 3
+    assert dict(context.step_journal.get_open_entry(0).placeholder_token_counts) == {
+        "11": 1,
+        "12": 2,
+    }
+
+
+def test_output_placeholders_consume_and_detect_underflow():
+    context = _fake_context()
+    context.add_output_placeholders([1, 2], [1, 1])
+
+    context.consume_output_placeholders([1, 2], [1, 0])
+
+    assert context.num_output_placeholders.tolist() == [0, 0, 1, 0]
+    assert context.async_overlap_debug_counters["placeholder_count"] == 1
+    with pytest.raises(AssertionError, match="underflow"):
+        context.consume_output_placeholders([1], [1])
+
+
+def test_output_placeholders_move_and_swap_with_request_slots():
+    context = _fake_context()
+    context.num_output_placeholders[:] = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+    context.request_in_prefill_status_tensor = torch.zeros(4, dtype=torch.int32)
+    context.request_to_kv_block_ids = torch.zeros((4, 1), dtype=torch.int32)
+    context.request_kv_block_counts = torch.ones(4, dtype=torch.int32)
+    context.request_last_kv_block_id = torch.zeros(4, dtype=torch.int32)
+    context.request_last_kv_block_offset = torch.zeros(4, dtype=torch.int32)
+    context.request_metadata = {}
+    context.is_hybrid_model = False
+    next_tokens = torch.arange(4)
+
+    context._move_book_keeping_tensors(torch.tensor([3]), torch.tensor([1]), next_tokens)
+    assert context.num_output_placeholders.tolist() == [0, 3, 2, 3]
+
+    context._swap_book_keeping_tensors(torch.tensor([1]), torch.tensor([2]), next_tokens)
+    assert context.num_output_placeholders.tolist() == [0, 2, 3, 3]
+
+
+def test_finished_or_failed_request_release_clears_placeholders():
+    context = _fake_context()
+    context.num_output_placeholders[:] = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+    context.request_to_kv_block_ids = torch.tensor([[1], [2], [-1], [3]], dtype=torch.int32)
+    context.is_hybrid_model = False
+    context.mamba_slot_allocator = None
+
+    class FakeAllocator:
+        def release_memory_blocks(self, block_ids):
+            self.released = block_ids.tolist()
+
+    context.kv_block_allocator = FakeAllocator()
+
+    context.release_memory_blocks_from_request_indexes(torch.tensor([1, 3]))
+
+    assert context.num_output_placeholders.tolist() == [0, 0, 2, 0]
+    assert context.async_overlap_debug_counters["placeholder_count"] == 2
+    assert context.kv_block_allocator.released == [2, 3]

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -793,6 +793,9 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         req3 = self._req(ctx3, p3.clone(), request_id=2)
         req3._mamba_num_matched_blocks = 0
         ctx3.add_request(req3)
+        # Deferred Mamba ops execute during transfer.
+        ctx3.initialize_attention_state()
+        ctx3.transfer_bookkeeping_to_gpu()
         assert ctx3.mamba_slot_allocator._eos_cache_block_id_gpu[1].item() >= 0
 
         # intermediate output buffers are pre-allocated

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -762,12 +762,12 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
             overall,
         )
         # Penultimate block offset (block 2 boundary) is a valid intermediate
-        count = msa._intermediate_counts_gpu[1].item()
+        count = msa._intermediate_counts_cpu[1].item()
         if count > 0:
-            offsets = msa._intermediate_offsets_gpu[1, :count].tolist()
+            offsets = msa._intermediate_offsets_cpu[1, :count].tolist()
             for o in offsets:
                 assert o > 0 and o % 128 == 0
-        assert msa._eos_cache_block_id_gpu[1].item() >= 0
+        assert msa._eos_cache_block_id_cpu[1].item() >= 0
 
         # non-aligned prompt produces last_aligned intermediate offset
         ctx2 = self._mctx(block_size_tokens=bs)
@@ -779,12 +779,12 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         req2b = self._req(ctx2, p2.clone(), request_id=2)
         req2b._mamba_num_matched_blocks = 2
         ctx2.add_request(req2b)
-        count2 = msa2._intermediate_counts_gpu[1].item()
+        count2 = msa2._intermediate_counts_cpu[1].item()
         if count2 > 0:
-            offsets = msa2._intermediate_offsets_gpu[1, :count2].tolist()
+            offsets = msa2._intermediate_offsets_cpu[1, :count2].tolist()
             for o in offsets:
                 assert o > 0 and o % 128 == 0
-        assert msa2._eos_cache_block_id_gpu[1].item() < 0
+        assert msa2._eos_cache_block_id_cpu[1].item() < 0
 
         # block-aligned prompts set EOS cache block ID
         ctx3 = self._mctx(block_size_tokens=bs)
@@ -796,7 +796,7 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         # Deferred Mamba ops execute during transfer.
         ctx3.initialize_attention_state()
         ctx3.transfer_bookkeeping_to_gpu()
-        assert ctx3.mamba_slot_allocator._eos_cache_block_id_gpu[1].item() >= 0
+        assert ctx3.mamba_slot_allocator._eos_cache_block_id_cpu[1].item() >= 0
 
         # intermediate output buffers are pre-allocated
         ctx4 = self._mctx()
@@ -1030,9 +1030,9 @@ class TestMambaSlotAllocator(PrefixCachingTestBase):
 
         # Set up intermediate offsets: 1 intermediate at src_offset=0
         bid0 = ctx.request_to_kv_block_ids[ctx_idx][0].item()
-        msa._intermediate_block_ids_gpu[ctx_idx, 0] = bid0
-        msa._intermediate_offsets_gpu[ctx_idx, 0] = 128
-        msa._intermediate_counts_gpu[ctx_idx] = 1
+        msa._intermediate_block_ids_cpu[ctx_idx, 0] = bid0
+        msa._intermediate_offsets_cpu[ctx_idx, 0] = 128
+        msa._intermediate_counts_cpu[ctx_idx] = 1
         msa._has_intermediates = True
 
         # Set metadata fields that would normally be set by _update_intermediate_offsets
@@ -1041,7 +1041,7 @@ class TestMambaSlotAllocator(PrefixCachingTestBase):
 
         # Set up EOS block (block-aligned prompt)
         eos_bid = ctx.request_to_kv_block_ids[ctx_idx][2].item()
-        msa._eos_cache_block_id_gpu[ctx_idx] = eos_bid
+        msa._eos_cache_block_id_cpu[ctx_idx] = eos_bid
 
         # Write known patterns to live mamba state for EOS copy
         mamba_idx = metadata.request_to_mamba_state_idx[ctx_idx].item()

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -901,6 +901,7 @@ class TestMixedCachedAndFreshPrefill(PrefixCachingTestBase):
 
         # last_token_logits
         ctx.initialize_attention_state()
+        ctx.transfer_bookkeeping_to_gpu()
         logits = torch.randn(
             1, ctx.padded_active_token_count, vocab_size, device=torch.cuda.current_device()
         )

--- a/tests/unit_tests/inference/contexts/test_gpu_input_preparer.py
+++ b/tests/unit_tests/inference/contexts/test_gpu_input_preparer.py
@@ -14,9 +14,48 @@ from megatron.core.inference.engines.dynamic_step import (
 
 
 class FakeGpuView:
-    def __init__(self, *, slot_id: int, max_tokens: int = 8):
+    def __init__(
+        self,
+        *,
+        slot_id: int,
+        max_tokens: int = 8,
+        max_requests: int = 4,
+        max_blocks: int = 8,
+    ):
         self.current_snapshot_slot_id = slot_id
         self.token_to_input_ids = torch.zeros(max_tokens, dtype=torch.int64, device="cuda")
+        self.token_to_pos_ids = torch.full(
+            (max_tokens,), -1, dtype=torch.int64, device="cuda"
+        )
+        self.token_to_request_idx = torch.full(
+            (max_tokens,), -1, dtype=torch.int32, device="cuda"
+        )
+        self.token_to_position_in_request = torch.full(
+            (max_tokens,), -1, dtype=torch.int32, device="cuda"
+        )
+        self.token_to_local_position_within_kv_block = torch.full(
+            (max_tokens,), -1, dtype=torch.int32, device="cuda"
+        )
+        self.token_to_block_idx = torch.full(
+            (max_tokens,), -1, dtype=torch.int32, device="cuda"
+        )
+        self.request_query_lengths = torch.zeros(
+            max_requests, dtype=torch.int32, device="cuda"
+        )
+        self.request_kv_length_offsets = (
+            torch.arange(max_requests, dtype=torch.int32, device="cuda") * 4 + 5
+        )
+        self.mha_query_lengths = torch.zeros(max_requests, dtype=torch.int32, device="cuda")
+        self.mha_kv_seq_lengths = torch.zeros(max_requests, dtype=torch.int32, device="cuda")
+        self.mha_cu_query_seq_lengths = torch.zeros(
+            max_requests + 1, dtype=torch.int32, device="cuda"
+        )
+        self.mha_cu_kv_seq_lengths = torch.zeros(
+            max_requests + 1, dtype=torch.int32, device="cuda"
+        )
+        self.mha_block_table = torch.arange(
+            max_requests * max_blocks, dtype=torch.int32, device="cuda"
+        ).view(max_requests, max_blocks)
 
 
 def _require_cuda():
@@ -31,6 +70,55 @@ def _snapshot(slot_id: int = 0) -> DynamicStepContextSnapshot:
         snapshot_slot_id=slot_id,
         request_plan=DynamicStepRequestPlan(step_id=step_id),
         gpu_view=FakeGpuView(slot_id=slot_id),
+    )
+
+
+def _seed_expected_decode_metadata(
+    gpu_view: FakeGpuView, plan: StepInputPlan, *, block_size_tokens: int
+) -> None:
+    request_slots = torch.tensor(plan.decode_request_slots, dtype=torch.long, device="cuda")
+    destinations = torch.tensor(
+        plan.decode_input_destination_indices, dtype=torch.long, device="cuda"
+    )
+    tokens_per_request = plan.speculative_width + 1
+    offsets = torch.arange(tokens_per_request, dtype=torch.long, device="cuda")
+    token_indices = (destinations[:, None] + offsets[None, :]).reshape(-1)
+    positions = (
+        gpu_view.request_kv_length_offsets[request_slots].to(torch.long)[:, None]
+        + offsets[None, :]
+    ).reshape(-1)
+    positions_i32 = positions.to(torch.int32)
+
+    gpu_view.token_to_pos_ids.index_copy_(0, token_indices, positions)
+    gpu_view.token_to_position_in_request.index_copy_(0, token_indices, positions_i32)
+    gpu_view.token_to_local_position_within_kv_block.index_copy_(
+        0, token_indices, torch.remainder(positions_i32, block_size_tokens)
+    )
+    gpu_view.token_to_request_idx.index_copy_(
+        0, token_indices, request_slots.to(torch.int32).repeat_interleave(tokens_per_request)
+    )
+    block_columns = torch.div(positions, block_size_tokens, rounding_mode="floor").to(torch.long)
+    block_ids = gpu_view.mha_block_table[
+        request_slots.repeat_interleave(tokens_per_request), block_columns
+    ]
+    gpu_view.token_to_block_idx.index_copy_(0, token_indices, block_ids)
+
+    query_lengths = torch.full(
+        (len(plan.decode_request_slots),), tokens_per_request, dtype=torch.int32, device="cuda"
+    )
+    gpu_view.request_query_lengths.index_copy_(0, request_slots, query_lengths)
+    gpu_view.mha_query_lengths.index_copy_(0, request_slots, query_lengths)
+    kv_seq_lengths = gpu_view.request_kv_length_offsets[request_slots] + query_lengths
+    gpu_view.mha_kv_seq_lengths.index_copy_(0, request_slots, kv_seq_lengths)
+    gpu_view.mha_cu_query_seq_lengths[: len(plan.decode_request_slots) + 1].copy_(
+        torch.arange(
+            len(plan.decode_request_slots) + 1, dtype=torch.int32, device="cuda"
+        )
+        * tokens_per_request
+    )
+    gpu_view.mha_cu_kv_seq_lengths[0].zero_()
+    gpu_view.mha_cu_kv_seq_lengths[1 : len(plan.decode_request_slots) + 1].copy_(
+        torch.cumsum(kv_seq_lengths, dim=0)
     )
 
 
@@ -52,13 +140,19 @@ def test_gpu_input_preparer_scatters_decode_tokens_into_snapshot():
         decode_input_destination_indices=(0, 2, 4),
         debug_expected_input_ids=torch.tensor([101, 0, 102, 0, 103], dtype=torch.int64),
     )
+    _seed_expected_decode_metadata(snapshot.gpu_view, plan, block_size_tokens=4)
 
-    ready_event = GpuInputPreparer(stream=stream, debug_enabled=True).prepare(
+    ready_event = GpuInputPreparer(
+        stream=stream, block_size_tokens=4, debug_enabled=True
+    ).prepare(
         snapshot, plan, sample_state
     )
 
     torch.cuda.current_stream().wait_event(ready_event)
     assert snapshot.gpu_view.token_to_input_ids[:5].tolist() == [101, 0, 102, 0, 103]
+    assert snapshot.gpu_view.token_to_pos_ids[[0, 2, 4]].tolist() == [5, 9, 13]
+    assert snapshot.gpu_view.token_to_request_idx[[0, 2, 4]].tolist() == [0, 1, 2]
+    assert snapshot.gpu_view.token_to_block_idx[[0, 2, 4]].tolist() == [1, 10, 19]
 
 
 def test_gpu_input_preparer_scatters_speculative_tokens():
@@ -82,13 +176,25 @@ def test_gpu_input_preparer_scatters_speculative_tokens():
         speculative_width=2,
         debug_expected_input_ids=torch.tensor([11, 21, 31, 12, 22, 32], dtype=torch.int64),
     )
+    _seed_expected_decode_metadata(snapshot.gpu_view, plan, block_size_tokens=4)
 
-    ready_event = GpuInputPreparer(stream=stream, debug_enabled=True).prepare(
+    ready_event = GpuInputPreparer(
+        stream=stream, block_size_tokens=4, debug_enabled=True
+    ).prepare(
         snapshot, plan, sample_state
     )
 
     torch.cuda.current_stream().wait_event(ready_event)
     assert snapshot.gpu_view.token_to_input_ids[:6].tolist() == [11, 21, 31, 12, 22, 32]
+    assert snapshot.gpu_view.token_to_pos_ids[:6].tolist() == [5, 6, 7, 9, 10, 11]
+    assert snapshot.gpu_view.token_to_local_position_within_kv_block[:6].tolist() == [
+        1,
+        2,
+        3,
+        1,
+        2,
+        3,
+    ]
 
 
 def test_gpu_input_preparer_rejects_mismatched_snapshot_slot():
@@ -110,7 +216,9 @@ def test_gpu_input_preparer_rejects_mismatched_snapshot_slot():
     )
 
     with pytest.raises(RuntimeError, match="targets snapshot slot"):
-        GpuInputPreparer(stream=stream).prepare(snapshot, plan, sample_state)
+        GpuInputPreparer(stream=stream, block_size_tokens=4).prepare(
+            snapshot, plan, sample_state
+        )
 
 
 def test_gpu_input_preparer_rejects_snapshot_view_bound_to_another_slot():
@@ -133,4 +241,6 @@ def test_gpu_input_preparer_rejects_snapshot_view_bound_to_another_slot():
     )
 
     with pytest.raises(RuntimeError, match="bound to slot"):
-        GpuInputPreparer(stream=stream).prepare(snapshot, plan, sample_state)
+        GpuInputPreparer(stream=stream, block_size_tokens=4).prepare(
+            snapshot, plan, sample_state
+        )

--- a/tests/unit_tests/inference/contexts/test_gpu_input_preparer.py
+++ b/tests/unit_tests/inference/contexts/test_gpu_input_preparer.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.inference.contexts.gpu_input_preparer import GpuInputPreparer
+from megatron.core.inference.contexts.gpu_input_state import GpuSampledTokenState
+from megatron.core.inference.engines.dynamic_step import (
+    DynamicStepContextSnapshot,
+    DynamicStepId,
+    DynamicStepRequestPlan,
+    StepInputPlan,
+)
+
+
+class FakeGpuView:
+    def __init__(self, *, slot_id: int, max_tokens: int = 8):
+        self.current_snapshot_slot_id = slot_id
+        self.token_to_input_ids = torch.zeros(max_tokens, dtype=torch.int64, device="cuda")
+
+
+def _require_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for GPU input preparer tests")
+
+
+def _snapshot(slot_id: int = 0) -> DynamicStepContextSnapshot:
+    step_id = DynamicStepId(1)
+    return DynamicStepContextSnapshot(
+        step_id=step_id,
+        snapshot_slot_id=slot_id,
+        request_plan=DynamicStepRequestPlan(step_id=step_id),
+        gpu_view=FakeGpuView(slot_id=slot_id),
+    )
+
+
+def test_gpu_input_preparer_scatters_decode_tokens_into_snapshot():
+    _require_cuda()
+    stream = torch.cuda.Stream()
+    sample_state = GpuSampledTokenState(
+        max_requests=4, num_speculative_tokens=0, device="cuda", stream=stream
+    )
+    sample_state.record(
+        sampled_tokens=torch.tensor([101, 102, 103, 104], dtype=torch.int64, device="cuda"),
+        active_request_count=4,
+    )
+    snapshot = _snapshot(slot_id=0)
+    plan = StepInputPlan(
+        step_id=snapshot.step_id,
+        snapshot_slot_id=0,
+        decode_request_slots=(0, 1, 2),
+        decode_input_destination_indices=(0, 2, 4),
+        debug_expected_input_ids=torch.tensor([101, 0, 102, 0, 103], dtype=torch.int64),
+    )
+
+    ready_event = GpuInputPreparer(stream=stream, debug_enabled=True).prepare(
+        snapshot, plan, sample_state
+    )
+
+    torch.cuda.current_stream().wait_event(ready_event)
+    assert snapshot.gpu_view.token_to_input_ids[:5].tolist() == [101, 0, 102, 0, 103]
+
+
+def test_gpu_input_preparer_scatters_speculative_tokens():
+    _require_cuda()
+    stream = torch.cuda.Stream()
+    sample_state = GpuSampledTokenState(
+        max_requests=2, num_speculative_tokens=2, device="cuda", stream=stream
+    )
+    sample_state.record(
+        sampled_tokens=torch.tensor([11, 12], dtype=torch.int64, device="cuda"),
+        active_request_count=2,
+        sampled_mtp_tokens=torch.tensor([[21, 22], [31, 32]], dtype=torch.int64, device="cuda"),
+        accepted_token_counts=torch.tensor([2, 1], dtype=torch.int64, device="cuda"),
+    )
+    snapshot = _snapshot(slot_id=0)
+    plan = StepInputPlan(
+        step_id=snapshot.step_id,
+        snapshot_slot_id=0,
+        decode_request_slots=(0, 1),
+        decode_input_destination_indices=(0, 3),
+        speculative_width=2,
+        debug_expected_input_ids=torch.tensor([11, 21, 31, 12, 22, 32], dtype=torch.int64),
+    )
+
+    ready_event = GpuInputPreparer(stream=stream, debug_enabled=True).prepare(
+        snapshot, plan, sample_state
+    )
+
+    torch.cuda.current_stream().wait_event(ready_event)
+    assert snapshot.gpu_view.token_to_input_ids[:6].tolist() == [11, 21, 31, 12, 22, 32]
+
+
+def test_gpu_input_preparer_rejects_mismatched_snapshot_slot():
+    _require_cuda()
+    stream = torch.cuda.Stream()
+    sample_state = GpuSampledTokenState(
+        max_requests=1, num_speculative_tokens=0, device="cuda", stream=stream
+    )
+    sample_state.record(
+        sampled_tokens=torch.tensor([7], dtype=torch.int64, device="cuda"),
+        active_request_count=1,
+    )
+    snapshot = _snapshot(slot_id=0)
+    plan = StepInputPlan(
+        step_id=snapshot.step_id,
+        snapshot_slot_id=1,
+        decode_request_slots=(0,),
+        decode_input_destination_indices=(0,),
+    )
+
+    with pytest.raises(RuntimeError, match="targets snapshot slot"):
+        GpuInputPreparer(stream=stream).prepare(snapshot, plan, sample_state)
+
+
+def test_gpu_input_preparer_rejects_snapshot_view_bound_to_another_slot():
+    _require_cuda()
+    stream = torch.cuda.Stream()
+    sample_state = GpuSampledTokenState(
+        max_requests=1, num_speculative_tokens=0, device="cuda", stream=stream
+    )
+    sample_state.record(
+        sampled_tokens=torch.tensor([7], dtype=torch.int64, device="cuda"),
+        active_request_count=1,
+    )
+    snapshot = _snapshot(slot_id=0)
+    snapshot.gpu_view.current_snapshot_slot_id = 1
+    plan = StepInputPlan(
+        step_id=snapshot.step_id,
+        snapshot_slot_id=0,
+        decode_request_slots=(0,),
+        decode_input_destination_indices=(0,),
+    )
+
+    with pytest.raises(RuntimeError, match="bound to slot"):
+        GpuInputPreparer(stream=stream).prepare(snapshot, plan, sample_state)

--- a/tests/unit_tests/inference/contexts/test_gpu_input_state.py
+++ b/tests/unit_tests/inference/contexts/test_gpu_input_state.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.inference.contexts.gpu_input_state import GpuSampledTokenState
+
+
+def _require_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for GPU sampled-token state tests")
+
+
+def test_gpu_sampled_token_state_records_base_tokens_without_cpu_sync():
+    _require_cuda()
+    handoff_stream = torch.cuda.Stream()
+    source_stream = torch.cuda.Stream()
+    state = GpuSampledTokenState(
+        max_requests=4, num_speculative_tokens=0, device="cuda", stream=handoff_stream
+    )
+    sampled_tokens = torch.empty(4, dtype=torch.int64, device="cuda")
+
+    with torch.cuda.stream(source_stream):
+        sampled_tokens.copy_(torch.tensor([10, 11, 12, 13], dtype=torch.int64, device="cuda"))
+
+    ready_event = state.record(
+        sampled_tokens=sampled_tokens,
+        active_request_count=4,
+        source_stream=source_stream,
+    )
+
+    torch.cuda.current_stream().wait_event(ready_event)
+    assert state.sampled_tokens.tolist() == [10, 11, 12, 13]
+    assert state.accepted_token_counts.tolist() == [1, 1, 1, 1]
+    assert state.last_active_request_count == 4
+
+
+def test_gpu_sampled_token_state_records_speculative_payloads_and_debug_compares():
+    _require_cuda()
+    handoff_stream = torch.cuda.Stream()
+    state = GpuSampledTokenState(
+        max_requests=4, num_speculative_tokens=2, device="cuda", stream=handoff_stream
+    )
+    sampled_tokens = torch.tensor([20, 21, 22, 23], dtype=torch.int64, device="cuda")
+    sampled_mtp_tokens = torch.tensor(
+        [[30, 31, 32, 33], [40, 41, 42, 43]], dtype=torch.int64, device="cuda"
+    )
+    accepted_counts = torch.tensor([0, 1, 2, 1], dtype=torch.int64, device="cuda")
+
+    state.record(
+        sampled_tokens=sampled_tokens,
+        active_request_count=3,
+        sampled_mtp_tokens=sampled_mtp_tokens,
+        accepted_token_counts=accepted_counts,
+    )
+
+    state.debug_compare_cpu(
+        sampled_tokens_cpu=torch.tensor([20, 21, 22], dtype=torch.int64),
+        active_request_count=3,
+        sampled_mtp_tokens_cpu=torch.tensor(
+            [[30, 31, 32], [40, 41, 42]], dtype=torch.int64
+        ),
+        accepted_token_counts_cpu=torch.tensor([0, 1, 2], dtype=torch.int64),
+    )
+
+
+def test_gpu_sampled_token_state_rejects_oversized_active_count():
+    _require_cuda()
+    state = GpuSampledTokenState(
+        max_requests=2,
+        num_speculative_tokens=0,
+        device="cuda",
+        stream=torch.cuda.Stream(),
+    )
+
+    with pytest.raises(ValueError, match="exceeds max_requests"):
+        state.record(
+            sampled_tokens=torch.zeros(3, dtype=torch.int64, device="cuda"),
+            active_request_count=3,
+        )

--- a/tests/unit_tests/inference/contexts/test_kv_reservations.py
+++ b/tests/unit_tests/inference/contexts/test_kv_reservations.py
@@ -4,6 +4,7 @@ import torch
 
 from megatron.core.inference.config import PrefixCachingEvictionPolicy
 from megatron.core.inference.contexts.kv_block_allocator import KVBlockAllocator
+from megatron.core.inference.contexts.step_journal import RollbackStatus
 
 
 class FakeContext:
@@ -11,6 +12,7 @@ class FakeContext:
         self.async_overlap_debug_counters = {
             "reservation_commits": 0,
             "reservation_rollbacks": 0,
+            "rollback_status_counts": {},
         }
         self.prefix_cache_lru_clock = 1
 
@@ -35,14 +37,16 @@ def test_kv_reservation_rollback_returns_blocks():
     allocator = KVBlockAllocator(context, total_count=5, paused_count=0)
     reservation = allocator.reserve_blocks(request_slot=0, count=2, step_id=4)
 
-    allocator.rollback_reservation(reservation)
+    status = allocator.rollback_reservation(reservation)
 
+    assert status == RollbackStatus.FULLY_RELEASED
     assert allocator.total_avail == 4
     assert allocator.get_total_used() == 0
     assert allocator._rolled_back_reservations[reservation.reservation_id] == reservation
     assert context.async_overlap_debug_counters["reservation_rollbacks"] == 1
 
-    allocator.rollback_reservation(reservation)
+    status = allocator.rollback_reservation(reservation)
+    assert status == RollbackStatus.ALREADY_ROLLED_BACK
     assert allocator.total_avail == 4
 
 
@@ -124,8 +128,76 @@ def test_prefix_refcount_reservation_rollback_undoes_increment():
     reservation = allocator.reserve_prefix_refcounts(
         request_slot=0, block_ids=block, step_id=8
     )
-    allocator.rollback_reservation(reservation)
+    status = allocator.rollback_reservation(reservation)
 
+    assert status == RollbackStatus.FULLY_RELEASED
     assert allocator.block_ref_counts[block].item() == 0
     assert allocator.kv_hash_to_block_id[123] == int(block.item())
     assert context.async_overlap_debug_counters["reservation_rollbacks"] == 1
+
+
+def test_kv_rollback_after_commit_reports_already_committed():
+    allocator = KVBlockAllocator(FakeContext(), total_count=5, paused_count=0)
+    reservation = allocator.reserve_blocks(request_slot=0, count=1, step_id=9)
+    allocator.commit_reservation(reservation)
+
+    status = allocator.rollback_reservation(reservation)
+
+    assert status == RollbackStatus.ALREADY_COMMITTED
+    assert allocator.total_avail == 3
+
+
+def test_kv_rollback_skips_blocks_already_released():
+    allocator = KVBlockAllocator(FakeContext(), total_count=5, paused_count=0)
+    reservation = allocator.reserve_blocks(request_slot=0, count=1, step_id=10)
+    allocator.release_memory_blocks(
+        torch.tensor(reservation.kv_block_ids, dtype=torch.int32, device='cpu')
+    )
+
+    status = allocator.rollback_reservation(reservation)
+
+    assert status == RollbackStatus.RESOURCE_ALREADY_EVICTED
+    assert allocator.total_avail == 4
+
+
+def test_prefix_refcount_rollback_never_underflows():
+    context = FakeContext()
+    allocator = KVBlockAllocator(
+        context,
+        total_count=5,
+        paused_count=0,
+        enable_prefix_caching=True,
+        prefix_caching_eviction_policy=PrefixCachingEvictionPolicy.LRU,
+    )
+    block = allocator.allocate_memory_blocks(1)
+    allocator.register_kv_block_hashes([int(block.item())], [123])
+    allocator.release_memory_blocks(block)
+
+    reservation = allocator.reserve_prefix_refcounts(
+        request_slot=0, block_ids=block, step_id=11
+    )
+    allocator.block_ref_counts[block] = 0
+    status = allocator.rollback_reservation(reservation)
+
+    assert status == RollbackStatus.RESOURCE_ALREADY_EVICTED
+    assert allocator.block_ref_counts[block].item() == 0
+
+
+def test_prefix_release_counts_duplicate_shared_blocks():
+    allocator = KVBlockAllocator(
+        FakeContext(),
+        total_count=5,
+        paused_count=0,
+        enable_prefix_caching=True,
+        prefix_caching_eviction_policy=PrefixCachingEvictionPolicy.LRU,
+    )
+    block = allocator.allocate_memory_blocks(1)
+    reservation = allocator.reserve_prefix_refcounts(
+        request_slot=1, block_ids=block, step_id=12
+    )
+    allocator.commit_reservation(reservation)
+
+    status = allocator.release_memory_blocks(torch.cat([block, block]))
+
+    assert status == RollbackStatus.FULLY_RELEASED
+    assert allocator.block_ref_counts[block].item() == 0

--- a/tests/unit_tests/inference/contexts/test_kv_reservations.py
+++ b/tests/unit_tests/inference/contexts/test_kv_reservations.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import torch
+
+from megatron.core.inference.contexts.kv_block_allocator import KVBlockAllocator
+
+
+class FakeContext:
+    def __init__(self):
+        self.async_overlap_debug_counters = {
+            "reservation_commits": 0,
+            "reservation_rollbacks": 0,
+        }
+
+
+def test_kv_reservation_commit_keeps_blocks_owned():
+    context = FakeContext()
+    allocator = KVBlockAllocator(context, total_count=5, paused_count=0)
+
+    reservation = allocator.reserve_blocks(request_slot=0, count=2, step_id=3)
+    allocator.commit_reservation(reservation)
+
+    assert reservation.kv_block_ids == (2, 3)
+    assert allocator.total_avail == 2
+    assert allocator.get_total_used() == 2
+    assert allocator._open_reservations == {}
+    assert allocator._committed_reservations[reservation.reservation_id] == reservation
+    assert context.async_overlap_debug_counters["reservation_commits"] == 1
+
+
+def test_kv_reservation_rollback_returns_blocks():
+    context = FakeContext()
+    allocator = KVBlockAllocator(context, total_count=5, paused_count=0)
+    reservation = allocator.reserve_blocks(request_slot=0, count=2, step_id=4)
+
+    allocator.rollback_reservation(reservation)
+
+    assert allocator.total_avail == 4
+    assert allocator.get_total_used() == 0
+    assert allocator._rolled_back_reservations[reservation.reservation_id] == reservation
+    assert context.async_overlap_debug_counters["reservation_rollbacks"] == 1
+
+    allocator.rollback_reservation(reservation)
+    assert allocator.total_avail == 4
+
+
+def test_kv_reservation_reports_unavailable_blocks():
+    allocator = KVBlockAllocator(FakeContext(), total_count=3, paused_count=0)
+
+    reservation = allocator.reserve_blocks(request_slot=0, count=3, step_id=5)
+
+    assert reservation is None
+    assert allocator.total_avail == 2
+    assert allocator._open_reservations == {}
+
+
+def test_deferred_release_waits_for_snapshot_retirement():
+    allocator = KVBlockAllocator(FakeContext(), total_count=5, paused_count=0)
+    blocks = allocator.allocate_memory_blocks(2)
+
+    allocator.defer_release_until_snapshot_retired(blocks, snapshot_slot_id=7)
+
+    assert allocator.total_avail == 2
+    allocator.release_deferred_blocks_for_snapshot(6)
+    assert allocator.total_avail == 2
+    allocator.release_deferred_blocks_for_snapshot(7)
+    assert allocator.total_avail == 4
+
+
+def test_reset_clears_reservation_state():
+    allocator = KVBlockAllocator(FakeContext(), total_count=5, paused_count=0)
+    reservation = allocator.reserve_blocks(request_slot=0, count=1, step_id=6)
+    allocator.defer_release_until_snapshot_retired(
+        torch.tensor([reservation.kv_block_ids[0]], dtype=torch.int32), snapshot_slot_id=1
+    )
+
+    allocator.reset()
+
+    assert allocator.total_avail == 4
+    assert allocator._open_reservations == {}
+    assert allocator._committed_reservations == {}
+    assert allocator._rolled_back_reservations == {}
+    assert allocator._deferred_snapshot_block_releases == {}

--- a/tests/unit_tests/inference/contexts/test_kv_reservations.py
+++ b/tests/unit_tests/inference/contexts/test_kv_reservations.py
@@ -2,6 +2,7 @@
 
 import torch
 
+from megatron.core.inference.config import PrefixCachingEvictionPolicy
 from megatron.core.inference.contexts.kv_block_allocator import KVBlockAllocator
 
 
@@ -11,6 +12,7 @@ class FakeContext:
             "reservation_commits": 0,
             "reservation_rollbacks": 0,
         }
+        self.prefix_cache_lru_clock = 1
 
 
 def test_kv_reservation_commit_keeps_blocks_owned():
@@ -81,3 +83,49 @@ def test_reset_clears_reservation_state():
     assert allocator._committed_reservations == {}
     assert allocator._rolled_back_reservations == {}
     assert allocator._deferred_snapshot_block_releases == {}
+
+
+def test_prefix_refcount_reservation_commit_keeps_increment():
+    context = FakeContext()
+    allocator = KVBlockAllocator(
+        context,
+        total_count=5,
+        paused_count=0,
+        enable_prefix_caching=True,
+        prefix_caching_eviction_policy=PrefixCachingEvictionPolicy.LRU,
+    )
+    block = allocator.allocate_memory_blocks(1)
+    allocator.register_kv_block_hashes([int(block.item())], [123])
+    allocator.release_memory_blocks(block)
+
+    reservation = allocator.reserve_prefix_refcounts(
+        request_slot=0, block_ids=block, step_id=7
+    )
+    allocator.commit_reservation(reservation)
+
+    assert allocator.block_ref_counts[block].item() == 1
+    assert reservation.prefix_cache_refcount_deltas[int(block.item())] == 1
+    assert context.async_overlap_debug_counters["reservation_commits"] == 1
+
+
+def test_prefix_refcount_reservation_rollback_undoes_increment():
+    context = FakeContext()
+    allocator = KVBlockAllocator(
+        context,
+        total_count=5,
+        paused_count=0,
+        enable_prefix_caching=True,
+        prefix_caching_eviction_policy=PrefixCachingEvictionPolicy.LRU,
+    )
+    block = allocator.allocate_memory_blocks(1)
+    allocator.register_kv_block_hashes([int(block.item())], [123])
+    allocator.release_memory_blocks(block)
+
+    reservation = allocator.reserve_prefix_refcounts(
+        request_slot=0, block_ids=block, step_id=8
+    )
+    allocator.rollback_reservation(reservation)
+
+    assert allocator.block_ref_counts[block].item() == 0
+    assert allocator.kv_hash_to_block_id[123] == int(block.item())
+    assert context.async_overlap_debug_counters["reservation_rollbacks"] == 1

--- a/tests/unit_tests/inference/contexts/test_snapshot_pool.py
+++ b/tests/unit_tests/inference/contexts/test_snapshot_pool.py
@@ -63,6 +63,23 @@ def test_snapshot_pool_releases_slots_out_of_order():
     assert sorted(pool.active_slot_ids) == [0, 1]
 
 
+def test_snapshot_pool_acquires_specific_slot_for_graph_capture():
+    pool = _pool(slot_count=2)
+    first = pool.acquire_specific(1, step_id=10)
+
+    assert first.slot_id == 1
+    assert first.state == SNAPSHOT_POPULATING
+    assert first.gpu_view.current_dynamic_step_id == 10
+
+    with pytest.raises(RuntimeError, match="not reusable"):
+        pool.acquire_specific(1, step_id=11)
+
+    pool.release(first)
+    second = pool.acquire_specific(1, step_id=12)
+    assert second.slot_id == 1
+    assert second.gpu_view.current_dynamic_step_id == 12
+
+
 def test_snapshot_pool_holds_forward_slot_while_another_slot_populates():
     pool = _pool(slot_count=2)
     held = pool.acquire(step_id=1)
@@ -110,7 +127,16 @@ def test_snapshot_pool_memory_accounting_includes_graph_captures():
     assert accounting["pinned_mirror_bytes"] == accounting["metadata_buffer_bytes"]
     assert accounting["graph_capture_count"] == 0
 
-    pool.register_graph_capture(1, byte_count=4096)
+    pool.record_graph_cache_lookup(1, hit=False)
+    pool.register_graph_capture(1, byte_count=4096, cache_key=("shape-a", 1), max_captures=1)
+    pool.record_graph_cache_lookup(1, hit=True)
+    pool.register_graph_capture(1, byte_count=8192, cache_key=("shape-a", 1), max_captures=1)
     accounting = pool.memory_accounting()
     assert accounting["graph_capture_count"] == 1
     assert accounting["graph_capture_bytes"] == 4096
+    assert accounting["graph_capture_key_count"] == 1
+    assert accounting["graph_cache_hits"] == 1
+    assert accounting["graph_cache_misses"] == 1
+
+    with pytest.raises(RuntimeError, match="exceeded CUDA graph capture budget"):
+        pool.register_graph_capture(1, byte_count=1024, cache_key=("shape-b", 1), max_captures=1)

--- a/tests/unit_tests/inference/contexts/test_snapshot_pool.py
+++ b/tests/unit_tests/inference/contexts/test_snapshot_pool.py
@@ -15,9 +15,14 @@ from megatron.core.inference.contexts.snapshot_pool import (
 class FakeEvent:
     def __init__(self, complete: bool):
         self.complete = complete
+        self.synchronize_calls = 0
 
     def query(self):
         return self.complete
+
+    def synchronize(self):
+        self.complete = True
+        self.synchronize_calls += 1
 
 
 def _pool(slot_count: int = 2) -> GpuSnapshotBufferPool:
@@ -140,3 +145,23 @@ def test_snapshot_pool_memory_accounting_includes_graph_captures():
 
     with pytest.raises(RuntimeError, match="exceeded CUDA graph capture budget"):
         pool.register_graph_capture(1, byte_count=1024, cache_key=("shape-b", 1), max_captures=1)
+
+
+def test_snapshot_pool_reset_for_suspend_releases_active_slots_and_graphs():
+    pool = _pool(slot_count=1)
+    held = pool.acquire(step_id=1)
+    read_event = FakeEvent(complete=False)
+    pool.mark_forward_in_flight(held, gpu_read_event=read_event)
+    pool.release(held)
+    pool.register_graph_capture(0, byte_count=1024, cache_key=("shape", 0), max_captures=1)
+
+    pool.reset_for_suspend()
+
+    assert held.state == SNAPSHOT_FREE
+    assert held.owning_step_id is None
+    assert held.last_gpu_read_event is None
+    assert read_event.synchronize_calls == 1
+    assert pool.active_slot_ids == ()
+    accounting = pool.memory_accounting()
+    assert accounting["graph_capture_count"] == 0
+    assert accounting["graph_capture_key_count"] == 0

--- a/tests/unit_tests/inference/contexts/test_snapshot_pool.py
+++ b/tests/unit_tests/inference/contexts/test_snapshot_pool.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.inference.contexts.snapshot_pool import (
+    SNAPSHOT_FORWARD_IN_FLIGHT,
+    SNAPSHOT_FREE,
+    SNAPSHOT_POPULATING,
+    SNAPSHOT_RETIRING,
+    GpuSnapshotBufferPool,
+)
+
+
+class FakeEvent:
+    def __init__(self, complete: bool):
+        self.complete = complete
+
+    def query(self):
+        return self.complete
+
+
+def _pool(slot_count: int = 2) -> GpuSnapshotBufferPool:
+    return GpuSnapshotBufferPool(
+        slot_count=slot_count,
+        max_requests=4,
+        max_tokens=16,
+        max_kv_blocks=8,
+        device=torch.cuda.current_device(),
+    )
+
+
+def test_snapshot_pool_acquires_and_releases_in_order_with_fixed_addresses():
+    pool = _pool(slot_count=1)
+    first = pool.acquire(step_id=10)
+    gpu_ptr = first.gpu_view._buf.data_ptr()
+    cpu_ptr = first.cpu_mirror.data_ptr()
+
+    assert first.slot_id == 0
+    assert first.state == SNAPSHOT_POPULATING
+    assert first.gpu_view.current_dynamic_step_id == 10
+
+    pool.release(first)
+    assert first.state == SNAPSHOT_FREE
+
+    second = pool.acquire(step_id=11)
+    assert second.slot_id == 0
+    assert second.gpu_view._buf.data_ptr() == gpu_ptr
+    assert second.cpu_mirror.data_ptr() == cpu_ptr
+    assert second.gpu_view.current_dynamic_step_id == 11
+
+
+def test_snapshot_pool_releases_slots_out_of_order():
+    pool = _pool(slot_count=2)
+    first = pool.acquire(step_id=1)
+    second = pool.acquire(step_id=2)
+
+    pool.release(second)
+    reacquired = pool.acquire(step_id=3)
+
+    assert reacquired.slot_id == second.slot_id
+    assert first.state == SNAPSHOT_POPULATING
+    assert sorted(pool.active_slot_ids) == [0, 1]
+
+
+def test_snapshot_pool_holds_forward_slot_while_another_slot_populates():
+    pool = _pool(slot_count=2)
+    held = pool.acquire(step_id=1)
+    pool.mark_ready(held)
+    read_event = FakeEvent(complete=False)
+    pool.mark_forward_in_flight(held, gpu_read_event=read_event)
+
+    assert held.state == SNAPSHOT_FORWARD_IN_FLIGHT
+    pool.release(held)
+    assert held.state == SNAPSHOT_RETIRING
+
+    next_slot = pool.acquire(step_id=2)
+    assert next_slot.slot_id != held.slot_id
+
+    read_event.complete = True
+    pool.poll_retired()
+    assert held.state == SNAPSHOT_FREE
+
+
+def test_snapshot_pool_requires_gpu_event_and_journal_retirement_before_reuse():
+    pool = _pool(slot_count=1)
+    held = pool.acquire(step_id=1)
+    read_event = FakeEvent(complete=False)
+    pool.mark_forward_in_flight(held, gpu_read_event=read_event)
+
+    with pytest.raises(RuntimeError, match="No reusable"):
+        pool.acquire(step_id=2)
+
+    pool.release(held)
+    assert held.state == SNAPSHOT_RETIRING
+    with pytest.raises(RuntimeError, match="No reusable"):
+        pool.acquire(step_id=2)
+
+    read_event.complete = True
+    reacquired = pool.acquire(step_id=2)
+    assert reacquired.slot_id == held.slot_id
+
+
+def test_snapshot_pool_memory_accounting_includes_graph_captures():
+    pool = _pool(slot_count=2)
+    accounting = pool.memory_accounting()
+
+    assert accounting["snapshot_slot_count"] == 2
+    assert accounting["metadata_buffer_bytes"] > 0
+    assert accounting["pinned_mirror_bytes"] == accounting["metadata_buffer_bytes"]
+    assert accounting["graph_capture_count"] == 0
+
+    pool.register_graph_capture(1, byte_count=4096)
+    accounting = pool.memory_accounting()
+    assert accounting["graph_capture_count"] == 1
+    assert accounting["graph_capture_bytes"] == 4096

--- a/tests/unit_tests/inference/contexts/test_step_journal.py
+++ b/tests/unit_tests/inference/contexts/test_step_journal.py
@@ -18,6 +18,8 @@ class FakeResourceReservation:
     kv_block_ids: tuple[int, ...] = field(default_factory=tuple)
     mamba_slot_ids: tuple[int, ...] = field(default_factory=tuple)
     prefix_cache_refcount_deltas: dict[str, int] = field(default_factory=dict)
+    mamba_zero_slot_ids: tuple[int, ...] = field(default_factory=tuple)
+    mamba_restore_block_ids: dict[int, int] = field(default_factory=dict)
 
 
 def _fake_dynamic_context():
@@ -69,12 +71,16 @@ def test_step_journal_records_resource_reservation():
         kv_block_ids=(7, 8),
         mamba_slot_ids=(2,),
         prefix_cache_refcount_deltas={"prefix": 1},
+        mamba_zero_slot_ids=(2,),
+        mamba_restore_block_ids={2: 11},
     )
     entry = journal.record_resource_reservation(4, reservation)
 
     assert entry.reserved_kv_blocks == (7, 8)
     assert entry.reserved_mamba_slots == (2,)
     assert entry.prefix_cache_refcount_deltas["prefix"] == 1
+    assert entry.mamba_zero_slot_ids == (2,)
+    assert entry.mamba_restore_block_ids[2] == 11
     assert entry.resources_waiting_on_snapshot == (reservation,)
 
 

--- a/tests/unit_tests/inference/contexts/test_step_journal.py
+++ b/tests/unit_tests/inference/contexts/test_step_journal.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from dataclasses import dataclass, field
+
+import pytest
+import torch
+
+from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
+from megatron.core.inference.contexts.step_journal import StepJournal
+
+
+class FakeGpuView:
+    current_snapshot_slot_id = 0
+
+
+@dataclass(frozen=True)
+class FakeResourceReservation:
+    kv_block_ids: tuple[int, ...] = field(default_factory=tuple)
+    mamba_slot_ids: tuple[int, ...] = field(default_factory=tuple)
+    prefix_cache_refcount_deltas: dict[str, int] = field(default_factory=dict)
+
+
+def _fake_dynamic_context():
+    context = object.__new__(DynamicInferenceContext)
+    context.step_journal = StepJournal()
+    context.total_request_count = 3
+    context.paused_request_count = 1
+    context.request_ids = torch.tensor([100, 101, 102], dtype=torch.int64)
+    context.gpu_view = FakeGpuView()
+    return context
+
+
+def test_step_journal_records_and_commits_entry():
+    journal = StepJournal()
+
+    entry = journal.begin_step_journal(
+        3, request_slots_before=(0, 1), active_request_ids=(10, 11)
+    )
+    assert entry.step_id == 3
+    assert entry.request_slots_before == (0, 1)
+    assert journal.open_step_ids == (3,)
+
+    journal.record_placeholder_delta(3, 10, 1)
+    journal.record_snapshot_slot(3, 2, cuda_graph_batch_dimensions=4)
+    journal.record_request_slot_transition(
+        3,
+        request_slots_after=(0, 1, 2),
+        active_request_ids=(10, 11, 12),
+        decode_input_destination_indices=(5, 6),
+    )
+
+    committed = journal.commit_step_journal(3)
+
+    assert committed.snapshot_slot_id == 2
+    assert committed.placeholder_token_counts["10"] == 1
+    assert committed.request_slots_after == (0, 1, 2)
+    assert committed.active_request_ids == ("10", "11", "12")
+    assert committed.decode_input_destination_indices == (5, 6)
+    assert committed.cuda_graph_batch_dimensions == 4
+    assert journal.open_entry_count == 0
+    assert journal.get_committed_entry(3) == committed
+
+
+def test_step_journal_records_resource_reservation():
+    journal = StepJournal()
+    journal.begin_step_journal(4)
+
+    reservation = FakeResourceReservation(
+        kv_block_ids=(7, 8),
+        mamba_slot_ids=(2,),
+        prefix_cache_refcount_deltas={"prefix": 1},
+    )
+    entry = journal.record_resource_reservation(4, reservation)
+
+    assert entry.reserved_kv_blocks == (7, 8)
+    assert entry.reserved_mamba_slots == (2,)
+    assert entry.prefix_cache_refcount_deltas["prefix"] == 1
+    assert entry.resources_waiting_on_snapshot == (reservation,)
+
+
+def test_step_journal_rolls_back_open_entries():
+    journal = StepJournal()
+    journal.begin_step_journal(1)
+    journal.begin_step_journal(2)
+
+    rolled_back = journal.rollback_all_open(reason="test")
+
+    assert [entry.step_id for entry in rolled_back] == [1, 2]
+    assert journal.open_step_ids == ()
+    assert journal.get_rolled_back_entry(1).step_id == 1
+    assert journal.get_rolled_back_entry(2).step_id == 2
+
+
+def test_step_journal_rejects_duplicate_or_terminal_entry():
+    journal = StepJournal()
+    journal.begin_step_journal(9)
+
+    with pytest.raises(RuntimeError, match="already open"):
+        journal.begin_step_journal(9)
+
+    journal.commit_step_journal(9)
+    with pytest.raises(RuntimeError, match="already terminal"):
+        journal.begin_step_journal(9)
+
+
+def test_dynamic_context_journal_api_captures_live_request_state():
+    context = _fake_dynamic_context()
+
+    context.begin_step_journal(5)
+    context.record_snapshot_slot(5, 3)
+    committed = context.commit_step_journal(5)
+
+    assert committed.request_slots_before == (0, 1, 2)
+    assert committed.request_slots_after == (0, 1, 2)
+    assert committed.active_request_ids == ("101", "102")
+    assert committed.snapshot_slot_id == 3
+    assert context.step_journal.open_entry_count == 0
+
+
+def test_dynamic_context_record_api_is_noop_without_open_journal():
+    context = _fake_dynamic_context()
+
+    assert context.record_snapshot_slot(99, 1) is None
+    assert context.record_placeholder_delta(99, 100, 1) is None

--- a/tests/unit_tests/inference/contexts/test_step_journal.py
+++ b/tests/unit_tests/inference/contexts/test_step_journal.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
-from megatron.core.inference.contexts.step_journal import StepJournal
+from megatron.core.inference.contexts.step_journal import RollbackStatus, StepJournal
 
 
 class FakeGpuView:
@@ -91,10 +91,29 @@ def test_step_journal_rolls_back_open_entries():
 
     rolled_back = journal.rollback_all_open(reason="test")
 
-    assert [entry.step_id for entry in rolled_back] == [1, 2]
+    assert [result.entry.step_id for result in rolled_back] == [1, 2]
+    assert [result.status for result in rolled_back] == [
+        RollbackStatus.FULLY_RELEASED,
+        RollbackStatus.FULLY_RELEASED,
+    ]
     assert journal.open_step_ids == ()
     assert journal.get_rolled_back_entry(1).step_id == 1
     assert journal.get_rolled_back_entry(2).step_id == 2
+
+    rolled_back_again = journal.rollback_step_journal(1, reason="again")
+    assert rolled_back_again.status == RollbackStatus.ALREADY_ROLLED_BACK
+    assert rolled_back_again.entry.step_id == 1
+
+
+def test_step_journal_rollback_after_commit_is_idempotent():
+    journal = StepJournal()
+    journal.begin_step_journal(3)
+    journal.commit_step_journal(3)
+
+    result = journal.rollback_step_journal(3, reason="after_commit")
+
+    assert result.status == RollbackStatus.ALREADY_COMMITTED
+    assert result.entry.step_id == 3
 
 
 def test_step_journal_rejects_duplicate_or_terminal_entry():

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -145,6 +145,8 @@ class DynamicEngineTestConfig:
     track_generated_token_events: bool = False
     num_speculative_tokens: int = 0
     position_embedding_type: str = "learned_absolute"
+    enable_async_overlap_architecture: bool = False
+    async_overlap_queue_depth: int = 1
 
     def __post_init__(self):
 
@@ -273,6 +275,8 @@ class TestDynamicInferenceEngine:
                 unified_memory_level=0,  # unit tests currently broken with UVM
                 track_generated_token_events=test_config.track_generated_token_events,
                 num_speculative_tokens=test_config.num_speculative_tokens,
+                enable_async_overlap_architecture=test_config.enable_async_overlap_architecture,
+                async_overlap_queue_depth=test_config.async_overlap_queue_depth,
             ),
         )
 
@@ -649,6 +653,45 @@ class TestDynamicInferenceEngine:
                 f"result ({request.generated_tokens}) != "
                 f"expected ({expected_generated_tokens})."
             )
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    def test_async_overlap_queue_depth_one_simple(self) -> None:
+        """Queue-depth-one pipeline matches the serial GPT output path."""
+        env = self._run_test(
+            num_tokens_to_generate=16,
+            model_provider="gpt",
+            num_cuda_graphs=None,
+            cuda_graph_scope=[],
+            force_build_cuda_graphs=True,
+            context_max_requests=128,
+            enable_async_overlap_architecture=True,
+            async_overlap_queue_depth=1,
+        )
+
+        assert env.engine.async_pipeline.pending_launch_count == 0
+        assert env.engine.step_retirement_service.pending_count == 0
+        assert env.engine.async_overlap_debug_counters.queue_depth == 1
+        assert env.requests[0].generated_tokens == [
+            69,
+            85,
+            55,
+            74,
+            56,
+            89,
+            64,
+            59,
+            55,
+            67,
+            15,
+            58,
+            6,
+            37,
+            54,
+            47,
+        ]
 
     @pytest.mark.skipif(
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -987,6 +987,139 @@ class TestDynamicInferenceEngine:
         assert qd2_finished == qd1_finished
         assert set(qd2_finished) == set(range(len(prompt_lengths)))
 
+    def _run_async_overlap_logprob_case(
+        self, *, queue_depth: int, top_n_logprobs: int
+    ) -> Tuple[Dict[int, Dict[str, object]], DynamicEngineTestEnv]:
+        """Run deterministic logprob/top-n generation and summarize completed requests."""
+        test_config = DynamicEngineTestConfig(
+            num_requests=0,
+            min_prompt_length=4,
+            max_prompt_length=4,
+            num_tokens_to_generate=4,
+            model_provider="gpt",
+            num_cuda_graphs=None,
+            cuda_graph_scope=[],
+            force_build_cuda_graphs=True,
+            context_max_requests=128,
+            materialize_only_last_token_logits=False,
+            enable_async_overlap_architecture=True,
+            async_overlap_queue_depth=queue_depth,
+        )
+        env = self._build_test_env(test_config)
+        env.engine.controller.tokenizer.detokenize = lambda tokens, **kw: f"tok_{int(tokens[0])}"
+        model = env.engine.controller.inference_wrapped_model.model
+
+        def deterministic_forward(*args, **kwargs):
+            tokens = kwargs.get("tokens", args[0] if args else kwargs.get("input_ids"))
+            batch, sequence = tokens.shape
+            logits = torch.zeros(
+                batch,
+                sequence,
+                test_config.vocab_size,
+                device=tokens.device,
+                dtype=torch.bfloat16,
+            )
+            next_tokens = (tokens + 1).clamp(max=test_config.vocab_size - 1)
+            logits.scatter_(2, next_tokens.unsqueeze(-1), 100.0)
+            return logits
+
+        model.forward = deterministic_forward
+
+        for request_id, prompt_start in enumerate((0, 10)):
+            prompt_tokens = torch.arange(
+                prompt_start, prompt_start + 4, dtype=torch.int64, device="cuda"
+            )
+            env.engine._add_request(
+                DynamicInferenceRequest(
+                    request_id=request_id,
+                    prompt_tokens=prompt_tokens,
+                    sampling_params=SamplingParams(
+                        num_tokens_to_generate=4,
+                        termination_id=test_config.vocab_size - 1,
+                        return_log_probs=True,
+                        top_n_logprobs=top_n_logprobs,
+                        top_k=1,
+                    ),
+                    block_size_tokens=env.engine.context.block_size_tokens,
+                )
+            )
+
+        summaries = {}
+        step_count = 0
+        while env.engine.has_unfinished_requests():
+            result = env.engine.step_modern()
+            if result is not None:
+                for record in result["finished_request_records"]:
+                    request = record.merge()
+                    assert request.status == Status.COMPLETED
+                    summaries[int(request.request_id)] = {
+                        "generated_tokens": list(request.generated_tokens),
+                        "prompt_log_probs": [
+                            round(float(value), 5) for value in request.prompt_log_probs
+                        ],
+                        "generated_log_probs": [
+                            round(float(value), 5) for value in request.generated_log_probs
+                        ],
+                        "prompt_top_n": self._summarize_top_n_logprobs(
+                            request.prompt_top_n_logprobs
+                        ),
+                        "generated_top_n": self._summarize_top_n_logprobs(
+                            request.generated_top_n_logprobs
+                        ),
+                    }
+            step_count += 1
+            assert step_count < 32, "Engine did not converge"
+
+        return summaries, env
+
+    @staticmethod
+    def _summarize_top_n_logprobs(top_n_logprobs):
+        if top_n_logprobs is None:
+            return None
+        return [
+            tuple(sorted((key, round(float(value), 5)) for key, value in token_logprobs.items()))
+            for token_logprobs in top_n_logprobs
+        ]
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_logprobs_match_queue_depth_one(self) -> None:
+        """Queue-depth-two preserves prompt and generated logprob ordering."""
+        qd1_summary, _ = self._run_async_overlap_logprob_case(
+            queue_depth=1, top_n_logprobs=0
+        )
+        qd2_summary, qd2_env = self._run_async_overlap_logprob_case(
+            queue_depth=2, top_n_logprobs=0
+        )
+
+        assert qd2_summary == qd1_summary
+        counters = qd2_env.engine.async_overlap_debug_counters
+        generated_count = sum(len(item["generated_tokens"]) for item in qd2_summary.values())
+        assert counters.accepted_output_tokens == generated_count
+        assert counters.discarded_lookahead_tokens == 0
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_top_n_logprobs_match_queue_depth_one(self) -> None:
+        """Queue-depth-two preserves request-keyed top-n logprob payloads."""
+        qd1_summary, _ = self._run_async_overlap_logprob_case(
+            queue_depth=1, top_n_logprobs=5
+        )
+        qd2_summary, _ = self._run_async_overlap_logprob_case(
+            queue_depth=2, top_n_logprobs=5
+        )
+
+        assert qd2_summary == qd1_summary
+        for summary in qd2_summary.values():
+            assert len(summary["prompt_top_n"]) == 3
+            assert len(summary["generated_top_n"]) == 4
+
     @pytest.mark.skipif(
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -822,6 +822,171 @@ class TestDynamicInferenceEngine:
         for generated_tokens in qd2_finished.values():
             assert len(generated_tokens) == 6
 
+    def _run_async_overlap_chunked_prefill_case(
+        self,
+        *,
+        queue_depth: int,
+        staged_long_request: bool,
+        prompt_lengths: List[int],
+    ) -> Tuple[Dict[int, List[int]], DynamicEngineTestEnv]:
+        """Run a deterministic chunked-prefill case and return completed outputs."""
+        test_config = DynamicEngineTestConfig(
+            num_requests=0,
+            min_prompt_length=4,
+            max_prompt_length=max([4, *prompt_lengths]),
+            num_tokens_to_generate=4,
+            model_provider="gpt",
+            num_cuda_graphs=None,
+            cuda_graph_scope=[],
+            force_build_cuda_graphs=True,
+            context_max_tokens=16,
+            context_max_requests=max(8, len(prompt_lengths) + 2),
+            context_block_size_tokens=256,
+            enable_chunked_prefill=True,
+            use_cuda_graphs_for_non_decode_steps=False,
+            enable_async_overlap_architecture=True,
+            async_overlap_queue_depth=queue_depth,
+        )
+        env = self._build_test_env(test_config)
+        model = env.engine.controller.inference_wrapped_model.model
+
+        def deterministic_forward(*args, **kwargs):
+            tokens = kwargs.get("tokens", args[0] if args else kwargs.get("input_ids"))
+            batch, sequence = tokens.shape
+            logits = torch.zeros(
+                batch,
+                sequence,
+                test_config.vocab_size,
+                device=tokens.device,
+                dtype=torch.bfloat16,
+            )
+            next_tokens = (tokens + 1).clamp(max=test_config.vocab_size - 1)
+            logits.scatter_(2, next_tokens.unsqueeze(-1), 100.0)
+            return logits
+
+        model.forward = deterministic_forward
+
+        def add_request(request_id: int, prompt_length: int):
+            prompt_tokens = torch.arange(prompt_length, dtype=torch.int64, device="cuda") % (
+                test_config.vocab_size - 8
+            )
+            env.engine._add_request(
+                DynamicInferenceRequest(
+                    request_id=request_id,
+                    prompt_tokens=prompt_tokens,
+                    sampling_params=SamplingParams(
+                        num_tokens_to_generate=4,
+                        termination_id=test_config.vocab_size - 1,
+                        top_k=1,
+                    ),
+                    block_size_tokens=env.engine.context.block_size_tokens,
+                )
+            )
+
+        finished = {}
+
+        def collect_finished(result):
+            if result is None:
+                return
+            for record in result["finished_request_records"]:
+                request = record.merge()
+                assert request.status == Status.COMPLETED
+                finished[int(request.request_id)] = list(request.generated_tokens)
+
+        next_request_id = 0
+        if staged_long_request:
+            add_request(next_request_id, 4)
+            next_request_id += 1
+            collect_finished(env.engine.step_modern())
+
+        for prompt_length in prompt_lengths:
+            add_request(next_request_id, prompt_length)
+            next_request_id += 1
+
+        step_count = 0
+        while env.engine.has_unfinished_requests():
+            collect_finished(env.engine.step_modern())
+            step_count += 1
+            assert step_count < 128, "Engine did not converge"
+
+        assert env.engine.async_pipeline.pending_launch_count == 0
+        assert env.engine.step_retirement_service.pending_count == 0
+        return finished, env
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_chunked_prefill_matches_queue_depth_one(
+        self,
+    ) -> None:
+        """Queue-depth-two preserves chunked-prefill outputs and no-output journals."""
+        qd1_finished, _ = self._run_async_overlap_chunked_prefill_case(
+            queue_depth=1,
+            staged_long_request=False,
+            prompt_lengths=[40],
+        )
+        qd2_finished, qd2_env = self._run_async_overlap_chunked_prefill_case(
+            queue_depth=2,
+            staged_long_request=False,
+            prompt_lengths=[40],
+        )
+
+        first_entry = qd2_env.engine.context.step_journal.get_committed_entry(0)
+        assert first_entry is not None
+        assert dict(first_entry.placeholder_token_counts) == {}
+        assert first_entry.active_request_ids == ()
+        assert qd2_finished == qd1_finished
+        assert set(qd2_finished) == {0}
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_chunked_prefill_mixed_decode_matches_queue_depth_one(
+        self,
+    ) -> None:
+        """Queue-depth-two matches qd1 when chunked prefill arrives during decode."""
+        qd1_finished, _ = self._run_async_overlap_chunked_prefill_case(
+            queue_depth=1,
+            staged_long_request=True,
+            prompt_lengths=[36],
+        )
+        qd2_finished, _ = self._run_async_overlap_chunked_prefill_case(
+            queue_depth=2,
+            staged_long_request=True,
+            prompt_lengths=[36],
+        )
+
+        assert qd2_finished == qd1_finished
+        assert set(qd2_finished) == {0, 1}
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_chunked_prefill_stress_matches_queue_depth_one(
+        self,
+    ) -> None:
+        """Queue-depth-two matches qd1 for several queued chunked prefills."""
+        prompt_lengths = [32, 34, 36, 38]
+        qd1_finished, _ = self._run_async_overlap_chunked_prefill_case(
+            queue_depth=1,
+            staged_long_request=False,
+            prompt_lengths=prompt_lengths,
+        )
+        qd2_finished, _ = self._run_async_overlap_chunked_prefill_case(
+            queue_depth=2,
+            staged_long_request=False,
+            prompt_lengths=prompt_lengths,
+        )
+
+        assert qd2_finished == qd1_finished
+        assert set(qd2_finished) == set(range(len(prompt_lengths)))
+
     @pytest.mark.skipif(
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -697,6 +697,45 @@ class TestDynamicInferenceEngine:
     @pytest.mark.skipif(
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )
+    @pytest.mark.parametrize(
+        "parallel_kwargs,blocked_reason",
+        [
+            pytest.param({"pipeline_model_parallel_size": 2}, "pipeline_parallel", id="pp2"),
+            pytest.param({"expert_model_parallel_size": 2}, "expert_parallel", id="ep2"),
+        ],
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_distributed_parallel_decode(
+        self, parallel_kwargs, blocked_reason
+    ) -> None:
+        """Queue-depth-two is not gated off for validated distributed parallel modes."""
+        if int(os.environ.get("WORLD_SIZE", "1")) < 2:
+            pytest.skip("Test requires at least 2 GPUs")
+
+        env = self._run_test(
+            num_requests=4,
+            min_prompt_length=4,
+            max_prompt_length=4,
+            num_tokens_to_generate=4,
+            num_cuda_graphs=None,
+            cuda_graph_scope=[],
+            force_build_cuda_graphs=True,
+            context_max_requests=16,
+            context_block_size_tokens=256,
+            enable_async_overlap_architecture=True,
+            async_overlap_queue_depth=2,
+            **parallel_kwargs,
+        )
+
+        assert env.engine.async_pipeline.pending_launch_count == 0
+        counters = env.engine.async_overlap_debug_counters
+        assert counters.queue_depth == 2
+        assert blocked_reason not in counters.fallback_or_queue_depth_one_reasons
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
     def test_async_overlap_queue_depth_two_decode_simple(self) -> None:
         """Queue-depth-two steady-state decode matches the serial GPT output path."""
         env = self._run_test(

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -776,6 +776,33 @@ class TestDynamicInferenceEngine:
     @pytest.mark.skipif(
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )
+    def test_async_overlap_queue_depth_two_suspend_resume_during_decode(self) -> None:
+        """Suspend drains a queue-depth-two in-flight step and resumes cleanly."""
+        env = self._run_test(
+            num_requests=2,
+            min_prompt_length=4,
+            max_prompt_length=4,
+            num_tokens_to_generate=4,
+            model_provider="gpt",
+            num_cuda_graphs=None,
+            cuda_graph_scope=[],
+            force_build_cuda_graphs=True,
+            context_max_requests=16,
+            num_gap_steps=0,
+            suspend_resume_interval=1,
+            enable_async_overlap_architecture=True,
+            async_overlap_queue_depth=2,
+        )
+
+        assert env.engine.async_pipeline.pending_launch_count == 0
+        assert env.engine.step_retirement_service.pending_count == 0
+        assert not env.engine.context.step_journal.has_open_entries()
+        assert env.engine.context.snapshot_pool.active_slot_ids == ()
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
     @torch.inference_mode()
     def test_async_overlap_queue_depth_two_mixed_prefill_decode(self) -> None:
         """Queue-depth-two matches qd1 when a prefill joins active decode requests."""

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -145,8 +145,8 @@ class DynamicEngineTestConfig:
     track_generated_token_events: bool = False
     num_speculative_tokens: int = 0
     position_embedding_type: str = "learned_absolute"
-    enable_async_overlap_architecture: bool = False
-    async_overlap_queue_depth: int = 1
+    enable_async_overlap_architecture: bool = True
+    async_overlap_queue_depth: int = 2
 
     def __post_init__(self):
 
@@ -242,6 +242,8 @@ class TestDynamicInferenceEngine:
         assert counters.distributed_consensus_mismatches == 1
         assert counters.distributed_prepare_reconciliations == 1
         assert counters.distributed_prepare_downgrades == 1
+        assert counters.queue_depth_one_downgrades == 1
+        assert counters.downgrade_reasons == {"distributed_prepare_divergence": 1}
         assert counters.fallback_or_queue_depth_one_reasons == {
             "distributed_prepare_divergence": 1
         }
@@ -800,7 +802,7 @@ class TestDynamicInferenceEngine:
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )
     def test_async_overlap_queue_depth_two_decode_simple(self) -> None:
-        """Queue-depth-two steady-state decode matches the serial GPT output path."""
+        """Default queue-depth-two steady-state decode matches queue-depth-one output."""
         env = self._run_test(
             num_tokens_to_generate=16,
             model_provider="gpt",
@@ -809,8 +811,6 @@ class TestDynamicInferenceEngine:
             force_build_cuda_graphs=True,
             context_max_requests=128,
             num_gap_steps=0,
-            enable_async_overlap_architecture=True,
-            async_overlap_queue_depth=2,
         )
 
         assert env.engine.async_pipeline.pending_launch_count == 0

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -723,7 +723,7 @@ class TestDynamicInferenceEngine:
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )
     def test_async_overlap_queue_depth_one_simple(self) -> None:
-        """Queue-depth-one pipeline matches the serial GPT output path."""
+        """Default queue-depth-one engine path uses the async pipeline."""
         env = self._run_test(
             num_tokens_to_generate=16,
             model_provider="gpt",
@@ -731,7 +731,6 @@ class TestDynamicInferenceEngine:
             cuda_graph_scope=[],
             force_build_cuda_graphs=True,
             context_max_requests=128,
-            enable_async_overlap_architecture=True,
             async_overlap_queue_depth=1,
         )
 

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -145,7 +145,6 @@ class DynamicEngineTestConfig:
     track_generated_token_events: bool = False
     num_speculative_tokens: int = 0
     position_embedding_type: str = "learned_absolute"
-    enable_async_overlap_architecture: bool = True
     async_overlap_queue_depth: int = 2
 
     def __post_init__(self):
@@ -341,7 +340,6 @@ class TestDynamicInferenceEngine:
                 unified_memory_level=0,  # unit tests currently broken with UVM
                 track_generated_token_events=test_config.track_generated_token_events,
                 num_speculative_tokens=test_config.num_speculative_tokens,
-                enable_async_overlap_architecture=test_config.enable_async_overlap_architecture,
                 async_overlap_queue_depth=test_config.async_overlap_queue_depth,
             ),
         )
@@ -787,7 +785,6 @@ class TestDynamicInferenceEngine:
             force_build_cuda_graphs=True,
             context_max_requests=16,
             context_block_size_tokens=256,
-            enable_async_overlap_architecture=True,
             async_overlap_queue_depth=2,
             **parallel_kwargs,
         )
@@ -853,7 +850,6 @@ class TestDynamicInferenceEngine:
             context_max_requests=16,
             num_gap_steps=0,
             suspend_resume_interval=1,
-            enable_async_overlap_architecture=True,
             async_overlap_queue_depth=2,
         )
 
@@ -881,7 +877,6 @@ class TestDynamicInferenceEngine:
                 cuda_graph_scope=[],
                 force_build_cuda_graphs=True,
                 context_max_requests=128,
-                enable_async_overlap_architecture=True,
                 async_overlap_queue_depth=queue_depth,
             )
             env = self._build_test_env(test_config)
@@ -973,7 +968,6 @@ class TestDynamicInferenceEngine:
             context_block_size_tokens=256,
             enable_chunked_prefill=True,
             use_cuda_graphs_for_non_decode_steps=False,
-            enable_async_overlap_architecture=True,
             async_overlap_queue_depth=queue_depth,
         )
         env = self._build_test_env(test_config)
@@ -1131,7 +1125,6 @@ class TestDynamicInferenceEngine:
             force_build_cuda_graphs=True,
             context_max_requests=128,
             materialize_only_last_token_logits=False,
-            enable_async_overlap_architecture=True,
             async_overlap_queue_depth=queue_depth,
         )
         env = self._build_test_env(test_config)
@@ -1268,7 +1261,6 @@ class TestDynamicInferenceEngine:
             context_max_tokens=512,
             context_block_size_tokens=64,
             position_embedding_type="none",
-            enable_async_overlap_architecture=True,
             async_overlap_queue_depth=queue_depth,
         )
         env = self._build_test_env(test_config)
@@ -1427,7 +1419,6 @@ class TestDynamicInferenceEngine:
             context_block_size_tokens=256,
             enable_chunked_prefill=enable_chunked_prefill,
             use_cuda_graphs_for_non_decode_steps=False,
-            enable_async_overlap_architecture=True,
             async_overlap_queue_depth=queue_depth,
         )
         env = self._build_test_env(test_config)

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -30,7 +30,7 @@ from megatron.core.inference.contexts.dynamic_context import (
     TokenOverflowError,
 )
 from megatron.core.inference.engines import DynamicInferenceEngine
-from megatron.core.inference.engines.dynamic_engine import EngineState
+from megatron.core.inference.engines.dynamic_engine import AsyncOverlapDebugCounters, EngineState
 from megatron.core.inference.inference_request import DynamicInferenceRequest, Status
 from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper import (
     GPTInferenceWrapper,
@@ -181,6 +181,70 @@ class DynamicEngineTestEnv:
 
 
 class TestDynamicInferenceEngine:
+    class _DivergentPrepareCommunicator:
+        async def all_reduce_max(self, *values, async_op=True):
+            del async_op
+            reduced = list(values)
+            # First prepare-metadata max value starts after work/consensus/launches.
+            reduced[3] += 1
+            return tuple(reduced)
+
+    class _FakeRetirementService:
+        def __init__(self):
+            self.max_retirement_backlog = 2
+            self.updated = False
+
+        def _update_backlog_counters(self):
+            self.updated = True
+
+    def _minimal_engine_for_prepare_consensus(self):
+        engine = object.__new__(DynamicInferenceEngine)
+        engine.ep_world_size = 2
+        engine.use_synchronous_zmq_collectives = True
+        engine.expert_parallel_zmq_communicator = self._DivergentPrepareCommunicator()
+        engine._step_nvtx_label = lambda name, step_id=None: name
+        return engine
+
+    def test_ep_consensus_detects_prepare_metadata_divergence(self) -> None:
+        engine = self._minimal_engine_for_prepare_consensus()
+
+        global_work, all_pausing, global_launches, metadata_agrees = asyncio.run(
+            engine._ep_establish_consensus(
+                1,
+                signal_consensus=False,
+                local_launches=1,
+                local_prepare_metadata={"step_id": 7, "queue_depth": 2},
+            )
+        )
+
+        assert global_work == 1
+        assert not all_pausing
+        assert global_launches == 1
+        assert not metadata_agrees
+
+    def test_prepare_divergence_downgrades_after_bounded_retry(self) -> None:
+        engine = object.__new__(DynamicInferenceEngine)
+        engine.async_overlap_queue_depth = 2
+        engine.async_pipeline = types.SimpleNamespace(queue_depth=2)
+        engine.step_retirement_service = self._FakeRetirementService()
+        engine.async_overlap_debug_counters = AsyncOverlapDebugCounters(queue_depth=2)
+        engine._distributed_prepare_mismatch_streak = 0
+        engine._distributed_prepare_reconcile_retry_limit = 1
+
+        engine._handle_distributed_prepare_divergence()
+
+        counters = engine.async_overlap_debug_counters
+        assert engine.async_overlap_queue_depth == 1
+        assert engine.async_pipeline.queue_depth == 1
+        assert engine.step_retirement_service.max_retirement_backlog == 1
+        assert engine.step_retirement_service.updated
+        assert counters.queue_depth == 1
+        assert counters.distributed_consensus_mismatches == 1
+        assert counters.distributed_prepare_reconciliations == 1
+        assert counters.distributed_prepare_downgrades == 1
+        assert counters.fallback_or_queue_depth_one_reasons == {
+            "distributed_prepare_divergence": 1
+        }
 
     @classmethod
     def _build_requests(cls, test_config: DynamicEngineTestConfig) -> List[DynamicInferenceRequest]:

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -733,6 +733,95 @@ class TestDynamicInferenceEngine:
             47,
         ]
 
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_mixed_prefill_decode(self) -> None:
+        """Queue-depth-two matches qd1 when a prefill joins active decode requests."""
+
+        def run_mixed_prefill_decode(queue_depth: int) -> Tuple[Dict[int, List[int]], int]:
+            test_config = DynamicEngineTestConfig(
+                num_requests=0,
+                min_prompt_length=4,
+                max_prompt_length=4,
+                num_tokens_to_generate=6,
+                model_provider="gpt",
+                num_cuda_graphs=None,
+                cuda_graph_scope=[],
+                force_build_cuda_graphs=True,
+                context_max_requests=128,
+                enable_async_overlap_architecture=True,
+                async_overlap_queue_depth=queue_depth,
+            )
+            env = self._build_test_env(test_config)
+            model = env.engine.controller.inference_wrapped_model.model
+
+            def deterministic_forward(*args, **kwargs):
+                tokens = kwargs.get("tokens", args[0] if args else kwargs.get("input_ids"))
+                batch, sequence = tokens.shape
+                logits = torch.zeros(
+                    batch,
+                    sequence,
+                    test_config.vocab_size,
+                    device=tokens.device,
+                    dtype=torch.bfloat16,
+                )
+                next_tokens = (tokens + 1).clamp(max=test_config.vocab_size - 1)
+                logits.scatter_(2, next_tokens.unsqueeze(-1), 100.0)
+                return logits
+
+            model.forward = deterministic_forward
+
+            def add_request(request_id: int):
+                env.engine._add_request(
+                    DynamicInferenceRequest(
+                        request_id=request_id,
+                        prompt_tokens=torch.tensor(
+                            [0, 1, 2, 3], dtype=torch.int64, device="cuda"
+                        ),
+                        sampling_params=SamplingParams(
+                            num_tokens_to_generate=6,
+                            termination_id=test_config.vocab_size - 1,
+                            top_k=1,
+                        ),
+                        block_size_tokens=env.engine.context.block_size_tokens,
+                    )
+                )
+
+            add_request(0)
+            add_request(1)
+            first_result = env.engine.step_modern()
+            assert first_result["finished_request_records"] == []
+            pending_after_first_step = env.engine.async_pipeline.pending_launch_count
+
+            add_request(2)
+
+            finished = {}
+            step_count = 0
+            while env.engine.has_unfinished_requests():
+                result = env.engine.step_modern()
+                for record in result["finished_request_records"]:
+                    request = record.merge()
+                    assert request.status == Status.COMPLETED
+                    finished[int(request.request_id)] = list(request.generated_tokens)
+                step_count += 1
+                assert step_count < 32, "Engine did not converge"
+
+            assert env.engine.async_pipeline.pending_launch_count == 0
+            return finished, pending_after_first_step
+
+        qd1_finished, qd1_pending_after_first_step = run_mixed_prefill_decode(queue_depth=1)
+        qd2_finished, qd2_pending_after_first_step = run_mixed_prefill_decode(queue_depth=2)
+
+        assert qd1_pending_after_first_step == 0
+        assert qd2_pending_after_first_step == 1
+        assert qd2_finished == qd1_finished
+        assert set(qd2_finished) == {0, 1, 2}
+        for generated_tokens in qd2_finished.values():
+            assert len(generated_tokens) == 6
+
     @pytest.mark.skipif(
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -693,6 +693,46 @@ class TestDynamicInferenceEngine:
             47,
         ]
 
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    def test_async_overlap_queue_depth_two_decode_simple(self) -> None:
+        """Queue-depth-two steady-state decode matches the serial GPT output path."""
+        env = self._run_test(
+            num_tokens_to_generate=16,
+            model_provider="gpt",
+            num_cuda_graphs=None,
+            cuda_graph_scope=[],
+            force_build_cuda_graphs=True,
+            context_max_requests=128,
+            num_gap_steps=0,
+            enable_async_overlap_architecture=True,
+            async_overlap_queue_depth=2,
+        )
+
+        assert env.engine.async_pipeline.pending_launch_count == 0
+        assert env.engine.step_retirement_service.pending_count == 0
+        assert env.engine.async_overlap_debug_counters.queue_depth == 2
+        assert env.requests[0].generated_tokens == [
+            69,
+            85,
+            55,
+            74,
+            56,
+            89,
+            64,
+            59,
+            55,
+            67,
+            15,
+            58,
+            6,
+            37,
+            54,
+            47,
+        ]
+
     @pytest.mark.skipif(
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -1273,6 +1273,165 @@ class TestDynamicInferenceEngine:
         assert int(context.num_output_placeholders.sum().item()) == 0
         assert torch.all(context.request_to_kv_block_ids == -1)
 
+    def _run_async_overlap_hybrid_mamba_case(
+        self,
+        *,
+        queue_depth: int,
+        prompt_lengths: Tuple[int, ...],
+        num_tokens_to_generate: int,
+        enable_chunked_prefill: bool = False,
+        context_max_tokens: Optional[int] = None,
+        termination_id: Optional[int] = None,
+    ) -> Tuple[Dict[int, List[int]], DynamicEngineTestEnv, int]:
+        """Run a hybrid Mamba qd1/qd2 case and summarize completed requests."""
+        test_config = DynamicEngineTestConfig(
+            num_requests=0,
+            min_prompt_length=min(prompt_lengths),
+            max_prompt_length=max(prompt_lengths),
+            num_tokens_to_generate=num_tokens_to_generate,
+            model_provider="mamba",
+            num_cuda_graphs=None,
+            cuda_graph_scope=[],
+            force_build_cuda_graphs=True,
+            context_max_requests=16,
+            context_max_tokens=context_max_tokens,
+            context_block_size_tokens=256,
+            enable_chunked_prefill=enable_chunked_prefill,
+            use_cuda_graphs_for_non_decode_steps=False,
+            enable_async_overlap_architecture=True,
+            async_overlap_queue_depth=queue_depth,
+        )
+        env = self._build_test_env(test_config)
+
+        for request_id, prompt_length in enumerate(prompt_lengths):
+            prompt_tokens = torch.arange(prompt_length, dtype=torch.int64, device="cuda") % (
+                test_config.vocab_size - 1
+            )
+            env.engine._add_request(
+                DynamicInferenceRequest(
+                    request_id=request_id,
+                    prompt_tokens=prompt_tokens,
+                    sampling_params=SamplingParams(
+                        num_tokens_to_generate=num_tokens_to_generate,
+                        termination_id=(
+                            test_config.vocab_size - 1
+                            if termination_id is None
+                            else termination_id
+                        ),
+                        top_k=1,
+                    ),
+                    block_size_tokens=env.engine.context.block_size_tokens,
+                )
+            )
+
+        finished = {}
+        max_pending_launches = 0
+        step_count = 0
+        while env.engine.has_unfinished_requests():
+            result = env.engine.step_modern()
+            max_pending_launches = max(
+                max_pending_launches, env.engine.async_pipeline.pending_launch_count
+            )
+            for record in result["finished_request_records"]:
+                request = record.merge()
+                assert request.status == Status.COMPLETED
+                finished[int(request.request_id)] = list(request.generated_tokens)
+            step_count += 1
+            assert step_count < 128, "Engine did not converge"
+
+        return finished, env, max_pending_launches
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_hybrid_mamba_matches_queue_depth_one(self) -> None:
+        """Queue-depth-two preserves hybrid Mamba decode output and slot cleanup."""
+        skip_if_mamba_sequence_packing_not_available("mamba")
+        qd1_finished, _, _ = self._run_async_overlap_hybrid_mamba_case(
+            queue_depth=1,
+            prompt_lengths=(4, 5),
+            num_tokens_to_generate=4,
+        )
+        qd2_finished, qd2_env, qd2_max_pending = self._run_async_overlap_hybrid_mamba_case(
+            queue_depth=2,
+            prompt_lengths=(4, 5),
+            num_tokens_to_generate=4,
+        )
+
+        assert qd2_finished == qd1_finished
+        assert qd2_max_pending > 0
+        counters = qd2_env.engine.async_overlap_debug_counters
+        assert "hybrid_mamba" not in counters.fallback_or_queue_depth_one_reasons
+        metadata = qd2_env.engine.context.mamba_metadata
+        assert metadata.mamba_state_free_slot_count == metadata.max_requests
+        assert torch.all(metadata.request_to_mamba_state_idx == -1)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_hybrid_mamba_eos_cleanup(self) -> None:
+        """Queue-depth-two frees hybrid Mamba live slots after EOS completion."""
+        skip_if_mamba_sequence_packing_not_available("mamba")
+        baseline, _, _ = self._run_async_overlap_hybrid_mamba_case(
+            queue_depth=1,
+            prompt_lengths=(4,),
+            num_tokens_to_generate=4,
+        )
+        termination_id = baseline[0][0]
+
+        qd1_finished, _, _ = self._run_async_overlap_hybrid_mamba_case(
+            queue_depth=1,
+            prompt_lengths=(4,),
+            num_tokens_to_generate=4,
+            termination_id=termination_id,
+        )
+        qd2_finished, qd2_env, _ = self._run_async_overlap_hybrid_mamba_case(
+            queue_depth=2,
+            prompt_lengths=(4,),
+            num_tokens_to_generate=4,
+            termination_id=termination_id,
+        )
+
+        assert qd2_finished == qd1_finished
+        assert qd2_finished[0][-1] == termination_id
+        metadata = qd2_env.engine.context.mamba_metadata
+        assert metadata.mamba_state_free_slot_count == metadata.max_requests
+        assert torch.all(metadata.request_to_mamba_state_idx == -1)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_hybrid_mamba_chunked_prefill_matches_queue_depth_one(
+        self,
+    ) -> None:
+        """Queue-depth-two preserves hybrid Mamba chunked-prefill output and slots."""
+        skip_if_mamba_sequence_packing_not_available("mamba")
+        qd1_finished, _, _ = self._run_async_overlap_hybrid_mamba_case(
+            queue_depth=1,
+            prompt_lengths=(28,),
+            num_tokens_to_generate=2,
+            enable_chunked_prefill=True,
+            context_max_tokens=16,
+        )
+        qd2_finished, qd2_env, _ = self._run_async_overlap_hybrid_mamba_case(
+            queue_depth=2,
+            prompt_lengths=(28,),
+            num_tokens_to_generate=2,
+            enable_chunked_prefill=True,
+            context_max_tokens=16,
+        )
+
+        assert qd2_finished == qd1_finished
+        metadata = qd2_env.engine.context.mamba_metadata
+        assert metadata.mamba_state_free_slot_count == metadata.max_requests
+        assert torch.all(metadata.request_to_mamba_state_idx == -1)
+
     @pytest.mark.skipif(
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -1407,6 +1407,8 @@ class TestDynamicInferenceEngine:
         enable_chunked_prefill: bool = False,
         context_max_tokens: Optional[int] = None,
         termination_id: Optional[int] = None,
+        num_cuda_graphs: Optional[int] = None,
+        max_steps: int = 128,
     ) -> Tuple[Dict[int, List[int]], DynamicEngineTestEnv, int]:
         """Run a hybrid Mamba qd1/qd2 case and summarize completed requests."""
         test_config = DynamicEngineTestConfig(
@@ -1415,7 +1417,7 @@ class TestDynamicInferenceEngine:
             max_prompt_length=max(prompt_lengths),
             num_tokens_to_generate=num_tokens_to_generate,
             model_provider="mamba",
-            num_cuda_graphs=None,
+            num_cuda_graphs=num_cuda_graphs,
             cuda_graph_scope=[],
             force_build_cuda_graphs=True,
             context_max_requests=16,
@@ -1461,7 +1463,7 @@ class TestDynamicInferenceEngine:
                 assert request.status == Status.COMPLETED
                 finished[int(request.request_id)] = list(request.generated_tokens)
             step_count += 1
-            assert step_count < 128, "Engine did not converge"
+            assert step_count < max_steps, "Engine did not converge"
 
         return finished, env, max_pending_launches
 
@@ -1491,6 +1493,35 @@ class TestDynamicInferenceEngine:
         metadata = qd2_env.engine.context.mamba_metadata
         assert metadata.mamba_state_free_slot_count == metadata.max_requests
         assert torch.all(metadata.request_to_mamba_state_idx == -1)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_hybrid_mamba_long_cuda_graphs_matches_queue_depth_one(
+        self,
+    ) -> None:
+        """Queue-depth-two preserves long hybrid Mamba output with CUDA graphs."""
+        skip_if_mamba_sequence_packing_not_available("mamba")
+        qd1_finished, _, _ = self._run_async_overlap_hybrid_mamba_case(
+            queue_depth=1,
+            prompt_lengths=(16,),
+            num_tokens_to_generate=128,
+            num_cuda_graphs=4,
+            max_steps=256,
+        )
+        qd2_finished, qd2_env, qd2_max_pending = self._run_async_overlap_hybrid_mamba_case(
+            queue_depth=2,
+            prompt_lengths=(16,),
+            num_tokens_to_generate=128,
+            num_cuda_graphs=4,
+            max_steps=256,
+        )
+
+        assert qd2_finished == qd1_finished
+        assert qd2_max_pending > 0
+        assert qd2_env.engine.context.snapshot_pool.slot_count == 3
 
     @pytest.mark.internal
     @pytest.mark.skipif(

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -737,6 +737,8 @@ class TestDynamicInferenceEngine:
         assert env.engine.async_pipeline.pending_launch_count == 0
         assert env.engine.step_retirement_service.pending_count == 0
         assert env.engine.async_overlap_debug_counters.queue_depth == 1
+        assert env.engine.context.snapshot_pool.slot_count == 1
+        assert env.engine.controller._async_step_output_pool.depth == 2
         assert env.requests[0].generated_tokens == [
             69,
             85,
@@ -813,6 +815,8 @@ class TestDynamicInferenceEngine:
         assert env.engine.async_pipeline.pending_launch_count == 0
         assert env.engine.step_retirement_service.pending_count == 0
         assert env.engine.async_overlap_debug_counters.queue_depth == 2
+        assert env.engine.context.snapshot_pool.slot_count == 3
+        assert env.engine.controller._async_step_output_pool.depth == 3
         assert env.requests[0].generated_tokens == [
             69,
             85,

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -1120,6 +1120,159 @@ class TestDynamicInferenceEngine:
             assert len(summary["prompt_top_n"]) == 3
             assert len(summary["generated_top_n"]) == 4
 
+    def _run_async_overlap_speculative_case(
+        self, *, queue_depth: int, mtp_token: int
+    ) -> Tuple[Dict[int, List[int]], DynamicEngineTestEnv, int]:
+        """Run deterministic speculative generation and return completed outputs."""
+        test_config = DynamicEngineTestConfig(
+            num_requests=0,
+            min_prompt_length=4,
+            max_prompt_length=4,
+            num_tokens_to_generate=6,
+            num_speculative_tokens=2,
+            model_provider="gpt",
+            materialize_only_last_token_logits=False,
+            num_cuda_graphs=None,
+            cuda_graph_scope=[],
+            force_build_cuda_graphs=True,
+            context_max_requests=16,
+            context_max_tokens=512,
+            context_block_size_tokens=64,
+            position_embedding_type="none",
+            enable_async_overlap_architecture=True,
+            async_overlap_queue_depth=queue_depth,
+        )
+        env = self._build_test_env(test_config)
+        model = env.engine.controller.inference_wrapped_model.model
+        hidden_size = model.config.hidden_size
+
+        def deterministic_forward(*args, **kwargs):
+            tokens = kwargs.get("tokens", args[0] if args else kwargs.get("input_ids"))
+            batch, sequence = tokens.shape
+            logits = torch.zeros(
+                batch,
+                sequence,
+                test_config.vocab_size,
+                device=tokens.device,
+                dtype=torch.bfloat16,
+            )
+            logits[..., 0] = 100.0
+            model._decoder_hidden_states_cache = torch.zeros(
+                sequence, batch, hidden_size, device=tokens.device, dtype=torch.bfloat16
+            )
+            return logits
+
+        def deterministic_mtp(hidden_states, next_token_ids, position_ids, depth):
+            del next_token_ids, position_ids, depth
+            logits = torch.zeros(
+                hidden_states.size(0),
+                1,
+                test_config.vocab_size,
+                device=hidden_states.device,
+                dtype=torch.bfloat16,
+            )
+            logits[..., mtp_token] = 100.0
+            return hidden_states, logits
+
+        model.forward = deterministic_forward
+        model.compute_mtp_single_step = deterministic_mtp
+
+        for request_id in range(2):
+            env.engine._add_request(
+                DynamicInferenceRequest(
+                    request_id=request_id,
+                    prompt_tokens=torch.full(
+                        (4,), request_id, dtype=torch.int64, device="cuda"
+                    ),
+                    sampling_params=SamplingParams(
+                        num_tokens_to_generate=6,
+                        termination_id=test_config.vocab_size - 1,
+                        top_k=1,
+                    ),
+                    block_size_tokens=env.engine.context.block_size_tokens,
+                )
+            )
+
+        finished = {}
+        max_pending_launches = 0
+        step_count = 0
+        while env.engine.has_unfinished_requests():
+            result = env.engine.step_modern()
+            max_pending_launches = max(
+                max_pending_launches, env.engine.async_pipeline.pending_launch_count
+            )
+            for record in result["finished_request_records"]:
+                request = record.merge()
+                assert request.status == Status.COMPLETED
+                finished[int(request.request_id)] = list(request.generated_tokens)
+            step_count += 1
+            assert step_count < 64, "Engine did not converge"
+
+        return finished, env, max_pending_launches
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_speculative_mtp_matches_queue_depth_one(
+        self,
+    ) -> None:
+        """Queue-depth-two preserves speculative full-acceptance output ordering."""
+        qd1_finished, _, _ = self._run_async_overlap_speculative_case(
+            queue_depth=1, mtp_token=0
+        )
+        qd2_finished, qd2_env, qd2_max_pending = self._run_async_overlap_speculative_case(
+            queue_depth=2, mtp_token=0
+        )
+
+        assert qd2_finished == qd1_finished
+        assert qd2_finished == {0: [0] * 6, 1: [0] * 6}
+        assert qd2_max_pending > 0
+        counters = qd2_env.engine.async_overlap_debug_counters
+        assert "speculative" not in counters.fallback_or_queue_depth_one_reasons
+        assert counters.accepted_output_tokens == 12
+        assert counters.speculative_rejected_tokens == 0
+        first_decode_entry = qd2_env.engine.context.step_journal.get_committed_entry(1)
+        assert first_decode_entry is not None
+        assert dict(first_decode_entry.speculative_accepted_token_counts) == {
+            "0": 2,
+            "1": 2,
+        }
+        assert dict(first_decode_entry.kv_rewind_token_counts) == {"0": 0, "1": 0}
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    @torch.inference_mode()
+    def test_async_overlap_queue_depth_two_speculative_rejection_rolls_back(self) -> None:
+        """Queue-depth-two rejects speculative tokens without leaking context state."""
+        qd1_finished, _, _ = self._run_async_overlap_speculative_case(
+            queue_depth=1, mtp_token=50
+        )
+        qd2_finished, qd2_env, _ = self._run_async_overlap_speculative_case(
+            queue_depth=2, mtp_token=50
+        )
+
+        assert qd2_finished == qd1_finished
+        assert qd2_finished == {0: [0] * 6, 1: [0] * 6}
+        counters = qd2_env.engine.async_overlap_debug_counters
+        assert counters.accepted_output_tokens == 12
+        assert counters.speculative_rejected_tokens > 0
+        first_decode_entry = qd2_env.engine.context.step_journal.get_committed_entry(1)
+        assert first_decode_entry is not None
+        assert dict(first_decode_entry.speculative_accepted_token_counts) == {
+            "0": 0,
+            "1": 0,
+        }
+        assert dict(first_decode_entry.kv_rewind_token_counts) == {"0": 2, "1": 2}
+        context = qd2_env.engine.context
+        assert context.active_token_count == 0
+        assert context.total_request_count == 0
+        assert int(context.num_output_placeholders.sum().item()) == 0
+        assert torch.all(context.request_to_kv_block_ids == -1)
+
     @pytest.mark.skipif(
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )

--- a/tests/unit_tests/inference/engines/test_dynamic_step.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_step.py
@@ -172,6 +172,25 @@ def test_dynamic_async_pipeline_can_stage_one_launch_per_distributed_tick():
     assert pipeline.pending_launch_count == 0
 
 
+def test_dynamic_async_pipeline_suspend_barrier_retires_pending_launches():
+    engine = FakePipelineEngine(max_launches=2)
+    retirement_service = FakeRetirementService()
+    pipeline = DynamicAsyncPipeline(
+        engine=engine, retirement_service=retirement_service, queue_depth=2
+    )
+
+    first = asyncio.run(pipeline.step(max_forward_launches=1))
+    assert first is None
+    assert pipeline.pending_launch_count == 1
+
+    result = asyncio.run(pipeline.drain_for_suspend_barrier())
+
+    assert result is None
+    assert pipeline.pending_launch_count == 0
+    assert [call[1]["dynamic_step_id"] for call in engine.bookkeep_calls] == [0]
+    assert retirement_service.suspend_drains == 1
+
+
 def test_dynamic_async_pipeline_queue_depth_two_falls_back_when_lookahead_blocked():
     engine = FakePipelineEngine(max_launches=2, lookahead_allowed=False)
     pipeline = DynamicAsyncPipeline(

--- a/tests/unit_tests/inference/engines/test_dynamic_step.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_step.py
@@ -39,19 +39,29 @@ class FakeRetirementService:
 
 
 class FakePipelineEngine:
-    def __init__(self, *, max_launches=1, lookahead_allowed=True):
+    def __init__(
+        self, *, max_launches=1, lookahead_allowed=True, yield_after_forward_launch=False
+    ):
         self.context = SimpleNamespace(snapshot_pool=object())
         self.max_launches = max_launches
         self.lookahead_allowed = lookahead_allowed
+        self.yield_after_forward_launch = yield_after_forward_launch
+        self.event_log = []
         self.forward_calls = []
         self.bookkeep_calls = []
 
     async def async_forward(self):
         step_id = len(self.forward_calls)
+        self.event_log.append(("forward_start", step_id))
         self.forward_calls.append(step_id)
+        if self.yield_after_forward_launch:
+            self.event_log.append(("forward_yield", step_id))
+            await asyncio.sleep(0)
+            self.event_log.append(("forward_finish", step_id))
         return ({"step": step_id}, {"dynamic_step_id": step_id}, float(step_id))
 
     async def async_bookkeep(self, step_result, context_state, step_time):
+        self.event_log.append(("bookkeep", context_state["dynamic_step_id"]))
         self.bookkeep_calls.append((step_result, context_state, step_time))
         return {"retired_step": context_state["dynamic_step_id"]}
 
@@ -168,6 +178,27 @@ def test_dynamic_async_pipeline_records_overlap_metrics():
     assert counters.queue_depth_two_steps == 1
     assert counters.max_pending_launches_observed == 2
     assert counters.cpu_time_hidden_under_gpu_s >= 0.0
+
+
+def test_dynamic_async_pipeline_retires_older_step_while_lookahead_yields():
+    engine = FakePipelineEngine(max_launches=2, yield_after_forward_launch=True)
+    pipeline = DynamicAsyncPipeline(
+        engine=engine, retirement_service=FakeRetirementService(), queue_depth=2
+    )
+
+    result = asyncio.run(pipeline.step())
+
+    assert result == {"retired_step": 0}
+    assert engine.event_log == [
+        ("forward_start", 0),
+        ("forward_yield", 0),
+        ("forward_finish", 0),
+        ("forward_start", 1),
+        ("forward_yield", 1),
+        ("bookkeep", 0),
+        ("forward_finish", 1),
+    ]
+    assert pipeline.pending_launch_count == 1
 
 
 def test_dynamic_async_pipeline_can_stage_one_launch_per_distributed_tick():

--- a/tests/unit_tests/inference/engines/test_dynamic_step.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_step.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import dataclasses
+
+import pytest
+
+from megatron.core.inference.engines.dynamic_step import (
+    AsyncStepOutput,
+    DynamicStepContextSnapshot,
+    DynamicStepGpuLaunch,
+    DynamicStepId,
+    DynamicStepRequestPlan,
+    ResourceReservation,
+    SnapshotSlotHandle,
+    StepInputPlan,
+    StepJournalEntry,
+    StepRetirementResult,
+)
+
+
+def test_dynamic_step_records_are_frozen_and_copy_mutable_inputs():
+    step_id = DynamicStepId(3)
+    request_ids = ["request-0"]
+    placeholders = {"request-0": 1}
+
+    plan = DynamicStepRequestPlan(
+        step_id=step_id,
+        active_request_ids=request_ids,
+        decode_request_ids=request_ids,
+        placeholder_token_counts=placeholders,
+    )
+    request_ids.append("request-1")
+    placeholders["request-0"] = 5
+
+    assert plan.active_request_ids == ("request-0",)
+    assert plan.placeholder_token_counts["request-0"] == 1
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        plan.active_request_ids = ()
+    with pytest.raises(TypeError):
+        plan.placeholder_token_counts["request-2"] = 1
+
+
+def test_empty_step_contract_construction():
+    step_id = DynamicStepId(0)
+    request_plan = DynamicStepRequestPlan(step_id=step_id)
+    snapshot_handle = SnapshotSlotHandle(step_id=step_id, snapshot_slot_id=0)
+    input_plan = StepInputPlan(step_id=step_id, snapshot_slot_id=0)
+    context_snapshot = DynamicStepContextSnapshot(
+        step_id=step_id, snapshot_slot_id=0, request_plan=request_plan
+    )
+    gpu_launch = DynamicStepGpuLaunch(step_id=step_id, snapshot_slot_id=0)
+    step_output = AsyncStepOutput(step_id=step_id, snapshot_slot_id=0)
+    journal = StepJournalEntry(step_id=step_id, snapshot_slot_id=0)
+    retirement = StepRetirementResult(step_id=step_id, snapshot_slot_id=0)
+
+    assert request_plan.active_request_ids == ()
+    assert snapshot_handle.metadata_ready_event is None
+    assert input_plan.decode_input_destination_indices == ()
+    assert context_snapshot.request_plan is request_plan
+    assert gpu_launch.compute_done_event is None
+    assert step_output.output_ready_event is None
+    assert journal.resources_waiting_on_snapshot == ()
+    assert retirement.committed_request_ids == ()
+
+
+def test_decode_only_step_contract_construction():
+    step_id = DynamicStepId(1)
+    request_plan = DynamicStepRequestPlan(
+        step_id=step_id,
+        active_request_ids=("decode-0", "decode-1"),
+        decode_request_ids=("decode-0", "decode-1"),
+    )
+    input_plan = StepInputPlan(
+        step_id=step_id,
+        snapshot_slot_id=0,
+        request_ids=request_plan.active_request_ids,
+        decode_request_ids=request_plan.decode_request_ids,
+        decode_input_destination_indices=(0, 1),
+    )
+    reservation = ResourceReservation(
+        step_id=step_id,
+        request_id="decode-0",
+        snapshot_slot_id=0,
+        kv_block_ids=(7,),
+        prefix_cache_refcount_deltas={"block-7": 1},
+    )
+    journal = StepJournalEntry(
+        step_id=step_id,
+        snapshot_slot_id=0,
+        active_request_ids=request_plan.active_request_ids,
+        reserved_kv_blocks=reservation.kv_block_ids,
+        decode_input_destination_indices=input_plan.decode_input_destination_indices,
+        resources_waiting_on_snapshot=(reservation,),
+    )
+
+    assert request_plan.prefill_request_ids == ()
+    assert input_plan.decode_input_destination_indices == (0, 1)
+    assert reservation.kv_block_ids == (7,)
+    assert journal.resources_waiting_on_snapshot == (reservation,)
+
+
+def test_mixed_prefill_decode_step_contract_construction():
+    step_id = DynamicStepId(2)
+    request_plan = DynamicStepRequestPlan(
+        step_id=step_id,
+        active_request_ids=("decode-0", "prefill-0"),
+        decode_request_ids=("decode-0",),
+        prefill_request_ids=("prefill-0",),
+    )
+    input_plan = StepInputPlan(
+        step_id=step_id,
+        snapshot_slot_id=1,
+        request_ids=request_plan.active_request_ids,
+        decode_request_ids=request_plan.decode_request_ids,
+        prefill_request_ids=request_plan.prefill_request_ids,
+        decode_input_destination_indices=(0,),
+    )
+    context_snapshot = DynamicStepContextSnapshot(
+        step_id=step_id,
+        snapshot_slot_id=1,
+        request_plan=request_plan,
+        metadata_ready_event="metadata-ready",
+        input_ready_event="input-ready",
+    )
+    gpu_launch = DynamicStepGpuLaunch(
+        step_id=step_id,
+        snapshot_slot_id=1,
+        metadata_ready_event=context_snapshot.metadata_ready_event,
+        input_ready_event=input_plan.input_ready_event,
+        compute_done_event="compute-done",
+    )
+
+    assert request_plan.decode_request_ids == ("decode-0",)
+    assert request_plan.prefill_request_ids == ("prefill-0",)
+    assert context_snapshot.snapshot_slot_id == 1
+    assert gpu_launch.compute_done_event == "compute-done"
+
+
+def test_speculative_placeholder_step_contract_construction():
+    step_id = DynamicStepId(4)
+    request_plan = DynamicStepRequestPlan(
+        step_id=step_id,
+        active_request_ids=("spec-0",),
+        decode_request_ids=("spec-0",),
+        speculative_request_ids=("spec-0",),
+        placeholder_token_counts={"spec-0": 4},
+    )
+    reservation = ResourceReservation(
+        step_id=step_id,
+        request_id="spec-0",
+        snapshot_slot_id=2,
+        kv_block_ids=(10, 11),
+        mamba_slot_ids=(3,),
+    )
+    journal = StepJournalEntry(
+        step_id=step_id,
+        snapshot_slot_id=2,
+        active_request_ids=request_plan.active_request_ids,
+        placeholder_token_counts=request_plan.placeholder_token_counts,
+        reserved_kv_blocks=reservation.kv_block_ids,
+        reserved_mamba_slots=reservation.mamba_slot_ids,
+        resources_waiting_on_snapshot=(reservation,),
+    )
+    output = AsyncStepOutput(
+        step_id=step_id,
+        snapshot_slot_id=2,
+        compute_done_event="compute-done",
+        output_ready_event="output-ready",
+        accepted_token_counts_cpu=(2,),
+    )
+
+    assert request_plan.speculative_request_ids == ("spec-0",)
+    assert request_plan.placeholder_token_counts["spec-0"] == 4
+    assert journal.placeholder_token_counts["spec-0"] == 4
+    assert output.accepted_token_counts_cpu == (2,)
+
+
+@pytest.mark.parametrize("record_factory", [DynamicStepId])
+def test_step_ids_reject_negative_values(record_factory):
+    with pytest.raises(ValueError):
+        record_factory(-1)
+
+
+@pytest.mark.parametrize(
+    "record_factory",
+    [
+        lambda step_id: SnapshotSlotHandle(step_id=step_id, snapshot_slot_id=-1),
+        lambda step_id: StepInputPlan(step_id=step_id, snapshot_slot_id=-1),
+        lambda step_id: DynamicStepContextSnapshot(
+            step_id=step_id,
+            snapshot_slot_id=-1,
+            request_plan=DynamicStepRequestPlan(step_id=step_id),
+        ),
+        lambda step_id: DynamicStepGpuLaunch(step_id=step_id, snapshot_slot_id=-1),
+        lambda step_id: AsyncStepOutput(step_id=step_id, snapshot_slot_id=-1),
+        lambda step_id: ResourceReservation(
+            step_id=step_id, request_id="request-0", snapshot_slot_id=-1
+        ),
+        lambda step_id: StepJournalEntry(step_id=step_id, snapshot_slot_id=-1),
+        lambda step_id: StepRetirementResult(step_id=step_id, snapshot_slot_id=-1),
+    ],
+)
+def test_snapshot_owners_reject_negative_slot_ids(record_factory):
+    with pytest.raises(ValueError):
+        record_factory(DynamicStepId(0))

--- a/tests/unit_tests/inference/engines/test_dynamic_step.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_step.py
@@ -94,6 +94,42 @@ def test_dynamic_async_pipeline_drains_before_shutdown_hooks():
     assert retirement_service.reused_request_ids == [7]
 
 
+def test_dynamic_async_pipeline_allows_unrelated_request_admission_with_pending_launch():
+    engine = FakePipelineEngine()
+    retirement_service = FakeRetirementService()
+    pipeline = DynamicAsyncPipeline(
+        engine=engine, retirement_service=retirement_service, queue_depth=2
+    )
+    pipeline.in_flight_launches.append(
+        (
+            {"active_request_ids": [1], "finished_request_ids": []},
+            {"dynamic_step_id": 0},
+            0.0,
+        )
+    )
+
+    pipeline.drain_for_request_reuse(2)
+
+    assert retirement_service.reused_request_ids == [2]
+
+
+def test_dynamic_async_pipeline_blocks_reused_request_admission_with_pending_launch():
+    engine = FakePipelineEngine()
+    pipeline = DynamicAsyncPipeline(
+        engine=engine, retirement_service=FakeRetirementService(), queue_depth=2
+    )
+    pipeline.in_flight_launches.append(
+        (
+            {"active_request_ids": [1], "finished_request_ids": []},
+            {"dynamic_step_id": 0},
+            0.0,
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="Cannot reuse request 1"):
+        pipeline.drain_for_request_reuse(1)
+
+
 def test_dynamic_async_pipeline_queue_depth_two_launches_before_retirement():
     engine = FakePipelineEngine(max_launches=3)
     pipeline = DynamicAsyncPipeline(

--- a/tests/unit_tests/inference/engines/test_dynamic_step.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_step.py
@@ -148,6 +148,30 @@ def test_dynamic_async_pipeline_queue_depth_two_launches_before_retirement():
     assert pipeline.pending_launch_count == 0
 
 
+def test_dynamic_async_pipeline_can_stage_one_launch_per_distributed_tick():
+    engine = FakePipelineEngine(max_launches=3)
+    pipeline = DynamicAsyncPipeline(
+        engine=engine, retirement_service=FakeRetirementService(), queue_depth=2
+    )
+
+    assert pipeline.planned_launch_count(max_forward_launches=1) == 1
+    first = asyncio.run(pipeline.step(max_forward_launches=1))
+    assert first is None
+    assert engine.forward_calls == [0]
+    assert pipeline.pending_launch_count == 1
+
+    assert pipeline.planned_launch_count(max_forward_launches=1) == 1
+    second = asyncio.run(pipeline.step(max_forward_launches=1))
+    assert second == {"retired_step": 0}
+    assert engine.forward_calls == [0, 1]
+    assert pipeline.pending_launch_count == 1
+
+    third = asyncio.run(pipeline.step(max_forward_launches=0))
+    assert third == {"retired_step": 1}
+    assert engine.forward_calls == [0, 1]
+    assert pipeline.pending_launch_count == 0
+
+
 def test_dynamic_async_pipeline_queue_depth_two_falls_back_when_lookahead_blocked():
     engine = FakePipelineEngine(max_launches=2, lookahead_allowed=False)
     pipeline = DynamicAsyncPipeline(

--- a/tests/unit_tests/inference/engines/test_dynamic_step.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_step.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
+import asyncio
 import dataclasses
+from types import SimpleNamespace
 
 import pytest
 
 from megatron.core.inference.engines.dynamic_step import (
     AsyncStepOutput,
+    DynamicAsyncPipeline,
     DynamicStepContextSnapshot,
     DynamicStepGpuLaunch,
     DynamicStepId,
@@ -17,6 +20,70 @@ from megatron.core.inference.engines.dynamic_step import (
     StepRetirementResult,
     assert_snapshot_gpu_view_bound,
 )
+
+
+class FakeRetirementService:
+    def __init__(self):
+        self.shutdown_drains = 0
+        self.suspend_drains = 0
+        self.reused_request_ids = []
+
+    def drain_for_shutdown(self):
+        self.shutdown_drains += 1
+
+    def drain_for_suspend(self):
+        self.suspend_drains += 1
+
+    def drain_for_request_reuse(self, request_id):
+        self.reused_request_ids.append(request_id)
+
+
+class FakePipelineEngine:
+    def __init__(self):
+        self.context = SimpleNamespace(snapshot_pool=object())
+        self.forward_calls = []
+        self.bookkeep_calls = []
+
+    async def async_forward(self):
+        step_id = len(self.forward_calls)
+        self.forward_calls.append(step_id)
+        return ({"step": step_id}, {"dynamic_step_id": step_id}, float(step_id))
+
+    async def async_bookkeep(self, step_result, context_state, step_time):
+        self.bookkeep_calls.append((step_result, context_state, step_time))
+        return {"retired_step": context_state["dynamic_step_id"]}
+
+
+def test_dynamic_async_pipeline_queue_depth_one_retires_immediately():
+    engine = FakePipelineEngine()
+    retirement_service = FakeRetirementService()
+    pipeline = DynamicAsyncPipeline(
+        engine=engine, retirement_service=retirement_service, queue_depth=1
+    )
+
+    result = asyncio.run(pipeline.step())
+
+    assert result == {"retired_step": 0}
+    assert engine.forward_calls == [0]
+    assert [call[1]["dynamic_step_id"] for call in engine.bookkeep_calls] == [0]
+    assert pipeline.pending_launch_count == 0
+    assert pipeline.snapshot_pool is engine.context.snapshot_pool
+
+
+def test_dynamic_async_pipeline_drains_before_shutdown_hooks():
+    engine = FakePipelineEngine()
+    retirement_service = FakeRetirementService()
+    pipeline = DynamicAsyncPipeline(
+        engine=engine, retirement_service=retirement_service, queue_depth=1
+    )
+
+    pipeline.drain_for_shutdown()
+    pipeline.drain_for_suspend()
+    pipeline.drain_for_request_reuse(7)
+
+    assert retirement_service.shutdown_drains == 1
+    assert retirement_service.suspend_drains == 1
+    assert retirement_service.reused_request_ids == [7]
 
 
 def test_dynamic_step_records_are_frozen_and_copy_mutable_inputs():

--- a/tests/unit_tests/inference/engines/test_dynamic_step.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_step.py
@@ -148,6 +148,28 @@ def test_dynamic_async_pipeline_queue_depth_two_launches_before_retirement():
     assert pipeline.pending_launch_count == 0
 
 
+def test_dynamic_async_pipeline_records_overlap_metrics():
+    engine = FakePipelineEngine(max_launches=2)
+    engine.async_overlap_debug_counters = SimpleNamespace(
+        queue_depth_one_steps=0,
+        queue_depth_two_steps=0,
+        max_pending_launches_observed=0,
+        cpu_time_hidden_under_gpu_s=0.0,
+    )
+    pipeline = DynamicAsyncPipeline(
+        engine=engine, retirement_service=FakeRetirementService(), queue_depth=2
+    )
+
+    result = asyncio.run(pipeline.step())
+
+    assert result == {"retired_step": 0}
+    counters = engine.async_overlap_debug_counters
+    assert counters.queue_depth_one_steps == 0
+    assert counters.queue_depth_two_steps == 1
+    assert counters.max_pending_launches_observed == 2
+    assert counters.cpu_time_hidden_under_gpu_s >= 0.0
+
+
 def test_dynamic_async_pipeline_can_stage_one_launch_per_distributed_tick():
     engine = FakePipelineEngine(max_launches=3)
     pipeline = DynamicAsyncPipeline(

--- a/tests/unit_tests/inference/engines/test_dynamic_step.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_step.py
@@ -15,6 +15,7 @@ from megatron.core.inference.engines.dynamic_step import (
     StepInputPlan,
     StepJournalEntry,
     StepRetirementResult,
+    assert_snapshot_gpu_view_bound,
 )
 
 
@@ -128,12 +129,30 @@ def test_mixed_prefill_decode_step_contract_construction():
         metadata_ready_event=context_snapshot.metadata_ready_event,
         input_ready_event=input_plan.input_ready_event,
         compute_done_event="compute-done",
+        gpu_view=context_snapshot.gpu_view,
     )
 
     assert request_plan.decode_request_ids == ("decode-0",)
     assert request_plan.prefill_request_ids == ("prefill-0",)
     assert context_snapshot.snapshot_slot_id == 1
     assert gpu_launch.compute_done_event == "compute-done"
+
+
+def test_snapshot_gpu_view_debug_guard_detects_mutable_context_reads():
+    step_id = DynamicStepId(8)
+    snapshot_view = object()
+    live_view = object()
+    snapshot = DynamicStepContextSnapshot(
+        step_id=step_id,
+        snapshot_slot_id=0,
+        request_plan=DynamicStepRequestPlan(step_id=step_id),
+        gpu_view=snapshot_view,
+    )
+
+    assert_snapshot_gpu_view_bound(snapshot, live_view, debug_enabled=False)
+    assert_snapshot_gpu_view_bound(snapshot, snapshot_view, debug_enabled=True)
+    with pytest.raises(RuntimeError, match="prepared snapshot"):
+        assert_snapshot_gpu_view_bound(snapshot, live_view, debug_enabled=True)
 
 
 def test_speculative_placeholder_step_contract_construction():

--- a/tests/unit_tests/inference/engines/test_dynamic_step.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_step.py
@@ -39,8 +39,10 @@ class FakeRetirementService:
 
 
 class FakePipelineEngine:
-    def __init__(self):
+    def __init__(self, *, max_launches=1, lookahead_allowed=True):
         self.context = SimpleNamespace(snapshot_pool=object())
+        self.max_launches = max_launches
+        self.lookahead_allowed = lookahead_allowed
         self.forward_calls = []
         self.bookkeep_calls = []
 
@@ -52,6 +54,12 @@ class FakePipelineEngine:
     async def async_bookkeep(self, step_result, context_state, step_time):
         self.bookkeep_calls.append((step_result, context_state, step_time))
         return {"retired_step": context_state["dynamic_step_id"]}
+
+    def has_async_overlap_launch_work(self):
+        return len(self.forward_calls) < self.max_launches
+
+    def can_launch_async_overlap_lookahead(self):
+        return self.lookahead_allowed
 
 
 def test_dynamic_async_pipeline_queue_depth_one_retires_immediately():
@@ -84,6 +92,40 @@ def test_dynamic_async_pipeline_drains_before_shutdown_hooks():
     assert retirement_service.shutdown_drains == 1
     assert retirement_service.suspend_drains == 1
     assert retirement_service.reused_request_ids == [7]
+
+
+def test_dynamic_async_pipeline_queue_depth_two_launches_before_retirement():
+    engine = FakePipelineEngine(max_launches=3)
+    pipeline = DynamicAsyncPipeline(
+        engine=engine, retirement_service=FakeRetirementService(), queue_depth=2
+    )
+
+    first = asyncio.run(pipeline.step())
+    second = asyncio.run(pipeline.step())
+    final = asyncio.run(pipeline.step())
+
+    assert first == {"retired_step": 0}
+    assert second == {"retired_step": 1}
+    assert final == {"retired_step": 2}
+    assert engine.forward_calls == [0, 1, 2]
+    assert [call[1]["dynamic_step_id"] for call in engine.bookkeep_calls] == [0, 1, 2]
+    assert pipeline.pending_launch_count == 0
+
+
+def test_dynamic_async_pipeline_queue_depth_two_falls_back_when_lookahead_blocked():
+    engine = FakePipelineEngine(max_launches=2, lookahead_allowed=False)
+    pipeline = DynamicAsyncPipeline(
+        engine=engine, retirement_service=FakeRetirementService(), queue_depth=2
+    )
+
+    first = asyncio.run(pipeline.step())
+    second = asyncio.run(pipeline.step())
+
+    assert first == {"retired_step": 0}
+    assert second == {"retired_step": 1}
+    assert engine.forward_calls == [0, 1]
+    assert [call[1]["dynamic_step_id"] for call in engine.bookkeep_calls] == [0, 1]
+    assert pipeline.pending_launch_count == 0
 
 
 def test_dynamic_step_records_are_frozen_and_copy_mutable_inputs():

--- a/tests/unit_tests/inference/engines/test_dynamic_step.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_step.py
@@ -56,7 +56,10 @@ def test_empty_step_contract_construction():
 
     assert request_plan.active_request_ids == ()
     assert snapshot_handle.metadata_ready_event is None
+    assert input_plan.decode_request_slots == ()
     assert input_plan.decode_input_destination_indices == ()
+    assert input_plan.prefill_prompt_token_ranges == ()
+    assert input_plan.speculative_width == 0
     assert context_snapshot.request_plan is request_plan
     assert gpu_launch.compute_done_event is None
     assert step_output.output_ready_event is None
@@ -75,6 +78,7 @@ def test_decode_only_step_contract_construction():
         step_id=step_id,
         snapshot_slot_id=0,
         request_ids=request_plan.active_request_ids,
+        decode_request_slots=(0, 1),
         decode_request_ids=request_plan.decode_request_ids,
         decode_input_destination_indices=(0, 1),
     )
@@ -95,6 +99,7 @@ def test_decode_only_step_contract_construction():
     )
 
     assert request_plan.prefill_request_ids == ()
+    assert input_plan.decode_request_slots == (0, 1)
     assert input_plan.decode_input_destination_indices == (0, 1)
     assert reservation.kv_block_ids == (7,)
     assert journal.resources_waiting_on_snapshot == (reservation,)
@@ -112,9 +117,11 @@ def test_mixed_prefill_decode_step_contract_construction():
         step_id=step_id,
         snapshot_slot_id=1,
         request_ids=request_plan.active_request_ids,
+        decode_request_slots=(0,),
         decode_request_ids=request_plan.decode_request_ids,
         prefill_request_ids=request_plan.prefill_request_ids,
         decode_input_destination_indices=(0,),
+        prefill_prompt_token_ranges=((1, 4),),
     )
     context_snapshot = DynamicStepContextSnapshot(
         step_id=step_id,
@@ -134,6 +141,7 @@ def test_mixed_prefill_decode_step_contract_construction():
 
     assert request_plan.decode_request_ids == ("decode-0",)
     assert request_plan.prefill_request_ids == ("prefill-0",)
+    assert input_plan.prefill_prompt_token_ranges == ((1, 4),)
     assert context_snapshot.snapshot_slot_id == 1
     assert gpu_launch.compute_done_event == "compute-done"
 
@@ -192,6 +200,25 @@ def test_speculative_placeholder_step_contract_construction():
     assert request_plan.placeholder_token_counts["spec-0"] == 4
     assert journal.placeholder_token_counts["spec-0"] == 4
     assert output.accepted_token_counts_cpu == (2,)
+
+
+def test_step_input_plan_rejects_mismatched_decode_destinations():
+    with pytest.raises(ValueError, match="same length"):
+        StepInputPlan(
+            step_id=DynamicStepId(5),
+            snapshot_slot_id=0,
+            decode_request_slots=(0, 1),
+            decode_input_destination_indices=(0,),
+        )
+
+
+def test_step_input_plan_rejects_invalid_prefill_ranges():
+    with pytest.raises(ValueError, match="invalid token range"):
+        StepInputPlan(
+            step_id=DynamicStepId(6),
+            snapshot_slot_id=0,
+            prefill_prompt_token_ranges=((3, 2),),
+        )
 
 
 @pytest.mark.parametrize("record_factory", [DynamicStepId])

--- a/tests/unit_tests/inference/engines/test_step_retirement.py
+++ b/tests/unit_tests/inference/engines/test_step_retirement.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.core.inference.engines.step_retirement import StepRetirementService
+
+
+class FakeContext:
+    enable_prefix_caching = False
+
+    def __init__(self):
+        self.commit_calls = []
+        self.rollback_reasons = []
+
+    def commit_step_journal(self, step_id):
+        self.commit_calls.append(step_id)
+
+    def rollback_all_open_step_journals(self, *, reason):
+        self.rollback_reasons.append(reason)
+
+
+class FakeEngine:
+    def __init__(self, *, queue_depth=1):
+        self.context = FakeContext()
+        self.async_overlap_queue_depth = queue_depth
+        self.async_overlap_debug_counters = SimpleNamespace()
+        self._current_dynamic_step_id = -1
+        self.failed_request_ids = []
+        self.use_coordinator = False
+        self.logging_step_interval = 0
+        self.metrics_writer = None
+
+    def _step_nvtx_label(self, name, step_id=None):
+        del step_id
+        return name
+
+
+def _context_state(step_id):
+    return {"dynamic_step_id": step_id, "kv_stats": None}
+
+
+def test_submit_step_retires_queue_depth_one_immediately():
+    engine = FakeEngine(queue_depth=1)
+    service = StepRetirementService(engine)
+
+    result = service.submit_step(None, _context_state(0), 0.0)
+
+    assert result["active_request_ids"] == []
+    assert result["finished_request_records"] == []
+    assert service.pending_count == 0
+    assert engine.context.commit_calls == [0]
+    assert engine.async_overlap_debug_counters.retirement_backlog == 0
+    assert engine.async_overlap_debug_counters.max_retirement_backlog == 1
+
+
+def test_retirement_backpressure_limits_pending_items():
+    engine = FakeEngine(queue_depth=1)
+    service = StepRetirementService(engine)
+
+    service.enqueue_step(None, _context_state(0), 0.0)
+
+    assert service.pending_count == 1
+    assert engine.async_overlap_debug_counters.retirement_backlog == 1
+    with pytest.raises(RuntimeError, match="backlog is full"):
+        service.enqueue_step(None, _context_state(1), 0.0)
+
+    result = service.drain_next()
+
+    assert result["finished_request_records"] == []
+    assert service.pending_count == 0
+    assert engine.context.commit_calls == [0]
+
+
+def test_shutdown_drain_retires_pending_before_rollback():
+    engine = FakeEngine(queue_depth=1)
+    service = StepRetirementService(engine)
+    service.enqueue_step(None, _context_state(0), 0.0)
+
+    service.drain_for_shutdown()
+
+    assert service.pending_count == 0
+    assert engine.context.commit_calls == [0]
+    assert engine.context.rollback_reasons == ["shutdown_drain"]

--- a/tests/unit_tests/inference/test_inference_config.py
+++ b/tests/unit_tests/inference/test_inference_config.py
@@ -18,13 +18,17 @@ class TestInferenceConfig:
         transformer_config_fields = set(dataclasses.fields(TransformerConfig))
         assert len(dynamic_inference_config_fields.intersection(transformer_config_fields)) == 0
 
-    def test_async_overlap_rollout_defaults_are_conservative(self):
+    def test_async_overlap_defaults_enable_queue_depth_two(self):
         config = InferenceConfig()
 
-        assert config.enable_async_overlap_architecture is False
-        assert config.async_overlap_queue_depth == 1
+        assert config.enable_async_overlap_architecture is True
+        assert config.async_overlap_queue_depth == 2
         assert config.async_overlap_debug_checks is False
 
     def test_async_overlap_queue_depth_must_be_positive(self):
         with pytest.raises(ValueError, match="async_overlap_queue_depth"):
             InferenceConfig(async_overlap_queue_depth=0)
+
+    def test_async_overlap_queue_depth_above_two_is_rejected_until_validated(self):
+        with pytest.raises(ValueError, match="async_overlap_queue_depth > 2"):
+            InferenceConfig(async_overlap_queue_depth=3)

--- a/tests/unit_tests/inference/test_inference_config.py
+++ b/tests/unit_tests/inference/test_inference_config.py
@@ -2,6 +2,8 @@
 
 import dataclasses
 
+import pytest
+
 from megatron.core.inference.config import InferenceConfig
 from megatron.core.transformer.transformer_config import TransformerConfig
 
@@ -15,3 +17,14 @@ class TestInferenceConfig:
         dynamic_inference_config_fields = set(dataclasses.fields(InferenceConfig))
         transformer_config_fields = set(dataclasses.fields(TransformerConfig))
         assert len(dynamic_inference_config_fields.intersection(transformer_config_fields)) == 0
+
+    def test_async_overlap_rollout_defaults_are_conservative(self):
+        config = InferenceConfig()
+
+        assert config.enable_async_overlap_architecture is False
+        assert config.async_overlap_queue_depth == 1
+        assert config.async_overlap_debug_checks is False
+
+    def test_async_overlap_queue_depth_must_be_positive(self):
+        with pytest.raises(ValueError, match="async_overlap_queue_depth"):
+            InferenceConfig(async_overlap_queue_depth=0)

--- a/tests/unit_tests/inference/test_inference_config.py
+++ b/tests/unit_tests/inference/test_inference_config.py
@@ -21,7 +21,6 @@ class TestInferenceConfig:
     def test_async_overlap_defaults_enable_queue_depth_two(self):
         config = InferenceConfig()
 
-        assert config.enable_async_overlap_architecture is True
         assert config.async_overlap_queue_depth == 2
         assert config.async_overlap_debug_checks is False
 

--- a/tests/unit_tests/inference/text_generation_controllers/test_async_output.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_async_output.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.inference.text_generation_controllers.async_output import (
+    AsyncStepOutput,
+    AsyncStepOutputPool,
+)
+
+
+def _require_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for async output copy tests")
+
+
+def test_async_step_output_requires_result_before_reading_cpu_views():
+    _require_cuda()
+    pool = AsyncStepOutputPool(max_requests=4, num_speculative_tokens=2, depth=1)
+    sampled_tokens_cuda = torch.arange(4, dtype=torch.int64, device="cuda")
+    sampled_mtp_tokens_cuda = torch.arange(8, dtype=torch.int64, device="cuda").reshape(2, 4)
+    accepted_tokens_cuda = torch.arange(8, dtype=torch.int64, device="cuda").reshape(4, 2)
+    accepted_token_counts_cuda = torch.arange(4, dtype=torch.int64, device="cuda")
+
+    output = AsyncStepOutput.begin_copy(
+        pool=pool,
+        active_request_count=4,
+        sampled_tokens_cuda=sampled_tokens_cuda,
+        sampled_mtp_tokens_cuda=sampled_mtp_tokens_cuda,
+        accepted_tokens_cuda=accepted_tokens_cuda,
+        accepted_token_counts_cuda=accepted_token_counts_cuda,
+    )
+
+    with pytest.raises(RuntimeError, match="result"):
+        _ = output.sampled_tokens_cpu
+
+    result = output.result()
+
+    assert result.sampled_tokens_cpu.tolist() == [0, 1, 2, 3]
+    assert result.sampled_mtp_tokens_cpu.tolist() == [[0, 1, 2, 3], [4, 5, 6, 7]]
+    assert result.accepted_tokens_cpu.tolist() == [[0, 1], [2, 3], [4, 5], [6, 7]]
+    assert result.accepted_token_counts_cpu.tolist() == [0, 1, 2, 3]
+    assert result.sampled_tokens_cpu.is_pinned()
+    assert result.output_ready_event.query()
+
+
+def test_async_step_output_waits_for_compute_stream_before_copying():
+    _require_cuda()
+    pool = AsyncStepOutputPool(max_requests=4, num_speculative_tokens=0, depth=1)
+    sampled_tokens_cuda = torch.empty(4, dtype=torch.int64, device="cuda")
+    expected = torch.tensor([11, 12, 13, 14], dtype=torch.int64, device="cuda")
+
+    compute_stream = torch.cuda.Stream()
+    with torch.cuda.stream(compute_stream):
+        sampled_tokens_cuda.copy_(expected)
+
+    output = AsyncStepOutput.begin_copy(
+        pool=pool,
+        active_request_count=4,
+        sampled_tokens_cuda=sampled_tokens_cuda,
+        compute_stream=compute_stream,
+    )
+    result = output.result()
+
+    assert result.sampled_tokens_cpu.tolist() == [11, 12, 13, 14]
+
+    # The single-slot pool should be reusable after result() retires the output.
+    second_output = AsyncStepOutput.begin_copy(
+        pool=pool,
+        active_request_count=4,
+        sampled_tokens_cuda=sampled_tokens_cuda,
+    )
+    assert second_output.result().sampled_tokens_cpu.tolist() == [11, 12, 13, 14]

--- a/tools/run_dynamic_text_generation_server.py
+++ b/tools/run_dynamic_text_generation_server.py
@@ -10,7 +10,7 @@ from megatron.core.inference.text_generation_server.dynamic_text_gen_server impo
     start_text_gen_server,
     stop_text_gen_server,
 )
-from megatron.core.utils import trace_async_exceptions
+from megatron.core.utils import configure_nvtx_profiling, trace_async_exceptions
 from megatron.inference.utils import add_inference_args, get_dynamic_inference_engine
 from megatron.post_training.arguments import add_modelopt_args
 from megatron.training.arguments import parse_and_validate_args
@@ -81,6 +81,13 @@ if __name__ == "__main__":
             args_defaults={'no_load_rng': True, 'no_load_optim': True},
         )
         initialize_megatron()
+
+        # Match training's NVTX gating (training.py only flips this when both
+        # --profile and --nvtx-ranges are set). Otherwise the engine-side
+        # nvtx_range_push labels (bookkeeping, Decode, _ep_establish_consensus,
+        # etc.) are no-ops and the inter-step gap is unattributable in nsys.
+        if args.profile and args.nvtx_ranges:
+            configure_nvtx_profiling(True)
 
         # Enable return_log_probs to allow prompt logprobs computation for echo=True requests
         # This sets materialize_only_last_token_logits=False in the inference context,

--- a/tools/run_dynamic_text_generation_server.py
+++ b/tools/run_dynamic_text_generation_server.py
@@ -13,7 +13,7 @@ from megatron.core.inference.text_generation_server.dynamic_text_gen_server impo
 from megatron.core.utils import trace_async_exceptions
 from megatron.inference.utils import add_inference_args, get_dynamic_inference_engine
 from megatron.post_training.arguments import add_modelopt_args
-from megatron.training import get_args
+from megatron.training.arguments import parse_and_validate_args
 from megatron.training.initialize import initialize_megatron
 
 
@@ -76,15 +76,15 @@ async def run_text_generation_server(
 
 if __name__ == "__main__":
     with torch.inference_mode():
-        initialize_megatron(
+        args = parse_and_validate_args(
             extra_args_provider=add_text_generation_server_args,
             args_defaults={'no_load_rng': True, 'no_load_optim': True},
         )
+        initialize_megatron()
 
         # Enable return_log_probs to allow prompt logprobs computation for echo=True requests
         # This sets materialize_only_last_token_logits=False in the inference context,
         # which is required for lm-eval compatibility (loglikelihood evaluation tasks)
-        args = get_args()
         args.return_log_probs = True
 
         engine = get_dynamic_inference_engine()


### PR DESCRIPTION
## Summary

This draft PR builds the `context-cpu` async scheduling stack for dynamic inference. The goal is to overlap GPU forward/sampling work with CPU-side scheduling, bookkeeping, output retirement, and response work.

The stack currently includes:

- explicit dynamic step IDs and NVTX ranges for overlap analysis
- queue-depth configuration and async overlap debug counters
- typed step contracts, transaction journals, and request ledgers
- async output-copy buffers and ordered step retirement
- fixed-address GPU bookkeeping snapshots for CUDA graph compatibility
- GPU-resident sampled-token handoff and GPU-side decode input preparation
- queue-depth-one and queue-depth-two dynamic engine pipeline paths
- support work for chunked prefill, logprobs/top-n logprobs, speculative MTP, hybrid Mamba, distributed coordination, suspend/resume, and rollback paths

## Current Status

This PR is still draft. The 37-commit implementation stack is present, and a follow-up correctness fix now makes queue-depth two match queue-depth one on the hybrid-100m CUDA-graph repro. The remaining blocker is performance/overlap: Nsight still shows 0 ms of GPU-kernel overlap for the target CPU retirement/post-processing/detokenization ranges, and qd2 is still slower than qd1 on the repro.

The next fix is to complete the phase split so step N CPU context bookkeeping and ordered retirement can run while step N+1 GPU work is active.

## Validation Notes

Focused unit tests were run while building the stack. The latest local checks include:

- 4-rank long hybrid/Mamba CUDA-graph qd1 vs qd2 parity test: passed
- dynamic async pipeline unit tests: passed
- hybrid-100m benchmark, CUDA graphs enabled, qd1 vs qd2 generated token comparison: passed with 0 mismatches across 16 requests
- qd1 throughput: 1897.7 tok/s
- qd2 throughput: 1825.9 tok/s
- qd2 delta: -3.8%
- target CPU/GPU kernel overlap: failed; target ranges remain at 0.000 ms overlap
