### PR TITLE
[Dev] Fix full CUDA graph capture reverted by pull main

### DIFF
--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -563,7 +563,7 @@ def get_batch_on_this_tp_rank(data_iterator, mtp_on_this_rank: bool = False):
         def _broadcast_cu_seqlens(cu_seqlens):
             dev = torch.cuda.current_device()
             n = 0 if cu_seqlens is None else int(cu_seqlens.numel())
-            n_tensor = torch.tensor(n, dtype=torch.int64, device=dev)
+            n_tensor = torch.empty(1, dtype=torch.int64, device=dev).fill_(n)
             _broadcast(n_tensor)
 
             if n == 0:


### PR DESCRIPTION
## Summary
- Restore the source-rank cu_seqlens length broadcast allocation to `torch.empty(1, dtype=torch.int64, device=dev).fill_(n)`.
- Avoid `torch.tensor(n, dtype=torch.int64, device=dev)`, which can perform a CPU-to-CUDA copy and fails during full-iteration CUDA graph capture when the CPU source is not pinned.
- This restores the earlier dev behavior from `f9f9fe415` (`Add minor tweaks to support full-iter CG capture`). The nightly pull-main https://github.com/NVIDIA/Megatron-LM/pull/4716/ post-merge commit `cd2001de7` (`chore: post-merge fixes for nightly sync main into dev (28_04_2026)`) took main's `megatron/training/utils.py` and reverted this line back to `torch.tensor(...)`.

## Test plan
- `python -m py_compile megatron/training/utils.py`
- `CHECK_ONLY=true BASE_REF=dev uv run --project /Users/denliu/Projects/repos/agentic-mcore-dev --extra mcore-lint -- bash tools/autoformat.sh`
- Copyright check: no `megatron/core` or `tests` Python files changed.
- Ran paged-stash dev config on Computelab B300 (`umb-b300-003`) with `local/b300-cudnnfe1221:latest`; reached iteration 100, printed validation loss, and no longer hit the CUDA graph capture error from `torch.tensor(n, device=dev)`.
