### PR TITLE
LanguageModelEmbedding: avoid kernel launch overhead for [b,s,h]→[s,b,h] in inference

### DIFF
--- a/megatron/core/models/common/embeddings/language_model_embedding.py
+++ b/megatron/core/models/common/embeddings/language_model_embedding.py
@@ -116,8 +116,14 @@ class LanguageModelEmbedding(MegatronModule):
             embeddings = word_embeddings
 
         if not self.reduce_scatter_embeddings:
-            # Data format change to avoid explicit tranposes : [b s h] --> [s b h].
-            embeddings = embeddings.transpose(0, 1).contiguous()
+            # Data format change [b s h] -> [s b h]. A contiguous [1, s, h] can be re-viewed as
+            # a contiguous [s, 1, h] via squeeze/unsqueeze (strides (H,H,1) satisfy contiguity for
+            # the new shape) — no kernel needed. This requires the source to be contiguous; for
+            # non-contiguous or batch>1 inputs we fall through to the materializing copy path.
+            if embeddings.size(0) == 1 and embeddings.is_contiguous():
+                embeddings = embeddings.squeeze(0).unsqueeze(1)
+            else:
+                embeddings = embeddings.transpose(0, 1).contiguous()
 
         if tokentype_ids is not None:
             assert self.tokentype_embeddings is not None

--- a/megatron/core/models/common/embeddings/language_model_embedding.py
+++ b/megatron/core/models/common/embeddings/language_model_embedding.py
@@ -116,10 +116,13 @@ class LanguageModelEmbedding(MegatronModule):
             embeddings = word_embeddings
 
         if not self.reduce_scatter_embeddings:
-            # Data format change [b s h] -> [s b h]. A contiguous [1, s, h] can be re-viewed as
-            # a contiguous [s, 1, h] via squeeze/unsqueeze (strides (H,H,1) satisfy contiguity for
-            # the new shape) — no kernel needed. This requires the source to be contiguous; for
-            # non-contiguous or batch>1 inputs we fall through to the materializing copy path.
+            # Data format change [b s h] -> [s b h]. The transformer block convention is
+            # [s b h] so converting once here means downstream layers do not transpose again.
+            # Optimization: a contiguous [1, s, h] can be re-viewed as a contiguous
+            # [s, 1, h] via squeeze/unsqueeze (as strides (H, H, 1) satisfy contiguity for the new
+            # shape) with no kernel needed. Dynamic batching always produces batch_size=1 (requests
+            # are packed along the sequence dim), so this fast path is hit per inference step.
+            # Falls through to a materializing copy for non-contiguous or batch>1 inputs.
             if embeddings.size(0) == 1 and embeddings.is_contiguous():
                 embeddings = embeddings.squeeze(0).unsqueeze(1)
             else:

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -698,7 +698,14 @@ class GPTModel(LanguageModule):
             log_config_to_disk(self.config, payload, prefix='input_and_logits')
 
         if labels is None:
-            # [s b h] => [b s h]
+            # [s b h] -> [b s h]. A contiguous [s, 1, h] can be re-viewed as a contiguous
+            # [1, s, h] via squeeze/unsqueeze (strides (s*H, H, 1) satisfy contiguity for the
+            # new shape) without a kernel call. Dynamic batching always produces batch_size=1
+            # (requests are packed along the sequence dim), so this fast path is hit per
+            # inference step. Falls through to a materializing copy for non-contiguous or
+            # batch>1 inputs.
+            if logits.size(1) == 1 and logits.is_contiguous():
+                return logits.squeeze(1).unsqueeze(0)
             return logits.transpose(0, 1).contiguous()
 
         loss = self.compute_language_model_loss(labels, logits)

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -559,7 +559,14 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             self.output_layer.sequence_parallel = True
 
         if labels is None:
-            # [s b h] => [b s h]
+            # [s b h] -> [b s h]. A contiguous [s, 1, h] can be re-viewed as a contiguous
+            # [1, s, h] via squeeze/unsqueeze (strides (s*H, H, 1) satisfy contiguity for the
+            # new shape) without a kernel call. Dynamic batching always produces batch_size=1
+            # (requests are packed along the sequence dim), so this fast path is hit per
+            # inference step. Falls through to a materializing copy for non-contiguous or
+            # batch>1 inputs.
+            if logits.size(1) == 1 and logits.is_contiguous():
+                return logits.squeeze(1).unsqueeze(0)
             return logits.transpose(0, 1).contiguous()
 
         loss = self.compute_language_model_loss(labels, logits)


### PR DESCRIPTION
# What does this PR do ?

In `LanguageModelEmbedding.forward`, `embeddings.transpose(0, 1).contiguous()` materializes a new tensor via a cuda kernel + D2D memcpy. When batch_size=1 and the input is contiguous (always true under dynamic batching, which packs all requests along the sequence dim), the layout transformation is a no-op _at the data level_ and can be done as a contiguous view via `squeeze(0).unsqueeze(1)`. We add this fast path for inference and training/other stride/other shapes fall through to the original implementation.

**Why does this work?** For a contiguous [1, N, H] tensor with strides (NH, H, 1), the linear memory layout is exactly `[t0_h0..t0_hH-1, t1_h0..t1_hH-1, ..., tN-1_h0..tN-1_hH-1]`. A contiguous [N, 1, H] with strides (H, H, 1) requires the same linear layout, so the underlying buffer is already in the form a contiguous [N, 1, H] would have; only the shape/stride metadata needs to change. `squeeze(0)` removes the size-1 dim, producing [N, H] with strides (H, 1) (a view). `unsqueeze(1)` inserts a size-1 dim at position 1, producing [N, 1, H] with strides (H, H, 1) (still a view).

The result has the same shape as transpose(0, 1).contiguous(), [N, 1, H], and the same buffer and identical layout. It preserves contiguity: (H, H, 1) satisfies the contiguity invariant for [N, 1, H] since `stride[i] == stride[i+1] * size[i+1]` holds at every dim. The output is bit-identical for downstream use.

This relies on the source tensor's memory being contiguous. If the input were a strided view (e.g. a permuted slice), the buffer would have gaps and the squeeze/unsqueeze trick would produce a view that doesn't match what `transpose(0, 1).contiguous()` would have produced. The `is_contiguous()` check is inexpensive (µs) and we fall through to the materializing path for any non-contiguous input, preserving correctness under future refactors that produce non-contiguous embeddings.

**Performance**
Measured on Nano inference (TP=1, EP=4, inference_optimized impl, GB300, 10-token decode):
* emb.transpose_contiguous NVTX range: 44 µs -> 9 µs per decode token
* This cuts a net 19us per every decode step.

Before:
<img width="1309" height="274" alt="Screenshot 2026-05-01 at 1 28 33 PM" src="https://github.com/user-attachments/assets/ec2be08e-8a33-4099-88d4-ab5ccb223b5b" />

9b | dynamic | graphs 12 | uvm 0 | requests: cli, n 1, g 10, dur 1.0e+01 r/sec 1.0e+02 | bf: 10 GB, 399 chunks [r 396, t 16384] … throughput: 69.154 tok/s …  total time: 0.145s … mem 28.7/32.1 GB … steps: 10 … capture --

After:
<img width="1305" height="270" alt="Screenshot 2026-05-01 at 2 53 09 PM" src="https://github.com/user-attachments/assets/494649eb-9671-4c16-82f8-48fd1a2a1d7a" />

9b | dynamic | graphs 12 | uvm 0 | requests: cli, n 1, g 10, dur 1.0e+01 r/sec 1.0e+02 | bf: 10 GB, 399 chunks [r 396, t 16384] … throughput: 83.283 tok/s …  total time: 0.120s … mem 28.7/32.1 GB … steps: 10 … capture --

## Issue tracking

For PRs from open-source community contributors:


- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
