### PR TITLE
[Backport] Fix Qwen3.5 context parallel in core_dev_r0.16.0

### DIFF
--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1491,6 +1491,14 @@ class SelfAttention(Attention):
         if output_gate:
             # Gate [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
             gate = gate.reshape(*gate.shape[:2], -1, self.hidden_size_per_attention_head)
+            if self.config.num_query_groups < self.world_size:
+                idx = get_tensor_model_parallel_rank() % (
+                    self.world_size // self.config.num_query_groups
+                )
+                size = self.num_attention_heads_per_partition // (
+                    self.world_size // self.config.num_query_groups
+                )
+                gate = gate[:, :, idx * size : (idx + 1) * size, :]
             return query, key, value, gate
 
         return query, key, value


### PR DESCRIPTION
When integrating mcore with ms-swift/llamafactory for Qwen3.5 context parallel (CP), the core_dev_r0.16.0 branch encounters the same bug resolved in #3529. This commit backports the fix from main to core_dev_r0.16.0 to unblock Qwen3.5 CP training.

# What does this PR do ?
This PR backports the context parallel (CP) fix for Qwen3.5 from PR #3529 to the `core_dev_r0.16.0` branch.

**Motivation & Context:**
While integrating Megatron Core with downstream open-source frameworks (such as LLaMA-Factory and ms-swift) to support Qwen3.5 with Context Parallelism (CP), the [ms-swift documentation](https://github.com/modelscope/ms-swift/pull/9022/files/553a3dbd0d9ffad647b6585634257e85e4d7a01d) explicitly points out that Qwen3.5 CP is currently ONLY supported in `mcore` dev branches. 

Consequently, we are relying on the **latest** dev branch, `core_dev_r0.16.0`. However, during Qwen3.5 training on this branch, we encountered the exact same bug that was previously resolved in the `main` branch via PR #3529. This critical fix has not yet been synchronized to `core_dev_r0.16.0`.

To unblock Qwen3.5 CP training for the open-source community relying on this latest dev branch, this PR backports the specific changes from #3529 (commit `6c02944`) to `core_dev_r0.16.0`. I have verified locally that this synchronization successfully resolves the issue.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.


## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: Related to #3529
*(Reference Commit from main: https://github.com/NVIDIA/Megatron-LM/pull/3529/commits/6c0294483dc04c1222ce378c6174d28ed3028ff4)*

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

*(Note for reviewers: As this is a pure backport of the already approved and merged PR #3529, no new logic is introduced beyond what was previously tested and reviewed in `main`.)*

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>