### PR TITLE
ci: tolerate git-gc race in /home/runner chown after checkout

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -77,7 +77,15 @@ runs:
 
     - name: Change ownership of /home/runner/
       shell: bash
-      run: sudo chown -R $(whoami) /home/runner/
+      # Tolerate vanishing `.git/objects/pack/.tmp-*` files: the prior
+      # `actions/checkout` may leave a background `git gc --auto` running,
+      # whose `git pack-objects` renames/deletes temp files while `chown`
+      # is walking the tree. On failure, wait 5 s for gc to settle, retry,
+      # then succeed unconditionally.
+      run: |
+        sudo chown -R $(whoami) /home/runner/ 2>/dev/null && exit 0
+        sleep 5
+        sudo chown -R $(whoami) /home/runner/ 2>/dev/null || true
 
     - name: Setup python
       uses: actions/setup-python@v5


### PR DESCRIPTION
# What does this PR do ?
Make the `Change ownership of /home/runner/` step in `.github/actions/action.yml` tolerant of a known infra race that was causing spurious test failures with the signature `FAILED (exit skipped)`.

After `actions/checkout@v6` finishes, it sometimes leaves a background `git gc --auto` running. The next step in the composite action runs `sudo chown -R $(whoami) /home/runner/`. While `chown` walks `.git/objects/pack/`, `git pack-objects` renames/deletes its temporary `.tmp-<pid>-pack-<hash>.idx` / `.rev` files. `chown` exits 1 with
`No such file or directory`, and because the composite shell uses `bash -e -o pipefail` by default, the step fails.
Every subsequent step (`Setup python`, `Install uv`, `Pull container`, **`Run main script`**, …) is then auto-skipped, so the test never runs. The final `Check result` step reads `MAIN_CONCLUSION=skipped` and prints `❌ FAILED (exit code: skipped)` — making it look like a test regression when really nothing was ever tested. This race is non-deterministic and hardware/timing-dependent. It has hit several PRs over the past weeks on randomly different test jobs, e.g.:
- PR #4787 attempt 2 (run 25831006107):
  `gpt3_mcore_te_tp2_pp2_resume_torch_dist_cross_entropy_loss_fusion`
- PR #4787 attempt 3 (run 25872017494):
  `gpt3_mcore_te_tp2_pp1_te_a2a_ovlp_8experts_etp1_ep4`
Both jobs show the identical `chown: ... '.tmp-…-pack-….idx': No such file or directory` line in the log immediately before the spurious `exit skipped` failure.


## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
