### PR TITLE
[main] feat(attention): add head_wise_attn_gate for Step-3.5-Flash

### DIFF
--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -11,6 +11,12 @@ import torch
 from torch import Tensor
 
 from megatron.core import tensor_parallel
+from megatron.core.dist_checkpointing import ShardedTensor
+from megatron.core.dist_checkpointing.mapping import (
+    ReplicaId,
+    ShardedStateDict,
+    ShardedTensorFactory,
+)
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
@@ -36,6 +42,7 @@ from megatron.core.tensor_parallel.mappings import all_gather_last_dim_from_tens
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
+from megatron.core.transformer.utils import cat_with_oom_fallback
 from megatron.core.typed_torch import apply_module, not_none
 from megatron.core.utils import (
     deprecate_inference_params,
@@ -701,15 +708,18 @@ class Attention(MegatronModule, ABC):
         hidden_states: Tensor,
         key_value_states: Tensor | None,
         output_gate: bool = False,
+        head_wise_gate: bool = False,
         split_qkv: bool = True,
     ) -> (
-        tuple[Tensor, Tensor, Tensor, Tensor]
+        tuple[Tensor, Tensor, Tensor, Tensor, Tensor]
+        | tuple[Tensor, Tensor, Tensor, Tensor]
         | tuple[Tensor, Tensor, Tensor]
         | tuple[Tensor, list[int]]
     ):
         """
         This method needs to be implemented based on whether the derived class
-        is "self-attn" or "cross-attn".
+        is "self-attn" or "cross-attn". When ``output_gate=True`` / ``head_wise_gate=True``
+        the corresponding gate tensor is appended as a trailing tuple element.
         """
 
     def flash_decode(
@@ -1099,19 +1109,27 @@ class Attention(MegatronModule, ABC):
                 self.k_layernorm is None or isinstance(self.k_layernorm, IdentityOp),
             ]
         )
+        output_gate = self.config.attention_output_gate
+        # head_wise_attn_gate is self-attention only (gate rows live in linear_qkv).
+        head_wise_gate_enabled = self.config.head_wise_attn_gate and self.attention_type != "cross"
         # Check if fused_single_qkv_rope is requested but either unavailable or not
         # supported for the current use case.
         if self.attention_type != "cross":
             assert not (
                 self.config.fused_single_qkv_rope and split_qkv
             ), "fused_single_qkv_rope requested but not available/supported for the config."
+        if output_gate:
+            assert split_qkv, "output_gate is not supported for unsplit mixed_qkv tensor."
+        if head_wise_gate_enabled:
+            assert split_qkv, "head_wise_attn_gate is not supported for unsplit mixed_qkv tensor."
 
         with off_interface(self.offload_qkv_linear, hidden_states, "qkv_linear") as hidden_states:
             qkv_output = self.get_query_key_value_tensors(
                 hidden_states,
                 key_value_states,
                 split_qkv=split_qkv,
-                output_gate=self.config.attention_output_gate,
+                output_gate=output_gate,
+                head_wise_gate=head_wise_gate_enabled,
             )
         if self.offload_qkv_linear:
             # `qkv_output` may be a tuple; commit supports tuple/list and will keep structure.
@@ -1121,9 +1139,15 @@ class Attention(MegatronModule, ABC):
         attn_mask_type = self.attn_mask_type
         block_table = None
         gate = None
+        head_wise_gate = None
         if split_qkv:
-            if self.config.attention_output_gate:
+            # qkv_output is (query, key, value, [output_gate], [head_wise_gate]).
+            if output_gate and head_wise_gate_enabled:
+                query, key, value, gate, head_wise_gate = qkv_output
+            elif output_gate:
                 query, key, value, gate = qkv_output
+            elif head_wise_gate_enabled:
+                query, key, value, head_wise_gate = qkv_output
             else:
                 query, key, value = qkv_output
             mixed_qkv = qkv_split_arg_list = None
@@ -1322,7 +1346,17 @@ class Attention(MegatronModule, ABC):
             core_attn_out = core_attn_out.reshape(core_attn_out.size(0), 1, -1)
         nvtx_range_pop(suffix="core_attention")
 
-        # Output gate
+        if head_wise_gate is not None:
+            nvtx_range_push(suffix="head_wise_attn_gate")
+            gate_states = head_wise_gate.view(*head_wise_gate.shape[:2], -1, 1)
+            core_attn_out = core_attn_out.view(*gate_states.shape[:3], -1)
+            core_attn_out = core_attn_out * torch.sigmoid(gate_states.float()).to(
+                core_attn_out.dtype
+            )
+            core_attn_out = core_attn_out.view(*gate_states.shape[:2], -1)
+            nvtx_range_pop(suffix="head_wise_attn_gate")
+
+        # Output gate (attention_output_gate: full head_dim gate fused into QKV)
         if gate is not None:
             nvtx_range_push(suffix="output_gate")
             core_attn_out = self._apply_output_gate(core_attn_out, gate)
@@ -1394,6 +1428,19 @@ class SelfAttention(Attention):
         self.linear_qkv_out_dim = self.query_projection_size + 2 * self.kv_projection_size
         if self.config.attention_output_gate:
             self.linear_qkv_out_dim += self.config.kv_channels * self.config.num_attention_heads
+        if self.config.head_wise_attn_gate:
+            # Defensive runtime guards against config-validation bypass; same
+            # invariants enforced earlier in TransformerConfig.__post_init__.
+            tp_world_size = get_pg_size(self.pg_collection.tp)
+            assert self.config.num_query_groups >= tp_world_size, (
+                f"head_wise_attn_gate requires num_query_groups "
+                f"({self.config.num_query_groups}) >= tp world_size ({tp_world_size})"
+            )
+            assert self.config.num_attention_heads % tp_world_size == 0, (
+                f"head_wise_attn_gate requires num_attention_heads "
+                f"({self.config.num_attention_heads}) % tp world_size ({tp_world_size}) == 0"
+            )
+            self.linear_qkv_out_dim += self.config.num_attention_heads
         self.linear_qkv = submodules.linear_qkv(
             self.config.hidden_size,
             self.linear_qkv_out_dim,
@@ -1406,6 +1453,19 @@ class SelfAttention(Attention):
             tp_comm_buffer_name='qkv',
             tp_group=self.pg_collection.tp,
         )
+
+        if self.config.head_wise_attn_gate:
+            # Bias gate rows to sigmoid~=1 at init (approximate identity);
+            # avoids halving every head's output from step 0.
+            num_heads_per_partition = self.num_attention_heads_per_partition
+            with torch.no_grad():
+                self.linear_qkv.weight[-num_heads_per_partition:].mul_(
+                    self.config.head_wise_attn_gate_init_weight_scale
+                )
+                if self.linear_qkv.bias is not None:
+                    self.linear_qkv.bias[-num_heads_per_partition:].fill_(
+                        self.config.head_wise_attn_gate_init_bias
+                    )
 
         # Resolve which norm class to use for Q and K.
         # Config selects the default norm class; spec overrides if set.
@@ -1529,20 +1589,44 @@ class SelfAttention(Attention):
         hidden_states: Tensor,
         key_value_states: Tensor | None = None,
         output_gate: bool = False,
+        head_wise_gate: bool = False,
         split_qkv: bool = True,
     ) -> (
-        tuple[Tensor, Tensor, Tensor, Tensor]
+        tuple[Tensor, Tensor, Tensor, Tensor, Tensor]
+        | tuple[Tensor, Tensor, Tensor, Tensor]
         | tuple[Tensor, Tensor, Tensor]
         | tuple[Tensor, list[int]]
     ):
         """
         Derives `query`, `key` and `value` tensors from `hidden_states`.
-        If `output_gate` is True, then also derives `gate` tensor.
-        If `split_qkv=False`, then the unsplit mixed_qkv tensor is returned.
+        If `output_gate` is True, also returns a per-head head_dim gate.
+        If `head_wise_gate` is True, also returns a per-head scalar gate.
+        If `split_qkv=False`, returns the unsplit mixed_qkv tensor.
         """
+        if head_wise_gate:
+            assert split_qkv and self.config.head_wise_attn_gate
         # If no output gate: Attention heads [sq, b, h] --> [sq, b, ng * (np/ng + 2) * hn)]
         # If have output gate: Attention heads [sq, b, h] --> [sq, b, ng * (2 * np/ng + 2) * hn)]
         mixed_qkv, _ = apply_module(self.linear_qkv)(hidden_states)
+
+        # Peel the trailing per-rank gate scalars before any reshape / AG.
+        # Correct only because (a) ColumnParallelLinear splits axis 0
+        # contiguously, (b) num_attention_heads % tp == 0, (c) global layout
+        # is [QKV; Gate] (preserved across dist-ckpt by
+        # apply_head_wise_attn_gate_sharded_factory). (a)+(b) checked at
+        # config / init time.
+        head_wise_gate_states = None
+        if head_wise_gate:
+            gate_size = self.num_attention_heads_per_partition
+            mixed_qkv, head_wise_gate_states = torch.split(
+                mixed_qkv, [mixed_qkv.size(-1) - gate_size, gate_size], dim=-1
+            )
+            # torch.split on the last dim leaves non-contiguous views: the
+            # outer-dim stride still spans the original (QKV+gate) width, so
+            # downstream key.view(sk, b*np, hn) in dot_product_attention would
+            # fail with "view size is not compatible with input tensor's size
+            # and stride." Materialize a contiguous QKV slab here.
+            mixed_qkv = mixed_qkv.contiguous()
         num_query_heads_per_group = (
             self.num_attention_heads_per_partition // self.num_query_groups_per_partition
         )
@@ -1652,7 +1736,12 @@ class SelfAttention(Attention):
                     self.world_size // self.config.num_query_groups
                 )
                 gate = gate[:, :, idx * size : (idx + 1) * size, :]
+            if head_wise_gate:
+                return query, key, value, gate, head_wise_gate_states
             return query, key, value, gate
+
+        if head_wise_gate:
+            return query, key, value, head_wise_gate_states
 
         return query, key, value
 
@@ -1772,6 +1861,83 @@ class SelfAttention(Attention):
 
         return weight_updated
 
+    def sharded_state_dict(
+        self, prefix: str = "", sharded_offsets: tuple = (), metadata: Optional[dict] = None
+    ) -> ShardedStateDict:
+        """Wrap linear_qkv.{weight,bias} with a factory that reshards QKV and
+        gate sub-blocks independently, analogous to apply_swiglu_sharded_factory."""
+        sharded_state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
+        if self.config.head_wise_attn_gate:
+            qkv_size = self.query_projection_size + 2 * self.kv_projection_size
+            gate_size = self.config.num_attention_heads
+            for sub_name in ("weight", "bias"):
+                key = f"{prefix}linear_qkv.{sub_name}"
+                if key in sharded_state_dict:
+                    sharded_state_dict[key] = apply_head_wise_attn_gate_sharded_factory(
+                        sharded_state_dict[key], sharded_offsets, qkv_size, gate_size
+                    )
+        return sharded_state_dict
+
+
+# pylint: disable=missing-function-docstring
+def apply_head_wise_attn_gate_sharded_factory(
+    original_sh_ten, sharded_offsets, qkv_size: int, gate_size: int
+):
+    """Split linear_qkv.{weight,bias} into QKV and gate sub-tensors with
+    distinct keys so each is resharded independently along axis 0 across TP.
+    Default {"weight": 0} sharding would otherwise re-balance the QKV/gate
+    boundary on TP change and turn V/K rows into gate rows (silent miscompute).
+    Same pattern as apply_swiglu_sharded_factory, but with unequal sub-block
+    sizes (QKV >> gate)."""
+    shard_axis = 0
+    prepend_axis_num = len(sharded_offsets)
+    local_axis_size = original_sh_ten.local_shape[shard_axis]
+    axis_frag = original_sh_ten.axis_fragmentations[shard_axis + prepend_axis_num]
+
+    qkv_local_size, qkv_rem = divmod(qkv_size, axis_frag)
+    gate_local_size, gate_rem = divmod(gate_size, axis_frag)
+    assert qkv_rem == 0 and gate_rem == 0, (
+        f"head_wise_attn_gate dist-ckpt requires QKV ({qkv_size}) and gate "
+        f"({gate_size}) divisible by TP world_size ({axis_frag})."
+    )
+    assert local_axis_size == qkv_local_size + gate_local_size
+    rank_offset = original_sh_ten.global_offset[shard_axis + prepend_axis_num] // local_axis_size
+
+    @torch.no_grad()
+    def sh_ten_build_fn(
+        key: str, t: torch.Tensor, replica_id: ReplicaId, flattened_range: Optional[slice]
+    ):
+        tensor_qkv, tensor_gate = torch.split(t, [qkv_local_size, gate_local_size], dim=shard_axis)
+        offset_qkv = (shard_axis + prepend_axis_num, rank_offset, axis_frag)
+        offset_gate = (shard_axis + prepend_axis_num, rank_offset, axis_frag)
+        return [
+            ShardedTensor.from_rank_offsets(
+                f"{key}._qkv",
+                tensor_qkv,
+                *sharded_offsets,
+                offset_qkv,
+                replica_id=replica_id,
+                prepend_axis_num=prepend_axis_num,
+            ),
+            ShardedTensor.from_rank_offsets(
+                f"{key}._gate",
+                tensor_gate,
+                *sharded_offsets,
+                offset_gate,
+                replica_id=replica_id,
+                prepend_axis_num=prepend_axis_num,
+            ),
+        ]
+
+    return ShardedTensorFactory(
+        original_sh_ten.key,
+        original_sh_ten.data,
+        sh_ten_build_fn,
+        cat_with_oom_fallback,
+        original_sh_ten.replica_id,
+        flattened_range=original_sh_ten.flattened_range,
+    )
+
 
 class CrossAttention(Attention):
     """Cross-attention layer class
@@ -1830,12 +1996,15 @@ class CrossAttention(Attention):
         hidden_states: Tensor,
         key_value_states: Optional[Tensor],
         output_gate: bool = False,
+        head_wise_gate: bool = False,
         split_qkv: bool = True,
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """
         Derives `query` tensor from `hidden_states`, and `key`/`value` tensors
         from `key_value_states`.
         """
+        assert not head_wise_gate, "head_wise_attn_gate is self-attention only."
+
         assert split_qkv, "split_qkv must be True for CrossAttention"
         assert not output_gate, "Output gate is not supported in cross attention for now."
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -253,7 +253,34 @@ class TransformerConfig(ModelParallelConfig):
     defualts to False. Setting qk_clip will automatically log the max logit"""
 
     attention_output_gate: bool = False
-    """Whether to apply output gate to the attention layers."""
+    """Apply a full head_dim output gate (num_attention_heads * head_dim rows
+    fused inline per-group [q, gate, k, v] into linear_qkv). Mutually
+    exclusive with `head_wise_attn_gate` (per-head scalar gate)."""
+
+    head_wise_attn_gate: bool = False
+    """Apply a per-head scalar output gate (Step-3.5-Flash g_proj):
+    num_attention_heads scalar gates fused as the trailing rows of
+    linear_qkv; sigmoid scales each head uniformly across head_dim.
+    Contrast with `attention_output_gate` (full head_dim gate, inline
+    per-group); the two are mutually exclusive. Self-attention only.
+    dist-ckpt TP resharding is handled by a ShardedTensorFactory in
+    SelfAttention.sharded_state_dict. Requires (validated in
+    __post_init__): num_attention_heads % tp == 0,
+    num_query_groups >= tp, and under fp8/fp4 a per-partition
+    linear_qkv_out_dim aligned to 16/32."""
+
+    head_wise_attn_gate_init_weight_scale: float = 0.1
+    """Multiplicative scale on the gate rows of linear_qkv.weight at init,
+    on top of init_method. Default 0.1 keeps the linear contribution small
+    so sigmoid is dominated by the bias term, while staying within ~1
+    decade of QKV magnitudes for FP8 tensor-scale safety. Only used when
+    head_wise_attn_gate=True."""
+
+    head_wise_attn_gate_init_bias: float = 2.0
+    """Constant fill for the gate rows of linear_qkv.bias at init (no-op
+    when linear_qkv has no bias). Default 2.0 -> sigmoid(2)~=0.88, near
+    identity; avoids halving every head's output from step 0. Only used
+    when head_wise_attn_gate=True."""
 
     test_mode: bool = False
     """Whether to run real-time tests."""
@@ -1175,6 +1202,47 @@ class TransformerConfig(ModelParallelConfig):
                 f"num_query_groups ({self.num_query_groups}) must be a multiple or divisor of "
                 f"tensor_model_parallel_size ({self.tensor_model_parallel_size})."
             )
+
+        if self.head_wise_attn_gate:
+            tp = self.tensor_model_parallel_size
+            if self.attention_output_gate:
+                raise ValueError(
+                    "head_wise_attn_gate and attention_output_gate cannot both be enabled "
+                    "(incompatible linear_qkv row layouts)."
+                )
+            if self.num_attention_heads % tp != 0:
+                raise ValueError(
+                    f"head_wise_attn_gate requires num_attention_heads "
+                    f"({self.num_attention_heads}) divisible by tp ({tp})."
+                )
+            # The gate peel-off in SelfAttention runs before the
+            # num_query_groups < world_size AllGather+reslice fallback, so the
+            # gate cannot ride that path without over-taking V/K rows.
+            if self.num_query_groups < tp:
+                raise ValueError(
+                    f"head_wise_attn_gate requires num_query_groups "
+                    f"({self.num_query_groups}) >= tp ({tp})."
+                )
+            # TE FP8/FP4 GEMM requires per-partition output dim aligned to
+            # 16/32. attention_output_gate's wider gate gets this for free;
+            # head_wise's num_attention_heads-row increment can mis-align.
+            if self.fp8 is not None or self.fp4 is not None:
+                align = 32 if self.fp4 is not None else 16
+                linear_qkv_out_dim = (
+                    self.kv_channels * self.num_attention_heads
+                    + 2 * self.kv_channels * self.num_query_groups
+                    + self.num_attention_heads
+                )
+                per_partition = linear_qkv_out_dim // tp
+                if per_partition % align != 0:
+                    fp_name = "fp4" if self.fp4 is not None else "fp8"
+                    raise ValueError(
+                        f"head_wise_attn_gate under {fp_name} requires per-partition "
+                        f"linear_qkv output dim ({per_partition}) to be a multiple of "
+                        f"{align}; got num_attention_heads={self.num_attention_heads}, "
+                        f"num_query_groups={self.num_query_groups}, "
+                        f"kv_channels={self.kv_channels}, tp={tp}."
+                    )
 
         if self.experimental_attention_variant == "gated_delta_net":
             assert (

--- a/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
+++ b/tests/unit_tests/dist_checkpointing/test_head_wise_attn_gate_resharding.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""End-to-end dist-ckpt regression test for head_wise_attn_gate.
+
+Parametrized over (src_tp, dst_tp) in {(1,2), (2,1)}, num_query_groups in
+{NUM_HEADS, NUM_HEADS//2} (MHA + GQA), and add_qkv_bias in {True, False}.
+"""
+
+import pytest
+import torch
+
+from megatron.core.dist_checkpointing import load, save
+from megatron.core.dist_checkpointing.validation import StrictHandling
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.attention import SelfAttention
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.dist_checkpointing import TempNamedDir
+from tests.unit_tests.test_utilities import Utils
+
+NUM_HEADS = 4
+HIDDEN_SIZE = 32
+SEQ_LEN = 4
+BATCH_SIZE = 2
+INPUT_SEED = 7
+
+
+def _make_config(num_query_groups: int, add_qkv_bias: bool) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=HIDDEN_SIZE,
+        num_attention_heads=NUM_HEADS,
+        num_query_groups=num_query_groups,
+        use_cpu_initialization=True,
+        params_dtype=torch.float32,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        add_qkv_bias=add_qkv_bias,
+        head_wise_attn_gate=True,
+    )
+
+
+def _build_attention(seed: int, num_query_groups: int, add_qkv_bias: bool) -> SelfAttention:
+    model_parallel_cuda_manual_seed(seed)
+    submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
+    config = _make_config(num_query_groups=num_query_groups, add_qkv_bias=add_qkv_bias)
+    attn = SelfAttention(config, submodules, layer_number=1).cuda()
+    attn.eval()
+    return attn
+
+
+def _fixed_input():
+    torch.manual_seed(INPUT_SEED)
+    hidden_states = torch.randn(
+        SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.float32, device="cuda"
+    )
+    attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+    return hidden_states, attention_mask
+
+
+class TestHeadWiseAttnGateTPResharding:
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("src_tp,dst_tp", [(1, 2), (2, 1)])
+    @pytest.mark.parametrize("num_query_groups", [NUM_HEADS, NUM_HEADS // 2])
+    @pytest.mark.parametrize("add_qkv_bias", [False, True])
+    def test_logits_equality_across_tp_reshard(
+        self, tmp_path_dist_ckpt, src_tp, dst_tp, num_query_groups, add_qkv_bias
+    ):
+        if Utils.world_size < max(src_tp, dst_tp):
+            pytest.skip(f"need world_size >= {max(src_tp, dst_tp)}")
+
+        Utils.initialize_model_parallel(src_tp, 1)
+        attn_src = _build_attention(
+            seed=123, num_query_groups=num_query_groups, add_qkv_bias=add_qkv_bias
+        )
+
+        hidden_states, attention_mask = _fixed_input()
+        with torch.no_grad():
+            output_src, _ = attn_src(hidden_states, attention_mask)
+        output_src_cpu = output_src.detach().to(torch.float32).cpu()
+
+        ckpt_tag = (
+            f"head_wise_gate_tp{src_tp}_to_tp{dst_tp}"
+            f"_g{num_query_groups}_bias{int(add_qkv_bias)}"
+        )
+        with TempNamedDir(tmp_path_dist_ckpt / ckpt_tag) as ckpt_dir:
+            save(attn_src.sharded_state_dict(prefix=""), ckpt_dir)
+            del attn_src
+            Utils.destroy_model_parallel()
+
+            Utils.initialize_model_parallel(dst_tp, 1)
+            attn_dst = _build_attention(
+                seed=999, num_query_groups=num_query_groups, add_qkv_bias=add_qkv_bias
+            )
+            state_dict, missing_keys, unexpected_keys = load(
+                attn_dst.sharded_state_dict(prefix=""), ckpt_dir, strict=StrictHandling.RETURN_ALL
+            )
+            assert all('_extra_state' in k for k in missing_keys), missing_keys
+            assert all('_extra_state' in k for k in unexpected_keys), unexpected_keys
+            attn_dst.load_state_dict(state_dict)
+
+            hidden_states, attention_mask = _fixed_input()
+            with torch.no_grad():
+                output_dst, _ = attn_dst(hidden_states, attention_mask)
+            output_dst_cpu = output_dst.detach().to(torch.float32).cpu()
+
+        if torch.distributed.get_rank() == 0:
+            torch.testing.assert_close(output_dst_cpu, output_src_cpu, atol=1e-4, rtol=1e-4)

--- a/tests/unit_tests/transformer/test_head_wise_attn_gate.py
+++ b/tests/unit_tests/transformer/test_head_wise_attn_gate.py
@@ -1,0 +1,353 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Tests for per-head scalar attention gate (head_wise_attn_gate).
+
+Unverified paths (follow-ups): CP, fp8, explicit backward-grad-to-gate,
+packed_seq_params.qkv_format == 'thd'.
+"""
+
+import pytest
+import torch
+
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_local_spec,
+    get_gpt_layer_with_transformer_engine_submodules,
+)
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.attention import SelfAttention
+from tests.unit_tests.test_utilities import Utils
+
+SEQ_LEN = 16
+BATCH_SIZE = 2
+HIDDEN_SIZE = 128
+NUM_HEADS = 4
+KV_CHANNELS = HIDDEN_SIZE // NUM_HEADS  # 32
+QKV_OUT_DIM = 3 * NUM_HEADS * KV_CHANNELS  # query + key + value, no GQA
+
+
+def _make_config(transformer_impl: str, head_wise_attn_gate: bool) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=HIDDEN_SIZE,
+        num_attention_heads=NUM_HEADS,
+        use_cpu_initialization=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        transformer_impl=transformer_impl,
+        head_wise_attn_gate=head_wise_attn_gate,
+    )
+
+
+def _make_attention(config: TransformerConfig, transformer_impl: str) -> SelfAttention:
+    if transformer_impl == "transformer_engine":
+        submodules = get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules
+    else:
+        submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
+    return SelfAttention(config, submodules, layer_number=1)
+
+
+class TestHeadWiseAttnGateConfigValidation:
+    """TransformerConfig.__post_init__ rejects misconfigurations at config time."""
+
+    def _config(self, **extra) -> TransformerConfig:
+        kwargs = dict(
+            num_layers=1,
+            hidden_size=HIDDEN_SIZE,
+            num_attention_heads=NUM_HEADS,
+            use_cpu_initialization=True,
+            params_dtype=torch.float32,
+        )
+        kwargs.update(extra)
+        return TransformerConfig(**kwargs)
+
+    def test_rejects_combination_with_attention_output_gate(self):
+        with pytest.raises(ValueError, match="cannot both be enabled"):
+            self._config(head_wise_attn_gate=True, attention_output_gate=True)
+
+    def test_rejects_num_heads_indivisible_by_tp(self):
+        with pytest.raises(ValueError, match="num_attention_heads"):
+            self._config(
+                num_attention_heads=3,
+                num_query_groups=3,
+                hidden_size=24,
+                tensor_model_parallel_size=2,
+                head_wise_attn_gate=True,
+            )
+
+    def test_rejects_num_query_groups_below_tp(self):
+        with pytest.raises(ValueError, match="num_query_groups"):
+            self._config(
+                num_attention_heads=4,
+                num_query_groups=1,
+                tensor_model_parallel_size=2,
+                head_wise_attn_gate=True,
+            )
+
+    def test_accepts_well_formed_config(self):
+        self._config(
+            num_attention_heads=4,
+            num_query_groups=4,
+            tensor_model_parallel_size=2,
+            head_wise_attn_gate=True,
+        )
+
+    def test_disabled_does_not_constrain_other_flags(self):
+        """Gate-off must not regress unrelated configs."""
+        self._config(head_wise_attn_gate=False, attention_output_gate=True)
+        self._config(
+            num_attention_heads=4,
+            num_query_groups=1,
+            tensor_model_parallel_size=2,
+            head_wise_attn_gate=False,
+        )
+
+    def test_rejects_fp8_misaligned_linear_qkv_out_dim(self):
+        # H=8, G=8, D=128, TP=1 -> linear_qkv_out_dim=3080; 3080 % 16 = 8.
+        with pytest.raises(ValueError, match=r"fp8.*multiple of 16"):
+            self._config(
+                num_attention_heads=8,
+                num_query_groups=8,
+                hidden_size=8 * 128,
+                head_wise_attn_gate=True,
+                fp8="hybrid",
+            )
+
+    def test_rejects_fp4_stricter_alignment(self):
+        # H=16, G=2, D=128, TP=1 -> 2576; passes fp8 (16) but fails fp4 (32).
+        with pytest.raises(ValueError, match=r"fp4.*multiple of 32"):
+            self._config(
+                num_attention_heads=16,
+                num_query_groups=2,
+                hidden_size=16 * 128,
+                head_wise_attn_gate=True,
+                fp4="e2m1",
+            )
+
+
+@pytest.mark.parametrize("transformer_impl", ["transformer_engine", "native"])
+class TestHeadWiseAttnGateInit:
+    """Verify linear_qkv is sized to include the fused gate rows iff enabled."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self, transformer_impl):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(42)
+        self.transformer_impl = transformer_impl
+        yield
+        Utils.destroy_model_parallel()
+
+    def test_linear_qkv_includes_gate_rows_when_enabled(self):
+        config = _make_config(self.transformer_impl, head_wise_attn_gate=True)
+        attn = _make_attention(config, self.transformer_impl)
+        # linear_qkv output dim = Q+K+V + num_attention_heads (gate rows).
+        assert attn.linear_qkv_out_dim == QKV_OUT_DIM + NUM_HEADS
+        assert attn.linear_qkv.weight.shape == (QKV_OUT_DIM + NUM_HEADS, HIDDEN_SIZE)
+
+    def test_linear_qkv_unchanged_when_disabled(self):
+        config = _make_config(self.transformer_impl, head_wise_attn_gate=False)
+        attn = _make_attention(config, self.transformer_impl)
+        assert attn.linear_qkv_out_dim == QKV_OUT_DIM
+        assert attn.linear_qkv.weight.shape == (QKV_OUT_DIM, HIDDEN_SIZE)
+
+
+@pytest.mark.parametrize("transformer_impl", ["transformer_engine", "native"])
+class TestHeadWiseAttnGateForward:
+    """Forward-pass shape sanity + zero-gate equivalence."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self, transformer_impl):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(42)
+        self.transformer_impl = transformer_impl
+        yield
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("use_gate", [True, False])
+    def test_output_shape(self, use_gate: bool):
+        config = _make_config(self.transformer_impl, head_wise_attn_gate=use_gate)
+        attn = _make_attention(config, self.transformer_impl).cuda()
+        hidden_states = torch.randn(
+            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.bfloat16, device="cuda"
+        )
+        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+        output, _ = attn(hidden_states, attention_mask)
+        assert output.shape == (SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE)
+
+    def test_zero_gate_halves_output(self):
+        """Zero gate rows -> sigmoid(0)=0.5 -> output = 0.5 * no-gate ref."""
+        config = _make_config(self.transformer_impl, head_wise_attn_gate=True)
+        attn = _make_attention(config, self.transformer_impl).cuda()
+        with torch.no_grad():
+            attn.linear_qkv.weight[-NUM_HEADS:].zero_()
+
+        hidden_states = torch.randn(
+            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.bfloat16, device="cuda"
+        )
+        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+
+        config_no_gate = _make_config(self.transformer_impl, head_wise_attn_gate=False)
+        attn_no_gate = _make_attention(config_no_gate, self.transformer_impl).cuda()
+        with torch.no_grad():
+            attn_no_gate.linear_qkv.weight.copy_(attn.linear_qkv.weight[:QKV_OUT_DIM])
+            attn_no_gate.linear_proj.weight.copy_(attn.linear_proj.weight)
+            if attn.linear_qkv.bias is not None:
+                attn_no_gate.linear_qkv.bias.copy_(attn.linear_qkv.bias[:QKV_OUT_DIM])
+            if attn.linear_proj.bias is not None:
+                attn_no_gate.linear_proj.bias.copy_(attn.linear_proj.bias)
+
+        with torch.no_grad():
+            out_gated, _ = attn(hidden_states, attention_mask)
+            out_plain, _ = attn_no_gate(hidden_states, attention_mask)
+
+        torch.testing.assert_close(
+            out_gated.float(), (out_plain * 0.5).float(), atol=1e-2, rtol=1e-2
+        )
+
+
+def _make_config_tp(
+    head_wise_attn_gate: bool, add_qkv_bias: bool = False, **extra: object
+) -> TransformerConfig:
+    """Float32 config for TP correctness tests; local-spec backend, no dropout.
+
+    Extra TransformerConfig kwargs (e.g. head_wise_attn_gate_init_*) can be
+    passed through ``extra``.
+    """
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=HIDDEN_SIZE,
+        num_attention_heads=NUM_HEADS,
+        use_cpu_initialization=True,
+        params_dtype=torch.float32,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        add_qkv_bias=add_qkv_bias,
+        head_wise_attn_gate=head_wise_attn_gate,
+        **extra,
+    )
+
+
+def _make_attention_local(config: TransformerConfig) -> SelfAttention:
+    """Local (ColumnParallelLinear) backend so the trailing-rows layout is
+    unambiguous -- TE variants may carry layer-norm params that don't matter
+    for these layout checks but would complicate weight surgery."""
+    submodules = get_gpt_layer_local_spec().submodules.self_attention.submodules
+    return SelfAttention(config, submodules, layer_number=1).cuda()
+
+
+def _copy_qkv_block_only(attn_dst: SelfAttention, attn_src: SelfAttention):
+    """Copy the non-gate (QKV-only) rows of linear_qkv and the full linear_proj
+    from attn_src into attn_dst. Used to build a no-gate reference that
+    shares all weights with a gated layer EXCEPT the trailing gate rows. Each
+    rank handles its own local slice."""
+    qkv_rows = attn_dst.linear_qkv.weight.size(0)
+    with torch.no_grad():
+        attn_dst.linear_qkv.weight.copy_(attn_src.linear_qkv.weight[:qkv_rows])
+        attn_dst.linear_proj.weight.copy_(attn_src.linear_proj.weight)
+        if attn_src.linear_qkv.bias is not None and attn_dst.linear_qkv.bias is not None:
+            attn_dst.linear_qkv.bias.copy_(attn_src.linear_qkv.bias[:qkv_rows])
+        if attn_src.linear_proj.bias is not None and attn_dst.linear_proj.bias is not None:
+            attn_dst.linear_proj.bias.copy_(attn_src.linear_proj.bias)
+
+
+class TestHeadWiseAttnGateUnderTP2:
+    """TP=2 forward equivalence under known constant gate values."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        if Utils.world_size < 2:
+            pytest.skip(f"need world_size >= 2 (got {Utils.world_size})")
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=2, pipeline_model_parallel_size=1
+        )
+        model_parallel_cuda_manual_seed(42)
+        yield
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("gate_value,expected_scale", [(0.0, 0.5), (1e4, 1.0), (-1e4, 0.0)])
+    def test_saturated_gate_under_tp2(self, gate_value: float, expected_scale: float):
+        """Zero gate weight rows + fill gate bias rows with gate_value, then
+        verify out_gated == sigmoid(gate_value) * out_no_gate. Catches layout
+        bugs where the slice would land on V/K rows instead of gate rows."""
+        gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
+        attn = _make_attention_local(gated_config)
+        gate_size = attn.num_attention_heads_per_partition
+        assert attn.linear_qkv.bias is not None
+        with torch.no_grad():
+            attn.linear_qkv.weight[-gate_size:].zero_()
+            attn.linear_qkv.bias[-gate_size:].fill_(gate_value)
+
+        ref_config = _make_config_tp(head_wise_attn_gate=False, add_qkv_bias=True)
+        attn_ref = _make_attention_local(ref_config)
+        _copy_qkv_block_only(attn_ref, attn)
+
+        torch.manual_seed(0)
+        hidden_states = torch.randn(
+            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.float32, device="cuda"
+        )
+        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+        with torch.no_grad():
+            out_gated, _ = attn(hidden_states, attention_mask)
+            out_plain, _ = attn_ref(hidden_states, attention_mask)
+
+        torch.testing.assert_close(out_gated, out_plain * expected_scale, atol=1e-4, rtol=1e-4)
+
+
+class TestHeadWiseAttnGateInitMagnitude:
+    """Init-time gate-row surgery: near-identity at start, knob propagation, FP8 safety."""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(42)
+        yield
+        Utils.destroy_model_parallel()
+
+    def _run_pair(self, gated_config: TransformerConfig) -> tuple[torch.Tensor, torch.Tensor]:
+        attn = _make_attention_local(gated_config)
+        ref_config = _make_config_tp(head_wise_attn_gate=False, add_qkv_bias=True)
+        attn_ref = _make_attention_local(ref_config)
+        _copy_qkv_block_only(attn_ref, attn)
+
+        torch.manual_seed(0)
+        hidden_states = torch.randn(
+            SEQ_LEN, BATCH_SIZE, HIDDEN_SIZE, dtype=torch.float32, device="cuda"
+        )
+        attention_mask = torch.ones(BATCH_SIZE, 1, 1, SEQ_LEN, dtype=bool, device="cuda")
+        with torch.no_grad():
+            out_gated, _ = attn(hidden_states, attention_mask)
+            out_plain, _ = attn_ref(hidden_states, attention_mask)
+        return out_gated, out_plain
+
+    def test_default_init_is_near_identity(self):
+        """out_gated ~= sigmoid(2.0) * out_plain at init; closer than 0.5 *
+        out_plain (catches regressions that drop the init surgery)."""
+        gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
+        out_gated, out_plain = self._run_pair(gated_config)
+        expected_scale = torch.sigmoid(
+            torch.tensor(gated_config.head_wise_attn_gate_init_bias)
+        ).item()
+        torch.testing.assert_close(out_gated, out_plain * expected_scale, atol=5e-2, rtol=5e-2)
+        near_id_err = (out_gated - out_plain * expected_scale).abs().mean().item()
+        half_err = (out_gated - out_plain * 0.5).abs().mean().item()
+        assert near_id_err < half_err
+
+    def test_init_knobs_reproduce_half_scaling(self):
+        """Both knobs=0 reproduces sigmoid(0)=0.5 -- proves the knobs flow."""
+        gated_config = _make_config_tp(
+            head_wise_attn_gate=True,
+            add_qkv_bias=True,
+            head_wise_attn_gate_init_weight_scale=0.0,
+            head_wise_attn_gate_init_bias=0.0,
+        )
+        out_gated, out_plain = self._run_pair(gated_config)
+        torch.testing.assert_close(out_gated, out_plain * 0.5, atol=1e-4, rtol=1e-4)
+
+    def test_init_preserves_fp8_friendly_gate_magnitude(self):
+        """gate_std ~ 0.1 * qkv_std (no zero-init, no FP8 underflow risk)."""
+        gated_config = _make_config_tp(head_wise_attn_gate=True, add_qkv_bias=True)
+        attn = _make_attention_local(gated_config)
+        gate_rows = attn.linear_qkv.weight[-attn.num_attention_heads_per_partition :]
+        qkv_rows = attn.linear_qkv.weight[: -attn.num_attention_heads_per_partition]
+        ratio = gate_rows.float().std().item() / qkv_rows.float().std().item()
+        assert 0.05 < ratio < 0.5


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

use_head_wise_attn_gate: bool -- enable a per-head scalar output gate
(a.k.a. g_proj). The gate is fused into linear_qkv as the trailing
num_attention_heads rows; in the forward pass each rank slices off its
num_attention_heads_per_partition gate scalars, applies sigmoid, and
scales each attention head's output before linear_proj.
Distinct from attention_output_gate, which fuses a full head_dim gate
into linear_qkv. The per-head gate adds only num_attention_heads extra
output rows on linear_qkv (vs. num_attention_heads * head_dim), so the
parameter and FLOP overhead is negligible.
Under tensor parallel, this requires that both num_query_groups and
num_attention_heads be divisible by the TP world size so the QKV and
gate sub-ranges stay aligned per rank.
The new feature defaults to False and has no effect on existing models.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>
