### PR TITLE
feat(gpt): add output postprocess hook

### DIFF
--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 from contextlib import nullcontext
-from typing import Optional
+from typing import Any, Callable, Optional
 
 import torch
 from torch import Tensor
@@ -282,6 +282,9 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         runtime_gather_output: Optional[bool] = None,
         loss_mask: Optional[Tensor] = None,
         padding_mask=None,
+        *,
+        output_processor: Optional[Callable[..., Tensor]] = None,
+        output_processor_context: Optional[Any] = None,
     ):
         """Initialize the schedule plan of all Transformer layers' sub-modules.
 
@@ -299,6 +302,10 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             extra_block_kwargs: Additional keyword arguments for blocks.
             runtime_gather_output: Whether to gather output at runtime.
             loss_mask (torch.Tensor): Used to mask out some portions of the loss
+            output_processor (Callable): Custom postprocess hook to run instead of the
+                default logits/loss path.
+            output_processor_context (Any): User-defined context object forwarded to
+                `output_processor`.
 
         Returns:
             The model chunk schedule plan.
@@ -324,6 +331,8 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         self._model_chunk_state.padding_mask = padding_mask
         self._model_chunk_state.extra_block_kwargs = extra_block_kwargs
         self._model_chunk_state.runtime_gather_output = runtime_gather_output
+        self._model_chunk_state.output_processor = output_processor
+        self._model_chunk_state.output_processor_context = output_processor_context
         self._model_chunk_state.model = model
         self._model_chunk_state.context = None
         self._model_chunk_state.context_mask = None

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -228,6 +228,8 @@ class PostProcessNode(ScheduleNode):
             sequence_len_offset=self.chunk_state.sequence_len_offset,
             runtime_gather_output=self.chunk_state.runtime_gather_output,
             extra_block_kwargs=self.chunk_state.extra_block_kwargs,
+            output_processor=self.chunk_state.output_processor,
+            output_processor_context=self.chunk_state.output_processor_context,
         )
 
         # For now, 1f1b only supports fp16 module

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from collections import OrderedDict
-from typing import Dict, Literal, Optional
+from typing import Any, Callable, Dict, Literal, Optional
 
 import torch
 from torch import Tensor
@@ -491,6 +491,8 @@ class GPTModel(LanguageModule):
         inference_params: Optional[BaseInferenceContext] = None,
         loss_mask: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
+        output_processor: Optional[Callable[..., Tensor]] = None,
+        output_processor_context: Optional[Any] = None,
     ) -> Tensor:
         """Forward function of the GPT Model This function passes the input tensors
         through the embedding layer, and then the decoder and finally into the post
@@ -504,6 +506,10 @@ class GPTModel(LanguageModule):
             padding_mask (Tensor, optional): Padding mask for MoE routing.
                 Shape [bsz, seq_length]. True = padding (exclude), False = valid (include).
                 Only used for MoE layers to exclude padding tokens from routing computations.
+            output_processor (Callable, optional): Custom postprocess hook that receives
+                decoder hidden states and output-layer helpers, then returns the model output.
+            output_processor_context (Any, optional): User-defined context object forwarded to
+                `output_processor`.
         """
         if self.config.fine_grained_activation_offloading:
             self.preprocess_for_fine_grained_offloading()
@@ -563,6 +569,8 @@ class GPTModel(LanguageModule):
             runtime_gather_output=runtime_gather_output,
             extra_block_kwargs=extra_block_kwargs,
             inference_context=inference_context,
+            output_processor=output_processor,
+            output_processor_context=output_processor_context,
         )
 
     def _postprocess(
@@ -584,6 +592,8 @@ class GPTModel(LanguageModule):
         runtime_gather_output=None,
         extra_block_kwargs=None,
         inference_context=None,
+        output_processor=None,
+        output_processor_context=None,
     ):
         """Postprocesses decoder hidden states to generate logits or compute loss.
 
@@ -649,6 +659,26 @@ class GPTModel(LanguageModule):
                     scale_logits_fn=self._scale_logits if self.config.use_mup else None,
                 )
         sequence_parallel_override = False
+
+        if output_processor is not None:
+            return output_processor(
+                hidden_states=hidden_states,
+                output_layer=self.output_layer,
+                output_weight=output_weight,
+                labels=labels,
+                loss_mask=loss_mask,
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                decoder_input=decoder_input,
+                inference_context=inference_context,
+                packed_seq_params=packed_seq_params,
+                runtime_gather_output=runtime_gather_output,
+                context=output_processor_context,
+                compute_language_model_loss=self.compute_language_model_loss,
+                scale_logits=self._scale_logits,
+                config=self.config,
+            )
 
         if in_inference_mode and inference_context.config.materialize_only_last_token_logits:
             if inference_context.is_static_batching():
@@ -719,6 +749,9 @@ class GPTModel(LanguageModule):
         inference_params: Optional[BaseInferenceContext] = None,
         loss_mask: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
+        *,
+        output_processor: Optional[Callable[..., Tensor]] = None,
+        output_processor_context: Optional[Any] = None,
     ):
         """Builds a computation schedule plan for the model.
 
@@ -745,6 +778,10 @@ class GPTModel(LanguageModule):
                 Parameters for inference. Defaults to None.
             loss_mask (Optional[Tensor], optional): Loss mask. Defaults to None.
             padding_mask (Optional[Tensor], optional): Padding mask. Defaults to None.
+            output_processor (Callable, optional): Custom postprocess hook to run in the
+                schedule-plan postprocess node instead of the default logits/loss path.
+            output_processor_context (Any, optional): User-defined context object forwarded to
+                `output_processor`.
 
         Returns:
             TransformerModelChunkSchedulePlan: The model chunk schedule plan.
@@ -767,6 +804,8 @@ class GPTModel(LanguageModule):
             runtime_gather_output,
             loss_mask,
             padding_mask,
+            output_processor=output_processor,
+            output_processor_context=output_processor_context,
         )
 
     def sharded_state_dict(

--- a/tests/unit_tests/models/test_gpt_model.py
+++ b/tests/unit_tests/models/test_gpt_model.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+import torch.nn.functional as F
 from packaging import version
 from pytest import approx
 from transformer_engine.pytorch.fp8 import check_fp8_support
@@ -111,6 +112,121 @@ class TestGPTModel:
         assert logits.shape[0] == micro_batch_size
         assert logits.shape[1] == sequence_length
         assert logits.shape[2] == self.gpt_model.vocab_size
+
+    @pytest.mark.internal
+    def test_output_processor_forward(self):
+        config: TransformerConfig = self.gpt_model.config
+        sequence_length = self.gpt_model.max_sequence_length
+        micro_batch_size = 2
+
+        self.gpt_model.cuda()
+        self.gpt_model.eval()
+
+        data = list(range(sequence_length))
+        input_ids = torch.tensor(data, dtype=torch.int64).repeat((micro_batch_size, 1)).cuda()
+        labels = (input_ids + 1) % self.gpt_model.vocab_size
+        position_ids = torch.tensor(data, dtype=torch.int64).repeat((micro_batch_size, 1)).cuda()
+        attention_mask = torch.ones(
+            (micro_batch_size, 1, sequence_length, sequence_length), dtype=bool
+        ).cuda()
+
+        context = {"selected_token_positions": torch.tensor([0, 2], device="cuda")}
+        seen = {}
+
+        def output_processor(**kwargs):
+            seen.update(kwargs)
+            logits, _ = kwargs["output_layer"](
+                kwargs["hidden_states"],
+                weight=kwargs["output_weight"],
+                runtime_gather_output=kwargs["runtime_gather_output"],
+            )
+            logits = kwargs["scale_logits"](logits).transpose(0, 1).contiguous().float()
+            token_logprobs = F.log_softmax(logits, dim=-1).gather(
+                dim=-1, index=kwargs["labels"].unsqueeze(-1)
+            )
+            token_logprobs = token_logprobs.squeeze(-1)
+            return token_logprobs.index_select(1, kwargs["context"]["selected_token_positions"])
+
+        with torch.no_grad():
+            logits = self.gpt_model.forward(
+                input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask
+            ).float()
+            expected = F.log_softmax(logits, dim=-1).gather(dim=-1, index=labels.unsqueeze(-1))
+            expected = expected.squeeze(-1).index_select(1, context["selected_token_positions"])
+
+            output = self.gpt_model.forward(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                labels=labels,
+                output_processor=output_processor,
+                output_processor_context=context,
+            )
+
+        assert torch.allclose(output, expected)
+        assert seen["context"] is context
+        assert seen["output_layer"] is self.gpt_model.output_layer
+        assert seen["output_weight"] is None
+        assert seen["labels"] is labels
+        assert seen["runtime_gather_output"] is None
+        assert seen["config"] is config
+        assert seen["compute_language_model_loss"].__self__ is self.gpt_model
+        assert seen["scale_logits"].__self__ is self.gpt_model
+
+    @pytest.mark.internal
+    def test_build_schedule_plan_threads_output_processor(self):
+        sequence_length = self.gpt_model.max_sequence_length
+        micro_batch_size = 2
+
+        self.gpt_model.cuda()
+
+        data = list(range(sequence_length))
+        input_ids = torch.tensor(data, dtype=torch.int64).repeat((micro_batch_size, 1)).cuda()
+        labels = torch.tensor(data, dtype=torch.int64).repeat((micro_batch_size, 1)).cuda()
+        position_ids = torch.tensor(data, dtype=torch.int64).repeat((micro_batch_size, 1)).cuda()
+        attention_mask = torch.ones(
+            (micro_batch_size, 1, sequence_length, sequence_length), dtype=bool
+        ).cuda()
+
+        context = {"loss_mask": torch.ones_like(labels)}
+
+        seen = {}
+
+        def output_processor(**kwargs):
+            seen.update(kwargs)
+            return kwargs["hidden_states"].sum()
+
+        schedule_plan = self.gpt_model.build_schedule_plan(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            labels=labels,
+            output_processor=output_processor,
+            output_processor_context=context,
+        )
+
+        assert schedule_plan.state.output_processor is output_processor
+        assert schedule_plan.state.output_processor_context is context
+
+        schedule_plan.state.decoder_input = None
+        schedule_plan.state.rotary_pos_emb = None
+        schedule_plan.state.rotary_pos_cos = None
+        schedule_plan.state.rotary_pos_sin = None
+        schedule_plan.state.sequence_len_offset = None
+
+        hidden_states = torch.randn(
+            sequence_length,
+            micro_batch_size,
+            self.gpt_model.config.hidden_size,
+            device="cuda",
+            requires_grad=True,
+        )
+        output = schedule_plan.post_process.forward(hidden_states)
+
+        assert output.item() == pytest.approx(hidden_states.sum().item())
+        assert seen["context"] is context
+        assert seen["labels"] is labels
+        assert seen["output_layer"] is self.gpt_model.output_layer
 
 
 def test_get_mlp_module_spec_interface():


### PR DESCRIPTION
# What does this PR do ?

Adds an objective-neutral GPT output postprocess hook so downstream RL callers can consume decoder hidden states and output-layer helpers without monkey-patching `GPTModel.forward` or the schedule-plan postprocess path.

## Issue tracking

Linked issue: Related to #4590

## Summary

- Adds keyword-only `output_processor` and `output_processor_context` arguments to `GPTModel.forward`.
- Runs the custom processor after decoder/MTP hidden-state preparation and before the default logits/loss path.
- Threads the same processor/context through `build_schedule_plan` and the 1F1B `PostProcessNode`.
- Adds unit coverage for a selected-token logprob processor that uses the output layer and matches the default logits path, plus schedule-plan postprocess threading.

This is intentionally a narrow first slice for #4590. It does not add RL-specific arguments to `GPTModel.forward`, and it leaves MTP-specific custom postprocess behavior as a follow-up unless maintainers prefer a broader API.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

## Testing

- `pre-commit run --files megatron/core/models/common/model_chunk_schedule_plan.py megatron/core/models/gpt/fine_grained_callables.py megatron/core/models/gpt/gpt_model.py tests/unit_tests/models/test_gpt_model.py`
  - Black, pylint, and isort passed.
- `python -m py_compile megatron/core/models/gpt/gpt_model.py megatron/core/models/common/model_chunk_schedule_plan.py megatron/core/models/gpt/fine_grained_callables.py tests/unit_tests/models/test_gpt_model.py`
- `PATH=/tmp/megatron-autoformat-stable/bin:$PATH CHECK_ONLY=true SKIP_DOCS=true ./tools/autoformat.sh`
  - Black, isort, pylint, and ruff passed.
  - Mypy is advisory in `tools/autoformat.sh` (`|| true`); running it in this local environment reports existing project typing issues in the touched files' surrounding code.
- Standalone CUDA smoke test using the local GPT layer spec:
  - direct `GPTModel.forward(..., output_processor=...)` selected-token logprobs match logprobs computed from the default logits path;
  - gradients flow through the custom processor to `output_layer.weight`;
  - schedule-plan `PostProcessNode` invokes the threaded processor/context.
- Simple GPT training run using the hook as the objective boundary:
  - 2-layer local GPT, batch size 4, sequence length 8, selected-token cross entropy computed entirely inside `output_processor`;
  - verified the hook loss matches loss computed from the default logits path before training;
  - ran 6 AdamW optimizer steps and confirmed the selected-token loss decreased: `4.2114 -> 2.4986`.
- Tiny Hugging Face text smoke run using `Salesforce/wikitext`, `wikitext-2-raw-v1`, `train[:64]`:
  - GPT-2 tokenizer, 2-layer local Megatron GPT, batch size 4, sequence length 16;
  - selected-token cross entropy computed entirely inside `output_processor`;
  - verified hook loss exactly matched loss computed from the default logits path before training: `10.833719` vs `10.833719`;
  - ran 10 AdamW optimizer steps and confirmed selected-token loss decreased: `10.8337 -> 10.3881`.

Full pytest collection was not run locally because this environment is missing `omegaconf` and `transformer_engine`.
