### PR TITLE
test: skip cuTile fused mHC tests on Hopper

### DIFF
--- a/docker/.ngc_version.dev
+++ b/docker/.ngc_version.dev
@@ -1,1 +1,1 @@
-nvcr.io/nvidia/pytorch:26.04-py3
+nvcr.io/nvidia/pytorch:26.02-py3

--- a/docker/.ngc_version.dev
+++ b/docker/.ngc_version.dev
@@ -1,1 +1,1 @@
-nvcr.io/nvidia/pytorch:26.02-py3
+nvcr.io/nvidia/pytorch:26.04-py3

--- a/tests/unit_tests/fusions/test_fused_mhc_kernels.py
+++ b/tests/unit_tests/fusions/test_fused_mhc_kernels.py
@@ -14,15 +14,14 @@ import pytest
 import torch
 from torch import Tensor
 
-from megatron.core.fusions.fused_mhc_kernels import is_cutile_available
 from megatron.core.transformer.hyper_connection import (
     native_h_aggregate,
     native_h_post_bda,
     native_proj_rms,
     native_sinkhorn,
 )
-
-_require_cutile = pytest.mark.skipif(not is_cutile_available(), reason="cuTile not installed")
+from tests.unit_tests.test_utilities import is_cutile_available
+from tests.unit_tests.test_utilities import requires_cutile as _require_cutile
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit_tests/test_utilities.py
+++ b/tests/unit_tests/test_utilities.py
@@ -2,6 +2,7 @@
 import os
 from datetime import timedelta
 
+import pytest
 import torch
 from torch._C._distributed_c10d import PrefixStore
 from torch.distributed import rendezvous
@@ -31,6 +32,28 @@ def clear_nvte_env_vars():
     os.environ.pop('NVTE_FLASH_ATTN', None)
     os.environ.pop('NVTE_FUSED_ATTN', None)
     os.environ.pop('NVTE_UNFUSED_ATTN', None)
+
+
+def is_cutile_available():
+    try:
+        import cuda.tile  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def is_hopper():
+    return (
+        torch.cuda.is_available()
+        and torch.cuda.get_device_properties(torch.device("cuda:0")).major == 9
+    )
+
+
+# cuda.tile imports in the 26.04 container on H100, but tileiras rejects sm_90.
+requires_cutile = pytest.mark.skipif(
+    not is_cutile_available() or is_hopper(),
+    reason="cuTile is unavailable or unsupported on Hopper/sm_90 in this container",
+)
 
 
 class Utils:


### PR DESCRIPTION
Not only should we skip cuTile if it's not available, we should also skip it if we're running on Hopper GPUs.