### PR TITLE
fix(mtp): bypass save_for_backward for non-tensor kwargs in _checkpointed_forward (Fixes #3643)

### DIFF
--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1077,22 +1077,31 @@ class MultiTokenPredictionLayer(MegatronModule):
         return hidden_states
 
     def _checkpointed_forward(self, forward_func, *args, **kwargs):
+        # `tensor_parallel.checkpoint` / `te_checkpoint` route every positional
+        # arg through `save_for_backward`, which only accepts tensors.
+        # See https://github.com/NVIDIA/Megatron-LM/issues/3643.
+        tensors = {k: v for k, v in kwargs.items() if v is None or torch.is_tensor(v)}
+        non_tensors = {k: v for k, v in kwargs.items() if k not in tensors}
+        tensor_keys = tuple(tensors.keys())
+
+        def custom_forward(*tensor_args):
+            return forward_func(*args, **dict(zip(tensor_keys, tensor_args)), **non_tensors)
+
         def checkpoint_handler():
             """Determines whether to use the `te_checkpoint` or `tensor_parallel.checkpoint`"""
             if self.config.fp8:
                 from megatron.core.extensions.transformer_engine import te_checkpoint
 
                 return te_checkpoint(
-                    forward_func,
+                    custom_forward,
                     self.config.distribute_saved_activations,
                     tensor_parallel.random.get_cuda_rng_tracker,
                     parallel_state.get_tensor_model_parallel_group(),
-                    *args,
-                    **kwargs,
+                    *tensors.values(),
                 )
             else:
                 return tensor_parallel.checkpoint(
-                    forward_func, self.config.distribute_saved_activations, *args, *kwargs.values()
+                    custom_forward, self.config.distribute_saved_activations, *tensors.values()
                 )
 
         if self.config.recompute_method == 'uniform':

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -169,6 +169,50 @@ class TestMultiTokenPredictionLayer:
         assert torch.equal(rolled_position_ids, expected_position_ids)
         assert torch.equal(rolled_padding_mask, expected_padding_mask)
 
+    def test_checkpointed_forward_with_packed_seq_params(self):
+        torch.manual_seed(_SEED)
+        config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
+        config.recompute_granularity = 'full'
+        config.recompute_method = 'uniform'
+        config.recompute_num_layers = 1
+        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec).cuda()
+        mtp_layer = mtp.layers[0]
+        mtp_layer.train()
+
+        seq_len, batch_size = 8, 1
+        hidden_states = torch.randn(
+            seq_len, batch_size, config.hidden_size, device='cuda', requires_grad=True
+        )
+        decoder_input = torch.randn(
+            seq_len, batch_size, config.hidden_size, device='cuda', requires_grad=True
+        )
+        cu_seqlens = torch.tensor([0, 5, 8], dtype=torch.int32, device='cuda')
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=5,
+            max_seqlen_kv=5,
+            qkv_format='thd',
+        )
+
+        captured = {}
+
+        def fake_forward(hidden_states, decoder_input, packed_seq_params=None, **_):
+            captured['packed_seq_params'] = packed_seq_params
+            return hidden_states + decoder_input
+
+        output = mtp_layer._checkpointed_forward(
+            fake_forward,
+            hidden_states=hidden_states,
+            decoder_input=decoder_input,
+            packed_seq_params=packed_seq_params,
+        )
+        output.sum().backward()
+
+        assert captured['packed_seq_params'] is packed_seq_params
+        assert hidden_states.grad is not None
+        assert decoder_input.grad is not None
+
     def test_forward_propagates_rolled_padding_mask(self, monkeypatch):
         """Test forward passes rolled padding_mask to transformer path."""
         torch.manual_seed(_SEED)
@@ -568,14 +612,16 @@ class TestMultiTokenPrediction:
         not HAVE_TE or not is_te_min_version("2.1.0"),
         reason="grouped_gemm requires TransformerEngine >= 2.1.0",
     )
+    @pytest.mark.parametrize("full_recompute", [False, True])
     @pytest.mark.parametrize(("tp", "cp"), [(1, 1), (2, 1), (2, 2)])
-    def test_packed_sequences(self, tp, cp):
-        """Test MTP with packed sequences."""
+    def test_packed_sequences(self, tp, cp, full_recompute):
         # Create args with packed sequences support
         seq_lengths = [16, 24, 12]  # Three sequences of different lengths
         total_seq_length = sum(seq_lengths)
 
-        args = self.create_test_args(tp, cp, total_seq_length, micro_batch_size=1)
+        args = self.create_test_args(
+            tp, cp, total_seq_length, micro_batch_size=1, full_recompute=full_recompute
+        )
         set_args(args)
 
         torch.manual_seed(_SEED)


### PR DESCRIPTION
# What does this PR do ?

Fix `TypeError: save_for_backward can only save variables, but argument N is of type PackedSeqParams` when training with **MTP + packed sequences + `recompute_granularity='full'`**.

## Issue tracking

Linked issue: Fixes #3643

### Root cause

`MultiTokenPredictionLayer._checkpointed_forward` unpacked all kwargs positionally into `tensor_parallel.checkpoint`, which routes them through `save_for_backward` (tensors / None only). With `PackedSeqParams` (or `InferenceParams`) in `kwargs` this crashes.

### Fix

Capture non-tensor kwargs via closure — same pattern as `megatron/core/recompute.py::checkpointed_forward`. Tensor-only paths are unchanged; FP8 and non-FP8 branches are now both positional.

### Tests

- New regression unit test `test_checkpointed_forward_with_packed_seq_params` — reproduces the exact `TypeError` without the fix, passes with it.
- Existing `test_packed_sequences` parametrized with `full_recompute=[False, True]`.

Verified locally on H200 (TE 2.12): both tests **PASSED**.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests (n/a — type-routing fix, no numerics change)
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
