### PR TITLE
Finalize all builders in preprocess_data, not just the last key

### DIFF
--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -191,7 +191,8 @@ class Partition(object):
                 self.print_processing_stats(i, proc_start, total_bytes_processed)
 
         fin.close()
-        builders[key].finalize(output_idx_files[key])
+        for key in self.args.json_keys:
+            builders[key].finalize(output_idx_files[key])
 
         pool.close()
         pool.join()


### PR DESCRIPTION
## Summary

Fixes #1010.

In `tools/preprocess_data.py`, the call to `builders[key].finalize(...)` sat outside the document-processing loop. The `key` variable referred to whatever value leaked from the inner `for key in doc.keys()` loop's last iteration, so only one builder was ever finalized. Any other keys passed via `--json-keys` produced a written `.bin` with no matching `.idx`, leaving the output unusable for downstream loaders.

The fix iterates over `self.args.json_keys` explicitly so every builder is finalized.

## Change

```diff
         fin.close()
-        builders[key].finalize(output_idx_files[key])
+        for key in self.args.json_keys:
+            builders[key].finalize(output_idx_files[key])
```

This matches the fix the original reporter proposed on the issue.

## Test plan

- [x] Run `tools/preprocess_data.py` with a single `--json-keys` value — output unchanged (single key still finalizes).
- [x] Run with multiple `--json-keys` values — each key now produces a complete `.bin`/`.idx` pair.