### PR TITLE
[Dev][fix] FSDP EP-overlap CUDA-graph guard uses post-refactor API

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -40,7 +40,6 @@ from megatron.core.config_logger import has_config_logger_enabled, log_config_to
 from megatron.core.distributed.data_parallel_base import _BaseDataParallel
 from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.utils import is_te_min_version, log_single_rank
@@ -163,18 +162,12 @@ class FullyShardedDataParallel(_BaseDataParallel):
                 "1F1B overlap with FSDP does not support double buffer. "
                 "Please set fsdp_double_buffer=False in the ddp config."
             )
-            if config.cuda_graph_impl not in ["none", "full_iteration"]:
-                partial_cuda_graph_scopes = [
-                    scope
-                    for scope in config.cuda_graph_scope
-                    if scope
-                    not in (CudaGraphScope.full_iteration, CudaGraphScope.full_iteration_inference)
-                ]
-                assert not partial_cuda_graph_scopes, (
-                    "1F1B overlap with FSDP does not support partial CUDA graph scopes "
-                    f"({partial_cuda_graph_scopes}). "
-                    "Please use cuda_graph_scope='full' or disable CUDA graphs."
-                )
+            assert config.cuda_graph_impl in ("none", "full_iteration"), (
+                "1F1B overlap with FSDP does not support per-layer CUDA graphs "
+                f"(cuda_graph_impl={config.cuda_graph_impl!r}). "
+                "Use cuda_graph_impl='full_iteration' or disable CUDA graphs "
+                "(cuda_graph_impl='none')."
+            )
 
         if (
             config.overlap_moe_expert_parallel_comm


### PR DESCRIPTION
## Summary

PR #3796 (A2A overlap for Megatron-FSDP) introduced a guard in
`mcore_fsdp_adapter.py` that iterates the legacy `config.cuda_graph_scope`
list. After PR #4293 normalized `cuda_graph_scope` to `None` in
`TransformerConfig.__post_init__`, this iteration raises
`TypeError: 'NoneType' object is not iterable` whenever a user combines
`overlap_moe_expert_parallel_comm=True` with `cuda_graph_impl in {"local", "transformer_engine"}`.

The bug is currently dormant on dev because:
- The functional test `deepseek_proxy_fsdp_ep2_fsdp2_ep_overlap` does not set `--cuda-graph-impl` (defaults to `"none"`).
- The unit test `test_fsdp_1f1b_overlap.py` likewise leaves `cuda_graph_impl="none"`.
- The outer guard `if config.cuda_graph_impl not in ["none", "full_iteration"]` short-circuits the buggy iteration in both cases.

But any legitimate config that combines EP overlap with per-layer CUDA graphs will crash immediately. The equivalent silent failure on main (PR #3797, where no outer guard exists) was triggering the analogous merge-queue failures the corresponding refactor PR (#4292) — that fix has already been pushed there.

This PR applies the same migration to dev: drop the legacy `for scope in config.cuda_graph_scope` iteration and the now-unused `CudaGraphScope` import, and rely on a single `cuda_graph_impl` assertion that matches the original intent (per-layer CUDA graphs are not supported with FSDP EP overlap).

## Test plan

- [ ] Verify existing `tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py` continues to pass (cuda_graph_impl defaults to "none", same path).
- [ ] Verify `tests/functional_tests/test_cases/moe/deepseek_proxy_fsdp_ep2_fsdp2_ep_overlap` continues to pass.
- [ ] Manually verify a config with `--overlap-moe-expert-parallel-comm --cuda-graph-impl=local` now produces a clear assertion error instead of a `TypeError` traceback.

cc @Wohox — friendly ping, this is a follow-up to your #3796 to make it compatible with the post-refactor CUDA-graph API. Please review when you have a moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)