### PR TITLE
ci: disable broken GRPO MR tests pending #4726

### DIFF
--- a/tests/test_utils/recipes/h100/gpt-grpo.yaml
+++ b/tests/test_utils/recipes/h100/gpt-grpo.yaml
@@ -57,17 +57,17 @@ products:
   - test_case: [gpt_grpo_basic_function]
     products:
       - environment: [dev]
-        scope: [mr, mr-github]
+        scope: [mr-broken, mr-github-broken]
         platforms: [dgx_h100]
   - test_case: [gpt_grpo_tp4_pp1_dp2_8b_throughput]
     products:
       - environment: [dev]
-        scope: [mr]
+        scope: [mr-broken]
         platforms: [dgx_h100]
   - test_case: [gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput]
     products:
       - environment: [dev]
-        scope: [mr]
+        scope: [mr-broken]
         platforms: [dgx_h100]
   - test_case: [gpt_grpo_tp4_pp1_dp2_8b_throughput_github]
     products:


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Disables three GRPO MR tests that are currently failing on `main` due to a `transformers` 5.x regression in the chat-completions endpoint (`TypeError: can not serialize 'BatchEncoding' object`).

Tracked in #4726.

Tests disabled (scope flipped to `*-broken`) in `tests/test_utils/recipes/h100/gpt-grpo.yaml`:

| Test | Old scope | New scope |
|---|---|---|
| `gpt_grpo_basic_function` | `[mr, mr-github]` | `[mr-broken, mr-github-broken]` |
| `gpt_grpo_tp4_pp1_dp2_8b_throughput` | `[mr]` | `[mr-broken]` |
| `gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput` | `[mr]` | `[mr-broken]` |

Re-enable once #4726 is resolved.

```diff
   - test_case: [gpt_grpo_basic_function]
     products:
       - environment: [dev]
-        scope: [mr, mr-github]
+        scope: [mr-broken, mr-github-broken]
         platforms: [dgx_h100]
   - test_case: [gpt_grpo_tp4_pp1_dp2_8b_throughput]
     products:
       - environment: [dev]
-        scope: [mr]
+        scope: [mr-broken]
         platforms: [dgx_h100]
   - test_case: [gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput]
     products:
       - environment: [dev]
-        scope: [mr]
+        scope: [mr-broken]
         platforms: [dgx_h100]
```

</details>
