### PR TITLE
docs: use @file-path notation for file references in skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 - All PRs must be created as **drafts**. Use `gh pr create --draft` or the GitHub UI draft option.
 - Never push branches directly to `https://github.com/NVIDIA/Megatron-LM`. You must push your branch to a personal fork (e.g. `https://github.com/<your-username>/Megatron-LM`), then open a PR from the fork's branch against `NVIDIA/Megatron-LM`.
-- Read [docs/developer/contribute.md](docs/developer/contribute.md) for the full contribution policy, including code style, commit message conventions, and issue guidelines.
+- Read @docs/developer/contribute.md for the full contribution policy, including code style, commit message conventions, and issue guidelines.
 
 ### Code Quality
 

--- a/skills/build-and-dependency/SKILL.md
+++ b/skills/build-and-dependency/SKILL.md
@@ -33,7 +33,7 @@ dependency.
 **Option A — NVIDIA-internal: pull a CI-built image**
 
 > ⚠️ Requires access to the internal GitLab instance.
-> See `tools/trigger_internal_ci.md` for setup (adding the git remote, obtaining a token).
+> See @tools/trigger_internal_ci.md for setup (adding the git remote, obtaining a token).
 
 The internal GitLab CI publishes images to its container registry.
 Derive the registry host from your configured `gitlab` remote — the same

--- a/skills/testsystem/SKILL.md
+++ b/skills/testsystem/SKILL.md
@@ -132,6 +132,7 @@ Apply this logic based on what the PR changes:
 | CI/tooling only (`.github/`, `tools/`, `Makefile`) | _(none)_ |
 | Test files only (`tests/`) — existing tests, no new golden values | `Run tests` |
 | **New test cases added** (no golden values exist yet) | `Run functional tests` |
+| **Re-enabling a disabled test** (scope `-broken` → active) | `Run functional tests` |
 | Non-numerical library code (logging, error handling, CLI flags, refactors) | `Run tests` |
 | Could affect training numerics (model arch, attention, optimizer, distributed, MoE routing) | `Run functional tests` |
 | Container or dependency changes (`docker/`, `pyproject.toml`, `uv.lock`) | `Run tests` + `container::lts` |
@@ -183,7 +184,7 @@ Apply this logic based on what the PR changes:
 
 Use `tools/trigger_internal_ci.py` to push the current branch to the internal
 GitLab remote and trigger a pipeline — without touching the GitLab UI.
-Full setup and usage details: `tools/trigger_internal_ci.md`.
+Full setup and usage details: @tools/trigger_internal_ci.md.
 
 **Prerequisites** (one-time):
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

File references in `AGENTS.md` and skill files now use `@<path>` syntax so Claude Code automatically includes those files in context when the skill is loaded.

**Changes:**
- `AGENTS.md`: `[docs/developer/contribute.md](...)` → `@docs/developer/contribute.md`
- `skills/testsystem/SKILL.md`: `` `tools/trigger_internal_ci.md` `` → `@tools/trigger_internal_ci.md`
- `skills/build-and-dependency/SKILL.md`: `` `tools/trigger_internal_ci.md` `` → `@tools/trigger_internal_ci.md`

</details>
