### PR TITLE
Fix CLI arg name mismatch for inference max sequence length

### DIFF
--- a/tools/run_inference_performance_test.py
+++ b/tools/run_inference_performance_test.py
@@ -77,7 +77,7 @@ def get_inference_engine(args: argparse.Namespace, model: MegatronModule) -> Abs
     if args.engine_type == "static":
         tokenizer = get_tokenizer()
         context = StaticInferenceContext(
-            args.inference_max_requests, args.inference_max_sequence_length
+            args.inference_max_requests, args.inference_max_seq_length
         )
         inference_wrapped_model = GPTInferenceWrapper(model, context)
         inference_wrapped_model.model_is_pipeline_parallel = not (

--- a/tools/run_text_generation_server.py
+++ b/tools/run_text_generation_server.py
@@ -61,7 +61,7 @@ def get_inference_engine(args: Namespace, model: MegatronModule) -> AbstractEngi
 
     tokenizer = get_tokenizer()
 
-    inference_context = StaticInferenceContext(args.inference_max_requests, args.inference_max_sequence_length)
+    inference_context = StaticInferenceContext(args.inference_max_requests, args.inference_max_seq_length)
     inference_wrapped_model = GPTInferenceWrapper(
         model, inference_context
     )


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->
Fixes mismatched argument names when instantiating `StaticInferenceContext` within the `get_inference_engine` function across text generation and performance testing tools (`tools/run_text_generation_server.py` and `tools/run_inference_performance_test.py`).

Problem:
The script uses `inference_max_sequence_length`, but the actual arg defined in `megatron\training\arguments.py:1769` is `inference_max_seq_length`. 
The incorrect attribute from args would lead to crashes with `AttributeError: 'Namespace' object has no attribute 'inference_max_sequence_length'`.

## Issue tracking
Linked issue: N/A (bug fix)

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>