### PR TITLE
[dev] feat(attention): add use_head_wise_attn_gate for Step-3.5-Flash

### DIFF
--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1158,9 +1158,7 @@ class Attention(MegatronModule, ABC):
         )
         output_gate = self.config.attention_output_gate
         # head_wise_attn_gate is self-attention only (gate rows live in linear_qkv).
-        head_wise_gate_enabled = (
-            self.config.head_wise_attn_gate and self.attention_type != "cross"
-        )
+        head_wise_gate_enabled = self.config.head_wise_attn_gate and self.attention_type != "cross"
         # Check if fused_single_qkv_rope is requested but either unavailable or not
         # supported for the current use case.
         if self.attention_type != "cross":
@@ -1170,9 +1168,7 @@ class Attention(MegatronModule, ABC):
         if output_gate:
             assert split_qkv, "output_gate is not supported for unsplit mixed_qkv tensor."
         if head_wise_gate_enabled:
-            assert split_qkv, (
-                "head_wise_attn_gate is not supported for unsplit mixed_qkv tensor."
-            )
+            assert split_qkv, "head_wise_attn_gate is not supported for unsplit mixed_qkv tensor."
 
         qkv_linear_manager = off_interface(self.offload_qkv_linear, hidden_states, "qkv_linear")
         with qkv_linear_manager as hidden_states:
@@ -1401,8 +1397,8 @@ class Attention(MegatronModule, ABC):
             nvtx_range_push(suffix="head_wise_attn_gate")
             gate_states = head_wise_gate.view(*head_wise_gate.shape[:2], -1, 1)
             core_attn_out = core_attn_out.view(*gate_states.shape[:3], -1)
-            core_attn_out = (
-                core_attn_out * torch.sigmoid(gate_states.float()).to(core_attn_out.dtype)
+            core_attn_out = core_attn_out * torch.sigmoid(gate_states.float()).to(
+                core_attn_out.dtype
             )
             core_attn_out = core_attn_out.view(*gate_states.shape[:2], -1)
             nvtx_range_pop(suffix="head_wise_attn_gate")
@@ -1908,10 +1904,7 @@ class SelfAttention(Attention):
         return weight_updated
 
     def sharded_state_dict(
-        self,
-        prefix: str = "",
-        sharded_offsets: tuple = (),
-        metadata: Optional[dict] = None,
+        self, prefix: str = "", sharded_offsets: tuple = (), metadata: Optional[dict] = None
     ) -> ShardedStateDict:
         """Wrap linear_qkv.{weight,bias} with a factory that reshards QKV and
         gate sub-blocks independently, analogous to apply_swiglu_sharded_factory."""
@@ -1930,10 +1923,7 @@ class SelfAttention(Attention):
 
 # pylint: disable=missing-function-docstring
 def apply_head_wise_attn_gate_sharded_factory(
-    original_sh_ten,
-    sharded_offsets,
-    qkv_size: int,
-    gate_size: int,
+    original_sh_ten, sharded_offsets, qkv_size: int, gate_size: int
 ):
     """Split linear_qkv.{weight,bias} into QKV and gate sub-tensors with
     distinct keys so each is resharded independently along axis 0 across TP.
@@ -1953,17 +1943,13 @@ def apply_head_wise_attn_gate_sharded_factory(
         f"({gate_size}) divisible by TP world_size ({axis_frag})."
     )
     assert local_axis_size == qkv_local_size + gate_local_size
-    rank_offset = (
-        original_sh_ten.global_offset[shard_axis + prepend_axis_num] // local_axis_size
-    )
+    rank_offset = original_sh_ten.global_offset[shard_axis + prepend_axis_num] // local_axis_size
 
     @torch.no_grad()
     def sh_ten_build_fn(
         key: str, t: torch.Tensor, replica_id: ReplicaId, flattened_range: Optional[slice]
     ):
-        tensor_qkv, tensor_gate = torch.split(
-            t, [qkv_local_size, gate_local_size], dim=shard_axis
-        )
+        tensor_qkv, tensor_gate = torch.split(t, [qkv_local_size, gate_local_size], dim=shard_axis)
         offset_qkv = (shard_axis + prepend_axis_num, rank_offset, axis_frag)
         offset_gate = (shard_axis + prepend_axis_num, rank_offset, axis_frag)
         return [

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1516,7 +1516,40 @@ class SelfAttention(Attention):
         if self.config.use_head_wise_attn_gate:
             # Fuse per-head scalar gate (Step-3.5-Flash g_proj) into linear_qkv.
             # Gate rows are appended after the QKV block, so the trailing
-            # num_attention_heads rows of linear_qkv.weight are the gate weights.
+            # num_attention_heads rows of linear_qkv.weight are the gate
+            # weights. Two layout invariants must hold for the forward-time
+            # peel-off (in get_query_key_value_tensors) to pick up actual gate
+            # rows on every rank; enforce both at init so the failure mode is
+            # a clear constructor error rather than a silent "wrong rows =
+            # gate" misalignment during training.
+            tp_world_size = get_pg_size(self.pg_collection.tp)
+            # (a) num_query_groups >= world_size: the head-wise gate slice
+            #     runs BEFORE the num_query_groups < world_size AllGather +
+            #     reslice fallback in get_query_key_value_tensors. Under that
+            #     fallback, num_attention_heads_per_partition is inflated to
+            #     num_attention_heads / num_query_groups (the pre-AG count),
+            #     which is larger than the actual per-rank gate scalar count
+            #     (num_attention_heads / world_size). The slice would then
+            #     take V/K rows as gate. Disallow the combination outright.
+            assert self.config.num_query_groups >= tp_world_size, (
+                f"use_head_wise_attn_gate requires num_query_groups "
+                f"({self.config.num_query_groups}) >= tensor-model-parallel "
+                f"world_size ({tp_world_size}). The gate peel-off happens "
+                f"before the num_query_groups < world_size AllGather + "
+                f"reslice path; under that fallback the gate slice would "
+                f"over-take and pick up V/K rows instead of gate rows."
+            )
+            # (b) num_attention_heads % world_size == 0: each rank must
+            #     carry an integer number of gate scalars. (Redundant with
+            #     parent's divide(num_attention_heads, world_size) under
+            #     invariant (a), but kept for an explicit error message.)
+            assert self.config.num_attention_heads % tp_world_size == 0, (
+                f"use_head_wise_attn_gate requires num_attention_heads "
+                f"({self.config.num_attention_heads}) to be divisible by the "
+                f"tensor-model-parallel world_size ({tp_world_size}); the "
+                f"trailing-rows-as-gate layout cannot place an integer number "
+                f"of gate rows on every rank otherwise."
+            )
             self.linear_qkv_out_dim += self.config.num_attention_heads
         self.linear_qkv = submodules.linear_qkv(
             self.config.hidden_size,
@@ -1682,15 +1715,39 @@ class SelfAttention(Attention):
         # If have output gate: Attention heads [sq, b, h] --> [sq, b, ng * (2 * np/ng + 2) * hn)]
         mixed_qkv, _ = apply_module(self.linear_qkv)(hidden_states)
 
-        # Peel off the fused per-head gate (use_head_wise_attn_gate). Under TP,
-        # ColumnParallelLinear splits the trailing num_attention_heads rows
-        # uniformly, so each rank gets num_attention_heads_per_partition gate
-        # scalars at the tail of mixed_qkv's last dim. Requires that both
-        # num_query_groups and num_attention_heads be divisible by tp world_size
-        # so the QKV and gate sub-ranges stay aligned per rank. The gate
-        # tensor is returned through the tuple at the end of this function;
-        # we slice it before any further reshape/AG so the trailing-dim
-        # arithmetic for the QKV path stays unchanged.
+        # Peel off the fused per-head gate (use_head_wise_attn_gate). The slice
+        # takes the trailing num_attention_heads_per_partition columns of the
+        # local mixed_qkv and treats them as one scalar gate per local query
+        # head. This is only correct when ALL THREE of the following hold:
+        #
+        #   1. The linear_qkv backend (ColumnParallelLinear /
+        #      TELayerNormColumnParallelLinear / TEColumnParallelLinear)
+        #      partitions weight axis 0 contiguously and uniformly across TP
+        #      with no row interleave or stride reordering. If a backend ever
+        #      adds row interleave, the trailing columns of the local
+        #      activation are NOT the trailing rows of linear_qkv.weight, and
+        #      the slice silently picks V/K rows instead -- no shape error.
+        #   2. num_attention_heads % tp_world_size == 0, so every rank carries
+        #      an integer number of gate scalars. Enforced at init time in
+        #      SelfAttention.__init__; see the assert there.
+        #   3. The global linear_qkv.weight layout is [QKV_block; Gate_block]
+        #      (gate strictly after QKV). The dist-ckpt path preserves this
+        #      under TP resharding via apply_head_wise_attn_gate_sharded_factory
+        #      in SelfAttention.sharded_state_dict; without that factory, save
+        #      TP=N -> load TP=M would re-balance the QKV/gate boundary and
+        #      break precondition (3) on the loaded ranks.
+        #
+        # The peel runs BEFORE the num_query_groups < world_size AllGather +
+        # reslice branch below, so the gate does not participate in that
+        # fallback. That is safe because the gate has exactly
+        # num_attention_heads scalars (matches the partition count under
+        # precondition 2), not a per-group head_dim block; the per-rank
+        # alignment for the gate is independent of the kv-group reshuffle the
+        # AllGather path performs for the QKV block.
+        #
+        # The gate tensor is returned through the tuple at the end of this
+        # function; we slice it before any further reshape/AG so the
+        # trailing-dim arithmetic for the QKV path stays unchanged.
         head_wise_gate_states = None
         if head_wise_gate:
             gate_size = self.num_attention_heads_per_partition

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -395,6 +395,13 @@ class Attention(MegatronModule, ABC):
             rotary_base = self.config.rotary_base_per_layer[self.layer_number - 1]
             self._build_per_layer_rotary_pos_emb(rotary_base)
 
+        # Per-head scalar output gate (Step-3.5-Flash g_proj) is fused into
+        # linear_qkv when use_head_wise_attn_gate is True; gate weights live in
+        # the trailing num_attention_heads rows of linear_qkv.weight. The gate
+        # tensor is sliced out in SelfAttention.get_query_key_value_tensors and
+        # consumed in Attention.forward.
+        self._head_wise_gate_states = None
+
     def _build_per_layer_rotary_pos_emb(self, rotary_base: float) -> None:
         """Build self.rotary_pos_emb using a layer-specific rotary base."""
         from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
@@ -1372,7 +1379,26 @@ class Attention(MegatronModule, ABC):
             core_attn_out = core_attn_out.reshape(core_attn_out.size(0), 1, -1)
         nvtx_range_pop(suffix="core_attention")
 
-        # Output gate
+        # Per-head scalar gate (use_head_wise_attn_gate). Gate states were
+        # sliced off the fused linear_qkv output in get_query_key_value_tensors;
+        # here we just apply the sigmoid gating to core_attn_out.
+        if self.config.use_head_wise_attn_gate:
+            nvtx_range_push(suffix="head_wise_attn_gate")
+            gate_states = self._head_wise_gate_states  # [sq, b, np_per_rank]
+            assert gate_states is not None, (
+                "use_head_wise_attn_gate is enabled but no fused gate tensor was "
+                "produced by get_query_key_value_tensors"
+            )
+            self._head_wise_gate_states = None
+            gate_states = gate_states.view(*gate_states.shape[:2], -1, 1)  # [sq, b, np, 1]
+            core_attn_out = core_attn_out.view(*gate_states.shape[:3], -1)     # [sq, b, np, hn]
+            core_attn_out = (
+                core_attn_out * torch.sigmoid(gate_states.float()).to(core_attn_out.dtype)
+            )
+            core_attn_out = core_attn_out.view(*gate_states.shape[:2], -1)     # [sq, b, np*hn]
+            nvtx_range_pop(suffix="head_wise_attn_gate")
+
+        # Output gate (attention_output_gate: full head_dim gate fused into QKV)
         if gate is not None:
             nvtx_range_push(suffix="output_gate")
             core_attn_out = self._apply_output_gate(core_attn_out, gate)
@@ -1445,6 +1471,11 @@ class SelfAttention(Attention):
         self.linear_qkv_out_dim = self.query_projection_size + 2 * self.kv_projection_size
         if self.config.attention_output_gate:
             self.linear_qkv_out_dim += self.config.kv_channels * self.config.num_attention_heads
+        if self.config.use_head_wise_attn_gate:
+            # Fuse per-head scalar gate (Step-3.5-Flash g_proj) into linear_qkv.
+            # Gate rows are appended after the QKV block, so the trailing
+            # num_attention_heads rows of linear_qkv.weight are the gate weights.
+            self.linear_qkv_out_dim += self.config.num_attention_heads
         self.linear_qkv = submodules.linear_qkv(
             self.config.hidden_size,
             self.linear_qkv_out_dim,
@@ -1594,6 +1625,21 @@ class SelfAttention(Attention):
         # If no output gate: Attention heads [sq, b, h] --> [sq, b, ng * (np/ng + 2) * hn)]
         # If have output gate: Attention heads [sq, b, h] --> [sq, b, ng * (2 * np/ng + 2) * hn)]
         mixed_qkv, _ = apply_module(self.linear_qkv)(hidden_states)
+
+        # Peel off the fused per-head gate (use_head_wise_attn_gate). Under TP,
+        # ColumnParallelLinear splits the trailing num_attention_heads rows
+        # uniformly, so each rank gets num_attention_heads_per_partition gate
+        # scalars at the tail of mixed_qkv's last dim. Requires that both
+        # num_query_groups and num_attention_heads be divisible by tp world_size
+        # so the QKV and gate sub-ranges stay aligned per rank.
+        if self.config.use_head_wise_attn_gate:
+            gate_size = self.num_attention_heads_per_partition
+            mixed_qkv, gate_states = torch.split(
+                mixed_qkv, [mixed_qkv.size(-1) - gate_size, gate_size], dim=-1
+            )
+            self._head_wise_gate_states = gate_states
+        else:
+            self._head_wise_gate_states = None
         num_query_heads_per_group = (
             self.num_attention_heads_per_partition // self.num_query_groups_per_partition
         )

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1669,6 +1669,12 @@ class SelfAttention(Attention):
             mixed_qkv, head_wise_gate_states = torch.split(
                 mixed_qkv, [mixed_qkv.size(-1) - gate_size, gate_size], dim=-1
             )
+            # torch.split on the last dim leaves non-contiguous views: the
+            # outer-dim stride still spans the original (QKV+gate) width, so
+            # downstream key.view(sk, b*np, hn) in dot_product_attention would
+            # fail with "view size is not compatible with input tensor's size
+            # and stride." Materialize a contiguous QKV slab here.
+            mixed_qkv = mixed_qkv.contiguous()
         num_query_heads_per_group = (
             self.num_attention_heads_per_partition // self.num_query_groups_per_partition
         )

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1502,19 +1502,6 @@ class SelfAttention(Attention):
             tp_group=self.pg_collection.tp,
         )
 
-        if self.config.head_wise_attn_gate:
-            # Bias gate rows to sigmoid~=1 at init (approximate identity);
-            # avoids halving every head's output from step 0.
-            num_heads_per_partition = self.num_attention_heads_per_partition
-            with torch.no_grad():
-                self.linear_qkv.weight[-num_heads_per_partition:].mul_(
-                    self.config.head_wise_attn_gate_init_weight_scale
-                )
-                if self.linear_qkv.bias is not None:
-                    self.linear_qkv.bias[-num_heads_per_partition:].fill_(
-                        self.config.head_wise_attn_gate_init_bias
-                    )
-
         # Resolve which norm class to use for Q and K.
         # Config selects the default norm class; spec overrides if set.
         if self.config.qk_l2_norm:

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -405,13 +405,16 @@ class Attention(MegatronModule, ABC):
         # Per-head scalar output gate (Step-3.5-Flash g_proj) is fused into
         # linear_qkv when use_head_wise_attn_gate is True; gate weights live in
         # the trailing num_attention_heads_per_partition rows of each rank's
-        # local linear_qkv tensor. The gate tensor is sliced out in
-        # SelfAttention.get_query_key_value_tensors and consumed in
-        # Attention.forward. For dist-ckpt TP resharding safety, the [QKV,
-        # gate] split is preserved via a ShardedTensorFactory wired up in
-        # SelfAttention.sharded_state_dict (see
-        # apply_head_wise_attn_gate_sharded_factory below).
-        self._head_wise_gate_states = None
+        # local linear_qkv tensor. The gate tensor is sliced out inside
+        # SelfAttention.get_query_key_value_tensors and threaded back to
+        # Attention.forward via the return tuple (as a trailing element
+        # alongside the existing output_gate slot) -- mirroring how
+        # attention_output_gate is plumbed. No instance attribute is used, so
+        # cross-attention layers, overlapping microbatches, and selective
+        # recompute do not introduce stale-gate hazards. For dist-ckpt TP
+        # resharding safety, the [QKV, gate] split is preserved via a
+        # ShardedTensorFactory wired up in SelfAttention.sharded_state_dict
+        # (see apply_head_wise_attn_gate_sharded_factory below).
 
     def _build_per_layer_rotary_pos_emb(self, rotary_base: float) -> None:
         """Build self.rotary_pos_emb using a layer-specific rotary base."""
@@ -756,15 +759,24 @@ class Attention(MegatronModule, ABC):
         hidden_states: Tensor,
         key_value_states: Tensor | None,
         output_gate: bool = False,
+        head_wise_gate: bool = False,
         split_qkv: bool = True,
     ) -> (
-        tuple[Tensor, Tensor, Tensor, Tensor]
+        tuple[Tensor, Tensor, Tensor, Tensor, Tensor]
+        | tuple[Tensor, Tensor, Tensor, Tensor]
         | tuple[Tensor, Tensor, Tensor]
         | tuple[Tensor, list[int]]
     ):
         """
         This method needs to be implemented based on whether the derived class
         is "self-attn" or "cross-attn".
+
+        When ``output_gate=True`` the return tuple gains a per-head head_dim
+        gate as a 4th element (used by attention_output_gate). When
+        ``head_wise_gate=True`` a per-head scalar gate is appended as a
+        trailing element (5th if output_gate is also True, otherwise 4th);
+        Attention.forward unpacks it and threads it through as a local so
+        there is no module-level side channel.
         """
 
     def flash_decode(
@@ -1165,6 +1177,13 @@ class Attention(MegatronModule, ABC):
             ]
         )
         output_gate = self.config.attention_output_gate
+        # Per-head scalar gate (use_head_wise_attn_gate) is only meaningful on
+        # the self-attention path: the gate weights are fused into linear_qkv,
+        # which CrossAttention does not own. Restrict to self-attn to avoid
+        # silently dropping the gate on cross-attn layers.
+        head_wise_gate_enabled = (
+            self.config.use_head_wise_attn_gate and self.attention_type != "cross"
+        )
         # Check if fused_single_qkv_rope is requested but either unavailable or not
         # supported for the current use case.
         if self.attention_type != "cross":
@@ -1173,6 +1192,10 @@ class Attention(MegatronModule, ABC):
             ), "fused_single_qkv_rope requested but not available/supported for the config."
         if output_gate:
             assert split_qkv, "output_gate is not supported for unsplit mixed_qkv tensor."
+        if head_wise_gate_enabled:
+            assert split_qkv, (
+                "use_head_wise_attn_gate is not supported for unsplit mixed_qkv tensor."
+            )
 
         qkv_linear_manager = off_interface(self.offload_qkv_linear, hidden_states, "qkv_linear")
         with qkv_linear_manager as hidden_states:
@@ -1180,16 +1203,27 @@ class Attention(MegatronModule, ABC):
                 hidden_states,
                 key_value_states,
                 split_qkv=split_qkv,
-                output_gate=self.config.attention_output_gate,
+                output_gate=output_gate,
+                head_wise_gate=head_wise_gate_enabled,
             )
         # `qkv_output` may be a tuple; commit supports tuple/list and will keep structure.
         qkv_output = qkv_linear_manager.group_offload(qkv_output, forced_released_tensors=[])
         attn_mask_type = self.attn_mask_type
         block_table = None
         gate = None
+        # Per-head scalar gate (use_head_wise_attn_gate) is threaded through as
+        # a local rather than via an instance attribute to keep the forward
+        # re-entrant under cross-attn / overlapped microbatches / recompute.
+        head_wise_gate = None
         if split_qkv:
-            if self.config.attention_output_gate:
+            # qkv_output layout (in order, trailing elements optional):
+            #   query, key, value, [output_gate], [head_wise_gate]
+            if output_gate and head_wise_gate_enabled:
+                query, key, value, gate, head_wise_gate = qkv_output
+            elif output_gate:
                 query, key, value, gate = qkv_output
+            elif head_wise_gate_enabled:
+                query, key, value, head_wise_gate = qkv_output
             else:
                 query, key, value = qkv_output
             mixed_qkv = qkv_split_arg_list = None
@@ -1391,17 +1425,14 @@ class Attention(MegatronModule, ABC):
         nvtx_range_pop(suffix="core_attention")
 
         # Per-head scalar gate (use_head_wise_attn_gate). Gate states were
-        # sliced off the fused linear_qkv output in get_query_key_value_tensors;
-        # here we just apply the sigmoid gating to core_attn_out.
-        if self.config.use_head_wise_attn_gate:
+        # sliced off the fused linear_qkv output inside
+        # get_query_key_value_tensors and returned through qkv_output; we
+        # already unpacked them into the local `head_wise_gate` above.
+        if head_wise_gate is not None:
             nvtx_range_push(suffix="head_wise_attn_gate")
-            gate_states = self._head_wise_gate_states  # [sq, b, np_per_rank]
-            assert gate_states is not None, (
-                "use_head_wise_attn_gate is enabled but no fused gate tensor was "
-                "produced by get_query_key_value_tensors"
+            gate_states = head_wise_gate.view(  # [sq, b, np, 1]
+                *head_wise_gate.shape[:2], -1, 1
             )
-            self._head_wise_gate_states = None
-            gate_states = gate_states.view(*gate_states.shape[:2], -1, 1)  # [sq, b, np, 1]
             core_attn_out = core_attn_out.view(*gate_states.shape[:3], -1)     # [sq, b, np, hn]
             core_attn_out = (
                 core_attn_out * torch.sigmoid(gate_states.float()).to(core_attn_out.dtype)
@@ -1622,17 +1653,31 @@ class SelfAttention(Attention):
         hidden_states: Tensor,
         key_value_states: Tensor | None = None,
         output_gate: bool = False,
+        head_wise_gate: bool = False,
         split_qkv: bool = True,
     ) -> (
-        tuple[Tensor, Tensor, Tensor, Tensor]
+        tuple[Tensor, Tensor, Tensor, Tensor, Tensor]
+        | tuple[Tensor, Tensor, Tensor, Tensor]
         | tuple[Tensor, Tensor, Tensor]
         | tuple[Tensor, list[int]]
     ):
         """
         Derives `query`, `key` and `value` tensors from `hidden_states`.
         If `output_gate` is True, then also derives `gate` tensor.
+        If `head_wise_gate` is True, also returns a per-head scalar gate
+        tensor (shape ``[sq, b, np_per_rank]``) as a trailing element of the
+        return tuple.
         If `split_qkv=False`, then the unsplit mixed_qkv tensor is returned.
         """
+        if head_wise_gate:
+            assert split_qkv, (
+                "head_wise_gate is not supported for unsplit mixed_qkv tensor."
+            )
+            assert self.config.use_head_wise_attn_gate, (
+                "head_wise_gate=True passed but config.use_head_wise_attn_gate is "
+                "False; this is an internal contract violation between forward "
+                "and get_query_key_value_tensors."
+            )
         # If no output gate: Attention heads [sq, b, h] --> [sq, b, ng * (np/ng + 2) * hn)]
         # If have output gate: Attention heads [sq, b, h] --> [sq, b, ng * (2 * np/ng + 2) * hn)]
         mixed_qkv, _ = apply_module(self.linear_qkv)(hidden_states)
@@ -1642,15 +1687,16 @@ class SelfAttention(Attention):
         # uniformly, so each rank gets num_attention_heads_per_partition gate
         # scalars at the tail of mixed_qkv's last dim. Requires that both
         # num_query_groups and num_attention_heads be divisible by tp world_size
-        # so the QKV and gate sub-ranges stay aligned per rank.
-        if self.config.use_head_wise_attn_gate:
+        # so the QKV and gate sub-ranges stay aligned per rank. The gate
+        # tensor is returned through the tuple at the end of this function;
+        # we slice it before any further reshape/AG so the trailing-dim
+        # arithmetic for the QKV path stays unchanged.
+        head_wise_gate_states = None
+        if head_wise_gate:
             gate_size = self.num_attention_heads_per_partition
-            mixed_qkv, gate_states = torch.split(
+            mixed_qkv, head_wise_gate_states = torch.split(
                 mixed_qkv, [mixed_qkv.size(-1) - gate_size, gate_size], dim=-1
             )
-            self._head_wise_gate_states = gate_states
-        else:
-            self._head_wise_gate_states = None
         num_query_heads_per_group = (
             self.num_attention_heads_per_partition // self.num_query_groups_per_partition
         )
@@ -1760,7 +1806,12 @@ class SelfAttention(Attention):
                     self.world_size // self.config.num_query_groups
                 )
                 gate = gate[:, :, idx * size : (idx + 1) * size, :]
+            if head_wise_gate:
+                return query, key, value, gate, head_wise_gate_states
             return query, key, value, gate
+
+        if head_wise_gate:
+            return query, key, value, head_wise_gate_states
 
         return query, key, value
 
@@ -2068,6 +2119,7 @@ class CrossAttention(Attention):
         hidden_states: Tensor,
         key_value_states: Optional[Tensor],
         output_gate: bool = False,
+        head_wise_gate: bool = False,
         split_qkv: bool = True,
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """
@@ -2075,6 +2127,10 @@ class CrossAttention(Attention):
         from `key_value_states`.
         """
         assert not output_gate, "Output gate is not supported in cross attention for now."
+        assert not head_wise_gate, (
+            "use_head_wise_attn_gate is not supported in cross attention "
+            "(linear_qkv with fused gate rows lives only on the self-attention path)."
+        )
 
         assert split_qkv, "split_qkv must be True for CrossAttention"
         assert not output_gate, "Output gate is not supported in cross attention for now."

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -402,20 +402,6 @@ class Attention(MegatronModule, ABC):
             rotary_base = self.config.rotary_base_per_layer[self.layer_number - 1]
             self._build_per_layer_rotary_pos_emb(rotary_base)
 
-        # Per-head scalar output gate (Step-3.5-Flash g_proj) is fused into
-        # linear_qkv when head_wise_attn_gate is True; gate weights live in
-        # the trailing num_attention_heads_per_partition rows of each rank's
-        # local linear_qkv tensor. The gate tensor is sliced out inside
-        # SelfAttention.get_query_key_value_tensors and threaded back to
-        # Attention.forward via the return tuple (as a trailing element
-        # alongside the existing output_gate slot) -- mirroring how
-        # attention_output_gate is plumbed. No instance attribute is used, so
-        # cross-attention layers, overlapping microbatches, and selective
-        # recompute do not introduce stale-gate hazards. For dist-ckpt TP
-        # resharding safety, the [QKV, gate] split is preserved via a
-        # ShardedTensorFactory wired up in SelfAttention.sharded_state_dict
-        # (see apply_head_wise_attn_gate_sharded_factory below).
-
     def _build_per_layer_rotary_pos_emb(self, rotary_base: float) -> None:
         """Build self.rotary_pos_emb using a layer-specific rotary base."""
         from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
@@ -769,14 +755,8 @@ class Attention(MegatronModule, ABC):
     ):
         """
         This method needs to be implemented based on whether the derived class
-        is "self-attn" or "cross-attn".
-
-        When ``output_gate=True`` the return tuple gains a per-head head_dim
-        gate as a 4th element (used by attention_output_gate). When
-        ``head_wise_gate=True`` a per-head scalar gate is appended as a
-        trailing element (5th if output_gate is also True, otherwise 4th);
-        Attention.forward unpacks it and threads it through as a local so
-        there is no module-level side channel.
+        is "self-attn" or "cross-attn". When ``output_gate=True`` / ``head_wise_gate=True``
+        the corresponding gate tensor is appended as a trailing tuple element.
         """
 
     def flash_decode(
@@ -1177,10 +1157,7 @@ class Attention(MegatronModule, ABC):
             ]
         )
         output_gate = self.config.attention_output_gate
-        # Per-head scalar gate (head_wise_attn_gate) is only meaningful on
-        # the self-attention path: the gate weights are fused into linear_qkv,
-        # which CrossAttention does not own. Restrict to self-attn to avoid
-        # silently dropping the gate on cross-attn layers.
+        # head_wise_attn_gate is self-attention only (gate rows live in linear_qkv).
         head_wise_gate_enabled = (
             self.config.head_wise_attn_gate and self.attention_type != "cross"
         )
@@ -1211,13 +1188,9 @@ class Attention(MegatronModule, ABC):
         attn_mask_type = self.attn_mask_type
         block_table = None
         gate = None
-        # Per-head scalar gate (head_wise_attn_gate) is threaded through as
-        # a local rather than via an instance attribute to keep the forward
-        # re-entrant under cross-attn / overlapped microbatches / recompute.
         head_wise_gate = None
         if split_qkv:
-            # qkv_output layout (in order, trailing elements optional):
-            #   query, key, value, [output_gate], [head_wise_gate]
+            # qkv_output is (query, key, value, [output_gate], [head_wise_gate]).
             if output_gate and head_wise_gate_enabled:
                 query, key, value, gate, head_wise_gate = qkv_output
             elif output_gate:
@@ -1424,20 +1397,14 @@ class Attention(MegatronModule, ABC):
             core_attn_out = core_attn_out.reshape(core_attn_out.size(0), 1, -1)
         nvtx_range_pop(suffix="core_attention")
 
-        # Per-head scalar gate (head_wise_attn_gate). Gate states were
-        # sliced off the fused linear_qkv output inside
-        # get_query_key_value_tensors and returned through qkv_output; we
-        # already unpacked them into the local `head_wise_gate` above.
         if head_wise_gate is not None:
             nvtx_range_push(suffix="head_wise_attn_gate")
-            gate_states = head_wise_gate.view(  # [sq, b, np, 1]
-                *head_wise_gate.shape[:2], -1, 1
-            )
-            core_attn_out = core_attn_out.view(*gate_states.shape[:3], -1)     # [sq, b, np, hn]
+            gate_states = head_wise_gate.view(*head_wise_gate.shape[:2], -1, 1)
+            core_attn_out = core_attn_out.view(*gate_states.shape[:3], -1)
             core_attn_out = (
                 core_attn_out * torch.sigmoid(gate_states.float()).to(core_attn_out.dtype)
             )
-            core_attn_out = core_attn_out.view(*gate_states.shape[:2], -1)     # [sq, b, np*hn]
+            core_attn_out = core_attn_out.view(*gate_states.shape[:2], -1)
             nvtx_range_pop(suffix="head_wise_attn_gate")
 
         # Output gate (attention_output_gate: full head_dim gate fused into QKV)
@@ -1514,41 +1481,16 @@ class SelfAttention(Attention):
         if self.config.attention_output_gate:
             self.linear_qkv_out_dim += self.config.kv_channels * self.config.num_attention_heads
         if self.config.head_wise_attn_gate:
-            # Fuse per-head scalar gate (Step-3.5-Flash g_proj) into linear_qkv.
-            # Gate rows are appended after the QKV block, so the trailing
-            # num_attention_heads rows of linear_qkv.weight are the gate
-            # weights. Two layout invariants must hold for the forward-time
-            # peel-off (in get_query_key_value_tensors) to pick up actual gate
-            # rows on every rank; enforce both at init so the failure mode is
-            # a clear constructor error rather than a silent "wrong rows =
-            # gate" misalignment during training.
+            # Defensive runtime guards against config-validation bypass; same
+            # invariants enforced earlier in TransformerConfig.__post_init__.
             tp_world_size = get_pg_size(self.pg_collection.tp)
-            # (a) num_query_groups >= world_size: the head-wise gate slice
-            #     runs BEFORE the num_query_groups < world_size AllGather +
-            #     reslice fallback in get_query_key_value_tensors. Under that
-            #     fallback, num_attention_heads_per_partition is inflated to
-            #     num_attention_heads / num_query_groups (the pre-AG count),
-            #     which is larger than the actual per-rank gate scalar count
-            #     (num_attention_heads / world_size). The slice would then
-            #     take V/K rows as gate. Disallow the combination outright.
             assert self.config.num_query_groups >= tp_world_size, (
                 f"head_wise_attn_gate requires num_query_groups "
-                f"({self.config.num_query_groups}) >= tensor-model-parallel "
-                f"world_size ({tp_world_size}). The gate peel-off happens "
-                f"before the num_query_groups < world_size AllGather + "
-                f"reslice path; under that fallback the gate slice would "
-                f"over-take and pick up V/K rows instead of gate rows."
+                f"({self.config.num_query_groups}) >= tp world_size ({tp_world_size})"
             )
-            # (b) num_attention_heads % world_size == 0: each rank must
-            #     carry an integer number of gate scalars. (Redundant with
-            #     parent's divide(num_attention_heads, world_size) under
-            #     invariant (a), but kept for an explicit error message.)
             assert self.config.num_attention_heads % tp_world_size == 0, (
                 f"head_wise_attn_gate requires num_attention_heads "
-                f"({self.config.num_attention_heads}) to be divisible by the "
-                f"tensor-model-parallel world_size ({tp_world_size}); the "
-                f"trailing-rows-as-gate layout cannot place an integer number "
-                f"of gate rows on every rank otherwise."
+                f"({self.config.num_attention_heads}) % tp world_size ({tp_world_size}) == 0"
             )
             self.linear_qkv_out_dim += self.config.num_attention_heads
         self.linear_qkv = submodules.linear_qkv(
@@ -1565,35 +1507,17 @@ class SelfAttention(Attention):
         )
 
         if self.config.head_wise_attn_gate:
-            # Re-initialize the gate sub-block of linear_qkv so sigmoid(gate)
-            # is near 1 at init (approximate identity), instead of the
-            # sigmoid(0)=0.5 that the default shared init_method gives. With
-            # a half-strength gate from step 0, every head's output is
-            # halved during warmup and the optimizer carries an extra burden
-            # to recover identity. Scale the gate rows by a small factor
-            # (default 0.1) rather than zero-init so:
-            #   - gate weight magnitudes stay on the same order as QKV,
-            #     keeping the shared FP8 tensor-level scale on
-            #     linear_qkv.weight from being dominated by a near-zero
-            #     gate sub-block;
-            #   - the gate is not literally constant at init (some signal
-            #     from the linear part still flows).
-            # The bias rows (when present) are filled with a positive
-            # constant (default 2.0, sigmoid(2.0)~=0.88) to bias the
-            # sigmoid toward 1 at init. When linear_qkv has no bias, only
-            # the weight scaling applies and the gate sits near 0.5 (still
-            # better than the bias-free default in expectation, though not
-            # identity).
-            # Both knobs are exposed on TransformerConfig:
-            # head_wise_attn_gate_init_weight_scale,
-            # head_wise_attn_gate_init_bias.
+            # Bias gate rows to sigmoid~=1 at init (approximate identity);
+            # avoids halving every head's output from step 0.
             num_heads_per_partition = self.num_attention_heads_per_partition
             with torch.no_grad():
-                gate_weight = self.linear_qkv.weight[-num_heads_per_partition:]
-                gate_weight.mul_(self.config.head_wise_attn_gate_init_weight_scale)
+                self.linear_qkv.weight[-num_heads_per_partition:].mul_(
+                    self.config.head_wise_attn_gate_init_weight_scale
+                )
                 if self.linear_qkv.bias is not None:
-                    gate_bias = self.linear_qkv.bias[-num_heads_per_partition:]
-                    gate_bias.fill_(self.config.head_wise_attn_gate_init_bias)
+                    self.linear_qkv.bias[-num_heads_per_partition:].fill_(
+                        self.config.head_wise_attn_gate_init_bias
+                    )
 
         # Resolve which norm class to use for Q and K.
         # Config selects the default norm class; spec overrides if set.
@@ -1727,58 +1651,22 @@ class SelfAttention(Attention):
     ):
         """
         Derives `query`, `key` and `value` tensors from `hidden_states`.
-        If `output_gate` is True, then also derives `gate` tensor.
-        If `head_wise_gate` is True, also returns a per-head scalar gate
-        tensor (shape ``[sq, b, np_per_rank]``) as a trailing element of the
-        return tuple.
-        If `split_qkv=False`, then the unsplit mixed_qkv tensor is returned.
+        If `output_gate` is True, also returns a per-head head_dim gate.
+        If `head_wise_gate` is True, also returns a per-head scalar gate.
+        If `split_qkv=False`, returns the unsplit mixed_qkv tensor.
         """
         if head_wise_gate:
-            assert split_qkv, (
-                "head_wise_gate is not supported for unsplit mixed_qkv tensor."
-            )
-            assert self.config.head_wise_attn_gate, (
-                "head_wise_gate=True passed but config.head_wise_attn_gate is "
-                "False; this is an internal contract violation between forward "
-                "and get_query_key_value_tensors."
-            )
+            assert split_qkv and self.config.head_wise_attn_gate
         # If no output gate: Attention heads [sq, b, h] --> [sq, b, ng * (np/ng + 2) * hn)]
         # If have output gate: Attention heads [sq, b, h] --> [sq, b, ng * (2 * np/ng + 2) * hn)]
         mixed_qkv, _ = apply_module(self.linear_qkv)(hidden_states)
 
-        # Peel off the fused per-head gate (head_wise_attn_gate). The slice
-        # takes the trailing num_attention_heads_per_partition columns of the
-        # local mixed_qkv and treats them as one scalar gate per local query
-        # head. This is only correct when ALL THREE of the following hold:
-        #
-        #   1. The linear_qkv backend (ColumnParallelLinear /
-        #      TELayerNormColumnParallelLinear / TEColumnParallelLinear)
-        #      partitions weight axis 0 contiguously and uniformly across TP
-        #      with no row interleave or stride reordering. If a backend ever
-        #      adds row interleave, the trailing columns of the local
-        #      activation are NOT the trailing rows of linear_qkv.weight, and
-        #      the slice silently picks V/K rows instead -- no shape error.
-        #   2. num_attention_heads % tp_world_size == 0, so every rank carries
-        #      an integer number of gate scalars. Enforced at init time in
-        #      SelfAttention.__init__; see the assert there.
-        #   3. The global linear_qkv.weight layout is [QKV_block; Gate_block]
-        #      (gate strictly after QKV). The dist-ckpt path preserves this
-        #      under TP resharding via apply_head_wise_attn_gate_sharded_factory
-        #      in SelfAttention.sharded_state_dict; without that factory, save
-        #      TP=N -> load TP=M would re-balance the QKV/gate boundary and
-        #      break precondition (3) on the loaded ranks.
-        #
-        # The peel runs BEFORE the num_query_groups < world_size AllGather +
-        # reslice branch below, so the gate does not participate in that
-        # fallback. That is safe because the gate has exactly
-        # num_attention_heads scalars (matches the partition count under
-        # precondition 2), not a per-group head_dim block; the per-rank
-        # alignment for the gate is independent of the kv-group reshuffle the
-        # AllGather path performs for the QKV block.
-        #
-        # The gate tensor is returned through the tuple at the end of this
-        # function; we slice it before any further reshape/AG so the
-        # trailing-dim arithmetic for the QKV path stays unchanged.
+        # Peel the trailing per-rank gate scalars before any reshape / AG.
+        # Correct only because (a) ColumnParallelLinear splits axis 0
+        # contiguously, (b) num_attention_heads % tp == 0, (c) global layout
+        # is [QKV; Gate] (preserved across dist-ckpt by
+        # apply_head_wise_attn_gate_sharded_factory). (a)+(b) checked at
+        # config / init time.
         head_wise_gate_states = None
         if head_wise_gate:
             gate_size = self.num_attention_heads_per_partition
@@ -2025,14 +1913,8 @@ class SelfAttention(Attention):
         sharded_offsets: tuple = (),
         metadata: Optional[dict] = None,
     ) -> ShardedStateDict:
-        """Return the sharded state dict, wrapping linear_qkv.{weight,bias}
-        with a factory that splits the trailing num_attention_heads gate rows
-        from the QKV block under dist-ckpt save/load. Without this override the
-        global tensor is sharded as one uniform axis-0 block, so save TP=N
-        -> load TP=M silently mixes V/K rows with gate rows; the factory makes
-        the QKV and gate sub-blocks reshard independently, analogous to
-        apply_swiglu_sharded_factory in megatron/core/transformer/mlp.py.
-        """
+        """Wrap linear_qkv.{weight,bias} with a factory that reshards QKV and
+        gate sub-blocks independently, analogous to apply_swiglu_sharded_factory."""
         sharded_state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
         if self.config.head_wise_attn_gate:
             qkv_size = self.query_projection_size + 2 * self.kv_projection_size
@@ -2053,38 +1935,12 @@ def apply_head_wise_attn_gate_sharded_factory(
     qkv_size: int,
     gate_size: int,
 ):
-    """Build a ShardedTensorFactory that splits linear_qkv.{weight,bias} into
-    independent QKV and gate sub-tensors for dist-ckpt save/load.
-
-    The forward path of SelfAttention with head_wise_attn_gate=True peels
-    the trailing num_attention_heads_per_partition rows off each rank's local
-    linear_qkv output and treats them as per-head gate scalars. That assumes
-    the local layout is [qkv_local; gate_local] — but the default
-    ColumnParallelLinear / TELayerNormColumnParallelLinear sharded_state_dict
-    only declares {"weight": 0}, so the global (QKV_dim + H, hidden_size)
-    tensor is uniformly resharded along axis 0 on TP change. Whenever the new
-    per-rank size < QKV_dim, the trailing rows on non-last ranks land inside
-    the QKV block, so a saved checkpoint reloads with V/K rows being treated
-    as gate scalars (no shape error — silently wrong).
-
-    This factory chunks each rank's local tensor at the QKV/gate boundary on
-    save, registering qkv_local and gate_local as two independent sub-tensors
-    (with distinct keys) each uniformly sharded along axis 0 across TP. On
-    load they are gathered, resharded for the new TP, and cat'd back so the
-    rank-local layout is again [qkv_local; gate_local]. Same pattern as
-    apply_swiglu_sharded_factory (megatron/core/transformer/mlp.py), but with
-    unequal sub-block sizes (QKV >> gate).
-
-    Args:
-        original_sh_ten: ShardedTensor produced for linear_qkv.weight or
-            linear_qkv.bias by the underlying ColumnParallelLinear /
-            TE-variant sharded_state_dict (axis-0 sharded across TP).
-        sharded_offsets: PP-style offsets passed from the parent module.
-        qkv_size: Global axis-0 size of the QKV sub-block
-            (query_projection_size + 2 * kv_projection_size).
-        gate_size: Global axis-0 size of the gate sub-block
-            (num_attention_heads).
-    """
+    """Split linear_qkv.{weight,bias} into QKV and gate sub-tensors with
+    distinct keys so each is resharded independently along axis 0 across TP.
+    Default {"weight": 0} sharding would otherwise re-balance the QKV/gate
+    boundary on TP change and turn V/K rows into gate rows (silent miscompute).
+    Same pattern as apply_swiglu_sharded_factory, but with unequal sub-block
+    sizes (QKV >> gate)."""
     shard_axis = 0
     prepend_axis_num = len(sharded_offsets)
     local_axis_size = original_sh_ten.local_shape[shard_axis]
@@ -2093,15 +1949,10 @@ def apply_head_wise_attn_gate_sharded_factory(
     qkv_local_size, qkv_rem = divmod(qkv_size, axis_frag)
     gate_local_size, gate_rem = divmod(gate_size, axis_frag)
     assert qkv_rem == 0 and gate_rem == 0, (
-        f"head_wise_attn_gate dist-ckpt requires both QKV ({qkv_size}) "
-        f"and gate ({gate_size}) sizes to be divisible by the TP world_size "
-        f"({axis_frag})."
+        f"head_wise_attn_gate dist-ckpt requires QKV ({qkv_size}) and gate "
+        f"({gate_size}) divisible by TP world_size ({axis_frag})."
     )
-    assert local_axis_size == qkv_local_size + gate_local_size, (
-        f"Unexpected linear_qkv local axis-0 size {local_axis_size} != "
-        f"{qkv_local_size} (qkv) + {gate_local_size} (gate). The factory "
-        f"assumes a uniform axis-0 sharding from ColumnParallelLinear."
-    )
+    assert local_axis_size == qkv_local_size + gate_local_size
     rank_offset = (
         original_sh_ten.global_offset[shard_axis + prepend_axis_num] // local_axis_size
     )
@@ -2110,10 +1961,6 @@ def apply_head_wise_attn_gate_sharded_factory(
     def sh_ten_build_fn(
         key: str, t: torch.Tensor, replica_id: ReplicaId, flattened_range: Optional[slice]
     ):
-        # Trailing rows of each rank's local tensor are the gate scalars; the
-        # rest is QKV. Split sizes are unequal, so we use torch.split rather
-        # than torch.chunk(2). Each sub-tensor lives under a distinct key
-        # (.{_qkv,_gate}) so dist-ckpt treats them as independent globals.
         tensor_qkv, tensor_gate = torch.split(
             t, [qkv_local_size, gate_local_size], dim=shard_axis
         )
@@ -2215,10 +2062,7 @@ class CrossAttention(Attention):
         from `key_value_states`.
         """
         assert not output_gate, "Output gate is not supported in cross attention for now."
-        assert not head_wise_gate, (
-            "head_wise_attn_gate is not supported in cross attention "
-            "(linear_qkv with fused gate rows lives only on the self-attention path)."
-        )
+        assert not head_wise_gate, "head_wise_attn_gate is self-attention only."
 
         assert split_qkv, "split_qkv must be True for CrossAttention"
         assert not output_gate, "Output gate is not supported in cross attention for now."

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -403,7 +403,7 @@ class Attention(MegatronModule, ABC):
             self._build_per_layer_rotary_pos_emb(rotary_base)
 
         # Per-head scalar output gate (Step-3.5-Flash g_proj) is fused into
-        # linear_qkv when use_head_wise_attn_gate is True; gate weights live in
+        # linear_qkv when head_wise_attn_gate is True; gate weights live in
         # the trailing num_attention_heads_per_partition rows of each rank's
         # local linear_qkv tensor. The gate tensor is sliced out inside
         # SelfAttention.get_query_key_value_tensors and threaded back to
@@ -1177,12 +1177,12 @@ class Attention(MegatronModule, ABC):
             ]
         )
         output_gate = self.config.attention_output_gate
-        # Per-head scalar gate (use_head_wise_attn_gate) is only meaningful on
+        # Per-head scalar gate (head_wise_attn_gate) is only meaningful on
         # the self-attention path: the gate weights are fused into linear_qkv,
         # which CrossAttention does not own. Restrict to self-attn to avoid
         # silently dropping the gate on cross-attn layers.
         head_wise_gate_enabled = (
-            self.config.use_head_wise_attn_gate and self.attention_type != "cross"
+            self.config.head_wise_attn_gate and self.attention_type != "cross"
         )
         # Check if fused_single_qkv_rope is requested but either unavailable or not
         # supported for the current use case.
@@ -1194,7 +1194,7 @@ class Attention(MegatronModule, ABC):
             assert split_qkv, "output_gate is not supported for unsplit mixed_qkv tensor."
         if head_wise_gate_enabled:
             assert split_qkv, (
-                "use_head_wise_attn_gate is not supported for unsplit mixed_qkv tensor."
+                "head_wise_attn_gate is not supported for unsplit mixed_qkv tensor."
             )
 
         qkv_linear_manager = off_interface(self.offload_qkv_linear, hidden_states, "qkv_linear")
@@ -1211,7 +1211,7 @@ class Attention(MegatronModule, ABC):
         attn_mask_type = self.attn_mask_type
         block_table = None
         gate = None
-        # Per-head scalar gate (use_head_wise_attn_gate) is threaded through as
+        # Per-head scalar gate (head_wise_attn_gate) is threaded through as
         # a local rather than via an instance attribute to keep the forward
         # re-entrant under cross-attn / overlapped microbatches / recompute.
         head_wise_gate = None
@@ -1424,7 +1424,7 @@ class Attention(MegatronModule, ABC):
             core_attn_out = core_attn_out.reshape(core_attn_out.size(0), 1, -1)
         nvtx_range_pop(suffix="core_attention")
 
-        # Per-head scalar gate (use_head_wise_attn_gate). Gate states were
+        # Per-head scalar gate (head_wise_attn_gate). Gate states were
         # sliced off the fused linear_qkv output inside
         # get_query_key_value_tensors and returned through qkv_output; we
         # already unpacked them into the local `head_wise_gate` above.
@@ -1513,7 +1513,7 @@ class SelfAttention(Attention):
         self.linear_qkv_out_dim = self.query_projection_size + 2 * self.kv_projection_size
         if self.config.attention_output_gate:
             self.linear_qkv_out_dim += self.config.kv_channels * self.config.num_attention_heads
-        if self.config.use_head_wise_attn_gate:
+        if self.config.head_wise_attn_gate:
             # Fuse per-head scalar gate (Step-3.5-Flash g_proj) into linear_qkv.
             # Gate rows are appended after the QKV block, so the trailing
             # num_attention_heads rows of linear_qkv.weight are the gate
@@ -1532,7 +1532,7 @@ class SelfAttention(Attention):
             #     (num_attention_heads / world_size). The slice would then
             #     take V/K rows as gate. Disallow the combination outright.
             assert self.config.num_query_groups >= tp_world_size, (
-                f"use_head_wise_attn_gate requires num_query_groups "
+                f"head_wise_attn_gate requires num_query_groups "
                 f"({self.config.num_query_groups}) >= tensor-model-parallel "
                 f"world_size ({tp_world_size}). The gate peel-off happens "
                 f"before the num_query_groups < world_size AllGather + "
@@ -1544,7 +1544,7 @@ class SelfAttention(Attention):
             #     parent's divide(num_attention_heads, world_size) under
             #     invariant (a), but kept for an explicit error message.)
             assert self.config.num_attention_heads % tp_world_size == 0, (
-                f"use_head_wise_attn_gate requires num_attention_heads "
+                f"head_wise_attn_gate requires num_attention_heads "
                 f"({self.config.num_attention_heads}) to be divisible by the "
                 f"tensor-model-parallel world_size ({tp_world_size}); the "
                 f"trailing-rows-as-gate layout cannot place an integer number "
@@ -1564,7 +1564,7 @@ class SelfAttention(Attention):
             tp_group=self.pg_collection.tp,
         )
 
-        if self.config.use_head_wise_attn_gate:
+        if self.config.head_wise_attn_gate:
             # Re-initialize the gate sub-block of linear_qkv so sigmoid(gate)
             # is near 1 at init (approximate identity), instead of the
             # sigmoid(0)=0.5 that the default shared init_method gives. With
@@ -1737,8 +1737,8 @@ class SelfAttention(Attention):
             assert split_qkv, (
                 "head_wise_gate is not supported for unsplit mixed_qkv tensor."
             )
-            assert self.config.use_head_wise_attn_gate, (
-                "head_wise_gate=True passed but config.use_head_wise_attn_gate is "
+            assert self.config.head_wise_attn_gate, (
+                "head_wise_gate=True passed but config.head_wise_attn_gate is "
                 "False; this is an internal contract violation between forward "
                 "and get_query_key_value_tensors."
             )
@@ -1746,7 +1746,7 @@ class SelfAttention(Attention):
         # If have output gate: Attention heads [sq, b, h] --> [sq, b, ng * (2 * np/ng + 2) * hn)]
         mixed_qkv, _ = apply_module(self.linear_qkv)(hidden_states)
 
-        # Peel off the fused per-head gate (use_head_wise_attn_gate). The slice
+        # Peel off the fused per-head gate (head_wise_attn_gate). The slice
         # takes the trailing num_attention_heads_per_partition columns of the
         # local mixed_qkv and treats them as one scalar gate per local query
         # head. This is only correct when ALL THREE of the following hold:
@@ -2034,7 +2034,7 @@ class SelfAttention(Attention):
         apply_swiglu_sharded_factory in megatron/core/transformer/mlp.py.
         """
         sharded_state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
-        if self.config.use_head_wise_attn_gate:
+        if self.config.head_wise_attn_gate:
             qkv_size = self.query_projection_size + 2 * self.kv_projection_size
             gate_size = self.config.num_attention_heads
             for sub_name in ("weight", "bias"):
@@ -2056,7 +2056,7 @@ def apply_head_wise_attn_gate_sharded_factory(
     """Build a ShardedTensorFactory that splits linear_qkv.{weight,bias} into
     independent QKV and gate sub-tensors for dist-ckpt save/load.
 
-    The forward path of SelfAttention with use_head_wise_attn_gate=True peels
+    The forward path of SelfAttention with head_wise_attn_gate=True peels
     the trailing num_attention_heads_per_partition rows off each rank's local
     linear_qkv output and treats them as per-head gate scalars. That assumes
     the local layout is [qkv_local; gate_local] — but the default
@@ -2093,7 +2093,7 @@ def apply_head_wise_attn_gate_sharded_factory(
     qkv_local_size, qkv_rem = divmod(qkv_size, axis_frag)
     gate_local_size, gate_rem = divmod(gate_size, axis_frag)
     assert qkv_rem == 0 and gate_rem == 0, (
-        f"use_head_wise_attn_gate dist-ckpt requires both QKV ({qkv_size}) "
+        f"head_wise_attn_gate dist-ckpt requires both QKV ({qkv_size}) "
         f"and gate ({gate_size}) sizes to be divisible by the TP world_size "
         f"({axis_frag})."
     )
@@ -2216,7 +2216,7 @@ class CrossAttention(Attention):
         """
         assert not output_gate, "Output gate is not supported in cross attention for now."
         assert not head_wise_gate, (
-            "use_head_wise_attn_gate is not supported in cross attention "
+            "head_wise_attn_gate is not supported in cross attention "
             "(linear_qkv with fused gate rows lives only on the self-attention path)."
         )
 

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -11,6 +11,12 @@ import torch
 from torch import Tensor
 
 from megatron.core import tensor_parallel
+from megatron.core.dist_checkpointing import ShardedTensor
+from megatron.core.dist_checkpointing.mapping import (
+    ReplicaId,
+    ShardedStateDict,
+    ShardedTensorFactory,
+)
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.jit import jit_fuser
@@ -36,6 +42,7 @@ from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
+from megatron.core.transformer.utils import cat_with_oom_fallback
 from megatron.core.typed_torch import apply_module, not_none
 from megatron.core.utils import (
     deprecate_inference_params,
@@ -397,9 +404,13 @@ class Attention(MegatronModule, ABC):
 
         # Per-head scalar output gate (Step-3.5-Flash g_proj) is fused into
         # linear_qkv when use_head_wise_attn_gate is True; gate weights live in
-        # the trailing num_attention_heads rows of linear_qkv.weight. The gate
-        # tensor is sliced out in SelfAttention.get_query_key_value_tensors and
-        # consumed in Attention.forward.
+        # the trailing num_attention_heads_per_partition rows of each rank's
+        # local linear_qkv tensor. The gate tensor is sliced out in
+        # SelfAttention.get_query_key_value_tensors and consumed in
+        # Attention.forward. For dist-ckpt TP resharding safety, the [QKV,
+        # gate] split is preserved via a ShardedTensorFactory wired up in
+        # SelfAttention.sharded_state_dict (see
+        # apply_head_wise_attn_gate_sharded_factory below).
         self._head_wise_gate_states = None
 
     def _build_per_layer_rotary_pos_emb(self, rotary_base: float) -> None:
@@ -1868,6 +1879,134 @@ class SelfAttention(Attention):
         )
 
         return weight_updated
+
+    def sharded_state_dict(
+        self,
+        prefix: str = "",
+        sharded_offsets: tuple = (),
+        metadata: Optional[dict] = None,
+    ) -> ShardedStateDict:
+        """Return the sharded state dict, wrapping linear_qkv.{weight,bias}
+        with a factory that splits the trailing num_attention_heads gate rows
+        from the QKV block under dist-ckpt save/load. Without this override the
+        global tensor is sharded as one uniform axis-0 block, so save TP=N
+        -> load TP=M silently mixes V/K rows with gate rows; the factory makes
+        the QKV and gate sub-blocks reshard independently, analogous to
+        apply_swiglu_sharded_factory in megatron/core/transformer/mlp.py.
+        """
+        sharded_state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
+        if self.config.use_head_wise_attn_gate:
+            qkv_size = self.query_projection_size + 2 * self.kv_projection_size
+            gate_size = self.config.num_attention_heads
+            for sub_name in ("weight", "bias"):
+                key = f"{prefix}linear_qkv.{sub_name}"
+                if key in sharded_state_dict:
+                    sharded_state_dict[key] = apply_head_wise_attn_gate_sharded_factory(
+                        sharded_state_dict[key], sharded_offsets, qkv_size, gate_size
+                    )
+        return sharded_state_dict
+
+
+# pylint: disable=missing-function-docstring
+def apply_head_wise_attn_gate_sharded_factory(
+    original_sh_ten,
+    sharded_offsets,
+    qkv_size: int,
+    gate_size: int,
+):
+    """Build a ShardedTensorFactory that splits linear_qkv.{weight,bias} into
+    independent QKV and gate sub-tensors for dist-ckpt save/load.
+
+    The forward path of SelfAttention with use_head_wise_attn_gate=True peels
+    the trailing num_attention_heads_per_partition rows off each rank's local
+    linear_qkv output and treats them as per-head gate scalars. That assumes
+    the local layout is [qkv_local; gate_local] — but the default
+    ColumnParallelLinear / TELayerNormColumnParallelLinear sharded_state_dict
+    only declares {"weight": 0}, so the global (QKV_dim + H, hidden_size)
+    tensor is uniformly resharded along axis 0 on TP change. Whenever the new
+    per-rank size < QKV_dim, the trailing rows on non-last ranks land inside
+    the QKV block, so a saved checkpoint reloads with V/K rows being treated
+    as gate scalars (no shape error — silently wrong).
+
+    This factory chunks each rank's local tensor at the QKV/gate boundary on
+    save, registering qkv_local and gate_local as two independent sub-tensors
+    (with distinct keys) each uniformly sharded along axis 0 across TP. On
+    load they are gathered, resharded for the new TP, and cat'd back so the
+    rank-local layout is again [qkv_local; gate_local]. Same pattern as
+    apply_swiglu_sharded_factory (megatron/core/transformer/mlp.py), but with
+    unequal sub-block sizes (QKV >> gate).
+
+    Args:
+        original_sh_ten: ShardedTensor produced for linear_qkv.weight or
+            linear_qkv.bias by the underlying ColumnParallelLinear /
+            TE-variant sharded_state_dict (axis-0 sharded across TP).
+        sharded_offsets: PP-style offsets passed from the parent module.
+        qkv_size: Global axis-0 size of the QKV sub-block
+            (query_projection_size + 2 * kv_projection_size).
+        gate_size: Global axis-0 size of the gate sub-block
+            (num_attention_heads).
+    """
+    shard_axis = 0
+    prepend_axis_num = len(sharded_offsets)
+    local_axis_size = original_sh_ten.local_shape[shard_axis]
+    axis_frag = original_sh_ten.axis_fragmentations[shard_axis + prepend_axis_num]
+
+    qkv_local_size, qkv_rem = divmod(qkv_size, axis_frag)
+    gate_local_size, gate_rem = divmod(gate_size, axis_frag)
+    assert qkv_rem == 0 and gate_rem == 0, (
+        f"use_head_wise_attn_gate dist-ckpt requires both QKV ({qkv_size}) "
+        f"and gate ({gate_size}) sizes to be divisible by the TP world_size "
+        f"({axis_frag})."
+    )
+    assert local_axis_size == qkv_local_size + gate_local_size, (
+        f"Unexpected linear_qkv local axis-0 size {local_axis_size} != "
+        f"{qkv_local_size} (qkv) + {gate_local_size} (gate). The factory "
+        f"assumes a uniform axis-0 sharding from ColumnParallelLinear."
+    )
+    rank_offset = (
+        original_sh_ten.global_offset[shard_axis + prepend_axis_num] // local_axis_size
+    )
+
+    @torch.no_grad()
+    def sh_ten_build_fn(
+        key: str, t: torch.Tensor, replica_id: ReplicaId, flattened_range: Optional[slice]
+    ):
+        # Trailing rows of each rank's local tensor are the gate scalars; the
+        # rest is QKV. Split sizes are unequal, so we use torch.split rather
+        # than torch.chunk(2). Each sub-tensor lives under a distinct key
+        # (.{_qkv,_gate}) so dist-ckpt treats them as independent globals.
+        tensor_qkv, tensor_gate = torch.split(
+            t, [qkv_local_size, gate_local_size], dim=shard_axis
+        )
+        offset_qkv = (shard_axis + prepend_axis_num, rank_offset, axis_frag)
+        offset_gate = (shard_axis + prepend_axis_num, rank_offset, axis_frag)
+        return [
+            ShardedTensor.from_rank_offsets(
+                f"{key}._qkv",
+                tensor_qkv,
+                *sharded_offsets,
+                offset_qkv,
+                replica_id=replica_id,
+                prepend_axis_num=prepend_axis_num,
+            ),
+            ShardedTensor.from_rank_offsets(
+                f"{key}._gate",
+                tensor_gate,
+                *sharded_offsets,
+                offset_gate,
+                replica_id=replica_id,
+                prepend_axis_num=prepend_axis_num,
+            ),
+        ]
+
+    return ShardedTensorFactory(
+        original_sh_ten.key,
+        original_sh_ten.data,
+        sh_ten_build_fn,
+        cat_with_oom_fallback,
+        original_sh_ten.replica_id,
+        flattened_range=original_sh_ten.flattened_range,
+    )
 
 
 class CrossAttention(Attention):

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1564,6 +1564,37 @@ class SelfAttention(Attention):
             tp_group=self.pg_collection.tp,
         )
 
+        if self.config.use_head_wise_attn_gate:
+            # Re-initialize the gate sub-block of linear_qkv so sigmoid(gate)
+            # is near 1 at init (approximate identity), instead of the
+            # sigmoid(0)=0.5 that the default shared init_method gives. With
+            # a half-strength gate from step 0, every head's output is
+            # halved during warmup and the optimizer carries an extra burden
+            # to recover identity. Scale the gate rows by a small factor
+            # (default 0.1) rather than zero-init so:
+            #   - gate weight magnitudes stay on the same order as QKV,
+            #     keeping the shared FP8 tensor-level scale on
+            #     linear_qkv.weight from being dominated by a near-zero
+            #     gate sub-block;
+            #   - the gate is not literally constant at init (some signal
+            #     from the linear part still flows).
+            # The bias rows (when present) are filled with a positive
+            # constant (default 2.0, sigmoid(2.0)~=0.88) to bias the
+            # sigmoid toward 1 at init. When linear_qkv has no bias, only
+            # the weight scaling applies and the gate sits near 0.5 (still
+            # better than the bias-free default in expectation, though not
+            # identity).
+            # Both knobs are exposed on TransformerConfig:
+            # head_wise_attn_gate_init_weight_scale,
+            # head_wise_attn_gate_init_bias.
+            num_heads_per_partition = self.num_attention_heads_per_partition
+            with torch.no_grad():
+                gate_weight = self.linear_qkv.weight[-num_heads_per_partition:]
+                gate_weight.mul_(self.config.head_wise_attn_gate_init_weight_scale)
+                if self.linear_qkv.bias is not None:
+                    gate_bias = self.linear_qkv.bias[-num_heads_per_partition:]
+                    gate_bias.fill_(self.config.head_wise_attn_gate_init_bias)
+
         # Resolve which norm class to use for Q and K.
         # Config selects the default norm class; spec overrides if set.
         if self.config.qk_l2_norm:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -277,19 +277,6 @@ class TransformerConfig(ModelParallelConfig):
     num_query_groups >= tp, and under fp8/fp4 a per-partition
     linear_qkv_out_dim aligned to 16/32."""
 
-    head_wise_attn_gate_init_weight_scale: float = 0.1
-    """Multiplicative scale on the gate rows of linear_qkv.weight at init,
-    on top of init_method. Default 0.1 keeps the linear contribution small
-    so sigmoid is dominated by the bias term, while staying within ~1
-    decade of QKV magnitudes for FP8 tensor-scale safety. Only used when
-    head_wise_attn_gate=True."""
-
-    head_wise_attn_gate_init_bias: float = 2.0
-    """Constant fill for the gate rows of linear_qkv.bias at init (no-op
-    when linear_qkv has no bias). Default 2.0 -> sigmoid(2)~=0.88, near
-    identity; avoids halving every head's output from step 0. Only used
-    when head_wise_attn_gate=True."""
-
     test_mode: bool = False
     """Whether to run real-time tests."""
 
@@ -2833,9 +2820,13 @@ class TransformerConfig(ModelParallelConfig):
             ), "Must have at least TE version 2.3 or higher to use symmetric memory all reduce"
 
         if self.rotary_base_per_layer is not None:
-            assert len(self.rotary_base_per_layer) == self.num_layers, (
+            if self.mtp_num_layers is not None:
+                total_num_layers = self.num_layers + self.mtp_num_layers
+            else:
+                total_num_layers = self.num_layers
+            assert len(self.rotary_base_per_layer) == total_num_layers, (
                 f"rotary_base_per_layer length ({len(self.rotary_base_per_layer)}) "
-                f"must equal num_layers ({self.num_layers})"
+                f"must equal num_layers ({total_num_layers})"
             )
 
         if self.no_rope_freq:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -256,27 +256,46 @@ class TransformerConfig(ModelParallelConfig):
     defualts to False. Setting qk_clip will automatically log the max logit"""
 
     attention_output_gate: bool = False
-    """Whether to apply output gate to the attention layers."""
+    """Whether to apply a full head_dim output gate to the attention layers.
+    The gate is fused into linear_qkv with an inline per-group [q, gate, k, v]
+    layout, contributing num_attention_heads * head_dim extra rows. The
+    sigmoid of the gate (head_dim values per head) is broadcast-multiplied
+    onto each head's attention output. Mutually exclusive with the related
+    `head_wise_attn_gate` flag, which fuses only a single SCALAR gate per
+    head (num_attention_heads rows) as trailing rows of linear_qkv; see
+    `head_wise_attn_gate` for the contrast."""
 
     rotary_base_per_layer: Optional[List[float]] = None
     """Per-layer RoPE theta values. Length must equal num_layers. When set, each
     SelfAttention layer creates its own RotaryEmbedding with the corresponding base;
     the shared model-level rotary_pos_emb is not created."""
 
-    use_head_wise_attn_gate: bool = False
-    """Apply a per-head scalar output gate (e.g., Step-3.5-Flash g_proj).
+    head_wise_attn_gate: bool = False
+    """Apply a per-head SCALAR output gate (e.g., Step-3.5-Flash g_proj).
     The gate weights are fused into linear_qkv as the trailing
-    num_attention_heads rows; the sigmoid of those scalars gates each
-    attention head independently. Self-attention only: cross-attention
-    layers do not own linear_qkv, so the gate path does not apply there
+    num_attention_heads rows; the sigmoid of those scalars (one per
+    attention head) is broadcast-multiplied onto each head's attention
+    output, so head i is scaled uniformly across all head_dim positions.
+
+    Contrast with `attention_output_gate`:
+
+        attention_output_gate:
+            Full head_dim gate per head -> num_attention_heads * head_dim
+            extra rows, inline per-group [q, gate, k, v] layout. Each head's
+            output is element-wise gated across head_dim.
+        head_wise_attn_gate (this flag):
+            Single scalar gate per head -> num_attention_heads extra rows,
+            trailing-rows layout. Each head's output is scaled by one
+            sigmoid(gate) value.
+
+    The two flags are mutually exclusive (validated in __post_init__).
+    Self-attention only: cross-attention layers do not own linear_qkv, so
+    the gate path does not apply there
     (CrossAttention.get_query_key_value_tensors rejects the flag with an
-    explicit assertion). Distinct from attention_output_gate, which fuses
-    a full head_dim gate into linear_qkv with an inline per-group layout;
-    the two flags are mutually exclusive (validated in __post_init__).
-    Distributed checkpoint TP resharding is handled via a
-    ShardedTensorFactory in SelfAttention.sharded_state_dict that splits
-    linear_qkv.{weight,bias} into independent [QKV, gate] sub-tensors
-    (analogous to apply_swiglu_sharded_factory). Requires
+    explicit assertion). Distributed checkpoint TP resharding is handled
+    via a ShardedTensorFactory in SelfAttention.sharded_state_dict that
+    splits linear_qkv.{weight,bias} into independent [QKV, gate]
+    sub-tensors (analogous to apply_swiglu_sharded_factory). Requires
     num_attention_heads % tensor_model_parallel_size == 0 and
     num_query_groups >= tensor_model_parallel_size; both are validated in
     __post_init__."""
@@ -290,7 +309,7 @@ class TransformerConfig(ModelParallelConfig):
     identity once head_wise_attn_gate_init_bias is set. Kept on the same
     order of magnitude as QKV so the FP8 tensor-level scale on
     linear_qkv.weight isn't dominated by an under/over-scaled gate sub-block.
-    Only relevant when use_head_wise_attn_gate=True."""
+    Only relevant when head_wise_attn_gate=True."""
 
     head_wise_attn_gate_init_bias: float = 2.0
     """Constant value written to the gate rows of linear_qkv.bias right after
@@ -298,7 +317,7 @@ class TransformerConfig(ModelParallelConfig):
     sigmoid(2.0) ~= 0.88 at init -- approximately identity, so the gate
     does not halve every head's output from step 0 and add an extra
     optimization burden during warmup. Only relevant when
-    use_head_wise_attn_gate=True and the linear_qkv layer has a bias
+    head_wise_attn_gate=True and the linear_qkv layer has a bias
     (add_bias_linear=True or add_qkv_bias=True)."""
 
     test_mode: bool = False
@@ -1360,20 +1379,20 @@ class TransformerConfig(ModelParallelConfig):
                 f"tensor_model_parallel_size ({self.tensor_model_parallel_size})."
             )
 
-        # use_head_wise_attn_gate layout/compose validation. Fails fast at
+        # head_wise_attn_gate layout/compose validation. Fails fast at
         # config time (before any layer is built) so users do not hit obscure
         # asserts deep inside the forward path.
-        if self.use_head_wise_attn_gate:
+        if self.head_wise_attn_gate:
             # (1) Mutual exclusion with attention_output_gate. Both flags
             #     append rows to linear_qkv: attention_output_gate uses an
             #     inline per-group (q, gate, k, v) layout, while
-            #     use_head_wise_attn_gate appends a trailing-rows block.
+            #     head_wise_attn_gate appends a trailing-rows block.
             #     The forward-time slicing paths assume each layout in
             #     isolation; their joint behavior is not currently tested
             #     or documented, so we refuse the combination outright.
             if self.attention_output_gate:
                 raise ValueError(
-                    "use_head_wise_attn_gate and attention_output_gate cannot both be "
+                    "head_wise_attn_gate and attention_output_gate cannot both be "
                     "enabled: each appends rows to linear_qkv with an incompatible "
                     "layout (per-group inline gate vs trailing-rows gate). Enable at "
                     "most one."
@@ -1384,7 +1403,7 @@ class TransformerConfig(ModelParallelConfig):
             #     with a gate-specific message so the failure mode is obvious.
             if self.num_attention_heads % self.tensor_model_parallel_size != 0:
                 raise ValueError(
-                    f"use_head_wise_attn_gate requires num_attention_heads "
+                    f"head_wise_attn_gate requires num_attention_heads "
                     f"({self.num_attention_heads}) to be divisible by "
                     f"tensor_model_parallel_size ({self.tensor_model_parallel_size}); "
                     f"otherwise the trailing num_attention_heads gate rows cannot be "
@@ -1400,7 +1419,7 @@ class TransformerConfig(ModelParallelConfig):
             #     Disallow the combination here.
             if self.num_query_groups < self.tensor_model_parallel_size:
                 raise ValueError(
-                    f"use_head_wise_attn_gate requires num_query_groups "
+                    f"head_wise_attn_gate requires num_query_groups "
                     f"({self.num_query_groups}) >= tensor_model_parallel_size "
                     f"({self.tensor_model_parallel_size}). The head-wise gate "
                     f"peel-off runs before the num_query_groups < world_size "

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -268,7 +268,13 @@ class TransformerConfig(ModelParallelConfig):
     The gate weights are fused into linear_qkv as the trailing
     num_attention_heads rows; the sigmoid of those scalars gates each
     attention head independently. Distinct from attention_output_gate,
-    which fuses a full head_dim gate into linear_qkv."""
+    which fuses a full head_dim gate into linear_qkv. Distributed checkpoint
+    TP resharding is handled via a ShardedTensorFactory in
+    SelfAttention.sharded_state_dict that splits linear_qkv.{weight,bias}
+    into independent [QKV, gate] sub-tensors (analogous to
+    apply_swiglu_sharded_factory). Both query_projection_size + 2 *
+    kv_projection_size and num_attention_heads must be divisible by every TP
+    world_size used for save/load."""
 
     test_mode: bool = False
     """Whether to run real-time tests."""

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -256,14 +256,9 @@ class TransformerConfig(ModelParallelConfig):
     defualts to False. Setting qk_clip will automatically log the max logit"""
 
     attention_output_gate: bool = False
-    """Whether to apply a full head_dim output gate to the attention layers.
-    The gate is fused into linear_qkv with an inline per-group [q, gate, k, v]
-    layout, contributing num_attention_heads * head_dim extra rows. The
-    sigmoid of the gate (head_dim values per head) is broadcast-multiplied
-    onto each head's attention output. Mutually exclusive with the related
-    `head_wise_attn_gate` flag, which fuses only a single SCALAR gate per
-    head (num_attention_heads rows) as trailing rows of linear_qkv; see
-    `head_wise_attn_gate` for the contrast."""
+    """Apply a full head_dim output gate (num_attention_heads * head_dim rows
+    fused inline per-group [q, gate, k, v] into linear_qkv). Mutually
+    exclusive with `head_wise_attn_gate` (per-head scalar gate)."""
 
     rotary_base_per_layer: Optional[List[float]] = None
     """Per-layer RoPE theta values. Length must equal num_layers. When set, each
@@ -271,60 +266,29 @@ class TransformerConfig(ModelParallelConfig):
     the shared model-level rotary_pos_emb is not created."""
 
     head_wise_attn_gate: bool = False
-    """Apply a per-head SCALAR output gate (e.g., Step-3.5-Flash g_proj).
-    The gate weights are fused into linear_qkv as the trailing
-    num_attention_heads rows; the sigmoid of those scalars (one per
-    attention head) is broadcast-multiplied onto each head's attention
-    output, so head i is scaled uniformly across all head_dim positions.
-
-    Contrast with `attention_output_gate`:
-
-        attention_output_gate:
-            Full head_dim gate per head -> num_attention_heads * head_dim
-            extra rows, inline per-group [q, gate, k, v] layout. Each head's
-            output is element-wise gated across head_dim.
-        head_wise_attn_gate (this flag):
-            Single scalar gate per head -> num_attention_heads extra rows,
-            trailing-rows layout. Each head's output is scaled by one
-            sigmoid(gate) value.
-
-    The two flags are mutually exclusive (validated in __post_init__).
-    Self-attention only: cross-attention layers do not own linear_qkv, so
-    the gate path does not apply there
-    (CrossAttention.get_query_key_value_tensors rejects the flag with an
-    explicit assertion). Distributed checkpoint TP resharding is handled
-    via a ShardedTensorFactory in SelfAttention.sharded_state_dict that
-    splits linear_qkv.{weight,bias} into independent [QKV, gate]
-    sub-tensors (analogous to apply_swiglu_sharded_factory). Requires
-    num_attention_heads % tensor_model_parallel_size == 0 and
-    num_query_groups >= tensor_model_parallel_size; both are validated in
-    __post_init__. Under fp8/fp4, the per-partition linear_qkv output dim
-    must additionally be a multiple of 16 (fp8) or 32 (fp4) for
-    Transformer Engine's GEMM alignment; this is validated in
-    __post_init__ too. attention_output_gate's wider gate (head_dim per
-    head) hits this alignment naturally; head_wise_attn_gate's tiny
-    num_attention_heads increment can mis-align, so users may need to
-    pick num_attention_heads / num_query_groups accordingly."""
+    """Apply a per-head scalar output gate (Step-3.5-Flash g_proj):
+    num_attention_heads scalar gates fused as the trailing rows of
+    linear_qkv; sigmoid scales each head uniformly across head_dim.
+    Contrast with `attention_output_gate` (full head_dim gate, inline
+    per-group); the two are mutually exclusive. Self-attention only.
+    dist-ckpt TP resharding is handled by a ShardedTensorFactory in
+    SelfAttention.sharded_state_dict. Requires (validated in
+    __post_init__): num_attention_heads % tp == 0,
+    num_query_groups >= tp, and under fp8/fp4 a per-partition
+    linear_qkv_out_dim aligned to 16/32."""
 
     head_wise_attn_gate_init_weight_scale: float = 0.1
-    """Multiplicative scale applied to the gate rows of linear_qkv.weight right
-    after construction, on top of the shared init_method (which is normal
-    init for QKV). Defaults to 0.1 so the gate's pre-sigmoid contribution
-    from the linear part is small at init (~10x smaller than QKV's), making
-    sigmoid(gate*x + bias) dominated by the gate bias term and so close to
-    identity once head_wise_attn_gate_init_bias is set. Kept on the same
-    order of magnitude as QKV so the FP8 tensor-level scale on
-    linear_qkv.weight isn't dominated by an under/over-scaled gate sub-block.
-    Only relevant when head_wise_attn_gate=True."""
+    """Multiplicative scale on the gate rows of linear_qkv.weight at init,
+    on top of init_method. Default 0.1 keeps the linear contribution small
+    so sigmoid is dominated by the bias term, while staying within ~1
+    decade of QKV magnitudes for FP8 tensor-scale safety. Only used when
+    head_wise_attn_gate=True."""
 
     head_wise_attn_gate_init_bias: float = 2.0
-    """Constant value written to the gate rows of linear_qkv.bias right after
-    construction (no-op when linear_qkv has no bias). Defaults to 2.0 so
-    sigmoid(2.0) ~= 0.88 at init -- approximately identity, so the gate
-    does not halve every head's output from step 0 and add an extra
-    optimization burden during warmup. Only relevant when
-    head_wise_attn_gate=True and the linear_qkv layer has a bias
-    (add_bias_linear=True or add_qkv_bias=True)."""
+    """Constant fill for the gate rows of linear_qkv.bias at init (no-op
+    when linear_qkv has no bias). Default 2.0 -> sigmoid(2)~=0.88, near
+    identity; avoids halving every head's output from step 0. Only used
+    when head_wise_attn_gate=True."""
 
     test_mode: bool = False
     """Whether to run real-time tests."""
@@ -1385,90 +1349,45 @@ class TransformerConfig(ModelParallelConfig):
                 f"tensor_model_parallel_size ({self.tensor_model_parallel_size})."
             )
 
-        # head_wise_attn_gate layout/compose validation. Fails fast at
-        # config time (before any layer is built) so users do not hit obscure
-        # asserts deep inside the forward path.
         if self.head_wise_attn_gate:
-            # (1) Mutual exclusion with attention_output_gate. Both flags
-            #     append rows to linear_qkv: attention_output_gate uses an
-            #     inline per-group (q, gate, k, v) layout, while
-            #     head_wise_attn_gate appends a trailing-rows block.
-            #     The forward-time slicing paths assume each layout in
-            #     isolation; their joint behavior is not currently tested
-            #     or documented, so we refuse the combination outright.
+            tp = self.tensor_model_parallel_size
             if self.attention_output_gate:
                 raise ValueError(
-                    "head_wise_attn_gate and attention_output_gate cannot both be "
-                    "enabled: each appends rows to linear_qkv with an incompatible "
-                    "layout (per-group inline gate vs trailing-rows gate). Enable at "
-                    "most one."
+                    "head_wise_attn_gate and attention_output_gate cannot both be enabled "
+                    "(incompatible linear_qkv row layouts)."
                 )
-            # (2) Per-rank gate-row count must be an integer. The
-            #     num_attention_heads % tensor_model_parallel_size == 0 check
-            #     above already enforces this globally, but re-state it here
-            #     with a gate-specific message so the failure mode is obvious.
-            if self.num_attention_heads % self.tensor_model_parallel_size != 0:
+            if self.num_attention_heads % tp != 0:
                 raise ValueError(
                     f"head_wise_attn_gate requires num_attention_heads "
-                    f"({self.num_attention_heads}) to be divisible by "
-                    f"tensor_model_parallel_size ({self.tensor_model_parallel_size}); "
-                    f"otherwise the trailing num_attention_heads gate rows cannot be "
-                    f"sharded into integer per-rank counts."
+                    f"({self.num_attention_heads}) divisible by tp ({tp})."
                 )
-            # (3) num_query_groups >= tensor_model_parallel_size. The gate
-            #     peel-off in SelfAttention.get_query_key_value_tensors runs
-            #     BEFORE the num_query_groups < world_size AllGather + reslice
-            #     fallback path; under that fallback
-            #     num_attention_heads_per_partition is inflated to
-            #     num_attention_heads / num_query_groups (the pre-AG count),
-            #     so the slice over-takes and pulls V/K rows in as gate rows.
-            #     Disallow the combination here.
-            if self.num_query_groups < self.tensor_model_parallel_size:
+            # The gate peel-off in SelfAttention runs before the
+            # num_query_groups < world_size AllGather+reslice fallback, so the
+            # gate cannot ride that path without over-taking V/K rows.
+            if self.num_query_groups < tp:
                 raise ValueError(
                     f"head_wise_attn_gate requires num_query_groups "
-                    f"({self.num_query_groups}) >= tensor_model_parallel_size "
-                    f"({self.tensor_model_parallel_size}). The head-wise gate "
-                    f"peel-off runs before the num_query_groups < world_size "
-                    f"AllGather + reslice fallback; under that fallback the gate "
-                    f"slice would over-take and pick up V/K rows as gate rows."
+                    f"({self.num_query_groups}) >= tp ({tp})."
                 )
-            # (4) FP8 / FP4 GEMM alignment. Transformer Engine's FP8 GEMM
-            #     requires the per-partition output dim of linear_qkv to be
-            #     a multiple of 16 (FP4: 32). attention_output_gate adds
-            #     num_attention_heads * kv_channels rows, which is already
-            #     16-aligned for typical kv_channels (64/128); head_wise
-            #     adds only num_attention_heads rows -- a much smaller and
-            #     potentially mis-aligned increment. TE would either error
-            #     out or silently pad the weight (shifted outputs); reject
-            #     up front so this is caught at config-time, not at first
-            #     fp8 forward.
+            # TE FP8/FP4 GEMM requires per-partition output dim aligned to
+            # 16/32. attention_output_gate's wider gate gets this for free;
+            # head_wise's num_attention_heads-row increment can mis-align.
             if self.fp8 is not None or self.fp4 is not None:
                 align = 32 if self.fp4 is not None else 16
-                # Mirror SelfAttention's linear_qkv_out_dim formula. Safe
-                # because checks (2)/(3) above already ensure the QKV and
-                # gate blocks each divide tensor_model_parallel_size cleanly.
                 linear_qkv_out_dim = (
                     self.kv_channels * self.num_attention_heads
                     + 2 * self.kv_channels * self.num_query_groups
                     + self.num_attention_heads
                 )
-                per_partition = linear_qkv_out_dim // self.tensor_model_parallel_size
+                per_partition = linear_qkv_out_dim // tp
                 if per_partition % align != 0:
                     fp_name = "fp4" if self.fp4 is not None else "fp8"
                     raise ValueError(
-                        f"head_wise_attn_gate under {fp_name} requires the "
-                        f"per-partition linear_qkv output dim "
-                        f"({per_partition}) to be a multiple of {align} for "
-                        f"Transformer Engine's {fp_name.upper()} GEMM alignment. "
-                        f"Got num_attention_heads={self.num_attention_heads}, "
+                        f"head_wise_attn_gate under {fp_name} requires per-partition "
+                        f"linear_qkv output dim ({per_partition}) to be a multiple of "
+                        f"{align}; got num_attention_heads={self.num_attention_heads}, "
                         f"num_query_groups={self.num_query_groups}, "
-                        f"kv_channels={self.kv_channels}, "
-                        f"tensor_model_parallel_size={self.tensor_model_parallel_size} "
-                        f"-> linear_qkv_out_dim={linear_qkv_out_dim}. "
-                        f"Pick num_attention_heads such that "
-                        f"(kv_channels*num_attention_heads + 2*kv_channels*"
-                        f"num_query_groups + num_attention_heads) / "
-                        f"tensor_model_parallel_size is divisible by {align}."
+                        f"kv_channels={self.kv_channels}, tp={tp}."
                     )
 
         if self.linear_attention_type is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -276,6 +276,26 @@ class TransformerConfig(ModelParallelConfig):
     kv_projection_size and num_attention_heads must be divisible by every TP
     world_size used for save/load."""
 
+    head_wise_attn_gate_init_weight_scale: float = 0.1
+    """Multiplicative scale applied to the gate rows of linear_qkv.weight right
+    after construction, on top of the shared init_method (which is normal
+    init for QKV). Defaults to 0.1 so the gate's pre-sigmoid contribution
+    from the linear part is small at init (~10x smaller than QKV's), making
+    sigmoid(gate*x + bias) dominated by the gate bias term and so close to
+    identity once head_wise_attn_gate_init_bias is set. Kept on the same
+    order of magnitude as QKV so the FP8 tensor-level scale on
+    linear_qkv.weight isn't dominated by an under/over-scaled gate sub-block.
+    Only relevant when use_head_wise_attn_gate=True."""
+
+    head_wise_attn_gate_init_bias: float = 2.0
+    """Constant value written to the gate rows of linear_qkv.bias right after
+    construction (no-op when linear_qkv has no bias). Defaults to 2.0 so
+    sigmoid(2.0) ~= 0.88 at init -- approximately identity, so the gate
+    does not halve every head's output from step 0 and add an extra
+    optimization burden during warmup. Only relevant when
+    use_head_wise_attn_gate=True and the linear_qkv layer has a bias
+    (add_bias_linear=True or add_qkv_bias=True)."""
+
     test_mode: bool = False
     """Whether to run real-time tests."""
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -267,14 +267,19 @@ class TransformerConfig(ModelParallelConfig):
     """Apply a per-head scalar output gate (e.g., Step-3.5-Flash g_proj).
     The gate weights are fused into linear_qkv as the trailing
     num_attention_heads rows; the sigmoid of those scalars gates each
-    attention head independently. Distinct from attention_output_gate,
-    which fuses a full head_dim gate into linear_qkv. Distributed checkpoint
-    TP resharding is handled via a ShardedTensorFactory in
-    SelfAttention.sharded_state_dict that splits linear_qkv.{weight,bias}
-    into independent [QKV, gate] sub-tensors (analogous to
-    apply_swiglu_sharded_factory). Both query_projection_size + 2 *
-    kv_projection_size and num_attention_heads must be divisible by every TP
-    world_size used for save/load."""
+    attention head independently. Self-attention only: cross-attention
+    layers do not own linear_qkv, so the gate path does not apply there
+    (CrossAttention.get_query_key_value_tensors rejects the flag with an
+    explicit assertion). Distinct from attention_output_gate, which fuses
+    a full head_dim gate into linear_qkv with an inline per-group layout;
+    the two flags are mutually exclusive (validated in __post_init__).
+    Distributed checkpoint TP resharding is handled via a
+    ShardedTensorFactory in SelfAttention.sharded_state_dict that splits
+    linear_qkv.{weight,bias} into independent [QKV, gate] sub-tensors
+    (analogous to apply_swiglu_sharded_factory). Requires
+    num_attention_heads % tensor_model_parallel_size == 0 and
+    num_query_groups >= tensor_model_parallel_size; both are validated in
+    __post_init__."""
 
     head_wise_attn_gate_init_weight_scale: float = 0.1
     """Multiplicative scale applied to the gate rows of linear_qkv.weight right
@@ -1354,6 +1359,54 @@ class TransformerConfig(ModelParallelConfig):
                 f"num_query_groups ({self.num_query_groups}) must be a multiple or divisor of "
                 f"tensor_model_parallel_size ({self.tensor_model_parallel_size})."
             )
+
+        # use_head_wise_attn_gate layout/compose validation. Fails fast at
+        # config time (before any layer is built) so users do not hit obscure
+        # asserts deep inside the forward path.
+        if self.use_head_wise_attn_gate:
+            # (1) Mutual exclusion with attention_output_gate. Both flags
+            #     append rows to linear_qkv: attention_output_gate uses an
+            #     inline per-group (q, gate, k, v) layout, while
+            #     use_head_wise_attn_gate appends a trailing-rows block.
+            #     The forward-time slicing paths assume each layout in
+            #     isolation; their joint behavior is not currently tested
+            #     or documented, so we refuse the combination outright.
+            if self.attention_output_gate:
+                raise ValueError(
+                    "use_head_wise_attn_gate and attention_output_gate cannot both be "
+                    "enabled: each appends rows to linear_qkv with an incompatible "
+                    "layout (per-group inline gate vs trailing-rows gate). Enable at "
+                    "most one."
+                )
+            # (2) Per-rank gate-row count must be an integer. The
+            #     num_attention_heads % tensor_model_parallel_size == 0 check
+            #     above already enforces this globally, but re-state it here
+            #     with a gate-specific message so the failure mode is obvious.
+            if self.num_attention_heads % self.tensor_model_parallel_size != 0:
+                raise ValueError(
+                    f"use_head_wise_attn_gate requires num_attention_heads "
+                    f"({self.num_attention_heads}) to be divisible by "
+                    f"tensor_model_parallel_size ({self.tensor_model_parallel_size}); "
+                    f"otherwise the trailing num_attention_heads gate rows cannot be "
+                    f"sharded into integer per-rank counts."
+                )
+            # (3) num_query_groups >= tensor_model_parallel_size. The gate
+            #     peel-off in SelfAttention.get_query_key_value_tensors runs
+            #     BEFORE the num_query_groups < world_size AllGather + reslice
+            #     fallback path; under that fallback
+            #     num_attention_heads_per_partition is inflated to
+            #     num_attention_heads / num_query_groups (the pre-AG count),
+            #     so the slice over-takes and pulls V/K rows in as gate rows.
+            #     Disallow the combination here.
+            if self.num_query_groups < self.tensor_model_parallel_size:
+                raise ValueError(
+                    f"use_head_wise_attn_gate requires num_query_groups "
+                    f"({self.num_query_groups}) >= tensor_model_parallel_size "
+                    f"({self.tensor_model_parallel_size}). The head-wise gate "
+                    f"peel-off runs before the num_query_groups < world_size "
+                    f"AllGather + reslice fallback; under that fallback the gate "
+                    f"slice would over-take and pick up V/K rows as gate rows."
+                )
 
         if self.linear_attention_type is not None:
             warnings.warn(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -298,7 +298,13 @@ class TransformerConfig(ModelParallelConfig):
     sub-tensors (analogous to apply_swiglu_sharded_factory). Requires
     num_attention_heads % tensor_model_parallel_size == 0 and
     num_query_groups >= tensor_model_parallel_size; both are validated in
-    __post_init__."""
+    __post_init__. Under fp8/fp4, the per-partition linear_qkv output dim
+    must additionally be a multiple of 16 (fp8) or 32 (fp4) for
+    Transformer Engine's GEMM alignment; this is validated in
+    __post_init__ too. attention_output_gate's wider gate (head_dim per
+    head) hits this alignment naturally; head_wise_attn_gate's tiny
+    num_attention_heads increment can mis-align, so users may need to
+    pick num_attention_heads / num_query_groups accordingly."""
 
     head_wise_attn_gate_init_weight_scale: float = 0.1
     """Multiplicative scale applied to the gate rows of linear_qkv.weight right
@@ -1426,6 +1432,44 @@ class TransformerConfig(ModelParallelConfig):
                     f"AllGather + reslice fallback; under that fallback the gate "
                     f"slice would over-take and pick up V/K rows as gate rows."
                 )
+            # (4) FP8 / FP4 GEMM alignment. Transformer Engine's FP8 GEMM
+            #     requires the per-partition output dim of linear_qkv to be
+            #     a multiple of 16 (FP4: 32). attention_output_gate adds
+            #     num_attention_heads * kv_channels rows, which is already
+            #     16-aligned for typical kv_channels (64/128); head_wise
+            #     adds only num_attention_heads rows -- a much smaller and
+            #     potentially mis-aligned increment. TE would either error
+            #     out or silently pad the weight (shifted outputs); reject
+            #     up front so this is caught at config-time, not at first
+            #     fp8 forward.
+            if self.fp8 is not None or self.fp4 is not None:
+                align = 32 if self.fp4 is not None else 16
+                # Mirror SelfAttention's linear_qkv_out_dim formula. Safe
+                # because checks (2)/(3) above already ensure the QKV and
+                # gate blocks each divide tensor_model_parallel_size cleanly.
+                linear_qkv_out_dim = (
+                    self.kv_channels * self.num_attention_heads
+                    + 2 * self.kv_channels * self.num_query_groups
+                    + self.num_attention_heads
+                )
+                per_partition = linear_qkv_out_dim // self.tensor_model_parallel_size
+                if per_partition % align != 0:
+                    fp_name = "fp4" if self.fp4 is not None else "fp8"
+                    raise ValueError(
+                        f"head_wise_attn_gate under {fp_name} requires the "
+                        f"per-partition linear_qkv output dim "
+                        f"({per_partition}) to be a multiple of {align} for "
+                        f"Transformer Engine's {fp_name.upper()} GEMM alignment. "
+                        f"Got num_attention_heads={self.num_attention_heads}, "
+                        f"num_query_groups={self.num_query_groups}, "
+                        f"kv_channels={self.kv_channels}, "
+                        f"tensor_model_parallel_size={self.tensor_model_parallel_size} "
+                        f"-> linear_qkv_out_dim={linear_qkv_out_dim}. "
+                        f"Pick num_attention_heads such that "
+                        f"(kv_channels*num_attention_heads + 2*kv_channels*"
+                        f"num_query_groups + num_attention_heads) / "
+                        f"tensor_model_parallel_size is divisible by {align}."
+                    )
 
         if self.linear_attention_type is not None:
             warnings.warn(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -263,6 +263,13 @@ class TransformerConfig(ModelParallelConfig):
     SelfAttention layer creates its own RotaryEmbedding with the corresponding base;
     the shared model-level rotary_pos_emb is not created."""
 
+    use_head_wise_attn_gate: bool = False
+    """Apply a per-head scalar output gate (e.g., Step-3.5-Flash g_proj).
+    The gate weights are fused into linear_qkv as the trailing
+    num_attention_heads rows; the sigmoid of those scalars gates each
+    attention head independently. Distinct from attention_output_gate,
+    which fuses a full head_dim gate into linear_qkv."""
+
     test_mode: bool = False
     """Whether to run real-time tests."""
 

--- a/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
+++ b/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
@@ -1,43 +1,8 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """End-to-end dist-ckpt regression test for head_wise_attn_gate.
 
-The forward path of SelfAttention peels the trailing
-num_attention_heads_per_partition rows off each rank's local linear_qkv tensor
-and treats them as per-head gate scalars. Default axis-0 sharding metadata
-({"weight": 0}) would re-balance the global (QKV_dim + H, hidden_size) tensor
-uniformly under a TP change, so the trailing rows on non-last new ranks land
-inside the QKV block -- silently turning V/K rows into gate scalars without a
-shape error. SelfAttention.sharded_state_dict installs a ShardedTensorFactory
-that registers QKV and gate as independent sub-tensors so each is resharded
-independently. These tests verify the fix by running save TP=N -> load TP=M
-and checking that the SelfAttention forward output is preserved up to
-numerical noise.
-
-Coverage matrix (this file):
-  - (src_tp, dst_tp) in (1->2) and (2->1).
-  - num_query_groups in (2, 4) at NUM_HEADS=4, exercising both GQA
-    (num_query_groups < num_attention_heads) and MHA
-    (num_query_groups == num_attention_heads).
-  - add_qkv_bias in (True, False), since the bias gate-row surgery in
-    SelfAttention.__init__ only fires when bias is present.
-
-Known unverified paths (acknowledged as follow-ups):
-
-  - context_parallel_size > 1: head_wise gate slicing happens BEFORE any
-    sequence-parallel / CP split (the slice is on the output-feature dim,
-    not the sequence dim), so it should compose, but no test pins it.
-  - fp8: linear_qkv shares a single tensor-level FP8 scale across the QKV
-    and gate sub-blocks. The init-time `head_wise_attn_gate_init_weight_scale`
-    default of 0.1 keeps the magnitudes within ~1 decade of QKV, but no
-    fp8 end-to-end run exists. set_save_original_input(self.linear_qkv)
-    interaction (selective recompute under fp8) is also un-tested.
-  - backward gradient flow to the gate rows: forward output equality
-    implies correct param values were loaded, but autograd through the
-    gate is not asserted explicitly. Easy to add but not done here.
-  - packed_seq_params.qkv_format == 'thd': core_attn_out is reshaped to
-    [t, 1, h] just before the gate is applied; the
-    `core_attn_out.view(*gate_states.shape[:3], -1)` chain composes with
-    that reshape, but no test runs the THD path.
+Parametrized over (src_tp, dst_tp) in {(1,2), (2,1)}, num_query_groups in
+{NUM_HEADS, NUM_HEADS//2} (MHA + GQA), and add_qkv_bias in {True, False}.
 """
 
 import pytest
@@ -53,10 +18,6 @@ from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 
 
-# Sized so that QKV_dim / gate boundary does NOT line up with uniform axis-0
-# splits at TP=2: with the default MHA case (num_query_groups=4), QKV_dim=96
-# and H=4, total=100; a naive reshard at TP=2 puts the boundary at row 50,
-# deep inside the QKV block.
 NUM_HEADS = 4
 HIDDEN_SIZE = 32
 SEQ_LEN = 4
@@ -72,8 +33,6 @@ def _make_config(num_query_groups: int, add_qkv_bias: bool) -> TransformerConfig
         num_query_groups=num_query_groups,
         use_cpu_initialization=True,
         params_dtype=torch.float32,
-        # Disable stochastic dropout so save/load forward pass is deterministic
-        # across the two TP configs.
         attention_dropout=0.0,
         hidden_dropout=0.0,
         add_qkv_bias=add_qkv_bias,
@@ -82,8 +41,6 @@ def _make_config(num_query_groups: int, add_qkv_bias: bool) -> TransformerConfig
 
 
 def _build_attention(seed: int, num_query_groups: int, add_qkv_bias: bool) -> SelfAttention:
-    """Build a SelfAttention layer with the local (non-TE) spec under the
-    currently-initialized model-parallel state."""
     model_parallel_cuda_manual_seed(seed)
     submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
     config = _make_config(num_query_groups=num_query_groups, add_qkv_bias=add_qkv_bias)
@@ -93,8 +50,6 @@ def _build_attention(seed: int, num_query_groups: int, add_qkv_bias: bool) -> Se
 
 
 def _fixed_input():
-    """Deterministic input shared across all ranks so different TP setups see
-    the same activations."""
     torch.manual_seed(INPUT_SEED)
     hidden_states = torch.randn(
         SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.float32, device="cuda"
@@ -104,58 +59,19 @@ def _fixed_input():
 
 
 class TestHeadWiseAttnGateTPResharding:
-    """Regression test for apply_head_wise_attn_gate_sharded_factory."""
 
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
 
     @pytest.mark.parametrize("src_tp,dst_tp", [(1, 2), (2, 1)])
-    @pytest.mark.parametrize(
-        "num_query_groups",
-        [
-            # MHA: gate rows aligned 1:1 with q heads, both = NUM_HEADS.
-            NUM_HEADS,
-            # GQA: 2 q heads per group; gate rows still 1:1 with q heads,
-            # but the QKV layout per group is heavier (q1 q2 k v) so the
-            # uniform-reshard boundary lands in different sub-block
-            # positions than MHA.
-            NUM_HEADS // 2,
-        ],
-    )
+    @pytest.mark.parametrize("num_query_groups", [NUM_HEADS, NUM_HEADS // 2])
     @pytest.mark.parametrize("add_qkv_bias", [False, True])
     def test_logits_equality_across_tp_reshard(
-        self,
-        tmp_path_dist_ckpt,
-        src_tp,
-        dst_tp,
-        num_query_groups,
-        add_qkv_bias,
+        self, tmp_path_dist_ckpt, src_tp, dst_tp, num_query_groups, add_qkv_bias
     ):
-        """Save at src_tp, load at dst_tp, verify SelfAttention's forward
-        output matches the source run up to numerical noise. Parametrized
-        over reshard direction, num_query_groups (MHA / GQA), and bias
-        presence, since:
-
-          - GQA changes the per-group QKV layout (q-block size) but not the
-            gate-row count, so the resharding factory must split at the
-            correct global axis even when QKV/gate ratios differ from MHA.
-          - add_qkv_bias=True exercises the linear_qkv.bias factory path
-            (1D tensor, separate from weight) AND the init-time bias-row
-            surgery (head_wise_attn_gate_init_bias=2.0), so a buggy
-            resharding of the bias would break sigmoid(gate) at the load
-            side.
-
-        SelfAttention.forward's output is replicated across the TP group
-        (linear_proj is RowParallelLinear and all-reduces), so rank 0's
-        output on both sides is directly comparable.
-        """
         if Utils.world_size < max(src_tp, dst_tp):
-            pytest.skip(
-                f"need world_size >= {max(src_tp, dst_tp)} "
-                f"(got {Utils.world_size})"
-            )
+            pytest.skip(f"need world_size >= {max(src_tp, dst_tp)}")
 
-        # ---- Phase 1: build at src_tp, forward, save ----
         Utils.initialize_model_parallel(src_tp, 1)
         attn_src = _build_attention(
             seed=123, num_query_groups=num_query_groups, add_qkv_bias=add_qkv_bias
@@ -164,7 +80,6 @@ class TestHeadWiseAttnGateTPResharding:
         hidden_states, attention_mask = _fixed_input()
         with torch.no_grad():
             output_src, _ = attn_src(hidden_states, attention_mask)
-        # Stash to CPU so it survives parallel-state teardown.
         output_src_cpu = output_src.detach().to(torch.float32).cpu()
 
         ckpt_tag = (
@@ -176,10 +91,7 @@ class TestHeadWiseAttnGateTPResharding:
             del attn_src
             Utils.destroy_model_parallel()
 
-            # ---- Phase 2: re-init at dst_tp, load ckpt, forward ----
             Utils.initialize_model_parallel(dst_tp, 1)
-            # Different init seed so the post-load weights only match if the
-            # dist-ckpt load actually populates them.
             attn_dst = _build_attention(
                 seed=999, num_query_groups=num_query_groups, add_qkv_bias=add_qkv_bias
             )
@@ -188,8 +100,6 @@ class TestHeadWiseAttnGateTPResharding:
                 ckpt_dir,
                 strict=StrictHandling.RETURN_ALL,
             )
-            # Any mismatches should only be TE-style _extra_state entries; the
-            # local backend doesn't have any, but assert defensively.
             assert all('_extra_state' in k for k in missing_keys), missing_keys
             assert all('_extra_state' in k for k in unexpected_keys), unexpected_keys
             attn_dst.load_state_dict(state_dict)
@@ -199,8 +109,6 @@ class TestHeadWiseAttnGateTPResharding:
                 output_dst, _ = attn_dst(hidden_states, attention_mask)
             output_dst_cpu = output_dst.detach().to(torch.float32).cpu()
 
-        # Output is identical on every TP rank post-AllReduce; compare on
-        # rank 0 to avoid duplicate work.
         if torch.distributed.get_rank() == 0:
             torch.testing.assert_close(
                 output_dst_cpu, output_src_cpu, atol=1e-4, rtol=1e-4

--- a/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
+++ b/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
@@ -9,9 +9,35 @@ uniformly under a TP change, so the trailing rows on non-last new ranks land
 inside the QKV block -- silently turning V/K rows into gate scalars without a
 shape error. SelfAttention.sharded_state_dict installs a ShardedTensorFactory
 that registers QKV and gate as independent sub-tensors so each is resharded
-independently. This test verifies the fix by running save TP=N -> load TP=M
-and checking the SelfAttention forward output is preserved up to numerical
-noise.
+independently. These tests verify the fix by running save TP=N -> load TP=M
+and checking that the SelfAttention forward output is preserved up to
+numerical noise.
+
+Coverage matrix (this file):
+  - (src_tp, dst_tp) in (1->2) and (2->1).
+  - num_query_groups in (2, 4) at NUM_HEADS=4, exercising both GQA
+    (num_query_groups < num_attention_heads) and MHA
+    (num_query_groups == num_attention_heads).
+  - add_qkv_bias in (True, False), since the bias gate-row surgery in
+    SelfAttention.__init__ only fires when bias is present.
+
+Known unverified paths (acknowledged as follow-ups):
+
+  - context_parallel_size > 1: head_wise gate slicing happens BEFORE any
+    sequence-parallel / CP split (the slice is on the output-feature dim,
+    not the sequence dim), so it should compose, but no test pins it.
+  - fp8: linear_qkv shares a single tensor-level FP8 scale across the QKV
+    and gate sub-blocks. The init-time `head_wise_attn_gate_init_weight_scale`
+    default of 0.1 keeps the magnitudes within ~1 decade of QKV, but no
+    fp8 end-to-end run exists. set_save_original_input(self.linear_qkv)
+    interaction (selective recompute under fp8) is also un-tested.
+  - backward gradient flow to the gate rows: forward output equality
+    implies correct param values were loaded, but autograd through the
+    gate is not asserted explicitly. Easy to add but not done here.
+  - packed_seq_params.qkv_format == 'thd': core_attn_out is reshaped to
+    [t, 1, h] just before the gate is applied; the
+    `core_attn_out.view(*gate_states.shape[:3], -1)` chain composes with
+    that reshape, but no test runs the THD path.
 """
 
 import pytest
@@ -28,8 +54,9 @@ from tests.unit_tests.test_utilities import Utils
 
 
 # Sized so that QKV_dim / gate boundary does NOT line up with uniform axis-0
-# splits at TP=2: head_dim=8, QKV_dim=3*4*8=96, H=4, total=100. Naive uniform
-# reshard at TP=2 puts the boundary at row 50, deep inside the QKV block.
+# splits at TP=2: with the default MHA case (num_query_groups=4), QKV_dim=96
+# and H=4, total=100; a naive reshard at TP=2 puts the boundary at row 50,
+# deep inside the QKV block.
 NUM_HEADS = 4
 HIDDEN_SIZE = 32
 SEQ_LEN = 4
@@ -37,27 +64,30 @@ BATCH_SIZE = 2
 INPUT_SEED = 7
 
 
-def _make_config() -> TransformerConfig:
+def _make_config(num_query_groups: int, add_qkv_bias: bool) -> TransformerConfig:
     return TransformerConfig(
         num_layers=1,
         hidden_size=HIDDEN_SIZE,
         num_attention_heads=NUM_HEADS,
+        num_query_groups=num_query_groups,
         use_cpu_initialization=True,
         params_dtype=torch.float32,
         # Disable stochastic dropout so save/load forward pass is deterministic
         # across the two TP configs.
         attention_dropout=0.0,
         hidden_dropout=0.0,
+        add_qkv_bias=add_qkv_bias,
         head_wise_attn_gate=True,
     )
 
 
-def _build_attention(seed: int) -> SelfAttention:
+def _build_attention(seed: int, num_query_groups: int, add_qkv_bias: bool) -> SelfAttention:
     """Build a SelfAttention layer with the local (non-TE) spec under the
     currently-initialized model-parallel state."""
     model_parallel_cuda_manual_seed(seed)
     submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
-    attn = SelfAttention(_make_config(), submodules, layer_number=1).cuda()
+    config = _make_config(num_query_groups=num_query_groups, add_qkv_bias=add_qkv_bias)
+    attn = SelfAttention(config, submodules, layer_number=1).cuda()
     attn.eval()
     return attn
 
@@ -80,13 +110,42 @@ class TestHeadWiseAttnGateTPResharding:
         Utils.destroy_model_parallel()
 
     @pytest.mark.parametrize("src_tp,dst_tp", [(1, 2), (2, 1)])
+    @pytest.mark.parametrize(
+        "num_query_groups",
+        [
+            # MHA: gate rows aligned 1:1 with q heads, both = NUM_HEADS.
+            NUM_HEADS,
+            # GQA: 2 q heads per group; gate rows still 1:1 with q heads,
+            # but the QKV layout per group is heavier (q1 q2 k v) so the
+            # uniform-reshard boundary lands in different sub-block
+            # positions than MHA.
+            NUM_HEADS // 2,
+        ],
+    )
+    @pytest.mark.parametrize("add_qkv_bias", [False, True])
     def test_logits_equality_across_tp_reshard(
-        self, tmp_path_dist_ckpt, src_tp, dst_tp
+        self,
+        tmp_path_dist_ckpt,
+        src_tp,
+        dst_tp,
+        num_query_groups,
+        add_qkv_bias,
     ):
         """Save at src_tp, load at dst_tp, verify SelfAttention's forward
-        output matches the source run up to numerical noise.
+        output matches the source run up to numerical noise. Parametrized
+        over reshard direction, num_query_groups (MHA / GQA), and bias
+        presence, since:
 
-        The output of SelfAttention.forward is replicated across the TP group
+          - GQA changes the per-group QKV layout (q-block size) but not the
+            gate-row count, so the resharding factory must split at the
+            correct global axis even when QKV/gate ratios differ from MHA.
+          - add_qkv_bias=True exercises the linear_qkv.bias factory path
+            (1D tensor, separate from weight) AND the init-time bias-row
+            surgery (head_wise_attn_gate_init_bias=2.0), so a buggy
+            resharding of the bias would break sigmoid(gate) at the load
+            side.
+
+        SelfAttention.forward's output is replicated across the TP group
         (linear_proj is RowParallelLinear and all-reduces), so rank 0's
         output on both sides is directly comparable.
         """
@@ -98,7 +157,9 @@ class TestHeadWiseAttnGateTPResharding:
 
         # ---- Phase 1: build at src_tp, forward, save ----
         Utils.initialize_model_parallel(src_tp, 1)
-        attn_src = _build_attention(seed=123)
+        attn_src = _build_attention(
+            seed=123, num_query_groups=num_query_groups, add_qkv_bias=add_qkv_bias
+        )
 
         hidden_states, attention_mask = _fixed_input()
         with torch.no_grad():
@@ -106,9 +167,11 @@ class TestHeadWiseAttnGateTPResharding:
         # Stash to CPU so it survives parallel-state teardown.
         output_src_cpu = output_src.detach().to(torch.float32).cpu()
 
-        with TempNamedDir(
-            tmp_path_dist_ckpt / f"head_wise_gate_tp{src_tp}_to_tp{dst_tp}"
-        ) as ckpt_dir:
+        ckpt_tag = (
+            f"head_wise_gate_tp{src_tp}_to_tp{dst_tp}"
+            f"_g{num_query_groups}_bias{int(add_qkv_bias)}"
+        )
+        with TempNamedDir(tmp_path_dist_ckpt / ckpt_tag) as ckpt_dir:
             save(attn_src.sharded_state_dict(prefix=""), ckpt_dir)
             del attn_src
             Utils.destroy_model_parallel()
@@ -117,7 +180,9 @@ class TestHeadWiseAttnGateTPResharding:
             Utils.initialize_model_parallel(dst_tp, 1)
             # Different init seed so the post-load weights only match if the
             # dist-ckpt load actually populates them.
-            attn_dst = _build_attention(seed=999)
+            attn_dst = _build_attention(
+                seed=999, num_query_groups=num_query_groups, add_qkv_bias=add_qkv_bias
+            )
             state_dict, missing_keys, unexpected_keys = load(
                 attn_dst.sharded_state_dict(prefix=""),
                 ckpt_dir,

--- a/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
+++ b/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""End-to-end dist-ckpt regression test for use_head_wise_attn_gate.
+
+The forward path of SelfAttention peels the trailing
+num_attention_heads_per_partition rows off each rank's local linear_qkv tensor
+and treats them as per-head gate scalars. Default axis-0 sharding metadata
+({"weight": 0}) would re-balance the global (QKV_dim + H, hidden_size) tensor
+uniformly under a TP change, so the trailing rows on non-last new ranks land
+inside the QKV block -- silently turning V/K rows into gate scalars without a
+shape error. SelfAttention.sharded_state_dict installs a ShardedTensorFactory
+that registers QKV and gate as independent sub-tensors so each is resharded
+independently. This test verifies the fix by running save TP=N -> load TP=M
+and checking the SelfAttention forward output is preserved up to numerical
+noise.
+"""
+
+import pytest
+import torch
+
+from megatron.core.dist_checkpointing import load, save
+from megatron.core.dist_checkpointing.validation import StrictHandling
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.attention import SelfAttention
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.dist_checkpointing import TempNamedDir
+from tests.unit_tests.test_utilities import Utils
+
+
+# Sized so that QKV_dim / gate boundary does NOT line up with uniform axis-0
+# splits at TP=2: head_dim=8, QKV_dim=3*4*8=96, H=4, total=100. Naive uniform
+# reshard at TP=2 puts the boundary at row 50, deep inside the QKV block.
+NUM_HEADS = 4
+HIDDEN_SIZE = 32
+SEQ_LEN = 4
+BATCH_SIZE = 2
+INPUT_SEED = 7
+
+
+def _make_config() -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=HIDDEN_SIZE,
+        num_attention_heads=NUM_HEADS,
+        use_cpu_initialization=True,
+        params_dtype=torch.float32,
+        # Disable stochastic dropout so save/load forward pass is deterministic
+        # across the two TP configs.
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        use_head_wise_attn_gate=True,
+    )
+
+
+def _build_attention(seed: int) -> SelfAttention:
+    """Build a SelfAttention layer with the local (non-TE) spec under the
+    currently-initialized model-parallel state."""
+    model_parallel_cuda_manual_seed(seed)
+    submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
+    attn = SelfAttention(_make_config(), submodules, layer_number=1).cuda()
+    attn.eval()
+    return attn
+
+
+def _fixed_input():
+    """Deterministic input shared across all ranks so different TP setups see
+    the same activations."""
+    torch.manual_seed(INPUT_SEED)
+    hidden_states = torch.randn(
+        SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.float32, device="cuda"
+    )
+    attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+    return hidden_states, attention_mask
+
+
+class TestHeadWiseAttnGateTPResharding:
+    """Regression test for apply_head_wise_attn_gate_sharded_factory."""
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("src_tp,dst_tp", [(1, 2), (2, 1)])
+    def test_logits_equality_across_tp_reshard(
+        self, tmp_path_dist_ckpt, src_tp, dst_tp
+    ):
+        """Save at src_tp, load at dst_tp, verify SelfAttention's forward
+        output matches the source run up to numerical noise.
+
+        The output of SelfAttention.forward is replicated across the TP group
+        (linear_proj is RowParallelLinear and all-reduces), so rank 0's
+        output on both sides is directly comparable.
+        """
+        if Utils.world_size < max(src_tp, dst_tp):
+            pytest.skip(
+                f"need world_size >= {max(src_tp, dst_tp)} "
+                f"(got {Utils.world_size})"
+            )
+
+        # ---- Phase 1: build at src_tp, forward, save ----
+        Utils.initialize_model_parallel(src_tp, 1)
+        attn_src = _build_attention(seed=123)
+
+        hidden_states, attention_mask = _fixed_input()
+        with torch.no_grad():
+            output_src, _ = attn_src(hidden_states, attention_mask)
+        # Stash to CPU so it survives parallel-state teardown.
+        output_src_cpu = output_src.detach().to(torch.float32).cpu()
+
+        with TempNamedDir(
+            tmp_path_dist_ckpt / f"head_wise_gate_tp{src_tp}_to_tp{dst_tp}"
+        ) as ckpt_dir:
+            save(attn_src.sharded_state_dict(prefix=""), ckpt_dir)
+            del attn_src
+            Utils.destroy_model_parallel()
+
+            # ---- Phase 2: re-init at dst_tp, load ckpt, forward ----
+            Utils.initialize_model_parallel(dst_tp, 1)
+            # Different init seed so the post-load weights only match if the
+            # dist-ckpt load actually populates them.
+            attn_dst = _build_attention(seed=999)
+            state_dict, missing_keys, unexpected_keys = load(
+                attn_dst.sharded_state_dict(prefix=""),
+                ckpt_dir,
+                strict=StrictHandling.RETURN_ALL,
+            )
+            # Any mismatches should only be TE-style _extra_state entries; the
+            # local backend doesn't have any, but assert defensively.
+            assert all('_extra_state' in k for k in missing_keys), missing_keys
+            assert all('_extra_state' in k for k in unexpected_keys), unexpected_keys
+            attn_dst.load_state_dict(state_dict)
+
+            hidden_states, attention_mask = _fixed_input()
+            with torch.no_grad():
+                output_dst, _ = attn_dst(hidden_states, attention_mask)
+            output_dst_cpu = output_dst.detach().to(torch.float32).cpu()
+
+        # Output is identical on every TP rank post-AllReduce; compare on
+        # rank 0 to avoid duplicate work.
+        if torch.distributed.get_rank() == 0:
+            torch.testing.assert_close(
+                output_dst_cpu, output_src_cpu, atol=1e-4, rtol=1e-4
+            )

--- a/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
+++ b/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""End-to-end dist-ckpt regression test for use_head_wise_attn_gate.
+"""End-to-end dist-ckpt regression test for head_wise_attn_gate.
 
 The forward path of SelfAttention peels the trailing
 num_attention_heads_per_partition rows off each rank's local linear_qkv tensor
@@ -48,7 +48,7 @@ def _make_config() -> TransformerConfig:
         # across the two TP configs.
         attention_dropout=0.0,
         hidden_dropout=0.0,
-        use_head_wise_attn_gate=True,
+        head_wise_attn_gate=True,
     )
 
 

--- a/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
+++ b/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
@@ -17,7 +17,6 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 
-
 NUM_HEADS = 4
 HIDDEN_SIZE = 32
 SEQ_LEN = 4

--- a/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
+++ b/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
@@ -96,9 +96,7 @@ class TestHeadWiseAttnGateTPResharding:
                 seed=999, num_query_groups=num_query_groups, add_qkv_bias=add_qkv_bias
             )
             state_dict, missing_keys, unexpected_keys = load(
-                attn_dst.sharded_state_dict(prefix=""),
-                ckpt_dir,
-                strict=StrictHandling.RETURN_ALL,
+                attn_dst.sharded_state_dict(prefix=""), ckpt_dir, strict=StrictHandling.RETURN_ALL
             )
             assert all('_extra_state' in k for k in missing_keys), missing_keys
             assert all('_extra_state' in k for k in unexpected_keys), unexpected_keys
@@ -110,6 +108,4 @@ class TestHeadWiseAttnGateTPResharding:
             output_dst_cpu = output_dst.detach().to(torch.float32).cpu()
 
         if torch.distributed.get_rank() == 0:
-            torch.testing.assert_close(
-                output_dst_cpu, output_src_cpu, atol=1e-4, rtol=1e-4
-            )
+            torch.testing.assert_close(output_dst_cpu, output_src_cpu, atol=1e-4, rtol=1e-4)

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -338,8 +338,6 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "moe_single_grouped_weight": False,
     "moe_single_grouped_bias": False,
     "head_wise_attn_gate": False,
-    "head_wise_attn_gate_init_weight_scale": 0.1,
-    "head_wise_attn_gate_init_bias": 2.0,
 }
 # Fields to ignore entirely (ephemeral, environment-specific, very large).
 SKIP_FIELDS = set()

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -337,6 +337,9 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "use_transformer_engine_op_fuser": False,
     "moe_single_grouped_weight": False,
     "moe_single_grouped_bias": False,
+    "head_wise_attn_gate": False,
+    "head_wise_attn_gate_init_weight_scale": 0.1,
+    "head_wise_attn_gate_init_bias": 2.0,
 }
 # Fields to ignore entirely (ephemeral, environment-specific, very large).
 SKIP_FIELDS = set()

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -174,36 +174,6 @@ class TestHeadWiseAttnGateForward:
         output, _ = attn(hidden_states, attention_mask)
         assert output.shape == (SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE)
 
-    def test_zero_gate_halves_output(self):
-        """Zero gate rows -> sigmoid(0)=0.5 -> output = 0.5 * no-gate ref."""
-        config = _make_config(self.transformer_impl, head_wise_attn_gate=True)
-        attn = _make_attention(config, self.transformer_impl).cuda()
-        with torch.no_grad():
-            attn.linear_qkv.weight[-NUM_HEADS:].zero_()
-
-        hidden_states = torch.randn(
-            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.bfloat16, device="cuda"
-        )
-        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
-
-        config_no_gate = _make_config(self.transformer_impl, head_wise_attn_gate=False)
-        attn_no_gate = _make_attention(config_no_gate, self.transformer_impl).cuda()
-        with torch.no_grad():
-            attn_no_gate.linear_qkv.weight.copy_(attn.linear_qkv.weight[:QKV_OUT_DIM])
-            attn_no_gate.linear_proj.weight.copy_(attn.linear_proj.weight)
-            if attn.linear_qkv.bias is not None:
-                attn_no_gate.linear_qkv.bias.copy_(attn.linear_qkv.bias[:QKV_OUT_DIM])
-            if attn.linear_proj.bias is not None:
-                attn_no_gate.linear_proj.bias.copy_(attn.linear_proj.bias)
-
-        with torch.no_grad():
-            out_gated, _ = attn(hidden_states, attention_mask)
-            out_plain, _ = attn_no_gate(hidden_states, attention_mask)
-
-        torch.testing.assert_close(
-            out_gated.float(), (out_plain * 0.5).float(), atol=1e-2, rtol=1e-2
-        )
-
 
 def _make_config_tp(
     head_wise_attn_gate: bool, add_qkv_bias: bool = False, **extra: object

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -175,14 +175,8 @@ class TestHeadWiseAttnGateForward:
         assert output.shape == (SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE)
 
 
-def _make_config_tp(
-    head_wise_attn_gate: bool, add_qkv_bias: bool = False, **extra: object
-) -> TransformerConfig:
-    """Float32 config for TP correctness tests; local-spec backend, no dropout.
-
-    Extra TransformerConfig kwargs (e.g. head_wise_attn_gate_init_*) can be
-    passed through ``extra``.
-    """
+def _make_config_tp(head_wise_attn_gate: bool, add_qkv_bias: bool = False) -> TransformerConfig:
+    """Float32 config for TP correctness tests; local-spec backend, no dropout"""
     return TransformerConfig(
         num_layers=1,
         hidden_size=HIDDEN_SIZE,
@@ -193,7 +187,6 @@ def _make_config_tp(
         hidden_dropout=0.0,
         add_qkv_bias=add_qkv_bias,
         head_wise_attn_gate=head_wise_attn_gate,
-        **extra,
     )
 
 
@@ -261,63 +254,3 @@ class TestHeadWiseAttnGateUnderTP2:
             out_plain, _ = attn_ref(hidden_states, attention_mask)
 
         torch.testing.assert_close(out_gated, out_plain * expected_scale, atol=1e-4, rtol=1e-4)
-
-
-class TestHeadWiseAttnGateInitMagnitude:
-    """Init-time gate-row surgery: near-identity at start, knob propagation, FP8 safety."""
-
-    @pytest.fixture(autouse=True)
-    def setup_teardown(self):
-        Utils.initialize_model_parallel(1, 1)
-        model_parallel_cuda_manual_seed(42)
-        yield
-        Utils.destroy_model_parallel()
-
-    def _run_pair(self, gated_config: TransformerConfig) -> tuple[torch.Tensor, torch.Tensor]:
-        attn = _make_attention_local(gated_config)
-        ref_config = _make_config_tp(head_wise_attn_gate=False, add_qkv_bias=True)
-        attn_ref = _make_attention_local(ref_config)
-        _copy_qkv_block_only(attn_ref, attn)
-
-        torch.manual_seed(0)
-        hidden_states = torch.randn(
-            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.float32, device="cuda"
-        )
-        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
-        with torch.no_grad():
-            out_gated, _ = attn(hidden_states, attention_mask)
-            out_plain, _ = attn_ref(hidden_states, attention_mask)
-        return out_gated, out_plain
-
-    def test_default_init_is_near_identity(self):
-        """out_gated ~= sigmoid(2.0) * out_plain at init; closer than 0.5 *
-        out_plain (catches regressions that drop the init surgery)."""
-        gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
-        out_gated, out_plain = self._run_pair(gated_config)
-        expected_scale = torch.sigmoid(
-            torch.tensor(gated_config.head_wise_attn_gate_init_bias)
-        ).item()
-        torch.testing.assert_close(out_gated, out_plain * expected_scale, atol=5e-2, rtol=5e-2)
-        near_id_err = (out_gated - out_plain * expected_scale).abs().mean().item()
-        half_err = (out_gated - out_plain * 0.5).abs().mean().item()
-        assert near_id_err < half_err
-
-    def test_init_knobs_reproduce_half_scaling(self):
-        """Both knobs=0 reproduces sigmoid(0)=0.5 -- proves the knobs flow."""
-        gated_config = _make_config_tp(
-            head_wise_attn_gate=True,
-            add_qkv_bias=True,
-            head_wise_attn_gate_init_weight_scale=0.0,
-            head_wise_attn_gate_init_bias=0.0,
-        )
-        out_gated, out_plain = self._run_pair(gated_config)
-        torch.testing.assert_close(out_gated, out_plain * 0.5, atol=1e-4, rtol=1e-4)
-
-    def test_init_preserves_fp8_friendly_gate_magnitude(self):
-        """gate_std ~ 0.1 * qkv_std (no zero-init, no FP8 underflow risk)."""
-        gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
-        attn = _make_attention_local(gated_config)
-        gate_rows = attn.linear_qkv.weight[-attn.num_attention_heads_per_partition :]
-        qkv_rows = attn.linear_qkv.weight[: -attn.num_attention_heads_per_partition]
-        ratio = gate_rows.float().std().item() / qkv_rows.float().std().item()
-        assert 0.05 < ratio < 0.5

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -18,7 +18,6 @@ from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.attention import SelfAttention
 from tests.unit_tests.test_utilities import Utils
 
-
 SEQ_LEN = 16
 BATCH_SIZE = 2
 HIDDEN_SIZE = 128

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Tests for per-head scalar attention gate (use_head_wise_attn_gate).
+
+The gate weights are fused into linear_qkv as the trailing num_attention_heads
+rows; in the forward pass those scalars are sliced out, passed through sigmoid,
+and used to scale each attention head's output independently.
+"""
+
+import pytest
+import torch
+
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_local_spec,
+    get_gpt_layer_with_transformer_engine_submodules,
+)
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.attention import SelfAttention
+from tests.unit_tests.test_utilities import Utils
+
+
+SEQ_LEN = 16
+BATCH_SIZE = 2
+HIDDEN_SIZE = 128
+NUM_HEADS = 4
+KV_CHANNELS = HIDDEN_SIZE // NUM_HEADS  # 32
+QKV_OUT_DIM = 3 * NUM_HEADS * KV_CHANNELS  # query + key + value, no GQA
+
+
+def _make_config(transformer_impl: str, use_head_wise_attn_gate: bool) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=HIDDEN_SIZE,
+        num_attention_heads=NUM_HEADS,
+        use_cpu_initialization=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        transformer_impl=transformer_impl,
+        use_head_wise_attn_gate=use_head_wise_attn_gate,
+    )
+
+
+def _make_attention(config: TransformerConfig, transformer_impl: str) -> SelfAttention:
+    if transformer_impl == "transformer_engine":
+        submodules = get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules
+    else:
+        submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
+    return SelfAttention(config, submodules, layer_number=1)
+
+
+@pytest.mark.parametrize("transformer_impl", ["transformer_engine", "native"])
+class TestHeadWiseAttnGateInit:
+    """Verify linear_qkv is sized to include the fused gate rows iff enabled."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self, transformer_impl):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(42)
+        self.transformer_impl = transformer_impl
+        yield
+        Utils.destroy_model_parallel()
+
+    def test_linear_qkv_includes_gate_rows_when_enabled(self):
+        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=True)
+        attn = _make_attention(config, self.transformer_impl)
+        # linear_qkv output dim = Q+K+V + num_attention_heads (gate rows).
+        assert attn.linear_qkv_out_dim == QKV_OUT_DIM + NUM_HEADS
+        assert attn.linear_qkv.weight.shape == (
+            QKV_OUT_DIM + NUM_HEADS,
+            HIDDEN_SIZE,
+        )
+
+    def test_linear_qkv_unchanged_when_disabled(self):
+        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=False)
+        attn = _make_attention(config, self.transformer_impl)
+        assert attn.linear_qkv_out_dim == QKV_OUT_DIM
+        assert attn.linear_qkv.weight.shape == (QKV_OUT_DIM, HIDDEN_SIZE)
+
+    def test_gate_buffer_initialized_to_none(self):
+        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=True)
+        attn = _make_attention(config, self.transformer_impl)
+        assert attn._head_wise_gate_states is None
+
+
+@pytest.mark.parametrize("transformer_impl", ["transformer_engine", "native"])
+class TestHeadWiseAttnGateForward:
+    """Verify forward-pass behaviour of the head-wise gate."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self, transformer_impl):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(42)
+        self.transformer_impl = transformer_impl
+        yield
+        Utils.destroy_model_parallel()
+
+    def _run_forward(self, use_gate: bool):
+        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=use_gate)
+        attn = _make_attention(config, self.transformer_impl).cuda()
+        hidden_states = torch.randn(
+            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.bfloat16, device="cuda"
+        )
+        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+        output, bias = attn(hidden_states, attention_mask)
+        return output, bias
+
+    def test_output_shape_with_gate(self):
+        output, _ = self._run_forward(use_gate=True)
+        assert output.shape == (SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE)
+
+    def test_output_shape_without_gate(self):
+        output, _ = self._run_forward(use_gate=False)
+        assert output.shape == (SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE)
+
+    def test_gate_buffer_cleared_after_forward(self):
+        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=True)
+        attn = _make_attention(config, self.transformer_impl).cuda()
+        hidden_states = torch.randn(
+            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.bfloat16, device="cuda"
+        )
+        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+        _ = attn(hidden_states, attention_mask)
+        assert attn._head_wise_gate_states is None
+
+    def test_zero_gate_halves_output(self):
+        """Zeroing the trailing gate rows of linear_qkv makes pre-sigmoid 0,
+        so the sigmoid is exactly 0.5 and the gated output is half the
+        ungated reference output that shares all other weights."""
+        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=True)
+        attn = _make_attention(config, self.transformer_impl).cuda()
+
+        # Zero only the trailing num_attention_heads rows (the gate weights);
+        # leave QKV weights intact so the rest of the computation is unchanged.
+        with torch.no_grad():
+            attn.linear_qkv.weight[-NUM_HEADS:].zero_()
+
+        hidden_states = torch.randn(
+            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.bfloat16, device="cuda"
+        )
+        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+
+        # Reference: a gate-disabled attention layer that shares the QKV rows.
+        config_no_gate = _make_config(self.transformer_impl, use_head_wise_attn_gate=False)
+        attn_no_gate = _make_attention(config_no_gate, self.transformer_impl).cuda()
+        with torch.no_grad():
+            attn_no_gate.linear_qkv.weight.copy_(attn.linear_qkv.weight[:QKV_OUT_DIM])
+            attn_no_gate.linear_proj.weight.copy_(attn.linear_proj.weight)
+            if attn.linear_qkv.bias is not None:
+                attn_no_gate.linear_qkv.bias.copy_(attn.linear_qkv.bias[:QKV_OUT_DIM])
+            if attn.linear_proj.bias is not None:
+                attn_no_gate.linear_proj.bias.copy_(attn.linear_proj.bias)
+
+        with torch.no_grad():
+            out_gated, _ = attn(hidden_states, attention_mask)
+            out_plain, _ = attn_no_gate(hidden_states, attention_mask)
+
+        torch.testing.assert_close(
+            out_gated.float(),
+            (out_plain * 0.5).float(),
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+
+class TestHeadWiseAttnGateNumerics:
+    """Low-level tensor-math tests (no model-parallel overhead, pure PyTorch)."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        Utils.initialize_model_parallel(1, 1)
+        yield
+        Utils.destroy_model_parallel()
+
+    def test_gate_reshape_correctness(self):
+        """Replicate the reshape logic and verify sigmoid is applied per-head."""
+        sq, b, np, hn = 4, 2, NUM_HEADS, 32
+        # Simulate core_attn_out: [sq, b, np*hn]
+        core_attn_out = torch.arange(
+            sq * b * np * hn, dtype=torch.float32
+        ).reshape(sq, b, np * hn)
+        # Simulate gate_states: [sq, b, np] (pre-sigmoid raw scores)
+        gate_scores = torch.zeros(sq, b, np)  # sigmoid(0) = 0.5
+
+        gate_states = gate_scores.view(sq, b, np, 1)
+        out = core_attn_out.view(sq, b, np, hn)
+        out = out * torch.sigmoid(gate_states)
+        out = out.view(sq, b, np * hn)
+
+        expected = core_attn_out * 0.5
+        torch.testing.assert_close(out, expected)
+
+    def test_gate_dtype_cast(self):
+        """Gate computation upcast to float32, result cast back to input dtype."""
+        sq, b, np, hn = 4, 2, NUM_HEADS, 32
+        core_attn_out = torch.randn(sq, b, np * hn, dtype=torch.bfloat16)
+        gate_scores = torch.randn(sq, b, np, dtype=torch.bfloat16)
+
+        gate_states = gate_scores.view(sq, b, np, 1)
+        out = core_attn_out.view(sq, b, np, hn)
+        # Mirrors the production code: float cast for sigmoid, then cast back
+        out = out * torch.sigmoid(gate_states.float()).to(out.dtype)
+        out = out.view(sq, b, np * hn)
+
+        assert out.dtype == torch.bfloat16
+
+    @pytest.mark.parametrize("gate_value,expected_scale", [(-1e6, 0.0), (1e6, 1.0), (0.0, 0.5)])
+    def test_gate_saturation(self, gate_value: float, expected_scale: float):
+        """Extreme gate values saturate sigmoid to 0 or 1; midpoint gives 0.5."""
+        sq, b, np, hn = 2, 1, 2, 8
+        core_attn_out = torch.ones(sq, b, np * hn)
+        gate_scores = torch.full((sq, b, np), gate_value)
+
+        gate_states = gate_scores.view(sq, b, np, 1)
+        out = core_attn_out.view(sq, b, np, hn)
+        out = out * torch.sigmoid(gate_states.float()).to(out.dtype)
+        out = out.view(sq, b, np * hn)
+
+        torch.testing.assert_close(out, torch.full_like(out, expected_scale), atol=1e-5, rtol=1e-5)

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -142,10 +142,7 @@ class TestHeadWiseAttnGateInit:
         attn = _make_attention(config, self.transformer_impl)
         # linear_qkv output dim = Q+K+V + num_attention_heads (gate rows).
         assert attn.linear_qkv_out_dim == QKV_OUT_DIM + NUM_HEADS
-        assert attn.linear_qkv.weight.shape == (
-            QKV_OUT_DIM + NUM_HEADS,
-            HIDDEN_SIZE,
-        )
+        assert attn.linear_qkv.weight.shape == (QKV_OUT_DIM + NUM_HEADS, HIDDEN_SIZE)
 
     def test_linear_qkv_unchanged_when_disabled(self):
         config = _make_config(self.transformer_impl, head_wise_attn_gate=False)
@@ -208,12 +205,8 @@ class TestHeadWiseAttnGateForward:
         )
 
 
-
-
 def _make_config_tp(
-    head_wise_attn_gate: bool,
-    add_qkv_bias: bool = False,
-    **extra: object,
+    head_wise_attn_gate: bool, add_qkv_bias: bool = False, **extra: object
 ) -> TransformerConfig:
     """Float32 config for TP correctness tests; local-spec backend, no dropout.
 
@@ -264,15 +257,14 @@ class TestHeadWiseAttnGateUnderTP2:
     def setup_teardown(self):
         if Utils.world_size < 2:
             pytest.skip(f"need world_size >= 2 (got {Utils.world_size})")
-        Utils.initialize_model_parallel(tensor_model_parallel_size=2, pipeline_model_parallel_size=1)
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=2, pipeline_model_parallel_size=1
+        )
         model_parallel_cuda_manual_seed(42)
         yield
         Utils.destroy_model_parallel()
 
-    @pytest.mark.parametrize(
-        "gate_value,expected_scale",
-        [(0.0, 0.5), (1e4, 1.0), (-1e4, 0.0)],
-    )
+    @pytest.mark.parametrize("gate_value,expected_scale", [(0.0, 0.5), (1e4, 1.0), (-1e4, 0.0)])
     def test_saturated_gate_under_tp2(self, gate_value: float, expected_scale: float):
         """Zero gate weight rows + fill gate bias rows with gate_value, then
         verify out_gated == sigmoid(gate_value) * out_no_gate. Catches layout
@@ -298,9 +290,7 @@ class TestHeadWiseAttnGateUnderTP2:
             out_gated, _ = attn(hidden_states, attention_mask)
             out_plain, _ = attn_ref(hidden_states, attention_mask)
 
-        torch.testing.assert_close(
-            out_gated, out_plain * expected_scale, atol=1e-4, rtol=1e-4
-        )
+        torch.testing.assert_close(out_gated, out_plain * expected_scale, atol=1e-4, rtol=1e-4)
 
 
 class TestHeadWiseAttnGateInitMagnitude:
@@ -337,9 +327,7 @@ class TestHeadWiseAttnGateInitMagnitude:
         expected_scale = torch.sigmoid(
             torch.tensor(gated_config.head_wise_attn_gate_init_bias)
         ).item()
-        torch.testing.assert_close(
-            out_gated, out_plain * expected_scale, atol=5e-2, rtol=5e-2
-        )
+        torch.testing.assert_close(out_gated, out_plain * expected_scale, atol=5e-2, rtol=5e-2)
         near_id_err = (out_gated - out_plain * expected_scale).abs().mean().item()
         half_err = (out_gated - out_plain * 0.5).abs().mean().item()
         assert near_id_err < half_err
@@ -359,7 +347,7 @@ class TestHeadWiseAttnGateInitMagnitude:
         """gate_std ~ 0.1 * qkv_std (no zero-init, no FP8 underflow risk)."""
         gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
         attn = _make_attention_local(gated_config)
-        gate_rows = attn.linear_qkv.weight[-attn.num_attention_heads_per_partition:]
+        gate_rows = attn.linear_qkv.weight[-attn.num_attention_heads_per_partition :]
         qkv_rows = attn.linear_qkv.weight[: -attn.num_attention_heads_per_partition]
         ratio = gate_rows.float().std().item() / qkv_rows.float().std().item()
         assert 0.05 < ratio < 0.5

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -2,32 +2,8 @@
 
 """Tests for per-head scalar attention gate (head_wise_attn_gate).
 
-The gate weights are fused into linear_qkv as the trailing num_attention_heads
-rows; in the forward pass those scalars are sliced out, passed through sigmoid,
-and used to scale each attention head's output independently.
-
-Coverage summary across this file plus
-tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py:
-
-  - Config-time validation (mutual exclusion, TP / num_query_groups
-    divisibility): TestHeadWiseAttnGateConfigValidation.
-  - linear_qkv shape with/without gate: TestHeadWiseAttnGateInit.
-  - TP=1 forward sanity, output shape, half/no-side-channel guards:
-    TestHeadWiseAttnGateForward.
-  - Pure-tensor reshape and sigmoid saturation: TestHeadWiseAttnGateNumerics.
-  - TP=2 layout correctness (saturated gate, per-rank gate independence,
-    init-time rejection of misaligned configs):
-    TestHeadWiseAttnGateUnderTP2.
-  - Init-time gate magnitude (sigmoid~=1 at start, knob propagation,
-    FP8-friendly weight std): TestHeadWiseAttnGateInitMagnitude.
-  - dist-ckpt save TP=N -> load TP=M logits equality, parametrized over
-    MHA/GQA and bias presence: test_head_wise_attn_gate_resharding.py.
-
-Known unverified paths (filed as follow-ups, see resharding test
-docstring for details): context_parallel_size > 1, fp8 (linear_qkv shared
-tensor scale across QKV and gate blocks; set_save_original_input
-interaction), explicit backward-grad-to-gate-rows assertion, and
-packed_seq_params.qkv_format == 'thd' reshape composition.
+Unverified paths (follow-ups): CP, fp8, explicit backward-grad-to-gate,
+packed_seq_params.qkv_format == 'thd'.
 """
 
 import pytest
@@ -73,18 +49,7 @@ def _make_attention(config: TransformerConfig, transformer_impl: str) -> SelfAtt
 
 
 class TestHeadWiseAttnGateConfigValidation:
-    """TransformerConfig.__post_init__ should reject misconfigurations up
-    front so users don't hit obscure asserts deep inside the forward path.
-
-    Three invariants are validated at config-creation time:
-
-      (a) Mutual exclusion with attention_output_gate (both append rows to
-          linear_qkv with incompatible layouts).
-      (b) num_attention_heads % tensor_model_parallel_size == 0.
-      (c) num_query_groups >= tensor_model_parallel_size (otherwise the
-          forward-time gate slice over-takes through the AG+reslice
-          fallback).
-    """
+    """TransformerConfig.__post_init__ rejects misconfigurations at config time."""
 
     def _config(self, **extra) -> TransformerConfig:
         return TransformerConfig(
@@ -101,23 +66,16 @@ class TestHeadWiseAttnGateConfigValidation:
             self._config(head_wise_attn_gate=True, attention_output_gate=True)
 
     def test_rejects_num_heads_indivisible_by_tp(self):
-        """Cross-check against the global num_attention_heads % tp check: the
-        gate-specific message is what we want users to see. The global check
-        fires first (line 1334-ish of transformer_config.py), but it carries
-        the same TP-divisibility wording, so either error is acceptable for
-        users; we accept either by matching the shared substring."""
         with pytest.raises(ValueError, match="num_attention_heads"):
             self._config(
-                num_attention_heads=3,  # not divisible by 2
+                num_attention_heads=3,
                 num_query_groups=3,
-                hidden_size=24,  # divisible by 3 for head_dim
+                hidden_size=24,
                 tensor_model_parallel_size=2,
                 head_wise_attn_gate=True,
             )
 
     def test_rejects_num_query_groups_below_tp(self):
-        """num_query_groups=1 < tensor_model_parallel_size=2 must fail at
-        config time, not silently produce a wrong forward."""
         with pytest.raises(ValueError, match="num_query_groups"):
             self._config(
                 num_attention_heads=4,
@@ -127,8 +85,6 @@ class TestHeadWiseAttnGateConfigValidation:
             )
 
     def test_accepts_well_formed_config(self):
-        """Sanity: a config that satisfies all three invariants does not
-        raise. (TP=2, num_heads=4 divisible by 2, num_query_groups=4 >= 2.)"""
         self._config(
             num_attention_heads=4,
             num_query_groups=4,
@@ -137,12 +93,8 @@ class TestHeadWiseAttnGateConfigValidation:
         )
 
     def test_disabled_does_not_constrain_other_flags(self):
-        """When the gate is off, the gate-specific validations must not fire
-        even if attention_output_gate is on or num_query_groups < tp.
-        Otherwise the validations would regress unrelated configs."""
-        # attention_output_gate on, head-wise off -- must NOT raise.
+        """Gate-off must not regress unrelated configs."""
         self._config(head_wise_attn_gate=False, attention_output_gate=True)
-        # num_query_groups < tp, head-wise off -- must NOT raise.
         self._config(
             num_attention_heads=4,
             num_query_groups=1,
@@ -151,36 +103,18 @@ class TestHeadWiseAttnGateConfigValidation:
         )
 
     def test_rejects_fp8_misaligned_linear_qkv_out_dim(self):
-        """H=8, G=8, kv_channels=128, TP=1 gives linear_qkv_out_dim=3080;
-        3080 % 16 = 8. TE's FP8 GEMM requires 16-alignment, so this must
-        be rejected at config time -- otherwise TE either errors or
-        silently pads the weight (shifted outputs)."""
+        # H=8, G=8, D=128, TP=1 -> linear_qkv_out_dim=3080; 3080 % 16 = 8.
         with pytest.raises(ValueError, match=r"fp8.*multiple of 16"):
             self._config(
                 num_attention_heads=8,
                 num_query_groups=8,
-                hidden_size=8 * 128,  # kv_channels=128
+                hidden_size=8 * 128,
                 head_wise_attn_gate=True,
                 fp8="hybrid",
             )
 
-    def test_accepts_fp8_aligned_linear_qkv_out_dim(self):
-        """H=16, G=2, kv_channels=128, TP=1 gives linear_qkv_out_dim=2576;
-        2576 % 16 = 0 -- valid for FP8 GEMM. Sanity that the check does
-        not fire on a well-aligned config."""
-        self._config(
-            num_attention_heads=16,
-            num_query_groups=2,
-            hidden_size=16 * 128,
-            head_wise_attn_gate=True,
-            fp8="hybrid",
-        )
-
     def test_rejects_fp4_stricter_alignment(self):
-        """FP4 requires 32-alignment. A config that passes FP8 (16-aligned)
-        but not FP4 (32-aligned) should still be rejected when fp4 is on.
-        H=16, G=2, kv_channels=128, TP=1: linear_qkv_out_dim=2576;
-        2576 % 16 = 0 but 2576 % 32 = 16, so fp4 must reject."""
+        # H=16, G=2, D=128, TP=1 -> 2576; passes fp8 (16) but fails fp4 (32).
         with pytest.raises(ValueError, match=r"fp4.*multiple of 32"):
             self._config(
                 num_attention_heads=16,
@@ -189,20 +123,6 @@ class TestHeadWiseAttnGateConfigValidation:
                 head_wise_attn_gate=True,
                 fp4="e2m1",
             )
-
-    def test_no_alignment_check_without_fp8_or_fp4(self):
-        """The alignment check must only fire under fp8/fp4. A config that
-        is otherwise valid (passes the other gate invariants) but
-        mis-aligns linear_qkv_out_dim must NOT raise when fp8/fp4 are off
-        -- bf16 / fp16 / fp32 GEMM have no such alignment requirement."""
-        # H=8, G=8 -> linear_qkv_out_dim=3080 (mis-aligned), but no
-        # fp8/fp4 -> no raise.
-        self._config(
-            num_attention_heads=8,
-            num_query_groups=8,
-            hidden_size=8 * 128,
-            head_wise_attn_gate=True,
-        )
 
 
 @pytest.mark.parametrize("transformer_impl", ["transformer_engine", "native"])
@@ -236,7 +156,7 @@ class TestHeadWiseAttnGateInit:
 
 @pytest.mark.parametrize("transformer_impl", ["transformer_engine", "native"])
 class TestHeadWiseAttnGateForward:
-    """Verify forward-pass behaviour of the head-wise gate."""
+    """Forward-pass shape sanity + zero-gate equivalence."""
 
     @pytest.fixture(autouse=True)
     def setup_teardown(self, transformer_impl):
@@ -246,33 +166,21 @@ class TestHeadWiseAttnGateForward:
         yield
         Utils.destroy_model_parallel()
 
-    def _run_forward(self, use_gate: bool):
+    @pytest.mark.parametrize("use_gate", [True, False])
+    def test_output_shape(self, use_gate: bool):
         config = _make_config(self.transformer_impl, head_wise_attn_gate=use_gate)
         attn = _make_attention(config, self.transformer_impl).cuda()
         hidden_states = torch.randn(
             SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.bfloat16, device="cuda"
         )
         attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
-        output, bias = attn(hidden_states, attention_mask)
-        return output, bias
-
-    def test_output_shape_with_gate(self):
-        output, _ = self._run_forward(use_gate=True)
-        assert output.shape == (SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE)
-
-    def test_output_shape_without_gate(self):
-        output, _ = self._run_forward(use_gate=False)
+        output, _ = attn(hidden_states, attention_mask)
         assert output.shape == (SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE)
 
     def test_zero_gate_halves_output(self):
-        """Zeroing the trailing gate rows of linear_qkv makes pre-sigmoid 0,
-        so the sigmoid is exactly 0.5 and the gated output is half the
-        ungated reference output that shares all other weights."""
+        """Zero gate rows -> sigmoid(0)=0.5 -> output = 0.5 * no-gate ref."""
         config = _make_config(self.transformer_impl, head_wise_attn_gate=True)
         attn = _make_attention(config, self.transformer_impl).cuda()
-
-        # Zero only the trailing num_attention_heads rows (the gate weights);
-        # leave QKV weights intact so the rest of the computation is unchanged.
         with torch.no_grad():
             attn.linear_qkv.weight[-NUM_HEADS:].zero_()
 
@@ -281,7 +189,6 @@ class TestHeadWiseAttnGateForward:
         )
         attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
 
-        # Reference: a gate-disabled attention layer that shares the QKV rows.
         config_no_gate = _make_config(self.transformer_impl, head_wise_attn_gate=False)
         attn_no_gate = _make_attention(config_no_gate, self.transformer_impl).cuda()
         with torch.no_grad():
@@ -297,67 +204,10 @@ class TestHeadWiseAttnGateForward:
             out_plain, _ = attn_no_gate(hidden_states, attention_mask)
 
         torch.testing.assert_close(
-            out_gated.float(),
-            (out_plain * 0.5).float(),
-            atol=1e-2,
-            rtol=1e-2,
+            out_gated.float(), (out_plain * 0.5).float(), atol=1e-2, rtol=1e-2
         )
 
 
-class TestHeadWiseAttnGateNumerics:
-    """Low-level tensor-math tests (no model-parallel overhead, pure PyTorch)."""
-
-    @pytest.fixture(autouse=True)
-    def setup_teardown(self):
-        Utils.initialize_model_parallel(1, 1)
-        yield
-        Utils.destroy_model_parallel()
-
-    def test_gate_reshape_correctness(self):
-        """Replicate the reshape logic and verify sigmoid is applied per-head."""
-        sq, b, np, hn = 4, 2, NUM_HEADS, 32
-        # Simulate core_attn_out: [sq, b, np*hn]
-        core_attn_out = torch.arange(
-            sq * b * np * hn, dtype=torch.float32
-        ).reshape(sq, b, np * hn)
-        # Simulate gate_states: [sq, b, np] (pre-sigmoid raw scores)
-        gate_scores = torch.zeros(sq, b, np)  # sigmoid(0) = 0.5
-
-        gate_states = gate_scores.view(sq, b, np, 1)
-        out = core_attn_out.view(sq, b, np, hn)
-        out = out * torch.sigmoid(gate_states)
-        out = out.view(sq, b, np * hn)
-
-        expected = core_attn_out * 0.5
-        torch.testing.assert_close(out, expected)
-
-    def test_gate_dtype_cast(self):
-        """Gate computation upcast to float32, result cast back to input dtype."""
-        sq, b, np, hn = 4, 2, NUM_HEADS, 32
-        core_attn_out = torch.randn(sq, b, np * hn, dtype=torch.bfloat16)
-        gate_scores = torch.randn(sq, b, np, dtype=torch.bfloat16)
-
-        gate_states = gate_scores.view(sq, b, np, 1)
-        out = core_attn_out.view(sq, b, np, hn)
-        # Mirrors the production code: float cast for sigmoid, then cast back
-        out = out * torch.sigmoid(gate_states.float()).to(out.dtype)
-        out = out.view(sq, b, np * hn)
-
-        assert out.dtype == torch.bfloat16
-
-    @pytest.mark.parametrize("gate_value,expected_scale", [(-1e6, 0.0), (1e6, 1.0), (0.0, 0.5)])
-    def test_gate_saturation(self, gate_value: float, expected_scale: float):
-        """Extreme gate values saturate sigmoid to 0 or 1; midpoint gives 0.5."""
-        sq, b, np, hn = 2, 1, 2, 8
-        core_attn_out = torch.ones(sq, b, np * hn)
-        gate_scores = torch.full((sq, b, np), gate_value)
-
-        gate_states = gate_scores.view(sq, b, np, 1)
-        out = core_attn_out.view(sq, b, np, hn)
-        out = out * torch.sigmoid(gate_states.float()).to(out.dtype)
-        out = out.view(sq, b, np * hn)
-
-        torch.testing.assert_close(out, torch.full_like(out, expected_scale), atol=1e-5, rtol=1e-5)
 
 
 def _make_config_tp(
@@ -408,20 +258,7 @@ def _copy_qkv_block_only(attn_dst: SelfAttention, attn_src: SelfAttention):
 
 
 class TestHeadWiseAttnGateUnderTP2:
-    """TP=2 forward tests that back-validate the trailing-rows-as-gate
-    layout. Three implicit preconditions are checked indirectly:
-
-      (1) ColumnParallelLinear partitions linear_qkv.weight along axis 0
-          contiguously and uniformly (no row interleave).
-      (2) num_attention_heads % world_size == 0.
-      (3) The global linear_qkv.weight layout is [QKV_block; Gate_block].
-
-    Each test forces the per-rank trailing gate scalars to a known constant
-    (via add_qkv_bias=True and bias surgery on the gate rows) and checks
-    that the gated output equals the expected scalar multiple of a no-gate
-    reference. If any precondition were violated, the slice would pick up
-    V/K rows instead of gate rows and the scalar relationship would not
-    hold."""
+    """TP=2 forward equivalence under known constant gate values."""
 
     @pytest.fixture(autouse=True)
     def setup_teardown(self):
@@ -434,37 +271,20 @@ class TestHeadWiseAttnGateUnderTP2:
 
     @pytest.mark.parametrize(
         "gate_value,expected_scale",
-        [
-            (0.0, 0.5),    # sigmoid(0)        = 0.5
-            (1e4, 1.0),    # sigmoid(+large)  -> 1
-            (-1e4, 0.0),   # sigmoid(-large)  -> 0
-        ],
+        [(0.0, 0.5), (1e4, 1.0), (-1e4, 0.0)],
     )
     def test_saturated_gate_under_tp2(self, gate_value: float, expected_scale: float):
-        """Force the LOCAL trailing num_attention_heads_per_partition gate rows
-        on every rank to produce a constant pre-sigmoid value (zero the gate
-        weight rows, set the gate bias rows to gate_value). The gated forward
-        output should then equal expected_scale * no-gate reference (which
-        shares all non-gate weights).
-
-        A layout bug -- e.g. trailing rows being V rows instead of gate --
-        would manifest here: setting V bias to +1e4 explodes attention
-        outputs, setting V bias to -1e4 wrecks softmax via huge negative V
-        contributions. Neither would produce the clean
-        ``expected_scale * out_plain`` relation.
-        """
+        """Zero gate weight rows + fill gate bias rows with gate_value, then
+        verify out_gated == sigmoid(gate_value) * out_no_gate. Catches layout
+        bugs where the slice would land on V/K rows instead of gate rows."""
         gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
         attn = _make_attention_local(gated_config)
         gate_size = attn.num_attention_heads_per_partition
-        # Per-rank gate-row surgery: zero gate weight rows, set gate bias rows
-        # to the target pre-sigmoid value. After this, the gate input to
-        # sigmoid is constant `gate_value` regardless of hidden_states.
-        assert attn.linear_qkv.bias is not None, "test requires add_qkv_bias=True"
+        assert attn.linear_qkv.bias is not None
         with torch.no_grad():
             attn.linear_qkv.weight[-gate_size:].zero_()
             attn.linear_qkv.bias[-gate_size:].fill_(gate_value)
 
-        # Reference: no-gate attention sharing every other weight with attn.
         ref_config = _make_config_tp(head_wise_attn_gate=False, add_qkv_bias=True)
         attn_ref = _make_attention_local(ref_config)
         _copy_qkv_block_only(attn_ref, attn)
@@ -482,118 +302,9 @@ class TestHeadWiseAttnGateUnderTP2:
             out_gated, out_plain * expected_scale, atol=1e-4, rtol=1e-4
         )
 
-    def test_per_rank_gate_independence_under_tp2(self):
-        """Drive the gate to +large on rank 0 and -large on rank 1 (and vice
-        versa via parametrization is overkill here). Each TP rank's local
-        trailing gate rows correspond ONLY to that rank's query heads. After
-        linear_proj's RowParallel AllReduce, half the heads contribute
-        full-strength and half contribute zero. This test verifies the
-        slice does not cross rank boundaries -- if a rank ever read its
-        partner's gate scalars (impossible under axis-0 contiguous TP, but
-        the test guards the assumption), the half-zero / half-pass pattern
-        would collapse and the result would not match the expected
-        per-rank-weighted reference.
-
-        Verification trick: build the reference by running the no-gate
-        attention on each rank with its OWN core_attn_out scaled to
-        sigmoid(rank_gate); since linear_proj is row-parallel and sums TP
-        partial outputs, scaling each rank's slice of linear_proj.weight by
-        sigmoid(rank_gate) BEFORE the all-reduce yields the same final
-        output as gating each rank's core_attn_out by sigmoid(rank_gate).
-        """
-        tp_rank = torch.distributed.get_rank() % 2
-        gate_value = 1e4 if tp_rank == 0 else -1e4
-        # sigmoid(+1e4) ~= 1, sigmoid(-1e4) ~= 0
-        expected_rank_scale = 1.0 if tp_rank == 0 else 0.0
-
-        gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
-        attn = _make_attention_local(gated_config)
-        gate_size = attn.num_attention_heads_per_partition
-        assert attn.linear_qkv.bias is not None
-        with torch.no_grad():
-            attn.linear_qkv.weight[-gate_size:].zero_()
-            attn.linear_qkv.bias[-gate_size:].fill_(gate_value)
-
-        # Reference: no-gate model with linear_proj.weight pre-scaled by this
-        # rank's expected_rank_scale. linear_proj is RowParallelLinear, so
-        # each rank holds (output, input_per_rank) and contributes
-        # `core_attn_local @ weight_local.T` to the all-reduced sum. Scaling
-        # weight_local by sigmoid(gate) on this rank == scaling that rank's
-        # contribution by sigmoid(gate), which is the per-rank effect of
-        # head-wise gating on rank-local heads.
-        ref_config = _make_config_tp(head_wise_attn_gate=False, add_qkv_bias=True)
-        attn_ref = _make_attention_local(ref_config)
-        _copy_qkv_block_only(attn_ref, attn)
-        with torch.no_grad():
-            attn_ref.linear_proj.weight.mul_(expected_rank_scale)
-
-        torch.manual_seed(0)
-        hidden_states = torch.randn(
-            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.float32, device="cuda"
-        )
-        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
-        with torch.no_grad():
-            out_gated, _ = attn(hidden_states, attention_mask)
-            out_ref, _ = attn_ref(hidden_states, attention_mask)
-
-        torch.testing.assert_close(out_gated, out_ref, atol=1e-4, rtol=1e-4)
-
-    @pytest.mark.parametrize(
-        "num_heads,num_query_groups,expected_match",
-        [
-            # num_query_groups (1) < world_size (2): gate slice would over-take
-            # via the AG+reslice fallback path.
-            (4, 1, "num_query_groups"),
-            # num_attention_heads (3) % world_size (2) != 0, with
-            # num_query_groups == num_attention_heads (default) and < world_size
-            # too, so parent's divide(...) uses num_query_groups not world_size
-            # and our explicit gate-row divisibility check is the one that
-            # fires.
-            (3, 1, "num_query_groups"),
-        ],
-    )
-    def test_init_rejects_misaligned_layout_under_tp2(
-        self, num_heads: int, num_query_groups: int, expected_match: str
-    ):
-        """Layout invariants for head_wise_attn_gate (both checked at
-        init):
-
-          (a) num_query_groups >= world_size -- otherwise the gate slice
-              over-takes through the AG+reslice fallback.
-          (b) num_attention_heads % world_size == 0 -- otherwise gate rows
-              cannot be partitioned cleanly across ranks.
-
-        Both should produce a clear AssertionError at SelfAttention
-        construction time, not a silent forward-time misalignment.
-        """
-        bad_config = TransformerConfig(
-            num_layers=1,
-            hidden_size=24,  # divisible by num_heads for head_dim
-            num_attention_heads=num_heads,
-            num_query_groups=num_query_groups,
-            use_cpu_initialization=True,
-            params_dtype=torch.float32,
-            attention_dropout=0.0,
-            hidden_dropout=0.0,
-            head_wise_attn_gate=True,
-        )
-        submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
-        with pytest.raises(AssertionError, match=expected_match):
-            SelfAttention(bad_config, submodules, layer_number=1)
-
 
 class TestHeadWiseAttnGateInitMagnitude:
-    """Verify the init-time surgery on the gate sub-block:
-
-      - With default knobs and a bias-enabled linear_qkv, sigmoid(gate)
-        sits near 1 at init (approximate identity) -- NOT 0.5, which
-        was the previous behavior and halved every head's output during
-        warmup.
-      - The two TransformerConfig knobs
-        (head_wise_attn_gate_init_weight_scale,
-        head_wise_attn_gate_init_bias) actually flow into the surgery:
-        setting both to 0 reproduces the old sigmoid(0)=0.5 behavior.
-    """
+    """Init-time gate-row surgery: near-identity at start, knob propagation, FP8 safety."""
 
     @pytest.fixture(autouse=True)
     def setup_teardown(self):
@@ -603,8 +314,6 @@ class TestHeadWiseAttnGateInitMagnitude:
         Utils.destroy_model_parallel()
 
     def _run_pair(self, gated_config: TransformerConfig) -> tuple[torch.Tensor, torch.Tensor]:
-        """Build a gated attention with `gated_config`, a no-gate reference
-        sharing all QKV weights, and run both forwards on a fixed input."""
         attn = _make_attention_local(gated_config)
         ref_config = _make_config_tp(head_wise_attn_gate=False, add_qkv_bias=True)
         attn_ref = _make_attention_local(ref_config)
@@ -621,39 +330,22 @@ class TestHeadWiseAttnGateInitMagnitude:
         return out_gated, out_plain
 
     def test_default_init_is_near_identity(self):
-        """Default knobs (weight_scale=0.1, bias=2.0) drive sigmoid(gate) to
-        sigmoid(2.0) ~= 0.88 at init, so the gated output is ~0.88 * no-gate
-        reference -- NOT the 0.5 halving that the shared init_method would
-        give. Also assert the near-identity scaling is closer to the truth
-        than the half-scaling, so a regression that drops the init surgery
-        (e.g. someone reverts the if-block in SelfAttention.__init__) is
-        caught even if the absolute tolerance is loose."""
+        """out_gated ~= sigmoid(2.0) * out_plain at init; closer than 0.5 *
+        out_plain (catches regressions that drop the init surgery)."""
         gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
         out_gated, out_plain = self._run_pair(gated_config)
-
         expected_scale = torch.sigmoid(
             torch.tensor(gated_config.head_wise_attn_gate_init_bias)
         ).item()
-        # Loose tolerance: the gate weight contribution (gate_weight @ hidden)
-        # is not literally zero, just small after the 0.1 scale, so
-        # sigmoid(2.0 + small) deviates slightly from sigmoid(2.0) per
-        # position/head.
         torch.testing.assert_close(
             out_gated, out_plain * expected_scale, atol=5e-2, rtol=5e-2
         )
         near_id_err = (out_gated - out_plain * expected_scale).abs().mean().item()
         half_err = (out_gated - out_plain * 0.5).abs().mean().item()
-        assert near_id_err < half_err, (
-            f"Default gate init is no longer near identity: "
-            f"|gated - sigmoid({gated_config.head_wise_attn_gate_init_bias})*plain|="
-            f"{near_id_err:.4g} >= |gated - 0.5*plain|={half_err:.4g}. Did the "
-            f"init-time surgery in SelfAttention.__init__ get dropped?"
-        )
+        assert near_id_err < half_err
 
     def test_init_knobs_reproduce_half_scaling(self):
-        """Setting both knobs to 0 should reproduce the old sigmoid(0)=0.5
-        behavior, confirming both flow into the init surgery (not silently
-        ignored)."""
+        """Both knobs=0 reproduces sigmoid(0)=0.5 -- proves the knobs flow."""
         gated_config = _make_config_tp(
             head_wise_attn_gate=True,
             add_qkv_bias=True,
@@ -664,26 +356,10 @@ class TestHeadWiseAttnGateInitMagnitude:
         torch.testing.assert_close(out_gated, out_plain * 0.5, atol=1e-4, rtol=1e-4)
 
     def test_init_preserves_fp8_friendly_gate_magnitude(self):
-        """Gate weight rows should stay on the same order of magnitude as QKV
-        weight rows after the init surgery, so the shared FP8 tensor-level
-        scale on linear_qkv.weight isn't dominated by the gate sub-block.
-
-        With weight_scale=0.1 default, the gate rows are ~10x smaller than
-        QKV but still within the same dynamic range (FP8 E4M3 / E5M2 cover
-        ~6 decades of magnitude, so a 1-decade gap is harmless).
-        """
+        """gate_std ~ 0.1 * qkv_std (no zero-init, no FP8 underflow risk)."""
         gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
         attn = _make_attention_local(gated_config)
         gate_rows = attn.linear_qkv.weight[-attn.num_attention_heads_per_partition:]
         qkv_rows = attn.linear_qkv.weight[: -attn.num_attention_heads_per_partition]
-        gate_std = gate_rows.float().std().item()
-        qkv_std = qkv_rows.float().std().item()
-        # Gate std should be ~0.1 * qkv std (because we mul_'d by 0.1) and
-        # definitely not 0 (which would zero the gate sub-block in FP8).
-        assert gate_std > 0, "gate weight rows zero-initialized -- FP8 underflow risk"
-        ratio = gate_std / qkv_std
-        assert 0.05 < ratio < 0.5, (
-            f"gate_std / qkv_std = {ratio:.3f}, expected close to "
-            f"head_wise_attn_gate_init_weight_scale (0.1). Gate magnitudes "
-            f"too far from QKV may break the FP8 shared tensor scale."
-        )
+        ratio = gate_rows.float().std().item() / qkv_rows.float().std().item()
+        assert 0.05 < ratio < 0.5

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -77,18 +77,6 @@ class TestHeadWiseAttnGateInit:
         assert attn.linear_qkv_out_dim == QKV_OUT_DIM
         assert attn.linear_qkv.weight.shape == (QKV_OUT_DIM, HIDDEN_SIZE)
 
-    def test_no_gate_side_channel_attribute(self):
-        """Regression guard: gate states must be threaded through the
-        get_query_key_value_tensors return tuple, not via a module-level
-        attribute. A stale gate attribute breaks cross-attention layers,
-        overlapped microbatches, and selective recompute paths."""
-        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=True)
-        attn = _make_attention(config, self.transformer_impl)
-        assert not hasattr(attn, "_head_wise_gate_states"), (
-            "SelfAttention should not stash gate states on the module; "
-            "thread them through the qkv_output tuple instead."
-        )
-
 
 @pytest.mark.parametrize("transformer_impl", ["transformer_engine", "native"])
 class TestHeadWiseAttnGateForward:
@@ -119,19 +107,6 @@ class TestHeadWiseAttnGateForward:
     def test_output_shape_without_gate(self):
         output, _ = self._run_forward(use_gate=False)
         assert output.shape == (SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE)
-
-    def test_no_gate_side_channel_after_forward(self):
-        """Regression guard: even after a forward pass, no per-instance gate
-        attribute should be left dangling on the module. This protects
-        recompute / overlapped-microbatch paths from picking up stale state."""
-        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=True)
-        attn = _make_attention(config, self.transformer_impl).cuda()
-        hidden_states = torch.randn(
-            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.bfloat16, device="cuda"
-        )
-        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
-        _ = attn(hidden_states, attention_mask)
-        assert not hasattr(attn, "_head_wise_gate_states")
 
     def test_zero_gate_halves_output(self):
         """Zeroing the trailing gate rows of linear_qkv makes pre-sigmoid 0,
@@ -227,3 +202,218 @@ class TestHeadWiseAttnGateNumerics:
         out = out.view(sq, b, np * hn)
 
         torch.testing.assert_close(out, torch.full_like(out, expected_scale), atol=1e-5, rtol=1e-5)
+
+
+def _make_config_tp(
+    use_head_wise_attn_gate: bool, add_qkv_bias: bool = False
+) -> TransformerConfig:
+    """Float32 config for TP correctness tests; local-spec backend, no dropout."""
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=HIDDEN_SIZE,
+        num_attention_heads=NUM_HEADS,
+        use_cpu_initialization=True,
+        params_dtype=torch.float32,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        add_qkv_bias=add_qkv_bias,
+        use_head_wise_attn_gate=use_head_wise_attn_gate,
+    )
+
+
+def _make_attention_local(config: TransformerConfig) -> SelfAttention:
+    """Local (ColumnParallelLinear) backend so the trailing-rows layout is
+    unambiguous -- TE variants may carry layer-norm params that don't matter
+    for these layout checks but would complicate weight surgery."""
+    submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
+    return SelfAttention(config, submodules, layer_number=1).cuda()
+
+
+def _copy_qkv_block_only(attn_dst: SelfAttention, attn_src: SelfAttention):
+    """Copy the non-gate (QKV-only) rows of linear_qkv and the full linear_proj
+    from attn_src into attn_dst. Used to build a no-gate reference that
+    shares all weights with a gated layer EXCEPT the trailing gate rows. Each
+    rank handles its own local slice."""
+    qkv_rows = attn_dst.linear_qkv.weight.size(0)
+    with torch.no_grad():
+        attn_dst.linear_qkv.weight.copy_(attn_src.linear_qkv.weight[:qkv_rows])
+        attn_dst.linear_proj.weight.copy_(attn_src.linear_proj.weight)
+        if attn_src.linear_qkv.bias is not None and attn_dst.linear_qkv.bias is not None:
+            attn_dst.linear_qkv.bias.copy_(attn_src.linear_qkv.bias[:qkv_rows])
+        if attn_src.linear_proj.bias is not None and attn_dst.linear_proj.bias is not None:
+            attn_dst.linear_proj.bias.copy_(attn_src.linear_proj.bias)
+
+
+class TestHeadWiseAttnGateUnderTP2:
+    """TP=2 forward tests that back-validate the trailing-rows-as-gate
+    layout. Three implicit preconditions are checked indirectly:
+
+      (1) ColumnParallelLinear partitions linear_qkv.weight along axis 0
+          contiguously and uniformly (no row interleave).
+      (2) num_attention_heads % world_size == 0.
+      (3) The global linear_qkv.weight layout is [QKV_block; Gate_block].
+
+    Each test forces the per-rank trailing gate scalars to a known constant
+    (via add_qkv_bias=True and bias surgery on the gate rows) and checks
+    that the gated output equals the expected scalar multiple of a no-gate
+    reference. If any precondition were violated, the slice would pick up
+    V/K rows instead of gate rows and the scalar relationship would not
+    hold."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        if Utils.world_size < 2:
+            pytest.skip(f"need world_size >= 2 (got {Utils.world_size})")
+        Utils.initialize_model_parallel(tensor_model_parallel_size=2, pipeline_model_parallel_size=1)
+        model_parallel_cuda_manual_seed(42)
+        yield
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize(
+        "gate_value,expected_scale",
+        [
+            (0.0, 0.5),    # sigmoid(0)        = 0.5
+            (1e4, 1.0),    # sigmoid(+large)  -> 1
+            (-1e4, 0.0),   # sigmoid(-large)  -> 0
+        ],
+    )
+    def test_saturated_gate_under_tp2(self, gate_value: float, expected_scale: float):
+        """Force the LOCAL trailing num_attention_heads_per_partition gate rows
+        on every rank to produce a constant pre-sigmoid value (zero the gate
+        weight rows, set the gate bias rows to gate_value). The gated forward
+        output should then equal expected_scale * no-gate reference (which
+        shares all non-gate weights).
+
+        A layout bug -- e.g. trailing rows being V rows instead of gate --
+        would manifest here: setting V bias to +1e4 explodes attention
+        outputs, setting V bias to -1e4 wrecks softmax via huge negative V
+        contributions. Neither would produce the clean
+        ``expected_scale * out_plain`` relation.
+        """
+        gated_config = _make_config_tp(use_head_wise_attn_gate=True, add_qkv_bias=True)
+        attn = _make_attention_local(gated_config)
+        gate_size = attn.num_attention_heads_per_partition
+        # Per-rank gate-row surgery: zero gate weight rows, set gate bias rows
+        # to the target pre-sigmoid value. After this, the gate input to
+        # sigmoid is constant `gate_value` regardless of hidden_states.
+        assert attn.linear_qkv.bias is not None, "test requires add_qkv_bias=True"
+        with torch.no_grad():
+            attn.linear_qkv.weight[-gate_size:].zero_()
+            attn.linear_qkv.bias[-gate_size:].fill_(gate_value)
+
+        # Reference: no-gate attention sharing every other weight with attn.
+        ref_config = _make_config_tp(use_head_wise_attn_gate=False, add_qkv_bias=True)
+        attn_ref = _make_attention_local(ref_config)
+        _copy_qkv_block_only(attn_ref, attn)
+
+        torch.manual_seed(0)
+        hidden_states = torch.randn(
+            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.float32, device="cuda"
+        )
+        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+        with torch.no_grad():
+            out_gated, _ = attn(hidden_states, attention_mask)
+            out_plain, _ = attn_ref(hidden_states, attention_mask)
+
+        torch.testing.assert_close(
+            out_gated, out_plain * expected_scale, atol=1e-4, rtol=1e-4
+        )
+
+    def test_per_rank_gate_independence_under_tp2(self):
+        """Drive the gate to +large on rank 0 and -large on rank 1 (and vice
+        versa via parametrization is overkill here). Each TP rank's local
+        trailing gate rows correspond ONLY to that rank's query heads. After
+        linear_proj's RowParallel AllReduce, half the heads contribute
+        full-strength and half contribute zero. This test verifies the
+        slice does not cross rank boundaries -- if a rank ever read its
+        partner's gate scalars (impossible under axis-0 contiguous TP, but
+        the test guards the assumption), the half-zero / half-pass pattern
+        would collapse and the result would not match the expected
+        per-rank-weighted reference.
+
+        Verification trick: build the reference by running the no-gate
+        attention on each rank with its OWN core_attn_out scaled to
+        sigmoid(rank_gate); since linear_proj is row-parallel and sums TP
+        partial outputs, scaling each rank's slice of linear_proj.weight by
+        sigmoid(rank_gate) BEFORE the all-reduce yields the same final
+        output as gating each rank's core_attn_out by sigmoid(rank_gate).
+        """
+        tp_rank = torch.distributed.get_rank() % 2
+        gate_value = 1e4 if tp_rank == 0 else -1e4
+        # sigmoid(+1e4) ~= 1, sigmoid(-1e4) ~= 0
+        expected_rank_scale = 1.0 if tp_rank == 0 else 0.0
+
+        gated_config = _make_config_tp(use_head_wise_attn_gate=True, add_qkv_bias=True)
+        attn = _make_attention_local(gated_config)
+        gate_size = attn.num_attention_heads_per_partition
+        assert attn.linear_qkv.bias is not None
+        with torch.no_grad():
+            attn.linear_qkv.weight[-gate_size:].zero_()
+            attn.linear_qkv.bias[-gate_size:].fill_(gate_value)
+
+        # Reference: no-gate model with linear_proj.weight pre-scaled by this
+        # rank's expected_rank_scale. linear_proj is RowParallelLinear, so
+        # each rank holds (output, input_per_rank) and contributes
+        # `core_attn_local @ weight_local.T` to the all-reduced sum. Scaling
+        # weight_local by sigmoid(gate) on this rank == scaling that rank's
+        # contribution by sigmoid(gate), which is the per-rank effect of
+        # head-wise gating on rank-local heads.
+        ref_config = _make_config_tp(use_head_wise_attn_gate=False, add_qkv_bias=True)
+        attn_ref = _make_attention_local(ref_config)
+        _copy_qkv_block_only(attn_ref, attn)
+        with torch.no_grad():
+            attn_ref.linear_proj.weight.mul_(expected_rank_scale)
+
+        torch.manual_seed(0)
+        hidden_states = torch.randn(
+            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.float32, device="cuda"
+        )
+        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+        with torch.no_grad():
+            out_gated, _ = attn(hidden_states, attention_mask)
+            out_ref, _ = attn_ref(hidden_states, attention_mask)
+
+        torch.testing.assert_close(out_gated, out_ref, atol=1e-4, rtol=1e-4)
+
+    @pytest.mark.parametrize(
+        "num_heads,num_query_groups,expected_match",
+        [
+            # num_query_groups (1) < world_size (2): gate slice would over-take
+            # via the AG+reslice fallback path.
+            (4, 1, "num_query_groups"),
+            # num_attention_heads (3) % world_size (2) != 0, with
+            # num_query_groups == num_attention_heads (default) and < world_size
+            # too, so parent's divide(...) uses num_query_groups not world_size
+            # and our explicit gate-row divisibility check is the one that
+            # fires.
+            (3, 1, "num_query_groups"),
+        ],
+    )
+    def test_init_rejects_misaligned_layout_under_tp2(
+        self, num_heads: int, num_query_groups: int, expected_match: str
+    ):
+        """Layout invariants for use_head_wise_attn_gate (both checked at
+        init):
+
+          (a) num_query_groups >= world_size -- otherwise the gate slice
+              over-takes through the AG+reslice fallback.
+          (b) num_attention_heads % world_size == 0 -- otherwise gate rows
+              cannot be partitioned cleanly across ranks.
+
+        Both should produce a clear AssertionError at SelfAttention
+        construction time, not a silent forward-time misalignment.
+        """
+        bad_config = TransformerConfig(
+            num_layers=1,
+            hidden_size=24,  # divisible by num_heads for head_dim
+            num_attention_heads=num_heads,
+            num_query_groups=num_query_groups,
+            use_cpu_initialization=True,
+            params_dtype=torch.float32,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+            use_head_wise_attn_gate=True,
+        )
+        submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
+        with pytest.raises(AssertionError, match=expected_match):
+            SelfAttention(bad_config, submodules, layer_number=1)

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -205,9 +205,15 @@ class TestHeadWiseAttnGateNumerics:
 
 
 def _make_config_tp(
-    use_head_wise_attn_gate: bool, add_qkv_bias: bool = False
+    use_head_wise_attn_gate: bool,
+    add_qkv_bias: bool = False,
+    **extra: object,
 ) -> TransformerConfig:
-    """Float32 config for TP correctness tests; local-spec backend, no dropout."""
+    """Float32 config for TP correctness tests; local-spec backend, no dropout.
+
+    Extra TransformerConfig kwargs (e.g. head_wise_attn_gate_init_*) can be
+    passed through ``extra``.
+    """
     return TransformerConfig(
         num_layers=1,
         hidden_size=HIDDEN_SIZE,
@@ -218,6 +224,7 @@ def _make_config_tp(
         hidden_dropout=0.0,
         add_qkv_bias=add_qkv_bias,
         use_head_wise_attn_gate=use_head_wise_attn_gate,
+        **extra,
     )
 
 
@@ -417,3 +424,110 @@ class TestHeadWiseAttnGateUnderTP2:
         submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
         with pytest.raises(AssertionError, match=expected_match):
             SelfAttention(bad_config, submodules, layer_number=1)
+
+
+class TestHeadWiseAttnGateInitMagnitude:
+    """Verify the init-time surgery on the gate sub-block:
+
+      - With default knobs and a bias-enabled linear_qkv, sigmoid(gate)
+        sits near 1 at init (approximate identity) -- NOT 0.5, which
+        was the previous behavior and halved every head's output during
+        warmup.
+      - The two TransformerConfig knobs
+        (head_wise_attn_gate_init_weight_scale,
+        head_wise_attn_gate_init_bias) actually flow into the surgery:
+        setting both to 0 reproduces the old sigmoid(0)=0.5 behavior.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(42)
+        yield
+        Utils.destroy_model_parallel()
+
+    def _run_pair(self, gated_config: TransformerConfig) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build a gated attention with `gated_config`, a no-gate reference
+        sharing all QKV weights, and run both forwards on a fixed input."""
+        attn = _make_attention_local(gated_config)
+        ref_config = _make_config_tp(use_head_wise_attn_gate=False, add_qkv_bias=True)
+        attn_ref = _make_attention_local(ref_config)
+        _copy_qkv_block_only(attn_ref, attn)
+
+        torch.manual_seed(0)
+        hidden_states = torch.randn(
+            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.float32, device="cuda"
+        )
+        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+        with torch.no_grad():
+            out_gated, _ = attn(hidden_states, attention_mask)
+            out_plain, _ = attn_ref(hidden_states, attention_mask)
+        return out_gated, out_plain
+
+    def test_default_init_is_near_identity(self):
+        """Default knobs (weight_scale=0.1, bias=2.0) drive sigmoid(gate) to
+        sigmoid(2.0) ~= 0.88 at init, so the gated output is ~0.88 * no-gate
+        reference -- NOT the 0.5 halving that the shared init_method would
+        give. Also assert the near-identity scaling is closer to the truth
+        than the half-scaling, so a regression that drops the init surgery
+        (e.g. someone reverts the if-block in SelfAttention.__init__) is
+        caught even if the absolute tolerance is loose."""
+        gated_config = _make_config_tp(use_head_wise_attn_gate=True, add_qkv_bias=True)
+        out_gated, out_plain = self._run_pair(gated_config)
+
+        expected_scale = torch.sigmoid(
+            torch.tensor(gated_config.head_wise_attn_gate_init_bias)
+        ).item()
+        # Loose tolerance: the gate weight contribution (gate_weight @ hidden)
+        # is not literally zero, just small after the 0.1 scale, so
+        # sigmoid(2.0 + small) deviates slightly from sigmoid(2.0) per
+        # position/head.
+        torch.testing.assert_close(
+            out_gated, out_plain * expected_scale, atol=5e-2, rtol=5e-2
+        )
+        near_id_err = (out_gated - out_plain * expected_scale).abs().mean().item()
+        half_err = (out_gated - out_plain * 0.5).abs().mean().item()
+        assert near_id_err < half_err, (
+            f"Default gate init is no longer near identity: "
+            f"|gated - sigmoid({gated_config.head_wise_attn_gate_init_bias})*plain|="
+            f"{near_id_err:.4g} >= |gated - 0.5*plain|={half_err:.4g}. Did the "
+            f"init-time surgery in SelfAttention.__init__ get dropped?"
+        )
+
+    def test_init_knobs_reproduce_half_scaling(self):
+        """Setting both knobs to 0 should reproduce the old sigmoid(0)=0.5
+        behavior, confirming both flow into the init surgery (not silently
+        ignored)."""
+        gated_config = _make_config_tp(
+            use_head_wise_attn_gate=True,
+            add_qkv_bias=True,
+            head_wise_attn_gate_init_weight_scale=0.0,
+            head_wise_attn_gate_init_bias=0.0,
+        )
+        out_gated, out_plain = self._run_pair(gated_config)
+        torch.testing.assert_close(out_gated, out_plain * 0.5, atol=1e-4, rtol=1e-4)
+
+    def test_init_preserves_fp8_friendly_gate_magnitude(self):
+        """Gate weight rows should stay on the same order of magnitude as QKV
+        weight rows after the init surgery, so the shared FP8 tensor-level
+        scale on linear_qkv.weight isn't dominated by the gate sub-block.
+
+        With weight_scale=0.1 default, the gate rows are ~10x smaller than
+        QKV but still within the same dynamic range (FP8 E4M3 / E5M2 cover
+        ~6 decades of magnitude, so a 1-decade gap is harmless).
+        """
+        gated_config = _make_config_tp(use_head_wise_attn_gate=True, add_qkv_bias=True)
+        attn = _make_attention_local(gated_config)
+        gate_rows = attn.linear_qkv.weight[-attn.num_attention_heads_per_partition:]
+        qkv_rows = attn.linear_qkv.weight[: -attn.num_attention_heads_per_partition]
+        gate_std = gate_rows.float().std().item()
+        qkv_std = qkv_rows.float().std().item()
+        # Gate std should be ~0.1 * qkv std (because we mul_'d by 0.1) and
+        # definitely not 0 (which would zero the gate sub-block in FP8).
+        assert gate_std > 0, "gate weight rows zero-initialized -- FP8 underflow risk"
+        ratio = gate_std / qkv_std
+        assert 0.05 < ratio < 0.5, (
+            f"gate_std / qkv_std = {ratio:.3f}, expected close to "
+            f"head_wise_attn_gate_init_weight_scale (0.1). Gate magnitudes "
+            f"too far from QKV may break the FP8 shared tensor scale."
+        )

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-"""Tests for per-head scalar attention gate (use_head_wise_attn_gate).
+"""Tests for per-head scalar attention gate (head_wise_attn_gate).
 
 The gate weights are fused into linear_qkv as the trailing num_attention_heads
 rows; in the forward pass those scalars are sliced out, passed through sigmoid,
@@ -28,7 +28,7 @@ KV_CHANNELS = HIDDEN_SIZE // NUM_HEADS  # 32
 QKV_OUT_DIM = 3 * NUM_HEADS * KV_CHANNELS  # query + key + value, no GQA
 
 
-def _make_config(transformer_impl: str, use_head_wise_attn_gate: bool) -> TransformerConfig:
+def _make_config(transformer_impl: str, head_wise_attn_gate: bool) -> TransformerConfig:
     return TransformerConfig(
         num_layers=1,
         hidden_size=HIDDEN_SIZE,
@@ -37,7 +37,7 @@ def _make_config(transformer_impl: str, use_head_wise_attn_gate: bool) -> Transf
         bf16=True,
         params_dtype=torch.bfloat16,
         transformer_impl=transformer_impl,
-        use_head_wise_attn_gate=use_head_wise_attn_gate,
+        head_wise_attn_gate=head_wise_attn_gate,
     )
 
 
@@ -75,7 +75,7 @@ class TestHeadWiseAttnGateConfigValidation:
 
     def test_rejects_combination_with_attention_output_gate(self):
         with pytest.raises(ValueError, match="cannot both be enabled"):
-            self._config(use_head_wise_attn_gate=True, attention_output_gate=True)
+            self._config(head_wise_attn_gate=True, attention_output_gate=True)
 
     def test_rejects_num_heads_indivisible_by_tp(self):
         """Cross-check against the global num_attention_heads % tp check: the
@@ -89,7 +89,7 @@ class TestHeadWiseAttnGateConfigValidation:
                 num_query_groups=3,
                 hidden_size=24,  # divisible by 3 for head_dim
                 tensor_model_parallel_size=2,
-                use_head_wise_attn_gate=True,
+                head_wise_attn_gate=True,
             )
 
     def test_rejects_num_query_groups_below_tp(self):
@@ -100,7 +100,7 @@ class TestHeadWiseAttnGateConfigValidation:
                 num_attention_heads=4,
                 num_query_groups=1,
                 tensor_model_parallel_size=2,
-                use_head_wise_attn_gate=True,
+                head_wise_attn_gate=True,
             )
 
     def test_accepts_well_formed_config(self):
@@ -110,7 +110,7 @@ class TestHeadWiseAttnGateConfigValidation:
             num_attention_heads=4,
             num_query_groups=4,
             tensor_model_parallel_size=2,
-            use_head_wise_attn_gate=True,
+            head_wise_attn_gate=True,
         )
 
     def test_disabled_does_not_constrain_other_flags(self):
@@ -118,13 +118,13 @@ class TestHeadWiseAttnGateConfigValidation:
         even if attention_output_gate is on or num_query_groups < tp.
         Otherwise the validations would regress unrelated configs."""
         # attention_output_gate on, head-wise off -- must NOT raise.
-        self._config(use_head_wise_attn_gate=False, attention_output_gate=True)
+        self._config(head_wise_attn_gate=False, attention_output_gate=True)
         # num_query_groups < tp, head-wise off -- must NOT raise.
         self._config(
             num_attention_heads=4,
             num_query_groups=1,
             tensor_model_parallel_size=2,
-            use_head_wise_attn_gate=False,
+            head_wise_attn_gate=False,
         )
 
 
@@ -141,7 +141,7 @@ class TestHeadWiseAttnGateInit:
         Utils.destroy_model_parallel()
 
     def test_linear_qkv_includes_gate_rows_when_enabled(self):
-        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=True)
+        config = _make_config(self.transformer_impl, head_wise_attn_gate=True)
         attn = _make_attention(config, self.transformer_impl)
         # linear_qkv output dim = Q+K+V + num_attention_heads (gate rows).
         assert attn.linear_qkv_out_dim == QKV_OUT_DIM + NUM_HEADS
@@ -151,7 +151,7 @@ class TestHeadWiseAttnGateInit:
         )
 
     def test_linear_qkv_unchanged_when_disabled(self):
-        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=False)
+        config = _make_config(self.transformer_impl, head_wise_attn_gate=False)
         attn = _make_attention(config, self.transformer_impl)
         assert attn.linear_qkv_out_dim == QKV_OUT_DIM
         assert attn.linear_qkv.weight.shape == (QKV_OUT_DIM, HIDDEN_SIZE)
@@ -170,7 +170,7 @@ class TestHeadWiseAttnGateForward:
         Utils.destroy_model_parallel()
 
     def _run_forward(self, use_gate: bool):
-        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=use_gate)
+        config = _make_config(self.transformer_impl, head_wise_attn_gate=use_gate)
         attn = _make_attention(config, self.transformer_impl).cuda()
         hidden_states = torch.randn(
             SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.bfloat16, device="cuda"
@@ -191,7 +191,7 @@ class TestHeadWiseAttnGateForward:
         """Zeroing the trailing gate rows of linear_qkv makes pre-sigmoid 0,
         so the sigmoid is exactly 0.5 and the gated output is half the
         ungated reference output that shares all other weights."""
-        config = _make_config(self.transformer_impl, use_head_wise_attn_gate=True)
+        config = _make_config(self.transformer_impl, head_wise_attn_gate=True)
         attn = _make_attention(config, self.transformer_impl).cuda()
 
         # Zero only the trailing num_attention_heads rows (the gate weights);
@@ -205,7 +205,7 @@ class TestHeadWiseAttnGateForward:
         attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
 
         # Reference: a gate-disabled attention layer that shares the QKV rows.
-        config_no_gate = _make_config(self.transformer_impl, use_head_wise_attn_gate=False)
+        config_no_gate = _make_config(self.transformer_impl, head_wise_attn_gate=False)
         attn_no_gate = _make_attention(config_no_gate, self.transformer_impl).cuda()
         with torch.no_grad():
             attn_no_gate.linear_qkv.weight.copy_(attn.linear_qkv.weight[:QKV_OUT_DIM])
@@ -284,7 +284,7 @@ class TestHeadWiseAttnGateNumerics:
 
 
 def _make_config_tp(
-    use_head_wise_attn_gate: bool,
+    head_wise_attn_gate: bool,
     add_qkv_bias: bool = False,
     **extra: object,
 ) -> TransformerConfig:
@@ -302,7 +302,7 @@ def _make_config_tp(
         attention_dropout=0.0,
         hidden_dropout=0.0,
         add_qkv_bias=add_qkv_bias,
-        use_head_wise_attn_gate=use_head_wise_attn_gate,
+        head_wise_attn_gate=head_wise_attn_gate,
         **extra,
     )
 
@@ -376,7 +376,7 @@ class TestHeadWiseAttnGateUnderTP2:
         contributions. Neither would produce the clean
         ``expected_scale * out_plain`` relation.
         """
-        gated_config = _make_config_tp(use_head_wise_attn_gate=True, add_qkv_bias=True)
+        gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
         attn = _make_attention_local(gated_config)
         gate_size = attn.num_attention_heads_per_partition
         # Per-rank gate-row surgery: zero gate weight rows, set gate bias rows
@@ -388,7 +388,7 @@ class TestHeadWiseAttnGateUnderTP2:
             attn.linear_qkv.bias[-gate_size:].fill_(gate_value)
 
         # Reference: no-gate attention sharing every other weight with attn.
-        ref_config = _make_config_tp(use_head_wise_attn_gate=False, add_qkv_bias=True)
+        ref_config = _make_config_tp(head_wise_attn_gate=False, add_qkv_bias=True)
         attn_ref = _make_attention_local(ref_config)
         _copy_qkv_block_only(attn_ref, attn)
 
@@ -429,7 +429,7 @@ class TestHeadWiseAttnGateUnderTP2:
         # sigmoid(+1e4) ~= 1, sigmoid(-1e4) ~= 0
         expected_rank_scale = 1.0 if tp_rank == 0 else 0.0
 
-        gated_config = _make_config_tp(use_head_wise_attn_gate=True, add_qkv_bias=True)
+        gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
         attn = _make_attention_local(gated_config)
         gate_size = attn.num_attention_heads_per_partition
         assert attn.linear_qkv.bias is not None
@@ -444,7 +444,7 @@ class TestHeadWiseAttnGateUnderTP2:
         # weight_local by sigmoid(gate) on this rank == scaling that rank's
         # contribution by sigmoid(gate), which is the per-rank effect of
         # head-wise gating on rank-local heads.
-        ref_config = _make_config_tp(use_head_wise_attn_gate=False, add_qkv_bias=True)
+        ref_config = _make_config_tp(head_wise_attn_gate=False, add_qkv_bias=True)
         attn_ref = _make_attention_local(ref_config)
         _copy_qkv_block_only(attn_ref, attn)
         with torch.no_grad():
@@ -478,7 +478,7 @@ class TestHeadWiseAttnGateUnderTP2:
     def test_init_rejects_misaligned_layout_under_tp2(
         self, num_heads: int, num_query_groups: int, expected_match: str
     ):
-        """Layout invariants for use_head_wise_attn_gate (both checked at
+        """Layout invariants for head_wise_attn_gate (both checked at
         init):
 
           (a) num_query_groups >= world_size -- otherwise the gate slice
@@ -498,7 +498,7 @@ class TestHeadWiseAttnGateUnderTP2:
             params_dtype=torch.float32,
             attention_dropout=0.0,
             hidden_dropout=0.0,
-            use_head_wise_attn_gate=True,
+            head_wise_attn_gate=True,
         )
         submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
         with pytest.raises(AssertionError, match=expected_match):
@@ -529,7 +529,7 @@ class TestHeadWiseAttnGateInitMagnitude:
         """Build a gated attention with `gated_config`, a no-gate reference
         sharing all QKV weights, and run both forwards on a fixed input."""
         attn = _make_attention_local(gated_config)
-        ref_config = _make_config_tp(use_head_wise_attn_gate=False, add_qkv_bias=True)
+        ref_config = _make_config_tp(head_wise_attn_gate=False, add_qkv_bias=True)
         attn_ref = _make_attention_local(ref_config)
         _copy_qkv_block_only(attn_ref, attn)
 
@@ -551,7 +551,7 @@ class TestHeadWiseAttnGateInitMagnitude:
         than the half-scaling, so a regression that drops the init surgery
         (e.g. someone reverts the if-block in SelfAttention.__init__) is
         caught even if the absolute tolerance is loose."""
-        gated_config = _make_config_tp(use_head_wise_attn_gate=True, add_qkv_bias=True)
+        gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
         out_gated, out_plain = self._run_pair(gated_config)
 
         expected_scale = torch.sigmoid(
@@ -578,7 +578,7 @@ class TestHeadWiseAttnGateInitMagnitude:
         behavior, confirming both flow into the init surgery (not silently
         ignored)."""
         gated_config = _make_config_tp(
-            use_head_wise_attn_gate=True,
+            head_wise_attn_gate=True,
             add_qkv_bias=True,
             head_wise_attn_gate_init_weight_scale=0.0,
             head_wise_attn_gate_init_bias=0.0,
@@ -595,7 +595,7 @@ class TestHeadWiseAttnGateInitMagnitude:
         QKV but still within the same dynamic range (FP8 E4M3 / E5M2 cover
         ~6 decades of magnitude, so a 1-decade gap is harmless).
         """
-        gated_config = _make_config_tp(use_head_wise_attn_gate=True, add_qkv_bias=True)
+        gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
         attn = _make_attention_local(gated_config)
         gate_rows = attn.linear_qkv.weight[-attn.num_attention_heads_per_partition:]
         qkv_rows = attn.linear_qkv.weight[: -attn.num_attention_heads_per_partition]

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -51,14 +51,15 @@ class TestHeadWiseAttnGateConfigValidation:
     """TransformerConfig.__post_init__ rejects misconfigurations at config time."""
 
     def _config(self, **extra) -> TransformerConfig:
-        return TransformerConfig(
+        kwargs = dict(
             num_layers=1,
             hidden_size=HIDDEN_SIZE,
             num_attention_heads=NUM_HEADS,
             use_cpu_initialization=True,
             params_dtype=torch.float32,
-            **extra,
         )
+        kwargs.update(extra)
+        return TransformerConfig(**kwargs)
 
     def test_rejects_combination_with_attention_output_gate(self):
         with pytest.raises(ValueError, match="cannot both be enabled"):

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -150,6 +150,60 @@ class TestHeadWiseAttnGateConfigValidation:
             head_wise_attn_gate=False,
         )
 
+    def test_rejects_fp8_misaligned_linear_qkv_out_dim(self):
+        """H=8, G=8, kv_channels=128, TP=1 gives linear_qkv_out_dim=3080;
+        3080 % 16 = 8. TE's FP8 GEMM requires 16-alignment, so this must
+        be rejected at config time -- otherwise TE either errors or
+        silently pads the weight (shifted outputs)."""
+        with pytest.raises(ValueError, match=r"fp8.*multiple of 16"):
+            self._config(
+                num_attention_heads=8,
+                num_query_groups=8,
+                hidden_size=8 * 128,  # kv_channels=128
+                head_wise_attn_gate=True,
+                fp8="hybrid",
+            )
+
+    def test_accepts_fp8_aligned_linear_qkv_out_dim(self):
+        """H=16, G=2, kv_channels=128, TP=1 gives linear_qkv_out_dim=2576;
+        2576 % 16 = 0 -- valid for FP8 GEMM. Sanity that the check does
+        not fire on a well-aligned config."""
+        self._config(
+            num_attention_heads=16,
+            num_query_groups=2,
+            hidden_size=16 * 128,
+            head_wise_attn_gate=True,
+            fp8="hybrid",
+        )
+
+    def test_rejects_fp4_stricter_alignment(self):
+        """FP4 requires 32-alignment. A config that passes FP8 (16-aligned)
+        but not FP4 (32-aligned) should still be rejected when fp4 is on.
+        H=16, G=2, kv_channels=128, TP=1: linear_qkv_out_dim=2576;
+        2576 % 16 = 0 but 2576 % 32 = 16, so fp4 must reject."""
+        with pytest.raises(ValueError, match=r"fp4.*multiple of 32"):
+            self._config(
+                num_attention_heads=16,
+                num_query_groups=2,
+                hidden_size=16 * 128,
+                head_wise_attn_gate=True,
+                fp4="e2m1",
+            )
+
+    def test_no_alignment_check_without_fp8_or_fp4(self):
+        """The alignment check must only fire under fp8/fp4. A config that
+        is otherwise valid (passes the other gate invariants) but
+        mis-aligns linear_qkv_out_dim must NOT raise when fp8/fp4 are off
+        -- bf16 / fp16 / fp32 GEMM have no such alignment requirement."""
+        # H=8, G=8 -> linear_qkv_out_dim=3080 (mis-aligned), but no
+        # fp8/fp4 -> no raise.
+        self._config(
+            num_attention_heads=8,
+            num_query_groups=8,
+            hidden_size=8 * 128,
+            head_wise_attn_gate=True,
+        )
+
 
 @pytest.mark.parametrize("transformer_impl", ["transformer_engine", "native"])
 class TestHeadWiseAttnGateInit:

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -49,6 +49,85 @@ def _make_attention(config: TransformerConfig, transformer_impl: str) -> SelfAtt
     return SelfAttention(config, submodules, layer_number=1)
 
 
+class TestHeadWiseAttnGateConfigValidation:
+    """TransformerConfig.__post_init__ should reject misconfigurations up
+    front so users don't hit obscure asserts deep inside the forward path.
+
+    Three invariants are validated at config-creation time:
+
+      (a) Mutual exclusion with attention_output_gate (both append rows to
+          linear_qkv with incompatible layouts).
+      (b) num_attention_heads % tensor_model_parallel_size == 0.
+      (c) num_query_groups >= tensor_model_parallel_size (otherwise the
+          forward-time gate slice over-takes through the AG+reslice
+          fallback).
+    """
+
+    def _config(self, **extra) -> TransformerConfig:
+        return TransformerConfig(
+            num_layers=1,
+            hidden_size=HIDDEN_SIZE,
+            num_attention_heads=NUM_HEADS,
+            use_cpu_initialization=True,
+            params_dtype=torch.float32,
+            **extra,
+        )
+
+    def test_rejects_combination_with_attention_output_gate(self):
+        with pytest.raises(ValueError, match="cannot both be enabled"):
+            self._config(use_head_wise_attn_gate=True, attention_output_gate=True)
+
+    def test_rejects_num_heads_indivisible_by_tp(self):
+        """Cross-check against the global num_attention_heads % tp check: the
+        gate-specific message is what we want users to see. The global check
+        fires first (line 1334-ish of transformer_config.py), but it carries
+        the same TP-divisibility wording, so either error is acceptable for
+        users; we accept either by matching the shared substring."""
+        with pytest.raises(ValueError, match="num_attention_heads"):
+            self._config(
+                num_attention_heads=3,  # not divisible by 2
+                num_query_groups=3,
+                hidden_size=24,  # divisible by 3 for head_dim
+                tensor_model_parallel_size=2,
+                use_head_wise_attn_gate=True,
+            )
+
+    def test_rejects_num_query_groups_below_tp(self):
+        """num_query_groups=1 < tensor_model_parallel_size=2 must fail at
+        config time, not silently produce a wrong forward."""
+        with pytest.raises(ValueError, match="num_query_groups"):
+            self._config(
+                num_attention_heads=4,
+                num_query_groups=1,
+                tensor_model_parallel_size=2,
+                use_head_wise_attn_gate=True,
+            )
+
+    def test_accepts_well_formed_config(self):
+        """Sanity: a config that satisfies all three invariants does not
+        raise. (TP=2, num_heads=4 divisible by 2, num_query_groups=4 >= 2.)"""
+        self._config(
+            num_attention_heads=4,
+            num_query_groups=4,
+            tensor_model_parallel_size=2,
+            use_head_wise_attn_gate=True,
+        )
+
+    def test_disabled_does_not_constrain_other_flags(self):
+        """When the gate is off, the gate-specific validations must not fire
+        even if attention_output_gate is on or num_query_groups < tp.
+        Otherwise the validations would regress unrelated configs."""
+        # attention_output_gate on, head-wise off -- must NOT raise.
+        self._config(use_head_wise_attn_gate=False, attention_output_gate=True)
+        # num_query_groups < tp, head-wise off -- must NOT raise.
+        self._config(
+            num_attention_heads=4,
+            num_query_groups=1,
+            tensor_model_parallel_size=2,
+            use_head_wise_attn_gate=False,
+        )
+
+
 @pytest.mark.parametrize("transformer_impl", ["transformer_engine", "native"])
 class TestHeadWiseAttnGateInit:
     """Verify linear_qkv is sized to include the fused gate rows iff enabled."""

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -77,10 +77,17 @@ class TestHeadWiseAttnGateInit:
         assert attn.linear_qkv_out_dim == QKV_OUT_DIM
         assert attn.linear_qkv.weight.shape == (QKV_OUT_DIM, HIDDEN_SIZE)
 
-    def test_gate_buffer_initialized_to_none(self):
+    def test_no_gate_side_channel_attribute(self):
+        """Regression guard: gate states must be threaded through the
+        get_query_key_value_tensors return tuple, not via a module-level
+        attribute. A stale gate attribute breaks cross-attention layers,
+        overlapped microbatches, and selective recompute paths."""
         config = _make_config(self.transformer_impl, use_head_wise_attn_gate=True)
         attn = _make_attention(config, self.transformer_impl)
-        assert attn._head_wise_gate_states is None
+        assert not hasattr(attn, "_head_wise_gate_states"), (
+            "SelfAttention should not stash gate states on the module; "
+            "thread them through the qkv_output tuple instead."
+        )
 
 
 @pytest.mark.parametrize("transformer_impl", ["transformer_engine", "native"])
@@ -113,7 +120,10 @@ class TestHeadWiseAttnGateForward:
         output, _ = self._run_forward(use_gate=False)
         assert output.shape == (SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE)
 
-    def test_gate_buffer_cleared_after_forward(self):
+    def test_no_gate_side_channel_after_forward(self):
+        """Regression guard: even after a forward pass, no per-instance gate
+        attribute should be left dangling on the module. This protects
+        recompute / overlapped-microbatch paths from picking up stale state."""
         config = _make_config(self.transformer_impl, use_head_wise_attn_gate=True)
         attn = _make_attention(config, self.transformer_impl).cuda()
         hidden_states = torch.randn(
@@ -121,7 +131,7 @@ class TestHeadWiseAttnGateForward:
         )
         attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
         _ = attn(hidden_states, attention_mask)
-        assert attn._head_wise_gate_states is None
+        assert not hasattr(attn, "_head_wise_gate_states")
 
     def test_zero_gate_halves_output(self):
         """Zeroing the trailing gate rows of linear_qkv makes pre-sigmoid 0,

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -5,6 +5,29 @@
 The gate weights are fused into linear_qkv as the trailing num_attention_heads
 rows; in the forward pass those scalars are sliced out, passed through sigmoid,
 and used to scale each attention head's output independently.
+
+Coverage summary across this file plus
+tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py:
+
+  - Config-time validation (mutual exclusion, TP / num_query_groups
+    divisibility): TestHeadWiseAttnGateConfigValidation.
+  - linear_qkv shape with/without gate: TestHeadWiseAttnGateInit.
+  - TP=1 forward sanity, output shape, half/no-side-channel guards:
+    TestHeadWiseAttnGateForward.
+  - Pure-tensor reshape and sigmoid saturation: TestHeadWiseAttnGateNumerics.
+  - TP=2 layout correctness (saturated gate, per-rank gate independence,
+    init-time rejection of misaligned configs):
+    TestHeadWiseAttnGateUnderTP2.
+  - Init-time gate magnitude (sigmoid~=1 at start, knob propagation,
+    FP8-friendly weight std): TestHeadWiseAttnGateInitMagnitude.
+  - dist-ckpt save TP=N -> load TP=M logits equality, parametrized over
+    MHA/GQA and bias presence: test_head_wise_attn_gate_resharding.py.
+
+Known unverified paths (filed as follow-ups, see resharding test
+docstring for details): context_parallel_size > 1, fp8 (linear_qkv shared
+tensor scale across QKV and gate blocks; set_save_original_input
+interaction), explicit backward-grad-to-gate-rows assertion, and
+packed_seq_params.qkv_format == 'thd' reshape composition.
 """
 
 import pytest


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

  - use_head_wise_attn_gate: bool -- enable a per-head scalar output gate
    (a.k.a. g_proj). The gate is fused into linear_qkv as the trailing
    num_attention_heads rows; in the forward pass each rank slices off its
    num_attention_heads_per_partition gate scalars, applies sigmoid, and
    scales each attention head's output before linear_proj.
  - Distinct from attention_output_gate, which fuses a full head_dim gate
    into linear_qkv. The per-head gate adds only num_attention_heads extra
    output rows on linear_qkv (vs. num_attention_heads * head_dim), so the
    parameter and FLOP overhead is negligible.
  - Under tensor parallel, this requires that both num_query_groups and
    num_attention_heads be divisible by the TP world size so the QKV and
    gate sub-ranges stay aligned per rank.

  The new feature defaults to False and has no effect on existing models.

  for main branch: https://github.com/NVIDIA/Megatron-LM/pull/4848

  Related: per-layer RoPE for Step-3.5-Flash is tracked separately in
  [#4473](https://github.com/NVIDIA/Megatron-LM/pull/4473).

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
