### PR TITLE
Fix hybrid M-FSDP numerics

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -320,8 +320,11 @@ class MegatronFSDP(torch.nn.Module):
             # Default to overlapped parameter gather when fully-sharding.
             self.ddp_config.overlap_param_gather = True
         if self.ddp_config.data_parallel_sharding_strategy in ["optim_grads_params", "optim_grads"]:
-            # Default to overlapped gradient reduce-scatter when sharding gradients.
-            self.ddp_config.overlap_grad_reduce = True
+            if not self.ddp_config.overlap_grad_reduce:
+                raise ValueError(
+                    "Megatron-FSDP requires `overlap_grad_reduce=True` when "
+                    "`data_parallel_sharding_strategy` is 'optim_grads' or 'optim_grads_params'."
+                )
         if not self.is_delay_grad_reduce:
             # Gradient reduce-scatter must be overlapped when using sharding optimizer
             # and gradients.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -4742,6 +4742,8 @@ def make_fsdp_dtensor(
         shape=param.shape,
         stride=param.stride(),
     )
+    setattr(fsdp_tensor, "megatron_fsdp_dist_index", dist_index)
+    setattr(fsdp_tensor, "megatron_fsdp_is_expert_param", is_expert_param)
 
     if run_check:
         validate_uneven_dtensor(fsdp_tensor)

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -49,7 +49,7 @@ except ImportError:
 
 from ..tensor_parallel import param_is_not_tensor_parallel_duplicate
 from ..transformer.module import param_is_not_shared
-from ..utils import get_data_parallel_group_if_dtensor, to_local_if_dtensor
+from ..utils import get_data_parallel_group_if_dtensor, is_same_process_group, to_local_if_dtensor
 
 
 def get_grad_norm_fp32(
@@ -99,9 +99,10 @@ def get_grad_norm_fp32(
             torch.distributed.all_reduce(
                 total_norm_cuda, op=torch.distributed.ReduceOp.MAX, group=data_parallel_group
             )
-        torch.distributed.all_reduce(
-            total_norm_cuda, op=torch.distributed.ReduceOp.MAX, group=grad_stats_parallel_group
-        )
+        if not is_same_process_group(data_parallel_group, grad_stats_parallel_group):
+            torch.distributed.all_reduce(
+                total_norm_cuda, op=torch.distributed.ReduceOp.MAX, group=grad_stats_parallel_group
+            )
         total_norm = total_norm_cuda[0].item()
 
     else:
@@ -133,9 +134,10 @@ def get_grad_norm_fp32(
             torch.distributed.all_reduce(
                 total_norm, op=torch.distributed.ReduceOp.SUM, group=data_parallel_group
             )
-        torch.distributed.all_reduce(
-            total_norm, op=torch.distributed.ReduceOp.SUM, group=grad_stats_parallel_group
-        )
+        if not is_same_process_group(data_parallel_group, grad_stats_parallel_group):
+            torch.distributed.all_reduce(
+                total_norm, op=torch.distributed.ReduceOp.SUM, group=grad_stats_parallel_group
+            )
         if multi_tensor_scale_tensor_impl is not None:
             total_norm = total_norm.pow(1.0 / norm_type)
         else:
@@ -232,18 +234,9 @@ def count_zeros_fp32(
     #   - should not be a replica due to tensor model parallelism
     total_num_zeros = torch.zeros(1, dtype=torch.int64, device='cuda')
     data_parallel_group = None
-    use_megatron_fsdp = False
     for param in parameters:
         grad_attr = "decoupled_grad" if use_decoupled_grad else "grad"
         grad_not_none = hasattr(param, grad_attr) and getattr(param, grad_attr) is not None
-        if getattr(param, "__fsdp_param__", False) and grad_not_none:
-            # If the parameter is managed by Megatron FSDP, the gradient is
-            # an FSDP-sharded DTensor, and we should use the local shard.
-            use_megatron_fsdp = True
-            grad = getattr(param, grad_attr)._local_tensor
-            num_zeros = grad.numel() - torch.count_nonzero(grad)
-            total_num_zeros += num_zeros
-            continue
         is_not_shared = param_is_not_shared(param)
         is_not_tp_duplicate = param_is_not_tensor_parallel_duplicate(param, tp_group=tp_group)
         if grad_not_none and is_not_shared and is_not_tp_duplicate:
@@ -253,23 +246,16 @@ def count_zeros_fp32(
             num_zeros = grad.numel() - torch.count_nonzero(grad)
             total_num_zeros = num_zeros + total_num_zeros
 
-    if use_megatron_fsdp and data_parallel_group is not None:
-        # Megatron-FSDP does not need to all-reduce the gradient across DP,
-        # as FSDP has already handled the DP reduction during BWD.
-        raise ValueError(
-            "Unexpected use of Megatron FSDP with data parallel group. "
-            "Please ensure that the parameters are properly managed by Megatron FSDP."
-        )
-
     # Sum across all data-parallel GPUs if using FSDP.
     if data_parallel_group:
         torch.distributed.all_reduce(
             total_num_zeros, op=torch.distributed.ReduceOp.SUM, group=data_parallel_group
         )
     # Sum across all model-parallel GPUs.
-    torch.distributed.all_reduce(
-        total_num_zeros, op=torch.distributed.ReduceOp.SUM, group=grad_stats_parallel_group
-    )
+    if not is_same_process_group(data_parallel_group, grad_stats_parallel_group):
+        torch.distributed.all_reduce(
+            total_num_zeros, op=torch.distributed.ReduceOp.SUM, group=grad_stats_parallel_group
+        )
 
     total_num_zeros = total_num_zeros.item()
 

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -198,16 +198,10 @@ class MegatronOptimizer(ABC):
                 and getattr(param, "__fsdp_param__", False)
             ):
                 grad = param.decoupled_grad if hasattr(param, "decoupled_grad") else None
-                if (
-                    getattr(param, "__fsdp_param__", False)
-                    and grad is not None
-                    and hasattr(grad, "_local_tensor")
-                ):
-                    # Megatron-FSDP gradients are DTensors.
-                    grad = grad._local_tensor
             elif getattr(param, "__fsdp_param__", False):
-                # Megatron-FSDP gradients are DTensors.
-                grad = param.grad._local_tensor if param.grad is not None else None
+                # Megatron-FSDP gradients are DTensors. Keep the DTensor
+                # wrapper so grad-norm code can reduce over FSDP shard groups.
+                grad = param.grad
             else:
                 grad = param.grad
             grad_not_none = grad is not None

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -40,6 +40,8 @@ try:
     HAVE_DTENSOR = True
 except ImportError:
     HAVE_DTENSOR = False
+    DTensor = None
+    Shard = None
 
 from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.mapping import ShardedTensor
@@ -1111,15 +1113,39 @@ def to_local_if_dtensor(tensor: Union[torch.Tensor, "DTensor"]) -> torch.Tensor:
         return tensor.to_local() if HAVE_DTENSOR and isinstance(tensor, DTensor) else tensor
 
 
+def is_same_process_group(
+    group: torch.distributed.ProcessGroup | None, other: torch.distributed.ProcessGroup | None
+) -> bool:
+    """Returns whether two process groups contain the same ranks."""
+    if group is None or other is None:
+        return False
+    if group is other:
+        return True
+    try:
+        return torch.distributed.get_process_group_ranks(
+            group
+        ) == torch.distributed.get_process_group_ranks(other)
+    except (RuntimeError, ValueError):
+        return False
+
+
 def get_data_parallel_group_if_dtensor(
     tensor: Union[torch.Tensor, "DTensor"], data_parallel_group: "ProcessGroup" = None
 ) -> Optional["ProcessGroup"]:
     """Gets the data parallel group of the given tensor if it is a DTensor."""
     if HAVE_DTENSOR and isinstance(tensor, DTensor):
-        current_group = tensor.device_mesh.get_group()
-        assert data_parallel_group is None or current_group == data_parallel_group
+        dist_index = getattr(tensor, "megatron_fsdp_dist_index", None)
+        if dist_index is not None:
+            current_group = dist_index.get_dp_group(
+                is_expert_parallel=getattr(tensor, "megatron_fsdp_is_expert_param", False)
+            )
+        else:
+            current_group = tensor.device_mesh.get_group()
+        assert data_parallel_group is None or is_same_process_group(
+            current_group, data_parallel_group
+        )
         return current_group
-    return None
+    return data_parallel_group
 
 
 def prepare_input_tensors_for_wgrad_compute(grad_output, all_gathered_input):

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
@@ -1125,6 +1125,7 @@ class TestMegatronFSDPE2E:
             vocab_size=256,
             bf16=True,
             use_megatron_fsdp=True,
+            overlap_grad_reduce=True,
             ckpt_format="fsdp_dtensor",
             use_precision_aware_optimizer=True,
             cuda_graph_impl="full_iteration",


### PR DESCRIPTION
Fixes M-FSDP numerics for hybrid topologies by correctly preserving `DTensor` gradient metadata through grad-stat collection and completing delayed outer-DP gradient reductions for HSDP/HFSDP before optimizer gradients are attached.

Testing Adam on `main` (currently 859b7197f19119f53113ab6d30d1901b87ca1197) vs. this PR branch over 100 training steps on a 1B model.

| Mode    | main mean / last loss abs diff | fix mean / last loss abs diff |
|---------|-------------------------------:|------------------------------:|
| M-FSDP  |          2.268e-01 / 3.986e-02 |         2.265e-01 / 4.621e-02 |
| M-HSDP  |          1.527e+00 / 3.017e-01 |         2.546e-01 / 4.859e-02 |
| M-HFSDP |          6.713e-01 / 1.252e-01 |         2.723e-01 / 1.628e-02 |