### PR TITLE
Fix bug with Megatron-FSDP zero counter not working with decoupled gradients.

### DIFF
--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -59,18 +59,18 @@ def get_grad_norm_fp32(
 ) -> float:
     """Calculate the p-norm of gradients in FP32 precision.
 
-    This function is adapted from `torch.nn.utils.clip_grad.clip_grad_norm_` 
-    and extends it with functionality to handle model-parallel parameters. 
-    It ensures that the norm is correctly computed and reduced across 
-    the specified process group (typically the model-parallel group for 
+    This function is adapted from `torch.nn.utils.clip_grad.clip_grad_norm_`
+    and extends it with functionality to handle model-parallel parameters.
+    It ensures that the norm is correctly computed and reduced across
+    the specified process group (typically the model-parallel group for
     non-distributed optimizers or the entire world for distributed optimizers).
 
     Args:
-        grads_for_norm (Union[List[torch.Tensor], torch.Tensor]): An iterable 
+        grads_for_norm (Union[List[torch.Tensor], torch.Tensor]): An iterable
             of Tensors or a single Tensor used to calculate the gradient norm.
-        norm_type (Union[int, float]): The type of the p-norm to use. Can be 
+        norm_type (Union[int, float]): The type of the p-norm to use. Can be
             'inf' for infinity norm. Defaults to 2.
-        grad_stats_parallel_group (ProcessGroup, optional): The process group 
+        grad_stats_parallel_group (ProcessGroup, optional): The process group
             used for reducing gradient statistics (e.g., norms and zero counts).
 
     Returns:
@@ -155,13 +155,13 @@ def clip_grad_by_total_norm_fp32(
     Note that the gradients are modified in-place.
 
     Args:
-        parameters (Union[List[torch.Tensor], torch.Tensor]): An iterable of 
+        parameters (Union[List[torch.Tensor], torch.Tensor]): An iterable of
             Tensors or a single Tensor that will have gradients normalized.
-        max_norm (Union[int, float]): The maximum permissible total norm 
+        max_norm (Union[int, float]): The maximum permissible total norm
             of the gradients.
         total_norm (float): The current total norm of the gradients.
-        use_decoupled_grad (bool, optional): Whether to read from the 
-            '.decoupled_grad' attribute instead of the standard '.grad'. 
+        use_decoupled_grad (bool, optional): Whether to read from the
+            '.decoupled_grad' attribute instead of the standard '.grad'.
             Defaults to False.
     """
     # Grads.
@@ -204,19 +204,19 @@ def count_zeros_fp32(
 ) -> float:
     """Counts the number of zero values in the gradients of the given parameters.
 
-    The count is performed in FP32. This method filters parameters to ensure 
-    gradients are not double-counted by checking if the gradient is not None, 
-    the parameter is not shared, and the parameter is not a replica due 
-    to tensor model parallelism. It also handles parameters managed by 
+    The count is performed in FP32. This method filters parameters to ensure
+    gradients are not double-counted by checking if the gradient is not None,
+    the parameter is not shared, and the parameter is not a replica due
+    to tensor model parallelism. It also handles parameters managed by
     Megatron FSDP specifically.
 
     Args:
-        parameters (Union[List[torch.Tensor], torch.Tensor]): An iterable of 
+        parameters (Union[List[torch.Tensor], torch.Tensor]): An iterable of
             Tensors or a single Tensor whose gradients will be checked for zeros.
-        grad_stats_parallel_group (ProcessGroup): The process group used for 
+        grad_stats_parallel_group (ProcessGroup): The process group used for
             reducing the zero count across distributed ranks.
-        use_decoupled_grad (bool, optional): If True, reads from the 
-            '.decoupled_grad' attribute instead of the standard '.grad'. 
+        use_decoupled_grad (bool, optional): If True, reads from the
+            '.decoupled_grad' attribute instead of the standard '.grad'.
             Defaults to False.
 
     Returns:
@@ -234,16 +234,16 @@ def count_zeros_fp32(
     data_parallel_group = None
     use_megatron_fsdp = False
     for param in parameters:
-        if getattr(param, "__fsdp_param__", False) and param.grad is not None:
-            # If the parameter is managed by Megatron FSDP, we need to handle it differently.
+        grad_attr = "decoupled_grad" if use_decoupled_grad else "grad"
+        grad_not_none = hasattr(param, grad_attr) and getattr(param, grad_attr) is not None
+        if getattr(param, "__fsdp_param__", False) and grad_not_none:
+            # If the parameter is managed by Megatron FSDP, the gradient is
+            # an FSDP-sharded DTensor, and we should use the local shard.
             use_megatron_fsdp = True
-            grad = param.grad._local_tensor
+            grad = getattr(param, grad_attr)._local_tensor
             num_zeros = grad.numel() - torch.count_nonzero(grad)
             total_num_zeros += num_zeros
             continue
-
-        grad_attr = "decoupled_grad" if use_decoupled_grad else "grad"
-        grad_not_none = hasattr(param, grad_attr) and getattr(param, grad_attr) is not None
         is_not_shared = param_is_not_shared(param)
         is_not_tp_duplicate = param_is_not_tensor_parallel_duplicate(param, tp_group=tp_group)
         if grad_not_none and is_not_shared and is_not_tp_duplicate:
@@ -254,6 +254,8 @@ def count_zeros_fp32(
             total_num_zeros = num_zeros + total_num_zeros
 
     if use_megatron_fsdp and data_parallel_group is not None:
+        # Megatron-FSDP does not need to all-reduce the gradient across DP,
+        # as FSDP has already handled the DP reduction during BWD.
         raise ValueError(
             "Unexpected use of Megatron FSDP with data parallel group. "
             "Please ensure that the parameters are properly managed by Megatron FSDP."


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

- Fix an edge case that was missed in https://github.com/NVIDIA/Megatron-LM/pull/4133, zero counting for gradients also need to support decoupled gradients. We should have proper MFSDP <> decoupled gradient handling across the entire optimizer now. (Famous last words.)

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
