### PR TITLE
[main] [3/5] Qwen3.5 support: SharedExpertMLP meta init

### DIFF
--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -190,6 +190,15 @@ class SharedExpertMLP(MLP):
             output = output * gate_score
         return output
 
+    def _reset_parameters(self):
+        """Initialize parameters owned directly by SharedExpertMLP for meta init."""
+
+        if self.use_shared_expert_gate and self.gate_weight is not None:
+            if self.config.perform_initialization:
+                self.config.init_method(self.gate_weight)
+            self.gate_weight.data = self.gate_weight.data.to(dtype=self.config.params_dtype)
+            setattr(self.gate_weight, 'sequence_parallel', self.config.sequence_parallel)
+
     def sharded_state_dict(
         self, prefix: str = '', sharded_offsets: tuple = (), metadata: Optional[dict] = None
     ) -> ShardedStateDict:


### PR DESCRIPTION
## Qwen3.5 support series

This is part of a 5-PR series adding Qwen3.5-VL support, split for review clarity.

**Main PRs (this series):**
- [1/5] MTP packed-seq CP+THD fix — #4495
- [2/5] FSDP DTensor Bridge checkpoint compatibility — #4753
- [3/5] SharedExpertMLP meta init — #4754 ← **this PR**
- [4/5] Interleaved MRoPE layout — #4755
- [5/5] Qwen3.5-VL training example — #4756

**Dev PRs (corresponding mirrors):**
- [1/5] #4494
- [2/5] #4748
- [3/5] #4749
- [4/5] #4750
- [5/5] #4751

---
## Summary

Add `_reset_parameters` to `SharedExpertMLP` so the directly-owned `gate_weight` is materialized off the meta device when `use_shared_expert_gate=True`.

## Why

Without this, meta-init leaves `gate_weight` on the meta device and the first forward fails with a meta-tensor error. Submodules already have their own `_reset_parameters`, so only the directly-owned `gate_weight` needs handling.

The implementation mirrors the standard per-parameter init pattern:
- run `init_method` when `config.perform_initialization`
- cast to `config.params_dtype`
- set `sequence_parallel` attribute

## Risk

Only fires when `use_shared_expert_gate=True` and `gate_weight is not None` — no effect on existing paths.

## Notes

Mirror of #4749 (same patch, targeting `main` instead of `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)