### PR TITLE
ci: replace uuidgen with /proc/sys/kernel/random/uuid

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -201,10 +201,10 @@ runs:
       env:
         IS_UNIT_TEST: ${{ inputs.is_unit_test == 'true' }}
       run: |
-        logs_report=logs-${{ inputs.test_case }}-${{ github.run_id }}-$(uuidgen)
+        logs_report=logs-${{ inputs.test_case }}-${{ github.run_id }}-$(cat /proc/sys/kernel/random/uuid)
         echo "logs_report=$logs_report" | sed 's/\//-/g' | sed 's/\*/-/g' | tee -a "$GITHUB_OUTPUT"
         if [[ "$IS_UNIT_TEST" == "true" ]]; then
-          coverage_report=coverage-unit-test-${{ github.run_id }}-$(uuidgen)
+          coverage_report=coverage-unit-test-${{ github.run_id }}-$(cat /proc/sys/kernel/random/uuid)
         else
           coverage_report=none
         fi

--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -79,14 +79,23 @@ runs:
       shell: bash
       run: sudo chown -R $(whoami) /home/runner/
 
-    - name: Setup python and install dependencies
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install uuid-runtime
       shell: bash -x -e -u -o pipefail {0}
       run: |
         for i in 1 2 3; do
-          apt-get update && apt-get install -y python3.12 python3.12-venv uuid-runtime && break
+          apt-get update && apt-get install -y uuid-runtime && break
           echo "apt attempt $i failed, retrying..."
           sleep 10
         done
+
+    - name: Install uv
+      shell: bash -x -e -u -o pipefail {0}
+      run: |
         for i in 1 2 3; do
           curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh && break
           echo "uv install attempt $i failed, retrying..."


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Two related fixes to `.github/actions/action.yml` so unit-test jobs stop reporting a failed exit code when the test suite itself passes.

1. **Split the runner-setup step** so installing Python, `uuid-runtime`, and `uv` each have an independent failure mode.
2. **Drop `python3.12` and `python3.12-venv` from the apt install** — they aren't in Ubuntu jammy's default repos, so the combined apt install always fails, silently dragging `uuid-runtime` down with it. Python 3.12 is now provided by `actions/setup-python@v5` instead.
3. **Replace `$(uuidgen)`** with `$(cat /proc/sys/kernel/random/uuid)` in the *Check result* step. Same UUID format, no apt package required — defense in depth in case `uuid-runtime` install ever regresses again.

## Why

Recent unit-test jobs on `main` (e.g. [run 25615335483 → `tests/unit_tests/dist_checkpointing/**/*.py - latest`](https://github.com/NVIDIA/Megatron-LM/actions/runs/25615335483/job/75216532902)) finish the test suite cleanly (`500 passed, 160 skipped`) but the job is reported as failed. The post-test step exits **127**:

```
/home/runner/_work/_temp/<id>.sh: line 1: uuidgen: command not found
##[error]Process completed with exit code 127.
```

`uuidgen` ships in `uuid-runtime`, which the `Setup python and install dependencies` step is supposed to install. Looking at the runner log for that step:

```bash
+ apt-get install -y python3.12 python3.12-venv uuid-runtime
E: Unable to locate package python3.12
E: Couldn't find any package by glob 'python3.12'
E: Unable to locate package python3.12-venv
+ echo 'apt attempt 3 failed, retrying...'
```

`python3.12` and `python3.12-venv` are not in the default Ubuntu jammy repos (deadsnakes PPA isn't enabled). Because the failure is masked by the `&& break` chain in a `for`-loop body (`set -e` does not propagate from `&&` chains inside a loop body), the loop just exits without erroring and `uuid-runtime` never gets installed.

Then in the *Check result* step, with `set -e -u -o pipefail`:

```bash
logs_report=...-$(uuidgen)
```

returns 127 and tanks every otherwise-passing job.

## Fix

```diff
- - name: Setup python and install dependencies
-   shell: bash -x -e -u -o pipefail {0}
-   run: |
-     for i in 1 2 3; do
-       apt-get update && apt-get install -y python3.12 python3.12-venv uuid-runtime && break
-       echo "apt attempt $i failed, retrying..."
-       sleep 10
-     done
-     for i in 1 2 3; do
-       curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh && break
-       echo "uv install attempt $i failed, retrying..."
-       sleep 10
-     done
+ - name: Setup python
+   uses: actions/setup-python@v5
+   with:
+     python-version: '3.12'
+
+ - name: Install uuid-runtime
+   shell: bash -x -e -u -o pipefail {0}
+   run: |
+     for i in 1 2 3; do
+       apt-get update && apt-get install -y uuid-runtime && break
+       echo "apt attempt $i failed, retrying..."
+       sleep 10
+     done
+
+ - name: Install uv
+   shell: bash -x -e -u -o pipefail {0}
+   run: |
+     for i in 1 2 3; do
+       curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh && break
+       echo "uv install attempt $i failed, retrying..."
+       sleep 10
+     done
```

```diff
- logs_report=logs-${{ inputs.test_case }}-${{ github.run_id }}-$(uuidgen)
+ logs_report=logs-${{ inputs.test_case }}-${{ github.run_id }}-$(cat /proc/sys/kernel/random/uuid)
  ...
- coverage_report=coverage-unit-test-${{ github.run_id }}-$(uuidgen)
+ coverage_report=coverage-unit-test-${{ github.run_id }}-$(cat /proc/sys/kernel/random/uuid)
```

`/proc/sys/kernel/random/uuid` is exposed by the kernel on every Linux runner and returns the same `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` format:

```bash
$ cat /proc/sys/kernel/random/uuid
3f7e1d62-9c4b-4f1a-bb8a-2d4f9d6c1e22
```

## Test plan

- [ ] CI green on this PR — *Install uuid-runtime* step succeeds, *Check result* step succeeds, no `uuidgen: command not found`
- [ ] Artifact names (`logs-*`, `coverage-unit-test-*`) still upload uniquely

</details>
