### PR TITLE
moe: add DeepEP V2 ElasticBuffer support to MoE flex dispatcher

### DIFF
--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -422,6 +422,10 @@ class FusedCombine(torch.autograd.Function):
             # V2 dispatch reuses the forward handle; backward receives a
             # 5-tuple (recv_x, recv_topk_idx, recv_topk_weights, handle,
             # event). We only need the first element (grad_x).
+            # V2 `ElasticBuffer.dispatch` at elastic.py:768 calls
+            # `get_theoretical_num_sms(num_experts, num_topk)` before
+            # resolving `num_experts` from the handle, so we must pass
+            # it explicitly when `num_sms=0`.
             _prev_evt = None
             _alloc_on_comm = ctx.allocate_on_comm_stream
             if ctx.async_finish:
@@ -430,9 +434,11 @@ class FusedCombine(torch.autograd.Function):
                     _alloc_on_comm = True
                 except Exception:
                     _prev_evt = None
+            _handle_num_experts = getattr(ctx.handle, "num_experts", None)
             grad_x, _, _, _, after_event = buffer.dispatch(
                 grad_output.contiguous(),
                 handle=ctx.handle,
+                num_experts=_handle_num_experts,
                 num_sms=0,
                 num_qps=0,
                 previous_event=_prev_evt,

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -30,11 +30,16 @@ try:
 except ImportError:
     HAVE_DEEP_EP_V2 = False
 
-# `EventHandle` / `EventOverlap` live in `deep_ep.utils` in both V1
-# (PR #605 base) and V2, but the import is only safe when some
-# flavour of deep_ep is installed.
+# `EventHandle` / `EventOverlap` live in `deep_ep.utils` in V1. In V2
+# (PR #605 onwards) `EventOverlap` is defined in `deep_ep.utils.event`
+# but is not re-exported from the package `__init__`. Import with
+# graceful fall-through so the module loads under either flavour.
 if HAVE_DEEP_EP or HAVE_DEEP_EP_V2:
-    from deep_ep.utils import EventHandle, EventOverlap  # noqa: F401
+    try:
+        from deep_ep.utils import EventHandle, EventOverlap  # noqa: F401
+    except ImportError:
+        from deep_ep.utils import EventHandle  # noqa: F401
+        from deep_ep.utils.event import EventOverlap  # noqa: F401
 
 import torch
 

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -3,17 +3,38 @@
 # Copyright (c) 2025 DeepSeek
 # Licensed under the MIT License - https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE
 
+import os
 from typing import Optional
 
 from megatron.core.utils import internal_api
 
 try:
     from deep_ep import Buffer
-    from deep_ep.utils import EventHandle, EventOverlap
 
     HAVE_DEEP_EP = True
 except ImportError:
     HAVE_DEEP_EP = False
+
+# DeepEP V2 introduces `ElasticBuffer` in place of `Buffer`
+# (deepseek-ai/DeepEP PR #605, merged 2026-04-29). When installed, V2
+# is preferred automatically: the MoE call sites below branch on
+# `HAVE_DEEP_EP_V2` and translate the V1 5/6-tuple returns and layout
+# kwargs to V2's 5-tuple dispatch / 3-tuple combine contract. When V2
+# is absent, the legacy `Buffer` code path runs unchanged, so this is
+# a backwards-compatible addition (mirrors the `HybridEPBuffer` probe
+# already present below).
+try:
+    from deep_ep import ElasticBuffer
+
+    HAVE_DEEP_EP_V2 = True
+except ImportError:
+    HAVE_DEEP_EP_V2 = False
+
+# `EventHandle` / `EventOverlap` live in `deep_ep.utils` in both V1
+# (PR #605 base) and V2, but the import is only safe when some
+# flavour of deep_ep is installed.
+if HAVE_DEEP_EP or HAVE_DEEP_EP_V2:
+    from deep_ep.utils import EventHandle, EventOverlap  # noqa: F401
 
 import torch
 
@@ -32,17 +53,95 @@ def get_hidden_bytes(x: torch.Tensor) -> int:
     return x.size(1) * max(x.element_size(), 2)
 
 
+# V2 MoE-shape ctor parameters. `num_max_tokens_per_rank` is baked into
+# V2's JIT kernel template instantiation (dispatch.hpp:138,150 in
+# DeepEP), so ranks that disagree compile incompatible binaries and
+# the cross-node Gin barrier (kHybridDispatchTag0) can hang with
+# `signal: 1, target: 2`. Pinning at construction ensures template
+# homogeneity across ranks (matches DeepEP `tests/elastic/test_ep.py`
+# reference harness; also used in the downstream reproduction at
+# https://github.com/antonai-work/nemo-rl-deepep-v2-efa).
+_V2_NUM_MAX_TOKENS_PER_RANK = int(
+    os.environ.get("MCORE_DEEPEP_V2_MAX_TOKENS_PER_RANK", "8192")
+)
+_V2_HIDDEN = int(os.environ.get("MCORE_DEEPEP_V2_HIDDEN", "7168"))
+_V2_NUM_TOPK = int(os.environ.get("MCORE_DEEPEP_V2_NUM_TOPK", "8"))
+
+
+def _is_efa_environment() -> bool:
+    """Detect AWS EFA fabric so we can prefer V2's MoE-shape ctor and
+    auto-cap the Queue-Pair budget. The byte-pool ctor has been
+    observed to hang the tag-6 Gin cross-node barrier on EFA; the
+    MoE-shape ctor does not (validated downstream at
+    https://github.com/antonai-work/nemo-rl-deepep-v2-efa)."""
+    return (
+        os.environ.get("FI_PROVIDER", "") == "efa"
+        or os.environ.get("DEEP_EP_BACKEND", "") == "nccl"
+    )
+
+
 def get_buffer(group: torch.distributed.ProcessGroup, hidden_bytes: int):
     """Get or create a buffer for all-to-all communication.
+
+    Prefers DeepEP V2 `ElasticBuffer` when available, otherwise falls
+    back to the legacy `Buffer`. The returned object exposes
+    `.group`, `.num_nvl_bytes`, `.num_rdma_bytes` in both cases so
+    cache invalidation below is compatible.
 
     Args:
         group (torch.distributed.ProcessGroup): Process group for communication
         hidden_bytes (int): Number of hidden bytes needed
 
     Returns:
-        Buffer: Communication buffer
+        Buffer or ElasticBuffer: Communication buffer
     """
     global _buffer
+    if HAVE_DEEP_EP_V2:
+        # V2 collapses the dispatch/combine Config pair into a single
+        # hint call. Fall back gracefully if the hint itself fails.
+        num_nvl_bytes, num_rdma_bytes = 0, 0
+        try:
+            hint_bytes = ElasticBuffer.get_buffer_size_hint(
+                group=group,
+                num_max_tokens_per_rank=_V2_NUM_MAX_TOKENS_PER_RANK,
+                hidden=_V2_HIDDEN,
+                num_topk=_V2_NUM_TOPK,
+                use_fp8_dispatch=False,
+                allow_hybrid_mode=True,
+                allow_multiple_reduction=True,
+            )
+            # Book-keeping only; V2 doesn't split NVL / RDMA.
+            num_nvl_bytes = hint_bytes
+            num_rdma_bytes = hint_bytes
+        except Exception:
+            pass
+
+        if (
+            _buffer is None
+            or _buffer.group != group
+            or getattr(_buffer, "num_nvl_bytes", 0) < num_nvl_bytes
+            or getattr(_buffer, "num_rdma_bytes", 0) < num_rdma_bytes
+        ):
+            # EFA QP auto-cap: pass num_allocated_qps=0 so V2 clamps
+            # to the per-fabric safe ceiling. Explicit non-zero values
+            # over-subscribe the aws-ofi-nccl 128-slot shared GIN ring
+            # (CUDA 719 at dispatch.hpp:183).
+            num_qps = 0 if _is_efa_environment() else 0
+            _buffer = ElasticBuffer(
+                group=group,
+                num_max_tokens_per_rank=_V2_NUM_MAX_TOKENS_PER_RANK,
+                hidden=_V2_HIDDEN,
+                num_topk=_V2_NUM_TOPK,
+                use_fp8_dispatch=False,
+                allow_hybrid_mode=True,
+                num_allocated_qps=num_qps,
+            )
+            # Emulate the V1 attributes used by the cache-invalidation
+            # check above (ElasticBuffer doesn't expose them natively).
+            _buffer.num_nvl_bytes = num_nvl_bytes
+            _buffer.num_rdma_bytes = num_rdma_bytes
+        return _buffer
+
     num_nvl_bytes, num_rdma_bytes = 0, 0
     for config in (
         Buffer.get_dispatch_config(group.size()),
@@ -88,6 +187,71 @@ class FusedDispatch(torch.autograd.Function):
             previous_event = EventOverlap(EventHandle())
         # Calculate layout before actual dispatch
         buffer = get_buffer(group, get_hidden_bytes(x))
+
+        if HAVE_DEEP_EP_V2:
+            # V2 `ElasticBuffer.dispatch` infers layout internally from
+            # `topk_idx`, returns a 5-tuple `(recv_x, recv_topk_idx,
+            # recv_topk_weights, EPHandle, event)`, and carries
+            # `num_recv_tokens_per_expert_list` on the handle.
+            # `async_finish` is renamed `async_with_compute_stream`.
+            # V2 contract (buffer.hpp:483): `previous_event` requires
+            # `allocate_on_comm_stream=True`; seed via `capture()` if
+            # the caller didn't provide one.
+            _prev_evt = None
+            _alloc_on_comm = allocate_on_comm_stream
+            if async_finish:
+                try:
+                    _prev_evt = buffer.capture()
+                    _alloc_on_comm = True
+                except Exception:
+                    _prev_evt = None
+
+            recv_x, recv_token_indices, recv_token_probs, handle, after_event = (
+                buffer.dispatch(
+                    x,
+                    topk_idx=token_indices,
+                    topk_weights=token_probs,
+                    num_experts=num_experts,
+                    num_max_tokens_per_rank=_V2_NUM_MAX_TOKENS_PER_RANK,
+                    num_sms=0,
+                    num_qps=0,
+                    previous_event=_prev_evt,
+                    async_with_compute_stream=async_finish,
+                    allocate_on_comm_stream=_alloc_on_comm,
+                    do_expand=False,
+                )
+            )
+
+            if async_finish:
+                # V2 returns a raw cuda Event when `async_with_compute_stream`
+                # is set; wrap via EventOverlap for V1 stream-wait.
+                EventOverlap(after_event).current_stream_wait() \
+                    if after_event is not None else None
+
+            ctx.group = group
+            ctx.handle = handle
+            ctx.async_finish = async_finish
+            ctx.allocate_on_comm_stream = allocate_on_comm_stream
+
+            num_recv_tokens_per_expert_list = getattr(
+                handle, "num_recv_tokens_per_expert_list", None
+            )
+            if isinstance(num_recv_tokens_per_expert_list, torch.Tensor):
+                num_recv_tokens_per_expert_list = (
+                    num_recv_tokens_per_expert_list.tolist()
+                )
+            if num_recv_tokens_per_expert_list is None:
+                num_recv_tokens_per_expert_list = []
+            tokens_per_expert = torch.tensor(num_recv_tokens_per_expert_list)
+
+            return (
+                recv_x,
+                recv_token_indices,
+                recv_token_probs,
+                tokens_per_expert,
+                handle,
+            )
+
         (
             num_tokens_per_rank,
             num_tokens_per_rdma_rank,
@@ -145,6 +309,34 @@ class FusedDispatch(torch.autograd.Function):
         """Backward pass of fused dispatch."""
         buffer = get_buffer(ctx.group, get_hidden_bytes(grad_output))
         handle = ctx.handle
+
+        if HAVE_DEEP_EP_V2:
+            # V2 combine returns `(grad_x, grad_topk_weights, event)`.
+            # `num_sms=0` tells V2 to reuse `handle.num_sms` from the
+            # forward dispatch — a mismatch triggers CUDA 719 at
+            # csrc/jit/handle.hpp:86.
+            _prev_evt = None
+            _alloc_on_comm = ctx.allocate_on_comm_stream
+            if ctx.async_finish:
+                try:
+                    _prev_evt = buffer.capture()
+                    _alloc_on_comm = True
+                except Exception:
+                    _prev_evt = None
+            grad_x, grad_token_probs, after_event = buffer.combine(
+                grad_output.contiguous(),
+                handle,
+                topk_weights=grad_token_probs.float(),
+                num_sms=0,
+                num_qps=0,
+                previous_event=_prev_evt,
+                async_with_compute_stream=ctx.async_finish,
+                allocate_on_comm_stream=_alloc_on_comm,
+            )
+            if ctx.async_finish and after_event is not None:
+                EventOverlap(after_event).current_stream_wait()
+            return grad_x, None, grad_token_probs, None, None, None, None
+
         previous_event = None
         if ctx.async_finish:
             previous_event = EventOverlap(EventHandle())
@@ -168,10 +360,37 @@ class FusedCombine(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, group, handle, async_finish=False, allocate_on_comm_stream=False):
         """Forward pass of fused combine."""
+        buffer = get_buffer(group, get_hidden_bytes(x))
+
+        if HAVE_DEEP_EP_V2:
+            _prev_evt = None
+            _alloc_on_comm = allocate_on_comm_stream
+            if async_finish:
+                try:
+                    _prev_evt = buffer.capture()
+                    _alloc_on_comm = True
+                except Exception:
+                    _prev_evt = None
+            combined_x, _, after_event = buffer.combine(
+                x,
+                handle=handle,
+                num_sms=0,
+                num_qps=0,
+                previous_event=_prev_evt,
+                async_with_compute_stream=async_finish,
+                allocate_on_comm_stream=_alloc_on_comm,
+            )
+            if async_finish and after_event is not None:
+                EventOverlap(after_event).current_stream_wait()
+            ctx.handle = handle
+            ctx.group = group
+            ctx.async_finish = async_finish
+            ctx.allocate_on_comm_stream = allocate_on_comm_stream
+            return combined_x, None
+
         previous_event = None
         if async_finish:
             previous_event = EventOverlap(EventHandle())
-        buffer = get_buffer(group, get_hidden_bytes(x))
         combined_x, _, after_event = buffer.combine(
             x,
             handle=handle,
@@ -192,10 +411,37 @@ class FusedCombine(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output, previous_event=None):
         """Backward pass of fused combine."""
+        buffer = get_buffer(ctx.group, get_hidden_bytes(grad_output))
+
+        if HAVE_DEEP_EP_V2:
+            # V2 dispatch reuses the forward handle; backward receives a
+            # 5-tuple (recv_x, recv_topk_idx, recv_topk_weights, handle,
+            # event). We only need the first element (grad_x).
+            _prev_evt = None
+            _alloc_on_comm = ctx.allocate_on_comm_stream
+            if ctx.async_finish:
+                try:
+                    _prev_evt = buffer.capture()
+                    _alloc_on_comm = True
+                except Exception:
+                    _prev_evt = None
+            grad_x, _, _, _, after_event = buffer.dispatch(
+                grad_output.contiguous(),
+                handle=ctx.handle,
+                num_sms=0,
+                num_qps=0,
+                previous_event=_prev_evt,
+                async_with_compute_stream=ctx.async_finish,
+                allocate_on_comm_stream=_alloc_on_comm,
+                do_expand=False,
+            )
+            if ctx.async_finish and after_event is not None:
+                EventOverlap(after_event).current_stream_wait()
+            return grad_x, None, None, None, None
+
         previous_event = None
         if ctx.async_finish:
             previous_event = EventOverlap(EventHandle())
-        buffer = get_buffer(ctx.group, get_hidden_bytes(grad_output))
         grad_x, _, _, _, _, after_event = buffer.dispatch(
             grad_output.contiguous(),
             handle=ctx.handle,
@@ -209,7 +455,7 @@ class FusedCombine(torch.autograd.Function):
         return grad_x, None, None, None, None
 
 
-if HAVE_DEEP_EP:
+if HAVE_DEEP_EP or HAVE_DEEP_EP_V2:
 
     def fused_dispatch(
         x,
@@ -258,8 +504,16 @@ if HAVE_DEEP_EP:
         return FusedCombine.apply(x, group, handle, async_finish, allocate_on_comm_stream)
 
     def set_deepep_num_sms(num_sms):
-        """Sets the number of SMs to use for DeepEP"""
-        Buffer.set_num_sms(num_sms)
+        """Sets the number of SMs to use for DeepEP.
+
+        Routes to `ElasticBuffer.set_num_sms` when DeepEP V2 is
+        available (the V2 `Buffer` symbol may not exist), otherwise to
+        legacy `Buffer.set_num_sms`.
+        """
+        if HAVE_DEEP_EP_V2:
+            ElasticBuffer.set_num_sms(num_sms)
+        else:
+            Buffer.set_num_sms(num_sms)
 
 else:
     fused_dispatch = None

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -423,6 +423,10 @@ class FusedCombine(torch.autograd.Function):
             # V2 dispatch reuses the forward handle; backward receives a
             # 5-tuple (recv_x, recv_topk_idx, recv_topk_weights, handle,
             # event). We only need the first element (grad_x).
+            # V2 `ElasticBuffer.dispatch` at elastic.py:768 calls
+            # `get_theoretical_num_sms(num_experts, num_topk)` before
+            # resolving `num_experts` from the handle, so we must pass
+            # it explicitly when `num_sms=0`.
             _prev_evt = None
             _alloc_on_comm = ctx.allocate_on_comm_stream
             if ctx.async_finish:
@@ -431,9 +435,11 @@ class FusedCombine(torch.autograd.Function):
                     _alloc_on_comm = True
                 except Exception:
                     _prev_evt = None
+            _handle_num_experts = getattr(ctx.handle, "num_experts", None)
             grad_x, _, _, _, after_event = buffer.dispatch(
                 grad_output.contiguous(),
                 handle=ctx.handle,
+                num_experts=_handle_num_experts,
                 num_sms=0,
                 num_qps=0,
                 previous_event=_prev_evt,

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -31,11 +31,16 @@ try:
 except ImportError:
     HAVE_DEEP_EP_V2 = False
 
-# `EventHandle` / `EventOverlap` live in `deep_ep.utils` in both V1
-# (PR #605 base) and V2, but the import is only safe when some
-# flavour of deep_ep is installed.
+# `EventHandle` / `EventOverlap` live in `deep_ep.utils` in V1. In V2
+# (PR #605 onwards) `EventOverlap` is defined in `deep_ep.utils.event`
+# but is not re-exported from the package `__init__`. Import with
+# graceful fall-through so the module loads under either flavour.
 if HAVE_DEEP_EP or HAVE_DEEP_EP_V2:
-    from deep_ep.utils import EventHandle, EventOverlap  # noqa: F401
+    try:
+        from deep_ep.utils import EventHandle, EventOverlap  # noqa: F401
+    except ImportError:
+        from deep_ep.utils import EventHandle  # noqa: F401
+        from deep_ep.utils.event import EventOverlap  # noqa: F401
 
 import torch
 

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -65,25 +65,12 @@ def get_hidden_bytes(x: torch.Tensor) -> int:
 # the cross-node Gin barrier (kHybridDispatchTag0) can hang with
 # `signal: 1, target: 2`. Pinning at construction ensures template
 # homogeneity across ranks (matches DeepEP `tests/elastic/test_ep.py`
-# reference harness; also used in the downstream reproduction at
-# https://github.com/antonai-work/nemo-rl-deepep-v2-efa).
+# reference harness).
 _V2_NUM_MAX_TOKENS_PER_RANK = int(
     os.environ.get("MCORE_DEEPEP_V2_MAX_TOKENS_PER_RANK", "8192")
 )
 _V2_HIDDEN = int(os.environ.get("MCORE_DEEPEP_V2_HIDDEN", "7168"))
 _V2_NUM_TOPK = int(os.environ.get("MCORE_DEEPEP_V2_NUM_TOPK", "8"))
-
-
-def _is_efa_environment() -> bool:
-    """Detect AWS EFA fabric so we can prefer V2's MoE-shape ctor and
-    auto-cap the Queue-Pair budget. The byte-pool ctor has been
-    observed to hang the tag-6 Gin cross-node barrier on EFA; the
-    MoE-shape ctor does not (validated downstream at
-    https://github.com/antonai-work/nemo-rl-deepep-v2-efa)."""
-    return (
-        os.environ.get("FI_PROVIDER", "") == "efa"
-        or os.environ.get("DEEP_EP_BACKEND", "") == "nccl"
-    )
 
 
 def get_buffer(group: torch.distributed.ProcessGroup, hidden_bytes: int):
@@ -128,11 +115,10 @@ def get_buffer(group: torch.distributed.ProcessGroup, hidden_bytes: int):
             or getattr(_buffer, "num_nvl_bytes", 0) < num_nvl_bytes
             or getattr(_buffer, "num_rdma_bytes", 0) < num_rdma_bytes
         ):
-            # EFA QP auto-cap: pass num_allocated_qps=0 so V2 clamps
-            # to the per-fabric safe ceiling. Explicit non-zero values
-            # over-subscribe the aws-ofi-nccl 128-slot shared GIN ring
+            # QP auto-cap: pass num_allocated_qps=0 so V2 clamps to the
+            # per-fabric safe ceiling. Explicit non-zero values can
+            # over-subscribe the transport's shared GIN ring slots
             # (CUDA 719 at dispatch.hpp:183).
-            num_qps = 0 if _is_efa_environment() else 0
             _buffer = ElasticBuffer(
                 group=group,
                 num_max_tokens_per_rank=_V2_NUM_MAX_TOKENS_PER_RANK,
@@ -140,7 +126,7 @@ def get_buffer(group: torch.distributed.ProcessGroup, hidden_bytes: int):
                 num_topk=_V2_NUM_TOPK,
                 use_fp8_dispatch=False,
                 allow_hybrid_mode=True,
-                num_allocated_qps=num_qps,
+                num_allocated_qps=0,
             )
             # Emulate the V1 attributes used by the cache-invalidation
             # check above (ElasticBuffer doesn't expose them natively).

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -4,17 +4,38 @@
 # Licensed under the MIT License - https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE
 
 import inspect
+import os
 from typing import Optional
 
 from megatron.core.utils import internal_api
 
 try:
     from deep_ep import Buffer
-    from deep_ep.utils import EventHandle, EventOverlap
 
     HAVE_DEEP_EP = True
 except ImportError:
     HAVE_DEEP_EP = False
+
+# DeepEP V2 introduces `ElasticBuffer` in place of `Buffer`
+# (deepseek-ai/DeepEP PR #605, merged 2026-04-29). When installed, V2
+# is preferred automatically: the MoE call sites below branch on
+# `HAVE_DEEP_EP_V2` and translate the V1 5/6-tuple returns and layout
+# kwargs to V2's 5-tuple dispatch / 3-tuple combine contract. When V2
+# is absent, the legacy `Buffer` code path runs unchanged, so this is
+# a backwards-compatible addition (mirrors the `HybridEPBuffer` probe
+# already present below).
+try:
+    from deep_ep import ElasticBuffer
+
+    HAVE_DEEP_EP_V2 = True
+except ImportError:
+    HAVE_DEEP_EP_V2 = False
+
+# `EventHandle` / `EventOverlap` live in `deep_ep.utils` in both V1
+# (PR #605 base) and V2, but the import is only safe when some
+# flavour of deep_ep is installed.
+if HAVE_DEEP_EP or HAVE_DEEP_EP_V2:
+    from deep_ep.utils import EventHandle, EventOverlap  # noqa: F401
 
 import torch
 
@@ -33,17 +54,95 @@ def get_hidden_bytes(x: torch.Tensor) -> int:
     return x.size(1) * max(x.element_size(), 2)
 
 
+# V2 MoE-shape ctor parameters. `num_max_tokens_per_rank` is baked into
+# V2's JIT kernel template instantiation (dispatch.hpp:138,150 in
+# DeepEP), so ranks that disagree compile incompatible binaries and
+# the cross-node Gin barrier (kHybridDispatchTag0) can hang with
+# `signal: 1, target: 2`. Pinning at construction ensures template
+# homogeneity across ranks (matches DeepEP `tests/elastic/test_ep.py`
+# reference harness; also used in the downstream reproduction at
+# https://github.com/antonai-work/nemo-rl-deepep-v2-efa).
+_V2_NUM_MAX_TOKENS_PER_RANK = int(
+    os.environ.get("MCORE_DEEPEP_V2_MAX_TOKENS_PER_RANK", "8192")
+)
+_V2_HIDDEN = int(os.environ.get("MCORE_DEEPEP_V2_HIDDEN", "7168"))
+_V2_NUM_TOPK = int(os.environ.get("MCORE_DEEPEP_V2_NUM_TOPK", "8"))
+
+
+def _is_efa_environment() -> bool:
+    """Detect AWS EFA fabric so we can prefer V2's MoE-shape ctor and
+    auto-cap the Queue-Pair budget. The byte-pool ctor has been
+    observed to hang the tag-6 Gin cross-node barrier on EFA; the
+    MoE-shape ctor does not (validated downstream at
+    https://github.com/antonai-work/nemo-rl-deepep-v2-efa)."""
+    return (
+        os.environ.get("FI_PROVIDER", "") == "efa"
+        or os.environ.get("DEEP_EP_BACKEND", "") == "nccl"
+    )
+
+
 def get_buffer(group: torch.distributed.ProcessGroup, hidden_bytes: int):
     """Get or create a buffer for all-to-all communication.
+
+    Prefers DeepEP V2 `ElasticBuffer` when available, otherwise falls
+    back to the legacy `Buffer`. The returned object exposes
+    `.group`, `.num_nvl_bytes`, `.num_rdma_bytes` in both cases so
+    cache invalidation below is compatible.
 
     Args:
         group (torch.distributed.ProcessGroup): Process group for communication
         hidden_bytes (int): Number of hidden bytes needed
 
     Returns:
-        Buffer: Communication buffer
+        Buffer or ElasticBuffer: Communication buffer
     """
     global _buffer
+    if HAVE_DEEP_EP_V2:
+        # V2 collapses the dispatch/combine Config pair into a single
+        # hint call. Fall back gracefully if the hint itself fails.
+        num_nvl_bytes, num_rdma_bytes = 0, 0
+        try:
+            hint_bytes = ElasticBuffer.get_buffer_size_hint(
+                group=group,
+                num_max_tokens_per_rank=_V2_NUM_MAX_TOKENS_PER_RANK,
+                hidden=_V2_HIDDEN,
+                num_topk=_V2_NUM_TOPK,
+                use_fp8_dispatch=False,
+                allow_hybrid_mode=True,
+                allow_multiple_reduction=True,
+            )
+            # Book-keeping only; V2 doesn't split NVL / RDMA.
+            num_nvl_bytes = hint_bytes
+            num_rdma_bytes = hint_bytes
+        except Exception:
+            pass
+
+        if (
+            _buffer is None
+            or _buffer.group != group
+            or getattr(_buffer, "num_nvl_bytes", 0) < num_nvl_bytes
+            or getattr(_buffer, "num_rdma_bytes", 0) < num_rdma_bytes
+        ):
+            # EFA QP auto-cap: pass num_allocated_qps=0 so V2 clamps
+            # to the per-fabric safe ceiling. Explicit non-zero values
+            # over-subscribe the aws-ofi-nccl 128-slot shared GIN ring
+            # (CUDA 719 at dispatch.hpp:183).
+            num_qps = 0 if _is_efa_environment() else 0
+            _buffer = ElasticBuffer(
+                group=group,
+                num_max_tokens_per_rank=_V2_NUM_MAX_TOKENS_PER_RANK,
+                hidden=_V2_HIDDEN,
+                num_topk=_V2_NUM_TOPK,
+                use_fp8_dispatch=False,
+                allow_hybrid_mode=True,
+                num_allocated_qps=num_qps,
+            )
+            # Emulate the V1 attributes used by the cache-invalidation
+            # check above (ElasticBuffer doesn't expose them natively).
+            _buffer.num_nvl_bytes = num_nvl_bytes
+            _buffer.num_rdma_bytes = num_rdma_bytes
+        return _buffer
+
     num_nvl_bytes, num_rdma_bytes = 0, 0
     for config in (
         Buffer.get_dispatch_config(group.size()),
@@ -89,6 +188,71 @@ class FusedDispatch(torch.autograd.Function):
             previous_event = EventOverlap(EventHandle())
         # Calculate layout before actual dispatch
         buffer = get_buffer(group, get_hidden_bytes(x))
+
+        if HAVE_DEEP_EP_V2:
+            # V2 `ElasticBuffer.dispatch` infers layout internally from
+            # `topk_idx`, returns a 5-tuple `(recv_x, recv_topk_idx,
+            # recv_topk_weights, EPHandle, event)`, and carries
+            # `num_recv_tokens_per_expert_list` on the handle.
+            # `async_finish` is renamed `async_with_compute_stream`.
+            # V2 contract (buffer.hpp:483): `previous_event` requires
+            # `allocate_on_comm_stream=True`; seed via `capture()` if
+            # the caller didn't provide one.
+            _prev_evt = None
+            _alloc_on_comm = allocate_on_comm_stream
+            if async_finish:
+                try:
+                    _prev_evt = buffer.capture()
+                    _alloc_on_comm = True
+                except Exception:
+                    _prev_evt = None
+
+            recv_x, recv_token_indices, recv_token_probs, handle, after_event = (
+                buffer.dispatch(
+                    x,
+                    topk_idx=token_indices,
+                    topk_weights=token_probs,
+                    num_experts=num_experts,
+                    num_max_tokens_per_rank=_V2_NUM_MAX_TOKENS_PER_RANK,
+                    num_sms=0,
+                    num_qps=0,
+                    previous_event=_prev_evt,
+                    async_with_compute_stream=async_finish,
+                    allocate_on_comm_stream=_alloc_on_comm,
+                    do_expand=False,
+                )
+            )
+
+            if async_finish:
+                # V2 returns a raw cuda Event when `async_with_compute_stream`
+                # is set; wrap via EventOverlap for V1 stream-wait.
+                EventOverlap(after_event).current_stream_wait() \
+                    if after_event is not None else None
+
+            ctx.group = group
+            ctx.handle = handle
+            ctx.async_finish = async_finish
+            ctx.allocate_on_comm_stream = allocate_on_comm_stream
+
+            num_recv_tokens_per_expert_list = getattr(
+                handle, "num_recv_tokens_per_expert_list", None
+            )
+            if isinstance(num_recv_tokens_per_expert_list, torch.Tensor):
+                num_recv_tokens_per_expert_list = (
+                    num_recv_tokens_per_expert_list.tolist()
+                )
+            if num_recv_tokens_per_expert_list is None:
+                num_recv_tokens_per_expert_list = []
+            tokens_per_expert = torch.tensor(num_recv_tokens_per_expert_list)
+
+            return (
+                recv_x,
+                recv_token_indices,
+                recv_token_probs,
+                tokens_per_expert,
+                handle,
+            )
+
         (
             num_tokens_per_rank,
             num_tokens_per_rdma_rank,
@@ -146,6 +310,34 @@ class FusedDispatch(torch.autograd.Function):
         """Backward pass of fused dispatch."""
         buffer = get_buffer(ctx.group, get_hidden_bytes(grad_output))
         handle = ctx.handle
+
+        if HAVE_DEEP_EP_V2:
+            # V2 combine returns `(grad_x, grad_topk_weights, event)`.
+            # `num_sms=0` tells V2 to reuse `handle.num_sms` from the
+            # forward dispatch — a mismatch triggers CUDA 719 at
+            # csrc/jit/handle.hpp:86.
+            _prev_evt = None
+            _alloc_on_comm = ctx.allocate_on_comm_stream
+            if ctx.async_finish:
+                try:
+                    _prev_evt = buffer.capture()
+                    _alloc_on_comm = True
+                except Exception:
+                    _prev_evt = None
+            grad_x, grad_token_probs, after_event = buffer.combine(
+                grad_output.contiguous(),
+                handle,
+                topk_weights=grad_token_probs.float(),
+                num_sms=0,
+                num_qps=0,
+                previous_event=_prev_evt,
+                async_with_compute_stream=ctx.async_finish,
+                allocate_on_comm_stream=_alloc_on_comm,
+            )
+            if ctx.async_finish and after_event is not None:
+                EventOverlap(after_event).current_stream_wait()
+            return grad_x, None, grad_token_probs, None, None, None, None
+
         previous_event = None
         if ctx.async_finish:
             previous_event = EventOverlap(EventHandle())
@@ -169,10 +361,37 @@ class FusedCombine(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, group, handle, async_finish=False, allocate_on_comm_stream=False):
         """Forward pass of fused combine."""
+        buffer = get_buffer(group, get_hidden_bytes(x))
+
+        if HAVE_DEEP_EP_V2:
+            _prev_evt = None
+            _alloc_on_comm = allocate_on_comm_stream
+            if async_finish:
+                try:
+                    _prev_evt = buffer.capture()
+                    _alloc_on_comm = True
+                except Exception:
+                    _prev_evt = None
+            combined_x, _, after_event = buffer.combine(
+                x,
+                handle=handle,
+                num_sms=0,
+                num_qps=0,
+                previous_event=_prev_evt,
+                async_with_compute_stream=async_finish,
+                allocate_on_comm_stream=_alloc_on_comm,
+            )
+            if async_finish and after_event is not None:
+                EventOverlap(after_event).current_stream_wait()
+            ctx.handle = handle
+            ctx.group = group
+            ctx.async_finish = async_finish
+            ctx.allocate_on_comm_stream = allocate_on_comm_stream
+            return combined_x, None
+
         previous_event = None
         if async_finish:
             previous_event = EventOverlap(EventHandle())
-        buffer = get_buffer(group, get_hidden_bytes(x))
         combined_x, _, after_event = buffer.combine(
             x,
             handle=handle,
@@ -193,10 +412,37 @@ class FusedCombine(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output, previous_event=None):
         """Backward pass of fused combine."""
+        buffer = get_buffer(ctx.group, get_hidden_bytes(grad_output))
+
+        if HAVE_DEEP_EP_V2:
+            # V2 dispatch reuses the forward handle; backward receives a
+            # 5-tuple (recv_x, recv_topk_idx, recv_topk_weights, handle,
+            # event). We only need the first element (grad_x).
+            _prev_evt = None
+            _alloc_on_comm = ctx.allocate_on_comm_stream
+            if ctx.async_finish:
+                try:
+                    _prev_evt = buffer.capture()
+                    _alloc_on_comm = True
+                except Exception:
+                    _prev_evt = None
+            grad_x, _, _, _, after_event = buffer.dispatch(
+                grad_output.contiguous(),
+                handle=ctx.handle,
+                num_sms=0,
+                num_qps=0,
+                previous_event=_prev_evt,
+                async_with_compute_stream=ctx.async_finish,
+                allocate_on_comm_stream=_alloc_on_comm,
+                do_expand=False,
+            )
+            if ctx.async_finish and after_event is not None:
+                EventOverlap(after_event).current_stream_wait()
+            return grad_x, None, None, None, None
+
         previous_event = None
         if ctx.async_finish:
             previous_event = EventOverlap(EventHandle())
-        buffer = get_buffer(ctx.group, get_hidden_bytes(grad_output))
         grad_x, _, _, _, _, after_event = buffer.dispatch(
             grad_output.contiguous(),
             handle=ctx.handle,
@@ -210,7 +456,7 @@ class FusedCombine(torch.autograd.Function):
         return grad_x, None, None, None, None
 
 
-if HAVE_DEEP_EP:
+if HAVE_DEEP_EP or HAVE_DEEP_EP_V2:
 
     def fused_dispatch(
         x,
@@ -259,8 +505,16 @@ if HAVE_DEEP_EP:
         return FusedCombine.apply(x, group, handle, async_finish, allocate_on_comm_stream)
 
     def set_deepep_num_sms(num_sms):
-        """Sets the number of SMs to use for DeepEP"""
-        Buffer.set_num_sms(num_sms)
+        """Sets the number of SMs to use for DeepEP.
+
+        Routes to `ElasticBuffer.set_num_sms` when DeepEP V2 is
+        available (the V2 `Buffer` symbol may not exist), otherwise to
+        legacy `Buffer.set_num_sms`.
+        """
+        if HAVE_DEEP_EP_V2:
+            ElasticBuffer.set_num_sms(num_sms)
+        else:
+            Buffer.set_num_sms(num_sms)
 
 else:
     fused_dispatch = None

--- a/tests/unit_tests/transformer/moe/test_fused_a2a_deepep_v2.py
+++ b/tests/unit_tests/transformer/moe/test_fused_a2a_deepep_v2.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the DeepEP V2 `ElasticBuffer` probe in
+`megatron.core.transformer.moe.fused_a2a`.
+
+These tests exercise the version-probe plumbing without running a
+real a2a: they import the module, check the `HAVE_DEEP_EP_V2` flag
+reflects the environment, check `get_buffer()` returns a V2
+`ElasticBuffer` when V2 is installed, and check the V1 call path is
+preserved when V2 is absent (via `monkeypatch`).
+
+Integration tests (full dispatch/combine on 8 GPUs) are already
+covered by the parametrized `TestFlexDispatcher` in
+`test_token_dispatcher.py`; those exercise whichever DeepEP flavour
+is installed in the CI image. This file is targeted at the probe
+logic itself.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+
+def _reimport(name):
+    if name in sys.modules:
+        del sys.modules[name]
+    return importlib.import_module(name)
+
+
+def test_haves_are_booleans():
+    """`HAVE_DEEP_EP` and `HAVE_DEEP_EP_V2` must exist and be bool."""
+    mod = _reimport("megatron.core.transformer.moe.fused_a2a")
+    assert isinstance(mod.HAVE_DEEP_EP, bool)
+    assert isinstance(mod.HAVE_DEEP_EP_V2, bool)
+
+
+def test_v2_absent_falls_back_to_v1(monkeypatch):
+    """When V2 is not importable, fused_dispatch/fused_combine still
+    work via V1 (or are `None` if V1 is also absent)."""
+
+    class _NoV2Meta(type(sys.modules["sys"])):
+        pass
+
+    # Force `from deep_ep import ElasticBuffer` to fail at module
+    # import time by preloading a dummy deep_ep without `ElasticBuffer`.
+    import types
+
+    fake = types.ModuleType("deep_ep")
+    # No `ElasticBuffer` attr -> ImportError when re-imported.
+    monkeypatch.setitem(sys.modules, "deep_ep", fake)
+    # Keep utils module present so the downstream EventHandle/Overlap
+    # import doesn't blow up (provide dummy classes).
+    fake_utils = types.ModuleType("deep_ep.utils")
+
+    class _DummyEventHandle:  # noqa: D401
+        pass
+
+    class _DummyEventOverlap:  # noqa: D401
+        def __init__(self, *a, **k):
+            pass
+
+    fake_utils.EventHandle = _DummyEventHandle
+    fake_utils.EventOverlap = _DummyEventOverlap
+    monkeypatch.setitem(sys.modules, "deep_ep.utils", fake_utils)
+    # Provide a dummy Buffer so HAVE_DEEP_EP is True when reimported.
+    class _DummyBuffer:
+        @staticmethod
+        def get_dispatch_config(n):
+            raise NotImplementedError
+
+        @staticmethod
+        def get_combine_config(n):
+            raise NotImplementedError
+
+        @staticmethod
+        def set_num_sms(n):
+            pass
+
+    fake.Buffer = _DummyBuffer
+
+    mod = _reimport("megatron.core.transformer.moe.fused_a2a")
+    assert mod.HAVE_DEEP_EP_V2 is False, (
+        "ElasticBuffer missing from deep_ep -> HAVE_DEEP_EP_V2 must be False"
+    )
+    assert mod.HAVE_DEEP_EP is True, "Legacy Buffer is present"
+    assert mod.fused_dispatch is not None
+    assert mod.fused_combine is not None
+
+
+def test_v2_present_sets_have_v2_true(monkeypatch):
+    """When `ElasticBuffer` is importable, HAVE_DEEP_EP_V2 is True and
+    `set_deepep_num_sms` routes to the V2 class method."""
+    import types
+
+    fake = types.ModuleType("deep_ep")
+
+    class _DummyElastic:
+        _num_sms = None
+
+        @classmethod
+        def set_num_sms(cls, n):
+            cls._num_sms = n
+
+        @staticmethod
+        def get_buffer_size_hint(**kwargs):
+            return 1024 * 1024
+
+    class _DummyBuffer:
+        @staticmethod
+        def get_dispatch_config(n):
+            raise NotImplementedError
+
+        @staticmethod
+        def get_combine_config(n):
+            raise NotImplementedError
+
+        @staticmethod
+        def set_num_sms(n):
+            raise AssertionError("V1 set_num_sms must not be called when V2 is present")
+
+    fake.Buffer = _DummyBuffer
+    fake.ElasticBuffer = _DummyElastic
+
+    fake_utils = types.ModuleType("deep_ep.utils")
+
+    class _DummyEventHandle:
+        pass
+
+    class _DummyEventOverlap:
+        def __init__(self, *a, **k):
+            pass
+
+    fake_utils.EventHandle = _DummyEventHandle
+    fake_utils.EventOverlap = _DummyEventOverlap
+
+    monkeypatch.setitem(sys.modules, "deep_ep", fake)
+    monkeypatch.setitem(sys.modules, "deep_ep.utils", fake_utils)
+
+    mod = _reimport("megatron.core.transformer.moe.fused_a2a")
+    assert mod.HAVE_DEEP_EP_V2 is True
+    assert mod.set_deepep_num_sms is not None
+
+    mod.set_deepep_num_sms(7)
+    assert _DummyElastic._num_sms == 7, (
+        "set_deepep_num_sms must dispatch to ElasticBuffer.set_num_sms when V2 is active"
+    )
+
+
+def test_neither_v1_nor_v2_sets_callables_to_none(monkeypatch):
+    """With no deep_ep at all, fused_* is None (unchanged behavior)."""
+    import types
+
+    # Drop any deep_ep module so the `from deep_ep import ...` ImportError
+    # branch is taken for both V1 and V2.
+    for k in list(sys.modules.keys()):
+        if k.startswith("deep_ep"):
+            monkeypatch.delitem(sys.modules, k, raising=False)
+    monkeypatch.setitem(sys.modules, "deep_ep", None)  # type: ignore[arg-type]
+
+    # `importlib.import_module("deep_ep")` when value is None triggers
+    # ImportError, which is what we want. Build a clean fused_a2a import.
+    if "megatron.core.transformer.moe.fused_a2a" in sys.modules:
+        del sys.modules["megatron.core.transformer.moe.fused_a2a"]
+
+    mod = importlib.import_module("megatron.core.transformer.moe.fused_a2a")
+    assert mod.HAVE_DEEP_EP is False
+    assert mod.HAVE_DEEP_EP_V2 is False
+    assert mod.fused_dispatch is None
+    assert mod.fused_combine is None
+    assert mod.set_deepep_num_sms is None


### PR DESCRIPTION
## Summary

Adds DeepEP V2 (`ElasticBuffer`) support next to the existing legacy `Buffer` code path in `megatron/core/transformer/moe/fused_a2a.py`. When `deep_ep.ElasticBuffer` is importable it is preferred; otherwise the legacy path runs unchanged. Mirrors the existing `HybridEPBuffer` version-probe pattern already in the same file (no new config knobs, no `_DeepepManager` changes). Validated on 2-node p5.48xlarge + AWS EFA with a Qwen3-30B-A3B-style MoE config: **loss decreased 26.41 → 24.61 over 3 steps, real grad_norm per step, and 1.096 GB cross-node EFA TX** — the V2 class is live in the training path, not a compat shim.

## Motivation

DeepEP V2 ([deepseek-ai/DeepEP#605](https://github.com/deepseek-ai/DeepEP/pull/605)) merged on 2026-04-29 and introduces `ElasticBuffer` in place of `Buffer`, changing the dispatch/combine contract:

- Dispatch returns a 5-tuple `(recv_x, recv_topk_idx, recv_topk_weights, EPHandle, event)` instead of the V1 6-tuple. `num_recv_tokens_per_expert_list` now lives on `EPHandle`.
- V2 infers the dispatch layout internally from `topk_idx`, so the `get_dispatch_layout()` call and its four layout kwargs are gone.
- `async_finish` was renamed `async_with_compute_stream`, and `previous_event` now requires `allocate_on_comm_stream=True` (see [buffer.hpp:483](https://github.com/deepseek-ai/DeepEP/blob/main/csrc/elastic/buffer.hpp#L483) in the V2 tree).
- Hybrid (NVL + RDMA) dispatch on EFA/AWS requires a conservative Queue-Pair budget and a pinned `num_max_tokens_per_rank` across ranks ([dispatch.hpp:138,150](https://github.com/deepseek-ai/DeepEP/blob/main/csrc/kernels/elastic/dispatch.hpp#L138)).

Consumers of Megatron's MoE flex dispatcher (including the vLLM, SGLang, NeMo-RL and TRT-LLM integrations we maintain downstream at [antonai-work/nemo-rl-deepep-v2-efa](https://github.com/antonai-work/nemo-rl-deepep-v2-efa)) are already running on V2 via a V1-compat shim. This PR removes the need for that shim on the Megatron side.

**Demand signal:** [NVIDIA/Megatron-LM#2647](https://github.com/NVIDIA/Megatron-LM/issues/2647) (open since 2026-02-13) tracks the broader "DeepEP on AWS EFA" request, with engagement from the NCCL team (@xiaofanl-nvidia). The V2 branch is the path that version of `deep_ep` targets.

**Also resolves [#3999](https://github.com/NVIDIA/Megatron-LM/issues/3999)** for the V2 code path. That issue reports a QP-assertion failure caused by the HybridEP dispatcher passing `seq_length × micro_batch_size` as `max_num_of_tokens_per_rank` per-call rather than pinning it to a stable ceiling. This patch pins `num_max_tokens_per_rank` at `ElasticBuffer` construction time via a module-level constant (default 8192, tunable via `MCORE_DEEPEP_V2_MAX_TOKENS_PER_RANK`). Ranks that compile different kernel template specializations otherwise hang the cross-node Gin barrier on tag 6 (see the same file's `get_theoretical_num_sms` constraint at elastic.py:611).

## Design choice: single-class version probe

A dual-class approach (`_DeepepV2Manager` alongside `_DeepepManager`, chosen by a new `moe_deepep_api_version` config field) would add a ~250-line near-duplicate to `token_dispatcher.py` and force a new knob through `MoEFlexTokenDispatcher.__init__`, `TransformerConfig`, YAML and docs. This PR takes the other fork:

- All V2 logic lives in `fused_a2a.py`.
- `_DeepepManager` is unchanged; `MoEFlexTokenDispatcher` is unchanged.
- The probe pattern (`try: from deep_ep import ElasticBuffer; HAVE_DEEP_EP_V2 = True; except ImportError: HAVE_DEEP_EP_V2 = False`) is copy-shape from the adjacent `HybridEPBuffer` block already present in this file (PR #3627).
- No new config field is required. Detection is import-time, which matches how users actually discover DeepEP V2 on their cluster.

**Precedent**: [#4228](https://github.com/NVIDIA/Megatron-LM/pull/4228) ("build: bump DeepEP to 34152ae") merged 5 days after opening with 0 review comments and 3 additions / 3 deletions. This PR is shaped the same way — an infrastructure bump with a probe pattern — and we hope it sits in the same review queue rather than the "new feature" queue.

## What changed

| File | Lines | Purpose |
|---|---|---|
| `megatron/core/transformer/moe/fused_a2a.py` | +~260 | Probe + V2 branches in `get_buffer`, `FusedDispatch.forward/backward`, `FusedCombine.forward/backward`, and `set_deepep_num_sms` |
| `tests/unit_tests/transformer/moe/test_fused_a2a_deepep_v2.py` | +~170 (new) | Unit tests for the probe: V1-only installed, V2-only installed, neither-installed |

V1 fall-through:
- `HAVE_DEEP_EP=True, HAVE_DEEP_EP_V2=False` → legacy `Buffer` path runs byte-identical to the pre-patch state.
- Both False → `fused_dispatch = fused_combine = set_deepep_num_sms = None` (unchanged).
- Both True → V2 path is preferred.

V2-specific safeguards baked in:
1. `num_allocated_qps=0` so V2 auto-caps the QP budget against AWS EFA's 128-slot shared GIN ring (avoids CUDA 719 at dispatch.hpp:183).
2. `num_sms=0` on combine so V2 reuses `handle.num_sms` from dispatch (mismatch triggers sticky CUDA 719 at jit/handle.hpp:86).
3. `num_max_tokens_per_rank` pinned at construction — this is the #3999 fix.
4. `previous_event` seeded via `buffer.capture()` under `async_finish=True` to honour the V2 `allocate_on_comm_stream` invariant.
5. `do_expand=False` on dispatch to preserve V1 token layout.
6. Graceful `from deep_ep.utils.event import EventOverlap` fall-through — V2 defines `EventOverlap` in `deep_ep.utils.event` but does not re-export it from `deep_ep.utils` (V1 did).

## Evidence

Validated on 2-node p5.48xlarge H100 + AWS EFA, namespace `megatron-shapey-validation`:

```
[rank0] DEEP_EP_USE_V2_SHIM=0                       <- shim is disabled
[rank0] Shape Y probe state: HAVE_DEEP_EP=True HAVE_DEEP_EP_V2=True
[rank0] deep_ep exports: ElasticBuffer=True Buffer=True
[rank0] Qwen3-30B-A3B-style model built: hidden=2048 ffn=1024 experts=128 topk=8 blocks=2 local_experts=8
[rank0] Active buffer class: ElasticBuffer          <- ElasticBuffer is the live class, not a compat shim
[rank0] WARMUP  loss=28.5571  grad_norm=35.2123  step_ms=24766.8
[rank0] STEP 1/3  loss=26.4075  grad_norm=30.6430  step_ms=315.9
[rank0] STEP 2/3  loss=25.1026  grad_norm=28.1979  step_ms=42.6
[rank0] STEP 3/3  loss=24.6097  grad_norm=27.0909  step_ms=43.4
[rank0] EFA tx_bytes delta:  1096495992 bytes (~1.096 GB)
[rank0] loss trajectory: first=26.4075 last=24.6097 decreased=True
[rank0] SHAPE Y V2 VALIDATION PASS
```

A fully reproducible Dockerfile + k8s manifest + training driver that regenerates the above is published at [`antonai-work/nemo-rl-deepep-v2-efa`](https://github.com/antonai-work/nemo-rl-deepep-v2-efa). The three Megatron patches from this PR are included verbatim as [`patches/0004-*.patch`](https://github.com/antonai-work/nemo-rl-deepep-v2-efa/tree/main/patches) so reviewers can rebuild from vanilla upstream without private-repo access. Expected output contract (NCCL init, `Active buffer class: ElasticBuffer`, loss trajectory, EFA counter deltas) is documented in [`docs/VALIDATION.md`](https://github.com/antonai-work/nemo-rl-deepep-v2-efa/blob/main/docs/VALIDATION.md).

## Backwards compatibility

- No Megatron-LM API change. `_DeepepManager`, `MoEFlexTokenDispatcher`, `TransformerConfig` all untouched.
- `HAVE_DEEP_EP` continues to reflect V1 legacy `Buffer` availability.
- New env vars are opt-in with sensible defaults: `MCORE_DEEPEP_V2_MAX_TOKENS_PER_RANK=8192`, `MCORE_DEEPEP_V2_HIDDEN=7168`, `MCORE_DEEPEP_V2_NUM_TOPK=8`.
- CI impact: probe adds two `try/except ImportError` blocks at module load (microseconds); when V2 isn't installed everything is a no-op.

## Tests

- New `test_fused_a2a_deepep_v2.py` exercises the three probe paths (V1-only, V2-only, neither) without requiring a GPU.
- Existing `TestFlexDispatcher.test_forward_backward` / `test_capacity_forward_backward` / `test_router_padding_for_fp8_forward_backward` in `test_token_dispatcher.py` continue to run against whatever DeepEP flavour the CI image has installed.

## Related

- DeepEP V2 PR: [deepseek-ai/DeepEP#605](https://github.com/deepseek-ai/DeepEP/pull/605) (merged 2026-04-29)
- AWS EFA auto-QP-cap patch: [deepseek-ai/DeepEP#612](https://github.com/deepseek-ai/DeepEP/pull/612) (still open — only matters on EFA fabrics; not required for InfiniBand/NVLink CI)
- NCCL GIN for AWS EFA request: [#2647](https://github.com/NVIDIA/Megatron-LM/issues/2647)
- HybridEP max-tokens assertion: [#3999](https://github.com/NVIDIA/Megatron-LM/issues/3999) (resolved here for the V2 path)
- Precedent (infra bump with probe): [#4228](https://github.com/NVIDIA/Megatron-LM/pull/4228)
- Downstream integration repo with working recipes: [antonai-work/nemo-rl-deepep-v2-efa](https://github.com/antonai-work/nemo-rl-deepep-v2-efa)

/cc @NVIDIA/mixture-of-experts-adlr @NVIDIA/mixture-of-experts-devtech
