### PR TITLE
Hybrid recipe layer config schema

### DIFF
--- a/megatron/core/models/hybrid/__init__.py
+++ b/megatron/core/models/hybrid/__init__.py
@@ -1,1 +1,27 @@
 # Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.models.hybrid.common_layer_config import CommonLayerConfig
+from megatron.core.models.hybrid.layer_configs import (
+    AttentionLayerConfig,
+    CrossEntropyLayerConfig,
+    DSALayerConfig,
+    EmbeddingLayerConfig,
+    GDNLayerConfig,
+    LayerConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+    MoELayerConfig,
+)
+
+__all__ = [
+    "AttentionLayerConfig",
+    "CommonLayerConfig",
+    "CrossEntropyLayerConfig",
+    "DSALayerConfig",
+    "EmbeddingLayerConfig",
+    "GDNLayerConfig",
+    "LayerConfig",
+    "MambaLayerConfig",
+    "MLPLayerConfig",
+    "MoELayerConfig",
+]

--- a/megatron/core/models/hybrid/common_layer_config.py
+++ b/megatron/core/models/hybrid/common_layer_config.py
@@ -1,0 +1,380 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Common (model-wide) configuration for the HybridModel Python DSL.
+
+:class:`CommonLayerConfig` is a focused dataclass exposing the fields that
+typical hybrid-model authors actually customise per-model. It is *not* a
+subclass of :class:`TransformerConfig`; instead, it normalises a small set of
+Python-native fields (e.g. ``mixed_precision_dtype=torch.bfloat16`` rather
+than the ``bf16: bool`` / ``fp16: bool`` pair) and converts to a full
+:class:`TransformerConfig` only at layer-construction time.
+
+All fields here are *defaults* shared by at least two decoder layer families
+in the HybridModel stack. Per-layer :class:`LayerConfig` instances may
+override or augment via either:
+
+- :meth:`update`: a sibling :class:`CommonLayerConfig` produced by
+  :func:`dataclasses.replace`. Use this for layer-class-wide overrides
+  (e.g. an MoE-specific common with a different ``ffn_hidden_size``).
+- per-layer fields on the layer-specific config (e.g.
+  :class:`MambaLayerConfig.head_dim`).
+
+Anything derivable from the model architecture (``num_layers`` from pattern
+length, ``num_query_groups`` from ``num_attention_heads``,
+``kv_channels`` from ``hidden_size // num_attention_heads``,
+``mamba_num_heads`` from ``hidden_size * expand // mamba_head_dim``) does
+**not** appear here — it is computed at compile time.
+"""
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict
+
+import torch
+
+from megatron.core.activations import squared_relu
+
+_ACTIVATION_BY_NAME: Dict[str, Callable] = {
+    "gelu": torch.nn.functional.gelu,
+    "relu": torch.nn.functional.relu,
+    "silu": torch.nn.functional.silu,
+    "swish": torch.nn.functional.silu,
+    "swiglu": torch.nn.functional.silu,  # SwiGLU = SiLU + GLU; gated_linear_unit=True separately
+    "squared_relu": squared_relu,
+}
+
+
+def _require_torch_dtype(value: Any, field_name: str) -> torch.dtype:
+    if not isinstance(value, torch.dtype):
+        raise TypeError(f"{field_name} must be a torch.dtype, got {value!r}.")
+    return value
+
+
+def _resolve_activation(name_or_callable: Any) -> Callable:
+    if callable(name_or_callable):
+        return name_or_callable
+    try:
+        return _ACTIVATION_BY_NAME[name_or_callable]
+    except KeyError as e:
+        raise ValueError(
+            f"Unknown activation {name_or_callable!r}; expected a callable or "
+            f"one of {sorted(_ACTIVATION_BY_NAME)}."
+        ) from e
+
+
+# --- the config itself ----------------------------------------------------
+
+
+@dataclass
+class CommonLayerConfig:
+    """Model-wide defaults shared across every layer in a HybridModel recipe."""
+
+    # === Architecture ===
+    hidden_size: int = 0
+    """Layer hidden size. Required (must be set by the recipe)."""
+
+    ffn_hidden_size: int | None = None
+    """MLP intermediate size. If None, ``TransformerConfig`` derives ``4 * hidden_size``."""
+
+    # === Precision ===
+    mixed_precision_dtype: torch.dtype = torch.float32
+    """Mixed-precision compute dtype. One of ``torch.float32``, ``torch.float16``,
+    ``torch.bfloat16``."""
+
+    params_dtype: torch.dtype | None = None
+    """Parameter storage dtype. ``None`` follows :attr:`mixed_precision_dtype`."""
+
+    first_last_layers_bf16: bool = False
+    """Retain the first and last N TransformerBlocks in BF16 instead of FP8."""
+
+    # === Parallelism (layer-level only) ===
+    # Model-level parallelism sizes (TP/PP/CP/EP/ETP) live on
+    # :class:`HybridModelConfig`, not here — they're job-/model-level
+    # concerns and can't actually vary per-layer in the current
+    # implementation. ``sequence_parallel`` stays here because it is a
+    # per-layer behaviour toggle for layer norms / dropout.
+    sequence_parallel: bool = False
+    """Enable sequence-parallel layer norms / dropout (paired with TP)."""
+
+    # === Initialisation ===
+    init_method_std: float = 0.02
+    """Standard deviation for the default normal-init method."""
+
+    perform_initialization: bool = True
+    """If False, skip weight init at construction (useful when loading checkpoints)."""
+
+    use_cpu_initialization: bool = False
+    """Initialise on CPU instead of GPU (slower but TP-deterministic)."""
+
+    # === Norms ===
+    normalization: str = "LayerNorm"
+    """``"LayerNorm"`` or ``"RMSNorm"``."""
+
+    layernorm_epsilon: float = 1e-5
+    """Epsilon for normalisation layers."""
+
+    layernorm_zero_centered_gamma: bool = False
+    """Centre LayerNorm gamma around 0 for numerical stability."""
+
+    # === Bias / activation ===
+    add_bias_linear: bool = True
+    """Bias in supported projection / MLP / expert linear layers."""
+
+    gated_linear_unit: bool = False
+    """Use GLU on the first MLP linear layer."""
+
+    activation_func: str = "gelu"
+    """MLP activation function name (looked up in :data:`_ACTIVATION_BY_NAME`)."""
+
+    # === Dropout ===
+    hidden_dropout: float = 0.0
+    """Dropout on the transformer hidden state."""
+
+    # === Residual ===
+    fp32_residual_connection: bool = False
+    """Cast residual connections to fp32."""
+
+    # === Fusions ===
+    apply_rope_fusion: bool = False
+    """Use the fused RoPE kernel for attention-like layers."""
+
+    persist_layer_norm: bool = False
+    """Use the persistent fused LayerNorm kernel (only supports a fixed set of hidden sizes)."""
+
+    # === Layer wiring ===
+    apply_residual_connection_post_layernorm: bool = False
+    """Apply the residual connection after layernorm (post-LN) instead of before it."""
+
+    # === FP8 quantization ===
+    fp8: str | None = None
+    """FP8 format (``"e4m3"`` / ``"hybrid"``); ``None`` disables FP8."""
+
+    fp8_recipe: str | None = None
+    """FP8 scaling recipe (``"tensorwise"`` / ``"delayed"`` / ``"mxfp8"`` /
+    ``"blockwise"`` / ``"custom"``); ``None`` keeps the TC default."""
+
+    fp8_param: bool = False
+    """Keep parameters in FP8 precision (requires :attr:`fp8` to be set)."""
+
+    fp8_margin: int = 0
+    """Margin used by the FP8 amax history."""
+
+    fp8_amax_history_len: int = 1
+    """Length of the FP8 amax history window."""
+
+    fp8_dot_product_attention: bool = False
+    """Apply FP8 to the dot-product attention kernel."""
+
+    # === FP4 quantization ===
+    fp4: str | None = None
+    """FP4 format (``"e2m1"``); ``None`` disables FP4."""
+
+    fp4_recipe: str | None = None
+    """FP4 scaling recipe (``"nvfp4"`` / ``"custom"``); ``None`` keeps the
+    TC default."""
+
+    fp4_param: bool = False
+    """Keep parameters in FP4 precision (requires :attr:`fp4` to be set)."""
+
+    # === Activation recomputation ===
+    recompute_granularity: str | None = None
+    """``"full"`` recomputes the whole transformer block; ``"selective"``
+    recomputes only the attention activations."""
+
+    recompute_method: str | None = None
+    """``"uniform"`` distributes recomputation evenly; ``"block"`` recomputes
+    a contiguous block."""
+
+    recompute_num_layers: int | None = None
+    """How many layers to recompute (interpretation depends on
+    :attr:`recompute_method`)."""
+
+    distribute_saved_activations: bool | None = False
+    """Distribute saved activations across the tensor-parallel group."""
+
+    # === Model family ===
+    # ``is_hybrid_model`` is intentionally NOT exposed here — every HybridModel
+    # recipe is a hybrid model by construction, so :meth:`HybridModelConfig.compile`
+    # forces it to ``True`` on every per-layer / stack-level TC. Putting it on the
+    # user surface would just be a redundant ``=True`` users have to write.
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # TransformerConfig-specific fields below this line.
+    #
+    # These knobs map directly to ``TransformerConfig`` settings that select
+    # implementation backends or kernel-fusion details specific to the
+    # ``TransformerConfig`` / ``TransformerLayer`` machinery. They exist to
+    # let recipes faithfully reproduce existing models that already set them.
+    # When the underlying layer infrastructure is rewritten with dedicated
+    # per-layer configs, these fields will move, change shape, or disappear —
+    # they are not a stable part of the DSL's contract. New recipes should
+    # only set them if they actually need to override the default.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    transformer_impl: str = "transformer_engine"
+    """Transformer implementation: ``"transformer_engine"``, ``"local"``, or
+    ``"inference_optimized"``."""
+
+    cuda_graph_impl: str | None = None
+    """CUDA graph capture implementation: ``"none"``, ``"local"``, or ``"transformer_engine"``."""
+
+    cuda_graph_scope: str = "full"
+    """CUDA graph capture scope (e.g. ``"full"``, ``"attn"``, ``"mlp"``, ``"full_iteration"``)."""
+
+    cuda_graph_warmup_steps: int = 3
+    """Number of warmup steps for CUDA graphs."""
+
+    # === Escape hatch for any TransformerConfig field not curated above ===
+    extra: Dict[str, Any] = field(default_factory=dict)
+    """Passthrough kwargs forwarded to :class:`TransformerConfig`.
+
+    Use this to set any TransformerConfig field that isn't a first-class
+    attribute on :class:`CommonLayerConfig`. New fields added to
+    TransformerConfig upstream propagate to recipes immediately without
+    needing a DSL update::
+
+        common = CommonLayerConfig(
+            hidden_size=2688,
+            extra={"qk_layernorm": True, "moe_expert_capacity_factor": 1.5},
+        )
+
+    Keys are validated against ``dataclasses.fields(TransformerConfig)`` at
+    compile time — typos raise ``ValueError``. Curated fields (e.g.
+    ``hidden_size``) take precedence; ``extra`` only fills in fields the
+    curated set does not cover.
+    """
+
+    # ---------------------------------------------------------------- helpers
+
+    def update(self, **overrides) -> "CommonLayerConfig":
+        """Return a fresh CommonLayerConfig with overrides applied."""
+        return dataclasses.replace(self, **overrides)
+
+    def to_transformer_config_kwargs(self) -> Dict[str, Any]:
+        """Translate to keyword arguments accepted by :class:`TransformerConfig`.
+
+        Validates torch dtype fields and performs string→callable mapping. Does
+        **not** include layer-specific fields (``num_attention_heads``,
+        ``mamba_head_dim``, ``num_moe_experts``, ...) — those come from the
+        per-layer :class:`LayerConfig` and are merged on top.
+
+        .. note::
+
+            This method is the bridge between the DSL's user-facing fields
+            and the underlying :class:`TransformerConfig` machinery the
+            current layer classes consume. When the layer classes are
+            rewritten with dedicated per-layer configs, this method's
+            output type and name change but the DSL's user-facing surface
+            (``CommonLayerConfig`` fields, ``LayerConfig`` subclasses) is
+            preserved. Recipe code does not need to touch this method.
+        """
+        mixed_precision_dtype = _require_torch_dtype(
+            self.mixed_precision_dtype, "mixed_precision_dtype"
+        )
+        if self.params_dtype is None:
+            params_dtype_resolved = mixed_precision_dtype
+        else:
+            params_dtype_resolved = _require_torch_dtype(self.params_dtype, "params_dtype")
+
+        kwargs: Dict[str, Any] = {
+            "hidden_size": self.hidden_size,
+            "params_dtype": params_dtype_resolved,
+            "sequence_parallel": self.sequence_parallel,
+            "init_method_std": self.init_method_std,
+            "perform_initialization": self.perform_initialization,
+            "use_cpu_initialization": self.use_cpu_initialization,
+            "normalization": self.normalization,
+            "layernorm_epsilon": self.layernorm_epsilon,
+            "layernorm_zero_centered_gamma": self.layernorm_zero_centered_gamma,
+            "add_bias_linear": self.add_bias_linear,
+            "gated_linear_unit": self.gated_linear_unit,
+            "activation_func": _resolve_activation(self.activation_func),
+            "hidden_dropout": self.hidden_dropout,
+            "fp32_residual_connection": self.fp32_residual_connection,
+            "first_last_layers_bf16": self.first_last_layers_bf16,
+            "apply_rope_fusion": self.apply_rope_fusion,
+            "persist_layer_norm": self.persist_layer_norm,
+            "apply_residual_connection_post_layernorm": (
+                self.apply_residual_connection_post_layernorm
+            ),
+            "fp8_param": self.fp8_param,
+            "fp8_margin": self.fp8_margin,
+            "fp8_amax_history_len": self.fp8_amax_history_len,
+            "fp8_dot_product_attention": self.fp8_dot_product_attention,
+            "fp4_param": self.fp4_param,
+            "distribute_saved_activations": self.distribute_saved_activations,
+            "transformer_impl": self.transformer_impl,
+            "cuda_graph_scope": self.cuda_graph_scope,
+            "cuda_graph_warmup_steps": self.cuda_graph_warmup_steps,
+        }
+        if self.ffn_hidden_size is not None:
+            kwargs["ffn_hidden_size"] = self.ffn_hidden_size
+        if self.cuda_graph_impl is not None:
+            kwargs["cuda_graph_impl"] = self.cuda_graph_impl
+        for name in (
+            "fp8",
+            "fp8_recipe",
+            "fp4",
+            "fp4_recipe",
+            "recompute_granularity",
+            "recompute_method",
+            "recompute_num_layers",
+        ):
+            v = getattr(self, name)
+            if v is not None:
+                kwargs[name] = v
+        # mixed_precision_dtype → bf16/fp16 booleans expected by TransformerConfig
+        if mixed_precision_dtype == torch.bfloat16:
+            kwargs["bf16"] = True
+        elif mixed_precision_dtype == torch.float16:
+            kwargs["fp16"] = True
+        elif mixed_precision_dtype != torch.float32:
+            raise ValueError(
+                "mixed_precision_dtype must be one of torch.float32, torch.float16, "
+                f"or torch.bfloat16; got {mixed_precision_dtype!r}."
+            )
+        # Escape-hatch passthrough: validate keys then merge over curated kwargs
+        # for any TransformerConfig field not exposed as a first-class attribute.
+        # Reject keys that name a curated CommonLayerConfig attribute — those
+        # would silently shadow the dataclass field.
+        if self.extra:
+            validate_extra_kwargs(self.extra, "CommonLayerConfig.extra")
+            curated = {f.name for f in dataclasses.fields(self) if f.name != "extra"}
+            curated_tc_keys = set(kwargs) | {"bf16", "fp16"}
+            shadowed = sorted(set(self.extra) & (curated | curated_tc_keys))
+            if shadowed:
+                raise ValueError(
+                    f"CommonLayerConfig.extra cannot name curated fields: {shadowed}. "
+                    f"Set them on the dataclass attribute directly."
+                )
+            kwargs.update(self.extra)
+        return kwargs
+
+
+def validate_extra_kwargs(
+    extra: Dict[str, Any], origin: str, config_cls: type | None = None
+) -> None:
+    """Validate that every key in ``extra`` names a real target config field.
+
+    The DSL accepts an ``extra: Dict[str, Any]`` passthrough on every config
+    class to keep the recipe surface complete relative to the TransformerConfig
+    class it lowers to without monotonically growing the curated DSL field set.
+    To catch typos early, this validator rejects keys that don't appear on the
+    target config dataclass.
+
+    Raises:
+        ValueError: if any key in ``extra`` is not a target config field.
+    """
+    from megatron.core.transformer.transformer_config import TransformerConfig
+
+    if config_cls is None:
+        config_cls = TransformerConfig
+
+    valid_fields = {f.name for f in dataclasses.fields(config_cls)}
+    unknown = sorted(set(extra) - valid_fields)
+    if unknown:
+        raise ValueError(
+            f"{origin} contains keys that are not {config_cls.__name__} fields: "
+            f"{unknown}. Either correct the spelling or add the field upstream "
+            f"in megatron/core/transformer/transformer_config.py."
+        )

--- a/megatron/core/models/hybrid/layer_configs.py
+++ b/megatron/core/models/hybrid/layer_configs.py
@@ -1,0 +1,595 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Per-type :class:`LayerConfig` subclasses for the HybridModel Python DSL.
+
+Each layer-type config exposes only the fields a recipe author actually needs
+to set: layer-specific architecture knobs and per-layer overrides of the
+common config. Anything derivable from other fields (``num_query_groups``,
+``kv_channels``, ``mamba_num_heads``, ``num_layers``) is computed at compile
+time inside :meth:`LayerConfig.to_transformer_config` rather than required
+from the recipe.
+
+Special pattern markers — :class:`EmbeddingLayerConfig` and
+:class:`CrossEntropyLayerConfig` — also live here. They participate in
+the layer pattern but are not "layers" the :class:`HybridStack`
+constructs; they encode model-wrapping metadata (vocab/sequence shape).
+"""
+
+from dataclasses import dataclass, field, fields
+from typing import Any, ClassVar, Dict, Union
+
+from megatron.core.models.hybrid.common_layer_config import (
+    CommonLayerConfig,
+    _resolve_activation,
+    validate_extra_kwargs,
+)
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.transformer.enums import AttnBackend
+from megatron.core.transformer.transformer_config import MLATransformerConfig, TransformerConfig
+
+# ------------------------------------------------------------------- LAYERS
+
+
+@dataclass
+class LayerConfig:
+    """Base class for layer-pattern leaves.
+
+    Concrete subclasses set a class-level ``SYMBOL`` matching one of
+    :class:`Symbols.VALID_LAYERS` and override
+    :meth:`_layer_specific_kwargs` to supply layer-class-specific fields
+    (e.g. ``mamba_state_dim``) for the per-layer
+    :class:`TransformerConfig`.
+    """
+
+    common_config: CommonLayerConfig | None = None
+    """Per-layer common config; ``None`` (the default) means
+    "inherit from the recipe's :attr:`HybridModelConfig.common_config`",
+    which :meth:`HybridModelConfig.compile` substitutes in. Pass an
+    explicit :class:`CommonLayerConfig` to override (e.g. via
+    :meth:`CommonLayerConfig.update`). After ``compile()`` runs, this
+    field is always non-None."""
+
+    extra: Dict[str, Any] = field(default_factory=dict)
+    """Per-layer passthrough kwargs forwarded to this layer's
+    :class:`TransformerConfig`. Same semantics as
+    :attr:`CommonLayerConfig.extra` but applied per-layer instead of
+    model-wide. Layer ``extra`` overrides curated layer fields, which
+    override common ``extra``, which overrides common curated fields."""
+
+    SYMBOL: ClassVar[str]
+
+    TC_CLASS: ClassVar[type] = TransformerConfig
+    """The :class:`TransformerConfig` subclass used to materialise this
+    layer's per-layer config. Subclasses override (e.g.
+    :class:`DSALayerConfig` uses :class:`MLATransformerConfig`) when they
+    need fields that only live on a specialised subclass."""
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        """Return the layer-class-specific TransformerConfig kwargs."""
+        return {}
+
+    def to_transformer_config(
+        self,
+        num_layers: int,
+        parallelism: Dict[str, Any] | None = None,
+        placeholders: Dict[str, Any] | None = None,
+    ) -> TransformerConfig:
+        """Build a per-layer :class:`TransformerConfig`.
+
+        ``num_layers`` is supplied by the caller (usually
+        :meth:`HybridModelConfig.compile`) after counting the flattened
+        layer pattern, so recipes never need to set it manually.
+
+        ``parallelism`` carries the universal model-level parallelism
+        settings (TP/CP) — these **always win** because they're
+        job-level. EP/ETP are MoE-only and are injected into MoE
+        per-layer TCs by :meth:`HybridModelConfig.compile`, not via this
+        path. ``placeholders`` carries values that satisfy
+        :meth:`TransformerConfig.__post_init__` invariants on layers that
+        don't naturally set them (e.g. ``num_attention_heads`` is required
+        for the ``kv_channels`` derivation even on Mamba layers) — these
+        **only fill in if absent**, so a recipe author's
+        ``common.extra={"num_attention_heads": 32}`` overrides the
+        placeholder.
+
+        Final precedence (lowest → highest): common curated → ``common.extra``
+        → ``parallelism`` → ``placeholders`` (only if absent) →
+        ``layer._layer_specific_kwargs()`` → ``layer.extra``.
+        """
+        kwargs = self.common_config.to_transformer_config_kwargs()
+        if parallelism:
+            kwargs.update(parallelism)
+        if placeholders:
+            for k, v in placeholders.items():
+                kwargs.setdefault(k, v)
+        layer_kwargs = self._layer_specific_kwargs()
+        kwargs.update({k: v for k, v in layer_kwargs.items() if v is not None})
+        if self.extra:
+            origin = f"{type(self).__name__}.extra"
+            validate_extra_kwargs(self.extra, origin, self.TC_CLASS)
+            # Reject ``extra`` keys that shadow this layer's curated fields
+            # (silent dataclass shadowing) or model-wide parallelism (process
+            # groups are global; a per-layer disagreement is invalid sharding).
+            # Layer ``extra`` may still override a value carried over from
+            # common scope — more-specific scope wins.
+            curated = {f.name for f in fields(self) if f.name not in ("common_config", "extra")}
+            curated_tc_keys = set(layer_kwargs)
+            shadowed = sorted(set(self.extra) & (curated | curated_tc_keys))
+            if shadowed:
+                raise ValueError(
+                    f"{origin} cannot name curated fields: {shadowed}. "
+                    f"Set them on the dataclass attribute directly."
+                )
+            if parallelism:
+                shadowed = sorted(set(parallelism) & set(self.extra))
+                if shadowed:
+                    raise ValueError(
+                        f"{origin} cannot override model-wide parallelism fields "
+                        f"{shadowed}; set them on HybridModelConfig instead."
+                    )
+            kwargs.update(self.extra)
+        # Test-friendly fallback: ``compile()`` always supplies a placeholder,
+        # but unit tests calling ``lc.to_transformer_config(num_layers=N)``
+        # directly need a non-zero baseline so TC's ``__post_init__`` doesn't
+        # divide by zero deriving ``kv_channels``.
+        kwargs.setdefault("num_attention_heads", 1)
+        kwargs["num_layers"] = num_layers
+        # Drop None values so TransformerConfig defaults apply.
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        return self.TC_CLASS(**kwargs)
+
+
+@dataclass
+class MambaLayerConfig(LayerConfig):
+    """Mamba SSM layer (symbol ``M``).
+
+    ``num_heads`` may be left ``None`` to auto-derive
+    ``hidden_size * expand // head_dim`` (TransformerConfig handles this
+    derivation when ``mamba_num_heads`` is ``None``).
+    """
+
+    head_dim: int = 64
+    """Mamba head dimension (``mamba_head_dim``)."""
+
+    state_size: int = 128
+    """SSM state dimension (``mamba_state_dim``)."""
+
+    num_groups: int = 8
+    """Mamba groups (``mamba_num_groups``)."""
+
+    num_heads: int | None = None
+    """Optional explicit head count; defaults to derived value."""
+
+    SYMBOL: ClassVar[str] = Symbols.MAMBA
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        return {
+            "mamba_head_dim": self.head_dim,
+            "mamba_state_dim": self.state_size,
+            "mamba_num_groups": self.num_groups,
+            "mamba_num_heads": self.num_heads,
+        }
+
+
+@dataclass
+class AttentionLayerConfig(LayerConfig):
+    """Self-attention layer (symbol ``*``).
+
+    ``num_query_groups`` and ``kv_channels`` may be left ``None`` to
+    auto-derive from ``num_attention_heads`` and ``hidden_size`` respectively
+    (handled in :meth:`TransformerConfig.__post_init__`).
+    """
+
+    num_attention_heads: int = 1
+    """Number of attention heads."""
+
+    num_query_groups: int | None = None
+    """GQA group count; ``None`` → ``num_attention_heads`` (i.e. MHA)."""
+
+    kv_channels: int | None = None
+    """KV head dim; ``None`` → ``hidden_size // num_attention_heads``."""
+
+    attention_dropout: float | None = None
+    """Dropout on attention weights; ``None`` → TransformerConfig default."""
+
+    attention_softmax_in_fp32: bool | None = None
+    """Run attention masking and softmax in fp32; ``None`` keeps the default."""
+
+    add_qkv_bias: bool | None = None
+    """Bias only in QKV projections, overriding ``add_bias_linear`` for QKV."""
+
+    masked_softmax_fusion: bool | None = None
+    """Use fused masked-softmax; ``None`` keeps the default."""
+
+    attention_backend: str | None = None
+    """Attention backend name (``"flash"`` / ``"fused"`` / ``"unfused"`` /
+    ``"local"`` / ``"auto"``); ``None`` → TransformerConfig default."""
+
+    SYMBOL: ClassVar[str] = Symbols.ATTENTION
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "num_attention_heads": self.num_attention_heads,
+            "num_query_groups": self.num_query_groups,
+            "kv_channels": self.kv_channels,
+            "attention_dropout": self.attention_dropout,
+            "attention_softmax_in_fp32": self.attention_softmax_in_fp32,
+            "add_qkv_bias": self.add_qkv_bias,
+            "masked_softmax_fusion": self.masked_softmax_fusion,
+        }
+        if self.attention_backend is not None:
+            kwargs["attention_backend"] = AttnBackend[self.attention_backend]
+        return kwargs
+
+
+@dataclass
+class DSALayerConfig(LayerConfig):
+    """DeepSeek Sparse Attention / MLA layer (symbol ``D``).
+
+    Cannot be combined with :class:`AttentionLayerConfig` in the same pattern.
+    The MLA-defining knobs (``q_lora_rank``, ``kv_lora_rank``,
+    ``qk_head_dim``, ``qk_pos_emb_head_dim``, ``v_head_dim``,
+    ``rope_type`` / YaRN fields, and DSA indexer fields) all default to
+    ``None``, which means "fall through to the underlying
+    :class:`MLATransformerConfig` default"; DeepSeek-style models override
+    them to the values the model card specifies.
+    """
+
+    num_attention_heads: int = 1
+    """Number of attention heads."""
+
+    num_query_groups: int | None = None
+    """GQA group count."""
+
+    kv_channels: int | None = None
+    """KV head dim."""
+
+    add_qkv_bias: bool | None = None
+    """Bias in the QKV projection only, overriding ``add_bias_linear`` for
+    QKV. Mirrors the same field on :class:`AttentionLayerConfig`."""
+
+    q_lora_rank: int | None = None
+    """Rank of the query tensor's low-rank representation."""
+
+    kv_lora_rank: int | None = None
+    """Rank of the key/value tensors' low-rank representation."""
+
+    qk_head_dim: int | None = None
+    """Dimension of the QK projection head. Together with
+    ``qk_pos_emb_head_dim`` this gives the full Q head dim
+    (``q_head_dim = qk_head_dim + qk_pos_emb_head_dim``)."""
+
+    qk_pos_emb_head_dim: int | None = None
+    """Position-embedding portion of the QK projection head dim."""
+
+    v_head_dim: int | None = None
+    """Dimension of the V projection head."""
+
+    rope_type: str | None = None
+    """MLA RoPE type (``"rope"`` or ``"yarn"``); ``None`` keeps the
+    :class:`MLATransformerConfig` default."""
+
+    rotary_base: float | None = None
+    """RoPE base for MLA-internal rotary embeddings."""
+
+    rotary_percent: float | None = None
+    """RoPE percentage for ``rope_type="rope"``."""
+
+    rotary_scaling_factor: float | None = None
+    """Rotary scaling factor for YaRN-style rope inside MLA."""
+
+    original_max_position_embeddings: int | None = None
+    """Original maximum position embeddings for YaRN-style MLA RoPE."""
+
+    beta_fast: float | None = None
+    """YaRN beta-fast value for MLA RoPE."""
+
+    beta_slow: float | None = None
+    """YaRN beta-slow value for MLA RoPE."""
+
+    mscale: float | None = None
+    """YaRN mscale value for MLA RoPE."""
+
+    mscale_all_dim: float | None = None
+    """YaRN mscale-all-dim value for MLA RoPE."""
+
+    cache_mla_latents: bool | None = None
+    """Cache compressed MLA latents for dynamic-backend inference."""
+
+    mla_down_proj_fusion: bool | None = None
+    """Enable fused MLA q/kv down-projection when the backend supports it."""
+
+    dsa_indexer_n_heads: int | None = None
+    """Number of DSA indexer heads."""
+
+    dsa_indexer_head_dim: int | None = None
+    """Dimension per DSA indexer head."""
+
+    dsa_indexer_topk: int | None = None
+    """Number of top-k tokens selected by the DSA indexer."""
+
+    dsa_indexer_loss_coeff: float | None = None
+    """KL-divergence loss coefficient for the DSA indexer."""
+
+    dsa_indexer_use_sparse_loss: bool | None = None
+    """Whether the DSA indexer loss is computed only over selected top-k
+    entries."""
+
+    SYMBOL: ClassVar[str] = Symbols.DS_ATTENTION
+    TC_CLASS: ClassVar[type] = MLATransformerConfig
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "num_attention_heads": self.num_attention_heads,
+            "num_query_groups": self.num_query_groups,
+            "kv_channels": self.kv_channels,
+            "multi_latent_attention": True,
+            "experimental_attention_variant": "dsa",
+            "q_lora_rank": self.q_lora_rank,
+            "kv_lora_rank": self.kv_lora_rank,
+            "qk_head_dim": self.qk_head_dim,
+            "qk_pos_emb_head_dim": self.qk_pos_emb_head_dim,
+            "v_head_dim": self.v_head_dim,
+            "rope_type": self.rope_type,
+            "rotary_base": self.rotary_base,
+            "rotary_percent": self.rotary_percent,
+            "rotary_scaling_factor": self.rotary_scaling_factor,
+            "original_max_position_embeddings": self.original_max_position_embeddings,
+            "beta_fast": self.beta_fast,
+            "beta_slow": self.beta_slow,
+            "mscale": self.mscale,
+            "mscale_all_dim": self.mscale_all_dim,
+            "cache_mla_latents": self.cache_mla_latents,
+            "mla_down_proj_fusion": self.mla_down_proj_fusion,
+            "dsa_indexer_n_heads": self.dsa_indexer_n_heads,
+            "dsa_indexer_head_dim": self.dsa_indexer_head_dim,
+            "dsa_indexer_topk": self.dsa_indexer_topk,
+            "dsa_indexer_loss_coeff": self.dsa_indexer_loss_coeff,
+            "dsa_indexer_use_sparse_loss": self.dsa_indexer_use_sparse_loss,
+        }
+        if self.add_qkv_bias is not None:
+            kwargs["add_qkv_bias"] = self.add_qkv_bias
+        return kwargs
+
+
+@dataclass
+class GDNLayerConfig(LayerConfig):
+    """Gated DeltaNet layer (symbol ``G``)."""
+
+    num_attention_heads: int = 1
+    """Used for the attention-shaped paths inside GDN."""
+
+    num_query_groups: int | None = None
+
+    kv_channels: int | None = None
+
+    SYMBOL: ClassVar[str] = Symbols.GDN
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        return {
+            "num_attention_heads": self.num_attention_heads,
+            "num_query_groups": self.num_query_groups,
+            "kv_channels": self.kv_channels,
+        }
+
+
+@dataclass
+class MLPLayerConfig(LayerConfig):
+    """Dense MLP layer (symbol ``-``)."""
+
+    ffn_hidden_size: int | None = None
+    """MLP intermediate size; ``None`` → ``4 * hidden_size``."""
+
+    SYMBOL: ClassVar[str] = Symbols.MLP
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        return {"ffn_hidden_size": self.ffn_hidden_size}
+
+
+@dataclass
+class MoELayerConfig(LayerConfig):
+    """Mixture-of-Experts layer (symbol ``E``).
+
+    Two distinct :class:`MoELayerConfig` instances with different
+    architecture overrides may coexist in the same pattern (e.g. one with
+    128 experts/top-6 and one with 64 experts/top-2). Expert parallelism
+    (EP/ETP) is a model-wide concept and lives on
+    :class:`HybridModelConfig`; :meth:`HybridModelConfig.compile` injects
+    those fields into MoE per-layer TransformerConfigs only.
+    """
+
+    num_experts: int = 1
+    """Total experts (``num_moe_experts``)."""
+
+    top_k: int = 1
+    """Top-k routing (``moe_router_topk``)."""
+
+    ffn_hidden_size: int | None = None
+    """Per-expert FFN size; falls back to ``moe_ffn_hidden_size`` semantics."""
+
+    router_score_function: str = "softmax"
+    """``"softmax"`` or ``"sigmoid"``."""
+
+    router_load_balancing_type: str = "aux_loss"
+    """``"aux_loss"`` / ``"seq_aux_loss"`` / ``"global_aux_loss"`` / ``"sinkhorn"`` / ``"none"``."""
+
+    router_topk_scaling_factor: float | None = None
+    """Optional scaling factor applied to top-k logits."""
+
+    router_enable_expert_bias: bool = False
+    """Enable learnable per-expert bias term in the router."""
+
+    router_dtype: str | None = None
+    """Router compute dtype name; ``None`` → input dtype."""
+
+    aux_loss_coeff: float = 0.0
+    """Auxiliary load-balancing loss coefficient (``moe_aux_loss_coeff``)."""
+
+    shared_expert_intermediate_size: int | None = None
+    """If set, enables shared experts at this size."""
+
+    token_dispatcher_type: str = "allgather"
+    """``"allgather"`` / ``"alltoall"`` / ``"flex"``."""
+
+    grouped_gemm: bool = False
+    """Use grouped GEMM for expert MLPs."""
+
+    permute_fusion: bool = False
+    """Fuse the token permutation kernel."""
+
+    activation: str | None = None
+    """Override the MLP activation for this layer (defaults to common)."""
+
+    # === Architecture / Routing / Fusion ===
+
+    router_num_groups: int | None = None
+    """Number of router groups for grouped top-k routing (``moe_router_num_groups``)."""
+
+    router_group_topk: int | None = None
+    """Per-group top-k for grouped routing (``moe_router_group_topk``)."""
+
+    shared_expert_overlap: bool = False
+    """Overlap shared-expert compute with dispatcher comms (``moe_shared_expert_overlap``)."""
+
+    flex_dispatcher_backend: str | None = None
+    """Flex token-dispatcher backend (``"deepep"`` / ``"hybridep"``);
+    ``None`` → TransformerConfig default."""
+
+    hybridep_num_sms: int | None = None
+    """Number of SMs reserved for the HybridEP dispatcher
+    (``moe_hybridep_num_sms``); ``None`` → TransformerConfig default."""
+
+    router_padding_for_fp8: bool = False
+    """Pad router output for FP8 alignment (``moe_router_padding_for_fp8``)."""
+
+    router_fusion: bool = False
+    """Enable fused router kernels (``moe_router_fusion``)."""
+
+    router_force_load_balancing: bool = False
+    """Force balanced routing assignment (``moe_router_force_load_balancing``)."""
+
+    use_fused_weighted_squared_relu: bool = False
+    """Enable the fused weighted squared-ReLU expert activation kernel."""
+
+    SYMBOL: ClassVar[str] = Symbols.MOE
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "num_moe_experts": self.num_experts,
+            "moe_router_topk": self.top_k,
+            "moe_ffn_hidden_size": self.ffn_hidden_size,
+            "moe_router_score_function": self.router_score_function,
+            "moe_router_load_balancing_type": self.router_load_balancing_type,
+            "moe_router_topk_scaling_factor": self.router_topk_scaling_factor,
+            "moe_router_enable_expert_bias": self.router_enable_expert_bias,
+            "moe_router_dtype": self.router_dtype,
+            "moe_aux_loss_coeff": self.aux_loss_coeff,
+            "moe_shared_expert_intermediate_size": self.shared_expert_intermediate_size,
+            "moe_token_dispatcher_type": self.token_dispatcher_type,
+            "moe_grouped_gemm": self.grouped_gemm,
+            "moe_permute_fusion": self.permute_fusion,
+            "moe_router_num_groups": self.router_num_groups,
+            "moe_router_group_topk": self.router_group_topk,
+            "moe_shared_expert_overlap": self.shared_expert_overlap,
+            "moe_flex_dispatcher_backend": self.flex_dispatcher_backend,
+            "moe_hybridep_num_sms": self.hybridep_num_sms,
+            "moe_router_padding_for_fp8": self.router_padding_for_fp8,
+            "moe_router_fusion": self.router_fusion,
+            "moe_router_force_load_balancing": self.router_force_load_balancing,
+            "use_fused_weighted_squared_relu": self.use_fused_weighted_squared_relu,
+        }
+        if self.activation is not None:
+            kwargs["activation_func"] = _resolve_activation(self.activation)
+        return kwargs
+
+
+# -------------------------------------------------------- PATTERN MARKERS
+
+
+@dataclass
+class EmbeddingLayerConfig:
+    """Input embedding marker (must appear at the start of a layer pattern).
+
+    Carries the runtime model-shape parameters that aren't part of any single
+    decoder layer: vocab size, max sequence length, position-embedding
+    selection, and rotary settings.
+    """
+
+    common_config: CommonLayerConfig | None = None
+    """Per-marker common config; ``None`` (the default) means "inherit from
+    the recipe's :attr:`HybridModelConfig.common_config`", which
+    :meth:`HybridModelConfig.compile` substitutes in. After ``compile()``
+    runs, this field is always non-None."""
+
+    vocab_size: int = 0
+    """Vocabulary size (post-padding)."""
+
+    max_sequence_length: int = 0
+    """Maximum sequence length the embedding supports."""
+
+    position_embedding_type: str = "none"
+    """``"learned_absolute"`` / ``"rope"`` / ``"yarn"`` / ``"none"``."""
+
+    rotary_percent: float = 1.0
+    """Fraction of the head dim to apply RoPE to (only when ``rope``/``yarn``)."""
+
+    rotary_base: int = 10000
+    """RoPE base period."""
+
+    seq_len_interpolation_factor: float | None = None
+    """Linear-interpolation scaling for longer-than-trained sequences."""
+
+    scatter_embedding_sequence_parallel: bool = True
+    """Scatter the embedding output along the sequence-parallel dim."""
+
+    yarn: Dict[str, Any] | None = None
+    """YARN scaling parameters (consumed only when
+    ``position_embedding_type == "yarn"``). These are not
+    :class:`TransformerConfig` dataclass fields today; they are attached
+    as ad-hoc attributes by :meth:`HybridModelConfig.compile` to match
+    the :func:`getattr` lookups in :class:`HybridModel.__init__`.
+    Recognised keys: ``yarn_rotary_scaling_factor``,
+    ``yarn_original_max_position_embeddings``, ``yarn_beta_fast``,
+    ``yarn_beta_slow``, ``yarn_mscale``, ``yarn_mscale_all_dim``,
+    ``yarn_correction_range_round_to_int``. Unknown keys raise at compile
+    time. When upstream lifts these onto :class:`TransformerConfig`, this
+    field collapses to a plain ``extra`` passthrough and the setattr
+    loop in ``compile()`` goes away."""
+
+    extra: Dict[str, Any] = field(default_factory=dict)
+    """Passthrough kwargs forwarded to the stack-level
+    :class:`TransformerConfig` (used for the embedding init / final norm).
+    Same semantics as :attr:`CommonLayerConfig.extra`."""
+
+
+@dataclass
+class CrossEntropyLayerConfig:
+    """Output / loss marker (must appear at the end of a layer pattern)."""
+
+    fp16_lm_cross_entropy: bool = False
+    """Compute the LM cross-entropy in fp16."""
+
+    parallel_output: bool = True
+    """Keep logits split across tensor-parallel ranks (no all-gather)."""
+
+    loss_fusion: bool = False
+    """Enable fused cross-entropy loss (``cross_entropy_loss_fusion``)."""
+
+    fusion_impl: str = "native"
+    """Fused CE implementation (``"native"`` / ``"te"``); maps to
+    ``cross_entropy_fusion_impl``."""
+
+    calculate_per_token_loss: bool = False
+    """Average loss per token rather than per microbatch
+    (``calculate_per_token_loss``)."""
+
+    extra: Dict[str, Any] = field(default_factory=dict)
+    """Passthrough kwargs forwarded to the stack-level
+    :class:`TransformerConfig`. Same semantics as
+    :attr:`CommonLayerConfig.extra`."""
+
+
+# ----------------------------------------------------------- type aliases
+
+#: Anything that may legally appear at a leaf of a layer pattern.
+PatternLeaf = Union[LayerConfig, EmbeddingLayerConfig, CrossEntropyLayerConfig]

--- a/megatron/core/models/hybrid/layer_configs.py
+++ b/megatron/core/models/hybrid/layer_configs.py
@@ -410,8 +410,8 @@ class MoELayerConfig(LayerConfig):
     router_score_function: str = "softmax"
     """``"softmax"`` or ``"sigmoid"``."""
 
-    router_load_balancing_type: str = "aux_loss"
-    """``"aux_loss"`` / ``"seq_aux_loss"`` / ``"global_aux_loss"`` / ``"sinkhorn"`` / ``"none"``."""
+    router_load_balancing_type: str | list[str] = "aux_loss"
+    """Load balancing type or ordered list of types for multi-loss MoE routing."""
 
     router_topk_scaling_factor: float | None = None
     """Optional scaling factor applied to top-k logits."""
@@ -422,8 +422,8 @@ class MoELayerConfig(LayerConfig):
     router_dtype: str | None = None
     """Router compute dtype name; ``None`` → input dtype."""
 
-    aux_loss_coeff: float = 0.0
-    """Auxiliary load-balancing loss coefficient (``moe_aux_loss_coeff``)."""
+    aux_loss_coeff: float | list[float] = 0.0
+    """Auxiliary load-balancing loss coefficient or per-loss coefficient list."""
 
     shared_expert_intermediate_size: int | None = None
     """If set, enables shared experts at this size."""

--- a/tests/unit_tests/models/hybrid/__init__.py
+++ b/tests/unit_tests/models/hybrid/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.

--- a/tests/unit_tests/models/hybrid/test_layer_configs.py
+++ b/tests/unit_tests/models/hybrid/test_layer_configs.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for HybridModel recipe layer config primitives."""
+
+import dataclasses
+
+import pytest
+import torch
+
+from megatron.core.models.hybrid.common_layer_config import CommonLayerConfig, validate_extra_kwargs
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.layer_configs import (
+    AttentionLayerConfig,
+    DSALayerConfig,
+    GDNLayerConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+    MoELayerConfig,
+)
+from megatron.core.transformer import MLATransformerConfig
+
+
+def _make_common(**overrides) -> CommonLayerConfig:
+    base = dict(hidden_size=256, use_cpu_initialization=True)
+    base.update(overrides)
+    return CommonLayerConfig(**base)
+
+
+@pytest.mark.internal
+class TestCommonLayerConfig:
+
+    COMMON_FIELD_LAYER_COVERAGE = {
+        "hidden_size": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "ffn_hidden_size": ("mlp", "moe"),
+        "mixed_precision_dtype": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "params_dtype": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "first_last_layers_bf16": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "sequence_parallel": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "init_method_std": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "perform_initialization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "use_cpu_initialization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "normalization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "layernorm_epsilon": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "layernorm_zero_centered_gamma": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "add_bias_linear": ("attention", "dsa", "mlp", "moe"),
+        "gated_linear_unit": ("mlp", "moe"),
+        "activation_func": ("gdn", "mlp", "moe"),
+        "hidden_dropout": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp32_residual_connection": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "apply_rope_fusion": ("attention", "dsa"),
+        "persist_layer_norm": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "transformer_impl": ("attention", "mlp", "moe"),
+        "cuda_graph_impl": ("mamba", "attention", "mlp", "moe"),
+        "cuda_graph_scope": ("mamba", "attention", "mlp", "moe"),
+        "cuda_graph_warmup_steps": ("mamba", "attention", "mlp", "moe"),
+        "apply_residual_connection_post_layernorm": (
+            "mamba",
+            "attention",
+            "dsa",
+            "gdn",
+            "mlp",
+            "moe",
+        ),
+        "fp8": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_recipe": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_param": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_margin": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_amax_history_len": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_dot_product_attention": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4_recipe": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4_param": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_granularity": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_method": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_num_layers": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "distribute_saved_activations": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+    }
+
+    NON_SHARED_FIELDS = {
+        "attention_dropout",
+        "attention_softmax_in_fp32",
+        "apply_query_key_layer_scaling",
+        "add_qkv_bias",
+        "masked_softmax_fusion",
+        "use_fused_weighted_squared_relu",
+    }
+
+    def test_common_fields_are_explicitly_audited_as_shared(self):
+        common_fields = {f.name for f in dataclasses.fields(CommonLayerConfig) if f.name != "extra"}
+        assert common_fields == set(self.COMMON_FIELD_LAYER_COVERAGE)
+
+    def test_non_shared_fields_are_not_common_fields(self):
+        common_fields = {f.name for f in dataclasses.fields(CommonLayerConfig)}
+        assert common_fields.isdisjoint(self.NON_SHARED_FIELDS)
+
+    def test_update_returns_new_instance(self):
+        common = _make_common()
+        updated = common.update(hidden_size=512)
+        assert updated is not common
+        assert common.hidden_size == 256
+        assert updated.hidden_size == 512
+
+    def test_mixed_precision_dtype_bf16_maps_to_bf16_true(self):
+        common = _make_common(mixed_precision_dtype=torch.bfloat16)
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.bf16 is True
+        assert tc.fp16 is False
+        assert tc.params_dtype == torch.bfloat16
+
+    def test_params_dtype_can_explicitly_differ_from_mixed_precision_dtype(self):
+        common = _make_common(
+            mixed_precision_dtype=torch.bfloat16,
+            params_dtype=torch.float32,
+        )
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.bf16 is True
+        assert tc.params_dtype == torch.float32
+
+    def test_invalid_mixed_precision_dtype_raises(self):
+        common = _make_common(mixed_precision_dtype="nope")
+        with pytest.raises(TypeError, match="mixed_precision_dtype"):
+            common.to_transformer_config_kwargs()
+
+    def test_unsupported_mixed_precision_torch_dtype_raises(self):
+        common = _make_common(mixed_precision_dtype=torch.float64)
+        with pytest.raises(ValueError, match="mixed_precision_dtype"):
+            common.to_transformer_config_kwargs()
+
+    def test_invalid_params_dtype_raises(self):
+        common = _make_common(params_dtype="bf16")
+        with pytest.raises(TypeError, match="params_dtype"):
+            common.to_transformer_config_kwargs()
+
+    def test_invalid_activation_func_raises(self):
+        common = _make_common(activation_func="not_a_real_activation")
+        with pytest.raises(ValueError, match="activation"):
+            common.to_transformer_config_kwargs()
+
+    def test_fp8_cluster_propagates(self):
+        common = _make_common(
+            fp8="hybrid",
+            fp8_recipe="delayed",
+            fp8_param=True,
+            fp8_margin=2,
+            fp8_amax_history_len=1024,
+            fp8_dot_product_attention=True,
+        )
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.fp8 == "hybrid"
+        assert tc.fp8_recipe == "delayed"
+        assert tc.fp8_param is True
+        assert tc.fp8_margin == 2
+        assert tc.fp8_amax_history_len == 1024
+        assert tc.fp8_dot_product_attention is True
+
+    def test_recompute_cluster_propagates(self):
+        common = _make_common(
+            recompute_granularity="full", recompute_method="uniform", recompute_num_layers=4
+        )
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=8)
+        assert tc.recompute_granularity == "full"
+        assert tc.recompute_method == "uniform"
+        assert tc.recompute_num_layers == 4
+
+
+@pytest.mark.internal
+class TestLayerConfigSymbols:
+
+    def test_symbol_assignments(self):
+        assert MambaLayerConfig.SYMBOL == Symbols.MAMBA
+        assert GDNLayerConfig.SYMBOL == Symbols.GDN
+        assert AttentionLayerConfig.SYMBOL == Symbols.ATTENTION
+        assert DSALayerConfig.SYMBOL == Symbols.DS_ATTENTION
+        assert MLPLayerConfig.SYMBOL == Symbols.MLP
+        assert MoELayerConfig.SYMBOL == Symbols.MOE
+
+    def test_symbols_are_valid(self):
+        for cls in (
+            MambaLayerConfig,
+            GDNLayerConfig,
+            AttentionLayerConfig,
+            DSALayerConfig,
+            MLPLayerConfig,
+            MoELayerConfig,
+        ):
+            assert cls.SYMBOL in Symbols.VALID_LAYERS
+
+
+@pytest.mark.internal
+class TestLayerConfigToTransformerConfig:
+
+    def test_mamba_layer_config(self):
+        common = _make_common()
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.mamba_head_dim == 64
+        assert tc.mamba_state_dim == 128
+        assert tc.mamba_num_groups == 8
+        assert tc.num_layers == 4
+
+    def test_attention_layer_config(self):
+        common = _make_common()
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=32)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.num_attention_heads == 32
+        assert tc.num_query_groups == 32
+        assert tc.kv_channels == common.hidden_size // 32
+
+    def test_moe_layer_config(self):
+        common = _make_common()
+        layer = MoELayerConfig(common_config=common, num_experts=8, top_k=2)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.num_moe_experts == 8
+        assert tc.moe_router_topk == 2
+
+    def test_none_layer_field_does_not_clobber_common_ffn_hidden_size(self):
+        common = _make_common(ffn_hidden_size=3072)
+        layer = MLPLayerConfig(common_config=common)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.ffn_hidden_size == 3072
+
+    def test_explicit_layer_field_overrides_common_field(self):
+        common = _make_common(ffn_hidden_size=3072)
+        layer = MLPLayerConfig(common_config=common, ffn_hidden_size=2048)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.ffn_hidden_size == 2048
+
+    def test_none_layer_fields_do_not_clobber_common_extra_attention_fields(self):
+        common = _make_common(
+            extra={
+                "attention_dropout": 0.25,
+                "attention_softmax_in_fp32": True,
+                "add_qkv_bias": True,
+                "masked_softmax_fusion": False,
+            }
+        )
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.attention_dropout == 0.25
+        assert tc.attention_softmax_in_fp32 is True
+        assert tc.add_qkv_bias is True
+        assert tc.masked_softmax_fusion is False
+
+    def test_dsa_uses_mla_transformer_config(self):
+        common = _make_common()
+        layer = DSALayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert isinstance(tc, MLATransformerConfig)
+        assert tc.multi_latent_attention is True
+        assert tc.experimental_attention_variant == "dsa"
+
+    def test_dsa_mla_knobs_curated(self):
+        common = _make_common()
+        layer = DSALayerConfig(
+            common_config=common,
+            num_attention_heads=128,
+            q_lora_rank=1536,
+            kv_lora_rank=512,
+            qk_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            v_head_dim=128,
+            rotary_scaling_factor=40.0,
+            dsa_indexer_topk=32,
+        )
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.q_lora_rank == 1536
+        assert tc.kv_lora_rank == 512
+        assert tc.qk_head_dim == 128
+        assert tc.qk_pos_emb_head_dim == 64
+        assert tc.v_head_dim == 128
+        assert tc.rotary_scaling_factor == 40.0
+        assert tc.dsa_indexer_topk == 32
+
+
+@pytest.mark.internal
+class TestExtraPassthrough:
+
+    def test_common_extra_propagates_to_layer_tc(self):
+        common = _make_common(extra={"qk_layernorm": True})
+        layer = MambaLayerConfig(common_config=common)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.qk_layernorm is True
+
+    def test_layer_extra_overrides_common_extra(self):
+        common = _make_common(extra={"qk_layernorm": False})
+        layer = AttentionLayerConfig(
+            common_config=common, num_attention_heads=4, extra={"qk_layernorm": True}
+        )
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.qk_layernorm is True
+
+    def test_common_extra_unknown_field_raises(self):
+        common = _make_common(extra={"definitely_not_a_real_tc_field": 7})
+        with pytest.raises(ValueError, match="not TransformerConfig fields"):
+            common.to_transformer_config_kwargs()
+
+    def test_layer_extra_unknown_field_raises(self):
+        common = _make_common()
+        layer = MambaLayerConfig(common_config=common, extra={"another_typo_field": 1.0})
+        with pytest.raises(ValueError, match="MambaLayerConfig.extra"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_extra_validation_can_target_mla_transformer_config(self):
+        validate_extra_kwargs(
+            {"mla_down_proj_fusion": True}, "DSALayerConfig.extra", MLATransformerConfig
+        )
+
+    def test_common_extra_cannot_shadow_curated_field(self):
+        common = _make_common(extra={"hidden_size": 999})
+        with pytest.raises(ValueError, match="hidden_size"):
+            common.to_transformer_config_kwargs()
+
+    def test_common_extra_cannot_shadow_curated_transformer_config_key(self):
+        common = _make_common(mixed_precision_dtype=torch.bfloat16, extra={"bf16": False})
+        with pytest.raises(ValueError, match="bf16"):
+            common.to_transformer_config_kwargs()
+
+    def test_layer_extra_cannot_shadow_curated_field(self):
+        common = _make_common()
+        layer = AttentionLayerConfig(
+            common_config=common, num_attention_heads=4, extra={"num_attention_heads": 8}
+        )
+        with pytest.raises(ValueError, match="num_attention_heads"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_layer_extra_cannot_shadow_curated_none_field(self):
+        common = _make_common()
+        layer = MLPLayerConfig(common_config=common, extra={"ffn_hidden_size": 4096})
+        with pytest.raises(ValueError, match="ffn_hidden_size"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_layer_extra_cannot_shadow_curated_transformer_config_key(self):
+        common = _make_common()
+        layer = MoELayerConfig(common_config=common, num_experts=8, extra={"num_moe_experts": 4})
+        with pytest.raises(ValueError, match="num_moe_experts"):
+            layer.to_transformer_config(num_layers=2)

--- a/tests/unit_tests/models/hybrid/test_layer_configs.py
+++ b/tests/unit_tests/models/hybrid/test_layer_configs.py
@@ -109,10 +109,7 @@ class TestCommonLayerConfig:
         assert tc.params_dtype == torch.bfloat16
 
     def test_params_dtype_can_explicitly_differ_from_mixed_precision_dtype(self):
-        common = _make_common(
-            mixed_precision_dtype=torch.bfloat16,
-            params_dtype=torch.float32,
-        )
+        common = _make_common(mixed_precision_dtype=torch.bfloat16, params_dtype=torch.float32)
         layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
         tc = layer.to_transformer_config(num_layers=4)
         assert tc.bf16 is True

--- a/tests/unit_tests/models/hybrid/test_layer_configs.py
+++ b/tests/unit_tests/models/hybrid/test_layer_configs.py
@@ -217,6 +217,19 @@ class TestLayerConfigToTransformerConfig:
         assert tc.num_moe_experts == 8
         assert tc.moe_router_topk == 2
 
+    def test_moe_layer_config_accepts_multi_loss_router_fields(self):
+        common = _make_common()
+        layer = MoELayerConfig(
+            common_config=common,
+            num_experts=8,
+            top_k=2,
+            router_load_balancing_type=["aux_loss", "seq_aux_loss"],
+            aux_loss_coeff=[0.1, 0.2],
+        )
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.moe_router_load_balancing_type == ["aux_loss", "seq_aux_loss"]
+        assert tc.moe_aux_loss_coeff == [0.1, 0.2]
+
     def test_none_layer_field_does_not_clobber_common_ffn_hidden_size(self):
         common = _make_common(ffn_hidden_size=3072)
         layer = MLPLayerConfig(common_config=common)


### PR DESCRIPTION
Splits the layer-config schema groundwork out of the original HybridModel recipe API PR.

This PR adds:
- CommonLayerConfig model-wide defaults
- per-layer LayerConfig dataclasses for Mamba, attention, DSA, GDN, MLP, and MoE
- embedding/loss marker config classes
- low-level extra passthrough validation
- focused unit coverage for config-to-TransformerConfig materialization

Follow-ups in the stack:
- #5030 adds recipe loading and lowering.
- #5031 wires HybridModel(config=recipe).
- #4538 adds the Nemotron-3 Nano recipe.
- #4539 adds the --model-recipe launcher path.