### PR TITLE
Fix: qk-clip causes a tensor shape error when tensor-model-parallel-size > 1 for GQA

### DIFF
--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -61,7 +61,9 @@ except ImportError:
     rearrange = None
 
 try:
-    from flash_attn_3.flash_attn_interface import _flash_attn_forward
+    from flash_attn_3.flash_attn_interface import (
+        _flash_attn_forward,
+    )
     from flash_attn_3.flash_attn_interface import (
         flash_attn_with_kvcache as flash_attn3_with_kvcache,
     )
@@ -72,7 +74,9 @@ except ImportError as e:
 
 if not HAVE_FA3:
     try:
-        from flashattn_hopper.flash_attn_interface import _flash_attn_forward
+        from flashattn_hopper.flash_attn_interface import (
+            _flash_attn_forward,
+        )
         from flashattn_hopper.flash_attn_interface import (
             flash_attn_with_kvcache as flash_attn3_with_kvcache,
         )
@@ -1695,33 +1699,18 @@ class SelfAttention(Attention):
     def _clip_linear_qkv(self, weight):
         """Apply qkclip to linear_qkv layer"""
         # Reshape to (g, query_projection_size + 2 * kv_projection_size, -1)
-        weight_reshaped = weight.view(
-            self.num_query_groups_per_partition,
-            (self.query_projection_size + 2 * self.kv_projection_size)
-            // self.num_query_groups_per_partition,
-            -1,
-        )
+        weight_reshaped = weight.view(self.num_query_groups_per_partition, -1, weight.shape[-1])
 
         # Split into query_projection_size and 2 * kv_projection_size parts:
         # (n, a, -1) and (n, b, -1)
-        weight_q = weight_reshaped[
-            :, : self.query_projection_size // self.num_query_groups_per_partition, :
+        qkv_split_shape = [
+            self.config.kv_channels
+            * self.config.num_attention_heads
+            // self.config.num_query_groups,
+            self.config.kv_channels,
+            self.config.kv_channels,
         ]
-        weight_k = weight_reshaped[
-            :,
-            self.query_projection_size
-            // self.num_query_groups_per_partition : (
-                self.query_projection_size + self.kv_projection_size
-            )
-            // self.num_query_groups_per_partition,
-            :,
-        ]
-        weight_v = weight_reshaped[
-            :,
-            (self.query_projection_size + self.kv_projection_size)
-            // self.num_query_groups_per_partition :,
-            :,
-        ]
+        (weight_q, weight_k, weight_v) = torch.split(weight_reshaped, qkv_split_shape, dim=1)
 
         # extend the qk_clip_balancing_eta to the same shape as weight_q and weight_k
         self.qk_clip_balancing_eta_extended = self.qk_clip_balancing_eta.repeat(
@@ -1734,9 +1723,7 @@ class SelfAttention(Attention):
 
         # Concatenate back and reshape to original shape
         weight_updated = torch.cat([weight_q, weight_k, weight_v], dim=1)
-        weight_updated = weight_updated.view(
-            self.query_projection_size + 2 * self.kv_projection_size, -1
-        )
+        weight_updated = weight_updated.view(weight.shape)
 
         return weight_updated
 

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -368,6 +368,57 @@ class TestClipQK:
         # current_max_attn_logits should be reset
         assert attention.core_attention.current_max_attn_logits is None
 
+    @pytest.mark.internal
+    def test_clip_qk_with_tensor_parallelism(self):
+        """Test clip_qk with TP > 1 and GQA configuration."""
+        Utils.destroy_model_parallel()
+        tp_size = 2
+        Utils.initialize_model_parallel(tensor_model_parallel_size=tp_size)
+        model_parallel_cuda_manual_seed(123)
+
+        # GQA configuration: 8 attention heads, 4 query groups (2 heads per group)
+        # With TP=2, each rank gets 2 query groups
+        transformer_config = TransformerConfig(
+            num_layers=2,
+            hidden_size=256,
+            num_attention_heads=8,
+            num_query_groups=4,
+            use_cpu_initialization=False,
+            qk_clip=True,
+            qk_clip_threshold=100.0,
+            qk_clip_alpha=0.5,
+            tensor_model_parallel_size=tp_size,
+        )
+        attention = SelfAttention(
+            transformer_config,
+            get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules,
+            layer_number=1,
+        )
+        attention.cuda()
+
+        # Verify the attention layer has correct partition sizes
+        assert attention.num_query_groups_per_partition == 2  # 4 groups / 2 TP ranks
+
+        # Save original weights
+        original_weight = attention.linear_qkv.weight.data.clone()
+
+        # Set current_max_attn_logits above threshold for all heads (8 heads total)
+        # This will trigger the clip_qk logic and call _clip_linear_qkv
+        attention.core_attention.current_max_attn_logits = torch.tensor(
+            [150.0, 160.0, 170.0, 180.0, 190.0, 200.0, 210.0, 220.0], device='cuda'
+        )
+
+        # Call clip_qk - this should not raise shape errors with TP > 1
+        try:
+            attention.clip_qk()
+        except Exception as e:
+            pytest.fail(f"clip_qk raised an exception with TP={tp_size} and GQA: {e}")
+
+        # Weights should be updated
+        assert not torch.equal(attention.linear_qkv.weight.data, original_weight)
+        # current_max_attn_logits should be reset
+        assert attention.core_attention.current_max_attn_logits is None
+
 
 @pytest.mark.parametrize("output_gate", [False, True])
 class TestSelfAttention:


### PR DESCRIPTION
# What does this PR do ?
Fix a bug: qk-clip causes a tensor shape error in function _clip_linear_qkv when tensor-model-parallel-size > 1 for GQA. Unit tests have been added.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
