### PR TITLE
test: mark TestFusedApplyMLARope::test_forward_backward_for_q flaky_in_dev

### DIFF
--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -248,6 +248,7 @@ def _test_fused_apply_mla_rope_for_kv(input_format):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("input_format", ["sbhd", "thd"])
 class TestFusedApplyMLARope:
+    @pytest.mark.flaky_in_dev
     def test_forward_backward_for_q(self, input_format):
         _test_fused_apply_mla_rope_for_q(input_format)
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Mark `TestFusedApplyMLARope::test_forward_backward_for_q` as `flaky_in_dev`.

The backward gradient `assert_close` intermittently exceeds bf16 tolerances
on the `thd` packed-sequence path. Observed failure in CI run
[25408640123](https://github.com/NVIDIA/Megatron-LM/actions/runs/25408640123):

```
FAILED tests/unit_tests/fusions/test_mla_yarn_rope_apply.py::TestFusedApplyMLARope::test_forward_backward_for_q[thd]
E   AssertionError: Mismatch in bwd: Tensor-likes are not close!
E   Mismatched elements: 31 / 786432 (0.0%)
E   Greatest absolute difference: 3.015625 at index (104, 29, 170) (up to 0.05 allowed)
E   Greatest relative difference: 33.509803771972656 at index (104, 28, 166) (up to 0.02 allowed)
```

The same merge-queue commit passed the unit-test job on rerun (run
[25415024224](https://github.com/NVIDIA/Megatron-LM/actions/runs/25415024224)),
confirming the bwd mismatch is non-deterministic in the fused
`fused_apply_mla_rope_for_q` kernel.

```python
@pytest.mark.experimental
@pytest.mark.internal
@pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@pytest.mark.parametrize("input_format", ["sbhd", "thd"])
class TestFusedApplyMLARope:
    @pytest.mark.flaky_in_dev
    def test_forward_backward_for_q(self, input_format):
        _test_fused_apply_mla_rope_for_q(input_format)
```

Owning code: `megatron/core/fusions/fused_mla_yarn_rope_apply.py`.

</details>
