### PR TITLE
Do not redundantly install weights with >1 optims

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -2719,7 +2719,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             # Update Megatron-FSDP's compute weights with optimized main weights.
             # If using quantized parameters, this will also perform quantization.
             for model_chunk in self.model_chunks:
-                model_chunk.param_and_grad_buffer.copy_main_weights_to_model_weights()
+                model_chunk.install_optimized_model_weights()
             return
 
         # When using precision-aware optimizer, main params are held by self.optimizer. It will also
@@ -2982,31 +2982,34 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         copy_group_params(self.model_fp32_groups, self.shard_fp32_groups)
 
     @torch.no_grad()
-    def step_with_ready_grads(self) -> bool:
+    def step_with_ready_grads(self, update_model_params: bool = True) -> bool:
         """Step the optimizer with ready gradients, return successful.
         Under the hood, either launch synchronous param all-gathers or get ready to launch
         asynchorous all-gathers that get overlapped with the next forward pass.
         """
-        update_successful = super().step_with_ready_grads()
+        update_successful = super().step_with_ready_grads(update_model_params=update_model_params)
 
-        timers = self.config.timers
-        if timers is not None:
-            timers('params-all-gather', log_level=1).start(barrier=self.config.barrier_with_L1_time)
+        if update_model_params:
+            timers = self.config.timers
+            if timers is not None:
+                timers('params-all-gather', log_level=1).start(
+                    barrier=self.config.barrier_with_L1_time
+                )
 
-        if self.ddp_config.use_megatron_fsdp:
-            # Optionally all-gather Megatron-FSDP sharded main weights
-            # early in preparation for the subsequent forward pass.
-            for model_chunk in self.model_chunks:
-                model_chunk.start_param_sync()
-        else:
-            # If not overlapping all-gather for parameters, launch synchronous all-gather
-            # communication calls here. If overlapping all-gather for parameters, the following
-            # the first all-gather is launched asynchronously in the next optimizer.zero_grad()
-            # call and subsequent all-gathers are launched in the forward pre-hook.
-            if not self.ddp_config.overlap_param_gather:
+            if self.ddp_config.use_megatron_fsdp:
+                # Optionally all-gather Megatron-FSDP sharded main weights
+                # early in preparation for the subsequent forward pass.
                 for model_chunk in self.model_chunks:
                     model_chunk.start_param_sync()
-        if timers is not None:
-            timers('params-all-gather').stop()
+            else:
+                # If not overlapping all-gather for parameters, launch synchronous all-gather
+                # communication calls here. If overlapping all-gather for parameters, the following
+                # the first all-gather is launched asynchronously in the next optimizer.zero_grad()
+                # call and subsequent all-gathers are launched in the forward pre-hook.
+                if not self.ddp_config.overlap_param_gather:
+                    for model_chunk in self.model_chunks:
+                        model_chunk.start_param_sync()
+            if timers is not None:
+                timers('params-all-gather').stop()
 
         return update_successful

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -204,7 +204,7 @@ class MegatronOptimizer(ABC):
         return False
 
     @abstractmethod
-    def step_with_ready_grads(self) -> bool:
+    def step_with_ready_grads(self, update_model_params: bool = True) -> bool:
         """Step the optimizer with ready gradients, return successful."""
         return True
 
@@ -585,7 +585,7 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
         return False
 
     @torch.no_grad()
-    def step_with_ready_grads(self) -> bool:
+    def step_with_ready_grads(self, update_model_params: bool = True) -> bool:
         """Step the optimizer with ready gradients, return successful."""
         timers = self.config.timers
         # Step the optimizer.
@@ -599,21 +599,22 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
             timers('optimizer-inner-step').stop()
 
         # Update params from main params.
-        if timers is not None:
-            timers('optimizer-copy-main-to-model-params', log_level=1).start(
-                barrier=self.config.barrier_with_L1_time
-            )
-        if not self.is_stub_optimizer:
-            if self.config.reuse_grad_buf_for_mxfp8_param_ag:
-                # In the case of overlap_param_gather,
-                # copy is manually called in the training loop
-                if not self.config.overlap_param_gather:
-                    self._copy_main_params_to_param_buffer()
-            else:
-                self._copy_main_params_to_model_params()
+        if update_model_params:
+            if timers is not None:
+                timers('optimizer-copy-main-to-model-params', log_level=1).start(
+                    barrier=self.config.barrier_with_L1_time
+                )
+            if not self.is_stub_optimizer:
+                if self.config.reuse_grad_buf_for_mxfp8_param_ag:
+                    # In the case of overlap_param_gather,
+                    # copy is manually called in the training loop
+                    if not self.config.overlap_param_gather:
+                        self._copy_main_params_to_param_buffer()
+                else:
+                    self._copy_main_params_to_model_params()
 
-        if timers is not None:
-            timers('optimizer-copy-main-to-model-params').stop()
+            if timers is not None:
+                timers('optimizer-copy-main-to-model-params').stop()
 
         return True
 
@@ -968,7 +969,7 @@ class FP32Optimizer(MegatronOptimizer):
         return False
 
     @torch.no_grad()
-    def step_with_ready_grads(self) -> bool:
+    def step_with_ready_grads(self, update_model_params: bool = True) -> bool:
         """Step the optimizer with ready gradients, return successful."""
         if self.is_stub_optimizer:
             return True
@@ -1280,16 +1281,63 @@ class ChainedOptimizer(MegatronOptimizer):
 
         return found_inf_flag
 
+    def _get_deferred_megatron_fsdp_model_chunks(self) -> list[Any]:
+        """Return Megatron-FSDP model chunks whose weight install can be deferred."""
+        if len(self.chained_optimizers) <= 1:
+            return []
+
+        model_chunks = []
+        seen_model_chunks = set()
+        for optimizer in self.chained_optimizers:
+            for model_chunk in getattr(optimizer, 'model_chunks', []):
+                ddp_config = getattr(model_chunk, 'ddp_config', None)
+                if not getattr(ddp_config, 'use_megatron_fsdp', False):
+                    continue
+                if not hasattr(model_chunk, 'install_optimized_model_weights'):
+                    continue
+                model_chunk_id = id(model_chunk)
+                if model_chunk_id in seen_model_chunks:
+                    continue
+                seen_model_chunks.add(model_chunk_id)
+                model_chunks.append(model_chunk)
+
+        return model_chunks
+
+    def _uses_deferred_megatron_fsdp_weight_install(self, optimizer, model_chunk_ids: set) -> bool:
+        """Check whether an inner optimizer owns model chunks with deferred install."""
+        return any(
+            id(model_chunk) in model_chunk_ids
+            for model_chunk in getattr(optimizer, 'model_chunks', [])
+        )
+
     @torch.no_grad()
-    def step_with_ready_grads(self) -> bool:
+    def step_with_ready_grads(self, update_model_params: bool = True) -> bool:
         """Step the optimizer with ready gradients, return successful."""
+        fsdp_model_chunks = (
+            self._get_deferred_megatron_fsdp_model_chunks() if update_model_params else []
+        )
+        fsdp_model_chunk_ids = {id(model_chunk) for model_chunk in fsdp_model_chunks}
         success = True
         for optimizer_idx, optimizer in enumerate(self.chained_optimizers):
-            success &= optimizer.step_with_ready_grads()
-            if self.config.overlap_param_gather_with_optimizer_step and optimizer_idx == 0:
+            defer_weight_install = (
+                self._uses_deferred_megatron_fsdp_weight_install(optimizer, fsdp_model_chunk_ids)
+                or not update_model_params
+            )
+            success &= optimizer.step_with_ready_grads(update_model_params=not defer_weight_install)
+            if (
+                update_model_params
+                and not fsdp_model_chunks
+                and self.config.overlap_param_gather_with_optimizer_step
+                and optimizer_idx == 0
+            ):
                 assert success
                 assert len(optimizer.model_chunks) == 1
                 optimizer.model_chunks[0].start_param_sync(force_dispatch=True)
+
+        if fsdp_model_chunks and success:
+            for model_chunk in fsdp_model_chunks:
+                model_chunk.install_optimized_model_weights()
+                model_chunk.start_param_sync()
 
         return success
 

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -324,6 +325,46 @@ def test_chained_optimizer():
 
     assert list(optimizer_1.state.values())[0]["exp_avg"].is_cuda
     assert list(optimizer_2.state.values())[0]["momentum_buffer"].is_cuda
+
+
+def test_chained_optimizer_defers_megatron_fsdp_weight_install():
+    """Chained M-FSDP optimizers install weights once after all inner steps."""
+
+    class MockMegatronFSDP:
+        def __init__(self):
+            self.ddp_config = SimpleNamespace(use_megatron_fsdp=True)
+
+        def install_optimized_model_weights(self):
+            events.append("install")
+
+        def start_param_sync(self):
+            events.append("sync")
+
+    class MockOptimizer:
+        def __init__(self, name, config, model_chunk):
+            self.name = name
+            self.config = config
+            self.model_chunks = [model_chunk]
+            self.update_model_params_values = []
+            self.param_groups = []
+
+        def step_with_ready_grads(self, update_model_params=True):
+            self.update_model_params_values.append(update_model_params)
+            events.append(f"step:{self.name}:{update_model_params}")
+            return True
+
+    events = []
+    config = SimpleNamespace(overlap_param_gather_with_optimizer_step=False)
+    model_chunk = MockMegatronFSDP()
+    muon_optimizer = MockOptimizer("muon", config, model_chunk)
+    adam_optimizer = MockOptimizer("adam", config, model_chunk)
+    chained_optimizer = ChainedOptimizer([muon_optimizer, adam_optimizer])
+
+    assert chained_optimizer.step_with_ready_grads()
+
+    assert muon_optimizer.update_model_params_values == [False]
+    assert adam_optimizer.update_model_params_values == [False]
+    assert events == ["step:muon:False", "step:adam:False", "install", "sync"]
 
 
 def test_chained_optimizer_get_parameters():


### PR DESCRIPTION
When using Muon, we also have to use Adam. Using both leads to calling `install_optimized_model_weights` twice, once after each optimizer. We now delay the call until all `chained_optimizers` in the `ChainedOptimizer` have run.