### PR TITLE
Add experimental Megatron Lite as agentic exploration

### DIFF
--- a/experimental/lite/README.md
+++ b/experimental/lite/README.md
@@ -1,0 +1,72 @@
+# Megatron Lite
+
+Megatron Lite is an experimental training runtime and model implementation layer
+for Megatron. The source lives under `experimental/lite/megatron/lite`, and the
+public import path is `megatron.lite`.
+
+Do not import `experimental.lite` from user code. Examples and public APIs should
+refer to `megatron.lite`.
+
+## Scope
+
+This initial drop contains:
+
+- A lightweight runtime API in `megatron.lite.runtime`.
+- Common training primitives in `megatron.lite.primitive`.
+- Lite-only model implementations for Qwen3 MoE and Qwen3.5 MoE.
+- Hugging Face safetensors load/export helpers for the included models.
+- Megatron-Core optimizer wrapping for the lite runtime.
+
+This initial drop intentionally does not include:
+
+- Hybrid model implementations.
+- Bridge model/runtime implementations.
+- FSDP2 optimizer primitives.
+- Benchmark entrypoints or experiment scripts.
+
+## Layout
+
+```text
+experimental/lite/
+  README.md
+  docs/                       Design and usage notes
+  megatron/
+    lite/
+      runtime/                Runtime API, config, backend registry, lite backend
+      model/                  Model registry and Qwen model implementations
+      primitive/              Parallel, checkpoint, optimizer, module, and op primitives
+```
+
+For local source-tree use:
+
+```bash
+export PYTHONPATH=/path/to/Megatron-LM/experimental/lite:$PYTHONPATH
+```
+
+## Public API
+
+```python
+from megatron.lite.runtime import LiteConfig, RuntimeConfig, create_runtime
+
+cfg = RuntimeConfig(
+    backend="lite",
+    hf_path="/path/to/hf-model",
+    backend_cfg=LiteConfig(model_name="qwen3", impl="lite"),
+)
+runtime = create_runtime(cfg)
+handle = runtime.build_model()
+```
+
+Model names currently registered by default:
+
+- `qwen3`: Qwen3 MoE lite implementation. HF `model_type` values
+  `qwen3_moe` and `qwen2_moe` resolve to this model name.
+- `qwen3_moe`: compatibility alias for the same Qwen3 MoE lite implementation.
+- `qwen3_5`: Qwen3.5 MoE lite implementation.
+
+## Docs
+
+- [Architecture](docs/architecture.md)
+- [Runtime](docs/runtime.md)
+- [Models](docs/models.md)
+- [Porting Notes](docs/porting.md)

--- a/experimental/lite/docs/architecture.md
+++ b/experimental/lite/docs/architecture.md
@@ -1,0 +1,43 @@
+# Architecture
+
+Megatron Lite source lives under `experimental/lite/megatron/lite` and is split
+into three layers:
+
+- `runtime`: lifecycle and training-step orchestration.
+- `model`: model registration plus model-specific build/load/export protocols.
+- `primitive`: reusable lower-level pieces such as parallel state, tensor-parallel
+  layers, checkpoint conversion, MoE utilities, and optimizer wrapping.
+
+The runtime does not know Qwen implementation details. It imports a model
+protocol from the model registry, builds the typed implementation config, then
+delegates model construction to that protocol.
+
+## Import Boundary
+
+The source root for local use is `experimental/lite`; adding that directory to
+`PYTHONPATH` exposes the package as `megatron.lite`. Internal imports also use
+`megatron.lite` so user-facing code matches the final package path.
+
+## Runtime Boundary
+
+The runtime API owns:
+
+- Distributed initialization.
+- Model protocol loading.
+- Model checkpoint save/load dispatch.
+- Forward/backward microbatch orchestration.
+- Optimizer and learning-rate scheduler stepping.
+- Optional model/optimizer offload hooks.
+
+The model protocol owns:
+
+- Architecture config creation.
+- Model chunk construction.
+- Model-specific recompute/offload wiring.
+- Model-specific optimizer construction.
+- HF checkpoint load/export mapping.
+
+## Current Deliberate Omissions
+
+This package currently includes only the lite path. It intentionally excludes
+hybrid implementations, bridge implementations, and FSDP2 optimizer primitives.

--- a/experimental/lite/docs/models.md
+++ b/experimental/lite/docs/models.md
@@ -1,0 +1,53 @@
+# Models
+
+Model code lives under `megatron.lite.model`.
+
+The model registry maps `(model_name, impl)` pairs to model protocol modules.
+The runtime loads the protocol and expects the following required symbols:
+
+- `ImplConfig`: dataclass for model-specific knobs.
+- `build_model_config(source, **overrides)`: returns a typed model config.
+- `build_model(model_cfg, *, impl_cfg)`: returns a `ModelBundle`.
+
+Optional protocol symbols:
+
+- `load_hf_weights(chunk, hf_path, model_cfg, ps)`
+- `export_hf_weights(chunks, model_cfg, ps, **kwargs)`
+- `vocab_size(model_cfg)`
+
+## Included Models
+
+`qwen3` maps to the Qwen3 MoE lite implementation:
+
+```text
+megatron.lite.model.qwen3_moe.lite.protocol
+```
+
+`qwen3_moe` is kept as a compatibility alias for the same implementation.
+Hugging Face `model_type` values `qwen3_moe` and `qwen2_moe` resolve to
+`qwen3`.
+
+`qwen3_5` maps to the Qwen3.5 MoE lite implementation:
+
+```text
+megatron.lite.model.qwen3_5.lite.protocol
+```
+
+## Adding A Model
+
+Add a model package under `model/`, then register it in
+`model/registry.py`:
+
+```python
+register_model(
+    "my_model",
+    package="megatron.lite.model.my_model",
+    hf_model_types=["my_model"],
+    impls={
+        "lite": "megatron.lite.model.my_model.lite.protocol",
+    },
+)
+```
+
+New models should keep heavyweight imports inside protocol functions when
+possible so importing `megatron.lite` stays cheap.

--- a/experimental/lite/docs/porting.md
+++ b/experimental/lite/docs/porting.md
@@ -1,0 +1,40 @@
+# Porting Notes
+
+This tree is prepared as an experimental Megatron package. The package code
+lives under `experimental/lite/megatron/lite`, so users can add
+`experimental/lite` to `PYTHONPATH` and import `megatron.lite`.
+
+## Naming Rules
+
+- Use `Megatron Lite` for the component name in docs and comments.
+- Use `megatron.lite` for public and internal imports.
+- Do not introduce project-specific legacy branding.
+- Prefer `lite` for backend names and runtime keys.
+
+## Included Surface
+
+Keep the first PR focused on the lite path:
+
+- Runtime backend: `lite`.
+- Models: Qwen3 MoE and Qwen3.5 MoE.
+- Model implementations: `lite` only.
+- Optimizer primitive: Megatron-Core optimizer wrapping.
+
+Keep these out of the first PR unless the scope changes:
+
+- Hybrid model implementation packages.
+- Bridge model/runtime implementation packages.
+- FSDP2 optimizer primitives.
+- Benchmark scripts and experiment-specific entrypoints.
+
+## Package Integration
+
+No repository-level packaging changes are made in this experimental drop. The
+current layout is importable from source with:
+
+```bash
+export PYTHONPATH=/path/to/Megatron-LM/experimental/lite:$PYTHONPATH
+```
+
+A future integration step can decide whether to keep the experimental location
+or move the tree into the final package location.

--- a/experimental/lite/docs/runtime.md
+++ b/experimental/lite/docs/runtime.md
@@ -1,0 +1,62 @@
+# Runtime
+
+The public runtime entrypoint is `megatron.lite.runtime`.
+
+```python
+from megatron.lite.runtime import LiteConfig, ParallelConfig, RuntimeConfig, create_runtime
+
+cfg = RuntimeConfig(
+    backend="lite",
+    hf_path="/path/to/hf-model",
+    backend_cfg=LiteConfig(
+        model_name="qwen3",
+        impl="lite",
+        parallel=ParallelConfig(tp=1, pp=1, cp=1, ep=1),
+    ),
+)
+runtime = create_runtime(cfg)
+handle = runtime.build_model()
+```
+
+## API Tiers
+
+All runtime backends implement the pretraining tier:
+
+- `build_model`
+- `save_checkpoint`
+- `load_checkpoint`
+- `train_mode`
+- `eval_mode`
+- `forward_backward`
+- `zero_grad`
+- `optimizer_step`
+- `lr_scheduler_step`
+
+The lite runtime also implements `export_weights` and `to` when the underlying
+model and optimizer support those operations.
+
+## Config Types
+
+`RuntimeConfig` selects the backend and carries the Hugging Face model path.
+
+`LiteConfig` carries lite-backend settings:
+
+- `model_name`: `qwen3`, `qwen3_moe`, or `qwen3_5`.
+- `impl`: currently only `lite`.
+- `parallel`: tensor, expert, pipeline, virtual pipeline, and context sizes.
+- `optimizer`: Megatron-Core optimizer settings.
+- `impl_cfg`: model-specific options consumed by each model protocol.
+
+## Backend Registry
+
+The only built-in backend key is `lite`.
+
+Custom runtime backends can be registered with:
+
+```python
+from megatron.lite.runtime import register_runtime
+
+register_runtime("my_backend", "my_package.my_runtime")
+```
+
+The target module must expose `create(hf_path, cfg)`.

--- a/experimental/lite/megatron/lite/__init__.py
+++ b/experimental/lite/megatron/lite/__init__.py
@@ -1,0 +1,30 @@
+"""Top-level Megatron Lite package exports."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from megatron.lite.runtime.backends.lite.config import DebugConfig, LiteConfig
+    from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+
+__all__ = [
+    "DebugConfig",
+    "LiteConfig",
+    "OptimizerConfig",
+    "ParallelConfig",
+]
+
+
+def __getattr__(name: str):
+    _lazy = {
+        "LiteConfig": "megatron.lite.runtime.backends.lite.config",
+        "DebugConfig": "megatron.lite.runtime.backends.lite.config",
+        "OptimizerConfig": "megatron.lite.runtime.contracts.config",
+        "ParallelConfig": "megatron.lite.runtime.contracts.config",
+    }
+    if name in _lazy:
+        mod = importlib.import_module(_lazy[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/experimental/lite/megatron/lite/model/__init__.py
+++ b/experimental/lite/megatron/lite/model/__init__.py
@@ -1,0 +1,17 @@
+"""Public model-registry helpers for Megatron Lite."""
+
+from megatron.lite.model.registry import (
+    get_model_package,
+    get_train_runtime_module,
+    register_model,
+    resolve_model_type_from_hf,
+    resolve_runtime_model_name,
+)
+
+__all__ = [
+    "get_model_package",
+    "get_train_runtime_module",
+    "register_model",
+    "resolve_model_type_from_hf",
+    "resolve_runtime_model_name",
+]

--- a/experimental/lite/megatron/lite/model/qwen3_5/__init__.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/__init__.py
@@ -1,0 +1,1 @@
+"""Qwen3.5 model package."""

--- a/experimental/lite/megatron/lite/model/qwen3_5/common.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/common.py
@@ -1,0 +1,67 @@
+"""Qwen3.5 bridge config contract — single maintenance point (Fix-M2)."""
+from __future__ import annotations
+
+
+def is_expert_param(name: str) -> bool:
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+def apply_qwen3_5_bridge_config(bridge, *, deterministic: bool = True) -> None:
+    """Register required TransformerConfig flags via set_extra_args (Fix-M2).
+
+    Must be called after AutoBridge.from_pretrained() AND before bridge_post_init
+    (or any _apply_moe_hack call). Uses set_extra_args so flags survive every
+    subsequent _build_config() rebuild via mbridge's extra_args highest-priority
+    override channel (llm_bridge.py::_build_base_config last update).
+
+    deterministic: when True, set MC deterministic_mode for bitwise runs.
+      MUST be False for THD / packed_seq_params runs (GDN hard assert).
+    fused_single_qkv_rope=False → full_attn output_gate layout is incompatible
+                               with fused QKV+RoPE fusion.
+    """
+    bridge.set_extra_args(
+        deterministic_mode=deterministic,
+        fused_single_qkv_rope=False,
+    )
+
+
+def _apply_moe_hack_to_bridge(bridge, model_cfg) -> None:
+    """Mirror model_cfg truncations into bridge.hf_config + install router monkey-patch.
+
+    Handles Qwen3.5's nested text_config structure. Must be called AFTER
+    apply_qwen3_5_bridge_config so extra_args flags survive the final _build_config.
+    Only mutates when cfg < bridge (truncation); no-ops otherwise.
+    """
+    hf_text = getattr(bridge.hf_config, "text_config", bridge.hf_config)
+
+    bridge_num_experts = getattr(hf_text, "num_experts", None)
+    bridge_num_layers = getattr(hf_text, "num_hidden_layers", None)
+    cfg_num_experts = getattr(model_cfg, "num_experts", None)
+    cfg_num_layers = getattr(model_cfg, "num_hidden_layers", None)
+
+    needs_rebuild = False
+
+    # ── expert truncation ────────────────────────────────────────────
+    if bridge_num_experts is not None and cfg_num_experts is not None:
+        if cfg_num_experts < bridge_num_experts:
+            hf_text.num_experts = cfg_num_experts
+            hf_text.num_experts_per_tok = model_cfg.num_experts_per_tok
+            needs_rebuild = True
+            keep = cfg_num_experts
+            orig_fn = bridge._weight_to_mcore_format
+
+            def patched(name: str, hf_weights: list, _k=keep, _f=orig_fn):
+                if "mlp.router.weight" in name and len(hf_weights) == 1:
+                    hf_weights = [hf_weights[0][:_k].contiguous()]
+                return _f(name, hf_weights)
+
+            bridge._weight_to_mcore_format = patched
+
+    # ── layer truncation ─────────────────────────────────────────────
+    if bridge_num_layers is not None and cfg_num_layers is not None:
+        if cfg_num_layers < bridge_num_layers:
+            hf_text.num_hidden_layers = cfg_num_layers
+            needs_rebuild = True
+
+    if needs_rebuild:
+        bridge.config = bridge._build_config()

--- a/experimental/lite/megatron/lite/model/qwen3_5/config.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/config.py
@@ -1,0 +1,212 @@
+"""Qwen3.5 model configuration."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from megatron.lite.primitive.config import load_hf_config_dict
+
+_HF_FIELDS = frozenset({
+    "num_hidden_layers",
+    "hidden_size",
+    "num_attention_heads",
+    "num_key_value_heads",
+    "head_dim",
+    "vocab_size",
+    "rms_norm_eps",
+    "max_position_embeddings",
+    "router_aux_loss_coef",
+    "num_experts",
+    "num_experts_per_tok",
+    "moe_intermediate_size",
+    "shared_expert_intermediate_size",
+    "linear_num_key_heads",
+    "linear_key_head_dim",
+    "linear_num_value_heads",
+    "linear_value_head_dim",
+    "linear_conv_kernel_dim",
+    "layer_types",
+    "partial_rotary_factor",
+    "mtp_num_hidden_layers",
+    "mtp_use_dedicated_embeddings",
+    "num_nextn_predict_layers",
+    "mtp_loss_scaling_factor",
+    "mtp_use_repeated_layer",
+    "mtp_layer_types",
+})
+
+
+@dataclass
+class Qwen35Config:
+    """Pure Qwen3.5-35B-A3B architecture parameters."""
+
+    num_hidden_layers: int = 40
+    hidden_size: int = 2048
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 2
+    head_dim: int = 256
+    vocab_size: int = 248320
+    rms_norm_eps: float = 1e-6
+    max_position_embeddings: int = 262144
+    router_aux_loss_coef: float = 0.001
+    num_experts: int = 256
+    num_experts_per_tok: int = 8
+    moe_intermediate_size: int = 512
+    shared_expert_intermediate_size: int = 512
+    linear_num_key_heads: int = 16
+    linear_key_head_dim: int = 128
+    linear_num_value_heads: int = 32
+    linear_value_head_dim: int = 128
+    linear_conv_kernel_dim: int = 4
+    layer_types: list[str] = field(
+        default_factory=lambda: (
+            ["linear_attention", "linear_attention", "linear_attention", "full_attention"] * 10
+        )
+    )
+    partial_rotary_factor: float = 0.25
+    rope_theta: float = 10_000_000.0
+    num_nextn_predict_layers: int = 0
+    mtp_loss_scaling_factor: float = 0.1
+    mtp_use_dedicated_embeddings: bool = False
+    mtp_use_repeated_layer: bool = False
+    mtp_layer_types: list[str] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Derived properties
+    # ------------------------------------------------------------------
+
+    @property
+    def rotary_dim(self) -> int:
+        return int(self.head_dim * self.partial_rotary_factor)
+
+    @property
+    def full_attn_qkv_size(self) -> int:
+        return (self.num_attention_heads + 2 * self.num_key_value_heads) * self.head_dim
+
+    @property
+    def linear_conv_dim(self) -> int:
+        return self.linear_num_key_heads * self.linear_key_head_dim
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def __post_init__(self):
+        if (
+            self.num_nextn_predict_layers > 0
+            and not self.mtp_layer_types
+            and len(self.layer_types) == self.num_hidden_layers + self.num_nextn_predict_layers
+        ):
+            self.mtp_layer_types = self.layer_types[self.num_hidden_layers:]
+            self.layer_types = self.layer_types[:self.num_hidden_layers]
+        if self.num_nextn_predict_layers > 0 and not self.mtp_layer_types:
+            self.mtp_layer_types = ["full_attention"] * self.num_nextn_predict_layers
+        if len(self.layer_types) != self.num_hidden_layers:
+            raise ValueError(
+                f"len(layer_types)={len(self.layer_types)} != "
+                f"num_hidden_layers={self.num_hidden_layers}"
+            )
+        if self.num_nextn_predict_layers > 0 and len(self.mtp_layer_types) != self.num_nextn_predict_layers:
+            raise ValueError(
+                f"len(mtp_layer_types)={len(self.mtp_layer_types)} != "
+                f"num_nextn_predict_layers={self.num_nextn_predict_layers}"
+            )
+        self._validate()
+
+    def _validate(self):
+        errors: list[str] = []
+
+        def _check(cond: bool, msg: str):
+            if not cond:
+                errors.append(msg)
+
+        _check(self.num_hidden_layers >= 1, f"num_hidden_layers must be >= 1, got {self.num_hidden_layers}")
+        _check(
+            self.num_nextn_predict_layers >= 0,
+            f"num_nextn_predict_layers must be >= 0, got {self.num_nextn_predict_layers}",
+        )
+        _check(
+            not self.mtp_use_dedicated_embeddings,
+            "Qwen35Config only supports shared embeddings for MTP "
+            "(mtp_use_dedicated_embeddings=False)",
+        )
+        _check(self.hidden_size > 0, f"hidden_size must be > 0, got {self.hidden_size}")
+        _check(self.head_dim > 0, f"head_dim must be > 0, got {self.head_dim}")
+        _check(self.vocab_size > 0, f"vocab_size must be > 0, got {self.vocab_size}")
+        _check(self.num_attention_heads >= 1, f"num_attention_heads must be >= 1, got {self.num_attention_heads}")
+        _check(
+            self.num_attention_heads % self.num_key_value_heads == 0,
+            f"num_attention_heads({self.num_attention_heads}) must be divisible by "
+            f"num_key_value_heads({self.num_key_value_heads})",
+        )
+        _check(self.num_experts >= 1, f"num_experts must be >= 1, got {self.num_experts}")
+        _check(
+            1 <= self.num_experts_per_tok <= self.num_experts,
+            f"num_experts_per_tok({self.num_experts_per_tok}) must be in "
+            f"[1, num_experts({self.num_experts})]",
+        )
+        _check(self.moe_intermediate_size > 0, f"moe_intermediate_size must be > 0, got {self.moe_intermediate_size}")
+        _check(
+            self.shared_expert_intermediate_size > 0,
+            f"shared_expert_intermediate_size must be > 0, got {self.shared_expert_intermediate_size}",
+        )
+        _check(self.linear_num_key_heads >= 1, f"linear_num_key_heads must be >= 1, got {self.linear_num_key_heads}")
+        _check(self.linear_key_head_dim > 0, f"linear_key_head_dim must be > 0, got {self.linear_key_head_dim}")
+        _check(self.linear_num_value_heads >= 1, f"linear_num_value_heads must be >= 1, got {self.linear_num_value_heads}")
+        _check(self.linear_value_head_dim > 0, f"linear_value_head_dim must be > 0, got {self.linear_value_head_dim}")
+        _check(
+            0.0 < self.partial_rotary_factor <= 1.0,
+            f"partial_rotary_factor must be in (0, 1], got {self.partial_rotary_factor}",
+        )
+        valid_types = {"linear_attention", "full_attention"}
+        for i, lt in enumerate(self.layer_types):
+            _check(lt in valid_types, f"layer_types[{i}] must be one of {valid_types}, got '{lt}'")
+        for i, lt in enumerate(self.mtp_layer_types):
+            _check(lt in valid_types, f"mtp_layer_types[{i}] must be one of {valid_types}, got '{lt}'")
+
+        if errors:
+            raise ValueError(
+                f"Invalid Qwen35Config ({len(errors)} error"
+                f"{'s' if len(errors) > 1 else ''}):\n  " + "\n  ".join(errors)
+            )
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_hf(cls, path: str, **overrides) -> Qwen35Config:
+        hf = load_hf_config_dict(path)
+        return cls._from_hf_dict(hf, **overrides)
+
+    @classmethod
+    def from_hf_config(cls, hf_config, **overrides) -> Qwen35Config:
+        return cls._from_hf_dict(hf_config.to_dict(), **overrides)
+
+    @classmethod
+    def _from_hf_dict(cls, hf: dict, **overrides) -> Qwen35Config:
+        if "text_config" in hf and isinstance(hf["text_config"], dict):
+            hf = hf["text_config"]
+        kwargs = {k: v for k, v in hf.items() if k in _HF_FIELDS}
+        mtp_num_hidden_layers = kwargs.pop("mtp_num_hidden_layers", None)
+        if kwargs.get("num_nextn_predict_layers") is None and mtp_num_hidden_layers is not None:
+            kwargs["num_nextn_predict_layers"] = int(mtp_num_hidden_layers)
+        if "rope_parameters" in hf and isinstance(hf["rope_parameters"], dict):
+            rp = hf["rope_parameters"]
+            if "rope_theta" not in kwargs:
+                kwargs["rope_theta"] = float(rp.get("rope_theta", 10_000_000.0))
+            if "partial_rotary_factor" not in kwargs and "partial_rotary_factor" in rp:
+                kwargs["partial_rotary_factor"] = float(rp["partial_rotary_factor"])
+        if "head_dim" not in kwargs or kwargs.get("head_dim") is None:
+            kwargs["head_dim"] = kwargs.get("hidden_size", 2048) // kwargs.get("num_attention_heads", 16)
+        if kwargs.get("num_nextn_predict_layers") is None:
+            kwargs["num_nextn_predict_layers"] = 0
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+    def layer_type_at(self, layer_idx: int) -> str:
+        if layer_idx < self.num_hidden_layers:
+            return self.layer_types[layer_idx]
+        mtp_idx = layer_idx - self.num_hidden_layers
+        if 0 <= mtp_idx < len(self.mtp_layer_types):
+            return self.mtp_layer_types[mtp_idx]
+        return "full_attention"

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/__init__.py
@@ -1,0 +1,1 @@
+"""Qwen3.5 lite sub-package."""

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/_mbridge_glue.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/_mbridge_glue.py
@@ -1,0 +1,155 @@
+"""Verbatim mbridge helpers for weight splitting and VL model hooks.
+
+Sources:
+  - mbridge/mbridge/models/qwen3_5/base_bridge.py  (weight-split)
+  - mbridge/mbridge/models/qwen3_5/model.py        (VL hooks)
+Only change from source: self. → bridge. / standalone functions (per R24).
+"""
+from __future__ import annotations
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+
+
+def _weight_split_across_tp(
+    bridge,
+    mcore_weights_name: str,
+    mcore_weights: torch.Tensor,
+    param: torch.Tensor,
+    tp_split_size: int,
+) -> list[torch.Tensor]:
+    # VERBATIM from mbridge base_bridge.py::_weight_split_across_tp (L656-762)
+    # Only change: self. → bridge.
+    if tp_split_size == 1:
+        return [mcore_weights]
+
+    if (
+        "self_attention.linear_qkv." in mcore_weights_name
+        and "layer_norm" not in mcore_weights_name
+    ):
+        return mcore_weights.chunk(tp_split_size)
+    elif "vision_model" not in mcore_weights_name and (
+        "linear_fc1.weight" in mcore_weights_name
+        or "linear_fc1.bias" in mcore_weights_name
+    ):
+        mcore_config = bridge._get_mcore_config_by_name(mcore_weights_name)
+        if not mcore_config.gated_linear_unit:
+            return mcore_weights.chunk(tp_split_size)
+
+        gate, up = mcore_weights.chunk(2)
+        gates = gate.chunk(tp_split_size)
+        ups = up.chunk(tp_split_size)
+        ret = [torch.cat([g, u], dim=0) for g, u in zip(gates, ups, strict=False)]
+    elif "mlp.experts.linear_fc2.weight" in mcore_weights_name:  # moe
+        ret = mcore_weights.chunk(tp_split_size, dim=1)
+    elif "self_attention.in_proj.weight" in mcore_weights_name:
+        mcore_config = bridge._get_mcore_config_by_name(mcore_weights_name)
+        k_dim = mcore_config.linear_num_key_heads * mcore_config.linear_key_head_dim
+        v_dim = (
+            mcore_config.linear_num_value_heads * mcore_config.linear_value_head_dim
+        )
+        split_shape = [
+            k_dim,
+            k_dim,
+            v_dim,
+            v_dim,
+            mcore_config.linear_num_value_heads,
+            mcore_config.linear_num_value_heads,
+        ]
+        split_w_lst = mcore_weights.split(split_shape, dim=0)
+        # split_w_lst: [wq, wk, wv, wz, wb, wa]
+        assert len(split_w_lst) == 6, f"split_shape {split_shape} not supported"
+        weight_list = []
+        for weight in split_w_lst:
+            weight_list.append(weight.chunk(tp_split_size))
+        ret = [
+            torch.cat(
+                [wq_slice, wk_slice, wv_slice, wz_slice, wb_slice, wa_slice], dim=0
+            )
+            for wq_slice, wk_slice, wv_slice, wz_slice, wb_slice, wa_slice in zip(
+                *weight_list, strict=False
+            )
+        ]
+    elif "self_attention.conv1d" in mcore_weights_name:
+        if "weight" in mcore_weights_name:
+            mcore_config = bridge._get_mcore_config_by_name(mcore_weights_name)
+            k_dim = (
+                mcore_config.linear_num_key_heads * mcore_config.linear_key_head_dim
+            )
+            v_dim = (
+                mcore_config.linear_num_value_heads
+                * mcore_config.linear_value_head_dim
+            )
+            split_shape = [
+                k_dim,
+                k_dim,
+                v_dim,
+            ]
+            split_w_lst = mcore_weights.split(split_shape, dim=0)
+            # split_w_lst: [X, B, C]
+            assert len(split_w_lst) == 3, f"split_shape {split_shape} not supported"
+            weight_list = []
+            for weight in split_w_lst:
+                weight_list.append(weight.chunk(tp_split_size))
+            ret = [
+                torch.cat([x_slice, b_slice, c_slice], dim=0)
+                for x_slice, b_slice, c_slice in zip(*weight_list, strict=False)
+            ]
+        else:
+            raise NotImplementedError(f"{mcore_weights_name} not supported yet")
+    else:
+        if param.shape == mcore_weights.shape:
+            return [mcore_weights for _ in range(tp_split_size)]
+        assert len(param.shape) == len(mcore_weights.shape)
+        for partition_dim, (s1, s2) in enumerate(  # noqa: B007
+            zip(param.shape, mcore_weights.shape, strict=False)
+        ):
+            if s1 != s2:
+                break
+
+        ret = mcore_weights.chunk(tp_split_size, dim=partition_dim)
+    return ret
+
+
+def _split_weight_by_size_and_merge_across_tp(
+    mcore_weights: list[torch.Tensor],
+    split_shape: list[int],
+) -> torch.Tensor:
+    # VERBATIM from mbridge base_bridge.py::_split_weight_by_size_and_merge_across_tp (L764-785)
+    tp_size = len(mcore_weights)
+
+    weight_lst = [[] for _ in range(len(split_shape))]
+    for mcore_weight in mcore_weights:
+        split_w_lst = mcore_weight.split(split_shape, dim=0)
+        assert len(split_w_lst) == len(weight_lst)
+        for wi, split_w in enumerate(split_w_lst):
+            weight_lst[wi].append(split_w)
+    for weight in weight_lst:
+        assert len(weight) == tp_size
+    ret = torch.cat([torch.cat(w_split, dim=0) for w_split in weight_lst], dim=0)
+    return ret
+
+
+def _hook_fp32_rotary_emb_verbatim(module: nn.Module) -> None:
+    # VERBATIM from mbridge/.../qwen3_5/model.py Qwen3_5VLModel._hook_fp32_rotary_emb (L122-139)
+    for submodule in module.modules():
+        if hasattr(submodule, "inv_freq") and submodule.inv_freq is not None:
+            submodule._inv_freq_fp32_original = (
+                submodule.inv_freq.detach().clone().float()
+            )
+
+            def _hook(mod, args):
+                if hasattr(mod, "_inv_freq_fp32_original"):
+                    mod.inv_freq = mod._inv_freq_fp32_original.to(
+                        device=mod.inv_freq.device
+                    )
+
+            submodule.register_forward_pre_hook(_hook)
+
+
+def _hook_vision_params_avg_grad_across_tp_verbatim(module: nn.Module) -> None:
+    # VERBATIM from mbridge/.../qwen3_5/model.py Qwen3_5VLModel._hook_vision_params_avg_grad_across_tp (L141-152)
+    if module is None:
+        return
+    for param in module.parameters(recurse=True):
+        param.average_gradients_across_tp_domain = True  # type: ignore[assignment]

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -1,0 +1,856 @@
+"""Qwen3.5: HF safetensors load/save, weight mapping, DCP spec.
+
+Post-Step-3: load_hf_weights uses mbridge bridge dispatch (MC naming).
+export_weights / save_hf_weights use bridge._weight_to_hf_format for reverse-map.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from safetensors.torch import save_file as safe_save
+from torch.distributed.tensor import Replicate, Shard
+
+from megatron.lite.model.qwen3_5.config import Qwen35Config
+from megatron.lite.primitive.ckpt.hf_bridge import SafeTensorReader as _HFSafeTensorReader
+from megatron.lite.primitive.ckpt.hf_bridge import unwrap_model
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.utils import ensure_divisible, log_rank0
+
+# ── DCP Placement & Expert Classifier ─────────────────────────────────
+
+
+def PLACEMENT_FN(param_name: str) -> list:
+    """DTensor placement for DCP checkpoint save/load."""
+    if "experts" in param_name and "router" not in param_name and "shared" not in param_name:
+        if "fc1" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(0)]
+        elif "fc2" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(1)]
+        else:
+            return [Replicate(), Replicate(), Replicate(), Replicate()]
+    else:
+        if ("in_proj" in param_name or "qkv" in param_name) and "layer_norm" not in param_name:
+            return [Replicate(), Replicate(), Replicate(), Shard(0)]
+        elif ("proj" in param_name or "o_proj" in param_name) and "attn" in param_name:
+            return [Replicate(), Replicate(), Replicate(), Shard(1)]
+        elif "gate_up" in param_name and "shared" in param_name:
+            return [Replicate(), Replicate(), Replicate(), Shard(0)]
+        elif "down" in param_name and "shared" in param_name:
+            return [Replicate(), Replicate(), Replicate(), Shard(1)]
+        elif "eh_proj" in param_name:
+            return [Replicate(), Replicate(), Replicate(), Shard(0)]
+        elif "embed" in param_name or "head" in param_name:
+            return [Replicate(), Replicate(), Replicate(), Shard(0)]
+        elif "conv1d" in param_name or "dt_bias" in param_name or "A_log" in param_name:
+            return [Replicate(), Replicate(), Replicate(), Shard(0)]
+        else:
+            return [Replicate(), Replicate(), Replicate(), Replicate()]
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    """Which params are expert params (for EP-aware DDP)."""
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+# ── Bridge-based loading (MC naming) ───────────────────────────────────
+
+_GLOBAL_MBRIDGE = {
+    "embed.embedding.weight": "embedding.word_embeddings.weight",
+    "mtp_embed.embedding.weight": "embedding.word_embeddings.weight",
+    "norm.weight": "decoder.final_layernorm.weight",
+    "head.col.linear.weight": "output_layer.weight",
+}
+
+_FULL_ATTN_MBRIDGE = {
+    "self_attention.linear_qkv.layer_norm_weight": "self_attention.linear_qkv.layer_norm_weight",
+    "self_attention.linear_qkv.weight": "self_attention.linear_qkv.weight",
+    "self_attention.q_layernorm.weight": "self_attention.q_layernorm.weight",
+    "self_attention.k_layernorm.weight": "self_attention.k_layernorm.weight",
+    "self_attention.linear_proj.weight": "self_attention.linear_proj.weight",
+}
+
+_GDN_MBRIDGE = {
+    "self_attention.gdn.in_proj.weight": "self_attention.in_proj.weight",
+    "self_attention.gdn.in_proj.layer_norm_weight": "self_attention.in_proj.layer_norm_weight",
+    "self_attention.gdn.conv1d.weight": "self_attention.conv1d.weight",
+    "self_attention.gdn.dt_bias": "self_attention.dt_bias",
+    "self_attention.gdn.A_log": "self_attention.A_log",
+    "self_attention.gdn.out_norm.weight": "self_attention.out_norm.weight",
+    "self_attention.gdn.out_proj.weight": "self_attention.out_proj.weight",
+}
+
+_MOE_MBRIDGE = {
+    "pre_mlp_layernorm.weight": "pre_mlp_layernorm.weight",
+    "mlp.router.weight": "mlp.router.weight",
+    "mlp.shared_experts.linear_fc1.weight": "mlp.shared_experts.linear_fc1.weight",
+    "mlp.shared_experts.linear_fc2.weight": "mlp.shared_experts.linear_fc2.weight",
+    "mlp.shared_experts.gate_weight": "mlp.shared_experts.gate_weight",
+}
+
+
+def _lite_to_mbridge_name(local_name: str, global_idx_map: dict[int, int]) -> str | None:
+    def _map() -> str | None:
+        if local_name in _GLOBAL_MBRIDGE:
+            return _GLOBAL_MBRIDGE[local_name]
+        if not local_name.startswith("layers."):
+            return None
+        parts = local_name.split(".", 2)
+        if len(parts) < 3:
+            return None
+        try:
+            local_i = int(parts[1])
+        except ValueError:
+            return None
+        g = global_idx_map.get(local_i)
+        if g is None:
+            return None
+        suffix = parts[2]
+        if suffix in _FULL_ATTN_MBRIDGE:
+            return f"decoder.layers.{g}.{_FULL_ATTN_MBRIDGE[suffix]}"
+        if suffix in _GDN_MBRIDGE:
+            return f"decoder.layers.{g}.{_GDN_MBRIDGE[suffix]}"
+        if suffix in _MOE_MBRIDGE:
+            return f"decoder.layers.{g}.{_MOE_MBRIDGE[suffix]}"
+        if suffix.startswith("mlp.experts.linear_fc1.weight") or suffix.startswith(
+            "mlp.experts.linear_fc2.weight"
+        ):
+            return f"decoder.layers.{g}.{suffix}"
+        return None
+
+    mc = _map()
+    return f"language_model.{mc}" if mc is not None else None
+
+
+def _is_mtp_param(local_name: str) -> bool:
+    return local_name.startswith("mtp.layers.")
+
+
+def _is_mtp_embedding_param(local_name: str) -> bool:
+    return local_name == "mtp_embed.embedding.weight"
+
+
+def _mtp_layer_parts(local_name: str) -> tuple[int, str] | None:
+    parts = local_name.split(".", 3)
+    if len(parts) != 4 or parts[0] != "mtp" or parts[1] != "layers":
+        return None
+    try:
+        return int(parts[2]), parts[3]
+    except ValueError:
+        return None
+
+
+def _mtp_direct_hf_name(local_name: str) -> str | None:
+    parts = _mtp_layer_parts(local_name)
+    if parts is None:
+        return None
+    _mtp_idx, suffix = parts
+    direct = {
+        "enorm.weight": "mtp.pre_fc_norm_embedding.weight",
+        "hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
+        "eh_proj.linear.weight": "mtp.fc.weight",
+        "final_layernorm.weight": "mtp.norm.weight",
+    }
+    return direct.get(suffix)
+
+
+def _mtp_proxy_layer_idx(config: Qwen35Config, mtp_idx: int) -> int:
+    mtp_type = config.layer_type_at(config.num_hidden_layers + mtp_idx)
+    for layer_idx in range(config.num_hidden_layers):
+        if config.layer_type_at(layer_idx) == mtp_type:
+            return layer_idx
+    return 0
+
+
+def _mtp_transformer_mbridge_name(local_name: str, config: Qwen35Config) -> tuple[str, int, int] | None:
+    parts = _mtp_layer_parts(local_name)
+    if parts is None:
+        return None
+    mtp_idx, suffix = parts
+    if not suffix.startswith("transformer_layer."):
+        return None
+    inner = suffix.removeprefix("transformer_layer.")
+    proxy_idx = _mtp_proxy_layer_idx(config, mtp_idx)
+    mc_name = _lite_to_mbridge_name(f"layers.{proxy_idx}.{inner}", {proxy_idx: proxy_idx})
+    if mc_name is None:
+        return None
+    return mc_name, proxy_idx, mtp_idx
+
+
+def _mtp_rewrite_proxy_hf_name(hf_name: str, proxy_idx: int, mtp_idx: int) -> str:
+    hf_name = str(hf_name)
+    marker = "language_mtp.layers."
+    if marker in hf_name:
+        return "mtp.layers." + hf_name.split(marker, 1)[1]
+    src_language_mtp = f"model.language_mtp.layers.{mtp_idx}."
+    dst = f"mtp.layers.{mtp_idx}."
+    if hf_name.startswith(src_language_mtp):
+        return dst + hf_name[len(src_language_mtp):]
+    src = f"model.layers.{proxy_idx}."
+    if hf_name.startswith(src):
+        return dst + hf_name[len(src):]
+    if src in hf_name:
+        return hf_name.replace(src, dst, 1)
+    return hf_name
+
+
+def _mtp_expert_info(local_name: str) -> tuple[int, str, str] | None:
+    parts = _mtp_layer_parts(local_name)
+    if parts is None:
+        return None
+    mtp_idx, suffix = parts
+    fc1_match = re.fullmatch(r"transformer_layer\.mlp\.experts\.linear_fc1\.weight(\d+)", suffix)
+    if fc1_match is not None:
+        return mtp_idx, "linear_fc1", fc1_match.group(1)
+    fc2_match = re.fullmatch(r"transformer_layer\.mlp\.experts\.linear_fc2\.weight(\d+)", suffix)
+    if fc2_match is not None:
+        return mtp_idx, "linear_fc2", fc2_match.group(1)
+    return None
+
+
+def _mtp_global_expert_id(local_expert_id: str, config: Qwen35Config, ps: ParallelState) -> int:
+    num_local = ensure_divisible(config.num_experts, max(ps.ep_size, 1))
+    return ps.ep_rank * num_local + int(local_expert_id)
+
+
+def _mtp_expert_hf_names(local_name: str, config: Qwen35Config, ps: ParallelState) -> list[str] | None:
+    info = _mtp_expert_info(local_name)
+    if info is None:
+        return None
+    mtp_idx, kind, local_expert_id = info
+    global_expert_id = _mtp_global_expert_id(local_expert_id, config, ps)
+    prefix = f"mtp.layers.{mtp_idx}.mlp.experts.{global_expert_id}."
+    if kind == "linear_fc1":
+        return [f"{prefix}gate_proj.weight", f"{prefix}up_proj.weight"]
+    return [f"{prefix}down_proj.weight"]
+
+
+def _mtp_expert_tensor_from_hf(local_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor | None:
+    info = _mtp_expert_info(local_name)
+    if info is None:
+        return None
+    _mtp_idx, kind, _expert_id = info
+    if kind == "linear_fc1":
+        return torch.cat(hf_tensors, dim=0)
+    return hf_tensors[0]
+
+
+def _split_mtp_expert_tensor_for_rank(
+    local_name: str,
+    tensor: torch.Tensor,
+    ps: ParallelState,
+) -> torch.Tensor:
+    info = _mtp_expert_info(local_name)
+    if info is None or ps.etp_size <= 1:
+        return tensor
+    _mtp_idx, kind, _expert_id = info
+    if kind == "linear_fc1":
+        gate, up = tensor.chunk(2, dim=0)
+        ensure_divisible(gate.shape[0], ps.etp_size)
+        ensure_divisible(up.shape[0], ps.etp_size)
+        return torch.cat(
+            [
+                gate.chunk(ps.etp_size, dim=0)[ps.etp_rank],
+                up.chunk(ps.etp_size, dim=0)[ps.etp_rank],
+            ],
+            dim=0,
+        )
+    ensure_divisible(tensor.shape[1], ps.etp_size)
+    return tensor.chunk(ps.etp_size, dim=1)[ps.etp_rank]
+
+
+def _mtp_expert_agg_info(local_name: str) -> tuple[int, str] | None:
+    parts = _mtp_layer_parts(local_name)
+    if parts is None:
+        return None
+    mtp_idx, suffix = parts
+    if suffix == "transformer_layer.mlp.experts.linear_fc1.weight":
+        return mtp_idx, "linear_fc1"
+    if suffix == "transformer_layer.mlp.experts.linear_fc2.weight":
+        return mtp_idx, "linear_fc2"
+    return None
+
+
+def _mtp_expert_export_items(local_name: str, tensor: torch.Tensor) -> dict[str, torch.Tensor] | None:
+    info = _mtp_expert_agg_info(local_name)
+    if info is None:
+        return None
+    mtp_idx, kind = info
+    out: dict[str, torch.Tensor] = {}
+    for expert_id, expert_tensor in enumerate(tensor):
+        prefix = f"mtp.layers.{mtp_idx}.mlp.experts.{expert_id}."
+        if kind == "linear_fc1":
+            gate, up = expert_tensor.chunk(2, dim=0)
+            out[f"{prefix}gate_proj.weight"] = gate
+            out[f"{prefix}up_proj.weight"] = up
+        else:
+            out[f"{prefix}down_proj.weight"] = expert_tensor
+    return out
+
+
+def _mtp_manual_transformer_hf_names(
+    local_name: str,
+    mtp_idx: int,
+    config: Qwen35Config | None = None,
+    ps: ParallelState | None = None,
+) -> list[str] | None:
+    parts = _mtp_layer_parts(local_name)
+    if parts is None:
+        return None
+    _, suffix = parts
+    if not suffix.startswith("transformer_layer."):
+        return None
+    inner = suffix.removeprefix("transformer_layer.")
+    prefix = f"mtp.layers.{mtp_idx}."
+
+    direct = {
+        "self_attention.linear_proj.weight": [f"{prefix}self_attn.o_proj.weight"],
+        "self_attention.linear_qkv.layer_norm_weight": [f"{prefix}input_layernorm.weight"],
+        "self_attention.linear_qkv.weight": [
+            f"{prefix}self_attn.q_proj.weight",
+            f"{prefix}self_attn.k_proj.weight",
+            f"{prefix}self_attn.v_proj.weight",
+        ],
+        "self_attention.q_layernorm.weight": [f"{prefix}self_attn.q_norm.weight"],
+        "self_attention.k_layernorm.weight": [f"{prefix}self_attn.k_norm.weight"],
+        "pre_mlp_layernorm.weight": [f"{prefix}post_attention_layernorm.weight"],
+        "mlp.router.weight": [f"{prefix}mlp.gate.weight"],
+        "mlp.shared_experts.gate_weight": [f"{prefix}mlp.shared_expert_gate.weight"],
+        "mlp.shared_experts.linear_fc1.weight": [
+            f"{prefix}mlp.shared_expert.gate_proj.weight",
+            f"{prefix}mlp.shared_expert.up_proj.weight",
+        ],
+        "mlp.shared_experts.linear_fc2.weight": [f"{prefix}mlp.shared_expert.down_proj.weight"],
+    }
+    if inner in direct:
+        return direct[inner]
+    if config is not None and ps is not None:
+        expert_hf_names = _mtp_expert_hf_names(local_name, config, ps)
+        if expert_hf_names is not None:
+            return expert_hf_names
+    return None
+
+
+def _mtp_transformer_hf_names(
+    local_name: str,
+    config: Qwen35Config,
+    bridge,
+    ps: ParallelState,
+) -> tuple[str, list[str]] | None:
+    mapped = _mtp_transformer_mbridge_name(local_name, config)
+    if mapped is None:
+        return None
+    mc_name, proxy_idx, mtp_idx = mapped
+    manual_hf_names = _mtp_manual_transformer_hf_names(local_name, mtp_idx, config, ps)
+    if manual_hf_names is not None:
+        return mc_name, manual_hf_names
+    hf_names = bridge._weight_name_mapping_mcore_to_hf(mc_name)
+    return mc_name, [_mtp_rewrite_proxy_hf_name(n, proxy_idx, mtp_idx) for n in hf_names]
+
+
+def _split_mtp_direct_tensor(
+    local_name: str,
+    tensor: torch.Tensor,
+    param: torch.nn.Parameter,
+    ps: ParallelState,
+) -> torch.Tensor:
+    if local_name.endswith(".eh_proj.linear.weight") and ps.tp_size > 1 and tensor.shape != param.data.shape:
+        ensure_divisible(tensor.shape[0], ps.tp_size)
+        start = ps.tp_rank * (tensor.shape[0] // ps.tp_size)
+        stop = (ps.tp_rank + 1) * (tensor.shape[0] // ps.tp_size)
+        tensor = tensor[start:stop]
+    return tensor
+
+
+def _mtp_direct_export_items(local_name: str, tensor: torch.Tensor) -> dict[str, torch.Tensor] | None:
+    hf_name = _mtp_direct_hf_name(local_name)
+    if hf_name is None:
+        return None
+    return {hf_name: tensor}
+
+
+def _mtp_transformer_export_items(
+    local_name: str,
+    tensor: torch.Tensor,
+    config: Qwen35Config,
+    bridge,
+) -> dict[str, torch.Tensor] | None:
+    mapped = _mtp_transformer_mbridge_name(local_name, config)
+    if mapped is None:
+        return None
+    mc_name, proxy_idx, mtp_idx = mapped
+    hf_names, hf_tensors = bridge._weight_to_hf_format(mc_name, tensor)
+    manual_hf_names = _mtp_manual_transformer_hf_names(local_name, mtp_idx)
+    if manual_hf_names is not None and len(manual_hf_names) == len(hf_tensors):
+        hf_names = manual_hf_names
+    return {
+        _mtp_rewrite_proxy_hf_name(hn, proxy_idx, mtp_idx): ht
+        for hn, ht in zip(hf_names, hf_tensors, strict=True)
+    }
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Main load entry point
+# ══════════════════════════════════════════════════════════════════════
+
+
+def load_hf_weights(
+    model: nn.Module,
+    path: str,
+    config: Qwen35Config,
+    ps: ParallelState,
+    *,
+    num_layers_override: int | None = None,  # noqa: ARG001 — model.layer_indices already correct
+) -> None:
+    """Load HF safetensors into a Qwen35Model via mbridge bridge dispatch."""
+    from megatron.lite.model.qwen3_5.lite._mbridge_glue import _weight_split_across_tp
+
+    base_model = unwrap_model(model)
+    bridge = getattr(base_model, "mbridge_bridge", None)
+    if bridge is None:
+        raise RuntimeError("Qwen35Model (lite) requires mbridge_bridge; pass hf_path to build_model.")
+
+    reader = _HFSafeTensorReader(path)
+    loaded: dict[str, torch.Tensor] = {}
+    global_idx_map = {i: g for i, g in enumerate(base_model.layer_indices)}
+
+    # D1: track failure reason for every param → greppable [lite/WARN-NOTLOADED] dump
+    _fail_reason: dict[str, tuple[str, list[str]]] = {}  # name → (mc_name, hf_keys_tried)
+
+    for local_name, param in base_model.named_parameters():
+        if _is_mtp_param(local_name):
+            direct_hf_name = _mtp_direct_hf_name(local_name)
+            if direct_hf_name is not None:
+                try:
+                    my_slice = _split_mtp_direct_tensor(
+                        local_name,
+                        reader.get_tensor(direct_hf_name),
+                        param,
+                        ps,
+                    )
+                except Exception as _e:
+                    _fail_reason[local_name] = (direct_hf_name, [f"<reader_error:{_e}>"])
+                    continue
+                if my_slice.shape != param.data.shape:
+                    _fail_reason[local_name] = (direct_hf_name, [direct_hf_name])
+                    log_rank0(
+                        f"[lite/WARN-NOTLOADED] name={local_name} hf_name={direct_hf_name} "
+                        f"shape_mismatch loaded={tuple(my_slice.shape)} param={tuple(param.data.shape)}"
+                    )
+                    continue
+                loaded[local_name] = my_slice.to(dtype=param.data.dtype)
+                continue
+
+            expert_hf_names = _mtp_expert_hf_names(local_name, config, ps)
+            if expert_hf_names is not None:
+                try:
+                    hf_tensors = [reader.get_tensor(n) for n in expert_hf_names]
+                except Exception as _e:
+                    _fail_reason[local_name] = ("mtp_expert_direct", expert_hf_names)
+                    log_rank0(
+                        f"[lite/WARN-NOTLOADED] name={local_name} mc_name=mtp_expert_direct "
+                        f"hf_keys={expert_hf_names} error={_e}"
+                    )
+                    continue
+                mcore_weight = _mtp_expert_tensor_from_hf(local_name, hf_tensors)
+                if mcore_weight is None:
+                    _fail_reason[local_name] = ("mtp_expert_direct", expert_hf_names)
+                    continue
+                my_slice = _split_mtp_expert_tensor_for_rank(local_name, mcore_weight, ps)
+                if my_slice.shape != param.data.shape:
+                    _fail_reason[local_name] = ("mtp_expert_direct", expert_hf_names)
+                    log_rank0(
+                        f"[lite/WARN-NOTLOADED] name={local_name} mc_name=mtp_expert_direct "
+                        f"shape_mismatch loaded={tuple(my_slice.shape)} param={tuple(param.data.shape)}"
+                    )
+                    continue
+                loaded[local_name] = my_slice.to(dtype=param.data.dtype)
+                continue
+
+            mapped = _mtp_transformer_hf_names(local_name, config, bridge, ps)
+            if mapped is None:
+                _fail_reason[local_name] = ("no_mtp_mapping", [])
+                continue
+            mc_name, hf_names = mapped
+            try:
+                hf_tensors = [reader.get_tensor(n) for n in hf_names]
+            except Exception as _e:
+                _fail_reason[local_name] = (mc_name, hf_names)
+                log_rank0(f"[lite/WARN-NOTLOADED] name={local_name} mc_name={mc_name} hf_keys={hf_names} error={_e}")
+                continue
+            mcore_weight = bridge._weight_to_mcore_format(mc_name, hf_tensors)
+            is_expert = "mlp.experts.linear_fc" in mc_name
+            tp_size = ps.etp_size if is_expert else ps.tp_size
+            tp_rank = ps.etp_rank if is_expert else ps.tp_rank
+            splits = _weight_split_across_tp(bridge, mc_name, mcore_weight, param, tp_size)
+            my_slice = splits[tp_rank]
+            if my_slice.shape != param.data.shape:
+                _fail_reason[local_name] = (mc_name, hf_names)
+                log_rank0(
+                    f"[lite/WARN-NOTLOADED] name={local_name} mc_name={mc_name} "
+                    f"shape_mismatch loaded={tuple(my_slice.shape)} param={tuple(param.data.shape)}"
+                )
+                continue
+            loaded[local_name] = my_slice.to(dtype=param.data.dtype)
+            continue
+
+        mc_name = _lite_to_mbridge_name(local_name, global_idx_map)
+        if mc_name is None:
+            _fail_reason[local_name] = ("no_mbridge_mapping", [])
+            continue
+        try:
+            hf_names = bridge._weight_name_mapping_mcore_to_hf(mc_name)
+        except (KeyError, NotImplementedError) as _e:
+            _fail_reason[local_name] = (mc_name, [f"<bridge_error:{_e}>"])
+            continue
+        try:
+            hf_tensors = [reader.get_tensor(n) for n in hf_names]
+        except Exception as _e:
+            _fail_reason[local_name] = (mc_name, hf_names)
+            log_rank0(f"[lite/WARN-NOTLOADED] name={local_name} mc_name={mc_name} hf_keys={hf_names} error={_e}")
+            continue
+        mcore_weight = bridge._weight_to_mcore_format(mc_name, hf_tensors)
+        is_expert = "mlp.experts.linear_fc" in mc_name
+        tp_size = ps.etp_size if is_expert else ps.tp_size
+        tp_rank = ps.etp_rank if is_expert else ps.tp_rank
+        splits = _weight_split_across_tp(bridge, mc_name, mcore_weight, param, tp_size)
+        my_slice = splits[tp_rank]
+        if my_slice.shape != param.data.shape:
+            _fail_reason[local_name] = (mc_name, hf_names)
+            log_rank0(
+                f"[lite/WARN-NOTLOADED] name={local_name} mc_name={mc_name} "
+                f"shape_mismatch loaded={tuple(my_slice.shape)} param={tuple(param.data.shape)}"
+            )
+            continue
+        loaded[local_name] = my_slice.to(dtype=torch.bfloat16)
+
+    if getattr(base_model, "vision_model", None) is not None:
+        for vname, _vparam in base_model.vision_model.named_parameters():
+            mcore_name = f"vision_model.{vname}"
+            try:
+                hf_names = bridge._weight_name_mapping_mcore_to_hf(mcore_name)
+            except (KeyError, NotImplementedError):
+                log_rank0(f"WARNING: vision param {mcore_name} has no HF mapping, skipping")
+                continue
+            if len(hf_names) != 1:
+                log_rank0(f"WARNING: vision param {mcore_name} maps to {len(hf_names)} HF names, skipping")
+                continue
+            loaded[f"vision_model.{vname}"] = reader.get_tensor(hf_names[0]).to(dtype=torch.bfloat16)
+
+    for name, param in base_model.named_parameters():
+        if name in loaded:
+            param.data.copy_(loaded[name])
+        else:
+            mc_name_fail, hf_keys_fail = _fail_reason.get(name, ("?", []))
+            log_rank0(
+                f"[lite/WARN-NOTLOADED] name={name} mc_name={mc_name_fail} hf_keys={hf_keys_fail}"
+            )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Export weights (gather shards → full tensors → HF format)
+# ══════════════════════════════════════════════════════════════════════
+
+
+def export_weights(
+    model: nn.Module | list[nn.Module],
+    config: Qwen35Config,
+    ps: ParallelState,
+    *,
+    include_mtp_only: bool = False,
+    include_local_prefixes: tuple[str, ...] | list[str] | None = None,
+) -> dict[str, torch.Tensor]:
+    """Gather distributed shards → HF flat dict.
+
+    Rank-0 returns full {hf_key: tensor} dict; other ranks return {}.
+    """
+    chunks = model if isinstance(model, list | nn.ModuleList) else [model]
+    base = unwrap_model(chunks[0])
+    bridge = getattr(base, "mbridge_bridge", None)
+    if bridge is None:
+        raise RuntimeError(
+            "export_weights requires mbridge_bridge; "
+            "ensure load_hf_weights was called first (attaches bridge)."
+        )
+
+    # Stage 1: gather distributed shards → full MC tensors keyed by global param name
+    mc: dict[str, torch.Tensor] = {}
+    identity_map = {g: g for g in range(config.num_hidden_layers)}
+    for chunk in chunks:
+        chunk_base = unwrap_model(chunk)
+        layer_map = (
+            {i: chunk_base.layer_indices[i] for i in range(len(chunk_base.layer_indices))}
+            if hasattr(chunk_base, "layer_indices") else {}
+        )
+        for name, param in chunk_base.named_parameters():
+            gname = _to_global_layer_name(name, layer_map)
+            if _is_mtp_embedding_param(gname):
+                continue
+            if include_mtp_only and not _is_mtp_param(gname):
+                continue
+            if include_local_prefixes and not any(
+                gname.startswith(prefix) for prefix in include_local_prefixes
+            ):
+                continue
+            if not _is_mtp_param(gname) and _lite_to_mbridge_name(gname, identity_map) is None:
+                continue
+            if _is_expert_weight(gname):
+                _gather_expert_param(gname, param.data, config, ps, mc)
+            else:
+                mc[gname] = _gather_dense_param(gname, param.data, ps, config)
+
+    # PP gather only on the canonical TP/CP/DP lane.  The per-param TP/EP
+    # gathers above already materialize full tensors on every lane, so gathering
+    # every PP group duplicates a full-model object on all ranks and OOMs large
+    # checkpoints.  Use the CPU PP group when available because object collectives
+    # over NCCL serialize through CUDA buffers.
+    if ps.pp_size > 1:
+        export_lane = ps.tp_rank == 0 and ps.cp_rank == 0 and ps.dp_rank == 0
+        if export_lane:
+            if ps.pp_global_ranks is None:
+                raise RuntimeError("Pipeline ranks were not initialized.")
+            dst_rank = ps.pp_global_ranks[0]
+            group = ps.pp_cpu_group or ps.pp_group
+            if group is None:
+                raise RuntimeError("Pipeline process group was not initialized.")
+            all_states: list[dict | None] | None
+            all_states = [None] * ps.pp_size if dist.get_rank() == dst_rank else None
+            dist.gather_object(mc, all_states, dst=dst_rank, group=group)
+            if dist.get_rank() == dst_rank:
+                merged: dict[str, torch.Tensor] = {}
+                for s in all_states or []:
+                    if s is not None:
+                        merged.update(s)
+                mc = merged
+            else:
+                mc = {}
+        else:
+            mc = {}
+
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    if rank != 0:
+        return {}
+
+    # Aggregate per-expert tensors into stacked [E, ...] tensors for bridge reverse-map
+    expert_fc1: dict[str, dict[int, torch.Tensor]] = {}
+    expert_fc2: dict[str, dict[int, torch.Tensor]] = {}
+    non_expert: dict[str, torch.Tensor] = {}
+    for name, tensor in mc.items():
+        if _is_expert_weight(name) and _is_mtp_param(name):
+            ei = _parse_expert_idx(name)
+            base_name = re.sub(r"weight\d+$", "weight", name)
+            if "fc1" in name:
+                expert_fc1.setdefault(base_name, {})[ei] = tensor
+            else:
+                expert_fc2.setdefault(base_name, {})[ei] = tensor
+        else:
+            non_expert[name] = tensor
+
+    mc_agg: dict[str, torch.Tensor] = dict(non_expert)
+    for base_name, experts in expert_fc1.items():
+        mc_agg[base_name] = torch.stack([experts[i] for i in sorted(experts)])
+    for base_name, experts in expert_fc2.items():
+        mc_agg[base_name] = torch.stack([experts[i] for i in sorted(experts)])
+
+    # Stage 2 (rank-0 only): reverse-map MC → HF via mbridge
+    hf_flat: dict[str, torch.Tensor] = {}
+    for name, tensor in mc_agg.items():
+        if _is_mtp_param(name):
+            expert = _mtp_expert_export_items(name, tensor)
+            if expert is not None:
+                hf_flat.update(expert)
+                continue
+            direct = _mtp_direct_export_items(name, tensor)
+            if direct is not None:
+                hf_flat.update(direct)
+                continue
+            transformer = _mtp_transformer_export_items(name, tensor, config, bridge)
+            if transformer is None:
+                log_rank0(f"[export/SKIP] no MTP mapping for {name}")
+                continue
+            hf_flat.update(transformer)
+            continue
+        mbridge_mc_name = _lite_to_mbridge_name(name, identity_map)
+        if mbridge_mc_name is None:
+            log_rank0(f"[export/SKIP] no mbridge mapping for {name}")
+            continue
+        try:
+            hf_names, hf_tensors = bridge._weight_to_hf_format(mbridge_mc_name, tensor)
+        except (KeyError, NotImplementedError) as e:
+            log_rank0(f"[export/SKIP] _weight_to_hf_format failed for {mbridge_mc_name}: {e}")
+            continue
+        for hn, ht in zip(hf_names, hf_tensors, strict=True):
+            hf_flat[hn] = ht
+
+    return hf_flat
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Save HF weights (sharded safetensors + index.json)
+# ══════════════════════════════════════════════════════════════════════
+
+
+def save_hf_weights(
+    model: nn.Module | list[nn.Module],
+    path: str,
+    config: Qwen35Config,
+    ps: ParallelState,
+    shard_size_bytes: int = 5 * 1024**3,  # 5 GB per shard
+) -> None:
+    """Export weights and write sharded HF safetensors + index.json to path."""
+    hf_flat = export_weights(model, config, ps)
+    if not hf_flat:  # non-rank-0
+        return
+
+    out = Path(path)
+    out.mkdir(parents=True, exist_ok=True)
+
+    keys_sorted = sorted(hf_flat.keys())
+
+    def _tensor_bytes(t: torch.Tensor) -> int:
+        return t.numel() * t.element_size()
+
+    # Greedy bin-pack: deterministic across runs for same model config
+    shards: list[dict[str, torch.Tensor]] = [{}]
+    shard_bytes = [0]
+    weight_map: dict[str, str] = {}
+
+    for k in keys_sorted:
+        t = hf_flat[k]
+        tb = _tensor_bytes(t)
+        if shard_bytes[-1] + tb > shard_size_bytes and shard_bytes[-1] > 0:
+            shards.append({})
+            shard_bytes.append(0)
+        shards[-1][k] = t
+        shard_bytes[-1] += tb
+
+    total = len(shards)
+    total_size = sum(shard_bytes)
+    for i, sh in enumerate(shards, 1):
+        fname = f"model-{i:05d}-of-{total:05d}.safetensors"
+        safe_save(sh, str(out / fname), metadata={"format": "pt"})
+        for k in sh:
+            weight_map[k] = fname
+
+    index = {
+        "metadata": {"total_size": total_size},
+        "weight_map": weight_map,
+    }
+    with open(out / "model.safetensors.index.json", "w") as f:
+        json.dump(index, f, indent=2)
+
+    log_rank0(f"[save_hf_weights] {len(hf_flat)} tensors → {path} ({total} shards, {total_size/1e9:.1f} GB)")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Gather helpers (used by export_weights)
+# ══════════════════════════════════════════════════════════════════════
+
+
+def _to_global_layer_name(name: str, layer_map: dict[int, int]) -> str:
+    if name.startswith("mtp.layers."):
+        return name
+    if not layer_map:
+        return name
+
+    def _replace(m: re.Match) -> str:
+        return f"layers.{layer_map.get(int(m.group(1)), int(m.group(1)))}."
+    return re.sub(r"layers\.(\d+)\.", _replace, name)
+
+
+def _is_expert_weight(name: str) -> bool:
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+def _gather_dense_param(
+    name: str, tensor: torch.Tensor, ps: ParallelState,
+    config: Qwen35Config,
+) -> torch.Tensor:
+    t = tensor.detach()
+    if ps.tp_size > 1:
+        # Post-Step-3 MC naming: col-parallel (dim=0) and row-parallel (dim=1)
+        tp_col_keys = [
+            "linear_qkv.weight",          # full_attn QKV
+            "in_proj.weight",             # GDN in_proj
+            "conv1d.weight",              # GDN conv1d
+            "dt_bias",                    # GDN dt_bias
+            "A_log",                      # GDN A_log
+            "shared_experts.linear_fc1.weight",  # shared expert gate_up
+            "eh_proj.linear.weight",
+            "eh_proj.weight",
+        ]
+        tp_row_keys = [
+            "linear_proj.weight",         # full_attn output proj
+            "out_proj.weight",            # GDN out_proj
+            "shared_experts.linear_fc2.weight",  # shared expert down
+        ]
+
+        if any(k in name for k in tp_col_keys):
+            t = _allgather_concat(t, ps.tp_size, ps.tp_group, dim=0)
+        elif any(k in name for k in tp_row_keys):
+            t = _allgather_concat(t, ps.tp_size, ps.tp_group, dim=1)
+        elif "embed" in name or "head" in name:
+            t = _allgather_concat(t, ps.tp_size, ps.tp_group, dim=0)
+    return t.contiguous().cpu()
+
+
+def _gather_expert_param(
+    name: str,
+    tensor: torch.Tensor,
+    config: Qwen35Config,
+    ps: ParallelState,
+    out: dict[str, torch.Tensor],
+) -> None:
+    t = tensor.detach()
+    is_fc1 = "fc1" in name
+
+    if ps.etp_size > 1 and ps.etp_group is not None:
+        if is_fc1:
+            t = _gather_gate_up_expert(t, ps.etp_size, ps.etp_group)
+        else:
+            t = _allgather_concat(t, ps.etp_size, ps.etp_group, dim=1)
+
+    n_local = ensure_divisible(config.num_experts, max(ps.ep_size, 1))
+    local_idx = _parse_expert_idx(name)
+
+    if ps.ep_size > 1 and ps.ep_group is not None:
+        ep_gathered = [torch.empty_like(t) for _ in range(ps.ep_size)]
+        dist.all_gather(ep_gathered, t.contiguous(), group=ps.ep_group)
+        for ep_rank, ep_tensor in enumerate(ep_gathered):
+            global_idx = ep_rank * n_local + local_idx
+            out[_set_expert_idx(name, global_idx)] = ep_tensor.contiguous().cpu()
+    else:
+        out[name] = t.contiguous().cpu()
+
+
+def _allgather_concat(
+    tensor: torch.Tensor, world_size: int, group, dim: int,
+) -> torch.Tensor:
+    gathered = [torch.empty_like(tensor) for _ in range(world_size)]
+    dist.all_gather(gathered, tensor.contiguous(), group=group)
+    return torch.cat(gathered, dim=dim)
+
+
+def _gather_gate_up_expert(
+    tensor: torch.Tensor, world_size: int, group,
+) -> torch.Tensor:
+    ffn_local = tensor.shape[0] // 2
+    gate_local = tensor[:ffn_local]
+    up_local = tensor[ffn_local:]
+    gate_full = _allgather_concat(gate_local, world_size, group, dim=0)
+    up_full = _allgather_concat(up_local, world_size, group, dim=0)
+    return torch.cat([gate_full, up_full], dim=0)
+
+
+def _parse_expert_idx(name: str) -> int:
+    m = re.search(r"weight(\d+)$", name)
+    return int(m.group(1)) if m else 0
+
+
+def _set_expert_idx(name: str, idx: int) -> str:
+    return re.sub(r"weight\d+$", f"weight{idx}", name)

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -1,0 +1,646 @@
+"""Qwen3.5 lite model: uses shared MCoreFullAttn/MCoreGDN/MCoreMoELayer ops."""
+
+from __future__ import annotations
+
+import os
+from contextlib import nullcontext
+
+import torch
+import torch.nn as nn
+import transformer_engine.pytorch as te
+
+from megatron.lite.model.qwen3_5.config import Qwen35Config
+from megatron.lite.model.qwen3_5.mc_ops import (
+    MCoreContext,
+    MCoreFullAttn,
+    MCoreGDN,
+    MCoreMoELayer,
+    _build_vision_model,
+    build_mcore_context,
+)
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
+from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
+from megatron.lite.primitive.parallel import (
+    ColumnParallelLinear,
+    ParallelState,
+    VocabParallelEmbedding,
+    VocabParallelOutput,
+    build_pipeline_chunk_layout,
+    gather_from_sequence_parallel,
+    roll_packed_thd_left,
+    scatter_to_sequence_parallel,
+)
+from megatron.lite.primitive.utils import build_fp8_recipe
+
+# ---------------------------------------------------------------------------
+# SP gradient suffixes — MC naming: self_attention / pre_mlp_layernorm / mlp
+# ---------------------------------------------------------------------------
+
+_SP_GRAD_SUFFIXES: tuple[str, ...] = (
+    ".self_attention.linear_qkv.layer_norm_weight",
+    ".self_attention.q_layernorm.weight",
+    ".self_attention.k_layernorm.weight",
+    ".self_attention.in_proj.layer_norm_weight",
+    ".self_attention.norm.weight",
+    ".pre_mlp_layernorm.weight",
+    ".mlp.router.weight",
+    ".mlp.shared_experts.gate_weight",
+    ".enorm.weight",
+    ".hnorm.weight",
+    ".final_layernorm.weight",
+)
+
+def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
+    params = []
+    for name, param in model.named_parameters():
+        if any(name.endswith(s) for s in _SP_GRAD_SUFFIXES) or name == "norm.weight":
+            params.append(param)
+    return params
+
+
+# ---------------------------------------------------------------------------
+# Qwen35Layer
+# ---------------------------------------------------------------------------
+
+
+class Qwen35Layer(nn.Module):
+    """Mixed attention layer: MCoreGDN or MCoreFullAttn + MCoreMoELayer."""
+
+    def __init__(
+        self,
+        config: Qwen35Config,
+        train_config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        mcore_context: MCoreContext,
+        use_deepep: bool = True,
+        router_bias_rate: float = 0.0,
+        fp8: bool = False,
+        moe_act_recompute: bool = False,
+        use_thd: bool = False,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        layer_type = config.layer_type_at(layer_idx)
+        self._layer_type = layer_type
+        is_mtp_layer = layer_idx >= config.num_hidden_layers
+        mtp_layer_number = layer_idx - config.num_hidden_layers + 1 if is_mtp_layer else None
+
+        if layer_type == "full_attention":
+            self.self_attention: nn.Module = MCoreFullAttn(
+                config,
+                train_config,
+                ps,
+                layer_idx,
+                mcore_context,
+                layer_number=mtp_layer_number,
+            )
+        else:
+            self.self_attention = MCoreGDN(
+                config,
+                train_config,
+                ps,
+                layer_idx,
+                mcore_context,
+                layer_number=mtp_layer_number,
+            )
+
+        self.pre_mlp_layernorm = te.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True
+        )
+        self.mlp: nn.Module = MCoreMoELayer(
+            config,
+            train_config,
+            ps,
+            layer_idx,
+            mcore_context,
+            layer_number=mtp_layer_number,
+            is_mtp_layer=is_mtp_layer,
+        )
+
+        # D3: verify mc_ops classes are used (not reverted to lite-specific impls)
+        assert isinstance(self.self_attention, MCoreFullAttn | MCoreGDN), (
+            f"Qwen35Layer[{layer_idx}] self_attention is {type(self.self_attention).__name__}, "
+            f"expected MCoreFullAttn or MCoreGDN"
+        )
+        assert isinstance(self.mlp, MCoreMoELayer), (
+            f"Qwen35Layer[{layer_idx}] mlp is {type(self.mlp).__name__}, expected MCoreMoELayer"
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+    ) -> torch.Tensor:
+        residual = x
+        if self._layer_type == "full_attention":
+            h = self.self_attention(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
+        else:
+            h = self.self_attention(x, packed_seq_params=packed_seq_params)
+        x = residual + h
+
+        residual = x
+        h = self.pre_mlp_layernorm(x)
+        h = self.mlp(h)
+        x = residual + h
+        return x
+
+
+class MTPLossAutoScaler(torch.autograd.Function):
+    main_loss_backward_scale: float = 1.0
+
+    @staticmethod
+    def forward(ctx, output: torch.Tensor, mtp_loss: torch.Tensor):
+        ctx.save_for_backward(mtp_loss)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (mtp_loss,) = ctx.saved_tensors
+        scaled_mtp_grad = torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        return grad_output, scaled_mtp_grad
+
+    @staticmethod
+    def set_loss_scale(scale: torch.Tensor | float) -> None:
+        if isinstance(scale, torch.Tensor):
+            scale = float(scale.detach().float().item())
+        MTPLossAutoScaler.main_loss_backward_scale = float(scale)
+
+
+class Qwen35MTPLayer(nn.Module):
+    def __init__(
+        self,
+        config: Qwen35Config,
+        train_config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        mcore_context: MCoreContext,
+        embedding: VocabParallelEmbedding,
+        router_bias_rate: float,
+        use_thd: bool,
+        detach_encoder: bool,
+    ):
+        super().__init__()
+        self.ps = ps
+        self.layer_idx = layer_idx
+        self.embedding = embedding
+        self.detach_encoder = detach_encoder
+        self.enorm = te.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True
+        )
+        self.hnorm = te.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True
+        )
+        self.eh_proj = ColumnParallelLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            ps,
+            gather_output=True,
+            sequence_parallel=ps.tp_size > 1,
+        )
+        self.transformer_layer = Qwen35Layer(
+            config,
+            train_config,
+            ps,
+            config.num_hidden_layers + layer_idx,
+            mcore_context=mcore_context,
+            use_deepep=train_config.use_deepep,
+            router_bias_rate=router_bias_rate,
+            fp8=train_config.fp8,
+            moe_act_recompute=(
+                "moe_act" in train_config.recompute_modules
+                and "moe" not in train_config.recompute_modules
+            ),
+            use_thd=use_thd,
+        )
+        self.final_layernorm = te.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True
+        )
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None,
+        hidden_states: torch.Tensor,
+        rotary_position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        attention_position_ids = rotary_position_ids if rotary_position_ids is not None else position_ids
+        input_ids, _ = roll_packed_thd_left(
+            input_ids,
+            packed_seq_params=packed_seq_params,
+            dims=-1,
+        )
+        if position_ids is not None:
+            position_ids, _ = roll_packed_thd_left(
+                position_ids,
+                packed_seq_params=packed_seq_params,
+                dims=-1,
+            )
+        decoder_input = self.embedding(input_ids)
+        decoder_input = scatter_to_sequence_parallel(decoder_input, self.ps)
+
+        if self.detach_encoder:
+            decoder_input = decoder_input.detach()
+            hidden_states = hidden_states.detach()
+
+        decoder_input = self.enorm(decoder_input)
+        hidden_states = self.hnorm(hidden_states)
+        hidden_states = torch.cat((decoder_input, hidden_states), dim=-1)
+        hidden_states = self.eh_proj(hidden_states)
+        hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
+        hidden_states = self.transformer_layer(
+            hidden_states,
+            position_ids=attention_position_ids,
+            packed_seq_params=packed_seq_params,
+        )
+        hidden_states = self.final_layernorm(hidden_states)
+        return hidden_states, input_ids, position_ids
+
+
+class Qwen35MTPBlock(nn.Module):
+    def __init__(
+        self,
+        config: Qwen35Config,
+        train_config,
+        ps: ParallelState,
+        *,
+        mcore_context: MCoreContext,
+        embedding: VocabParallelEmbedding,
+        router_bias_rate: float,
+        use_thd: bool,
+        detach_encoder: bool,
+    ):
+        super().__init__()
+        self.num_layers = config.num_nextn_predict_layers
+        layers_to_build = 1 if config.mtp_use_repeated_layer else self.num_layers
+        self.repeated_layer = config.mtp_use_repeated_layer
+        self.layers = nn.ModuleList(
+            [
+                Qwen35MTPLayer(
+                    config,
+                    train_config,
+                    ps,
+                    idx,
+                    mcore_context=mcore_context,
+                    embedding=embedding,
+                    router_bias_rate=router_bias_rate,
+                    use_thd=use_thd,
+                    detach_encoder=detach_encoder,
+                )
+                for idx in range(layers_to_build)
+            ]
+        )
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None,
+        hidden_states: torch.Tensor,
+        packed_seq_params=None,
+    ) -> list[torch.Tensor]:
+        outputs: list[torch.Tensor] = []
+        rotary_position_ids = position_ids
+        for depth in range(self.num_layers):
+            layer = self.layers[0] if self.repeated_layer else self.layers[depth]
+            hidden_states, input_ids, position_ids = layer(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                rotary_position_ids=rotary_position_ids,
+                hidden_states=hidden_states,
+                packed_seq_params=packed_seq_params,
+            )
+            outputs.append(hidden_states)
+        return outputs
+
+
+def _temperature_to_float(temperature: float | torch.Tensor) -> float:
+    if isinstance(temperature, torch.Tensor):
+        if temperature.numel() != 1:
+            raise ValueError("Qwen35Model fused/MTP SFT supports scalar temperature only.")
+        return float(temperature.detach().float().item())
+    return float(temperature)
+
+
+def _ensure_mrope_position_ids(position_ids: torch.Tensor | None) -> torch.Tensor | None:
+    if position_ids is None:
+        return None
+    if position_ids.dim() == 2:
+        return position_ids.unsqueeze(0).expand(3, -1, -1).contiguous()
+    if position_ids.dim() == 3:
+        if position_ids.shape[0] == 1:
+            return position_ids.expand(3, -1, -1).contiguous()
+        if position_ids.shape[0] == 3:
+            return position_ids
+    raise ValueError(
+        "Qwen3.5 multimodal RoPE expects position_ids with shape (B, S), "
+        "(1, B, S), or (3, B, S)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Qwen35Model
+# ---------------------------------------------------------------------------
+
+
+class Qwen35Model(nn.Module):
+    """Qwen3.5 lite: Embedding → N×Qwen35Layer → RMSNorm → Output (PP-aware)."""
+
+    def __init__(
+        self,
+        config: Qwen35Config,
+        train_config,
+        ps: ParallelState,
+        *,
+        vpp_chunk_id: int | None = None,
+        router_bias_rate: float = 0.001,
+        use_thd: bool = False,
+        hf_path: str = "",
+        attention_backend_override: str | None = None,
+        mtp_enable: bool = False,
+        mtp_enable_train: bool = False,
+        mtp_detach_encoder: bool = False,
+    ):
+        super().__init__()
+        self.config = config
+        self.train_config = train_config
+        self.ps = ps
+        self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
+        self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
+        self._input_tensor: torch.Tensor | None = None
+
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id,
+        )
+        self.layer_indices = layout.layer_indices
+        has_embed = layout.has_embed
+        has_head = layout.has_head
+        self.pre_process = has_embed
+        self.post_process = has_head
+        self.share_embeddings_and_output_weights = False
+
+        use_deepep = train_config.use_deepep
+        fp8 = train_config.fp8
+        deterministic_embedding = getattr(train_config, "deterministic_embedding", None)
+        if deterministic_embedding is None:
+            deterministic_embedding = bool(getattr(train_config, "deterministic", False))
+        moe_act_recompute = (
+            "moe_act" in train_config.recompute_modules
+            and "moe" not in train_config.recompute_modules
+        )
+        mcore_context = build_mcore_context(
+            config, train_config, hf_path=hf_path,
+            attention_backend_override=attention_backend_override,
+            vp_stage=vpp_chunk_id,
+        )
+        self.mbridge_bridge = mcore_context.bridge
+
+        # vision_model registered before embed to match Qwen3_5VLModel param order
+        if has_embed:
+            self.vision_model: nn.Module | None = _build_vision_model(self.mbridge_bridge)
+        else:
+            self.vision_model = None
+
+        self.embed: VocabParallelEmbedding | None = None
+        if has_embed:
+            self.embed = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                ps,
+                deterministic=deterministic_embedding,
+            )
+
+        self.layers = nn.ModuleList(
+            [
+                Qwen35Layer(
+                    config,
+                    train_config,
+                    ps,
+                    idx,
+                    mcore_context=mcore_context,
+                    use_deepep=use_deepep,
+                    router_bias_rate=router_bias_rate,
+                    fp8=fp8,
+                    moe_act_recompute=moe_act_recompute,
+                    use_thd=use_thd,
+                )
+                for idx in self.layer_indices
+            ]
+        )
+
+        self.norm: nn.Module | None = None
+        self.head: VocabParallelOutput | None = None
+        if has_head:
+            self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True)
+            self.head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
+
+        self.mtp_embed: VocabParallelEmbedding | None = None
+        self.mtp: Qwen35MTPBlock | None = None
+        if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
+            mtp_embedding = self.embed
+            if mtp_embedding is None:
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size,
+                    config.hidden_size,
+                    ps,
+                    deterministic=deterministic_embedding,
+                )
+                self.mtp_embed = mtp_embedding
+            self.mtp = Qwen35MTPBlock(
+                config,
+                train_config,
+                ps,
+                mcore_context=mcore_context,
+                embedding=mtp_embedding,
+                router_bias_rate=router_bias_rate,
+                use_thd=use_thd,
+                detach_encoder=mtp_detach_encoder,
+            )
+
+        self.sp_params: list[nn.Parameter] = []
+        if ps.tp_size > 1:
+            self.sp_params = _collect_sp_grad_params(self)
+
+    def set_input_tensor(self, input_tensor):
+        if isinstance(input_tensor, list):
+            if len(input_tensor) > 1:
+                raise ValueError("Qwen35Model expects a single pipeline input tensor.")
+            input_tensor = input_tensor[0] if input_tensor else None
+        self._input_tensor = input_tensor
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+        labels: torch.Tensor | None = None,
+        loss_mask: torch.Tensor | None = None,
+        temperature: float | torch.Tensor = 1.0,
+        use_fused_kernels: bool = False,
+        calculate_entropy: bool = False,
+    ) -> dict:
+        if self.embed is not None:
+            assert input_ids is not None
+            h = self.embed(input_ids)
+        else:
+            if hidden_states is None:
+                hidden_states = self._input_tensor
+            assert hidden_states is not None
+            h = hidden_states
+
+        if packed_seq_params is not None:
+            assert position_ids is not None, (
+                "THD path requires caller-supplied position_ids with shape (3, 1, T)"
+            )
+        elif position_ids is None and input_ids is not None:
+            from megatron.core import parallel_state as mpu  # pyright: ignore[reportMissingImports]
+            if mpu.is_initialized() and mpu.get_context_parallel_world_size() > 1:
+                raise ValueError(
+                    "CP>1 requires caller-supplied FULL position_ids (3, B, S); "
+                    "cannot auto-build from CP-sliced input_ids."
+                )
+            _b, _s = input_ids.shape
+            _pos = torch.arange(_s, device=input_ids.device, dtype=torch.long)
+            position_ids = _pos.unsqueeze(0).unsqueeze(0).expand(3, _b, _s).contiguous()
+        position_ids = _ensure_mrope_position_ids(position_ids)
+
+        fp8_ctx = (
+            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            if self.train_config.fp8
+            else nullcontext()
+        )
+
+        with fp8_ctx:
+            if self.embed is not None:
+                h = scatter_to_sequence_parallel(h, self.ps)
+            for layer in self.layers:
+                h = layer(h, position_ids=position_ids, packed_seq_params=packed_seq_params)
+
+        output = {"hidden_states": h}
+        if self.head is not None:
+            hidden_for_head = self.norm(h)
+            if labels is not None:
+                temperature_value = _temperature_to_float(temperature)
+                mtp_result = self._apply_mtp_loss(
+                    hidden_for_head,
+                    input_ids=input_ids,
+                    position_ids=position_ids,
+                    labels=labels,
+                    loss_mask=loss_mask,
+                    packed_seq_params=packed_seq_params,
+                    temperature=temperature_value,
+                    use_fused_kernels=use_fused_kernels,
+                )
+                if mtp_result is not None:
+                    hidden_for_head, mtp_loss = mtp_result
+                    output["mtp_loss"] = mtp_loss
+                labels_sb = labels.transpose(0, 1).contiguous()
+                if use_fused_kernels:
+                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    log_probs, entropy = linear_cross_entropy(
+                        hidden_full,
+                        self.head.col.linear.weight,
+                        labels_sb,
+                        temperature_value,
+                        self.ps.tp_group,
+                    )
+                    output["loss"] = (-log_probs).mean()
+                    output["log_probs"] = log_probs.transpose(0, 1).contiguous()
+                    if calculate_entropy:
+                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+                else:
+                    logits = self.head(hidden_for_head)
+                    if temperature_value != 1.0:
+                        logits = logits / temperature_value
+                    loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    output["loss"] = loss.mean()
+                    output["log_probs"] = (-loss).transpose(0, 1).contiguous()
+                    if calculate_entropy:
+                        entropy = vocab_parallel_entropy(logits, self.ps.tp_group)
+                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+            if labels is None:
+                logits = self.head(hidden_for_head)
+                output["logits"] = self.head.gather(logits).transpose(0, 1).contiguous()
+        return output
+
+    def _apply_mtp_loss(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        labels: torch.Tensor,
+        loss_mask: torch.Tensor | None,
+        packed_seq_params,
+        temperature: float,
+        use_fused_kernels: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if self.mtp is None or not self.mtp_enable_train:
+            return None
+        if input_ids is None:
+            raise ValueError("MTP training requires input_ids.")
+        if loss_mask is None:
+            loss_mask = torch.ones_like(labels, dtype=torch.float32)
+        else:
+            loss_mask = loss_mask.to(dtype=torch.float32)
+
+        mtp_hidden_states = self.mtp(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            packed_seq_params=packed_seq_params,
+        )
+
+        mtp_labels = labels.clone()
+        mtp_loss_mask = loss_mask.clone()
+        mtp_loss_values = []
+        for mtp_hidden in mtp_hidden_states:
+            mtp_labels, _ = roll_packed_thd_left(
+                mtp_labels,
+                packed_seq_params=packed_seq_params,
+                dims=-1,
+            )
+            mtp_loss_mask, num_tokens = roll_packed_thd_left(
+                mtp_loss_mask,
+                packed_seq_params=packed_seq_params,
+                dims=-1,
+            )
+            labels_sb = mtp_labels.transpose(0, 1).contiguous()
+            mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
+
+            if use_fused_kernels:
+                mtp_hidden_full = gather_from_sequence_parallel(mtp_hidden, self.ps)
+                log_probs, _entropy = linear_cross_entropy(
+                    mtp_hidden_full,
+                    self.head.col.linear.weight,
+                    labels_sb,
+                    temperature,
+                    self.ps.tp_group,
+                )
+                token_loss = -log_probs
+            else:
+                logits = self.head(mtp_hidden)
+                if temperature != 1.0:
+                    logits = logits / temperature
+                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+            token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
+            num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
+            mtp_loss_values.append(token_loss.sum() / num_tokens)
+
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_scale * token_loss / num_tokens)
+
+        if not mtp_loss_values:
+            return None
+        mtp_loss = torch.stack([loss.detach().float() for loss in mtp_loss_values]).mean()
+        return hidden_states, mtp_loss
+
+
+__all__ = ["MTPLossAutoScaler", "Qwen35Layer", "Qwen35MTPBlock", "Qwen35MTPLayer", "Qwen35Model"]

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -1,0 +1,254 @@
+"""Qwen3.5 lite implementation for the Megatron Lite runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.model.qwen3_5.config import Qwen35Config
+from megatron.lite.model.qwen3_5.common import is_expert_param
+from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+
+
+@dataclass(frozen=True)
+class ImplConfig:
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: str | None = "mc"
+    recompute: list[str] = field(default_factory=list)
+    offload: list[str] = field(default_factory=list)
+    use_deepep: bool = False
+    use_thd: bool = False
+    hf_path: str = ""
+    attention_backend_override: str | None = None
+    router_aux_loss_coef: float | None = None
+    router_bias_rate: float = 0.0
+    deterministic: bool = True
+    optimizer_config: OptimizerConfig | None = None
+    mtp_enable: bool = False
+    mtp_enable_train: bool = False
+    mtp_detach_encoder: bool = False
+    mtp_loss_scaling_factor: float = 0.1
+    mtp_use_repeated_layer: bool | None = None
+    deterministic_embedding: bool | None = None
+
+
+MODULE_MAP = {
+    "core_attn": lambda layer: layer.self_attention.core_attention,
+    "experts":   lambda layer: layer.mlp.experts,
+    "moe":       lambda layer: layer.mlp,
+    "router":    lambda layer: layer.mlp.router,
+    "mlp_norm":  lambda layer: layer.pre_mlp_layernorm,
+}
+
+
+def build_model_config(source: str | Path | dict, **overrides) -> Qwen35Config:
+    """Build Qwen3.5 architecture config from HF source."""
+    if isinstance(source, dict):
+        cfg = Qwen35Config._from_hf_dict(source)
+    else:
+        cfg = Qwen35Config.from_hf(str(source))
+    for k, v in overrides.items():
+        if hasattr(cfg, k):
+            setattr(cfg, k, v)
+    return cfg
+
+
+def _forward_step(model: nn.Module, batch: dict) -> dict:
+    kwargs: dict[str, Any] = {
+        "input_ids": batch["input_ids"],
+        "labels": batch["labels"],
+    }
+    if "position_ids" in batch:
+        kwargs["position_ids"] = batch["position_ids"]
+    if "packed_seq_params" in batch:
+        kwargs["packed_seq_params"] = batch["packed_seq_params"]
+    for key in ("loss_mask", "temperature", "use_fused_kernels", "calculate_entropy"):
+        if key in batch:
+            kwargs[key] = batch[key]
+    if kwargs["input_ids"].dim() == 1:
+        kwargs["input_ids"] = kwargs["input_ids"].unsqueeze(0)
+    return model(**kwargs)
+
+
+def _make_aux_loss_hook():
+    from megatron.core.transformer.moe.moe_utils import (  # pyright: ignore[reportMissingImports]
+        MoEAuxLossAutoScaler as _MCMoEAuxLossAutoScaler,
+    )
+
+    from megatron.lite.primitive.modules.moe import (
+        MoEAuxLossAutoScaler as _LiteMoEAuxLossAutoScaler,
+    )
+    from megatron.lite.model.qwen3_5.lite.model import MTPLossAutoScaler
+
+    def hook(scale: torch.Tensor) -> None:
+        _MCMoEAuxLossAutoScaler.set_loss_scale(scale)
+        _LiteMoEAuxLossAutoScaler.set_loss_scale(scale)
+        MTPLossAutoScaler.set_loss_scale(scale)
+
+    return hook
+
+
+def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+    from megatron.lite.model.qwen3_5.lite.model import Qwen35Model
+
+    p = impl_cfg.parallel
+
+    if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
+        raise ValueError("use_deepep and etp>1 are mutually exclusive")
+
+    if impl_cfg.router_aux_loss_coef is not None:
+        model_cfg.router_aux_loss_coef = impl_cfg.router_aux_loss_coef
+    mtp_enable = bool(impl_cfg.mtp_enable)
+    mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
+    if mtp_enable:
+        if model_cfg.num_nextn_predict_layers <= 0:
+            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+        model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
+        if impl_cfg.mtp_use_repeated_layer is not None:
+            model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
+    else:
+        model_cfg.num_nextn_predict_layers = 0
+
+    ps = init_parallel(p)
+    recompute_spec = parse_recompute_spec(impl_cfg.recompute)
+    vpp = None if p.vpp == 1 else p.vpp
+    deterministic = impl_cfg.deterministic
+    if impl_cfg.use_thd and deterministic and "linear_attention" in model_cfg.layer_types:
+        deterministic = False
+    effective_impl_cfg = (
+        impl_cfg if deterministic == impl_cfg.deterministic else replace(impl_cfg, deterministic=deterministic)
+    )
+    train_cfg = SimpleNamespace(
+        tp=ps.tp_size,
+        ep=ps.ep_size,
+        etp=ps.etp_size,
+        pp=ps.pp_size,
+        cp=ps.cp_size,
+        vpp=vpp,
+        use_deepep=impl_cfg.use_deepep,
+        fp8=False,
+        recompute_modules=recompute_spec,
+        deterministic=deterministic,
+        deterministic_embedding=impl_cfg.deterministic_embedding,
+    )
+    model_kwargs: dict[str, Any] = dict(
+        router_bias_rate=impl_cfg.router_bias_rate,
+        use_thd=impl_cfg.use_thd,
+        hf_path=impl_cfg.hf_path,
+        attention_backend_override=impl_cfg.attention_backend_override,
+        mtp_enable=mtp_enable,
+        mtp_enable_train=mtp_enable_train,
+        mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
+    )
+
+    if vpp is None:
+        chunks = [
+            Qwen35Model(model_cfg, train_cfg, ps, **model_kwargs)
+            .to(torch.bfloat16)
+            .cuda()
+        ]
+    else:
+        chunks = [
+            Qwen35Model(
+                model_cfg,
+                train_cfg,
+                ps,
+                vpp_chunk_id=i,
+                **model_kwargs,
+            )
+            .to(torch.bfloat16)
+            .cuda()
+            for i in range(vpp)
+        ]
+
+    if recompute_spec:
+        for chunk in chunks:
+            apply_recompute(chunk.layers, recompute_spec, MODULE_MAP)
+
+    if impl_cfg.offload:
+        from megatron.lite.primitive.recompute import apply_offload
+
+        for chunk in chunks:
+            apply_offload(chunk.layers, impl_cfg.offload, MODULE_MAP)
+
+    optimizer = None
+    finalize_grads = None
+    post_model_load_hook = None
+    optimizer_backend = "none"
+    if impl_cfg.optimizer == "mc":
+        from megatron.lite.primitive.optimizers.megatron_wrap import (
+            build_mc_training_optimizer,
+        )
+
+        optimizer, finalize_grads = build_mc_training_optimizer(
+            chunks,
+            model_cfg=model_cfg,
+            impl_cfg=effective_impl_cfg,
+            ps=ps,
+            model_name="qwen3_5",
+            is_expert=is_expert_param,
+        )
+        optimizer_backend = "mc"
+
+        from megatron.lite.runtime.megatron_utils import (
+            register_training_hooks,
+        )
+
+        register_training_hooks(chunks, optimizer)
+    elif impl_cfg.optimizer is not None:
+        raise ValueError(f"Unknown qwen3_5 lite optimizer: {impl_cfg.optimizer!r}.")
+
+    return ModelBundle(
+        chunks=chunks,
+        parallel_state=ps,
+        optimizer=optimizer,
+        finalize_grads=finalize_grads,
+        forward_step=_forward_step,
+        extras={
+            "model_cfg": model_cfg,
+            "optimizer_backend": optimizer_backend,
+            "post_model_load_hook": post_model_load_hook,
+            "pre_forward_hook": _make_aux_loss_hook(),
+        },
+    )
+
+
+def load_hf_weights(
+    chunk: nn.Module, hf_path: str, model_cfg: Qwen35Config, ps: ParallelState
+) -> None:
+    if not hf_path:
+        return
+    _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+
+
+def export_hf_weights(
+    chunks: list[nn.Module],
+    model_cfg: Qwen35Config,
+    ps: ParallelState,
+    **kwargs,
+):
+    from megatron.lite.model.qwen3_5.lite.checkpoint import export_weights as _export_weights
+
+    limit = kwargs.pop("limit", None)
+    if limit is not None and limit <= 0:
+        limit = None
+    hf_flat = _export_weights(chunks, model_cfg, ps, **kwargs)
+    for idx, item in enumerate(hf_flat.items(), start=1):
+        yield item
+        if limit is not None and idx >= limit:
+            break
+
+
+def vocab_size(model_cfg) -> int | None:
+    cfg = getattr(model_cfg, "text_config", model_cfg)
+    return getattr(cfg, "vocab_size", None)

--- a/experimental/lite/megatron/lite/model/qwen3_5/mc_ops.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/mc_ops.py
@@ -1,0 +1,432 @@
+"""Shared MC-derived ops for the Qwen3.5 lite path.
+
+MCoreFullAttn / MCoreGDN / MCoreMoELayer + their build helpers live here so
+that lite keeps the mbridge-derived code in one place.
+
+Vision helpers (_build_vision_model, _resolve_hf_vision_cls) are also here so
+that the vision_model DDP bucket anchor is registered consistently.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+from mbridge import AutoBridge  # pyright: ignore[reportMissingImports,reportAttributeAccessIssue]
+from mbridge.models.qwen3_5.attention import (  # pyright: ignore[reportMissingImports]
+    Qwen3_5VLSelfAttention,
+)
+from mbridge.models.qwen3_5.rope_utils import (  # pyright: ignore[reportMissingImports]
+    Qwen3VLMultimodalRotaryEmbedding,
+)
+from megatron.core import (
+    parallel_state as mcore_parallel_state,  # pyright: ignore[reportMissingImports]
+)
+from megatron.core.process_groups_config import (
+    ProcessGroupCollection,  # pyright: ignore[reportMissingImports]
+)
+from megatron.core.transformer.enums import (  # pyright: ignore[reportMissingImports]
+    AttnMaskType,
+)
+from megatron.core.transformer.moe.moe_layer import (
+    MoELayer as MCoreBaseMoELayer,  # pyright: ignore[reportMissingImports]
+)
+
+from megatron.lite.model.qwen3_5.lite._mbridge_glue import (
+    _hook_fp32_rotary_emb_verbatim,
+    _hook_vision_params_avg_grad_across_tp_verbatim,
+)
+
+# ---------------------------------------------------------------------------
+# MC parallel-state helpers
+# ---------------------------------------------------------------------------
+
+
+def _effective_etp(train_cfg) -> int:
+    return train_cfg.etp if train_cfg.etp is not None else 1
+
+
+def _current_parallel_sizes() -> tuple[int, int, int, int, int]:
+    return (
+        int(mcore_parallel_state.get_tensor_model_parallel_world_size()),
+        int(mcore_parallel_state.get_expert_model_parallel_world_size()),
+        int(mcore_parallel_state.get_expert_tensor_parallel_world_size() or 1),
+        int(mcore_parallel_state.get_pipeline_model_parallel_world_size()),
+        int(mcore_parallel_state.get_context_parallel_world_size()),
+    )
+
+
+def ensure_mcore_parallel_state(train_cfg) -> None:
+    expected = (
+        train_cfg.tp,
+        train_cfg.ep,
+        _effective_etp(train_cfg),
+        train_cfg.pp,
+        train_cfg.cp,
+    )
+    if mcore_parallel_state.is_initialized():
+        if _current_parallel_sizes() != expected:
+            raise RuntimeError(
+                "Hybrid runtime found an incompatible existing Megatron-Core parallel state."
+            )
+        return
+
+    mcore_parallel_state.initialize_model_parallel(
+        tensor_model_parallel_size=train_cfg.tp,
+        pipeline_model_parallel_size=train_cfg.pp,
+        virtual_pipeline_model_parallel_size=train_cfg.vpp,
+        context_parallel_size=train_cfg.cp,
+        expert_model_parallel_size=train_cfg.ep,
+        expert_tensor_parallel_size=_effective_etp(train_cfg),
+        create_gloo_process_groups=bool(getattr(train_cfg, "deterministic", False)),
+    )
+    # GatedDeltaNet.reset_parameters() requires model-parallel-rng in the
+    # cuda rng tracker; initialize_model_parallel does not add it.
+    from megatron.core.tensor_parallel.random import (  # pyright: ignore[reportMissingImports]
+        model_parallel_cuda_manual_seed,
+    )
+    model_parallel_cuda_manual_seed(torch.initial_seed() % (2**31))
+
+
+def _set_mcore_virtual_pipeline_rank(vp_stage: int | None) -> None:
+    if vp_stage is None or not mcore_parallel_state.is_initialized():
+        return
+    vpp_size = mcore_parallel_state.get_virtual_pipeline_model_parallel_world_size()
+    if vpp_size is not None and vpp_size > 1:
+        mcore_parallel_state.set_virtual_pipeline_model_parallel_rank(vp_stage)
+
+
+# ---------------------------------------------------------------------------
+# mbridge bridge factory
+# ---------------------------------------------------------------------------
+
+
+def _build_mbridge_bridge(
+    model_cfg, train_cfg, *, hf_path: str = "", attention_backend_override: str | None = None
+):
+    import os
+
+    bridge = AutoBridge.from_pretrained(
+        hf_path,
+        trust_remote_code=True,
+    )
+    hf_text = getattr(bridge.hf_config, "text_config", bridge.hf_config)
+    hf_text.moe_intermediate_size = model_cfg.moe_intermediate_size
+    hf_text.router_aux_loss_coef = model_cfg.router_aux_loss_coef
+    hf_text.rope_theta = model_cfg.rope_theta
+    bridge.config = bridge._build_config()
+    from megatron.lite.model.qwen3_5.common import (
+        _apply_moe_hack_to_bridge,
+        apply_qwen3_5_bridge_config,
+    )
+    apply_qwen3_5_bridge_config(bridge, deterministic=getattr(train_cfg, "deterministic", True))
+    bridge.set_extra_args(sequence_parallel=train_cfg.tp > 1)
+    # Match the bridge runtime default. Precision validation compares bridge and
+    # lite MC layerwise, so the attention backend must not silently diverge.
+    backend_name = attention_backend_override or getattr(model_cfg, "attention_backend", None) or "flash"
+    bridge.set_extra_args(attention_backend=backend_name)
+    cp_comm_type_override = os.environ.get("BUMBLEBEE_Q35_CP_COMM_TYPE_OVERRIDE")
+    if cp_comm_type_override:
+        bridge.set_extra_args(cp_comm_type=cp_comm_type_override)
+    _apply_moe_hack_to_bridge(bridge, model_cfg)
+    bridge.config = bridge._build_config()
+    return bridge
+
+
+# ---------------------------------------------------------------------------
+# MCoreContext
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MCoreContext:
+    config: Any
+    pg_collection: Any
+    full_attn_submodules: Any
+    gdn_submodules: Any
+    moe_submodules: Any
+    rotary_base: float
+    bridge: Any
+
+
+def build_mcore_context(
+    model_cfg,
+    train_cfg,
+    *,
+    hf_path: str = "",
+    attention_backend_override: str | None = None,
+    vp_stage: int | None = None,
+) -> MCoreContext:
+    ensure_mcore_parallel_state(train_cfg)
+    _set_mcore_virtual_pipeline_rank(vp_stage)
+    bridge = _build_mbridge_bridge(
+        model_cfg, train_cfg, hf_path=hf_path,
+        attention_backend_override=attention_backend_override,
+    )
+    block_spec = bridge._get_transformer_layer_spec(vp_stage=vp_stage)
+    layer_specs = getattr(block_spec, "layer_specs", None)
+    if not layer_specs:
+        raise RuntimeError("Hybrid runtime could not extract layer specs from mbridge.")
+
+    def _split_specs(specs):
+        full = None
+        gdn = None
+        for spec in specs:
+            submodules = spec.submodules.self_attention.submodules
+            if hasattr(submodules, "core_attention"):
+                full = full or spec
+            else:
+                gdn = gdn or spec
+        return full, gdn
+
+    full_spec, gdn_spec = _split_specs(layer_specs)
+    if full_spec is None or gdn_spec is None:
+        for stage in range(max(int(getattr(train_cfg, "vpp", 1) or 1), 1)):
+            stage_block_spec = bridge._get_transformer_layer_spec(vp_stage=stage)
+            stage_layer_specs = getattr(stage_block_spec, "layer_specs", None)
+            if not stage_layer_specs:
+                continue
+            stage_full_spec, stage_gdn_spec = _split_specs(stage_layer_specs)
+            full_spec = full_spec or stage_full_spec
+            gdn_spec = gdn_spec or stage_gdn_spec
+            if full_spec is not None and gdn_spec is not None:
+                break
+    if full_spec is None or gdn_spec is None:
+        raise RuntimeError("Hybrid runtime could not identify both full-attention and GDN layer specs.")
+
+    full_attn_submodules = full_spec.submodules.self_attention.submodules
+    gdn_submodules = gdn_spec.submodules.self_attention.submodules
+    moe_submodules = gdn_spec.submodules.mlp.submodules
+
+    return MCoreContext(
+        config=bridge.config,
+        pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
+        full_attn_submodules=full_attn_submodules,
+        gdn_submodules=gdn_submodules,
+        moe_submodules=moe_submodules,
+        rotary_base=bridge._get_gptmodel_args()["rotary_base"],
+        bridge=bridge,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCoreFullAttn
+# ---------------------------------------------------------------------------
+
+
+class MCoreFullAttn(Qwen3_5VLSelfAttention):
+    """MCore full-attention with an ML-compatible forward signature."""
+
+    def __init__(
+        self,
+        model_cfg,
+        train_cfg,
+        ps,
+        layer_idx: int,
+        mcore_context: MCoreContext,
+        *,
+        layer_number: int | None = None,
+    ):
+        super().__init__(
+            config=mcore_context.config,
+            submodules=mcore_context.full_attn_submodules,
+            layer_number=layer_number if layer_number is not None else layer_idx + 1,
+            attn_mask_type=AttnMaskType.causal,
+            pg_collection=mcore_context.pg_collection,
+        )
+        self.model_cfg = model_cfg
+        self.train_cfg = train_cfg
+        self.ps = ps
+        self.layer_idx = layer_idx
+        self.rotary_embedding = Qwen3VLMultimodalRotaryEmbedding(
+            kv_channels=mcore_context.config.kv_channels,
+            rotary_percent=mcore_context.config.rotary_percent,
+            rotary_interleaved=mcore_context.config.rotary_interleaved,
+            seq_len_interpolation_factor=None,
+            rotary_base=int(mcore_context.rotary_base),
+        )
+        self.mrope_section = mcore_context.config.mrope_section
+
+    @property
+    def qkv(self):
+        return self.linear_qkv
+
+    @property
+    def core_attn(self):
+        return self.core_attention
+
+    @property
+    def proj(self):
+        return self.linear_proj
+
+    @property
+    def q_norm(self):
+        return self.q_layernorm
+
+    @property
+    def k_norm(self):
+        return self.k_layernorm
+
+    def _build_rotary_pos_emb(self, position_ids: torch.Tensor):
+        return self.rotary_embedding(position_ids, self.mrope_section)
+
+    def forward(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+    ) -> torch.Tensor:
+        if position_ids is None:
+            raise ValueError(
+                "Hybrid MCore full_attention requires position_ids (shape (3,b,s) for mrope)."
+            )
+        rotary_pos_emb = self._build_rotary_pos_emb(position_ids)
+        output, bias = super().forward(
+            hidden_states=x,
+            attention_mask=None,
+            rotary_pos_emb=rotary_pos_emb,
+            packed_seq_params=packed_seq_params,
+        )
+        if bias is not None:
+            output = output + bias
+        return output
+
+
+# ---------------------------------------------------------------------------
+# MCoreGDN
+# ---------------------------------------------------------------------------
+
+
+class MCoreGDN(nn.Module):
+    """MC GatedDeltaNet wrapper for linear_attention layers."""
+
+    def __init__(
+        self,
+        model_cfg,
+        train_cfg,
+        ps,
+        layer_idx: int,
+        mcore_context: MCoreContext,
+        *,
+        layer_number: int | None = None,
+    ):
+        super().__init__()
+        from megatron.core.ssm.gated_delta_net import GatedDeltaNet  # pyright: ignore
+
+        self.model_cfg = model_cfg
+        self.train_cfg = train_cfg
+        self.ps = ps
+        self.layer_idx = layer_idx
+        self.layer_number = layer_number if layer_number is not None else layer_idx + 1
+        self.gdn = GatedDeltaNet(
+            config=mcore_context.config,
+            submodules=mcore_context.gdn_submodules,
+            layer_number=self.layer_number,
+            pg_collection=mcore_context.pg_collection,
+        )
+        assert self.gdn.pg_collection.cp.size() == mcore_parallel_state.get_context_parallel_world_size(), (
+            f"MCoreGDN cp group size {self.gdn.pg_collection.cp.size()} != "
+            f"mcore CP world size {mcore_parallel_state.get_context_parallel_world_size()}"
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+    ) -> torch.Tensor:
+        out, out_bias = self.gdn(hidden_states=x, attention_mask=None, packed_seq_params=packed_seq_params)
+        if out_bias is not None:
+            out = out + out_bias
+        return out
+
+
+# ---------------------------------------------------------------------------
+# MCoreMoELayer
+# ---------------------------------------------------------------------------
+
+
+class MCoreMoELayer(MCoreBaseMoELayer):
+    """MCore MoE with an ML-compatible forward signature."""
+
+    def __init__(
+        self,
+        model_cfg,
+        train_cfg,
+        ps,
+        layer_idx: int,
+        mcore_context: MCoreContext,
+        *,
+        layer_number: int | None = None,
+        is_mtp_layer: bool = False,
+    ):
+        super().__init__(
+            config=mcore_context.config,
+            submodules=mcore_context.moe_submodules,
+            layer_number=layer_number if layer_number is not None else layer_idx + 1,
+            pg_collection=mcore_context.pg_collection,
+            is_mtp_layer=is_mtp_layer,
+        )
+        self.model_cfg = model_cfg
+        self.train_cfg = train_cfg
+        self.ps = ps
+        self.layer_idx = layer_idx
+
+    @property
+    def dispatcher(self):
+        return self.token_dispatcher
+
+    def forward(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        output, mlp_bias = cast(
+            tuple[torch.Tensor, torch.Tensor | None],
+            super().forward(hidden_states, padding_mask=None),
+        )
+        if mlp_bias is not None:
+            output = output + mlp_bias
+        return output.to(hidden_states.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Vision model helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_hf_vision_cls(bridge) -> type:
+    cls = getattr(type(bridge), "HfVisionClass", None)
+    if cls is None:
+        raise RuntimeError("Bridge does not expose HfVisionClass; cannot build vision_model.")
+    return cls
+
+
+def _build_vision_model(bridge) -> nn.Module:
+    """Instantiate HF vision encoder and apply mbridge VL hooks.
+
+    vision_model is NOT called in text-only forward; its parameters exist
+    solely to make the DDP bucket layout match the mbridge Qwen3_5VLModel.
+    """
+    hf_vision_cls = _resolve_hf_vision_cls(bridge)
+    vision = hf_vision_cls._from_config(bridge.hf_config.vision_config)
+    _hook_fp32_rotary_emb_verbatim(vision)
+    _hook_vision_params_avg_grad_across_tp_verbatim(vision)
+    return vision.to(torch.bfloat16)
+
+
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "MCoreContext",
+    "MCoreFullAttn",
+    "MCoreGDN",
+    "MCoreMoELayer",
+    "_build_mbridge_bridge",
+    "_build_vision_model",
+    "_current_parallel_sizes",
+    "_effective_etp",
+    "_resolve_hf_vision_cls",
+    "build_mcore_context",
+    "ensure_mcore_parallel_state",
+]

--- a/experimental/lite/megatron/lite/model/qwen3_5/stats.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/stats.py
@@ -1,0 +1,196 @@
+"""Model-level Qwen3.5 benchmark statistics."""
+
+from __future__ import annotations
+
+from megatron.lite.model.qwen3_5.config import Qwen35Config
+
+
+def num_floating_point_operations(
+    model_cfg: Qwen35Config,
+    *,
+    seq_len: int,
+    global_batch_size: int,
+    tp_size: int = 1,
+) -> int | None:
+    """Megatron-aligned FLOPs estimate for one training step."""
+
+    cfg = getattr(model_cfg, "text_config", model_cfg)
+
+    def _get(name: str):
+        if isinstance(cfg, dict):
+            return cfg.get(name)
+        return getattr(cfg, name, None)
+
+    try:
+        if seq_len <= 0 or global_batch_size <= 0:
+            return None
+
+        hidden_size = int(_get("hidden_size"))
+        num_hidden_layers = int(_get("num_hidden_layers"))
+        if num_hidden_layers <= 0:
+            return None
+
+        layer_types_obj = _get("layer_types")
+        if layer_types_obj is not None:
+            layer_types = list(layer_types_obj)
+            if len(layer_types) < num_hidden_layers:
+                return None
+            layer_types = layer_types[:num_hidden_layers]
+        else:
+            full_attention_interval = int(_get("full_attention_interval"))
+            if full_attention_interval <= 0:
+                return None
+            layer_types = [
+                "full_attention" if (i + 1) % full_attention_interval == 0 else "linear_attention"
+                for i in range(num_hidden_layers)
+            ]
+
+        num_full_attention_layers = sum(layer_type == "full_attention" for layer_type in layer_types)
+        num_linear_attention_layers = sum(layer_type == "linear_attention" for layer_type in layer_types)
+        if num_full_attention_layers + num_linear_attention_layers != num_hidden_layers:
+            return None
+
+        total_tokens = seq_len * global_batch_size
+        total_tokens_squared = seq_len * seq_len * global_batch_size
+
+        num_attention_heads = int(_get("num_attention_heads"))
+        num_key_value_heads = int(_get("num_key_value_heads"))
+        head_dim = int(_get("head_dim"))
+        query_projection_size = head_dim * num_attention_heads
+        key_projection_size = head_dim * num_key_value_heads
+        value_projection_size = head_dim * num_key_value_heads
+        gate_projection_size = query_projection_size
+        standard_attention_flops = 6 * (
+            total_tokens
+            * hidden_size
+            * (
+                query_projection_size
+                + key_projection_size
+                + value_projection_size
+                + gate_projection_size
+            )
+            + query_projection_size * total_tokens_squared
+            + total_tokens * query_projection_size * hidden_size
+        )
+
+        linear_num_key_heads = int(_get("linear_num_key_heads"))
+        linear_key_head_dim = int(_get("linear_key_head_dim"))
+        linear_num_value_heads = int(_get("linear_num_value_heads"))
+        linear_value_head_dim = int(_get("linear_value_head_dim"))
+        linear_conv_kernel_dim = int(_get("linear_conv_kernel_dim"))
+        qk_dim = linear_key_head_dim * linear_num_key_heads
+        v_dim = linear_value_head_dim * linear_num_value_heads
+        linear_attention_flops = 6 * total_tokens * (
+            hidden_size * (2 * qk_dim + 2 * v_dim + 2 * linear_num_value_heads)
+            + linear_conv_kernel_dim * (2 * qk_dim + v_dim)
+            + linear_num_value_heads * (linear_value_head_dim**2) * 4
+            + hidden_size * v_dim
+        )
+
+        moe_intermediate_size = int(_get("moe_intermediate_size"))
+        num_experts_per_tok = int(_get("num_experts_per_tok"))
+        shared_expert_intermediate_size = int(_get("shared_expert_intermediate_size"))
+        moe_flops = (
+            18
+            * total_tokens
+            * hidden_size
+            * (
+                moe_intermediate_size * num_experts_per_tok
+                + shared_expert_intermediate_size
+            )
+            * num_hidden_layers
+        )
+
+        from megatron.lite.primitive.parallel.linear import pad_vocab_for_tp
+
+        padded_vocab_size = pad_vocab_for_tp(int(_get("vocab_size")), max(tp_size, 1))
+        logits_flops = 6 * total_tokens * hidden_size * padded_vocab_size
+
+        return int(
+            standard_attention_flops * num_full_attention_layers
+            + linear_attention_flops * num_linear_attention_layers
+            + moe_flops
+            + logits_flops
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def activated_params(model_cfg: Qwen35Config) -> int | None:
+    """Approximate active params/token for benchmark TFLOPS reporting."""
+
+    cfg = getattr(model_cfg, "text_config", model_cfg)
+
+    def _get(name: str):
+        if isinstance(cfg, dict):
+            return cfg.get(name)
+        return getattr(cfg, name, None)
+
+    try:
+        hidden_size = int(_get("hidden_size"))
+        num_hidden_layers = int(_get("num_hidden_layers"))
+        layer_types_obj = _get("layer_types")
+        if layer_types_obj is None:
+            return None
+        layer_types = list(layer_types_obj)
+        if not layer_types:
+            return None
+        if len(layer_types) < num_hidden_layers:
+            return None
+        layer_types = layer_types[:num_hidden_layers]
+
+        num_attention_heads = int(_get("num_attention_heads"))
+        num_key_value_heads = int(_get("num_key_value_heads"))
+        head_dim = int(_get("head_dim"))
+        full_qkv_dim = (num_attention_heads + 2 * num_key_value_heads) * head_dim
+        full_attention = hidden_size * full_qkv_dim + (num_attention_heads * head_dim) * hidden_size
+
+        linear_num_key_heads = int(_get("linear_num_key_heads"))
+        linear_key_head_dim = int(_get("linear_key_head_dim"))
+        linear_num_value_heads = int(_get("linear_num_value_heads"))
+        linear_value_head_dim = int(_get("linear_value_head_dim"))
+        linear_conv_kernel_dim = int(_get("linear_conv_kernel_dim"))
+        qk_dim = linear_num_key_heads * linear_key_head_dim
+        v_dim = linear_num_value_heads * linear_value_head_dim
+        gdn_in_proj_dim = 2 * qk_dim + 2 * v_dim + 2 * linear_num_value_heads
+        gdn_conv_dim = 2 * qk_dim + v_dim
+        linear_attention = (
+            hidden_size * gdn_in_proj_dim
+            + gdn_conv_dim * linear_conv_kernel_dim
+            + 2 * linear_num_value_heads
+            + linear_value_head_dim
+            + v_dim * hidden_size
+        )
+
+        num_experts = int(_get("num_experts"))
+        num_experts_per_tok = int(_get("num_experts_per_tok"))
+        moe_intermediate_size = int(_get("moe_intermediate_size"))
+        shared_expert_intermediate_size = int(_get("shared_expert_intermediate_size"))
+        router = hidden_size * num_experts
+        routed_expert = (
+            hidden_size * (2 * moe_intermediate_size)
+            + moe_intermediate_size * hidden_size
+        )
+        shared_expert = (
+            hidden_size * (2 * shared_expert_intermediate_size)
+            + shared_expert_intermediate_size * hidden_size
+            + hidden_size
+        )
+        moe = router + num_experts_per_tok * routed_expert + shared_expert
+
+        total = 0
+        for layer_type in layer_types:
+            if layer_type == "full_attention":
+                total += full_attention
+            elif layer_type == "linear_attention":
+                total += linear_attention
+            else:
+                return None
+            total += moe
+
+        return int(total)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = ["activated_params", "num_floating_point_operations"]

--- a/experimental/lite/megatron/lite/model/qwen3_moe/__init__.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/__init__.py
@@ -1,0 +1,1 @@
+"""qwen3_moe model package for Megatron Lite."""

--- a/experimental/lite/megatron/lite/model/qwen3_moe/common.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/common.py
@@ -1,0 +1,10 @@
+"""Shared Qwen3MoE model helpers."""
+
+from __future__ import annotations
+
+
+def is_expert_param(name: str) -> bool:
+    return "experts" in name and "router" not in name
+
+
+__all__ = ["is_expert_param"]

--- a/experimental/lite/megatron/lite/model/qwen3_moe/config.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/config.py
@@ -1,0 +1,123 @@
+"""Qwen3MoE model configuration — pure architecture parameters.
+
+Like HuggingFace's model config: only describes the model architecture.
+Impl-specific knobs live in protocol.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from dataclasses import fields as dc_fields
+from typing import Any
+
+from megatron.lite.primitive.config import load_hf_config_dict
+
+
+@dataclass
+class Qwen3MoEConfig:
+    """Pure Qwen3MoE architecture parameters (Qwen3-30B-A3B defaults)."""
+
+    num_hidden_layers: int = 48
+    hidden_size: int = 2048
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 4
+    head_dim: int = 128
+    vocab_size: int = 151936
+    num_experts: int = 128
+    num_experts_per_tok: int = 8
+    moe_intermediate_size: int = 768
+    rope_theta: float = 1_000_000.0
+    rms_norm_eps: float = 1e-6
+    max_position_embeddings: int = 32768
+    router_aux_loss_coef: float = 0.001
+    num_nextn_predict_layers: int = 0
+    mtp_loss_scaling_factor: float = 0.1
+    mtp_use_repeated_layer: bool = False
+    layer_types: list[str] = field(
+        default_factory=lambda: ["full_attention"] * 48
+    )
+
+    def __post_init__(self):
+        self._validate()
+
+    def _validate(self):
+        errors: list[str] = []
+
+        def _check(cond: bool, msg: str):
+            if not cond:
+                errors.append(msg)
+
+        _check(
+            self.hidden_size % self.num_attention_heads == 0,
+            f"hidden_size({self.hidden_size}) % num_attention_heads({self.num_attention_heads}) != 0",
+        )
+        _check(
+            self.num_attention_heads % self.num_key_value_heads == 0,
+            f"num_attention_heads({self.num_attention_heads}) % num_key_value_heads({self.num_key_value_heads}) != 0",
+        )
+        _check(self.head_dim > 0, f"head_dim must be > 0, got {self.head_dim}")
+        _check(self.num_experts >= 1, f"num_experts must be >= 1, got {self.num_experts}")
+        _check(
+            1 <= self.num_experts_per_tok <= self.num_experts,
+            f"num_experts_per_tok({self.num_experts_per_tok}) not in [1, {self.num_experts}]",
+        )
+        _check(self.moe_intermediate_size > 0, "moe_intermediate_size must be > 0")
+        _check(self.vocab_size > 0, "vocab_size must be > 0")
+        _check(self.num_hidden_layers >= 1, "num_hidden_layers must be >= 1")
+        _check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
+        _check(
+            len(self.layer_types) == self.num_hidden_layers,
+            f"len(layer_types)={len(self.layer_types)} != "
+            f"num_hidden_layers={self.num_hidden_layers}",
+        )
+        valid_types = {"full_attention"}
+        for i, lt in enumerate(self.layer_types):
+            _check(
+                lt in valid_types,
+                f"layer_types[{i}] must be one of {valid_types}, got '{lt}'",
+            )
+
+        if errors:
+            raise ValueError(
+                f"Invalid Qwen3MoEConfig ({len(errors)} errors):\n  " + "\n  ".join(errors)
+            )
+
+    @property
+    def qkv_size(self) -> int:
+        return (self.num_attention_heads + 2 * self.num_key_value_heads) * self.head_dim
+
+    def to_dict(self) -> dict[str, Any]:
+        return {f.name: getattr(self, f.name) for f in dc_fields(self)}
+
+    @classmethod
+    def from_hf(cls, path_or_name: str, **overrides) -> Qwen3MoEConfig:
+        hf_dict = load_hf_config_dict(path_or_name)
+        return cls._from_hf_dict(hf_dict, **overrides)
+
+    @classmethod
+    def from_hf_config(cls, hf_config, **overrides) -> Qwen3MoEConfig:
+        hf_dict = hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
+        return cls._from_hf_dict(hf_dict, **overrides)
+
+    @classmethod
+    def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> Qwen3MoEConfig:
+        valid_fields = {f.name for f in dc_fields(cls)}
+        kwargs = {k: v for k, v in hf.items() if k in valid_fields}
+
+        if "rope_theta" not in kwargs:
+            if "rope_parameters" in hf and isinstance(hf["rope_parameters"], dict):
+                kwargs["rope_theta"] = float(hf["rope_parameters"].get("rope_theta", 1_000_000.0))
+
+        if "head_dim" not in kwargs or kwargs["head_dim"] is None:
+            hs = kwargs.get("hidden_size", 2048)
+            nh = kwargs.get("num_attention_heads", 32)
+            kwargs["head_dim"] = hs // nh
+        if kwargs.get("num_nextn_predict_layers") is None:
+            kwargs["num_nextn_predict_layers"] = 0
+
+        if "layer_types" not in kwargs:
+            kwargs["layer_types"] = ["full_attention"] * kwargs.get(
+                "num_hidden_layers", 48
+            )
+        kwargs.update(overrides)
+        return cls(**kwargs)

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/__init__.py
@@ -1,0 +1,1 @@
+"""Native Qwen3MoE implementation."""

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
@@ -1,0 +1,265 @@
+"""Qwen3MoE WeightSpec — name mapping + format conversion.
+
+Orchestration (TP scatter, EP sharding, PP remap) lives in
+primitive/ckpt/weight_loader.py. This file only defines what's
+model-specific: the weight map and tensor conversions.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch.distributed.tensor import Replicate, Shard
+
+from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+from megatron.lite.primitive.ckpt.dcp import (  # noqa: F401 — re-export
+    canonicalize_fc1_for_dcp,
+    canonicalize_qkv_for_dcp,
+    decanon_fc1_after_dcp,
+    decanon_qkv_after_dcp,
+)
+from megatron.lite.primitive.ckpt.hf_bridge import extract_layer_idx, parse_expert_idx
+
+
+def _pack_mcore_qkv(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, config: Qwen3MoEConfig) -> torch.Tensor:
+    q_per_group = config.num_attention_heads // config.num_key_value_heads
+    q = q.view(config.num_key_value_heads, q_per_group * config.head_dim, -1)
+    k = k.view(config.num_key_value_heads, config.head_dim, -1)
+    v = v.view(config.num_key_value_heads, config.head_dim, -1)
+    return torch.cat([q, k, v], dim=1).reshape(-1, q.shape[-1]).contiguous()
+
+
+def _unpack_mcore_qkv(tensor: torch.Tensor, config: Qwen3MoEConfig) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    q_per_group = config.num_attention_heads // config.num_key_value_heads
+    group_width = (q_per_group + 2) * config.head_dim
+    packed = tensor.view(config.num_key_value_heads, group_width, -1)
+    q_end = q_per_group * config.head_dim
+    k_end = q_end + config.head_dim
+    q = packed[:, :q_end].reshape(config.num_attention_heads * config.head_dim, -1)
+    k = packed[:, q_end:k_end].reshape(config.num_key_value_heads * config.head_dim, -1)
+    v = packed[:, k_end:].reshape(config.num_key_value_heads * config.head_dim, -1)
+    return q, k, v
+
+
+class Qwen3MoEWeightSpec:
+    """WeightSpec for Qwen3MoE native impl."""
+
+    def __init__(self, config: Qwen3MoEConfig):
+        self.config = config
+
+    @property
+    def num_experts(self) -> int:
+        return self.config.num_experts
+
+    def weight_map(self) -> dict[str, list[str]]:
+        c = self.config
+        wm: dict[str, list[str]] = {
+            "embed.embedding.weight": ["model.embed_tokens.weight"],
+            "mtp_embed.embedding.weight": ["model.embed_tokens.weight"],
+            "norm.weight": ["model.norm.weight"],
+            "head.col.linear.weight": ["lm_head.weight"],
+        }
+        for li in range(c.num_hidden_layers):
+            ap = f"model.layers.{li}.self_attn"
+            mp = f"model.layers.{li}.mlp"
+            lp = f"layers.{li}"
+            wm.update({
+                f"{lp}.attn.qkv.linear.layer_norm_weight": [f"model.layers.{li}.input_layernorm.weight"],
+                f"{lp}.attn.qkv.linear.weight": [f"{ap}.q_proj.weight", f"{ap}.k_proj.weight", f"{ap}.v_proj.weight"],
+                f"{lp}.attn.q_norm.weight": [f"{ap}.q_norm.weight"],
+                f"{lp}.attn.k_norm.weight": [f"{ap}.k_norm.weight"],
+                f"{lp}.attn.proj.linear.weight": [f"{ap}.o_proj.weight"],
+                f"{lp}.mlp_norm.weight": [f"model.layers.{li}.post_attention_layernorm.weight"],
+                f"{lp}.moe.router.gate.weight": [f"{mp}.gate.weight"],
+            })
+            for e in range(c.num_experts):
+                wm[f"{lp}.moe.experts._fc1_weight_{e}"] = [
+                    f"{mp}.experts.{e}.gate_proj.weight",
+                    f"{mp}.experts.{e}.up_proj.weight",
+                ]
+                wm[f"{lp}.moe.experts._fc2_weight_{e}"] = [
+                    f"{mp}.experts.{e}.down_proj.weight",
+                ]
+        for mi in range(c.num_nextn_predict_layers):
+            hf_li = c.num_hidden_layers + mi
+            hp = f"model.layers.{hf_li}"
+            ap = f"{hp}.self_attn"
+            mp = f"{hp}.mlp"
+            lp = f"mtp.layers.{mi}"
+            tlp = f"{lp}.transformer_layer"
+            wm.update({
+                f"{lp}.enorm.weight": [f"{hp}.enorm.weight"],
+                f"{lp}.hnorm.weight": [f"{hp}.hnorm.weight"],
+                f"{lp}.eh_proj.linear.weight": [f"{hp}.eh_proj.weight"],
+                f"{lp}.final_layernorm.weight": [f"{hp}.shared_head.norm.weight"],
+                f"{tlp}.attn.qkv.linear.layer_norm_weight": [f"{hp}.input_layernorm.weight"],
+                f"{tlp}.attn.qkv.linear.weight": [f"{ap}.q_proj.weight", f"{ap}.k_proj.weight", f"{ap}.v_proj.weight"],
+                f"{tlp}.attn.q_norm.weight": [f"{ap}.q_norm.weight"],
+                f"{tlp}.attn.k_norm.weight": [f"{ap}.k_norm.weight"],
+                f"{tlp}.attn.proj.linear.weight": [f"{ap}.o_proj.weight"],
+                f"{tlp}.mlp_norm.weight": [f"{hp}.post_attention_layernorm.weight"],
+                f"{tlp}.moe.router.gate.weight": [f"{mp}.gate.weight"],
+            })
+            for e in range(c.num_experts):
+                wm[f"{tlp}.moe.experts._fc1_weight_{e}"] = [
+                    f"{mp}.experts.{e}.gate_proj.weight",
+                    f"{mp}.experts.{e}.up_proj.weight",
+                ]
+                wm[f"{tlp}.moe.experts._fc2_weight_{e}"] = [
+                    f"{mp}.experts.{e}.down_proj.weight",
+                ]
+        return wm
+
+    def hf_to_native(self, lite_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+        if len(hf_tensors) == 3 and "qkv" in lite_name:
+            # Match MCore SelfAttention's local qkv packing:
+            # [q heads for kv-group 0, k0, v0, q heads for kv-group 1, k1, v1, ...].
+            return _pack_mcore_qkv(*hf_tensors, self.config)
+        if len(hf_tensors) == 2:
+            # gate + up → concat
+            return torch.cat(hf_tensors, dim=0)
+        t = hf_tensors[0]
+        if "router.gate.weight" in lite_name:
+            return t[: self.config.num_experts]
+        return t
+
+    def native_to_hf(self, lite_name: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+        c = self.config
+        if lite_name == "mtp_embed.embedding.weight":
+            return []
+        if lite_name.startswith("mtp.layers."):
+            parts = lite_name.split(".")
+            mtp_idx = int(parts[2])
+            hf_li = c.num_hidden_layers + mtp_idx
+            hp = f"model.layers.{hf_li}"
+            if lite_name.endswith(".enorm.weight"):
+                return [(f"{hp}.enorm.weight", tensor)]
+            if lite_name.endswith(".hnorm.weight"):
+                return [(f"{hp}.hnorm.weight", tensor)]
+            if lite_name.endswith(".eh_proj.linear.weight"):
+                return [(f"{hp}.eh_proj.weight", tensor)]
+            if lite_name.endswith(".final_layernorm.weight"):
+                return [(f"{hp}.shared_head.norm.weight", tensor)]
+            proxy = lite_name.replace(f"mtp.layers.{mtp_idx}.transformer_layer", f"layers.{hf_li}")
+            return self.native_to_hf(proxy, tensor)
+        if "embed" in lite_name and "embedding" in lite_name:
+            return [("model.embed_tokens.weight", tensor)]
+        if lite_name.endswith("norm.weight") and "layers" not in lite_name and "attn" not in lite_name and "mlp" not in lite_name:
+            return [("model.norm.weight", tensor)]
+        if "head" in lite_name:
+            return [("lm_head.weight", tensor)]
+        if "layer_norm_weight" in lite_name and "qkv" in lite_name:
+            li = extract_layer_idx(lite_name)
+            return [(f"model.layers.{li}.input_layernorm.weight", tensor)]
+        if "mlp_norm" in lite_name:
+            li = extract_layer_idx(lite_name)
+            return [(f"model.layers.{li}.post_attention_layernorm.weight", tensor)]
+        if "qkv" in lite_name and "layer_norm" not in lite_name:
+            li = extract_layer_idx(lite_name)
+            ap = f"model.layers.{li}.self_attn"
+            q, k, v = _unpack_mcore_qkv(tensor, c)
+            return [
+                (f"{ap}.q_proj.weight", q),
+                (f"{ap}.k_proj.weight", k),
+                (f"{ap}.v_proj.weight", v),
+            ]
+        if "q_norm" in lite_name:
+            li = extract_layer_idx(lite_name)
+            return [(f"model.layers.{li}.self_attn.q_norm.weight", tensor)]
+        if "k_norm" in lite_name:
+            li = extract_layer_idx(lite_name)
+            return [(f"model.layers.{li}.self_attn.k_norm.weight", tensor)]
+        if "proj.linear" in lite_name:
+            li = extract_layer_idx(lite_name)
+            return [(f"model.layers.{li}.self_attn.o_proj.weight", tensor)]
+        if "router.gate" in lite_name:
+            li = extract_layer_idx(lite_name)
+            return [(f"model.layers.{li}.mlp.gate.weight", tensor)]
+        if "experts" in lite_name and "fc1" in lite_name:
+            li = extract_layer_idx(lite_name)
+            ei = parse_expert_idx(lite_name)
+            mp = f"model.layers.{li}.mlp"
+            gate, up = tensor.chunk(2, dim=0)
+            return [(f"{mp}.experts.{ei}.gate_proj.weight", gate), (f"{mp}.experts.{ei}.up_proj.weight", up)]
+        if "experts" in lite_name and "fc2" in lite_name:
+            li = extract_layer_idx(lite_name)
+            ei = parse_expert_idx(lite_name)
+            return [(f"model.layers.{li}.mlp.experts.{ei}.down_proj.weight", tensor)]
+        return [(lite_name, tensor)]
+
+    def qkv_spec(self, lite_name: str) -> tuple[int, int, int] | None:
+        return None
+
+    def tp_spec(self, lite_name: str) -> tuple[int, int] | None:
+        if self.is_expert(lite_name):
+            if "fc1" in lite_name:
+                return (0, 1)  # ETP dim 0
+            if "fc2" in lite_name:
+                return (1, 1)  # ETP dim 1
+            return None
+        if "eh_proj" in lite_name:
+            return (0, 0)
+        if "qkv" in lite_name and "layer_norm" not in lite_name:
+            return (0, 0)
+        if "proj" in lite_name and "attn" in lite_name:
+            return (1, 0)
+        if "embed" in lite_name or "head" in lite_name:
+            return (0, 0)
+        return None
+
+    def is_expert(self, lite_name: str) -> bool:
+        return "experts" in lite_name and "router" not in lite_name
+
+    def expert_global_id(self, lite_name: str) -> int | None:
+        if "_fc1_weight_" in lite_name or "_fc2_weight_" in lite_name:
+            return int(lite_name.split("_")[-1])
+        return None
+
+    def expert_local_name(self, lite_name: str, local_idx: int) -> str:
+        prefix = lite_name.rsplit("._fc", 1)[0]
+        fc_tag = "fc1" if "_fc1_weight_" in lite_name else "fc2"
+        return f"{prefix}.{fc_tag}.weight{local_idx}"
+
+
+# ---------------------------------------------------------------------------
+# Convenience: standalone functions wrapping WeightSpec + generic loader
+# ---------------------------------------------------------------------------
+
+
+def load_hf_weights(model, path: str, config: Qwen3MoEConfig, ps) -> None:
+    from megatron.lite.primitive.ckpt.hf_bridge import load_hf_weights as _load
+
+    _load(model, path, Qwen3MoEWeightSpec(config), ps, vocab_size=config.vocab_size)
+
+
+def export_hf_weights(model, config: Qwen3MoEConfig, ps, **kwargs):
+    from megatron.lite.primitive.ckpt.hf_bridge import export_hf_weights as _export
+
+    yield from _export(model, Qwen3MoEWeightSpec(config), ps, vocab_size=config.vocab_size, **kwargs)
+
+
+def save_hf_weights(model, path: str, config: Qwen3MoEConfig, ps) -> None:
+    from megatron.lite.primitive.ckpt.hf_bridge import save_hf_weights as _save
+
+    _save(model, path, Qwen3MoEWeightSpec(config), ps, vocab_size=config.vocab_size)
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    return "experts" in name and "router" not in name
+
+
+def PLACEMENT_FN(param_name: str) -> list:
+    if "experts" in param_name and "router" not in param_name:
+        if "fc1" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(0)]
+        if "fc2" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(1)]
+        return [Replicate(), Replicate(), Replicate(), Replicate()]
+    if "eh_proj" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "qkv" in param_name and "layer_norm" not in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "proj" in param_name and "attn" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(1)]
+    if "embed" in param_name or "head" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    return [Replicate(), Replicate(), Replicate(), Replicate()]

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -1,0 +1,611 @@
+"""Native Qwen3MoE: TransformerLayer + Qwen3MoEModel.
+
+Attention and MoE come from primitive/modules; this file only
+defines the model-specific composition (Layer stacking, PP layout,
+loss computation).
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import torch
+import torch.nn as nn
+import transformer_engine.pytorch as te
+
+from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.experts import Experts
+from megatron.lite.primitive.modules.gqa import GQAttention
+from megatron.lite.primitive.modules.router import TopKRouter
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
+from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
+from megatron.lite.primitive.parallel import (
+    ParallelState,
+    VanillaColumnParallelLinear,
+    VocabParallelEmbedding,
+    VocabParallelOutput,
+    build_pipeline_chunk_layout,
+    gather_from_sequence_parallel,
+    roll_packed_thd_left,
+    scatter_to_sequence_parallel,
+)
+from megatron.lite.primitive.utils import build_fp8_recipe
+
+# ---------------------------------------------------------------------------
+# MoE Layer (thin assembly over megatron.lite.primitive.modules)
+# ---------------------------------------------------------------------------
+
+
+class MoELayer(nn.Module):
+    def __init__(
+        self,
+        config: Qwen3MoEConfig,
+        ps: ParallelState,
+        *,
+        use_deepep: bool = True,
+        router_bias_rate: float = 0.0,
+        fp8: bool = False,
+        moe_act_recompute: bool = False,
+    ):
+        super().__init__()
+        # Mirror bridge's `load_balancing_type="none"` for Qwen3-MoE: no aux loss.
+        self.router = TopKRouter(
+            config, ps,
+            router_bias_rate=router_bias_rate,
+            compute_aux_loss=False,
+        )
+        self.experts = Experts(config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute)
+        self.dispatcher = TokenDispatcher(
+            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        input_shape = x.shape
+        if x.dim() == 3:
+            x_2d = x.view(-1, x.size(-1))
+        else:
+            x_2d = x
+
+        scores, indices = self.router(x_2d)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x_2d, scores, indices)
+        del scores, indices
+        self.dispatcher.wait_dispatch_event()
+        expert_out = self.experts(
+            dispatched,
+            tpe,
+            permuted_probs,
+            tokens_per_expert_list=getattr(self.dispatcher, "_local_tpe_list", None),
+        )
+        del dispatched, tpe, permuted_probs
+        combined = self.dispatcher.combine(expert_out)
+        del expert_out
+
+        return combined.view(input_shape).to(x.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Transformer Layer + Model
+# ---------------------------------------------------------------------------
+
+_SP_GRAD_SUFFIXES: tuple[str, ...] = (
+    ".attn.qkv.linear.layer_norm_weight",
+    ".mlp_norm.weight",
+    ".q_norm.weight",
+    ".k_norm.weight",
+    ".moe.router.gate.weight",
+    ".enorm.weight",
+    ".hnorm.weight",
+    ".final_layernorm.weight",
+)
+
+
+def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
+    """Collect non-TP-sharded params needing coalesced all_reduce after backward."""
+    params = []
+    for name, p in model.named_parameters():
+        if any(name.endswith(s) for s in _SP_GRAD_SUFFIXES) or name == "norm.weight":
+            params.append(p)
+    return params
+
+
+class TransformerLayer(nn.Module):
+    def __init__(
+        self,
+        config: Qwen3MoEConfig,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        use_deepep: bool = True,
+        router_bias_rate: float = 0.0,
+        fp8: bool = False,
+        moe_act_recompute: bool = False,
+        use_thd: bool = False,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+
+        # Declaration order follows MC's TransformerLayer (self_attention →
+        # pre_mlp_layernorm → mlp). `named_parameters()` iterates in
+        # declaration order, and MC's `DistributedDataParallel` lays out
+        # gradient buckets by that order; mismatching it would make step-0
+        # fp32 master shard layouts diverge from the MC reference path and break
+        # bitwise alignment from step 1 onwards.
+        self.attn = GQAttention(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            ps=ps,
+            rms_norm_eps=config.rms_norm_eps,
+            rope_theta=config.rope_theta,
+            use_thd=use_thd,
+            qkv_layout="mcore",
+        )
+        self.mlp_norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.moe = MoELayer(
+            config, ps,
+            use_deepep=use_deepep,
+            router_bias_rate=router_bias_rate,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+    ) -> torch.Tensor:
+        residual = x
+        h = self.attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
+        x = residual + h
+
+        residual = x
+        h = self.mlp_norm(x)
+        moe_out = self.moe(h)
+        x = residual + moe_out
+
+        return x
+
+
+class MTPLossAutoScaler(torch.autograd.Function):
+    """Attach MTP loss gradients to the main LM hidden state."""
+
+    main_loss_backward_scale: float = 1.0
+
+    @staticmethod
+    def forward(ctx, output: torch.Tensor, mtp_loss: torch.Tensor):
+        ctx.save_for_backward(mtp_loss)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (mtp_loss,) = ctx.saved_tensors
+        scaled_mtp_grad = torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        return grad_output, scaled_mtp_grad
+
+    @staticmethod
+    def set_loss_scale(scale: torch.Tensor | float) -> None:
+        if isinstance(scale, torch.Tensor):
+            scale = float(scale.detach().float().item())
+        MTPLossAutoScaler.main_loss_backward_scale = float(scale)
+
+
+class MultiTokenPredictionLayer(nn.Module):
+    """MCore-style MTP layer for the THD SFT lite path."""
+
+    def __init__(
+        self,
+        config: Qwen3MoEConfig,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        embedding: VocabParallelEmbedding,
+        use_deepep: bool,
+        router_bias_rate: float,
+        fp8: bool,
+        moe_act_recompute: bool,
+        use_thd: bool,
+        detach_encoder: bool,
+    ):
+        super().__init__()
+        self.ps = ps
+        self.embedding = embedding
+        self.detach_encoder = detach_encoder
+        self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = VanillaColumnParallelLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            ps,
+            sp=ps.tp_size > 1,
+            gather_output=True,
+        )
+        self.transformer_layer = TransformerLayer(
+            config,
+            ps,
+            config.num_hidden_layers + layer_idx,
+            use_deepep=use_deepep,
+            router_bias_rate=router_bias_rate,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+            use_thd=use_thd,
+        )
+        self.final_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None,
+        hidden_states: torch.Tensor,
+        rotary_position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        attention_position_ids = rotary_position_ids if rotary_position_ids is not None else position_ids
+        input_ids, _ = roll_packed_thd_left(
+            input_ids,
+            packed_seq_params=packed_seq_params,
+            dims=-1,
+        )
+        if position_ids is not None:
+            position_ids, _ = roll_packed_thd_left(
+                position_ids,
+                packed_seq_params=packed_seq_params,
+                dims=-1,
+            )
+        decoder_input = self.embedding(input_ids)
+        decoder_input = scatter_to_sequence_parallel(decoder_input, self.ps)
+
+        if self.detach_encoder:
+            decoder_input = decoder_input.detach()
+            hidden_states = hidden_states.detach()
+
+        decoder_input = self.enorm(decoder_input)
+        hidden_states = self.hnorm(hidden_states)
+        hidden_states = torch.cat((decoder_input, hidden_states), dim=-1)
+        hidden_states = self.eh_proj(hidden_states)
+        hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
+        hidden_states = self.transformer_layer(
+            hidden_states,
+            position_ids=attention_position_ids,
+            packed_seq_params=packed_seq_params,
+        )
+        hidden_states = self.final_layernorm(hidden_states)
+        return hidden_states, input_ids, position_ids
+
+
+class MultiTokenPredictionBlock(nn.Module):
+    def __init__(
+        self,
+        config: Qwen3MoEConfig,
+        ps: ParallelState,
+        *,
+        embedding: VocabParallelEmbedding,
+        use_deepep: bool,
+        router_bias_rate: float,
+        fp8: bool,
+        moe_act_recompute: bool,
+        use_thd: bool,
+        detach_encoder: bool,
+        repeated_layer: bool,
+    ):
+        super().__init__()
+        self.num_layers = config.num_nextn_predict_layers
+        self.repeated_layer = repeated_layer
+        layers_to_build = 1 if repeated_layer else self.num_layers
+        self.layers = nn.ModuleList(
+            [
+                MultiTokenPredictionLayer(
+                    config,
+                    ps,
+                    idx,
+                    embedding=embedding,
+                    use_deepep=use_deepep,
+                    router_bias_rate=router_bias_rate,
+                    fp8=fp8,
+                    moe_act_recompute=moe_act_recompute,
+                    use_thd=use_thd,
+                    detach_encoder=detach_encoder,
+                )
+                for idx in range(layers_to_build)
+            ]
+        )
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None,
+        hidden_states: torch.Tensor,
+        packed_seq_params=None,
+    ) -> list[torch.Tensor]:
+        outputs: list[torch.Tensor] = []
+        rotary_position_ids = position_ids
+        for depth in range(self.num_layers):
+            layer = self.layers[0] if self.repeated_layer else self.layers[depth]
+            hidden_states, input_ids, position_ids = layer(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                rotary_position_ids=rotary_position_ids,
+                packed_seq_params=packed_seq_params,
+            )
+            outputs.append(hidden_states)
+        return outputs
+
+
+def _temperature_to_float(temperature: float | torch.Tensor) -> float:
+    if isinstance(temperature, torch.Tensor):
+        if temperature.numel() != 1:
+            raise ValueError("Megatron Lite fused/MTP SFT currently supports scalar temperature only.")
+        return float(temperature.detach().float().item())
+    return float(temperature)
+
+
+class Qwen3MoEModel(nn.Module):
+    def __init__(
+        self,
+        config: Qwen3MoEConfig,
+        ps: ParallelState,
+        vpp: int | None = None,
+        vpp_chunk_id: int | None = None,
+        *,
+        use_deepep: bool = False,
+        fp8: bool = False,
+        recompute_modules: list[str] | None = None,
+        router_bias_rate: float = 0.0,
+        use_thd: bool = False,
+        mtp_enable: bool = False,
+        mtp_enable_train: bool = False,
+        mtp_detach_encoder: bool = False,
+    ):
+        super().__init__()
+        self.config = config
+        self.ps = ps
+        self.fp8 = fp8
+        self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
+        self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
+        self._input_tensor: torch.Tensor | None = None
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers, ps, vpp, vpp_chunk_id,
+        )
+        self.layer_indices = layout.layer_indices
+        has_embed = layout.has_embed
+        has_head = layout.has_head
+
+        self.embed: VocabParallelEmbedding | None = None
+        if has_embed:
+            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+
+        _recompute = recompute_modules or []
+        moe_act_recompute = "moe_act" in _recompute and "moe" not in _recompute
+        self.layers = nn.ModuleList(
+            [
+                TransformerLayer(
+                    config, ps, idx,
+                    use_deepep=use_deepep,
+                    router_bias_rate=router_bias_rate,
+                    fp8=fp8,
+                    moe_act_recompute=moe_act_recompute,
+                    use_thd=use_thd,
+                )
+                for idx in self.layer_indices
+            ]
+        )
+
+        self.norm: nn.Module | None = None
+        self.head: VocabParallelOutput | None = None
+        if has_head:
+            self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
+
+        self.mtp_embed: VocabParallelEmbedding | None = None
+        self.mtp: MultiTokenPredictionBlock | None = None
+        if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
+            mtp_embedding = self.embed
+            if mtp_embedding is None:
+                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                self.mtp_embed = mtp_embedding
+            self.mtp = MultiTokenPredictionBlock(
+                config,
+                ps,
+                embedding=mtp_embedding,
+                use_deepep=use_deepep,
+                router_bias_rate=router_bias_rate,
+                fp8=fp8,
+                moe_act_recompute=moe_act_recompute,
+                use_thd=use_thd,
+                detach_encoder=mtp_detach_encoder,
+                repeated_layer=config.mtp_use_repeated_layer,
+            )
+
+        self.sp_params: list[nn.Parameter] = []
+        if ps.tp_size > 1:
+            self.sp_params = _collect_sp_grad_params(self)
+
+    def set_input_tensor(self, input_tensor):
+        if isinstance(input_tensor, list):
+            if len(input_tensor) > 1:
+                raise ValueError("Qwen3MoEModel expects a single pipeline input tensor.")
+            input_tensor = input_tensor[0] if input_tensor else None
+        self._input_tensor = input_tensor
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+        labels: torch.Tensor | None = None,
+        loss_mask: torch.Tensor | None = None,
+        temperature: float | torch.Tensor = 1.0,
+        use_fused_kernels: bool = False,
+        calculate_entropy: bool = False,
+    ) -> dict:
+        if self.embed is not None:
+            assert input_ids is not None
+            h = self.embed(input_ids)
+        else:
+            if hidden_states is None:
+                hidden_states = self._input_tensor
+            assert hidden_states is not None
+            h = hidden_states
+
+        fp8_ctx = (
+            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe())
+            if self.fp8
+            else nullcontext()
+        )
+
+        with fp8_ctx:
+            if self.embed is not None:
+                h = scatter_to_sequence_parallel(h, self.ps)
+            for layer in self.layers:
+                h = layer(h, position_ids=position_ids, packed_seq_params=packed_seq_params)
+            # Head path is SP-aware: norm runs on SP-sharded [S/tp, B, H] and
+            # head's internal all-gather happens inside VocabParallelOutput.
+            # Mirrors MC GPTModel's final_layernorm → output_layer(sp=True).
+
+        output = {"hidden_states": h}
+
+        if self.head is not None:
+            hidden_for_head = self.norm(h)
+
+            if labels is not None:
+                temperature_value = _temperature_to_float(temperature)
+                mtp_result = self._apply_mtp_loss(
+                    hidden_for_head,
+                    input_ids=input_ids,
+                    position_ids=position_ids,
+                    labels=labels,
+                    loss_mask=loss_mask,
+                    packed_seq_params=packed_seq_params,
+                    temperature=temperature_value,
+                    use_fused_kernels=use_fused_kernels,
+                )
+                if mtp_result is not None:
+                    hidden_for_head, mtp_loss = mtp_result
+                    output["mtp_loss"] = mtp_loss
+                labels_sb = labels.transpose(0, 1).contiguous()
+                if use_fused_kernels:
+                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    log_probs, entropy = linear_cross_entropy(
+                        hidden_full,
+                        self._head_weight_for_fused_ce(hidden_full),
+                        labels_sb,
+                        temperature_value,
+                        self.ps.tp_group,
+                    )
+                    output["loss"] = (-log_probs).mean()
+                    output["log_probs"] = log_probs.transpose(0, 1).contiguous()
+                    if calculate_entropy:
+                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+                else:
+                    logits = self.head(hidden_for_head)
+                    if temperature_value != 1.0:
+                        logits = logits / temperature_value
+                    token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    output["loss"] = token_loss.mean()
+                    output["log_probs"] = (-token_loss).transpose(0, 1).contiguous()
+                    if calculate_entropy:
+                        entropy = vocab_parallel_entropy(logits, self.ps.tp_group)
+                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+
+            if labels is None:
+                logits = self.head(hidden_for_head)
+                output["logits"] = self.head.gather(logits)
+
+        return output
+
+    def _apply_mtp_loss(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        labels: torch.Tensor,
+        loss_mask: torch.Tensor | None,
+        packed_seq_params,
+        temperature: float,
+        use_fused_kernels: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if self.mtp is None:
+            return None
+        if not self.mtp_enable_train:
+            return None
+        if input_ids is None:
+            raise ValueError("MTP training requires input_ids.")
+        if loss_mask is None:
+            loss_mask = torch.ones_like(labels, dtype=torch.float32)
+        else:
+            loss_mask = loss_mask.to(dtype=torch.float32)
+
+        mtp_hidden_states = self.mtp(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            packed_seq_params=packed_seq_params,
+        )
+
+        mtp_labels = labels.clone()
+        mtp_loss_mask = loss_mask.clone()
+        mtp_loss_values = []
+        for mtp_hidden in mtp_hidden_states:
+            mtp_labels, _ = roll_packed_thd_left(
+                mtp_labels,
+                packed_seq_params=packed_seq_params,
+                dims=-1,
+            )
+            mtp_loss_mask, num_tokens = roll_packed_thd_left(
+                mtp_loss_mask,
+                packed_seq_params=packed_seq_params,
+                dims=-1,
+            )
+            labels_sb = mtp_labels.transpose(0, 1).contiguous()
+            mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
+
+            if use_fused_kernels:
+                mtp_hidden_full = gather_from_sequence_parallel(mtp_hidden, self.ps)
+                log_probs, _entropy = linear_cross_entropy(
+                    mtp_hidden_full,
+                    self._head_weight_for_fused_ce(mtp_hidden_full),
+                    labels_sb,
+                    temperature,
+                    self.ps.tp_group,
+                )
+                token_loss = -log_probs
+            else:
+                logits = self.head(mtp_hidden)
+                if temperature != 1.0:
+                    logits = logits / temperature
+                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+            token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
+            num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
+            mtp_loss_values.append(token_loss.sum() / num_tokens)
+
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_scale * token_loss / num_tokens)
+
+        if not mtp_loss_values:
+            return None
+        return hidden_states, torch.stack([loss.detach().float() for loss in mtp_loss_values]).mean()
+
+    def _head_weight_for_fused_ce(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        assert self.head is not None
+        weight = self.head.col.linear.weight
+        if weight.dtype == hidden_states.dtype:
+            return weight
+        return weight.to(dtype=hidden_states.dtype)
+
+
+__all__ = [
+    "MoELayer",
+    "MTPLossAutoScaler",
+    "MultiTokenPredictionBlock",
+    "MultiTokenPredictionLayer",
+    "Qwen3MoEModel",
+    "TransformerLayer",
+]

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -1,0 +1,263 @@
+"""Qwen3 MoE lite implementation for the Megatron Lite runtime.
+
+This file is the reference implementation of the Megatron Lite model protocol.
+New model authors: copy this file and adapt.
+
+Protocol convention (what runtime calls):
+  Required:
+    ImplConfig                                      — @dataclass, per-impl knobs
+    build_model_config(source, **overrides)          → ModelConfig
+    build_model(model_cfg, *, impl_cfg)              → ModelBundle
+  Optional (in ModelBundle.extras or module-level):
+    load_hf_weights(chunk, hf_path, model_cfg, ps)  — HF weight loading
+    export_hf_weights(chunks, model_cfg, ps)         — HF weight export
+    vocab_size(model_cfg) -> int                     — benchmark metadata
+  Escape hatch:
+    create_runtime(hf_path, cfg) -> Runtime          — fully override runtime
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+from megatron.lite.model.qwen3_moe.common import is_expert_param
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.model.qwen3_moe.lite.model import MTPLossAutoScaler, Qwen3MoEModel
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+
+# ---------------------------------------------------------------------------
+# ImplConfig
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ImplConfig:
+    """Lite impl knobs. Constructed by runtime from user config."""
+
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: str | None = "mc"  # None = no optimizer (inference)
+    recompute: list[str] = field(default_factory=list)
+    offload: list[str] = field(default_factory=list)
+    use_deepep: bool = False
+    use_thd: bool = False
+    router_aux_loss_coef: float | None = None
+    router_bias_rate: float = 0.0
+    # Accepted as no-op; bench.deterministic drives process-wide flags
+    # (torch/cuDNN/NVTE) via _enable_deterministic_mode() before runtime builds.
+    deterministic: bool = False
+    # User-level OptimizerConfig threaded from the runtime.
+    optimizer_config: OptimizerConfig | None = None
+    mtp_enable: bool = False
+    mtp_enable_train: bool = False
+    mtp_detach_encoder: bool = False
+    mtp_loss_scaling_factor: float = 0.1
+    mtp_use_repeated_layer: bool | None = None
+
+
+# ---------------------------------------------------------------------------
+# Module map for recompute/offload
+# ---------------------------------------------------------------------------
+
+MODULE_MAP = {
+    "core_attn": lambda layer: layer.attn.core_attn,
+    "experts": lambda layer: layer.moe.experts,
+    "moe": lambda layer: layer.moe,
+    "router": lambda layer: layer.moe.router,
+    "mlp_norm": lambda layer: layer.mlp_norm,
+    "attn_proj": lambda layer: layer.attn.proj,
+}
+
+
+# ---------------------------------------------------------------------------
+# Required: build_model_config
+# ---------------------------------------------------------------------------
+
+
+def build_model_config(source: str | Path | dict, **overrides) -> Qwen3MoEConfig:
+    """Build Qwen3MoE architecture config from HF source."""
+    if isinstance(source, dict):
+        cfg = Qwen3MoEConfig._from_hf_dict(source)
+    else:
+        cfg = Qwen3MoEConfig.from_hf(str(source))
+    for k, v in overrides.items():
+        if hasattr(cfg, k):
+            setattr(cfg, k, v)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Required: build_model
+# ---------------------------------------------------------------------------
+
+
+def _forward_step(model: nn.Module, batch: dict) -> dict:
+    kwargs = {"input_ids": batch["input_ids"], "labels": batch["labels"]}
+    if "packed_seq_params" in batch:
+        kwargs["packed_seq_params"] = batch["packed_seq_params"]
+    if "position_ids" in batch:
+        kwargs["position_ids"] = batch["position_ids"]
+    for key in ("loss_mask", "temperature", "use_fused_kernels", "calculate_entropy"):
+        if key in batch:
+            kwargs[key] = batch[key]
+    if kwargs["input_ids"].dim() == 1:
+        kwargs["input_ids"] = kwargs["input_ids"].unsqueeze(0)
+    return model(**kwargs)
+
+
+def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBundle:
+    """Build lite Qwen3MoE: model, parallel state, optimizer — everything.
+
+    Model owns all construction. Runtime just consumes the ModelBundle.
+    """
+    p = impl_cfg.parallel
+
+    # ── validation ──
+    if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
+        raise ValueError("use_deepep and etp>1 are mutually exclusive")
+
+    # ── override model config from impl_cfg ──
+    if impl_cfg.router_aux_loss_coef is not None:
+        model_cfg.router_aux_loss_coef = impl_cfg.router_aux_loss_coef
+    mtp_enable = bool(impl_cfg.mtp_enable)
+    mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
+    if mtp_enable:
+        if model_cfg.num_nextn_predict_layers <= 0:
+            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+        model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
+        if impl_cfg.mtp_use_repeated_layer is not None:
+            model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
+    else:
+        model_cfg.num_nextn_predict_layers = 0
+
+    # ── parallel state (model creates its own) ──
+    ps = init_parallel(p)
+
+    # ── build chunks ──
+    recompute_spec = parse_recompute_spec(impl_cfg.recompute)
+    model_kwargs: dict[str, Any] = dict(
+        use_deepep=impl_cfg.use_deepep,
+        fp8=False,
+        recompute_modules=recompute_spec,
+        router_bias_rate=impl_cfg.router_bias_rate,
+        use_thd=impl_cfg.use_thd,
+        mtp_enable=mtp_enable,
+        mtp_enable_train=mtp_enable_train,
+        mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
+    )
+
+    vpp = None if p.vpp == 1 else p.vpp
+    if vpp is None:
+        chunks = [Qwen3MoEModel(model_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+    else:
+        chunks = [
+            Qwen3MoEModel(model_cfg, ps, vpp=vpp, vpp_chunk_id=i, **model_kwargs)
+            .to(torch.bfloat16).cuda()
+            for i in range(vpp)
+        ]
+
+    # ── recompute ──
+    if recompute_spec:
+        for chunk in chunks:
+            apply_recompute(chunk.layers, recompute_spec, MODULE_MAP)
+
+    # ── offload ──
+    if impl_cfg.offload:
+        from megatron.lite.primitive.recompute import apply_offload
+
+        for chunk in chunks:
+            apply_offload(chunk.layers, impl_cfg.offload, MODULE_MAP)
+
+    # ── optimizer (model chooses which primitive) ──
+    optimizer = None
+    finalize_grads = None
+    post_model_load_hook = None
+    if impl_cfg.optimizer == "mc":
+        from megatron.lite.primitive.optimizers.megatron_wrap import (
+            build_mc_training_optimizer,
+        )
+
+        optimizer, finalize_grads = build_mc_training_optimizer(
+            chunks,
+            model_cfg=model_cfg,
+            impl_cfg=impl_cfg,
+            ps=ps,
+            model_name="qwen3_moe",
+            is_expert=is_expert_param,
+        )
+        optimizer_backend = "mc"
+    elif impl_cfg.optimizer is None:
+        optimizer_backend = "none"
+    else:
+        raise ValueError(f"Unknown qwen3_moe lite optimizer: {impl_cfg.optimizer!r}.")
+
+    from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
+
+    def _pre_forward_hook(loss_scale):
+        MoEAuxLossAutoScaler.set_loss_scale(loss_scale)
+        MTPLossAutoScaler.set_loss_scale(loss_scale)
+
+    return ModelBundle(
+        chunks=chunks,
+        parallel_state=ps,
+        optimizer=optimizer,
+        finalize_grads=finalize_grads,
+        forward_step=_forward_step,
+        extras={
+            "model_cfg": model_cfg,
+            # Lite's router uses Megatron Lite's MoEAuxLossAutoScaler; hand the
+            # classmethod directly as the per-microbatch hook.
+            "pre_forward_hook": _pre_forward_hook,
+            "optimizer_backend": optimizer_backend,
+            "post_model_load_hook": post_model_load_hook,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Optional: load_hf_weights
+# ---------------------------------------------------------------------------
+
+
+def load_hf_weights(
+    chunk: nn.Module,
+    hf_path: str,
+    model_cfg: Qwen3MoEConfig,
+    ps: ParallelState,
+) -> None:
+    """Load HF pretrained weights into model chunk."""
+    if not hf_path:
+        return
+    _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+
+
+def export_hf_weights(
+    chunks: list[nn.Module],
+    model_cfg: Qwen3MoEConfig,
+    ps: ParallelState,
+    **kwargs,
+):
+    """Export HF weights from model chunks (bridge-compatible format)."""
+    from megatron.lite.model.qwen3_moe.lite.checkpoint import export_hf_weights as _export
+
+    for chunk in chunks:
+        yield from _export(chunk, model_cfg, ps, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Tooling metadata (benchmark / debug)
+# ---------------------------------------------------------------------------
+
+
+def vocab_size(model_cfg: Qwen3MoEConfig) -> int | None:
+    return getattr(model_cfg, "vocab_size", None)

--- a/experimental/lite/megatron/lite/model/qwen3_moe/stats.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/stats.py
@@ -1,0 +1,25 @@
+"""Model-level Qwen3MoE benchmark statistics."""
+
+from __future__ import annotations
+
+from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+
+
+def activated_params(model_cfg: Qwen3MoEConfig) -> int | None:
+    try:
+        h = model_cfg.hidden_size
+        n_layers = model_cfg.num_hidden_layers
+        n_q = model_cfg.num_attention_heads
+        n_kv = model_cfg.num_key_value_heads
+        d = model_cfg.head_dim
+        attn = h * (n_q + n_kv + n_kv) * d + (n_q * d) * h
+        router = h * model_cfg.num_experts
+        inter = model_cfg.moe_intermediate_size
+        expert = h * (inter * 2) + inter * h
+        experts_active = model_cfg.num_experts_per_tok * expert
+        return int((attn + router + experts_active) * n_layers)
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+__all__ = ["activated_params"]

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -1,0 +1,174 @@
+"""Model and protocol registry."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Registry tables (populated by register_model)
+# ---------------------------------------------------------------------------
+
+# model_name → model package module path
+MODEL_PACKAGES: dict[str, str] = {}
+
+# HF model_type string -> Megatron Lite model_name
+_HF_MODEL_TYPE_MAP: dict[str, str] = {}
+
+# (model_name, impl) → runtime_model_name
+_IMPL_TO_RUNTIME_MODEL: dict[tuple[str, str], str] = {}
+
+# runtime_model_name → protocol module path
+TRAIN_RUNTIME_MODULES: dict[str, str] = {}
+
+# ---------------------------------------------------------------------------
+# Registration API
+# ---------------------------------------------------------------------------
+
+
+def register_model(
+    model_name: str,
+    *,
+    package: str,
+    hf_model_types: list[str] | None = None,
+    impls: dict[str, str] | None = None,
+) -> None:
+    """Register a model and all its implementations in one call.
+
+    Args:
+        model_name: Megatron Lite model name (e.g. ``"qwen3"``).
+        package: Model package module path (e.g. ``"megatron.lite.model.qwen3_moe"``).
+        hf_model_types: HF ``model_type`` strings that map to this model.
+        impls: ``{impl_name: protocol_module_path}``.
+            The first impl is also registered as the bare ``model_name`` runtime key.
+
+    Example::
+
+        register_model(
+            "qwen3",
+            package="megatron.lite.model.qwen3_moe",
+            hf_model_types=["qwen3_moe", "qwen2_moe"],
+            impls={
+                "lite": "megatron.lite.model.qwen3_moe.lite.protocol",
+            },
+        )
+    """
+    MODEL_PACKAGES[model_name] = package
+
+    if hf_model_types:
+        for hf_type in hf_model_types:
+            _HF_MODEL_TYPE_MAP[hf_type] = model_name
+
+    if impls:
+        for i, (impl_name, proto_module) in enumerate(impls.items()):
+            runtime_key = model_name if i == 0 else f"{model_name}_{impl_name}"
+            _IMPL_TO_RUNTIME_MODEL[(model_name, impl_name)] = runtime_key
+            TRAIN_RUNTIME_MODULES[runtime_key] = proto_module
+
+
+# ---------------------------------------------------------------------------
+# Built-in models
+# ---------------------------------------------------------------------------
+
+register_model(
+    "qwen3",
+    package="megatron.lite.model.qwen3_moe",
+    hf_model_types=["qwen3_moe", "qwen2_moe"],
+    impls={
+        "lite": "megatron.lite.model.qwen3_moe.lite.protocol",
+    },
+)
+
+register_model(
+    "qwen3_moe",
+    package="megatron.lite.model.qwen3_moe",
+    hf_model_types=None,
+    impls={
+        "lite": "megatron.lite.model.qwen3_moe.lite.protocol",
+    },
+)
+
+register_model(
+    "qwen3_5",
+    package="megatron.lite.model.qwen3_5",
+    hf_model_types=["qwen3_5_moe"],
+    impls={
+        "lite": "megatron.lite.model.qwen3_5.lite.protocol",
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Lookup functions
+# ---------------------------------------------------------------------------
+
+
+def get_model_package(model_name: str):
+    if model_name not in MODEL_PACKAGES:
+        raise ValueError(
+            f"Unknown model: {model_name!r}. Available: {list(MODEL_PACKAGES)}"
+        )
+    return importlib.import_module(MODEL_PACKAGES[model_name])
+
+
+def get_train_runtime_module(model_name: str):
+    if model_name in TRAIN_RUNTIME_MODULES:
+        return importlib.import_module(TRAIN_RUNTIME_MODULES[model_name])
+    raise ValueError(f"No protocol module for: {model_name!r}")
+
+
+def resolve_runtime_model_name(model_name: str, impl: str) -> str:
+    key = (model_name, impl)
+    if key not in _IMPL_TO_RUNTIME_MODEL:
+        raise ValueError(
+            f"No runtime for ({model_name!r}, {impl!r}). "
+            f"Known: {list(_IMPL_TO_RUNTIME_MODEL)}"
+        )
+    return _IMPL_TO_RUNTIME_MODEL[key]
+
+
+def resolve_model_type_from_hf(source: str | Path | dict) -> str:
+    """Resolve Megatron Lite model_name from an HF source.
+
+    Args:
+        source: One of:
+            - Directory path (str/Path) containing ``config.json``
+            - Path to a ``config.json`` file directly
+            - A dict / HF config object with a ``model_type`` key
+    """
+    if isinstance(source, dict):
+        hf_config = source
+    elif hasattr(source, "model_type"):
+        # HF PretrainedConfig object
+        hf_config = {"model_type": source.model_type}
+    else:
+        p = Path(source)
+        if p.is_file():
+            config_path = p
+        elif p.is_dir():
+            config_path = p / "config.json"
+        else:
+            raise FileNotFoundError(f"Not a file or directory: {source}")
+        if not config_path.exists():
+            raise FileNotFoundError(f"No config.json found at {source}")
+        with open(config_path) as f:
+            hf_config = json.load(f)
+
+    hf_model_type = hf_config.get("model_type", "")
+    model_name = _HF_MODEL_TYPE_MAP.get(hf_model_type)
+    if model_name is not None:
+        return model_name
+    raise ValueError(
+        f"Cannot resolve model_type={hf_model_type!r}. "
+        f"Known: {list(_HF_MODEL_TYPE_MAP)}. Set model_name explicitly."
+    )
+
+
+__all__ = [
+    "get_model_package",
+    "get_train_runtime_module",
+    "register_model",
+    "resolve_model_type_from_hf",
+    "resolve_runtime_model_name",
+]

--- a/experimental/lite/megatron/lite/primitive/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/__init__.py
@@ -1,0 +1,2 @@
+"""Public primitive-layer entrypoints."""
+

--- a/experimental/lite/megatron/lite/primitive/bundle.py
+++ b/experimental/lite/megatron/lite/primitive/bundle.py
@@ -1,0 +1,28 @@
+"""ModelBundle — return type of protocol.build_model()."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch.nn as nn
+
+from megatron.lite.primitive.parallel.state import ParallelState
+
+
+@dataclass
+class ModelBundle:
+    """Everything runtime needs to run a training loop.
+
+    Returned by protocol.build_model(). Model owns the construction
+    of all fields — runtime just consumes them.
+    """
+
+    chunks: list[nn.Module]
+    parallel_state: ParallelState
+    optimizer: Any | None = None
+    finalize_grads: Callable[[], None] | None = None
+    forward_step: Callable[[nn.Module, dict], dict] | None = None
+    # extra metadata (expert_classifier, model_cfg, etc.)
+    extras: dict[str, Any] = field(default_factory=dict)

--- a/experimental/lite/megatron/lite/primitive/ckpt/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/__init__.py
@@ -1,0 +1,10 @@
+"""Checkpoint helpers."""
+
+from megatron.lite.primitive.ckpt.dcp import load_training_checkpoint, save_training_checkpoint
+from megatron.lite.primitive.ckpt.hf_bridge import HFBridge
+
+__all__ = [
+    "HFBridge",
+    "load_training_checkpoint",
+    "save_training_checkpoint",
+]

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -1,0 +1,211 @@
+"""
+DCP (Distributed Checkpoint) framework for training checkpoints.
+
+Model-agnostic: takes a placement function to describe how each parameter is sharded.
+HF weight loading/saving is model-specific and lives in models/<name>/checkpoint.py.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+import torch.distributed.checkpoint as dcp  # pyright: ignore[reportMissingImports]
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+from torch.distributed.device_mesh import DeviceMesh  # pyright: ignore[reportMissingImports]
+from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.protocols import (
+    ExpertClassifierFn,
+    PlacementFn,
+    default_expert_classifier,
+    default_placement_fn,
+)
+
+
+def save_training_checkpoint(
+    model: nn.Module,
+    optimizer,
+    step: int,
+    path: str,
+    config,
+    ps: ParallelState,
+    get_placements: PlacementFn = default_placement_fn,
+    is_expert: ExpertClassifierFn = default_expert_classifier,
+) -> None:
+    """Save training checkpoint using DTensor + DCP for automatic resharding."""
+    dense_mesh, expert_mesh = _build_meshes(config)
+    state_dict: dict = {"step": step}
+
+    for name, param in model.named_parameters():
+        placements = get_placements(name)
+        mesh = expert_mesh if is_expert(name) else dense_mesh
+        state_dict[f"model.{name}"] = DTensor.from_local(param.data.detach(), mesh, placements)
+
+    ckpt_path = os.path.join(path, f"step_{step}")
+    dcp.save(state_dict, checkpoint_id=ckpt_path)
+    log_rank0(f"Saved training checkpoint at step {step} to {ckpt_path}")
+
+
+def load_training_checkpoint(
+    model: nn.Module,
+    optimizer,
+    path: str,
+    config,
+    ps: ParallelState,
+    get_placements: PlacementFn = default_placement_fn,
+    is_expert: ExpertClassifierFn = default_expert_classifier,
+) -> int:
+    """Load training checkpoint with automatic resharding across different parallel configs."""
+    dense_mesh, expert_mesh = _build_meshes(config)
+
+    ckpt_path = path
+    step_dirs = sorted(
+        [d for d in os.listdir(path) if d.startswith("step_")],
+        key=lambda d: int(d.split("_")[1]),
+    )
+    if step_dirs:
+        ckpt_path = os.path.join(path, step_dirs[-1])
+
+    state_dict: dict = {"step": 0}
+
+    for name, param in model.named_parameters():
+        placements = get_placements(name)
+        mesh = expert_mesh if is_expert(name) else dense_mesh
+        state_dict[f"model.{name}"] = DTensor.from_local(torch.empty_like(param.data), mesh, placements)
+
+    dcp.load(state_dict, checkpoint_id=ckpt_path)
+
+    for name, param in model.named_parameters():
+        key = f"model.{name}"
+        if key in state_dict:
+            t = state_dict[key]
+            param.data.copy_(t.to_local() if isinstance(t, DTensor) else t)
+
+    step = state_dict.get("step", 0)
+    log_rank0(f"Loaded training checkpoint from {path} at step {step}")
+    return step
+
+
+def _build_meshes(config):
+    """Build separate meshes for dense and expert parameters.
+
+    Dense mesh  [PP, DP, CP, TP]  — matches init_parallel dense decomposition.
+    Expert mesh [PP, EDP, EP, ETP] — matches init_parallel expert decomposition.
+
+    Both meshes use C-order layout so the innermost (rightmost) dimension
+    corresponds to the fastest-changing rank index, consistent with
+    init_parallel's rank = (...) * inner_size + inner_rank formula.
+    """
+    ws = dist.get_world_size()
+    tp, ep = config.tp, config.ep
+    etp = max(config.etp, 1)
+    cp = max(config.cp, 1)
+    pp = max(config.pp, 1)
+
+    dense_dp = ws // (tp * cp * pp)
+    expert_dp = ws // (etp * ep * pp)
+
+    ranks = torch.arange(ws)
+    dense_mesh = DeviceMesh("cuda", ranks.reshape(pp, dense_dp, cp, tp))
+    expert_mesh = DeviceMesh("cuda", ranks.reshape(pp, expert_dp, ep, etp))
+    return dense_mesh, expert_mesh
+
+
+def log_rank0(msg: str) -> None:
+    if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+        print(f"[Megatron Lite] {msg}", flush=True)
+
+# ======================================================================
+# QKV / FC1 canonicalize for DCP (interleaved-TP ↔ canonical layout)
+# ======================================================================
+
+
+def _ag(data, size, group, dim=0):
+    from megatron.lite.primitive.ckpt.hf_bridge import allgather_concat
+
+    return allgather_concat(data, size, group, dim)
+
+
+def canonicalize_qkv_for_dcp(model, num_attention_heads, num_key_value_heads, head_dim, ps):
+    """Rearrange fused QKV from interleaved-TP to canonical (Q|K|V) for DCP save."""
+    if ps.tp_size <= 1:
+        return
+    from megatron.lite.primitive.utils import ensure_divisible
+
+    nq = ensure_divisible(num_attention_heads, ps.tp_size) * head_dim
+    nkv = ensure_divisible(num_key_value_heads, ps.tp_size) * head_dim
+    for name, param in model.named_parameters():
+        if "qkv" not in name or "layer_norm" in name:
+            continue
+        full = _ag(param.data, ps.tp_size, ps.tp_group)
+        cs = param.data.shape[0]
+        q, k, v = [], [], []
+        for r in range(ps.tp_size):
+            s = full[r * cs : (r + 1) * cs]
+            q.append(s[:nq])
+            k.append(s[nq : nq + nkv])
+            v.append(s[nq + nkv :])
+        canon = torch.cat([torch.cat(q), torch.cat(k), torch.cat(v)], dim=0)
+        param.data.copy_(canon.chunk(ps.tp_size, dim=0)[ps.tp_rank])
+
+
+def decanon_qkv_after_dcp(model, num_attention_heads, num_key_value_heads, head_dim, ps):
+    """Reverse of canonicalize_qkv_for_dcp."""
+    if ps.tp_size <= 1:
+        return
+    qs = num_attention_heads * head_dim
+    kvs = num_key_value_heads * head_dim
+    for name, param in model.named_parameters():
+        if "qkv" not in name or "layer_norm" in name:
+            continue
+        full = _ag(param.data, ps.tp_size, ps.tp_group)
+        ql = full[:qs].chunk(ps.tp_size)[ps.tp_rank]
+        kl = full[qs : qs + kvs].chunk(ps.tp_size)[ps.tp_rank]
+        vl = full[qs + kvs :].chunk(ps.tp_size)[ps.tp_rank]
+        param.data.copy_(torch.cat([ql, kl, vl], dim=0))
+
+
+def canonicalize_fc1_for_dcp(model, ps):
+    """Rearrange fused gate-up FC1 from interleaved-ETP to canonical for DCP save."""
+    if ps.etp_size <= 1:
+        return
+    for name, param in model.named_parameters():
+        if "experts" not in name or "fc1" not in name:
+            continue
+        full = _ag(param.data, ps.etp_size, ps.etp_group)
+        cs = param.data.shape[0]
+        ffn = cs // 2
+        g, u = [], []
+        for r in range(ps.etp_size):
+            s = full[r * cs : (r + 1) * cs]
+            g.append(s[:ffn])
+            u.append(s[ffn:])
+        canon = torch.cat([torch.cat(g), torch.cat(u)], dim=0)
+        param.data.copy_(canon.chunk(ps.etp_size, dim=0)[ps.etp_rank])
+
+
+def decanon_fc1_after_dcp(model, ps):
+    """Reverse of canonicalize_fc1_for_dcp."""
+    if ps.etp_size <= 1:
+        return
+    for name, param in model.named_parameters():
+        if "experts" not in name or "fc1" not in name:
+            continue
+        full = _ag(param.data, ps.etp_size, ps.etp_group)
+        ffn = full.shape[0] // 2
+        gl = full[:ffn].chunk(ps.etp_size)[ps.etp_rank]
+        ul = full[ffn:].chunk(ps.etp_size)[ps.etp_rank]
+        param.data.copy_(torch.cat([gl, ul], dim=0))
+
+
+__all__ = [
+    "canonicalize_fc1_for_dcp",
+    "canonicalize_qkv_for_dcp",
+    "decanon_fc1_after_dcp",
+    "decanon_qkv_after_dcp",
+    "load_training_checkpoint",
+    "save_training_checkpoint",
+]

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_bridge.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_bridge.py
@@ -1,0 +1,488 @@
+"""HF ↔ Megatron Lite weight bridge.
+
+Everything needed for HuggingFace safetensors ↔ Megatron Lite model conversion:
+- HFBridge protocol (model implements this)
+- SafeTensorReader / save_safetensors (file I/O)
+- Tensor utilities (split_dim, allgather_concat, remap_layer_index, ...)
+- Generic load_hf_weights / export_hf_weights / save_hf_weights (orchestration)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Generator
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from safetensors import safe_open
+from safetensors.torch import save_file as _safe_save
+
+# ======================================================================
+# HFBridge protocol — model implements this
+# ======================================================================
+
+
+@runtime_checkable
+class HFBridge(Protocol):
+    """Protocol for HF ↔ Megatron Lite weight conversion.
+
+    Model-specific implementations only do tensor math, never distributed comm.
+    """
+
+    def weight_map(self) -> dict[str, list[str]]:
+        """Lite param name → [HF param names]. Multiple = concat (QKV, gate+up)."""
+        ...
+
+    def hf_to_native(self, lite_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+        """Convert HF tensors → single lite tensor (e.g. merge QKV)."""
+        ...
+
+    def native_to_hf(self, lite_name: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+        """Convert lite tensor → [(hf_name, hf_tensor)] (e.g. split QKV back)."""
+        ...
+
+    def tp_spec(self, lite_name: str) -> tuple[int, int] | None:
+        """TP sharding: ``(split_dim, 0=TP|1=ETP)``, or None if replicated."""
+        ...
+
+    def qkv_spec(self, lite_name: str) -> tuple[int, int, int] | None:
+        """If lite_name is a fused QKV weight, return (num_q_heads, num_kv_heads, head_dim).
+
+        Needed for correct GQA TP sharding — Q/K/V must be split independently.
+        Return None for non-QKV parameters.
+        """
+        return None
+
+    @property
+    def num_experts(self) -> int:
+        """Total number of experts (needed for EP gather index math)."""
+        ...
+
+    def is_expert(self, lite_name: str) -> bool:
+        """Whether this param belongs to an expert (for EP sharding)."""
+        ...
+
+    def expert_global_id(self, lite_name: str) -> int | None:
+        """Global expert ID from synthetic name. None if not expert."""
+        ...
+
+    def expert_local_name(self, lite_name: str, local_idx: int) -> str:
+        """Synthetic expert name → actual model param name."""
+        ...
+
+
+# ======================================================================
+# SafeTensors I/O
+# ======================================================================
+
+
+class SafeTensorReader:
+    """Read individual tensors from an HF safetensors directory."""
+
+    def __init__(self, path: str):
+        self.path = Path(path)
+        self.index = self._load_index()
+
+    def _load_index(self) -> dict[str, str]:
+        idx_file = self.path / "model.safetensors.index.json"
+        if idx_file.exists():
+            with open(idx_file) as f:
+                return json.load(f)["weight_map"]
+        return {}
+
+    def get_tensor(self, name: str) -> torch.Tensor:
+        if self.index:
+            filepath = self.path / self.index[name]
+        else:
+            filepath = self.path / "model.safetensors"
+        with safe_open(str(filepath), framework="pt", device="cpu") as f:
+            return f.get_tensor(name)
+
+
+def unwrap_model(model: nn.Module) -> nn.Module:
+    """Strip nested wrapper modules like DDP -> model."""
+    base_model = model
+    seen: set[int] = set()
+    while hasattr(base_model, "module"):
+        ident = id(base_model)
+        if ident in seen:
+            break
+        seen.add(ident)
+        next_model = base_model.module
+        if not isinstance(next_model, nn.Module) or next_model is base_model:
+            break
+        base_model = next_model
+    return base_model
+
+
+def save_safetensors(
+    tensors: dict[str, torch.Tensor],
+    path: str,
+    filename: str = "model.safetensors",
+) -> None:
+    os.makedirs(path, exist_ok=True)
+    _safe_save(tensors, os.path.join(path, filename))
+
+
+# ======================================================================
+# Tensor utilities
+# ======================================================================
+
+
+def split_dim(tensor: torch.Tensor, rank: int, world: int, dim: int = 0) -> torch.Tensor:
+    if world <= 1:
+        return tensor
+    return tensor.chunk(world, dim=dim)[rank].contiguous()
+
+
+def split_qkv(
+    tensor: torch.Tensor,
+    rank: int,
+    world: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+) -> torch.Tensor:
+    """TP-shard a fused [Q, K, V] weight, splitting Q/K/V heads independently.
+
+    Naive ``split_dim`` would slice across the Q/K/V boundary incorrectly
+    when num_q_heads != num_kv_heads (GQA).
+    """
+    if world <= 1:
+        return tensor
+    q_size = num_q_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+    q = tensor[:q_size]
+    k = tensor[q_size:q_size + kv_size]
+    v = tensor[q_size + kv_size:]
+    q_shard = q.chunk(world, dim=0)[rank]
+    k_shard = k.chunk(world, dim=0)[rank]
+    v_shard = v.chunk(world, dim=0)[rank]
+    return torch.cat([q_shard, k_shard, v_shard], dim=0).contiguous()
+
+
+def split_gate_up(tensor: torch.Tensor, rank: int, world: int) -> torch.Tensor:
+    if world <= 1:
+        return tensor
+    ffn = tensor.shape[0] // 2
+    gate = tensor[:ffn].chunk(world, dim=0)[rank]
+    up = tensor[ffn:].chunk(world, dim=0)[rank]
+    return torch.cat([gate, up], dim=0).contiguous()
+
+
+def allgather_concat(
+    tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup | None, dim: int,
+) -> torch.Tensor:
+    gathered = [torch.empty_like(tensor) for _ in range(world_size)]
+    dist.all_gather(gathered, tensor.contiguous(), group=group)
+    return torch.cat(gathered, dim=dim)
+
+
+def remap_layer_index(name: str, global_to_local: dict[int, int]) -> str | None:
+    if not global_to_local:
+        return name
+    m = re.match(r"(layers\.)(\d+)(\..*)", name)
+    if not m:
+        return name
+    gidx = int(m.group(2))
+    if gidx not in global_to_local:
+        return None
+    return f"{m.group(1)}{global_to_local[gidx]}{m.group(3)}"
+
+
+def extract_layer_idx(name: str) -> int:
+    m = re.search(r"layers\.(\d+)\.", name)
+    return int(m.group(1)) if m else 0
+
+
+def parse_expert_idx(name: str) -> int:
+    m = re.search(r"weight(\d+)$", name)
+    return int(m.group(1)) if m else 0
+
+
+def set_expert_idx(name: str, idx: int) -> str:
+    return re.sub(r"weight\d+$", f"weight{idx}", name)
+
+
+def to_global_layer_name(name: str, layer_map: dict[int, int]) -> str:
+    if not layer_map:
+        return name
+
+    def _replace(m: re.Match) -> str:
+        return f"layers.{layer_map.get(int(m.group(1)), int(m.group(1)))}."
+
+    return re.sub(r"layers\.(\d+)\.", _replace, name)
+
+
+def gather_gate_up(
+    tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup,
+) -> torch.Tensor:
+    ffn_local = tensor.shape[0] // 2
+    gate_full = allgather_concat(tensor[:ffn_local], world_size, group, dim=0)
+    up_full = allgather_concat(tensor[ffn_local:], world_size, group, dim=0)
+    return torch.cat([gate_full, up_full], dim=0)
+
+
+# ======================================================================
+# Generic load / export / save using HFBridge
+# ======================================================================
+
+
+def load_hf_weights(
+    model: nn.Module,
+    hf_path: str,
+    spec: HFBridge,
+    ps,
+    *,
+    vocab_size: int | None = None,
+) -> None:
+    """Load HF safetensors into a Megatron Lite model using an HFBridge.
+
+    Handles PP layer filtering, TP split, EP shard assignment.
+    ``ps`` is a ParallelState (lazy import to avoid GPU dep at module level).
+    """
+    from megatron.lite.primitive.parallel import pad_vocab_for_tp
+    from megatron.lite.primitive.utils import log_rank0
+
+    base_model = unwrap_model(model)
+    reader = SafeTensorReader(hf_path)
+    wmap = spec.weight_map()
+
+    global_to_local: dict[int, int] = (
+        {gi: li for li, gi in enumerate(base_model.layer_indices)}
+        if hasattr(base_model, "layer_indices")
+        else {}
+    )
+
+    state = base_model.state_dict()
+    loaded: dict[str, torch.Tensor] = {}
+
+    for lite_name, hf_names in wmap.items():
+        mapped = remap_layer_index(lite_name, global_to_local)
+        if mapped is None:
+            continue
+
+        expert_gid = spec.expert_global_id(mapped)
+        if expert_gid is not None:
+            _load_expert_weight(mapped, hf_names, reader, spec, ps, loaded, expert_gid)
+            continue
+
+        hf_tensors = [reader.get_tensor(n) for n in hf_names]
+        tensor = spec.hf_to_native(mapped, hf_tensors)
+
+        tp_info = spec.tp_spec(mapped)
+        if tp_info is not None:
+            split_d, tp_or_etp = tp_info
+            if tp_or_etp == 0:
+                if vocab_size is not None and ("embed" in mapped or "head" in mapped):
+                    padded = pad_vocab_for_tp(vocab_size, ps.tp_size)
+                    if tensor.size(0) < padded:
+                        pad = torch.zeros(padded - tensor.size(0), *tensor.shape[1:], dtype=tensor.dtype)
+                        tensor = torch.cat([tensor, pad], dim=0)
+                qkv = spec.qkv_spec(mapped) if hasattr(spec, "qkv_spec") else None
+                if qkv is not None:
+                    tensor = split_qkv(tensor, ps.tp_rank, ps.tp_size, *qkv)
+                else:
+                    tensor = split_dim(tensor, ps.tp_rank, ps.tp_size, dim=split_d)
+            else:
+                tensor = split_dim(tensor, ps.etp_rank, ps.etp_size, dim=split_d)
+
+        actual = _resolve_param_name(mapped, state)
+        if actual:
+            loaded[actual] = tensor.to(dtype=torch.bfloat16)
+
+    for name, param in base_model.named_parameters():
+        if name in loaded:
+            param.data.copy_(loaded[name])
+        else:
+            log_rank0(f"WARNING: {name} not loaded from checkpoint")
+
+
+def _load_expert_weight(lite_name, hf_names, reader, spec, ps, loaded, expert_gid):
+    from megatron.lite.primitive.utils import ensure_divisible
+
+    num_experts_total = sum(1 for k in spec.weight_map() if spec.expert_global_id(k) is not None
+                           and k.rsplit("_", 1)[0] == lite_name.rsplit("_", 1)[0])
+    experts_per_rank = ensure_divisible(num_experts_total, ps.ep_size)
+    local_start = ps.ep_rank * experts_per_rank
+    if expert_gid < local_start or expert_gid >= local_start + experts_per_rank:
+        return
+
+    hf_tensors = [reader.get_tensor(n) for n in hf_names]
+    tensor = spec.hf_to_native(lite_name, hf_tensors)
+
+    if ps.etp_size > 1:
+        tp_info = spec.tp_spec(lite_name)
+        if tp_info is not None:
+            split_d, _ = tp_info
+            if "fc1" in lite_name:
+                tensor = split_gate_up(tensor, ps.etp_rank, ps.etp_size)
+            else:
+                tensor = split_dim(tensor, ps.etp_rank, ps.etp_size, dim=split_d)
+
+    loaded[spec.expert_local_name(lite_name, expert_gid - local_start)] = tensor.to(dtype=torch.bfloat16)
+
+
+def _resolve_param_name(name: str, state_dict: dict) -> str | None:
+    if name in state_dict:
+        return name
+    for key in state_dict:
+        if name in key:
+            return key
+    return None
+
+
+def export_hf_weights(
+    model: nn.Module | list[nn.Module],
+    spec: HFBridge,
+    ps,
+    *,
+    vocab_size: int | None = None,
+    limit: int | None = None,
+    rank0_only: bool = False,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Export model weights as HF-format (name, tensor) pairs.
+
+    Gathers across TP/ETP/EP/PP so the output is the full unsharded HF state on
+    every participating rank. RL weight sync needs every colocated rollout rank
+    to receive weights; save paths can pass ``rank0_only=True`` to avoid
+    materializing duplicate writers.
+    """
+    if isinstance(model, nn.ModuleList):
+        chunks: list[nn.Module] = list(model)
+    elif isinstance(model, list):
+        chunks = model
+    else:
+        chunks = [model]
+
+    rank = dist.get_rank() if dist.is_initialized() else 0
+
+    if ps.pp_size <= 1:
+        exported_params = 0
+        for chunk in chunks:
+            base_chunk = unwrap_model(chunk)
+            layer_map = (
+                {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
+                if hasattr(base_chunk, "layer_indices")
+                else {}
+            )
+            for name, param in base_chunk.named_parameters():
+                gname = to_global_layer_name(name, layer_map)
+                tensor = param.data.detach()
+
+                gathered_one: dict[str, torch.Tensor] = {}
+                if spec.is_expert(gname):
+                    _gather_expert(gname, tensor, spec, ps, gathered_one)
+                else:
+                    gathered_one[gname] = _gather_dense(gname, tensor, spec, ps)
+
+                exported_params += 1
+                if not rank0_only or rank == 0:
+                    for lite_name, gathered_tensor in gathered_one.items():
+                        if vocab_size is not None and ("embed" in lite_name or "head" in lite_name):
+                            gathered_tensor = gathered_tensor[:vocab_size]
+                        yield from spec.native_to_hf(lite_name, gathered_tensor)
+
+                if limit is not None and exported_params >= limit:
+                    return
+        return
+
+    gathered: dict[str, torch.Tensor] = {}
+    for chunk in chunks:
+        base_chunk = unwrap_model(chunk)
+        # Map local layer indices to global for PP
+        layer_map = (
+            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
+            if hasattr(base_chunk, "layer_indices")
+            else {}
+        )
+        for name, param in base_chunk.named_parameters():
+            gname = to_global_layer_name(name, layer_map)
+            t = param.data.detach()
+
+            if spec.is_expert(gname):
+                _gather_expert(gname, t, spec, ps, gathered)
+            else:
+                gathered[gname] = _gather_dense(gname, t, spec, ps)
+
+    # PP gather
+    if ps.pp_size > 1:
+        all_states: list[dict | None] = [None] * ps.pp_size
+        dist.all_gather_object(all_states, gathered, group=ps.pp_group)
+        gathered = {}
+        for s in all_states:
+            if s is not None:
+                gathered.update(s)
+
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    if rank0_only and rank != 0:
+        return
+
+    # Vocab trim
+    if vocab_size is not None:
+        for key in list(gathered.keys()):
+            if "embed" in key or "head" in key:
+                gathered[key] = gathered[key][:vocab_size]
+
+    # Convert lite names → HF names via spec
+    for lite_name, tensor in gathered.items():
+        yield from spec.native_to_hf(lite_name, tensor)
+
+
+def _gather_dense(name: str, tensor: torch.Tensor, spec: HFBridge, ps) -> torch.Tensor:
+    """Gather a dense (non-expert) param across TP."""
+    tp_info = spec.tp_spec(name)
+    if tp_info is not None and ps.tp_size > 1:
+        split_d, tp_or_etp = tp_info
+        if tp_or_etp == 0:
+            tensor = allgather_concat(tensor, ps.tp_size, ps.tp_group, dim=split_d)
+    return tensor.float().cpu()
+
+
+def _gather_expert(
+    name: str, tensor: torch.Tensor, spec: HFBridge, ps, out: dict[str, torch.Tensor],
+) -> None:
+    """Gather an expert param across ETP + EP."""
+    # ETP gather
+    if ps.etp_size > 1 and ps.etp_group is not None:
+        tp_info = spec.tp_spec(name)
+        if tp_info is not None:
+            split_d, _ = tp_info
+            if "fc1" in name:
+                tensor = gather_gate_up(tensor, ps.etp_size, ps.etp_group)
+            else:
+                tensor = allgather_concat(tensor, ps.etp_size, ps.etp_group, dim=split_d)
+
+    # EP gather (mbridge pattern: global_id = ep_rank * n_local + local_id)
+    local_idx = parse_expert_idx(name)
+    if ps.ep_size > 1 and ps.ep_group is not None:
+        n_local = spec.num_experts // ps.ep_size
+        ep_gathered = [torch.empty_like(tensor) for _ in range(ps.ep_size)]
+        dist.all_gather(ep_gathered, tensor.contiguous(), group=ps.ep_group)
+        for ep_rank, ep_tensor in enumerate(ep_gathered):
+            global_idx = ep_rank * n_local + local_idx
+            out[set_expert_idx(name, global_idx)] = ep_tensor.float().cpu()
+    else:
+        out[name] = tensor.float().cpu()
+
+
+def save_hf_weights(
+    model: nn.Module | list[nn.Module],
+    hf_path: str,
+    spec: HFBridge,
+    ps,
+    *,
+    vocab_size: int | None = None,
+) -> None:
+    """Export + write to safetensors."""
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    out = dict(export_hf_weights(model, spec, ps, vocab_size=vocab_size, rank0_only=True))
+    if rank == 0 and out:
+        save_safetensors(out, hf_path)
+    if dist.is_initialized():
+        dist.barrier()

--- a/experimental/lite/megatron/lite/primitive/config.py
+++ b/experimental/lite/megatron/lite/primitive/config.py
@@ -1,0 +1,56 @@
+"""Configuration utilities.
+
+Model-specific configs live under `Megatron Lite/models/*/config.py`
+as standalone dataclasses.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields as dc_fields
+from pathlib import Path
+from typing import Any
+
+
+def to_dataclass(oc_cfg, cls):
+    """Convert an OmegaConf DictConfig back to a typed dataclass instance."""
+    from omegaconf import OmegaConf
+
+    init_names = {f.name for f in dc_fields(cls) if f.init}
+    d = OmegaConf.to_container(oc_cfg, resolve=True)
+    return cls(**{k: v for k, v in d.items() if k in init_names})
+
+
+def load_hf_config_dict(path_or_name: str) -> dict[str, Any]:
+    """Load HF config dict from local path or Hub."""
+    p = Path(path_or_name)
+
+    if p.is_file() and p.name == "config.json":
+        with open(p) as f:
+            return json.load(f)
+
+    if p.is_dir():
+        cfg_file = p / "config.json"
+        if cfg_file.exists():
+            with open(cfg_file) as f:
+                return json.load(f)
+        raise FileNotFoundError(f"No config.json in {p}")
+
+    try:
+        from transformers import AutoConfig
+
+        hf_config = AutoConfig.from_pretrained(path_or_name, trust_remote_code=True)
+        return hf_config.to_dict()
+    except ImportError as err:
+        raise ImportError(
+            f"'{path_or_name}' is not a local path. "
+            "Install transformers to load from HuggingFace Hub: pip install transformers"
+        ) from err
+    except Exception as e:
+        raise ValueError(f"Failed to load config from '{path_or_name}': {e}") from e
+
+
+__all__ = [
+    "load_hf_config_dict",
+    "to_dataclass",
+]

--- a/experimental/lite/megatron/lite/primitive/data.py
+++ b/experimental/lite/megatron/lite/primitive/data.py
@@ -1,0 +1,211 @@
+"""Batch generation utilities for Megatron Lite runtime."""
+
+from __future__ import annotations
+
+import os
+
+import torch  # pyright: ignore[reportMissingImports]
+
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
+_FALSE_ENV_VALUES = {"0", "false", "no", "off"}
+
+
+def _read_bool_env(name: str) -> bool | None:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return None
+    normalized = value.strip().lower()
+    if normalized in _TRUE_ENV_VALUES:
+        return True
+    if normalized in _FALSE_ENV_VALUES:
+        return False
+    raise ValueError(f"{name} must be a boolean value, got {value!r}")
+
+
+def _resolve_thd_padding(seq_len: int, cp_size: int) -> tuple[int, int, bool]:
+    """Return (padded_seq_len, alignment_multiple, pad_enabled) for THD input."""
+    if seq_len <= 0:
+        raise ValueError(f"seq_len must be positive, got {seq_len}")
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be >= 1, got {cp_size}")
+
+    pad_to_alignment = _read_bool_env("BUMBLEBEE_THD_PAD_TO_ALIGNMENT")
+    if pad_to_alignment is None:
+        pad_to_alignment = cp_size > 1
+
+    pad_multiple_env = os.environ.get("BUMBLEBEE_THD_PAD_MULTIPLE", "auto").strip().lower()
+    if pad_multiple_env in ("", "auto", "cp", "min_cp"):
+        align_size = cp_size * 2 if cp_size > 1 else 1
+    else:
+        try:
+            align_size = int(pad_multiple_env)
+        except ValueError as exc:
+            raise ValueError(
+                "BUMBLEBEE_THD_PAD_MULTIPLE must be 'auto' or a positive integer, "
+                f"got {pad_multiple_env!r}"
+            ) from exc
+        if align_size <= 0:
+            raise ValueError(
+                "BUMBLEBEE_THD_PAD_MULTIPLE must be 'auto' or a positive integer, "
+                f"got {pad_multiple_env!r}"
+            )
+
+    if not pad_to_alignment:
+        return seq_len, align_size, False
+
+    seq_len_padded = ((seq_len + align_size - 1) // align_size) * align_size
+    return seq_len_padded, align_size, True
+
+
+def fixed_batches(
+    vocab_size: int,
+    seq_len: int,
+    num_steps: int,
+    batch_size: int = 1,
+    device: str = "cuda",
+    seed: int = 42,
+) -> list[tuple[torch.Tensor, torch.Tensor]]:
+    """Deterministic (input_ids, labels) pairs, identical across all ranks."""
+    g = torch.Generator().manual_seed(seed)
+    batches = []
+    for _ in range(num_steps):
+        ids = torch.randint(0, vocab_size, (batch_size, seq_len), generator=g).to(device)
+        labels = torch.randint(0, vocab_size, (batch_size, seq_len), generator=g).to(device)
+        batches.append((ids, labels))
+    return batches
+
+
+def infinite_batches(
+    vocab_size: int,
+    seq_len: int,
+    batch_size: int = 1,
+    device: str = "cuda",
+    seed: int = 42,
+):
+    """Infinite deterministic batch generator (for throughput benchmarks)."""
+    g = torch.Generator(device=device).manual_seed(seed)
+    while True:
+        yield {
+            "input_ids": torch.randint(
+                0,
+                vocab_size,
+                (batch_size, seq_len),
+                device=device,
+                generator=g,
+            ),
+            "labels": torch.randint(
+                0,
+                vocab_size,
+                (batch_size, seq_len),
+                device=device,
+                generator=g,
+            ),
+        }
+
+
+def infinite_batches_thd(
+    vocab_size: int,
+    seq_len: int,
+    *,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+    device: str = "cuda",
+    seed: int = 42,
+):
+    """Infinite deterministic batch generator in THD (packed variable-length) format.
+
+    Produces plain dicts consumed directly by the lite model forward
+    (input_ids 2-D batch=1, mrope position_ids (3,1,T), pre-built PackedSeqParams).
+
+    cp_size/cp_rank should be supplied explicitly by the caller (for example
+    from handle._parallel_state). The defaults keep older single-CP call sites
+    working, but CP runs must pass the real CP rank and world size.
+
+    When context parallelism is active (cp_size > 1), each rank's packed tokens are
+    split via zigzag striping. position_ids stay FULL because lite's RoPE
+    (is_thd_format=False) auto-slices emb internally, same as BSH path.
+    """
+    from megatron.core.packed_seq_params import PackedSeqParams  # pyright: ignore[reportMissingImports]  # noqa: I001
+
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be >= 1, got {cp_size}")
+    if cp_rank < 0 or cp_rank >= cp_size:
+        raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}")
+
+    g = torch.Generator(device=device).manual_seed(seed)
+    seq_len_padded, _align_size, _pad_to_alignment = _resolve_thd_padding(seq_len, cp_size)
+
+    # position_ids always stay full length; RoPE auto-slices for CP.
+    position_ids = (
+        torch.arange(seq_len_padded, device=device)
+        .view(1, 1, -1)
+        .expand(3, 1, seq_len_padded)
+        .contiguous()
+    )
+    cu_seqlens = torch.tensor([0, seq_len], dtype=torch.int32, device=device)
+    cu_seqlens_padded = torch.tensor([0, seq_len_padded], dtype=torch.int32, device=device)
+
+    if cp_size > 1:
+        from megatron.lite.primitive.parallel.cp import zigzag_split_for_cp  # noqa: I001
+
+        # cu_seqlens stays full; MC GDN internally divides by cp_size.
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=seq_len_padded,
+            max_seqlen_kv=seq_len_padded,
+            cu_seqlens_q_padded=cu_seqlens_padded,
+            cu_seqlens_kv_padded=cu_seqlens_padded,
+        )
+        while True:
+            ids_full = torch.randint(0, vocab_size, (seq_len,), device=device, generator=g)
+            lbl_full = torch.randint(0, vocab_size, (seq_len,), device=device, generator=g)
+            if seq_len_padded != seq_len:
+                ids_padded = torch.zeros(seq_len_padded, dtype=ids_full.dtype, device=device)
+                lbl_padded = torch.zeros(seq_len_padded, dtype=lbl_full.dtype, device=device)
+                ids_padded[:seq_len] = ids_full
+                lbl_padded[:seq_len] = lbl_full
+            else:
+                ids_padded = ids_full
+                lbl_padded = lbl_full
+            ids_cp = zigzag_split_for_cp(ids_padded, cp_rank, cp_size, seq_dim=0)
+            lbl_cp = zigzag_split_for_cp(lbl_padded, cp_rank, cp_size, seq_dim=0)
+            yield {
+                "input_ids": ids_cp.unsqueeze(0),   # (1, T/cp)
+                "labels": lbl_cp.unsqueeze(0),       # (1, T/cp)
+                "position_ids": position_ids,         # FULL (3, 1, T)
+                "packed_seq_params": packed_seq_params,
+            }
+    else:
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=seq_len_padded,
+            max_seqlen_kv=seq_len_padded,
+            cu_seqlens_q_padded=cu_seqlens_padded,
+            cu_seqlens_kv_padded=cu_seqlens_padded,
+        )
+        while True:
+            input_ids = torch.zeros((1, seq_len_padded), dtype=torch.long, device=device)
+            labels = torch.zeros((1, seq_len_padded), dtype=torch.long, device=device)
+            input_ids[:, :seq_len] = torch.randint(
+                0, vocab_size, (1, seq_len), device=device, generator=g
+            )
+            labels[:, :seq_len] = torch.randint(
+                0, vocab_size, (1, seq_len), device=device, generator=g
+            )
+            yield {
+                "input_ids": input_ids,
+                "labels": labels,
+                "position_ids": position_ids,
+                "packed_seq_params": packed_seq_params,
+            }
+
+
+__all__ = [
+    "fixed_batches",
+    "infinite_batches",
+    "infinite_batches_thd",
+]

--- a/experimental/lite/megatron/lite/primitive/deterministic.py
+++ b/experimental/lite/megatron/lite/primitive/deterministic.py
@@ -1,0 +1,25 @@
+"""Deterministic computation utilities for bitwise reproducible experiments."""
+from __future__ import annotations
+
+import os
+
+import torch
+
+_is_deterministic: bool = False
+
+
+def set_deterministic(seed: int = 42) -> None:
+    """Enable all deterministic flags. Must call before first CUDA op in process."""
+    global _is_deterministic
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    torch.use_deterministic_algorithms(True, warn_only=False)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    _is_deterministic = True
+
+
+def is_deterministic() -> bool:
+    return _is_deterministic

--- a/experimental/lite/megatron/lite/primitive/modules/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/__init__.py
@@ -1,0 +1,17 @@
+"""Shared model modules owned by Megatron Lite."""
+
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.experts import Experts
+from megatron.lite.primitive.modules.gqa import GQAttention
+from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler, _AllToAll
+from megatron.lite.primitive.modules.router import SigmoidTopKRouter, TopKRouter
+
+__all__ = [
+    "Experts",
+    "GQAttention",
+    "MoEAuxLossAutoScaler",
+    "SigmoidTopKRouter",
+    "TokenDispatcher",
+    "TopKRouter",
+    "_AllToAll",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -1,0 +1,623 @@
+"""Token dispatcher: AllToAll and DeepEP dispatch/combine."""
+
+from __future__ import annotations
+
+import os
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+from megatron.core.transformer.moe.moe_utils import (  # pyright: ignore[reportMissingImports]
+    permute,
+    unpermute,
+)
+
+from megatron.lite.primitive.modules.moe import _AllToAll
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.utils import ensure_divisible
+
+try:
+    import deep_ep  # pyright: ignore[reportMissingImports]
+    from deep_ep.utils import EventHandle, EventOverlap  # pyright: ignore[reportMissingImports]
+except ImportError:
+    deep_ep = None  # type: ignore
+    EventHandle = None  # type: ignore
+    EventOverlap = None  # type: ignore
+
+
+def _hidden_bytes(hidden_size: int) -> int:
+    return hidden_size * 2
+
+
+def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
+    if deep_ep is None:
+        raise RuntimeError("DeepEP buffer requested but deep_ep is not installed.")
+
+    group_size = dist.get_world_size(group=group)
+    hidden_bytes = _hidden_bytes(hidden_size)
+    num_nvl_bytes = 0
+    num_rdma_bytes = 0
+
+    for config in (
+        deep_ep.Buffer.get_dispatch_config(group_size),
+        deep_ep.Buffer.get_combine_config(group_size),
+    ):
+        num_nvl_bytes = max(
+            config.get_nvl_buffer_size_hint(hidden_bytes, group_size),
+            num_nvl_bytes,
+        )
+        num_rdma_bytes = max(
+            config.get_rdma_buffer_size_hint(hidden_bytes, group_size),
+            num_rdma_bytes,
+        )
+
+    return deep_ep.Buffer(
+        group=group,
+        num_nvl_bytes=num_nvl_bytes,
+        num_rdma_bytes=num_rdma_bytes,
+    )
+
+
+def _use_moe_permute_fusion() -> bool:
+    return os.environ.get("BUMBLEBEE_MOE_PERMUTE_FUSION", "0") == "1"
+
+
+def _tensor_hidden_bytes(x: torch.Tensor) -> int:
+    return x.size(1) * max(x.element_size(), 2)
+
+
+class _DeepEPDispatch(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        buffer,
+        hidden_states: torch.Tensor,
+        topk_indices: torch.Tensor,
+        topk_scores: torch.Tensor,
+        num_experts: int,
+        async_finish: bool,
+        allocate_on_comm_stream: bool,
+    ):
+        previous_event = (
+            EventOverlap(EventHandle())
+            if async_finish and EventHandle is not None and EventOverlap is not None
+            else None
+        )
+        (
+            num_tokens_per_rank,
+            num_tokens_per_rdma_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            event,
+        ) = buffer.get_dispatch_layout(
+            topk_indices,
+            num_experts=num_experts,
+            previous_event=previous_event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        (
+            recv_hidden,
+            recv_indices,
+            recv_probs,
+            recv_per_expert,
+            handle,
+            after_event,
+        ) = buffer.dispatch(
+            hidden_states.contiguous(),
+            topk_idx=topk_indices,
+            topk_weights=topk_scores.float(),
+            num_tokens_per_rank=num_tokens_per_rank,
+            num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+            is_token_in_rank=is_token_in_rank,
+            num_tokens_per_expert=num_tokens_per_expert,
+            previous_event=event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        if async_finish:
+            after_event.current_stream_wait()
+
+        ctx.buffer = buffer
+        ctx.handle = handle
+        ctx.async_finish = async_finish
+        ctx.allocate_on_comm_stream = allocate_on_comm_stream
+        recv_per_expert_tensor = torch.tensor(
+            recv_per_expert,
+            dtype=torch.int64,
+            device=recv_hidden.device,
+        )
+        return recv_hidden, recv_indices, recv_probs, recv_per_expert_tensor, handle
+
+    @staticmethod
+    def backward(
+        ctx,
+        grad_recv_hidden,
+        grad_recv_indices,
+        grad_recv_probs,
+        grad_recv_per_expert,
+        grad_handle,
+    ):
+        del grad_recv_indices, grad_recv_per_expert, grad_handle
+        previous_event = (
+            EventOverlap(EventHandle())
+            if ctx.async_finish and EventHandle is not None and EventOverlap is not None
+            else None
+        )
+        grad_scores = None if grad_recv_probs is None else grad_recv_probs.float()
+        grad_hidden, grad_topk_scores, after_event = ctx.buffer.combine(
+            grad_recv_hidden.contiguous(),
+            ctx.handle,
+            topk_weights=grad_scores,
+            previous_event=previous_event,
+            async_finish=ctx.async_finish,
+            allocate_on_comm_stream=ctx.allocate_on_comm_stream,
+        )
+        if ctx.async_finish:
+            after_event.current_stream_wait()
+        return None, grad_hidden, None, grad_topk_scores, None, None, None
+
+
+class _DeepEPCombine(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        buffer,
+        rank_grouped: torch.Tensor,
+        handle,
+        async_finish: bool,
+        allocate_on_comm_stream: bool,
+    ):
+        previous_event = (
+            EventOverlap(EventHandle())
+            if async_finish and EventHandle is not None and EventOverlap is not None
+            else None
+        )
+        combined, _, after_event = buffer.combine(
+            rank_grouped,
+            handle,
+            previous_event=previous_event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        if async_finish:
+            after_event.current_stream_wait()
+        ctx.buffer = buffer
+        ctx.handle = handle
+        ctx.async_finish = async_finish
+        ctx.allocate_on_comm_stream = allocate_on_comm_stream
+        return combined
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        previous_event = (
+            EventOverlap(EventHandle())
+            if ctx.async_finish and EventHandle is not None and EventOverlap is not None
+            else None
+        )
+        grad_rank_grouped, _, _, _, _, after_event = ctx.buffer.dispatch(
+            grad_output.contiguous(),
+            handle=ctx.handle,
+            previous_event=previous_event,
+            async_finish=ctx.async_finish,
+            allocate_on_comm_stream=ctx.allocate_on_comm_stream,
+        )
+        if ctx.async_finish:
+            after_event.current_stream_wait()
+        return None, grad_rank_grouped, None, None, None
+
+
+class TokenDispatcher:
+
+    def __init__(
+        self,
+        num_experts: int,
+        hidden_size: int,
+        ps: ParallelState,
+        *,
+        use_deepep: bool = True,
+    ):
+        self.ps = ps
+        self.num_experts = num_experts
+        self.ep_size = ps.ep_size
+        self.num_local_experts = ensure_divisible(num_experts, ps.ep_size)
+
+        self.use_deepep = use_deepep and deep_ep is not None and ps.ep_size > 1
+        if self.use_deepep:
+            assert ps.tp_ep_group is not None
+            self.buffer = _build_deepep_buffer(ps.tp_ep_group, hidden_size)
+
+        self._row_id_map: torch.Tensor | None = None
+        self._restore_shape: tuple | None = None
+        self._input_splits: list[int] | None = None
+        self._output_splits: list[int] | None = None
+        self._handle = None
+        self._deepep_event = None
+
+        if self.ep_size > 1 and self.num_local_experts > 1:
+            chunk_idxs = torch.arange(self.ep_size * self.num_local_experts)
+            self._sort_by_experts = chunk_idxs.reshape(
+                self.ep_size, self.num_local_experts,
+            ).T.ravel().tolist()
+            self._restore_by_ranks = chunk_idxs.reshape(
+                self.num_local_experts, self.ep_size,
+            ).T.ravel().tolist()
+
+    def dispatch(
+        self,
+        hidden_states: torch.Tensor,
+        topk_scores: torch.Tensor,
+        topk_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        if self.ep_size <= 1:
+            return self._dispatch_local(hidden_states, topk_scores, topk_indices)
+        if self.use_deepep:
+            return self._dispatch_deepep(hidden_states, topk_scores, topk_indices)
+        dispatched, tpe, sorted_scores = self._dispatch_alltoall(
+            hidden_states, topk_scores, topk_indices,
+        )
+        return dispatched, tpe, sorted_scores
+
+    def combine(self, expert_output: torch.Tensor) -> torch.Tensor:
+        if self.ep_size <= 1:
+            return self._combine_local(expert_output)
+        if self.use_deepep:
+            return self._combine_deepep(expert_output)
+        return self._combine_alltoall(expert_output)
+
+    def submit_deepep_combine(
+        self,
+        expert_output: torch.Tensor,
+        *,
+        allocate_on_comm_stream: bool = False,
+    ):
+        if not self.use_deepep:
+            raise RuntimeError("submit_deepep_combine requires DeepEP combine.")
+        rank_grouped = unpermute(
+            expert_output,
+            self._row_id_map,
+            restore_shape=self._restore_shape,
+            fused=_use_moe_permute_fusion(),
+        )
+        previous_event = (
+            EventOverlap(EventHandle())
+            if EventHandle is not None and EventOverlap is not None
+            else None
+        )
+        combined = self.buffer.combine(
+            rank_grouped,
+            self._handle,
+            previous_event=previous_event,
+            async_finish=True,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        event = None
+        if isinstance(combined, tuple):
+            if len(combined) >= 3:
+                event = combined[2]
+            combined = combined[0]
+        return {
+            "combined": combined,
+            "event": event,
+        }
+
+    def finish_deepep_combine(self, state):
+        if not self.use_deepep:
+            raise RuntimeError("finish_deepep_combine requires DeepEP combine.")
+        event = state.get("event")
+        if event is not None:
+            event.current_stream_wait()
+        self._row_id_map = None
+        self._restore_shape = None
+        self._handle = None
+        self._local_tpe_list = None
+        return state["combined"]
+
+    def _dispatch_local(self, hidden_states, topk_scores, topk_indices):
+        t, h = hidden_states.shape
+        e = self.num_experts
+
+        routing_map = torch.zeros(t, e, dtype=torch.bool, device=hidden_states.device)
+        routing_map.scatter_(1, topk_indices, True)
+        num_out = int(routing_map.sum().item())
+
+        probs_2d = torch.zeros(t, e, dtype=topk_scores.dtype, device=hidden_states.device)
+        probs_2d.scatter_(1, topk_indices, topk_scores)
+
+        permuted, permuted_probs, sorted_indices = permute(
+            hidden_states, routing_map,
+            probs=probs_2d, num_out_tokens=num_out, fused=_use_moe_permute_fusion(),
+        )[:3]
+
+        self._row_id_map = sorted_indices
+        self._restore_shape = hidden_states.shape
+
+        tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
+        return permuted, tokens_per_expert, permuted_probs
+
+    def _combine_local(self, expert_output):
+        result = unpermute(
+            expert_output, self._row_id_map,
+            restore_shape=self._restore_shape,
+            fused=_use_moe_permute_fusion(),
+        )
+        self._row_id_map = None
+        self._restore_shape = None
+        return result
+
+    def _dispatch_alltoall(self, hidden_states, topk_scores, topk_indices):
+        t, h = hidden_states.shape
+        e = self.num_experts
+
+        routing_map = torch.zeros(t, e, dtype=torch.bool, device=hidden_states.device)
+        routing_map.scatter_(1, topk_indices, True)
+        num_out = t * topk_indices.size(1)
+
+        probs_2d = torch.zeros(
+            t, e, dtype=topk_scores.dtype, device=hidden_states.device,
+        )
+        probs_2d.scatter_(1, topk_indices, topk_scores)
+
+        permuted, permuted_probs, sorted_indices = permute(
+            hidden_states, routing_map,
+            probs=probs_2d, num_out_tokens=num_out, fused=_use_moe_permute_fusion(),
+        )[:3]
+        self._row_id_map = sorted_indices
+        self._restore_shape = hidden_states.shape
+
+        tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
+        tpe_by_rank = tokens_per_expert.view(self.ep_size, self.num_local_experts).sum(dim=1)
+        self._input_splits = tpe_by_rank.tolist()
+
+        global_tpe_flat = tokens_per_expert.new_empty(self.ep_size * e)
+        dist.all_gather_into_tensor(global_tpe_flat, tokens_per_expert, group=self.ps.ep_group)
+        global_tpe_2d = global_tpe_flat.view(self.ep_size, e)
+        ep_rank = dist.get_rank(group=self.ps.ep_group)
+        my_start = ep_rank * self.num_local_experts
+        recv_tpe_2d = global_tpe_2d[:, my_start : my_start + self.num_local_experts].contiguous()
+        self._output_splits = recv_tpe_2d.sum(dim=1).tolist()
+
+        recv_flat = _AllToAll.apply(
+            permuted, self._input_splits, self._output_splits, self.ps.ep_group,
+        )
+        recv_scores = _AllToAll.apply(
+            permuted_probs.unsqueeze(-1),
+            self._input_splits, self._output_splits, self.ps.ep_group,
+        )
+
+        if self.num_local_experts > 1:
+            chunk_sizes = recv_tpe_2d.ravel().tolist()
+            chunks = torch.split(recv_flat, chunk_sizes, dim=0)
+            score_chunks = torch.split(recv_scores, chunk_sizes, dim=0)
+            sort_idxs = self._sort_by_experts
+            restore_idxs = self._restore_by_ranks
+            dispatched = torch.cat([chunks[i] for i in sort_idxs], dim=0)
+            permuted_probs_out = torch.cat([score_chunks[i] for i in sort_idxs], dim=0)
+            self._combine_chunk_sizes = [chunk_sizes[i] for i in sort_idxs]
+            self._combine_restore_idxs = restore_idxs
+        else:
+            dispatched = recv_flat
+            permuted_probs_out = recv_scores
+            self._combine_chunk_sizes = None
+            self._combine_restore_idxs = None
+
+        recv_tpe = recv_tpe_2d.sum(dim=0)
+        return dispatched, recv_tpe, permuted_probs_out.squeeze(-1)
+
+    def _combine_alltoall(self, expert_output):
+        if self._combine_chunk_sizes is not None:
+            chunks = torch.split(expert_output, self._combine_chunk_sizes, dim=0)
+            restore_idxs = (
+                self._combine_restore_idxs
+                if self._combine_restore_idxs is not None
+                else self._restore_by_ranks
+            )
+            rank_grouped = torch.cat([chunks[i] for i in restore_idxs], dim=0)
+        else:
+            rank_grouped = expert_output
+
+        combined = _AllToAll.apply(
+            rank_grouped, self._output_splits, self._input_splits, self.ps.ep_group,
+        )
+        result = unpermute(
+            combined,
+            self._row_id_map,
+            restore_shape=self._restore_shape,
+            fused=_use_moe_permute_fusion(),
+        )
+        self._row_id_map = None
+        self._restore_shape = None
+        self._input_splits = None
+        self._output_splits = None
+        self._combine_chunk_sizes = None
+        self._combine_restore_idxs = None
+        self._local_tpe_list = None
+        return result
+
+    def submit_deepep_dispatch(
+        self,
+        hidden_states,
+        topk_scores,
+        topk_indices,
+        *,
+        allocate_on_comm_stream: bool = False,
+    ):
+        if not self.use_deepep:
+            raise RuntimeError("submit_deepep_dispatch requires DeepEP dispatch.")
+        previous_event = (
+            EventOverlap(EventHandle())
+            if EventHandle is not None and EventOverlap is not None
+            else None
+        )
+        (
+            num_tokens_per_rank,
+            num_tokens_per_rdma_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            event,
+        ) = self.buffer.get_dispatch_layout(
+            topk_indices,
+            num_experts=self.num_experts,
+            previous_event=previous_event,
+            async_finish=True,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+
+        topk_scores = topk_scores.float()
+        recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, event = self.buffer.dispatch(
+            hidden_states,
+            topk_idx=topk_indices,
+            topk_weights=topk_scores,
+            num_tokens_per_rank=num_tokens_per_rank,
+            num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+            is_token_in_rank=is_token_in_rank,
+            num_tokens_per_expert=num_tokens_per_expert,
+            previous_event=event,
+            async_finish=True,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        return {
+            "recv_hidden": recv_hidden,
+            "recv_indices": recv_indices,
+            "recv_probs": recv_probs,
+            "recv_per_expert": recv_per_expert,
+            "handle": handle,
+            "event": event,
+        }
+
+    def finish_deepep_dispatch(self, state):
+        if not self.use_deepep:
+            raise RuntimeError("finish_deepep_dispatch requires DeepEP dispatch.")
+        self._handle = state["handle"]
+        self._deepep_event = state["event"]
+        self.wait_dispatch_event()
+        return self._finish_deepep_dispatch(
+            state["recv_hidden"],
+            state["recv_indices"],
+            state["recv_probs"],
+            state["recv_per_expert"],
+        )
+
+    def _finish_deepep_dispatch(
+        self,
+        recv_hidden: torch.Tensor,
+        recv_indices: torch.Tensor,
+        recv_probs: torch.Tensor,
+        recv_per_expert,
+    ):
+        if isinstance(recv_per_expert, torch.Tensor):
+            recv_per_expert = [int(x) for x in recv_per_expert.detach().cpu().tolist()]
+        local_tpe = torch.tensor(
+            recv_per_expert[: self.num_local_experts],
+            dtype=torch.int64, device=recv_hidden.device,
+        )
+        self._local_tpe_list = [int(x) for x in recv_per_expert[: self.num_local_experts]]
+        rows = recv_hidden.size(0)
+        recv_indices = recv_indices.to(torch.long)
+        routing_map = torch.zeros(
+            rows, self.num_local_experts, dtype=torch.bool, device=recv_hidden.device,
+        )
+        probs_2d = torch.zeros(
+            rows, self.num_local_experts, dtype=recv_probs.dtype, device=recv_hidden.device,
+        )
+        valid = recv_indices >= 0
+        row_ids = torch.arange(rows, device=recv_hidden.device).unsqueeze(1)
+        row_ids = row_ids.expand_as(recv_indices)[valid]
+        expert_ids = recv_indices[valid]
+        routing_map[row_ids, expert_ids] = True
+        probs_2d[row_ids, expert_ids] = recv_probs[valid]
+        num_out = sum(int(x) for x in recv_per_expert)
+        dispatched, permuted_probs, sorted_indices = permute(
+            recv_hidden,
+            routing_map,
+            probs=probs_2d,
+            num_out_tokens=num_out,
+            fused=_use_moe_permute_fusion(),
+        )[:3]
+        self._row_id_map = sorted_indices
+        self._restore_shape = recv_hidden.shape
+        if os.environ.get("BUMBLEBEE_DEEPEP_DEBUG_METADATA") == "1":
+            ep_rank = dist.get_rank(group=self.ps.ep_group)
+            print(
+                "[DEEPEP_METADATA] "
+                f"ep_rank={ep_rank} recv_rows={int(recv_hidden.shape[0])} "
+                f"expert_rows={int(dispatched.shape[0])} "
+                f"recv_indices_shape={tuple(recv_indices.shape)} "
+                f"recv_per_expert_len={len(recv_per_expert)} "
+                f"recv_per_expert_sum={sum(int(x) for x in recv_per_expert)} "
+                f"recv_per_expert_head={recv_per_expert[: self.num_local_experts]} "
+                f"local_tpe_sum={int(local_tpe.sum().item())}",
+                flush=True,
+            )
+        if (
+            os.environ.get("BUMBLEBEE_DEEPEP_SKIP_DISPATCH_METADATA_CHECK") != "1"
+            and int(local_tpe.sum().item()) != int(dispatched.shape[0])
+        ):
+            ep_rank = dist.get_rank(group=self.ps.ep_group)
+            raise RuntimeError(
+                "DeepEP dispatch metadata mismatch: "
+                f"ep_rank={ep_rank} dispatched_tokens={int(dispatched.shape[0])} "
+                f"local_tpe={local_tpe.tolist()} recv_per_expert_len={len(recv_per_expert)}"
+            )
+        return dispatched, local_tpe, permuted_probs
+
+    def _dispatch_deepep(self, hidden_states, topk_scores, topk_indices):
+        if torch.is_grad_enabled():
+            recv_hidden, recv_indices, recv_probs, recv_per_expert, handle = (
+                _DeepEPDispatch.apply(
+                    self.buffer,
+                    hidden_states,
+                    topk_indices,
+                    topk_scores.float(),
+                    self.num_experts,
+                    False,
+                    False,
+                )
+            )
+            self._handle = handle
+            self._deepep_event = None
+            return self._finish_deepep_dispatch(
+                recv_hidden,
+                recv_indices,
+                recv_probs,
+                recv_per_expert,
+            )
+        state = self.submit_deepep_dispatch(
+            hidden_states,
+            topk_scores,
+            topk_indices,
+            allocate_on_comm_stream=False,
+        )
+        return self.finish_deepep_dispatch(state)
+
+    def wait_dispatch_event(self):
+        if self._deepep_event is not None:
+            self._deepep_event.current_stream_wait()
+            self._deepep_event = None
+
+    def _combine_deepep(self, expert_output):
+        rank_grouped = unpermute(
+            expert_output,
+            self._row_id_map,
+            restore_shape=self._restore_shape,
+            fused=_use_moe_permute_fusion(),
+        )
+        if torch.is_grad_enabled():
+            combined = _DeepEPCombine.apply(
+                self.buffer,
+                rank_grouped,
+                self._handle,
+                False,
+                False,
+            )
+        else:
+            combined = self.buffer.combine(rank_grouped, self._handle)
+        if isinstance(combined, tuple):
+            combined = combined[0]
+        self._row_id_map = None
+        self._restore_shape = None
+        self._handle = None
+        self._local_tpe_list = None
+        return combined
+
+
+__all__ = ["TokenDispatcher"]

--- a/experimental/lite/megatron/lite/primitive/modules/experts.py
+++ b/experimental/lite/megatron/lite/primitive/modules/experts.py
@@ -1,0 +1,256 @@
+"""MoE expert compute: SwiGLU fusions, _AllReduceETP, and Experts."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Any
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+import torch.nn.functional as F  # pyright: ignore[reportMissingImports]
+import transformer_engine.pytorch as te  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.recompute import CheckpointWithoutOutput
+from megatron.lite.primitive.utils import ensure_divisible
+
+__all__ = ["Experts", "_AllReduceETP"]
+
+
+@contextmanager
+def _expert_nvtx_range(name: str):
+    if os.environ.get("BUMBLEBEE_EP_EXPERT_NVTX") != "1" or not torch.cuda.is_available():
+        yield
+        return
+    torch.cuda.nvtx.range_push(name)
+    try:
+        yield
+    finally:
+        torch.cuda.nvtx.range_pop()
+
+
+@torch.compile
+def _swiglu(y):
+    y_1, y_2 = torch.chunk(y, 2, -1)
+    return F.silu(y_1) * y_2
+
+
+@torch.compile
+def _weighted_swiglu(y, weights):
+    dtype = y.dtype
+    res = _swiglu(y) * weights
+    return res.to(dtype)
+
+
+@torch.compile
+def _swiglu_back(g, y):
+    y_1, y_2 = torch.chunk(y, 2, -1)
+    return torch.cat(
+        (
+            g * torch.sigmoid(y_1) * (1 + y_1 * (1 - torch.sigmoid(y_1))) * y_2,
+            g * F.silu(y_1),
+        ),
+        -1,
+    )
+
+
+@torch.compile
+def _weighted_swiglu_back(g, y, weights):
+    input_dtype = y.dtype
+    w_dtype = weights.dtype
+    input_grad = _swiglu_back(g * weights, y)
+    weights_grad = _swiglu(y) * g.to(w_dtype)
+    weights_grad = torch.sum(weights_grad, dim=-1, keepdim=True)
+    return input_grad.to(input_dtype), weights_grad.to(w_dtype)
+
+
+class _WeightedSwiGLUFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input, weights, fp8_input_store):
+        input_for_backward = input.to(torch.float8_e4m3fn) if fp8_input_store else input
+        ctx.save_for_backward(input_for_backward, weights)
+        ctx.ori_input_dtype = input.dtype
+        ctx.fp8_input_store = fp8_input_store
+        return _weighted_swiglu(input, weights)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, weights = ctx.saved_tensors
+        input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
+        tmp, wgrad = _weighted_swiglu_back(grad_output, input, weights)
+        return tmp, wgrad, None
+
+
+def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False):
+    """Token-wise-weighted bias swiglu fusion (copied from MC)."""
+    ori_shape = input.shape
+    assert len(ori_shape) in [2, 3]
+    input = input.view(-1, ori_shape[-1])
+    if bias is not None:
+        raise NotImplementedError("Bias is not supported for weighted swiglu fusion")
+    output = _WeightedSwiGLUFunction.apply(input, weights, fp8_input_store)
+    return output if len(ori_shape) == 2 else output.view(
+        ori_shape[0], ori_shape[1], -1,
+    )
+
+
+def swiglu_with_probs(y: torch.Tensor, probs: torch.Tensor | None) -> torch.Tensor:
+    """SwiGLU with optional expert probability scaling."""
+    if probs is not None:
+        return weighted_bias_swiglu_impl(y, bias=None, weights=probs)
+    y1, y2 = torch.chunk(y, 2, -1)
+    return F.silu(y1) * y2
+
+
+class _AllReduceETP(torch.autograd.Function):
+    """AllReduce with proper autograd: grad(AllReduce) = AllReduce."""
+
+    @staticmethod
+    def forward(ctx, x, group):
+        ctx.group = group
+        dist.all_reduce(x, group=group)
+        return x
+
+    @staticmethod
+    def backward(ctx, grad):
+        return grad, None
+
+
+class Experts(nn.Module):
+
+    def __init__(
+        self,
+        config: Any,
+        ps: ParallelState,
+        *,
+        fp8: bool = False,
+        moe_act_recompute: bool = False,
+    ):
+        super().__init__()
+        self.num_local_experts = ensure_divisible(config.num_experts, ps.ep_size)
+        self.fp8 = fp8
+        self.moe_act_recompute = moe_act_recompute
+        self.etp_group = ps.etp_group if ps.etp_size > 1 else None
+
+        self.fc1 = te.GroupedLinear(
+            self.num_local_experts,
+            config.hidden_size,
+            config.moe_intermediate_size * 2 // ps.etp_size,
+            bias=False,
+            params_dtype=torch.bfloat16,
+        )
+        self.fc2 = te.GroupedLinear(
+            self.num_local_experts,
+            config.moe_intermediate_size // ps.etp_size,
+            config.hidden_size,
+            bias=False,
+            params_dtype=torch.bfloat16,
+        )
+        if ps.tp_size > 1 and ps.ep_size == 1 and ps.etp_size == 1:
+            tp_group = ps.tp_group
+            for param in self.fc1.parameters():
+
+                def _ar(grad, g=tp_group):
+                    dist.all_reduce(grad, op=dist.ReduceOp.SUM, group=g)
+                    return grad
+
+                param.register_hook(_ar)
+            for param in self.fc2.parameters():
+
+                def _ar(grad, g=tp_group):
+                    dist.all_reduce(grad, op=dist.ReduceOp.SUM, group=g)
+                    return grad
+
+                param.register_hook(_ar)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        permuted_probs: torch.Tensor | None = None,
+        tokens_per_expert_list: list[int] | None = None,
+    ) -> torch.Tensor:
+        m_splits = (
+            tokens_per_expert.tolist()
+            if tokens_per_expert_list is None
+            else list(tokens_per_expert_list)
+        )
+        pad_mask = None
+        if self.fp8:
+            x, permuted_probs, m_splits, pad_mask = self._fp8_pad(x, permuted_probs, m_splits)
+
+        etp_real_len = x.shape[0]
+        if self.etp_group is not None:
+            max_len = torch.tensor([etp_real_len], device=x.device, dtype=torch.int64)
+            dist.all_reduce(max_len, op=dist.ReduceOp.MAX, group=self.etp_group)
+            max_len = int(max_len.item())
+            if etp_real_len < max_len:
+                x = torch.cat(
+                    [
+                        x,
+                        torch.zeros(
+                            max_len - etp_real_len,
+                            x.shape[1],
+                            dtype=x.dtype,
+                            device=x.device,
+                        ),
+                    ],
+                    dim=0,
+                )
+                if permuted_probs is not None:
+                    permuted_probs = torch.cat(
+                        [
+                            permuted_probs,
+                            torch.zeros(
+                                max_len - etp_real_len,
+                                dtype=permuted_probs.dtype,
+                                device=x.device,
+                            ),
+                        ],
+                        dim=0,
+                    )
+                m_splits = list(m_splits)
+                m_splits[-1] += max_len - etp_real_len
+
+        probs = permuted_probs.unsqueeze(-1) if permuted_probs is not None else None
+        with _expert_nvtx_range("ep_experts.forward"):
+            if self.moe_act_recompute and probs is not None:
+                act_ckpt = CheckpointWithoutOutput(preserve_rng_state=True)
+                h = act_ckpt.checkpoint(swiglu_with_probs, self.fc1(x, m_splits), probs)
+                out = self.fc2(h, m_splits)
+                act_ckpt.discard_output_and_register_recompute(out)
+            else:
+                h = swiglu_with_probs(self.fc1(x, m_splits), probs)
+                out = self.fc2(h, m_splits)
+
+        if self.etp_group is not None:
+            out = _AllReduceETP.apply(out, self.etp_group)
+            out = out[:etp_real_len]
+
+        if pad_mask is not None:
+            out = out[pad_mask]
+        return out
+
+    @staticmethod
+    def _fp8_pad(x, permuted_probs, m_splits):
+        padded = [(s + 15) // 16 * 16 for s in m_splits]
+        if padded == m_splits:
+            return x, permuted_probs, m_splits, None
+        device, dtype = x.device, x.dtype
+        total_padded = sum(padded)
+        x_pad = torch.zeros(total_padded, x.size(1), device=device, dtype=dtype)
+        mask = torch.zeros(total_padded, dtype=torch.bool, device=device)
+        probs_pad = None
+        if permuted_probs is not None:
+            probs_pad = torch.zeros(total_padded, device=device, dtype=permuted_probs.dtype)
+        src_off, dst_off = 0, 0
+        for real, pad in zip(m_splits, padded, strict=True):
+            x_pad[dst_off:dst_off + real] = x[src_off:src_off + real]
+            mask[dst_off:dst_off + real] = True
+            if probs_pad is not None:
+                probs_pad[dst_off:dst_off + real] = permuted_probs[src_off:src_off + real]
+            src_off += real
+            dst_off += pad
+        return x_pad, probs_pad, padded, mask

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -1,0 +1,251 @@
+"""Grouped Query Attention + Rotary Embedding (MC-atoms).
+
+Model-agnostic: takes explicit params instead of model-specific config.
+Supports sequence parallel, context parallel, and THD (packed sequences).
+
+RoPE internals call Megatron-Core's atomic
+`megatron.core.models.common.embeddings.rotary_pos_embedding.RotaryEmbedding`
+and `rope_utils._apply_rotary_pos_emb_bshd / _apply_rotary_pos_emb_thd` — this
+matches the mbridge Qwen3MoE reference path (both run the unfused rotate-half
+kernel because ``config.apply_rope_fusion`` defaults to ``False``). See
+`docs/gqa_mc_atoms_plan.md` §4 (Option A).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import transformer_engine.pytorch as te
+from megatron.core.models.common.embeddings.rope_utils import (  # pyright: ignore[reportMissingImports]
+    _apply_rotary_pos_emb_bshd,
+    _apply_rotary_pos_emb_thd,
+)
+from megatron.core.models.common.embeddings.rotary_pos_embedding import (  # pyright: ignore[reportMissingImports]
+    RotaryEmbedding as MCoreRotaryEmbedding,
+)
+
+from megatron.lite.primitive.parallel import ColumnParallelLinear, ParallelState, RowParallelLinear
+from megatron.lite.primitive.utils import ensure_divisible
+
+# Whitelist of MC PackedSeqParams fields accepted by TE DotProductAttention.forward().
+# MC-only fields (local_cp_size, cp_group, total_tokens, seq_idx) are excluded.
+# Mirror MC TEDotProductAttention.kept_packed_seq_params pattern
+# (Megatron-LM/megatron/core/extensions/transformer_engine.py:1501-1593).
+_KEPT_PSP_FIELDS = (
+    "qkv_format",
+    "cu_seqlens_q", "cu_seqlens_kv",
+    "cu_seqlens_q_padded", "cu_seqlens_kv_padded",
+    "max_seqlen_q", "max_seqlen_kv",
+)
+
+
+class GQAttention(nn.Module):
+    """Grouped Query Attention with TE DotProductAttention.
+
+    Model-agnostic: all architecture params passed explicitly.
+    """
+
+    _cp_stream: torch.cuda.Stream | None = None
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        ps: ParallelState,
+        *,
+        rms_norm_eps: float = 1e-6,
+        rope_theta: float = 1_000_000.0,
+        rotary_percent: float = 1.0,
+        use_thd: bool = False,
+        output_gate: bool = False,
+        use_fp32_rope: bool = False,
+        zero_centered_gamma: bool = False,
+        qkv_layout: str = "flat",
+    ):
+        super().__init__()
+        self.num_heads_local = ensure_divisible(num_attention_heads, ps.tp_size)
+        self.num_kv_heads_local = ensure_divisible(num_key_value_heads, ps.tp_size)
+        self.head_dim = head_dim
+        self.ps = ps
+        self._output_gate = output_gate
+        self._use_fp32_rope = use_fp32_rope
+        if qkv_layout not in {"flat", "mcore"}:
+            raise ValueError(f"Unsupported qkv_layout={qkv_layout!r}")
+        self._qkv_layout = qkv_layout
+
+        # Declaration order follows MC's `SelfAttention` submodule order
+        # (linear_proj → linear_qkv → q_layernorm → k_layernorm). `named_
+        # parameters()` iterates in registration order, and MC's
+        # `DistributedDataParallel` partitions gradient buckets by that order.
+        # Mismatched order would put bucket boundaries in different places
+        # between lite and MC reference paths, producing different per-rank fp32
+        # master shard layouts and non-bitwise step-1 divergence.
+        self.proj = RowParallelLinear(
+            num_attention_heads * head_dim, hidden_size, ps, bias=False,
+        )
+        q_cols = num_attention_heads * (2 if output_gate else 1)
+        qkv_size = (q_cols + 2 * num_key_value_heads) * head_dim
+        self.qkv = ColumnParallelLinear(
+            hidden_size, qkv_size, ps,
+            bias=False, normalization="RMSNorm", eps=rms_norm_eps,
+            zero_centered_gamma=zero_centered_gamma,
+        )
+        self.q_norm = te.RMSNorm(head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma)
+        self.k_norm = te.RMSNorm(head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma)
+
+        # MC's RotaryEmbedding is atomic (flat kwargs, no TransformerConfig).
+        # cp_group is read from self.cp_group inside forward() when not passed
+        # — no manual CP shard needed on our side.
+        self.rotary = MCoreRotaryEmbedding(
+            kv_channels=head_dim,
+            rotary_percent=rotary_percent,
+            rotary_interleaved=False,
+            rotary_base=int(rope_theta),
+            use_cpu_initialization=False,
+            cp_group=ps.cp_group if ps.cp_size > 1 else None,
+        )
+
+        cp_kwargs = {}
+        if ps.cp_size > 1:
+            if GQAttention._cp_stream is None:
+                GQAttention._cp_stream = torch.cuda.Stream()
+            cp_kwargs = dict(
+                cp_group=ps.cp_group,
+                cp_global_ranks=ps.cp_global_ranks,
+                cp_stream=GQAttention._cp_stream,
+            )
+
+        self.core_attn = te.DotProductAttention(
+            num_attention_heads=self.num_heads_local,
+            kv_channels=head_dim,
+            num_gqa_groups=self.num_kv_heads_local,
+            attention_dropout=0.0,
+            attn_mask_type="causal",
+            qkv_format="thd" if use_thd else "sbhd",
+            **cp_kwargs,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+    ) -> torch.Tensor:
+        q, gate, k, v = self._split_qkv(self.qkv(x))
+
+        is_thd = packed_seq_params is not None
+        if is_thd:
+            q, k, v = q.squeeze(1), k.squeeze(1), v.squeeze(1)
+
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+
+        # RoPE — unfused bshd/thd to match MC's default apply_rope_fusion=False.
+        # MC's RotaryEmbedding.forward takes only `max_seq_len` + optional
+        # `offset`; position_ids is NOT consumed here (MC handles position via
+        # offset for inference / mRoPE via a separate class).
+        if self._use_fp32_rope:
+            orig_dtype = q.dtype
+            q, k = q.float(), k.float()
+        if is_thd:
+            max_q = getattr(packed_seq_params, "max_seqlen_q", None)
+            max_kv = getattr(packed_seq_params, "max_seqlen_kv", None)
+            if max_q is None or max_kv is None:
+                seq_len_for_rope = int(packed_seq_params.cu_seqlens_q[-1])
+            else:
+                seq_len_for_rope = int(max(max_q, max_kv))
+            # Match MC RotaryEmbedding.get_rotary_seq_len for packed THD: the
+            # rotary length is the max per-sequence padded length, not total
+            # packed tokens. Using total tokens makes rope_utils switch to
+            # offset mapping, so later packed sequences do not restart at pos 0.
+            #
+            # MC contract (gpt_model.py:380-381): THD path passes packed_seq=True so the
+            # rotary skips its internal cp-slice; _apply_rotary_pos_emb_thd does the
+            # cp-zigzag slice itself via _get_thd_freqs_on_this_cp_rank.
+            freqs = self.rotary(seq_len_for_rope, packed_seq=True)
+            q = _apply_rotary_pos_emb_thd(
+                q, packed_seq_params.cu_seqlens_q, freqs,
+                rotary_interleaved=False, mscale=1.0,
+                cp_group=self.ps.cp_group,
+            )
+            k = _apply_rotary_pos_emb_thd(
+                k, packed_seq_params.cu_seqlens_kv, freqs,
+                rotary_interleaved=False, mscale=1.0,
+                cp_group=self.ps.cp_group,
+            )
+        else:
+            # q is CP-zigzag pre-sliced; rotary needs FULL seq len,
+            # its internal get_pos_emb_on_this_cp_rank re-slices to local len.
+            local_seq_len = q.size(0)
+            seq_len_for_rope = local_seq_len * self.ps.cp_size
+            freqs = self.rotary(seq_len_for_rope)
+            q = _apply_rotary_pos_emb_bshd(q, freqs, rotary_interleaved=False, mscale=1.0)
+            k = _apply_rotary_pos_emb_bshd(k, freqs, rotary_interleaved=False, mscale=1.0)
+        if self._use_fp32_rope:
+            q, k = q.to(orig_dtype), k.to(orig_dtype)
+
+        if is_thd:
+            psp_kwargs = {
+                k: getattr(packed_seq_params, k)
+                for k in _KEPT_PSP_FIELDS
+                if getattr(packed_seq_params, k, None) is not None
+            }
+            attn_out = self.core_attn(
+                q, k, v,
+                core_attention_bias_type="no_bias",
+                attn_mask_type="padding_causal",
+                **psp_kwargs,
+            )
+            attn_out = attn_out.reshape(attn_out.size(0), 1, -1)
+        else:
+            attn_out = self.core_attn(q, k, v, core_attention_bias_type="no_bias")
+            if attn_out.dim() > x.dim():
+                shape = attn_out.shape
+                attn_out = attn_out.reshape(*shape[:-2], self.num_heads_local * self.head_dim)
+
+        if gate is not None:
+            gate_fp32 = gate.reshape(attn_out.shape).float().sigmoid()
+            attn_out = (attn_out.float() * gate_fp32).to(attn_out.dtype)
+        output = self.proj(attn_out)
+        return output
+
+    def _split_qkv(self, qkv: torch.Tensor):
+        nq, nkv, hd = self.num_heads_local, self.num_kv_heads_local, self.head_dim
+        lead = qkv.shape[:-1]
+        if self._qkv_layout == "mcore":
+            q_per_group = ensure_divisible(nq, nkv)
+            if self._output_gate:
+                qkv = qkv.view(*lead, nkv, (2 * q_per_group + 2) * hd)
+                q = qkv[..., : q_per_group * hd].reshape(*lead, nq, hd)
+                gate = qkv[..., q_per_group * hd : 2 * q_per_group * hd].reshape(
+                    *lead, nq, hd,
+                )
+                k_start = 2 * q_per_group * hd
+                k = qkv[..., k_start : k_start + hd]
+                v = qkv[..., k_start + hd : k_start + 2 * hd]
+                return q, gate, k, v
+
+            qkv = qkv.view(*lead, nkv, (q_per_group + 2) * hd)
+            q = qkv[..., : q_per_group * hd].reshape(*lead, nq, hd)
+            k = qkv[..., q_per_group * hd : (q_per_group + 1) * hd]
+            v = qkv[..., (q_per_group + 1) * hd : (q_per_group + 2) * hd]
+            return q, None, k, v
+
+        if self._output_gate:
+            q_block = qkv[..., : nq * 2 * hd].reshape(*lead, nq, 2 * hd)
+            kv_block = qkv[..., nq * 2 * hd :].reshape(*lead, 2 * nkv, hd)
+            q = q_block[..., :hd]
+            gate = q_block[..., hd:]
+            k = kv_block[..., :nkv, :]
+            v = kv_block[..., nkv:, :]
+            return q, gate, k, v
+        qkv = qkv.view(*lead, nq + 2 * nkv, hd)
+        # Match MCore SelfAttention's split path: keep q/k/v as views instead
+        # of inserting copy nodes, since those copy nodes alter backward
+        # accumulation at the qkv boundary under TP/CP.
+        q = qkv[..., :nq, :]
+        k = qkv[..., nq : nq + nkv, :]
+        v = qkv[..., nq + nkv :, :]
+        return q, None, k, v

--- a/experimental/lite/megatron/lite/primitive/modules/moe.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe.py
@@ -1,0 +1,81 @@
+"""Shared MoE utilities: _AllToAll and MoEAuxLossAutoScaler.
+
+Extracted from models/*/moe.py (Level 0 Option C — pure extraction, no behavior change).
+All three models (qwen3_moe, qwen3_5, deepseek_v3) had identical _AllToAll
+implementations and functionally identical MoEAuxLossAutoScaler implementations.
+The qwen3_moe version is used as the canonical form (adds docstring and named
+intermediate variable for clarity).
+
+Note: this is Megatron Lite's own MoEAuxLossAutoScaler, kept deliberately separate
+from MC's `megatron.core.transformer.moe.moe_utils.MoEAuxLossAutoScaler`.
+`runtime/backends/lite/runtime.py` calls `set_loss_scale` on this class to apply
+the 1/num_microbatches aux-loss gradient scale.
+"""
+
+from __future__ import annotations
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+__all__ = ["MoEAuxLossAutoScaler", "_AllToAll"]
+
+
+class MoEAuxLossAutoScaler(torch.autograd.Function):
+    """Piggyback aux_loss onto autograd so main_loss.backward() triggers it."""
+
+    main_loss_backward_scale: torch.Tensor | None = None
+
+    @staticmethod
+    def forward(ctx, output: torch.Tensor, aux_loss: torch.Tensor) -> torch.Tensor:
+        ctx.save_for_backward(aux_loss)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        (aux_loss,) = ctx.saved_tensors
+        scale = (
+            MoEAuxLossAutoScaler.main_loss_backward_scale.to(aux_loss.device)
+            if MoEAuxLossAutoScaler.main_loss_backward_scale is not None
+            else torch.ones(1, device=aux_loss.device)
+        )
+        scaled_aux_loss_grad = torch.ones_like(aux_loss) * scale
+        return grad_output, scaled_aux_loss_grad
+
+    @staticmethod
+    def set_loss_scale(scale: torch.Tensor) -> None:
+        MoEAuxLossAutoScaler.main_loss_backward_scale = scale
+
+
+class _AllToAll(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input_tensor, input_splits, output_splits, group):
+        ctx.input_splits = input_splits
+        ctx.output_splits = output_splits
+        ctx.group = group
+        input_tensor = input_tensor.contiguous()
+        output = input_tensor.new_empty(
+            [sum(output_splits)] + list(input_tensor.shape[1:])
+        )
+        dist.all_to_all_single(
+            output,
+            input_tensor,
+            output_split_sizes=output_splits,
+            input_split_sizes=input_splits,
+            group=group,
+        )
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        grad_output = grad_output.contiguous()
+        grad_input = grad_output.new_empty(
+            [sum(ctx.input_splits)] + list(grad_output.shape[1:])
+        )
+        dist.all_to_all_single(
+            grad_input,
+            grad_output,
+            output_split_sizes=ctx.input_splits,
+            input_split_sizes=ctx.output_splits,
+            group=ctx.group,
+        )
+        return grad_input, None, None, None

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -1,0 +1,224 @@
+"""MoE router implementations: TopKRouter (softmax) and SigmoidTopKRouter.
+
+Internals call the atomic free functions in Megatron-Core's
+`megatron.core.transformer.moe.moe_utils` (plan `docs/moe_mc_wrap_plan.md`
+D3/D4). The outer classes keep the flat-kwargs + `ParallelState` constructor
+style of Megatron Lite primitives — no `TransformerConfig`, no mpu globals.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+from megatron.core.transformer.moe.moe_utils import (  # pyright: ignore[reportMissingImports]
+    compute_routing_scores_for_aux_loss,
+    router_gating_linear,
+    switch_load_balancing_loss_func,
+    topk_routing_with_score_function,
+)
+
+from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
+
+if TYPE_CHECKING:
+    from megatron.lite.primitive.parallel import ParallelState
+
+
+def _accepts_kwarg(fn, name: str) -> bool:
+    try:
+        params = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return False
+    return name in params or any(
+        param.kind == inspect.Parameter.VAR_KEYWORD
+        for param in params.values()
+    )
+
+
+_TOPK_ROUTING_SUPPORTS_DENSE_OUTPUT = _accepts_kwarg(
+    topk_routing_with_score_function,
+    "dense_output",
+)
+
+
+class TopKRouter(nn.Module):
+    """TopK gating: linear(input_dtype) → topk → softmax(fp32) → cast to input dtype."""
+
+    def __init__(
+        self,
+        config,
+        ps: ParallelState,
+        *,
+        router_bias_rate: float = 0.0,
+        compute_aux_loss: bool = True,
+        use_pre_softmax: bool = False,
+        moe_router_fusion: bool = False,
+    ):
+        super().__init__()
+        if router_bias_rate > 0:
+            raise NotImplementedError(
+                "expert-bias EMA is not implemented in the primitive router; "
+                "use load_balancing_type='none' or extend ParallelState."
+            )
+        self.topk = config.num_experts_per_tok
+        self.num_experts = config.num_experts
+        self.aux_loss_coeff = config.router_aux_loss_coef
+        self.router_bias_rate = router_bias_rate
+        self.compute_aux_loss = compute_aux_loss
+        self.use_pre_softmax = use_pre_softmax
+        self.moe_router_fusion = moe_router_fusion
+
+        self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
+        self.register_buffer(
+            "expert_bias",
+            torch.zeros(config.num_experts, dtype=torch.float32),
+            persistent=False,
+        )
+
+        self._aux_loss_group = ps.tp_group if ps.tp_size > 1 else None
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = router_gating_linear(x, self.gate.weight, None, x.dtype)
+        num_tokens = logits.size(0)
+        if self.moe_router_fusion:
+            probs_dense, _ = topk_routing_with_score_function(
+                logits,
+                self.topk,
+                use_pre_softmax=self.use_pre_softmax,
+                score_function="softmax",
+                fused=True,
+            )
+            topk_scores, topk_indices = torch.topk(probs_dense, k=self.topk, dim=-1)
+        else:
+            if _TOPK_ROUTING_SUPPORTS_DENSE_OUTPUT:
+                topk_scores, topk_indices = topk_routing_with_score_function(
+                    logits,
+                    self.topk,
+                    use_pre_softmax=self.use_pre_softmax,
+                    score_function="softmax",
+                    fused=False,
+                    dense_output=True,
+                )
+            else:
+                probs_dense, _ = topk_routing_with_score_function(
+                    logits,
+                    self.topk,
+                    use_pre_softmax=self.use_pre_softmax,
+                    score_function="softmax",
+                    fused=False,
+                )
+                topk_scores, topk_indices = torch.topk(probs_dense, k=self.topk, dim=-1)
+        topk_scores = topk_scores.to(x.dtype)
+
+        if self.compute_aux_loss and self.training and torch.is_grad_enabled():
+            routing_map, aux_scores = compute_routing_scores_for_aux_loss(
+                logits,
+                self.topk,
+                score_function="softmax",
+                fused=self.moe_router_fusion,
+            )
+            tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
+            total_num_tokens = num_tokens
+            if self._aux_loss_group is not None:
+                dist.all_reduce(tokens_per_expert, group=self._aux_loss_group)
+                total_num_tokens = num_tokens * dist.get_world_size(
+                    group=self._aux_loss_group
+                )
+            aux_loss = switch_load_balancing_loss_func(
+                aux_scores,
+                tokens_per_expert,
+                total_num_tokens,
+                self.topk,
+                self.num_experts,
+                self.aux_loss_coeff,
+                fused=False,
+            )
+            topk_scores = MoEAuxLossAutoScaler.apply(topk_scores, aux_loss)
+
+        return topk_scores, topk_indices
+
+
+class SigmoidTopKRouter(nn.Module):
+    """Sigmoid-based TopK router for DeepSeek V3."""
+
+    def __init__(
+        self,
+        config,
+        ps: ParallelState,
+        *,
+        router_bias_rate: float = 0.0,
+        compute_aux_loss: bool = True,
+        use_pre_softmax: bool = False,
+        moe_router_fusion: bool = False,
+    ):
+        super().__init__()
+        if router_bias_rate > 0:
+            raise NotImplementedError(
+                "expert-bias EMA is not implemented in the primitive router; "
+                "use load_balancing_type='none' or extend ParallelState."
+            )
+        self.topk = config.num_experts_per_tok
+        self.num_experts = config.n_routed_experts
+        self.aux_loss_coeff = config.aux_loss_alpha
+        self.scaling_factor = config.routed_scaling_factor
+        self.router_bias_rate = router_bias_rate
+        self.compute_aux_loss = compute_aux_loss
+        self.use_pre_softmax = use_pre_softmax
+        self.moe_router_fusion = moe_router_fusion
+
+        self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
+        self.register_buffer(
+            "expert_bias",
+            torch.zeros(config.n_routed_experts, dtype=torch.float32),
+            persistent=False,
+        )
+
+        self._aux_loss_group = ps.tp_group if ps.tp_size > 1 else None
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = self.gate(x)
+        num_tokens = logits.size(0)
+        probs_dense, routing_map = topk_routing_with_score_function(
+            logits,
+            self.topk,
+            score_function="sigmoid",
+            expert_bias=self.expert_bias.to(logits.dtype),
+            scaling_factor=(self.scaling_factor or None),
+            fused=self.moe_router_fusion,
+        )
+        # Recover topk from dense probs (see TopKRouter for rationale).
+        topk_scores, topk_indices = torch.topk(probs_dense, k=self.topk, dim=-1)
+        topk_scores = topk_scores.to(logits.dtype)
+
+        if self.compute_aux_loss and self.training and torch.is_grad_enabled():
+            _, aux_scores = compute_routing_scores_for_aux_loss(
+                logits,
+                self.topk,
+                score_function="sigmoid",
+                fused=self.moe_router_fusion,
+            )
+            tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
+            total_num_tokens = num_tokens
+            if self._aux_loss_group is not None:
+                dist.all_reduce(tokens_per_expert, group=self._aux_loss_group)
+                total_num_tokens = num_tokens * dist.get_world_size(
+                    group=self._aux_loss_group
+                )
+            aux_loss = switch_load_balancing_loss_func(
+                aux_scores,
+                tokens_per_expert,
+                total_num_tokens,
+                self.topk,
+                self.num_experts,
+                self.aux_loss_coeff,
+                fused=False,
+            )
+            topk_scores = MoEAuxLossAutoScaler.apply(topk_scores, aux_loss)
+
+        return topk_scores, topk_indices
+
+
+__all__ = ["SigmoidTopKRouter", "TopKRouter"]

--- a/experimental/lite/megatron/lite/primitive/ops/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/ops/__init__.py
@@ -1,0 +1,23 @@
+"""Runtime math primitives for Megatron Lite."""
+
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops.logprob import (
+    vocab_parallel_entropy,
+    vocab_parallel_log_probs_from_logits,
+)
+from megatron.lite.primitive.ops.sp_ops import (
+    AllGatherDim0,
+    AllGatherDim0ForNonSPConsumer,
+    ReduceScatterDim0,
+    ScatterToSP,
+)
+
+__all__ = [
+    "AllGatherDim0",
+    "AllGatherDim0ForNonSPConsumer",
+    "ReduceScatterDim0",
+    "ScatterToSP",
+    "vocab_parallel_cross_entropy",
+    "vocab_parallel_entropy",
+    "vocab_parallel_log_probs_from_logits",
+]

--- a/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
@@ -1,0 +1,114 @@
+"""Vocab-parallel cross entropy loss (copied from Megatron-Core).
+
+Computes cross entropy when logits are split across TP ranks.
+With TP=1 the all-reduce calls are no-ops and this degenerates to a
+standard cross-entropy with in-place ops and a memory-efficient custom backward.
+"""
+
+from __future__ import annotations
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+
+def _vocab_range(partition_vocab_size: int, rank: int, world_size: int):
+    start = rank * partition_vocab_size
+    return start, start + partition_vocab_size
+
+
+class _VocabParallelCrossEntropy(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, vocab_parallel_logits, target, tp_group):
+        # Cast to float32 and compute max for numerical stability.
+        vocab_parallel_logits = vocab_parallel_logits.float()
+        logits_max = torch.max(vocab_parallel_logits, dim=-1)[0]
+
+        if tp_group is not None and dist.get_world_size(tp_group) > 1:
+            dist.all_reduce(logits_max, op=dist.ReduceOp.MAX, group=tp_group)
+
+        # In-place subtract max.
+        vocab_parallel_logits -= logits_max.unsqueeze(dim=-1)
+
+        # Partition info.
+        partition_vocab_size = vocab_parallel_logits.size(-1)
+        if tp_group is not None and dist.get_world_size(tp_group) > 1:
+            rank = dist.get_rank(tp_group)
+            world_size = dist.get_world_size(tp_group)
+        else:
+            rank = 0
+            world_size = 1
+        vocab_start_index, vocab_end_index = _vocab_range(
+            partition_vocab_size, rank, world_size,
+        )
+
+        # Mask targets outside this partition's vocab range.
+        target_mask = (target < vocab_start_index) | (target >= vocab_end_index)
+        masked_target = target.clone() - vocab_start_index
+        masked_target[target_mask] = 0
+
+        # Get predicted logits = logits[target].
+        logits_2d = vocab_parallel_logits.view(-1, partition_vocab_size)
+        masked_target_1d = masked_target.view(-1)
+        arange_1d = torch.arange(logits_2d.size(0), device=logits_2d.device)
+        predicted_logits_1d = logits_2d[arange_1d, masked_target_1d]
+        predicted_logits_1d = predicted_logits_1d.clone().contiguous()
+        predicted_logits = predicted_logits_1d.view_as(target)
+        predicted_logits[target_mask] = 0.0
+
+        # Sum of exp(logits).
+        exp_logits = vocab_parallel_logits
+        torch.exp(vocab_parallel_logits, out=exp_logits)
+        sum_exp_logits = exp_logits.sum(dim=-1)
+
+        # All-reduce predicted_logits and sum_exp_logits across TP.
+        if tp_group is not None and dist.get_world_size(tp_group) > 1:
+            dist.all_reduce(predicted_logits, op=dist.ReduceOp.SUM, group=tp_group)
+            dist.all_reduce(sum_exp_logits, op=dist.ReduceOp.SUM, group=tp_group)
+
+        # Loss = log(sum(exp(logits))) - predicted_logit.
+        loss = torch.log(sum_exp_logits) - predicted_logits
+
+        # Normalize exp_logits to get softmax (reused in backward).
+        exp_logits.div_(sum_exp_logits.unsqueeze(dim=-1))
+
+        # Save for backward.
+        ctx.save_for_backward(exp_logits, target_mask, masked_target_1d)
+
+        return loss
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        softmax, target_mask, masked_target_1d = ctx.saved_tensors
+
+        # grad_input = softmax (copy is implicit since softmax is saved).
+        grad_input = softmax
+        partition_vocab_size = softmax.size(-1)
+        grad_2d = grad_input.view(-1, partition_vocab_size)
+
+        arange_1d = torch.arange(grad_2d.size(0), device=grad_2d.device)
+        softmax_update = 1.0 - target_mask.view(-1).float()
+
+        grad_2d[arange_1d, masked_target_1d] -= softmax_update
+
+        # Scale by upstream gradient.
+        grad_input.mul_(grad_output.unsqueeze(dim=-1))
+
+        return grad_input, None, None
+
+
+def vocab_parallel_cross_entropy(vocab_parallel_logits, target, tp_group=None):
+    """Cross entropy loss for vocab-parallel logits.
+
+    Args:
+        vocab_parallel_logits: [S, B, V/tp] logits split across TP ranks.
+        target: [S, B] integer target token ids.
+        tp_group: TP process group (None or single-rank group → no communication).
+
+    Returns:
+        Per-token loss tensor of shape [S, B].
+    """
+    return _VocabParallelCrossEntropy.apply(vocab_parallel_logits, target, tp_group)
+
+
+__all__ = ["vocab_parallel_cross_entropy"]

--- a/experimental/lite/megatron/lite/primitive/ops/linear_cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/linear_cross_entropy.py
@@ -1,0 +1,69 @@
+"""Linear + vocab-parallel cross entropy helpers.
+
+The fast path delegates to VERL's Triton-backed fused kernel when available.
+The fallback keeps the same contract and is used by unit/smoke tests that do
+not have the fused extension on ``PYTHONPATH``.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+
+
+def _all_reduce_if_needed(tensor: torch.Tensor, group, op=dist.ReduceOp.SUM) -> torch.Tensor:
+    if group is not None and dist.is_initialized() and dist.get_world_size(group) > 1:
+        dist.all_reduce(tensor, op=op, group=group)
+    return tensor
+
+
+def _vocab_parallel_entropy(logits: torch.Tensor, tp_group=None) -> torch.Tensor:
+    logits = logits.float()
+    logits_max = logits.max(dim=-1).values
+    _all_reduce_if_needed(logits_max, tp_group, op=dist.ReduceOp.MAX)
+
+    shifted = logits - logits_max.unsqueeze(-1)
+    exp_logits = torch.exp(shifted)
+    sum_exp = exp_logits.sum(dim=-1)
+    _all_reduce_if_needed(sum_exp, tp_group)
+
+    weighted_logits = (exp_logits * logits).sum(dim=-1)
+    _all_reduce_if_needed(weighted_logits, tp_group)
+    expected_logits = weighted_logits / sum_exp
+    return torch.log(sum_exp) + logits_max - expected_logits
+
+
+def _reshape_like_labels(values: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    if values.shape != labels.shape and values.numel() == labels.numel():
+        return values.reshape(labels.shape)
+    return values
+
+
+def linear_cross_entropy(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    labels: torch.Tensor,
+    temperature: float = 1.0,
+    tp_group=None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return token log-probs and entropy without changing VERL's fused API."""
+    try:
+        from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy as _verl_lce
+    except Exception:
+        _verl_lce = None
+
+    if _verl_lce is not None and hidden.is_cuda:
+        log_probs, entropy = _verl_lce(hidden, weight, labels, float(temperature), "none", tp_group)
+        return _reshape_like_labels(log_probs, labels), _reshape_like_labels(entropy, labels)
+
+    logits = torch.matmul(hidden, weight.t())
+    if temperature != 1.0:
+        logits = logits / float(temperature)
+    loss = vocab_parallel_cross_entropy(logits, labels, tp_group)
+    entropy = _vocab_parallel_entropy(logits, tp_group)
+    return _reshape_like_labels(-loss, labels), _reshape_like_labels(entropy, labels)
+
+
+__all__ = ["linear_cross_entropy"]

--- a/experimental/lite/megatron/lite/primitive/ops/logprob.py
+++ b/experimental/lite/megatron/lite/primitive/ops/logprob.py
@@ -1,0 +1,74 @@
+"""Probability-first primitives for Megatron Lite phase 1."""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+
+
+def vocab_parallel_log_probs_from_logits(
+    logits: torch.Tensor, labels: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute log-probabilities from already materialized logits.
+
+    Phase 1 assumes logits are already full-vocab tensors on the local rank.
+    If `labels` are provided, this returns token-selected log-probabilities with
+    the same shape as `labels` (modulo an internal transpose when logits are
+    `[S, B, V]` and labels are `[B, S]`).
+    """
+
+    log_probs = torch.log_softmax(logits.float(), dim=-1)
+    if labels is None:
+        return log_probs
+
+    aligned_labels, transposed = _align_labels_to_logits(logits, labels)
+    gathered = log_probs.gather(dim=-1, index=aligned_labels.unsqueeze(-1)).squeeze(-1)
+    return gathered.transpose(0, 1).contiguous() if transposed else gathered
+
+
+def _all_reduce_if_needed(tensor: torch.Tensor, group=None, op=dist.ReduceOp.SUM) -> torch.Tensor:
+    if group is not None and dist.is_initialized() and dist.get_world_size(group) > 1:
+        dist.all_reduce(tensor, op=op, group=group)
+    return tensor
+
+
+def vocab_parallel_entropy(logits: torch.Tensor, tp_group=None) -> torch.Tensor:
+    """Compute per-token entropy from logits."""
+
+    logits = logits.float()
+    logits_max = logits.max(dim=-1).values
+    _all_reduce_if_needed(logits_max, tp_group, op=dist.ReduceOp.MAX)
+
+    shifted = logits - logits_max.unsqueeze(-1)
+    exp_logits = torch.exp(shifted)
+    sum_exp = exp_logits.sum(dim=-1)
+    _all_reduce_if_needed(sum_exp, tp_group)
+
+    weighted_logits = (exp_logits * logits).sum(dim=-1)
+    _all_reduce_if_needed(weighted_logits, tp_group)
+    expected_logits = weighted_logits / sum_exp
+    return torch.log(sum_exp) + logits_max - expected_logits
+
+
+def _align_labels_to_logits(
+    logits: torch.Tensor, labels: torch.Tensor,
+) -> tuple[torch.Tensor, bool]:
+    if logits.ndim != labels.ndim + 1:
+        raise ValueError(
+            f"logits rank must be labels rank + 1, got logits={logits.shape}, labels={labels.shape}."
+        )
+
+    if logits.shape[:-1] == labels.shape:
+        return labels, False
+
+    if (
+        logits.ndim == 3
+        and labels.ndim == 2
+        and logits.shape[0] == labels.shape[1]
+        and logits.shape[1] == labels.shape[0]
+    ):
+        return labels.transpose(0, 1).contiguous(), True
+
+    raise ValueError(
+        f"Could not align labels {labels.shape} with logits {logits.shape}."
+    )

--- a/experimental/lite/megatron/lite/primitive/ops/sp_ops.py
+++ b/experimental/lite/megatron/lite/primitive/ops/sp_ops.py
@@ -1,0 +1,100 @@
+"""Sequence-parallel autograd primitives for non-TE layers (embedding, scatter/gather).
+
+AllGather/ReduceScatter operate on the sequence dimension (dim 0) with layout
+[S, B, H]. NCCL operates on dim 0 directly — no transpose needed.
+TE-based layers use TE's native sequence_parallel=True instead.
+"""
+
+from __future__ import annotations
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+
+def _ag_dim0(x: torch.Tensor, tp_size: int, group: dist.ProcessGroup) -> torch.Tensor:
+    """AllGather on dim 0: [S/tp, B, H] → [S, B, H]."""
+    out = torch.empty(
+        tp_size * x.shape[0], x.shape[1], x.shape[2],
+        dtype=x.dtype, device=x.device,
+    )
+    dist.all_gather_into_tensor(out, x.contiguous(), group=group)
+    return out
+
+
+def _rs_dim0(x: torch.Tensor, local_seq: int, group: dist.ProcessGroup) -> torch.Tensor:
+    """ReduceScatter on dim 0: [S, B, H] → [S/tp, B, H]."""
+    out = torch.empty(
+        local_seq, x.shape[1], x.shape[2],
+        dtype=x.dtype, device=x.device,
+    )
+    dist.reduce_scatter_tensor(out, x.contiguous(), group=group)
+    return out
+
+
+class AllGatherDim0(torch.autograd.Function):
+    """AllGather [S/tp, B, H] → [S, B, H]. Backward: ReduceScatter."""
+
+    @staticmethod
+    def forward(ctx, x, tp_size, tp_rank, group):
+        ctx.group = group
+        ctx.local_seq = x.shape[0]
+        return _ag_dim0(x, tp_size, group)
+
+    @staticmethod
+    def backward(ctx, grad):
+        out = _rs_dim0(grad, ctx.local_seq, ctx.group)
+        return out, None, None, None
+
+
+class ReduceScatterDim0(torch.autograd.Function):
+    """ReduceScatter [S, B, H] → [S/tp, B, H]. Backward: AllGather."""
+
+    @staticmethod
+    def forward(ctx, x, tp_size, tp_rank, group):
+        ctx.tp_size = tp_size
+        ctx.group = group
+        local_seq = x.shape[0] // tp_size
+        return _rs_dim0(x, local_seq, ctx.group)
+
+    @staticmethod
+    def backward(ctx, grad):
+        return _ag_dim0(grad, ctx.tp_size, ctx.group), None, None, None
+
+
+class AllGatherDim0ForNonSPConsumer(torch.autograd.Function):
+    """AllGather [S/tp, B, H] → [S, B, H]. Backward: Scatter (no reduce)."""
+
+    @staticmethod
+    def forward(ctx, x, tp_size, tp_rank, group):
+        ctx.tp_rank = tp_rank
+        ctx.local_seq = x.shape[0]
+        return _ag_dim0(x, tp_size, group)
+
+    @staticmethod
+    def backward(ctx, grad):
+        start = ctx.tp_rank * ctx.local_seq
+        return grad[start:start + ctx.local_seq].contiguous(), None, None, None
+
+
+class ScatterToSP(torch.autograd.Function):
+    """Scatter [S, B, H] → [S/tp, B, H] (no comm). Backward: AllGather."""
+
+    @staticmethod
+    def forward(ctx, x, tp_size, tp_rank, group):
+        ctx.tp_size = tp_size
+        ctx.group = group
+        local_seq = x.shape[0] // tp_size
+        start = tp_rank * local_seq
+        return x[start:start + local_seq, :, :].contiguous()
+
+    @staticmethod
+    def backward(ctx, grad):
+        return _ag_dim0(grad, ctx.tp_size, ctx.group), None, None, None
+
+
+__all__ = [
+    "AllGatherDim0",
+    "AllGatherDim0ForNonSPConsumer",
+    "ReduceScatterDim0",
+    "ScatterToSP",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
@@ -1,0 +1,18 @@
+"""Optimizer backend registry."""
+
+from __future__ import annotations
+
+import importlib
+
+BACKENDS = {
+    "mc": "megatron.lite.primitive.optimizers.megatron_wrap",
+}
+
+
+def get_optimizer_backend(name: str):
+    if name not in BACKENDS:
+        raise ValueError(f"Unknown Megatron Lite optimizer backend: {name!r}.")
+    return importlib.import_module(BACKENDS[name]).BACKEND
+
+
+__all__ = ["get_optimizer_backend"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -1,0 +1,456 @@
+"""Megatron-Core optimizer wrap backend for Megatron Lite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.protocols import ExpertClassifierFn, default_expert_classifier
+
+
+def validate_mc_config(engine_cfg) -> None:
+    """Guard the current proof-of-concept surface for mc."""
+    if engine_cfg.model_name not in {"qwen3", "qwen3_moe", "qwen3_5"}:
+        raise ValueError(
+            "optimizer_impl='mc' currently supports only qwen3 and qwen3_5."
+        )
+    p = engine_cfg.parallel
+    if p.vpp > 1 and p.pp == 1:
+        raise ValueError(
+            "optimizer_impl='mc' requires pp>1 when vpp>1."
+        )
+
+
+# Legacy alias — kept for compat shim path
+validate_mc_session = validate_mc_config
+
+
+def _effective_etp(parallel) -> int:
+    return int(parallel.etp if parallel.etp is not None else 1)
+
+
+def _ensure_mc_mpu_parallel_state(engine_cfg) -> None:
+    """Initialize Megatron-Core mpu globals when MC fallback groups are used."""
+
+    from megatron.core import parallel_state as mpu  # pyright: ignore[reportMissingImports]
+
+    p = engine_cfg.parallel
+    expected = (
+        int(p.tp),
+        int(p.ep),
+        _effective_etp(p),
+        int(p.pp),
+        int(p.cp),
+    )
+    if mpu.is_initialized():
+        current = (
+            int(mpu.get_tensor_model_parallel_world_size()),
+            int(mpu.get_expert_model_parallel_world_size()),
+            int(mpu.get_expert_tensor_parallel_world_size() or 1),
+            int(mpu.get_pipeline_model_parallel_world_size()),
+            int(mpu.get_context_parallel_world_size()),
+        )
+        if current != expected:
+            raise RuntimeError(
+                "MC optimizer found an incompatible existing Megatron-Core parallel state: "
+                f"current={current}, expected={expected}."
+            )
+        return
+
+    mpu.initialize_model_parallel(
+        tensor_model_parallel_size=p.tp,
+        pipeline_model_parallel_size=p.pp,
+        virtual_pipeline_model_parallel_size=None if int(p.vpp or 1) <= 1 else p.vpp,
+        context_parallel_size=p.cp,
+        expert_model_parallel_size=p.ep,
+        expert_tensor_parallel_size=_effective_etp(p),
+        create_gloo_process_groups=bool(getattr(engine_cfg, "deterministic", False)),
+    )
+
+
+def build_mc_optimizer_config(opt, *, override_optimizer_config: dict[str, Any] | None = None):
+    """Build MC OptimizerConfig from user's OptimizerConfig (duck-typed).
+
+    Single source of truth for the lite `build_mc_stack` path.
+
+    Works on either `runtime.contracts.config.OptimizerConfig` (real dataclass)
+    or a `SimpleNamespace` with the same field names (legacy lite path).
+    """
+    from megatron.core.optimizer.optimizer_config import (  # pyright: ignore[reportMissingImports]
+        OptimizerConfig as MCOptimizerConfig,
+    )
+
+    offload = getattr(opt, "offload_fraction", None) or 0.0
+    args: dict[str, Any] = {
+        "optimizer": opt.optimizer,
+        "lr": opt.lr,
+        "min_lr": getattr(opt, "min_lr", 0.0),
+        "weight_decay": opt.weight_decay,
+        "clip_grad": opt.clip_grad,
+        "use_distributed_optimizer": True,
+        "bf16": True,
+        "params_dtype": torch.bfloat16,
+    }
+    if offload > 0:
+        args["optimizer_offload_fraction"] = offload
+        args["overlap_cpu_optimizer_d2h_h2d"] = True
+        args["optimizer_cpu_offload"] = True
+    if getattr(opt, "adam_beta1", None) is not None:
+        args["adam_beta1"] = opt.adam_beta1
+    if getattr(opt, "adam_beta2", None) is not None:
+        args["adam_beta2"] = opt.adam_beta2
+    if getattr(opt, "adam_eps", None) is not None:
+        args["adam_eps"] = opt.adam_eps
+    if getattr(opt, "use_precision_aware_optimizer", None) is not None:
+        args["use_precision_aware_optimizer"] = opt.use_precision_aware_optimizer
+    if getattr(opt, "decoupled_weight_decay", None) is not None:
+        args["decoupled_weight_decay"] = opt.decoupled_weight_decay
+    if override_optimizer_config:
+        args.update(override_optimizer_config)
+    return MCOptimizerConfig(**args)
+
+
+def build_mc_stack(
+    model_chunks: list[nn.Module],
+    *,
+    model_cfg,
+    engine_cfg,
+    ps,
+    is_expert: ExpertClassifierFn | None = None,
+    proto=None,
+    skip_ddp_wrap: bool = False,
+):
+    """Wrap ML model chunks with MC DDP and build the matching MC optimizer.
+
+    Args:
+        skip_ddp_wrap: when True, ``model_chunks`` are assumed to already be
+            MC ``DistributedDataParallel``-wrapped (e.g. produced by
+            ``mbridge.AutoBridge.get_model(wrap_with_ddp=True, ...)``); we skip
+            our own wrapping and feed them directly to the optimizer. Use this
+            when matching bridge backend behaviour bit-for-bit — mbridge fills
+            ``DistributedDataParallelConfig`` with different field defaults
+            than our explicit 3-field construction below, and the bucket
+            layout influences optimizer master-grad sharding.
+    """
+    from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+    from megatron.core.distributed.finalize_model_grads import finalize_model_grads
+    from megatron.core.optimizer import get_megatron_optimizer
+    from megatron.core.transformer.enums import ModelType
+
+    validate_mc_config(engine_cfg)
+
+    p = engine_cfg.parallel
+    opt = engine_cfg.optimizer
+
+    mc_transformer_cfg = _build_transformer_config(model_cfg, engine_cfg)
+    mc_transformer_cfg.finalize_model_grads_func = finalize_model_grads
+    if is_expert is not None:
+        is_expert_param = is_expert
+    elif proto is not None and hasattr(proto, "EXPERT_CLASSIFIER"):
+        is_expert_param = proto.EXPERT_CLASSIFIER
+    else:
+        is_expert_param = default_expert_classifier
+    use_mpu_groups = bool(getattr(engine_cfg, "deterministic", False))
+    if use_mpu_groups:
+        _ensure_mc_mpu_parallel_state(engine_cfg)
+    pg_collection = None if use_mpu_groups else _build_pg_collection(ps, engine_cfg)
+
+    if skip_ddp_wrap:
+        # Caller already wrapped (e.g. bridge.get_model(wrap_with_ddp=True)).
+        # Do NOT run `_mark_mc_parallel_attrs` here — bridge backend never
+        # calls it either. mbridge's internal
+        # `set_defaults_if_not_set_tensor_model_parallel_attributes` has
+        # already marked every param; our helper setting `param.allreduce`
+        # on dense params could clash with MC code paths that distinguish
+        # `hasattr(param,'allreduce')` from `getattr(..., True)`.
+        wrapped_chunks = list(model_chunks)
+    else:
+        ddp_config = DistributedDataParallelConfig(
+            use_distributed_optimizer=True,
+            overlap_grad_reduce=False,
+            grad_reduce_in_fp32=True,
+        )
+        wrapped_chunks = []
+        for chunk_idx, chunk in enumerate(model_chunks):
+            chunk.model_type = ModelType.encoder_or_decoder
+            _mark_mc_parallel_attrs(chunk, is_expert_param, tp_size=p.tp)
+            ddp_kwargs = {}
+            if pg_collection is not None:
+                ddp_kwargs["pg_collection"] = pg_collection
+            wrapped_chunks.append(
+                DistributedDataParallel(
+                    mc_transformer_cfg,
+                    ddp_config,
+                    chunk,
+                    disable_bucketing=(chunk_idx > 0),
+                    **ddp_kwargs,
+                )
+            )
+
+    # Single-source-of-truth OptimizerConfig construction.
+    opt_config = build_mc_optimizer_config(opt)
+
+    # This branch falls back to MC mpu globals for the optimizer's process
+    # groups. Long term, primitive code should not rely on mpu globals; fix
+    # `_build_pg_collection` below so its groups match MC's rank-ordering,
+    # then always pass our own `pg_collection`.
+    if skip_ddp_wrap or use_mpu_groups:
+        optimizer = get_megatron_optimizer(
+            config=opt_config,
+            model_chunks=wrapped_chunks,
+        )
+        optimizer._mc_pg_collection = None  # pyright: ignore[reportAttributeAccessIssue]
+    else:
+        optimizer = get_megatron_optimizer(
+            config=opt_config,
+            model_chunks=wrapped_chunks,
+            use_gloo_process_groups=False,
+            pg_collection=pg_collection,
+        )
+        optimizer._mc_pg_collection = pg_collection  # pyright: ignore[reportAttributeAccessIssue]
+    return wrapped_chunks, optimizer
+
+
+def build_mc_training_optimizer(
+    model_chunks: list[nn.Module],
+    *,
+    model_cfg,
+    impl_cfg,
+    ps,
+    model_name: str,
+    is_expert: ExpertClassifierFn | None = None,
+    skip_ddp_wrap: bool = False,
+):
+    """Build the MC DDP+optimizer stack from a Megatron Lite model ImplConfig."""
+
+    opt = impl_cfg.optimizer_config
+    if opt is None:
+        opt = SimpleNamespace(
+            optimizer="adam",
+            lr=1e-4,
+            weight_decay=0.01,
+            clip_grad=1.0,
+            offload_fraction=None,
+            adam_beta1=None,
+            adam_beta2=None,
+            adam_eps=None,
+        )
+
+    engine_cfg = SimpleNamespace(
+        model_name=model_name,
+        parallel=impl_cfg.parallel,
+        optimizer=opt,
+        deterministic=getattr(impl_cfg, "deterministic", False),
+    )
+    model_chunks[:], optimizer = build_mc_stack(
+        model_chunks,
+        model_cfg=model_cfg,
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=is_expert,
+        skip_ddp_wrap=skip_ddp_wrap,
+    )
+
+    def finalize_grads() -> None:
+        finalize_mc_grads(model_chunks, optimizer)
+
+    return optimizer, finalize_grads
+
+
+def finalize_mc_grads(model_chunks: list[nn.Module], optimizer) -> None:
+    """Run MC gradient finalization to match the optimizer's expected contract."""
+    from megatron.core.distributed.finalize_model_grads import finalize_model_grads
+
+    finalize_model_grads(model_chunks, pg_collection=optimizer._mc_pg_collection)
+
+
+def _build_transformer_config(model_cfg, engine_cfg):
+    from megatron.core.transformer.transformer_config import TransformerConfig
+
+    p = engine_cfg.parallel
+    kwargs = dict(
+        num_layers=max(getattr(model_cfg, "num_hidden_layers", 1), 1),
+        hidden_size=max(getattr(model_cfg, "hidden_size", 1), 1),
+        num_attention_heads=max(getattr(model_cfg, "num_attention_heads", 1), 1),
+        num_query_groups=getattr(model_cfg, "num_key_value_heads", None),
+        num_moe_experts=getattr(model_cfg, "num_experts", None),
+        moe_ffn_hidden_size=getattr(model_cfg, "moe_intermediate_size", None),
+        tensor_model_parallel_size=p.tp,
+        pipeline_model_parallel_size=p.pp,
+        context_parallel_size=p.cp,
+        expert_model_parallel_size=p.ep,
+        expert_tensor_parallel_size=p.etp if p.etp is not None else 1,
+        sequence_parallel=p.tp > 1,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+    )
+    if p.pp > 1:
+        kwargs["pipeline_dtype"] = torch.bfloat16
+    return TransformerConfig(**kwargs)
+
+
+def _mark_mc_parallel_attrs(
+    model: nn.Module, is_expert_param: ExpertClassifierFn, *, tp_size: int,
+) -> None:
+    """Mark per-param MC metadata (allreduce / tensor_model_parallel / sequence_parallel).
+
+    IMPORTANT: respect attrs that are already set — mbridge-built MC models
+    mark these correctly per-param (e.g. `moe.router.weight` is 2D but
+    TP-replicated, and must NOT have `tensor_model_parallel=True`).
+    Blind override would cause MC grad-norm to over-count replicated params
+    (one overcount per TP rank) and shift grad_norm by ~1-2%.
+    """
+    sp_param_ids = {id(param) for param in getattr(model, "sp_params", [])}
+    for name, param in model.named_parameters():
+        # MC uses `allreduce=False` to route expert params into expert-DP buffers.
+        if not hasattr(param, "allreduce"):
+            param.allreduce = not is_expert_param(name)
+        if tp_size > 1 and id(param) not in sp_param_ids and param.ndim > 1:
+            # vision params are replicated across TP (AVG all-reduce, not TP-split).
+            # tensor_model_parallel=True would cause MC to wrong-account their grad-norm.
+            if getattr(param, "average_gradients_across_tp_domain", False):
+                continue
+            # Skip params already marked sequence_parallel=True: they are TP-replicated
+            # with SP-sharded input (e.g. shared_experts.gate_weight, RMSNorm weights).
+            # Stacking tensor_model_parallel=True on top would cause double all-reduce.
+            if getattr(param, "sequence_parallel", False):
+                continue
+            # MC excludes TP replicas from grad-norm accounting via this metadata.
+            if not hasattr(param, "tensor_model_parallel"):
+                param.tensor_model_parallel = True
+
+    for param in getattr(model, "sp_params", []):
+        if not hasattr(param, "sequence_parallel"):
+            param.sequence_parallel = True
+        param.allreduce = True
+        param.tensor_model_parallel = False
+
+
+def _build_pg_collection(ps, engine_cfg):
+    import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+    from megatron.core.process_groups_config import ProcessGroupCollection
+
+    if ps.pp_group is None:
+        raise ValueError("optimizer_impl='mc' requires a local pp_group.")
+
+    def _dense_rank(tp_i: int, cp_i: int, dp_i: int, pp_i: int) -> int:
+        return ((pp_i * ps.dp_size + dp_i) * ps.cp_size + cp_i) * ps.tp_size + tp_i
+
+    def _expert_rank(etp_i: int, ep_i: int, edp_i: int, pp_i: int) -> int:
+        return ((pp_i * ps.expert_dp_size + edp_i) * ps.ep_size + ep_i) * ps.etp_size + etp_i
+
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+
+    singleton_group = None
+    for singleton_rank in range(world):
+        group = dist.new_group([singleton_rank])
+        if rank == singleton_rank:
+            singleton_group = group
+    if singleton_group is None:
+        raise RuntimeError("Failed to construct singleton process group for optional MC reductions.")
+
+    if engine_cfg.parallel.pp == 1:
+        mp_group = ps.tp_group
+        tp_ep_pp_group = ps.tp_ep_group
+    else:
+        mp_group = None
+        for dp_idx in range(ps.dp_size):
+            for cp_idx in range(ps.cp_size):
+                ranks = [
+                    _dense_rank(tp_idx, cp_idx, dp_idx, pp_idx)
+                    for pp_idx in range(ps.pp_size)
+                    for tp_idx in range(ps.tp_size)
+                ]
+                group = dist.new_group(ranks)
+                if rank in ranks:
+                    mp_group = group
+
+        tp_ep_pp_group = None
+        for expert_dp_idx in range(ps.expert_dp_size):
+            ranks = [
+                _expert_rank(etp_idx, ep_idx, expert_dp_idx, pp_idx)
+                for pp_idx in range(ps.pp_size)
+                for ep_idx in range(ps.ep_size)
+                for etp_idx in range(ps.etp_size)
+            ]
+            group = dist.new_group(ranks)
+            if rank in ranks:
+                tp_ep_pp_group = group
+
+        if mp_group is None or tp_ep_pp_group is None:
+            raise RuntimeError("Failed to construct mc pipeline-aware process groups.")
+
+    return ProcessGroupCollection(
+        tp=ps.tp_group,
+        cp=ps.cp_group,
+        pp=ps.pp_group,
+        ep=ps.ep_group,
+        mp=mp_group,
+        dp=ps.dp_group,
+        dp_cp=ps.dp_cp_group,
+        expt_dp=ps.ep_dp_group,
+        expt_tp=ps.etp_group,
+        tp_ep=ps.tp_ep_group,
+        tp_ep_pp=tp_ep_pp_group,
+        # For MC distributed optimizer, grad stats are reduced over the full optimizer instance.
+        # With a single dist-opt instance in this benchmark proof, that is the global world group.
+        intra_dist_opt=dist.group.WORLD,
+        # ML models do not expose MC's embedding/position-embedding sharing surface.
+        # Use singleton groups so MC's optional embedding reductions become no-ops
+        # without falling back to the global MCore embedding group.
+        embd=singleton_group,
+        pos_embd=singleton_group,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend adapter (consumed by runtime/session.py)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class MCBackend:
+    name: str = "mc"
+    runtime_backend: str = "mc"
+
+    def zero_grad(self, optimizer: Any) -> None:
+        optimizer.zero_grad()
+
+    def finish_grad_sync(self, optimizer: Any) -> None:
+        if hasattr(optimizer, "finish_grad_sync"):
+            optimizer.finish_grad_sync()
+
+    def clip_grad_norm(self, optimizer: Any):
+        if hasattr(optimizer, "clip_grad_norm"):
+            return optimizer.clip_grad_norm()
+        return None
+
+    def step(self, optimizer: Any):
+        return optimizer.step()
+
+    def state_dict(self, optimizer: Any) -> dict:
+        return optimizer.state_dict()
+
+    def load_state_dict(self, optimizer: Any, state_dict: dict) -> None:
+        optimizer.load_state_dict(state_dict)
+
+    def finalize_grads(self, finalize_fn, model_chunks: list[Any], optimizer: Any) -> None:
+        finalize_fn(model_chunks, optimizer)
+
+
+BACKEND = MCBackend()
+
+__all__ = [
+    "BACKEND",
+    "MCBackend",
+    "build_mc_stack",
+    "build_mc_training_optimizer",
+    "finalize_mc_grads",
+    "validate_mc_config",
+    "validate_mc_session",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -1,0 +1,67 @@
+"""Megatron Lite-owned parallel runtime exports."""
+
+from __future__ import annotations
+
+from megatron.lite.primitive.parallel.cp import (
+    split_packed_for_cp,
+    zigzag_position_ids_for_cp,
+    zigzag_split_for_cp,
+)
+from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+from megatron.lite.primitive.parallel.pp import PipelineChunkLayout, build_pipeline_chunk_layout
+from megatron.lite.primitive.parallel.sp import (
+    gather_for_non_sp_head,
+    gather_from_sequence_parallel,
+    scatter_to_sequence_parallel,
+)
+from megatron.lite.primitive.parallel.state import ParallelState, init_parallel
+from megatron.lite.primitive.parallel.thd import (
+    PackedSeqParams,
+    PackedTHDBatch,
+    pack_nested_thd,
+    roll_packed_thd_left,
+    unpack_packed_thd_to_nested,
+)
+
+_LAZY_LINEAR_EXPORTS = {
+    "ColumnParallelLinear",
+    "RowParallelLinear",
+    "VanillaColumnParallelLinear",
+    "VocabParallelEmbedding",
+    "VocabParallelOutput",
+    "pad_vocab_for_tp",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_LINEAR_EXPORTS:
+        from megatron.lite.primitive.parallel import linear as _linear
+
+        return getattr(_linear, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "ColumnParallelLinear",
+    "PackedSeqParams",
+    "PackedTHDBatch",
+    "PipelineChunkLayout",
+    "ParallelState",
+    "RowParallelLinear",
+    "VanillaColumnParallelLinear",
+    "VocabParallelEmbedding",
+    "VocabParallelOutput",
+    "build_pipeline_chunk_layout",
+    "forward_backward_pipelining",
+    "gather_for_non_sp_head",
+    "gather_from_sequence_parallel",
+    "init_parallel",
+    "pad_vocab_for_tp",
+    "pack_nested_thd",
+    "roll_packed_thd_left",
+    "scatter_to_sequence_parallel",
+    "split_packed_for_cp",
+    "unpack_packed_thd_to_nested",
+    "zigzag_position_ids_for_cp",
+    "zigzag_split_for_cp",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -1,0 +1,108 @@
+"""Context parallel zigzag sequence splitting helpers."""
+
+from __future__ import annotations
+
+import torch
+
+
+def zigzag_split_for_cp(
+    tensor: torch.Tensor, cp_rank: int, cp_size: int, seq_dim: int = 1,
+) -> torch.Tensor:
+    """Split tensor along sequence dim using zigzag (striped) pattern for CP.
+
+    Splits into 2*cp_size chunks; GPU i gets chunk[i] + chunk[2*cp_size-1-i].
+    This balances causal-mask workload across CP ranks.
+
+    Example (CP=2, seq=8): chunks [0,1,2,3] ->
+        GPU0: chunk[0]+chunk[3] = tokens [0,1,6,7]
+        GPU1: chunk[1]+chunk[2] = tokens [2,3,4,5]
+    """
+    if cp_size <= 1:
+        return tensor
+    seq_len = tensor.shape[seq_dim]
+    assert seq_len % (2 * cp_size) == 0, (
+        f"seq_len={seq_len} must be divisible by 2*cp_size={2 * cp_size}"
+    )
+    shape = list(tensor.shape)
+    shape[seq_dim:seq_dim + 1] = [2 * cp_size, seq_len // (2 * cp_size)]
+    tensor = tensor.view(*shape)
+    idx = torch.tensor(
+        [cp_rank, 2 * cp_size - cp_rank - 1],
+        dtype=torch.long, device=tensor.device,
+    )
+    tensor = tensor.index_select(seq_dim, idx)
+    shape[seq_dim:seq_dim + 2] = [seq_len // cp_size]
+    return tensor.reshape(*shape)
+
+
+def zigzag_position_ids_for_cp(
+    seq_len: int, cp_rank: int, cp_size: int, device: torch.device,
+) -> torch.Tensor:
+    """Return global position IDs for this CP rank under zigzag splitting.
+
+    Returns shape [1, seq_len // cp_size] matching batch dim convention.
+    """
+    if cp_size <= 1:
+        return torch.arange(seq_len, device=device).unsqueeze(0)
+    chunk = seq_len // (2 * cp_size)
+    first = torch.arange(cp_rank * chunk, (cp_rank + 1) * chunk, device=device)
+    second_start = (2 * cp_size - cp_rank - 1) * chunk
+    second = torch.arange(second_start, second_start + chunk, device=device)
+    return torch.cat([first, second]).unsqueeze(0)
+
+
+def split_packed_for_cp(
+    input_ids: torch.Tensor,
+    position_ids: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    max_seqlen: int,
+    cp_rank: int,
+    cp_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Zigzag-split a packed sequence batch for context parallelism.
+
+    Each sample defined by *cu_seqlens* is split with the same zigzag
+    (striped) pattern as :func:`zigzag_split_for_cp`: tokens are divided
+    into ``2 * cp_size`` chunks, and this rank keeps
+    ``chunk[cp_rank] + chunk[2*cp_size - 1 - cp_rank]``.
+
+    Returns:
+        ``(input_ids, position_ids, cu_seqlens, max_seqlen)`` for this CP rank.
+    """
+    if cp_size <= 1:
+        return input_ids, position_ids, cu_seqlens, max_seqlen
+
+    num_seqs = cu_seqlens.size(0) - 1
+    ids_parts: list[torch.Tensor] = []
+    pos_parts: list[torch.Tensor] = []
+    new_lengths: list[int] = []
+
+    for i in range(num_seqs):
+        start = int(cu_seqlens[i].item())
+        end = int(cu_seqlens[i + 1].item())
+        seq_len = end - start
+        assert seq_len % (2 * cp_size) == 0, (
+            f"Sample {i} length {seq_len} not divisible by 2*cp_size={2 * cp_size}"
+        )
+        chunk = seq_len // (2 * cp_size)
+        c1 = start + cp_rank * chunk
+        c2 = start + (2 * cp_size - cp_rank - 1) * chunk
+        ids_parts.append(input_ids[c1:c1 + chunk])
+        ids_parts.append(input_ids[c2:c2 + chunk])
+        pos_parts.append(position_ids[c1:c1 + chunk])
+        pos_parts.append(position_ids[c2:c2 + chunk])
+        new_lengths.append(2 * chunk)
+
+    new_ids = torch.cat(ids_parts)
+    new_pos = torch.cat(pos_parts)
+    lens = torch.tensor(new_lengths, dtype=torch.int32, device=cu_seqlens.device)
+    new_cu = torch.zeros(num_seqs + 1, dtype=torch.int32, device=cu_seqlens.device)
+    torch.cumsum(lens, dim=0, out=new_cu[1:])
+    return new_ids, new_pos, new_cu, max(new_lengths)
+
+
+__all__ = [
+    "split_packed_for_cp",
+    "zigzag_position_ids_for_cp",
+    "zigzag_split_for_cp",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/linear.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/linear.py
@@ -1,0 +1,439 @@
+"""TP-parallel linear layers and vocab-parallel embedding/output."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+import transformer_engine.pytorch as te  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.utils import ensure_divisible
+
+if TYPE_CHECKING:
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+
+# ---------------------------------------------------------------------------
+# Vanilla column-parallel linear (torch.matmul kernel, NOT TE).
+#
+# Matches Megatron-Core `tensor_parallel.ColumnParallelLinear` bit-for-bit
+# in bf16: same `torch.matmul(input, weight.t())` forward, same
+# all-reduce-on-backward-grad_input pattern. Use this for heads like the
+# vocab LM projection where MC's GPT model uses vanilla torch matmul
+# (hardcoded in `LinearCrossEntropyModule(tensor_parallel.ColumnParallelLinear)`)
+# — TE's `te.Linear` uses a different cuBLAS algo selection that introduces
+# ~3e-4 loss-level drift under bf16 vs torch.matmul.
+#
+# For QKV / MoE experts we still prefer the TE path (fused LN+linear, FP8
+# readiness) — this vanilla path is a drop-in substitute only when kernel
+# parity with bridge is required.
+# ---------------------------------------------------------------------------
+
+
+class _VanillaColParallelMatmul(torch.autograd.Function):
+    """forward: output = matmul(input, weight.t()) — replicated input, sharded output.
+    backward: grad_input = grad_output @ weight (+ all-reduce across TP);
+              grad_weight = grad_output.T @ input.
+    Mirrors MC `LinearWithGradAccumulationAndAsyncCommunication`.
+    """
+
+    @staticmethod
+    def forward(ctx, input_, weight, tp_group):
+        ctx.save_for_backward(input_, weight)
+        ctx.tp_group = tp_group
+        return torch.matmul(input_, weight.t())
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input_, weight = ctx.saved_tensors
+        grad_input = grad_output.matmul(weight)
+        if ctx.tp_group is not None and dist.get_world_size(ctx.tp_group) > 1:
+            dist.all_reduce(grad_input, group=ctx.tp_group)
+        # grad_weight = grad_output^T @ input (sum over leading dims).
+        gi = grad_output.reshape(-1, grad_output.shape[-1])
+        xi = input_.reshape(-1, input_.shape[-1])
+        grad_weight = gi.t().matmul(xi)
+        return grad_input, grad_weight, None
+
+
+class _VanillaColParallelMatmulSP(torch.autograd.Function):
+    """SP-aware column-parallel matmul matching MC's
+    `ColumnParallelLinear(sequence_parallel=True)` kernel bit-for-bit.
+
+    forward:
+      - all-gather input along dim-0 from [S/tp, B, H] → [S, B, H]
+      - matmul(gathered, weight.t()) → [S, B, V/tp]
+    backward:
+      - grad_input_full = grad_output @ weight  → [S, B, H]
+      - reduce-scatter dim-0 → [S/tp, B, H]
+      - grad_weight = grad_output^T @ gathered_input
+    """
+
+    @staticmethod
+    def forward(ctx, input_, weight, tp_group):
+        ws = dist.get_world_size(tp_group) if tp_group is not None else 1
+        if ws > 1:
+            s_local = input_.shape[0]
+            total_shape = (s_local * ws, *input_.shape[1:])
+            total_input = torch.empty(
+                total_shape, dtype=input_.dtype, device=input_.device,
+            )
+            dist.all_gather_into_tensor(total_input, input_.contiguous(), group=tp_group)
+        else:
+            total_input = input_
+        ctx.save_for_backward(total_input, weight)
+        ctx.tp_group = tp_group
+        ctx.tp_size = ws
+        ctx.local_s = input_.shape[0]
+        return torch.matmul(total_input, weight.t())
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        total_input, weight = ctx.saved_tensors
+        grad_input_full = grad_output.matmul(weight)
+        if ctx.tp_size > 1:
+            out_shape = (ctx.local_s, *grad_input_full.shape[1:])
+            grad_input = torch.empty(
+                out_shape,
+                dtype=grad_input_full.dtype,
+                device=grad_input_full.device,
+            )
+            dist.reduce_scatter_tensor(
+                grad_input, grad_input_full.contiguous(), group=ctx.tp_group,
+            )
+        else:
+            grad_input = grad_input_full
+        gi = grad_output.reshape(-1, grad_output.shape[-1])
+        xi = total_input.reshape(-1, total_input.shape[-1])
+        grad_weight = gi.t().matmul(xi)
+        return grad_input, grad_weight, None
+
+
+class _VanillaColLinear(nn.Module):
+    """Drop-in for `te.Linear(parallel_mode='column')` using torch.matmul.
+
+    Shape: `self.weight` is (out_features_per_tp, in_features). Exposes
+    `.weight` at the same attribute path as TE Linear for checkpoint-loader
+    compatibility.
+
+    When `sp=True`, input is assumed SP-sharded on dim-0; forward gathers
+    before matmul and backward reduce-scatters grad_input — matching MC's
+    `ColumnParallelLinear(sequence_parallel=True)` bit-for-bit. When
+    `sp=False`, input is assumed replicated and grad_input is all-reduced.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        ps: ParallelState,
+        *,
+        sp: bool = False,
+    ):
+        super().__init__()
+        self.tp_group = ps.tp_group
+        self.tp_size = ps.tp_size
+        self.sp = sp
+        local_out = ensure_divisible(out_features, ps.tp_size)
+        self.weight = nn.Parameter(
+            torch.empty(local_out, in_features, dtype=torch.bfloat16)
+        )
+        nn.init.xavier_uniform_(self.weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.sp:
+            return _VanillaColParallelMatmulSP.apply(x, self.weight, self.tp_group)
+        return _VanillaColParallelMatmul.apply(x, self.weight, self.tp_group)
+
+
+class VanillaColumnParallelLinear(nn.Module):
+    """Public vanilla column-parallel linear matching MCore torch matmul."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        ps: ParallelState,
+        *,
+        sp: bool = False,
+        gather_output: bool = False,
+    ):
+        super().__init__()
+        self.linear = _VanillaColLinear(in_features, out_features, ps, sp=sp)
+        self.tp_size = ps.tp_size
+        self.tp_group = ps.tp_group
+        self.gather_output = gather_output
+
+    @property
+    def weight(self) -> torch.nn.Parameter:
+        return self.linear.weight
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.linear(x)
+        if self.gather_output and self.tp_size > 1:
+            out = _AllGatherLastDim.apply(out, self.tp_size, self.tp_group)
+        return out
+
+
+class ColumnParallelLinear(nn.Module):
+    """TE-based column-parallel linear. Splits output dim across TP."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        ps: ParallelState,
+        bias: bool = False,
+        gather_output: bool = False,
+        normalization: str | None = None,
+        eps: float = 1e-6,
+        zero_centered_gamma: bool = False,
+        sequence_parallel: bool | None = None,
+    ):
+        super().__init__()
+        self.tp_size = ps.tp_size
+        self.tp_rank = ps.tp_rank
+        self.tp_group = ps.tp_group
+        self.local_out = ensure_divisible(out_features, ps.tp_size)
+        self.use_sp = ps.tp_size > 1 and not gather_output if sequence_parallel is None else sequence_parallel
+        if normalization is not None:
+            self.linear = te.LayerNormLinear(
+                in_features,
+                out_features,
+                bias=bias,
+                normalization=normalization,
+                eps=eps,
+                zero_centered_gamma=zero_centered_gamma,
+                params_dtype=torch.bfloat16,
+                parallel_mode="column",
+                sequence_parallel=self.use_sp,
+                tp_group=ps.tp_group,
+                tp_size=ps.tp_size,
+            )
+        else:
+            self.linear = te.Linear(
+                in_features,
+                out_features,
+                bias=bias,
+                params_dtype=torch.bfloat16,
+                parallel_mode="column",
+                sequence_parallel=self.use_sp,
+                tp_group=ps.tp_group,
+                tp_size=ps.tp_size,
+            )
+        self.gather_output = gather_output
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.linear(x)
+        if self.gather_output and self.tp_size > 1:
+            out = _AllGatherLastDim.apply(out, self.tp_size, self.tp_group)
+        return out
+
+
+class RowParallelLinear(nn.Module):
+    """TE-based row-parallel linear. Splits input dim across TP."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        ps: ParallelState,
+        bias: bool = False,
+        input_is_parallel: bool = True,
+    ):
+        super().__init__()
+        self.tp_size = ps.tp_size
+        self.tp_rank = ps.tp_rank
+        self.tp_group = ps.tp_group
+        self.use_sp = ps.tp_size > 1
+        self.local_in = ensure_divisible(in_features, ps.tp_size)
+        self.linear = te.Linear(
+            in_features,
+            out_features,
+            bias=bias,
+            params_dtype=torch.bfloat16,
+            parallel_mode="row",
+            sequence_parallel=self.use_sp,
+            tp_group=ps.tp_group,
+            tp_size=ps.tp_size,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+def pad_vocab_for_tp(vocab_size: int, tp_size: int) -> int:
+    """Round vocab up to be divisible by `lcm(128, tp_size)`.
+
+    Matches MC's `_vocab_size_with_padding(..., make_vocab_size_divisible_by=128)`:
+    pad to 128-multiple for GEMM alignment, and also require tp-divisibility.
+    For typical `tp_size ∈ {1,2,4,...,128}`, `lcm = 128` so a vocab already
+    divisible by 128 (e.g. Qwen3-MoE's 151936) stays unchanged — which is
+    what MC's `output_layer` sees, and what the lite logits vocab dim
+    is. Using `128 * tp_size` instead would over-pad (e.g. 151936 → 152064
+    at tp=2), introducing 128 extra logits into the vocab-parallel cross-
+    entropy log-sum-exp and driving a ~3e-4 loss drift.
+    """
+    import math
+
+    divisor = math.lcm(128, tp_size)
+    return ((vocab_size + divisor - 1) // divisor) * divisor
+
+
+class VocabParallelEmbedding(nn.Module):
+    """Embedding table split across TP on the vocab dimension."""
+
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        ps: ParallelState,
+        *,
+        deterministic: bool = False,
+    ):
+        super().__init__()
+        self.tp_size = ps.tp_size
+        self.tp_rank = ps.tp_rank
+        self.deterministic = bool(deterministic)
+        padded_vocab = pad_vocab_for_tp(vocab_size, ps.tp_size)
+        self.local_vocab = ensure_divisible(padded_vocab, ps.tp_size)
+        self.vocab_start = self.tp_rank * self.local_vocab
+        self.vocab_end = self.vocab_start + self.local_vocab
+        self.embedding = nn.Embedding(self.local_vocab, hidden_size)
+        self.tp_group = ps.tp_group
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        # input_ids: [B, S] → out: [S, B, H]
+        mask = (input_ids >= self.vocab_start) & (input_ids < self.vocab_end)
+        local_ids = (input_ids - self.vocab_start).clamp(min=0, max=self.local_vocab - 1)
+        if self.deterministic:
+            out = self.embedding.weight[local_ids]
+        else:
+            out = self.embedding(local_ids)
+        out = out * mask.unsqueeze(-1)
+        if self.tp_size > 1:
+            out = _ReduceFromTP.apply(out, self.tp_group)
+        return out.transpose(0, 1).contiguous()
+
+
+class _ColForLMHead(nn.Module):
+    """Thin wrapper exposing `.linear` (with `.weight`) for checkpoint-loader
+    compat, switchable between TE and vanilla torch.matmul kernel.
+
+    `sp=True` threads to the underlying linear: vanilla uses the SP-aware
+    matmul (gather-in / reduce-scatter-on-bwd); TE uses `sequence_parallel=True`
+    on `te.Linear`. Both match MC's `output_layer(sequence_parallel=True)`
+    semantics so the upstream final_layernorm can run on SP-sharded input.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        ps: ParallelState,
+        *,
+        backend: str = "vanilla",
+        sp: bool = False,
+    ):
+        super().__init__()
+        if backend == "vanilla":
+            # Matches MC's LinearCrossEntropyModule → tensor_parallel.ColumnParallelLinear
+            # kernel bit-for-bit in bf16. Preferred for LM head parity with bridge.
+            self.linear = _VanillaColLinear(in_features, out_features, ps, sp=sp)
+        elif backend == "te":
+            # TE-backed path — cuBLAS algo may differ from MC's torch.matmul
+            # under bf16, producing ~3e-4 loss-level drift. Keep for future
+            # FP8 / fused-norm paths.
+            _wrapper = ColumnParallelLinear(
+                in_features, out_features, ps,
+                bias=False, gather_output=not sp,
+            )
+            self.linear = _wrapper.linear
+        else:
+            raise ValueError(f"Unknown LM-head backend: {backend!r}")
+
+
+class VocabParallelOutput(nn.Module):
+    """Output projection split across TP on the vocab dimension (column parallel).
+
+    Default backend is `"vanilla"` (torch.matmul) to match bridge backend's
+    `tensor_parallel.ColumnParallelLinear` bit-for-bit. Pass `backend="te"`
+    to use TE's `te.Linear` kernel (e.g. for FP8 inference paths).
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        ps: ParallelState,
+        *,
+        backend: str = "vanilla",
+    ):
+        super().__init__()
+        padded_vocab = pad_vocab_for_tp(vocab_size, ps.tp_size)
+        # SP-aware head: when tp>1 we run on SP-sharded input (matches MC
+        # GPTModel where final_layernorm runs on SP-sharded hiddens and
+        # output_layer gathers internally + reduce-scatters on backward).
+        self.col = _ColForLMHead(
+            hidden_size, padded_vocab, ps, backend=backend, sp=ps.tp_size > 1,
+        )
+        self.padded_vocab = padded_vocab
+        self.local_vocab = padded_vocab // ps.tp_size
+        self.vocab_size = vocab_size
+        self.ps = ps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.col.linear(x)
+
+    def gather(self, logits: torch.Tensor) -> torch.Tensor:
+        """All-gather TP-sharded logits and trim to actual vocab_size."""
+        if self.ps.tp_size > 1:
+            chunks = [torch.empty_like(logits) for _ in range(self.ps.tp_size)]
+            dist.all_gather(chunks, logits, group=self.ps.tp_group)
+            logits = torch.cat(chunks, dim=-1)
+        return logits[..., :self.vocab_size]
+
+
+class _AllGatherLastDim(torch.autograd.Function):
+    """all-gather along last dim; backward = take local shard."""
+
+    @staticmethod
+    def forward(ctx, x, tp_size, group):
+        ctx.tp_size = tp_size
+        ctx.group = group
+        ctx.local_dim = x.shape[-1]
+        ctx.rank = dist.get_rank(group)
+        chunks = [torch.empty_like(x) for _ in range(tp_size)]
+        dist.all_gather(chunks, x.contiguous(), group=group)
+        return torch.cat(chunks, dim=-1)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        start = ctx.rank * ctx.local_dim
+        return grad_output[..., start:start + ctx.local_dim].contiguous(), None, None
+
+
+class _ReduceFromTP(torch.autograd.Function):
+    """all-reduce forward; identity backward."""
+
+    @staticmethod
+    def forward(ctx, x, group):
+        out = x.clone()
+        dist.all_reduce(out, group=group)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return grad_output, None
+
+
+__all__ = [
+    "ColumnParallelLinear",
+    "RowParallelLinear",
+    "VanillaColumnParallelLinear",
+    "VocabParallelEmbedding",
+    "VocabParallelOutput",
+    "pad_vocab_for_tp",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -1,0 +1,800 @@
+"""Pipeline parallel: 1F1B schedule with correct backward handling."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.utils import ensure_divisible
+
+if TYPE_CHECKING:
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+
+def forward_backward_pipelining(
+    forward_step_fn: Callable,
+    model_chunks: list,
+    data_iter,
+    config,
+    ps: ParallelState,
+    tensor_shape: tuple[int, ...] | None = None,
+    grad_sync_fn: Callable[[], None] | None = None,
+    pre_forward_hook: Callable[[torch.Tensor], None] | None = None,
+    loss_fn: Callable | None = None,
+    forward_only: bool = False,
+) -> list[dict]:
+    """
+    Run forward and backward passes with pipeline parallelism.
+
+    Args:
+        forward_step_fn: Callable(model, batch) -> output_dict with "loss" and "hidden_states"
+        model_chunks: local model chunks. ``len>1`` enables interleaved VPP.
+        data_iter: iterator yielding micro-batches
+        config: training config
+        ps: parallel state
+        tensor_shape: shape of hidden states passed between stages [B, S, H]
+        grad_sync_fn: called before the last micro-batch's backward to enable
+                       overlapped gradient ReduceScatter in DistributedOptimizer.
+
+    Returns:
+        List of output dicts from forward passes.
+    """
+    if ps.pp_size <= 1:
+        if forward_only:
+            return _forward_only_no_pipeline(
+                forward_step_fn,
+                model_chunks[0],
+                data_iter,
+                config,
+                ps,
+                pre_forward_hook=pre_forward_hook,
+                loss_fn=loss_fn,
+            )
+        return _no_pipeline(
+            forward_step_fn,
+            model_chunks[0],
+            data_iter,
+            config,
+            ps,
+            grad_sync_fn=grad_sync_fn,
+            pre_forward_hook=pre_forward_hook,
+            loss_fn=loss_fn,
+        )
+
+    if tensor_shape is None:
+        raise ValueError("tensor_shape is required when PP > 1")
+
+    num_microbatches = _num_microbatches_from_config(config, ps)
+
+    if forward_only:
+        return _forward_only_pipeline_schedule(
+            forward_step_fn,
+            model_chunks,
+            data_iter,
+            num_microbatches,
+            ps,
+            tensor_shape,
+            pre_forward_hook=pre_forward_hook,
+            loss_fn=loss_fn,
+        )
+
+    if len(model_chunks) > 1:
+        return _interleaved_1f1b_schedule(
+            forward_step_fn,
+            model_chunks,
+            data_iter,
+            num_microbatches,
+            config,
+            ps,
+            tensor_shape,
+            grad_sync_fn=grad_sync_fn,
+            pre_forward_hook=pre_forward_hook,
+            loss_fn=loss_fn,
+        )
+
+    return _1f1b_schedule(
+        forward_step_fn,
+        model_chunks[0],
+        data_iter,
+        num_microbatches,
+        config,
+        ps,
+        tensor_shape,
+        grad_sync_fn=grad_sync_fn,
+        pre_forward_hook=pre_forward_hook,
+        loss_fn=loss_fn,
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# No pipeline (PP=1)
+# ══════════════════════════════════════════════════════════════════════
+def _num_microbatches_from_config(config, ps: ParallelState) -> int:
+    explicit = getattr(config, "num_microbatches", None)
+    if explicit is not None:
+        return int(explicit)
+    return ensure_divisible(config.gbs, config.mbs * ps.dp_size)
+
+
+def _set_aux_loss_scale(pre_forward_hook, num_microbatches: int) -> None:
+    if pre_forward_hook is not None:
+        scale = torch.tensor(1.0 / num_microbatches, device="cuda")
+        pre_forward_hook(scale)
+
+
+def _batch_get(batch, key: str):
+    if isinstance(batch, dict):
+        return batch.get(key)
+    return getattr(batch, key, None)
+
+
+def _batch_input_ids(batch):
+    input_ids = _batch_get(batch, "input_ids")
+    if input_ids is not None and input_ids.dim() == 1:
+        input_ids = input_ids.unsqueeze(0)
+    return input_ids
+
+
+def _apply_external_loss(out: dict, batch, loss_fn) -> tuple[torch.Tensor, dict] | tuple[None, None]:
+    if loss_fn is None:
+        return None, None
+    loss, metrics = loss_fn(out, batch)
+    out["loss"] = loss
+    out["_loss_fn_metrics"] = metrics
+    return loss, metrics
+
+
+def _compact_pipeline_output(out: dict | None) -> dict:
+    if not out:
+        return {}
+    compact: dict = {}
+    if "_verl_model_output" in out:
+        compact["model_output"] = out["_verl_model_output"]
+    if "loss" in out and out["loss"] is not None:
+        loss = out["loss"]
+        compact["loss"] = loss.detach().item() if isinstance(loss, torch.Tensor) else float(loss)
+    if "_loss_fn_metrics" in out:
+        compact["metrics"] = out["_loss_fn_metrics"]
+    elif "_verl_metrics" in out:
+        compact["metrics"] = out["_verl_metrics"]
+    return compact
+
+
+def _no_pipeline(
+    forward_step_fn,
+    model,
+    data_iter,
+    config,
+    ps,
+    *,
+    grad_sync_fn=None,
+    pre_forward_hook=None,
+    loss_fn=None,
+):
+    num_microbatches = _num_microbatches_from_config(config, ps)
+    outputs = []
+    for i in range(num_microbatches):
+        if grad_sync_fn and i == num_microbatches - 1:
+            grad_sync_fn()
+        batch = next(data_iter)
+        _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+        output = forward_step_fn(model, batch)
+        if loss_fn is not None:
+            loss, _metrics = _apply_external_loss(output, batch, loss_fn)
+            assert loss is not None
+        else:
+            loss = output["loss"]
+        loss = loss / num_microbatches
+        loss.backward()
+        outputs.append(_compact_pipeline_output(output))
+    return outputs
+
+
+def _forward_only_no_pipeline(
+    forward_step_fn,
+    model,
+    data_iter,
+    config,
+    ps,
+    *,
+    pre_forward_hook=None,
+    loss_fn=None,
+):
+    num_microbatches = _num_microbatches_from_config(config, ps)
+    del ps
+    outputs = []
+    for _ in range(num_microbatches):
+        batch = next(data_iter)
+        _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+        output = forward_step_fn(model, batch)
+        _apply_external_loss(output, batch, loss_fn)
+        outputs.append(_compact_pipeline_output(output))
+    return outputs
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 1F1B Schedule
+# ══════════════════════════════════════════════════════════════════════
+def _1f1b_schedule(
+    forward_step_fn,
+    model,
+    data_iter,
+    num_microbatches: int,
+    config,
+    ps: ParallelState,
+    tensor_shape: tuple[int, ...],
+    *,
+    grad_sync_fn=None,
+    pre_forward_hook=None,
+    loss_fn=None,
+):
+    """
+    1-Forward-1-Backward pipeline schedule using batch_isend_irecv.
+
+    Communication is always done via combined send+recv to avoid deadlocks.
+    """
+    num_warmup = min(ps.pp_size - ps.pp_rank - 1, num_microbatches)
+    num_steady = num_microbatches - num_warmup
+
+    batches = [next(data_iter) for _ in range(num_microbatches)]
+    mb_idx = 0
+
+    input_tensors: list[torch.Tensor | None] = []
+    output_hiddens: list[torch.Tensor | None] = []
+    losses: list[torch.Tensor | None] = []
+    outputs: list[dict] = []
+
+    # Fix 3: Pre-allocate recv buffers to avoid torch.empty per P2P call.
+    _fwd_recv_buf = (
+        torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
+        if not ps.pp_is_first
+        else None
+    )
+    _bwd_recv_buf = (
+        torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
+        if not ps.pp_is_last
+        else None
+    )
+
+    def _run_forward(input_tensor, batch):
+        _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+        position_ids = _batch_get(batch, "position_ids")
+        packed_seq_params = _batch_get(batch, "packed_seq_params")
+        if ps.pp_is_first:
+            return forward_step_fn(model, batch)
+        if ps.pp_is_last:
+            out = model(
+                input_ids=_batch_input_ids(batch),
+                hidden_states=input_tensor,
+                position_ids=position_ids,
+                packed_seq_params=packed_seq_params,
+                labels=_batch_get(batch, "labels"),
+                loss_mask=_batch_get(batch, "loss_mask"),
+                temperature=_batch_get(batch, "temperature") or 1.0,
+                use_fused_kernels=bool(_batch_get(batch, "use_fused_kernels") or False),
+                calculate_entropy=bool(_batch_get(batch, "calculate_entropy") or False),
+            )
+            _apply_external_loss(out, batch, loss_fn)
+            return out
+        return model(
+            hidden_states=input_tensor,
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+        )
+
+    def _run_backward(inp_t, hid_t, loss_t, grad_t):
+        if ps.pp_is_last:
+            if loss_t is not None:
+                loss_t.backward()
+        else:
+            if hid_t is not None and hid_t.requires_grad:
+                torch.autograd.backward(hid_t, grad_t)
+        return inp_t.grad if inp_t is not None else None
+
+    def _p2p(send_fwd=None, send_bwd=None, recv_fwd=False, recv_bwd=False):
+        return _send_recv_pipeline(
+            send_fwd,
+            send_bwd,
+            recv_fwd,
+            recv_bwd,
+            ps,
+            tensor_shape,
+            fwd_recv_buf=_fwd_recv_buf,
+            bwd_recv_buf=_bwd_recv_buf,
+        )
+
+    # ── Warmup: pure forward passes ──
+    fwd_input: torch.Tensor | None = None
+    for k in range(num_warmup):
+        if not ps.pp_is_first and k == 0:
+            fwd_input, _ = _p2p(recv_fwd=True)
+
+        batch = batches[mb_idx]
+        mb_idx += 1
+        current_input = fwd_input
+        out = _run_forward(fwd_input, batch)
+        hidden = out.get("hidden_states")
+        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+
+        need_recv_next = not ps.pp_is_first and k < num_warmup - 1
+        if not ps.pp_is_last:
+            fwd_input, _ = _p2p(send_fwd=hidden, recv_fwd=need_recv_next)
+        elif need_recv_next:
+            fwd_input, _ = _p2p(recv_fwd=True)
+
+        input_tensors.append(current_input if not ps.pp_is_first else None)
+        output_hiddens.append(hidden)
+        losses.append(loss_s)
+        # Fix 4: only keep loss from output, drop logits/hidden references
+        outputs.append(_compact_pipeline_output(out))
+
+    # ── Steady: interleaved forward + backward ──
+    for k in range(num_steady):
+        if grad_sync_fn and num_warmup == 0 and k == num_steady - 1:
+            grad_sync_fn()
+
+        if not ps.pp_is_first and k == 0 and num_warmup == 0:
+            fwd_input, _ = _p2p(recv_fwd=True)
+
+        batch = batches[mb_idx]
+        mb_idx += 1
+        out = _run_forward(fwd_input, batch)
+        hidden = out.get("hidden_states")
+        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+
+        input_tensors.append(fwd_input if not ps.pp_is_first else None)
+        output_hiddens.append(hidden)
+        losses.append(loss_s)
+        outputs.append(_compact_pipeline_output(out))
+
+        send_fwd = hidden if not ps.pp_is_last else None
+        need_bwd = not ps.pp_is_last
+        _, bwd_grad = _p2p(send_fwd=send_fwd, recv_bwd=need_bwd)
+
+        old_inp = input_tensors.pop(0)
+        old_hid = output_hiddens.pop(0)
+        old_loss = losses.pop(0)
+        in_grad = _run_backward(old_inp, old_hid, old_loss, bwd_grad)
+
+        send_bwd = in_grad if not ps.pp_is_first else None
+        need_fwd = not ps.pp_is_first and k < num_steady - 1
+        fwd_input, _ = _p2p(send_bwd=send_bwd, recv_fwd=need_fwd)
+
+    # ── Cooldown: drain remaining backwards ──
+    for k in range(num_warmup):
+        if grad_sync_fn and k == num_warmup - 1:
+            grad_sync_fn()
+
+        need_bwd = not ps.pp_is_last
+        _, bwd_grad = _p2p(recv_bwd=need_bwd)
+
+        old_inp = input_tensors.pop(0)
+        old_hid = output_hiddens.pop(0)
+        old_loss = losses.pop(0)
+        in_grad = _run_backward(old_inp, old_hid, old_loss, bwd_grad)
+
+        send_bwd = in_grad if not ps.pp_is_first else None
+        if send_bwd is not None:
+            _p2p(send_bwd=send_bwd)
+
+    return outputs
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Pipeline communication helpers
+# ══════════════════════════════════════════════════════════════════════
+_PIPELINE_TENSOR_DTYPE = torch.bfloat16
+
+
+def _deallocate_output_tensor(tensor: torch.Tensor | None) -> None:
+    """Free a large output tensor after it has been sent to the next stage."""
+    if tensor is not None:
+        tensor.data = torch.empty(1, device=tensor.device, dtype=tensor.dtype)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Interleaved 1F1B (VPP) Schedule
+# ══════════════════════════════════════════════════════════════════════
+def _build_schedule_table(
+    num_microbatches: int,
+    num_chunks: int,
+    group_size: int,
+) -> list[tuple[int, int]]:
+    """Build (microbatch_id, model_chunk_id) table for VPP scheduling."""
+    table: list[tuple[int, int]] = []
+    for start in range(0, num_microbatches, group_size):
+        end = min(start + group_size, num_microbatches)
+        for chunk in range(num_chunks):
+            for mb in range(start, end):
+                table.append((mb, chunk))
+    return table
+
+
+def _send_recv_pipeline(
+    send_fwd: torch.Tensor | None,
+    send_bwd: torch.Tensor | None,
+    recv_fwd: bool,
+    recv_bwd: bool,
+    ps: ParallelState,
+    tensor_shape: tuple[int, ...],
+    *,
+    fwd_recv_buf: torch.Tensor | None = None,
+    bwd_recv_buf: torch.Tensor | None = None,
+    batch_p2p: bool = True,
+    clone_recv: bool = False,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """P2P communication between pipeline stages."""
+    _dbg = int(os.environ.get("MEGATRON_LITE_PP_DEBUG", "0"))
+    rank = dist.get_rank()
+
+    ops: list[dist.P2POp] = []
+    fwd_buf: torch.Tensor | None = None
+    bwd_buf: torch.Tensor | None = None
+
+    p2p_group = ps.pp_group
+
+    if send_fwd is not None:
+        t = send_fwd.to(_PIPELINE_TENSOR_DTYPE)
+        ops.append(dist.P2POp(dist.isend, t, ps.pp_next_rank, p2p_group))
+    if recv_fwd:
+        fwd_buf = (
+            fwd_recv_buf
+            if fwd_recv_buf is not None
+            else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
+        )
+        ops.append(dist.P2POp(dist.irecv, fwd_buf, ps.pp_prev_rank, p2p_group))
+    if send_bwd is not None:
+        t = send_bwd.to(_PIPELINE_TENSOR_DTYPE)
+        ops.append(dist.P2POp(dist.isend, t, ps.pp_prev_rank, p2p_group))
+    if recv_bwd:
+        bwd_buf = (
+            bwd_recv_buf
+            if bwd_recv_buf is not None
+            else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
+        )
+        ops.append(dist.P2POp(dist.irecv, bwd_buf, ps.pp_next_rank, p2p_group))
+
+    if ops:
+        if _dbg:
+            desc = []
+            if send_fwd is not None:
+                desc.append(f"send_fwd→{ps.pp_next_rank}({list(send_fwd.shape)})")
+            if recv_fwd:
+                desc.append(f"recv_fwd←{ps.pp_prev_rank}")
+            if send_bwd is not None:
+                desc.append(f"send_bwd→{ps.pp_prev_rank}")
+            if recv_bwd:
+                desc.append(f"recv_bwd←{ps.pp_next_rank}")
+            op_name = "batch_isend_irecv" if batch_p2p else "isend_irecv"
+            print(f"[P2P r{rank}] {op_name}: {' '.join(desc)}", flush=True)
+        if batch_p2p:
+            reqs = dist.batch_isend_irecv(ops)
+        else:
+            direct_tensors = []
+            reqs = []
+            if send_fwd is not None:
+                t = send_fwd.to(_PIPELINE_TENSOR_DTYPE)
+                direct_tensors.append(t)
+                reqs.append(dist.isend(t, ps.pp_next_rank, group=p2p_group))
+            if recv_fwd:
+                reqs.append(dist.irecv(fwd_buf, ps.pp_prev_rank, group=p2p_group))
+            if send_bwd is not None:
+                t = send_bwd.to(_PIPELINE_TENSOR_DTYPE)
+                direct_tensors.append(t)
+                reqs.append(dist.isend(t, ps.pp_prev_rank, group=p2p_group))
+            if recv_bwd:
+                reqs.append(dist.irecv(bwd_buf, ps.pp_next_rank, group=p2p_group))
+        for req in reqs:
+            req.wait()
+        if _dbg:
+            print(f"[P2P r{rank}] batch done", flush=True)
+
+    if fwd_buf is not None:
+        if clone_recv:
+            fwd_buf = fwd_buf.clone()
+        fwd_buf.grad = None
+        fwd_buf.requires_grad_()
+    if bwd_buf is not None and clone_recv:
+        bwd_buf = bwd_buf.clone()
+    return fwd_buf, bwd_buf
+
+
+def _pipeline_stage_barrier(ps: ParallelState) -> None:
+    if ps.pp_cpu_group is not None and ps.pp_size > 1:
+        dist.barrier(group=ps.pp_cpu_group)
+
+
+def _set_virtual_pipeline_rank(chunk_id: int | None, num_chunks: int) -> None:
+    if chunk_id is None or num_chunks <= 1:
+        return
+    try:
+        from megatron.core import parallel_state as mpu  # pyright: ignore[reportMissingImports]
+    except Exception:
+        return
+    if not mpu.is_initialized():
+        return
+    vpp_size = mpu.get_virtual_pipeline_model_parallel_world_size()
+    if vpp_size is not None and vpp_size > 1:
+        mpu.set_virtual_pipeline_model_parallel_rank(chunk_id)
+
+
+def _run_pipeline_chunk_forward(
+    forward_step_fn,
+    model,
+    batch,
+    input_tensor: torch.Tensor | None,
+    *,
+    is_first_stage: bool,
+    is_last_stage: bool,
+    num_microbatches: int,
+    pre_forward_hook=None,
+    loss_fn=None,
+) -> dict:
+    _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+    position_ids = _batch_get(batch, "position_ids")
+    packed_seq_params = _batch_get(batch, "packed_seq_params")
+    if is_first_stage:
+        return forward_step_fn(model, batch)
+    if is_last_stage:
+        out = model(
+            input_ids=_batch_input_ids(batch),
+            hidden_states=input_tensor,
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+            labels=_batch_get(batch, "labels"),
+            loss_mask=_batch_get(batch, "loss_mask"),
+            temperature=_batch_get(batch, "temperature") or 1.0,
+            use_fused_kernels=bool(_batch_get(batch, "use_fused_kernels") or False),
+            calculate_entropy=bool(_batch_get(batch, "calculate_entropy") or False),
+        )
+        _apply_external_loss(out, batch, loss_fn)
+        return out
+    return model(
+        hidden_states=input_tensor,
+        position_ids=position_ids,
+        packed_seq_params=packed_seq_params,
+    )
+
+
+def _forward_only_pipeline_schedule(
+    forward_step_fn,
+    model_chunks: list,
+    data_iter,
+    num_microbatches: int,
+    ps: ParallelState,
+    tensor_shape: tuple[int, ...],
+    *,
+    pre_forward_hook=None,
+    loss_fn=None,
+):
+    """Simple PP/VPP forward-only schedule used for log-prob inference."""
+    num_chunks = len(model_chunks)
+    total_stages = ps.pp_size * num_chunks
+    outputs: list[dict] = []
+
+    for _mb in range(num_microbatches):
+        batch = next(data_iter)
+        _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+        pending_activation: torch.Tensor | None = None
+        last_output: dict | None = None
+        for stage_id in range(total_stages):
+            stage_pp_rank = stage_id % ps.pp_size
+            is_local_stage = stage_pp_rank == ps.pp_rank
+            hidden: torch.Tensor | None = None
+            if is_local_stage:
+                chunk_id = stage_id // ps.pp_size
+                _set_virtual_pipeline_rank(chunk_id, num_chunks)
+                model = model_chunks[chunk_id]
+                is_first_stage = stage_id == 0
+                is_last_stage = stage_id == total_stages - 1
+                activation = None if is_first_stage else pending_activation
+                pending_activation = None
+                out = _run_pipeline_chunk_forward(
+                    forward_step_fn,
+                    model,
+                    batch,
+                    activation,
+                    is_first_stage=is_first_stage,
+                    is_last_stage=is_last_stage,
+                    num_microbatches=num_microbatches,
+                    pre_forward_hook=None,
+                    loss_fn=loss_fn,
+                )
+                if is_last_stage:
+                    last_output = out
+                else:
+                    hidden = out.get("hidden_states")
+
+            if stage_id < total_stages - 1:
+                recv_next = (stage_id + 1) % ps.pp_size == ps.pp_rank
+                _pipeline_stage_barrier(ps)
+                fwd_buf, _ = _send_recv_pipeline(
+                    hidden if is_local_stage else None,
+                    None,
+                    recv_next,
+                    False,
+                    ps,
+                    tensor_shape,
+                    batch_p2p=False,
+                    clone_recv=True,
+                )
+                if recv_next:
+                    pending_activation = fwd_buf
+
+        outputs.append(_compact_pipeline_output(last_output) if last_output is not None else {})
+
+    return outputs
+
+
+def _interleaved_1f1b_schedule(
+    forward_step_fn,
+    model_chunks: list,
+    data_iter,
+    num_microbatches: int,
+    config,
+    ps: ParallelState,
+    tensor_shape: tuple[int, ...],
+    *,
+    grad_sync_fn=None,
+    pre_forward_hook=None,
+    loss_fn=None,
+):
+    """
+    Correct non-overlapped schedule for Virtual Pipeline Parallelism (VPP).
+
+    Local chunks are laid out in global layer order as
+    ``chunk_id * pp_size + pp_rank``.  The previous interleaved 1F1B bringup
+    schedule could ask the first physical PP stage to receive the next virtual
+    chunk before the last physical stage had produced it.  This schedule keeps
+    the same VPP semantics but runs one micro-batch at a time in global stage
+    order, which is slower but deterministic and easy to validate against
+    Megatron.
+    """
+    num_chunks = len(model_chunks)
+    total_stages = ps.pp_size * num_chunks
+    rank = dist.get_rank()
+    outputs: list[dict] = []
+
+    _dbg = int(os.environ.get("MEGATRON_LITE_PP_DEBUG", "0"))
+    if _dbg:
+        print(
+            f"[VPP r{rank}] entered simple schedule pp_rank={ps.pp_rank} "
+            f"microbatches={num_microbatches} chunks={num_chunks} total_stages={total_stages}",
+            flush=True,
+        )
+
+    for mb_id in range(num_microbatches):
+        batch = next(data_iter)
+        _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+        saved: dict[int, tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, dict]] = {}
+        pending_activation: torch.Tensor | None = None
+
+        # Forward in true virtual-stage order:
+        # chunk0/rank0 -> chunk0/rank1 -> ... -> chunkN/rankP.
+        for stage_id in range(total_stages):
+            stage_pp_rank = stage_id % ps.pp_size
+            is_local_stage = stage_pp_rank == ps.pp_rank
+            hidden: torch.Tensor | None = None
+            if is_local_stage:
+                chunk_id = stage_id // ps.pp_size
+                _set_virtual_pipeline_rank(chunk_id, num_chunks)
+                model = model_chunks[chunk_id]
+                is_first_stage = stage_id == 0
+                is_last_stage = stage_id == total_stages - 1
+                activation = None if is_first_stage else pending_activation
+                pending_activation = None
+                if _dbg:
+                    activation_shape = None if activation is None else tuple(activation.shape)
+                    print(
+                        f"[VPP r{rank}] mb={mb_id} fwd stage={stage_id} "
+                        f"chunk={chunk_id} activation_shape={activation_shape}",
+                        flush=True,
+                    )
+                out = _run_pipeline_chunk_forward(
+                    forward_step_fn,
+                    model,
+                    batch,
+                    activation,
+                    is_first_stage=is_first_stage,
+                    is_last_stage=is_last_stage,
+                    num_microbatches=num_microbatches,
+                    pre_forward_hook=None,
+                    loss_fn=loss_fn,
+                )
+
+                hidden = out.get("hidden_states")
+                if _dbg:
+                    hidden_shape = None if hidden is None else tuple(hidden.shape)
+                    print(
+                        f"[VPP r{rank}] mb={mb_id} fwd stage={stage_id} "
+                        f"chunk={chunk_id} hidden_shape={hidden_shape}",
+                        flush=True,
+                    )
+                loss = out["loss"] / num_microbatches if is_last_stage and "loss" in out else None
+                saved[stage_id] = (activation, hidden, loss, out)
+
+                if is_last_stage:
+                    outputs.append(_compact_pipeline_output(out))
+
+            if stage_id < total_stages - 1:
+                recv_next = (stage_id + 1) % ps.pp_size == ps.pp_rank
+                if _dbg and (is_local_stage or recv_next):
+                    print(
+                        f"[VPP r{rank}] mb={mb_id} fwd boundary={stage_id} "
+                        f"send={is_local_stage and hidden is not None} recv_next={recv_next}",
+                        flush=True,
+                    )
+                _pipeline_stage_barrier(ps)
+                fwd_buf, _ = _send_recv_pipeline(
+                    hidden if is_local_stage else None,
+                    None,
+                    recv_next,
+                    False,
+                    ps,
+                    tensor_shape,
+                    batch_p2p=False,
+                    clone_recv=True,
+                )
+                if recv_next:
+                    pending_activation = fwd_buf
+
+        if grad_sync_fn and mb_id == num_microbatches - 1:
+            grad_sync_fn()
+
+        # Backward in the reverse virtual-stage order.
+        pending_grad: torch.Tensor | None = None
+        for stage_id in range(total_stages - 1, -1, -1):
+            stage_pp_rank = stage_id % ps.pp_size
+            is_local_stage = stage_pp_rank == ps.pp_rank
+            inp_grad: torch.Tensor | None = None
+            if is_local_stage:
+                chunk_id = stage_id // ps.pp_size
+                _set_virtual_pipeline_rank(chunk_id, num_chunks)
+                is_first_stage = stage_id == 0
+                is_last_stage = stage_id == total_stages - 1
+                inp, out_t, loss, _out = saved[stage_id]
+                grad = None if is_last_stage else pending_grad
+                pending_grad = None
+                if _dbg:
+                    print(f"[VPP r{rank}] mb={mb_id} bwd stage={stage_id}", flush=True)
+                if is_last_stage:
+                    if loss is not None:
+                        loss.backward()
+                elif out_t is not None and out_t.requires_grad:
+                    torch.autograd.backward(out_t, grad)
+                if not is_first_stage:
+                    inp_grad = inp.grad if inp is not None else None
+
+            if stage_id > 0:
+                recv_prev = (stage_id - 1) % ps.pp_size == ps.pp_rank
+                if _dbg and (is_local_stage or recv_prev):
+                    print(
+                        f"[VPP r{rank}] mb={mb_id} bwd boundary={stage_id} "
+                        f"send={is_local_stage and inp_grad is not None} recv_prev={recv_prev}",
+                        flush=True,
+                    )
+                _pipeline_stage_barrier(ps)
+                _, bwd_buf = _send_recv_pipeline(
+                    None,
+                    inp_grad if is_local_stage else None,
+                    False,
+                    recv_prev,
+                    ps,
+                    tensor_shape,
+                    batch_p2p=False,
+                    clone_recv=True,
+                )
+                if recv_prev:
+                    pending_grad = bwd_buf
+
+        if _dbg:
+            print(f"[VPP r{rank}] mb={mb_id} complete", flush=True)
+
+    return outputs
+
+
+__all__ = ["forward_backward_pipelining"]

--- a/experimental/lite/megatron/lite/primitive/parallel/pp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pp.py
@@ -1,0 +1,56 @@
+"""Context/pipeline parallel sequence splitting utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from megatron.lite.primitive.utils import ensure_divisible
+
+if TYPE_CHECKING:
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+
+@dataclass
+class PipelineChunkLayout:
+    layer_indices: list[int] = field(default_factory=list)
+    has_embed: bool = False
+    has_head: bool = False
+
+
+def build_pipeline_chunk_layout(
+    num_hidden_layers: int,
+    ps: ParallelState,
+    vpp: int | None = None,
+    vpp_chunk_id: int | None = None,
+) -> PipelineChunkLayout:
+    """Compute layer_indices, has_embed, has_head for this PP rank / VPP chunk."""
+    if vpp_chunk_id is not None:
+        assert vpp is not None
+        layers_per_chunk = ensure_divisible(num_hidden_layers, ps.pp_size * vpp)
+        start = ps.pp_rank * layers_per_chunk + vpp_chunk_id * (ps.pp_size * layers_per_chunk)
+        layer_indices = list(range(start, start + layers_per_chunk))
+        has_embed = ps.pp_is_first and vpp_chunk_id == 0
+        has_head = ps.pp_is_last and vpp_chunk_id == vpp - 1
+    elif vpp is not None:
+        layers_per_chunk = ensure_divisible(num_hidden_layers, ps.pp_size * vpp)
+        layer_indices = []
+        for chunk in range(vpp):
+            start = ps.pp_rank * layers_per_chunk + chunk * (ps.pp_size * layers_per_chunk)
+            layer_indices.extend(range(start, start + layers_per_chunk))
+        has_embed = ps.pp_is_first
+        has_head = ps.pp_is_last
+    else:
+        layers_per_stage = ensure_divisible(num_hidden_layers, ps.pp_size)
+        start = ps.pp_rank * layers_per_stage
+        layer_indices = list(range(start, start + layers_per_stage))
+        has_embed = ps.pp_is_first
+        has_head = ps.pp_is_last
+    return PipelineChunkLayout(
+        layer_indices=layer_indices,
+        has_embed=has_embed,
+        has_head=has_head,
+    )
+
+
+__all__ = ["PipelineChunkLayout", "build_pipeline_chunk_layout"]

--- a/experimental/lite/megatron/lite/primitive/parallel/sp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/sp.py
@@ -1,0 +1,40 @@
+"""Sequence parallel scatter/gather helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.ops.sp_ops import AllGatherDim0, AllGatherDim0ForNonSPConsumer, ScatterToSP
+
+if TYPE_CHECKING:
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+
+def scatter_to_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+    """Scatter [S, B, H] → [S/tp, B, H] for sequence parallel. No-op when tp=1."""
+    if ps.tp_size == 1:
+        return x
+    return ScatterToSP.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
+
+
+def gather_from_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+    """Gather [S/tp, B, H] → [S, B, H] from sequence parallel. No-op when tp=1."""
+    if ps.tp_size == 1:
+        return x
+    return AllGatherDim0.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
+
+
+def gather_for_non_sp_head(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+    """AllGather for non-SP consumer (e.g. vocab parallel head)."""
+    if ps.tp_size == 1:
+        return x
+    return AllGatherDim0ForNonSPConsumer.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
+
+
+__all__ = [
+    "gather_for_non_sp_head",
+    "gather_from_sequence_parallel",
+    "scatter_to_sequence_parallel",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/state.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/state.py
@@ -1,0 +1,191 @@
+"""ParallelState and process group initialization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.utils import ensure_divisible
+
+
+@dataclass
+class ParallelState:
+    tp_group: dist.ProcessGroup | None = None
+    ep_group: dist.ProcessGroup | None = None
+    etp_group: dist.ProcessGroup | None = None
+    cp_group: dist.ProcessGroup | None = None
+    pp_group: dist.ProcessGroup | None = None
+    pp_cpu_group: dist.ProcessGroup | None = None
+    dp_group: dist.ProcessGroup | None = None
+    dp_cp_group: dist.ProcessGroup | None = None
+    tp_ep_group: dist.ProcessGroup | None = None
+    ep_dp_group: dist.ProcessGroup | None = None
+    cp_global_ranks: list[int] | None = None
+    pp_global_ranks: list[int] | None = None
+
+    tp_size: int = 1
+    ep_size: int = 1
+    etp_size: int = 1
+    cp_size: int = 1
+    pp_size: int = 1
+    dp_size: int = 1
+    dp_cp_size: int = 1
+    expert_dp_size: int = 1
+
+    tp_rank: int = 0
+    ep_rank: int = 0
+    etp_rank: int = 0
+    cp_rank: int = 0
+    pp_rank: int = 0
+    dp_rank: int = 0
+    dp_cp_rank: int = 0
+    expert_dp_rank: int = 0
+
+    pp_is_first: bool = True
+    pp_is_last: bool = True
+    pp_next_rank: int = -1
+    pp_prev_rank: int = -1
+
+
+def init_parallel(config) -> ParallelState:
+    """
+    Initialize all process groups using dual rank decomposition.
+
+    Dense layers: world = TP × CP × PP × DP
+    Expert layers: world = ETP × EP × PP × expert_DP
+    """
+    assert dist.is_initialized(), "Call torch.distributed.init_process_group first"
+
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    tp, ep, etp, cp, pp = config.tp, config.ep, config.etp, config.cp, config.pp
+    assert etp == 1, "ETP>1 is temporarily disabled pending fix"
+
+    dense_dp = ensure_divisible(world, tp * cp * pp)
+    expert_dp = ensure_divisible(world, etp * ep * pp)
+
+    ps = ParallelState()
+    ps.tp_size, ps.ep_size, ps.etp_size = tp, ep, etp
+    ps.cp_size, ps.pp_size, ps.dp_size = cp, pp, dense_dp
+    ps.expert_dp_size = expert_dp
+    ps.dp_cp_size = dense_dp * cp
+
+    def _d(tp_i, cp_i, dp_i, pp_i):
+        return ((pp_i * dense_dp + dp_i) * cp + cp_i) * tp + tp_i
+
+    def _e(etp_i, ep_i, edp_i, pp_i):
+        return ((pp_i * expert_dp + edp_i) * ep + ep_i) * etp + etp_i
+
+    t = rank
+    my_tp = t % tp
+    t //= tp
+    my_cp = t % cp
+    t //= cp
+    my_ddp = t % dense_dp
+    t //= dense_dp
+    my_pp = t
+
+    t = rank
+    my_etp = t % etp
+    t //= etp
+    my_ep = t % ep
+    t //= ep
+    my_edp = t % expert_dp
+    t //= expert_dp
+    assert t == my_pp, "PP rank must agree between dense and expert decompositions"
+
+    ps.tp_rank, ps.cp_rank, ps.dp_rank, ps.pp_rank = my_tp, my_cp, my_ddp, my_pp
+    ps.dp_cp_rank = my_ddp * cp + my_cp
+    ps.ep_rank, ps.etp_rank, ps.expert_dp_rank = my_ep, my_etp, my_edp
+    ps.pp_is_first = my_pp == 0
+    ps.pp_is_last = my_pp == pp - 1
+
+    for d in range(dense_dp):
+        for p in range(pp):
+            for c in range(cp):
+                ranks = [_d(t, c, d, p) for t in range(tp)]
+                g = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.tp_group = g
+
+    for d in range(dense_dp):
+        for p in range(pp):
+            for t in range(tp):
+                ranks = [_d(t, c, d, p) for c in range(cp)]
+                g = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.cp_group = g
+                    ps.cp_global_ranks = ranks
+
+    for d in range(dense_dp):
+        for c in range(cp):
+            for t in range(tp):
+                ranks = [_d(t, c, d, p) for p in range(pp)]
+                g = dist.new_group(ranks)
+                try:
+                    cpu_g = dist.new_group(ranks, backend="gloo")
+                except (RuntimeError, ValueError):
+                    cpu_g = None
+                if rank in ranks:
+                    ps.pp_group = g
+                    ps.pp_cpu_group = cpu_g
+                    ps.pp_global_ranks = ranks
+
+    for p in range(pp):
+        for c in range(cp):
+            for t in range(tp):
+                ranks = [_d(t, c, d, p) for d in range(dense_dp)]
+                g = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.dp_group = g
+
+    for p in range(pp):
+        for t in range(tp):
+            ranks = [_d(t, c, d, p) for d in range(dense_dp) for c in range(cp)]
+            g = dist.new_group(ranks)
+            if rank in ranks:
+                ps.dp_cp_group = g
+
+    for d in range(expert_dp):
+        for p in range(pp):
+            for t in range(etp):
+                ranks = [_e(t, e, d, p) for e in range(ep)]
+                g = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.ep_group = g
+
+    if etp > 1:
+        for d in range(expert_dp):
+            for p in range(pp):
+                for e in range(ep):
+                    ranks = [_e(t, e, d, p) for t in range(etp)]
+                    g = dist.new_group(ranks)
+                    if rank in ranks:
+                        ps.etp_group = g
+
+    for d in range(expert_dp):
+        for p in range(pp):
+            ranks = [_e(t, e, d, p) for e in range(ep) for t in range(etp)]
+            g = dist.new_group(ranks)
+            if rank in ranks:
+                ps.tp_ep_group = g
+
+    for p in range(pp):
+        for e in range(ep):
+            for t in range(etp):
+                ranks = [_e(t, e, d, p) for d in range(expert_dp)]
+                g = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.ep_dp_group = g
+
+    pp_ranks = ps.pp_global_ranks
+    if pp_ranks is None:
+        raise RuntimeError("Pipeline ranks were not initialized.")
+    ps.pp_next_rank = pp_ranks[(my_pp + 1) % pp] if pp > 1 else rank
+    ps.pp_prev_rank = pp_ranks[(my_pp - 1) % pp] if pp > 1 else rank
+
+    return ps
+
+
+__all__ = ["ParallelState", "init_parallel"]

--- a/experimental/lite/megatron/lite/primitive/parallel/thd.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/thd.py
@@ -1,0 +1,462 @@
+"""Packed sequence helpers for variable-length (THD) attention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+
+@dataclass
+class PackedSeqParams:
+    """Parameters for THD-format packed-sequence attention.
+
+    Mirrors the fields consumed by TE's ``DotProductAttention.forward()``
+    when ``qkv_format="thd"`` is used (total-tokens x heads x dim).
+
+    Typical construction::
+
+        params = PackedSeqParams.from_cu_seqlens(batch.cu_seqlens, batch.max_seqlen)
+    """
+
+    qkv_format: str = "thd"
+    cu_seqlens_q: torch.Tensor | None = None
+    cu_seqlens_kv: torch.Tensor | None = None
+    max_seqlen_q: int | None = None
+    max_seqlen_kv: int | None = None
+    cu_seqlens_q_padded: torch.Tensor | None = None
+    cu_seqlens_kv_padded: torch.Tensor | None = None
+    local_cp_size: int | None = None
+    cp_group: Any | None = None
+    cp_rank: int | None = None
+
+    @staticmethod
+    def from_cu_seqlens(cu_seqlens: torch.Tensor, max_seqlen: int) -> PackedSeqParams:
+        """Build from shared Q/KV cu_seqlens (self-attention)."""
+        return PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+        )
+
+
+@dataclass(frozen=True)
+class PackedTHDBatch:
+    """Dense packed representation of a jagged no-padding batch."""
+
+    input_ids: torch.Tensor
+    labels: torch.Tensor | None
+    loss_mask: torch.Tensor | None
+    position_ids: torch.Tensor
+    packed_seq_params: Any
+    cu_seqlens_padded: torch.Tensor
+    lengths: torch.Tensor
+    padded_lengths: torch.Tensor
+    cp_size: int = 1
+    cp_rank: int = 0
+    cp_group: Any | None = None
+
+
+def _make_packed_seq_params(
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    max_seqlen: int,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+    cp_group: Any | None = None,
+):
+    extra_args = {}
+    if cp_size > 1:
+        extra_args["local_cp_size"] = cp_size
+        if cp_group is not None:
+            extra_args["cp_group"] = cp_group
+    try:
+        from megatron.core.packed_seq_params import PackedSeqParams as MCorePackedSeqParams
+
+        params = MCorePackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens_padded,
+            cu_seqlens_kv=cu_seqlens_padded,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            cu_seqlens_q_padded=cu_seqlens_padded,
+            cu_seqlens_kv_padded=cu_seqlens_padded,
+            **extra_args,
+        )
+        # MCore's PackedSeqParams does not carry rank, but local rolling needs it.
+        params.cp_rank = cp_rank
+        return params
+    except Exception:
+        return PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens_padded,
+            cu_seqlens_kv=cu_seqlens_padded,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            cu_seqlens_q_padded=cu_seqlens_padded,
+            cu_seqlens_kv_padded=cu_seqlens_padded,
+            cp_rank=cp_rank,
+            **extra_args,
+        )
+
+
+def _slice_along_dim(tensor: torch.Tensor, dim: int, start: int, end: int) -> torch.Tensor:
+    index = [slice(None)] * tensor.dim()
+    index[dim] = slice(start, end)
+    return tensor[tuple(index)]
+
+
+def _assign_along_dim(dst: torch.Tensor, dim: int, start: int, src: torch.Tensor) -> None:
+    index = [slice(None)] * dst.dim()
+    index[dim] = slice(start, start + src.size(dim))
+    dst[tuple(index)] = src
+
+
+def _split_full_to_cp_local(
+    tensor: torch.Tensor,
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    cp_size: int,
+    cp_rank: int,
+    dim: int,
+) -> torch.Tensor:
+    if cp_size <= 1:
+        return tensor
+
+    total_local = int(cu_seqlens_padded[-1].item()) // cp_size
+    out_shape = list(tensor.shape)
+    out_shape[dim] = total_local
+    local = torch.zeros(out_shape, dtype=tensor.dtype, device=tensor.device)
+
+    for idx in range(int(cu_seqlens_padded.numel()) - 1):
+        full_start = int(cu_seqlens_padded[idx].item())
+        full_end = int(cu_seqlens_padded[idx + 1].item())
+        padded_len = full_end - full_start
+        if padded_len <= 0:
+            continue
+        chunk = padded_len // (2 * cp_size)
+        local_start = full_start // cp_size
+
+        first = _slice_along_dim(
+            tensor,
+            dim,
+            full_start + cp_rank * chunk,
+            full_start + (cp_rank + 1) * chunk,
+        )
+        second = _slice_along_dim(
+            tensor,
+            dim,
+            full_end - (cp_rank + 1) * chunk,
+            full_end - cp_rank * chunk,
+        )
+        _assign_along_dim(local, dim, local_start, first)
+        _assign_along_dim(local, dim, local_start + chunk, second)
+
+    return local
+
+
+def _reconstruct_full_from_cp_parts(
+    parts: list[torch.Tensor],
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    cp_size: int,
+    dim: int,
+) -> torch.Tensor:
+    if cp_size <= 1:
+        return parts[0]
+
+    total_full = int(cu_seqlens_padded[-1].item())
+    out_shape = list(parts[0].shape)
+    out_shape[dim] = total_full
+    full = torch.zeros(out_shape, dtype=parts[0].dtype, device=parts[0].device)
+
+    for idx in range(int(cu_seqlens_padded.numel()) - 1):
+        full_start = int(cu_seqlens_padded[idx].item())
+        full_end = int(cu_seqlens_padded[idx + 1].item())
+        padded_len = full_end - full_start
+        if padded_len <= 0:
+            continue
+        chunk = padded_len // (2 * cp_size)
+        local_start = full_start // cp_size
+
+        for rank, part in enumerate(parts):
+            first = _slice_along_dim(part, dim, local_start, local_start + chunk)
+            second = _slice_along_dim(part, dim, local_start + chunk, local_start + 2 * chunk)
+            _assign_along_dim(full, dim, full_start + rank * chunk, first)
+            _assign_along_dim(full, dim, full_end - (rank + 1) * chunk, second)
+
+    return full
+
+
+def _all_gather_cp_tensor(tensor: torch.Tensor, *, cp_size: int, cp_group: Any) -> list[torch.Tensor]:
+    if cp_size <= 1:
+        return [tensor]
+    if cp_group is None:
+        raise ValueError("CP THD gather requires cp_group.")
+    try:
+        from torch.distributed.nn.functional import all_gather
+
+        return list(all_gather(tensor, group=cp_group))
+    except Exception:
+        parts = [torch.empty_like(tensor) for _ in range(cp_size)]
+        dist.all_gather(parts, tensor, group=cp_group)
+        return parts
+
+
+def _roll_packed_thd_left_local(
+    tensor: torch.Tensor,
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    dims: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    dim = dims if dims >= 0 else tensor.dim() + dims
+    if dim < 0 or dim >= tensor.dim():
+        raise ValueError(f"Invalid roll dim {dims} for tensor with {tensor.dim()} dims.")
+
+    rolled = tensor.clone()
+    for idx in range(int(cu_seqlens_padded.numel()) - 1):
+        start = int(cu_seqlens_padded[idx].item())
+        end = int(cu_seqlens_padded[idx + 1].item())
+        if end <= start:
+            continue
+
+        index = [slice(None)] * tensor.dim()
+        index[dim] = slice(start, end)
+        seq = torch.roll(tensor[tuple(index)], shifts=-1, dims=dim)
+
+        zero_index = [slice(None)] * seq.dim()
+        zero_index[dim] = slice(-1, None)
+        seq[tuple(zero_index)] = 0
+        rolled[tuple(index)] = seq
+
+    return rolled, rolled.sum()
+
+
+def roll_packed_thd_left(
+    tensor: torch.Tensor,
+    *,
+    cu_seqlens_padded: torch.Tensor | None = None,
+    packed_seq_params: Any | None = None,
+    dims: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Roll a THD packed tensor left without crossing sequence boundaries."""
+
+    cp_size = 1
+    cp_rank = 0
+    cp_group = None
+    if packed_seq_params is not None:
+        cu_seqlens_padded = getattr(packed_seq_params, "cu_seqlens_q", None)
+        cp_size = int(getattr(packed_seq_params, "local_cp_size", None) or 1)
+        cp_rank = int(getattr(packed_seq_params, "cp_rank", 0) or 0)
+        cp_group = getattr(packed_seq_params, "cp_group", None)
+    if cu_seqlens_padded is None:
+        raise ValueError("THD packed roll requires cu_seqlens.")
+
+    dim = dims if dims >= 0 else tensor.dim() + dims
+    if cp_size <= 1:
+        return _roll_packed_thd_left_local(tensor, cu_seqlens_padded=cu_seqlens_padded, dims=dim)
+
+    parts = _all_gather_cp_tensor(tensor, cp_size=cp_size, cp_group=cp_group)
+    full = _reconstruct_full_from_cp_parts(
+        parts,
+        cu_seqlens_padded=cu_seqlens_padded,
+        cp_size=cp_size,
+        dim=dim,
+    )
+    rolled_full, token_sum = _roll_packed_thd_left_local(
+        full,
+        cu_seqlens_padded=cu_seqlens_padded,
+        dims=dim,
+    )
+    local = _split_full_to_cp_local(
+        rolled_full,
+        cu_seqlens_padded=cu_seqlens_padded,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        dim=dim,
+    )
+    return local, token_sum
+
+
+def pack_nested_thd(
+    input_ids: torch.Tensor,
+    *,
+    tp_size: int = 1,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+    cp_group: Any | None = None,
+    labels: torch.Tensor | None = None,
+    roll_labels: bool = False,
+    loss_mask: torch.Tensor | None = None,
+    roll_loss_mask: bool = False,
+) -> PackedTHDBatch:
+    """Pack a jagged no-padding batch into Megatron Lite's THD model input.
+
+    Mirrors VERL/Megatron's THD engine convention: each sequence is
+    padded to the tensor-parallel alignment, concatenated, then represented as
+    a single ``[1, local_padded_tokens]`` token row plus ``PackedSeqParams``.
+    For CP>1 the local row uses Megatron/TE zigzag chunking.
+    """
+
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be >= 1, got {cp_size}")
+    if cp_rank < 0 or cp_rank >= cp_size:
+        raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}")
+    if not getattr(input_ids, "is_nested", False):
+        raise TypeError("pack_nested_thd expects a jagged NestedTensor input_ids.")
+    if labels is not None and not getattr(labels, "is_nested", False):
+        raise TypeError("pack_nested_thd expects jagged NestedTensor labels when labels are provided.")
+    if loss_mask is not None and not getattr(loss_mask, "is_nested", False):
+        raise TypeError("pack_nested_thd expects jagged NestedTensor loss_mask when loss_mask is provided.")
+
+    align_size = max(int(tp_size), 1) * (2 * cp_size if cp_size > 1 else 1)
+    device = input_ids.device
+    offsets = input_ids.offsets().to(device=device)
+    lengths = offsets.diff().to(dtype=torch.int32)
+    pad_size = (align_size - lengths % align_size) % align_size
+    padded_lengths = lengths + pad_size
+
+    cu_seqlens_padded = torch.zeros(
+        lengths.numel() + 1,
+        dtype=torch.int32,
+        device=device,
+    )
+    cu_seqlens_padded[1:] = torch.cumsum(padded_lengths, dim=0)
+    total_padded = int(cu_seqlens_padded[-1].item())
+    total_local = total_padded // cp_size
+    max_seqlen = int(padded_lengths.max().item()) if padded_lengths.numel() else 0
+
+    packed_input = torch.zeros(total_local, dtype=input_ids.dtype, device=device)
+    packed_labels = (
+        torch.zeros(total_local, dtype=labels.dtype, device=device)
+        if labels is not None
+        else None
+    )
+    packed_loss_mask = (
+        torch.zeros(total_local, dtype=loss_mask.dtype, device=device)
+        if loss_mask is not None
+        else None
+    )
+    # Megatron's rotary embedding slices position embeddings on the CP rank.
+    # Keep packed position ids full-length while CP-slicing tokens/labels/masks.
+    position_ids = torch.zeros(total_padded, dtype=torch.long, device=device)
+
+    for idx, length_t in enumerate(lengths):
+        length = int(length_t.item())
+        padded_length = int(padded_lengths[idx].item())
+        full_start = int(cu_seqlens_padded[idx].item())
+        local_start = full_start // cp_size
+
+        seq_input = torch.zeros(padded_length, dtype=input_ids.dtype, device=device)
+        seq_input[:length] = input_ids[idx]
+        seq_labels = None
+        if labels is not None:
+            assert packed_labels is not None
+            seq_labels = torch.zeros(padded_length, dtype=labels.dtype, device=device)
+            seq_labels[:length] = labels[idx]
+            if roll_labels and length > 0:
+                seq_labels[:length] = torch.roll(seq_labels[:length], shifts=-1, dims=0)
+                seq_labels[length - 1] = 0
+        seq_loss_mask = None
+        if loss_mask is not None:
+            assert packed_loss_mask is not None
+            seq_loss_mask = torch.zeros(padded_length, dtype=loss_mask.dtype, device=device)
+            seq_loss_mask[:length] = loss_mask[idx]
+            if roll_loss_mask and length > 0:
+                seq_loss_mask[:length] = torch.roll(seq_loss_mask[:length], shifts=-1, dims=0)
+                seq_loss_mask[length - 1] = 0
+        seq_positions = torch.zeros(padded_length, dtype=torch.long, device=device)
+        seq_positions[:length] = torch.arange(length, dtype=torch.long, device=device)
+
+        local_input = _split_full_to_cp_local(
+            seq_input,
+            cu_seqlens_padded=torch.tensor([0, padded_length], dtype=torch.int32, device=device),
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            dim=0,
+        )
+        packed_input[local_start : local_start + local_input.numel()] = local_input
+        if seq_labels is not None:
+            local_labels = _split_full_to_cp_local(
+                seq_labels,
+                cu_seqlens_padded=torch.tensor([0, padded_length], dtype=torch.int32, device=device),
+                cp_size=cp_size,
+                cp_rank=cp_rank,
+                dim=0,
+            )
+            assert packed_labels is not None
+            packed_labels[local_start : local_start + local_labels.numel()] = local_labels
+        if seq_loss_mask is not None:
+            local_loss_mask = _split_full_to_cp_local(
+                seq_loss_mask,
+                cu_seqlens_padded=torch.tensor([0, padded_length], dtype=torch.int32, device=device),
+                cp_size=cp_size,
+                cp_rank=cp_rank,
+                dim=0,
+            )
+            assert packed_loss_mask is not None
+            packed_loss_mask[local_start : local_start + local_loss_mask.numel()] = local_loss_mask
+        position_ids[full_start : full_start + padded_length] = seq_positions
+
+    return PackedTHDBatch(
+        input_ids=packed_input.unsqueeze(0),
+        labels=packed_labels.unsqueeze(0) if packed_labels is not None else None,
+        loss_mask=packed_loss_mask.unsqueeze(0) if packed_loss_mask is not None else None,
+        position_ids=position_ids.unsqueeze(0),
+        packed_seq_params=_make_packed_seq_params(
+            cu_seqlens_padded=cu_seqlens_padded,
+            max_seqlen=max_seqlen,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            cp_group=cp_group,
+        ),
+        cu_seqlens_padded=cu_seqlens_padded,
+        lengths=lengths,
+        padded_lengths=padded_lengths,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        cp_group=cp_group,
+    )
+
+
+def unpack_packed_thd_to_nested(output: torch.Tensor, batch: PackedTHDBatch) -> torch.Tensor:
+    """Unpack ``[1, total_padded, ...]`` THD model output back to jagged form."""
+
+    if output.dim() >= 2 and output.shape[0] == 1:
+        flat = output[0]
+    elif output.dim() >= 2 and output.shape[1] == 1:
+        flat = output[:, 0]
+    else:
+        flat = output
+
+    if batch.cp_size > 1:
+        dim = 0
+        parts = _all_gather_cp_tensor(flat, cp_size=batch.cp_size, cp_group=batch.cp_group)
+        flat = _reconstruct_full_from_cp_parts(
+            parts,
+            cu_seqlens_padded=batch.cu_seqlens_padded,
+            cp_size=batch.cp_size,
+            dim=dim,
+        )
+
+    pieces = []
+    for idx, length_t in enumerate(batch.lengths):
+        length = int(length_t.item())
+        start = int(batch.cu_seqlens_padded[idx].item())
+        pieces.append(flat[start : start + length])
+    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+
+
+__all__ = [
+    "PackedSeqParams",
+    "PackedTHDBatch",
+    "pack_nested_thd",
+    "roll_packed_thd_left",
+    "unpack_packed_thd_to_nested",
+]

--- a/experimental/lite/megatron/lite/primitive/protocols.py
+++ b/experimental/lite/megatron/lite/primitive/protocols.py
@@ -1,0 +1,28 @@
+"""Train-side lightweight protocols and defaults."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from torch.distributed.tensor import Replicate  # pyright: ignore[reportMissingImports]
+
+ExpertClassifierFn = Callable[[str], bool]
+PlacementFn = Callable[[str], list]
+
+
+def default_expert_classifier(name: str) -> bool:
+    """Default: params with 'experts' (but not 'router' or 'shared') are expert params."""
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+def default_placement_fn(name: str) -> list:
+    """Default: all Replicate (safe but no resharding benefit)."""
+    return [Replicate(), Replicate(), Replicate(), Replicate()]
+
+
+__all__ = [
+    "ExpertClassifierFn",
+    "PlacementFn",
+    "default_expert_classifier",
+    "default_placement_fn",
+]

--- a/experimental/lite/megatron/lite/primitive/recompute.py
+++ b/experimental/lite/megatron/lite/primitive/recompute.py
@@ -1,0 +1,383 @@
+"""Model-agnostic activation recompute and offload wrappers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+
+# ── CheckpointWithoutOutput ───────────────────────────────────────────────────
+# Zero-copy C++ extension: makes dst's UntypedStorage point to src's data.
+# Operates below TensorImpl level → ALL views/reshapes that share dst's StorageImpl
+# (e.g. TE GroupedLinear's inp.reshape() saved for backward) see the restored data.
+# Equivalent to MC's share_storage in megatron/core/tensor_parallel/random.py.
+_SHARE_STORAGE_SRC = r"""
+#include <torch/extension.h>
+
+void share_storage(at::Tensor dst, at::Tensor src) {
+    auto* dst_impl = dst.storage().unsafeGetStorageImpl();
+    auto* src_ref  = new c10::Storage(src.storage());
+    void*       data   = src_ref->data_ptr().get();
+    size_t      nbytes = src_ref->nbytes();
+    c10::Device device = src_ref->device();
+    c10::DataPtr shared(
+        data,
+        static_cast<void*>(src_ref),
+        [](void* ctx) { delete static_cast<c10::Storage*>(ctx); },
+        device);
+    dst_impl->set_data_ptr(std::move(shared));
+    dst_impl->set_nbytes(nbytes);
+}
+"""
+
+_share_storage_ext = None
+
+
+def _get_share_storage() -> Callable:
+    global _share_storage_ext
+    if _share_storage_ext is None:
+        from torch.utils.cpp_extension import load_inline
+
+        _share_storage_ext = load_inline(
+            name="share_storage_ext",
+            cpp_sources=_SHARE_STORAGE_SRC,
+            functions=["share_storage"],
+            verbose=False,
+        )
+    return _share_storage_ext.share_storage
+
+
+class _CheckpointWithoutOutputFn(torch.autograd.Function):
+    """Autograd Function for CheckpointWithoutOutput.
+
+    Forward: runs function with no_grad, saves inputs.
+    Backward: uses outputs/inputs set by CheckpointWithoutOutput._recompute().
+    """
+
+    @staticmethod
+    def forward(ctx, run_function, ckpt_obj, *args):
+        ctx.run_function = run_function
+        ctx.preserve_rng_state = ckpt_obj.preserve_rng_state
+        if ckpt_obj.preserve_rng_state:
+            ctx.cpu_rng_state = torch.get_rng_state()
+            ctx.cuda_rng_state = torch.cuda.get_rng_state()
+
+        ctx.tensor_indices = [i for i, a in enumerate(args) if isinstance(a, torch.Tensor)]
+        ctx.non_tensor_args = [(i, a) for i, a in enumerate(args) if not isinstance(a, torch.Tensor)]
+        ctx.num_args = len(args)
+        ctx.save_for_backward(*[a for a in args if isinstance(a, torch.Tensor)])
+
+        with torch.no_grad():
+            outputs = run_function(*args)
+
+        ckpt_obj.ctx = ctx
+        return outputs
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        # inputs and outputs are set by CheckpointWithoutOutput._recompute()
+        # before this backward runs (via the hook registered on the downstream tensor).
+        inputs = ctx.inputs
+        outputs = ctx.outputs
+        torch.autograd.backward(outputs, grad_outputs)
+        ctx.outputs = None
+        ctx.inputs = None
+        grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else None for inp in inputs)
+        return (None, None) + grads
+
+
+class CheckpointWithoutOutput:
+    """Checkpoint a function and discard its output to save memory.
+
+    Equivalent to MC's CheckpointWithoutOutput from megatron/core/tensor_parallel/random.py.
+    The output tensor's storage is freed immediately after downstream computation;
+    it is recomputed just-in-time during backward via a hook on the downstream output.
+
+    The C++ share_storage extension restores the output at the StorageImpl level so
+    that ALL aliases (including views saved by TE GroupedLinear's backward) see the data.
+
+    Usage (mirrors MC's moe_act pattern)::
+
+        ckpt = CheckpointWithoutOutput()
+        h = ckpt.checkpoint(activation_func, fc1_out, probs)
+        fc2_out = fc2(h, m_splits)
+        ckpt.discard_output_and_register_recompute(fc2_out)
+    """
+
+    def __init__(self, preserve_rng_state: bool = True):
+        self.preserve_rng_state = preserve_rng_state
+        self.run_function: Callable | None = None
+        self._cpu_rng: torch.Tensor | None = None
+        self._cuda_rng: torch.Tensor | None = None
+        self.ctx: Any | None = None
+        self.outputs: tuple[torch.Tensor, ...] | None = None
+
+    def checkpoint(self, run_function: Callable, *args) -> Any:
+        self.run_function = run_function
+        if self.preserve_rng_state:
+            self._cpu_rng = torch.get_rng_state()
+            self._cuda_rng = torch.cuda.get_rng_state()
+
+        outputs = _CheckpointWithoutOutputFn.apply(run_function, self, *args)
+        self.outputs = (outputs,) if isinstance(outputs, torch.Tensor) else tuple(outputs)
+        return outputs
+
+    def _recompute(self, _) -> None:
+        if self.ctx is None:
+            return
+
+        # Reconstruct args from saved context.
+        tensors = list(self.ctx.saved_tensors)
+        args: list = [None] * self.ctx.num_args
+        t_it = iter(tensors)
+        for i in self.ctx.tensor_indices:
+            t = next(t_it)
+            args[i] = t.detach().requires_grad_(t.requires_grad)
+        for i, val in self.ctx.non_tensor_args:
+            args[i] = val
+
+        # Recompute with forward-time RNG states.
+        if self.preserve_rng_state:
+            saved_cpu = torch.get_rng_state()
+            saved_cuda = torch.cuda.get_rng_state()
+            torch.set_rng_state(self._cpu_rng)
+            torch.cuda.set_rng_state(self._cuda_rng)
+        with torch.enable_grad():
+            outputs = self.run_function(*args)
+        if self.preserve_rng_state:
+            torch.set_rng_state(saved_cpu)
+            torch.cuda.set_rng_state(saved_cuda)
+
+        if isinstance(outputs, torch.Tensor):
+            outputs = (outputs,)
+
+        # Zero-copy: make original output's StorageImpl point to recomputed data.
+        share_storage = _get_share_storage()
+        for orig, new in zip(self.outputs, outputs, strict=False):
+            share_storage(orig, new)
+
+        self.ctx.outputs = list(outputs)
+        self.ctx.inputs = args
+        self.run_function = None
+        self._cpu_rng = None
+        self._cuda_rng = None
+        self.outputs = None
+        self.ctx = None
+
+    def reset(self) -> None:
+        """Reset state so the instance can be reused across forward passes."""
+        self.run_function = None
+        self._cpu_rng = None
+        self._cuda_rng = None
+        self.ctx = None
+        self.outputs = None
+
+    def discard_output_and_register_recompute(self, hook_tensor: torch.Tensor) -> None:
+        """Free output tensor storage; recompute when hook_tensor's grad is computed."""
+        for out in self.outputs:
+            out.untyped_storage().resize_(0)
+        if hook_tensor.requires_grad:
+            hook_tensor.register_hook(self._recompute)
+
+
+ModuleMap = dict[str, Callable[[nn.Module], nn.Module | None]]
+"""Maps module name → lambda that extracts a sub-module from a layer."""
+
+
+def apply_recompute(
+    layers: nn.ModuleList,
+    module_names: list[str],
+    module_map: ModuleMap,
+    no_rng_modules: set[str] | None = None,
+) -> None:
+    """Wrap specified sub-modules with activation checkpointing for recomputation."""
+    if not module_names:
+        return
+    no_rng = no_rng_modules or set()
+    for layer in layers:
+        if "full" in module_names:
+            wrap_checkpoint(layer)
+        else:
+            for mod_name in module_names:
+                if mod_name in module_map:
+                    submod = module_map[mod_name](layer)
+                    if submod is not None:
+                        wrap_checkpoint(
+                            submod, preserve_rng_state=mod_name not in no_rng,
+                        )
+
+
+def apply_offload(
+    layers: nn.ModuleList,
+    module_names: list[str],
+    module_map: ModuleMap,
+) -> None:
+    """Wrap specified sub-modules with activation offloading to CPU."""
+    if not module_names:
+        return
+    try:
+        from torch.utils.checkpoint import CheckpointPolicy  # noqa: F401
+    except ImportError:
+        log_rank0("WARNING: torch.utils.checkpoint policy_fn not available, skipping offload")
+        return
+    for layer in layers:
+        for mod_name in module_names:
+            if mod_name in module_map:
+                submod = module_map[mod_name](layer)
+                if submod is not None:
+                    wrap_offload(submod)
+
+
+class CheckpointFunction(torch.autograd.Function):
+    """Reentrant activation checkpoint using custom autograd.Function.
+
+    Adapted from Megatron-Core's CheckpointFunction. Key differences:
+    - No distribute_saved_activations (not needed for our TP implementation)
+    - No model-parallel RNG tracker (we use TE's built-in RNG management)
+    - Handles expert_bias restore for MoE router determinism
+    """
+
+    @staticmethod
+    def forward(
+        ctx: Any, run_function: Callable, preserve_rng_state: bool, *args: torch.Tensor,
+    ) -> Any:
+        ctx.run_function = run_function
+        ctx.preserve_rng_state = preserve_rng_state
+
+        # Save RNG states for deterministic recomputation.
+        if preserve_rng_state:
+            ctx.cpu_rng_state = torch.get_rng_state()
+            ctx.cuda_rng_state = torch.cuda.get_rng_state()
+
+        # Run forward without gradient tracking — discard intermediate activations.
+        with torch.no_grad():
+            outputs = run_function(*args)
+
+        # Save inputs for recomputation in backward.
+        ctx.save_for_backward(*args)
+        return outputs
+
+    @staticmethod
+    def backward(ctx: Any, *grad_outputs: torch.Tensor) -> tuple:
+        if not torch.autograd._is_checkpoint_valid():
+            raise RuntimeError(
+                "Checkpointing is not compatible with .grad(), use .backward() instead"
+            )
+
+        inputs = ctx.saved_tensors
+
+        # Fork RNG: restore forward-time states, then reset to current after recompute.
+        if ctx.preserve_rng_state:
+            current_cpu_rng = torch.get_rng_state()
+            current_cuda_rng = torch.cuda.get_rng_state()
+            torch.set_rng_state(ctx.cpu_rng_state)
+            torch.cuda.set_rng_state(ctx.cuda_rng_state)
+
+        # Recompute forward pass with gradients enabled.
+        detached = tuple(
+            t.detach().requires_grad_(t.requires_grad) if isinstance(t, torch.Tensor) else t
+            for t in inputs
+        )
+        with torch.enable_grad():
+            outputs = ctx.run_function(*detached)
+
+        # Restore RNG states.
+        if ctx.preserve_rng_state:
+            torch.set_rng_state(current_cpu_rng)
+            torch.cuda.set_rng_state(current_cuda_rng)
+
+        if isinstance(outputs, torch.Tensor):
+            outputs = (outputs,)
+
+        # Filter to outputs that need gradients.
+        outputs_with_grad = []
+        grad_for_outputs = []
+        for out, grad in zip(outputs, grad_outputs, strict=False):
+            if torch.is_tensor(out) and out.requires_grad:
+                outputs_with_grad.append(out)
+                grad_for_outputs.append(grad)
+
+        if outputs_with_grad:
+            torch.autograd.backward(outputs_with_grad, grad_for_outputs)
+
+        grads = tuple(
+            inp.grad if isinstance(inp, torch.Tensor) else None for inp in detached
+        )
+        # None for run_function, None for preserve_rng_state, then grads for each input.
+        return (None, None) + grads
+
+
+def wrap_checkpoint(module: nn.Module, *, preserve_rng_state: bool = True) -> None:
+    """Wrap a module's forward with reentrant activation checkpointing."""
+    original_forward = module.forward
+    _routers = [m for m in module.modules() if hasattr(m, "expert_bias")]
+
+    def _checkpointed_forward(*args, **kwargs):
+        # expert_bias is modified in-place by the router during forward.
+        # Save and restore it so the recomputation in backward sees the same values.
+        if _routers:
+            saved = [r.expert_bias.clone() for r in _routers]
+            call_count = [0]
+
+            def _fwd(*a, **kw):
+                call_count[0] += 1
+                if call_count[0] > 1:
+                    for r, s in zip(_routers, saved, strict=False):
+                        r.expert_bias.copy_(s)
+                return original_forward(*a, **kw)
+        else:
+            _fwd = original_forward
+
+        # CheckpointFunction.apply only accepts positional tensor args.
+        # Wrap kwargs into the function closure.
+        if kwargs:
+            def _fn(*a):
+                return _fwd(*a, **kwargs)
+        else:
+            _fn = _fwd
+
+        return CheckpointFunction.apply(_fn, preserve_rng_state, *args)
+
+    module.forward = _checkpointed_forward
+
+
+def wrap_offload(module: nn.Module) -> None:
+    """Wrap a module's forward with activation offloading."""
+    original_forward = module.forward
+
+    def _offloaded_forward(*args, **kwargs):
+        return torch.utils.checkpoint.checkpoint(
+            original_forward, *args, use_reentrant=False, **kwargs,
+        )
+
+    module.forward = _offloaded_forward
+
+
+def log_rank0(msg: str) -> None:
+    if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+        print(f"[Megatron Lite] {msg}", flush=True)
+
+
+def parse_recompute_spec(recompute: str | list[str] | None) -> list[str]:
+    """Parse a recompute spec into a list of module names."""
+    if recompute is None or recompute == "none":
+        return []
+    if recompute == "full":
+        return ["full"]
+    if isinstance(recompute, list):
+        return recompute
+    return recompute.split(",")
+
+
+__all__ = [
+    "CheckpointFunction",
+    "CheckpointWithoutOutput",
+    "ModuleMap",
+    "apply_offload",
+    "apply_recompute",
+    "parse_recompute_spec",
+    "wrap_checkpoint",
+    "wrap_offload",
+]

--- a/experimental/lite/megatron/lite/primitive/train_step.py
+++ b/experimental/lite/megatron/lite/primitive/train_step.py
@@ -1,0 +1,188 @@
+"""Reusable train-step primitives owned by Megatron Lite."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import torch
+import torch.distributed as dist
+
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.protocols import ExpertClassifierFn, default_expert_classifier
+
+
+def run_microbatch_loop(
+    model,
+    data_iter,
+    num_microbatches: int,
+    forward_fn,
+    optimizer=None,
+    dist_opt: bool = False,
+    pre_forward_hook: Callable[[torch.Tensor], None] | None = None,
+    loss_fn: Callable | None = None,
+):
+    """Run forward-backward over microbatches with loss accumulation.
+
+    Args:
+        forward_fn: ``forward_fn(model, batch) -> dict`` with at least ``"loss"`` key
+            (when ``loss_fn`` is None) or model outputs (when ``loss_fn`` is provided).
+        pre_forward_hook: Optional callable ``hook(scale: torch.Tensor) -> None``
+            invoked once per microbatch, right before ``forward_fn``. ``scale`` is
+            ``1.0 / num_microbatches`` (matches MC's ``schedules.forward_step``,
+            see `pipeline_parallel/schedules.py`). Used e.g. by MoE aux-loss
+            scale-setting; runtime stays model-agnostic by passing the hook
+            through from the model bundle's extras.
+            # TODO: once CP is supported, align with MC's
+            # `schedules:297`-style scale of `cp_group_size / num_microbatches`
+            # (currently assumes ``cp_group_size == 1``).
+        loss_fn: Optional external loss function.
+            ``loss_fn(model_output: dict, batch) -> (loss: Tensor, metrics: dict)``.
+            When provided, ``forward_fn`` output is passed to ``loss_fn`` instead of
+            reading ``out["loss"]`` directly. This enables RLHF policy/value losses.
+    """
+    last_out = None
+    all_metrics: list[dict] = []
+    for mb in range(num_microbatches):
+        batch = next(data_iter)
+        if pre_forward_hook is not None:
+            scale = torch.tensor(1.0 / num_microbatches, device="cuda")
+            pre_forward_hook(scale)
+        out = forward_fn(model, batch)
+        if dist_opt and optimizer is not None and mb == num_microbatches - 1:
+            optimizer.grad_sync_enabled = True
+        if loss_fn is not None:
+            loss, metrics = loss_fn(out, batch)
+            (loss / num_microbatches).backward()
+            out["loss"] = loss.detach()
+            all_metrics.append(metrics)
+        else:
+            (out["loss"] / num_microbatches).backward()
+        last_out = out
+    if last_out is not None and all_metrics:
+        last_out["_loss_fn_metrics"] = all_metrics
+    return last_out
+
+
+def compute_and_clip_grad_norm(
+    model,
+    optimizer,
+    max_norm: float,
+    use_dist_opt: bool,
+    sp_params=None,
+    sp_group=None,
+    *,
+    report_global_norm: bool = False,
+    ps: ParallelState | None = None,
+    is_expert_param: ExpertClassifierFn = default_expert_classifier,
+):
+    """SP AllReduce + finish grad sync + clip grad norm. Returns grad_norm."""
+    if sp_params:
+        sp_grads = [p.grad for p in sp_params if p.grad is not None]
+        if sp_grads:
+            flat = torch.cat([g.view(-1) for g in sp_grads])
+            dist.all_reduce(flat, op=dist.ReduceOp.SUM, group=sp_group)
+            offset = 0
+            for g in sp_grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+    report_norm = None
+    if report_global_norm:
+        if ps is None:
+            raise ValueError("`ps` is required when `report_global_norm=True`.")
+        report_norm = compute_global_grad_norm(
+            model,
+            ps,
+            is_expert_param=is_expert_param,
+        )
+    if use_dist_opt:
+        optimizer.finish_grad_sync()
+        return optimizer.clip_grad_norm()
+    local_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
+    return report_norm if report_norm is not None else local_norm
+
+
+def compute_global_grad_norm(
+    model,
+    ps: ParallelState,
+    *,
+    is_expert_param: ExpertClassifierFn = default_expert_classifier,
+) -> torch.Tensor:
+    """Compute benchmark global grad norm with dist-opt-aligned reduction order."""
+    dense_sq = _bucketed_grad_sq_sum(
+        model,
+        include_param=lambda name: not is_expert_param(name),
+        replica_group=ps.dp_cp_group,
+        replica_size=ps.dp_cp_size,
+    )
+    expert_sq = _bucketed_grad_sq_sum(
+        model,
+        include_param=is_expert_param,
+        replica_group=ps.ep_dp_group,
+        replica_size=ps.expert_dp_size,
+    )
+
+    if ps.tp_size > 1 and ps.tp_group is not None:
+        dist.all_reduce(dense_sq, group=ps.tp_group)
+
+    if ps.ep_size > 1 and ps.ep_group is not None:
+        dist.all_reduce(expert_sq, group=ps.ep_group)
+    if ps.etp_size > 1 and ps.etp_group is not None:
+        dist.all_reduce(expert_sq, group=ps.etp_group)
+
+    total_sq = dense_sq + expert_sq
+    if ps.pp_size > 1 and ps.pp_group is not None:
+        dist.all_reduce(total_sq, group=ps.pp_group)
+    return total_sq.sqrt()
+
+
+def _bucketed_grad_sq_sum(
+    model,
+    *,
+    include_param: Callable[[str], bool],
+    replica_group,
+    replica_size: int,
+    max_bucket_bytes: int = 80 * 1024 * 1024,
+) -> torch.Tensor:
+    """Accumulate squared norm after averaging replica grads within each bucket."""
+    total_sq = torch.zeros(1, device="cuda")
+    bucket: list[torch.Tensor] = []
+    bucket_bytes = 0
+
+    def flush_bucket() -> None:
+        nonlocal bucket_bytes, bucket, total_sq
+        if not bucket:
+            return
+        flat = torch.cat(bucket)
+        if replica_size > 1 and replica_group is not None:
+            dist.all_reduce(flat, group=replica_group)
+            flat.div_(replica_size)
+        total_sq += flat.float().norm().pow(2)
+        bucket = []
+        bucket_bytes = 0
+
+    for name, param in model.named_parameters():
+        if param.grad is None or not include_param(name):
+            continue
+        grad = param.grad.view(-1)
+        grad_bytes = grad.numel() * grad.element_size()
+        if bucket and bucket_bytes + grad_bytes > max_bucket_bytes:
+            flush_bucket()
+        bucket.append(grad)
+        bucket_bytes += grad_bytes
+
+    flush_bucket()
+    return total_sq
+
+
+def optimizer_step(optimizer) -> None:
+    """Execute optimizer step."""
+    optimizer.step()
+
+
+__all__ = [
+    "compute_and_clip_grad_norm",
+    "compute_global_grad_norm",
+    "optimizer_step",
+    "run_microbatch_loop",
+]

--- a/experimental/lite/megatron/lite/primitive/utils.py
+++ b/experimental/lite/megatron/lite/primitive/utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import torch  # pyright: ignore[reportMissingImports]
+
+
+def build_fp8_recipe(train_config=None):
+    """Build the standard TE FP8 recipe (DelayedScaling, HYBRID format, H100)."""
+    from transformer_engine.common.recipe import DelayedScaling, Format
+
+    return DelayedScaling(margin=0, fp8_format=Format.HYBRID)
+
+
+def ensure_divisible(numerator: int, denominator: int, msg: str = "") -> int:
+    if numerator % denominator != 0:
+        detail = f" ({msg})" if msg else ""
+        raise ValueError(f"{numerator} is not divisible by {denominator}{detail}")
+    return numerator // denominator
+
+
+def log_rank0(msg: str) -> None:
+    if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+        print(f"[Megatron Lite] {msg}", flush=True)
+
+
+__all__ = [
+    "build_fp8_recipe",
+    "ensure_divisible",
+    "log_rank0",
+]

--- a/experimental/lite/megatron/lite/runtime/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/__init__.py
@@ -1,0 +1,79 @@
+"""Runtime entrypoints for Megatron Lite."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+from megatron.lite.runtime.contracts.config import RuntimeConfig
+
+if TYPE_CHECKING:
+    from megatron.lite.runtime.backends import Runtime
+    from megatron.lite.runtime.backends.lite.config import LiteConfig
+    from megatron.lite.runtime.contracts.data import (
+        Batch,
+        ForwardResult,
+        ModelOutputs,
+        PackedBatch,
+        TrainBatch,
+    )
+    from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+def _runtime_registry() -> dict[str, str]:
+    from megatron.lite.runtime.backends import RUNTIME_REGISTRY
+
+    return RUNTIME_REGISTRY
+
+
+def register_runtime(name: str, module_path: str) -> None:
+    """Register a custom runtime backend.
+
+    Args:
+        name: Backend name (used in ``RuntimeConfig.backend``).
+        module_path: Dotted module path providing a ``create(hf_path, cfg)`` function.
+
+    Example::
+
+        from megatron.lite.runtime import register_runtime
+        register_runtime("my_backend", "my_package.my_runtime")
+    """
+    _runtime_registry()[name] = module_path
+
+
+def create_runtime(cfg: RuntimeConfig) -> Runtime:
+    """Create a Runtime instance for the given config."""
+    mod = importlib.import_module(_runtime_registry()[cfg.backend])
+    return mod.create(cfg.hf_path, cfg.backend_cfg)
+
+
+def __getattr__(name: str):
+    _lazy = {
+        "Batch": "megatron.lite.runtime.contracts.data",
+        "LiteConfig": "megatron.lite.runtime.backends.lite.config",
+        "ForwardResult": "megatron.lite.runtime.contracts.data",
+        "ModelHandle": "megatron.lite.runtime.contracts.handle",
+        "ModelOutputs": "megatron.lite.runtime.contracts.data",
+        "PackedBatch": "megatron.lite.runtime.contracts.data",
+        "Runtime": "megatron.lite.runtime.backends",
+        "TrainBatch": "megatron.lite.runtime.contracts.data",
+    }
+    if name in _lazy:
+        mod = importlib.import_module(_lazy[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "Batch",
+    "ForwardResult",
+    "LiteConfig",
+    "ModelHandle",
+    "ModelOutputs",
+    "PackedBatch",
+    "Runtime",
+    "RuntimeConfig",
+    "TrainBatch",
+    "create_runtime",
+    "register_runtime",
+]

--- a/experimental/lite/megatron/lite/runtime/backends/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/__init__.py
@@ -1,0 +1,178 @@
+"""Runtime ABC and registry.
+
+Runtime API tiers
+-----------------
+L1 — **Pretrain Ready** (9 abstract methods, must implement):
+    build_model, save_checkpoint, load_checkpoint,
+    train_mode, eval_mode,
+    forward_backward, zero_grad, optimizer_step, lr_scheduler_step
+
+L2 — **RL Ready** (+ export_weights):
+    Enables RL frameworks to extract weights for the inference engine.
+
+L3 — **RL Best** (+ to):
+    Enables offloading model/optimizer/grad between training and rollout
+    phases to free GPU memory for the inference engine.
+
+A new backend only needs to implement L1 to work for pretraining.
+Override ``export_weights`` and/or ``to`` to unlock higher tiers.
+Check ``runtime.tier`` to see which level a backend supports.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterator
+from typing import Any, Literal
+
+import torch
+
+from megatron.lite.runtime.contracts.data import ForwardResult
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+class Runtime(ABC):
+    """Base class for runtime implementations."""
+
+    # ── L1: Pretrain Ready (必须实现) ────────────────────────────
+
+    # Model lifecycle
+
+    @abstractmethod
+    def build_model(
+        self,
+        hf_path: str | None = None,
+        cfg: Any = None,
+        **kwargs,
+    ) -> ModelHandle:
+        """Build model state for this runtime.
+
+        Implementations should default to the ``hf_path`` / ``backend_cfg``
+        captured by ``create_runtime(RuntimeConfig(...))``. Passing arguments to
+        ``build_model`` is supported as an advanced override path, but public
+        examples should prefer ``handle = rt.build_model()``.
+        """
+        ...
+
+    @abstractmethod
+    def save_checkpoint(self, handle: ModelHandle, path: str, **kwargs) -> None: ...
+
+    @abstractmethod
+    def load_checkpoint(self, handle: ModelHandle, path: str, **kwargs) -> None: ...
+
+    # Mode switching
+
+    @abstractmethod
+    def train_mode(self, handle: ModelHandle) -> Any: ...
+
+    @abstractmethod
+    def eval_mode(self, handle: ModelHandle) -> Any: ...
+
+    # Training atoms
+
+    @abstractmethod
+    def forward_backward(
+        self,
+        handle: ModelHandle,
+        data: Any,
+        loss_fn: Callable | None,
+        *,
+        num_microbatches: int = 1,
+        forward_only: bool = False,
+    ) -> ForwardResult:
+        """Forward + backward pass over data.
+
+        Args:
+            num_microbatches: Number of microbatches to accumulate inside one
+                logical training step.
+            loss_fn: Optional external loss function with signature::
+
+                loss_fn(model_output: dict, batch) -> (loss: Tensor, metrics: dict)
+
+            When ``loss_fn`` is None, the model computes loss internally
+            (standard pretrain/SFT path).  When provided, ``model_output``
+            is the dict returned by the model's forward (logits, log_probs, etc.)
+            and ``batch`` is the current microbatch.
+        """
+        ...
+
+    @abstractmethod
+    def zero_grad(self, handle: ModelHandle) -> None: ...
+
+    @abstractmethod
+    def optimizer_step(self, handle: ModelHandle) -> tuple[bool, float, int]:
+        """Run optimizer step.
+
+        Returns:
+            (update_successful, grad_norm, num_zeros_in_grad)
+        """
+        ...
+
+    @abstractmethod
+    def lr_scheduler_step(self, handle: ModelHandle) -> float | list[float]: ...
+
+    # ── Parallel state queries ───────────────────────────────────
+
+    def is_mp_src_rank_with_outputs(self, handle: ModelHandle) -> bool:
+        """True if this rank is PP-last, TP-0, CP-0 (has full output)."""
+        return True  # default: no parallelism, every rank has outputs
+
+    # ── L2: RL Ready (覆盖即解锁) ───────────────────────────────
+
+    def export_weights(
+        self, handle: ModelHandle, **kwargs,
+    ) -> Iterator[tuple[str, torch.Tensor]]:
+        """Iterate over (name, tensor) pairs for HF-compatible weight export.
+
+        Required by RL frameworks to send weights to the inference engine.
+        Override to unlock **RL Ready** tier.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement export_weights. "
+            "Implement it to unlock the RL Ready tier."
+        )
+
+    # ── L3: RL Best (覆盖即解锁) ────────────────────────────────
+
+    def to(
+        self,
+        handle: ModelHandle,
+        device: str,
+        *,
+        model: bool = True,
+        optimizer: bool = True,
+        grad: bool = True,
+    ) -> None:
+        """Move model / optimizer / gradients to *device*.
+
+        Enables offloading between training and rollout phases so the
+        inference engine can reclaim GPU memory.
+        Override to unlock **RL Best** tier.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement to(). "
+            "Implement it to unlock the RL Best tier."
+        )
+
+    # ── Tier introspection ──────────────────────────────────────
+
+    @property
+    def tier(self) -> Literal["pretrain", "rl_ready", "rl_best"]:
+        """Report the highest API tier this runtime supports."""
+        cls = type(self)
+        has_export = cls.export_weights is not Runtime.export_weights
+        has_to = cls.to is not Runtime.to
+        if has_export and has_to:
+            return "rl_best"
+        if has_export:
+            return "rl_ready"
+        return "pretrain"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+RUNTIME_REGISTRY: dict[str, str] = {
+    "lite": "megatron.lite.runtime.backends.lite",
+}

--- a/experimental/lite/megatron/lite/runtime/backends/lite/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/lite/__init__.py
@@ -1,0 +1,17 @@
+"""Megatron Lite runtime backend."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from megatron.lite.runtime.backends import Runtime as RuntimeBase
+from megatron.lite.runtime.backends.lite.config import LiteConfig
+from megatron.lite.runtime.backends.lite.runtime import MegatronLiteRuntime
+
+
+def create(hf_path: str, cfg: LiteConfig | dict[str, Any]) -> RuntimeBase:
+    """Factory called by create_runtime.
+
+    create_runtime escape hatch is checked inside MegatronLiteRuntime.build_model().
+    """
+    return MegatronLiteRuntime(hf_path, cfg)

--- a/experimental/lite/megatron/lite/runtime/backends/lite/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/lite/config.py
@@ -1,0 +1,97 @@
+"""Megatron Lite backend configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, pick_fields
+
+
+@dataclass(slots=True)
+class DebugConfig:
+    """Lite backend debug flags. Not exposed to end users."""
+
+    param_update: bool = False
+    optimizer_state: bool = False
+    grad_phases: bool = False
+    router_summary: bool = False
+    moe_io: bool = False
+    attn_io: bool = False
+
+
+@dataclass
+class LiteConfig:
+    """Config for MegatronLiteRuntime.
+
+    Runtime-specific training features live in ``impl_cfg`` (a plain dict);
+    each model implementation reads the keys it needs through its typed
+    ``ImplConfig``.
+    """
+
+    # ── identity ──
+    model_name: str = "auto"
+    impl: str = "lite"
+    hf_path: str = ""
+
+    # ── shared runtime knobs ──
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: OptimizerConfig = field(default_factory=OptimizerConfig)
+
+    # ── common runtime/model fields ──
+    attention_backend_override: str | None = "flash"
+    router_aux_loss_coef: float | None = None
+    load_hf_weights: bool = True
+
+    # ── impl-specific (each impl reads its own keys) ──
+    impl_cfg: dict[str, Any] = field(default_factory=dict)
+
+    # ── debug ──
+    debug: DebugConfig = field(default_factory=DebugConfig)
+
+    # ── bench-only hook: mutate model_cfg after build (e.g. expert truncation) ──
+    model_config_hook: Any = None
+
+    @classmethod
+    def from_dict(cls, hf_path: str, cfg: dict[str, Any]) -> LiteConfig:
+        """Construct LiteConfig from a flat dict (legacy / OmegaConf path)."""
+        if "num_microbatches" in cfg:
+            raise ValueError(
+                "LiteConfig no longer accepts `num_microbatches`; "
+                "pass it to Runtime.forward_backward(..., num_microbatches=...) instead"
+            )
+        parallel = ParallelConfig(**pick_fields(ParallelConfig, cfg))
+
+        opt_d = cfg.get("optimizer", {})
+        optimizer = (
+            OptimizerConfig(**pick_fields(OptimizerConfig, opt_d))
+            if isinstance(opt_d, dict)
+            else OptimizerConfig()
+        )
+
+        # impl_cfg: merge nested dict + top-level overrides
+        impl_cfg: dict[str, Any] = {}
+        nested = cfg.get("impl_cfg")
+        if isinstance(nested, dict):
+            impl_cfg.update(nested)
+        for k in list(impl_cfg):
+            if k in cfg:
+                impl_cfg[k] = cfg[k]
+        for k in ("recompute", "use_thd", "use_deepep", "precision_aware_opt"):
+            if k in cfg and k not in impl_cfg:
+                impl_cfg[k] = cfg[k]
+
+        skip = {"parallel", "optimizer", "impl_cfg", "debug"}
+        return cls(
+            **{k: v for k, v in pick_fields(cls, cfg).items() if k not in skip},
+            hf_path=hf_path,
+            parallel=parallel,
+            optimizer=optimizer,
+            impl_cfg=impl_cfg,
+        )
+
+
+__all__ = [
+    "LiteConfig",
+    "DebugConfig",
+]

--- a/experimental/lite/megatron/lite/runtime/backends/lite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/lite/runtime.py
@@ -1,0 +1,453 @@
+"""MegatronLiteRuntime training backend."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterator
+from dataclasses import fields as dc_fields
+from datetime import timedelta
+from itertools import chain
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from megatron.lite.runtime.backends import Runtime as RuntimeBase
+from megatron.lite.runtime.backends.lite.config import LiteConfig
+from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+def _build_impl_cfg(proto, rt_cfg: LiteConfig):
+    """Construct typed impl config, backfilling hf_path + optimizer_config."""
+    impl_cfg_kwargs = {**rt_cfg.impl_cfg, "parallel": rt_cfg.parallel}
+    init_fields = {f.name for f in dc_fields(proto.ImplConfig) if f.init}
+    if (
+        "attention_backend_override" in init_fields
+        and impl_cfg_kwargs.get("attention_backend_override") is None
+    ):
+        impl_cfg_kwargs["attention_backend_override"] = rt_cfg.attention_backend_override
+    if (
+        "hf_path" in init_fields
+        and impl_cfg_kwargs.get("hf_path") in (None, "")
+        and rt_cfg.hf_path
+    ):
+        impl_cfg_kwargs["hf_path"] = rt_cfg.hf_path
+    # Thread the user-level OptimizerConfig (from BackendConfig.optimizer) so
+    # the protocol can pass it to build_mc_stack.
+    if (
+        "optimizer_config" in init_fields
+        and impl_cfg_kwargs.get("optimizer_config") is None
+        and getattr(rt_cfg, "optimizer", None) is not None
+    ):
+        impl_cfg_kwargs["optimizer_config"] = rt_cfg.optimizer
+    return proto.ImplConfig(**impl_cfg_kwargs)
+
+
+def _apply_attention_backend_env(backend: str | None, *, tag: str) -> None:
+    if backend is None:
+        return
+
+    env_overrides = {
+        "auto": ("1", "1", "1"),
+        "flash": ("1", "0", "0"),
+        "fused": ("0", "1", "0"),
+        "unfused": ("0", "0", "1"),
+        "local": ("0", "0", "0"),
+    }
+    try:
+        flash, fused, unfused = env_overrides[backend]
+    except KeyError as exc:
+        raise ValueError(
+            "attention_backend_override must be one of {'auto', 'flash', 'fused', 'unfused', 'local'}"
+        ) from exc
+
+    os.environ["NVTE_FLASH_ATTN"] = flash
+    os.environ["NVTE_FUSED_ATTN"] = fused
+    os.environ["NVTE_UNFUSED_ATTN"] = unfused
+
+
+def _infer_pipeline_tensor_shape(batch: Any, model_cfg: Any, ps) -> tuple[int, int, int]:
+    if model_cfg is None or not hasattr(model_cfg, "hidden_size"):
+        raise ValueError("Megatron Lite pipeline runtime requires model_cfg.hidden_size.")
+    if not isinstance(batch, dict) or "input_ids" not in batch:
+        raise TypeError("Megatron Lite pipeline runtime requires dict batches with input_ids.")
+
+    input_ids = batch["input_ids"]
+    if input_ids.dim() == 1:
+        batch_size = 1
+        local_seq_len = int(input_ids.size(0))
+    elif input_ids.dim() == 2:
+        batch_size = int(input_ids.size(0))
+        local_seq_len = int(input_ids.size(1))
+    else:
+        raise ValueError(f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}.")
+
+    if local_seq_len < 1:
+        raise ValueError("Pipeline tensor shape requires non-empty sequence.")
+
+    tp_size = int(getattr(ps, "tp_size", 1) or 1)
+    if tp_size > 1:
+        if local_seq_len % tp_size != 0:
+            raise ValueError(
+                f"Pipeline tensor sequence length {local_seq_len} is not divisible by TP={tp_size}."
+            )
+        # Qwen3.5 scatters embeddings into Megatron sequence-parallel form
+        # before the first layer, so PP activations carry S / (CP * TP).
+        local_seq_len //= tp_size
+
+    return (local_seq_len, batch_size, int(model_cfg.hidden_size))
+
+
+def _last_loss_output(outputs: list[dict]) -> dict:
+    for output in reversed(outputs):
+        if output.get("loss") is not None:
+            return output
+    return {}
+
+
+class MegatronLiteRuntime(RuntimeBase):
+    """Megatron Lite default training backend (Megatron-style 5D parallel)."""
+
+    def __init__(self, hf_path: str, cfg: LiteConfig | dict[str, Any]):
+        self._hf_path = hf_path
+        self._cfg = cfg if isinstance(cfg, LiteConfig) else LiteConfig.from_dict(hf_path, cfg)
+
+    # ── build_model ──
+
+    def build_model(self, hf_path: str | None = None, cfg: LiteConfig | dict[str, Any] | None = None, **kwargs) -> ModelHandle:
+        if cfg is not None and isinstance(cfg, dict):
+            rt_cfg = LiteConfig.from_dict(hf_path or self._hf_path, cfg)
+        elif cfg is not None and isinstance(cfg, LiteConfig):
+            rt_cfg = cfg
+        else:
+            rt_cfg = self._cfg
+
+        # ── init distributed ──
+        if not dist.is_initialized():
+            dist.init_process_group("nccl", timeout=timedelta(minutes=10))
+        torch.cuda.set_device(dist.get_rank() % torch.cuda.device_count())
+        torch.cuda.manual_seed(42)
+
+        # ── load model protocol module ──
+        proto = self._load_protocol(rt_cfg)
+
+        _apply_attention_backend_env(
+            rt_cfg.attention_backend_override,
+            tag=f"{rt_cfg.model_name}:{rt_cfg.impl}",
+        )
+
+        # ── escape hatch: model takes over ──
+        if hasattr(proto, "create_runtime"):
+            return proto.create_runtime(rt_cfg.hf_path, rt_cfg).build_model()
+
+        # ── construct impl_cfg (parallel injected) ──
+        impl_cfg = _build_impl_cfg(proto, rt_cfg)
+
+        # ── build model config ──
+        model_cfg = proto.build_model_config(rt_cfg.hf_path)
+        if callable(rt_cfg.model_config_hook):
+            model_cfg = rt_cfg.model_config_hook(model_cfg)
+
+        # ── build model (model owns ps + optimizer + everything) ──
+        bundle = proto.build_model(model_cfg, impl_cfg=impl_cfg)
+
+        # ── load HF weights (optional) ──
+        loaded_hf_weights = False
+        if rt_cfg.load_hf_weights and rt_cfg.hf_path and hasattr(proto, "load_hf_weights"):
+            for chunk in bundle.chunks:
+                proto.load_hf_weights(chunk, rt_cfg.hf_path, model_cfg, bundle.parallel_state)
+            loaded_hf_weights = True
+
+        post_load_hook = bundle.extras.pop("post_model_load_hook", None)
+        if callable(post_load_hook):
+            post_load_updates = post_load_hook()
+            if post_load_updates is not None:
+                if not isinstance(post_load_updates, dict):
+                    raise TypeError("post_model_load_hook must return a dict or None.")
+                if "optimizer" in post_load_updates:
+                    bundle.optimizer = post_load_updates["optimizer"]
+                if "finalize_grads" in post_load_updates:
+                    bundle.finalize_grads = post_load_updates["finalize_grads"]
+                extra_updates = post_load_updates.get("extras")
+                if extra_updates:
+                    if not isinstance(extra_updates, dict):
+                        raise TypeError("post_model_load_hook extras update must be a dict.")
+                    bundle.extras.update(extra_updates)
+
+        if loaded_hf_weights and bundle.optimizer is not None:
+            reload_model_params = getattr(bundle.optimizer, "reload_model_params", None)
+            if callable(reload_model_params):
+                reload_model_params()
+
+        # ── forward_step default ──
+        forward_fn = bundle.forward_step or (lambda m, b: m(**b))
+
+        p = rt_cfg.parallel
+        model = bundle.chunks[0] if len(bundle.chunks) == 1 else bundle.chunks
+        return ModelHandle(
+            model=model,
+            optimizer=bundle.optimizer,
+            lr_scheduler=None,
+            parallel_state=bundle.parallel_state,
+            config=rt_cfg,
+            _extras={
+                "model_chunks": bundle.chunks,
+                "model_cfg": model_cfg,
+                "forward_step": forward_fn,
+                "protocol": proto,
+                "finalize_grads": bundle.finalize_grads,
+                "world_size": dist.get_world_size(),
+                "cp_range": (p.cp, p.cp),
+                **bundle.extras,
+            },
+        )
+
+    def _load_protocol(self, rt_cfg: LiteConfig):
+        """Load and return the model protocol module."""
+        from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES, resolve_runtime_model_name
+
+        try:
+            runtime_key = resolve_runtime_model_name(rt_cfg.model_name, rt_cfg.impl)
+        except ValueError as exc:
+            raise ValueError(
+                f"No protocol registered for model={rt_cfg.model_name!r}, "
+                f"impl={rt_cfg.impl!r}. Register with register_model(...)."
+            ) from exc
+
+        mod_path = TRAIN_RUNTIME_MODULES.get(runtime_key)
+        if mod_path is None:
+            raise ValueError(f"No protocol module for runtime key {runtime_key!r}")
+
+        import importlib
+
+        proto = importlib.import_module(mod_path)
+
+        for fn_name in ("build_model_config", "build_model"):
+            if not callable(getattr(proto, fn_name, None)):
+                raise ValueError(
+                    f"Protocol module {mod_path} missing required function: {fn_name}"
+                )
+        if not hasattr(proto, "ImplConfig"):
+            raise ValueError(f"Protocol module {mod_path} missing ImplConfig class")
+
+        return proto
+
+    # ── Checkpoint ──
+
+    def save_checkpoint(self, handle: ModelHandle, path: str, **kwargs) -> None:
+        from megatron.lite.primitive.ckpt import save_training_checkpoint
+
+        save_training_checkpoint(handle._model, handle._optimizer, path)
+
+    def load_checkpoint(self, handle: ModelHandle, path: str, **kwargs) -> None:
+        from megatron.lite.primitive.ckpt import load_training_checkpoint
+
+        load_training_checkpoint(handle._model, handle._optimizer, path)
+
+    def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
+        model_chunks = handle._extras.get("model_chunks", [handle._model])
+        proto = handle._extras.get("protocol")
+        model_cfg = handle._extras.get("model_cfg")
+        ps = handle._parallel_state
+
+        if proto and hasattr(proto, "export_hf_weights"):
+            yield from proto.export_hf_weights(model_chunks, model_cfg, ps, **kwargs)
+        else:
+            for chunk in model_chunks:
+                yield from chunk.named_parameters()
+
+    # ── Memory ──
+
+    def to(
+        self, handle: ModelHandle, device: str,
+        *, model: bool = True, optimizer: bool = True, grad: bool = True,
+    ) -> None:
+        model_chunks = handle._extras.get("model_chunks", [handle._model])
+        from megatron.lite.runtime.megatron_utils import (
+            load_model_to_gpu,
+            load_optimizer,
+            offload_model_to_cpu,
+            offload_optimizer,
+        )
+
+        if device == "cpu":
+            if model:
+                offload_model_to_cpu(model_chunks)
+            if optimizer and handle._optimizer is not None:
+                offload_state = getattr(handle._optimizer, "offload_state_to_cpu", None)
+                if callable(offload_state):
+                    offload_state()
+                else:
+                    offload_optimizer(handle._optimizer)
+        elif device == "cuda":
+            if model:
+                load_model_to_gpu(model_chunks, load_grad=grad)
+            if optimizer and handle._optimizer is not None:
+                load_state = getattr(handle._optimizer, "load_state_to_device", None)
+                if callable(load_state):
+                    load_state()
+                else:
+                    load_optimizer(handle._optimizer)
+
+    # ── Mode switching ──
+
+    def train_mode(self, handle: ModelHandle):
+        return _TrainModeCtx(handle)
+
+    def eval_mode(self, handle: ModelHandle):
+        return _EvalModeCtx(handle)
+
+    # ── Training atoms ──
+
+    def forward_backward(
+        self, handle: ModelHandle, data: Any, loss_fn: Callable | None,
+        *, num_microbatches: int = 1, forward_only: bool = False,
+    ) -> ForwardResult:
+        from megatron.lite.primitive.train_step import run_microbatch_loop
+
+        forward_step = handle._extras["forward_step"]
+        if num_microbatches < 1:
+            raise ValueError("num_microbatches must be >= 1")
+
+        if hasattr(data, "__next__"):
+            data_iter = data
+        elif hasattr(data, "__iter__"):
+            data_iter = iter(data)
+        else:
+            data_iter = iter([data])
+
+        ps = handle._parallel_state
+        if ps.pp_size > 1:
+            from types import SimpleNamespace
+
+            from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+
+            first_batch = next(data_iter)
+            data_iter = chain([first_batch], data_iter)
+            tensor_shape = _infer_pipeline_tensor_shape(
+                first_batch,
+                handle._extras.get("model_cfg"),
+                ps,
+            )
+            outputs = forward_backward_pipelining(
+                forward_step,
+                handle._extras.get("model_chunks", [handle._model]),
+                data_iter,
+                SimpleNamespace(num_microbatches=num_microbatches),
+                ps,
+                tensor_shape=tensor_shape,
+                pre_forward_hook=handle._extras.get("pre_forward_hook"),
+                loss_fn=loss_fn,
+                forward_only=forward_only,
+            )
+            out = _last_loss_output(outputs)
+            loss_obj = out.get("loss") if out else None
+            if isinstance(loss_obj, torch.Tensor):
+                loss_float = float(loss_obj.detach().item())
+            elif loss_obj is not None:
+                loss_float = float(loss_obj)
+            else:
+                loss_float = 0.0
+            loss_t = torch.tensor(
+                [loss_float],
+                device="cuda",
+            )
+            if ps.pp_group is not None and ps.pp_global_ranks is not None:
+                dist.broadcast(loss_t, src=ps.pp_global_ranks[-1], group=ps.pp_group)
+            out = {"loss": loss_t.squeeze(0)}
+        else:
+            out = run_microbatch_loop(
+                handle._model, data_iter, num_microbatches,
+                forward_step,
+                optimizer=handle._optimizer if not forward_only else None,
+                dist_opt=not forward_only,
+                pre_forward_hook=handle._extras.get("pre_forward_hook"),
+                loss_fn=loss_fn,
+            )
+
+        if not forward_only:
+            finalize_grads = handle._extras.get("finalize_grads")
+            if finalize_grads is not None:
+                finalize_grads()
+
+        loss_tensor = out.get("loss") if out else None
+        loss_val = loss_tensor.item() if isinstance(loss_tensor, torch.Tensor) else float(loss_tensor or 0.0)
+        metrics: dict = {"loss": loss_val}
+        for m in out.get("_loss_fn_metrics", []) if out else []:
+            for k, v in m.items():
+                if k not in metrics:
+                    metrics[k] = v
+        if ps.pp_size > 1:
+            for item in outputs:
+                for k, v in item.get("metrics", {}).items():
+                    if k not in metrics:
+                        metrics[k] = v
+            metrics["_micro_outputs"] = outputs
+
+        return ForwardResult(
+            model_output=ModelOutputs(
+                loss=loss_tensor,
+                vocab_parallel_logits=out.get("logits") if out else None,
+                log_probs=out.get("log_probs") if out else None,
+                routed_experts=out.get("routed_experts") if out else None,
+            ),
+            metrics=metrics,
+        )
+
+    def is_mp_src_rank_with_outputs(self, handle: ModelHandle) -> bool:
+        ps = handle._parallel_state
+        return ps.tp_rank == 0 and ps.cp_rank == 0 and ps.pp_rank == ps.pp_size - 1
+
+    def zero_grad(self, handle: ModelHandle) -> None:
+        for chunk in handle._extras.get("model_chunks", [handle._model]):
+            if hasattr(chunk, "zero_grad_buffer"):
+                chunk.zero_grad_buffer()
+        if handle._optimizer is not None:
+            handle._optimizer.zero_grad()
+
+    def optimizer_step(self, handle: ModelHandle) -> tuple[bool, float, int]:
+        if handle._optimizer is None:
+            return True, 0.0, 0
+        update_successful, grad_norm, num_zeros = handle._optimizer.step()
+        return update_successful, float(grad_norm), num_zeros
+
+    def lr_scheduler_step(self, handle: ModelHandle) -> float | list[float]:
+        if handle._lr_scheduler is not None:
+            handle._lr_scheduler.step()
+            return handle._lr_scheduler.get_last_lr()
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Context managers
+# ---------------------------------------------------------------------------
+
+
+class _TrainModeCtx:
+    def __init__(self, handle: ModelHandle):
+        self._handle = handle
+
+    def __enter__(self):
+        for chunk in self._handle._extras.get("model_chunks", [self._handle._model]):
+            chunk.train()
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _EvalModeCtx:
+    def __init__(self, handle: ModelHandle):
+        self._handle = handle
+        self._prev_grad = torch.is_grad_enabled()
+
+    def __enter__(self):
+        for chunk in self._handle._extras.get("model_chunks", [self._handle._model]):
+            chunk.eval()
+        torch.set_grad_enabled(False)
+        return self
+
+    def __exit__(self, *exc):
+        torch.set_grad_enabled(self._prev_grad)
+        return False

--- a/experimental/lite/megatron/lite/runtime/contracts/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/__init__.py
@@ -1,0 +1,57 @@
+"""Lazy re-export hub for ``megatron.lite.runtime.contracts``.
+
+This preserves imports like ``from megatron.lite.runtime.contracts import X`` while
+avoiding eager imports of heavyweight modules (for example ``torch`` from
+``contracts.data``) during package import.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from megatron.lite.runtime.backends.lite.config import DebugConfig, LiteConfig
+    from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+    from megatron.lite.runtime.contracts.data import (
+        Batch,
+        ForwardResult,
+        ModelOutputs,
+        PackedBatch,
+        TrainBatch,
+    )
+    from megatron.lite.runtime.contracts.handle import ModelHandle
+
+__all__ = [
+    "LiteConfig",
+    "Batch",
+    "DebugConfig",
+    "ForwardResult",
+    "ModelHandle",
+    "ModelOutputs",
+    "OptimizerConfig",
+    "PackedBatch",
+    "ParallelConfig",
+    "RuntimeConfig",
+    "TrainBatch",
+]
+
+
+def __getattr__(name: str):
+    _lazy = {
+        "Batch": "megatron.lite.runtime.contracts.data",
+        "DebugConfig": "megatron.lite.runtime.backends.lite.config",
+        "LiteConfig": "megatron.lite.runtime.backends.lite.config",
+        "ForwardResult": "megatron.lite.runtime.contracts.data",
+        "ModelHandle": "megatron.lite.runtime.contracts.handle",
+        "ModelOutputs": "megatron.lite.runtime.contracts.data",
+        "OptimizerConfig": "megatron.lite.runtime.contracts.config",
+        "PackedBatch": "megatron.lite.runtime.contracts.data",
+        "ParallelConfig": "megatron.lite.runtime.contracts.config",
+        "RuntimeConfig": "megatron.lite.runtime.contracts.config",
+        "TrainBatch": "megatron.lite.runtime.contracts.data",
+    }
+    if name in _lazy:
+        mod = importlib.import_module(_lazy[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/experimental/lite/megatron/lite/runtime/contracts/config.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/config.py
@@ -1,0 +1,84 @@
+"""Shared runtime configuration for Megatron Lite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from dataclasses import fields as dc_fields
+from typing import TYPE_CHECKING, Any
+
+
+def pick_fields(cls, src: dict[str, Any]) -> dict[str, Any]:
+    """Extract fields of dataclass *cls* that exist in *src*."""
+    return {f.name: src[f.name] for f in dc_fields(cls) if f.name in src}
+
+if TYPE_CHECKING:
+    from megatron.lite.runtime.backends.lite.config import LiteConfig
+
+
+@dataclass
+class ParallelConfig:
+    """Parallel dimensions used by the lite runtime."""
+
+    tp: int = 1
+    etp: int | None = None
+    ep: int = 1
+    pp: int = 1
+    vpp: int = 1
+    cp: int = 1
+
+
+@dataclass
+class OptimizerConfig:
+    """Optimizer + LR scheduler config. Aligned with VERL McoreOptimizerConfig.
+
+    Stable VERL fields use VERL default values.
+    Compatibility aliases are lowered into backend-specific override dicts
+    by the adapter layer before consumption.
+    """
+
+    # --- stable VERL fields ---
+    optimizer: str = "adam"
+    lr: float = 1e-3
+    min_lr: float = 0.0
+    clip_grad: float = 1.0
+    weight_decay: float = 0.01
+    lr_warmup_steps_ratio: float = 0.0
+    total_training_steps: int = -1
+    lr_warmup_steps: int = -1
+    lr_warmup_init: float = 0.0
+    lr_decay_steps: int | None = None
+    lr_decay_style: str = "linear"
+    weight_decay_incr_style: str = "constant"
+    lr_wsd_decay_style: str = "exponential"
+    lr_wsd_decay_steps: int | None = None
+    use_checkpoint_opt_param_scheduler: bool = False
+
+    # --- compatibility aliases ---
+    adam_beta1: float | None = None
+    adam_beta2: float | None = None
+    adam_eps: float | None = None
+    offload_fraction: float | None = None
+    use_precision_aware_optimizer: bool | None = None
+    decoupled_weight_decay: bool | None = None
+
+
+@dataclass
+class RuntimeConfig:
+    """Top-level runtime configuration.
+
+    Attributes:
+        backend: Backend name. Defaults to "lite".
+        hf_path: Path to HuggingFace model directory. Required.
+        backend_cfg: Backend-specific config (LiteConfig or dict).
+    """
+
+    backend: str = "lite"
+    hf_path: str = ""
+    backend_cfg: LiteConfig | dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = [
+    "OptimizerConfig",
+    "ParallelConfig",
+    "RuntimeConfig",
+]

--- a/experimental/lite/megatron/lite/runtime/contracts/data.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/data.py
@@ -1,0 +1,126 @@
+"""Data contracts — forward_backward input/output types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+
+class Batch:
+    """Protocol for data passed to Runtime.forward_backward.
+
+    Sequences are packed without padding.  ``sizes()`` gives per-sequence
+    lengths so the runtime can reconstruct ``cu_seqlens`` / ``position_ids``
+    for THD attention.
+
+    Subclass this to carry domain-specific fields (loss_mask, routed_experts,
+    etc.) while keeping the runtime interface uniform.
+    """
+
+    def __len__(self) -> int:
+        """Number of sequences in this batch."""
+        raise NotImplementedError
+
+    def sizes(self) -> torch.Tensor:
+        """Per-sequence token counts.  Shape ``[num_seqs]``."""
+        raise NotImplementedError
+
+    def __getitem__(self, key: str) -> Any:
+        """Dict-like field access (``batch["input_ids"]``)."""
+        raise NotImplementedError
+
+
+@dataclass(slots=True)
+class PackedBatch(Batch):
+    """Variable-length packed batch — no padding.
+
+    All token-level tensors are 1-D with length ``sum(seq_lens)``.
+    ``cu_seqlens`` and ``position_ids`` are derived automatically.
+    """
+
+    input_ids: torch.Tensor       # [total_tokens]
+    labels: torch.Tensor          # [total_tokens]
+    seq_lens: torch.Tensor        # [num_seqs]
+    loss_mask: torch.Tensor | None = None   # [total_tokens]
+    position_ids: torch.Tensor | None = None  # [total_tokens], auto if None
+    routed_experts: torch.Tensor | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def __len__(self) -> int:
+        return len(self.seq_lens)
+
+    def sizes(self) -> torch.Tensor:
+        return self.seq_lens
+
+    def __getitem__(self, key: str) -> Any:
+        if key in self.__slots__:
+            return getattr(self, key)
+        return self.extras[key]
+
+    @property
+    def cu_seqlens(self) -> torch.Tensor:
+        """Cumulative sequence lengths for THD attention.  Shape ``[num_seqs+1]``."""
+        return torch.cat([
+            torch.zeros(1, dtype=torch.int32, device=self.seq_lens.device),
+            self.seq_lens.cumsum(0).to(torch.int32),
+        ])
+
+    @property
+    def total_tokens(self) -> int:
+        return int(self.seq_lens.sum())
+
+    def make_position_ids(self) -> torch.Tensor:
+        """Generate per-token position_ids from seq_lens."""
+        if self.position_ids is not None:
+            return self.position_ids
+        return torch.cat([
+            torch.arange(s, device=self.seq_lens.device) for s in self.seq_lens.tolist()
+        ])
+
+
+@dataclass(slots=True)
+class TrainBatch:
+    """Legacy fixed-shape batch (padded).  Use PackedBatch for new code."""
+
+    input_ids: torch.Tensor
+    labels: torch.Tensor
+    loss_mask: torch.Tensor | None = None
+    position_ids: torch.Tensor | None = None
+    routed_experts: torch.Tensor | None = None
+    cp_size: int | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ModelOutputs:
+    """Model forward output."""
+
+    loss: torch.Tensor | None = None
+    vocab_parallel_logits: torch.Tensor | None = None
+    log_probs: torch.Tensor | None = None
+    hidden_states: torch.Tensor | None = None
+    values: torch.Tensor | None = None
+    # MTP
+    mtp_logits: torch.Tensor | None = None
+    mtp_loss: torch.Tensor | None = None
+    # Router Replay: recorded routing decisions
+    routed_experts: torch.Tensor | None = None
+
+
+@dataclass(slots=True)
+class ForwardResult:
+    """Output of forward_backward."""
+
+    model_output: ModelOutputs = field(default_factory=ModelOutputs)
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = [
+    "Batch",
+    "ForwardResult",
+    "ModelOutputs",
+    "PackedBatch",
+    "TrainBatch",
+]

--- a/experimental/lite/megatron/lite/runtime/contracts/handle.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/handle.py
@@ -1,0 +1,64 @@
+"""ModelHandle — opaque handle returned by Runtime.build_model()."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ModelHandle:
+    """Opaque handle returned by Runtime.build_model().
+
+    Only documented properties on this class are part of the public contract.
+    Internal helpers may still use ``_model`` / ``_optimizer`` / ``_extras``
+    while the higher-level runtime API is being stabilized.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: Any,
+        optimizer: Any = None,
+        lr_scheduler: Any = None,
+        parallel_state: Any = None,
+        config: Any = None,
+        _extras: dict[str, Any] | None = None,
+    ):
+        self._model = model
+        self._optimizer = optimizer
+        self._lr_scheduler = lr_scheduler
+        self._parallel_state = parallel_state
+        self._config = config
+        self._extras = _extras or {}
+
+    @property
+    def dp_rank(self) -> int:
+        ps = self._parallel_state
+        if ps is None:
+            return 0
+        return getattr(ps, "dp_rank", 0)
+
+    @property
+    def dp_size(self) -> int:
+        ps = self._parallel_state
+        if ps is None:
+            return 1
+        return getattr(ps, "dp_size", 1)
+
+    @property
+    def dp_group(self):
+        ps = self._parallel_state
+        if ps is None:
+            return None
+        return getattr(ps, "dp_group", None)
+
+    @property
+    def cp_range(self) -> tuple[int, int]:
+        return self._extras.get("cp_range", (1, 1))
+
+    @property
+    def config(self) -> Any:
+        """Backend config captured when this handle was built."""
+        return self._config
+
+
+__all__ = ["ModelHandle"]

--- a/experimental/lite/megatron/lite/runtime/megatron_utils.py
+++ b/experimental/lite/megatron/lite/runtime/megatron_utils.py
@@ -1,0 +1,226 @@
+"""Megatron-Core utilities aligned with VERL's megatron_utils.
+
+All functions here are ported from VERL and could theoretically be replaced
+by ``from verl.utils.megatron_utils import ...`` if this package depends on VERL.
+
+Sources:
+  - verl/utils/megatron_utils.py  (offload/load, register_megatron_training_hooks)
+  - verl/utils/megatron/optimizer.py  (get_megatron_last_lr)
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+
+import torch
+
+# ======================================================================
+# Rank utilities
+# ======================================================================
+
+
+def is_mp_src_rank_with_outputs() -> bool:
+    """True on the rank that holds the final model output (loss).
+
+    Only last PP stage, first TP rank, first CP rank has the output.
+    VERL: MegatronEngine.is_mp_src_rank_with_outputs
+    """
+    from megatron.core import parallel_state as mpu
+
+    return (
+        mpu.get_tensor_model_parallel_rank() == 0
+        and mpu.get_pipeline_model_parallel_rank()
+        == mpu.get_pipeline_model_parallel_world_size() - 1
+        and mpu.get_context_parallel_rank() == 0
+    )
+
+
+# ======================================================================
+# Training hooks — register_megatron_training_hooks
+# ======================================================================
+
+
+def register_training_hooks(model_list: list, optimizer) -> None:
+    """Register megatron training callbacks on model config.
+
+    Ref: megatron/training/training.py (core_v0.15.0rc7, L2039-L2057)
+    """
+    from megatron.core.distributed import DistributedDataParallel as DDP
+    from megatron.core.distributed import finalize_model_grads
+    from megatron.core.utils import get_model_config
+
+    for one_model in model_list:
+        config = get_model_config(one_model)
+        if optimizer is not None:
+            config.grad_scale_func = optimizer.scale_loss
+        config.finalize_model_grads_func = finalize_model_grads
+
+        optimizer_config = getattr(optimizer, "config", None)
+        overlap_param_gather = getattr(optimizer_config, "overlap_param_gather", False)
+        overlap_grad_reduce = getattr(one_model.ddp_config, "overlap_grad_reduce", False)
+        align_grad_reduce = True
+        align_param_gather = getattr(one_model.ddp_config, "align_param_gather", False)
+
+        if isinstance(model_list[0], DDP) and overlap_grad_reduce:
+            config.no_sync_func = [m.no_sync for m in model_list]
+            if len(model_list) == 1:
+                config.no_sync_func = config.no_sync_func[0]
+            if align_grad_reduce:
+                config.grad_sync_func = [m.start_grad_sync for m in model_list]
+                if len(model_list) == 1:
+                    config.grad_sync_func = config.grad_sync_func[0]
+        if overlap_param_gather and align_param_gather:
+            config.param_sync_func = [m.start_param_sync for m in model_list]
+            if len(model_list) == 1:
+                config.param_sync_func = config.param_sync_func[0]
+
+
+# ======================================================================
+# Model offload / load — offload_megatron_model_to_cpu / load_megatron_model_to_gpu
+# ======================================================================
+
+
+def offload_model_to_cpu(model_list: list) -> None:
+    """Offload DDP model to CPU via buffer-resize (zero-copy on GPU side)."""
+    from megatron.core.distributed import DistributedDataParallel as DDP
+
+    for model_chunk in model_list:
+        if isinstance(model_chunk, DDP):
+            all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
+            for buffers in all_buffers:
+                for buffer in buffers:
+                    if buffer.param_data.storage().size() > 0:
+                        buffer.param_data.cpu_data = buffer.param_data.data.cpu().pin_memory()
+                        buffer.param_data_size = buffer.param_data.storage().size()
+                        buffer.param_data.storage().resize_(0)
+
+                    if buffer.grad_data.storage().size() > 0:
+                        buffer.grad_data_size = buffer.grad_data.storage().size()
+                        buffer.grad_data.storage().resize_(0)
+
+            for param in model_chunk.module.parameters():
+                if not param.requires_grad and param.device.type != "cpu":
+                    param.data = param.data.to("cpu", non_blocking=True)
+        else:
+            for p in model_chunk.parameters():
+                p.data = p.data.cpu()
+                if p.grad is not None:
+                    p.grad = p.grad.cpu()
+
+
+def load_model_to_gpu(model_list: list, load_grad: bool = True) -> None:
+    """Load DDP model back to GPU from pinned CPU copy."""
+    from megatron.core.distributed import DistributedDataParallel as DDP
+
+    for model_chunk in model_list:
+        if isinstance(model_chunk, DDP):
+            all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
+            for buffers in all_buffers:
+                for buffer in buffers:
+                    if load_grad and hasattr(buffer, "grad_data_size"):
+                        current_size = buffer.grad_data.storage().size()
+                        if current_size == 0 or current_size == buffer.grad_data_size:
+                            buffer.grad_data.storage().resize_(buffer.grad_data_size)
+                            buffer.grad_data.zero_()
+                        else:
+                            buffer.grad_data.zero_()
+
+                    if buffer.param_data.storage().size() == 0:
+                        buffer.param_data.storage().resize_(buffer.param_data_size)
+                        buffer.param_data.copy_(buffer.param_data.cpu_data, non_blocking=True)
+
+            for param in model_chunk.module.parameters():
+                if not param.requires_grad and param.device.type == "cpu":
+                    param.data = param.data.to("cuda", non_blocking=True)
+        else:
+            model_chunk.cuda()
+
+
+# ======================================================================
+# Optimizer offload / load — offload_megatron_optimizer / load_megatron_optimizer
+# ======================================================================
+
+
+def offload_optimizer(optimizer) -> None:
+    """Offload optimizer states to CPU."""
+    from megatron.core.optimizer import ChainedOptimizer
+
+    for _opt in _iter_opts(optimizer, ChainedOptimizer):
+        if _opt.optimizer is not None:
+            hdo = _opt.optimizer
+            if all(hasattr(hdo, a) for a in ("sub_optimizers", "inner_param_to_orig_param", "state")):
+                for sub_opt in hdo.sub_optimizers:
+                    for param, state in sub_opt.state.items():
+                        for k, v in state.items():
+                            if not isinstance(v, torch.Tensor):
+                                continue
+                            orig_param = hdo.inner_param_to_orig_param.get(param, param)
+                            hdo.state[orig_param][k] = state[k] = v.to("cpu")
+            else:
+                for v in _opt.optimizer.state.values():
+                    if "exp_avg" in v:
+                        v["exp_avg"] = v["exp_avg"].to("cpu", non_blocking=True)
+                    if "exp_avg_sq" in v:
+                        v["exp_avg_sq"] = v["exp_avg_sq"].to("cpu", non_blocking=True)
+
+    gc.collect()
+    torch.cuda.empty_cache()
+
+
+def load_optimizer(optimizer) -> None:
+    """Load optimizer states back to GPU."""
+    from megatron.core.optimizer import ChainedOptimizer
+
+    for _opt in _iter_opts(optimizer, ChainedOptimizer):
+        if _opt.optimizer is not None:
+            if hasattr(_opt.optimizer, "_move_new_state_to_right_device"):
+                _opt.optimizer._move_new_state_to_right_device()
+            else:
+                for v in _opt.optimizer.state.values():
+                    if "exp_avg" in v:
+                        v["exp_avg"] = v["exp_avg"].to("cuda", non_blocking=True)
+                    if "exp_avg_sq" in v:
+                        v["exp_avg_sq"] = v["exp_avg_sq"].to("cuda", non_blocking=True)
+
+    gc.collect()
+    torch.cuda.empty_cache()
+
+
+def _iter_opts(optimizer, chained_cls):
+    if isinstance(optimizer, chained_cls):
+        return optimizer.chained_optimizers
+    return [optimizer]
+
+
+# ======================================================================
+# Checkpoint helpers
+# ======================================================================
+
+
+def build_sharded_state_dict(
+    model_list: list,
+    optimizer: Any = None,
+    lr_scheduler: Any = None,
+) -> dict[str, Any]:
+    """Build sharded state dict for model + optimizer + lr_scheduler.
+
+    Uses ``model0.`` / ``model1.`` prefix for VPP (multiple model chunks).
+    """
+    sharded_state_dict: dict[str, Any] = {}
+
+    for i, model_chunk in enumerate(model_list):
+        prefix = f"model{i}." if len(model_list) > 1 else "model."
+        chunk_sd = model_chunk.sharded_state_dict(prefix=prefix)
+        sharded_state_dict.update(chunk_sd)
+
+    if optimizer is not None:
+        opt_sd = optimizer.sharded_state_dict(
+            model_sharded_state_dict=sharded_state_dict,
+        )
+        sharded_state_dict.update(opt_sd)
+
+    if lr_scheduler is not None:
+        sharded_state_dict["lr_scheduler"] = lr_scheduler.state_dict()
+
+    return sharded_state_dict


### PR DESCRIPTION
# What does this PR do ?

Adds an experimental `megatron.lite` package under `experimental/lite` with a lite runtime, common primitives, and lite-only Qwen3/Qwen3.5 model implementations.

This is an experimental package layout that is source-tree importable with:

```bash
export PYTHONPATH=$PWD/experimental/lite:$PYTHONPATH
```

and user-facing imports use:

```python
from megatron.lite.runtime import LiteConfig, RuntimeConfig, create_runtime
```

Included:
- Lite runtime API and backend under `megatron.lite.runtime`
- Common lite primitives under `megatron.lite.primitive`
- Lite-only Qwen3 MoE and Qwen3.5 MoE model implementations
- HF safetensors load/export helpers
- Megatron-Core optimizer wrapping
- README and initial design docs under `experimental/lite/docs`

Intentionally excluded from this PR:
- Hybrid model implementations
- Bridge model/runtime implementations
- FSDP2 optimizer primitives
- Benchmark scripts
- Repository-level packaging changes

## Issue tracking

Linked issue: TODO

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

Validation run locally:

```bash
python -B -m compileall -q experimental/lite/megatron/lite
PYTHONPATH=$PWD/experimental/lite:$PWD python -B -c "import megatron.lite as ml; from megatron.lite.runtime import RuntimeConfig, LiteConfig; from megatron.lite.model.registry import resolve_model_type_from_hf; print(ml.__name__, RuntimeConfig().backend, LiteConfig.__name__, resolve_model_type_from_hf({'model_type': 'qwen3_moe'}))"
```

Expected output includes:

```text
megatron.lite lite LiteConfig qwen3
```
