### PR TITLE
Fix release tests: remove --global-batch-size conflicting with --step-batch-size-schedule

### DIFF
--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release/model_config.yaml
@@ -22,7 +22,6 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --global-batch-size: 1152
   --step-batch-size-schedule: "0:384 200B:768 400B:1152"
   --train-samples: 19531250
   --manual-gc: true

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_gb200/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_gb200/model_config.yaml
@@ -24,7 +24,6 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --global-batch-size: 1152
   --step-batch-size-schedule: "0:384 200B:768 400B:1152"
   --train-samples: 19531250
   --manual-gc: true

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm/model_config.yaml
@@ -22,7 +22,6 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --global-batch-size: 1152
   --step-batch-size-schedule: "0:384 200B:768 400B:1152"
   --train-samples: 4882812
   --manual-gc: true

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm_gb200/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm_gb200/model_config.yaml
@@ -24,7 +24,6 @@ MODEL_ARGS:
   --sequence-parallel: true
   --disable-bias-linear: true
   --micro-batch-size: 4
-  --global-batch-size: 1152
   --step-batch-size-schedule: "0:384 200B:768 400B:1152"
   --train-samples: 19531250
   --manual-gc: true


### PR DESCRIPTION
## Summary
- Remove `--global-batch-size` from 4 GPT 15B release test configs that also specify `--step-batch-size-schedule`, which are mutually exclusive args
- Affected tests: `gpt3_15b_8t_release`, `gpt3_15b_8t_release_sm`, `gpt3_15b_8t_release_gb200`, `gpt3_15b_8t_release_sm_gb200`
- The `--step-batch-size-schedule` already defines the batch size ramp (`0:384 200B:768 400B:1152`), making `--global-batch-size` redundant

## Test plan
- [ ] Verify release tests no longer fail with `ValueError: Cannot specify both --step-batch-size-schedule and --global-batch-size`

🤖 Generated with [Claude Code](https://claude.com/claude-code)