### PR TITLE
[ci] fix: treat cancelled run-main-script step as failure

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -209,6 +209,8 @@ runs:
       if: always()
       env:
         IS_UNIT_TEST: ${{ inputs.is_unit_test == 'true' }}
+        MAIN_CONCLUSION: ${{ steps.run-main-script.conclusion }}
+        MAIN_EXIT_CODE: ${{ steps.run-main-script.outputs.exit_code }}
       run: |
         logs_report=logs-${{ inputs.test_case }}-${{ github.run_id }}-$(cat /proc/sys/kernel/random/uuid)
         echo "logs_report=$logs_report" | sed 's/\//-/g' | sed 's/\*/-/g' | tee -a "$GITHUB_OUTPUT"
@@ -219,8 +221,12 @@ runs:
         fi
         echo "coverage_report=$coverage_report" | tee -a "$GITHUB_OUTPUT"
 
-        EXIT_CODE=${{ steps.run-main-script.outputs.exit_code }}
-        IS_SUCCESS=$([[ "$EXIT_CODE" -eq 0 ]] && echo "true" || echo "false")
+        EXIT_CODE="${MAIN_EXIT_CODE:-${MAIN_CONCLUSION}}"
+        if [[ "$MAIN_CONCLUSION" == "success" ]]; then
+          IS_SUCCESS=true
+        else
+          IS_SUCCESS=false
+        fi
 
         if [[ "$IS_SUCCESS" == "false" && "${{ inputs.is-optional }}" == "true" ]]; then
           echo "::warning::Test failed but is marked optional — treating as success."


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

When the job-level 60-minute timeout kills the `Run main script` step in `.github/actions/action.yml`, the step's `exit_code` output is never written. The downstream `Check result` step (`if: always()`) then expands `${{ steps.run-main-script.outputs.exit_code }}` to an empty string, and bash treats `[[ "" -eq 0 ]]` as **true** — so a test that hit the 1-hour wall reports `✅ PASSED`.

Observed instance: `gpt_grpo_basic_function` falsely reported as PASSED after timing out.

## Fix

Use the step's GitHub-tracked `conclusion` (`success` / `failure` / `cancelled`) as the source of truth, not the missing exit-code output. The exit-code output is still used for the display message when it exists, falling back to the conclusion string (e.g. `FAILED (exit code: cancelled)`).

```yaml
env:
  MAIN_CONCLUSION: ${{ steps.run-main-script.conclusion }}
  MAIN_EXIT_CODE: ${{ steps.run-main-script.outputs.exit_code }}
run: |
  EXIT_CODE="${MAIN_EXIT_CODE:-${MAIN_CONCLUSION}}"
  if [[ "$MAIN_CONCLUSION" == "success" ]]; then
    IS_SUCCESS=true
  else
    IS_SUCCESS=false
  fi
```

</details>
