### PR TITLE
fix(ci): correct off-by-one in total_steps_evaluated formula

### DIFF
--- a/tests/functional_tests/python_test_utils/common.py
+++ b/tests/functional_tests/python_test_utils/common.py
@@ -109,7 +109,9 @@ def read_tb_logs_as_list(
     files += glob.glob(f"{path}/results/events*tfevents*")
 
     if not files:
-        logger.error(f"File not found matching: {path}/events* || {path}/results/events*")
+        logger.error(
+            f"File not found matching: {path}/events* || {path}/results/events*"
+        )
         return None
 
     files.sort(key=lambda x: os.path.getmtime(os.path.join(path, pathlib.Path(x).name)))
@@ -117,7 +119,9 @@ def read_tb_logs_as_list(
 
     if index == -1:
         for event_file in files:
-            ea = event_accumulator.EventAccumulator(event_file, size_guidance=SIZE_GUIDANCE)
+            ea = event_accumulator.EventAccumulator(
+                event_file, size_guidance=SIZE_GUIDANCE
+            )
             ea.Reload()
             accumulators.append(ea)
     else:
@@ -160,7 +164,7 @@ def read_tb_logs_as_list(
 
 
 def read_golden_values_from_json(
-    golden_values_path: Union[str, pathlib.Path]
+    golden_values_path: Union[str, pathlib.Path],
 ) -> Dict[str, GoldenValueMetric]:
     with open(golden_values_path) as f:
         if os.path.exists(golden_values_path):
@@ -173,7 +177,9 @@ def read_golden_values_from_json(
 def _filter_checks(
     checks: List[Union[ApproximateTest, DeterministicTest]], filter_for_type_of_check
 ):
-    return [test for test in checks if test.type_of_test_result == filter_for_type_of_check]
+    return [
+        test for test in checks if test.type_of_test_result == filter_for_type_of_check
+    ]
 
 
 def pipeline(
@@ -209,17 +215,27 @@ def pipeline(
 
                 if metric_name == "iteration-time":
                     actual_value_list = [
-                        np.median([np.inf if type(v) is str else v for v in actual_value_list])
+                        np.median(
+                            [np.inf if type(v) is str else v for v in actual_value_list]
+                        )
                     ]
                     golden_value_list = [
-                        np.median([np.inf if type(v) is str else v for v in golden_value_list])
+                        np.median(
+                            [np.inf if type(v) is str else v for v in golden_value_list]
+                        )
                     ]
                     total_steps_evaluated = 1
                 else:
-                    total_steps_evaluated = golden_value.end_step / golden_value.step_interval + 1
+                    total_steps_evaluated = (
+                        golden_value.end_step - golden_value.start_step
+                    ) / golden_value.step_interval + 1
 
-                    actual_value_list = [np.inf if type(v) is str else v for v in actual_value_list]
-                    golden_value_list = [np.inf if type(v) is str else v for v in golden_value_list]
+                    actual_value_list = [
+                        np.inf if type(v) is str else v for v in actual_value_list
+                    ]
+                    golden_value_list = [
+                        np.inf if type(v) is str else v for v in golden_value_list
+                    ]
 
                 actual = np.array(actual_value_list)
                 golden = np.array(golden_value_list)
@@ -233,28 +249,38 @@ def pipeline(
                 ):
                     passing = bool(np.all(is_close))
                 else:
-                    num_failing_steps_allowed = min(max(total_steps_evaluated // 100, 1), 50)
+                    num_failing_steps_allowed = min(
+                        max(total_steps_evaluated // 100, 1), 50
+                    )
                     passing = np.mean(is_close) >= 1 - (
                         num_failing_steps_allowed / total_steps_evaluated
                     )
 
                 if not passing:
                     logger.info(
-                        "Actual values: %s", ", ".join([str(v) for v in (*actual_value_list,)])
+                        "Actual values: %s",
+                        ", ".join([str(v) for v in (*actual_value_list,)]),
                     )
                     logger.info(
-                        "Golden values: %s", ", ".join([str(v) for v in (*golden_value_list,)])
+                        "Golden values: %s",
+                        ", ".join([str(v) for v in (*golden_value_list,)]),
                     )
                     raise test.error_message(metric_name)
 
                 result = f"{test.type_of_test_result.name} test for metric {metric_name}: PASSED"
                 result_code = 0
 
-            except (NotApproximateError, NotDeterminsticError, MissingTensorboardLogsError) as e:
+            except (
+                NotApproximateError,
+                NotDeterminsticError,
+                MissingTensorboardLogsError,
+            ) as e:
                 result = str(e)
                 result_code = 1
             except SkipMetricError:
-                logger.info(f"{test.type_of_test_result.name} test for {metric_name}: SKIPPED")
+                logger.info(
+                    f"{test.type_of_test_result.name} test for {metric_name}: SKIPPED"
+                )
                 continue
 
             log_emitter = logger.info if result_code == 0 else logger.error

--- a/tests/functional_tests/python_test_utils/common.py
+++ b/tests/functional_tests/python_test_utils/common.py
@@ -109,9 +109,7 @@ def read_tb_logs_as_list(
     files += glob.glob(f"{path}/results/events*tfevents*")
 
     if not files:
-        logger.error(
-            f"File not found matching: {path}/events* || {path}/results/events*"
-        )
+        logger.error(f"File not found matching: {path}/events* || {path}/results/events*")
         return None
 
     files.sort(key=lambda x: os.path.getmtime(os.path.join(path, pathlib.Path(x).name)))
@@ -119,9 +117,7 @@ def read_tb_logs_as_list(
 
     if index == -1:
         for event_file in files:
-            ea = event_accumulator.EventAccumulator(
-                event_file, size_guidance=SIZE_GUIDANCE
-            )
+            ea = event_accumulator.EventAccumulator(event_file, size_guidance=SIZE_GUIDANCE)
             ea.Reload()
             accumulators.append(ea)
     else:
@@ -164,7 +160,7 @@ def read_tb_logs_as_list(
 
 
 def read_golden_values_from_json(
-    golden_values_path: Union[str, pathlib.Path],
+    golden_values_path: Union[str, pathlib.Path]
 ) -> Dict[str, GoldenValueMetric]:
     with open(golden_values_path) as f:
         if os.path.exists(golden_values_path):
@@ -177,9 +173,7 @@ def read_golden_values_from_json(
 def _filter_checks(
     checks: List[Union[ApproximateTest, DeterministicTest]], filter_for_type_of_check
 ):
-    return [
-        test for test in checks if test.type_of_test_result == filter_for_type_of_check
-    ]
+    return [test for test in checks if test.type_of_test_result == filter_for_type_of_check]
 
 
 def pipeline(
@@ -215,14 +209,10 @@ def pipeline(
 
                 if metric_name == "iteration-time":
                     actual_value_list = [
-                        np.median(
-                            [np.inf if type(v) is str else v for v in actual_value_list]
-                        )
+                        np.median([np.inf if type(v) is str else v for v in actual_value_list])
                     ]
                     golden_value_list = [
-                        np.median(
-                            [np.inf if type(v) is str else v for v in golden_value_list]
-                        )
+                        np.median([np.inf if type(v) is str else v for v in golden_value_list])
                     ]
                     total_steps_evaluated = 1
                 else:
@@ -230,12 +220,8 @@ def pipeline(
                         golden_value.end_step - golden_value.start_step
                     ) / golden_value.step_interval + 1
 
-                    actual_value_list = [
-                        np.inf if type(v) is str else v for v in actual_value_list
-                    ]
-                    golden_value_list = [
-                        np.inf if type(v) is str else v for v in golden_value_list
-                    ]
+                    actual_value_list = [np.inf if type(v) is str else v for v in actual_value_list]
+                    golden_value_list = [np.inf if type(v) is str else v for v in golden_value_list]
 
                 actual = np.array(actual_value_list)
                 golden = np.array(golden_value_list)
@@ -249,38 +235,28 @@ def pipeline(
                 ):
                     passing = bool(np.all(is_close))
                 else:
-                    num_failing_steps_allowed = min(
-                        max(total_steps_evaluated // 100, 1), 50
-                    )
+                    num_failing_steps_allowed = min(max(total_steps_evaluated // 100, 1), 50)
                     passing = np.mean(is_close) >= 1 - (
                         num_failing_steps_allowed / total_steps_evaluated
                     )
 
                 if not passing:
                     logger.info(
-                        "Actual values: %s",
-                        ", ".join([str(v) for v in (*actual_value_list,)]),
+                        "Actual values: %s", ", ".join([str(v) for v in (*actual_value_list,)])
                     )
                     logger.info(
-                        "Golden values: %s",
-                        ", ".join([str(v) for v in (*golden_value_list,)]),
+                        "Golden values: %s", ", ".join([str(v) for v in (*golden_value_list,)])
                     )
                     raise test.error_message(metric_name)
 
                 result = f"{test.type_of_test_result.name} test for metric {metric_name}: PASSED"
                 result_code = 0
 
-            except (
-                NotApproximateError,
-                NotDeterminsticError,
-                MissingTensorboardLogsError,
-            ) as e:
+            except (NotApproximateError, NotDeterminsticError, MissingTensorboardLogsError) as e:
                 result = str(e)
                 result_code = 1
             except SkipMetricError:
-                logger.info(
-                    f"{test.type_of_test_result.name} test for {metric_name}: SKIPPED"
-                )
+                logger.info(f"{test.type_of_test_result.name} test for {metric_name}: SKIPPED")
                 continue
 
             log_emitter = logger.info if result_code == 0 else logger.error


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Problem

The `total_steps_evaluated` formula in `common.py` did not account for `start_step` when computing how many steps are evaluated in a nondeterministic test run:

```python
# Before (buggy)
total_steps_evaluated = golden_value.end_step / golden_value.step_interval + 1
```

For the standard test configuration (`start_step=1, end_step=50, step_interval=1`) this produces **51** instead of **50**, because it counts from step 0 (which doesn't exist) rather than from `start_step`.

## Effect

The overcounted denominator tightens the nondeterministic pass threshold:

| | Correct | Buggy |
|---|---|---|
| `total_steps_evaluated` | 50 | 51 |
| `num_failing_steps_allowed` | 1 | 1 |
| Pass threshold | `1 - 1/50 = 0.9800` | `1 - 1/51 = 0.98039…` |

A test where exactly 1 out of 50 steps is outside tolerance (`np.mean(is_close) = 0.9800`) should pass but instead fails with `0.9800 < 0.98039`.

This caused a spurious CI failure in `gpt3_mcore_te_tp2_pp2_cp2_etp4_nondeterministic_dp_last` on the `num-zeros` metric (introduced in commit `4e85d74ae9`).

## Fix

```python
# After (correct)
total_steps_evaluated = (golden_value.end_step - golden_value.start_step) / golden_value.step_interval + 1
```

Example with the standard configuration:
```
(50 - 1) / 1 + 1 = 50  ✓
```

</details>
