### PR TITLE
Add --qad-train-target {base|mtp|both} for QAD / MTP QAT (frozen-base, frozen-MTP, or co-train)

### DIFF
--- a/megatron/post_training/arguments.py
+++ b/megatron/post_training/arguments.py
@@ -94,6 +94,26 @@ def add_modelopt_args(parser):
         "--finetune-data-split", type=str, default="train", help="HF dataset split used for finetuning."
     )
 
+    # MTP / base train-target selection for QAD and MTP QAT.
+    group.add_argument(
+        '--qad-train-target',
+        type=str,
+        default=None,
+        choices=['base', 'mtp', 'both'],
+        help='Which side of an MTP model to train during QAD / MTP QAT. '
+        '"mtp": train MTP heads only, freeze the base (post-QAD two-phase recipe); '
+        '"base": train the base only, freeze the MTP heads; '
+        '"both": co-train the base and MTP heads together. '
+        'Routers on the frozen side also have their expert_bias update skipped.',
+    )
+    group.add_argument(
+        '--freeze-base-for-mtp',
+        action='store_true',
+        default=False,
+        help='Deprecated alias for --qad-train-target mtp: freeze all base model '
+        'parameters and only train MTP heads.',
+    )
+
     # Special model architecture option
     group.add_argument(
         '--export-qk-l2-norm',

--- a/megatron/post_training/model_builder.py
+++ b/megatron/post_training/model_builder.py
@@ -157,6 +157,67 @@ def _build_teacher_model(config, config_raw: Namespace, model_kwargs: Dict[str, 
     return teacher
 
 
+def _freeze_for_qad(model, target):
+    """Select which side of an MTP model trains during QAD / MTP QAT.
+
+    Splits parameters into the MTP heads (``mtp.layers.*``) and the base model,
+    and freezes one side so controlled QAD+MTP experiments can be run:
+
+    * ``"mtp"``  — train the MTP heads only, freeze the base. Used after QAD:
+      load a quantized checkpoint, add MTP heads, and train them while the
+      quantized base stays fixed (the production two-phase recipe).
+    * ``"base"`` — train the base only, freeze the MTP heads. QAD on the base
+      with the MTP head held at its init (e.g. measuring how well a frozen MTP
+      head rides on a quantizing base).
+    * ``"both"`` — train the base and the MTP heads together (QAD co-training).
+    """
+    if target not in ("mtp", "base", "both"):
+        raise ValueError(f"qad train target must be one of mtp/base/both, got {target!r}")
+
+    if target == "both":
+        for param in model.parameters():
+            param.requires_grad = True
+        # Nothing is frozen, so no router expert_bias should be pinned.
+        for module in model.modules():
+            if hasattr(module, 'expert_bias'):
+                module.frozen_expert_bias = False
+        print_rank_0("QAD train target 'both': all parameters trainable")
+        return
+
+    train_mtp = target == "mtp"
+    trainable, frozen = 0, 0
+    for name, param in model.named_parameters():
+        is_mtp = 'mtp.layers.' in name
+        param.requires_grad = is_mtp == train_mtp
+        if param.requires_grad:
+            trainable += 1
+        else:
+            frozen += 1
+
+    # The MoE router's expert bias is updated from load-balancing token counts in
+    # finalize_model_grads._update_router_expert_bias, independently of requires_grad.
+    # Setting requires_grad=False does NOT stop it, so the frozen side would keep
+    # drifting. Flag the frozen side's routers so the update is skipped; the trainable
+    # side's routers must keep updating (so we clear the flag there).
+    frozen_bias = 0
+    for name, module in model.named_modules():
+        if hasattr(module, 'expert_bias'):
+            is_mtp = 'mtp.layers.' in name
+            freeze_this = is_mtp != train_mtp
+            module.frozen_expert_bias = freeze_this
+            if freeze_this:
+                frozen_bias += 1
+    print_rank_0(
+        f"QAD train target '{target}': training {'MTP' if train_mtp else 'base'} "
+        f"({trainable} trainable, {frozen} frozen, {frozen_bias} router expert_bias frozen)"
+    )
+
+
+def _freeze_base_for_mtp(model):
+    """Deprecated alias for ``_freeze_for_qad(model, "mtp")``."""
+    _freeze_for_qad(model, "mtp")
+
+
 def modelopt_gpt_hybrid_builder(
     args,
     pre_process,
@@ -260,6 +321,22 @@ def modelopt_gpt_hybrid_builder(
                 use_arbitrary_attention_mask=False,
             )
 
+        # Build MTP block spec if MTP is enabled.
+        mtp_block_spec = None
+        if args.mtp_num_layers is not None:
+            from megatron.core.models.gpt.gpt_layer_specs import (
+                get_gpt_decoder_layer_specs,
+                get_gpt_mtp_block_spec,
+            )
+
+            use_te = args.transformer_impl == "transformer_engine"
+            decoder_layer_specs = get_gpt_decoder_layer_specs(
+                config, use_transformer_engine=use_te,
+            )
+            mtp_block_spec = get_gpt_mtp_block_spec(
+                config, decoder_layer_specs[-1], use_transformer_engine=use_te,
+            )
+
         model_kwargs = {
             "transformer_layer_spec": transformer_layer_spec,
             "vocab_size": args.padded_vocab_size,
@@ -273,6 +350,7 @@ def modelopt_gpt_hybrid_builder(
             "rotary_percent": args.rotary_percent,
             "rotary_base": args.rotary_base,
             "rope_scaling": args.use_rope_scaling,
+            "mtp_block_spec": mtp_block_spec,
             "pg_collection": pg_collection,
         }
         model = MCoreGPTModel(config=config, **model_kwargs)
@@ -337,6 +415,17 @@ def modelopt_gpt_hybrid_builder(
     # modelopt_state (which transforms the model to have additional parameters) before returning.
     if args.load is not None:
         load_modelopt_state(model=model)
+
+    qad_train_target = getattr(args, 'qad_train_target', None)
+    if args.freeze_base_for_mtp:
+        if qad_train_target not in (None, 'mtp'):
+            raise ValueError(
+                "--freeze-base-for-mtp is an alias for --qad-train-target mtp and "
+                f"conflicts with --qad-train-target {qad_train_target}"
+            )
+        qad_train_target = 'mtp'
+    if qad_train_target is not None:
+        _freeze_for_qad(model, qad_train_target)
 
     _add_load_convert_hooks(model)
 

--- a/tests/unit_tests/post_training/test_freeze_base_for_mtp.py
+++ b/tests/unit_tests/post_training/test_freeze_base_for_mtp.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the --qad-train-target / --freeze-base-for-mtp feature in model_builder."""
+
+import pytest
+import torch
+from packaging.version import Version
+
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_decoder_layer_specs,
+    get_gpt_mtp_block_spec,
+)
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.post_training.modelopt.gpt.model_specs import get_gpt_modelopt_spec
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from megatron.post_training.model_builder import _freeze_base_for_mtp, _freeze_for_qad
+from tests.unit_tests.test_utilities import Utils
+
+
+class TestFreezeBaseForMTP:
+    """Test that _freeze_base_for_mtp correctly freezes base and keeps MTP trainable."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+
+        self.config = TransformerConfig(
+            num_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            mtp_num_layers=1,
+        )
+
+        # Build model with modelopt spec (base layers) + MTP block spec (standard layers).
+        modelopt_spec = get_gpt_modelopt_spec(self.config)
+        decoder_layer_specs = get_gpt_decoder_layer_specs(self.config, use_transformer_engine=True)
+        mtp_block_spec = get_gpt_mtp_block_spec(
+            self.config, decoder_layer_specs[-1], use_transformer_engine=True
+        )
+
+        self.model = GPTModel(
+            config=self.config,
+            transformer_layer_spec=modelopt_spec,
+            mtp_block_spec=mtp_block_spec,
+            vocab_size=100,
+            max_sequence_length=8,
+        )
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_model_has_mtp(self):
+        """Verify model was built with MTP layers."""
+        assert hasattr(self.model, 'mtp'), "Model should have MTP attribute"
+        mtp_params = [n for n, _ in self.model.named_parameters() if 'mtp.layers.' in n]
+        assert len(mtp_params) > 0, "Model should have MTP parameters"
+
+    def test_freeze_only_keeps_mtp_trainable(self):
+        """After freezing, only mtp.layers.* params should have requires_grad=True."""
+        _freeze_base_for_mtp(self.model)
+
+        trainable_params = []
+        frozen_params = []
+        for name, param in self.model.named_parameters():
+            if param.requires_grad:
+                trainable_params.append(name)
+            else:
+                frozen_params.append(name)
+
+        # All trainable params must be MTP params.
+        for name in trainable_params:
+            assert (
+                'mtp.layers.' in name
+            ), f"Non-MTP param '{name}' should be frozen but has requires_grad=True"
+
+        # All MTP params must be trainable.
+        for name, param in self.model.named_parameters():
+            if 'mtp.layers.' in name:
+                assert (
+                    param.requires_grad
+                ), f"MTP param '{name}' should be trainable but has requires_grad=False"
+
+        # Sanity: we should have both frozen and trainable params.
+        assert len(frozen_params) > 0, "Should have frozen base params"
+        assert len(trainable_params) > 0, "Should have trainable MTP params"
+
+    def test_base_params_are_frozen(self):
+        """Embedding, decoder, and output_layer params should all be frozen."""
+        _freeze_base_for_mtp(self.model)
+
+        for name, param in self.model.named_parameters():
+            if 'mtp.layers.' not in name:
+                assert not param.requires_grad, f"Base param '{name}' should be frozen"
+
+    def test_freeze_is_idempotent(self):
+        """Calling freeze twice should produce the same result."""
+        _freeze_base_for_mtp(self.model)
+        trainable_1 = {n for n, p in self.model.named_parameters() if p.requires_grad}
+
+        _freeze_base_for_mtp(self.model)
+        trainable_2 = {n for n, p in self.model.named_parameters() if p.requires_grad}
+
+        assert trainable_1 == trainable_2
+
+    def test_freezes_base_router_expert_bias_only(self):
+        """Non-MTP routers get frozen_expert_bias=True; MTP routers stay updatable.
+
+        The MoE router's expert_bias is updated from load-balancing token counts
+        independently of requires_grad, so freezing must flag base routers to be
+        skipped while leaving the MTP block's own routers free to update.
+        """
+
+        class _Router(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.expert_bias = torch.nn.Parameter(torch.zeros(4), requires_grad=False)
+
+        class _Tree(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                # base MoE router + an MTP block with its own MoE router
+                self.decoder = torch.nn.Module()
+                self.decoder.router = _Router()
+                self.mtp = torch.nn.Module()
+                self.mtp.layers = torch.nn.Module()
+                self.mtp.layers.router = _Router()
+
+        tree = _Tree()
+        _freeze_base_for_mtp(tree)
+
+        for name, module in tree.named_modules():
+            if hasattr(module, 'expert_bias'):
+                if 'mtp.layers.' in name:
+                    assert not getattr(
+                        module, 'frozen_expert_bias', False
+                    ), f"MTP router '{name}' expert_bias must stay updatable"
+                else:
+                    assert getattr(
+                        module, 'frozen_expert_bias', False
+                    ), f"Base router '{name}' expert_bias must be frozen"
+
+    def test_target_base_trains_base_freezes_mtp(self):
+        """target='base' trains the base and freezes the MTP heads (the inverse of 'mtp')."""
+        _freeze_for_qad(self.model, "base")
+
+        for name, param in self.model.named_parameters():
+            if 'mtp.layers.' in name:
+                assert not param.requires_grad, f"MTP param '{name}' should be frozen"
+            else:
+                assert param.requires_grad, f"Base param '{name}' should be trainable"
+
+    def test_target_both_trains_everything(self):
+        """target='both' re-enables every parameter, even after a prior freeze."""
+        _freeze_for_qad(self.model, "mtp")
+        _freeze_for_qad(self.model, "both")
+
+        for name, param in self.model.named_parameters():
+            assert param.requires_grad, f"Param '{name}' should be trainable with target='both'"
+
+    def test_freeze_base_for_mtp_is_alias_for_target_mtp(self):
+        """The deprecated --freeze-base-for-mtp helper matches target='mtp'."""
+        _freeze_base_for_mtp(self.model)
+        alias = {n for n, p in self.model.named_parameters() if p.requires_grad}
+
+        _freeze_for_qad(self.model, "mtp")
+        target = {n for n, p in self.model.named_parameters() if p.requires_grad}
+
+        assert alias == target
+
+    def test_invalid_target_raises(self):
+        """An unknown target is rejected."""
+        with pytest.raises(ValueError):
+            _freeze_for_qad(self.model, "bogus")
+
+    def test_target_base_freezes_mtp_router_expert_bias(self):
+        """target='base' pins the MTP routers' expert_bias and frees the base routers."""
+
+        class _Router(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.expert_bias = torch.nn.Parameter(torch.zeros(4), requires_grad=False)
+
+        class _Tree(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.decoder = torch.nn.Module()
+                self.decoder.router = _Router()
+                self.mtp = torch.nn.Module()
+                self.mtp.layers = torch.nn.Module()
+                self.mtp.layers.router = _Router()
+
+        tree = _Tree()
+        _freeze_for_qad(tree, "base")
+
+        for name, module in tree.named_modules():
+            if hasattr(module, 'expert_bias'):
+                if 'mtp.layers.' in name:
+                    assert getattr(
+                        module, 'frozen_expert_bias', False
+                    ), f"MTP router '{name}' expert_bias must be frozen when training base"
+                else:
+                    assert not getattr(
+                        module, 'frozen_expert_bias', False
+                    ), f"Base router '{name}' expert_bias must stay updatable"


### PR DESCRIPTION
## Summary

Enable MTP (multi-token prediction) head training **and export** on ModelOpt-quantized models, for both GPT and hybrid (Mamba+MoE) architectures. Three commits:

1. **`--freeze-base-for-mtp`** — freeze all base-model parameters and train only MTP heads. Adds `_freeze_base_for_mtp()` (sets `requires_grad=False` on all non-`mtp.layers.*` params) and builds `mtp_block_spec` in `modelopt_gpt_hybrid_builder()` so MTP heads can be added to a ModelOpt-quantized GPT model.
2. **Unit tests** for the freeze behavior.
3. **MTP block spec for the ModelOpt HybridModel local spec** (`model_specs.py`) — adds `mtp_block_spec` (enorm / hnorm / eh_proj / final layernorm via non-TE `Norm` + `ColumnParallelLinear`) to `HybridStackSubmodules`. Without this, `MCoreHybridModel` cannot build or export MTP for hybrid architectures, so MTP weights were silently dropped on export.

**Use case:** After NVFP4 QAD, load the quantized checkpoint with `--mtp-num-layers 1 --mtp-hybrid-override-pattern "*E" --freeze-base-for-mtp`. MTP heads are added and trained with lm_loss while the quantized base stays frozen; the MTP weights then export to HF format for vLLM speculative decoding.

## Test plan

- [x] Unit test: build model with `freeze_base_for_mtp=True`, verify only `mtp.layers.*` params have `requires_grad=True` (`tests/unit_tests/post_training/test_freeze_base_for_mtp.py`)
- [x] End-to-end (hybrid): full NVFP4 QAD → QAT-MTP → export → vLLM pipeline on Nemotron-3.5-Nano (OCI-HSG `cicd_1779387587`). Export emits 1059 MTP tensors (NVFP4) / 270 (BF16); MTP QAT loss decreases with base frozen.
- [x] Acceptance length on MT-Bench (num_speculative_tokens=3): BF16 AL=2.077 (3.077 w/ bonus), NVFP4 AL=1.832 (2.832 w/ bonus), vs AL=1.00 / 0 accepted before the fix.

## Notes

- Rebased onto current `main` (de-conflicted; the only conflict was a now-redundant local import of `get_hybrid_stack_modelopt_spec`, which `main` already imports at module scope).
- Downstream integration: omniml/integration/nmm-sandbox!159 pins this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
