### PR TITLE
ci: Gate optional CI jobs with repository variables

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -406,6 +406,7 @@ jobs:
       && needs.configure.result != 'cancelled'
       && needs.cicd-wait-in-queue.result != 'cancelled'
       && needs.cicd-parse-downstream-testing.result != 'cancelled'
+      && vars.ENABLE_CICD_MBRIDGE_TESTING == 'true'
       && (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
@@ -473,6 +474,7 @@ jobs:
         id: compute
         env:
           IS_MAINTAINER: ${{ needs.is-not-external-contributor.outputs.is_maintainer }}
+          ENABLE_GB200_TESTING: ${{ vars.ENABLE_GB200_TESTING }}
           SELECTED_RUNNER: ${{ needs.is-not-external-contributor.outputs.selected_runner }}
           SELECTED_RUNNER_GB200: ${{ needs.is-not-external-contributor.outputs.selected_runner_gb200 }}
           REGISTRY_AWS: ${{ env.container-registry }}
@@ -480,7 +482,7 @@ jobs:
         run: |
           AWS_ENTRY=$(jq -nc --arg registry "$REGISTRY_AWS" --arg runner "$SELECTED_RUNNER" \
             '{"cloud": "aws", "registry": $registry, "runner": $runner}')
-          if [ "$IS_MAINTAINER" == "true" ]; then
+          if [ "$IS_MAINTAINER" == "true" ] && [ "$ENABLE_GB200_TESTING" == "true" ]; then
             GCP_ENTRY=$(jq -nc --arg registry "$REGISTRY_GCP" --arg runner "$SELECTED_RUNNER_GB200" \
               '{"cloud": "gcp", "registry": $registry, "runner": $runner}')
             MATRIX=$(jq -nc --argjson aws "$AWS_ENTRY" --argjson gcp "$GCP_ENTRY" \
@@ -814,6 +816,7 @@ jobs:
       - cicd-unit-tests-latest
     if: |
       needs.is-not-external-contributor.outputs.is_maintainer == 'true'
+      && vars.ENABLE_GB200_TESTING == 'true'
       && needs.pre-flight.result != 'cancelled'
       && needs.configure.result != 'cancelled'
       && needs.cicd-wait-in-queue.result != 'cancelled'
@@ -891,6 +894,7 @@ jobs:
       PIP_ROOT_USER_ACTION: ignore
     if: |
       needs.is-not-external-contributor.outputs.is_maintainer == 'true'
+      && vars.ENABLE_GB200_TESTING == 'true'
       && needs.is-not-external-contributor.result != 'cancelled'
       && needs.pre-flight.result != 'cancelled'
       && needs.configure.result != 'cancelled'
@@ -957,6 +961,7 @@ jobs:
           DOCS_ONLY: ${{ needs.pre-flight.outputs.docs_only }}
           IS_DEPLOYMENT: ${{ needs.pre-flight.outputs.is_deployment_workflow }}
           IS_MAINTAINER: ${{ needs.is-not-external-contributor.outputs.is_maintainer }}
+          ENABLE_GB200_TESTING: ${{ vars.ENABLE_GB200_TESTING }}
           UNIT_RESULT: ${{ needs.cicd-unit-tests-latest.result }}
           H100_RESULT: ${{ needs.cicd-integration-tests-latest-h100.result }}
           GB200_RESULT: ${{ needs.cicd-integration-tests-latest-gb200.result }}
@@ -981,14 +986,16 @@ jobs:
             FAILED=true
           fi
 
-          # GB200 integration tests may be skipped only for non-maintainer PRs
-          # (no GB200 runners available); maintainer runs must always succeed
-          if [ "$GB200_RESULT" == "skipped" ] && [ "$IS_MAINTAINER" == "true" ]; then
-            echo "❌ cicd-integration-tests-latest-gb200: skipped unexpectedly for a maintainer run"
-            FAILED=true
-          elif [ "$GB200_RESULT" != "success" ] && [ "$GB200_RESULT" != "skipped" ]; then
-            echo "❌ cicd-integration-tests-latest-gb200: $GB200_RESULT"
-            FAILED=true
+          # GB200 integration tests are required only when explicitly enabled.
+          if [ "$ENABLE_GB200_TESTING" == "true" ]; then
+            # GB200 integration tests may be skipped only for non-maintainer PRs
+            # (no GB200 runners available); maintainer runs must always succeed.
+            if [ "$GB200_RESULT" == "skipped" ] && [ "$IS_MAINTAINER" == "true" ]; then
+              echo "❌ cicd-integration-tests-latest-gb200: skipped unexpectedly for a maintainer run"
+              FAILED=true
+            fi
+          else
+            echo "✅ GB200 integration tests disabled by ENABLE_GB200_TESTING"
           fi
 
           # Broad scan: catch any individual job failures or cancellations


### PR DESCRIPTION
## Summary
- Gate MBridge testing behind `ENABLE_CICD_MBRIDGE_TESTING`.
- Gate GB200 container builds and GB200 tests behind `ENABLE_GB200_TESTING`.
- Stop requiring GB200 tests to pass when GB200 testing is disabled.

## Testing
- `git diff --check -- .github/workflows/cicd-main.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cicd-main.yml"); puts "yaml ok"'`

`actionlint` is not installed locally, so I could not run it.