### PR TITLE
Fix DistributedOptimizer OOM when resuming from checkpoint

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -651,6 +651,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             log_config_to_disk(config, locals(), prefix=type(self).__name__)
 
         super().__init__(optimizer, config, grad_scaler, init_state_fn)
+        # True when load_state_dict() has pinned Adam states to CPU; cleared after the first
+        # optimizer step restores them to GPU via _ensure_adam_states_on_gpu().
+        self._has_cpu_adam_states = False
         self.model_chunks = model_chunks
         self.ddp_config = self.model_chunks[0].ddp_config
         for model_chunk in self.model_chunks:
@@ -988,6 +991,22 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         self.optimizer.load_state_dict(
             {"state": state_dict_state, "param_groups": state_dict_param_groups}
         )
+
+        # Offload Adam states to CPU pinned memory so they do not occupy GPU memory
+        # during the first forward pass when resuming from a checkpoint.
+        # _ensure_adam_states_on_gpu() restores them to GPU just before the first
+        # optimizer step, i.e. after activations have been freed.
+        # We always pin the host buffer so that _ensure_adam_states_on_gpu() can
+        # identify our offloaded tensors via val.is_pinned() — leaving other
+        # intentionally-CPU state (e.g. HybridDeviceOptimizer) untouched.
+        _offloaded_any = False
+        for _param_state in self.optimizer.state.values():
+            for _key, _val in list(_param_state.items()):
+                if isinstance(_val, torch.Tensor) and _val.is_cuda:
+                    _param_state[_key] = _val.cpu().pin_memory()
+                    _offloaded_any = True
+        if _offloaded_any:
+            self._has_cpu_adam_states = True
 
         # Grad scaler.
         if 'grad_scaler' not in state_dict:
@@ -2824,12 +2843,33 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         copy_group_params(self.model_float16_groups, self.shard_fp32_from_float16_groups)
         copy_group_params(self.model_fp32_groups, self.shard_fp32_groups)
 
+    def _ensure_adam_states_on_gpu(self) -> None:
+        """Move Adam states to GPU if they were offloaded to CPU pinned memory by load_state_dict().
+
+        load_state_dict() pins Adam states to CPU to avoid occupying GPU memory before the
+        first forward pass when resuming from a checkpoint.  This method restores them to
+        GPU just before the first optimizer step, after activations have been freed.  On all
+        subsequent steps _has_cpu_adam_states is False and this method returns immediately.
+
+        We match on val.is_pinned() rather than not val.is_cuda to avoid accidentally
+        moving tensors that are intentionally CPU-resident (e.g. HybridDeviceOptimizer
+        states) — only the pinned buffers we created during offload are restored.
+        """
+        if not self._has_cpu_adam_states:
+            return
+        for param_state in self.optimizer.state.values():
+            for key, val in list(param_state.items()):
+                if isinstance(val, torch.Tensor) and val.is_pinned():
+                    param_state[key] = val.to(device=torch.cuda.current_device(), non_blocking=True)
+        self._has_cpu_adam_states = False
+
     @torch.no_grad()
     def step_with_ready_grads(self) -> bool:
         """Step the optimizer with ready gradients, return successful.
         Under the hood, either launch synchronous param all-gathers or get ready to launch
         asynchorous all-gathers that get overlapped with the next forward pass.
         """
+        self._ensure_adam_states_on_gpu()
         update_successful = super().step_with_ready_grads()
 
         timers = self.config.timers

--- a/tests/unit_tests/optimizer/test_distrib_optimizer_resume.py
+++ b/tests/unit_tests/optimizer/test_distrib_optimizer_resume.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Unit tests for DistributedOptimizer Adam-state offload / restore on checkpoint resume.
+
+The resume cycle:
+  load_state_dict() offloads Adam states (exp_avg, exp_avg_sq) to CPU pinned memory
+  → _ensure_adam_states_on_gpu() moves them back to GPU just before the first optimizer
+    step (after activations have been freed).
+
+This tests the invariants without requiring the full DistributedOptimizer infrastructure
+(buffers, DDP, process groups, etc.) by invoking the relevant methods on a minimal stub.
+"""
+
+import pytest
+import torch
+from torch.optim import Adam
+
+from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+class TestDistribOptimizerAdamStateOffload:
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_stub(self, optimizer, has_cpu_adam_states: bool = True):
+        """Minimal stub exposing only the attributes consumed by the two methods under test."""
+
+        class _Stub:
+            pass
+
+        stub = _Stub()
+        stub.optimizer = optimizer
+        stub._has_cpu_adam_states = has_cpu_adam_states
+        return stub
+
+    def _populated_adam(self):
+        """Adam optimizer whose state is fully populated (one step performed on GPU)."""
+        param = torch.nn.Parameter(torch.randn(8, 8, device='cuda'))
+        optimizer = Adam([param], lr=1e-3)
+        (param * param).sum().backward()
+        optimizer.step()
+        optimizer.zero_grad()
+        return optimizer
+
+    def _offload(self, optimizer):
+        """Apply the same offload loop as DistributedOptimizer.load_state_dict().
+
+        Returns the set of keys that were actually moved to CPU pinned memory.
+        Note: some state tensors (e.g. 'step' in modern PyTorch Adam) are already
+        on CPU and are not touched by the offload loop.
+        """
+        offloaded_keys: set = set()
+        for param_state in optimizer.state.values():
+            for key, val in list(param_state.items()):
+                if isinstance(val, torch.Tensor) and val.is_cuda:
+                    param_state[key] = val.cpu().pin_memory()
+                    offloaded_keys.add(key)
+        return offloaded_keys
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_offload_moves_cuda_states_to_cpu_pinned(self):
+        """Offload loop must move all CUDA Adam state tensors to CPU pinned memory.
+
+        Note: 'step' in modern PyTorch Adam is already CPU-resident; the offload
+        loop does not touch it (is_cuda is False), so we only check the keys that
+        were actually moved (exp_avg, exp_avg_sq, etc.).
+        """
+        optimizer = self._populated_adam()
+
+        offloaded_keys = self._offload(optimizer)
+
+        assert offloaded_keys, "No CUDA tensors found in Adam state — test setup broken"
+        # exp_avg and exp_avg_sq are always CUDA tensors in standard Adam.
+        assert 'exp_avg' in offloaded_keys
+        assert 'exp_avg_sq' in offloaded_keys
+
+        for param_state in optimizer.state.values():
+            for key in offloaded_keys:
+                val = param_state[key]
+                assert not val.is_cuda, f"state['{key}'] still on GPU after offload"
+                assert val.is_pinned(), f"state['{key}'] not pinned after offload"
+
+    def test_ensure_adam_states_on_gpu_restores_and_clears_flag(self):
+        """_ensure_adam_states_on_gpu() must move pinned states to GPU and clear the flag."""
+        optimizer = self._populated_adam()
+        offloaded_keys = self._offload(optimizer)
+
+        stub = self._make_stub(optimizer, has_cpu_adam_states=True)
+        DistributedOptimizer._ensure_adam_states_on_gpu(stub)
+        torch.cuda.synchronize()
+
+        assert not stub._has_cpu_adam_states, "_has_cpu_adam_states not cleared after restore"
+        # Only the keys that were actually pinned (CUDA→CPU) should now be back on GPU.
+        for param_state in optimizer.state.values():
+            for key in offloaded_keys:
+                val = param_state[key]
+                assert val.is_cuda, f"state['{key}'] not back on GPU after restore"
+
+    def test_ensure_adam_states_on_gpu_noop_when_flag_false(self):
+        """_ensure_adam_states_on_gpu() must be a no-op on every step after the first."""
+        optimizer = self._populated_adam()
+        self._offload(optimizer)
+
+        # Flag is False — as it would be on every step after the first restore.
+        stub = self._make_stub(optimizer, has_cpu_adam_states=False)
+        DistributedOptimizer._ensure_adam_states_on_gpu(stub)
+
+        # States remain on CPU (not moved) because the early-return fired.
+        for param_state in optimizer.state.values():
+            for key, val in param_state.items():
+                if isinstance(val, torch.Tensor):
+                    assert not val.is_cuda, (
+                        f"state['{key}'] moved to GPU despite _has_cpu_adam_states=False"
+                    )
+
+    def test_ensure_adam_states_on_gpu_ignores_non_pinned_cpu_tensors(self):
+        """is_pinned() filter must leave intentionally-CPU-resident tensors untouched.
+
+        This guards against accidentally GPU-ifying HybridDeviceOptimizer's CPU-resident
+        optimizer states, which are not pinned.
+        """
+        optimizer = self._populated_adam()
+        self._offload(optimizer)
+
+        # Inject a non-pinned CPU tensor into the state (simulates HybridDeviceOptimizer).
+        _SENTINEL = '__non_pinned_cpu_state__'
+        first_state = next(iter(optimizer.state.values()))
+        first_state[_SENTINEL] = torch.zeros(4)  # CPU, not pinned
+        assert not first_state[_SENTINEL].is_pinned()
+
+        stub = self._make_stub(optimizer, has_cpu_adam_states=True)
+        DistributedOptimizer._ensure_adam_states_on_gpu(stub)
+        torch.cuda.synchronize()
+
+        # Non-pinned CPU tensor must remain on CPU.
+        assert not first_state[_SENTINEL].is_cuda, (
+            "Non-pinned CPU tensor was incorrectly moved to GPU by _ensure_adam_states_on_gpu"
+        )
+        # Offloaded (pinned) Adam tensors must be back on GPU.
+        for key in ('exp_avg', 'exp_avg_sq'):
+            assert first_state[key].is_cuda, f"Offloaded tensor '{key}' not restored to GPU"
+
+        del first_state[_SENTINEL]


### PR DESCRIPTION
## What

Fix `DistributedOptimizer` OOM when resuming from a checkpoint.

When resuming from a checkpoint, `DistributedOptimizer.load_state_dict()` calls
`self.optimizer.load_state_dict()` (PyTorch's native Adam), which casts all Adam
state tensors (`exp_avg`, `exp_avg_sq`) to match the parameter device (GPU).
These tensors then sit on GPU throughout the first forward pass, causing a peak
GPU memory spike that doesn't occur during fresh training — and can cause OOM.

In fresh training, Adam states are allocated lazily inside the first
`optimizer.step()` call — after the forward and backward passes have freed
activations. The resumed case should match this behaviour exactly.

## Root cause

```
sharded_state_dict(is_loading=True)
  └── self.load_state_dict(self.state_dict())
        └── self.optimizer.load_state_dict(...)   # ← casts all state to GPU
```

The GPU allocation happens before training starts, so the first forward pass
runs with: model params + FP32 main params + Adam states (2× FP32 params) all
on GPU simultaneously — much higher than fresh training where Adam states aren't
present yet.

## Fix

Two changes to `distrib_optimizer.py`:

1. **After `self.optimizer.load_state_dict()`**, immediately offload all Adam
   state tensors to CPU pinned memory. This reduces GPU footprint back to the
   fresh-training baseline before the first forward pass.

2. **`_ensure_adam_states_on_gpu()`** — new method called at the start of
   `step_with_ready_grads()`. Restores CPU tensors to GPU just before the first
   Adam step (i.e., after activations have been freed). On subsequent steps all
   tensors are already on GPU, so this is a cheap no-op.

## Verification

Tested with Llama 3.2 1B (4 layers) and Qwen3 1.7B (4 layers), measuring
step-1 peak GPU memory above the pre-step baseline:

| | Fresh | Resume (before fix) | Resume (after fix) |
|---|---|---|---|
| Llama 3.2 1B | 4.59 GB | ~10 GB | 3.82 GB ✓ |
| Qwen3 1.7B   | same pattern | OOM in original report | matched ✓ |

Peak == current in both cases after fix, confirming Adam states are not on GPU
during the forward pass.

Fixes: NVIDIA-NeMo/Megatron-Bridge#3576