### PR TITLE
Ignore Vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 .coverage_*
 *.egg-info
 *~
+*.swp
 slurm*
 logs
 .vscode


### PR DESCRIPTION
## Summary

- Ignore Vim swap files generated during local edits.
- Restore the final newline in .gitignore.

## Tests

- git diff --check