### PR TITLE
[main] [4/5] Qwen3.5 support: Interleaved MRoPE layout

### DIFF
--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -280,6 +280,9 @@ class MultimodalRotaryEmbedding(nn.Module):
             for longer sequences. The value must be a float larger than 1.0. Defaults to None
         rotary_base (int, optional): Base period for rotary position embeddings. Defaults to
             10000.
+        interleaved_mrope (bool, optional): If True, use the interleaved T/H/W MRoPE layout
+            (Qwen3.5-VL style). If False (default), use the original section-based layout
+            (Qwen2-VL style).
     """
 
     def __init__(
@@ -290,6 +293,7 @@ class MultimodalRotaryEmbedding(nn.Module):
         seq_len_interpolation_factor: Optional[float] = None,
         rotary_base: int = 10000,
         cp_group: Optional[torch.distributed.ProcessGroup] = None,
+        interleaved_mrope: bool = False,
     ) -> None:
         super().__init__()
 
@@ -297,6 +301,7 @@ class MultimodalRotaryEmbedding(nn.Module):
         if rotary_percent < 1.0:
             dim = int(dim * rotary_percent)
         self.rotary_interleaved = rotary_interleaved
+        self.interleaved_mrope = interleaved_mrope
 
         self.seq_len_interpolation_factor = seq_len_interpolation_factor
         self.inv_freq = 1.0 / (
@@ -311,6 +316,25 @@ class MultimodalRotaryEmbedding(nn.Module):
             if cp_group is not None
             else parallel_state.get_context_parallel_group(check_initialized=False)
         )
+
+    @staticmethod
+    def _apply_interleaved_mrope(freqs: Tensor, mrope_section: List[int]) -> Tensor:
+        """Merge T/H/W frequency channels into a single interleaved vector.
+
+        Converts from the per-channel outer-product layout ``(3, bs, seq_len, dim)``
+        to the interleaved layout ``(bs, seq_len, dim)`` used by HF
+        ``Qwen3VLTextRotaryEmbedding.apply_interleaved_mrope`` (unified 2026-02-24)
+        and Megatron-Bridge ``Qwen3VLMultimodalRotaryEmbedding``.
+
+        H freqs occupy stride-3 positions ``{1, 4, 7, ...}`` and W freqs occupy
+        ``{2, 5, 8, ...}``, while T freqs remain at ``{0, 3, 6, ...}``.
+        """
+        freqs_out = freqs[0].clone()  # start with T channel: shape (bs, seq_len, dim)
+        for dim_idx, offset in enumerate((1, 2), start=1):  # H then W
+            length = mrope_section[dim_idx] * 3
+            idx = slice(offset, length, 3)
+            freqs_out[..., idx] = freqs[dim_idx, ..., idx]
+        return freqs_out
 
     def forward(
         self,
@@ -341,20 +365,35 @@ class MultimodalRotaryEmbedding(nn.Module):
         seq_expanded = seq[:, :, None, :].float()
         # shape (3, bs, seq_length, dim)
         freqs = (inv_freq_expanded @ seq_expanded).transpose(2, 3)
+
         # first part even vector components, second part odd vector components,
         #  2 * dim in dimension size
-        if not self.rotary_interleaved:
-            emb = torch.cat((freqs, freqs), dim=-1)  # shape (3, bs, seq_length, 2 * dim)
+        if self.interleaved_mrope:
+            # Qwen3.5-VL: merge T/H/W with interleaved layout [T₀,H₀,W₀,T₁,H₁,W₁,...].
+            # freqs becomes shape (bs, seq_length, dim).
+            freqs = self._apply_interleaved_mrope(freqs, mrope_section)
+            if not self.rotary_interleaved:
+                emb = torch.cat((freqs, freqs), dim=-1)  # shape (bs, seq_length, 2 * dim)
+            else:
+                bs = freqs.shape[0]
+                emb = torch.stack(
+                    (freqs.view(bs, -1, 1), freqs.view(bs, -1, 1)), dim=-1
+                ).view(bs, freqs.shape[1], -1)
         else:
-            bs = freqs.shape[1]
-            emb = torch.stack((freqs.view(3, bs, -1, 1), freqs.view(3, bs, -1, 1)), dim=-1).view(
-                3, bs, freqs.shape[0], -1
-            )
-
-        # generate freqs with mrope_section
-        # shape (bs, seq_length, 2 * dim)
-        mrope_section = mrope_section * 2
-        emb = torch.cat([m[i % 3] for i, m in enumerate(emb.split(mrope_section, dim=-1))], dim=-1)
+            # Original section-based layout (Qwen2-VL style).
+            if not self.rotary_interleaved:
+                emb = torch.cat((freqs, freqs), dim=-1)  # shape (3, bs, seq_length, 2 * dim)
+            else:
+                bs = freqs.shape[1]
+                emb = torch.stack(
+                    (freqs.view(3, bs, -1, 1), freqs.view(3, bs, -1, 1)), dim=-1
+                ).view(3, bs, freqs.shape[0], -1)
+            # generate freqs with mrope_section: cycle T/H/W per section chunk
+            mrope_section_doubled = list(mrope_section) * 2
+            emb = torch.cat(
+                [m[i % 3] for i, m in enumerate(emb.split(mrope_section_doubled, dim=-1))],
+                dim=-1,
+            )  # shape (bs, seq_length, 2 * dim)
 
         # shape (seq_length, bs, 1, 2 * dim)
         emb = emb[..., None, :].transpose(0, 1).contiguous()

--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -376,9 +376,9 @@ class MultimodalRotaryEmbedding(nn.Module):
                 emb = torch.cat((freqs, freqs), dim=-1)  # shape (bs, seq_length, 2 * dim)
             else:
                 bs = freqs.shape[0]
-                emb = torch.stack(
-                    (freqs.view(bs, -1, 1), freqs.view(bs, -1, 1)), dim=-1
-                ).view(bs, freqs.shape[1], -1)
+                emb = torch.stack((freqs.view(bs, -1, 1), freqs.view(bs, -1, 1)), dim=-1).view(
+                    bs, freqs.shape[1], -1
+                )
         else:
             # Original section-based layout (Qwen2-VL style).
             if not self.rotary_interleaved:
@@ -391,8 +391,7 @@ class MultimodalRotaryEmbedding(nn.Module):
             # generate freqs with mrope_section: cycle T/H/W per section chunk
             mrope_section_doubled = list(mrope_section) * 2
             emb = torch.cat(
-                [m[i % 3] for i, m in enumerate(emb.split(mrope_section_doubled, dim=-1))],
-                dim=-1,
+                [m[i % 3] for i, m in enumerate(emb.split(mrope_section_doubled, dim=-1))], dim=-1
             )  # shape (bs, seq_length, 2 * dim)
 
         # shape (seq_length, bs, 1, 2 * dim)

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -196,6 +196,7 @@ class GPTModel(LanguageModule):
                 rotary_interleaved=self.config.rotary_interleaved,
                 seq_len_interpolation_factor=seq_len_interpolation_factor,
                 rotary_base=rotary_base,
+                interleaved_mrope=self.config.mrope_interleaved,
             )
             self.mrope_section = self.config.mrope_section
             assert (

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -965,6 +965,12 @@ class TransformerConfig(ModelParallelConfig):
     """ Multimodal rope section is for channel dimension of temporal, height and width
     in rope calculation. """
 
+    mrope_interleaved: bool = False
+    """When True, use the interleaved T/H/W MRoPE layout (Qwen3.5-VL style) where
+    H freqs occupy stride-3 positions {1,4,7,...} and W freqs occupy {2,5,8,...}.
+    When False (default), use the original section-based layout (Qwen2-VL style)
+    that cycles through T/H/W per mrope_section chunk."""
+
     is_hybrid_model: bool = False
     """ Indicates whether this is a hybrid model. """
 

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -197,6 +197,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "moe_token_dropping": False,
     "moe_z_loss_coeff": None,
     "moe_enable_routing_replay": False,
+    "mrope_interleaved": False,
     "mrope_section": None,
     "mup_attn_scale_power": 1.0,
     "mup_base_head_dim": None,


### PR DESCRIPTION
## Qwen3.5 support series

This is part of a 5-PR series adding Qwen3.5-VL support, split for review clarity.

**Main PRs (this series):**
- [1/5] MTP packed-seq CP+THD fix — #4495
- [2/5] FSDP DTensor Bridge checkpoint compatibility — #4753
- [3/5] SharedExpertMLP meta init — #4754
- [4/5] Interleaved MRoPE layout — #4755 ← **this PR**
- [5/5] Qwen3.5-VL training example — #4756

**Dev PRs (corresponding mirrors):**
- [1/5] #4494
- [2/5] #4748
- [3/5] #4749
- [4/5] #4750
- [5/5] #4751

---
## Summary

Add the interleaved MRoPE layout used by Qwen3.5-VL, gated by a new config flag.

- New `TransformerConfig.mrope_interleaved: bool = False`.
- New `MultimodalRotaryEmbedding(interleaved_mrope=...)` argument.
- New helper `_apply_interleaved_mrope(freqs, mrope_section)` that converts the per-channel outer-product layout `(3, bs, seq_len, dim)` into the interleaved single-tensor layout `(bs, seq_len, dim)`.
- `GPTModel` passes `config.mrope_interleaved` through to the embedding.

## Why

`MultimodalRotaryEmbedding` currently produces the section-based T/H/W cycling used by Qwen2-VL. Qwen3.5-VL (and the matching HuggingFace `Qwen3VLTextRotaryEmbedding.apply_interleaved_mrope`) use a different layout where:
- T freqs occupy stride-3 positions `{0, 3, 6, ...}`
- H freqs occupy `{1, 4, 7, ...}`
- W freqs occupy `{2, 5, 8, ...}`

Both layouts are now supported; the flag picks between them.

## Risk

`mrope_interleaved` defaults to `False`, so existing Qwen2-VL / GPT users see no behavior change.

## Notes

Mirror of #4750 (same patch, targeting `main` instead of `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)