### PR TITLE
Add `--model-recipe` CLI flag for HybridModel

### DIFF
--- a/examples/nemotron3/__init__.py
+++ b/examples/nemotron3/__init__.py
@@ -1,1 +1,3 @@
-# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Nemotron-3 example recipes and launchers."""

--- a/examples/nemotron3/nano.py
+++ b/examples/nemotron3/nano.py
@@ -1,26 +1,17 @@
-# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
-
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """Nemotron-3 Nano model recipe expressed in the HybridModel Python DSL.
 
-A 52-layer hybrid model interleaving Mamba SSM, attention, and MoE layers.
-Faithful 1:1 with the canonical
-``Megatron-Bridge/recipes/nemotronh/nemotron_3_nano.py::nemotron_3_nano_pretrain_config``.
+The recipe defines the same 52-layer hybrid model as the legacy string DSL
+pattern used by :mod:`examples.nemotron3.nano.sh`:
 
-Recipe entry point: :func:`make_recipe`. ``num_layers`` is intentionally
-**not** set anywhere — it is derived at lowering time from the flattened
-decoder length of ``layer_pattern``.
+``MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME``
 
-Use this recipe via the ``--model-recipe`` flag in any of these forms::
-
-    --model-recipe examples.nemotron3.nano
-    --model-recipe examples.nemotron3.nano:make_recipe
-    --model-recipe /path/to/this/file.py
-    --model-recipe /path/to/this/file.py:make_recipe
-
-Run this file directly to print the resulting ``layer_type_list``::
-
-    uv run python -m examples.nemotron3.nano
+Use it with ``pretrain_hybrid.py --model-recipe examples.nemotron3.nano``.
+The SLURM launcher can override topology with ``NANO_TP``, ``NANO_CP``,
+``NANO_EP``, ``NANO_ETP``, and ``NANO_SP``.
 """
+
+import os
 
 import torch
 
@@ -34,173 +25,125 @@ from megatron.core.models.hybrid import (
     MoELayerConfig,
 )
 
-VOCAB_SIZE: int = 131072
-MAX_SEQUENCE_LENGTH: int = 8192
+LEGACY_HYBRID_LAYER_PATTERN = "MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME"
+VOCAB_SIZE = 131072
+MAX_SEQUENCE_LENGTH = 8192
 
 
-# --- Common (model-wide) defaults ------------------------------------------
-
-#
-# Each field below either differs from the TransformerConfig default OR is
-# unique to Nemotron-3 Nano. TC-default-matching fields (``apply_rope_fusion``,
-# ``gated_linear_unit``, ``transformer_impl``,
-# ``cuda_graph_impl``, ``cuda_graph_scope``, ``cuda_graph_warmup_steps``,
-# ``moe_layer_freq``, ``moe_router_bias_update_rate``,
-# ``mtp_loss_scaling_factor``, ``overlap_p2p_comm``) are intentionally
-# omitted — they fall through to TC's own defaults at lowering time.
-#
-# ``is_hybrid_model=True`` is also intentionally absent — every HybridModel
-# recipe is a hybrid model by construction; the DSL's internal lowering
-# forces it on every per-layer TC.
-#
-# ``make_vocab_size_divisible_by=128`` from the canonical config is NOT a
-# TransformerConfig field — it's a launcher-side tokenizer pad. The DSL
-# expresses it by setting ``EmbeddingLayerConfig.vocab_size`` to the already-
-# padded value (131072 below = 1024 * 128).
-common_config = CommonLayerConfig(
-    # Architecture
-    hidden_size=2688,
-    ffn_hidden_size=1856,
-    # Precision
-    mixed_precision_dtype=torch.bfloat16,
-    first_last_layers_bf16=True,
-    # Layer-level parallelism (TP/CP/EP sizes live on HybridModelConfig).
-    sequence_parallel=True,
-    # Initialisation
-    init_method_std=0.0173,
-    # Norms
-    normalization="RMSNorm",
-    # Bias / activation
-    add_bias_linear=False,
-    activation_func="squared_relu",
-    # Fusions
-    persist_layer_norm=True,
-    # ``tp_comm_overlap`` is not a curated DSL field today; the Bridge config
-    # sets it via CommOverlapConfig. Use ``extra`` to project it onto every
-    # per-layer TransformerConfig (matches the legacy ``--tp-comm-overlap``
-    # CLI flag).
-    extra={"tp_comm_overlap": True},
-)
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    return default if value is None else int(value)
 
 
-# --- Per-layer configs -----------------------------------------------------
-
-Embedding = EmbeddingLayerConfig(
-    common_config=common_config,
-    vocab_size=VOCAB_SIZE,
-    max_sequence_length=MAX_SEQUENCE_LENGTH,
-    position_embedding_type="none",
-)
-
-Mamba = MambaLayerConfig(
-    common_config=common_config, head_dim=64, state_size=128, num_groups=8, num_heads=64
-)
-
-Att = AttentionLayerConfig(
-    common_config=common_config,
-    num_attention_heads=32,
-    num_query_groups=2,
-    kv_channels=128,
-    attention_softmax_in_fp32=False,
-    masked_softmax_fusion=True,
-    attention_backend="fused",
-)
-
-MoE = MoELayerConfig(
-    common_config=common_config,
-    num_experts=128,
-    top_k=6,
-    ffn_hidden_size=1856,
-    router_score_function="sigmoid",
-    router_load_balancing_type="seq_aux_loss",
-    router_topk_scaling_factor=2.5,
-    router_enable_expert_bias=True,
-    router_dtype="fp32",
-    aux_loss_coeff=1e-4,
-    shared_expert_intermediate_size=3712,
-    # DeepEP-backed flex dispatcher (final canonical value).
-    token_dispatcher_type="flex",
-    flex_dispatcher_backend="deepep",
-    hybridep_num_sms=16,
-    grouped_gemm=True,
-    permute_fusion=True,
-    router_num_groups=1,
-    router_group_topk=1,
-    router_fusion=False,
-    shared_expert_overlap=False,
-    use_fused_weighted_squared_relu=True,
-)
-
-Loss = CrossEntropyLayerConfig(loss_fusion=True, fusion_impl="native")
-
-
-# --- Layer pattern composition ---------------------------------------------
-#
-# Decoder layout (52 layers total = 6 + 28 + 9 + 9). ``num_layers`` is never
-# set explicitly; ``HybridModelConfig.num_layers`` derives it from the
-# flattened pattern length.
-
-stage0 = [Mamba] + [MoE, Mamba] * 2 + [Att]
-stage1 = [MoE, Mamba] * 3 + [Att]
-stage2 = [MoE, Mamba] * 4 + [Att]
-stage3 = [MoE, Mamba] * 4 + [MoE]
-
-decoder = stage0 + stage1 * 4 + stage2 + stage3
-
-layer_pattern = [Embedding] + decoder + [Loss]
-
-
-# --- Recipe entry point ----------------------------------------------------
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "t", "yes", "y", "on"}
 
 
 def make_recipe() -> HybridModelConfig:
-    """Return the Nemotron-3 Nano HybridModel pretrain recipe.
+    """Return the Nemotron-3 Nano HybridModel pretrain recipe."""
 
-    ``make_recipe`` is the canonical default entry point used when
-    ``--model-recipe`` is passed without a ``:func`` suffix.
-    """
+    common_config = CommonLayerConfig(
+        hidden_size=2688,
+        ffn_hidden_size=1856,
+        mixed_precision_dtype=torch.bfloat16,
+        first_last_layers_bf16=True,
+        sequence_parallel=_env_bool("NANO_SP", True),
+        init_method_std=0.0173,
+        normalization="RMSNorm",
+        add_bias_linear=False,
+        activation_func="squared_relu",
+        persist_layer_norm=True,
+        cuda_graph_impl="none",
+    )
+
+    embedding = EmbeddingLayerConfig(
+        common_config=common_config,
+        vocab_size=_env_int("NANO_VOCAB_SIZE", VOCAB_SIZE),
+        max_sequence_length=_env_int("NANO_MAX_SEQUENCE_LENGTH", MAX_SEQUENCE_LENGTH),
+        position_embedding_type="none",
+    )
+    mamba = MambaLayerConfig(
+        common_config=common_config,
+        head_dim=64,
+        state_size=128,
+        num_groups=8,
+        num_heads=64,
+    )
+    attention = AttentionLayerConfig(
+        common_config=common_config,
+        num_attention_heads=32,
+        num_query_groups=2,
+        kv_channels=128,
+        attention_softmax_in_fp32=False,
+        masked_softmax_fusion=True,
+        attention_backend="fused",
+    )
+    moe = MoELayerConfig(
+        common_config=common_config,
+        num_experts=128,
+        top_k=6,
+        ffn_hidden_size=1856,
+        router_score_function="sigmoid",
+        router_load_balancing_type="seq_aux_loss",
+        router_topk_scaling_factor=2.5,
+        router_enable_expert_bias=True,
+        router_dtype="fp32",
+        aux_loss_coeff=0.0001,
+        shared_expert_intermediate_size=3712,
+        token_dispatcher_type="flex",
+        flex_dispatcher_backend="deepep",
+        hybridep_num_sms=16,
+        grouped_gemm=True,
+        permute_fusion=True,
+        router_num_groups=1,
+        router_group_topk=1,
+        router_fusion=False,
+        shared_expert_overlap=False,
+        use_fused_weighted_squared_relu=True,
+    )
+    loss = CrossEntropyLayerConfig(loss_fusion=True, fusion_impl="native")
+
+    stage0 = [mamba] + [moe, mamba] * 2 + [attention]
+    stage1 = [moe, mamba] * 3 + [attention]
+    stage2 = [moe, mamba] * 4 + [attention]
+    stage3 = [moe, mamba] * 4 + [moe]
+    decoder = stage0 + stage1 * 4 + stage2 + stage3
+
     return HybridModelConfig(
         common_config=common_config,
-        layer_pattern=layer_pattern,
+        layer_pattern=[embedding] + decoder + [loss],
         untie_embeddings_and_output_weights=True,
-        # Model-level parallelism (PP intentionally absent — the recipe DSL
-        # is PP-free; recipes that need PP must use the legacy string DSL).
-        tensor_model_parallel_size=4,
-        expert_model_parallel_size=8,
-        expert_tensor_parallel_size=1,
+        tensor_model_parallel_size=_env_int("NANO_TP", 4),
+        context_parallel_size=_env_int("NANO_CP", 1),
+        expert_model_parallel_size=_env_int("NANO_EP", 8),
+        expert_tensor_parallel_size=_env_int("NANO_ETP", 1),
     )
 
 
-def nemotron_3_nano_pretrain_config():
-    """Bridge-style alias retained for explicit ``:func`` selection."""
+def nemotron_3_nano_pretrain_config() -> HybridModelConfig:
+    """Bridge-style alias for explicit ``--model-recipe ...:func`` selection."""
+
     return make_recipe()
 
 
 if __name__ == "__main__":
-    # Lower the recipe and print the resulting layer_type_list. This is
-    # the same code path ``--model-recipe`` exercises in production via
-    # ``HybridModel.from_recipe``.
-    #
-    # The full lowering requires Transformer Engine
-    # (``moe_permute_fusion=True``, ``transformer_impl="transformer_engine"``,
-    # etc. trigger TE checks at config-construction time). In dev environments
-    # without TE, fall back to the pure-Python ``flatten_decoder`` +
-    # ``SYMBOL`` derivation so the smoke test can still verify the pattern
-    # composition.
     recipe = make_recipe()
     try:
         _, layer_type_list, _ = recipe._lower()
-    except (ValueError, ImportError, ModuleNotFoundError) as e:
-        msg = str(e)
-        if "fused permutation" not in msg and "TE" not in msg and "transformer_engine" not in msg:
-            raise
+    except (ValueError, ImportError, ModuleNotFoundError) as exc:
         print(
-            f"NOTE: full lowering needs Transformer Engine "
-            f"({type(e).__name__}: {e}). Falling back to pattern-only "
-            f"verification — production runs go through HybridModel.from_recipe."
+            "NOTE: full lowering failed "
+            f"({type(exc).__name__}: {exc}). Falling back to pattern-only verification."
         )
         layer_type_list = [type(lc).SYMBOL for lc in recipe.flatten_decoder()]
-    composed_string = "".join(layer_type_list)
 
-    print(f"Composed layer pattern: {composed_string}")
+    composed = "".join(layer_type_list)
+    print(f"Composed layer pattern: {composed}")
     print(f"Layer count:            {len(layer_type_list)}")
+    print(f"Legacy reference:       {LEGACY_HYBRID_LAYER_PATTERN}")
+    print(f"Match:                  {composed == LEGACY_HYBRID_LAYER_PATTERN}")
+    if composed != LEGACY_HYBRID_LAYER_PATTERN:
+        raise SystemExit("Composed pattern does not match the legacy string DSL pattern.")

--- a/examples/nemotron3/nano.sh
+++ b/examples/nemotron3/nano.sh
@@ -1,118 +1,162 @@
-# Megatron-LM legacy-CLI launch line for Nemotron-3 Nano (30B-A3B MoE).
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 #
-# Faithful 1:1 with the canonical Megatron-Bridge recipe at
-# Megatron-Bridge/src/megatron/bridge/recipes/nemotronh/nemotron_3_nano.py
-# ::nemotron_3_nano_pretrain_config.
-#
-# This file is the legacy ``--hybrid-layer-pattern`` baseline; the recommended
-# path is the Python recipe at examples/nemotron3/nano.py
-# (entry point: ``--model-recipe examples.nemotron3.nano``). Both produce
-# byte-identical models when seeded the same way.
-#
-# Usage (assumes a running torchrun environment):
-#   torchrun ... pretrain_hybrid.py $(cat examples/nemotron3/nano.sh)
+# Legacy string-DSL launcher for the Nemotron-3 Nano experiment.
 
-  --use-mcore-models \
-  --transformer-impl transformer_engine \
-  --group-query-attention \
-  --squared-relu \
-  --bf16 \
-  --first-last-layers-bf16 \
-  --use-fused-weighted-squared-relu \
-  --split 9999,8,2 \
-  --cuda-graph-scope full \
-  --cuda-graph-impl none \
-  --cuda-graph-warmup-steps 3 \
-  --seq-length 8192 \
-  --max-position-embeddings 8192 \
-  --seed 1234 \
-  --micro-batch-size 2 \
-  --global-batch-size 3072 \
-  --train-iters 39735 \
-  --manual-gc-interval 0 \
-  --tensor-model-parallel-size 4 \
-  --pipeline-model-parallel-size 1 \
-  --sequence-parallel \
-  --context-parallel-size 1 \
-  --expert-model-parallel-size 8 \
-  --expert-tensor-parallel-size 1 \
-  --tp-comm-overlap \
-  --cross-entropy-loss-fusion \
-  --cross-entropy-fusion-impl native \
-  --no-overlap-p2p-communication \
-  --num-layers 52 \
-  --hybrid-layer-pattern "MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME" \
-  --hidden-size 2688 \
-  --num-attention-heads 32 \
-  --attention-backend fused \
-  --num-query-groups 2 \
-  --ffn-hidden-size 1856 \
-  --kv-channels 128 \
-  --hidden-dropout 0.0 \
-  --attention-dropout 0.0 \
-  --norm-epsilon 1e-05 \
-  --disable-bias-linear \
-  --normalization RMSNorm \
-  --init-method-std 0.0173 \
-  --no-rope-fusion \
-  --mamba-num-heads 64 \
-  --mamba-state-dim 128 \
-  --mamba-head-dim 64 \
-  --mamba-num-groups 8 \
-  --num-experts 128 \
-  --moe-shared-expert-intermediate-size 3712 \
-  --moe-layer-freq 1 \
-  --moe-ffn-hidden-size 1856 \
-  --moe-router-load-balancing-type seq_aux_loss \
-  --moe-router-topk 6 \
-  --moe-router-num-groups 1 \
-  --moe-router-group-topk 1 \
-  --moe-router-topk-scaling-factor 2.5 \
-  --moe-router-score-function sigmoid \
-  --moe-router-dtype fp32 \
-  --moe-router-enable-expert-bias \
-  --moe-router-bias-update-rate 0.001 \
-  --moe-grouped-gemm \
-  --moe-aux-loss-coeff 0.0001 \
-  --moe-token-dispatcher-type flex \
-  --moe-flex-dispatcher-backend deepep \
-  --moe-hybridep-num-sms 16 \
-  --moe-permute-fusion \
-  --untie-embeddings-and-output-weights \
-  --position-embedding-type none \
-  --rotary-percent 1.0 \
-  --rotary-base 10000 \
-  --make-vocab-size-divisible-by 128 \
-  --lr 0.0016 \
-  --min-lr 1.6e-05 \
-  --weight-decay 0.1 \
-  --adam-beta1 0.9 \
-  --adam-beta2 0.95 \
-  --adam-eps 1e-08 \
-  --clip-grad 1.0 \
-  --grad-reduce-in-fp32 \
-  --overlap-grad-reduce \
-  --overlap-param-gather \
-  --use-distributed-optimizer \
-  --eval-iters 32 \
-  --eval-interval 500 \
-  --lr-decay-style cosine \
-  --lr-warmup-iters 333 \
-  --lr-warmup-samples 0 \
-  --lr-warmup-init 0.0 \
-  --override-opt-param-scheduler \
-  --start-weight-decay 0.1 \
-  --end-weight-decay 0.1 \
-  --weight-decay-incr-style constant \
-  --dataloader-type single \
-  --num-workers 8 \
-  --num-dataset-builder-threads 1 \
-  --no-mmap-bin-files \
-  --log-interval 10 \
-  --tokenizer-type HuggingFaceTokenizer \
-  --tokenizer-model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
-  --save-interval 200 \
-  --ckpt-format torch_dist \
-  --use-persistent-ckpt-worker \
-  --dist-ckpt-strictness log_all \
-  --distributed-timeout-minutes 10
+set -euo pipefail
+
+SOURCE=${SOURCE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}
+cd "${SOURCE}"
+
+LEGACY_HYBRID_LAYER_PATTERN=${LEGACY_HYBRID_LAYER_PATTERN:-"MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME"}
+WORKSPACE=${WORKSPACE:-/workspace}
+RUN_NAME=${RUN_NAME:-nano_sh}
+
+GPUS_PER_NODE=${GPUS_PER_NODE:-${SLURM_GPUS_ON_NODE:-8}}
+NUM_NODES=${NUM_NODES:-${SLURM_JOB_NUM_NODES:-1}}
+NODE_RANK=${NODE_RANK:-${SLURM_NODEID:-0}}
+MASTER_PORT=${MASTER_PORT:-29500}
+if [ -z "${MASTER_ADDR:-}" ]; then
+    if [ -n "${SLURM_JOB_NODELIST:-}" ] && command -v scontrol >/dev/null 2>&1; then
+        MASTER_ADDR=$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)
+    else
+        MASTER_ADDR=localhost
+    fi
+fi
+
+NANO_TP=${NANO_TP:-4}
+NANO_PP=${NANO_PP:-1}
+NANO_EP=${NANO_EP:-8}
+NANO_ETP=${NANO_ETP:-1}
+NANO_CP=${NANO_CP:-1}
+NANO_SP=${NANO_SP:-True}
+
+SEQ_LENGTH=${SEQ_LENGTH:-512}
+MAX_SEQUENCE_LENGTH=${MAX_SEQUENCE_LENGTH:-8192}
+TRAIN_ITERS=${TRAIN_ITERS:-50}
+GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE:-32}
+MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE:-1}
+EVAL_ITERS=${EVAL_ITERS:-10}
+LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-5}
+LOG_INTERVAL=${LOG_INTERVAL:-1}
+VOCAB_SIZE=${VOCAB_SIZE:-131072}
+
+CHECKPOINT_DIR=${CHECKPOINT_DIR:-${WORKSPACE}/results/${RUN_NAME}_tp${NANO_TP}_pp${NANO_PP}_ep${NANO_EP}_cp${NANO_CP}}
+TENSORBOARD_DIR=${TENSORBOARD_DIR:-${WORKSPACE}/tensorboard/${RUN_NAME}_tp${NANO_TP}_pp${NANO_PP}_ep${NANO_EP}_cp${NANO_CP}}
+DATA_CACHE_DIR=${DATA_CACHE_DIR:-${WORKSPACE}/data-cache/${RUN_NAME}}
+
+mkdir -p "${CHECKPOINT_DIR}" "${TENSORBOARD_DIR}" "${DATA_CACHE_DIR}"
+
+export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
+export TORCH_NCCL_AVOID_RECORD_STREAMS=${TORCH_NCCL_AVOID_RECORD_STREAMS:-1}
+export NCCL_NVLS_ENABLE=${NCCL_NVLS_ENABLE:-0}
+export TRITON_CACHE_DIR=${TRITON_CACHE_DIR:-${WORKSPACE}/triton-cache}
+export TRITON_CACHE_MANAGER=${TRITON_CACHE_MANAGER:-megatron.core.ssm.triton_cache_manager:ParallelFileCacheManager}
+
+DISTRIBUTED_ARGS=(
+    --nproc_per_node "${GPUS_PER_NODE}"
+    --nnodes "${NUM_NODES}"
+    --node_rank "${NODE_RANK}"
+    --master_addr "${MASTER_ADDR}"
+    --master_port "${MASTER_PORT}"
+)
+
+MODEL_ARGS=(
+    --use-mcore-models
+    --spec megatron.core.models.hybrid.hybrid_layer_specs hybrid_stack_spec
+    --hybrid-layer-pattern "${LEGACY_HYBRID_LAYER_PATTERN}"
+    --hidden-size 2688
+    --ffn-hidden-size 1856
+    --num-attention-heads 32
+    --group-query-attention
+    --num-query-groups 2
+    --kv-channels 128
+    --mamba-num-heads 64
+    --mamba-head-dim 64
+    --mamba-state-dim 128
+    --mamba-num-groups 8
+    --position-embedding-type none
+    --normalization RMSNorm
+    --untie-embeddings-and-output-weights
+    --init-method-std 0.0173
+    --disable-bias-linear
+    --squared-relu
+    --first-last-layers-bf16
+    --use-fused-weighted-squared-relu
+    --transformer-impl transformer_engine
+    --attention-backend fused
+    --cross-entropy-loss-fusion
+    --cross-entropy-fusion-impl native
+    --tensor-model-parallel-size "${NANO_TP}"
+    --pipeline-model-parallel-size "${NANO_PP}"
+    --context-parallel-size "${NANO_CP}"
+    --expert-model-parallel-size "${NANO_EP}"
+    --expert-tensor-parallel-size "${NANO_ETP}"
+    --num-experts 128
+    --moe-ffn-hidden-size 1856
+    --moe-shared-expert-intermediate-size 3712
+    --moe-router-topk 6
+    --moe-router-topk-scaling-factor 2.5
+    --moe-router-num-groups 1
+    --moe-router-group-topk 1
+    --moe-router-score-function sigmoid
+    --moe-router-enable-expert-bias
+    --moe-router-load-balancing-type seq_aux_loss
+    --moe-router-dtype fp32
+    --moe-aux-loss-coeff 0.0001
+    --moe-grouped-gemm
+    --moe-token-dispatcher-type flex
+    --moe-flex-dispatcher-backend deepep
+    --moe-hybridep-num-sms 16
+    --moe-permute-fusion
+)
+
+if [[ "${NANO_SP,,}" == "true" || "${NANO_SP}" == "1" ]]; then
+    MODEL_ARGS+=(--sequence-parallel)
+fi
+
+TRAINING_ARGS=(
+    --mock-data
+    --tokenizer-type NullTokenizer
+    --vocab-size "${VOCAB_SIZE}"
+    --make-vocab-size-divisible-by 128
+    --seq-length "${SEQ_LENGTH}"
+    --max-position-embeddings "${MAX_SEQUENCE_LENGTH}"
+    --split 949,50,1
+    --distributed-backend nccl
+    --micro-batch-size "${MICRO_BATCH_SIZE}"
+    --global-batch-size "${GLOBAL_BATCH_SIZE}"
+    --train-iters "${TRAIN_ITERS}"
+    --lr 1.6e-3
+    --min-lr 1.6e-5
+    --lr-decay-style cosine
+    --lr-warmup-iters "${LR_WARMUP_ITERS}"
+    --weight-decay 0.1
+    --clip-grad 1.0
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+    --adam-beta1 0.9
+    --adam-beta2 0.95
+    --bf16
+    --use-distributed-optimizer
+    --overlap-grad-reduce
+    --overlap-param-gather
+    --no-create-attention-mask-in-dataloader
+    --save "${CHECKPOINT_DIR}"
+    --save-interval 10000
+    --no-save-optim
+    --no-save-rng
+    --ckpt-format torch_dist
+    --eval-interval 1000
+    --eval-iters "${EVAL_ITERS}"
+    --log-interval "${LOG_INTERVAL}"
+    --tensorboard-dir "${TENSORBOARD_DIR}"
+    --data-cache-path "${DATA_CACHE_DIR}"
+)
+
+echo "Running legacy nano.sh experiment"
+echo "Topology: TP=${NANO_TP} PP=${NANO_PP} EP=${NANO_EP} ETP=${NANO_ETP} CP=${NANO_CP} SP=${NANO_SP}"
+echo "torchrun: nnodes=${NUM_NODES} nproc_per_node=${GPUS_PER_NODE} node_rank=${NODE_RANK} master=${MASTER_ADDR}:${MASTER_PORT}"
+
+exec uv run --no-sync python -m torch.distributed.run "${DISTRIBUTED_ARGS[@]}" \
+    pretrain_hybrid.py "${MODEL_ARGS[@]}" "${TRAINING_ARGS[@]}" "$@"

--- a/examples/nemotron3/sbatch_pretrain_nano_py.sh
+++ b/examples/nemotron3/sbatch_pretrain_nano_py.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Submit with: sbatch examples/nemotron3/sbatch_pretrain_nano_py.sh
+
+#SBATCH --job-name=nano-py
+#SBATCH --nodes=4
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --time=24:00:00
+#SBATCH --partition=gpu
+#SBATCH --account=my_account
+#SBATCH --output=logs/nano_py_%j.out
+#SBATCH --error=logs/nano_py_%j.err
+#SBATCH --exclusive
+
+set -euo pipefail
+
+CONTAINER_IMAGE=${CONTAINER_IMAGE:-gitlab-master.nvidia.com:5005/ppetrakian/containers/mcore/dsl:latest}
+CONTAINER_WORKDIR=${CONTAINER_WORKDIR:-/workspace}
+HOST_REPO=${HOST_REPO:-$(pwd)}
+CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-${HOST_REPO}:${CONTAINER_WORKDIR}}
+WORKSPACE=${WORKSPACE:-/workspace}
+MODEL_RECIPE=${MODEL_RECIPE:-examples.nemotron3.nano}
+
+SEQ_LENGTH=${SEQ_LENGTH:-512}
+TRAIN_ITERS=${TRAIN_ITERS:-50}
+GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE:-32}
+MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE:-1}
+EVAL_ITERS=${EVAL_ITERS:-10}
+LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-5}
+LOG_INTERVAL=${LOG_INTERVAL:-1}
+VOCAB_SIZE=${VOCAB_SIZE:-131072}
+MAX_SEQUENCE_LENGTH=${MAX_SEQUENCE_LENGTH:-8192}
+
+# "TP,PP,EP,CP,SP" per entry. The Python recipe DSL is PP-free, so PP must stay 1.
+PARALLELISM_CONFIGS=(${PARALLELISM_CONFIGS:-"4,1,8,1,True"})
+
+export TORCH_NCCL_AVOID_RECORD_STREAMS=${TORCH_NCCL_AVOID_RECORD_STREAMS:-1}
+export NCCL_NVLS_ENABLE=${NCCL_NVLS_ENABLE:-0}
+
+mkdir -p logs
+
+if [ -z "${CONTAINER_IMAGE}" ]; then
+    echo "ERROR: CONTAINER_IMAGE must be set."
+    exit 1
+fi
+
+MASTER_ADDR=${MASTER_ADDR:-$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)}
+GPUS_PER_NODE=${GPUS_PER_NODE:-${SLURM_GPUS_ON_NODE:-8}}
+BASE_MASTER_PORT=${MASTER_PORT:-29500}
+
+SRUN_CMD=(
+    srun
+    --mpi=pmix
+    --ntasks="${SLURM_JOB_NUM_NODES}"
+    --ntasks-per-node=1
+    --container-image="${CONTAINER_IMAGE}"
+    --container-workdir="${CONTAINER_WORKDIR}"
+)
+if [ -n "${CONTAINER_MOUNTS}" ]; then
+    SRUN_CMD+=(--container-mounts="${CONTAINER_MOUNTS}")
+fi
+
+echo "======================================"
+echo "Nemotron-3 Nano Python recipe DSL job"
+echo "Job ID: ${SLURM_JOB_ID}"
+echo "Nodes: ${SLURM_JOB_NUM_NODES}"
+echo "GPUs per node: ${GPUS_PER_NODE}"
+echo "Container: ${CONTAINER_IMAGE}"
+echo "Mounts: ${CONTAINER_MOUNTS}"
+echo "Model recipe: ${MODEL_RECIPE}"
+echo "Parallelism configs: ${PARALLELISM_CONFIGS[*]}"
+echo "======================================"
+
+CONFIG_INDEX=0
+for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
+    IFS=',' read -r TP PP EP CP SP <<< "${CONFIG}"
+    CONFIG_INDEX=$((CONFIG_INDEX + 1))
+    if [ "${PP}" != "1" ]; then
+        echo "ERROR: nano.py recipe DSL runs require PP=1; got PP=${PP}."
+        exit 1
+    fi
+
+    MASTER_PORT_FOR_CONFIG=$((BASE_MASTER_PORT + CONFIG_INDEX - 1))
+    RUN_NAME="nano_py_tp${TP}_pp${PP}_ep${EP}_sp${SP}_cp${CP}"
+    CHECKPOINT_DIR="${WORKSPACE}/results/${RUN_NAME}"
+    TENSORBOARD_DIR="${WORKSPACE}/tensorboard/${RUN_NAME}"
+    DATA_CACHE_DIR="${WORKSPACE}/data-cache/${RUN_NAME}"
+    SEQUENCE_PARALLEL_ARG=""
+    if [[ "${SP,,}" == "true" || "${SP}" == "1" ]]; then
+        SEQUENCE_PARALLEL_ARG="--sequence-parallel"
+    fi
+
+    echo ""
+    echo "======================================"
+    echo "Config ${CONFIG_INDEX}/${#PARALLELISM_CONFIGS[@]}: TP=${TP}, PP=${PP}, EP=${EP}, CP=${CP}, SP=${SP}"
+    echo "======================================"
+
+    CMD="cd ${CONTAINER_WORKDIR} && \
+        mkdir -p ${CHECKPOINT_DIR} ${TENSORBOARD_DIR} ${DATA_CACHE_DIR} && \
+        export CUDA_DEVICE_MAX_CONNECTIONS=\${CUDA_DEVICE_MAX_CONNECTIONS:-1} && \
+        export TRITON_CACHE_DIR=\${TRITON_CACHE_DIR:-${WORKSPACE}/triton-cache} && \
+        export TRITON_CACHE_MANAGER=\${TRITON_CACHE_MANAGER:-megatron.core.ssm.triton_cache_manager:ParallelFileCacheManager} && \
+        NANO_TP=${TP} NANO_EP=${EP} NANO_CP=${CP} NANO_SP=${SP} NANO_ETP=1 \
+        NANO_VOCAB_SIZE=${VOCAB_SIZE} NANO_MAX_SEQUENCE_LENGTH=${MAX_SEQUENCE_LENGTH} \
+        uv run --no-sync python -m torch.distributed.run \
+            --nproc_per_node ${GPUS_PER_NODE} \
+            --nnodes ${SLURM_JOB_NUM_NODES} \
+            --node_rank \${SLURM_NODEID} \
+            --master_addr ${MASTER_ADDR} \
+            --master_port ${MASTER_PORT_FOR_CONFIG} \
+            pretrain_hybrid.py \
+            --model-recipe ${MODEL_RECIPE} \
+            ${SEQUENCE_PARALLEL_ARG} \
+            --mock-data \
+            --tokenizer-type NullTokenizer \
+            --vocab-size ${VOCAB_SIZE} \
+            --make-vocab-size-divisible-by 128 \
+            --seq-length ${SEQ_LENGTH} \
+            --split 949,50,1 \
+            --distributed-backend nccl \
+            --micro-batch-size ${MICRO_BATCH_SIZE} \
+            --global-batch-size ${GLOBAL_BATCH_SIZE} \
+            --train-iters ${TRAIN_ITERS} \
+            --lr 1.6e-3 \
+            --min-lr 1.6e-5 \
+            --lr-decay-style cosine \
+            --lr-warmup-iters ${LR_WARMUP_ITERS} \
+            --weight-decay 0.1 \
+            --clip-grad 1.0 \
+            --attention-dropout 0.0 \
+            --hidden-dropout 0.0 \
+            --adam-beta1 0.9 \
+            --adam-beta2 0.95 \
+            --bf16 \
+            --use-mcore-models \
+            --use-distributed-optimizer \
+            --overlap-grad-reduce \
+            --overlap-param-gather \
+            --no-create-attention-mask-in-dataloader \
+            --save ${CHECKPOINT_DIR} \
+            --save-interval 10000 \
+            --no-save-optim \
+            --no-save-rng \
+            --ckpt-format torch_dist \
+            --eval-interval 1000 \
+            --eval-iters ${EVAL_ITERS} \
+            --log-interval ${LOG_INTERVAL} \
+            --tensorboard-dir ${TENSORBOARD_DIR} \
+            --data-cache-path ${DATA_CACHE_DIR}"
+
+    echo "Executing command:"
+    echo "${CMD}"
+    "${SRUN_CMD[@]}" bash -lc "${CMD}"
+done
+
+echo "======================================"
+echo "Python recipe nano.py job completed"
+echo "======================================"

--- a/examples/nemotron3/sbatch_pretrain_nano_sh.sh
+++ b/examples/nemotron3/sbatch_pretrain_nano_sh.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Submit with: sbatch examples/nemotron3/sbatch_pretrain_nano_sh.sh
+
+#SBATCH --job-name=nano-sh
+#SBATCH --nodes=4
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --time=24:00:00
+#SBATCH --partition=gpu
+#SBATCH --account=my_account
+#SBATCH --output=logs/nano_sh_%j.out
+#SBATCH --error=logs/nano_sh_%j.err
+#SBATCH --exclusive
+
+set -euo pipefail
+
+CONTAINER_IMAGE=${CONTAINER_IMAGE:-gitlab-master.nvidia.com:5005/ppetrakian/containers/mcore/dsl:latest}
+CONTAINER_WORKDIR=${CONTAINER_WORKDIR:-/workspace}
+HOST_REPO=${HOST_REPO:-$(pwd)}
+CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-${HOST_REPO}:${CONTAINER_WORKDIR}}
+WORKSPACE=${WORKSPACE:-/workspace}
+
+SEQ_LENGTH=${SEQ_LENGTH:-512}
+TRAIN_ITERS=${TRAIN_ITERS:-50}
+GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE:-32}
+MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE:-1}
+EVAL_ITERS=${EVAL_ITERS:-10}
+LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-5}
+LOG_INTERVAL=${LOG_INTERVAL:-1}
+
+# "TP,PP,EP,CP,SP" per entry. Keep PP=1 for direct comparison with nano.py.
+PARALLELISM_CONFIGS=(${PARALLELISM_CONFIGS:-"4,1,8,1,True"})
+
+export TORCH_NCCL_AVOID_RECORD_STREAMS=${TORCH_NCCL_AVOID_RECORD_STREAMS:-1}
+export NCCL_NVLS_ENABLE=${NCCL_NVLS_ENABLE:-0}
+
+mkdir -p logs
+
+if [ -z "${CONTAINER_IMAGE}" ]; then
+    echo "ERROR: CONTAINER_IMAGE must be set."
+    exit 1
+fi
+
+MASTER_ADDR=${MASTER_ADDR:-$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)}
+GPUS_PER_NODE=${GPUS_PER_NODE:-${SLURM_GPUS_ON_NODE:-8}}
+BASE_MASTER_PORT=${MASTER_PORT:-29500}
+
+SRUN_CMD=(
+    srun
+    --mpi=pmix
+    --ntasks="${SLURM_JOB_NUM_NODES}"
+    --ntasks-per-node=1
+    --container-image="${CONTAINER_IMAGE}"
+    --container-workdir="${CONTAINER_WORKDIR}"
+)
+if [ -n "${CONTAINER_MOUNTS}" ]; then
+    SRUN_CMD+=(--container-mounts="${CONTAINER_MOUNTS}")
+fi
+
+echo "======================================"
+echo "Nemotron-3 Nano legacy string DSL job"
+echo "Job ID: ${SLURM_JOB_ID}"
+echo "Nodes: ${SLURM_JOB_NUM_NODES}"
+echo "GPUs per node: ${GPUS_PER_NODE}"
+echo "Container: ${CONTAINER_IMAGE}"
+echo "Mounts: ${CONTAINER_MOUNTS}"
+echo "Parallelism configs: ${PARALLELISM_CONFIGS[*]}"
+echo "======================================"
+
+CONFIG_INDEX=0
+for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
+    IFS=',' read -r TP PP EP CP SP <<< "${CONFIG}"
+    CONFIG_INDEX=$((CONFIG_INDEX + 1))
+    MASTER_PORT_FOR_CONFIG=$((BASE_MASTER_PORT + CONFIG_INDEX - 1))
+    RUN_NAME="nano_sh_tp${TP}_pp${PP}_ep${EP}_sp${SP}_cp${CP}"
+
+    echo ""
+    echo "======================================"
+    echo "Config ${CONFIG_INDEX}/${#PARALLELISM_CONFIGS[@]}: TP=${TP}, PP=${PP}, EP=${EP}, CP=${CP}, SP=${SP}"
+    echo "======================================"
+
+    CMD="cd ${CONTAINER_WORKDIR} && \
+        RUN_NAME=${RUN_NAME} \
+        WORKSPACE=${WORKSPACE} \
+        GPUS_PER_NODE=${GPUS_PER_NODE} \
+        NUM_NODES=${SLURM_JOB_NUM_NODES} \
+        MASTER_ADDR=${MASTER_ADDR} \
+        MASTER_PORT=${MASTER_PORT_FOR_CONFIG} \
+        NANO_TP=${TP} NANO_PP=${PP} NANO_EP=${EP} NANO_CP=${CP} NANO_SP=${SP} \
+        SEQ_LENGTH=${SEQ_LENGTH} TRAIN_ITERS=${TRAIN_ITERS} \
+        GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE} MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE} \
+        EVAL_ITERS=${EVAL_ITERS} LR_WARMUP_ITERS=${LR_WARMUP_ITERS} \
+        LOG_INTERVAL=${LOG_INTERVAL} \
+        bash examples/nemotron3/nano.sh"
+
+    echo "Executing command:"
+    echo "${CMD}"
+    "${SRUN_CMD[@]}" bash -lc "${CMD}"
+done
+
+echo "======================================"
+echo "Legacy nano.sh job completed"
+echo "======================================"

--- a/hybrid_builders.py
+++ b/hybrid_builders.py
@@ -1,46 +1,86 @@
 # Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 
-from model_provider import count_parameters_in_layer
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_inference_stack_spec
 from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.models.hybrid.layer_pattern import load_recipe
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.spec_utils import import_module
 from megatron.training import print_rank_0
 from megatron.training.arguments import core_transformer_config_from_args
-from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_inference_stack_spec
+from model_provider import count_parameters_in_layer
 
 
 def hybrid_builder(args, pre_process, post_process, vp_stage=None, config=None, pg_collection=None):
+    """Construct a HybridModel from CLI args, dispatching on ``--model-recipe``."""
     print_rank_0('building Hybrid model ...')
-    if config is None:
-        config = core_transformer_config_from_args(args, TransformerConfig)
+    assert args.use_legacy_models is False, "Hybrid model only supported in Mcore!"
 
-    if config.transformer_impl == "inference_optimized":
-        hybrid_stack_spec = hybrid_inference_stack_spec
-        assert (
-            not config.inference_fuse_tp_communication
-        ), "inference_fuse_tp_communication is not supported for HybridModel"
-    elif args.spec is not None:
-        hybrid_stack_spec = import_module(args.spec)
+    # --model-recipe path: the recipe is the source of truth for the model
+    # architecture (config + layer pattern). Skip args→config conversion entirely.
+    if getattr(args, 'model_recipe', None) is not None:
+        if config is not None:
+            print_rank_0(
+                "Note: --model-recipe was provided; ignoring caller-supplied config "
+                "and using the recipe."
+            )
+        recipe = getattr(args, '_model_recipe', None)
+        if recipe is None:
+            recipe = load_recipe(args.model_recipe)
+
+        # Spec selection: ``--spec`` (CLI) overrides everything; otherwise
+        # auto-pick by ``transformer_impl`` set on the recipe's common
+        # config. ``None`` falls through to HybridModel's default
+        # hybrid_stack_spec. Same precedence as the legacy path below —
+        # recipe-built models get spec selection from the launcher, not
+        # from the recipe itself.
+        if getattr(args, 'spec', None) is not None:
+            recipe_stack_spec = import_module(args.spec)
+        elif recipe.common_config.transformer_impl == "inference_optimized":
+            recipe_stack_spec = hybrid_inference_stack_spec
+        else:
+            recipe_stack_spec = None
+
+        # Phase 2: call the new TC-free constructor directly.
+        # ``HybridModel(config: HybridModelConfig, ...)`` is the public
+        # surface; ``from_recipe`` now exists only as a thin alias.
+        model = HybridModel(
+            config=recipe,
+            hybrid_stack_spec=recipe_stack_spec,
+            pre_process=pre_process,
+            post_process=post_process,
+            pg_collection=pg_collection,
+            vp_stage=vp_stage,
+        )
     else:
-        raise ValueError("You must provide a valid hybrid layer spec via --spec")
+        if config is None:
+            config = core_transformer_config_from_args(args, TransformerConfig)
+        if config.transformer_impl == "inference_optimized":
+            hybrid_stack_spec = hybrid_inference_stack_spec
+            assert (
+                not config.inference_fuse_tp_communication
+            ), "inference_fuse_tp_communication is not supported for HybridModel"
+        elif args.spec is not None:
+            hybrid_stack_spec = import_module(args.spec)
+        else:
+            raise ValueError("You must provide a valid hybrid layer spec via --spec")
 
-    model = HybridModel(
-        config=config,
-        hybrid_stack_spec=hybrid_stack_spec,
-        vocab_size=args.padded_vocab_size,
-        max_sequence_length=args.max_position_embeddings,
-        hybrid_layer_pattern=args.hybrid_layer_pattern,
-        pre_process=pre_process,
-        post_process=post_process,
-        fp16_lm_cross_entropy=args.fp16_lm_cross_entropy,
-        parallel_output=True,
-        share_embeddings_and_output_weights=not args.untie_embeddings_and_output_weights,
-        position_embedding_type=args.position_embedding_type,
-        rotary_percent=args.rotary_percent,
-        rotary_base=args.rotary_base,
-        pg_collection=pg_collection,
-        vp_stage=vp_stage,
-    )
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=hybrid_stack_spec,
+            vocab_size=args.padded_vocab_size,
+            max_sequence_length=args.max_position_embeddings,
+            pre_process=pre_process,
+            post_process=post_process,
+            fp16_lm_cross_entropy=args.fp16_lm_cross_entropy,
+            parallel_output=True,
+            share_embeddings_and_output_weights=not args.untie_embeddings_and_output_weights,
+            position_embedding_type=args.position_embedding_type,
+            rotary_percent=args.rotary_percent,
+            rotary_base=args.rotary_base,
+            pg_collection=pg_collection,
+            vp_stage=vp_stage,
+            hybrid_layer_pattern=args.hybrid_layer_pattern,
+        )
 
     for l in range(model.decoder.num_layers_per_pipeline_rank):
         layer_params = count_parameters_in_layer(model, f'decoder.layers.{l}.')

--- a/megatron/core/models/hybrid/layer_configs.py
+++ b/megatron/core/models/hybrid/layer_configs.py
@@ -44,9 +44,9 @@ class LayerConfig:
     common_config: CommonLayerConfig | None = None
     """Per-layer common config; ``None`` (the default) means
     "inherit from the recipe's :attr:`HybridModelConfig.common_config`",
-    which :meth:`HybridModelConfig.compile` substitutes in. Pass an
+    which the recipe's internal lowering substitutes in. Pass an
     explicit :class:`CommonLayerConfig` to override (e.g. via
-    :meth:`CommonLayerConfig.update`). After ``compile()`` runs, this
+    :meth:`CommonLayerConfig.update`). After lowering runs, this
     field is always non-None."""
 
     extra: Dict[str, Any] = field(default_factory=dict)
@@ -128,10 +128,11 @@ class LayerConfig:
                         f"{shadowed}; set them on HybridModelConfig instead."
                     )
             kwargs.update(self.extra)
-        # Test-friendly fallback: ``compile()`` always supplies a placeholder,
-        # but unit tests calling ``lc.to_transformer_config(num_layers=N)``
-        # directly need a non-zero baseline so TC's ``__post_init__`` doesn't
-        # divide by zero deriving ``kv_channels``.
+        # Test-friendly fallback: the recipe's lowering always supplies a
+        # placeholder, but unit tests calling
+        # ``lc.to_transformer_config(num_layers=N)`` directly need a non-zero
+        # baseline so TC's ``__post_init__`` doesn't divide by zero deriving
+        # ``kv_channels``.
         kwargs.setdefault("num_attention_heads", 1)
         kwargs["num_layers"] = num_layers
         # Drop None values so TransformerConfig defaults apply.
@@ -517,9 +518,9 @@ class EmbeddingLayerConfig:
 
     common_config: CommonLayerConfig | None = None
     """Per-marker common config; ``None`` (the default) means "inherit from
-    the recipe's :attr:`HybridModelConfig.common_config`", which
-    :meth:`HybridModelConfig.compile` substitutes in. After ``compile()``
-    runs, this field is always non-None."""
+    the recipe's :attr:`HybridModelConfig.common_config`", which the
+    recipe's internal lowering substitutes in. After lowering runs,
+    this field is always non-None."""
 
     vocab_size: int = 0
     """Vocabulary size (post-padding)."""
@@ -545,16 +546,16 @@ class EmbeddingLayerConfig:
     yarn: Dict[str, Any] | None = None
     """YARN scaling parameters (consumed only when
     ``position_embedding_type == "yarn"``). These are not
-    :class:`TransformerConfig` dataclass fields today; they are attached
-    as ad-hoc attributes by :meth:`HybridModelConfig.compile` to match
-    the :func:`getattr` lookups in :class:`HybridModel.__init__`.
+    :class:`TransformerConfig` dataclass fields today; the recipe's
+    internal lowering attaches them as ad-hoc attributes to match the
+    :func:`getattr` lookups in :class:`HybridModel.__init__`.
     Recognised keys: ``yarn_rotary_scaling_factor``,
     ``yarn_original_max_position_embeddings``, ``yarn_beta_fast``,
     ``yarn_beta_slow``, ``yarn_mscale``, ``yarn_mscale_all_dim``,
-    ``yarn_correction_range_round_to_int``. Unknown keys raise at compile
+    ``yarn_correction_range_round_to_int``. Unknown keys raise at lowering
     time. When upstream lifts these onto :class:`TransformerConfig`, this
-    field collapses to a plain ``extra`` passthrough and the setattr
-    loop in ``compile()`` goes away."""
+    field collapses to a plain ``extra`` passthrough and the setattr loop
+    in the lowering goes away."""
 
     extra: Dict[str, Any] = field(default_factory=dict)
     """Passthrough kwargs forwarded to the stack-level

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -6,18 +6,24 @@ import argparse
 import dataclasses
 import json
 import os
-from pathlib import Path
 import re
 import types
+from pathlib import Path
 
 import torch
 import torch.nn.functional as F
 from packaging.version import Version as PkgVersion
 
+from megatron.core.activations import squared_relu
 from megatron.core.dist_checkpointing.validation import StrictHandling
+from megatron.core.fusions.fused_bias_geglu import quick_gelu
+from megatron.core.msc_utils import MultiStorageClientFeature
+from megatron.core.quantization.utils import (
+    kitchen_quantization_recipe_config,
+    load_quantization_recipe,
+)
 from megatron.core.rerun_state_machine import RerunStateMachine
 from megatron.core.transformer import MLATransformerConfig, TransformerConfig
-from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.transformer.cuda_graph_config import (
     ALLOWED_INFERENCE_SCOPES,
     get_deprecated_cuda_graph_modules_migration,
@@ -30,29 +36,22 @@ from megatron.core.transformer.heterogeneous.heterogeneous_config import (
     HeterogeneousTransformerConfig,
     MLPConfig,
 )
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.utils import (
     get_torch_version,
     is_flashinfer_min_version,
     is_te_min_version,
     is_torch_min_version,
 )
-from megatron.core.activations import squared_relu
-from megatron.core.fusions.fused_bias_geglu import quick_gelu
+from megatron.training.argument_utils import ArgumentGroupFactory, core_transformer_config_from_args
 from megatron.training.global_vars import set_global_variables
 from megatron.training.utils import (
     get_device_arch_version,
-    update_use_dist_ckpt,
     print_rank_0,
+    update_use_dist_ckpt,
     warn_rank_0,
 )
-from megatron.core.msc_utils import MultiStorageClientFeature
 
-from megatron.core.quantization.utils import (
-    kitchen_quantization_recipe_config,
-    load_quantization_recipe,
-)
-
-from megatron.training.argument_utils import ArgumentGroupFactory, core_transformer_config_from_args
 
 def add_megatron_arguments(parser: argparse.ArgumentParser):
     """"Add Megatron-LM arguments to the given parser."""
@@ -396,6 +395,104 @@ def tuple_type(x):
     assert isinstance(x, str)
     return tuple(int(i) for i in x.strip('()').split(','))
 
+
+def _apply_model_recipe_to_args(args):
+    """Project a HybridModel recipe onto the legacy argparse namespace.
+
+    ``--model-recipe`` makes the Python recipe the source of truth for model
+    architecture, but launcher setup still reads a few shape/topology fields
+    from ``args``. This adapter is intentionally one-way: recipe values win,
+    and the recipe itself is cached on ``args._model_recipe`` so the builder
+    can consume it without re-loading or depending on the lowering output.
+    """
+    from megatron.core.models.hybrid.layer_configs import (
+        AttentionLayerConfig,
+        DSALayerConfig,
+        MoELayerConfig,
+    )
+    from megatron.core.models.hybrid.layer_pattern import load_recipe
+
+    # Reject user-supplied conflicts up front; the projection below sets
+    # ``args.hybrid_layer_pattern`` so existing hybrid-model checks keep
+    # recognizing recipe-built HybridModels on the legacy launcher path.
+    assert getattr(args, 'hybrid_layer_pattern', None) is None, (
+        '--model-recipe and --hybrid-layer-pattern are mutually exclusive. '
+        'The recipe supplies the layer pattern; remove --hybrid-layer-pattern.'
+    )
+    assert getattr(args, 'hybrid_override_pattern', None) is None, (
+        '--model-recipe and --hybrid-override-pattern are mutually exclusive.'
+    )
+    assert not getattr(args, 'mtp_num_layers', None), (
+        '--model-recipe does not support Multi-Token Prediction yet; remove '
+        '--mtp-num-layers and use the legacy hybrid string DSL for MTP.'
+    )
+    assert getattr(args, 'mtp_hybrid_override_pattern', None) is None, (
+        '--model-recipe does not support Multi-Token Prediction yet; remove '
+        '--mtp-hybrid-override-pattern and use the legacy hybrid string DSL for MTP.'
+    )
+
+    recipe = load_recipe(args.model_recipe)
+    args._model_recipe = recipe
+
+    decoder_layers = recipe.flatten_decoder()
+    embedding = recipe.embedding_marker
+    loss = recipe.loss_marker
+    common = recipe.common_config
+
+    # Uniform attention-head count across attention/DSA layers, when one
+    # exists. If attention is heterogeneous, the launcher has no single right
+    # value and the recipe lowering remains responsible for validation.
+    attention_layers = [
+        lc for lc in decoder_layers if isinstance(lc, (AttentionLayerConfig, DSALayerConfig))
+    ]
+    head_counts = {
+        lc.num_attention_heads
+        for lc in attention_layers
+        if lc.num_attention_heads is not None
+    }
+    num_attention_heads = head_counts.pop() if len(head_counts) == 1 else None
+
+    # Topology values read from the recipe directly. ``None`` means "defer to
+    # the launcher's CLI flag"; do not read substituted values from lowering
+    # or recipes would silently clobber explicit launcher choices.
+    recipe_values = {
+        "num_layers": recipe.num_layers,
+        "hidden_size": common.hidden_size,
+        "num_attention_heads": num_attention_heads,
+        "max_position_embeddings": embedding.max_sequence_length,
+        "padded_vocab_size": embedding.vocab_size,
+        "tensor_model_parallel_size": recipe.tensor_model_parallel_size,
+        "context_parallel_size": recipe.context_parallel_size,
+        "expert_model_parallel_size": recipe.expert_model_parallel_size,
+        "expert_tensor_parallel_size": recipe.expert_tensor_parallel_size,
+        "position_embedding_type": embedding.position_embedding_type,
+        "rotary_percent": embedding.rotary_percent,
+        "rotary_base": embedding.rotary_base,
+        "rotary_seq_len_interpolation_factor": embedding.seq_len_interpolation_factor,
+        "untie_embeddings_and_output_weights": recipe.untie_embeddings_and_output_weights,
+        "fp16_lm_cross_entropy": loss.fp16_lm_cross_entropy,
+    }
+    for attr, value in recipe_values.items():
+        if value is not None and hasattr(args, attr):
+            setattr(args, attr, value)
+
+    # The generic num_layers/encoder_num_layers normalization below asserts
+    # they are not both populated. A recipe describes the decoder stack.
+    if hasattr(args, "encoder_num_layers"):
+        args.encoder_num_layers = None
+
+    moe_experts = [lc.num_experts for lc in decoder_layers if isinstance(lc, MoELayerConfig)]
+    args._model_recipe_num_experts = tuple(moe_experts)
+    unique_moe_experts = set(moe_experts)
+    if len(unique_moe_experts) == 1 and hasattr(args, "num_experts"):
+        args.num_experts = unique_moe_experts.pop()
+
+    if recipe.has_multi_latent_attention and hasattr(args, "multi_latent_attention"):
+        args.multi_latent_attention = True
+
+    args.hybrid_layer_pattern = "".join(type(lc).SYMBOL for lc in decoder_layers)
+
+
 def validate_args(args, defaults={}):
 
     # Prep for checkpoint conversion.
@@ -409,8 +506,9 @@ def validate_args(args, defaults={}):
         'Currently only global and local checkpoints are supported'
     if args.non_persistent_ckpt_type == 'local':
         try:
-            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import \
-                LocalCheckpointManager
+            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import (
+                LocalCheckpointManager,
+            )
         except ModuleNotFoundError as e:
             raise RuntimeError('nvidia_resiliency_ext is required for local checkpointing') from e
 
@@ -418,6 +516,12 @@ def validate_args(args, defaults={}):
     validate_model_config_args_from_heterogeneous_config(args)
 
     update_use_dist_ckpt(args)
+
+    # A HybridModel Python recipe is the source of truth for model
+    # architecture. Project its supported values onto the argparse namespace
+    # before generic validation and process-group setup inspect them.
+    if getattr(args, 'model_recipe', None) is not None:
+        _apply_model_recipe_to_args(args)
 
     total_model_size = args.tensor_model_parallel_size * args.pipeline_model_parallel_size * args.context_parallel_size
 
@@ -756,8 +860,10 @@ def validate_args(args, defaults={}):
         )
 
     from megatron.core.models.hybrid.hybrid_layer_allocation import (
-        Symbols, parse_hybrid_pattern, get_hybrid_total_layer_count,
+        Symbols,
+        get_hybrid_total_layer_count,
         get_hybrid_total_pipeline_segment_count,
+        parse_hybrid_pattern,
     )
     sep = Symbols.MTP_SEPARATOR
 
@@ -2501,8 +2607,7 @@ def _add_rl_args(parser):
     return parser
 
 def _add_training_args(parser):
-    from megatron.training.config import TrainingConfig
-    from megatron.training.config import ProfilingConfig
+    from megatron.training.config import ProfilingConfig, TrainingConfig
 
     prof_factory = ArgumentGroupFactory(ProfilingConfig)
     prof_group = prof_factory.build_group(parser, "profiling")
@@ -3261,6 +3366,14 @@ def _add_experimental_args(parser):
                        'Example: "M-M-|M-M*-|M-M-|M-M*-" or "M-M-|M-M*-/MM/MM". '
                        'When this flag is used, it is the sole indicator that a hybrid model '
                        'is being run.')
+    group.add_argument('--model-recipe', type=str, default=None,
+                       help='Recipe spec for a HybridModel. Accepts a dotted module path, '
+                       'module:function, filesystem path, or filesystem path:function. '
+                       'When no function is supplied, the loader calls make_recipe(). '
+                       'When set, the recipe is the source of truth for the model '
+                       'architecture; --hidden-size, --num-layers, '
+                       '--hybrid-layer-pattern, etc. are ignored. Mutually exclusive '
+                       'with --hybrid-layer-pattern.')
     group.add_argument('--hybrid-override-pattern', type=str, default=None,
                        help='Deprecated. Use --hybrid-layer-pattern instead. '
                        'If specified, its value will be forwarded to --hybrid-layer-pattern.')
@@ -3338,7 +3451,7 @@ def _add_kitchen_quantization_arguments(parser: argparse.ArgumentParser):
     If kitchen isn't available, nothing to do here, return unchanged parser
     """
     try:
-        from megatron.core.extensions.kitchen import KitchenSpecProvider, HAVE_KITCHEN
+        from megatron.core.extensions.kitchen import HAVE_KITCHEN, KitchenSpecProvider
 
     except (ImportError, ModuleNotFoundError):
         HAVE_KITCHEN = False

--- a/tests/functional_tests/test_cases/hybrid/hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/model_config.yaml
@@ -1,0 +1,58 @@
+ENV_VARS:
+  CUDA_DEVICE_MAX_CONNECTIONS: 1
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: 1
+  NCCL_ALGO: Ring
+  CUBLAS_WORKSPACE_CONFIG: :4096:8
+MODEL_ARGS:
+  # Architecture is defined entirely by the recipe — no --hybrid-layer-pattern,
+  # --hidden-size, --num-attention-heads, --num-query-groups, --spec, etc.
+  # The launcher's --model-recipe path projects recipe values onto args; this
+  # config carries only training/runtime concerns.
+  --model-recipe: ./tests/functional_tests/test_cases/hybrid/hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/recipe.py
+  --log-params-norm: true
+  --log-num-zeros-in-grad: true
+  --log-validation-ppl-to-tensorboard: true
+  --log-timers-to-tensorboard: true
+  --tensorboard-dir: ${TENSORBOARD_PATH}
+  --micro-batch-size: 4
+  --global-batch-size: 32
+  --seq-length: 1024
+  --max-position-embeddings: 1024
+  --train-iters: 50
+  --timing-log-level: 0
+  --lr-decay-iters: 320000
+  --save: ${CHECKPOINT_SAVE_PATH}
+  --load: ${CHECKPOINT_LOAD_PATH}
+  --data-path: ${DATA_PATH}/text/common_pile/v01_filtered_data/my-gpt3_00_text_document
+  --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
+  --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
+  --split: 949,50,1
+  --distributed-backend: nccl
+  --lr: 0.00015
+  --lr-decay-style: cosine
+  --min-lr: 1.0e-5
+  --weight-decay: 1e-2
+  --clip-grad: 1.0
+  --lr-warmup-fraction: .01
+  --log-interval: 1
+  --save-interval: 10000
+  --eval-interval: 1000
+  --eval-iters: 10
+  --transformer-impl: transformer_engine
+  --tensor-model-parallel-size: 1
+  --pipeline-model-parallel-size: 1
+  --use-distributed-optimizer: true
+  --overlap-grad-reduce: true
+  --overlap-param-gather: true
+  --check-weight-hash-across-dp-replicas-interval: 10
+  --ckpt-fully-parallel-load: true
+  --no-gradient-accumulation-fusion: true
+  --use-mcore-models: true
+  --ckpt-format: torch_dist
+  --data-cache-path: ${DATA_CACHE_PATH}
+  --bf16: true
+  --attention-backend: unfused
+  --log-memory-to-tensorboard: true
+  --async-save: true
+  --use-persistent-ckpt-worker: true
+TEST_TYPE: regular

--- a/tests/functional_tests/test_cases/hybrid/hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/recipe.py
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/recipe.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Smoke-test recipe for the HybridModel Python DSL construction path.
+
+A small Mamba / Attention / MLP hybrid that exercises
+``HybridModel(config: HybridModelConfig, ...)`` end-to-end through the
+real training launcher (``pretrain_hybrid.py --model-recipe``). The CI
+test that consumes this recipe trains for ~50 iterations and locks loss /
+gradient-norm golden values on the first successful run; subsequent runs
+detect numerical regressions.
+
+The recipe is deliberately small (12 decoder layers, hidden_size=1024) so
+the test runs quickly. Architecture style mirrors the existing
+``hybrid_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G`` legacy-string-DSL
+functional test, but the entry point is the new constructor surface.
+"""
+
+import torch
+
+from megatron.core.models.hybrid import (
+    AttentionLayerConfig,
+    CommonLayerConfig,
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    HybridModelConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+)
+
+# Model-wide defaults shared by every layer below.
+common = CommonLayerConfig(
+    hidden_size=1024,
+    mixed_precision_dtype=torch.bfloat16,
+    normalization="RMSNorm",
+    add_bias_linear=False,
+    activation_func="silu",
+    gated_linear_unit=True,
+)
+
+# Pattern markers — embedding at the head, loss at the tail.
+Embedding = EmbeddingLayerConfig(
+    common_config=common,
+    vocab_size=131072,
+    max_sequence_length=1024,
+    position_embedding_type="none",
+)
+Loss = CrossEntropyLayerConfig()
+
+# Layer building blocks. Mamba uses CommonLayerConfig defaults; Attention
+# pins the GQA group count to match the legacy functional test.
+Mamba = MambaLayerConfig(common_config=common)
+Attn = AttentionLayerConfig(
+    common_config=common, num_attention_heads=16, num_query_groups=8, attention_softmax_in_fp32=True
+)
+MLP = MLPLayerConfig(common_config=common)
+
+# 12-layer decoder: two repeats of [Mamba, MLP, Mamba, MLP, Attn, MLP].
+# Plain Python list operations replace the legacy string DSL.
+decoder = [Mamba, MLP, Mamba, MLP, Attn, MLP] * 2
+layer_pattern = [Embedding] + decoder + [Loss]
+
+
+def make_recipe() -> HybridModelConfig:
+    """Recipe entry point consumed by ``--model-recipe``."""
+    return HybridModelConfig(
+        common_config=common,
+        layer_pattern=layer_pattern,
+        # Match HybridModel's legacy default
+        # (``share_embeddings_and_output_weights=False``).
+        untie_embeddings_and_output_weights=True,
+    )

--- a/tests/test_utils/recipes/h100/mamba.yaml
+++ b/tests/test_utils/recipes/h100/mamba.yaml
@@ -11,7 +11,6 @@ spec:
   n_repeat: 5
   platforms: dgx_a100
   script_setup: |
-    set -euo pipefail
     unset https_proxy
     echo "machine gitlab-master.nvidia.com login okoenig password $RO_API_TOKEN" | tee -a /root/.netrc
 
@@ -35,7 +34,6 @@ spec:
     git rev-parse HEAD
     rm -rf megatron; cp -a /opt/megatron-lm/megatron ./
   script: |-
-    set -euo pipefail
     ls
     cd /opt/megatron-lm
 
@@ -50,8 +48,8 @@ spec:
         "TRAINING_PARAMS_PATH=./tests/functional_tests/test_cases/{model}/{test_case}/model_config.yaml"
         "GOLDEN_VALUES_PATH=./tests/functional_tests/test_cases/{model}/{test_case}/golden_values_{environment}_{platforms}.json"
         "N_REPEAT={n_repeat}"
-        "ENABLE_LIGHTWEIGHT_MODE=${{ENABLE_LIGHTWEIGHT_MODE:-}}"
-        "RECORD_CHECKPOINTS=${{RECORD_CHECKPOINTS:-}}"
+        "ENABLE_LIGHTWEIGHT_MODE=${{ENABLE_LIGHTWEIGHT_MODE}}"
+        "RECORD_CHECKPOINTS=${{RECORD_CHECKPOINTS}}"
     )
 
     bash ./tests/functional_tests/shell_test_utils/run_ci_test.sh ${{ARGUMENTS[@]}}
@@ -90,6 +88,23 @@ products:
       #   scope: [nightly]
 
   - test_case: [hybrid_mr_mcore_te_tp2_pp1_cp4_dgx_a100_1N8G]
+    products:
+      - environment: [dev]
+        scope: [mr, mr-github]
+        platforms: [dgx_h100]
+      # - environment: [lts] # disabled until triton is bumped
+      #   scope: [nightly]
+
+  # End-to-end smoke test for the HybridModel Python DSL recipe path:
+  # exercises HybridModel(config: HybridModelConfig, ...) through the real
+  # training launcher (pretrain_hybrid.py --model-recipe), trains for 50
+  # iterations, and locks loss / gradient-norm golden values. Architecture
+  # and entry point are defined in:
+  #   tests/functional_tests/test_cases/hybrid/
+  #     hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/{recipe.py,model_config.yaml}
+  # This test lives on the launcher branch (4539) because PR 4537 (recipe DSL
+  # surface) does not register the --model-recipe argparse flag.
+  - test_case: [hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G]
     products:
       - environment: [dev]
         scope: [mr, mr-github]

--- a/tests/unit_tests/models/hybrid/test_load_recipe.py
+++ b/tests/unit_tests/models/hybrid/test_load_recipe.py
@@ -197,9 +197,8 @@ class TestFilesystemPath:
             """
             from megatron.core.models.hybrid import (
                 AttentionLayerConfig, CommonLayerConfig, CrossEntropyLayerConfig,
-                EmbeddingLayerConfig,
+                EmbeddingLayerConfig, HybridModelConfig,
             )
-            from megatron.training.models.hybrid import HybridModelConfig
             def make_recipe() -> HybridModelConfig:
                 common = CommonLayerConfig(hidden_size=128, use_cpu_initialization=True)
                 return HybridModelConfig(
@@ -222,9 +221,8 @@ class TestFilesystemPath:
             """
             from megatron.core.models.hybrid import (
                 AttentionLayerConfig, CommonLayerConfig, CrossEntropyLayerConfig,
-                EmbeddingLayerConfig,
+                EmbeddingLayerConfig, HybridModelConfig,
             )
-            from megatron.training.models.hybrid import HybridModelConfig
             def my_pretrain_config() -> HybridModelConfig:
                 common = CommonLayerConfig(hidden_size=128, use_cpu_initialization=True)
                 return HybridModelConfig(
@@ -302,6 +300,35 @@ class TestRecipeArgProjection:
     values are ignored later by hybrid_builder.
     """
 
+    def _projection_args(self, model_recipe: str, **overrides):
+        values = dict(
+            model_recipe=model_recipe,
+            num_layers=None,
+            hidden_size=None,
+            num_attention_heads=None,
+            max_position_embeddings=None,
+            padded_vocab_size=None,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=None,
+            position_embedding_type=None,
+            rotary_percent=None,
+            rotary_base=None,
+            rotary_seq_len_interpolation_factor=None,
+            untie_embeddings_and_output_weights=False,
+            fp16_lm_cross_entropy=False,
+            mtp_num_layers=None,
+            mtp_hybrid_override_pattern=None,
+            hybrid_layer_pattern=None,
+            hybrid_override_pattern=None,
+            encoder_num_layers=None,
+            num_experts=None,
+        )
+        values.update(overrides)
+        return types.SimpleNamespace(**values)
+
     def test_apply_model_recipe_to_args_sets_legacy_namespace_fields(self, monkeypatch):
         from megatron.training.arguments import _apply_model_recipe_to_args
 
@@ -352,3 +379,78 @@ class TestRecipeArgProjection:
         assert args.max_position_embeddings == 512
         assert args.padded_vocab_size == 1024
         assert args.tensor_model_parallel_size == 2
+
+    def test_unset_recipe_topology_does_not_clobber_cli_flag(self, monkeypatch):
+        """The headline contract for the recipe→args projection: a recipe
+        that leaves ``tensor_model_parallel_size=None`` (= "defer to the
+        launcher") must NOT overwrite a value the user passed via
+        ``--tensor-model-parallel-size`` on the CLI. Same for CP/EP/ETP.
+
+        Regression guard: the launcher reads topology from the recipe's
+        ``int | None`` fields directly; reading from the lowered stack
+        TC instead would see substituted concrete values (TC always carries
+        them) and silently clobber ``args.tensor_model_parallel_size``."""
+        from megatron.training.arguments import _apply_model_recipe_to_args
+
+        common = _make_common()
+        # No topology pinned on the recipe.
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+        _register_synthetic_module(
+            monkeypatch, "tests._args_projection_recipe_no_topology", make_recipe=lambda: recipe
+        )
+        # CLI-supplied values that the projection must preserve.
+        args = types.SimpleNamespace(
+            model_recipe="tests._args_projection_recipe_no_topology",
+            num_layers=None,
+            hidden_size=None,
+            num_attention_heads=None,
+            max_position_embeddings=None,
+            padded_vocab_size=None,
+            tensor_model_parallel_size=4,  # ← from CLI; must survive
+            pipeline_model_parallel_size=1,
+            context_parallel_size=2,  # ← from CLI; must survive
+            expert_model_parallel_size=8,  # ← from CLI; must survive
+            expert_tensor_parallel_size=1,  # ← from CLI; must survive
+            position_embedding_type=None,
+            rotary_percent=None,
+            rotary_base=None,
+            rotary_seq_len_interpolation_factor=None,
+            untie_embeddings_and_output_weights=False,
+            fp16_lm_cross_entropy=False,
+            mtp_num_layers=None,
+            encoder_num_layers=None,
+            num_experts=None,
+        )
+
+        _apply_model_recipe_to_args(args)
+
+        assert args.tensor_model_parallel_size == 4
+        assert args.context_parallel_size == 2
+        assert args.expert_model_parallel_size == 8
+        assert args.expert_tensor_parallel_size == 1
+
+    def test_model_recipe_rejects_mtp_num_layers(self, monkeypatch):
+        from megatron.training.arguments import _apply_model_recipe_to_args
+
+        common = _make_common()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+        module_name = "tests._args_projection_recipe_mtp_num_layers"
+        _register_synthetic_module(monkeypatch, module_name, make_recipe=lambda: recipe)
+
+        args = self._projection_args(module_name, mtp_num_layers=1)
+
+        with pytest.raises(AssertionError, match="Multi-Token Prediction"):
+            _apply_model_recipe_to_args(args)
+
+    def test_model_recipe_rejects_mtp_hybrid_override_pattern(self, monkeypatch):
+        from megatron.training.arguments import _apply_model_recipe_to_args
+
+        common = _make_common()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+        module_name = "tests._args_projection_recipe_mtp_override"
+        _register_synthetic_module(monkeypatch, module_name, make_recipe=lambda: recipe)
+
+        args = self._projection_args(module_name, mtp_hybrid_override_pattern="MM")
+
+        with pytest.raises(AssertionError, match="Multi-Token Prediction"):
+            _apply_model_recipe_to_args(args)

--- a/tests/unit_tests/models/hybrid/test_python_dsl_equivalence.py
+++ b/tests/unit_tests/models/hybrid/test_python_dsl_equivalence.py
@@ -25,6 +25,7 @@ from megatron.core.models.hybrid import (
     CommonLayerConfig,
     CrossEntropyLayerConfig,
     EmbeddingLayerConfig,
+    HybridModelConfig,
     MambaLayerConfig,
     MLPLayerConfig,
 )
@@ -32,7 +33,6 @@ from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
-from megatron.training.models.hybrid import HybridModelConfig
 from tests.unit_tests.test_utilities import Utils
 
 
@@ -66,7 +66,10 @@ def _loss() -> CrossEntropyLayerConfig:
 
 
 def _build_model_from_recipe(recipe: HybridModelConfig) -> HybridModel:
-    return HybridModel.from_recipe(recipe)
+    # Phase 2: call the new TC-free constructor directly. ``from_recipe``
+    # is now a thin alias; the equivalence between the two paths is
+    # asserted in test_recipe_constructor.py.
+    return HybridModel(config=recipe)
 
 
 @pytest.mark.internal


### PR DESCRIPTION
Adds the --model-recipe launcher path on top of #4538.

This PR now contains only the CLI/launcher integration and functional recipe wiring. The lower stack is #4537 -> #5030 -> #5031 -> #4538.