### PR TITLE
Fix GDN DTensor splitting for FSDP checkpointing

### DIFF
--- a/megatron/core/transformer/fsdp_dtensor_checkpoint.py
+++ b/megatron/core/transformer/fsdp_dtensor_checkpoint.py
@@ -31,6 +31,7 @@ try:
         make_fsdp_dtensor,
     )
     from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+        split_dtensor,
         uneven_dtensor_to_full_tensor,
     )
     from megatron.core.distributed.fsdp.src.megatron_fsdp.utils import (
@@ -463,12 +464,19 @@ def handle_gdn_in_state_dict(model, model_state_dict, optimizer_state_dict):
 
     def split_gdn_fused(data, dist_param, split_sizes, split_dim):
         """Split a fused GDN projection DTensor into per-component DTensors."""
+        total_split = sum(split_sizes)
+        if isinstance(data, DTensor) and data.shape[split_dim] == total_split:
+            return list(
+                split_dtensor(
+                    data, split_sizes, dim=split_dim, update_uneven_dtensor_chunk_meta=True
+                )
+            )
+
         fsdp_slice = dist_param.megatron_fsdp_slice
         dist_index = dist_param.megatron_fsdp_dist_index
         tp_mesh = dist_index.get_submesh([dist_index.tp_dim], is_expert_parallel=False)
 
         data_size = data.numel() // tp_mesh.mesh.numel()
-        total_split = sum(split_sizes)
         elems_per_unit = data_size // total_split
 
         local_tensor = data.to_local()


### PR DESCRIPTION
cherry picked from https://github.com/NVIDIA/Megatron-LM/pull/4799

# What does this PR do ?

When using [convert_checkpoints_fsdp.py](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/conversion/mfsdp/convert_checkpoints_fsdp.py) to convert Qwen3.5-35B-A3B HuggingFace weights into an fsdp_dtensor checkpoint (TP=2, CP=2, EP=2), the following error occurs:

```bash
traceback : Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 362, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/root/mfsdp-intergration/Megatron-Bridge/examples/conversion/mfsdp/convert_checkpoints_fsdp.py", line 197, in import_hf_to_megatron_fsdp
    save_native_megatron_model(
  File "/root/mfsdp-intergration/Megatron-Bridge/src/megatron/bridge/training/model_load_save.py", line 711, in save_megatron_model
    save_checkpoint(
  File "/root/mfsdp-intergration/Megatron-Bridge/src/megatron/bridge/training/checkpointing.py", line 987, in save_checkpoint
    state_dict = preprocess_fsdp_dtensor_state_dict(cfg, state_dict, model[0])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/mfsdp-intergration/Megatron-Bridge/src/megatron/bridge/training/checkpointing.py", line 1663, in preprocess_fsdp_dtensor_state_dict
    model_state_dict, _ = handle_gdn_in_state_dict(model, state_dict["model"], None)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/mfsdp-intergration/Megatron-LM/megatron/core/transformer/fsdp_dtensor_checkpoint.py", line 531, in handle_gdn_in_state_dict
    sub_tensors = split_gdn_fused(model_state_dict[key], dist_param, sizes, dim)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/mfsdp-intergration/Megatron-LM/megatron/core/transformer/fsdp_dtensor_checkpoint.py", line 509, in split_gdn_fused
    dtensor = make_fsdp_dtensor(
              ^^^^^^^^^^^^^^^^^^
  File "/root/mfsdp-intergration/Megatron-LM/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py", line 4699, in make_fsdp_dtensor
    validate_uneven_dtensor(fsdp_tensor)
  File "/root/mfsdp-intergration/Megatron-LM/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py", line 196, in validate_uneven_dtensor
    assert torch.all(boundary_checks), (
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: [Megatron-FSDP] DTensor chunk metadata boundary check failed. Offsets: (0, 0, 0), Sizes: (512, 1, 4), Global shape: torch.Size([1024, 1, 4]), Local shape: torch.Size([512, 1, 4]), Device mesh: DeviceMesh((dp_cp=4), 'cuda', stride=(2,)).
```

This bug occurs because, during the DTensor splitting step in the FSDP save preprocessing for GDN fused projection, a DTensor that is already TP-local is incorrectly reconstructed again using FSDP/TP logic. This results in invalid uneven DTensor metadata.

Fix: when the data is already a TP-local DTensor and `data.shape[split_dim] == sum(split_sizes)`, directly use `split_dtensor(..., update_uneven_dtensor_chunk_meta=True)` to split it, instead of calling `make_fsdp_dtensor(...)` again.

## Issue tracking

Linked issue: N/A - small bug fix found during downstream Qwen3.5 Megatron-FSDP checkpoint saving.

  ## Contribution process

  ### Pre-checks

  - [ ] I have added relevant unit tests
  - [ ] I have added relevant functional tests
  - [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
  - [ ] I have added relevant documentation
  - [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

