### PR TITLE
feat: skip final full recompute unit

### DIFF
--- a/megatron/core/recompute.py
+++ b/megatron/core/recompute.py
@@ -136,6 +136,8 @@ def checkpointed_forward(
             if (start + layer_offset) in extract_layer_indices:
                 intermediate_hidden_states.append(hidden_states)
 
+    skip_final_recompute = getattr(self.config, "skip_final_recompute", False)
+
     if self.config.recompute_method == 'uniform':
         # Uniformly divide the total number of layers and checkpoint
         # the input activation of each divided chunk.
@@ -144,7 +146,10 @@ def checkpointed_forward(
             chunk_end = min(
                 layer_idx + self.config.recompute_num_layers, self.num_layers_per_pipeline_rank
             )
-            chunk_runner(layer_idx, chunk_end, True)
+            use_checkpoint = not (
+                skip_final_recompute and chunk_end == self.num_layers_per_pipeline_rank
+            )
+            chunk_runner(layer_idx, chunk_end, use_checkpoint)
             layer_idx += self.config.recompute_num_layers
     elif self.config.recompute_method == 'block':
         # Checkpoint the input activation of only a set number of individual
@@ -160,6 +165,12 @@ def checkpointed_forward(
                 layer_idx >= recompute_skip_num_layers
                 and layer_idx < self.config.recompute_num_layers + recompute_skip_num_layers
             )
+            if use_checkpoint and skip_final_recompute:
+                recompute_end = min(
+                    self.config.recompute_num_layers + recompute_skip_num_layers,
+                    self.num_layers_per_pipeline_rank,
+                )
+                use_checkpoint = layer_idx < recompute_end - 1
             chunk_runner(layer_idx, layer_idx + 1, use_checkpoint)
     else:
         raise ValueError("Invalid activation recompute method.")

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -494,6 +494,10 @@ class TransformerConfig(ModelParallelConfig):
     the number of transformer layers to recompute within each pipeline stage.  Must be None for
     'selective' activation checkpointing."""
 
+    skip_final_recompute: bool = False
+    """If True, skip checkpointing the final full-recompute unit in each pipeline stage. Its
+    activations are retained from the forward pass because backward consumes them first."""
+
     distribute_saved_activations: Optional[bool] = False
     """If True, distribute recomputed activations across the model parallel group."""
 
@@ -1486,6 +1490,11 @@ class TransformerConfig(ModelParallelConfig):
         if self.cpu_offloading and self.recompute_granularity is not None:
             raise ValueError(
                 "CPU offloading does not work when activation recomputation is enabled"
+            )
+
+        if self.skip_final_recompute and self.recompute_granularity != "full":
+            raise ValueError(
+                "skip_final_recompute is only supported with full activation recomputation."
             )
 
         if self.recompute_granularity is not None:

--- a/tests/unit_tests/transformer/test_recompute.py
+++ b/tests/unit_tests/transformer/test_recompute.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from collections import Counter
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core import recompute
+from megatron.core.transformer import TransformerConfig
+
+
+class _TraceLayer(torch.nn.Module):
+    def __init__(self, layer_idx, calls):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.layer_number = layer_idx + 1
+        self.calls = calls
+
+    def forward(self, hidden_states, **_kwargs):
+        self.calls[self.layer_idx] += 1
+        return hidden_states * 1.01 + float(self.layer_number)
+
+
+class _RecomputeBlock:
+    def __init__(self, num_layers, recompute_method, recompute_num_layers, skip_final_recompute):
+        self.calls = Counter()
+        self.config = SimpleNamespace(
+            fp8=False,
+            fp4=False,
+            distribute_saved_activations=False,
+            recompute_method=recompute_method,
+            recompute_num_layers=recompute_num_layers,
+            skip_final_recompute=skip_final_recompute,
+        )
+        self.layers = [_TraceLayer(layer_idx, self.calls) for layer_idx in range(num_layers)]
+        self.num_layers_per_pipeline_rank = num_layers
+        self.pg_collection = SimpleNamespace(tp=None)
+
+
+def _run_forward_backward(block):
+    hidden_states = torch.zeros((2, 1, 4), requires_grad=True)
+    output = recompute.checkpointed_forward(
+        block,
+        hidden_states=hidden_states,
+        attention_mask=None,
+        context=None,
+        context_mask=None,
+        rotary_pos_emb=None,
+        attention_bias=None,
+        packed_seq_params=None,
+        use_inner_quantization_context=False,
+    )
+    output.sum().backward()
+    return dict(block.calls)
+
+
+def test_skip_final_recompute_requires_full_recompute():
+    with pytest.raises(ValueError, match="full activation recomputation"):
+        TransformerConfig(num_layers=2, num_attention_heads=1, skip_final_recompute=True)
+    with pytest.raises(ValueError, match="full activation recomputation"):
+        TransformerConfig(
+            num_layers=2,
+            num_attention_heads=1,
+            recompute_granularity='selective',
+            skip_final_recompute=True,
+        )
+
+    config = TransformerConfig(
+        num_layers=2,
+        num_attention_heads=1,
+        recompute_granularity='full',
+        recompute_method='uniform',
+        recompute_num_layers=1,
+        skip_final_recompute=True,
+    )
+
+    assert config.skip_final_recompute
+
+
+@pytest.mark.parametrize(
+    ("recompute_method", "recompute_num_layers", "skip_final_recompute", "expected_calls"),
+    [
+        ("uniform", 2, False, {0: 2, 1: 2, 2: 2, 3: 2, 4: 2}),
+        ("uniform", 2, True, {0: 2, 1: 2, 2: 2, 3: 2, 4: 1}),
+        ("block", 3, False, {0: 2, 1: 2, 2: 2, 3: 1, 4: 1}),
+        ("block", 3, True, {0: 2, 1: 2, 2: 1, 3: 1, 4: 1}),
+    ],
+)
+def test_skip_final_recompute_avoids_final_backward_recompute(
+    recompute_method, recompute_num_layers, skip_final_recompute, expected_calls
+):
+    block = _RecomputeBlock(
+        num_layers=5,
+        recompute_method=recompute_method,
+        recompute_num_layers=recompute_num_layers,
+        skip_final_recompute=skip_final_recompute,
+    )
+
+    calls = _run_forward_backward(block)
+
+    assert calls == expected_calls


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Adds an opt-in MCore flag to skip checkpointing the final full-recompute unit in each pipeline stage, retaining its forward activations because backward consumes them first.

## Issue tracking

Linked issue: Fixes #4546

## Scope

This PR intentionally scopes the optimization to `recompute_granularity='full'`. `skip_final_recompute` now raises a config error when used without full activation recomputation, so the flag cannot silently no-op for selective recompute.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

## Validation

- `LD_LIBRARY_PATH=/home/shivanjanc/.pyenv/versions/3.12.9/lib/python3.12/site-packages/nvidia/cudnn/lib:$LD_LIBRARY_PATH SKIP_DOCS=true bash tools/autoformat.sh`
  - Completed successfully; the script still reports the known non-fatal mypy internal error and exits 0.
- `LD_LIBRARY_PATH=/home/shivanjanc/.pyenv/versions/3.12.9/lib/python3.12/site-packages/nvidia/cudnn/lib:$LD_LIBRARY_PATH python -m pytest tests/unit_tests/transformer/test_recompute.py -q`
  - `5 passed`
- `git diff --check`
  - clean
- CLI/config path checked with `--recompute-granularity full --recompute-method uniform --recompute-num-layers 1 --skip-final-recompute`; both parsed args and `TransformerConfig` set `skip_final_recompute=True`.

## Notes

I validated the functional recompute behavior with focused autograd tests. I did not claim or run a large-scale multi-GPU performance benchmark locally.
