### PR TITLE
Fix Mamba conv1d FSDP gathers

### DIFF
--- a/megatron/core/ssm/mamba_context_parallel.py
+++ b/megatron/core/ssm/mamba_context_parallel.py
@@ -231,12 +231,12 @@ class MambaContextParallel:
     def get_conv1d_weight(self) -> torch.Tensor:
         """Returns a slice of the conv1d weight relevant to the current context parallel rank"""
         # weight shape: [conv_dim, 1, d_conv]
-        return self._slice_conv_param(self.conv1d_cp1.weight)
+        return self.slice_conv_param(self.conv1d_cp1.weight)
 
     def get_conv1d_bias(self) -> torch.Tensor:
         """Returns a slice of the conv1d bias relevant to the current context parallel rank"""
         # bias shape: [conv_dim]
-        return self._slice_conv_param(self.conv1d_cp1.bias)
+        return self.slice_conv_param(self.conv1d_cp1.bias)
 
     def get_dt_bias(self) -> torch.Tensor:
         """Returns a slice of dt_bias relevant to the current context parallel rank"""
@@ -250,7 +250,7 @@ class MambaContextParallel:
         """Returns a slice of D relevant to the current context parallel rank"""
         return self._slice_vector_param(self.D_cp1, has_hdim=self.D_has_hdim)
 
-    def _slice_conv_param(self, param: torch.Tensor) -> torch.Tensor:
+    def slice_conv_param(self, param: torch.Tensor) -> torch.Tensor:
         """
         Slices a cp_size=1 conv1d parameter (either weight or bias) along the first dimension,
         returning the parts of the parameter needed for convolution on the current context parallel

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -112,6 +112,45 @@ class ExtendedRMSNorm(RMSNormGated):
         )
 
 
+class MambaConv1d(nn.Conv1d):
+    """Conv1d owner for Mamba fused-kernel weight and bias views."""
+
+    def _weight_bias(self, cp: Optional[MambaContextParallel] = None):
+        if cp is None:
+            return self.weight, self.bias
+
+        weight = cp.slice_conv_param(self.weight)
+        bias = cp.slice_conv_param(self.bias) if self.bias is not None else None
+        return weight, bias
+
+    def forward(
+        self,
+        input_: Optional[torch.Tensor] = None,
+        *,
+        cp: Optional[MambaContextParallel] = None,
+        return_weight_bias: bool = False,
+    ):
+        if return_weight_bias:
+            return self._weight_bias(cp)
+
+        if input_ is None:
+            raise ValueError("MambaConv1d.forward requires input unless return_weight_bias=True")
+
+        if cp is None or cp.cp_size == 1:
+            return super().forward(input_)
+
+        weight, bias = self._weight_bias(cp)
+        return F.conv1d(
+            input=input_,
+            weight=weight,
+            bias=bias,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=cp.conv1d_channels(),
+        )
+
+
 @dataclass
 class MambaMixerSubmodules:
     """
@@ -287,7 +326,7 @@ class MambaMixer(MegatronModule):
         with get_cuda_rng_tracker().fork():
             # weight shape: [conv_dim, 1, d_conv]
             # bias shape: [conv_dim]
-            self.conv1d = nn.Conv1d(
+            self.conv1d = MambaConv1d(
                 in_channels=conv_dim,
                 out_channels=conv_dim,
                 bias=conv_bias,
@@ -412,6 +451,9 @@ class MambaMixer(MegatronModule):
             D_has_hdim=self.D_has_hdim,
         )
         self.tp_group = pg_collection.tp
+
+    def _conv1d_weight_bias(self):
+        return self.conv1d(cp=self.cp, return_weight_bias=True)
 
     def forward(
         self,
@@ -690,9 +732,7 @@ class MambaMixer(MegatronModule):
         # (nheads_local_tpcp)
         A = -torch.exp(self.cp.get_A_log().float())
 
-        # TODO(duncan): Can this code be removed?
-        if self.conv1d.bias is not None:
-            self.conv1d.bias.data_ptr()
+        conv_weight, conv_bias = self._conv1d_weight_bias()
 
         seq_idx = None
         if packed_seq_params is not None:
@@ -704,8 +744,8 @@ class MambaMixer(MegatronModule):
 
         y = mamba_split_conv1d_scan_combined(
             zxBCdt,
-            rearrange(self.cp.get_conv1d_weight(), "d 1 w -> d w"),
-            self.cp.get_conv1d_bias(),
+            rearrange(conv_weight, "d 1 w -> d w"),
+            conv_bias,
             self.cp.get_dt_bias().float(),
             A,
             D=(
@@ -828,10 +868,9 @@ class MambaMixer(MegatronModule):
             conv_state_dtype = conv_state.dtype
 
             xBC = xBC.to(conv_state_dtype)
-            conv_weight = rearrange(self.cp.get_conv1d_weight(), "d 1 w -> d w").to(
-                conv_state_dtype
-            )
-            conv_bias = self.cp.get_conv1d_bias().to(conv_state_dtype)
+            conv_weight, conv_bias = self._conv1d_weight_bias()
+            conv_weight = rearrange(conv_weight, "d 1 w -> d w").to(conv_state_dtype)
+            conv_bias = conv_bias.to(conv_state_dtype) if conv_bias is not None else None
 
             xBC_pre_conv = xBC if intermediate_conv_out is not None else None
             from megatron.core.ssm.ops.causal_conv1d_varlen import causal_conv1d_varlen_fn
@@ -859,13 +898,14 @@ class MambaMixer(MegatronModule):
 
             seqlen = xBC.size(2)
             if causal_conv1d_fn is None:
-                xBC = self.act(self.cp.conv1d(xBC)[..., :seqlen])
+                xBC = self.act(self.conv1d(xBC, cp=self.cp)[..., :seqlen])
             else:
                 assert self.activation in ["silu", "swish"]
+                conv_weight, conv_bias = self._conv1d_weight_bias()
                 xBC = causal_conv1d_fn(
                     x=xBC,
-                    weight=rearrange(self.cp.get_conv1d_weight(), "d 1 w -> d w"),
-                    bias=self.cp.get_conv1d_bias(),
+                    weight=rearrange(conv_weight, "d 1 w -> d w"),
+                    bias=conv_bias,
                     activation=self.activation,
                     seq_idx=seq_idx,
                 )
@@ -1095,6 +1135,7 @@ class MambaMixer(MegatronModule):
         )
 
         # Conv step
+        conv_weight, conv_bias = self._conv1d_weight_bias()
         if causal_conv1d_update is None:
             # TODO(ksanthanam): Consider deprecating this path
             assert seq_len == 1, "Native PyTorch fallback only supports 1 token at a time"
@@ -1102,22 +1143,23 @@ class MambaMixer(MegatronModule):
             conv_state.copy_(torch.roll(conv_state, shifts=-1, dims=-1))  # Update state (B D W)
             conv_state[:, :, -1] = xBC_squeeze
             xBC_squeeze = torch.sum(
-                conv_state * rearrange(self.conv1d.weight, "d 1 w -> d w"), dim=-1
+                conv_state * rearrange(conv_weight, "d 1 w -> d w"), dim=-1
             )  # (B D)
-            if self.conv1d.bias is not None:
-                xBC_squeeze = xBC_squeeze + self.conv1d.bias
+            if conv_bias is not None:
+                xBC_squeeze = xBC_squeeze + conv_bias
             xBC = self.act(xBC_squeeze).to(dtype=xBC.dtype).unsqueeze(1)
         else:
             # Conv state dtype might differ from params dtype, so cast xBC and weight / bias
             # tensors to the conv state dtype for causal_conv1d_update and then cast xBC
             # back to the original dtype
             xBC_dtype = xBC.dtype
-            weight = rearrange(self.conv1d.weight, "d 1 w -> d w")
+            weight = rearrange(conv_weight, "d 1 w -> d w")
+            bias = conv_bias.to(conv_state.dtype) if conv_bias is not None else None
             xBC = causal_conv1d_update(
                 xBC.to(conv_state.dtype),
                 conv_state,
                 weight.to(conv_state.dtype),
-                self.conv1d.bias.to(conv_state.dtype),
+                bias,
                 self.activation,
                 conv_state_indices=batch_indices,
                 intermediate_conv_states=intermediate_conv_state,

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -130,6 +130,7 @@ class MambaConv1d(nn.Conv1d):
         cp: Optional[MambaContextParallel] = None,
         return_weight_bias: bool = False,
     ):
+        """Run conv1d or return CP-local parameter views for fused Mamba kernels."""
         if return_weight_bias:
             return self._weight_bias(cp)
 

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
@@ -949,14 +949,14 @@ def compare_losses(loss_a: float, loss_b: float, reference: str = "b"):
     return {"abs_diff": abs_diff, "rel_diff": rel_diff, "better": better}
 
 
-class TestFsdpMambaDirectWeightAccess:
-    """Regression repro for Mamba raw child-parameter reads under Megatron FSDP.
+class TestFsdpMambaConv1dGather:
+    """Regression repro for Mamba fused conv params under Megatron FSDP.
 
-    MambaMixer reads ``self.conv1d.weight`` through the fused causal-conv path instead
-    of invoking ``self.conv1d(...)``. That bypasses the child module pre-forward hook,
-    so the conv1d bucket is only gathered if another hook prefetches it incidentally.
-    This test makes that dependency deterministic by disabling AG prefetch before the
-    first forward.
+    The fused causal-conv path must invoke the conv1d owner module before using
+    its weight and bias views. Otherwise, the child module pre-forward hook is
+    bypassed and the conv1d bucket is only gathered if another hook prefetches
+    it incidentally. This test makes that dependency deterministic by disabling
+    AG prefetch before the first forward.
     """
 
     @classmethod
@@ -967,7 +967,7 @@ class TestFsdpMambaDirectWeightAccess:
     def teardown_class(cls):
         Utils.destroy_model_parallel()
 
-    def test_mamba_conv1d_raw_weight_read_without_prefetch(self):
+    def test_mamba_conv1d_fused_path_without_prefetch(self):
         if not is_torch_min_version("2.4.0"):
             pytest.skip("Megatron FSDP requires torch >= 2.4.0")
         if Utils.world_size < 2:
@@ -1036,7 +1036,7 @@ class TestFsdpMambaDirectWeightAccess:
             "bucket_size may be too large and could mask this repro."
         )
 
-        # Disabling prefetch isolates the raw conv1d weight read: the forward cannot
+        # Disabling prefetch isolates the fused conv path: the forward cannot
         # incidentally gather conv1d.weight from an earlier module hook.
         x = torch.randn(64, 2, HIDDEN, device="cuda", dtype=torch.bfloat16)
         fsdp_model.module.suggested_AG_prefetch_size = 0

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
@@ -14,10 +14,14 @@ from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import HAVE_TE_MXFP8TENSOR
 from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.optimizer import OptimizerConfig
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.ssm.mamba_layer import MambaLayer
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.utils import is_torch_min_version
 from tests.unit_tests.distributed.megatron_fsdp.utils import (
     make_gpt_mock_data_iterator,
@@ -943,3 +947,100 @@ def compare_losses(loss_a: float, loss_b: float, reference: str = "b"):
         better = "equal"
 
     return {"abs_diff": abs_diff, "rel_diff": rel_diff, "better": better}
+
+
+class TestFsdpMambaDirectWeightAccess:
+    """Regression repro for Mamba raw child-parameter reads under Megatron FSDP.
+
+    MambaMixer reads ``self.conv1d.weight`` through the fused causal-conv path instead
+    of invoking ``self.conv1d(...)``. That bypasses the child module pre-forward hook,
+    so the conv1d bucket is only gathered if another hook prefetches it incidentally.
+    This test makes that dependency deterministic by disabling AG prefetch before the
+    first forward.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel()
+
+    @classmethod
+    def teardown_class(cls):
+        Utils.destroy_model_parallel()
+
+    def test_mamba_conv1d_raw_weight_read_without_prefetch(self):
+        if not is_torch_min_version("2.4.0"):
+            pytest.skip("Megatron FSDP requires torch >= 2.4.0")
+        if Utils.world_size < 2:
+            pytest.skip("Requires at least 2 GPUs (DP>=2).")
+
+        # MambaMixer's __init__ reads the 'model-parallel-rng' tracker.
+        model_parallel_cuda_manual_seed(0)
+
+        # HIDDEN=256 is the floor: d_inner = 2 * HIDDEN, nheads = d_inner / 64,
+        # and nheads must be divisible by the default mamba_num_groups=8.
+        HIDDEN = 256
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=HIDDEN,
+            num_attention_heads=4,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            normalization="RMSNorm",
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        )
+
+        class HybridStack(torch.nn.Module):
+            def __init__(self, config, pg_collection):
+                super().__init__()
+                self.attn_layer = TransformerLayer(
+                    config=config,
+                    submodules=hybrid_stack_spec.submodules.attention_layer.submodules,
+                    layer_number=1,
+                    pg_collection=pg_collection,
+                    add_layer_offset=False,
+                )
+                self.mamba_layer = MambaLayer(
+                    config=config,
+                    submodules=hybrid_stack_spec.submodules.mamba_layer.submodules,
+                    layer_number=2,
+                    pg_collection=pg_collection,
+                )
+
+            def forward(self, hidden_states):
+                h, _ = self.attn_layer(hidden_states=hidden_states, attention_mask=None)
+                return self.mamba_layer(hidden_states=h)
+
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=["tp", "cp"])
+        model = HybridStack(config, pg_collection).cuda().to(torch.bfloat16)
+        fsdp_model = FullyShardedDataParallel(
+            config=config,
+            ddp_config=DistributedDataParallelConfig(
+                data_parallel_sharding_strategy="optim_grads_params",
+                overlap_grad_reduce=True,
+                overlap_param_gather=True,
+                bucket_size=4096,
+                use_megatron_fsdp=True,
+            ),
+            module=model,
+            fsdp_unit_modules=[TransformerLayer],
+        )
+
+        non_unit_buckets = [
+            pg
+            for pg in fsdp_model.param_and_grad_buffer.parameter_groups
+            if pg.fsdp_unit_id is None
+        ]
+        assert len(non_unit_buckets) >= 2, (
+            "Expected non-unit params to split across multiple buckets; "
+            "bucket_size may be too large and could mask this repro."
+        )
+
+        # Disabling prefetch isolates the raw conv1d weight read: the forward cannot
+        # incidentally gather conv1d.weight from an earlier module hook.
+        x = torch.randn(64, 2, HIDDEN, device="cuda", dtype=torch.bfloat16)
+        fsdp_model.module.suggested_AG_prefetch_size = 0
+        fsdp_model(x)
+
+        # Surface any deferred CUDA errors before teardown.
+        torch.cuda.synchronize()


### PR DESCRIPTION
## Summary
- Route Mamba fused conv weight/bias access through the owning `conv1d` module so M-FSDP pre-forward hooks all-gather `conv1d.weight` and `conv1d.bias` before fused kernels use them.
- Add `MambaConv1d` to return CP-local weight/bias views from the conv module while preserving the existing CP slicing logic.
- Keep the deterministic regression with AG prefetch disabled, updated to assert the fixed fused conv path.

## Testing
- `python -m py_compile megatron/core/ssm/mamba_mixer.py megatron/core/ssm/mamba_context_parallel.py tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py`
- `git diff --check`
- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh`
- `uv run python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py::TestFsdpMambaConv1dGather::test_mamba_conv1d_fused_path_without_prefetch`

Draft while CI validates the fix.
