### PR TITLE
[dev] [1/5] Qwen3.5 support: MTP packed-seq CP+THD fix

### DIFF
--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -239,7 +239,18 @@ def _roll_tensor_packed_seq(tensor, shifts, dims, packed_seq_params, cp_group=No
         dims == -1 or dims == tensor.dim() - 1
     ), "Packed sequence roll only supports the last dimension."
     assert shifts == -1, "Packed sequence roll only supports a single-token left shift."
-    cu_seqlens = packed_seq_params.cu_seqlens_q
+    # Prefer cu_seqlens_q_padded so per-sample boundaries on each rank line
+    # up with the per-sample CP partition produced by
+    # ``tex.thd_get_partitioned_indices`` (which slices on padded
+    # boundaries). Falling back to cu_seqlens_q only when padded is unset
+    # keeps backward compatibility with callers that don't pad samples to
+    # multiples of 2*cp_size. Padding tokens carry loss_mask=0 / label=-100,
+    # so rolling them is a no-op for the loss.
+    cu_seqlens = (
+        packed_seq_params.cu_seqlens_q_padded
+        if packed_seq_params.cu_seqlens_q_padded is not None
+        else packed_seq_params.cu_seqlens_q
+    )
     assert cu_seqlens is not None, "Packed sequence parameters must provide cu_seqlens_q."
 
     rolled_tensor = tensor.clone()


### PR DESCRIPTION
## Superseded

This PR is **superseded by #4494**, which lands the same MTP CP+THD fix.
Closing once the replacement merges.

---

## Qwen3.5 support series

This is part of a 5-PR series adding Qwen3.5-VL support, split for review clarity.

**Dev PRs (this series):**
- [1/5] MTP packed-seq CP+THD fix — #4494
- [2/5] FSDP DTensor Bridge checkpoint compatibility — #4748
- [3/5] SharedExpertMLP meta init — #4749
- [4/5] Interleaved MRoPE layout — #4750
- [5/5] Qwen3.5-VL training example — #4751

**Main PRs (corresponding mirrors):**
- [1/5] #4495
- [2/5] #4753
- [3/5] #4754
- [4/5] #4755
- [5/5] #4756

---
## Summary

- In `_roll_tensor_packed_seq`, prefer `packed_seq_params.cu_seqlens_q_padded` when available, falling back to `cu_seqlens_q`.

## Why

Under CP+THD, the per-sample CP partition produced by `tex.thd_get_partitioned_indices` slices on **padded** boundaries (each sample padded to a multiple of `2 * cp_size`). Using the unpadded `cu_seqlens_q` to roll the MTP target on each rank therefore misaligns boundaries and shifts tokens across sample edges on some ranks.

Padding tokens carry `loss_mask=0` / `label=-100`, so rolling across them is a no-op for the loss but unaligned rolling on unpadded boundaries is not.

The fallback preserves behavior for callers that don't pad to a multiple of `2 * cp_size`.

## Test plan

- [ ] Existing MTP unit tests still pass (no padded CP path required).
- [ ] CP+THD training run with MTP enabled converges; per-rank loss matches CP=1 reference.

## Notes

Extracted from a larger Qwen3.5-VL development branch to keep this fix reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)