### PR TITLE
ci: declare workflow-level `contents: read` on 7 read-only workflows

### DIFF
--- a/.github/workflows/auto-reminder-bot.yml
+++ b/.github/workflows/auto-reminder-bot.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 12 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   run-script:
     name: Run Auto Reminder Bot

--- a/.github/workflows/auto-update-copy-pr-bot.yml
+++ b/.github/workflows/auto-update-copy-pr-bot.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   auto-update-copy-pr-bot:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd-approve-test-queue.yml
+++ b/.github/workflows/cicd-approve-test-queue.yml
@@ -19,6 +19,9 @@ on:
     - cron: "*/5 * * * *" # Runs every 5 minutes
   workflow_dispatch: # Allows manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   approve-queue:
     runs-on: ubuntu-latest

--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -19,6 +19,9 @@ on:
   issue_comment:
     types: [created, edited, deleted]
 
+permissions:
+  contents: read
+
 jobs:
   community-bot:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@v0.65.10

--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -21,6 +21,8 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   community-bot:

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -9,6 +9,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+
 jobs:
   signal:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -22,6 +22,9 @@ on:
       - "skills/**"
       - "AGENTS.md"
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_sync_skills.yml@v0.91.0

--- a/.github/workflows/trigger-mbridge-tests.yml
+++ b/.github/workflows/trigger-mbridge-tests.yml
@@ -20,6 +20,9 @@ on:
           - "functional-only"
         default: "all"
 
+permissions:
+  contents: read
+
 jobs:
   trigger-mbridge-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What does this PR do?

Pins the default `GITHUB_TOKEN` to `contents: read` on the 7 workflows in `.github/workflows/` that don't actually use the default token for any write operation:

- `auto-reminder-bot.yml`: scheduled cron reminder, no GitHub API.
- `auto-update-copy-pr-bot.yml`: regenerates `.github/copy-pr-bot.yaml` from mcore team membership. The `gh api` calls and the final `git push` both go through `secrets.PAT`, not `GITHUB_TOKEN`.
- `cicd-approve-test-queue.yml`: runs `gh release download v0.1.0`. Release-asset read is covered by `contents: read`.
- `community-bot.yml`: community-PR labeling helper, no API mutation in the GITHUB_TOKEN path.
- `review-trigger.yml`: triggers downstream workflows, no `GITHUB_TOKEN` use.
- `sync-skills.yml`: filesystem sync only.
- `trigger-mbridge-tests.yml`: triggers a downstream test pipeline.

Left implicit on purpose:

- `build-docs.yml`, `copyright-check.yml`, `install-test.yml`, `multi-approval-bot.yml` all use `gh run view` with `github.token`. That needs `actions: read` on top of `contents: read`, which I'd rather leave to a maintainer who knows whether to grant it at workflow or job scope.
- `sync-team-usergroups.yml` falls back to `GITHUB_TOKEN` when no `NVIDIA_MCORE_ONCALL_TOKEN`/`PAT` is configured, and the script's actual scope needs aren't clear from outside.
- The release/cherry-pick/stale/close-inactive workflows obviously need write scopes and are not touched here.

## Issue tracking

Linked issue: N/A. Standalone CI hygiene change.

## Pre-checks

- [x] YAML validated locally with `yaml.safe_load` on each touched file.
- [x] No functional change. Only the scope of the implicit `GITHUB_TOKEN` is narrowed.
- [x] Workflows whose writes use `secrets.PAT` are unaffected by this scope change.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. The leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.