### PR TITLE
Add minimal DBuffer implementation

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/dbuffer.py
@@ -1,0 +1,497 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Distributed flat buffers for Megatron-FSDP."""
+
+import dataclasses
+import math
+from typing import Sequence
+
+import torch
+import torch.distributed as dist
+import torch.distributed.tensor as dist_tensor
+from torch.distributed import DeviceMesh
+from torch.distributed.tensor import DTensor
+
+MeshAxis = int | str
+
+
+class Placement:
+    """Base class for DBuffer placements."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Replicate(Placement):
+    """Replicated local buffer placement."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Partial(Placement):
+    """Unreduced replicated local buffer placement."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Flat(Placement):
+    """Flat per-unit dim-0 sharded local buffer placement."""
+
+
+@dataclasses.dataclass(frozen=True)
+class GlobalLayout:
+    """Global flat-buffer layout in element coordinates."""
+
+    tensor_shapes: tuple[torch.Size, ...]
+    tensor_to_offset: tuple[int, ...]
+    size: int
+
+    def get_local_range(self, mesh: DeviceMesh, placements: Sequence[Placement]) -> tuple[int, int]:
+        """Return this rank's local element offset and length for ``placements``."""
+        offset = 0
+        numel = self.size
+        for axis, placement in reversed(tuple(enumerate(placements))):
+            if not isinstance(placement, Flat):
+                continue
+            axis_size = mesh.size(axis)
+            if numel % axis_size != 0:
+                raise ValueError(
+                    f"Local range size {numel} is not divisible by Flat axis size {axis_size}."
+                )
+            shard_size = numel // axis_size
+            offset += mesh.get_local_rank(axis) * shard_size
+            numel = shard_size
+        return offset, numel
+
+
+def _non_leading_numel(shape: torch.Size) -> int:
+    return shape[1:].numel() if len(shape) > 1 else 1
+
+
+def _pad_to_multiple(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
+    if isinstance(axis, int):
+        if axis < 0:
+            axis += mesh.ndim
+        if axis < 0 or axis >= mesh.ndim:
+            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
+        return axis
+
+    dim_names = mesh.mesh_dim_names
+    if dim_names is None or axis not in dim_names:
+        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
+    return dim_names.index(axis)
+
+
+def _validate_placement(placement: Placement) -> None:
+    if not isinstance(placement, (Replicate, Partial, Flat)):
+        raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
+
+
+def _validate_placements(placements: Sequence[Placement]) -> None:
+    seen_flat = False
+    for placement in placements:
+        _validate_placement(placement)
+        if isinstance(placement, Flat):
+            seen_flat = True
+        elif seen_flat:
+            raise ValueError(
+                "Flat placements must be a suffix of the placement list so each "
+                "local buffer is a contiguous global-buffer range."
+            )
+
+
+def _compute_layout(shapes: Sequence[torch.Size], dp_size: int) -> GlobalLayout:
+    """Compute flat-buffer element offsets and globally padded size.
+
+    Args:
+        shapes: Logical tensor shapes in tensor-id order.
+        dp_size: Data-parallel shard count for this flat buffer layout.
+
+    Returns:
+        Global layout with element offsets and size padded to a multiple of
+        ``LCM(shape[1:].numel()) * dp_size``.
+    """
+    if dp_size <= 0:
+        raise ValueError(f"DP size must be positive, got {dp_size}.")
+
+    shapes = tuple(torch.Size(shape) for shape in shapes)
+    chunk_size = 1
+    for shape in shapes:
+        non_leading_numel = _non_leading_numel(shape)
+        if non_leading_numel <= 0:
+            raise ValueError(f"Cannot compute a layout for zero-sized non-leading dims: {shape}.")
+        chunk_size = math.lcm(chunk_size, non_leading_numel)
+
+    tensor_to_offset: list[int | None] = [None] * len(shapes)
+    fragment_items = []
+    regular_items = []
+    for tensor_id, shape in enumerate(shapes):
+        if shape.numel() < chunk_size:
+            fragment_items.append((tensor_id, shape))
+        else:
+            regular_items.append((tensor_id, shape))
+
+    fragment_items.sort(key=lambda id_shape: -id_shape[1].numel())
+
+    data_index = 0
+    while regular_items:
+        tensor_id, shape = regular_items.pop(0)
+        tensor_numel = shape.numel()
+        tensor_to_offset[tensor_id] = data_index
+
+        if tensor_numel % chunk_size == 0:
+            data_index += tensor_numel
+            continue
+
+        gap_offset = data_index + tensor_numel
+        data_index += _pad_to_multiple(tensor_numel, chunk_size)
+        fragment_gap_end = data_index
+        remain = tensor_numel % chunk_size
+
+        found_rhs = None
+        for rhs in regular_items[:]:
+            _, rhs_shape = rhs
+            rhs_numel = rhs_shape.numel()
+            rhs_remain = rhs_numel % chunk_size
+            if rhs_remain == 0:
+                continue
+            if remain + rhs_remain <= chunk_size:
+                found_rhs = rhs
+                regular_items.remove(rhs)
+                break
+
+        if found_rhs is not None:
+            rhs_id, rhs_shape = found_rhs
+            rhs_numel = rhs_shape.numel()
+            rhs_remain = rhs_numel % chunk_size
+            rhs_offset = data_index - rhs_remain
+            tensor_to_offset[rhs_id] = rhs_offset
+            fragment_gap_end = rhs_offset
+            data_index += (rhs_numel // chunk_size) * chunk_size
+
+        for fragment in fragment_items[:]:
+            frag_id, frag_shape = fragment
+            frag_numel = frag_shape.numel()
+            aligned_gap_offset = _pad_to_multiple(gap_offset, _non_leading_numel(frag_shape))
+            if aligned_gap_offset + frag_numel > fragment_gap_end:
+                continue
+            tensor_to_offset[frag_id] = aligned_gap_offset
+            gap_offset = aligned_gap_offset + frag_numel
+            fragment_items.remove(fragment)
+
+    for frag_id, frag_shape in fragment_items:
+        data_index = _pad_to_multiple(data_index, _non_leading_numel(frag_shape))
+        tensor_to_offset[frag_id] = data_index
+        data_index += frag_shape.numel()
+
+    if any(offset is None for offset in tensor_to_offset):
+        raise AssertionError(f"Incomplete DBuffer layout for shapes {shapes}.")
+
+    resolved_tensor_to_offset = tuple(offset for offset in tensor_to_offset if offset is not None)
+    for shape, offset in zip(shapes, resolved_tensor_to_offset, strict=True):
+        row_size = _non_leading_numel(shape)
+        if offset % row_size != 0:
+            raise AssertionError(f"Tensor offset {offset} is not aligned to row size {row_size}.")
+    size = _pad_to_multiple(data_index, chunk_size * dp_size)
+    return GlobalLayout(tensor_shapes=shapes, tensor_to_offset=resolved_tensor_to_offset, size=size)
+
+
+class DBuffer:
+    """A flat distributed buffer holding a group of logical tensors.
+
+    DBuffer stores one flat local tensor and enough metadata to return per-tensor
+    views, redistribute the buffer across mesh axes, and materialize per-tensor
+    DTensors for optimizer state or distributed checkpointing.
+    """
+
+    mesh: DeviceMesh
+    placements: tuple[Placement, ...]
+    layout: GlobalLayout
+    offset: int
+    local_buffer: torch.Tensor
+
+    def __init__(
+        self,
+        mesh: DeviceMesh,
+        placements: Sequence[Placement],
+        tensor_shapes: Sequence[torch.Size],
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> None:
+        """Create a DBuffer and allocate its local flat buffer.
+
+        Args:
+            mesh: Device mesh whose dimensions correspond to ``placements``.
+            placements: Per-mesh-axis DBuffer placements.
+            tensor_shapes: Global shapes for each logical tensor in this buffer.
+            dtype: Dtype for the local flat buffer.
+            device: Device for the local flat buffer.
+        """
+        placements = tuple(placements)
+        if len(placements) != mesh.ndim:
+            raise ValueError(
+                f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
+            )
+        _validate_placements(placements)
+
+        self.mesh = mesh
+        self.placements = placements
+
+        tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
+        self.layout = _compute_layout(tensor_shapes, dp_size=self.mesh.size())
+
+        self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
+        self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
+
+    @classmethod
+    def distribute_tensors(
+        cls, tensors: Sequence[torch.Tensor], mesh: DeviceMesh, placements: Sequence[Placement]
+    ) -> "DBuffer":
+        """Distribute full local tensor values into a DBuffer.
+
+        Args:
+            tensors: Full tensor values available on this rank.
+            mesh: Device mesh whose dimensions correspond to ``placements``.
+            placements: Per-mesh-axis DBuffer placements.
+
+        Returns:
+            A DBuffer whose local storage matches ``placements``.
+        """
+        if not tensors:
+            raise ValueError("DBuffer.distribute_tensors() requires at least one tensor.")
+
+        tensors = tuple(
+            (
+                tensor.to(mesh.device_type)
+                if tensor.device.type != mesh.device_type and not tensor.is_meta
+                else tensor
+            )
+            for tensor in tensors
+        )
+        dtype = tensors[0].dtype
+        device = tensors[0].device
+        for tensor in tensors:
+            if tensor.dtype != dtype or tensor.device != device:
+                raise ValueError("All tensors in a DBuffer must have the same dtype and device.")
+            if not tensor.is_contiguous():
+                raise ValueError("DBuffer.distribute_tensors() expects contiguous tensors.")
+
+        tensor_shapes = tuple(tensor.shape for tensor in tensors)
+        buffer = cls(
+            mesh=mesh,
+            placements=placements,
+            tensor_shapes=tensor_shapes,
+            dtype=dtype,
+            device=device,
+        )
+        full_buffer = torch.zeros(buffer.layout.size, dtype=dtype, device=device)
+        for tensor, offset in zip(tensors, buffer.layout.tensor_to_offset, strict=True):
+            full_buffer.narrow(0, offset, tensor.numel()).copy_(tensor.view(-1))
+
+        local_buffer = full_buffer.narrow(0, buffer.offset, buffer.local_buffer.numel())
+        buffer.local_buffer.copy_(local_buffer)
+        return buffer
+
+    def redistribute(self, new_placements: Sequence[Placement]) -> "DBuffer":
+        """Redistribute this buffer to ``new_placements``.
+
+        This dispatcher composes the supported one-axis transitions:
+        Flat -> Replicate, Partial -> Replicate, Partial -> Flat, and
+        Replicate -> Flat. Other placement changes are intentionally unsupported.
+        """
+        new_placements = tuple(new_placements)
+        if len(new_placements) != self.mesh.ndim:
+            raise ValueError(
+                f"Expected {self.mesh.ndim} placements for device mesh, got "
+                f"{len(new_placements)}."
+            )
+        _validate_placements(new_placements)
+
+        buffer = self
+        for axis, new_placement in enumerate(new_placements):
+            old_placement = buffer.placements[axis]
+            if old_placement == new_placement:
+                continue
+            if isinstance(old_placement, Flat) and isinstance(new_placement, Replicate):
+                buffer = buffer.allgather(axis)
+            elif isinstance(old_placement, Partial) and isinstance(new_placement, Replicate):
+                buffer = buffer.allreduce(axis)
+            elif isinstance(old_placement, Partial) and isinstance(new_placement, Flat):
+                buffer = buffer.reduce_scatter(axis, new_placement)
+            elif isinstance(old_placement, Replicate) and isinstance(new_placement, Flat):
+                buffer = buffer.scatter(axis, new_placement)
+            else:
+                raise NotImplementedError(
+                    "Unsupported DBuffer placement transition on axis "
+                    f"{axis}: {old_placement!r} -> {new_placement!r}."
+                )
+
+        if buffer.placements != new_placements:
+            raise AssertionError(
+                f"Redistribute produced placements {buffer.placements}, expected {new_placements}."
+            )
+        return buffer
+
+    def allgather(self, mesh_axis: MeshAxis) -> "DBuffer":
+        """All-gather a Flat axis into Replicate placement."""
+        axis = _axis_index(self.mesh, mesh_axis)
+        if not isinstance(self.placements[axis], Flat):
+            raise ValueError(f"allgather() requires Flat placement on axis {mesh_axis!r}.")
+
+        placements = list(self.placements)
+        placements[axis] = Replicate()
+        _validate_placements(placements)
+        buffer = DBuffer(
+            mesh=self.mesh,
+            placements=placements,
+            tensor_shapes=self.layout.tensor_shapes,
+            dtype=self.local_buffer.dtype,
+            device=self.local_buffer.device,
+        )
+        dist.all_gather_into_tensor(
+            output_tensor=buffer.local_buffer,
+            input_tensor=self.local_buffer,
+            group=self.mesh.get_group(axis),
+        )
+        return buffer
+
+    def allreduce(self, mesh_axis: MeshAxis) -> "DBuffer":
+        """All-reduce a Partial axis into Replicate placement."""
+        axis = _axis_index(self.mesh, mesh_axis)
+        if not isinstance(self.placements[axis], Partial):
+            raise ValueError(f"allreduce() requires Partial placement on axis {mesh_axis!r}.")
+
+        placements = list(self.placements)
+        placements[axis] = Replicate()
+        buffer = DBuffer(
+            mesh=self.mesh,
+            placements=placements,
+            tensor_shapes=self.layout.tensor_shapes,
+            dtype=self.local_buffer.dtype,
+            device=self.local_buffer.device,
+        )
+        buffer.local_buffer.copy_(self.local_buffer)
+        dist.all_reduce(buffer.local_buffer, op=dist.ReduceOp.SUM, group=self.mesh.get_group(axis))
+        return buffer
+
+    def reduce_scatter(self, mesh_axis: MeshAxis, new_placement: Placement) -> "DBuffer":
+        """Reduce-scatter a Partial axis into ``new_placement``."""
+        axis = _axis_index(self.mesh, mesh_axis)
+        if not isinstance(new_placement, Flat):
+            raise NotImplementedError("DBuffer currently supports reduce_scatter() to Flat only.")
+        if not isinstance(self.placements[axis], Partial):
+            raise ValueError(f"reduce_scatter() requires Partial placement on axis {mesh_axis!r}.")
+
+        placements = list(self.placements)
+        placements[axis] = new_placement
+        _validate_placements(placements)
+        buffer = DBuffer(
+            mesh=self.mesh,
+            placements=placements,
+            tensor_shapes=self.layout.tensor_shapes,
+            dtype=self.local_buffer.dtype,
+            device=self.local_buffer.device,
+        )
+        dist.reduce_scatter_tensor(
+            output=buffer.local_buffer,
+            input=self.local_buffer,
+            op=dist.ReduceOp.SUM,
+            group=self.mesh.get_group(axis),
+        )
+        return buffer
+
+    def scatter(self, mesh_axis: MeshAxis, new_placement: Placement) -> "DBuffer":
+        """Locally chunk a Replicate axis into ``new_placement``."""
+        axis = _axis_index(self.mesh, mesh_axis)
+        if not isinstance(new_placement, Flat):
+            raise NotImplementedError("DBuffer currently supports scatter() to Flat only.")
+        if not isinstance(self.placements[axis], Replicate):
+            raise ValueError(f"scatter() requires Replicate placement on axis {mesh_axis!r}.")
+
+        placements = list(self.placements)
+        placements[axis] = new_placement
+        _validate_placements(placements)
+        buffer = DBuffer(
+            mesh=self.mesh,
+            placements=placements,
+            tensor_shapes=self.layout.tensor_shapes,
+            dtype=self.local_buffer.dtype,
+            device=self.local_buffer.device,
+        )
+        local_buffer_offset = buffer.offset - self.offset
+        if (
+            local_buffer_offset < 0
+            or local_buffer_offset + buffer.local_buffer.numel() > self.local_buffer.numel()
+        ):
+            raise RuntimeError("scatter() destination is not contained in the source local buffer.")
+        buffer.local_buffer.copy_(
+            self.local_buffer.narrow(0, local_buffer_offset, buffer.local_buffer.numel())
+        )
+        return buffer
+
+    def get_tensor(self, index: int) -> torch.Tensor:
+        """Return this rank's local view for logical tensor ``index``.
+
+        Flat placements shard dim 0, so the returned view preserves all
+        non-leading dimensions and only changes the leading dimension.
+        """
+        shape = self.layout.tensor_shapes[index]
+        offset = self.layout.tensor_to_offset[index]
+        numel = shape.numel()
+
+        tensor_start = offset
+        tensor_end = offset + numel
+        overlap_start = max(tensor_start, self.offset)
+        overlap_end = min(tensor_end, self.offset + self.local_buffer.numel())
+
+        row_size = _non_leading_numel(shape)
+        if overlap_end <= overlap_start:
+            empty_shape = torch.Size((0, *shape[1:]))
+            return torch.empty(
+                empty_shape, dtype=self.local_buffer.dtype, device=self.local_buffer.device
+            )
+
+        local_numel = overlap_end - overlap_start
+        local_buffer_offset = overlap_start - self.offset
+        if (overlap_start - tensor_start) % row_size != 0 or local_numel % row_size != 0:
+            raise RuntimeError(
+                f"Local tensor shard for tensor {index} does not preserve dim-0 boundaries."
+            )
+        local_shape = torch.Size((local_numel // row_size, *shape[1:]))
+        return self.local_buffer.narrow(0, local_buffer_offset, local_numel).view(local_shape)
+
+    def get_dtensor(self, index: int) -> DTensor:
+        """Return logical tensor ``index`` as a DTensor."""
+        torch_placements = []
+        for placement in self.placements:
+            if isinstance(placement, Replicate):
+                torch_placements.append(dist_tensor.Replicate())
+            elif isinstance(placement, Flat):
+                torch_placements.append(dist_tensor.Shard(0))
+            elif isinstance(placement, Partial):
+                raise ValueError("Partial DBuffer placements cannot be represented as DTensor.")
+            else:
+                raise TypeError(f"Unsupported placement for DTensor conversion: {placement!r}.")
+
+        local_tensor = self.get_tensor(index)
+        tensor_shape = self.layout.tensor_shapes[index]
+        return DTensor.from_local(
+            local_tensor=local_tensor,
+            device_mesh=self.mesh,
+            placements=tuple(torch_placements),
+            run_check=False,
+            shape=tensor_shape,
+            stride=local_tensor.stride(),
+        )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -16,11 +16,4 @@
 
 from .dbuffer import DBuffer, Flat, MeshAxis, Partial, Placement, Replicate
 
-__all__ = [
-    "DBuffer",
-    "Flat",
-    "MeshAxis",
-    "Partial",
-    "Placement",
-    "Replicate",
-]
+__all__ = ["DBuffer", "Flat", "MeshAxis", "Partial", "Placement", "Replicate"]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -14,6 +14,7 @@
 
 """Experimental Megatron-FSDP implementation."""
 
-from .dbuffer import DBuffer, Flat, MeshAxis, Partial, Placement, Replicate
+from .dbuffer import DBuffer, MeshAxis
+from .placement import Flat, Partial, Placement, Replicate
 
 __all__ = ["DBuffer", "Flat", "MeshAxis", "Partial", "Placement", "Replicate"]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Experimental Megatron-FSDP implementation."""
+
+from .dbuffer import DBuffer, Flat, MeshAxis, Partial, Placement, Replicate
+
+__all__ = [
+    "DBuffer",
+    "Flat",
+    "MeshAxis",
+    "Partial",
+    "Placement",
+    "Replicate",
+]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -14,7 +14,7 @@
 
 """Experimental Megatron-FSDP implementation."""
 
-from .dbuffer import DBuffer, MeshAxis
+from .dbuffer import DBuffer
 from .placement import Flat, Partial, Placement, Replicate
 
-__all__ = ["DBuffer", "Flat", "MeshAxis", "Partial", "Placement", "Replicate"]
+__all__ = ["DBuffer", "Flat", "Partial", "Placement", "Replicate"]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -243,6 +243,11 @@ class DBuffer:
         """Dtype of the local buffer."""
         return self.local_buffer.dtype
 
+    @property
+    def device(self) -> torch.device:
+        """Device of the local buffer."""
+        return self.local_buffer.device
+
     @classmethod
     def from_local(
         cls,
@@ -302,24 +307,14 @@ class DBuffer:
         Returns:
             A DBuffer whose local storage matches ``placements``.
         """
-        tensors = tuple(
-            (
-                tensor.to(mesh.device_type)
-                if tensor.device.type != mesh.device_type and not tensor.is_meta
-                else tensor
-            )
-            .detach()
-            .contiguous()
-            for tensor in tensors
-        )
+        tensors = tuple(tensor.detach().contiguous() for tensor in tensors)
         if not tensors:
             raise ValueError("DBuffer.distribute_tensors() requires at least one tensor.")
 
         dtype = tensors[0].dtype
-        device = tensors[0].device
         for tensor in tensors:
-            if tensor.dtype != dtype or tensor.device != device:
-                raise ValueError("All tensors in a DBuffer must have the same dtype and device.")
+            if tensor.dtype != dtype:
+                raise ValueError("All tensors in a DBuffer must have the same dtype.")
 
         tensor_shapes = tuple(tensor.shape for tensor in tensors)
         buffer = cls(
@@ -327,7 +322,7 @@ class DBuffer:
             placements=placements,
             tensor_shapes=tensor_shapes,
             dtype=dtype,
-            device=device,
+            device=mesh.device_type,
         )
         local_start = buffer.offset
         local_end = local_start + buffer.local_buffer.numel()
@@ -343,8 +338,9 @@ class DBuffer:
             overlap_numel = overlap_end - overlap_start
             source_offset = overlap_start - tensor_start
             destination_offset = overlap_start - local_start
+            source_slice = tensor.view(-1).narrow(0, source_offset, overlap_numel)
             buffer.local_buffer.narrow(0, destination_offset, overlap_numel).copy_(
-                tensor.view(-1).narrow(0, source_offset, overlap_numel)
+                source_slice.to(buffer.device)
             )
         return buffer
 
@@ -358,7 +354,7 @@ class DBuffer:
                 placements=placements,
                 tensor_shapes=self.layout.tensor_shapes,
                 dtype=self.dtype,
-                device=self.local_buffer.device,
+                device=self.device,
             )
 
         if out.mesh != self.mesh:
@@ -369,10 +365,8 @@ class DBuffer:
             raise ValueError(f"Expected out layout {self.layout!r}, got {out.layout!r}.")
         if out.dtype != self.dtype:
             raise ValueError(f"Expected out dtype {self.dtype}, got {out.dtype}.")
-        if out.local_buffer.device != self.local_buffer.device:
-            raise ValueError(
-                f"Expected out device {self.local_buffer.device}, got {out.local_buffer.device}."
-            )
+        if out.device != self.device:
+            raise ValueError(f"Expected out device {self.device}, got {out.device}.")
         return out
 
     def redistribute(
@@ -542,7 +536,7 @@ class DBuffer:
         row_size = _non_leading_numel(shape)
         if overlap_end <= overlap_start:
             empty_shape = torch.Size((0, *shape[1:]))
-            return torch.empty(empty_shape, dtype=self.dtype, device=self.local_buffer.device)
+            return torch.empty(empty_shape, dtype=self.dtype, device=self.device)
 
         local_numel = overlap_end - overlap_start
         local_buffer_offset = overlap_start - self.offset

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -367,15 +367,17 @@ class DBuffer:
             )
 
         if out.mesh != self.mesh:
-            raise ValueError("out must use the same mesh.")
+            raise ValueError(f"Expected out mesh {self.mesh!r}, got {out.mesh!r}.")
         if out.placements != placements:
-            raise ValueError(f"Expected out placements {placements}, got {out.placements}.")
+            raise ValueError(f"Expected out placements {placements!r}, got {out.placements!r}.")
         if out.layout != self.layout:
-            raise ValueError("out layout must match the source layout.")
+            raise ValueError(f"Expected out layout {self.layout!r}, got {out.layout!r}.")
         if out.dtype != self.dtype:
-            raise ValueError("out dtype must match the source dtype.")
+            raise ValueError(f"Expected out dtype {self.dtype}, got {out.dtype}.")
         if out.local_buffer.device != self.local_buffer.device:
-            raise ValueError("out device must match the source device.")
+            raise ValueError(
+                f"Expected out device {self.local_buffer.device}, got {out.local_buffer.device}."
+            )
         return out
 
     def redistribute(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -24,7 +24,7 @@ from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
 from .layout import GlobalLayout, Shape, non_leading_numel
-from .placement import Flat, Partial, Placement, Replicate, validate_placements
+from .placement import Flat, Partial, Placement, Replicate
 
 
 @dataclasses.dataclass(frozen=True)
@@ -39,6 +39,20 @@ def _validate_mesh_axis(mesh: DeviceMesh, axis: int) -> None:
         raise TypeError(f"Mesh axis must be an int, got {type(axis).__name__}.")
     if axis < 0 or axis >= mesh.ndim:
         raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
+
+
+def _validate_placements(placements: Iterable[Placement]) -> None:
+    seen_flat = False
+    for placement in placements:
+        if not isinstance(placement, (Replicate, Partial, Flat)):
+            raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
+        if isinstance(placement, Flat):
+            seen_flat = True
+        elif seen_flat:
+            raise ValueError(
+                "Flat placements must be a suffix of the placement list so each "
+                "local buffer is a contiguous global-buffer range."
+            )
 
 
 class DBuffer:
@@ -81,7 +95,7 @@ class DBuffer:
             raise ValueError(
                 f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
             )
-        validate_placements(placements)
+        _validate_placements(placements)
 
         self.mesh = mesh
         self.placements = placements
@@ -146,7 +160,7 @@ class DBuffer:
             raise ValueError(
                 f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
             )
-        validate_placements(placements)
+        _validate_placements(placements)
         if local_buffer.dim() != 1:
             raise ValueError("local_buffer must be a flat 1D tensor.")
         if not local_buffer.is_contiguous():
@@ -255,7 +269,7 @@ class DBuffer:
                 f"Expected {self.mesh.ndim} placements for device mesh, got "
                 f"{len(new_placements)}."
             )
-        validate_placements(new_placements)
+        _validate_placements(new_placements)
 
         changed_axis: int | None = None
         for axis, (old_placement, new_placement) in enumerate(
@@ -303,7 +317,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[mesh_axis] = Replicate()
-        validate_placements(placements)
+        _validate_placements(placements)
         out = self._create_or_validate_out(placements, out)
         dist.all_gather_into_tensor(
             output_tensor=out.local_buffer,
@@ -343,7 +357,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = new_placement
-        validate_placements(placements)
+        _validate_placements(placements)
         out = self._create_or_validate_out(placements, out)
         dist.reduce_scatter_tensor(
             output=out.local_buffer,
@@ -366,7 +380,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = new_placement
-        validate_placements(placements)
+        _validate_placements(placements)
 
         if out is None:
             destination_offset, destination_numel = self.layout.get_local_range(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -423,20 +423,21 @@ class DBuffer:
         )
 
     def allgather(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
-        """All-gather a Flat axis into Replicate placement."""
+        """All-gather a sharded axis into Replicate placement."""
         _validate_mesh_axis(self.mesh, mesh_axis)
-        axis = mesh_axis
-        if not isinstance(self.placements[axis], Flat):
-            raise ValueError(f"allgather() requires Flat placement on axis {mesh_axis!r}.")
+        if not isinstance(self.placements[mesh_axis], Flat):
+            raise ValueError(
+                f"allgather() currently requires Flat placement on axis {mesh_axis!r}."
+            )
 
         placements = list(self.placements)
-        placements[axis] = Replicate()
+        placements[mesh_axis] = Replicate()
         validate_placements(placements)
         out = self._create_or_validate_out(placements, out)
         dist.all_gather_into_tensor(
             output_tensor=out.local_buffer,
             input_tensor=self.local_buffer,
-            group=self.mesh.get_group(axis),
+            group=self.mesh.get_group(mesh_axis),
         )
         return out
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -24,29 +24,10 @@ import torch.distributed.tensor as dist_tensor
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
+from .placement import Flat, Partial, Placement, Replicate, validate_placements
+
 MeshAxis = int | str
 Shape = torch.Size | Iterable[int]
-
-
-class Placement:
-    """Base class for DBuffer placements."""
-
-
-@dataclasses.dataclass(frozen=True)
-class Replicate(Placement):
-    """Replicated local buffer placement."""
-
-
-@dataclasses.dataclass(frozen=True)
-class Partial(Placement):
-    """Unreduced replicated local buffer placement."""
-
-    reduce_op: dist.ReduceOp.RedOpType = dist.ReduceOp.SUM
-
-
-@dataclasses.dataclass(frozen=True)
-class Flat(Placement):
-    """Flat per-unit dim-0 sharded local buffer placement."""
 
 
 @dataclasses.dataclass(frozen=True)
@@ -95,24 +76,6 @@ def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
     if dim_names is None or axis not in dim_names:
         raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
     return dim_names.index(axis)
-
-
-def _validate_placement(placement: Placement) -> None:
-    if not isinstance(placement, (Replicate, Partial, Flat)):
-        raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
-
-
-def _validate_placements(placements: Iterable[Placement]) -> None:
-    seen_flat = False
-    for placement in placements:
-        _validate_placement(placement)
-        if isinstance(placement, Flat):
-            seen_flat = True
-        elif seen_flat:
-            raise ValueError(
-                "Flat placements must be a suffix of the placement list so each "
-                "local buffer is a contiguous global-buffer range."
-            )
 
 
 def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
@@ -254,7 +217,7 @@ class DBuffer:
             raise ValueError(
                 f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
             )
-        _validate_placements(placements)
+        validate_placements(placements)
 
         self.mesh = mesh
         self.placements = placements
@@ -294,7 +257,7 @@ class DBuffer:
             raise ValueError(
                 f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
             )
-        _validate_placements(placements)
+        validate_placements(placements)
         if local_buffer.dim() != 1:
             raise ValueError("local_buffer must be a flat 1D tensor.")
 
@@ -415,7 +378,7 @@ class DBuffer:
                 f"Expected {self.mesh.ndim} placements for device mesh, got "
                 f"{len(new_placements)}."
             )
-        _validate_placements(new_placements)
+        validate_placements(new_placements)
 
         changed_axis: int | None = None
         for axis, (old_placement, new_placement) in enumerate(
@@ -461,7 +424,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = Replicate()
-        _validate_placements(placements)
+        validate_placements(placements)
         destination = self._create_or_validate_out(placements, out)
         dist.all_gather_into_tensor(
             output_tensor=destination.local_buffer,
@@ -501,7 +464,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = new_placement
-        _validate_placements(placements)
+        validate_placements(placements)
         destination = self._create_or_validate_out(placements, out)
         dist.reduce_scatter_tensor(
             output=destination.local_buffer,
@@ -523,7 +486,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = new_placement
-        _validate_placements(placements)
+        validate_placements(placements)
 
         if out is None:
             destination_offset, destination_numel = self.layout.get_local_range(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -327,7 +327,7 @@ class DBuffer:
         local_start = buffer.offset
         local_end = local_start + buffer.local_buffer.numel()
         # Only logical tensor ranges are initialized. Padding and layout gaps are not
-        # observable through get_tensor() and can remain unspecified.
+        # observable through get_local_tensor() and can remain unspecified.
         for tensor, tensor_start in zip(tensors, buffer.layout.tensor_to_offset, strict=True):
             tensor_end = tensor_start + tensor.numel()
             overlap_start = max(local_start, tensor_start)
@@ -518,7 +518,7 @@ class DBuffer:
         out.local_buffer.copy_(local_slice)
         return out
 
-    def get_tensor(self, index: int) -> torch.Tensor:
+    def get_local_tensor(self, index: int) -> torch.Tensor:
         """Return this rank's local view for logical tensor ``index``.
 
         Flat placements shard dim 0, so the returned view preserves all
@@ -560,7 +560,7 @@ class DBuffer:
             else:
                 raise TypeError(f"Unsupported placement for DTensor conversion: {placement!r}.")
 
-        local_tensor = self.get_tensor(index)
+        local_tensor = self.get_local_tensor(index)
         tensor_shape = self.layout.tensor_shapes[index]
         return DTensor.from_local(
             local_tensor=local_tensor,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -16,7 +16,7 @@
 
 import dataclasses
 import math
-from typing import Sequence
+from collections.abc import Iterable, Sequence
 
 import torch
 import torch.distributed as dist
@@ -39,6 +39,8 @@ class Replicate(Placement):
 @dataclasses.dataclass(frozen=True)
 class Partial(Placement):
     """Unreduced replicated local buffer placement."""
+
+    reduce_op: dist.ReduceOp.RedOpType = dist.ReduceOp.SUM
 
 
 @dataclasses.dataclass(frozen=True)
@@ -257,7 +259,7 @@ class DBuffer:
 
     @classmethod
     def distribute_tensors(
-        cls, tensors: Sequence[torch.Tensor], mesh: DeviceMesh, placements: Sequence[Placement]
+        cls, tensors: Iterable[torch.Tensor], mesh: DeviceMesh, placements: Sequence[Placement]
     ) -> "DBuffer":
         """Distribute full local tensor values into a DBuffer.
 
@@ -269,24 +271,24 @@ class DBuffer:
         Returns:
             A DBuffer whose local storage matches ``placements``.
         """
-        if not tensors:
-            raise ValueError("DBuffer.distribute_tensors() requires at least one tensor.")
-
         tensors = tuple(
             (
                 tensor.to(mesh.device_type)
                 if tensor.device.type != mesh.device_type and not tensor.is_meta
                 else tensor
             )
+            .detach()
+            .contiguous()
             for tensor in tensors
         )
+        if not tensors:
+            raise ValueError("DBuffer.distribute_tensors() requires at least one tensor.")
+
         dtype = tensors[0].dtype
         device = tensors[0].device
         for tensor in tensors:
             if tensor.dtype != dtype or tensor.device != device:
                 raise ValueError("All tensors in a DBuffer must have the same dtype and device.")
-            if not tensor.is_contiguous():
-                raise ValueError("DBuffer.distribute_tensors() expects contiguous tensors.")
 
         tensor_shapes = tuple(tensor.shape for tensor in tensors)
         buffer = cls(
@@ -296,12 +298,23 @@ class DBuffer:
             dtype=dtype,
             device=device,
         )
-        full_buffer = torch.zeros(buffer.layout.size, dtype=dtype, device=device)
-        for tensor, offset in zip(tensors, buffer.layout.tensor_to_offset, strict=True):
-            full_buffer.narrow(0, offset, tensor.numel()).copy_(tensor.view(-1))
+        local_start = buffer.offset
+        local_end = local_start + buffer.local_buffer.numel()
+        # Only logical tensor ranges are initialized. Padding and layout gaps are not
+        # observable through get_tensor() and can remain unspecified.
+        for tensor, tensor_start in zip(tensors, buffer.layout.tensor_to_offset, strict=True):
+            tensor_end = tensor_start + tensor.numel()
+            overlap_start = max(local_start, tensor_start)
+            overlap_end = min(local_end, tensor_end)
+            if overlap_start >= overlap_end:
+                continue
 
-        local_buffer = full_buffer.narrow(0, buffer.offset, buffer.local_buffer.numel())
-        buffer.local_buffer.copy_(local_buffer)
+            overlap_numel = overlap_end - overlap_start
+            source_offset = overlap_start - tensor_start
+            destination_offset = overlap_start - local_start
+            buffer.local_buffer.narrow(0, destination_offset, overlap_numel).copy_(
+                tensor.view(-1).narrow(0, source_offset, overlap_numel)
+            )
         return buffer
 
     def redistribute(self, new_placements: Sequence[Placement]) -> "DBuffer":
@@ -370,7 +383,8 @@ class DBuffer:
     def allreduce(self, mesh_axis: MeshAxis) -> "DBuffer":
         """All-reduce a Partial axis into Replicate placement."""
         axis = _axis_index(self.mesh, mesh_axis)
-        if not isinstance(self.placements[axis], Partial):
+        partial_placement = self.placements[axis]
+        if not isinstance(partial_placement, Partial):
             raise ValueError(f"allreduce() requires Partial placement on axis {mesh_axis!r}.")
 
         placements = list(self.placements)
@@ -383,7 +397,11 @@ class DBuffer:
             device=self.local_buffer.device,
         )
         buffer.local_buffer.copy_(self.local_buffer)
-        dist.all_reduce(buffer.local_buffer, op=dist.ReduceOp.SUM, group=self.mesh.get_group(axis))
+        dist.all_reduce(
+            buffer.local_buffer,
+            op=partial_placement.reduce_op,
+            group=self.mesh.get_group(axis),
+        )
         return buffer
 
     def reduce_scatter(self, mesh_axis: MeshAxis, new_placement: Placement) -> "DBuffer":
@@ -391,7 +409,8 @@ class DBuffer:
         axis = _axis_index(self.mesh, mesh_axis)
         if not isinstance(new_placement, Flat):
             raise NotImplementedError("DBuffer currently supports reduce_scatter() to Flat only.")
-        if not isinstance(self.placements[axis], Partial):
+        partial_placement = self.placements[axis]
+        if not isinstance(partial_placement, Partial):
             raise ValueError(f"reduce_scatter() requires Partial placement on axis {mesh_axis!r}.")
 
         placements = list(self.placements)
@@ -407,7 +426,7 @@ class DBuffer:
         dist.reduce_scatter_tensor(
             output=buffer.local_buffer,
             input=self.local_buffer,
-            op=dist.ReduceOp.SUM,
+            op=partial_placement.reduce_op,
             group=self.mesh.get_group(axis),
         )
         return buffer

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -112,21 +112,21 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         else:
             regular_items.append((tensor_id, shape))
 
-    fragment_items.sort(key=lambda id_shape: -id_shape[1].numel())
+    fragment_items.sort(key=lambda id_shape: id_shape[1].numel(), reverse=True)
 
-    data_index = 0
+    next_offset = 0
     while regular_items:
         tensor_id, shape = regular_items.pop(0)
         tensor_numel = shape.numel()
-        tensor_to_offset[tensor_id] = data_index
+        tensor_to_offset[tensor_id] = next_offset
 
         if tensor_numel % chunk_size == 0:
-            data_index += tensor_numel
+            next_offset += tensor_numel
             continue
 
-        gap_offset = data_index + tensor_numel
-        data_index += _pad_to_multiple(tensor_numel, chunk_size)
-        fragment_gap_end = data_index
+        gap_offset = next_offset + tensor_numel
+        next_offset += _pad_to_multiple(tensor_numel, chunk_size)
+        fragment_gap_end = next_offset
         remain = tensor_numel % chunk_size
 
         found_rhs = None
@@ -145,10 +145,10 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             rhs_id, rhs_shape = found_rhs
             rhs_numel = rhs_shape.numel()
             rhs_remain = rhs_numel % chunk_size
-            rhs_offset = data_index - rhs_remain
+            rhs_offset = next_offset - rhs_remain
             tensor_to_offset[rhs_id] = rhs_offset
             fragment_gap_end = rhs_offset
-            data_index += (rhs_numel // chunk_size) * chunk_size
+            next_offset += (rhs_numel // chunk_size) * chunk_size
 
         for fragment in fragment_items[:]:
             frag_id, frag_shape = fragment
@@ -161,9 +161,9 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             fragment_items.remove(fragment)
 
     for frag_id, frag_shape in fragment_items:
-        data_index = _pad_to_multiple(data_index, _non_leading_numel(frag_shape))
-        tensor_to_offset[frag_id] = data_index
-        data_index += frag_shape.numel()
+        next_offset = _pad_to_multiple(next_offset, _non_leading_numel(frag_shape))
+        tensor_to_offset[frag_id] = next_offset
+        next_offset += frag_shape.numel()
 
     if any(offset is None for offset in tensor_to_offset):
         raise AssertionError(f"Incomplete DBuffer layout for shapes {shapes}.")
@@ -173,7 +173,7 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         row_size = _non_leading_numel(shape)
         if offset % row_size != 0:
             raise AssertionError(f"Tensor offset {offset} is not aligned to row size {row_size}.")
-    size = _pad_to_multiple(data_index, chunk_size * dp_size)
+    size = _pad_to_multiple(next_offset, chunk_size * dp_size)
     return GlobalLayout(tensor_shapes=shapes, tensor_to_offset=resolved_tensor_to_offset, size=size)
 
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -81,6 +81,11 @@ def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
 def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
     """Compute global tensor element offsets and padded size.
 
+    This is a DBuffer-specific reimplementation of
+    ``param_and_grad_buffer.build_data_parallel_buffer_index``. It keeps only
+    the global offset construction and final DP-LCM padding; DBuffer derives
+    rank-local slices later through DTensor placements.
+
     The computed layout is compatible with Flat, TensorAtomic, and BlockAtomic,
     even though the latter two are not implemented.
 
@@ -103,6 +108,8 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             raise ValueError(f"Cannot compute a layout for zero-sized non-leading dims: {shape}.")
         chunk_size = math.lcm(chunk_size, non_leading_numel)
 
+    # The LCM part is the packing grid. Since every row size divides this grid,
+    # DP shard boundaries that are multiples of the grid avoid splitting dim-0 rows.
     tensor_to_offset: list[int | None] = [None] * len(shapes)
     fragment_items = []
     regular_items = []
@@ -112,6 +119,8 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         else:
             regular_items.append((tensor_id, shape))
 
+    # Regular tensors anchor the layout. Fragments are held back to fill padding
+    # gaps left by regular tensors whose sizes are not exact multiples of the grid.
     fragment_items.sort(key=lambda id_shape: id_shape[1].numel(), reverse=True)
 
     next_offset = 0
@@ -127,29 +136,34 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         gap_offset = next_offset + tensor_numel
         next_offset += _pad_to_multiple(tensor_numel, chunk_size)
         fragment_gap_end = next_offset
-        remain = tensor_numel % chunk_size
+        remainder = tensor_numel % chunk_size
 
-        found_rhs = None
-        for rhs in regular_items[:]:
-            _, rhs_shape = rhs
-            rhs_numel = rhs_shape.numel()
-            rhs_remain = rhs_numel % chunk_size
-            if rhs_remain == 0:
+        # Try to pair this non-divisible regular tensor with a conjugate regular
+        # tensor whose remainder fits in the same LCM part. The conjugate starts
+        # in the gap and then continues with full LCM parts after this one.
+        conjugate_item = None
+        for candidate_item in regular_items[:]:
+            _, candidate_shape = candidate_item
+            candidate_numel = candidate_shape.numel()
+            candidate_remainder = candidate_numel % chunk_size
+            if candidate_remainder == 0:
                 continue
-            if remain + rhs_remain <= chunk_size:
-                found_rhs = rhs
-                regular_items.remove(rhs)
+            if remainder + candidate_remainder <= chunk_size:
+                conjugate_item = candidate_item
+                regular_items.remove(candidate_item)
                 break
 
-        if found_rhs is not None:
-            rhs_id, rhs_shape = found_rhs
-            rhs_numel = rhs_shape.numel()
-            rhs_remain = rhs_numel % chunk_size
-            rhs_offset = next_offset - rhs_remain
-            tensor_to_offset[rhs_id] = rhs_offset
-            fragment_gap_end = rhs_offset
-            next_offset += (rhs_numel // chunk_size) * chunk_size
+        if conjugate_item is not None:
+            conjugate_id, conjugate_shape = conjugate_item
+            conjugate_numel = conjugate_shape.numel()
+            conjugate_remainder = conjugate_numel % chunk_size
+            conjugate_offset = next_offset - conjugate_remainder
+            tensor_to_offset[conjugate_id] = conjugate_offset
+            fragment_gap_end = conjugate_offset
+            next_offset += (conjugate_numel // chunk_size) * chunk_size
 
+        # Fill any remaining gap with fragments, keeping each fragment aligned to
+        # its own row size so dim-0 rows remain contiguous within DP shards.
         for fragment in fragment_items[:]:
             frag_id, frag_shape = fragment
             frag_numel = frag_shape.numel()
@@ -160,6 +174,7 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             gap_offset = aligned_gap_offset + frag_numel
             fragment_items.remove(fragment)
 
+    # Fragments that did not fit into regular-tensor gaps are appended at the tail.
     for frag_id, frag_shape in fragment_items:
         next_offset = _pad_to_multiple(next_offset, _non_leading_numel(frag_shape))
         tensor_to_offset[frag_id] = next_offset

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -259,7 +259,9 @@ class DBuffer:
         """Create a DBuffer from an existing local buffer.
 
         Args:
-            local_buffer: Local tensor storage for this rank.
+            local_buffer: Contiguous local tensor storage for this rank. DBuffer
+                uses it directly in collectives such as all-gather and
+                reduce-scatter, which are efficient with contiguous tensors.
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
             tensor_shapes: Global shapes for each logical tensor in this buffer.
@@ -275,6 +277,8 @@ class DBuffer:
         validate_placements(placements)
         if local_buffer.dim() != 1:
             raise ValueError("local_buffer must be a flat 1D tensor.")
+        if not local_buffer.is_contiguous():
+            raise ValueError("local_buffer must be contiguous for collective operations.")
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
         layout = _compute_layout(tensor_shapes, dp_size=mesh.size())
@@ -563,6 +567,8 @@ class DBuffer:
 
         local_tensor = self.get_local_tensor(index)
         tensor_shape = self.layout.tensor_shapes[index]
+        # DBuffer uses contiguous flat storage, and Flat only shards dim 0, so
+        # the local view's stride matches the logical global tensor stride.
         return DTensor.from_local(
             local_tensor=local_tensor,
             device_mesh=self.mesh,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -15,9 +15,7 @@
 """Distributed tensor buffers for Megatron-FSDP."""
 
 import dataclasses
-import math
 from collections.abc import Iterable
-from typing import TypeAlias
 
 import torch
 import torch.distributed as dist
@@ -25,9 +23,8 @@ import torch.distributed.tensor as dist_tensor
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
+from .layout import GlobalLayout, Shape, non_leading_numel
 from .placement import Flat, Partial, Placement, Replicate, validate_placements
-
-Shape: TypeAlias = torch.Size | Iterable[int]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -37,228 +34,11 @@ class _OwnedRange:
     buffer_relative_offset: int
 
 
-@dataclasses.dataclass(frozen=True)
-class GlobalLayout:
-    """Global tensor layout in element coordinates."""
-
-    tensor_shapes: tuple[torch.Size, ...]
-    tensor_to_offset: tuple[int, ...]
-    size: int
-
-    def __post_init__(self) -> None:
-        """Validate tensor offsets are row-aligned, in bounds, and non-overlapping."""
-
-        @dataclasses.dataclass(frozen=True)
-        class TensorRange:
-            start: int
-            end: int
-            tensor_id: int
-
-        if self.size < 0:
-            raise AssertionError(f"Global layout size {self.size} is negative.")
-        if len(self.tensor_shapes) != len(self.tensor_to_offset):
-            raise AssertionError(
-                "Global layout has mismatched tensor shapes and offsets: "
-                f"{len(self.tensor_shapes)} shapes and {len(self.tensor_to_offset)} offsets."
-            )
-
-        tensor_ranges: list[TensorRange] = []
-        for tensor_id, (shape, start) in enumerate(
-            zip(self.tensor_shapes, self.tensor_to_offset, strict=True)
-        ):
-            if start < 0:
-                raise AssertionError(f"Tensor {tensor_id} offset {start} is negative.")
-
-            row_size = _non_leading_numel(shape)
-            if row_size <= 0:
-                raise AssertionError(f"Tensor {tensor_id} has invalid row size {row_size}.")
-            if start % row_size != 0:
-                raise AssertionError(
-                    f"Tensor {tensor_id} offset {start} is not aligned to row size {row_size}."
-                )
-
-            end = start + shape.numel()
-            if end > self.size:
-                raise AssertionError(
-                    f"Tensor {tensor_id} range [{start}, {end}) exceeds "
-                    f"layout size {self.size}."
-                )
-            tensor_ranges.append(TensorRange(start, end, tensor_id))
-
-        previous_range: TensorRange | None = None
-        for current_range in sorted(tensor_ranges, key=lambda tensor_range: tensor_range.start):
-            if previous_range is not None and current_range.start < previous_range.end:
-                raise AssertionError(
-                    "Global layout tensors overlap: "
-                    f"tensor {previous_range.tensor_id} "
-                    f"[{previous_range.start}, {previous_range.end}) and "
-                    f"tensor {current_range.tensor_id} "
-                    f"[{current_range.start}, {current_range.end})."
-                )
-            previous_range = current_range
-
-    def get_local_range(self, mesh: DeviceMesh, placements: Iterable[Placement]) -> tuple[int, int]:
-        """Return this rank's local element offset and length for ``placements``."""
-        offset = 0
-        numel = self.size
-        for axis, placement in reversed(tuple(enumerate(placements))):
-            if not isinstance(placement, Flat):
-                continue
-            axis_size = mesh.size(axis)
-            if numel % axis_size != 0:
-                raise ValueError(
-                    f"Local range size {numel} is not divisible by Flat axis size {axis_size}."
-                )
-            shard_size = numel // axis_size
-            offset += mesh.get_local_rank(axis) * shard_size
-            numel = shard_size
-        return offset, numel
-
-
-def _non_leading_numel(shape: torch.Size) -> int:
-    return shape[1:].numel() if len(shape) > 1 else 1
-
-
-def _pad_to_multiple(value: int, multiple: int) -> int:
-    return ((value + multiple - 1) // multiple) * multiple
-
-
 def _validate_mesh_axis(mesh: DeviceMesh, axis: int) -> None:
     if not isinstance(axis, int) or isinstance(axis, bool):
         raise TypeError(f"Mesh axis must be an int, got {type(axis).__name__}.")
     if axis < 0 or axis >= mesh.ndim:
         raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
-
-
-def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
-    """Compute global tensor element offsets and padded size.
-
-    This is a DBuffer-specific reimplementation of
-    ``param_and_grad_buffer.build_data_parallel_buffer_index``. It keeps only
-    the global offset construction and final padding so each rank-local shard
-    size is a multiple of ``chunk_size``; DBuffer derives rank-local slices
-    later through DTensor placements.
-
-    The computed layout is compatible with Flat, TensorAtomic, and BlockAtomic,
-    even though the latter two are not implemented.
-
-    ``chunk_size`` is the least common multiple of each tensor's row size
-    (``shape[1:].numel()``). For example, with shapes P0=(2, 6), P1=(4, 4),
-    P2=(4, 4), P3=(1, 2), P4=(1, 6), ``chunk_size = LCM(6, 4, 4, 2, 6) = 12``
-    and a 5-rank DP layout has equal-size rank shards:
-
-    ```
-    rank 0 [ 0, 12): | P0 row 0              | P0 row 1               |
-    rank 1 [12, 24): | P1 row 0      | P1 row 1      | P1 row 2       |
-    rank 2 [24, 36): | P1 row 3      | P3    | gap   | P2 row 0       |
-    rank 3 [36, 48): | P2 row 1      | P2 row 2      | P2 row 3       |
-    rank 4 [48, 60): | P4                    | pad                    |
-    ```
-
-    The diagram uses four character columns per element; segment widths are
-    proportional. Every chunk boundary is aligned to each tensor's row size,
-    so each DP shard owns full rows even when fragments fill regular-tensor
-    padding gaps.
-
-    Args:
-        shapes: Logical tensor shapes in tensor-id order.
-        dp_size: Data-parallel shard count for this global layout.
-
-    Returns:
-        Global layout with row-aligned tensor offsets and a total size padded
-        to a multiple of ``chunk_size * dp_size``, so every rank-local shard
-        length is a multiple of ``chunk_size``.
-    """
-    if dp_size <= 0:
-        raise ValueError(f"DP size must be positive, got {dp_size}.")
-
-    tensor_shapes = tuple(torch.Size(shape) for shape in shapes)
-    chunk_size = 1
-    for shape in tensor_shapes:
-        non_leading_numel = _non_leading_numel(shape)
-        if non_leading_numel <= 0:
-            raise ValueError(f"Cannot compute a layout for zero-sized non-leading dims: {shape}.")
-        chunk_size = math.lcm(chunk_size, non_leading_numel)
-
-    # chunk_size is the packing unit. Since every tensor row size divides it,
-    # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
-    UNASSIGNED_OFFSET = -1
-    tensor_to_offset: list[int] = [UNASSIGNED_OFFSET] * len(tensor_shapes)
-    fragment_items = []
-    regular_items = []
-    for tensor_id, shape in enumerate(tensor_shapes):
-        if shape.numel() < chunk_size:
-            fragment_items.append((tensor_id, shape))
-        else:
-            regular_items.append((tensor_id, shape))
-
-    # Regular tensors anchor the layout. Fragments are held back to fill padding
-    # gaps left by regular tensors whose sizes are not exact multiples of chunk_size.
-    fragment_items.sort(key=lambda id_shape: id_shape[1].numel(), reverse=True)
-
-    next_offset = 0
-    while regular_items:
-        tensor_id, shape = regular_items.pop(0)
-        tensor_numel = shape.numel()
-        tensor_to_offset[tensor_id] = next_offset
-
-        if tensor_numel % chunk_size == 0:
-            next_offset += tensor_numel
-            continue
-
-        gap_offset = next_offset + tensor_numel
-        next_offset += _pad_to_multiple(tensor_numel, chunk_size)
-        fragment_gap_end = next_offset
-        remainder = tensor_numel % chunk_size
-
-        # Try to pair this non-divisible regular tensor with a conjugate regular
-        # tensor whose remainder fits in the same chunk_size interval. The
-        # conjugate starts in the gap and then continues with full chunk_size
-        # intervals after this one.
-        conjugate_item = None
-        for candidate_item in regular_items[:]:
-            _, candidate_shape = candidate_item
-            candidate_numel = candidate_shape.numel()
-            candidate_remainder = candidate_numel % chunk_size
-            if candidate_remainder == 0:
-                continue
-            if remainder + candidate_remainder <= chunk_size:
-                conjugate_item = candidate_item
-                regular_items.remove(candidate_item)
-                break
-
-        if conjugate_item is not None:
-            conjugate_id, conjugate_shape = conjugate_item
-            conjugate_numel = conjugate_shape.numel()
-            conjugate_remainder = conjugate_numel % chunk_size
-            conjugate_offset = next_offset - conjugate_remainder
-            tensor_to_offset[conjugate_id] = conjugate_offset
-            fragment_gap_end = conjugate_offset
-            next_offset += (conjugate_numel // chunk_size) * chunk_size
-
-        # Fill any remaining gap with fragments, keeping each fragment aligned to
-        # its own row size so dim-0 rows remain contiguous within DP shards.
-        for fragment in fragment_items[:]:
-            frag_id, frag_shape = fragment
-            frag_numel = frag_shape.numel()
-            aligned_gap_offset = _pad_to_multiple(gap_offset, _non_leading_numel(frag_shape))
-            if aligned_gap_offset + frag_numel > fragment_gap_end:
-                continue
-            tensor_to_offset[frag_id] = aligned_gap_offset
-            gap_offset = aligned_gap_offset + frag_numel
-            fragment_items.remove(fragment)
-
-    # Fragments that did not fit into regular-tensor gaps are appended at the tail.
-    for frag_id, frag_shape in fragment_items:
-        next_offset = _pad_to_multiple(next_offset, _non_leading_numel(frag_shape))
-        tensor_to_offset[frag_id] = next_offset
-        next_offset += frag_shape.numel()
-
-    return GlobalLayout(
-        tensor_shapes=tensor_shapes,
-        tensor_to_offset=tuple(tensor_to_offset),
-        size=_pad_to_multiple(next_offset, chunk_size * dp_size),
-    )
 
 
 class DBuffer:
@@ -307,7 +87,7 @@ class DBuffer:
         self.placements = placements
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        self.layout = _compute_layout(tensor_shapes, dp_size=self.mesh.size())
+        self.layout = GlobalLayout.build(tensor_shapes, dp_size=self.mesh.size())
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
@@ -373,7 +153,7 @@ class DBuffer:
             raise ValueError("local_buffer must be contiguous for collective operations.")
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        layout = _compute_layout(tensor_shapes, dp_size=mesh.size())
+        layout = GlobalLayout.build(tensor_shapes, dp_size=mesh.size())
         offset, local_numel = layout.get_local_range(mesh, placements)
         if local_buffer.numel() != local_numel:
             raise ValueError(
@@ -619,7 +399,7 @@ class DBuffer:
         shape = self.layout.tensor_shapes[index]
         owned_range = self._get_owned_range(index)
 
-        row_size = _non_leading_numel(shape)
+        row_size = non_leading_numel(shape)
         if owned_range is None:
             empty_shape = torch.Size((0, *shape[1:]))
             return torch.empty(empty_shape, dtype=self.dtype, device=self.device)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -16,7 +16,7 @@
 
 import dataclasses
 import math
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 import torch
 import torch.distributed as dist
@@ -56,7 +56,7 @@ class GlobalLayout:
     tensor_to_offset: tuple[int, ...]
     size: int
 
-    def get_local_range(self, mesh: DeviceMesh, placements: Sequence[Placement]) -> tuple[int, int]:
+    def get_local_range(self, mesh: DeviceMesh, placements: Iterable[Placement]) -> tuple[int, int]:
         """Return this rank's local element offset and length for ``placements``."""
         offset = 0
         numel = self.size
@@ -101,7 +101,7 @@ def _validate_placement(placement: Placement) -> None:
         raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
 
 
-def _validate_placements(placements: Sequence[Placement]) -> None:
+def _validate_placements(placements: Iterable[Placement]) -> None:
     seen_flat = False
     for placement in placements:
         _validate_placement(placement)
@@ -114,7 +114,7 @@ def _validate_placements(placements: Sequence[Placement]) -> None:
             )
 
 
-def _compute_layout(shapes: Sequence[torch.Size], dp_size: int) -> GlobalLayout:
+def _compute_layout(shapes: Iterable[torch.Size], dp_size: int) -> GlobalLayout:
     """Compute flat-buffer element offsets and globally padded size.
 
     Args:
@@ -227,8 +227,8 @@ class DBuffer:
     def __init__(
         self,
         mesh: DeviceMesh,
-        placements: Sequence[Placement],
-        tensor_shapes: Sequence[torch.Size],
+        placements: Iterable[Placement],
+        tensor_shapes: Iterable[torch.Size],
         dtype: torch.dtype,
         device: torch.device | str,
     ) -> None:
@@ -257,9 +257,59 @@ class DBuffer:
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
 
+    @property
+    def dtype(self) -> torch.dtype:
+        """Dtype of the local flat buffer."""
+        return self.local_buffer.dtype
+
+    @classmethod
+    def from_local(
+        cls,
+        local_buffer: torch.Tensor,
+        mesh: DeviceMesh,
+        placements: Iterable[Placement],
+        tensor_shapes: Iterable[torch.Size],
+    ) -> "DBuffer":
+        """Create a DBuffer from an existing local flat buffer.
+
+        Args:
+            local_buffer: Local flat tensor storage for this rank.
+            mesh: Device mesh whose dimensions correspond to ``placements``.
+            placements: Per-mesh-axis DBuffer placements.
+            tensor_shapes: Global shapes for each logical tensor in this buffer.
+
+        Returns:
+            A DBuffer that reuses ``local_buffer`` without allocating storage.
+        """
+        placements = tuple(placements)
+        if len(placements) != mesh.ndim:
+            raise ValueError(
+                f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
+            )
+        _validate_placements(placements)
+        if local_buffer.dim() != 1:
+            raise ValueError("local_buffer must be a flat 1D tensor.")
+
+        tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
+        layout = _compute_layout(tensor_shapes, dp_size=mesh.size())
+        offset, local_numel = layout.get_local_range(mesh, placements)
+        if local_buffer.numel() != local_numel:
+            raise ValueError(
+                f"Expected local_buffer with {local_numel} elements, got "
+                f"{local_buffer.numel()}."
+            )
+
+        buffer = cls.__new__(cls)
+        buffer.mesh = mesh
+        buffer.placements = placements
+        buffer.layout = layout
+        buffer.offset = offset
+        buffer.local_buffer = local_buffer
+        return buffer
+
     @classmethod
     def distribute_tensors(
-        cls, tensors: Iterable[torch.Tensor], mesh: DeviceMesh, placements: Sequence[Placement]
+        cls, tensors: Iterable[torch.Tensor], mesh: DeviceMesh, placements: Iterable[Placement]
     ) -> "DBuffer":
         """Distribute full local tensor values into a DBuffer.
 
@@ -317,10 +367,37 @@ class DBuffer:
             )
         return buffer
 
-    def redistribute(self, new_placements: Sequence[Placement]) -> "DBuffer":
+    def _create_or_validate_out(
+        self, placements: Iterable[Placement], out: "DBuffer | None"
+    ) -> "DBuffer":
+        placements = tuple(placements)
+        if out is None:
+            return DBuffer(
+                mesh=self.mesh,
+                placements=placements,
+                tensor_shapes=self.layout.tensor_shapes,
+                dtype=self.dtype,
+                device=self.local_buffer.device,
+            )
+
+        if out.mesh != self.mesh:
+            raise ValueError("out must use the same mesh.")
+        if out.placements != placements:
+            raise ValueError(f"Expected out placements {placements}, got {out.placements}.")
+        if out.layout != self.layout:
+            raise ValueError("out layout must match the source layout.")
+        if out.dtype != self.dtype:
+            raise ValueError("out dtype must match the source dtype.")
+        if out.local_buffer.device != self.local_buffer.device:
+            raise ValueError("out device must match the source device.")
+        return out
+
+    def redistribute(
+        self, new_placements: Iterable[Placement], *, out: "DBuffer | None" = None
+    ) -> "DBuffer":
         """Redistribute this buffer to ``new_placements``.
 
-        This dispatcher composes the supported one-axis transitions:
+        This dispatcher supports the one-axis transitions:
         Flat -> Replicate, Partial -> Replicate, Partial -> Flat, and
         Replicate -> Flat. Other placement changes are intentionally unsupported.
         """
@@ -332,32 +409,43 @@ class DBuffer:
             )
         _validate_placements(new_placements)
 
-        buffer = self
-        for axis, new_placement in enumerate(new_placements):
-            old_placement = buffer.placements[axis]
+        changed_axis: int | None = None
+        for axis, (old_placement, new_placement) in enumerate(
+            zip(self.placements, new_placements, strict=True)
+        ):
             if old_placement == new_placement:
                 continue
-            if isinstance(old_placement, Flat) and isinstance(new_placement, Replicate):
-                buffer = buffer.allgather(axis)
-            elif isinstance(old_placement, Partial) and isinstance(new_placement, Replicate):
-                buffer = buffer.allreduce(axis)
-            elif isinstance(old_placement, Partial) and isinstance(new_placement, Flat):
-                buffer = buffer.reduce_scatter(axis, new_placement)
-            elif isinstance(old_placement, Replicate) and isinstance(new_placement, Flat):
-                buffer = buffer.scatter(axis, new_placement)
-            else:
+            if changed_axis is not None:
                 raise NotImplementedError(
-                    "Unsupported DBuffer placement transition on axis "
-                    f"{axis}: {old_placement!r} -> {new_placement!r}."
+                    "redistribute() currently supports one placement change, "
+                    f"got changed axes {changed_axis} and {axis}."
                 )
+            changed_axis = axis
 
-        if buffer.placements != new_placements:
-            raise AssertionError(
-                f"Redistribute produced placements {buffer.placements}, expected {new_placements}."
-            )
-        return buffer
+        if changed_axis is None:
+            if out is None:
+                return self
+            destination = self._create_or_validate_out(new_placements, out)
+            destination.local_buffer.copy_(self.local_buffer)
+            return destination
 
-    def allgather(self, mesh_axis: MeshAxis) -> "DBuffer":
+        axis = changed_axis
+        old_placement = self.placements[axis]
+        new_placement = new_placements[axis]
+        if isinstance(old_placement, Flat) and isinstance(new_placement, Replicate):
+            return self.allgather(axis, out=out)
+        if isinstance(old_placement, Partial) and isinstance(new_placement, Replicate):
+            return self.allreduce(axis, out=out)
+        if isinstance(old_placement, Partial) and isinstance(new_placement, Flat):
+            return self.reduce_scatter(axis, new_placement, out=out)
+        if isinstance(old_placement, Replicate) and isinstance(new_placement, Flat):
+            return self.scatter(axis, new_placement, out=out)
+        raise NotImplementedError(
+            "Unsupported DBuffer placement transition on axis "
+            f"{axis}: {old_placement!r} -> {new_placement!r}."
+        )
+
+    def allgather(self, mesh_axis: MeshAxis, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-gather a Flat axis into Replicate placement."""
         axis = _axis_index(self.mesh, mesh_axis)
         if not isinstance(self.placements[axis], Flat):
@@ -366,21 +454,15 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = Replicate()
         _validate_placements(placements)
-        buffer = DBuffer(
-            mesh=self.mesh,
-            placements=placements,
-            tensor_shapes=self.layout.tensor_shapes,
-            dtype=self.local_buffer.dtype,
-            device=self.local_buffer.device,
-        )
+        destination = self._create_or_validate_out(placements, out)
         dist.all_gather_into_tensor(
-            output_tensor=buffer.local_buffer,
+            output_tensor=destination.local_buffer,
             input_tensor=self.local_buffer,
             group=self.mesh.get_group(axis),
         )
-        return buffer
+        return destination
 
-    def allreduce(self, mesh_axis: MeshAxis) -> "DBuffer":
+    def allreduce(self, mesh_axis: MeshAxis, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-reduce a Partial axis into Replicate placement."""
         axis = _axis_index(self.mesh, mesh_axis)
         partial_placement = self.placements[axis]
@@ -389,22 +471,18 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = Replicate()
-        buffer = DBuffer(
-            mesh=self.mesh,
-            placements=placements,
-            tensor_shapes=self.layout.tensor_shapes,
-            dtype=self.local_buffer.dtype,
-            device=self.local_buffer.device,
-        )
-        buffer.local_buffer.copy_(self.local_buffer)
+        destination = self._create_or_validate_out(placements, out)
+        destination.local_buffer.copy_(self.local_buffer)
         dist.all_reduce(
-            buffer.local_buffer,
+            destination.local_buffer,
             op=partial_placement.reduce_op,
             group=self.mesh.get_group(axis),
         )
-        return buffer
+        return destination
 
-    def reduce_scatter(self, mesh_axis: MeshAxis, new_placement: Placement) -> "DBuffer":
+    def reduce_scatter(
+        self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
+    ) -> "DBuffer":
         """Reduce-scatter a Partial axis into ``new_placement``."""
         axis = _axis_index(self.mesh, mesh_axis)
         if not isinstance(new_placement, Flat):
@@ -416,22 +494,18 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = new_placement
         _validate_placements(placements)
-        buffer = DBuffer(
-            mesh=self.mesh,
-            placements=placements,
-            tensor_shapes=self.layout.tensor_shapes,
-            dtype=self.local_buffer.dtype,
-            device=self.local_buffer.device,
-        )
+        destination = self._create_or_validate_out(placements, out)
         dist.reduce_scatter_tensor(
-            output=buffer.local_buffer,
+            output=destination.local_buffer,
             input=self.local_buffer,
             op=partial_placement.reduce_op,
             group=self.mesh.get_group(axis),
         )
-        return buffer
+        return destination
 
-    def scatter(self, mesh_axis: MeshAxis, new_placement: Placement) -> "DBuffer":
+    def scatter(
+        self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
+    ) -> "DBuffer":
         """Locally chunk a Replicate axis into ``new_placement``."""
         axis = _axis_index(self.mesh, mesh_axis)
         if not isinstance(new_placement, Flat):
@@ -442,23 +516,30 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = new_placement
         _validate_placements(placements)
-        buffer = DBuffer(
-            mesh=self.mesh,
-            placements=placements,
-            tensor_shapes=self.layout.tensor_shapes,
-            dtype=self.local_buffer.dtype,
-            device=self.local_buffer.device,
-        )
-        local_buffer_offset = buffer.offset - self.offset
+
+        if out is None:
+            destination_offset, destination_numel = self.layout.get_local_range(
+                self.mesh, placements
+            )
+        else:
+            destination = self._create_or_validate_out(placements, out)
+            destination_offset = destination.offset
+            destination_numel = destination.local_buffer.numel()
+
+        local_buffer_offset = destination_offset - self.offset
         if (
             local_buffer_offset < 0
-            or local_buffer_offset + buffer.local_buffer.numel() > self.local_buffer.numel()
+            or local_buffer_offset + destination_numel > self.local_buffer.numel()
         ):
             raise RuntimeError("scatter() destination is not contained in the source local buffer.")
-        buffer.local_buffer.copy_(
-            self.local_buffer.narrow(0, local_buffer_offset, buffer.local_buffer.numel())
-        )
-        return buffer
+        local_slice = self.local_buffer.narrow(0, local_buffer_offset, destination_numel)
+        if out is None:
+            return DBuffer.from_local(
+                local_slice, self.mesh, placements, self.layout.tensor_shapes
+            )
+
+        destination.local_buffer.copy_(local_slice)
+        return destination
 
     def get_tensor(self, index: int) -> torch.Tensor:
         """Return this rank's local view for logical tensor ``index``.
@@ -479,7 +560,7 @@ class DBuffer:
         if overlap_end <= overlap_start:
             empty_shape = torch.Size((0, *shape[1:]))
             return torch.empty(
-                empty_shape, dtype=self.local_buffer.dtype, device=self.local_buffer.device
+                empty_shape, dtype=self.dtype, device=self.local_buffer.device
             )
 
         local_numel = overlap_end - overlap_start

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -31,6 +31,13 @@ Shape: TypeAlias = torch.Size | Iterable[int]
 
 
 @dataclasses.dataclass(frozen=True)
+class _OwnedRange:
+    numel: int
+    tensor_relative_offset: int
+    buffer_relative_offset: int
+
+
+@dataclasses.dataclass(frozen=True)
 class GlobalLayout:
     """Global tensor layout in element coordinates."""
 
@@ -248,6 +255,24 @@ class DBuffer:
         """Device of the local buffer."""
         return self.local_buffer.device
 
+    def _get_owned_range(self, tensor_index: int) -> _OwnedRange | None:
+        """Return this buffer's owned range for logical tensor ``tensor_index``."""
+        tensor_start = self.layout.tensor_to_offset[tensor_index]
+        tensor_end = tensor_start + self.layout.tensor_shapes[tensor_index].numel()
+        buffer_start = self.offset
+        buffer_end = self.offset + self.local_buffer.numel()
+
+        overlap_start = max(tensor_start, buffer_start)
+        overlap_end = min(tensor_end, buffer_end)
+        if overlap_start >= overlap_end:
+            return None
+
+        return _OwnedRange(
+            numel=overlap_end - overlap_start,
+            tensor_relative_offset=overlap_start - tensor_start,
+            buffer_relative_offset=overlap_start - buffer_start,
+        )
+
     @classmethod
     def from_local(
         cls,
@@ -328,24 +353,19 @@ class DBuffer:
             dtype=dtype,
             device=mesh.device_type,
         )
-        local_start = buffer.offset
-        local_end = local_start + buffer.local_buffer.numel()
         # Only logical tensor ranges are initialized. Padding and layout gaps are not
         # observable through get_local_tensor() and can remain unspecified.
-        for tensor, tensor_start in zip(tensors, buffer.layout.tensor_to_offset, strict=True):
-            tensor_end = tensor_start + tensor.numel()
-            overlap_start = max(local_start, tensor_start)
-            overlap_end = min(local_end, tensor_end)
-            if overlap_start >= overlap_end:
+        for index, tensor in enumerate(tensors):
+            owned_range = buffer._get_owned_range(index)
+            if owned_range is None:
                 continue
 
-            overlap_numel = overlap_end - overlap_start
-            source_offset = overlap_start - tensor_start
-            destination_offset = overlap_start - local_start
-            source_slice = tensor.view(-1).narrow(0, source_offset, overlap_numel)
-            buffer.local_buffer.narrow(0, destination_offset, overlap_numel).copy_(
-                source_slice.to(buffer.device)
+            source_slice = tensor.view(-1).narrow(
+                0, owned_range.tensor_relative_offset, owned_range.numel
             )
+            buffer.local_buffer.narrow(
+                0, owned_range.buffer_relative_offset, owned_range.numel
+            ).copy_(source_slice)
         return buffer
 
     def _create_or_validate_out(
@@ -530,27 +550,21 @@ class DBuffer:
         non-leading dimensions and only changes the leading dimension.
         """
         shape = self.layout.tensor_shapes[index]
-        offset = self.layout.tensor_to_offset[index]
-        numel = shape.numel()
-
-        tensor_start = offset
-        tensor_end = offset + numel
-        overlap_start = max(tensor_start, self.offset)
-        overlap_end = min(tensor_end, self.offset + self.local_buffer.numel())
+        owned_range = self._get_owned_range(index)
 
         row_size = _non_leading_numel(shape)
-        if overlap_end <= overlap_start:
+        if owned_range is None:
             empty_shape = torch.Size((0, *shape[1:]))
             return torch.empty(empty_shape, dtype=self.dtype, device=self.device)
 
-        local_numel = overlap_end - overlap_start
-        local_buffer_offset = overlap_start - self.offset
-        if (overlap_start - tensor_start) % row_size != 0 or local_numel % row_size != 0:
+        if owned_range.tensor_relative_offset % row_size != 0 or owned_range.numel % row_size != 0:
             raise RuntimeError(
                 f"Local tensor shard for tensor {index} does not preserve dim-0 boundaries."
             )
-        local_shape = torch.Size((local_numel // row_size, *shape[1:]))
-        return self.local_buffer.narrow(0, local_buffer_offset, local_numel).view(local_shape)
+        local_shape = torch.Size((owned_range.numel // row_size, *shape[1:]))
+        return self.local_buffer.narrow(
+            0, owned_range.buffer_relative_offset, owned_range.numel
+        ).view(local_shape)
 
     def get_dtensor(self, index: int) -> DTensor:
         """Return logical tensor ``index`` as a DTensor."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Distributed flat buffers for Megatron-FSDP."""
+"""Distributed tensor buffers for Megatron-FSDP."""
 
 import dataclasses
 import math
@@ -25,6 +25,7 @@ from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
 MeshAxis = int | str
+Shape = torch.Size | Iterable[int]
 
 
 class Placement:
@@ -50,7 +51,7 @@ class Flat(Placement):
 
 @dataclasses.dataclass(frozen=True)
 class GlobalLayout:
-    """Global flat-buffer layout in element coordinates."""
+    """Global tensor layout in element coordinates."""
 
     tensor_shapes: tuple[torch.Size, ...]
     tensor_to_offset: tuple[int, ...]
@@ -114,12 +115,15 @@ def _validate_placements(placements: Iterable[Placement]) -> None:
             )
 
 
-def _compute_layout(shapes: Iterable[torch.Size], dp_size: int) -> GlobalLayout:
-    """Compute flat-buffer element offsets and globally padded size.
+def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
+    """Compute global tensor element offsets and padded size.
+
+    The computed layout is compatible with Flat, TensorAtomic, and BlockAtomic,
+    even though the latter two are not implemented.
 
     Args:
         shapes: Logical tensor shapes in tensor-id order.
-        dp_size: Data-parallel shard count for this flat buffer layout.
+        dp_size: Data-parallel shard count for this global layout.
 
     Returns:
         Global layout with element offsets and size padded to a multiple of
@@ -211,13 +215,17 @@ def _compute_layout(shapes: Iterable[torch.Size], dp_size: int) -> GlobalLayout:
 
 
 class DBuffer:
-    """A flat distributed buffer holding a group of logical tensors.
+    """A distributed buffer holding a group of logical tensors.
 
-    DBuffer stores one flat local tensor and enough metadata to return per-tensor
+    DBuffer is analogous to DTensor, but manages a group of logical tensors in
+    one local storage tensor. It stores enough metadata to return per-tensor
     views, redistribute the buffer across mesh axes, and materialize per-tensor
     DTensors for optimizer state or distributed checkpointing.
     """
 
+    # DBuffer owns only the data-parallel sub-mesh. Higher-level callers, such as
+    # ParameterGroup, should extend returned DTensors with tensor-parallel mesh axes
+    # because TP sharding metadata lives on nn.Parameter in MCore/TransformerEngine.
     mesh: DeviceMesh
     placements: tuple[Placement, ...]
     layout: GlobalLayout
@@ -228,18 +236,18 @@ class DBuffer:
         self,
         mesh: DeviceMesh,
         placements: Iterable[Placement],
-        tensor_shapes: Iterable[torch.Size],
+        tensor_shapes: Iterable[Shape],
         dtype: torch.dtype,
         device: torch.device | str,
     ) -> None:
-        """Create a DBuffer and allocate its local flat buffer.
+        """Create a DBuffer and allocate its local buffer.
 
         Args:
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
             tensor_shapes: Global shapes for each logical tensor in this buffer.
-            dtype: Dtype for the local flat buffer.
-            device: Device for the local flat buffer.
+            dtype: Dtype for the local buffer.
+            device: Device for the local buffer.
         """
         placements = tuple(placements)
         if len(placements) != mesh.ndim:
@@ -259,7 +267,7 @@ class DBuffer:
 
     @property
     def dtype(self) -> torch.dtype:
-        """Dtype of the local flat buffer."""
+        """Dtype of the local buffer."""
         return self.local_buffer.dtype
 
     @classmethod
@@ -268,12 +276,12 @@ class DBuffer:
         local_buffer: torch.Tensor,
         mesh: DeviceMesh,
         placements: Iterable[Placement],
-        tensor_shapes: Iterable[torch.Size],
+        tensor_shapes: Iterable[Shape],
     ) -> "DBuffer":
-        """Create a DBuffer from an existing local flat buffer.
+        """Create a DBuffer from an existing local buffer.
 
         Args:
-            local_buffer: Local flat tensor storage for this rank.
+            local_buffer: Local tensor storage for this rank.
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
             tensor_shapes: Global shapes for each logical tensor in this buffer.
@@ -534,9 +542,7 @@ class DBuffer:
             raise RuntimeError("scatter() destination is not contained in the source local buffer.")
         local_slice = self.local_buffer.narrow(0, local_buffer_offset, destination_numel)
         if out is None:
-            return DBuffer.from_local(
-                local_slice, self.mesh, placements, self.layout.tensor_shapes
-            )
+            return DBuffer.from_local(local_slice, self.mesh, placements, self.layout.tensor_shapes)
 
         destination.local_buffer.copy_(local_slice)
         return destination
@@ -559,9 +565,7 @@ class DBuffer:
         row_size = _non_leading_numel(shape)
         if overlap_end <= overlap_start:
             empty_shape = torch.Size((0, *shape[1:]))
-            return torch.empty(
-                empty_shape, dtype=self.dtype, device=self.local_buffer.device
-            )
+            return torch.empty(empty_shape, dtype=self.dtype, device=self.local_buffer.device)
 
         local_numel = overlap_end - overlap_start
         local_buffer_offset = overlap_start - self.offset

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -45,6 +45,58 @@ class GlobalLayout:
     tensor_to_offset: tuple[int, ...]
     size: int
 
+    def __post_init__(self) -> None:
+        """Validate tensor offsets are row-aligned, in bounds, and non-overlapping."""
+
+        @dataclasses.dataclass(frozen=True)
+        class TensorRange:
+            start: int
+            end: int
+            tensor_id: int
+
+        if self.size < 0:
+            raise AssertionError(f"Global layout size {self.size} is negative.")
+        if len(self.tensor_shapes) != len(self.tensor_to_offset):
+            raise AssertionError(
+                "Global layout has mismatched tensor shapes and offsets: "
+                f"{len(self.tensor_shapes)} shapes and {len(self.tensor_to_offset)} offsets."
+            )
+
+        tensor_ranges: list[TensorRange] = []
+        for tensor_id, (shape, start) in enumerate(
+            zip(self.tensor_shapes, self.tensor_to_offset, strict=True)
+        ):
+            if start < 0:
+                raise AssertionError(f"Tensor {tensor_id} offset {start} is negative.")
+
+            row_size = _non_leading_numel(shape)
+            if row_size <= 0:
+                raise AssertionError(f"Tensor {tensor_id} has invalid row size {row_size}.")
+            if start % row_size != 0:
+                raise AssertionError(
+                    f"Tensor {tensor_id} offset {start} is not aligned to row size {row_size}."
+                )
+
+            end = start + shape.numel()
+            if end > self.size:
+                raise AssertionError(
+                    f"Tensor {tensor_id} range [{start}, {end}) exceeds "
+                    f"layout size {self.size}."
+                )
+            tensor_ranges.append(TensorRange(start, end, tensor_id))
+
+        previous_range: TensorRange | None = None
+        for current_range in sorted(tensor_ranges, key=lambda tensor_range: tensor_range.start):
+            if previous_range is not None and current_range.start < previous_range.end:
+                raise AssertionError(
+                    "Global layout tensors overlap: "
+                    f"tensor {previous_range.tensor_id} "
+                    f"[{previous_range.start}, {previous_range.end}) and "
+                    f"tensor {current_range.tensor_id} "
+                    f"[{current_range.start}, {current_range.end})."
+                )
+            previous_range = current_range
+
     def get_local_range(self, mesh: DeviceMesh, placements: Iterable[Placement]) -> tuple[int, int]:
         """Return this rank's local element offset and length for ``placements``."""
         offset = 0
@@ -130,7 +182,8 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
 
     # chunk_size is the packing unit. Since every tensor row size divides it,
     # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
-    tensor_to_offset: list[int | None] = [None] * len(tensor_shapes)
+    UNASSIGNED_OFFSET = -1
+    tensor_to_offset: list[int] = [UNASSIGNED_OFFSET] * len(tensor_shapes)
     fragment_items = []
     regular_items = []
     for tensor_id, shape in enumerate(tensor_shapes):
@@ -201,17 +254,10 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         tensor_to_offset[frag_id] = next_offset
         next_offset += frag_shape.numel()
 
-    if any(offset is None for offset in tensor_to_offset):
-        raise AssertionError(f"Incomplete DBuffer layout for shapes {tensor_shapes}.")
-
-    resolved_tensor_to_offset = tuple(offset for offset in tensor_to_offset if offset is not None)
-    for shape, offset in zip(tensor_shapes, resolved_tensor_to_offset, strict=True):
-        row_size = _non_leading_numel(shape)
-        if offset % row_size != 0:
-            raise AssertionError(f"Tensor offset {offset} is not aligned to row size {row_size}.")
-    size = _pad_to_multiple(next_offset, chunk_size * dp_size)
     return GlobalLayout(
-        tensor_shapes=tensor_shapes, tensor_to_offset=resolved_tensor_to_offset, size=size
+        tensor_shapes=tensor_shapes,
+        tensor_to_offset=tuple(tensor_to_offset),
+        size=_pad_to_multiple(next_offset, chunk_size * dp_size),
     )
 
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -83,19 +83,39 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
 
     This is a DBuffer-specific reimplementation of
     ``param_and_grad_buffer.build_data_parallel_buffer_index``. It keeps only
-    the global offset construction and final DP-LCM padding; DBuffer derives
-    rank-local slices later through DTensor placements.
+    the global offset construction and final padding so each rank-local shard
+    size is a multiple of ``chunk_size``; DBuffer derives rank-local slices
+    later through DTensor placements.
 
     The computed layout is compatible with Flat, TensorAtomic, and BlockAtomic,
     even though the latter two are not implemented.
+
+    ``chunk_size`` is the least common multiple of each tensor's row size
+    (``shape[1:].numel()``). For example, with shapes P0=(2, 6), P1=(4, 4),
+    P2=(4, 4), P3=(1, 2), P4=(1, 6), ``chunk_size = LCM(6, 4, 4, 2, 6) = 12``
+    and a 5-rank DP layout has equal-size rank shards:
+
+    ```
+    rank 0 [ 0, 12): | P0 row 0              | P0 row 1               |
+    rank 1 [12, 24): | P1 row 0      | P1 row 1      | P1 row 2       |
+    rank 2 [24, 36): | P1 row 3      | P3    | gap   | P2 row 0       |
+    rank 3 [36, 48): | P2 row 1      | P2 row 2      | P2 row 3       |
+    rank 4 [48, 60): | P4                    | pad                    |
+    ```
+
+    The diagram uses four character columns per element; segment widths are
+    proportional. Every chunk boundary is aligned to each tensor's row size,
+    so each DP shard owns full rows even when fragments fill regular-tensor
+    padding gaps.
 
     Args:
         shapes: Logical tensor shapes in tensor-id order.
         dp_size: Data-parallel shard count for this global layout.
 
     Returns:
-        Global layout with element offsets and size padded to a multiple of
-        ``LCM(shape[1:].numel()) * dp_size``.
+        Global layout with row-aligned tensor offsets and a total size padded
+        to a multiple of ``chunk_size * dp_size``, so every rank-local shard
+        length is a multiple of ``chunk_size``.
     """
     if dp_size <= 0:
         raise ValueError(f"DP size must be positive, got {dp_size}.")
@@ -108,8 +128,8 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             raise ValueError(f"Cannot compute a layout for zero-sized non-leading dims: {shape}.")
         chunk_size = math.lcm(chunk_size, non_leading_numel)
 
-    # The LCM part is the packing grid. Since every row size divides this grid,
-    # DP shard boundaries that are multiples of the grid avoid splitting dim-0 rows.
+    # chunk_size is the packing unit. Since every tensor row size divides it,
+    # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
     tensor_to_offset: list[int | None] = [None] * len(tensor_shapes)
     fragment_items = []
     regular_items = []
@@ -120,7 +140,7 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             regular_items.append((tensor_id, shape))
 
     # Regular tensors anchor the layout. Fragments are held back to fill padding
-    # gaps left by regular tensors whose sizes are not exact multiples of the grid.
+    # gaps left by regular tensors whose sizes are not exact multiples of chunk_size.
     fragment_items.sort(key=lambda id_shape: id_shape[1].numel(), reverse=True)
 
     next_offset = 0
@@ -139,8 +159,9 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         remainder = tensor_numel % chunk_size
 
         # Try to pair this non-divisible regular tensor with a conjugate regular
-        # tensor whose remainder fits in the same LCM part. The conjugate starts
-        # in the gap and then continues with full LCM parts after this one.
+        # tensor whose remainder fits in the same chunk_size interval. The
+        # conjugate starts in the gap and then continues with full chunk_size
+        # intervals after this one.
         conjugate_item = None
         for candidate_item in regular_items[:]:
             _, candidate_shape = candidate_item

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -411,9 +411,9 @@ class DBuffer:
         if changed_axis is None:
             if out is None:
                 return self
-            destination = self._create_or_validate_out(new_placements, out)
-            destination.local_buffer.copy_(self.local_buffer)
-            return destination
+            out = self._create_or_validate_out(new_placements, out)
+            out.local_buffer.copy_(self.local_buffer)
+            return out
 
         axis = changed_axis
         old_placement = self.placements[axis]
@@ -440,13 +440,13 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = Replicate()
         validate_placements(placements)
-        destination = self._create_or_validate_out(placements, out)
+        out = self._create_or_validate_out(placements, out)
         dist.all_gather_into_tensor(
-            output_tensor=destination.local_buffer,
+            output_tensor=out.local_buffer,
             input_tensor=self.local_buffer,
             group=self.mesh.get_group(axis),
         )
-        return destination
+        return out
 
     def allreduce(self, mesh_axis: MeshAxis, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-reduce a Partial axis into Replicate placement."""
@@ -457,14 +457,14 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = Replicate()
-        destination = self._create_or_validate_out(placements, out)
-        destination.local_buffer.copy_(self.local_buffer)
+        out = self._create_or_validate_out(placements, out)
+        out.local_buffer.copy_(self.local_buffer)
         dist.all_reduce(
-            destination.local_buffer,
+            out.local_buffer,
             op=partial_placement.reduce_op,
             group=self.mesh.get_group(axis),
         )
-        return destination
+        return out
 
     def reduce_scatter(
         self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
@@ -480,14 +480,14 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = new_placement
         validate_placements(placements)
-        destination = self._create_or_validate_out(placements, out)
+        out = self._create_or_validate_out(placements, out)
         dist.reduce_scatter_tensor(
-            output=destination.local_buffer,
+            output=out.local_buffer,
             input=self.local_buffer,
             op=partial_placement.reduce_op,
             group=self.mesh.get_group(axis),
         )
-        return destination
+        return out
 
     def scatter(
         self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
@@ -508,9 +508,9 @@ class DBuffer:
                 self.mesh, placements
             )
         else:
-            destination = self._create_or_validate_out(placements, out)
-            destination_offset = destination.offset
-            destination_numel = destination.local_buffer.numel()
+            out = self._create_or_validate_out(placements, out)
+            destination_offset = out.offset
+            destination_numel = out.local_buffer.numel()
 
         local_buffer_offset = destination_offset - self.offset
         if (
@@ -522,8 +522,8 @@ class DBuffer:
         if out is None:
             return DBuffer.from_local(local_slice, self.mesh, placements, self.layout.tensor_shapes)
 
-        destination.local_buffer.copy_(local_slice)
-        return destination
+        out.local_buffer.copy_(local_slice)
+        return out
 
     def get_tensor(self, index: int) -> torch.Tensor:
         """Return this rank's local view for logical tensor ``index``.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -17,6 +17,7 @@
 import dataclasses
 import math
 from collections.abc import Iterable
+from typing import TypeAlias
 
 import torch
 import torch.distributed as dist
@@ -26,8 +27,7 @@ from torch.distributed.tensor import DTensor
 
 from .placement import Flat, Partial, Placement, Replicate, validate_placements
 
-MeshAxis = int | str
-Shape = torch.Size | Iterable[int]
+Shape: TypeAlias = torch.Size | Iterable[int]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -64,18 +64,11 @@ def _pad_to_multiple(value: int, multiple: int) -> int:
     return ((value + multiple - 1) // multiple) * multiple
 
 
-def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
-    if isinstance(axis, int):
-        if axis < 0:
-            axis += mesh.ndim
-        if axis < 0 or axis >= mesh.ndim:
-            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
-        return axis
-
-    dim_names = mesh.mesh_dim_names
-    if dim_names is None or axis not in dim_names:
-        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
-    return dim_names.index(axis)
+def _validate_mesh_axis(mesh: DeviceMesh, axis: int) -> None:
+    if not isinstance(axis, int) or isinstance(axis, bool):
+        raise TypeError(f"Mesh axis must be an int, got {type(axis).__name__}.")
+    if axis < 0 or axis >= mesh.ndim:
+        raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
 
 
 def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
@@ -100,9 +93,9 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
     if dp_size <= 0:
         raise ValueError(f"DP size must be positive, got {dp_size}.")
 
-    shapes = tuple(torch.Size(shape) for shape in shapes)
+    tensor_shapes = tuple(torch.Size(shape) for shape in shapes)
     chunk_size = 1
-    for shape in shapes:
+    for shape in tensor_shapes:
         non_leading_numel = _non_leading_numel(shape)
         if non_leading_numel <= 0:
             raise ValueError(f"Cannot compute a layout for zero-sized non-leading dims: {shape}.")
@@ -110,10 +103,10 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
 
     # The LCM part is the packing grid. Since every row size divides this grid,
     # DP shard boundaries that are multiples of the grid avoid splitting dim-0 rows.
-    tensor_to_offset: list[int | None] = [None] * len(shapes)
+    tensor_to_offset: list[int | None] = [None] * len(tensor_shapes)
     fragment_items = []
     regular_items = []
-    for tensor_id, shape in enumerate(shapes):
+    for tensor_id, shape in enumerate(tensor_shapes):
         if shape.numel() < chunk_size:
             fragment_items.append((tensor_id, shape))
         else:
@@ -181,15 +174,17 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         next_offset += frag_shape.numel()
 
     if any(offset is None for offset in tensor_to_offset):
-        raise AssertionError(f"Incomplete DBuffer layout for shapes {shapes}.")
+        raise AssertionError(f"Incomplete DBuffer layout for shapes {tensor_shapes}.")
 
     resolved_tensor_to_offset = tuple(offset for offset in tensor_to_offset if offset is not None)
-    for shape, offset in zip(shapes, resolved_tensor_to_offset, strict=True):
+    for shape, offset in zip(tensor_shapes, resolved_tensor_to_offset, strict=True):
         row_size = _non_leading_numel(shape)
         if offset % row_size != 0:
             raise AssertionError(f"Tensor offset {offset} is not aligned to row size {row_size}.")
     size = _pad_to_multiple(next_offset, chunk_size * dp_size)
-    return GlobalLayout(tensor_shapes=shapes, tensor_to_offset=resolved_tensor_to_offset, size=size)
+    return GlobalLayout(
+        tensor_shapes=tensor_shapes, tensor_to_offset=resolved_tensor_to_offset, size=size
+    )
 
 
 class DBuffer:
@@ -433,9 +428,10 @@ class DBuffer:
             f"{axis}: {old_placement!r} -> {new_placement!r}."
         )
 
-    def allgather(self, mesh_axis: MeshAxis, *, out: "DBuffer | None" = None) -> "DBuffer":
+    def allgather(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-gather a Flat axis into Replicate placement."""
-        axis = _axis_index(self.mesh, mesh_axis)
+        _validate_mesh_axis(self.mesh, mesh_axis)
+        axis = mesh_axis
         if not isinstance(self.placements[axis], Flat):
             raise ValueError(f"allgather() requires Flat placement on axis {mesh_axis!r}.")
 
@@ -450,9 +446,10 @@ class DBuffer:
         )
         return out
 
-    def allreduce(self, mesh_axis: MeshAxis, *, out: "DBuffer | None" = None) -> "DBuffer":
+    def allreduce(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-reduce a Partial axis into Replicate placement."""
-        axis = _axis_index(self.mesh, mesh_axis)
+        _validate_mesh_axis(self.mesh, mesh_axis)
+        axis = mesh_axis
         partial_placement = self.placements[axis]
         if not isinstance(partial_placement, Partial):
             raise ValueError(f"allreduce() requires Partial placement on axis {mesh_axis!r}.")
@@ -462,17 +459,16 @@ class DBuffer:
         out = self._create_or_validate_out(placements, out)
         out.local_buffer.copy_(self.local_buffer)
         dist.all_reduce(
-            out.local_buffer,
-            op=partial_placement.reduce_op,
-            group=self.mesh.get_group(axis),
+            out.local_buffer, op=partial_placement.reduce_op, group=self.mesh.get_group(axis)
         )
         return out
 
     def reduce_scatter(
-        self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
+        self, mesh_axis: int, new_placement: Placement, *, out: "DBuffer | None" = None
     ) -> "DBuffer":
         """Reduce-scatter a Partial axis into ``new_placement``."""
-        axis = _axis_index(self.mesh, mesh_axis)
+        _validate_mesh_axis(self.mesh, mesh_axis)
+        axis = mesh_axis
         if not isinstance(new_placement, Flat):
             raise NotImplementedError("DBuffer currently supports reduce_scatter() to Flat only.")
         partial_placement = self.placements[axis]
@@ -492,10 +488,11 @@ class DBuffer:
         return out
 
     def scatter(
-        self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
+        self, mesh_axis: int, new_placement: Placement, *, out: "DBuffer | None" = None
     ) -> "DBuffer":
         """Locally chunk a Replicate axis into ``new_placement``."""
-        axis = _axis_index(self.mesh, mesh_axis)
+        _validate_mesh_axis(self.mesh, mesh_axis)
+        axis = mesh_axis
         if not isinstance(new_placement, Flat):
             raise NotImplementedError("DBuffer currently supports scatter() to Flat only.")
         if not isinstance(self.placements[axis], Replicate):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Global tensor layout metadata for DBuffer."""
+
+import dataclasses
+import math
+from collections.abc import Iterable
+from typing import TypeAlias
+
+import torch
+from torch.distributed import DeviceMesh
+
+from .placement import Flat, Placement
+
+Shape: TypeAlias = torch.Size | Iterable[int]
+
+
+@dataclasses.dataclass(frozen=True)
+class GlobalLayout:
+    """Global tensor layout in element coordinates."""
+
+    tensor_shapes: tuple[torch.Size, ...]
+    tensor_to_offset: tuple[int, ...]
+    size: int
+
+    @classmethod
+    def build(cls, shapes: Iterable[Shape], dp_size: int) -> "GlobalLayout":
+        """Compute global tensor element offsets and padded size.
+
+        This is a DBuffer-specific reimplementation of
+        ``param_and_grad_buffer.build_data_parallel_buffer_index``. It keeps only
+        the global offset construction and final padding so each rank-local shard
+        size is a multiple of ``chunk_size``; DBuffer derives rank-local slices
+        later through DTensor placements.
+
+        The computed layout is compatible with Flat, TensorAtomic, and BlockAtomic,
+        even though the latter two are not implemented.
+
+        ``chunk_size`` is the least common multiple of each tensor's row size
+        (``shape[1:].numel()``). For example, with shapes P0=(2, 6), P1=(4, 4),
+        P2=(4, 4), P3=(1, 2), P4=(1, 6), ``chunk_size = LCM(6, 4, 4, 2, 6) = 12``
+        and a 5-rank DP layout has equal-size rank shards:
+
+        ```
+        rank 0 [ 0, 12): | P0 row 0              | P0 row 1               |
+        rank 1 [12, 24): | P1 row 0      | P1 row 1      | P1 row 2       |
+        rank 2 [24, 36): | P1 row 3      | P3    | gap   | P2 row 0       |
+        rank 3 [36, 48): | P2 row 1      | P2 row 2      | P2 row 3       |
+        rank 4 [48, 60): | P4                    | pad                    |
+        ```
+
+        The diagram uses four character columns per element; segment widths are
+        proportional. Every chunk boundary is aligned to each tensor's row size,
+        so each DP shard owns full rows even when fragments fill regular-tensor
+        padding gaps.
+
+        Args:
+            shapes: Logical tensor shapes in tensor-id order.
+            dp_size: Data-parallel shard count for this global layout.
+
+        Returns:
+            Global layout with row-aligned tensor offsets and a total size padded
+            to a multiple of ``chunk_size * dp_size``, so every rank-local shard
+            length is a multiple of ``chunk_size``.
+        """
+        if dp_size <= 0:
+            raise ValueError(f"DP size must be positive, got {dp_size}.")
+
+        tensor_shapes = tuple(torch.Size(shape) for shape in shapes)
+        chunk_size = 1
+        for shape in tensor_shapes:
+            row_size = non_leading_numel(shape)
+            if row_size <= 0:
+                raise ValueError(
+                    f"Cannot compute a layout for zero-sized non-leading dims: {shape}."
+                )
+            chunk_size = math.lcm(chunk_size, row_size)
+
+        # chunk_size is the packing unit. Since every tensor row size divides it,
+        # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
+        UNASSIGNED_OFFSET = -1
+        tensor_to_offset: list[int] = [UNASSIGNED_OFFSET] * len(tensor_shapes)
+        fragment_items = []
+        regular_items = []
+        for tensor_id, shape in enumerate(tensor_shapes):
+            if shape.numel() < chunk_size:
+                fragment_items.append((tensor_id, shape))
+            else:
+                regular_items.append((tensor_id, shape))
+
+        # Regular tensors anchor the layout. Fragments are held back to fill padding
+        # gaps left by regular tensors whose sizes are not exact multiples of chunk_size.
+        fragment_items.sort(key=lambda id_shape: id_shape[1].numel(), reverse=True)
+
+        next_offset = 0
+        while regular_items:
+            tensor_id, shape = regular_items.pop(0)
+            tensor_numel = shape.numel()
+            tensor_to_offset[tensor_id] = next_offset
+
+            if tensor_numel % chunk_size == 0:
+                next_offset += tensor_numel
+                continue
+
+            gap_offset = next_offset + tensor_numel
+            next_offset += _pad_to_multiple(tensor_numel, chunk_size)
+            fragment_gap_end = next_offset
+            remainder = tensor_numel % chunk_size
+
+            # Try to pair this non-divisible regular tensor with a conjugate regular
+            # tensor whose remainder fits in the same chunk_size interval. The
+            # conjugate starts in the gap and then continues with full chunk_size
+            # intervals after this one.
+            conjugate_item = None
+            for candidate_item in regular_items[:]:
+                _, candidate_shape = candidate_item
+                candidate_numel = candidate_shape.numel()
+                candidate_remainder = candidate_numel % chunk_size
+                if candidate_remainder == 0:
+                    continue
+                if remainder + candidate_remainder <= chunk_size:
+                    conjugate_item = candidate_item
+                    regular_items.remove(candidate_item)
+                    break
+
+            if conjugate_item is not None:
+                conjugate_id, conjugate_shape = conjugate_item
+                conjugate_numel = conjugate_shape.numel()
+                conjugate_remainder = conjugate_numel % chunk_size
+                conjugate_offset = next_offset - conjugate_remainder
+                tensor_to_offset[conjugate_id] = conjugate_offset
+                fragment_gap_end = conjugate_offset
+                next_offset += (conjugate_numel // chunk_size) * chunk_size
+
+            # Fill any remaining gap with fragments, keeping each fragment aligned to
+            # its own row size so dim-0 rows remain contiguous within DP shards.
+            for fragment in fragment_items[:]:
+                frag_id, frag_shape = fragment
+                frag_numel = frag_shape.numel()
+                aligned_gap_offset = _pad_to_multiple(gap_offset, non_leading_numel(frag_shape))
+                if aligned_gap_offset + frag_numel > fragment_gap_end:
+                    continue
+                tensor_to_offset[frag_id] = aligned_gap_offset
+                gap_offset = aligned_gap_offset + frag_numel
+                fragment_items.remove(fragment)
+
+        # Fragments that did not fit into regular-tensor gaps are appended at the tail.
+        for frag_id, frag_shape in fragment_items:
+            next_offset = _pad_to_multiple(next_offset, non_leading_numel(frag_shape))
+            tensor_to_offset[frag_id] = next_offset
+            next_offset += frag_shape.numel()
+
+        return cls(
+            tensor_shapes=tensor_shapes,
+            tensor_to_offset=tuple(tensor_to_offset),
+            size=_pad_to_multiple(next_offset, chunk_size * dp_size),
+        )
+
+    def __post_init__(self) -> None:
+        """Validate tensor offsets are row-aligned, in bounds, and non-overlapping."""
+
+        @dataclasses.dataclass(frozen=True)
+        class TensorRange:
+            start: int
+            end: int
+            tensor_id: int
+
+        if self.size < 0:
+            raise AssertionError(f"Global layout size {self.size} is negative.")
+        if len(self.tensor_shapes) != len(self.tensor_to_offset):
+            raise AssertionError(
+                "Global layout has mismatched tensor shapes and offsets: "
+                f"{len(self.tensor_shapes)} shapes and {len(self.tensor_to_offset)} offsets."
+            )
+
+        tensor_ranges: list[TensorRange] = []
+        for tensor_id, (shape, start) in enumerate(
+            zip(self.tensor_shapes, self.tensor_to_offset, strict=True)
+        ):
+            if start < 0:
+                raise AssertionError(f"Tensor {tensor_id} offset {start} is negative.")
+
+            row_size = non_leading_numel(shape)
+            if row_size <= 0:
+                raise AssertionError(f"Tensor {tensor_id} has invalid row size {row_size}.")
+            if start % row_size != 0:
+                raise AssertionError(
+                    f"Tensor {tensor_id} offset {start} is not aligned to row size {row_size}."
+                )
+
+            end = start + shape.numel()
+            if end > self.size:
+                raise AssertionError(
+                    f"Tensor {tensor_id} range [{start}, {end}) exceeds "
+                    f"layout size {self.size}."
+                )
+            tensor_ranges.append(TensorRange(start, end, tensor_id))
+
+        previous_range: TensorRange | None = None
+        for current_range in sorted(tensor_ranges, key=lambda tensor_range: tensor_range.start):
+            if previous_range is not None and current_range.start < previous_range.end:
+                raise AssertionError(
+                    "Global layout tensors overlap: "
+                    f"tensor {previous_range.tensor_id} "
+                    f"[{previous_range.start}, {previous_range.end}) and "
+                    f"tensor {current_range.tensor_id} "
+                    f"[{current_range.start}, {current_range.end})."
+                )
+            previous_range = current_range
+
+    def get_local_range(self, mesh: DeviceMesh, placements: Iterable[Placement]) -> tuple[int, int]:
+        """Return this rank's local element offset and length for ``placements``."""
+        offset = 0
+        numel = self.size
+        for axis, placement in reversed(tuple(enumerate(placements))):
+            if not isinstance(placement, Flat):
+                continue
+            axis_size = mesh.size(axis)
+            if numel % axis_size != 0:
+                raise ValueError(
+                    f"Local range size {numel} is not divisible by Flat axis size {axis_size}."
+                )
+            shard_size = numel // axis_size
+            offset += mesh.get_local_rank(axis) * shard_size
+            numel = shard_size
+        return offset, numel
+
+
+def non_leading_numel(shape: torch.Size) -> int:
+    """Return the number of elements after dim 0 for a non-scalar shape."""
+    if len(shape) == 0:
+        raise ValueError(f"DBuffer layout does not support 0D tensor shapes: {shape}.")
+    return shape[1:].numel()
+
+
+def _pad_to_multiple(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -173,6 +173,8 @@ class GlobalLayout:
 
         @dataclasses.dataclass(frozen=True)
         class TensorRange:
+            """Contiguous global element range occupied by one logical tensor."""
+
             start: int
             end: int
             tensor_id: int

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DBuffer placement definitions."""
+
+import dataclasses
+from collections.abc import Iterable
+
+import torch.distributed as dist
+
+
+class Placement:
+    """Base class for DBuffer placements."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Replicate(Placement):
+    """Replicated local buffer placement."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Partial(Placement):
+    """Unreduced replicated local buffer placement."""
+
+    reduce_op: dist.ReduceOp.RedOpType = dist.ReduceOp.SUM
+
+
+@dataclasses.dataclass(frozen=True)
+class Flat(Placement):
+    """Flat per-unit dim-0 sharded local buffer placement."""
+
+
+def _validate_placement(placement: Placement) -> None:
+    if not isinstance(placement, (Replicate, Partial, Flat)):
+        raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
+
+
+def validate_placements(placements: Iterable[Placement]) -> None:
+    """Validate DBuffer placements form a supported contiguous local layout."""
+    seen_flat = False
+    for placement in placements:
+        _validate_placement(placement)
+        if isinstance(placement, Flat):
+            seen_flat = True
+        elif seen_flat:
+            raise ValueError(
+                "Flat placements must be a suffix of the placement list so each "
+                "local buffer is a contiguous global-buffer range."
+            )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -30,7 +30,6 @@ sharded        ``Replicate``  ``allgather()``
 """
 
 import dataclasses
-from collections.abc import Iterable
 
 import torch.distributed as dist
 
@@ -54,22 +53,3 @@ class Partial(Placement):
 @dataclasses.dataclass(frozen=True)
 class Flat(Placement):
     """Flat per-unit dim-0 sharded local buffer placement."""
-
-
-def _validate_placement(placement: Placement) -> None:
-    if not isinstance(placement, (Replicate, Partial, Flat)):
-        raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
-
-
-def validate_placements(placements: Iterable[Placement]) -> None:
-    """Validate DBuffer placements form a supported contiguous local layout."""
-    seen_flat = False
-    for placement in placements:
-        _validate_placement(placement)
-        if isinstance(placement, Flat):
-            seen_flat = True
-        elif seen_flat:
-            raise ValueError(
-                "Flat placements must be a suffix of the placement list so each "
-                "local buffer is a contiguous global-buffer range."
-            )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -12,7 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""DBuffer placement definitions."""
+"""DBuffer placement definitions.
+
+These placement concepts are borrowed from PyTorch DTensor placements:
+``Replicate`` and ``Partial`` mirror DTensor's placements. ``Flat`` is the
+only sharded DBuffer placement implemented so far; it stores dim-0 shards in a
+flattened local buffer.
+
+=============  =============  ====================
+Source         Destination    DBuffer operation
+=============  =============  ====================
+sharded        ``Replicate``  ``allgather()``
+``Partial``    sharded        ``reduce_scatter()``
+``Partial``    ``Replicate``  ``allreduce()``
+``Replicate``  sharded        ``scatter()`` (local)
+=============  =============  ====================
+"""
 
 import dataclasses
 from collections.abc import Iterable

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -61,7 +61,7 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
 
 def _assert_dbuffer_contains_tensors(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
-        torch.testing.assert_close(buffer.get_tensor(index), tensor)
+        torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
 
 
 @pytest.mark.distributed
@@ -147,7 +147,7 @@ def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
     assert layout.size == 60
     expected_local_shapes = expected_local_shapes_by_rank[mesh.get_local_rank(0)]
     for index, expected_shape in enumerate(expected_local_shapes):
-        assert buffer.get_tensor(index).shape == torch.Size(expected_shape)
+        assert buffer.get_local_tensor(index).shape == torch.Size(expected_shape)
         assert buffer.get_dtensor(index).shape == shapes[index]
 
 
@@ -207,7 +207,7 @@ def test_from_local_reuses_required_local_buffer(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_replicate_get_tensor_and_dtensor(setup: DistributedSetup):
+def test_replicate_get_local_tensor_and_dtensor(setup: DistributedSetup):
     """Replicated DBuffer returns full local tensors and replicated DTensors."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     tensors = _same_tensors_on_all_ranks(setup.device)
@@ -240,7 +240,7 @@ def test_sharded_allgather_round_trip(setup: DistributedSetup):
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
     layout = sharded_buffer.layout
     for index, tensor in enumerate(tensors):
-        local_tensor = sharded_buffer.get_tensor(index)
+        local_tensor = sharded_buffer.get_local_tensor(index)
         assert local_tensor.shape[1:] == tensor.shape[1:]
         assert local_tensor.is_contiguous()
 
@@ -449,7 +449,9 @@ def test_get_dtensor_from_sharded_buffer(setup: DistributedSetup):
 
     dtensor = sharded_buffer.get_dtensor(0)
 
-    torch.testing.assert_close(dtensor.to_local(), sharded_buffer.get_tensor(0), rtol=0, atol=0)
+    torch.testing.assert_close(
+        dtensor.to_local(), sharded_buffer.get_local_tensor(0), rtol=0, atol=0
+    )
     assert dtensor.shape == tensors[0].shape
 
 
@@ -514,7 +516,7 @@ def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
         fully_sharded_buffer.local_buffer.numel() == fully_sharded_buffer.layout.size // mesh.size()
     )
     for index, _ in enumerate(tensors):
-        assert fully_sharded_buffer.get_tensor(index).is_contiguous()
+        assert fully_sharded_buffer.get_local_tensor(index).is_contiguous()
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -48,7 +48,10 @@ def setup() -> Iterator[DistributedSetup]:
     yield DistributedSetup(rank=rank, world_size=world_size, device=device)
 
     if dist.is_initialized():
-        dist.destroy_process_group()
+        dist.barrier()
+        # Leave the default process group alive for later distributed tests;
+        # only clear DeviceMesh bookkeeping from this module.
+        _clear_device_mesh_resources()
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -62,6 +65,21 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
 def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
         torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
+
+
+def _clear_device_mesh_resources() -> None:
+    from torch.distributed.device_mesh import _mesh_resources
+
+    for resource_name in (
+        "child_to_root_mapping",
+        "root_to_flatten_mapping",
+        "mesh_stack",
+        "mesh_dim_group_options",
+        "flatten_name_to_root_dims",
+    ):
+        resource = getattr(_mesh_resources, resource_name, None)
+        if resource is not None:
+            resource.clear()
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -16,6 +16,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer impor
     Partial,
     Replicate,
 )
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.layout import GlobalLayout
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -29,6 +30,12 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
 def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
         torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
+
+
+def test_dbuffer_layout_rejects_0d_tensor_shapes():
+    """DBuffer layout does not silently reinterpret scalar tensors as dim-0 rows."""
+    with pytest.raises(ValueError, match="0D tensor shapes"):
+        GlobalLayout.build([torch.Size(())], dp_size=1)
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -316,10 +316,10 @@ def test_replicate_scatter_round_trip(setup: DistributedSetup):
     assert redistributed_sharded_buffer.placements == (Flat(),)
     expected_sharded_local_numel = replicated_buffer.layout.size // setup.world_size
     assert sharded_buffer.offset == setup.rank * expected_sharded_local_numel
-    source_slice = replicated_buffer.local_buffer.narrow(
-        0, sharded_buffer.offset - replicated_buffer.offset, sharded_buffer.local_buffer.numel()
+    assert (
+        sharded_buffer.local_buffer.untyped_storage()
+        is replicated_buffer.local_buffer.untyped_storage()
     )
-    assert sharded_buffer.local_buffer.data_ptr() == source_slice.data_ptr()
     torch.testing.assert_close(
         sharded_buffer.local_buffer, redistributed_sharded_buffer.local_buffer, rtol=0, atol=0
     )

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -59,7 +59,7 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
     ]
 
 
-def _assert_dbuffer_contains_tensors(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
+def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
         torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
 
@@ -203,7 +203,7 @@ def test_from_local_reuses_required_local_buffer(setup: DistributedSetup):
     assert sharded_buffer.layout == replicated_buffer.layout
     assert sharded_buffer.offset == offset
     assert sharded_buffer.local_buffer.data_ptr() == local_buffer.data_ptr()
-    _assert_dbuffer_contains_tensors(sharded_buffer.allgather(0), tensors)
+    _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
 
 @pytest.mark.distributed
@@ -214,7 +214,7 @@ def test_replicate_get_local_tensor_and_dtensor(setup: DistributedSetup):
 
     buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
 
-    _assert_dbuffer_contains_tensors(buffer, tensors)
+    _assert_dbuffer_local_tensors_close(buffer, tensors)
     dtensor = buffer.get_dtensor(0)
     torch.testing.assert_close(dtensor.to_local(), tensors[0], rtol=0, atol=0)
 
@@ -228,7 +228,7 @@ def test_distribute_tensors_moves_inputs_to_mesh_device(setup: DistributedSetup)
     buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
 
     assert buffer.local_buffer.device == setup.device
-    _assert_dbuffer_contains_tensors(buffer, [tensor.to(setup.device) for tensor in tensors])
+    _assert_dbuffer_local_tensors_close(buffer, [tensor.to(setup.device) for tensor in tensors])
 
 
 @pytest.mark.distributed
@@ -247,7 +247,7 @@ def test_sharded_allgather_round_trip(setup: DistributedSetup):
     replicated_buffer = sharded_buffer.allgather(0)
 
     assert replicated_buffer.layout == layout
-    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, tensors)
 
 
 @pytest.mark.distributed
@@ -269,7 +269,7 @@ def test_sharded_allgather_into_existing_buffer(setup: DistributedSetup):
 
     assert result is destination
     assert destination.local_buffer.data_ptr() == destination_data_ptr
-    _assert_dbuffer_contains_tensors(destination, tensors)
+    _assert_dbuffer_local_tensors_close(destination, tensors)
 
 
 @pytest.mark.distributed
@@ -323,7 +323,7 @@ def test_replicate_scatter_round_trip(setup: DistributedSetup):
     torch.testing.assert_close(
         sharded_buffer.local_buffer, redistributed_sharded_buffer.local_buffer, rtol=0, atol=0
     )
-    _assert_dbuffer_contains_tensors(sharded_buffer.allgather(0), tensors)
+    _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
 
 @pytest.mark.distributed
@@ -344,7 +344,7 @@ def test_partial_allreduce(setup: DistributedSetup):
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
@@ -375,7 +375,7 @@ def test_partial_allreduce_average(setup: DistributedSetup):
         torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
@@ -409,7 +409,7 @@ def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
@@ -437,7 +437,7 @@ def test_partial_reduce_scatter_to_flat_average(setup: DistributedSetup):
         torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
@@ -469,7 +469,7 @@ def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
     replicated_buffer = sharded_buffer.allgather(1)
 
-    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, tensors)
 
 
 @pytest.mark.distributed
@@ -556,7 +556,7 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetu
         torch.full((6, 2), outer_scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), outer_scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
@@ -586,4 +586,4 @@ def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
         fully_sharded_buffer.local_buffer.numel()
         == replicated_sharded_buffer.local_buffer.numel() // 2
     )
-    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, tensors)

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -5,6 +5,7 @@
 import dataclasses
 import os
 from collections.abc import Iterable, Iterator
+from typing import cast
 
 import pytest
 import torch
@@ -272,6 +273,26 @@ def test_sharded_allgather_into_existing_buffer(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
+def test_mesh_axis_must_be_non_negative_int(setup: DistributedSetup):
+    """DBuffer communication methods require explicit non-negative integer mesh axes."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    buffer = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=[torch.Size((4,))],
+        dtype=torch.float32,
+        device=setup.device,
+    )
+
+    with pytest.raises(TypeError, match="Mesh axis must be an int"):
+        buffer.allgather(cast(int, "dp"))
+    with pytest.raises(TypeError, match="Mesh axis must be an int"):
+        buffer.allgather(True)
+    with pytest.raises(ValueError, match="Mesh axis -1 is out of bounds"):
+        buffer.allgather(-1)
+
+
+@pytest.mark.distributed
 def test_replicate_scatter_round_trip(setup: DistributedSetup):
     """Replicated buffers locally chunk into sharded buffers and all-gather back."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
@@ -444,7 +465,7 @@ def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
     )
 
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
-    replicated_buffer = sharded_buffer.allgather("flat")
+    replicated_buffer = sharded_buffer.allgather(1)
 
     _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
 
@@ -485,8 +506,8 @@ def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
     expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
     expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
-        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
-        + mesh.get_local_rank("dp_outer") * expected_local_numel
+        mesh.get_local_rank(1) * expected_inner_axis_shard_numel
+        + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
     assert (
@@ -512,15 +533,15 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetu
     ]
 
     partial_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial(), Flat()])
-    fully_sharded_buffer = partial_sharded_buffer.reduce_scatter("dp_outer", Flat())
-    replicated_buffer = fully_sharded_buffer.allgather("dp_outer").allgather("dp_inner")
+    fully_sharded_buffer = partial_sharded_buffer.reduce_scatter(0, Flat())
+    replicated_buffer = fully_sharded_buffer.allgather(0).allgather(1)
 
     assert fully_sharded_buffer.placements == (Flat(), Flat())
     expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
     expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
-        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
-        + mesh.get_local_rank("dp_outer") * expected_local_numel
+        mesh.get_local_rank(1) * expected_inner_axis_shard_numel
+        + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
     assert (
@@ -548,15 +569,15 @@ def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
     )
 
     replicated_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
-    fully_sharded_buffer = replicated_sharded_buffer.scatter("dp_outer", Flat())
-    replicated_buffer = fully_sharded_buffer.allgather("dp_outer").allgather("dp_inner")
+    fully_sharded_buffer = replicated_sharded_buffer.scatter(0, Flat())
+    replicated_buffer = fully_sharded_buffer.allgather(0).allgather(1)
 
     assert fully_sharded_buffer.placements == (Flat(), Flat())
     expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
     expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
-        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
-        + mesh.get_local_rank("dp_outer") * expected_local_numel
+        mesh.get_local_rank(1) * expected_inner_axis_shard_numel
+        + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
     assert (

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -107,6 +107,50 @@ def test_dbuffer_layout_aligns_fragment_offsets_to_rows(setup: DistributedSetup)
 
 
 @pytest.mark.distributed
+def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
+    """LCM packing fills row-aligned padding gaps on a 5-rank flat-sharded mesh."""
+    if setup.world_size < 5:
+        pytest.skip("LCM padding-gap layout test requires at least 5 ranks.")
+
+    # P0-P4 are zero-based logical tensor names matching tensor indices.
+    shapes = [
+        torch.Size((2, 6)),  # P0
+        torch.Size((4, 4)),  # P1
+        torch.Size((4, 4)),  # P2
+        torch.Size((1, 2)),  # P3
+        torch.Size((1, 6)),  # P4
+    ]
+
+    mesh = init_device_mesh(setup.device.type, (5,))
+    if mesh.get_coordinate() is None:
+        pytest.skip("Rank is outside the 5-rank DBuffer mesh.")
+
+    buffer = DBuffer(
+        mesh=mesh,
+        placements=[Flat()],
+        tensor_shapes=shapes,
+        dtype=torch.float32,
+        device=setup.device,
+    )
+    layout = buffer.layout
+    expected_local_shapes_by_rank = [
+        [(2, 6), (0, 4), (0, 4), (0, 2), (0, 6)],
+        [(0, 6), (3, 4), (0, 4), (0, 2), (0, 6)],
+        [(0, 6), (1, 4), (1, 4), (1, 2), (0, 6)],
+        [(0, 6), (0, 4), (3, 4), (0, 2), (0, 6)],
+        [(0, 6), (0, 4), (0, 4), (0, 2), (1, 6)],
+    ]
+
+    assert layout.tensor_shapes == tuple(shapes)
+    assert layout.tensor_to_offset == (0, 12, 32, 28, 48)
+    assert layout.size == 60
+    expected_local_shapes = expected_local_shapes_by_rank[mesh.get_local_rank(0)]
+    for index, expected_shape in enumerate(expected_local_shapes):
+        assert buffer.get_tensor(index).shape == torch.Size(expected_shape)
+        assert buffer.get_dtensor(index).shape == shapes[index]
+
+
+@pytest.mark.distributed
 def test_constructor_allocates_local_buffer(setup: DistributedSetup):
     """DBuffer allocates local storage from shape, mesh, placement, dtype, and device."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -1,0 +1,417 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for Megatron-FSDP DBuffer."""
+
+import dataclasses
+import os
+from collections.abc import Iterator
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.dbuffer import (
+    DBuffer,
+    Flat,
+    Partial,
+    Replicate,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class DistributedSetup:
+    """Per-rank distributed test setup."""
+
+    rank: int
+    world_size: int
+    device: torch.device
+
+
+@pytest.fixture(scope="module")
+def setup() -> Iterator[DistributedSetup]:
+    """Read torchrun rank state and set up this rank's local device."""
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Not running under torchrun.")
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+
+    if torch.cuda.is_available():
+        torch.cuda.set_device(local_rank)
+        device = torch.device(f"cuda:{local_rank}")
+    else:
+        device = torch.device("cpu")
+
+    yield DistributedSetup(rank=rank, world_size=world_size, device=device)
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
+    return [
+        torch.arange(21, dtype=torch.float32, device=device).reshape(7, 3),
+        torch.arange(10, dtype=torch.float32, device=device).reshape(2, 5) + 100,
+        torch.arange(7, dtype=torch.float32, device=device) + 200,
+    ]
+
+
+def _assert_dbuffer_contains_tensors(
+    buffer: DBuffer, expected: list[torch.Tensor], *, exact: bool = True
+) -> None:
+    for index, tensor in enumerate(expected):
+        if exact:
+            torch.testing.assert_close(buffer.get_tensor(index), tensor, rtol=0, atol=0)
+        else:
+            torch.testing.assert_close(buffer.get_tensor(index), tensor)
+
+
+@pytest.mark.distributed
+def test_dbuffer_layout_pads_to_lcm_times_dp_size_and_fills_gaps(setup: DistributedSetup):
+    """DBuffer layout returns element offsets and pads to LCM * DP size."""
+    if setup.world_size < 2:
+        pytest.skip("DBuffer layout test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (2,))
+    shapes = [torch.Size((5, 4)), torch.Size((2, 6)), torch.Size((3,))]
+
+    buffer = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=shapes,
+        dtype=torch.float32,
+        device=setup.device,
+    )
+
+    assert buffer.layout.tensor_shapes == tuple(shapes)
+    assert buffer.layout.tensor_to_offset == (0, 24, 20)
+    assert buffer.layout.size == 48
+
+
+@pytest.mark.distributed
+def test_dbuffer_layout_aligns_fragment_offsets_to_rows(setup: DistributedSetup):
+    """DBuffer layout keeps small tensors aligned to their non-leading dimensions."""
+    if setup.world_size < 2:
+        pytest.skip("DBuffer layout test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (2,))
+    shapes = [torch.Size((4, 4)), torch.Size((1, 6))]
+
+    buffer = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=shapes,
+        dtype=torch.float32,
+        device=setup.device,
+    )
+
+    assert buffer.layout.tensor_to_offset == (0, 18)
+    assert buffer.layout.size == 24
+
+
+@pytest.mark.distributed
+def test_constructor_allocates_local_buffer(setup: DistributedSetup):
+    """DBuffer allocates local storage from shape, mesh, placement, dtype, and device."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensor_shapes = [torch.Size((7, 3)), torch.Size((2, 5)), torch.Size((7,))]
+    mesh_size = mesh.size()
+
+    replicated_buffer = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=tensor_shapes,
+        dtype=torch.float32,
+        device=setup.device,
+    )
+    flat_buffer = DBuffer(
+        mesh=mesh,
+        placements=[Flat()],
+        tensor_shapes=tensor_shapes,
+        dtype=torch.float32,
+        device=setup.device,
+    )
+
+    assert replicated_buffer.layout == flat_buffer.layout
+    assert replicated_buffer.layout.tensor_shapes == tuple(tensor_shapes)
+    assert replicated_buffer.offset == 0
+    expected_flat_local_numel = replicated_buffer.layout.size // setup.world_size
+    assert flat_buffer.offset == setup.rank * expected_flat_local_numel
+    assert replicated_buffer.local_buffer.numel() == replicated_buffer.layout.size
+    assert flat_buffer.local_buffer.numel() == replicated_buffer.layout.size // setup.world_size
+    assert flat_buffer.layout.size % (15 * mesh_size) == 0
+    assert replicated_buffer.local_buffer.dtype == torch.float32
+    assert flat_buffer.local_buffer.device == setup.device
+
+
+@pytest.mark.distributed
+def test_replicate_get_tensor_and_dtensor(setup: DistributedSetup):
+    """Replicated DBuffer returns full local tensors and replicated DTensors."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+
+    buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+
+    _assert_dbuffer_contains_tensors(buffer, tensors)
+    dtensor = buffer.get_dtensor(0)
+    torch.testing.assert_close(dtensor.to_local(), tensors[0], rtol=0, atol=0)
+
+
+@pytest.mark.distributed
+def test_distribute_tensors_moves_inputs_to_mesh_device(setup: DistributedSetup):
+    """distribute_tensors moves full input tensors to the mesh device type."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(torch.device("cpu"))
+
+    buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+
+    assert buffer.local_buffer.device == setup.device
+    _assert_dbuffer_contains_tensors(buffer, [tensor.to(setup.device) for tensor in tensors])
+
+
+@pytest.mark.distributed
+def test_flat_allgather_round_trip(setup: DistributedSetup):
+    """Flat buffers round-trip through all-gather as contiguous tensor fragments."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+
+    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
+    layout = flat_buffer.layout
+    for index, tensor in enumerate(tensors):
+        local_tensor = flat_buffer.get_tensor(index)
+        assert local_tensor.shape[1:] == tensor.shape[1:]
+        assert local_tensor.is_contiguous()
+
+    replicated_buffer = flat_buffer.allgather(0)
+
+    assert replicated_buffer.layout == layout
+    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+
+
+@pytest.mark.distributed
+def test_replicate_scatter_round_trip(setup: DistributedSetup):
+    """Replicated buffers locally chunk into Flat buffers and all-gather back."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+
+    replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+    flat_buffer = replicated_buffer.scatter(0, Flat())
+    redistributed_flat_buffer = replicated_buffer.redistribute([Flat()])
+
+    assert flat_buffer.placements == (Flat(),)
+    assert redistributed_flat_buffer.placements == (Flat(),)
+    expected_flat_local_numel = replicated_buffer.layout.size // setup.world_size
+    assert flat_buffer.offset == setup.rank * expected_flat_local_numel
+    torch.testing.assert_close(
+        flat_buffer.local_buffer, redistributed_flat_buffer.local_buffer, rtol=0, atol=0
+    )
+    _assert_dbuffer_contains_tensors(flat_buffer.allgather(0), tensors)
+
+
+@pytest.mark.distributed
+def test_partial_allreduce(setup: DistributedSetup):
+    """Partial buffers all-reduce into replicated buffers."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    rank_scale = float(setup.rank + 1)
+    tensors = [
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+    ]
+    partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
+
+    replicated_buffer = partial_buffer.allreduce(0)
+
+    scale_sum = float(setup.world_size * (setup.world_size + 1) // 2)
+    expected = [
+        torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
+        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
+    ]
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+
+
+@pytest.mark.distributed
+def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
+    """Partial buffers reduce-scatter into Flat buffers."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    rank_scale = float(setup.rank + 1)
+    tensors = [
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+    ]
+    partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
+    layout = partial_buffer.layout
+
+    flat_buffer = partial_buffer.reduce_scatter(0, Flat())
+    replicated_buffer = flat_buffer.allgather(0)
+
+    assert flat_buffer.placements == (Flat(),)
+    assert flat_buffer.layout == layout
+    assert replicated_buffer.layout == layout
+    scale_sum = float(setup.world_size * (setup.world_size + 1) // 2)
+    expected_tensors = [
+        torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
+        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
+    ]
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors, exact=False)
+
+
+@pytest.mark.distributed
+def test_get_dtensor_from_flat_buffer(setup: DistributedSetup):
+    """Flat DBuffer exposes per-tensor local shards as DTensors."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
+
+    dtensor = flat_buffer.get_dtensor(0)
+
+    torch.testing.assert_close(dtensor.to_local(), flat_buffer.get_tensor(0), rtol=0, atol=0)
+    assert dtensor.shape == tensors[0].shape
+
+
+@pytest.mark.distributed
+def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
+    """A 2D mesh can replicate on one axis and flat-shard on the other."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("replicate", "flat")
+    )
+
+    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
+    replicated_buffer = flat_buffer.allgather("flat")
+
+    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+
+
+@pytest.mark.distributed
+def test_2d_mesh_flat_before_replicate_is_rejected(setup: DistributedSetup):
+    """Flat axes must be a suffix to keep every local buffer contiguous."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("flat", "replicate")
+    )
+
+    with pytest.raises(ValueError, match="Flat placements must be a suffix"):
+        DBuffer(
+            mesh=mesh,
+            placements=[Flat(), Replicate()],
+            tensor_shapes=[torch.Size((6, 4))],
+            dtype=torch.float32,
+            device=setup.device,
+        )
+
+
+@pytest.mark.distributed
+def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
+    """Multiple Flat axes shard local storage by the product of their mesh sizes."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+    )
+    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
+
+    assert flat_buffer.layout.tensor_shapes == tuple(tensor.shape for tensor in tensors)
+    expected_local_numel = flat_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = flat_buffer.layout.size // mesh.size(1)
+    expected_offset = (
+        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
+        + mesh.get_local_rank("dp_outer") * expected_local_numel
+    )
+    assert flat_buffer.offset == expected_offset
+    assert flat_buffer.local_buffer.numel() == flat_buffer.layout.size // mesh.size()
+    for index, _ in enumerate(tensors):
+        assert flat_buffer.get_tensor(index).is_contiguous()
+
+
+@pytest.mark.distributed
+def test_2d_mesh_flat_flat_redistribute_to_replicate_replicate(setup: DistributedSetup):
+    """Redistribute composes all-gathers across both Flat axes."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+    )
+    flat_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
+    layout = flat_flat_buffer.layout
+
+    replicated_buffer = flat_flat_buffer.redistribute([Replicate(), Replicate()])
+
+    assert replicated_buffer.placements == (Replicate(), Replicate())
+    assert replicated_buffer.layout == layout
+    assert replicated_buffer.offset == 0
+    assert replicated_buffer.local_buffer.numel() == layout.size
+    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+
+
+@pytest.mark.distributed
+def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetup):
+    """Partial+Flat reduce-scatter reduces the existing Flat local shard."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+    )
+    outer_scale = float(mesh.get_local_rank(0) + 1)
+    tensors = [
+        torch.full((6, 2), outer_scale, dtype=torch.float32, device=setup.device),
+        torch.full((4,), outer_scale * 10, dtype=torch.float32, device=setup.device),
+    ]
+
+    partial_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial(), Flat()])
+    flat_flat_buffer = partial_flat_buffer.reduce_scatter("dp_outer", Flat())
+    replicated_buffer = flat_flat_buffer.allgather("dp_outer").allgather("dp_inner")
+
+    assert flat_flat_buffer.placements == (Flat(), Flat())
+    expected_local_numel = flat_flat_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = flat_flat_buffer.layout.size // mesh.size(1)
+    expected_offset = (
+        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
+        + mesh.get_local_rank("dp_outer") * expected_local_numel
+    )
+    assert flat_flat_buffer.offset == expected_offset
+    assert flat_flat_buffer.local_buffer.numel() == partial_flat_buffer.local_buffer.numel() // 2
+
+    outer_scale_sum = float(mesh.size(0) * (mesh.size(0) + 1) // 2)
+    expected = [
+        torch.full((6, 2), outer_scale_sum, dtype=torch.float32, device=setup.device),
+        torch.full((4,), outer_scale_sum * 10, dtype=torch.float32, device=setup.device),
+    ]
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+
+
+@pytest.mark.distributed
+def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
+    """Replicate+Flat scatter chunks the existing Flat local shard."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+    )
+
+    replicate_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
+    flat_flat_buffer = replicate_flat_buffer.scatter("dp_outer", Flat())
+    replicated_buffer = flat_flat_buffer.allgather("dp_outer").allgather("dp_inner")
+
+    assert flat_flat_buffer.placements == (Flat(), Flat())
+    expected_local_numel = flat_flat_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = flat_flat_buffer.layout.size // mesh.size(1)
+    expected_offset = (
+        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
+        + mesh.get_local_rank("dp_outer") * expected_local_numel
+    )
+    assert flat_flat_buffer.offset == expected_offset
+    assert flat_flat_buffer.local_buffer.numel() == replicate_flat_buffer.local_buffer.numel() // 2
+    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -4,7 +4,7 @@
 
 import dataclasses
 import os
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 
 import pytest
 import torch
@@ -58,14 +58,9 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
     ]
 
 
-def _assert_dbuffer_contains_tensors(
-    buffer: DBuffer, expected: list[torch.Tensor], *, exact: bool = True
-) -> None:
+def _assert_dbuffer_contains_tensors(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
-        if exact:
-            torch.testing.assert_close(buffer.get_tensor(index), tensor, rtol=0, atol=0)
-        else:
-            torch.testing.assert_close(buffer.get_tensor(index), tensor)
+        torch.testing.assert_close(buffer.get_tensor(index), tensor)
 
 
 @pytest.mark.distributed
@@ -125,7 +120,7 @@ def test_constructor_allocates_local_buffer(setup: DistributedSetup):
         dtype=torch.float32,
         device=setup.device,
     )
-    flat_buffer = DBuffer(
+    sharded_buffer = DBuffer(
         mesh=mesh,
         placements=[Flat()],
         tensor_shapes=tensor_shapes,
@@ -133,16 +128,37 @@ def test_constructor_allocates_local_buffer(setup: DistributedSetup):
         device=setup.device,
     )
 
-    assert replicated_buffer.layout == flat_buffer.layout
+    assert replicated_buffer.layout == sharded_buffer.layout
     assert replicated_buffer.layout.tensor_shapes == tuple(tensor_shapes)
     assert replicated_buffer.offset == 0
-    expected_flat_local_numel = replicated_buffer.layout.size // setup.world_size
-    assert flat_buffer.offset == setup.rank * expected_flat_local_numel
+    expected_sharded_local_numel = replicated_buffer.layout.size // setup.world_size
+    assert sharded_buffer.offset == setup.rank * expected_sharded_local_numel
     assert replicated_buffer.local_buffer.numel() == replicated_buffer.layout.size
-    assert flat_buffer.local_buffer.numel() == replicated_buffer.layout.size // setup.world_size
-    assert flat_buffer.layout.size % (15 * mesh_size) == 0
-    assert replicated_buffer.local_buffer.dtype == torch.float32
-    assert flat_buffer.local_buffer.device == setup.device
+    assert sharded_buffer.local_buffer.numel() == replicated_buffer.layout.size // setup.world_size
+    assert sharded_buffer.layout.size % (15 * mesh_size) == 0
+    assert replicated_buffer.dtype == torch.float32
+    assert sharded_buffer.local_buffer.device == setup.device
+
+
+@pytest.mark.distributed
+def test_from_local_reuses_required_local_buffer(setup: DistributedSetup):
+    """DBuffer.from_local reuses caller-provided local storage without allocation."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+    local_numel = replicated_buffer.layout.size // setup.world_size
+    offset = setup.rank * local_numel
+    local_buffer = replicated_buffer.local_buffer.narrow(0, offset, local_numel)
+
+    sharded_buffer = DBuffer.from_local(
+        local_buffer, mesh, iter([Flat()]), replicated_buffer.layout.tensor_shapes
+    )
+
+    assert sharded_buffer.placements == (Flat(),)
+    assert sharded_buffer.layout == replicated_buffer.layout
+    assert sharded_buffer.offset == offset
+    assert sharded_buffer.local_buffer.data_ptr() == local_buffer.data_ptr()
+    _assert_dbuffer_contains_tensors(sharded_buffer.allgather(0), tensors)
 
 
 @pytest.mark.distributed
@@ -171,42 +187,78 @@ def test_distribute_tensors_moves_inputs_to_mesh_device(setup: DistributedSetup)
 
 
 @pytest.mark.distributed
-def test_flat_allgather_round_trip(setup: DistributedSetup):
-    """Flat buffers round-trip through all-gather as contiguous tensor fragments."""
+def test_sharded_allgather_round_trip(setup: DistributedSetup):
+    """Sharded buffers round-trip through all-gather as contiguous tensor fragments."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     tensors = _same_tensors_on_all_ranks(setup.device)
 
-    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
-    layout = flat_buffer.layout
+    sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
+    layout = sharded_buffer.layout
     for index, tensor in enumerate(tensors):
-        local_tensor = flat_buffer.get_tensor(index)
+        local_tensor = sharded_buffer.get_tensor(index)
         assert local_tensor.shape[1:] == tensor.shape[1:]
         assert local_tensor.is_contiguous()
 
-    replicated_buffer = flat_buffer.allgather(0)
+    replicated_buffer = sharded_buffer.allgather(0)
 
     assert replicated_buffer.layout == layout
     _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
 
 
 @pytest.mark.distributed
+def test_sharded_allgather_into_existing_buffer(setup: DistributedSetup):
+    """Sharded buffers can all-gather directly into a preallocated replicated buffer."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
+    destination = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=sharded_buffer.layout.tensor_shapes,
+        dtype=sharded_buffer.dtype,
+        device=sharded_buffer.local_buffer.device,
+    )
+    destination_data_ptr = destination.local_buffer.data_ptr()
+
+    result = sharded_buffer.allgather(0, out=destination)
+
+    assert result is destination
+    assert destination.local_buffer.data_ptr() == destination_data_ptr
+    _assert_dbuffer_contains_tensors(destination, tensors)
+
+
+@pytest.mark.distributed
 def test_replicate_scatter_round_trip(setup: DistributedSetup):
-    """Replicated buffers locally chunk into Flat buffers and all-gather back."""
+    """Replicated buffers locally chunk into sharded buffers and all-gather back."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     tensors = _same_tensors_on_all_ranks(setup.device)
 
     replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
-    flat_buffer = replicated_buffer.scatter(0, Flat())
-    redistributed_flat_buffer = replicated_buffer.redistribute([Flat()])
-
-    assert flat_buffer.placements == (Flat(),)
-    assert redistributed_flat_buffer.placements == (Flat(),)
-    expected_flat_local_numel = replicated_buffer.layout.size // setup.world_size
-    assert flat_buffer.offset == setup.rank * expected_flat_local_numel
-    torch.testing.assert_close(
-        flat_buffer.local_buffer, redistributed_flat_buffer.local_buffer, rtol=0, atol=0
+    sharded_buffer = replicated_buffer.scatter(0, Flat())
+    redistribute_destination = DBuffer(
+        mesh=mesh,
+        placements=[Flat()],
+        tensor_shapes=replicated_buffer.layout.tensor_shapes,
+        dtype=replicated_buffer.dtype,
+        device=replicated_buffer.local_buffer.device,
     )
-    _assert_dbuffer_contains_tensors(flat_buffer.allgather(0), tensors)
+    redistributed_sharded_buffer = replicated_buffer.redistribute(
+        [Flat()], out=redistribute_destination
+    )
+
+    assert sharded_buffer.placements == (Flat(),)
+    assert redistributed_sharded_buffer is redistribute_destination
+    assert redistributed_sharded_buffer.placements == (Flat(),)
+    expected_sharded_local_numel = replicated_buffer.layout.size // setup.world_size
+    assert sharded_buffer.offset == setup.rank * expected_sharded_local_numel
+    source_slice = replicated_buffer.local_buffer.narrow(
+        0, sharded_buffer.offset - replicated_buffer.offset, sharded_buffer.local_buffer.numel()
+    )
+    assert sharded_buffer.local_buffer.data_ptr() == source_slice.data_ptr()
+    torch.testing.assert_close(
+        sharded_buffer.local_buffer, redistributed_sharded_buffer.local_buffer, rtol=0, atol=0
+    )
+    _assert_dbuffer_contains_tensors(sharded_buffer.allgather(0), tensors)
 
 
 @pytest.mark.distributed
@@ -227,7 +279,7 @@ def test_partial_allreduce(setup: DistributedSetup):
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
@@ -243,19 +295,27 @@ def test_partial_allreduce_average(setup: DistributedSetup):
         tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
     )
 
-    replicated_buffer = partial_buffer.allreduce(0)
+    destination = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=partial_buffer.layout.tensor_shapes,
+        dtype=partial_buffer.dtype,
+        device=partial_buffer.local_buffer.device,
+    )
+    replicated_buffer = partial_buffer.allreduce(0, out=destination)
 
+    assert replicated_buffer is destination
     scale_average = float(setup.world_size + 1) / 2.0
     expected = [
         torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
 def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
-    """Partial buffers reduce-scatter into Flat buffers."""
+    """Partial buffers reduce-scatter into sharded buffers."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     rank_scale = float(setup.rank + 1)
     tensors = [
@@ -265,18 +325,26 @@ def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
     partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
     layout = partial_buffer.layout
 
-    flat_buffer = partial_buffer.reduce_scatter(0, Flat())
-    replicated_buffer = flat_buffer.allgather(0)
+    destination = DBuffer(
+        mesh=mesh,
+        placements=[Flat()],
+        tensor_shapes=partial_buffer.layout.tensor_shapes,
+        dtype=partial_buffer.dtype,
+        device=partial_buffer.local_buffer.device,
+    )
+    sharded_buffer = partial_buffer.reduce_scatter(0, Flat(), out=destination)
+    replicated_buffer = sharded_buffer.allgather(0)
 
-    assert flat_buffer.placements == (Flat(),)
-    assert flat_buffer.layout == layout
+    assert sharded_buffer is destination
+    assert sharded_buffer.placements == (Flat(),)
+    assert sharded_buffer.layout == layout
     assert replicated_buffer.layout == layout
     scale_sum = float(setup.world_size * (setup.world_size + 1) // 2)
     expected_tensors = [
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors, exact=False)
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
@@ -293,30 +361,30 @@ def test_partial_reduce_scatter_to_flat_average(setup: DistributedSetup):
     )
     layout = partial_buffer.layout
 
-    flat_buffer = partial_buffer.reduce_scatter(0, Flat())
-    replicated_buffer = flat_buffer.allgather(0)
+    sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
+    replicated_buffer = sharded_buffer.allgather(0)
 
-    assert flat_buffer.placements == (Flat(),)
-    assert flat_buffer.layout == layout
+    assert sharded_buffer.placements == (Flat(),)
+    assert sharded_buffer.layout == layout
     assert replicated_buffer.layout == layout
     scale_average = float(setup.world_size + 1) / 2.0
     expected_tensors = [
         torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors, exact=False)
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
-def test_get_dtensor_from_flat_buffer(setup: DistributedSetup):
-    """Flat DBuffer exposes per-tensor local shards as DTensors."""
+def test_get_dtensor_from_sharded_buffer(setup: DistributedSetup):
+    """Sharded DBuffer exposes per-tensor local shards as DTensors."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     tensors = _same_tensors_on_all_ranks(setup.device)
-    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
+    sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
 
-    dtensor = flat_buffer.get_dtensor(0)
+    dtensor = sharded_buffer.get_dtensor(0)
 
-    torch.testing.assert_close(dtensor.to_local(), flat_buffer.get_tensor(0), rtol=0, atol=0)
+    torch.testing.assert_close(dtensor.to_local(), sharded_buffer.get_tensor(0), rtol=0, atol=0)
     assert dtensor.shape == tensors[0].shape
 
 
@@ -331,8 +399,8 @@ def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
         setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("replicate", "flat")
     )
 
-    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
-    replicated_buffer = flat_buffer.allgather("flat")
+    sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
+    replicated_buffer = sharded_buffer.allgather("flat")
 
     _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
 
@@ -367,41 +435,19 @@ def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
     mesh = init_device_mesh(
         setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
     )
-    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
+    fully_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
 
-    assert flat_buffer.layout.tensor_shapes == tuple(tensor.shape for tensor in tensors)
-    expected_local_numel = flat_buffer.layout.size // mesh.size()
-    expected_inner_axis_shard_numel = flat_buffer.layout.size // mesh.size(1)
+    assert fully_sharded_buffer.layout.tensor_shapes == tuple(tensor.shape for tensor in tensors)
+    expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
         mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
-    assert flat_buffer.offset == expected_offset
-    assert flat_buffer.local_buffer.numel() == flat_buffer.layout.size // mesh.size()
+    assert fully_sharded_buffer.offset == expected_offset
+    assert fully_sharded_buffer.local_buffer.numel() == fully_sharded_buffer.layout.size // mesh.size()
     for index, _ in enumerate(tensors):
-        assert flat_buffer.get_tensor(index).is_contiguous()
-
-
-@pytest.mark.distributed
-def test_2d_mesh_flat_flat_redistribute_to_replicate_replicate(setup: DistributedSetup):
-    """Redistribute composes all-gathers across both Flat axes."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
-        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
-
-    tensors = _same_tensors_on_all_ranks(setup.device)
-    mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
-    )
-    flat_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
-    layout = flat_flat_buffer.layout
-
-    replicated_buffer = flat_flat_buffer.redistribute([Replicate(), Replicate()])
-
-    assert replicated_buffer.placements == (Replicate(), Replicate())
-    assert replicated_buffer.layout == layout
-    assert replicated_buffer.offset == 0
-    assert replicated_buffer.local_buffer.numel() == layout.size
-    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+        assert fully_sharded_buffer.get_tensor(index).is_contiguous()
 
 
 @pytest.mark.distributed
@@ -419,26 +465,26 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetu
         torch.full((4,), outer_scale * 10, dtype=torch.float32, device=setup.device),
     ]
 
-    partial_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial(), Flat()])
-    flat_flat_buffer = partial_flat_buffer.reduce_scatter("dp_outer", Flat())
-    replicated_buffer = flat_flat_buffer.allgather("dp_outer").allgather("dp_inner")
+    partial_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial(), Flat()])
+    fully_sharded_buffer = partial_sharded_buffer.reduce_scatter("dp_outer", Flat())
+    replicated_buffer = fully_sharded_buffer.allgather("dp_outer").allgather("dp_inner")
 
-    assert flat_flat_buffer.placements == (Flat(), Flat())
-    expected_local_numel = flat_flat_buffer.layout.size // mesh.size()
-    expected_inner_axis_shard_numel = flat_flat_buffer.layout.size // mesh.size(1)
+    assert fully_sharded_buffer.placements == (Flat(), Flat())
+    expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
         mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
-    assert flat_flat_buffer.offset == expected_offset
-    assert flat_flat_buffer.local_buffer.numel() == partial_flat_buffer.local_buffer.numel() // 2
+    assert fully_sharded_buffer.offset == expected_offset
+    assert fully_sharded_buffer.local_buffer.numel() == partial_sharded_buffer.local_buffer.numel() // 2
 
     outer_scale_sum = float(mesh.size(0) * (mesh.size(0) + 1) // 2)
     expected = [
         torch.full((6, 2), outer_scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), outer_scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
@@ -452,17 +498,17 @@ def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
         setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
     )
 
-    replicate_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
-    flat_flat_buffer = replicate_flat_buffer.scatter("dp_outer", Flat())
-    replicated_buffer = flat_flat_buffer.allgather("dp_outer").allgather("dp_inner")
+    replicated_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
+    fully_sharded_buffer = replicated_sharded_buffer.scatter("dp_outer", Flat())
+    replicated_buffer = fully_sharded_buffer.allgather("dp_outer").allgather("dp_inner")
 
-    assert flat_flat_buffer.placements == (Flat(), Flat())
-    expected_local_numel = flat_flat_buffer.layout.size // mesh.size()
-    expected_inner_axis_shard_numel = flat_flat_buffer.layout.size // mesh.size(1)
+    assert fully_sharded_buffer.placements == (Flat(), Flat())
+    expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
         mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
-    assert flat_flat_buffer.offset == expected_offset
-    assert flat_flat_buffer.local_buffer.numel() == replicate_flat_buffer.local_buffer.numel() // 2
+    assert fully_sharded_buffer.offset == expected_offset
+    assert fully_sharded_buffer.local_buffer.numel() == replicated_sharded_buffer.local_buffer.numel() // 2
     _assert_dbuffer_contains_tensors(replicated_buffer, tensors)

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -16,7 +16,6 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer impor
     Partial,
     Replicate,
 )
-from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.layout import GlobalLayout
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -30,12 +29,6 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
 def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
         torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
-
-
-def test_dbuffer_layout_rejects_0d_tensor_shapes():
-    """DBuffer layout does not silently reinterpret scalar tensors as dim-0 rows."""
-    with pytest.raises(ValueError, match="0D tensor shapes"):
-        GlobalLayout.build([torch.Size(())], dp_size=1)
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -48,10 +48,8 @@ def setup() -> Iterator[DistributedSetup]:
     yield DistributedSetup(rank=rank, world_size=world_size, device=device)
 
     if dist.is_initialized():
+        # Leave the default process group alive for later distributed tests.
         dist.barrier()
-        # Leave the default process group alive for later distributed tests;
-        # only clear DeviceMesh bookkeeping from this module.
-        _clear_device_mesh_resources()
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -65,21 +63,6 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
 def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
         torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
-
-
-def _clear_device_mesh_resources() -> None:
-    from torch.distributed.device_mesh import _mesh_resources
-
-    for resource_name in (
-        "child_to_root_mapping",
-        "root_to_flatten_mapping",
-        "mesh_stack",
-        "mesh_dim_group_options",
-        "flatten_name_to_root_dims",
-    ):
-        resource = getattr(_mesh_resources, resource_name, None)
-        if resource is not None:
-            resource.clear()
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -11,7 +11,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import init_device_mesh
 
-from megatron.core.distributed.fsdp.src.megatron_fsdp.dbuffer import (
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import (
     DBuffer,
     Flat,
     Partial,
@@ -231,6 +231,29 @@ def test_partial_allreduce(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
+def test_partial_allreduce_average(setup: DistributedSetup):
+    """Partial buffers can all-reduce with AVG."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    rank_scale = float(setup.rank + 1)
+    tensors = [
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+    ]
+    partial_buffer = DBuffer.distribute_tensors(
+        tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
+    )
+
+    replicated_buffer = partial_buffer.allreduce(0)
+
+    scale_average = float(setup.world_size + 1) / 2.0
+    expected = [
+        torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
+        torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
+    ]
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+
+
+@pytest.mark.distributed
 def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
     """Partial buffers reduce-scatter into Flat buffers."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
@@ -252,6 +275,34 @@ def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
     expected_tensors = [
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
+    ]
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors, exact=False)
+
+
+@pytest.mark.distributed
+def test_partial_reduce_scatter_to_flat_average(setup: DistributedSetup):
+    """Partial buffers can reduce-scatter with AVG."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    rank_scale = float(setup.rank + 1)
+    tensors = [
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+    ]
+    partial_buffer = DBuffer.distribute_tensors(
+        tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
+    )
+    layout = partial_buffer.layout
+
+    flat_buffer = partial_buffer.reduce_scatter(0, Flat())
+    replicated_buffer = flat_buffer.allgather(0)
+
+    assert flat_buffer.placements == (Flat(),)
+    assert flat_buffer.layout == layout
+    assert replicated_buffer.layout == layout
+    scale_average = float(setup.world_size + 1) / 2.0
+    expected_tensors = [
+        torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
+        torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
     ]
     _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors, exact=False)
 

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -2,9 +2,7 @@
 
 """Unit tests for Megatron-FSDP DBuffer."""
 
-import dataclasses
-import os
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from typing import cast
 
 import pytest
@@ -18,38 +16,6 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer impor
     Partial,
     Replicate,
 )
-
-
-@dataclasses.dataclass(frozen=True)
-class DistributedSetup:
-    """Per-rank distributed test setup."""
-
-    rank: int
-    world_size: int
-    device: torch.device
-
-
-@pytest.fixture(scope="module")
-def setup() -> Iterator[DistributedSetup]:
-    """Read torchrun rank state and set up this rank's local device."""
-    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
-        pytest.skip("Not running under torchrun.")
-
-    rank = int(os.environ["RANK"])
-    world_size = int(os.environ["WORLD_SIZE"])
-    local_rank = int(os.environ.get("LOCAL_RANK", rank))
-
-    if torch.cuda.is_available():
-        torch.cuda.set_device(local_rank)
-        device = torch.device(f"cuda:{local_rank}")
-    else:
-        device = torch.device("cpu")
-
-    yield DistributedSetup(rank=rank, world_size=world_size, device=device)
-
-    if dist.is_initialized():
-        # Leave the default process group alive for later distributed tests.
-        dist.barrier()
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -66,12 +32,12 @@ def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torc
 
 
 @pytest.mark.distributed
-def test_dbuffer_layout_pads_to_lcm_times_dp_size_and_fills_gaps(setup: DistributedSetup):
+def test_dbuffer_layout_pads_to_lcm_times_dp_size_and_fills_gaps(distributed_setup):
     """DBuffer layout returns element offsets and pads to LCM * DP size."""
-    if setup.world_size < 2:
+    if distributed_setup.world_size < 2:
         pytest.skip("DBuffer layout test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (2,))
+    mesh = init_device_mesh(distributed_setup.device.type, (2,))
     shapes = [torch.Size((5, 4)), torch.Size((2, 6)), torch.Size((3,))]
 
     buffer = DBuffer(
@@ -79,7 +45,7 @@ def test_dbuffer_layout_pads_to_lcm_times_dp_size_and_fills_gaps(setup: Distribu
         placements=[Replicate()],
         tensor_shapes=shapes,
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
 
     assert buffer.layout.tensor_shapes == tuple(shapes)
@@ -88,12 +54,12 @@ def test_dbuffer_layout_pads_to_lcm_times_dp_size_and_fills_gaps(setup: Distribu
 
 
 @pytest.mark.distributed
-def test_dbuffer_layout_aligns_fragment_offsets_to_rows(setup: DistributedSetup):
+def test_dbuffer_layout_aligns_fragment_offsets_to_rows(distributed_setup):
     """DBuffer layout keeps small tensors aligned to their non-leading dimensions."""
-    if setup.world_size < 2:
+    if distributed_setup.world_size < 2:
         pytest.skip("DBuffer layout test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (2,))
+    mesh = init_device_mesh(distributed_setup.device.type, (2,))
     shapes = [torch.Size((4, 4)), torch.Size((1, 6))]
 
     buffer = DBuffer(
@@ -101,7 +67,7 @@ def test_dbuffer_layout_aligns_fragment_offsets_to_rows(setup: DistributedSetup)
         placements=[Replicate()],
         tensor_shapes=shapes,
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
 
     assert buffer.layout.tensor_to_offset == (0, 18)
@@ -109,9 +75,9 @@ def test_dbuffer_layout_aligns_fragment_offsets_to_rows(setup: DistributedSetup)
 
 
 @pytest.mark.distributed
-def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
+def test_compute_layout_fills_lcm_padding_gaps(distributed_setup):
     """LCM packing fills row-aligned padding gaps on a 5-rank flat-sharded mesh."""
-    if setup.world_size < 5:
+    if distributed_setup.world_size < 5:
         pytest.skip("LCM padding-gap layout test requires at least 5 ranks.")
 
     # P0-P4 are zero-based logical tensor names matching tensor indices.
@@ -123,7 +89,7 @@ def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
         torch.Size((1, 6)),  # P4
     ]
 
-    mesh = init_device_mesh(setup.device.type, (5,))
+    mesh = init_device_mesh(distributed_setup.device.type, (5,))
     if mesh.get_coordinate() is None:
         pytest.skip("Rank is outside the 5-rank DBuffer mesh.")
 
@@ -132,7 +98,7 @@ def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
         placements=[Flat()],
         tensor_shapes=shapes,
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
     layout = buffer.layout
     expected_local_shapes_by_rank = [
@@ -153,9 +119,9 @@ def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_constructor_allocates_local_buffer(setup: DistributedSetup):
+def test_constructor_allocates_local_buffer(distributed_setup):
     """DBuffer allocates local storage from shape, mesh, placement, dtype, and device."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     tensor_shapes = [torch.Size((7, 3)), torch.Size((2, 5)), torch.Size((7,))]
     mesh_size = mesh.size()
 
@@ -164,36 +130,39 @@ def test_constructor_allocates_local_buffer(setup: DistributedSetup):
         placements=[Replicate()],
         tensor_shapes=tensor_shapes,
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
     sharded_buffer = DBuffer(
         mesh=mesh,
         placements=[Flat()],
         tensor_shapes=tensor_shapes,
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
 
     assert replicated_buffer.layout == sharded_buffer.layout
     assert replicated_buffer.layout.tensor_shapes == tuple(tensor_shapes)
     assert replicated_buffer.offset == 0
-    expected_sharded_local_numel = replicated_buffer.layout.size // setup.world_size
-    assert sharded_buffer.offset == setup.rank * expected_sharded_local_numel
+    expected_sharded_local_numel = replicated_buffer.layout.size // distributed_setup.world_size
+    assert sharded_buffer.offset == distributed_setup.rank * expected_sharded_local_numel
     assert replicated_buffer.local_buffer.numel() == replicated_buffer.layout.size
-    assert sharded_buffer.local_buffer.numel() == replicated_buffer.layout.size // setup.world_size
+    assert (
+        sharded_buffer.local_buffer.numel()
+        == replicated_buffer.layout.size // distributed_setup.world_size
+    )
     assert sharded_buffer.layout.size % (15 * mesh_size) == 0
     assert replicated_buffer.dtype == torch.float32
-    assert sharded_buffer.local_buffer.device == setup.device
+    assert sharded_buffer.local_buffer.device == distributed_setup.device
 
 
 @pytest.mark.distributed
-def test_from_local_reuses_required_local_buffer(setup: DistributedSetup):
+def test_from_local_reuses_required_local_buffer(distributed_setup):
     """DBuffer.from_local reuses caller-provided local storage without allocation."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
-    local_numel = replicated_buffer.layout.size // setup.world_size
-    offset = setup.rank * local_numel
+    local_numel = replicated_buffer.layout.size // distributed_setup.world_size
+    offset = distributed_setup.rank * local_numel
     local_buffer = replicated_buffer.local_buffer.narrow(0, offset, local_numel)
 
     sharded_buffer = DBuffer.from_local(
@@ -208,10 +177,10 @@ def test_from_local_reuses_required_local_buffer(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_replicate_get_local_tensor_and_dtensor(setup: DistributedSetup):
+def test_replicate_get_local_tensor_and_dtensor(distributed_setup):
     """Replicated DBuffer returns full local tensors and replicated DTensors."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
 
     buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
 
@@ -221,22 +190,24 @@ def test_replicate_get_local_tensor_and_dtensor(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_distribute_tensors_moves_inputs_to_mesh_device(setup: DistributedSetup):
+def test_distribute_tensors_moves_inputs_to_mesh_device(distributed_setup):
     """distribute_tensors moves full input tensors to the mesh device type."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     tensors = _same_tensors_on_all_ranks(torch.device("cpu"))
 
     buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
 
-    assert buffer.local_buffer.device == setup.device
-    _assert_dbuffer_local_tensors_close(buffer, [tensor.to(setup.device) for tensor in tensors])
+    assert buffer.local_buffer.device == distributed_setup.device
+    _assert_dbuffer_local_tensors_close(
+        buffer, [tensor.to(distributed_setup.device) for tensor in tensors]
+    )
 
 
 @pytest.mark.distributed
-def test_sharded_allgather_round_trip(setup: DistributedSetup):
+def test_sharded_allgather_round_trip(distributed_setup):
     """Sharded buffers round-trip through all-gather as contiguous tensor fragments."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
 
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
     layout = sharded_buffer.layout
@@ -252,10 +223,10 @@ def test_sharded_allgather_round_trip(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_sharded_allgather_into_existing_buffer(setup: DistributedSetup):
+def test_sharded_allgather_into_existing_buffer(distributed_setup):
     """Sharded buffers can all-gather directly into a preallocated replicated buffer."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
     destination = DBuffer(
         mesh=mesh,
@@ -274,15 +245,15 @@ def test_sharded_allgather_into_existing_buffer(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_mesh_axis_must_be_non_negative_int(setup: DistributedSetup):
+def test_mesh_axis_must_be_non_negative_int(distributed_setup):
     """DBuffer communication methods require explicit non-negative integer mesh axes."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     buffer = DBuffer(
         mesh=mesh,
         placements=[Replicate()],
         tensor_shapes=[torch.Size((4,))],
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
 
     with pytest.raises(TypeError, match="Mesh axis must be an int"):
@@ -294,10 +265,10 @@ def test_mesh_axis_must_be_non_negative_int(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_replicate_scatter_round_trip(setup: DistributedSetup):
+def test_replicate_scatter_round_trip(distributed_setup):
     """Replicated buffers locally chunk into sharded buffers and all-gather back."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
 
     replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
     sharded_buffer = replicated_buffer.scatter(0, Flat())
@@ -315,8 +286,8 @@ def test_replicate_scatter_round_trip(setup: DistributedSetup):
     assert sharded_buffer.placements == (Flat(),)
     assert redistributed_sharded_buffer is redistribute_destination
     assert redistributed_sharded_buffer.placements == (Flat(),)
-    expected_sharded_local_numel = replicated_buffer.layout.size // setup.world_size
-    assert sharded_buffer.offset == setup.rank * expected_sharded_local_numel
+    expected_sharded_local_numel = replicated_buffer.layout.size // distributed_setup.world_size
+    assert sharded_buffer.offset == distributed_setup.rank * expected_sharded_local_numel
     assert (
         sharded_buffer.local_buffer.untyped_storage()
         is replicated_buffer.local_buffer.untyped_storage()
@@ -328,34 +299,34 @@ def test_replicate_scatter_round_trip(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_partial_allreduce(setup: DistributedSetup):
+def test_partial_allreduce(distributed_setup):
     """Partial buffers all-reduce into replicated buffers."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    rank_scale = float(setup.rank + 1)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    rank_scale = float(distributed_setup.rank + 1)
     tensors = [
-        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
-        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
 
     replicated_buffer = partial_buffer.allreduce(0)
 
-    scale_sum = float(setup.world_size * (setup.world_size + 1) // 2)
+    scale_sum = float(distributed_setup.world_size * (distributed_setup.world_size + 1) // 2)
     expected = [
-        torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
-        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), scale_sum, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
-def test_partial_allreduce_average(setup: DistributedSetup):
+def test_partial_allreduce_average(distributed_setup):
     """Partial buffers can all-reduce with AVG."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    rank_scale = float(setup.rank + 1)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    rank_scale = float(distributed_setup.rank + 1)
     tensors = [
-        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
-        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     partial_buffer = DBuffer.distribute_tensors(
         tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
@@ -371,22 +342,22 @@ def test_partial_allreduce_average(setup: DistributedSetup):
     replicated_buffer = partial_buffer.allreduce(0, out=destination)
 
     assert replicated_buffer is destination
-    scale_average = float(setup.world_size + 1) / 2.0
+    scale_average = float(distributed_setup.world_size + 1) / 2.0
     expected = [
-        torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
-        torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), scale_average, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), scale_average * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
-def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
+def test_partial_reduce_scatter_to_flat(distributed_setup):
     """Partial buffers reduce-scatter into sharded buffers."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    rank_scale = float(setup.rank + 1)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    rank_scale = float(distributed_setup.rank + 1)
     tensors = [
-        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
-        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
     layout = partial_buffer.layout
@@ -405,22 +376,22 @@ def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == layout
     assert replicated_buffer.layout == layout
-    scale_sum = float(setup.world_size * (setup.world_size + 1) // 2)
+    scale_sum = float(distributed_setup.world_size * (distributed_setup.world_size + 1) // 2)
     expected_tensors = [
-        torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
-        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), scale_sum, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
-def test_partial_reduce_scatter_to_flat_average(setup: DistributedSetup):
+def test_partial_reduce_scatter_to_flat_average(distributed_setup):
     """Partial buffers can reduce-scatter with AVG."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    rank_scale = float(setup.rank + 1)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    rank_scale = float(distributed_setup.rank + 1)
     tensors = [
-        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
-        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     partial_buffer = DBuffer.distribute_tensors(
         tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
@@ -433,19 +404,19 @@ def test_partial_reduce_scatter_to_flat_average(setup: DistributedSetup):
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == layout
     assert replicated_buffer.layout == layout
-    scale_average = float(setup.world_size + 1) / 2.0
+    scale_average = float(distributed_setup.world_size + 1) / 2.0
     expected_tensors = [
-        torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
-        torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), scale_average, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), scale_average * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
-def test_get_dtensor_from_sharded_buffer(setup: DistributedSetup):
+def test_get_dtensor_from_sharded_buffer(distributed_setup):
     """Sharded DBuffer exposes per-tensor local shards as DTensors."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
 
     dtensor = sharded_buffer.get_dtensor(0)
@@ -457,14 +428,16 @@ def test_get_dtensor_from_sharded_buffer(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
+def test_2d_mesh_replicate_flat_round_trip(distributed_setup):
     """A 2D mesh can replicate on one axis and flat-shard on the other."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
+    if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("replicate", "flat")
+        distributed_setup.device.type,
+        (2, distributed_setup.world_size // 2),
+        mesh_dim_names=("replicate", "flat"),
     )
 
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
@@ -474,13 +447,15 @@ def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_2d_mesh_flat_before_replicate_is_rejected(setup: DistributedSetup):
+def test_2d_mesh_flat_before_replicate_is_rejected(distributed_setup):
     """Flat axes must be a suffix to keep every local buffer contiguous."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
+    if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
     mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("flat", "replicate")
+        distributed_setup.device.type,
+        (2, distributed_setup.world_size // 2),
+        mesh_dim_names=("flat", "replicate"),
     )
 
     with pytest.raises(ValueError, match="Flat placements must be a suffix"):
@@ -489,19 +464,21 @@ def test_2d_mesh_flat_before_replicate_is_rejected(setup: DistributedSetup):
             placements=[Flat(), Replicate()],
             tensor_shapes=[torch.Size((6, 4))],
             dtype=torch.float32,
-            device=setup.device,
+            device=distributed_setup.device,
         )
 
 
 @pytest.mark.distributed
-def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
+def test_2d_mesh_shards_across_all_ranks(distributed_setup):
     """Multiple Flat axes shard local storage by the product of their mesh sizes."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
+    if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+        distributed_setup.device.type,
+        (2, distributed_setup.world_size // 2),
+        mesh_dim_names=("dp_outer", "dp_inner"),
     )
     fully_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
 
@@ -521,18 +498,20 @@ def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetup):
+def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(distributed_setup):
     """Partial+Flat reduce-scatter reduces the existing Flat local shard."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
+    if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
     mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+        distributed_setup.device.type,
+        (2, distributed_setup.world_size // 2),
+        mesh_dim_names=("dp_outer", "dp_inner"),
     )
     outer_scale = float(mesh.get_local_rank(0) + 1)
     tensors = [
-        torch.full((6, 2), outer_scale, dtype=torch.float32, device=setup.device),
-        torch.full((4,), outer_scale * 10, dtype=torch.float32, device=setup.device),
+        torch.full((6, 2), outer_scale, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), outer_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
 
     partial_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial(), Flat()])
@@ -554,21 +533,25 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetu
 
     outer_scale_sum = float(mesh.size(0) * (mesh.size(0) + 1) // 2)
     expected = [
-        torch.full((6, 2), outer_scale_sum, dtype=torch.float32, device=setup.device),
-        torch.full((4,), outer_scale_sum * 10, dtype=torch.float32, device=setup.device),
+        torch.full((6, 2), outer_scale_sum, dtype=torch.float32, device=distributed_setup.device),
+        torch.full(
+            (4,), outer_scale_sum * 10, dtype=torch.float32, device=distributed_setup.device
+        ),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
-def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
+def test_2d_mesh_replicate_flat_scatter_to_flat_flat(distributed_setup):
     """Replicate+Flat scatter chunks the existing Flat local shard."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
+    if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+        distributed_setup.device.type,
+        (2, distributed_setup.world_size // 2),
+        mesh_dim_names=("dp_outer", "dp_inner"),
     )
 
     replicated_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -445,7 +445,9 @@ def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert fully_sharded_buffer.local_buffer.numel() == fully_sharded_buffer.layout.size // mesh.size()
+    assert (
+        fully_sharded_buffer.local_buffer.numel() == fully_sharded_buffer.layout.size // mesh.size()
+    )
     for index, _ in enumerate(tensors):
         assert fully_sharded_buffer.get_tensor(index).is_contiguous()
 
@@ -477,7 +479,10 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetu
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert fully_sharded_buffer.local_buffer.numel() == partial_sharded_buffer.local_buffer.numel() // 2
+    assert (
+        fully_sharded_buffer.local_buffer.numel()
+        == partial_sharded_buffer.local_buffer.numel() // 2
+    )
 
     outer_scale_sum = float(mesh.size(0) * (mesh.size(0) + 1) // 2)
     expected = [
@@ -510,5 +515,8 @@ def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert fully_sharded_buffer.local_buffer.numel() == replicated_sharded_buffer.local_buffer.numel() // 2
+    assert (
+        fully_sharded_buffer.local_buffer.numel()
+        == replicated_sharded_buffer.local_buffer.numel() // 2
+    )
     _assert_dbuffer_contains_tensors(replicated_buffer, tensors)


### PR DESCRIPTION
## Summary
- Add a minimal Megatron-FSDP DBuffer implementation following http://nv/mfsdp-design
- Add global flat-buffer layout computation with row-aligned offsets and padded global size.
- Add unit coverage for construction, tensor views, DTensor conversion, scatter/allgather, allreduce/reduce-scatter, and 2D mesh cases.

For broader context on how DBuffer will be used, refer to https://github.com/NVIDIA/Megatron-LM/pull/4976.