### PR TITLE
Fix oncall references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **Describe the bug**
 
-A clear and concise description of what the bug is. Tag the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) 
+A clear and concise description of what the bug is. Tag @NVIDIA/mcore-oncall
 to get oncall's attention to this issue.
 
 **Steps/Code to reproduce bug**
@@ -26,4 +26,4 @@ A clear and concise description of what you expected to happen.
 
 **Additional context**
 
-Add any other context about the problem here. 
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ assignees: ''
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-Tag the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) 
+Tag @NVIDIA/mcore-oncall
 to get oncall's attention to this issue.
 
 **Describe the solution you'd like**

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -9,5 +9,5 @@ assignees: ''
 ---
 
 **Your question**
-Ask a clear and concise question about Megatron-LM. Tag the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) 
+Ask a clear and concise question about Megatron-LM. Tag @NVIDIA/mcore-oncall
 to get oncall's attention to this issue.

--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Describe the regression**
-A clear and concise description of what the regression is. Tag the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) 
+A clear and concise description of what the regression is. Tag @NVIDIA/mcore-oncall
 to get oncall's attention to this issue.
 
 **To Reproduce**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 # What does this PR do ?
 <!-- Add a one line overview of what this PR aims to accomplish. -->
 
-:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.
+:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.
 
 ## Issue tracking
 
@@ -24,7 +24,7 @@ Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->
 
 ### Code review
 
-Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!
+Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!
 
 All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.
 

--- a/docs/developer/contribute.md
+++ b/docs/developer/contribute.md
@@ -55,11 +55,11 @@ You should receive a response within 2 business days.
 
 ### I need help, who should I ping?
 
-Use [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall).
+Use @NVIDIA/mcore-oncall.
 
 ### If my issue or PR isn't getting attention, what should I do?
 
-After 2 business days, tag the user [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall).
+After 2 business days, tag the user @NVIDIA/mcore-oncall.
 
 ### Is there a policy for issues and PRs that haven't been touched in X days? Should they be closed?
 

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -137,7 +137,7 @@ Use the bug-report template body structure:
 **Describe the bug**
 
 CI test `<failed-test-node-id>` failed in job [`<job-name>`](<job-url>).
-Tag the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to get oncall's attention to this issue.
+Tag @NVIDIA/mcore-oncall to get oncall's attention to this issue.
 
 **Failing run**
 

--- a/tests/test_utils/python_scripts/auto_reminder_github.py
+++ b/tests/test_utils/python_scripts/auto_reminder_github.py
@@ -244,7 +244,7 @@ class PRReviewTracker:
                     mcore_members = {m.login for m in mcore_team.get_members()}
                     valid_approvers = approvers & mcore_members
                     reviewer_emails = sorted([self.get_user_email(u) for u in valid_approvers])
-                    action_message = "All Final Reviewers approved the PR. Please ping the @mcore-oncall to merge the PR."
+                    action_message = "All Final Reviewers approved the PR. Please ping @NVIDIA/mcore-oncall to merge the PR."
 
                 except Exception as e:
                     logger.warning(


### PR DESCRIPTION
Apparently the name to tag changed from @mcore-oncall to @NVIDIA/mcore-oncall.

@Phlip79 please check in case the broken reference is intentional (e.g., to reduce pings).