### PR TITLE
fix(async_ckpt): import inspect in async_utils on core_r0.17.0

### DIFF
--- a/megatron/training/async_utils.py
+++ b/megatron/training/async_utils.py
@@ -4,6 +4,7 @@
 This module provides a singleton instance of AsyncCallsQueue which manages
 the async checkpoint save calls.
 """
+import inspect
 import logging
 import time
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Add the missing `import inspect` to `megatron/training/async_utils.py` on `core_r0.17.0`.

## Why

`init_persistent_async_worker` calls `inspect.signature(...)` in three places (around lines 74, 84, 99) but `inspect` is not imported on this branch, causing a hard failure during `initialize_megatron`:

```
File "/opt/megatron-lm/megatron/training/async_utils.py", line 79, in init_persistent_async_worker
    if "mp_mode" not in inspect.signature(get_write_results_queue).parameters:
NameError: name 'inspect' is not defined. Did you forget to import 'inspect'?
```

The `inspect.signature(...)` usage was introduced by the NVRx async checkpoint compatibility backport (#4453, commit `bb8e34cb86`). On `main`, `import inspect` was already present from an earlier change, so the backport diff didn't surface the missing import — on `core_r0.17.0` it slipped through.

## Repro

Any test that exercises the persistent async checkpoint worker on `core_r0.17.0`, e.g. `moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_resume_torch_dist_dist_optimizer` — see https://github.com/NVIDIA/Megatron-LM/actions/runs/24986791266/job/73546733227.

## Fix

One-line change: add `import inspect` to the imports.

</details>
