### PR TITLE
test(transformer): add DSv4 hybrid hash MoE integration coverage

### DIFF
--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 import megatron.core.parallel_state as parallel_state
 from megatron.core.extensions.transformer_engine import HAVE_TE
@@ -69,6 +70,7 @@ def _make_config(
     dsa_indexer_head_dim=64,
     dsa_indexer_topk=8,
     dsa_indexer_loss_coeff=0.0,
+    **extra_config_kwargs,
 ):
     """Create an MLATransformerConfig for DSv4 hybrid attention tests."""
     if csa_compress_ratios is None:
@@ -101,6 +103,7 @@ def _make_config(
         dsa_indexer_head_dim=dsa_indexer_head_dim,
         dsa_indexer_topk=dsa_indexer_topk,
         dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
+        **extra_config_kwargs,
     )
 
 
@@ -414,3 +417,170 @@ class TestDSv4HybridGroupedOutput:
         expected_in = (config.v_head_dim * config.num_attention_heads) // o_groups
         assert attn.linear_o_group_proj.shape == (expected_out, expected_in)
         assert attn.linear_o_group_proj.requires_grad
+
+
+# ===========================================================================
+# DSv4 Hybrid Attention + Hash MoE integration tests
+# ===========================================================================
+
+
+def _make_dsv4_hash_moe_config():
+    """Create a compact DSv4 config that combines CSA/HCA with hash MoE."""
+    return _make_config(
+        num_layers=2,
+        hidden_size=128,
+        num_attention_heads=8,
+        v_head_dim=32,
+        qk_pos_emb_head_dim=16,
+        q_lora_rank=32,
+        o_groups=4,
+        o_lora_rank=32,
+        csa_compress_ratios=[4, 128],
+        csa_window_size=16,
+        dsa_indexer_n_heads=4,
+        dsa_indexer_head_dim=32,
+        dsa_indexer_topk=8,
+        ffn_hidden_size=256,
+        num_moe_experts=4,
+        moe_ffn_hidden_size=256,
+        moe_layer_freq=1,
+        moe_router_topk=2,
+        moe_router_load_balancing_type="aux_loss",
+        moe_aux_loss_coeff=0.0,
+        moe_router_dtype="fp32",
+        moe_router_score_function="sqrtsoftplus",
+        moe_n_hash_layers=1,
+        actual_vocab_size=128,
+        activation_func=F.silu,
+        gated_linear_unit=True,
+        activation_func_clamp_value=10.0,
+        bias_activation_fusion=False,
+        moe_grouped_gemm=False,
+    )
+
+
+def _build_dsv4_moe_layer(config, layer_number, pg_collection):
+    """Instantiate a TransformerLayer from the DSv4 experimental attention spec."""
+    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+    from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
+        get_transformer_layer_with_experimental_attention_variant_spec,
+    )
+    from megatron.core.transformer.spec_utils import build_module
+
+    layer_specs = get_transformer_layer_with_experimental_attention_variant_spec(
+        config=config, backend=TESpecProvider()
+    )
+    return build_module(
+        layer_specs[layer_number - 1],
+        config=config,
+        layer_number=layer_number,
+        pg_collection=pg_collection,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not HAVE_TE, reason="transformer_engine not available")
+class TestDSv4HybridHashMoEIntegration:
+    """Integration coverage for DSv4 hybrid attention with hash MoE and clamped SwiGLU."""
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup_method(self, request):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+        )
+        torch.manual_seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+
+        cls = request.cls
+        cls.config = _make_dsv4_hash_moe_config()
+        cls.pg = ProcessGroupCollection.use_mpu_process_groups()
+
+        yield
+        Utils.destroy_model_parallel()
+
+    def test_csa_hash_moe_layer_forward_backward(self):
+        """Layer 1 should combine DSv4 CSA, hash routing, and clamped SwiGLU."""
+        from megatron.core.transformer.experimental_attention_variant.deepseek_v4_hybrid_attention import (
+            DSv4HybridSelfAttention,
+        )
+        from megatron.core.transformer.moe.moe_layer import MoELayer
+
+        seq_len = 256
+        batch_size = 1
+
+        torch.manual_seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+
+        layer = _build_dsv4_moe_layer(self.config, layer_number=1, pg_collection=self.pg).cuda()
+        layer.train()
+
+        assert isinstance(layer.self_attention, DSv4HybridSelfAttention)
+        assert layer.self_attention.core_attention.compress_ratio == 4
+        assert isinstance(layer.mlp, MoELayer)
+        assert layer.mlp.router.is_hash_layer is True
+        assert layer.mlp.router.tid2eid is not None
+        assert layer.config.activation_func_clamp_value == 10.0
+        assert layer.config.activation_func is F.silu
+        assert layer.config.gated_linear_unit is True
+
+        hidden = torch.randn(
+            seq_len,
+            batch_size,
+            self.config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        input_ids = torch.randint(
+            0, self.config.actual_vocab_size, (batch_size, seq_len), device="cuda"
+        )
+
+        output, context = layer(hidden_states=hidden, attention_mask=None, input_ids=input_ids)
+        loss = output.float().square().mean()
+        loss.backward()
+
+        assert context is None
+        assert output.shape == hidden.shape
+        assert output.dtype == torch.bfloat16
+        assert torch.isfinite(output).all()
+        assert hidden.grad is not None
+        assert torch.isfinite(hidden.grad).all()
+        assert any(
+            p.grad is not None and torch.isfinite(p.grad).all()
+            for p in layer.self_attention.parameters()
+            if p.requires_grad
+        )
+        assert any(
+            p.grad is not None and torch.isfinite(p.grad).all()
+            for p in layer.mlp.parameters()
+            if p.requires_grad
+        )
+
+    def test_hash_moe_layer_requires_input_ids_but_hca_layer_does_not(self):
+        """Hash routing is limited to leading layers while later HCA MoE layers remain runnable."""
+        seq_len = 256
+        batch_size = 1
+
+        torch.manual_seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+
+        hash_layer = _build_dsv4_moe_layer(
+            self.config, layer_number=1, pg_collection=self.pg
+        ).cuda()
+        hidden = torch.randn(
+            seq_len, batch_size, self.config.hidden_size, dtype=torch.bfloat16, device="cuda"
+        )
+        with pytest.raises(AssertionError, match="input_ids is required for hash-based routing"):
+            hash_layer(hidden_states=hidden, attention_mask=None)
+
+        hca_layer = _build_dsv4_moe_layer(self.config, layer_number=2, pg_collection=self.pg).cuda()
+        assert hca_layer.self_attention.core_attention.compress_ratio == 128
+        assert hca_layer.mlp.router.is_hash_layer is False
+
+        output, context = hca_layer(hidden_states=hidden, attention_mask=None)
+
+        assert context is None
+        assert output.shape == hidden.shape
+        assert torch.isfinite(output).all()


### PR DESCRIPTION
# What does this PR do ?
Adds integration coverage for DSv4 hybrid transformer layers that combine CSA/HCA attention, hash MoE routing, and clamped SwiGLU.

Related to #4468.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests (N/A: unit-test-only coverage)
- [ ] I have added proper typing to my code (N/A: test-only change)
- [ ] I have added relevant documentation (N/A: no user-facing API or docs change)
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

## Summary

- Add an integration test config that builds compact DSv4 hybrid transformer layers with MoE and activation settings enabled.
- Verify the layer-1 CSA path uses hash MoE routing and requires `input_ids`.
- Verify the layer-2 HCA path is not hash-routed and remains runnable without `input_ids`.

## Tests

- `BASE_REF=dev PATH=/tmp/megatron-lint-venv/bin:$PATH tools/autoformat.sh`
- `pytest -q tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention.py::TestDSv4HybridHashMoEIntegration` (skipped locally: `transformer_engine` not available)
- `pytest -q tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention.py` (skipped locally: `transformer_engine` not available)
- `uvx isort==5.13.2 --check-only tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention.py`
- `uvx black==24.4.2 --check tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention.py`
- `git diff --check`