### PR TITLE
Reduce MoE peak memory in unfused EP combine path

### DIFF
--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -1270,7 +1270,7 @@ class SequentialMLP(MegatronModule):
                     output, output_bias = expert(tokens, probs)
                 if output_local is None:
                     output_local = output.new_empty(
-                        (permuted_local_hidden_states.shape[0], output.shape[-1])
+                        (permuted_local_hidden_states.shape[0], *output.shape[1:])
                     )
                 output_local[output_offset : output_offset + output.shape[0]].copy_(output)
                 output_offset += output.shape[0]

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -1258,7 +1258,8 @@ class SequentialMLP(MegatronModule):
             tokens_list = torch.split(permuted_local_hidden_states, tokens_per_expert)
             probs_list = torch.split(permuted_probs, tokens_per_expert)
 
-            output_local_list = []
+            output_local = None
+            output_offset = 0
 
             for expert, tokens, probs in zip(self.local_experts, tokens_list, probs_list):
                 if self.config.fp8 or self.config.fp4:
@@ -1267,9 +1268,17 @@ class SequentialMLP(MegatronModule):
                     output = output[: tokens.shape[0]]
                 else:
                     output, output_bias = expert(tokens, probs)
-                output_local_list.append(output)
+                if output_local is None:
+                    output_local = output.new_empty(
+                        (permuted_local_hidden_states.shape[0], output.shape[-1])
+                    )
+                output_local[output_offset : output_offset + output.shape[0]].copy_(output)
+                output_offset += output.shape[0]
 
-            output_local = torch.cat(output_local_list, dim=0)
+            if output_local is None:
+                output_local = permuted_local_hidden_states.new_empty(
+                    (0, permuted_local_hidden_states.shape[-1])
+                )
             output_bias_local = None
             # Note: if bias is enabled on experts, it is already added to the output at this point
             return output_local, output_bias_local

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -531,6 +531,72 @@ def unpermute(
     return output_tokens.to(dtype=input_dtype)
 
 
+class _SortChunksByIdxs(torch.autograd.Function):
+    """Chunk reorder that does not retain the source tensor storage for backward."""
+
+    @staticmethod
+    def forward(
+        ctx, input: torch.Tensor, split_sizes: torch.Tensor, sorted_idxs: torch.Tensor
+    ) -> torch.Tensor:
+        """Reorder input chunks according to sorted_idxs."""
+        split_size_list = [int(size) for size in split_sizes.tolist()]
+        sorted_idx_list = [int(idx) for idx in sorted_idxs.tolist()]
+        if len(set(sorted_idx_list)) != len(sorted_idx_list):
+            raise ValueError("sort_chunks_by_idxs requires a permutation, got duplicate indices")
+        if sorted_idx_list and (
+            min(sorted_idx_list) < 0 or max(sorted_idx_list) >= len(split_size_list)
+        ):
+            raise ValueError("sort_chunks_by_idxs index out of range for split_sizes")
+
+        total_rows = sum(split_size_list)
+        if input.size(0) != total_rows:
+            raise ValueError(
+                f"sort_chunks_by_idxs split sizes cover {total_rows} rows, "
+                f"but input has {input.size(0)} rows"
+            )
+        selected_rows = sum(split_size_list[idx] for idx in sorted_idx_list)
+        if selected_rows != total_rows:
+            raise ValueError("sort_chunks_by_idxs sorted indices must cover every input chunk")
+
+        input_offsets = []
+        offset = 0
+        for size in split_size_list:
+            input_offsets.append(offset)
+            offset += size
+
+        output = input.new_empty((total_rows, *input.shape[1:]))
+        output_offset = 0
+        for idx in sorted_idx_list:
+            size = split_size_list[idx]
+            if size:
+                output.narrow(0, output_offset, size).copy_(
+                    input.narrow(0, input_offsets[idx], size)
+                )
+            output_offset += size
+
+        ctx.split_size_list = split_size_list
+        ctx.sorted_idx_list = sorted_idx_list
+        ctx.input_offsets = input_offsets
+        ctx.input_shape = tuple(input.shape)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> Tuple[Optional[torch.Tensor], None, None]:
+        """Scatter gradients back to the original chunk order."""
+        if grad_output is None:
+            return None, None, None
+        grad_input = grad_output.new_empty(ctx.input_shape)
+        output_offset = 0
+        for idx in ctx.sorted_idx_list:
+            size = ctx.split_size_list[idx]
+            if size:
+                grad_input.narrow(0, ctx.input_offsets[idx], size).copy_(
+                    grad_output.narrow(0, output_offset, size)
+                )
+            output_offset += size
+        return grad_input, None, None
+
+
 def sort_chunks_by_idxs(
     input: torch.Tensor,
     split_sizes: torch.Tensor,
@@ -566,11 +632,9 @@ def sort_chunks_by_idxs(
             )
         return fused_sort_chunks_by_index_with_probs(input, probs, split_sizes, sorted_idxs)
 
-    input = torch.split(input, split_sizes.tolist(), dim=0)
-    output = torch.cat([input[i] for i in sorted_idxs.tolist()], dim=0)
+    output = _SortChunksByIdxs.apply(input, split_sizes, sorted_idxs)
     if probs is not None:
-        probs = torch.split(probs, split_sizes.tolist(), dim=0)
-        permuted_probs = torch.cat([probs[i] for i in sorted_idxs.tolist()], dim=0)
+        permuted_probs = _SortChunksByIdxs.apply(probs, split_sizes, sorted_idxs)
     else:
         permuted_probs = None
     return output, permuted_probs

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -74,9 +74,9 @@ def _get_ep_combine_max_rows(tokens_per_expert: torch.Tensor, ep_size: int) -> t
         )
 
     split_matrix = tokens_per_expert.reshape(ep_size, ep_size, -1).sum(dim=-1)
-    max_input_rows = split_matrix.sum(dim=0).max()
-    max_output_rows = split_matrix.sum(dim=1).max()
-    return torch.maximum(max_input_rows, max_output_rows)
+    max_received_rows = split_matrix.sum(dim=0).max()
+    max_sent_rows = split_matrix.sum(dim=1).max()
+    return torch.maximum(max_received_rows, max_sent_rows)
 
 
 class _ChunkedAllToAllAndUnpermute(torch.autograd.Function):

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -17,6 +17,7 @@ from megatron.core.tensor_parallel import (
     gather_from_sequence_parallel_region,
     reduce_scatter_to_sequence_parallel_region,
 )
+from megatron.core.transformer.cuda_graphs import is_graph_capturing
 from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.moe.fused_a2a import (
     ensure_nccl_ep_bootstrapped,
@@ -53,6 +54,173 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 """
 
 logger = logging.getLogger(__name__)
+
+
+def _get_ep_combine_max_rows(tokens_per_expert: torch.Tensor, ep_size: int) -> torch.Tensor:
+    """Get a rank-common row bound from the gathered EP routing matrix.
+
+    ``tokens_per_expert`` has shape ``[source_ep, num_experts]``. Collapsing local
+    experts produces the complete source-to-destination split matrix, which is
+    available on every rank before the per-rank routing metadata is sliced.
+    """
+    if tokens_per_expert.dim() != 2 or tokens_per_expert.size(0) != ep_size:
+        raise RuntimeError(
+            "EP routing counts must have shape [ep_size, num_experts], got "
+            f"{tuple(tokens_per_expert.shape)} for ep_size={ep_size}"
+        )
+    if tokens_per_expert.size(1) % ep_size != 0:
+        raise RuntimeError(
+            f"num_experts={tokens_per_expert.size(1)} must be divisible by ep_size={ep_size}"
+        )
+
+    split_matrix = tokens_per_expert.reshape(ep_size, ep_size, -1).sum(dim=-1)
+    max_input_rows = split_matrix.sum(dim=0).max()
+    max_output_rows = split_matrix.sum(dim=1).max()
+    return torch.maximum(max_input_rows, max_output_rows)
+
+
+class _ChunkedAllToAllAndUnpermute(torch.autograd.Function):
+    """Fuse EP return all-to-all with final unpermute using bounded column chunks."""
+
+    @staticmethod
+    def _as_int_tuple(values: object) -> Tuple[int, ...]:
+        if torch.is_tensor(values):
+            return tuple(int(x) for x in values.detach().cpu().tolist())
+        if hasattr(values, "tolist"):
+            return tuple(int(x) for x in values.tolist())
+        return tuple(int(x) for x in values)
+
+    @staticmethod
+    def _as_int(value: object, name: str) -> int:
+        if torch.is_tensor(value):
+            if value.is_cuda:
+                raise RuntimeError(f"{name} must be copied to CPU before chunked combine")
+            return int(value)
+        if hasattr(value, "tolist"):
+            return int(value.tolist())
+        return int(value)
+
+    @staticmethod
+    def _chunks(
+        hidden: int, row_count: int, element_size: int, max_chunk_bytes: int
+    ) -> Tuple[Tuple[int, int], ...]:
+        if max_chunk_bytes <= 0:
+            raise RuntimeError(f"max_chunk_bytes must be positive, got {max_chunk_bytes}")
+        row_bytes = max(1, int(row_count) * int(element_size))
+        width = max(1, max_chunk_bytes // row_bytes)
+        if width >= hidden:
+            return ((0, hidden),)
+        return tuple((start, min(width, hidden - start)) for start in range(0, hidden, width))
+
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        output_split_sizes,
+        input_split_sizes,
+        group,
+        sorted_indices: torch.Tensor,
+        restore_shape: torch.Size,
+        max_rows,
+        max_chunk_bytes: int,
+    ) -> torch.Tensor:
+        """Run return EP all-to-all and unpermute in bounded hidden-size chunks."""
+        if hidden_states.dim() != 2:
+            raise RuntimeError(
+                f"chunked token combine expects [tokens, hidden], got {tuple(hidden_states.shape)}"
+            )
+
+        output_split_sizes = _ChunkedAllToAllAndUnpermute._as_int_tuple(output_split_sizes)
+        input_split_sizes = _ChunkedAllToAllAndUnpermute._as_int_tuple(input_split_sizes)
+        world_size = group.size()
+        if len(output_split_sizes) != world_size or len(input_split_sizes) != world_size:
+            raise RuntimeError(
+                f"split sizes must have {world_size} entries, got "
+                f"output={len(output_split_sizes)} input={len(input_split_sizes)}"
+            )
+
+        input_rows = int(hidden_states.size(0))
+        hidden = int(hidden_states.size(1))
+        output_rows = int(sum(output_split_sizes))
+        if input_rows != int(sum(input_split_sizes)):
+            raise RuntimeError(
+                f"input rows {input_rows} do not match input splits {sum(input_split_sizes)}"
+            )
+        if sorted_indices.numel() != output_rows:
+            raise RuntimeError(
+                f"sorted_indices rows {sorted_indices.numel()} do not match "
+                f"output rows {output_rows}"
+            )
+        if len(restore_shape) != 2 or int(restore_shape[-1]) != hidden:
+            raise RuntimeError(
+                f"restore_shape {tuple(restore_shape)} is incompatible with hidden {hidden}"
+            )
+
+        max_rows = _ChunkedAllToAllAndUnpermute._as_int(max_rows, "max_rows")
+        max_chunk_bytes = _ChunkedAllToAllAndUnpermute._as_int(max_chunk_bytes, "max_chunk_bytes")
+        if max_rows < max(input_rows, output_rows):
+            raise RuntimeError(
+                f"max_rows {max_rows} does not bound local input/output rows "
+                f"({input_rows}, {output_rows})"
+            )
+
+        output_tokens = torch.zeros(
+            restore_shape, dtype=hidden_states.dtype, device=hidden_states.device
+        )
+        sorted_indices = sorted_indices.to(device=hidden_states.device, non_blocking=True)
+
+        chunks = _ChunkedAllToAllAndUnpermute._chunks(
+            hidden, max_rows, hidden_states.element_size(), max_chunk_bytes
+        )
+
+        for start, width in chunks:
+            send = hidden_states.narrow(1, start, width).contiguous()
+            recv = hidden_states.new_empty((output_rows, width))
+            torch.distributed.all_to_all_single(
+                recv,
+                send,
+                output_split_sizes=output_split_sizes,
+                input_split_sizes=input_split_sizes,
+                group=group,
+            )
+            output_tokens.narrow(1, start, width).index_add_(0, sorted_indices, recv)
+            del send, recv
+
+        ctx.group = group
+        ctx.output_split_sizes = output_split_sizes
+        ctx.input_split_sizes = input_split_sizes
+        ctx.restore_shape = torch.Size(restore_shape)
+        ctx.input_rows = input_rows
+        ctx.hidden = hidden
+        ctx.chunks = chunks
+        ctx.save_for_backward(sorted_indices)
+        return output_tokens
+
+    @staticmethod
+    def backward(
+        ctx, grad_output: torch.Tensor
+    ) -> Tuple[torch.Tensor, None, None, None, None, None, None, None]:
+        """Backpropagate through the fused unpermute and return all-to-all."""
+        (sorted_indices,) = ctx.saved_tensors
+        grad_output = grad_output.reshape(ctx.restore_shape)
+        sorted_indices = sorted_indices.to(device=grad_output.device, non_blocking=True)
+        grad_input = grad_output.new_empty((ctx.input_rows, ctx.hidden))
+
+        for start, width in ctx.chunks:
+            grad_slice = grad_output.narrow(1, start, width)
+            send = grad_slice.index_select(0, sorted_indices).contiguous()
+            recv = grad_output.new_empty((ctx.input_rows, width))
+            torch.distributed.all_to_all_single(
+                recv,
+                send,
+                output_split_sizes=ctx.input_split_sizes,
+                input_split_sizes=ctx.output_split_sizes,
+                group=ctx.group,
+            )
+            grad_input.narrow(1, start, width).copy_(recv)
+            del send, recv
+
+        return grad_input, None, None, None, None, None, None, None
 
 
 class MoETokenDispatcher:
@@ -412,6 +580,9 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
         # [tp_size]. Represents the number of tokens received by the current rank from
         # other TP ranks.
         self.output_splits_tp = None
+        # Rank-common maximum row count for chunked EP combine. When enabled, this is copied
+        # to CPU alongside the existing split metadata without adding another synchronization.
+        self._chunked_ep_combine_max_rows = None
         self.permute_idx_device = torch.device("cuda") if self.config.moe_permute_fusion else "cpu"
         input_chunk_idxs = torch.arange(
             self.num_experts * self.tp_size, device=self.permute_idx_device
@@ -495,6 +666,8 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
         Returns:
             A tensor with the number of tokens for each local expert.
         """
+        self._chunked_ep_combine_max_rows = None
+
         if self.drop_and_pad:
             # Drop and pad the input to capacity.
             num_tokens = routing_map.size(0) * self.config.moe_router_topk
@@ -555,6 +728,15 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
                 .reshape(self.ep_size, self.tp_size, self.num_experts)
                 .transpose(0, 1)
             )
+            if (
+                self.config.moe_chunked_ep_combine
+                and self.config.cuda_graph_impl == "none"
+                and not is_graph_capturing()
+                and self.ep_size > 1
+            ):
+                self._chunked_ep_combine_max_rows = _get_ep_combine_max_rows(
+                    num_global_tokens_per_expert[self.tp_rank], self.ep_size
+                )
             # [tp_size, ep_size, num_experts] -> [tp_size, ep_size, num_local_experts]
             num_global_tokens_per_local_expert = num_global_tokens_per_expert[
                 :, :, self.local_expert_indices[0] : self.local_expert_indices[-1] + 1
@@ -839,6 +1021,10 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
         # when CUDA_DEVICE_MAX_CONNECTIONS>1.
         if self.shared_experts is not None:
             self.shared_experts.wait_current_stream()
+
+        if self._can_chunk_ep_combine_unpermute():
+            return self._chunk_ep_combine_unpermute(hidden_states)
+
         # Perform expert parallel AlltoAll communication
         # hidden_states: [SEQL, H] -> [SEQL, H/TP]
         permutated_local_input_tokens = all_to_all(
@@ -853,6 +1039,32 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
             self.shared_experts.post_forward_comm()
         return permutated_local_input_tokens
 
+    def _can_chunk_ep_combine_unpermute(self) -> bool:
+        return (
+            self.config.moe_chunked_ep_combine
+            and self.config.cuda_graph_impl == "none"
+            and not is_graph_capturing()
+            and self._chunked_ep_combine_max_rows is not None
+            and self.ep_size > 1
+            and self.input_splits is not None
+            and self.output_splits is not None
+            and not self.drop_and_pad
+            and not self.config.moe_permute_fusion
+            and self.shared_experts is None
+        )
+
+    def _chunk_ep_combine_unpermute(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return _ChunkedAllToAllAndUnpermute.apply(
+            hidden_states,
+            self.input_splits,
+            self.output_splits,
+            self.ep_group,
+            self.reversed_local_input_permutation_mapping,
+            self.hidden_shape_before_permute,
+            self._chunked_ep_combine_max_rows,
+            self.config.moe_chunked_ep_combine_max_chunk_bytes,
+        ).view(self.hidden_shape)
+
     def combine_postprocess(self, permutated_local_input_tokens):
         """Finalizes token reconstruction with un-permutation and reshaping.
 
@@ -866,6 +1078,8 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
         Returns:
             The final MoE layer output reshaped to its original dimensions.
         """
+        if self._can_chunk_ep_combine_unpermute():
+            return permutated_local_input_tokens
 
         # Unpermutation 1: AlltoAll output to output
         output = unpermute(
@@ -923,6 +1137,10 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
                     self.output_splits_tp = maybe_move_tensor_to_cpu(
                         self.output_splits_tp, as_numpy=True, record_stream=on_side_stream
                     )
+                    if self._chunked_ep_combine_max_rows is not None:
+                        self._chunked_ep_combine_max_rows = maybe_move_tensor_to_cpu(
+                            self._chunked_ep_combine_max_rows, record_stream=on_side_stream
+                        )
                     self.num_out_tokens = maybe_move_tensor_to_cpu(
                         self.num_out_tokens, record_stream=on_side_stream
                     )

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -843,6 +843,15 @@ class TransformerConfig(ModelParallelConfig):
     """The type of token dispatcher to use. The default is 'allgather'.
     Options are 'allgather','alltoall' and 'flex'."""
 
+    moe_chunked_ep_combine: bool = False
+    """Enable the memory-saving chunked expert-parallel combine path for the unfused all-to-all
+    token dispatcher. This is opt-in because it replaces one all-to-all with multiple collectives
+    and may reduce throughput. The path is disabled when CUDA graphs are configured or active."""
+
+    moe_chunked_ep_combine_max_chunk_bytes: int = 8 * 1024 * 1024
+    """Target maximum bytes for each send or receive buffer used by chunked expert-parallel
+    combine. A chunk always contains at least one hidden-dimension column."""
+
     moe_enable_deepep: bool = False
     """[Experimental] Enable DeepEP for efficient token dispatching and combine in MoE models."""
 
@@ -1501,6 +1510,9 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.num_moe_experts is not None and self.num_moe_experts <= 0:
             raise ValueError("num_moe_experts must be non-negative.")
+
+        if self.moe_chunked_ep_combine_max_chunk_bytes <= 0:
+            raise ValueError("moe_chunked_ep_combine_max_chunk_bytes must be greater than zero.")
 
         if self.num_moe_experts is not None and self.moe_ffn_hidden_size is None:
             self.moe_ffn_hidden_size = self.ffn_hidden_size

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -172,6 +172,8 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "mlp_chunks_for_training": 1,
     "moe_apply_probs_on_input": False,
     "moe_aux_loss_coeff": 0.0,
+    "moe_chunked_ep_combine": False,
+    "moe_chunked_ep_combine_max_chunk_bytes": 8388608,
     "moe_deepep_num_sms": None,
     "moe_enable_deepep": False,
     "moe_expert_capacity_factor": None,

--- a/tests/unit_tests/transformer/moe/test_a2a_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_a2a_token_dispatcher.py
@@ -4,11 +4,16 @@ import pytest
 import torch
 
 from megatron.core import config
+from megatron.core.transformer.moe import token_dispatcher as token_dispatcher_module
+from megatron.core.transformer.moe.token_dispatcher import _get_ep_combine_max_rows
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.typed_torch import apply_module
 from megatron.core.utils import is_te_min_version
 from tests.unit_tests.test_utilities import Utils
 from tests.unit_tests.transformer.moe.test_token_dispatcher import (
     MoEModelTestContainer,
     permute_fusion_params,
+    token_permutation,
 )
 
 
@@ -16,6 +21,31 @@ def test_placeholder():
     """This is here because otherwise there's no other test in this module (all disabled)
     and pytest would fail."""
     pass
+
+
+def test_get_ep_combine_max_rows_uses_full_split_matrix():
+    """The common bound must include the most-loaded source and destination ranks."""
+    destination_skew = torch.tensor([[4, 0, 0, 0], [3, 0, 0, 0], [5, 0, 0, 0], [2, 0, 0, 0]])
+    source_skew = torch.tensor([[2, 2, 2, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
+
+    assert int(_get_ep_combine_max_rows(destination_skew, ep_size=4)) == 14
+    assert int(_get_ep_combine_max_rows(source_skew, ep_size=4)) == 8
+
+
+def test_chunked_ep_combine_config_defaults_and_validation():
+    config = TransformerConfig(num_layers=1, hidden_size=16, num_attention_heads=4)
+    assert not config.moe_chunked_ep_combine
+    assert config.moe_chunked_ep_combine_max_chunk_bytes == 8 * 1024 * 1024
+
+    with pytest.raises(
+        ValueError, match="moe_chunked_ep_combine_max_chunk_bytes must be greater than zero"
+    ):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            moe_chunked_ep_combine_max_chunk_bytes=0,
+        )
 
 
 class TestAlltoAllDispatcher:
@@ -52,6 +82,94 @@ class TestAlltoAllDispatcher:
             moe_permute_fusion=permute_fusion,
         )
         container.dispatcher_dropless_test()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.internal
+    @pytest.mark.timeout(120)
+    @pytest.mark.parametrize("tp_size,ep_size", [(1, 8), (2, 4)])
+    def test_chunked_combine_unpermute_matches_reference(self, tp_size, ep_size, monkeypatch):
+        """Compare chunked EP combine/unpermute to the existing unfused reference path."""
+        container = MoEModelTestContainer(
+            tp_size=tp_size,
+            ep_size=ep_size,
+            pp_size=1,
+            num_moe_experts=8,
+            moe_router_topk=2,
+            moe_router_load_balancing_type="aux_loss",
+            moe_token_dispatcher_type="alltoall",
+            moe_permute_fusion=False,
+            moe_chunked_ep_combine=True,
+            moe_chunked_ep_combine_max_chunk_bytes=1,
+            hidden_size=16,
+        )
+        moe_layer = container.moe_layer
+        token_dispatcher = moe_layer.token_dispatcher
+        hidden_states = torch.randn(
+            (16, 4, moe_layer.config.hidden_size), dtype=container.test_dtype, device="cuda"
+        )
+        probs, routing_map = apply_module(moe_layer.router)(hidden_states)
+        # Route every source rank to the first two experts. This heavily skews one or two
+        # destinations and leaves the remaining expert ranks empty.
+        routing_map = torch.zeros_like(routing_map)
+        routing_map[:, : moe_layer.router.topk] = True
+        probs = routing_map.to(dtype=probs.dtype) / moe_layer.router.topk
+
+        permuted_tokens, _, permuted_probs = token_permutation(
+            token_dispatcher, hidden_states, probs, routing_map
+        )
+        routed_output = permuted_tokens * permuted_probs.unsqueeze(-1)
+        combine_input = token_dispatcher.combine_preprocess(
+            routed_output.to(dtype=container.test_dtype)
+        )
+        max_rows = token_dispatcher._chunked_ep_combine_max_rows
+        assert torch.is_tensor(max_rows) and not max_rows.is_cuda
+        assignments_to_busiest_rank = min(moe_layer.router.topk, container.num_local_experts)
+        assert (
+            int(max_rows)
+            == hidden_states.shape[0]
+            * hidden_states.shape[1]
+            * token_dispatcher.ep_size
+            * assignments_to_busiest_rank
+        )
+
+        ref_input = combine_input.detach().clone().requires_grad_(True)
+        chunk_input = combine_input.detach().clone().requires_grad_(True)
+
+        monkeypatch.setattr(token_dispatcher.config, "moe_chunked_ep_combine", False)
+        assert not token_dispatcher._can_chunk_ep_combine_unpermute()
+        ref_output = token_dispatcher.combine_postprocess(token_dispatcher.token_combine(ref_input))
+
+        monkeypatch.setattr(token_dispatcher.config, "moe_chunked_ep_combine", True)
+        assert token_dispatcher._can_chunk_ep_combine_unpermute()
+        monkeypatch.setattr(token_dispatcher_module, "is_graph_capturing", lambda: True)
+        assert not token_dispatcher._can_chunk_ep_combine_unpermute()
+        monkeypatch.setattr(token_dispatcher_module, "is_graph_capturing", lambda: False)
+        assert token_dispatcher._can_chunk_ep_combine_unpermute()
+
+        def fail_on_all_reduce(*args, **kwargs):
+            raise AssertionError("chunked combine must not issue an all-reduce")
+
+        monkeypatch.setattr(torch.distributed, "all_reduce", fail_on_all_reduce)
+        all_to_all_single = torch.distributed.all_to_all_single
+        all_to_all_calls = 0
+
+        def count_all_to_all_calls(*args, **kwargs):
+            nonlocal all_to_all_calls
+            all_to_all_calls += 1
+            return all_to_all_single(*args, **kwargs)
+
+        monkeypatch.setattr(torch.distributed, "all_to_all_single", count_all_to_all_calls)
+        chunk_output = token_dispatcher.combine_postprocess(
+            token_dispatcher.token_combine(chunk_input)
+        )
+        assert all_to_all_calls == moe_layer.config.hidden_size
+
+        torch.testing.assert_close(chunk_output, ref_output)
+
+        grad_output = torch.randn_like(ref_output)
+        torch.autograd.backward(ref_output, grad_output)
+        torch.autograd.backward(chunk_output, grad_output)
+        torch.testing.assert_close(chunk_input.grad, ref_input.grad)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @pytest.mark.internal

--- a/tests/unit_tests/transformer/moe/test_moe_utils.py
+++ b/tests/unit_tests/transformer/moe/test_moe_utils.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.transformer.moe.moe_utils import sort_chunks_by_idxs
+
+
+def _reference_sort_chunks(
+    input_tensor: torch.Tensor, split_sizes: torch.Tensor, sorted_idxs: torch.Tensor
+) -> torch.Tensor:
+    chunks = torch.split(input_tensor, split_sizes.tolist(), dim=0)
+    return torch.cat([chunks[idx] for idx in sorted_idxs.tolist()], dim=0)
+
+
+@pytest.mark.internal
+def test_sort_chunks_by_idxs_unfused_matches_split_cat_and_backward():
+    """Check the memory-saving unfused chunk reorder against split/cat semantics."""
+    split_sizes = torch.tensor([2, 0, 3, 1], dtype=torch.long)
+    sorted_idxs = torch.tensor([2, 1, 0, 3], dtype=torch.long)
+
+    input_tensor = torch.arange(24, dtype=torch.float32).view(6, 4).requires_grad_(True)
+    probs = torch.arange(6, dtype=torch.float32).requires_grad_(True)
+    ref_input = input_tensor.detach().clone().requires_grad_(True)
+    ref_probs = probs.detach().clone().requires_grad_(True)
+
+    output, permuted_probs = sort_chunks_by_idxs(
+        input_tensor, split_sizes, sorted_idxs, probs=probs
+    )
+    ref_output = _reference_sort_chunks(ref_input, split_sizes, sorted_idxs)
+    ref_permuted_probs = _reference_sort_chunks(ref_probs, split_sizes, sorted_idxs)
+
+    torch.testing.assert_close(output, ref_output)
+    torch.testing.assert_close(permuted_probs, ref_permuted_probs)
+
+    output_grad = torch.arange(output.numel(), dtype=output.dtype).view_as(output)
+    probs_grad = torch.arange(permuted_probs.numel(), dtype=permuted_probs.dtype)
+    torch.autograd.backward((output, permuted_probs), (output_grad, probs_grad))
+    torch.autograd.backward((ref_output, ref_permuted_probs), (output_grad, probs_grad))
+
+    torch.testing.assert_close(input_tensor.grad, ref_input.grad)
+    torch.testing.assert_close(probs.grad, ref_probs.grad)

--- a/tests/unit_tests/transformer/moe/test_sequential_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_sequential_mlp.py
@@ -156,6 +156,8 @@ class TestTEParallelSequentialMLP:
 
         output_local, _ = self.local_sequential_mlp(hidden_states, tokens_per_expert, probs)
         output_te, _ = self.te_sequential_mlp(hidden_states, tokens_per_expert, probs)
+        assert output_local.shape == hidden_states.shape
+        assert output_te.shape == hidden_states.shape
         assert torch.equal(output_local, output_te)
 
     @pytest.mark.internal
@@ -211,6 +213,8 @@ class TestTEParallelSequentialMLP:
 
         output_local, _ = self.local_sequential_mlp(hidden_states, tokens_per_expert, probs)
         output_te, _ = self.te_sequential_mlp(hidden_states, tokens_per_expert, probs)
+        assert output_local.shape == hidden_states.shape
+        assert output_te.shape == hidden_states.shape
         assert torch.equal(output_local, output_te)
 
     def teardown_method(self, method):

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -91,6 +91,10 @@ class MoEModelTestContainer:
             use_cpu_initialization=kwargs.get("use_cpu_initialization", True),
             sequence_parallel=tp_size > 1,
             add_bias_linear=kwargs.get("add_bias_linear", False),
+            moe_chunked_ep_combine=kwargs.get("moe_chunked_ep_combine", False),
+            moe_chunked_ep_combine_max_chunk_bytes=kwargs.get(
+                "moe_chunked_ep_combine_max_chunk_bytes", 8 * 1024 * 1024
+            ),
             moe_permute_fusion=kwargs.get("moe_permute_fusion", False),
             moe_flex_dispatcher_backend=kwargs.get("moe_flex_dispatcher_backend", None),
             moe_expert_rank_capacity_factor=kwargs.get("moe_expert_rank_capacity_factor", None),


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

Reduces transient memory usage in MoE expert output assembly and EP token combine by avoiding full intermediate list/cat buffers and chunking the return all-to-all/unpermute path.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [X] I have added relevant unit tests
- [X] I have added relevant functional tests
- [X] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [X] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

This PR targets peak memory in the unfused MoE all-to-all dispatcher path:

- Preallocates `SequentialMLP` local expert output and copies each expert result into the final buffer instead of storing per-expert outputs and `torch.cat`-ing them.
- Replaces the unfused `sort_chunks_by_idxs` split/cat fallback with a custom autograd reorder that copies into a preallocated output and scatters gradients back without retaining chunked source views.
- Adds a chunked EP combine path that performs return `all_to_all_single` and final unpermute by hidden-dimension chunks, reducing the full-size temporary allocation during token combine.
- Keeps the chunked path gated to the supported case: `ep_size > 1`, no `drop_and_pad`, no `moe_permute_fusion`, and no shared experts. Existing paths are preserved otherwise.

Large MoE runs can hit OOM from transient buffers in the combine side of expert parallelism, especially when the full all-to-all output and unpermuted output are both live. This change lowers that peak by streaming the combine/unpermute work through bounded chunks.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
