### PR TITLE
Add LLM PP>1 support for colocated MIMO training (NMFW-19)

### DIFF
--- a/megatron/core/models/mimo/_finalize.py
+++ b/megatron/core/models/mimo/_finalize.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""Gradient finalization for colocated MimoModel training.
+
+A colocated :class:`MimoModel` is a ``MegatronModule`` whose language model and
+modality submodules are *separately* wrapped in ``DistributedDataParallel`` over
+*different* data-parallel groups (the encoder and LLM can run different DP
+factorizations under fan-in / fan-out). The stock
+:func:`megatron.core.distributed.finalize_model_grads.finalize_model_grads`
+expects a list of DDP chunks and a single ``pg_collection``; called on a bare
+``MimoModel`` it raises ``AttributeError`` (``MimoModel`` has no
+``finish_grad_sync`` / ``scale_gradients``) and it cannot reduce two submodules
+over two different DP groups.
+
+:func:`finalize_mimo_grads` dispatches finalization to each DDP submodule with
+its own ``pg_collection``. Wire it into ``config.finalize_model_grads_func`` for
+colocated runs (see :func:`colocated_forward_backward_with_pp`).
+"""
+
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+from megatron.core.distributed.finalize_model_grads import finalize_model_grads
+from megatron.core.process_groups_config import ProcessGroupCollection
+
+
+def finalize_mimo_grads(
+    mimo_model,
+    num_tokens: Optional[torch.Tensor],
+    language_pg: ProcessGroupCollection,
+    vision_pg: ProcessGroupCollection,
+    force_all_reduce: bool = False,
+) -> None:
+    """Finalize gradients for a colocated MimoModel's two DDP submodules.
+
+    Mirrors :func:`finalize_model_grads` but dispatches per submodule with its
+    own process-group collection, so the encoder (over ``vision_pg``) and the
+    LLM (over ``language_pg``) are each reduced over the correct DP group.
+
+    When ``num_tokens`` is provided (``calculate_per_token_loss=True``), it is the
+    LLM-local valid-token sum (the loss runs LLM-side). It is reduced to a single
+    global divisor ``N_global`` over the LLM PP+DP groups and applied *uniformly*
+    to both submodules, so the encoder and LLM see the same normalization. When
+    ``num_tokens`` is ``None`` (the per-microbatch-mean default), each submodule's
+    DDP applies its own ``1/dp_size`` scaling and no extra divide is performed.
+
+    Args:
+        mimo_model: The colocated ``MimoModel`` (not DDP-wrapped itself).
+        num_tokens: LLM-local token-count tensor, or ``None``.
+        language_pg: Process-group collection for the language model's DDP.
+        vision_pg: Process-group collection for the modality submodules' DDP.
+        force_all_reduce: Forwarded to per-submodule ``finalize_model_grads``.
+    """
+    submodules = []  # list[(ddp_chunk, pg_collection)]
+    if mimo_model.language_model is not None:
+        submodules.append((mimo_model.language_model, language_pg))
+    for submodule in mimo_model.modality_submodules.values():
+        if submodule is not None:
+            submodules.append((submodule, vision_pg))
+
+    # Reduce the LLM-local token count to a single global divisor (over the LLM
+    # PP+DP groups) so both submodules normalize identically. The encoder's own
+    # DP group would yield a different count under DP mismatch.
+    n_global = None
+    if num_tokens is not None:
+        pp = getattr(language_pg, 'pp', None)
+        if pp is not None and pp.size() > 1:
+            last_rank = dist.get_global_rank(pp, pp.size() - 1)
+            dist.broadcast(num_tokens, src=last_rank, group=pp)
+        dp = (
+            language_pg.dp_cp if getattr(language_pg, 'dp_cp', None) is not None else language_pg.dp
+        )
+        dist.all_reduce(num_tokens, group=dp, op=dist.ReduceOp.SUM)
+        n_global = num_tokens.item()
+
+    # Per-side DDP finish with no built-in num_tokens scaling.
+    for chunk, pg in submodules:
+        finalize_model_grads(
+            [chunk], num_tokens=None, pg_collection=pg, force_all_reduce=force_all_reduce
+        )
+
+    # Uniform divide by the global token count (guard the fully-masked batch).
+    if n_global is not None and n_global > 0:
+        inv = 1.0 / n_global
+        for chunk, _ in submodules:
+            chunk.scale_gradients(inv)

--- a/megatron/core/models/mimo/colocated_schedule.py
+++ b/megatron/core/models/mimo/colocated_schedule.py
@@ -248,6 +248,10 @@ def _slice_for_encoder_dp(full_encoder_input, encoder_grid, llm_grid):
                     f"[seq, batch, hidden], got shape={tuple(tensor.shape)}"
                 )
             bs = tensor.shape[1]
+            if bs % scale != 0:
+                raise ValueError(
+                    f"Encoder fan-in: tensor batch={bs} not divisible by scale={scale}."
+                )
             ss = bs // scale
             if ss == 0:
                 raise ValueError(

--- a/megatron/core/models/mimo/colocated_schedule.py
+++ b/megatron/core/models/mimo/colocated_schedule.py
@@ -1,0 +1,426 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Three-phase schedule for colocated MIMO training with LLM PP>1.
+
+Phase 1: Encoder forward + communicate for the full batch (all ranks synchronized).
+Phase 2: LLM 1F1B pipeline with detached encoder embeddings sliced per microbatch.
+Phase 3: Encoder backward for the full batch (all ranks synchronized).
+
+Encoder runs on all ranks (PP=1) and its TP/DP collectives require all ranks
+to participate simultaneously. The 1F1B pipeline staggers ranks across PP stages,
+so encoder collectives cannot run inside the pipeline. The three-phase design
+separates encoder (synchronized) from LLM (pipelined) by detaching the autograd
+graph at the encoder-LLM boundary.
+
+Shape contract: encoder input tensors are 3D ``[seq, batch, hidden]`` with
+the batch dim at ``dim=1``. Encoder output embeddings are either 3D
+``[seq, batch, hidden]`` (batch dim = 1) or 2D ``[seq*batch, hidden]``
+(batch dim = 0); the bridge may collapse the leading two dims. Other
+layouts (e.g. ``[B, C, H, W]`` images) are not supported.
+
+DP-direction contract: fan-in (enc_dp > llm_dp), fan-out (enc_dp < llm_dp),
+and equal-DP are all supported. The ColocatedBridgeCommunicator handles
+the encoder-side reshape on both forward (fan-in: all-gather, fan-out:
+narrow) and backward (fan-in: scatter, fan-out: all-gather). The schedule's
+job is to hand each side its correctly-sized slice of the global batch:
+
+  * Fan-in: data iterator yields LLM-DP-sized per-rank batches; the
+    schedule narrows encoder inputs to the encoder rank's smaller slot
+    in ``_slice_for_encoder_dp`` before encode_and_communicate.
+  * Fan-out: data iterator yields encoder-DP-sized per-rank batches; the
+    bridge narrows encoder embeddings to the LLM-DP rank's slot inside
+    encode_and_communicate, and ``_build_lm_microbatches`` narrows the
+    LLM-side passthrough fields (input_ids, labels, loss_mask,
+    position_ids) to the same slot so they line up with the bridge
+    output for the LLM forward.
+"""
+
+from contextlib import contextmanager
+from functools import partial
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.pipeline_parallel import schedules
+
+
+def colocated_forward_backward_with_pp(
+    mimo_model,
+    data_iterator,
+    num_microbatches: int,
+    encoder_grid: Optional[HyperCommGrid] = None,
+    llm_grid: Optional[HyperCommGrid] = None,
+    encoder_name: str = "images",
+    forward_only: bool = False,
+    **schedule_kwargs,
+):
+    """Three-phase colocated training: encoder batch -> LLM pipeline -> encoder backward.
+
+    Args:
+        mimo_model: MimoModel with colocated communicators and lm_has_pp=True.
+        data_iterator: Yields dicts with input_ids, labels, etc.
+        num_microbatches: Number of microbatches for the LLM pipeline.
+        encoder_grid: Encoder HyperCommGrid (for DP fan-in slicing).
+        llm_grid: LLM HyperCommGrid (for PP group).
+        encoder_name: Modality name for the encoder (e.g., "images").
+        forward_only: Skip backward passes if True.
+        **schedule_kwargs: Passed to forward_backward_pipelining_without_interleaving.
+            Must include p2p_communicator, pg_collection, seq_length, micro_batch_size.
+    """
+    pp_group = llm_grid.get_pg("pp") if llm_grid and 'pp' in llm_grid.dim_names else None
+    is_pp_first = pp_group is None or pp_group.rank() == 0
+
+    # ── Phase 1: Encoder forward on full batch (one pass) ────────────────
+    # All ranks participate (encoder is PP=1, communicate is collective).
+    all_batches = [next(data_iterator) for _ in range(num_microbatches)]
+    full_encoder_input = _concat_encoder_inputs(all_batches, encoder_name)
+    _slice_for_encoder_dp(full_encoder_input, encoder_grid, llm_grid)
+
+    enc_out = mimo_model.encode_and_communicate({encoder_name: full_encoder_input})
+
+    # Detach so Phase 2 runs no encoder collectives; microbatch views accumulate
+    # .grad into detached_full.grad automatically.
+    detached_full = {k: v.detach().requires_grad_(True) for k, v in enc_out.items()}
+    lm_data = _build_lm_microbatches(
+        detached_full, all_batches, num_microbatches, encoder_grid, llm_grid
+    )
+
+    # ── Phase 2: LLM 1F1B pipeline ──────────────────────────────────────
+    # Only LLM P2P communication (within PP group). No encoder collectives.
+    cache_iter = iter(lm_data)
+
+    def _lm_forward_step(data_iterator_unused, model, *args):
+        cached = next(cache_iter)
+        forward_kwargs = dict(
+            input_ids=cached['input_ids'],
+            labels=cached['labels'],
+            loss_mask=cached['loss_mask'],
+            position_ids=cached['position_ids'],
+            encoder_embeddings=cached['encoder_embeddings'],
+        )
+        if cached.get('attention_mask') is not None:
+            forward_kwargs['attention_mask'] = cached['attention_mask']
+        if cached.get('packing_kwargs') is not None:
+            forward_kwargs['packing_kwargs'] = cached['packing_kwargs']
+        output_tensor, loss_mask = model(**forward_kwargs)
+        return output_tensor, partial(_loss_func, cached['loss_mask'])
+
+    # Swap in a capturing finalize so the inner PP schedule does not run DDP
+    # grad sync before Phase 3 has produced encoder grads. The capture also
+    # records ``num_tokens`` and ``force_all_reduce`` that the inner schedule
+    # would have passed — we forward them to the original finalize after
+    # Phase 3 so per-token-loss configs see the correct global divisor and
+    # any caller-requested all-reduce semantics are preserved.
+    with _deferred_finalize(mimo_model.config) as (original_finalize, capture):
+        losses = schedules.forward_backward_pipelining_without_interleaving(
+            forward_step_func=_lm_forward_step,
+            data_iterator=cache_iter,
+            model=[mimo_model],
+            num_microbatches=num_microbatches,
+            forward_only=forward_only,
+            **schedule_kwargs,
+        )
+
+    # ── Phase 3: Encoder backward (one pass, all ranks sync) ────────────
+    # detached_full.grad was populated by Phase 2's per-microbatch LLM backward
+    # (accumulated across microbatch view slices on PP stage 0).
+    # Broadcast to PP stage 1+ then run one encoder backward for the full batch.
+    if not forward_only and enc_out:
+        _broadcast_encoder_grad(detached_full, enc_out, pp_group, is_pp_first)
+        for key in enc_out:
+            grad = detached_full[key].grad
+            if grad is not None:
+                torch.autograd.backward(enc_out[key], grad_tensors=grad)
+
+    # Single post-Phase-3 finalize: reduces LLM grads (from Phase 2) and
+    # encoder grads (from Phase 3) together. Without this call, encoder
+    # grads remain local to each rank and Adam steps on un-reduced grads,
+    # causing silent divergence from the equal-DP reference. Forward the
+    # captured force_all_reduce so callers requesting that semantics
+    # (e.g. final-microbatch sync with overlap_grad_reduce) get it.
+    if not forward_only and original_finalize is not None:
+        original_finalize(
+            [mimo_model],
+            capture.num_tokens,
+            pg_collection=schedule_kwargs.get('pg_collection'),
+            force_all_reduce=capture.force_all_reduce,
+        )
+
+    return losses
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _fan_out_slot(encoder_grid, llm_grid):
+    """Return ``(scale, slot)`` for fan-out LLM-side narrowing.
+
+    For fan-out (``llm_dp > enc_dp``) the data iterator yields encoder-DP-
+    sized per-rank batches. The bridge narrows encoder embeddings to this
+    LLM-DP rank's slot inside ``encode_and_communicate``; LLM-side fields
+    (input_ids, labels, ...) must be narrowed to the SAME slot so they
+    line up with the bridge output for the LLM forward. Returns
+    ``(scale, slot)`` where ``slot`` is this rank's index inside the
+    fan-out sibling group; ``(1, 0)`` for equal-DP and fan-in (where the
+    LLM-side fields are already correctly sized for the LLM-DP rank).
+    """
+    if encoder_grid is None or llm_grid is None:
+        return 1, 0
+    enc_dp = encoder_grid.get_pg("dp").size()
+    llm_dp = llm_grid.get_pg("dp").size()
+    if llm_dp <= enc_dp:
+        return 1, 0
+    scale = llm_dp // enc_dp
+    slot = llm_grid.get_pg("dp").rank() % scale
+    return scale, slot
+
+
+def _modality_present(batch, encoder_name):
+    """Return True iff this batch carries inputs for ``encoder_name``."""
+    mod_in = batch.get('modality_inputs')
+    return bool(mod_in) and encoder_name in mod_in and mod_in[encoder_name] is not None
+
+
+def _concat_encoder_inputs(all_batches, encoder_name):
+    """Concatenate encoder inputs from all microbatches along batch dim (dim=1).
+
+    All encoder input tensors must be 3D ``[seq, batch, hidden]``. All
+    microbatches must uniformly have or lack ``modality_inputs[encoder_name]``;
+    mixed batches are rejected because Phase 2 reuses one detached encoder
+    output across every LLM microbatch.
+    """
+    first = all_batches[0]
+    has_first = _modality_present(first, encoder_name)
+    for idx, b in enumerate(all_batches):
+        if _modality_present(b, encoder_name) != has_first:
+            raise ValueError(
+                f"colocated_forward_backward_with_pp requires uniform "
+                f"modality_inputs across microbatches for '{encoder_name}'; "
+                f"microbatch 0 has it = {has_first} but microbatch {idx} differs."
+            )
+    if not has_first:
+        return {}
+    result = {}
+    for enc_name in first['modality_inputs'][encoder_name]:
+        result[enc_name] = {}
+        for key in first['modality_inputs'][encoder_name][enc_name]:
+            vals = [b['modality_inputs'][encoder_name][enc_name][key] for b in all_batches]
+            tensors = [v for v in vals if isinstance(v, torch.Tensor)]
+            if tensors:
+                for v in tensors:
+                    if v.ndim != 3:
+                        raise ValueError(
+                            f"encoder input '{enc_name}.{key}' must be 3D "
+                            f"[seq, batch, hidden], got shape={tuple(v.shape)}"
+                        )
+                result[enc_name][key] = torch.cat(tensors, dim=1)
+            else:
+                result[enc_name][key] = vals[0]
+    return result
+
+
+def _slice_for_encoder_dp(full_encoder_input, encoder_grid, llm_grid):
+    """Slice concatenated encoder input for fan-in (enc_dp > llm_dp).
+
+    Encoder input tensors must be 3D ``[seq, batch, hidden]``. For fan-in
+    the data iterator yields LLM-DP-sized per-rank batches; this helper
+    narrows them to the encoder rank's smaller slot before forward.
+    Equal-DP and fan-out (where the per-rank batch is already encoder-DP-
+    sized — the bridge narrows on the LLM side) are no-ops.
+    """
+    if encoder_grid is None or llm_grid is None:
+        return
+    enc_dp = encoder_grid.get_pg("dp").size()
+    llm_dp = llm_grid.get_pg("dp").size()
+    if enc_dp <= llm_dp:
+        return
+    scale = enc_dp // llm_dp
+    slot = encoder_grid.get_pg("dp").rank() % scale
+    for enc_name in full_encoder_input:
+        for key, tensor in full_encoder_input[enc_name].items():
+            if not isinstance(tensor, torch.Tensor):
+                continue
+            if tensor.ndim != 3:
+                raise ValueError(
+                    f"encoder input '{enc_name}.{key}' must be 3D "
+                    f"[seq, batch, hidden], got shape={tuple(tensor.shape)}"
+                )
+            bs = tensor.shape[1]
+            ss = bs // scale
+            if ss == 0:
+                raise ValueError(
+                    f"Encoder fan-in produces zero-sized batch: "
+                    f"total_batch={bs}, scale={scale}. Increase micro_batch_size."
+                )
+            full_encoder_input[enc_name][key] = tensor[
+                :, slot * ss : (slot + 1) * ss, :
+            ].contiguous()
+
+
+def _build_lm_microbatches(
+    detached_full, all_batches, num_microbatches, encoder_grid=None, llm_grid=None
+):
+    """Slice detached encoder output into per-microbatch views for the LLM pipeline.
+
+    Encoder embeddings are either 3D ``[seq, batch, hidden]`` (batch dim = 1)
+    or 2D ``[seq*batch, hidden]`` (batch dim = 0); the bridge may collapse
+    the leading two dims. Other layouts are rejected. Pass-through fields
+    (input_ids, labels, loss_mask, position_ids, attention_mask, packing_kwargs)
+    are copied per microbatch from the corresponding ``all_batches`` entry.
+
+    For fan-out (``llm_dp > enc_dp``) the per-microbatch passthrough fields
+    arrive at the encoder-DP-sized batch; this helper narrows them to the
+    LLM-DP rank's slot via :func:`_fan_out_slot` so they line up with the
+    bridge-narrowed encoder embeddings. Fan-in and equal-DP leave the
+    fields unchanged (``scale=1, slot=0``).
+    """
+    fan_out_scale, fan_out_slot = _fan_out_slot(encoder_grid, llm_grid)
+
+    def _maybe_narrow(tensor):
+        """Narrow a batch-dim-0 tensor to this LLM-DP rank's fan-out slot."""
+        if fan_out_scale == 1 or tensor is None or not isinstance(tensor, torch.Tensor):
+            return tensor
+        bs = tensor.shape[0]
+        if bs % fan_out_scale != 0:
+            raise ValueError(
+                f"Fan-out narrowing: tensor batch={bs} not divisible by " f"scale={fan_out_scale}."
+            )
+        ss = bs // fan_out_scale
+        return tensor[fan_out_slot * ss : (fan_out_slot + 1) * ss].contiguous()
+
+    def _maybe_narrow_attn(tensor, ref_batch):
+        """Narrow ``attention_mask`` only when its dim-0 matches the input batch.
+
+        Some callers pass attention_mask as ``[b, 1, s, s]`` (batch-first,
+        narrow the way ``input_ids`` is narrowed); others pass shapes that
+        broadcast across batch (e.g. ``[1, 1, s, s]`` causal mask). We only
+        narrow when dim-0 equals the pre-narrowing batch size, leaving
+        broadcastable masks alone.
+        """
+        if (
+            fan_out_scale == 1
+            or tensor is None
+            or not isinstance(tensor, torch.Tensor)
+            or ref_batch is None
+            or not isinstance(ref_batch, torch.Tensor)
+            or tensor.ndim < 1
+            or tensor.shape[0] != ref_batch.shape[0]
+        ):
+            return tensor
+        return _maybe_narrow(tensor)
+
+    def _passthrough(batch_idx):
+        b = all_batches[batch_idx]
+        input_ids = b.get('input_ids')
+        return {
+            'input_ids': _maybe_narrow(input_ids),
+            'labels': _maybe_narrow(b.get('labels')),
+            'loss_mask': _maybe_narrow(b.get('loss_mask')),
+            'position_ids': _maybe_narrow(b.get('position_ids')),
+            'attention_mask': _maybe_narrow_attn(b.get('attention_mask'), input_ids),
+            'packing_kwargs': b.get('packing_kwargs'),
+        }
+
+    if not detached_full:
+        # Text-only batch: no encoder embeddings to slice
+        return [{'encoder_embeddings': {}, **_passthrough(mb)} for mb in range(num_microbatches)]
+
+    sample = next(iter(detached_full.values()))
+    if sample.ndim not in (2, 3):
+        raise ValueError(
+            f"encoder output must be 2D [seq*batch, hidden] or 3D "
+            f"[seq, batch, hidden], got shape={tuple(sample.shape)}"
+        )
+    batch_dim = 1 if sample.ndim == 3 else 0
+    total_batch = sample.shape[batch_dim]
+    if total_batch % num_microbatches != 0:
+        raise ValueError(
+            f"Encoder output batch dim ({total_batch}) must be divisible "
+            f"by num_microbatches ({num_microbatches})"
+        )
+    mb_size = total_batch // num_microbatches
+
+    lm_data = []
+    for mb in range(num_microbatches):
+        s, e = mb * mb_size, (mb + 1) * mb_size
+        mb_enc = {k: (v[:, s:e, :] if v.ndim == 3 else v[s:e, :]) for k, v in detached_full.items()}
+        lm_data.append({'encoder_embeddings': mb_enc, **_passthrough(mb)})
+    return lm_data
+
+
+def _broadcast_encoder_grad(detached_full, enc_out, pp_group, is_pp_first):
+    """Broadcast encoder gradient from PP stage 0 to stage 1+ ranks."""
+    if pp_group is None or pp_group.size() <= 1:
+        return
+    src = dist.get_global_rank(pp_group, 0)
+    for key in enc_out:
+        if is_pp_first:
+            if detached_full[key].grad is None:
+                raise RuntimeError(
+                    f"No encoder gradient on PP stage 0 for '{key}'; "
+                    f"Phase 2 LLM backward did not populate detached_full.grad."
+                )
+            dist.broadcast(detached_full[key].grad, src=src, group=pp_group)
+        else:
+            grad = torch.empty_like(detached_full[key])
+            dist.broadcast(grad, src=src, group=pp_group)
+            detached_full[key].grad = grad
+
+
+def _loss_func(loss_mask, output_tensor):
+    """Default loss function for the LLM pipeline.
+
+    Returns the 3-tuple ``(local_sum, local_num_tokens, log_dict)`` contract
+    expected when ``calculate_per_token_loss=True`` is set on the
+    TransformerConfig. When it is not set, the schedule divides
+    ``local_sum`` by ``local_num_tokens`` (clamped to 1), so the 3-tuple
+    form is also safe for standard per-microbatch-mean configs.
+    """
+    if output_tensor is None:
+        zero_loss = torch.tensor(0.0, device='cuda', requires_grad=True)
+        zero_count = torch.tensor(0, device='cuda', dtype=torch.int)
+        return zero_loss, zero_count, {'loss_reduced': 0.0}
+    masked = output_tensor.float() * loss_mask.float()
+    local_sum = masked.sum()
+    local_num_tokens = loss_mask.float().sum().to(torch.int)
+    return local_sum, local_num_tokens, {'loss_reduced': local_sum.detach().item()}
+
+
+class _CapturingFinalize:
+    """Capture finalize args the inner PP schedule would have passed.
+
+    The three-phase schedule defers grad finalization until after Phase 3
+    runs encoder backward. Replacing the config's ``finalize_model_grads_func``
+    with this object absorbs the inner schedule's invocation and stores
+    ``num_tokens`` (required for ``calculate_per_token_loss=True`` configs
+    whose finalize hook divides by the global valid-token count) and
+    ``force_all_reduce`` (preserves any caller-requested all-reduce
+    semantics on the final microbatch) so the post-Phase-3 call to the
+    original finalize can forward both.
+    """
+
+    def __init__(self):
+        self.num_tokens = None
+        self.force_all_reduce = False
+
+    def __call__(self, model_list, num_tokens, *args, **kwargs):
+        self.num_tokens = num_tokens
+        self.force_all_reduce = kwargs.get('force_all_reduce', False)
+        return None
+
+
+@contextmanager
+def _deferred_finalize(config):
+    """Suppress the PP schedule's end-of-run DDP grad sync; yield the
+    original finalize and a capture object so callers can invoke the
+    original (with the captured ``num_tokens``) once after Phase 3.
+    """
+    original = config.finalize_model_grads_func
+    capture = _CapturingFinalize()
+    config.finalize_model_grads_func = capture
+    try:
+        yield original, capture
+    finally:
+        config.finalize_model_grads_func = original

--- a/megatron/core/models/mimo/colocated_schedule.py
+++ b/megatron/core/models/mimo/colocated_schedule.py
@@ -105,7 +105,7 @@ def colocated_forward_backward_with_pp(
         if cached.get('packing_kwargs') is not None:
             forward_kwargs['packing_kwargs'] = cached['packing_kwargs']
         output_tensor, loss_mask = model(**forward_kwargs)
-        return output_tensor, partial(_loss_func, cached['loss_mask'])
+        return output_tensor, partial(_loss_func, loss_mask)
 
     # Swap in a capturing finalize so the inner PP schedule does not run DDP
     # grad sync before Phase 3 has produced encoder grads. The capture also

--- a/megatron/core/models/mimo/colocated_schedule.py
+++ b/megatron/core/models/mimo/colocated_schedule.py
@@ -141,12 +141,27 @@ def colocated_forward_backward_with_pp(
     # captured force_all_reduce so callers requesting that semantics
     # (e.g. final-microbatch sync with overlap_grad_reduce) get it.
     if not forward_only and original_finalize is not None:
-        original_finalize(
-            [mimo_model],
-            capture.num_tokens,
-            pg_collection=schedule_kwargs.get('pg_collection'),
-            force_all_reduce=capture.force_all_reduce,
-        )
+        try:
+            original_finalize(
+                [mimo_model],
+                capture.num_tokens,
+                pg_collection=schedule_kwargs.get('pg_collection'),
+                force_all_reduce=capture.force_all_reduce,
+            )
+        except AttributeError as exc:
+            # The stock finalize_model_grads iterates `model_chunk.finish_grad_sync()`
+            # / `.scale_gradients()`, which a bare MimoModel does not implement, and it
+            # takes a single pg_collection while the encoder/LLM submodules are separate
+            # DDPs over different DP groups. Fail fast with guidance instead of a cryptic
+            # AttributeError.
+            raise RuntimeError(
+                "colocated_forward_backward_with_pp: config.finalize_model_grads_func "
+                "cannot finalize a MimoModel. MimoModel is not a DistributedDataParallel "
+                "and its encoder/LLM submodules are separately DDP-wrapped over different "
+                "DP groups, so the stock finalize_model_grads fails. Wire a MimoModel-aware "
+                "finalize — megatron.core.models.mimo._finalize.finalize_mimo_grads — into "
+                "config.finalize_model_grads_func."
+            ) from exc
 
     return losses
 
@@ -282,17 +297,37 @@ def _build_lm_microbatches(
     """
     fan_out_scale, fan_out_slot = _fan_out_slot(encoder_grid, llm_grid)
 
+    def _narrow_on_dim(tensor, dim):
+        """Narrow ``tensor`` to this LLM-DP rank's fan-out slot along ``dim``."""
+        bs = tensor.shape[dim]
+        if bs % fan_out_scale != 0:
+            raise ValueError(
+                f"Fan-out narrowing: tensor batch={bs} (dim {dim}) not divisible "
+                f"by scale={fan_out_scale}."
+            )
+        ss = bs // fan_out_scale
+        sl = [slice(None)] * tensor.ndim
+        sl[dim] = slice(fan_out_slot * ss, (fan_out_slot + 1) * ss)
+        return tensor[tuple(sl)].contiguous()
+
     def _maybe_narrow(tensor):
         """Narrow a batch-dim-0 tensor to this LLM-DP rank's fan-out slot."""
         if fan_out_scale == 1 or tensor is None or not isinstance(tensor, torch.Tensor):
             return tensor
-        bs = tensor.shape[0]
-        if bs % fan_out_scale != 0:
-            raise ValueError(
-                f"Fan-out narrowing: tensor batch={bs} not divisible by " f"scale={fan_out_scale}."
-            )
-        ss = bs // fan_out_scale
-        return tensor[fan_out_slot * ss : (fan_out_slot + 1) * ss].contiguous()
+        return _narrow_on_dim(tensor, 0)
+
+    def _maybe_narrow_position_ids(tensor):
+        """Narrow ``position_ids`` to the fan-out slot on its BATCH dim.
+
+        ``position_ids`` is 2D ``[batch, seq]`` (batch dim 0) or, for
+        multimodal RoPE, 3D ``[rope_dim, batch, seq]`` (batch dim 1, consumed
+        that way at ``MimoModel.get_text_embeddings``). The generic dim-0
+        narrowing would slice ``rope_dim`` for the 3D layout, so select the
+        batch dim explicitly.
+        """
+        if fan_out_scale == 1 or tensor is None or not isinstance(tensor, torch.Tensor):
+            return tensor
+        return _narrow_on_dim(tensor, 1 if tensor.ndim == 3 else 0)
 
     def _maybe_narrow_attn(tensor, ref_batch):
         """Narrow ``attention_mask`` only when its dim-0 matches the input batch.
@@ -318,11 +353,25 @@ def _build_lm_microbatches(
     def _passthrough(batch_idx):
         b = all_batches[batch_idx]
         input_ids = b.get('input_ids')
+        if fan_out_scale > 1 and b.get('packing_kwargs') is not None:
+            # packing_kwargs (cu_seqlens / num_samples / max_seqlen) describes the
+            # full encoder-DP batch, but input_ids/labels/... are narrowed to this
+            # LLM-DP slot below. Slicing the data without recomputing the THD
+            # offsets would desync packed-sequence attention (cu_seqlens would
+            # index past the narrowed token count). Reject loudly instead of
+            # silently corrupting; equal-DP and fan-in are unaffected.
+            raise NotImplementedError(
+                "Colocated fan-out (llm_dp > enc_dp) with sequence packing is not "
+                "supported: packing_kwargs cu_seqlens/num_samples describe the full "
+                "encoder-DP batch but input_ids are narrowed to this LLM-DP slot. "
+                "Use equal or fan-in DP, or extend _passthrough to recompute "
+                "per-slot cu_seqlens."
+            )
         return {
             'input_ids': _maybe_narrow(input_ids),
             'labels': _maybe_narrow(b.get('labels')),
             'loss_mask': _maybe_narrow(b.get('loss_mask')),
-            'position_ids': _maybe_narrow(b.get('position_ids')),
+            'position_ids': _maybe_narrow_position_ids(b.get('position_ids')),
             'attention_mask': _maybe_narrow_attn(b.get('attention_mask'), input_ids),
             'packing_kwargs': b.get('packing_kwargs'),
         }
@@ -361,12 +410,15 @@ def _broadcast_encoder_grad(detached_full, enc_out, pp_group, is_pp_first):
     src = dist.get_global_rank(pp_group, 0)
     for key in enc_out:
         if is_pp_first:
-            if detached_full[key].grad is None:
-                raise RuntimeError(
-                    f"No encoder gradient on PP stage 0 for '{key}'; "
-                    f"Phase 2 LLM backward did not populate detached_full.grad."
-                )
-            dist.broadcast(detached_full[key].grad, src=src, group=pp_group)
+            grad = detached_full[key].grad
+            if grad is None:
+                # A microbatch that contributed no loss (e.g. fully-masked
+                # loss_mask) leaves .grad unpopulated on stage 0. Broadcast
+                # zeros rather than raising: a one-sided raise here would leave
+                # stages 1+ blocked in the matching collective below (NCCL hang).
+                grad = torch.zeros_like(detached_full[key])
+                detached_full[key].grad = grad
+            dist.broadcast(grad, src=src, group=pp_group)
         else:
             grad = torch.empty_like(detached_full[key])
             dist.broadcast(grad, src=src, group=pp_group)
@@ -383,8 +435,9 @@ def _loss_func(loss_mask, output_tensor):
     form is also safe for standard per-microbatch-mean configs.
     """
     if output_tensor is None:
-        zero_loss = torch.tensor(0.0, device='cuda', requires_grad=True)
-        zero_count = torch.tensor(0, device='cuda', dtype=torch.int)
+        device = loss_mask.device if isinstance(loss_mask, torch.Tensor) else 'cuda'
+        zero_loss = torch.tensor(0.0, device=device, requires_grad=True)
+        zero_count = torch.tensor(0, device=device, dtype=torch.int)
         return zero_loss, zero_count, {'loss_reduced': 0.0}
     masked = output_tensor.float() * loss_mask.float()
     local_sum = masked.sum()
@@ -417,14 +470,29 @@ class _CapturingFinalize:
 
 @contextmanager
 def _deferred_finalize(config):
-    """Suppress the PP schedule's end-of-run DDP grad sync; yield the
-    original finalize and a capture object so callers can invoke the
-    original (with the captured ``num_tokens``) once after Phase 3.
+    """Suppress the PP schedule's in-pipeline DDP grad reduction; yield the
+    original finalize and a capture object so callers can invoke the original
+    (with the captured ``num_tokens``) once after Phase 3.
+
+    Deferral must neutralize BOTH grad-sync hooks the inner 1F1B schedule may
+    fire, not just ``finalize_model_grads_func``:
+
+    * ``finalize_model_grads_func`` — swapped for a capturing no-op.
+    * ``grad_sync_func`` — set to ``None``. With ``overlap_grad_reduce=True`` /
+      the distributed optimizer (production sets ``config.grad_sync_func =
+      start_grad_sync``), the inner schedule launches async LLM DP
+      reduce-scatter during Phase 2, BEFORE Phase 3 produces encoder grads.
+      That would reduce LLM grads on a buffer the encoder backward then writes
+      into, racing the single post-Phase-3 finalize. Setting it to ``None``
+      keeps all grads un-reduced until that finalize owns the reduction.
     """
     original = config.finalize_model_grads_func
+    original_grad_sync = config.grad_sync_func
     capture = _CapturingFinalize()
     config.finalize_model_grads_func = capture
+    config.grad_sync_func = None
     try:
         yield original, capture
     finally:
         config.finalize_model_grads_func = original
+        config.grad_sync_func = original_grad_sync

--- a/megatron/core/models/mimo/comm/colocated_communicator.py
+++ b/megatron/core/models/mimo/comm/colocated_communicator.py
@@ -95,12 +95,7 @@ class ColocatedBridgeCommunicator:
         elif self.dest_dp_size > self.src_dp_size:
             self.direction = BridgeDirection.FAN_OUT
             self.scale = self.dest_dp_size // self.src_dp_size
-            self.gather_group_ranks = self._build_gather_groups(
-                iter_size=self.src_dp_size,
-                sibling_tp_size=self.dest_tp_size,
-                scale=self.scale,
-                rank_to_pos=self.rank_to_dest_pos,
-            )
+            self.gather_group_ranks = self._build_fan_out_gather_groups()
             self.gather_pg, _ = dist.new_subgroups_by_enumeration(
                 self.gather_group_ranks, backend='nccl'
             )
@@ -128,8 +123,9 @@ class ColocatedBridgeCommunicator:
                 f"src={self.src_grid.rank_offset}, dest={self.dest_grid.rank_offset}"
             )
 
-        # Per-grid dim checks: tp/dp required; pp and cp (if present) must be 1.
-        # CP>1 also corrupts dp_idx when iterating get_rank_enum(['tp']) groups.
+        # Per-grid dim checks: tp/dp required; cp (if present) must be 1.
+        # Src PP must be 1; dest PP>1 is allowed. CP>1 corrupts dp_idx when
+        # iterating get_rank_enum(['tp']) groups.
         for name, grid in [("src", self.src_grid), ("dest", self.dest_grid)]:
             for required in ('tp', 'dp'):
                 if required not in grid.dim_names:
@@ -137,14 +133,16 @@ class ColocatedBridgeCommunicator:
                         f"{name} grid must have '{required}' dimension, "
                         f"got dim_names={grid.dim_names}"
                     )
-            for singleton in ('pp', 'cp'):
-                if singleton in grid.dim_names:
-                    size = grid.shape[grid.dim_names.index(singleton)]
-                    if size != 1:
-                        raise ValueError(
-                            f"{name} {singleton.upper()} must be 1 for "
-                            f"ColocatedBridgeCommunicator, got {size}"
-                        )
+            if 'cp' in grid.dim_names:
+                cp_size = grid.shape[grid.dim_names.index('cp')]
+                if cp_size != 1:
+                    raise ValueError(
+                        f"{name} CP must be 1 for ColocatedBridgeCommunicator, got {cp_size}"
+                    )
+        if 'pp' in self.src_grid.dim_names:
+            src_pp = self.src_grid.shape[self.src_grid.dim_names.index('pp')]
+            if src_pp != 1:
+                raise ValueError(f"src PP must be 1 for ColocatedBridgeCommunicator, got {src_pp}")
 
         src_dp = self.src_grid.shape[self.src_grid.dim_names.index('dp')]
         dest_dp = self.dest_grid.shape[self.dest_grid.dim_names.index('dp')]
@@ -158,20 +156,35 @@ class ColocatedBridgeCommunicator:
         self.src_dp_size = self.src_grid.shape[self.src_grid.dim_names.index('dp')]
         self.dest_tp_size = self.dest_grid.shape[self.dest_grid.dim_names.index('tp')]
         self.dest_dp_size = self.dest_grid.shape[self.dest_grid.dim_names.index('dp')]
+        self.dest_pp_size = (
+            self.dest_grid.shape[self.dest_grid.dim_names.index('pp')]
+            if 'pp' in self.dest_grid.dim_names
+            else 1
+        )
 
     def _build_rank_mappings(self):
         self.rank_to_src_pos: Dict[int, Tuple[int, int]] = {}
         self.rank_to_dest_pos: Dict[int, Tuple[int, int]] = {}
+        self.rank_to_dest_pp_pos: Dict[int, Tuple[int, int, int]] = {}
+        self.dest_pp_pos_to_rank: Dict[Tuple[int, int, int], int] = {}
 
         src_tp_groups = self.src_grid.get_rank_enum(['tp'])
         for dp_idx, tp_group in enumerate(src_tp_groups):
             for tp_idx, rank in enumerate(tp_group):
                 self.rank_to_src_pos[rank] = (dp_idx, tp_idx)
 
-        dest_tp_groups = self.dest_grid.get_rank_enum(['tp'])
-        for dp_idx, tp_group in enumerate(dest_tp_groups):
-            for tp_idx, rank in enumerate(tp_group):
+        # Include destination PP when enumerating destination ranks so DP
+        # indices stay true DP coordinates instead of flattened (dp, pp)
+        # positions. Fan-out gather groups then stay within one PP stage.
+        dest_group_dims = ['tp', 'pp'] if 'pp' in self.dest_grid.dim_names else ['tp']
+        dest_tp_pp_groups = self.dest_grid.get_rank_enum(dest_group_dims)
+        for dp_idx, tp_pp_group in enumerate(dest_tp_pp_groups):
+            for local_idx, rank in enumerate(tp_pp_group):
+                pp_idx = local_idx // self.dest_tp_size if self.dest_pp_size > 1 else 0
+                tp_idx = local_idx % self.dest_tp_size
                 self.rank_to_dest_pos[rank] = (dp_idx, tp_idx)
+                self.rank_to_dest_pp_pos[rank] = (dp_idx, pp_idx, tp_idx)
+                self.dest_pp_pos_to_rank[(dp_idx, pp_idx, tp_idx)] = rank
 
     @staticmethod
     def _build_gather_groups(
@@ -196,6 +209,21 @@ class ColocatedBridgeCommunicator:
                             group_ranks.append(rank)
                             break
                 groups.append(group_ranks)
+        return groups
+
+    def _build_fan_out_gather_groups(self) -> List[List[int]]:
+        """Build dest-side fan-out gather groups, preserving destination PP stage."""
+        groups: List[List[int]] = []
+        for src_dp_idx in range(self.src_dp_size):
+            sibling_dp_indices = range(src_dp_idx * self.scale, (src_dp_idx + 1) * self.scale)
+            for dest_pp_idx in range(self.dest_pp_size):
+                for dest_tp_idx in range(self.dest_tp_size):
+                    group_ranks = []
+                    for dest_dp_idx in sibling_dp_indices:
+                        group_ranks.append(
+                            self.dest_pp_pos_to_rank[(dest_dp_idx, dest_pp_idx, dest_tp_idx)]
+                        )
+                    groups.append(group_ranks)
         return groups
 
     def is_fan_in(self) -> bool:

--- a/megatron/core/models/mimo/comm/colocated_communicator.py
+++ b/megatron/core/models/mimo/comm/colocated_communicator.py
@@ -139,6 +139,18 @@ class ColocatedBridgeCommunicator:
                     raise ValueError(
                         f"{name} CP must be 1 for ColocatedBridgeCommunicator, got {cp_size}"
                     )
+            # ep / expt_dp interleave into the get_rank_enum group ordering exactly
+            # like cp, so a value > 1 would conflate the DP index in _build_rank_mappings
+            # and silently build wrong fan-in/fan-out gather groups (wrong-batch gather
+            # or NCCL hang). Reject them explicitly rather than corrupt rank mappings.
+            for forbidden in ('ep', 'expt_dp'):
+                if forbidden in grid.dim_names:
+                    sz = grid.shape[grid.dim_names.index(forbidden)]
+                    if sz != 1:
+                        raise ValueError(
+                            f"{name} {forbidden} must be 1 for "
+                            f"ColocatedBridgeCommunicator, got {sz}"
+                        )
         if 'pp' in self.src_grid.dim_names:
             src_pp = self.src_grid.shape[self.src_grid.dim_names.index('pp')]
             if src_pp != 1:

--- a/megatron/core/models/mimo/config/role.py
+++ b/megatron/core/models/mimo/config/role.py
@@ -79,7 +79,7 @@ class RankRole:
         Grids differ → NON_COLOCATED with PP-stage info per module.
         """
         if module_to_grid_map is None or cls._all_grids_colocated(module_to_grid_map):
-            return cls._colocated(modality_module_names)
+            return cls._colocated(modality_module_names, module_to_grid_map)
         return cls._from_grid_map(module_to_grid_map)
 
     @staticmethod
@@ -89,16 +89,30 @@ class RankRole:
         return all(g.rank_offset == first.rank_offset and g.size == first.size for g in grids[1:])
 
     @classmethod
-    def _colocated(cls, modality_module_names: List[str]) -> 'RankRole':
-        """Colocated layout: every module on every rank, PP=1."""
+    def _colocated(
+        cls,
+        modality_module_names: List[str],
+        module_to_grid_map: Optional[Dict[str, 'HyperCommGrid']] = None,
+    ) -> 'RankRole':
+        """Colocated layout: every module on every rank.
+
+        When a grid map is supplied, per-module stage info is derived from
+        each grid's pp group (LLM PP>1 is allowed). With no grid map, every
+        module is both first and last stage.
+        """
         all_module_names = list(modality_module_names) + [MIMO_LANGUAGE_MODULE_KEY]
-        return cls(
-            modules={
-                name: ModuleStageInfo(is_first_stage=True, is_last_stage=True)
-                for name in all_module_names
-            },
-            mode=ModuleLayout.COLOCATED,
-        )
+        modules = {}
+        for name in all_module_names:
+            grid = module_to_grid_map.get(name) if module_to_grid_map else None
+            if grid is not None and 'pp' in grid.dim_names:
+                pp_group = grid.get_pg('pp')
+                pp_rank, pp_size = pp_group.rank(), pp_group.size()
+                modules[name] = ModuleStageInfo(
+                    is_first_stage=(pp_rank == 0), is_last_stage=(pp_rank == pp_size - 1)
+                )
+            else:
+                modules[name] = ModuleStageInfo(is_first_stage=True, is_last_stage=True)
+        return cls(modules=modules, mode=ModuleLayout.COLOCATED)
 
     @classmethod
     def _from_grid_map(cls, module_to_grid_map: Dict[str, HyperCommGrid]) -> 'RankRole':

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -67,6 +67,11 @@ class MimoModel(MegatronModule):
             # in TP/DP within those ranks.
             self._build_colocated_communicators()
 
+        lang_info = self.role.modules.get(MIMO_LANGUAGE_MODULE_KEY)
+        self.lm_has_pp = lang_info is not None and not (
+            lang_info.is_first_stage and lang_info.is_last_stage
+        )
+
         # Use special token IDs from the config
         self.special_token_ids = (
             mimo_config.special_token_ids.copy() if mimo_config.special_token_ids else {}
@@ -340,6 +345,7 @@ class MimoModel(MegatronModule):
         labels: Optional[torch.Tensor] = None,
         modality_inputs: Optional[Dict[str, Dict[str, Any]]] = None,
         packing_kwargs: Optional[dict] = None,
+        encoder_embeddings: Optional[Dict[str, torch.Tensor]] = None,
     ):
         """Forward pass through the multimodal model.
 
@@ -384,6 +390,20 @@ class MimoModel(MegatronModule):
         input_tensors = getattr(self, 'input_tensors', None)
 
         if self.role.mode == ModuleLayout.COLOCATED:
+            if self.lm_has_pp and input_tensors is not None:
+                # PP>1 non-first stage: hidden states from P2P
+                lm_result = self._forward_language_module(
+                    input_ids,
+                    position_ids,
+                    attention_mask,
+                    labels,
+                    {MIMO_LANGUAGE_MODULE_KEY: input_tensors},
+                )
+                # Unwrap dict for P2P (schedule uses plain tensors, not dicts)
+                if isinstance(lm_result, dict):
+                    lm_result = lm_result[MIMO_LANGUAGE_MODULE_KEY]
+                return lm_result, loss_mask
+
             return self._forward_all_modules(
                 input_ids,
                 position_ids,
@@ -392,6 +412,7 @@ class MimoModel(MegatronModule):
                 labels,
                 modality_inputs,
                 packing_kwargs,
+                encoder_embeddings=encoder_embeddings,
             )
 
         if self.role.mode == ModuleLayout.NON_COLOCATED:
@@ -699,7 +720,12 @@ class MimoModel(MegatronModule):
             )
 
     def destroy(self) -> None:
-        """Release process groups owned by this MimoModel."""
+        """Release process groups owned by this MimoModel.
+
+        NCCL caps concurrent communicators, so long-lived or
+        repeatedly-rebuilt models leak subgroups without explicit
+        destroy. Tests should call this before ``destroy_all_grids()``.
+        """
         for comm in self.colocated_comms.values():
             comm.destroy()
         self.colocated_comms.clear()
@@ -715,6 +741,22 @@ class MimoModel(MegatronModule):
                 )
         return modality_embeddings
 
+    def encode_and_communicate(self, modality_inputs):
+        """Run encoder forward + colocated TP/DP transform (collective)."""
+        modality_embeddings = {}
+        for modality_name, submodule in self.modality_submodules.items():
+            if (
+                modality_inputs
+                and modality_name in modality_inputs
+                and modality_inputs[modality_name] is not None
+            ):
+                embeddings = submodule.forward(encoder_inputs=modality_inputs[modality_name])
+                if embeddings is not None:
+                    modality_embeddings[modality_name] = embeddings
+        if self.colocated_comms:
+            modality_embeddings = self._apply_colocated_comms(modality_embeddings)
+        return modality_embeddings
+
     def _forward_all_modules(
         self,
         input_ids: torch.Tensor,
@@ -724,6 +766,7 @@ class MimoModel(MegatronModule):
         labels: Optional[torch.Tensor],
         modality_inputs: Optional[Dict[str, Dict[str, Any]]],
         packing_kwargs: Optional[dict] = None,
+        encoder_embeddings: Optional[Dict[str, torch.Tensor]] = None,
     ):
         """Forward pass when all modules are on all ranks (no multi-module PP).
 
@@ -731,26 +774,12 @@ class MimoModel(MegatronModule):
         """
         packed_seq_params = self._build_packed_seq_params(packing_kwargs)
 
-        # 1. Process each modality to get embeddings
-        modality_embeddings = {}
-
-        for modality_name, submodule in self.modality_submodules.items():
-            if (
-                modality_inputs
-                and modality_name in modality_inputs
-                and modality_inputs[modality_name] is not None
-            ):
-                logger.debug(f"Processing {modality_name} modality")
-                embeddings = submodule.forward(encoder_inputs=modality_inputs[modality_name])
-                if embeddings is not None:
-                    modality_embeddings[modality_name] = embeddings
-                    logger.debug(
-                        f"Generated embeddings for {modality_name} with shape {embeddings.shape}"
-                    )
-
-        # Apply colocated communication if configured (no-op when colocated_comms is empty)
-        if self.colocated_comms:
-            modality_embeddings = self._apply_colocated_comms(modality_embeddings)
+        if encoder_embeddings is not None:
+            # PP>1 path: encoder forward + communicate already ran in Phase 1;
+            # reuse the precomputed embeddings for every LLM microbatch.
+            modality_embeddings = encoder_embeddings
+        else:
+            modality_embeddings = self.encode_and_communicate(modality_inputs)
 
         # Get text embeddings
         text_embeddings = self.get_text_embeddings(input_ids, position_ids, self.special_token_ids)

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -392,12 +392,14 @@ class MimoModel(MegatronModule):
         if self.role.mode == ModuleLayout.COLOCATED:
             if self.lm_has_pp and input_tensors is not None:
                 # PP>1 non-first stage: hidden states from P2P
-                lm_result = self._forward_language_module(
+                lm_result, loss_mask = self._forward_language_module(
                     input_ids,
                     position_ids,
                     attention_mask,
+                    loss_mask,
                     labels,
                     {MIMO_LANGUAGE_MODULE_KEY: input_tensors},
+                    packing_kwargs,
                 )
                 # Unwrap dict for P2P (schedule uses plain tensors, not dicts)
                 if isinstance(lm_result, dict):

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_communicator.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_communicator.py
@@ -234,8 +234,8 @@ class TestValidateGrids:
         "side,dim,expected",
         [
             ("src", "pp", "src PP must be 1"),
-            ("dest", "pp", "dest PP must be 1"),
             ("src", "cp", "CP must be 1"),
+            ("dest", "cp", "CP must be 1"),
         ],
     )
     def test_pp_or_cp_gt_one_rejected(self, side, dim, expected):
@@ -249,6 +249,13 @@ class TestValidateGrids:
             dest_grid = create_hypercomm_grid(**bad)
         with pytest.raises(ValueError, match=expected):
             make_comm(src_grid, dest_grid)
+
+    def test_dest_pp_gt_one_accepted(self):
+        # Dest PP>1 is valid: the three-phase colocated schedule handles
+        # the LLM pipeline orchestration. The bridge only needs src PP=1.
+        src_grid = create_hypercomm_grid(tp=4, dp=2)
+        dest_grid = create_hypercomm_grid(tp=2, pp=2, dp=2)
+        make_comm(src_grid, dest_grid)
 
     def test_dp_not_divisible(self):
         # 6-rank grids with DP sizes (3 vs 2) that neither divides the other.

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
@@ -51,6 +51,7 @@ Run with::
 """
 
 import os
+import re
 from functools import partial
 
 import pytest
@@ -61,8 +62,10 @@ from packaging import version
 import megatron.core.pipeline_parallel.schedules as schedule
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.finalize_model_grads import finalize_model_grads
+from megatron.core.models.mimo.colocated_schedule import colocated_forward_backward_with_pp
 from megatron.core.models.mimo.optimizer import get_mimo_optimizer
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
 from megatron.core.transformer.enums import ModelType
 from megatron.core.utils import unwrap_model
 from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
@@ -164,7 +167,7 @@ def _set_deterministic_env():
     os.environ.pop('NVTE_UNFUSED_ATTN', None)
 
 
-def _wire_training_hooks(mimo_model, language_pg, vision_pg):
+def _wire_training_hooks(mimo_model, language_pg, vision_pg, llm_grid=None):
     """Attach no_sync / finalize_grads / grad_scale hooks to a MimoModel.
 
     The finalize hook implements the heterogeneous-DP grad-scaling story
@@ -185,6 +188,12 @@ def _wire_training_hooks(mimo_model, language_pg, vision_pg):
       3. Calls ``scale_gradients(1/N_global)`` on each side — lands the
          true global per-token mean uniformly on encoder and LLM grads.
 
+    ``llm_grid`` is required for LLM PP>1 callers: with PP>1 the inner
+    schedule only populates ``num_tokens`` on the last LLM PP stage; this
+    hook broadcasts it from the last PP rank to earlier stages before the
+    DP all-reduce so every rank arrives at the same ``N_global``.
+    Pass ``None`` (default) for PP=1, where the broadcast is a no-op.
+
     Note: encoder has no loss_func (so nothing emits a per-encoder-DP
     ``num_tokens`` to feed ``finalize_model_grads``' internal all-reduce).
     Doing the all-reduce once ourselves and calling ``scale_gradients``
@@ -193,6 +202,7 @@ def _wire_training_hooks(mimo_model, language_pg, vision_pg):
     """
 
     no_sync_func = build_no_sync_func(mimo_model)
+    pp_group = llm_grid.get_pg("pp") if llm_grid is not None else None
 
     def finalize_grads_func(model_list, num_tokens, force_all_reduce=False, **kwargs):
         # Schedule passes the per-rank sum-across-microbatches of what the
@@ -202,6 +212,13 @@ def _wire_training_hooks(mimo_model, language_pg, vision_pg):
             "finalize_grads_func expects calculate_per_token_loss=True on the "
             "TransformerConfig so the schedule forwards total_num_tokens; got None."
         )
+
+        # PP>1: only the last LLM PP stage emits a non-zero num_tokens
+        # from the loss_func. Broadcast to earlier stages so every rank
+        # holds the same value before the DP all-reduce below.
+        if pp_group is not None and pp_group.size() > 1:
+            last_rank = dist.get_global_rank(pp_group, pp_group.size() - 1)
+            dist.broadcast(num_tokens, src=last_rank, group=pp_group)
 
         # Phase 1: lift the all-reduce. After this, every rank (including
         # encoder-only replicas) has N_global = total non-padded tokens in
@@ -828,6 +845,173 @@ def _assert_encoder_weights_match(ref_module, dist_module, rtol=1e-3, atol=1e-3)
         )
 
 
+_LLM_LAYER_RX = re.compile(r'^(.*decoder\.layers\.)(\d+)(\..*)$')
+
+
+def _llm_pp_remap_name(name, pp_rank, layers_per_stage):
+    """Remap a dist LLM param name (local layer idx) to its ref PP=1 name (global idx).
+
+    Dist's ``decoder.layers.{local_idx}`` on PP stage ``s`` corresponds to
+    ref's global layer ``s * layers_per_stage + local_idx``. Non-layer
+    params (embedding, final_layernorm, output_layer) are present only on
+    stages that own them and their names match exactly between ref and dist.
+    """
+    m = _LLM_LAYER_RX.match(name)
+    if not m:
+        return name
+    prefix, local_idx_s, suffix = m.groups()
+    return f"{prefix}{pp_rank * layers_per_stage + int(local_idx_s)}{suffix}"
+
+
+def _copy_llm_params_pp_aware(ref_module, dist_module, pp_rank, pp_size, num_layers):
+    """Copy LLM params ref (PP=1) → dist (PP>=1) with layer-index remapping.
+
+    Assumes ``dist_llm_tp == ref_llm_tp`` so shards line up 1:1; callers
+    must verify (the consolidated correctness test only enables LLM PP-aware
+    copy/oracle when this holds).
+    """
+    assert num_layers % pp_size == 0, (
+        f"num_layers={num_layers} not divisible by pp_size={pp_size}; "
+        f"oracle requires even PP split."
+    )
+    layers_per_stage = num_layers // pp_size
+    ref_params = dict(ref_module.named_parameters())
+
+    with torch.no_grad():
+        for name, dist_param in dist_module.named_parameters():
+            ref_name = _llm_pp_remap_name(name, pp_rank, layers_per_stage)
+            assert ref_name in ref_params, (
+                f"LLM param '{name}' on PP stage {pp_rank} maps to ref name "
+                f"'{ref_name}' which does not exist in ref (ref has llm_pp=1)."
+            )
+            ref_param = ref_params[ref_name]
+            assert ref_param.shape == dist_param.shape, (
+                f"LLM param '{name}': ref.shape={tuple(ref_param.shape)} != "
+                f"dist.shape={tuple(dist_param.shape)} — oracle requires "
+                f"dist_llm_tp == ref_llm_tp."
+            )
+            dist_param.data.copy_(ref_param.data.to(dist_param.dtype))
+
+
+def _copy_ref_llm_with_tp_and_pp_remap(
+    ref_module, dist_module, ref_tp_group, dist_tp_group, pp_rank, pp_size, num_layers
+):
+    """Copy ref LLM (PP=1, ``ref_llm_tp``) → dist LLM (PP>=1, ``dist_llm_tp``).
+
+    Combines the PP-aware layer-index remap (from
+    :func:`_llm_pp_remap_name`) with the TP reshard
+    (all-gather-across-ref-TP + slice-by-dist-TP). Needed when fan-out
+    PP>1 forces ``dist_llm_tp != enc_tp`` on a fixed rank count (e.g.
+    fan-out PP=2 on 8 GPUs).
+
+    Two-phase to avoid cross-PP-stage collectives:
+
+    * Phase 1 — gather full ref params across ``ref_tp_group``. Iterates
+      ``ref_module.named_parameters()``, which is identical on every
+      rank in the same ``ref_tp_group``, so the all-gather collective is
+      lockstep regardless of how dist's PP layout splits those ranks.
+    * Phase 2 — copy from ``full_ref`` into this rank's local dist params
+      (PP-staged) using the layer-index remap. No collectives.
+
+    The naive "iterate dist_module and all-gather inside the loop"
+    approach hangs whenever dist's PP split spreads across a ref TP
+    group: ranks on different dist PP stages iterate different params
+    and never reach the same all-gather call together.
+    """
+    assert num_layers % pp_size == 0, f"num_layers={num_layers} not divisible by pp_size={pp_size}."
+    layers_per_stage = num_layers // pp_size
+    ref_tp_size = dist.get_world_size(ref_tp_group)
+    dist_tp_rank = dist.get_rank(dist_tp_group)
+    dist_tp_size = dist.get_world_size(dist_tp_group)
+
+    # Phase 1: gather full ref params across ref_tp_group. Safe because
+    # every rank in ref_tp_group iterates ref_module.named_parameters()
+    # in the same order.
+    full_ref = {}
+    with torch.no_grad():
+        for name, ref_param in ref_module.named_parameters():
+            partition_dim = getattr(ref_param, 'partition_dim', -1)
+            if ref_tp_size <= 1 or partition_dim < 0:
+                full_ref[name] = ref_param.data.detach().clone()
+                continue
+            shards = [torch.empty_like(ref_param.data) for _ in range(ref_tp_size)]
+            dist.all_gather(shards, ref_param.data.contiguous(), group=ref_tp_group)
+            full_ref[name] = torch.cat(shards, dim=partition_dim)
+
+    # Phase 2: per-rank local copy into dist's PP-staged params, with
+    # PP-aware layer-index remap and dist-TP slicing. No collectives.
+    with torch.no_grad():
+        for name, dist_param in dist_module.named_parameters():
+            ref_name = _llm_pp_remap_name(name, pp_rank, layers_per_stage)
+            assert ref_name in full_ref, (
+                f"LLM param '{name}' on PP stage {pp_rank} maps to ref name "
+                f"'{ref_name}' which does not exist in ref (ref has llm_pp=1)."
+            )
+            full_weight = full_ref[ref_name]
+            partition_dim = getattr(dist_param, 'partition_dim', -1)
+
+            if dist_tp_size <= 1 or partition_dim < 0:
+                # Replicated on dist (or no TP): full ref weight should
+                # match dist's local shape.
+                assert full_weight.shape == dist_param.shape, (
+                    f"Param '{name}' (ref '{ref_name}'): full_ref.shape="
+                    f"{tuple(full_weight.shape)} != dist.shape="
+                    f"{tuple(dist_param.shape)} (dist_tp={dist_tp_size}, "
+                    f"partition_dim={partition_dim})"
+                )
+                dist_param.data.copy_(full_weight.to(dist_param.dtype))
+                continue
+
+            dist_slice = torch.tensor_split(full_weight, dist_tp_size, dim=partition_dim)[
+                dist_tp_rank
+            ]
+            assert dist_slice.shape == dist_param.shape, (
+                f"Param '{name}' (ref '{ref_name}'): sliced.shape="
+                f"{tuple(dist_slice.shape)} != dist.shape="
+                f"{tuple(dist_param.shape)} (ref_tp={ref_tp_size}, "
+                f"dist_tp={dist_tp_size}, partition_dim={partition_dim})"
+            )
+            dist_param.data.copy_(dist_slice.to(dist_param.dtype))
+
+
+def _assert_llm_weights_match_pp_aware(
+    ref_module, dist_module, pp_rank, pp_size, num_layers, rtol=1e-2, atol=1e-2
+):
+    """Assert dist LLM shards match ref (PP=1) via the PP-aware layer-index remap.
+
+    Counterpart to :func:`_copy_llm_params_pp_aware`. Non-layer params
+    (embedding, final_layernorm, output_layer) only exist on stages that
+    own them and their names are unchanged between ref and dist.
+    """
+    layers_per_stage = num_layers // pp_size
+    ref_params = dict(ref_module.named_parameters())
+
+    mismatches = []
+    for name, dist_param in dist_module.named_parameters():
+        ref_name = _llm_pp_remap_name(name, pp_rank, layers_per_stage)
+        assert ref_name in ref_params, (
+            f"LLM param '{name}' maps to ref '{ref_name}' which does not exist "
+            f"(ref has llm_pp=1)."
+        )
+        ref_param = ref_params[ref_name]
+        assert ref_param.shape == dist_param.shape, (
+            f"LLM param '{name}': ref.shape={tuple(ref_param.shape)} != "
+            f"dist.shape={tuple(dist_param.shape)}."
+        )
+        try:
+            torch.testing.assert_close(dist_param.data, ref_param.data, rtol=rtol, atol=atol)
+        except AssertionError as e:
+            mismatches.append((name, ref_name, str(e)))
+
+    if mismatches:
+        rank = dist.get_rank()
+        details = "\n".join(f"  {n} -> {rn}: {msg}" for n, rn, msg in mismatches)
+        raise AssertionError(
+            f"Rank {rank}: {len(mismatches)} LLM param(s) diverged between "
+            f"PP>1 dist model and PP=1 reference:\n{details}"
+        )
+
+
 class _BatchIterator:
     """Minimal iterator over a pre-generated list of batches."""
 
@@ -857,17 +1041,39 @@ def _run_forward_backward(
     seq_length,
     num_microbatches,
 ):
-    """One forward/backward pass through the mimo schedule."""
-    return schedule.forward_backward_no_pipelining(
-        forward_step_func=partial(
-            forward_step, encoder_grid=enc_grid, llm_grid=llm_grid, encoder_name=encoder_name
-        ),
+    """Dispatch to no-pipelining (LLM PP=1) or three-phase (LLM PP>1) schedule.
+
+    PP=1 path uses :func:`forward_step` so per-rank slicing for fan-in/
+    fan-out happens at forward-time inside the no-pipelining schedule.
+    PP>1 path uses :func:`colocated_forward_backward_with_pp`, which
+    applies the same fan-in/fan-out narrowing internally (encoder side
+    in ``_slice_for_encoder_dp``, LLM side in ``_build_lm_microbatches``).
+    """
+    pp_size = llm_grid.get_pg("pp").size() if 'pp' in llm_grid.dim_names else 1
+    if pp_size <= 1:
+        return schedule.forward_backward_no_pipelining(
+            forward_step_func=partial(
+                forward_step, encoder_grid=enc_grid, llm_grid=llm_grid, encoder_name=encoder_name
+            ),
+            data_iterator=_BatchIterator(batches),
+            model=[mimo_model],
+            num_microbatches=num_microbatches,
+            seq_length=seq_length,
+            micro_batch_size=micro_batch_size,
+            forward_only=False,
+            pg_collection=language_pg,
+        )
+
+    return colocated_forward_backward_with_pp(
+        mimo_model=mimo_model,
         data_iterator=_BatchIterator(batches),
-        model=[mimo_model],
         num_microbatches=num_microbatches,
+        encoder_grid=enc_grid,
+        llm_grid=llm_grid,
+        encoder_name=encoder_name,
         seq_length=seq_length,
         micro_batch_size=micro_batch_size,
-        forward_only=False,
+        p2p_communicator=P2PCommunicator(pp_group=llm_grid.get_pg("pp"), config=mimo_model.config),
         pg_collection=language_pg,
     )
 
@@ -919,43 +1125,93 @@ class TestColocatedGradientScalingCorrectness:
         version.parse(torch.__version__) < version.parse("2.3.0"), reason="Requires PyTorch 2.3+"
     )
     @pytest.mark.parametrize(
-        "enc_tp,enc_dp,llm_tp,llm_dp", [(2, 4, 4, 2), (4, 2, 2, 4)], ids=["fan_in", "fan_out"]
+        "enc_tp,enc_dp,llm_tp,llm_pp,llm_dp",
+        [
+            (2, 4, 4, 1, 2),  # fan-in,  PP=1
+            (4, 2, 2, 1, 4),  # fan-out, PP=1
+            (2, 4, 2, 2, 2),  # fan-in,  PP=2 (dist_llm_tp == enc_tp → LLM weight oracle on)
+            (4, 2, 1, 2, 4),  # fan-out, PP=2 (dist_llm_tp != enc_tp → LLM weight oracle off)
+        ],
+        ids=["fan_in_pp1", "fan_out_pp1", "fan_in_pp2", "fan_out_pp2"],
     )
     @pytest.mark.parametrize(
         "mask_pattern", ["uniform", "asymmetric"], ids=["uniform", "asymmetric"]
     )
     @pytest.mark.parametrize("num_microbatches", [1, 4], ids=["mbs1", "mbs4"])
     def test_dist_matches_dp1_reference_post_step_weights(
-        self, enc_tp, enc_dp, llm_tp, llm_dp, mask_pattern, num_microbatches
+        self, enc_tp, enc_dp, llm_tp, llm_pp, llm_dp, mask_pattern, num_microbatches
     ):
-        """Heterogeneous-DP dist post-step encoder weights match equal-DP reference.
+        """Heterogeneous-(TP/DP/PP) dist post-step weights match equal-DP PP=1 reference.
 
         Builds two MimoModels on every rank:
 
-        * Dist: the heterogeneous TP/DP config under test, with
+        * Dist: the heterogeneous TP/DP/PP config under test, with
           ``calculate_per_token_loss=True`` + custom finalize hook that
           pure-SUMs DDP and externally divides by ``N_global``.
         * Ref: equal-DP uniform with ``enc_tp=dist_enc_tp``,
-          ``enc_dp=dist_enc_dp``, ``llm_tp=dist_enc_tp``,
-          ``llm_dp=dist_enc_dp`` — bridge is
-          ``BridgeDirection.EQUAL`` (identity passthrough), and the
-          encoder TP sharding matches dist's exactly so shards line up
-          1:1 for comparison.
+          ``enc_dp=dist_enc_dp``, ``llm_tp=dist_enc_tp``, ``llm_pp=1``,
+          ``llm_dp=dist_enc_dp`` — bridge is ``BridgeDirection.EQUAL``
+          (identity passthrough), and the encoder TP sharding matches
+          dist's exactly so shards line up 1:1 for comparison.
 
-        Both models run the same finalize wiring; both DDPs pure-SUM
-        across their own DP group, then divide uniformly by ``N_global``.
-        LLM TP differs between the two models, which introduces fp32 TP
-        accumulation-order drift in the gradient flowing back to the
-        encoder but does not change the per-token-mean invariant that the
-        post-step encoder oracle checks.
+        For ``llm_pp == 1`` the dist side runs the no-pipelining schedule
+        with the existing ``forward_step`` (which narrows for fan-in/
+        fan-out at forward time). For ``llm_pp > 1`` the dist side runs
+        :func:`colocated_forward_backward_with_pp` (three-phase: encoder
+        forward → LLM 1F1B → encoder backward), which applies the same
+        narrowing internally. Ref always runs no-pipelining (``llm_pp=1``).
 
         Reference weights are copied into the distributed model so both
         start from identical state. One Adam step later, the dist shards
-        should match the ref shards within fp32 precision.
+        should match the ref shards within fp32 precision. Oracles:
+
+        * Always: encoder weights, first-layer encoder grads.
+        * ``llm_pp == 1``: LLM input + LLM logits (TP+DP-gathered, robust
+          to different LLM TP layouts).
+        * ``llm_pp > 1`` AND ``dist_llm_tp == enc_tp``: LLM weights via
+          PP-aware layer-index remap (shards align 1:1 only if dist and
+          ref share the same LLM TP).
+
+        Fan-out PP>1 with ``dist_llm_tp == enc_tp`` is impossible on 8
+        GPUs (``enc_tp * 2 * llm_dp = 8`` and ``llm_dp > enc_dp = 8/enc_tp``
+        contradict), so the LLM weight oracle is skipped there — encoder
+        weight match alone is the gold-standard end-to-end signal because
+        the encoder's grads pass through the LLM forward + backward.
         """
         if self.world_size != 8:
             pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
+        if num_microbatches < llm_pp:
+            pytest.skip(
+                f"PP={llm_pp} requires num_microbatches >= {llm_pp}; " f"got {num_microbatches}"
+            )
 
+        # Wrap the entire test body so we can catch and PRINT any
+        # exception before pytest's distributed traceback formatter gets
+        # jumbled across 8 ranks. Without this, NCCL teardown across
+        # ranks that fail asymmetrically (some raise, some don't) tends
+        # to SIGABRT before pytest emits per-rank tracebacks.
+        rank = dist.get_rank()
+        try:
+            self._run_test_body(
+                rank, enc_tp, enc_dp, llm_tp, llm_pp, llm_dp, mask_pattern, num_microbatches
+            )
+        except Exception:
+            import traceback as _tb
+
+            print(
+                f"\n=== rank {rank} TEST EXCEPTION ===\n"
+                f"config: enc_tp={enc_tp} enc_dp={enc_dp} llm_tp={llm_tp} "
+                f"llm_pp={llm_pp} llm_dp={llm_dp} mbs={num_microbatches} "
+                f"mask={mask_pattern}\n"
+                f"{_tb.format_exc()}\n"
+                f"=== end rank {rank} exception ===\n",
+                flush=True,
+            )
+            raise
+
+    def _run_test_body(
+        self, rank, enc_tp, enc_dp, llm_tp, llm_pp, llm_dp, mask_pattern, num_microbatches
+    ):
         _set_deterministic_env()
         torch.use_deterministic_algorithms(True)
         torch.backends.cudnn.deterministic = True
@@ -963,17 +1219,21 @@ class TestColocatedGradientScalingCorrectness:
 
         encoder_name = "images"
         hidden_size, seq_length, vocab_size = 256, 64, 1000
+        num_layers = 2
+        # PP-aware param copy/oracle requires layers divisible by pp_size.
+        assert num_layers % llm_pp == 0
         micro_batch_size = 2
 
         # Global batch spans the larger DP side; dist pre-slices per rank
-        # before forward_step (which further slices encoder/LLM side).
+        # via _slice_global_batch_for_dist (LLM-DP-sized for fan-in,
+        # encoder-DP-sized for fan-out).
         global_batch_size = micro_batch_size * max(enc_dp, llm_dp)
 
         # Grids: dist is heterogeneous; ref is equal-DP uniform matching
         # dist's encoder so the bridge is identity and encoder shards
         # align 1:1 for direct comparison.
         dist_enc_grid = create_hypercomm_grid(offset=0, tp=enc_tp, cp=1, pp=1, dp=enc_dp)
-        dist_llm_grid = create_hypercomm_grid(offset=0, tp=llm_tp, cp=1, pp=1, dp=llm_dp)
+        dist_llm_grid = create_hypercomm_grid(offset=0, tp=llm_tp, cp=1, pp=llm_pp, dp=llm_dp)
         ref_enc_grid = create_hypercomm_grid(offset=0, tp=enc_tp, cp=1, pp=1, dp=enc_dp)
         ref_llm_grid = create_hypercomm_grid(offset=0, tp=enc_tp, cp=1, pp=1, dp=enc_dp)
         create_all_embedding_groups([dist_enc_grid, dist_llm_grid, ref_enc_grid, ref_llm_grid])
@@ -988,14 +1248,14 @@ class TestColocatedGradientScalingCorrectness:
             overlap_grad_reduce=True, bucket_size=10000, use_distributed_optimizer=True
         )
 
-        # Build dist first (heterogeneous TP/DP).
+        # Build dist first (heterogeneous TP/DP/PP).
         torch.manual_seed(12345)
         dist_mimo, _, _, dist_language_pg, dist_vision_pg = get_mimo_model(
             encoder_name=encoder_name,
             encoder_grid=dist_enc_grid,
             llm_grid=dist_llm_grid,
             hidden_size=hidden_size,
-            num_layers=2,
+            num_layers=num_layers,
             vocab_size=vocab_size,
             seq_len=seq_length,
             ddp_config=ddp_config,
@@ -1007,14 +1267,14 @@ class TestColocatedGradientScalingCorrectness:
         dist_mimo.model_type = ModelType.encoder_or_decoder
         self._mimo_models.append(dist_mimo)
 
-        # Reference with equal-DP uniform (enc_tp == llm_tp, enc_dp == llm_dp).
+        # Reference with equal-DP uniform (enc_tp == llm_tp, enc_dp == llm_dp, PP=1).
         torch.manual_seed(12345)
         ref_mimo, _, _, ref_language_pg, ref_vision_pg = get_mimo_model(
             encoder_name=encoder_name,
             encoder_grid=ref_enc_grid,
             llm_grid=ref_llm_grid,
             hidden_size=hidden_size,
-            num_layers=2,
+            num_layers=num_layers,
             vocab_size=vocab_size,
             seq_len=seq_length,
             ddp_config=ddp_config,
@@ -1026,25 +1286,57 @@ class TestColocatedGradientScalingCorrectness:
         ref_mimo.model_type = ModelType.encoder_or_decoder
         self._mimo_models.append(ref_mimo)
 
-        # Force identical initial state: encoder shards already match
-        # (same TP layout), so the helper copies shard-to-shard. LLM
-        # shards don't match (ref_llm_tp=enc_tp, dist_llm_tp=llm_tp), so
-        # the helper all-gathers ref's shards across ref's TP group and
-        # re-slices for dist's TP group.
+        # Force identical initial state. Encoder shards already match
+        # (same TP layout), so the helper copies shard-to-shard.
         _copy_ref_params_to_dist(
             ref_mimo.modality_submodules[encoder_name].module,
             dist_mimo.modality_submodules[encoder_name].module,
             ref_enc_grid.get_pg("tp"),
             dist_enc_grid.get_pg("tp"),
         )
-        _copy_ref_params_to_dist(
-            ref_mimo.language_model.module,
-            dist_mimo.language_model.module,
-            ref_llm_grid.get_pg("tp"),
-            dist_llm_grid.get_pg("tp"),
-        )
+        if llm_pp == 1:
+            # LLM shards may not match (ref_llm_tp=enc_tp, dist_llm_tp=llm_tp);
+            # the helper all-gathers ref's shards across ref's TP group and
+            # re-slices for dist's TP group.
+            _copy_ref_params_to_dist(
+                ref_mimo.language_model.module,
+                dist_mimo.language_model.module,
+                ref_llm_grid.get_pg("tp"),
+                dist_llm_grid.get_pg("tp"),
+            )
+        elif llm_tp == enc_tp:
+            # PP>1 with matching TP: dist's local layers map to a slice of
+            # ref's global layers and shards align 1:1 post-remap.
+            _copy_llm_params_pp_aware(
+                ref_mimo.language_model.module,
+                dist_mimo.language_model.module,
+                pp_rank=dist_llm_grid.get_pg("pp").rank(),
+                pp_size=llm_pp,
+                num_layers=num_layers,
+            )
+        else:
+            # PP>1 with mismatched TP (e.g. fan-out PP=2 on 8 GPUs):
+            # combine TP-reshard (all-gather ref's TP shards, slice for
+            # dist's TP) with PP-aware layer-index remap.
+            _copy_ref_llm_with_tp_and_pp_remap(
+                ref_mimo.language_model.module,
+                dist_mimo.language_model.module,
+                ref_llm_grid.get_pg("tp"),
+                dist_llm_grid.get_pg("tp"),
+                pp_rank=dist_llm_grid.get_pg("pp").rank(),
+                pp_size=llm_pp,
+                num_layers=num_layers,
+            )
 
-        _wire_training_hooks(dist_mimo, dist_language_pg, dist_vision_pg)
+        # PP>1 dist needs the broadcast-from-last-PP-stage variant of the
+        # finalize hook so num_tokens lands consistently on every rank.
+        # Ref is always PP=1 (no broadcast needed).
+        _wire_training_hooks(
+            dist_mimo,
+            dist_language_pg,
+            dist_vision_pg,
+            llm_grid=dist_llm_grid if llm_pp > 1 else None,
+        )
         _wire_training_hooks(ref_mimo, ref_language_pg, ref_vision_pg)
 
         # Distributed optimizers snapshot current param.data into fp32 master
@@ -1061,7 +1353,7 @@ class TestColocatedGradientScalingCorrectness:
         dist_optimizer = get_mimo_optimizer(dist_mimo, opt_config)
         ref_optimizer = get_mimo_optimizer(ref_mimo, opt_config)
 
-        # Data: one deterministic global batch, identical on every rank.
+        # Data: deterministic global batches, identical on every rank.
         torch.manual_seed(99999)
         global_batches = _generate_and_broadcast_global_batches(
             global_mbs=global_batch_size,
@@ -1083,16 +1375,23 @@ class TestColocatedGradientScalingCorrectness:
         ]
         ref_per_rank_batch_size = global_batch_size // enc_dp
 
-        # Logits capture: hook fires on every microbatch forward.
-        # Registered before forward/backward, removed right after so the
-        # hook doesn't leak across the second model's run.
-        dist_logits, dist_logits_hook = _register_logits_capture(dist_mimo)
-        ref_logits, ref_logits_hook = _register_logits_capture(ref_mimo)
-        dist_llm_input, dist_input_hook = _register_llm_input_capture(dist_mimo)
-        ref_llm_input, ref_input_hook = _register_llm_input_capture(ref_mimo)
+        # Capture hooks: only meaningful for PP=1 (output_layer / decoder
+        # captures fire on every microbatch; for PP>1 they fire only on
+        # specific PP stages of dist, breaking the per-microbatch
+        # alignment with ref's PP=1 captures). Skip registration for PP>1.
+        capture_hooks = []
+        if llm_pp == 1:
+            dist_logits, dist_logits_hook = _register_logits_capture(dist_mimo)
+            ref_logits, ref_logits_hook = _register_logits_capture(ref_mimo)
+            dist_llm_input, dist_input_hook = _register_llm_input_capture(dist_mimo)
+            ref_llm_input, ref_input_hook = _register_llm_input_capture(ref_mimo)
+            capture_hooks = [dist_logits_hook, ref_logits_hook, dist_input_hook, ref_input_hook]
+        else:
+            dist_logits = ref_logits = dist_llm_input = ref_llm_input = None
 
         try:
-            # One optimizer step on dist (heterogeneous forward_step slicing).
+            # One optimizer step on dist (PP=1: no-pipelining + forward_step;
+            # PP>1: three-phase schedule with internal narrowing).
             dist_optimizer.zero_grad()
             _run_forward_backward(
                 mimo_model=dist_mimo,
@@ -1115,7 +1414,7 @@ class TestColocatedGradientScalingCorrectness:
                 "silently zeroed by wrong scaling"
             )
 
-            # One optimizer step on ref (enc_dp == llm_dp → forward_step skips slicing).
+            # One optimizer step on ref (always PP=1, equal-DP).
             ref_optimizer.zero_grad()
             _run_forward_backward(
                 mimo_model=ref_mimo,
@@ -1133,18 +1432,14 @@ class TestColocatedGradientScalingCorrectness:
             assert ref_success, "Ref optimizer step failed"
             assert ref_grad_norm is not None and ref_grad_norm > 0, f"Ref grad_norm={ref_grad_norm}"
         finally:
-            dist_logits_hook.remove()
-            ref_logits_hook.remove()
-            dist_input_hook.remove()
-            ref_input_hook.remove()
+            for h in capture_hooks:
+                h.remove()
 
-        # Run all three oracles regardless of individual failures so the
-        # diff-stats print covers every layer. Order: encoder weights /
-        # first-layer grads first (tightest — same encoder TP/DP layout
-        # → shards align 1:1), then LLM logits last (loosest — different
-        # LLM TP layout drives fp32 accumulation drift). Each oracle
-        # printed its own min/mean/p95/p99/max before its assertion ran,
-        # so the user sees the full drift distribution for every test.
+        # Run all oracles regardless of individual failures so the diff-
+        # stats print covers every layer. Order: encoder weights / first-
+        # layer grads first (tightest — same encoder TP/DP layout → shards
+        # align 1:1), then LLM oracles (looser — different LLM TP layout
+        # drives fp32 accumulation drift).
         failures = []
 
         try:
@@ -1164,20 +1459,60 @@ class TestColocatedGradientScalingCorrectness:
         except AssertionError as e:
             failures.append(('first_layer_grads', str(e)))
 
-        try:
-            _assert_llm_input_match(
-                ref_llm_input, dist_llm_input, ref_llm_grid, dist_llm_grid, rtol=1e-3, atol=1e-3
-            )
-        except AssertionError as e:
-            failures.append(('llm_input', str(e)))
+        if llm_pp == 1:
+            # LLM input + logits oracles use TP+DP all-gather, so they
+            # work for any LLM TP layout. They expect one capture per
+            # microbatch, which only PP=1 satisfies.
+            try:
+                _assert_llm_input_match(
+                    ref_llm_input, dist_llm_input, ref_llm_grid, dist_llm_grid, rtol=1e-3, atol=1e-3
+                )
+            except AssertionError as e:
+                failures.append(('llm_input', str(e)))
 
-        try:
-            _assert_llm_logits_match(
-                ref_logits, dist_logits, ref_llm_grid, dist_llm_grid, rtol=1e-2, atol=1e-2
-            )
-        except AssertionError as e:
-            failures.append(('llm_logits', str(e)))
+            try:
+                _assert_llm_logits_match(
+                    ref_logits, dist_logits, ref_llm_grid, dist_llm_grid, rtol=1e-2, atol=1e-2
+                )
+            except AssertionError as e:
+                failures.append(('llm_logits', str(e)))
+        elif llm_tp == enc_tp:
+            # PP>1 with matching TP: assert LLM weights match ref via
+            # PP-aware layer-index remap. (LLM forward differs between
+            # 1F1B and no-pipelining, plus TP shards may accumulate in
+            # different order; tolerances absorb that drift even in fp32.)
+            try:
+                _assert_llm_weights_match_pp_aware(
+                    ref_mimo.language_model.module,
+                    dist_mimo.language_model.module,
+                    pp_rank=dist_llm_grid.get_pg("pp").rank(),
+                    pp_size=llm_pp,
+                    num_layers=num_layers,
+                    rtol=1e-2,
+                    atol=1e-2,
+                )
+            except AssertionError as e:
+                failures.append(('llm_weights_pp_aware', str(e)))
+        # else: PP>1 with mismatched TP (fan-out on 8 GPUs). The init copy
+        # via _copy_ref_llm_with_tp_and_pp_remap aligns starting state, but
+        # post-step shape comparison would require the same TP-reshard of
+        # ref's PP=1 weights. Skipped here — encoder weight oracle alone
+        # is sufficient end-to-end (it requires a working LLM forward +
+        # backward + bridge for the encoder grads to land correctly).
 
         if failures:
             summary = "\n\n".join(f"== {oracle} ==\n{msg}" for oracle, msg in failures)
+            # Print before raising so the message lands in stdout even when
+            # post-test cleanup blows up (NCCL teardown across asymmetric
+            # pass/fail ranks can SIGABRT before pytest formats the
+            # traceback).
+            rank = dist.get_rank()
+            print(
+                f"\n=== rank {rank} test_dist_matches failures ===\n"
+                f"config: enc_tp={enc_tp} enc_dp={enc_dp} llm_tp={llm_tp} "
+                f"llm_pp={llm_pp} llm_dp={llm_dp} mbs={num_microbatches} mask={mask_pattern}\n"
+                f"{summary}\n"
+                f"=== end rank {rank} failures ===\n",
+                flush=True,
+            )
             raise AssertionError(f"{len(failures)} oracle(s) failed:\n{summary}")

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
@@ -61,7 +61,7 @@ from packaging import version
 
 import megatron.core.pipeline_parallel.schedules as schedule
 from megatron.core.distributed import DistributedDataParallelConfig
-from megatron.core.distributed.finalize_model_grads import finalize_model_grads
+from megatron.core.models.mimo._finalize import finalize_mimo_grads
 from megatron.core.models.mimo.colocated_schedule import colocated_forward_backward_with_pp
 from megatron.core.models.mimo.optimizer import get_mimo_optimizer
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
@@ -202,59 +202,21 @@ def _wire_training_hooks(mimo_model, language_pg, vision_pg, llm_grid=None):
     """
 
     no_sync_func = build_no_sync_func(mimo_model)
-    pp_group = llm_grid.get_pg("pp") if llm_grid is not None else None
 
     def finalize_grads_func(model_list, num_tokens, force_all_reduce=False, **kwargs):
-        # Schedule passes the per-rank sum-across-microbatches of what the
-        # loss_func returned. Because loss_func runs only on the LLM side,
-        # this is the LLM-local token count.
-        assert num_tokens is not None, (
-            "finalize_grads_func expects calculate_per_token_loss=True on the "
-            "TransformerConfig so the schedule forwards total_num_tokens; got None."
+        # Delegate to the production colocated finalize helper. This both
+        # exercises finalize_mimo_grads against the oracle (any divergence
+        # surfaces as a weight/grad mismatch) and keeps a single source of
+        # truth for the heterogeneous-DP grad-scaling story. The helper sources
+        # the LLM PP group from ``language_pg.pp``; the PP>1 cases below confirm
+        # that matches ``llm_grid.get_pg('pp')``.
+        finalize_mimo_grads(
+            mimo_model,
+            num_tokens,
+            language_pg=language_pg,
+            vision_pg=vision_pg,
+            force_all_reduce=force_all_reduce,
         )
-
-        # PP>1: only the last LLM PP stage emits a non-zero num_tokens
-        # from the loss_func. Broadcast to earlier stages so every rank
-        # holds the same value before the DP all-reduce below.
-        if pp_group is not None and pp_group.size() > 1:
-            last_rank = dist.get_global_rank(pp_group, pp_group.size() - 1)
-            dist.broadcast(num_tokens, src=last_rank, group=pp_group)
-
-        # Phase 1: lift the all-reduce. After this, every rank (including
-        # encoder-only replicas) has N_global = total non-padded tokens in
-        # the global batch.
-        llm_dp_pg = language_pg.dp_cp if language_pg.dp_cp is not None else language_pg.dp
-        dist.all_reduce(num_tokens, group=llm_dp_pg, op=dist.ReduceOp.SUM)
-        n_global = num_tokens.item()
-
-        # Phase 2: per-side DDP finish without built-in num_tokens scaling.
-        # Forward ``force_all_reduce`` so PP grad-sync semantics (if ever
-        # exercised here) aren't silently dropped.
-        if mimo_model.language_model is not None:
-            finalize_model_grads(
-                [mimo_model.language_model],
-                num_tokens=None,
-                pg_collection=language_pg,
-                force_all_reduce=force_all_reduce,
-            )
-        for submodule in mimo_model.modality_submodules.values():
-            if submodule is not None:
-                finalize_model_grads(
-                    [submodule],
-                    num_tokens=None,
-                    pg_collection=vision_pg,
-                    force_all_reduce=force_all_reduce,
-                )
-
-        # Phase 3: uniform divide by N_global. Guard div-by-zero for the
-        # degenerate fully-masked batch.
-        if n_global > 0:
-            inv = 1.0 / n_global
-            if mimo_model.language_model is not None:
-                mimo_model.language_model.scale_gradients(inv)
-            for submodule in mimo_model.modality_submodules.values():
-                if submodule is not None:
-                    submodule.scale_gradients(inv)
 
     mimo_model.config.no_sync_func = no_sync_func
     mimo_model.config.finalize_model_grads_func = finalize_grads_func

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_fanout_packing.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_fanout_packing.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""Adversarial test for NMFW-19 fan-out passthrough narrowing in
+``_build_lm_microbatches`` / ``_passthrough``.
+
+Finding under test
+------------------
+Under fan-out (``llm_dp > enc_dp``) the three-phase colocated schedule
+narrows the bridge-side encoder embeddings to each LLM-DP rank's slot, and
+``_build_lm_microbatches`` narrows the LLM-side passthrough tensors
+(``input_ids``, ``labels``, ``loss_mask``, ``position_ids``,
+``attention_mask``) to the SAME slot via ``_maybe_narrow`` so they line up.
+
+However ``_passthrough`` (colocated_schedule.py:318-328):
+
+  * hard-codes exactly six fields. Any OTHER per-sample field present in the
+    batch dict is silently dropped from the LM microbatch.
+  * forwards ``packing_kwargs`` UN-narrowed (L327): ``b.get('packing_kwargs')``
+    with no ``_maybe_narrow`` call, even though ``input_ids`` / ``labels`` /
+    ``loss_mask`` / ``position_ids`` in the SAME microbatch ARE narrowed.
+
+For packed (THD) sequences the ``cu_seqlens`` / per-sample metadata inside
+``packing_kwargs`` describes the FULL encoder-DP batch, while ``input_ids``
+afterwards describes only this LLM-DP slot. The two desync: the packing
+metadata claims more samples / a longer cumulative sequence length than the
+narrowed ``input_ids`` actually contains, which under THD attention indexes
+out of range.
+
+This test exercises the bug at the HELPER level (``_build_lm_microbatches``)
+with a real fan-out grid (enc_dp=1, llm_dp=2). It asserts the invariant that
+should hold under fan-out: every per-sample field the LLM consumes lines up
+with the narrowed ``input_ids``. If the code is correct (narrows or rejects
+packing_kwargs, and does not drop arbitrary fields) the test PASSES; if the
+finding is real the documented assertions FAIL with a clear message.
+
+Smallest config that exhibits it: enc_tp=1, enc_dp=1, llm_tp=1, llm_pp=1,
+llm_dp=2 (fan-out scale=2). Runs on 2 GPUs; no model is built — only the
+schedule helper is called, so runtime is sub-second.
+
+Run with::
+
+    uv run python -m torch.distributed.run --nproc_per_node=2 \\
+        -m pytest tests/unit_tests/models/mimo/\\
+test_mimo_colocated_fanout_packing.py -v -s
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from packaging import version
+
+from megatron.core.models.mimo.colocated_schedule import _build_lm_microbatches, _fan_out_slot
+from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
+    create_all_embedding_groups,
+    create_hypercomm_grid,
+    destroy_all_grids,
+)
+from tests.unit_tests.test_utilities import Utils
+
+
+def _make_packing_kwargs(total_batch, seq_per_sample):
+    """Build THD-style packing metadata sized for the FULL enc-DP batch.
+
+    ``cu_seqlens`` is the cumulative sequence-length prefix-sum over all
+    ``total_batch`` samples (length ``total_batch + 1``); ``max_seqlen`` and
+    ``num_samples`` describe the same full batch. This is exactly what the
+    encoder-DP-sized data iterator would emit for a packed sequence before
+    any fan-out narrowing.
+    """
+    cu_seqlens = torch.arange(
+        0, (total_batch + 1) * seq_per_sample, seq_per_sample, device='cuda', dtype=torch.int32
+    )
+    return {
+        'cu_seqlens': cu_seqlens,
+        'cu_seqlens_q': cu_seqlens.clone(),
+        'cu_seqlens_kv': cu_seqlens.clone(),
+        'max_seqlen': seq_per_sample,
+        'max_seqlen_q': seq_per_sample,
+        'max_seqlen_kv': seq_per_sample,
+        'num_samples': total_batch,
+    }
+
+
+class TestFanOutPassthroughNarrowing:
+    """Helper-level fan-out narrowing-consistency checks for ``_passthrough``."""
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_distributed()
+        cls.world_size = dist.get_world_size()
+
+    @classmethod
+    def teardown_class(cls):
+        Utils.destroy_model_parallel()
+
+    def setup_method(self):
+        os.environ.pop('NVTE_FLASH_ATTN', None)
+        os.environ.pop('NVTE_FUSED_ATTN', None)
+        os.environ.pop('NVTE_UNFUSED_ATTN', None)
+
+    def teardown_method(self):
+        destroy_all_grids()
+
+    @pytest.mark.skipif(
+        version.parse(torch.__version__) < version.parse("2.3.0"), reason="Requires PyTorch 2.3+"
+    )
+    def test_packing_kwargs_and_arbitrary_fields_narrowed_under_fan_out(self):
+        """Fan-out (enc_dp=1, llm_dp=2): every per-sample field must line up
+        with the narrowed ``input_ids``.
+
+        Builds a single microbatch whose passthrough tensors and
+        ``packing_kwargs`` are sized for the full encoder-DP batch
+        (``total_batch`` samples). After ``_build_lm_microbatches`` the
+        ``input_ids`` are narrowed to ``total_batch / 2`` samples (fan-out
+        scale=2). We then assert:
+
+          1. ``packing_kwargs`` describes the SAME number of samples as the
+             narrowed ``input_ids`` (it won't — it's forwarded un-narrowed,
+             still claiming ``total_batch`` samples -> THD desync).
+          2. an arbitrary extra per-sample field (``token_type_ids``) survives
+             into the microbatch and is narrowed (it won't — ``_passthrough``
+             drops any field outside the hard-coded six).
+
+        Either failing assertion proves the finding; if the schedule narrows
+        packing metadata and preserves/narrows arbitrary fields (or rejects
+        the combination), both assertions pass and the finding is disproved.
+        """
+        if self.world_size < 2:
+            pytest.skip(f"Requires >=2 GPUs for fan-out (llm_dp=2), got {self.world_size}")
+
+        rank = dist.get_rank()
+
+        # Fan-out: encoder DP=1, LLM DP=2 — both grids must span BOTH ranks.
+        # The encoder is replicated (dp=1) so it uses tp=2 to cover {0,1};
+        # the LLM splits {0,1} into 2 DP ranks (tp=1, dp=2). enc_dp=1 < llm_dp=2
+        # gives fan-out scale=2. (enc_tp=1,dp=1 would span only rank 0, leaving
+        # enc_grid.get_pg('dp') None on rank 1.)
+        enc_grid = create_hypercomm_grid(offset=0, tp=2, cp=1, pp=1, dp=1)
+        llm_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=2)
+        create_all_embedding_groups([enc_grid, llm_grid])
+
+        # Confirm we really are in the fan-out regime that triggers narrowing.
+        scale, slot = _fan_out_slot(enc_grid, llm_grid)
+        assert scale == 2, f"Expected fan-out scale=2, got {scale} (config not fan-out?)"
+
+        # Full encoder-DP-sized batch: total_batch samples, seq_per_sample
+        # tokens each. The data iterator under fan-out yields this size; the
+        # bridge narrows encoder embeddings on the LLM side and the schedule
+        # is responsible for narrowing the LLM-side fields to match.
+        total_batch = 4  # divisible by scale=2 -> narrowed batch = 2
+        seq_per_sample = 8
+        narrowed_batch = total_batch // scale
+
+        input_ids = torch.arange(
+            total_batch * seq_per_sample, device='cuda', dtype=torch.long
+        ).reshape(total_batch, seq_per_sample)
+        labels = input_ids.clone()
+        loss_mask = torch.ones(total_batch, seq_per_sample, device='cuda', dtype=torch.float32)
+        position_ids = (
+            torch.arange(seq_per_sample, device='cuda').unsqueeze(0).expand(total_batch, -1).clone()
+        )
+        # Arbitrary extra per-sample field the LLM might consume (e.g. a
+        # multimodal token-type tensor). Per-sample dim-0 == total_batch.
+        token_type_ids = torch.zeros(total_batch, seq_per_sample, device='cuda', dtype=torch.long)
+
+        packing_kwargs = _make_packing_kwargs(total_batch, seq_per_sample)
+
+        batch = {
+            'input_ids': input_ids,
+            'labels': labels,
+            'loss_mask': loss_mask,
+            'position_ids': position_ids,
+            'attention_mask': None,
+            'token_type_ids': token_type_ids,
+            'packing_kwargs': packing_kwargs,
+        }
+
+        # Encoder output sized for THIS LLM-DP slot (the bridge already
+        # narrowed it to narrowed_batch). 3D [seq, batch, hidden].
+        hidden = 16
+        detached_full = {
+            'images': torch.randn(
+                seq_per_sample, narrowed_batch, hidden, device='cuda', dtype=torch.float32
+            )
+        }
+
+        # --- Contract after fix: fan-out + sequence packing is REJECTED ---
+        # cu_seqlens / num_samples describe the full encoder-DP batch and cannot be
+        # slot-narrowed without recomputing THD offsets, so _build_lm_microbatches
+        # raises NotImplementedError rather than silently desyncing packed attention.
+        with pytest.raises(NotImplementedError, match="sequence packing"):
+            _build_lm_microbatches(
+                detached_full, [batch], num_microbatches=1, encoder_grid=enc_grid, llm_grid=llm_grid
+            )
+
+        # --- Without packing, the per-sample fields narrow correctly to the slot ---
+        batch_no_pack = {k: v for k, v in batch.items() if k != 'packing_kwargs'}
+        mb = _build_lm_microbatches(
+            detached_full,
+            [batch_no_pack],
+            num_microbatches=1,
+            encoder_grid=enc_grid,
+            llm_grid=llm_grid,
+        )[0]
+        for field in ('input_ids', 'labels', 'loss_mask', 'position_ids'):
+            assert mb[field].shape[0] == narrowed_batch, (
+                f"rank {rank}: {field} should be narrowed to {narrowed_batch} samples "
+                f"on the batch dim, got {mb[field].shape[0]}"
+            )
+        print(
+            f"\n=== rank {rank} fan-out packing rejection + narrowing OK ===\n"
+            f"narrowed_batch={narrowed_batch}, total_batch={total_batch}, "
+            f"scale={scale}, slot={slot}\n=== end rank {rank} ===\n",
+            flush=True,
+        )

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_fanout_position_ids.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_fanout_position_ids.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Adversarial test (NMFW-19): fan-out narrows 3D mRoPE position_ids wrongly.
+
+Finding under test
+------------------
+``_build_lm_microbatches`` in ``megatron/core/models/mimo/colocated_schedule.py``
+narrows every LLM-side passthrough field (``input_ids``, ``labels``,
+``loss_mask``, ``position_ids``) for fan-out (``llm_dp > enc_dp``) via the
+inner helper ``_maybe_narrow``, which unconditionally slices ``tensor`` on
+``dim=0``::
+
+    bs = tensor.shape[0]
+    ss = bs // fan_out_scale
+    return tensor[fan_out_slot * ss : (fan_out_slot + 1) * ss].contiguous()
+
+This is correct for 2D ``[batch, seq]`` fields, where ``dim=0`` is the batch.
+
+For **multimodal RoPE** the language model consumes ``position_ids`` shaped
+``[rope_dim, batch, seq]`` — exactly the layout ``MimoModel.get_text_embeddings``
+explicitly supports at ``model/base.py:311-314`` (it indexes
+``position_ids[0, batch_idx, seq_idx]`` for the 3D case). For that layout
+``dim=0`` is ``rope_dim``, **not** the batch dimension. ``_maybe_narrow``
+therefore slices away RoPE channels and leaves the batch dimension
+un-narrowed, so the LLM-side ``position_ids`` no longer line up with the
+bridge-narrowed encoder embeddings or with the (correctly narrowed)
+``input_ids`` / ``labels`` / ``loss_mask``.
+
+Note that ``attention_mask`` got a dedicated ``_maybe_narrow_attn`` guard for
+non-batch-first layouts; ``position_ids`` got none.
+
+What this test does
+-------------------
+Rather than spin up a full model, it drives the pure tensor-narrowing function
+``_build_lm_microbatches`` directly with real HyperCommGrids in a fan-out
+config (``enc_tp=4, enc_dp=2`` / ``llm_tp=1, llm_pp=2, llm_dp=4`` on 8 GPUs,
+``fan_out_scale = llm_dp // enc_dp = 2``). It feeds a 3D mRoPE
+``position_ids`` of shape ``[rope_dim=3, batch=B, seq]`` alongside 2D
+``input_ids`` / ``labels`` / ``loss_mask`` of shape ``[batch=B, seq]``.
+
+Correct behavior: the narrowed ``position_ids`` is ``[3, B//scale, seq]`` —
+``rope_dim`` intact (still 3), batch halved, lining up with the narrowed 2D
+fields whose batch is also ``B//scale``.
+
+Buggy behavior (current code): ``_maybe_narrow`` slices ``dim=0`` (rope_dim),
+yielding ``[3//scale, B, seq] = [1, B, seq]`` — rope channels destroyed and
+batch left un-narrowed. The assertion below fails with a clear message.
+
+If the code is fixed (e.g. an ndim/shape-aware narrow that targets the batch
+dim), this test PASSES — disproving the finding.
+
+Run with::
+
+    uv run python -m torch.distributed.run --nproc_per_node=8 \\
+        -m pytest tests/unit_tests/models/mimo/test_mimo_colocated_fanout_position_ids.py -v -s
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from packaging import version
+
+from megatron.core.models.mimo.colocated_schedule import _build_lm_microbatches
+from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
+    create_all_embedding_groups,
+    create_hypercomm_grid,
+    destroy_all_grids,
+)
+from tests.unit_tests.test_utilities import Utils
+
+ROPE_DIM = 3
+
+
+def _set_deterministic_env():
+    for k, v in {
+        "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+        "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+    }.items():
+        os.environ[k] = v
+
+
+def _make_batch(enc_per_rank_batch, seq_length, hidden_size, encoder_name, image_seq_length):
+    """Build one encoder-DP-sized per-rank batch with a 3D mRoPE position_ids.
+
+    ``position_ids`` is shaped ``[rope_dim, batch, seq]`` — the multimodal-RoPE
+    layout consumed at ``model/base.py:311-314``. The 2D fields
+    (``input_ids`` / ``labels`` / ``loss_mask``) keep the conventional
+    ``[batch, seq]`` layout so the test can verify that, after narrowing, the
+    batch dimension of every field agrees.
+    """
+    input_ids = torch.arange(
+        enc_per_rank_batch * seq_length, device='cuda', dtype=torch.long
+    ).reshape(enc_per_rank_batch, seq_length)
+    labels = input_ids.clone()
+    loss_mask = torch.ones(enc_per_rank_batch, seq_length, device='cuda', dtype=torch.float32)
+
+    # 3D mRoPE position_ids: [rope_dim, batch, seq]. Encode (rope_channel,
+    # batch_idx) into the values so a wrong-dim slice is detectable by content
+    # as well as by shape.
+    rope = torch.arange(ROPE_DIM, device='cuda', dtype=torch.long).view(ROPE_DIM, 1, 1)
+    bidx = torch.arange(enc_per_rank_batch, device='cuda', dtype=torch.long).view(1, -1, 1)
+    sidx = torch.arange(seq_length, device='cuda', dtype=torch.long).view(1, 1, -1)
+    position_ids = rope * 1_000_000 + bidx * 1_000 + sidx
+    assert position_ids.shape == (ROPE_DIM, enc_per_rank_batch, seq_length)
+
+    encoder_hidden = torch.randn(
+        image_seq_length, enc_per_rank_batch, hidden_size, device='cuda', dtype=torch.float32
+    )
+    return {
+        "input_ids": input_ids,
+        "labels": labels,
+        "loss_mask": loss_mask,
+        "position_ids": position_ids,
+        "modality_inputs": {
+            encoder_name: {
+                "clip_encoder": {"hidden_states": encoder_hidden, "attention_mask": None}
+            }
+        },
+    }
+
+
+class TestFanOutNarrows3DmRoPEPositionIds:
+    """Fan-out must narrow 3D ``[rope_dim, batch, seq]`` position_ids on batch."""
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_distributed()
+        cls.world_size = dist.get_world_size()
+
+    @classmethod
+    def teardown_class(cls):
+        Utils.destroy_model_parallel()
+
+    def setup_method(self):
+        _set_deterministic_env()
+
+    def teardown_method(self):
+        destroy_all_grids()
+
+    @pytest.mark.skipif(
+        version.parse(torch.__version__) < version.parse("2.3.0"), reason="Requires PyTorch 2.3+"
+    )
+    def test_fan_out_narrows_position_ids_on_batch_not_rope_dim(self):
+        """3D mRoPE position_ids must be narrowed on batch (dim=1), not rope_dim.
+
+        Fan-out config ``enc_dp=2`` / ``llm_dp=4`` → ``fan_out_scale=2``.
+
+        Expected (correct): narrowed position_ids has shape
+        ``[ROPE_DIM, enc_batch // scale, seq]`` — rope_dim intact, batch halved,
+        agreeing with the narrowed 2D ``input_ids`` batch.
+
+        Actual (buggy current code): ``_maybe_narrow`` slices dim 0 (rope_dim),
+        yielding ``[ROPE_DIM // scale, enc_batch, seq] = [1, enc_batch, seq]`` —
+        rope channels dropped, batch un-narrowed. The shape assertion fails.
+        """
+        if self.world_size != 8:
+            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
+
+        encoder_name = "images"
+        enc_tp, enc_dp = 4, 2
+        llm_tp, llm_pp, llm_dp = 1, 2, 4
+        scale = llm_dp // enc_dp  # 2
+        assert scale >= 2, "fan-out scale must be >=2 to exercise the bug"
+
+        hidden_size, seq_length = 32, 8
+        image_seq_length = seq_length // 2
+        num_microbatches = 1
+        # Encoder-DP per-rank batch must be divisible by fan_out_scale (so the
+        # narrowed batch is non-degenerate) and by num_microbatches.
+        enc_per_rank_batch = scale * num_microbatches * 2  # 4
+
+        enc_grid = create_hypercomm_grid(offset=0, tp=enc_tp, cp=1, pp=1, dp=enc_dp)
+        llm_grid = create_hypercomm_grid(offset=0, tp=llm_tp, cp=1, pp=llm_pp, dp=llm_dp)
+        create_all_embedding_groups([enc_grid, llm_grid])
+
+        rank = dist.get_rank()
+        try:
+            all_batches = [
+                _make_batch(
+                    enc_per_rank_batch, seq_length, hidden_size, encoder_name, image_seq_length
+                )
+                for _ in range(num_microbatches)
+            ]
+
+            # Stand in for the bridge-narrowed encoder embeddings: fan-out
+            # narrows encoder output to the LLM-DP rank's slot, so the detached
+            # embeddings the LLM consumes have batch == enc_per_rank_batch //
+            # scale. 3D [seq, batch, hidden] layout (the bridge's 3D output).
+            llm_batch = enc_per_rank_batch // scale
+            detached_full = {
+                "clip_encoder": torch.randn(
+                    image_seq_length, llm_batch, hidden_size, device='cuda', dtype=torch.float32
+                ).requires_grad_(True)
+            }
+
+            lm_data = _build_lm_microbatches(
+                detached_full, all_batches, num_microbatches, enc_grid, llm_grid
+            )
+
+            assert len(lm_data) == num_microbatches
+            mb = lm_data[0]
+            pos = mb["position_ids"]
+            ids = mb["input_ids"]
+            enc_emb = mb["encoder_embeddings"]["clip_encoder"]
+
+            # The 2D fields are narrowed correctly on dim 0 (batch).
+            assert ids.shape == (
+                llm_batch,
+                seq_length,
+            ), f"input_ids should narrow batch to {llm_batch}; got {tuple(ids.shape)}"
+            # The encoder embeddings carry batch == llm_batch on dim 1.
+            assert enc_emb.shape[1] == llm_batch, (
+                f"encoder_embeddings batch (dim1) should be {llm_batch}; "
+                f"got {tuple(enc_emb.shape)}"
+            )
+
+            # CORE ASSERTION: 3D mRoPE position_ids must keep rope_dim intact
+            # and narrow the BATCH dim so it lines up with input_ids and the
+            # bridge-narrowed encoder embeddings.
+            #
+            # Buggy code slices dim 0 (rope_dim) → shape [ROPE_DIM//scale,
+            # enc_per_rank_batch, seq] = [1, 4, 8], failing this assertion.
+            expected = (ROPE_DIM, llm_batch, seq_length)
+            assert pos.shape == expected, (
+                f"Rank {rank}: 3D mRoPE position_ids narrowed on the WRONG "
+                f"dimension. Expected {expected} (rope_dim intact, batch "
+                f"halved), but got {tuple(pos.shape)}. _maybe_narrow sliced "
+                f"dim=0 (rope_dim) instead of the batch dim. enc_batch="
+                f"{enc_per_rank_batch}, fan_out_scale={scale}."
+            )
+
+            # Stronger content check: the surviving slice must contain ALL
+            # rope channels (0..ROPE_DIM-1) and a CONTIGUOUS batch sub-range of
+            # size llm_batch, matching this LLM-DP rank's fan-out slot.
+            rope_channels = (pos[:, 0, 0] // 1_000_000).tolist()
+            assert rope_channels == list(range(ROPE_DIM)), (
+                f"Rank {rank}: rope channels corrupted — expected "
+                f"{list(range(ROPE_DIM))}, got {rope_channels}. The narrow "
+                f"sliced rope_dim instead of batch."
+            )
+            batch_ids_present = ((pos[0, :, 0] // 1_000) % 1_000).tolist()
+            assert len(batch_ids_present) == llm_batch, (
+                f"Rank {rank}: position_ids batch dim should be {llm_batch}; "
+                f"got {len(batch_ids_present)} entries: {batch_ids_present}."
+            )
+
+            _passed = True
+        except Exception:
+            import traceback as _tb
+
+            print(
+                f"\n=== rank {rank} TEST EXCEPTION ===\n"
+                f"config: enc_tp={enc_tp} enc_dp={enc_dp} llm_tp={llm_tp} "
+                f"llm_pp={llm_pp} llm_dp={llm_dp}\n{_tb.format_exc()}\n"
+                f"=== end rank {rank} exception ===\n",
+                flush=True,
+            )
+            _passed = False
+
+        # Reduce pass/fail across ranks so a single-rank failure fails the test
+        # everywhere (avoids asymmetric NCCL teardown hiding the assertion).
+        flag = torch.tensor([1 if _passed else 0], device='cuda', dtype=torch.int)
+        dist.all_reduce(flag, op=dist.ReduceOp.MIN)
+        assert flag.item() == 1, (
+            "Fan-out 3D mRoPE position_ids narrowing failed on at least one "
+            "rank (see per-rank TEST EXCEPTION above)."
+        )

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_per_token_loss.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_per_token_loss.py
@@ -1,0 +1,443 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""Adversarial test for the ``calculate_per_token_loss=False`` claim in
+``colocated_schedule._loss_func`` (NMFW-19 / PR #4784).
+
+``_loss_func``'s docstring (colocated_schedule.py:381-383) asserts that the
+3-tuple return is "also safe for standard per-microbatch-mean configs", i.e.
+that the colocated PP>1 / heterogeneous-DP schedule works correctly with the
+production-default loss configuration ``calculate_per_token_loss=False``.
+
+This test empirically checks that claim under FAN-OUT DP (``enc_dp != llm_dp``)
+using the STOCK production grad-finalize path (``finalize_model_grads`` per
+sub-model, no custom uniform ``1/N_global`` divide). It is the same
+encoder-weight oracle the existing correctness test uses for
+``per_token_loss=True``, but with the production default loss config and the
+default scaling story instead of the bespoke one.
+
+Why this surfaces the bug
+--------------------------
+With ``calculate_per_token_loss=False``:
+
+  * The schedule divides each microbatch loss by the LLM-local
+    ``num_tokens`` and by ``num_microbatches`` (schedules.py:295-299). That
+    divisor is computed from the LLM rank's local slice — and in fan-out the
+    LLM is split into MORE DP slices than the encoder, so each LLM rank's
+    local token count is smaller than an encoder rank's.
+  * Each sub-model's DDP then applies ``gradient_scaling_factor =
+    1/dp_size`` of ITS OWN DP group (distributed_data_parallel.py:203). The
+    LLM grads are scaled by ``1/llm_dp``; the encoder grads (flowing from the
+    same loss through the detached embedding grad) are reduced over the
+    encoder DP group and scaled by ``1/enc_dp``.
+
+Because ``enc_dp != llm_dp`` in fan-out, the encoder:LLM effective scale is
+``llm_dp/enc_dp != 1``. The stock per-side finalize has no uniform divide to
+re-normalize the two sides, so the encoder update lands off by that factor
+relative to an equal-DP reference where the bridge is the identity and
+``enc_dp == llm_dp``.
+
+The existing correctness test masks this by running ONLY with
+``per_token_loss=True`` (which pins ``gradient_scaling_factor=1.0`` on both
+DDPs and applies an external uniform ``1/N_global`` divide to both sides),
+asserting ``num_tokens is not None`` at L211.
+
+Config (smallest fan-out that isolates the bug, PP=1, 8 GPUs)
+-------------------------------------------------------------
+Dist: ``enc_tp=4, enc_dp=2, llm_tp=2, llm_pp=1, llm_dp=4`` (fan-out, scale=2).
+Ref:  equal-DP uniform ``enc_tp=4, enc_dp=2, llm_tp=4, llm_pp=1, llm_dp=2``
+      (identity bridge). Encoder TP/DP match dist exactly, so encoder shards
+      align 1:1 and the encoder oracles compare shard-to-shard with no
+      gather-and-slice. The LLM TP differs (ref=4 vs dist=2), so the LLM
+      starting state is copied with the same two-phase TP-reshard the
+      existing correctness test uses (all-gather ref's TP shards across
+      ``ref_tp_group``, slice for dist's TP) — any encoder-side divergence is
+      then pure grad-scaling skew, not TP accumulation drift.
+
+Why the ref MUST span all 8 ranks (deadlock fix)
+------------------------------------------------
+The reference grids are built as ``tp=enc_tp, dp=enc_dp``. With
+``enc_tp * enc_dp == 8`` the reference covers every world rank, so the
+ref-side collectives in the parameter-copy oracle (the TP all-gather inside
+``_copy_ref_params_to_dist``) are issued in lockstep by all 8 ranks. The
+earlier ``enc_tp=2, enc_dp=2`` reference spanned only ranks 0-3 while the
+dist LLM spanned all 8 — so ranks 4-7 iterated dist params with no ref
+all-gather partner and the copy deadlocked (ranks 0-3 stuck in ALLGATHER,
+ranks 4-5 elsewhere). Matching the existing correctness test's
+``enc_tp * enc_dp == 8`` invariant keeps every collective symmetric.
+
+Observable signal
+------------------
+After one Adam step, the dist encoder's first-layer ``layers.0.*`` shards are
+compared against the equal-DP reference's matching shards. If the finding is
+correct the encoder weights diverge well beyond ``rtol=atol=1e-3`` (expected
+relative skew ~ ``llm_dp/enc_dp = 2``). If the schedule is actually correct
+under ``per_token_loss=False`` the weights match and the test PASSES,
+disproving the finding.
+
+Run with::
+
+    uv run python -m torch.distributed.run --nproc_per_node=8 \\
+        -m pytest tests/unit_tests/models/mimo/\\
+test_mimo_colocated_per_token_loss.py -v -s
+"""
+
+import os
+from functools import partial
+
+import pytest
+import torch
+import torch.distributed as dist
+from packaging import version
+
+import megatron.core.pipeline_parallel.schedules as schedule
+from megatron.core.distributed import DistributedDataParallelConfig
+from megatron.core.distributed.finalize_model_grads import finalize_model_grads
+from megatron.core.models.mimo.optimizer import get_mimo_optimizer
+from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from megatron.core.transformer.enums import ModelType
+from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
+    build_no_sync_func,
+    create_all_embedding_groups,
+    create_hypercomm_grid,
+    destroy_all_grids,
+    get_mimo_model,
+)
+from tests.unit_tests.models.mimo.test_mimo_colocated_correctness import (
+    _assert_encoder_weights_match,
+    _assert_first_layer_grads_match,
+    _copy_ref_params_to_dist,
+    _generate_and_broadcast_global_batches,
+    _set_deterministic_env,
+    _slice_global_batch_by_dp,
+    _slice_global_batch_for_dist,
+    _snapshot_first_layer_encoder_grads,
+    forward_step,
+)
+from tests.unit_tests.test_utilities import Utils
+
+
+def _wire_production_default_hooks(mimo_model, language_pg, vision_pg):
+    """Attach the PRODUCTION-DEFAULT finalize: stock ``finalize_model_grads``
+    per sub-model, with NO custom uniform ``1/N_global`` divide.
+
+    This is the path the ``_loss_func`` docstring claims is safe for
+    ``calculate_per_token_loss=False`` configs. Each DDP applies its own
+    ``gradient_scaling_factor = 1/dp_size`` (distributed_data_parallel.py:203);
+    the schedule already divided the per-microbatch loss by the LLM-local
+    ``num_tokens`` and ``num_microbatches`` (schedules.py:295-299). Nothing
+    here re-normalizes encoder vs LLM relative scale across differing DP
+    sizes — that is exactly the property under test.
+    """
+    no_sync_func = build_no_sync_func(mimo_model)
+
+    def finalize_grads_func(model_list, num_tokens, force_all_reduce=False, **kwargs):
+        # Production default: forward the schedule's num_tokens straight into
+        # the stock finalize per side. For calculate_per_token_loss=False the
+        # schedule already applied the per-microbatch mean, so finalize does
+        # the usual DP all-reduce + layernorm/embedding sync with the DDP's
+        # built-in 1/dp_size scaling and no extra divide.
+        if mimo_model.language_model is not None:
+            finalize_model_grads(
+                [mimo_model.language_model],
+                num_tokens=None,
+                pg_collection=language_pg,
+                force_all_reduce=force_all_reduce,
+            )
+        for submodule in mimo_model.modality_submodules.values():
+            if submodule is not None:
+                finalize_model_grads(
+                    [submodule],
+                    num_tokens=None,
+                    pg_collection=vision_pg,
+                    force_all_reduce=force_all_reduce,
+                )
+
+    mimo_model.config.no_sync_func = no_sync_func
+    mimo_model.config.finalize_model_grads_func = finalize_grads_func
+    mimo_model.config.grad_scale_func = lambda loss: (
+        torch.tensor(loss, dtype=torch.float32, device='cuda', requires_grad=True)
+        if isinstance(loss, (int, float))
+        else loss
+    )
+
+
+class _BatchIterator:
+    """Minimal iterator over a pre-generated list of batches."""
+
+    def __init__(self, batches):
+        self.batches = batches
+        self.idx = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.idx >= len(self.batches):
+            raise StopIteration
+        b = self.batches[self.idx]
+        self.idx += 1
+        return b
+
+
+class TestColocatedPerTokenLossFalseScaling:
+    """Disprove-or-confirm: does the colocated fan-out path scale encoder vs
+    LLM grads consistently under ``calculate_per_token_loss=False``?
+    """
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_distributed()
+        cls.world_size = dist.get_world_size()
+
+    @classmethod
+    def teardown_class(cls):
+        Utils.destroy_model_parallel()
+
+    def setup_method(self):
+        self._mimo_models = []
+
+    def teardown_method(self):
+        torch.use_deterministic_algorithms(False)
+        for model in self._mimo_models:
+            model.destroy()
+        self._mimo_models.clear()
+        destroy_all_grids()
+
+    @pytest.mark.skipif(
+        version.parse(torch.__version__) < version.parse("2.3.0"), reason="Requires PyTorch 2.3+"
+    )
+    def test_fan_out_per_token_loss_false_encoder_weights_match_equal_dp_ref(self):
+        """Fan-out + ``per_token_loss=False`` + stock finalize: dist encoder
+        post-step weights must match an equal-DP reference.
+
+        Smallest isolating config (8 GPUs, PP=1):
+          * Dist: enc_tp=4, enc_dp=2, llm_tp=2, llm_pp=1, llm_dp=4 (fan-out).
+          * Ref:  enc_tp=4, enc_dp=2, llm_tp=4, llm_pp=1, llm_dp=2 (identity
+            bridge, equal DP). Encoder TP/DP layout matches dist exactly, so
+            the encoder oracles are pure grad-scaling-skew detectors. The
+            reference spans all 8 ranks (enc_tp * enc_dp == 8), so the LLM
+            param-copy's TP all-gather is issued in lockstep by every rank.
+
+        If the finding holds, the encoder weights diverge by ~ llm_dp/enc_dp
+        and the assertion fails with a printed weight/grad diff. If the path
+        is correct, the test passes and the finding is disproved.
+        """
+        if self.world_size != 8:
+            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
+
+        _set_deterministic_env()
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+        rank = dist.get_rank()
+        encoder_name = "images"
+        hidden_size, seq_length, vocab_size = 256, 64, 1000
+        num_layers = 2
+        micro_batch_size = 2
+
+        enc_tp, enc_dp, llm_tp, llm_pp, llm_dp = 4, 2, 2, 1, 4
+        num_microbatches = 1
+
+        # Global batch spans the larger DP side (llm_dp here).
+        global_batch_size = micro_batch_size * max(enc_dp, llm_dp)
+
+        dist_enc_grid = create_hypercomm_grid(offset=0, tp=enc_tp, cp=1, pp=1, dp=enc_dp)
+        dist_llm_grid = create_hypercomm_grid(offset=0, tp=llm_tp, cp=1, pp=llm_pp, dp=llm_dp)
+        ref_enc_grid = create_hypercomm_grid(offset=0, tp=enc_tp, cp=1, pp=1, dp=enc_dp)
+        ref_llm_grid = create_hypercomm_grid(offset=0, tp=enc_tp, cp=1, pp=1, dp=enc_dp)
+        create_all_embedding_groups([dist_enc_grid, dist_llm_grid, ref_enc_grid, ref_llm_grid])
+
+        # PRODUCTION DEFAULT loss config: calculate_per_token_loss=False on
+        # both sub-model TransformerConfigs (per_token_loss=False below). This
+        # is the configuration the _loss_func docstring claims is safe.
+        ddp_config = DistributedDataParallelConfig(
+            overlap_grad_reduce=True, bucket_size=10000, use_distributed_optimizer=True
+        )
+
+        torch.manual_seed(12345)
+        dist_mimo, _, _, dist_language_pg, dist_vision_pg = get_mimo_model(
+            encoder_name=encoder_name,
+            encoder_grid=dist_enc_grid,
+            llm_grid=dist_llm_grid,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            vocab_size=vocab_size,
+            seq_len=seq_length,
+            ddp_config=ddp_config,
+            bf16=False,
+            bias=False,
+            dropout=False,
+            per_token_loss=False,
+        )
+        dist_mimo.model_type = ModelType.encoder_or_decoder
+        self._mimo_models.append(dist_mimo)
+
+        torch.manual_seed(12345)
+        ref_mimo, _, _, ref_language_pg, ref_vision_pg = get_mimo_model(
+            encoder_name=encoder_name,
+            encoder_grid=ref_enc_grid,
+            llm_grid=ref_llm_grid,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            vocab_size=vocab_size,
+            seq_len=seq_length,
+            ddp_config=ddp_config,
+            bf16=False,
+            bias=False,
+            dropout=False,
+            per_token_loss=False,
+        )
+        ref_mimo.model_type = ModelType.encoder_or_decoder
+        self._mimo_models.append(ref_mimo)
+
+        # Identical initial state. Encoder shards match exactly (same
+        # enc_tp/enc_dp) so the encoder copy is shard-to-shard. The LLM TP
+        # differs (ref_llm_tp == enc_tp == 4 vs dist_llm_tp == 2), so
+        # _copy_ref_params_to_dist all-gathers ref's TP shards across
+        # ref_llm_grid's TP group (which, because enc_tp * enc_dp == 8, spans
+        # every world rank in lockstep) and slices for dist's TP. This is the
+        # SAME symmetric two-phase copy the existing correctness test uses for
+        # its llm_pp == 1 fan-out case — no per-rank-divergent collectives.
+        _copy_ref_params_to_dist(
+            ref_mimo.modality_submodules[encoder_name].module,
+            dist_mimo.modality_submodules[encoder_name].module,
+            ref_enc_grid.get_pg("tp"),
+            dist_enc_grid.get_pg("tp"),
+        )
+        _copy_ref_params_to_dist(
+            ref_mimo.language_model.module,
+            dist_mimo.language_model.module,
+            ref_llm_grid.get_pg("tp"),
+            dist_llm_grid.get_pg("tp"),
+        )
+
+        # PRODUCTION DEFAULT finalize on both sides (no uniform 1/N_global).
+        _wire_production_default_hooks(dist_mimo, dist_language_pg, dist_vision_pg)
+        _wire_production_default_hooks(ref_mimo, ref_language_pg, ref_vision_pg)
+
+        opt_config = OptimizerConfig(
+            optimizer='adam',
+            lr=1e-4,
+            weight_decay=0.01,
+            clip_grad=1.0,
+            bf16=False,
+            use_distributed_optimizer=True,
+        )
+        dist_optimizer = get_mimo_optimizer(dist_mimo, opt_config)
+        ref_optimizer = get_mimo_optimizer(ref_mimo, opt_config)
+
+        # Deterministic global batches identical on every rank. Use the
+        # "uniform" mask so all valid-token counts are equal across samples —
+        # this removes any per-sample asymmetry and leaves DP-split count
+        # differences (fan-out) as the only token-count effect.
+        torch.manual_seed(99999)
+        global_batches = _generate_and_broadcast_global_batches(
+            global_mbs=global_batch_size,
+            seq_length=seq_length,
+            hidden_size=hidden_size,
+            vocab_size=vocab_size,
+            encoder_name=encoder_name,
+            num_batches=num_microbatches,
+            mask_pattern="uniform",
+        )
+        dist_batches = [
+            _slice_global_batch_for_dist(b, dist_enc_grid, dist_llm_grid) for b in global_batches
+        ]
+        ref_batches = [
+            _slice_global_batch_by_dp(b, ref_enc_grid.get_pg("dp")) for b in global_batches
+        ]
+        ref_per_rank_batch_size = global_batch_size // enc_dp
+
+        try:
+            # Dist step (PP=1 fan-out, no-pipelining schedule + forward_step).
+            dist_optimizer.zero_grad()
+            schedule.forward_backward_no_pipelining(
+                forward_step_func=partial(
+                    forward_step,
+                    encoder_grid=dist_enc_grid,
+                    llm_grid=dist_llm_grid,
+                    encoder_name=encoder_name,
+                ),
+                data_iterator=_BatchIterator(dist_batches),
+                model=[dist_mimo],
+                num_microbatches=num_microbatches,
+                seq_length=seq_length,
+                micro_batch_size=micro_batch_size,
+                forward_only=False,
+                pg_collection=dist_language_pg,
+            )
+            dist_first_layer_grads = _snapshot_first_layer_encoder_grads(dist_mimo, encoder_name)
+            dist_success, dist_grad_norm, _ = dist_optimizer.step()
+            assert dist_success, "Dist optimizer step failed"
+            assert dist_grad_norm is not None and dist_grad_norm > 0, (
+                f"Dist grad_norm={dist_grad_norm} — encoder grads may have been " "silently zeroed."
+            )
+
+            # Ref step (equal-DP, identity bridge, no-pipelining).
+            ref_optimizer.zero_grad()
+            schedule.forward_backward_no_pipelining(
+                forward_step_func=partial(
+                    forward_step,
+                    encoder_grid=ref_enc_grid,
+                    llm_grid=ref_llm_grid,
+                    encoder_name=encoder_name,
+                ),
+                data_iterator=_BatchIterator(ref_batches),
+                model=[ref_mimo],
+                num_microbatches=num_microbatches,
+                seq_length=seq_length,
+                micro_batch_size=ref_per_rank_batch_size,
+                forward_only=False,
+                pg_collection=ref_language_pg,
+            )
+            ref_first_layer_grads = _snapshot_first_layer_encoder_grads(ref_mimo, encoder_name)
+            ref_success, ref_grad_norm, _ = ref_optimizer.step()
+            assert ref_success, "Ref optimizer step failed"
+            assert ref_grad_norm is not None and ref_grad_norm > 0, f"Ref grad_norm={ref_grad_norm}"
+        except Exception:
+            import traceback as _tb
+
+            print(
+                f"\n=== rank {rank} TEST EXCEPTION ===\n"
+                f"config: enc_tp={enc_tp} enc_dp={enc_dp} llm_tp={llm_tp} "
+                f"llm_pp={llm_pp} llm_dp={llm_dp} mbs={num_microbatches}\n"
+                f"{_tb.format_exc()}\n=== end rank {rank} exception ===\n",
+                flush=True,
+            )
+            raise
+
+        # Oracles. First-layer encoder grads come straight off the DP reduce
+        # (before optimizer munges them), so they pin the bug to scaling;
+        # encoder weights are the end-to-end post-step signal.
+        failures = []
+        try:
+            _assert_first_layer_grads_match(
+                ref_first_layer_grads, dist_first_layer_grads, rtol=1e-3, atol=1e-3
+            )
+        except AssertionError as e:
+            failures.append(('first_layer_grads', str(e)))
+
+        try:
+            _assert_encoder_weights_match(
+                ref_mimo.modality_submodules[encoder_name].module,
+                dist_mimo.modality_submodules[encoder_name].module,
+                rtol=1e-3,
+                atol=1e-3,
+            )
+        except AssertionError as e:
+            failures.append(('encoder_weights', str(e)))
+
+        if failures:
+            summary = "\n\n".join(f"== {oracle} ==\n{msg}" for oracle, msg in failures)
+            print(
+                f"\n=== rank {rank} per_token_loss=False fan-out failures ===\n"
+                f"config: enc_tp={enc_tp} enc_dp={enc_dp} llm_tp={llm_tp} "
+                f"llm_pp={llm_pp} llm_dp={llm_dp} mbs={num_microbatches}\n"
+                f"{summary}\n=== end rank {rank} failures ===\n",
+                flush=True,
+            )
+            raise AssertionError(
+                f"{len(failures)} oracle(s) failed under calculate_per_token_loss=False "
+                f"fan-out (enc_dp={enc_dp}, llm_dp={llm_dp}); encoder vs LLM grad scaling "
+                f"is inconsistent (expected ~llm_dp/enc_dp skew):\n{summary}"
+            )

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_single_microbatch.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_single_microbatch.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Adversarial: three-phase colocated schedule with num_microbatches=1 and LLM PP>1.
+
+The consolidated correctness test
+(:mod:`test_mimo_colocated_correctness`) parametrizes
+``num_microbatches in {1, 4}`` but gates out the single-microbatch
+PP>1 cell::
+
+    if num_microbatches < llm_pp:
+        pytest.skip(...)
+
+So the smallest *pipeline-active* case — a single microbatch driven
+through an LLM PP>1 1F1B pipeline (all warmup/cooldown bubble, no
+steady state) — is never exercised by the three-phase schedule. The
+PP=1 ``mbs=1`` cell takes the separate ``forward_backward_no_pipelining``
+path, so it does not cover the three-phase code either.
+
+``colocated_forward_backward_with_pp`` claims to support any
+``num_microbatches`` (``total_batch % num_microbatches == 0`` at
+``colocated_schedule.py:342`` and ``L77`` eagerly drains exactly
+``num_microbatches`` batches). The single-microbatch path is the most
+likely to expose an off-by-one in the warmup/cooldown grad accumulation
+into ``detached_full.grad`` on PP stage 0, or in the deferred
+finalize / encoder-grad-broadcast handoff, because there is exactly one
+LLM backward feeding ``detached_full.grad`` before Phase 3.
+
+This test relaxes that skip for a single config and checks that the
+``num_microbatches=1`` PP=2 result still matches the equal-DP PP=1
+reference (which is computed via the no-pipelining path) after one
+Adam step. If the deferred finalize or the encoder-grad broadcast
+mishandles the single-microbatch shape, the encoder weights / grads
+and the PP-aware LLM weights diverge from the reference beyond
+tolerance, or the schedule deadlocks (guarded by the runner-level
+NCCL timeout). If the code is correct, this test PASSES — disproving
+the finding.
+
+Smallest config that exhibits it: ``fan_in_pp2`` with
+``num_microbatches=1``::
+
+    enc_tp=2, enc_dp=4, llm_tp=2, llm_pp=2, llm_dp=2
+
+``dist_llm_tp == enc_tp`` keeps the PP-aware LLM weight oracle active
+(shards align 1:1 with the PP=1 ref after layer-index remap), and the
+encoder TP/DP layout matches the ref so encoder shards compare directly.
+
+Run with::
+
+    uv run python -m torch.distributed.run --nproc_per_node=8 \\
+        -m pytest \\
+        tests/unit_tests/models/mimo/test_mimo_colocated_single_microbatch.py \\
+        -v -s
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from packaging import version
+
+from megatron.core.distributed import DistributedDataParallelConfig
+from megatron.core.models.mimo.optimizer import get_mimo_optimizer
+from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from megatron.core.transformer.enums import ModelType
+from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
+    create_all_embedding_groups,
+    create_hypercomm_grid,
+    destroy_all_grids,
+    get_mimo_model,
+)
+from tests.unit_tests.models.mimo.test_mimo_colocated_correctness import (
+    _assert_encoder_weights_match,
+    _assert_first_layer_grads_match,
+    _assert_llm_weights_match_pp_aware,
+    _copy_llm_params_pp_aware,
+    _copy_ref_params_to_dist,
+    _generate_and_broadcast_global_batches,
+    _run_forward_backward,
+    _set_deterministic_env,
+    _slice_global_batch_by_dp,
+    _slice_global_batch_for_dist,
+    _snapshot_first_layer_encoder_grads,
+    _wire_training_hooks,
+)
+from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse("2.3.0"), reason="Requires PyTorch 2.3+"
+)
+class TestThreePhaseScheduleSingleMicrobatch:
+    """num_microbatches=1 + LLM PP>1 must match the equal-DP PP=1 reference.
+
+    This is the (num_microbatches=1, llm_pp>1) cell that the consolidated
+    correctness test skips. The three-phase schedule must either run it
+    correctly (single microbatch through the pipeline) or reject it with a
+    clear error — silent divergence from the PP=1 reference is a bug.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_distributed()
+        cls.world_size = dist.get_world_size()
+
+    @classmethod
+    def teardown_class(cls):
+        Utils.destroy_model_parallel()
+
+    def setup_method(self):
+        self._mimo_models = []
+
+    def teardown_method(self):
+        torch.use_deterministic_algorithms(False)
+        for model in self._mimo_models:
+            model.destroy()
+        self._mimo_models.clear()
+        destroy_all_grids()
+
+    @pytest.mark.parametrize(
+        "enc_tp,enc_dp,llm_tp,llm_pp,llm_dp",
+        [(2, 4, 2, 2, 2)],  # fan-in, PP=2 (dist_llm_tp == enc_tp → LLM weight oracle on)
+        ids=["fan_in_pp2"],
+    )
+    @pytest.mark.parametrize(
+        "mask_pattern", ["uniform", "asymmetric"], ids=["uniform", "asymmetric"]
+    )
+    def test_single_microbatch_pp2_matches_dp1_reference(
+        self, enc_tp, enc_dp, llm_tp, llm_pp, llm_dp, mask_pattern
+    ):
+        """One microbatch through PP=2 three-phase schedule == equal-DP PP=1 ref.
+
+        Deliberately exercises the (num_microbatches=1, llm_pp>1) cell the
+        correctness test gates out. With a single microbatch the LLM 1F1B
+        pipeline is pure warmup/cooldown and exactly one LLM backward feeds
+        ``detached_full.grad`` before the encoder-grad broadcast + deferred
+        finalize. If that handoff mishandles the single-microbatch shape,
+        the post-step encoder weights / first-layer grads and the PP-aware
+        LLM weights diverge from the PP=1 reference beyond tolerance.
+        """
+        if self.world_size != 8:
+            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
+
+        # The finding: this is precisely the cell the correctness test skips.
+        # Assert the precondition holds so the test self-documents *why* it
+        # exists (and fails loudly if the schedule's PP requirement changes).
+        num_microbatches = 1
+        assert num_microbatches < llm_pp, (
+            "This adversarial test only makes sense for the (mbs < llm_pp) cell "
+            "that the correctness suite skips."
+        )
+
+        rank = dist.get_rank()
+        try:
+            self._run_body(
+                rank, enc_tp, enc_dp, llm_tp, llm_pp, llm_dp, mask_pattern, num_microbatches
+            )
+        except Exception:
+            import traceback as _tb
+
+            print(
+                f"\n=== rank {rank} SINGLE-MBS TEST EXCEPTION ===\n"
+                f"config: enc_tp={enc_tp} enc_dp={enc_dp} llm_tp={llm_tp} "
+                f"llm_pp={llm_pp} llm_dp={llm_dp} mbs={num_microbatches} "
+                f"mask={mask_pattern}\n"
+                f"{_tb.format_exc()}\n"
+                f"=== end rank {rank} exception ===\n",
+                flush=True,
+            )
+            raise
+
+    def _run_body(
+        self, rank, enc_tp, enc_dp, llm_tp, llm_pp, llm_dp, mask_pattern, num_microbatches
+    ):
+        _set_deterministic_env()
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+        encoder_name = "images"
+        hidden_size, seq_length, vocab_size = 256, 64, 1000
+        num_layers = 2
+        assert num_layers % llm_pp == 0
+        micro_batch_size = 2
+
+        # Global batch spans the larger DP side (fan-in: enc_dp). Dist
+        # pre-slices per rank; ref consumes the full global batch per DP rank.
+        global_batch_size = micro_batch_size * max(enc_dp, llm_dp)
+
+        dist_enc_grid = create_hypercomm_grid(offset=0, tp=enc_tp, cp=1, pp=1, dp=enc_dp)
+        dist_llm_grid = create_hypercomm_grid(offset=0, tp=llm_tp, cp=1, pp=llm_pp, dp=llm_dp)
+        ref_enc_grid = create_hypercomm_grid(offset=0, tp=enc_tp, cp=1, pp=1, dp=enc_dp)
+        ref_llm_grid = create_hypercomm_grid(offset=0, tp=enc_tp, cp=1, pp=1, dp=enc_dp)
+        create_all_embedding_groups([dist_enc_grid, dist_llm_grid, ref_enc_grid, ref_llm_grid])
+
+        ddp_config = DistributedDataParallelConfig(
+            overlap_grad_reduce=True, bucket_size=10000, use_distributed_optimizer=True
+        )
+
+        # Dist: heterogeneous TP/DP + LLM PP=2.
+        torch.manual_seed(12345)
+        dist_mimo, _, _, dist_language_pg, dist_vision_pg = get_mimo_model(
+            encoder_name=encoder_name,
+            encoder_grid=dist_enc_grid,
+            llm_grid=dist_llm_grid,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            vocab_size=vocab_size,
+            seq_len=seq_length,
+            ddp_config=ddp_config,
+            bf16=False,
+            bias=False,
+            dropout=False,
+            per_token_loss=True,
+        )
+        dist_mimo.model_type = ModelType.encoder_or_decoder
+        self._mimo_models.append(dist_mimo)
+
+        # Ref: equal-DP uniform, LLM PP=1 (no-pipelining path).
+        torch.manual_seed(12345)
+        ref_mimo, _, _, ref_language_pg, ref_vision_pg = get_mimo_model(
+            encoder_name=encoder_name,
+            encoder_grid=ref_enc_grid,
+            llm_grid=ref_llm_grid,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            vocab_size=vocab_size,
+            seq_len=seq_length,
+            ddp_config=ddp_config,
+            bf16=False,
+            bias=False,
+            dropout=False,
+            per_token_loss=True,
+        )
+        ref_mimo.model_type = ModelType.encoder_or_decoder
+        self._mimo_models.append(ref_mimo)
+
+        # Identical initial state. Encoder TP/DP matches → shard-to-shard copy.
+        _copy_ref_params_to_dist(
+            ref_mimo.modality_submodules[encoder_name].module,
+            dist_mimo.modality_submodules[encoder_name].module,
+            ref_enc_grid.get_pg("tp"),
+            dist_enc_grid.get_pg("tp"),
+        )
+        # PP>1 with matching TP: dist's local layers map to ref's global
+        # layers, shards align 1:1 post-remap.
+        assert llm_tp == enc_tp, "fan_in_pp2 config must keep dist_llm_tp == enc_tp"
+        _copy_llm_params_pp_aware(
+            ref_mimo.language_model.module,
+            dist_mimo.language_model.module,
+            pp_rank=dist_llm_grid.get_pg("pp").rank(),
+            pp_size=llm_pp,
+            num_layers=num_layers,
+        )
+
+        # PP>1 dist needs the broadcast-from-last-PP-stage finalize variant.
+        _wire_training_hooks(dist_mimo, dist_language_pg, dist_vision_pg, llm_grid=dist_llm_grid)
+        _wire_training_hooks(ref_mimo, ref_language_pg, ref_vision_pg)
+
+        opt_config = OptimizerConfig(
+            optimizer='adam',
+            lr=1e-4,
+            weight_decay=0.01,
+            clip_grad=1.0,
+            bf16=False,
+            use_distributed_optimizer=True,
+        )
+        dist_optimizer = get_mimo_optimizer(dist_mimo, opt_config)
+        ref_optimizer = get_mimo_optimizer(ref_mimo, opt_config)
+
+        # Single deterministic global batch, identical on every rank.
+        torch.manual_seed(99999)
+        global_batches = _generate_and_broadcast_global_batches(
+            global_mbs=global_batch_size,
+            seq_length=seq_length,
+            hidden_size=hidden_size,
+            vocab_size=vocab_size,
+            encoder_name=encoder_name,
+            num_batches=num_microbatches,
+            mask_pattern=mask_pattern,
+        )
+        dist_batches = [
+            _slice_global_batch_for_dist(b, dist_enc_grid, dist_llm_grid) for b in global_batches
+        ]
+        ref_batches = [
+            _slice_global_batch_by_dp(b, ref_enc_grid.get_pg("dp")) for b in global_batches
+        ]
+        ref_per_rank_batch_size = global_batch_size // enc_dp
+
+        # Dist step: three-phase schedule with num_microbatches=1.
+        dist_optimizer.zero_grad()
+        _run_forward_backward(
+            mimo_model=dist_mimo,
+            batches=dist_batches,
+            enc_grid=dist_enc_grid,
+            llm_grid=dist_llm_grid,
+            encoder_name=encoder_name,
+            language_pg=dist_language_pg,
+            micro_batch_size=micro_batch_size,
+            seq_length=seq_length,
+            num_microbatches=num_microbatches,
+        )
+        dist_first_layer_grads = _snapshot_first_layer_encoder_grads(dist_mimo, encoder_name)
+        dist_success, dist_grad_norm, _ = dist_optimizer.step()
+        assert dist_success, "Dist optimizer step failed"
+        assert dist_grad_norm is not None and dist_grad_norm > 0, (
+            f"Dist grad_norm={dist_grad_norm} — with a single microbatch the "
+            "three-phase schedule may have failed to accumulate encoder grads "
+            "into detached_full.grad before the deferred finalize."
+        )
+
+        # Ref step: no-pipelining (PP=1), equal-DP.
+        ref_optimizer.zero_grad()
+        _run_forward_backward(
+            mimo_model=ref_mimo,
+            batches=ref_batches,
+            enc_grid=ref_enc_grid,
+            llm_grid=ref_llm_grid,
+            encoder_name=encoder_name,
+            language_pg=ref_language_pg,
+            micro_batch_size=ref_per_rank_batch_size,
+            seq_length=seq_length,
+            num_microbatches=num_microbatches,
+        )
+        ref_first_layer_grads = _snapshot_first_layer_encoder_grads(ref_mimo, encoder_name)
+        ref_success, ref_grad_norm, _ = ref_optimizer.step()
+        assert ref_success, "Ref optimizer step failed"
+        assert ref_grad_norm is not None and ref_grad_norm > 0, f"Ref grad_norm={ref_grad_norm}"
+
+        # Oracles: run all so the diff-stats print covers every layer.
+        failures = []
+
+        try:
+            _assert_encoder_weights_match(
+                ref_mimo.modality_submodules[encoder_name].module,
+                dist_mimo.modality_submodules[encoder_name].module,
+                rtol=1e-3,
+                atol=1e-3,
+            )
+        except AssertionError as e:
+            failures.append(('encoder_weights', str(e)))
+
+        try:
+            _assert_first_layer_grads_match(
+                ref_first_layer_grads, dist_first_layer_grads, rtol=1e-3, atol=1e-3
+            )
+        except AssertionError as e:
+            failures.append(('first_layer_grads', str(e)))
+
+        # PP>1 with matching TP: PP-aware LLM weight oracle.
+        try:
+            _assert_llm_weights_match_pp_aware(
+                ref_mimo.language_model.module,
+                dist_mimo.language_model.module,
+                pp_rank=dist_llm_grid.get_pg("pp").rank(),
+                pp_size=llm_pp,
+                num_layers=num_layers,
+                rtol=1e-2,
+                atol=1e-2,
+            )
+        except AssertionError as e:
+            failures.append(('llm_weights_pp_aware', str(e)))
+
+        if failures:
+            summary = "\n\n".join(f"== {oracle} ==\n{msg}" for oracle, msg in failures)
+            print(
+                f"\n=== rank {rank} single-mbs PP=2 failures ===\n"
+                f"config: enc_tp={enc_tp} enc_dp={enc_dp} llm_tp={llm_tp} "
+                f"llm_pp={llm_pp} llm_dp={llm_dp} mbs={num_microbatches} mask={mask_pattern}\n"
+                f"{summary}\n"
+                f"=== end rank {rank} failures ===\n",
+                flush=True,
+            )
+            raise AssertionError(
+                f"{len(failures)} oracle(s) diverged for num_microbatches=1 PP=2 vs PP=1 "
+                f"reference — the three-phase schedule mishandles the single-microbatch "
+                f"shape:\n{summary}"
+            )


### PR DESCRIPTION
## Summary

Adds PP>1 support for the language model in colocated MIMO training. Encoder modules stay PP=1 on all ranks, while the LLM runs a 1F1B pipeline over microbatches of precomputed encoder embeddings.

Key pieces:

- Allows colocated layouts where the destination language grid has PP>1 while the source encoder grid remains PP=1.
- Adds a three-phase colocated schedule:
  1. encoder forward plus colocated TP/DP communication over the full batch,
  2. LLM 1F1B over detached encoder-embedding microbatches,
  3. encoder backward after broadcasting the LLM-side encoder gradient from PP stage 0.
- Defers `finalize_model_grads_func` until after encoder backward so LLM and encoder grads are finalized together.
- Handles fan-in, fan-out, and equal-DP colocated bridge directions, including fan-out narrowing of LLM-side passthrough tensors.
- Extends colocated correctness coverage to PP>1 fan-in/fan-out cases and adds validation for non-divisible fan-in encoder batches.

## Test Plan

- [x] `python3 -m py_compile megatron/core/models/mimo/colocated_schedule.py megatron/core/models/mimo/comm/colocated_communicator.py megatron/core/models/mimo/config/role.py megatron/core/models/mimo/model/base.py tests/unit_tests/models/test_mimo_colocated_communicator.py tests/unit_tests/models/test_mimo_colocated_correctness.py`
- [x] `git diff --check upstream/main...HEAD`
- [x] pre-commit hooks during commit/push: `black`, `pylint`, `isort`
- [ ] 8-GPU distributed test not run in this container (`nvidia-smi` is unavailable):

```bash
uv run python -m torch.distributed.run --nproc_per_node=8 \
  -m pytest tests/unit_tests/models/test_mimo_colocated_correctness.py -v -s
```