### PR TITLE
[Main] Fix MTP layer recompute 

### DIFF
--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1150,20 +1150,29 @@ class MultiTokenPredictionLayer(MegatronModule):
         )
 
         if self.config.recompute_granularity == 'full' and self.training:
+            # TE checkpoint only treats positional tensor arguments as checkpoint inputs.
+            # Keep the differentiable MTP activations positional so recompute backward
+            # preserves gradients through the MTP projection and transformer layer.
+            def custom_forward(hidden_states, decoder_input):
+                return self._proj_and_transformer_layer(
+                    hidden_states=hidden_states,
+                    decoder_input=decoder_input,
+                    attention_mask=attention_mask,
+                    context=context,
+                    context_mask=context_mask,
+                    rotary_pos_emb=rotary_pos_emb,
+                    rotary_pos_cos=rotary_pos_cos,
+                    rotary_pos_sin=rotary_pos_sin,
+                    attention_bias=attention_bias,
+                    inference_params=inference_params,
+                    packed_seq_params=packed_seq_params,
+                    sequence_len_offset=sequence_len_offset,
+                )
+
             hidden_states = self._checkpointed_forward(
-                self._proj_and_transformer_layer,
-                hidden_states=hidden_states,
-                decoder_input=decoder_input,
-                attention_mask=attention_mask,
-                context=context,
-                context_mask=context_mask,
-                rotary_pos_emb=rotary_pos_emb,
-                rotary_pos_cos=rotary_pos_cos,
-                rotary_pos_sin=rotary_pos_sin,
-                attention_bias=attention_bias,
-                inference_params=inference_params,
-                packed_seq_params=packed_seq_params,
-                sequence_len_offset=sequence_len_offset,
+                custom_forward,
+                hidden_states,
+                decoder_input,
             )
         else:
             hidden_states = self._proj_and_transformer_layer(


### PR DESCRIPTION
# What does this PR do ?

dev PR: https://github.com/NVIDIA/Megatron-LM/pull/4766

Assistant: GPT5.5 codex

Summary:

Fix MTP activation recompute with TransformerEngine FP8/MXFP8 checkpointing.

The MTP full-recompute path passed differentiable tensors such as hidden_states and decoder_input to te_checkpoint() as keyword arguments. TE’s reentrant checkpoint implementation only tracks positional tensor inputs as checkpoint inputs, so those tensors were not properly represented in the recompute backward path.

This could detach or drop gradients for MTP internals under fp8/mxfp8 + mtp + full recompute, causing missing DDP grad-ready hooks and numerical divergence in MTP loss.

Fix

Wrap the MTP recompute call in a local custom_forward(hidden_states, decoder_input) and pass the differentiable activation tensors positionally to _checkpointed_forward(). Static/non-gradient metadata such as masks, rotary embeddings, packed sequence params, and inference params
are captured by closure.

This keeps the te_checkpoint() API unchanged and aligns MTP recompute with TE checkpoint’s expected calling convention.

Test:

E2E validation of Qwen3.5 helped close the MTP loss gap of MXFP8 with BF16 when we enable full act recompute 

<img width="1470" height="957" alt="image" src="https://github.com/user-attachments/assets/d189bcbe-42cd-4c80-bd6a-1e2a6a8f409c" />


## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
