### PR TITLE
Fix Megatron-FSDP optimizer CPU offload and checkpointing

### DIFF
--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -4,6 +4,20 @@ from typing import Dict
 
 import torch
 
+try:
+    from torch.distributed._tensor import DTensor
+
+    HAVE_DTENSOR = True
+except ImportError:
+    HAVE_DTENSOR = False
+    DTensor = None
+
+
+def _to_local_if_dtensor(tensor):
+    if HAVE_DTENSOR and isinstance(tensor, DTensor):
+        return tensor.to_local()
+    return tensor
+
 
 def _param_generator(cpu_optimizer):
     for group in cpu_optimizer.param_groups:
@@ -90,6 +104,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                 fp32_param = self.param_to_fp32_param[param]
                 grad = getattr(param, "decoupled_grad", param.grad)
                 if grad is not None:
+                    grad = _to_local_if_dtensor(grad)
                     fp32_param.grad = grad.to(fp32_param.dtype)
                     fp32_param.requires_grad = True
                 else:
@@ -105,6 +120,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                     continue
 
                 param.requires_grad = False
+                grad = _to_local_if_dtensor(grad)
                 if param not in self.cpu_copy_map_grad:
                     self.cpu_copy_map_grad[param] = torch.empty(
                         param.shape, dtype=param.dtype, pin_memory=self.pin_cpu_grads, device="cpu"
@@ -121,6 +137,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                 with torch.cuda.stream(self._h2d_stream):
                     for param in _param_generator(optimizer):
                         gpu_param = self.cpu_copys_map_gpu_param[param]
+                        gpu_param = _to_local_if_dtensor(gpu_param)
                         gpu_param.data.copy_(param.data, non_blocking=True)
                 self._h2d_stream.record_event().wait(torch.cuda.current_stream())
 
@@ -137,6 +154,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
 
                         if param in self.param_to_fp32_param:
                             fp32_param = self.param_to_fp32_param[param]
+                            param = _to_local_if_dtensor(param)
                             param.data.copy_(fp32_param.data)
 
             return fp32_param_copy_back_gpu_hook
@@ -252,8 +270,14 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         params = []
         for group in self.param_groups:
             params.extend(group["params"])
-        params_total_numel = sum([param.numel() for param in params])
-        gpu_params_total_numel = sum([param.numel() for param in params if param.is_cuda])
+        params_total_numel = sum([_to_local_if_dtensor(param).numel() for param in params])
+        gpu_params_total_numel = sum(
+            [
+                _to_local_if_dtensor(param).numel()
+                for param in params
+                if _to_local_if_dtensor(param).is_cuda
+            ]
+        )
         cpu_params_total_numel = params_total_numel - gpu_params_total_numel
         offload_threshold = gpu_params_total_numel * offload_fraction
         offload_params_numel = 0
@@ -270,11 +294,15 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
             for param in group["params"]:
                 orig_param = param
                 cpu_copy = False
-                if offload_params_numel < offload_threshold and param.is_cuda:
-                    param = param.detach().clone().cpu().pin_memory()
+                local_param = _to_local_if_dtensor(param)
+                if offload_params_numel < offload_threshold and local_param.is_cuda:
+                    param = local_param.detach().clone().cpu()
+                    if self.pin_cpu_params:
+                        param = param.pin_memory()
                     offload_params_numel += param.numel()
                     cpu_copy = True
                 if self.param_update_in_fp32 and param.dtype != torch.float32:
+                    param = _to_local_if_dtensor(param)
                     param = param.detach().clone().float()
                     param_to_fp32_param[orig_param] = param
 
@@ -378,6 +406,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         Update the fp32 parameters by the new parameters.
         """
         for param, fp32_param in self.param_to_fp32_param.items():
+            param = _to_local_if_dtensor(param)
             fp32_param.data.copy_(param)
 
     def _register_load_state_dict_hooks(self):

--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -388,6 +388,9 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                 for k, v in state.items():
                     if not isinstance(v, torch.Tensor):
                         continue
+                    v = _to_local_if_dtensor(v)
+                    if v.numel() == param.numel() and v.shape != param.shape:
+                        v = v.view_as(param)
                     orig_param = self.inner_param_to_orig_param.get(param, param)
                     if isinstance(optimizer, self.defaults["cpu_optimizer_cls"]):
                         self.state[orig_param][k] = state[k] = v.to("cpu")
@@ -399,7 +402,12 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
             return
         for param, v in self.state.items():
             fp32_param = self.param_to_fp32_param[param]
-            fp32_param.data.copy_(v["master_param"])
+            master_param = v.get("master_param")
+            if master_param is None:
+                master_param = _to_local_if_dtensor(param)
+            else:
+                master_param = _to_local_if_dtensor(master_param)
+            fp32_param.data.copy_(master_param)
 
     def update_fp32_param_by_new_param(self):
         """

--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -15,7 +15,7 @@ except ImportError:
 
 def _to_local_if_dtensor(tensor):
     if HAVE_DTENSOR and isinstance(tensor, DTensor):
-        return tensor.to_local()
+        return tensor._local_tensor
     return tensor
 
 

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -36,6 +36,28 @@ except ImportError:
 
 from megatron.core.optimizer.cpu_offloading import HybridDeviceOptimizer
 
+try:
+    from torch.distributed._tensor import DTensor
+    from torch.distributed.checkpoint.metadata import (
+        ChunkStorageMetadata,
+        MetadataIndex,
+        TensorProperties,
+    )
+    from torch.distributed.checkpoint.planner import TensorWriteData, WriteItem, WriteItemType
+
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer import (
+        make_fsdp_dtensor,
+    )
+except ImportError:
+    ChunkStorageMetadata = None
+    DTensor = None
+    MetadataIndex = None
+    TensorProperties = None
+    TensorWriteData = None
+    WriteItem = None
+    WriteItemType = None
+    make_fsdp_dtensor = None
+
 from .. import tensor_parallel
 from ..config_logger import has_config_logger_enabled, log_config_to_disk
 from ..dist_checkpointing import ShardedTensor
@@ -1594,14 +1616,166 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         # Get the optimizer's parameter groups in distributed key value format.
         param_to_group_meta = self._param_groups_to_param2group_meta(self.optimizer.param_groups)
 
-        # Remap state to use order indices as keys
-        packed_state = {
-            (self._param_name(k) if isinstance(k, torch.Tensor) else k): v
-            for k, v in self.state.items()
-        }
+        # Remap state to use parameter names as keys. HybridDeviceOptimizer keeps
+        # CPU-offloaded optimizer tensors as FSDP-local plain tensors; wrap them
+        # back into FSDP DTensors so DCP saves shard metadata instead of treating
+        # each local shard as replicated data. Its fp32 master params duplicate
+        # Megatron-FSDP's model-state main weights, so they are intentionally not
+        # stored in the optimizer state.
+        if isinstance(self.optimizer, HybridDeviceOptimizer):
+            packed_state = self._pack_hybrid_optimizer_fsdp_state_dict()
+        else:
+            packed_state = {
+                (self._param_name(k) if isinstance(k, torch.Tensor) else k): v
+                for k, v in self.state.items()
+            }
 
         state_dict = {"state": packed_state, "param_to_group_meta": param_to_group_meta}
         return state_dict
+
+    def _pack_hybrid_optimizer_fsdp_state_dict(self) -> dict[str, Any]:
+        """Pack HybridDeviceOptimizer state in a deterministic cross-rank order."""
+        packed_state = {}
+        packed_params = set()
+
+        named_params = []
+        for group in self.optimizer.param_groups:
+            for param in group["params"]:
+                named_params.append((self._param_name(param), param))
+
+        for param_name, param in sorted(named_params, key=lambda item: item[0]):
+            param_state = self.state.get(param, {})
+            packed_param_state = self._pack_hybrid_optimizer_fsdp_state(
+                param, param_name, param_state
+            )
+            if packed_param_state:
+                packed_state[param_name] = packed_param_state
+            if param in self.state:
+                packed_params.add(param)
+
+        # Preserve any non-parameter state if a future optimizer adds it. Tensor
+        # parameter state must be packed above so all ranks present the same
+        # deterministic parameter order to DCP.
+        for key, state in self.state.items():
+            if isinstance(key, torch.Tensor):
+                assert key in packed_params, (
+                    f"Optimizer state for parameter {self._param_name(key)} is not in "
+                    "HybridDeviceOptimizer param_groups."
+                )
+                continue
+            packed_state[key] = state
+
+        return packed_state
+
+    def _pack_hybrid_optimizer_fsdp_state(
+        self, param: torch.nn.Parameter, param_name: str, state: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Convert HybridDeviceOptimizer FSDP-local tensor state to DTensors."""
+        if (
+            make_fsdp_dtensor is None
+            or DTensor is None
+            or ChunkStorageMetadata is None
+            or MetadataIndex is None
+            or TensorProperties is None
+            or TensorWriteData is None
+            or WriteItem is None
+            or WriteItemType is None
+        ):
+            raise RuntimeError("Megatron-FSDP DTensor support is required for fsdp_dtensor.")
+
+        packed_state = {}
+        is_expert_param = "mlp.experts" in param_name
+        fsdp_local_numel = param.megatron_fsdp_slice.stop - param.megatron_fsdp_slice.start
+
+        expected_tensor_state_dtypes = {}
+        if self.config.optimizer == "adam":
+            expected_tensor_state_dtypes = {
+                "exp_avg": self.config.exp_avg_dtype,
+                "exp_avg_sq": self.config.exp_avg_sq_dtype,
+            }
+        tensor_state_keys = {
+            key
+            for key, value in state.items()
+            if key != "master_param"
+            and isinstance(value, torch.Tensor)
+            and not isinstance(value, DTensor)
+            and value.dim() > 0
+        }
+        key_order = sorted((set(state) - {"master_param"}) | set(expected_tensor_state_dtypes))
+
+        for key in key_order:
+            value = state.get(key)
+            if value is None and key in expected_tensor_state_dtypes:
+                value = torch.zeros(
+                    (fsdp_local_numel,), dtype=expected_tensor_state_dtypes[key], device="cpu"
+                )
+
+            if (
+                isinstance(value, torch.Tensor)
+                and not isinstance(value, DTensor)
+                and (key in tensor_state_keys or key in expected_tensor_state_dtypes)
+            ):
+                assert value.numel() == fsdp_local_numel, (
+                    f"HybridDeviceOptimizer state {key} for {param_name} must be the "
+                    f"FSDP-local shard (expected numel={fsdp_local_numel}, "
+                    f"got {value.numel()})."
+                )
+                flat_param = torch.empty(param.numel(), device="meta")
+                try:
+                    value = make_fsdp_dtensor(
+                        value.data.view(-1),
+                        flat_param,
+                        dist_index=param.megatron_fsdp_dist_index,
+                        is_expert_param=is_expert_param,
+                        run_check=False,
+                        update_uneven_dtensor_chunk_meta=False,
+                    )
+                    self._set_flat_fsdp_dtensor_chunk_metadata(
+                        value, param.megatron_fsdp_slice
+                    )
+                except Exception as exc:
+                    rank = torch.distributed.get_rank()
+                    raise RuntimeError(
+                        f"Failed to pack HybridDeviceOptimizer state '{key}' for "
+                        f"FSDP parameter '{param_name}' on rank {rank}."
+                    ) from exc
+            packed_state[key] = value
+
+        return packed_state
+
+    @staticmethod
+    def _set_flat_fsdp_dtensor_chunk_metadata(tensor: DTensor, fsdp_slice: slice) -> None:
+        """Attach DCP chunk metadata for a flat FSDP-local shard without collectives."""
+        local_numel = fsdp_slice.stop - fsdp_slice.start
+        chunk_meta = ChunkStorageMetadata(
+            offsets=(fsdp_slice.start,),
+            sizes=(local_numel,),
+        )
+
+        def _chunk_list_closure(chunk_metadata):
+            return lambda: [chunk_metadata]
+
+        def _write_items_closure(chunk_metadata):
+            def _write_items(fqn: str, dtensor: DTensor) -> list[WriteItem]:
+                if dtensor.to_local().numel() == 0:
+                    return []
+
+                return [
+                    WriteItem(
+                        type=WriteItemType.SHARD,
+                        index=MetadataIndex(fqn, chunk_metadata.offsets),
+                        tensor_data=TensorWriteData(
+                            chunk=chunk_metadata,
+                            properties=TensorProperties.create_from_tensor(dtensor.to_local()),
+                            size=dtensor.size(),
+                        ),
+                    )
+                ]
+
+            return _write_items
+
+        tensor._local_tensor.__create_chunk_list__ = _chunk_list_closure(chunk_meta)
+        tensor._local_tensor.__create_write_items__ = _write_items_closure(chunk_meta)
 
     def sharded_param_state_dp_zero(
         self,

--- a/megatron/core/transformer/fsdp_dtensor_checkpoint.py
+++ b/megatron/core/transformer/fsdp_dtensor_checkpoint.py
@@ -276,8 +276,8 @@ def handle_swiglu_in_state_dict(model, model_state_dict, optimizer_state_dict):
         Split the SWiGLU linear_fc1 parameter into two parts: weight_w and weight_v.
 
         Args:
-            data: The tensor to split. May be a DTensor (model state dict) or a
-                plain Tensor (optimizer states from FusedAdam).
+            data: The tensor to split. May be a DTensor from model state, a
+                flat optimizer DTensor, or a plain optimizer Tensor.
             dist_param: The corresponding model parameter (always a DTensor).
                 Used for global shape, numel, FSDP slice, and dist index metadata.
             swiglu_shard_axis: Axis along which to split W and V gates.
@@ -304,11 +304,14 @@ def handle_swiglu_in_state_dict(model, model_state_dict, optimizer_state_dict):
         view_shape = list(global_shape)
         view_shape[swiglu_shard_axis] = -1
         if isinstance(data, DTensor):
-            assert data.shape == global_shape, (
-                f"DTensor shape mismatch: data.shape={data.shape} vs "
-                f"dist_param.shape={global_shape}"
-            )
-            local_tensor = data.to_local()
+            if data.shape == global_shape:
+                local_tensor = data.to_local()
+            else:
+                assert data.numel() == dist_param.numel(), (
+                    f"DTensor shape mismatch: data.shape={data.shape} vs "
+                    f"dist_param.shape={global_shape}"
+                )
+                local_tensor = data.to_local().view(-1)
         else:
             # Plain Tensor must already be the FSDP-local shard; other layouts
             # (TP-local / global) would silently misalign in the slice below.
@@ -491,8 +494,8 @@ def handle_gdn_in_state_dict(model, model_state_dict, optimizer_state_dict):
         """Split a fused GDN projection DTensor into per-component DTensors.
 
         Args:
-            data: The tensor to split. May be a DTensor (model state dict) or a
-                plain Tensor (optimizer states from FusedAdam).
+            data: The tensor to split. May be a DTensor from model state, a
+                flat optimizer DTensor, or a plain optimizer Tensor.
             dist_param: The corresponding model parameter (always a DTensor).
                 Used for global shape, numel, FSDP slice, and dist index metadata.
             split_sizes: List of sizes for each component along split_dim.
@@ -519,11 +522,14 @@ def handle_gdn_in_state_dict(model, model_state_dict, optimizer_state_dict):
         elems_per_unit = data_size // total_split
 
         if isinstance(data, DTensor):
-            assert data.shape == global_shape, (
-                f"DTensor shape mismatch: data.shape={data.shape} vs "
-                f"dist_param.shape={global_shape}"
-            )
-            local_tensor = data.to_local()
+            if data.shape == global_shape:
+                local_tensor = data.to_local()
+            else:
+                assert data.numel() == dist_param.numel(), (
+                    f"DTensor shape mismatch: data.shape={data.shape} vs "
+                    f"dist_param.shape={global_shape}"
+                )
+                local_tensor = data.to_local().view(-1)
         else:
             # Plain Tensor must already be the FSDP-local shard; other layouts
             # (TP-local / global) would silently misalign in the slice below.


### PR DESCRIPTION
## Summary
- Handle Megatron-FSDP DTensor parameters and gradients by operating on local shards before optimizer CPU offload copies.
- Save `HybridDeviceOptimizer` state for `fsdp_dtensor` checkpoints as deterministic FSDP DTensors, skipping duplicate `master_param` entries and attaching local DCP chunk metadata without metadata collectives.
- Allow SWiGLU/GDN optimizer checkpoint preprocessing to split flat optimizer DTensors using the corresponding model parameter metadata, and restore loaded DTensor optimizer state back to local tensors.

Fixes https://github.com/NVIDIA/Megatron-LM/issues/4910.

## Tests
- `uv run isort megatron/core/optimizer/distrib_optimizer.py`
- `python -m py_compile megatron/core/optimizer/distrib_optimizer.py megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py megatron/core/transformer/fsdp_dtensor_checkpoint.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. uv run python -m pytest tests/unit_tests/test_optimizer_cpu_offloading.py -q` (`72 passed`)
- Local Qwen3.5-VL proxy repro with `optimizer_cpu_offload=True`, `optimizer_offload_fraction=1`, `overlap_cpu_optimizer_d2h_h2d=True`, `use_precision_aware_optimizer=True`, and `fsdp_dtensor` optimizer checkpointing: checkpoint saves at iterations 10 and 12 completed successfully.