### PR TITLE
Delete output tensor early

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -708,6 +708,13 @@ def forward_backward_no_pipelining(
                 total_num_tokens += num_tokens
                 if not forward_only:
                     backward_step(input_tensor, output_tensor, output_tensor_grad, config)
+                    # Release the autograd graph head before the next forward_step.
+                    # Without this, the previous microbatch's output_tensor stays
+                    # live until the next iteration rebinds the variable, deferring
+                    # autograd-node teardown onto the next forward's dispatch path
+                    # and triggering PyTorch's "AccumulateGrad node's stream does
+                    # not match" warning. See issue #4124.
+                    del output_tensor
         # Run computation for last microbatch out of context handler (want to
         # synchronize gradients).
         output_tensor, num_tokens = forward_step(
@@ -730,6 +737,7 @@ def forward_backward_no_pipelining(
 
         if not forward_only:
             backward_step(input_tensor, output_tensor, output_tensor_grad, config)
+            del output_tensor
 
     if config.finalize_model_grads_func is not None and not forward_only:
         # Finalize model grads (perform full grad all-reduce / reduce-scatter for


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/Megatron-LM/issues/4124.

# What does this PR do ?

In `forward_backward_no_pipelining`, the `output_tensor` is not released until the next `output_tensor` is assigned. As reported in https://github.com/NVIDIA/Megatron-LM/issues/4124, this causes the return call to takes a few ms.

This change releases the `output_tensor` ahead of time after the backwards pass completes, removing the cleanup from the critical-path.

# Results

I created a Qwen 3.5 reproducer and measured the following improvements for the change to `megatron/core/pipeline_parallel/schedules.py`:

- `return output_tensor` (median): 2,627 us -> 3.29 us (~800x faster)
  - the `output_tensor` is no longer released during the `return` call
- e2e iteration wall time (median): 2997 ms -> 2982 ms (~15 ms or ~0.5% reduction)