### PR TITLE
Add dev-feature preservation gate and change schedule

### DIFF
--- a/.github/workflows/nightly-sync-main-to-dev.yml
+++ b/.github/workflows/nightly-sync-main-to-dev.yml
@@ -17,9 +17,10 @@ name: Nightly Sync Main to Dev
 on:
   workflow_dispatch:
   schedule:
-    # 21:00 UTC = 2 PM PDT (1 PM PST during winter — GitHub Actions cron
-    # is UTC-only and does not follow DST).
-    - cron: '0 21 * * *'
+    # Twice-weekly cadence: Monday and Thursday at 15:00 UTC.
+    # 15:00 UTC = 8 AM PDT (7 AM PST during winter — GitHub Actions cron
+    # is UTC-only and does not follow DST). Days-of-week: 1=Mon, 4=Thu.
+    - cron: '0 15 * * 1,4'
 
 concurrency:
   group: nightly-sync-main-to-dev

--- a/.github/workflows/nightly-sync-main-to-dev.yml
+++ b/.github/workflows/nightly-sync-main-to-dev.yml
@@ -111,6 +111,76 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Install pre-push merge guard
+        if: steps.check-sync.outputs.skip != 'true'
+        run: |
+          cat > .git/hooks/pre-push <<'HOOK'
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          echo "=== nightly-sync pre-push guard ==="
+
+          merge_commit=$(git rev-list --min-parents=2 --max-count=1 HEAD || true)
+          if [ -n "$merge_commit" ]; then
+            dev_ref="${merge_commit}^1"
+            main_ref="${merge_commit}^2"
+          else
+            dev_ref="origin/dev"
+            main_ref="origin/main"
+          fi
+
+          if ! git diff --quiet "$dev_ref" HEAD -- .github/CODEOWNERS; then
+            echo "ABORT: .github/CODEOWNERS differs from dev. Restore it before pushing."
+            exit 1
+          fi
+
+          for f in pyproject.toml uv.lock docker/Dockerfile.ci.dev; do
+            if ! git diff --quiet "$dev_ref" HEAD -- "$f"; then
+              echo "WARNING: $f differs from dev"
+            fi
+          done
+
+          if [ -z "$merge_commit" ]; then
+            echo "No merge commit found in HEAD history; skipping dev-feature audit."
+            exit 0
+          fi
+
+          intentional_override_regex='^(megatron/training/training\.py|megatron/training/initialize\.py|megatron/training/utils\.py|megatron/training/datasets/data_samplers\.py|megatron/core/optimizer/layer_wise_optimizer\.py)$'
+          skip_regex='^(pyproject\.toml|uv\.lock|docker/Dockerfile\.ci\.dev|\.github/CODEOWNERS)$'
+
+          violations=0
+          while IFS= read -r f; do
+            [[ "$f" =~ $skip_regex ]] && continue
+            [[ "$f" =~ $intentional_override_regex ]] && continue
+            git cat-file -e "HEAD:$f" 2>/dev/null || continue
+
+            missing=$(comm -23 \
+                        <(git show "$dev_ref:$f" 2>/dev/null | sort -u) \
+                        <(git show "$main_ref:$f" 2>/dev/null | sort -u) \
+                      | comm -23 - <(git show "HEAD:$f" 2>/dev/null | sort -u) \
+                      | grep -E '[[:alnum:]_]' \
+                      || true)
+
+            if [ -n "$missing" ]; then
+              echo "=== $f ==="
+              printf '%s\n' "$missing"
+              violations=$((violations + $(printf '%s\n' "$missing" | grep -c .)))
+            fi
+          done < <(git diff --name-only "$dev_ref"..HEAD \
+                    -- '*.py' '*.md' '*.yaml' '*.yml' '*.toml' \
+                       '*.sh' '*.cpp' '*.cu' '*.h' \
+                    | sort -u)
+
+          if [ "$violations" -gt 0 ]; then
+            echo "ABORT: $violations dev-only line(s) were dropped by the merge."
+            echo "Restore the dev-only code, or document the exact main commit that intentionally removed it."
+            exit 1
+          fi
+
+          echo "nightly-sync pre-push guard passed"
+          HOOK
+          chmod +x .git/hooks/pre-push
+
       - name: Run Claude Code to merge, fix, and iterate
         if: steps.check-sync.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
@@ -161,6 +231,21 @@ jobs:
             state). Do NOT break a long wait into many short polls with
             conversation in between — that wastes `--max-turns` and
             creates windows where the agent could forget the loop.
+
+            **Pre-push guard:** The workflow installs a local git pre-push
+            hook that enforces CODEOWNERS, dependency-triple, and dev-feature
+            preservation checks. You MUST NOT bypass it with `--no-verify`.
+            If a push fails, read the hook output, restore the dropped dev
+            code unless main explicitly removed it, and push again only after
+            the hook passes.
+
+            **Merge strategy:** Start from `origin/dev` and run
+            `git merge origin/main --no-edit`. Do NOT use global
+            `git merge -X theirs`. Main's version may be taken wholesale only
+            for files explicitly listed in the nightly-sync skill's
+            "Files to Override from Main" section. For other conflicts,
+            preserve recent dev-only additions and combine them with main's
+            incoming changes.
 
             **Source of truth for CI status:**
             `gh pr view <PR_NUMBER> --repo $REPO --json statusCheckRollup`

--- a/.github/workflows/nightly-sync-main-to-dev.yml
+++ b/.github/workflows/nightly-sync-main-to-dev.yml
@@ -56,8 +56,10 @@ jobs:
 
   sync-main-to-dev:
     if: github.event_name == 'workflow_dispatch' && github.repository == 'NVIDIA/Megatron-LM'
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
+    # GitHub-hosted runners are capped at 6h; use an NVIDIA runner so the
+    # sync bot can wait through long CI queues and retries.
+    runs-on: linux-amd64-cpu16
+    timeout-minutes: 720
     env:
       GH_TOKEN: ${{ secrets.PAT }}
     steps:

--- a/skills/nightly-sync/SKILL.md
+++ b/skills/nightly-sync/SKILL.md
@@ -244,9 +244,92 @@ for f in pyproject.toml uv.lock docker/Dockerfile.ci.dev; do
     echo "WARNING: $f differs from origin/dev"
   fi
 done
+
+# 3. Dev-feature preservation audit.
+#
+# The most common sync regression is silently dropping a dev-only feature
+# that main does not have yet. Pattern:
+#   T0: a feature lands on dev
+#   T1 > T0: the same feature lands on main (possibly reformatted)
+#   The sync runs between T0 and T1. `-X theirs` resolves any conflict in
+#   main's favour, dropping dev's addition wherever main happened to
+#   touch a nearby line for an unrelated reason.
+#
+# For each file the sync touched (modulo skill-sanctioned overrides and
+# the dependency triple), find every line that satisfies ALL of:
+#   line is on origin/dev        (dev had it)
+#   line is NOT on origin/main   (main never owned it)
+#   line is NOT in the merged tree  (the merge dropped it)
+# Filter out whitespace-only lines and bracket-only lines (they
+# frequently differ for cosmetic reasons).
+#
+# Files in the "Files to Override from Main" list (training.py,
+# initialize.py, utils.py, data_samplers.py, layer_wise_optimizer.py)
+# are exempt by skill convention — main may legitimately win there.
+# CODEOWNERS and the dep triple are checked above; skip them here.
+
+INTENTIONAL_OVERRIDE_REGEX='^(megatron/training/training\.py|megatron/training/initialize\.py|megatron/training/utils\.py|megatron/training/datasets/data_samplers\.py|megatron/core/optimizer/layer_wise_optimizer\.py)$'
+SKIP_REGEX='^(pyproject\.toml|uv\.lock|docker/Dockerfile\.ci\.dev|\.github/CODEOWNERS)$'
+
+BASE=$(git merge-base origin/dev origin/main)
+VIOLATIONS=0
+for f in $(git diff --name-only "$BASE"...HEAD \
+            -- '*.py' '*.md' '*.yaml' '*.yml' '*.toml' \
+               '*.sh' '*.cpp' '*.cu' '*.h' \
+            | sort -u); do
+  [[ "$f" =~ $SKIP_REGEX ]] && continue
+  [[ "$f" =~ $INTENTIONAL_OVERRIDE_REGEX ]] && continue
+  [ -f "$f" ] || continue
+
+  missing=$(comm -23 \
+              <(git show "origin/dev:$f"  2>/dev/null | sort -u) \
+              <(git show "origin/main:$f" 2>/dev/null | sort -u) \
+            | comm -23 - <(sort -u "$f") \
+            | grep -E '[[:alnum:]_]' \
+            || true)
+
+  if [ -n "$missing" ]; then
+    echo "=== $f ==="
+    printf '%s\n' "$missing"
+    VIOLATIONS=$((VIOLATIONS + $(printf '%s\n' "$missing" | grep -c .)))
+  fi
+done
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "ABORT: $VIOLATIONS dev-only line(s) dropped by the merge. For each:"
+  echo "  (a) MAIN INTENTIONALLY REMOVED — find the specific commit in"
+  echo "      'git log origin/main -- <file>' that removed it; document the"
+  echo "      SHA in the PR body, then the drop is acceptable."
+  echo "  (b) MERGE ACCIDENT — main never explicitly touched that line."
+  echo "      RESTORE the dev line (Edit/Write to put it back)."
+  echo "Default to (b); only declare (a) with a specific main commit as evidence."
+  exit 1
+fi
 ```
 
-The CODEOWNERS check is a HARD abort — never push if it fails.
+The CODEOWNERS check and the dev-feature preservation audit are HARD
+aborts — never push if either fails. The dep-triple check is a warning
+because git-source reconciliation can produce legitimate diffs there.
+
+Recent regressions the dev-feature audit would have flagged (all
+"merge accident" type from #4659 and #4716):
+
+- `transformer_layer.py` lost `_forward_mlp_router(input_ids=None)`
+- `token_dispatcher.py` lost the
+  `num_sms_preprocessing_api=...` kwarg on the `_HybridEPManager` call
+- `moe_layer.py` lost `self._maybe_record_overload_factor(...)`
+- `gpt_dynamic_inference_with_coordinator.py` lost
+  `from megatron.training.arguments import parse_and_validate_args`
+- `datasets/readme.md` lost the dev-only "Packing Scheduler" section
+- `data_samplers.py` / `utils.py` / `training.py` kept main's
+  `args.hybrid_context_parallel` instead of dev's
+  `args.dynamic_context_parallel` (counts as a MERGE ACCIDENT — dev's
+  reference is present, main's is the deprecated alias that's False
+  when callers pass `--dynamic-context-parallel`). These files are on
+  the override list so the audit treats them as "advisory", but you
+  should still rename `args.hybrid_context_parallel` →
+  `args.dynamic_context_parallel` on every reference after taking
+  main's version of these files.
 
 ### Commit and Push
 

--- a/skills/nightly-sync/SKILL.md
+++ b/skills/nightly-sync/SKILL.md
@@ -17,8 +17,13 @@ conflicts, iterating on CI, and shipping the PR.
 ### Branch Setup
 
 1. Create branch `$BRANCH` from `origin/dev`
-2. Merge: `git merge origin/main -X theirs --no-edit`
-3. If conflicts remain (e.g. add/add), resolve by favoring main
+2. Merge: `git merge origin/main --no-edit`
+3. Resolve conflicts surgically. Do NOT use global `-X theirs`, and do NOT
+   blanket-checkout main's version of a shared file. Main's version may be
+   taken wholesale only for files in "Files to Override from Main" below, or
+   when you have identified a specific main commit that intentionally removes
+   the dev-only code. For all other conflicts, combine both sides so recent
+   dev-only additions remain present.
 
 ### Preserving Dev-Only Additions
 
@@ -31,14 +36,13 @@ conflict.
 
 Dev often develops features as a chain of PRs (PR1 → PR2 → PR3) where each
 builds on the last. When PR1 is squash-merged to main, git sees main's squashed
-version and dev's original commits as unrelated changes. `-X theirs` will pick
-main's PR1 code and silently discard PR2/PR3's improvements on dev.
+version and dev's original commits as unrelated changes. A conflict resolution
+that blindly picks main can silently discard PR2/PR3's improvements on dev.
 
 After the merge, check for this pattern:
 
-1. For each file where `-X theirs` resolved a conflict, run
-   `git log --oneline origin/dev -- <file>` to see if dev has commits that
-   came AFTER the code main is bringing in.
+1. For each conflicted file, run `git log --oneline origin/dev -- <file>` to
+   see if dev has commits that came AFTER the code main is bringing in.
 2. If dev has follow-up commits (bug fixes, refactors, extensions), **favor
    dev's version** for those sections.
 3. If the conflict is just main bringing in a clean copy of what dev already
@@ -50,7 +54,7 @@ more evolved one.
 
 Real examples from PR #4291:
 - `emerging_optimizers.py`: Main's version was MORE complete — it squash-merged
-  dev's PRs plus added more. `-X theirs` was correct.
+  dev's PRs plus added more. Taking main for that section was correct.
 - `distrib_optimizer.py`: Main overwrote dev's `GroupedQuantizedTensor` support.
   Had to restore `_is_distopt_quantized_param` and the expanded
   `_expand_quantized_param_shard_for_cast` loop while keeping main's NVFP4
@@ -59,6 +63,13 @@ Real examples from PR #4291:
 Key insight: squash-merge chains can go in EITHER direction. Sometimes main
 is ahead (it squash-merged dev's work + more), sometimes dev is ahead (it has
 follow-up PRs). Always diff both ways before deciding which version to favor.
+
+Real example from PR #4882 / PR #4318:
+- `transformer_engine.py`: main had unrelated `TEFusedMLP` refactors, while dev
+  had the new `TEFusedDenseMLP` class. The sync kept the config flag and test
+  but dropped the class and `gpt_layer_specs.py` selection. That is a merge
+  accident: restore the dev class and selection while preserving main's
+  `TEFusedMLP.as_mlp_submodule` refactor.
 
 ### Files to Override from Main
 
@@ -228,20 +239,29 @@ AND every fix-push in Phase 3), run these bash checks. If any fails,
 fix the condition and re-check before pushing:
 
 ```bash
+MERGE_COMMIT=$(git rev-list --min-parents=2 --max-count=1 HEAD || true)
+if [ -n "$MERGE_COMMIT" ]; then
+  DEV_REF="${MERGE_COMMIT}^1"
+  MAIN_REF="${MERGE_COMMIT}^2"
+else
+  DEV_REF="origin/dev"
+  MAIN_REF="origin/main"
+fi
+
 # 1. CODEOWNERS must be identical to dev's.
-if ! git diff --quiet origin/dev -- .github/CODEOWNERS; then
-  echo "ABORT: .github/CODEOWNERS differs from origin/dev. Restore with:"
-  echo "  git checkout origin/dev -- .github/CODEOWNERS"
+if ! git diff --quiet "$DEV_REF" HEAD -- .github/CODEOWNERS; then
+  echo "ABORT: .github/CODEOWNERS differs from dev. Restore with:"
+  echo "  git checkout $DEV_REF -- .github/CODEOWNERS"
   exit 1
 fi
 
 # 2. Dependency-management triple must be identical to dev's.
 for f in pyproject.toml uv.lock docker/Dockerfile.ci.dev; do
-  if ! git diff --quiet origin/dev -- "$f"; then
+  if ! git diff --quiet "$DEV_REF" HEAD -- "$f"; then
     # pyproject.toml is allowed to differ ONLY for git source reconciliation
     # (new [tool.uv.sources] entries from main). If you intentionally edited
     # it for that reason, bypass this check by re-running with $f skipped.
-    echo "WARNING: $f differs from origin/dev"
+    echo "WARNING: $f differs from dev"
   fi
 done
 
@@ -251,9 +271,9 @@ done
 # that main does not have yet. Pattern:
 #   T0: a feature lands on dev
 #   T1 > T0: the same feature lands on main (possibly reformatted)
-#   The sync runs between T0 and T1. `-X theirs` resolves any conflict in
-#   main's favour, dropping dev's addition wherever main happened to
-#   touch a nearby line for an unrelated reason.
+#   The sync runs between T0 and T1. Blindly resolving a conflict in
+#   main's favour drops dev's addition wherever main happened to touch a
+#   nearby line for an unrelated reason.
 #
 # For each file the sync touched (modulo skill-sanctioned overrides and
 # the dependency triple), find every line that satisfies ALL of:
@@ -271,20 +291,19 @@ done
 INTENTIONAL_OVERRIDE_REGEX='^(megatron/training/training\.py|megatron/training/initialize\.py|megatron/training/utils\.py|megatron/training/datasets/data_samplers\.py|megatron/core/optimizer/layer_wise_optimizer\.py)$'
 SKIP_REGEX='^(pyproject\.toml|uv\.lock|docker/Dockerfile\.ci\.dev|\.github/CODEOWNERS)$'
 
-BASE=$(git merge-base origin/dev origin/main)
 VIOLATIONS=0
-for f in $(git diff --name-only "$BASE"...HEAD \
+for f in $(git diff --name-only "$DEV_REF"..HEAD \
             -- '*.py' '*.md' '*.yaml' '*.yml' '*.toml' \
                '*.sh' '*.cpp' '*.cu' '*.h' \
             | sort -u); do
   [[ "$f" =~ $SKIP_REGEX ]] && continue
   [[ "$f" =~ $INTENTIONAL_OVERRIDE_REGEX ]] && continue
-  [ -f "$f" ] || continue
+  git cat-file -e "HEAD:$f" 2>/dev/null || continue
 
   missing=$(comm -23 \
-              <(git show "origin/dev:$f"  2>/dev/null | sort -u) \
-              <(git show "origin/main:$f" 2>/dev/null | sort -u) \
-            | comm -23 - <(sort -u "$f") \
+              <(git show "$DEV_REF:$f"  2>/dev/null | sort -u) \
+              <(git show "$MAIN_REF:$f" 2>/dev/null | sort -u) \
+            | comm -23 - <(git show "HEAD:$f" 2>/dev/null | sort -u) \
             | grep -E '[[:alnum:]_]' \
             || true)
 
@@ -321,6 +340,8 @@ Recent regressions the dev-feature audit would have flagged (all
 - `gpt_dynamic_inference_with_coordinator.py` lost
   `from megatron.training.arguments import parse_and_validate_args`
 - `datasets/readme.md` lost the dev-only "Packing Scheduler" section
+- PR #4882 / PR #4318 dropped the `TEFusedDenseMLP` implementation and
+  `gpt_layer_specs.py` selection while leaving the config flag and unit test
 - `data_samplers.py` / `utils.py` / `training.py` kept main's
   `args.hybrid_context_parallel` instead of dev's
   `args.dynamic_context_parallel` (counts as a MERGE ACCIDENT — dev's
@@ -673,8 +694,11 @@ comment should include:
 
 ## Rules
 
-- Prioritize main over dev on genuine conflicts. Preserve dev-only additions
-  that do not conflict.
+- Do not globally prioritize main over dev. Preserve recent dev-only additions
+  unless a specific main commit intentionally removed them. Main may win
+  wholesale only for the explicit override list above; otherwise resolve
+  conflicts by combining main's incoming changes with dev's still-unmerged
+  features.
 - **Two-commit policy:** the PR contains at most two bot-authored
   commits — the Phase 1 merge commit (immutable once pushed) and a
   single rolling fix commit on top. The fix commit is created on


### PR DESCRIPTION
# What does this PR do ?

Adds a deterministic dev-feature preservation audit to the nightly main-to-dev sync instructions, and changes the scheduled sync cadence from daily to twice weekly.

## Summary

- Adds a hard-abort "Dev-feature preservation audit" to the `skills/nightly-sync/SKILL.md` pre-push invariant checks.
- The audit scans files touched by the sync and reports lines that are present on `origin/dev`, absent from `origin/main`, and missing from the merged tree. This catches the common `-X theirs` regression where a dev-only feature is silently dropped during main-to-dev conflict resolution.
- Keeps the existing skip/override semantics explicit:
  - skips `pyproject.toml`, `uv.lock`, `docker/Dockerfile.ci.dev`, and `.github/CODEOWNERS`, which are already covered by dedicated rules;
  - skips the skill's intentional "Files to Override from Main" list, where main may legitimately win.
- Documents how to classify audit hits:
  - if main intentionally removed the line, document the specific main commit SHA in the PR body;
  - otherwise treat it as a merge accident and restore the dev line before pushing.
- Records recent regressions from #4659 and #4716 that this audit would have flagged, including dropped dynamic-context-parallel references, missing MoE/router call sites, and the missing packing scheduler documentation.
- Changes `.github/workflows/nightly-sync-main-to-dev.yml` from daily at `21:00 UTC` to Monday and Thursday at `15:00 UTC` (`8 AM PDT` / `7 AM PST`).