### PR TITLE
Revert "Add Python-side guardrail for HybridEP InfiniBand limit and rename seq_len (#4094)"

### DIFF
--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -280,7 +280,7 @@ _hybrid_ep_buffer = None
 def init_hybrid_ep_buffer(
     group: torch.distributed.ProcessGroup,
     hidden_dim: int,
-    num_tokens: int,
+    seq_len: int,
     num_local_experts: int,
     num_sms_dispatch_api: Optional[int] = None,
     num_sms_combine_api: Optional[int] = None,
@@ -330,7 +330,7 @@ def init_hybrid_ep_buffer(
     _hybrid_ep_buffer = HybridEPBuffer(
         group=group,
         hidden_dim=hidden_dim,
-        max_num_of_tokens_per_rank=num_tokens,
+        max_num_of_tokens_per_rank=seq_len,
         num_local_experts=num_local_experts,
         use_fp8=fp8_dispatch,
         **kwargs,
@@ -387,25 +387,12 @@ class HybridEPDispatch(torch.autograd.Function):
                 num_blocks_unpermute = None
 
         if _hybrid_ep_buffer is None:
-            num_tokens, hidden_dim = x.shape[-2:]
-
-            # --- Hardware Limit Guardrail ---
-            # DeepEP calculates tx_depth = 3 * num_tokens + 1.
-            # InfiniBand strictly asserts tx_depth < 65536.
-            tx_depth = 3 * num_tokens + 1
-            if tx_depth >= 65536:
-                raise ValueError(
-                    f"HybridEP RDMA Queue Pair depth ({tx_depth}) exceeds the InfiniBand "
-                    f"hardware limit of 65535. This occurs because the total tokens per rank "
-                    f"({num_tokens}) too high. Reduce sequence length or micro-batch size, "
-                    f"or increase Tensor Parallelism (TP) / Context Parallelism (CP) to reduce "
-                    f"the number of tokens processed per rank."
-                )
+            seq_len, hidden_dim = x.shape[-2:]
             fp8_dispatch = False  # Currently, we do not support fp8 dispatch
             init_hybrid_ep_buffer(
                 group,
                 hidden_dim,
-                num_tokens,
+                seq_len,
                 num_local_experts,
                 num_sms_dispatch_api,
                 num_sms_combine_api,


### PR DESCRIPTION
## What

Revert PR #4094 ("Add Python-side guardrail for HybridEP InfiniBand limit and rename seq_len").

## Why

The guardrail at `megatron/core/transformer/moe/fused_a2a.py:398` is **overly conservative** — it raises `ValueError` for `tx_depth = 3*num_tokens + 1 >= 65536`, citing InfiniBand's `tx_depth < 65536` limit. Empirically, DeepEP / the underlying RDMA stack already handles dispatch at `tx_depth = 98305` without crashing on the affected GB300/B300 clusters; the Python pre-check rejects workloads that *would have run fine*.

## Evidence

End-to-end re-test of every test that the guardrail was preventing from running, with the revert applied:

- **Revert SHA:** [`9924c3f205`](https://github.com/NVIDIA/Megatron-LM/commit/9924c3f2050724e877f61b042f411d0506a4e707) (this PR's HEAD)
- **Test image:** `dgxctestingtemp-nemofw-nightly.50777079` (the same nightly that contains the guardrail baked-in, with the revert overlaid at runtime)
- **Pinning:** MBridge `main` (original `MBS=4/8` values, *not* halved)
- **Verification pipeline (nemo-ci internal):** [50889489](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/50889489)
- **Test cases:** all 9 tests the guardrail was rejecting:

| Test | Cluster | MBS | Result with revert |
|---|---|---|---|
| `nemotron_3_nano_8gpu_b300_bf16_perf` | bia (b300) | 4 | (still running at write time) |
| `nemotron_3_nano_8gpu_b300_fp8_mx_perf` | bia (b300) | 4 | (still running at write time) |
| `nemotron_3_nano_8gpu_gb300_bf16_perf` | lyris (gb300) | 4 | ✅ success |
| `nemotron_3_nano_8gpu_gb300_fp8_mx_perf` | lyris (gb300) | 4 | ✅ success |
| `qwen3_30b_a3b_64gpu_b300_bf16_perf` | bia (b300) | 8 | ✅ success |
| `qwen3_30b_a3b_64gpu_b300_fp8_mx_perf` | bia (b300) | 8 | ✅ success |
| `qwen3_30b_a3b_64gpu_gb300_bf16_perf` | lyris (gb300) | 8 | ✅ success |
| `qwen3_30b_a3b_64gpu_gb300_fp8_mx_perf` | lyris (gb300) | 8 | ✅ success |
| `qwen3_vl_30b_a3b_8gpu_gb300_bf16_perf` | lyris (gb300) | 8 | ✅ success |

(I'll update the table with the 2 remaining results when they land.)

## Path forward

- If maintainers want to keep some form of guardrail, please re-introduce it with a more accurate threshold (e.g. the actual `max_qp_wr` reported by the IB device at runtime), and behind a feature flag so platforms where it's wrong can opt out.
- If the goal is just to surface a clearer error than DeepEP's lower-level assert, a `warnings.warn` or a try/except wrapper around the dispatch call would achieve that without rejecting valid configurations.

## Test plan

- [ ] `Run tests` label triggers MCore unit tests
- [x] End-to-end CI: pipeline 50889489 (above)

