### PR TITLE
ci: restore perf test torchrun logs

### DIFF
--- a/tests/performance_tests/shell_test_utils/run_perf_test.sh
+++ b/tests/performance_tests/shell_test_utils/run_perf_test.sh
@@ -40,7 +40,10 @@ YQ=/usr/local/bin/yq
 mkdir -p "$RESULTS_ROOT"
 RESULTS_JSON="$RESULTS_ROOT/results.json"
 SERVER_LOG_DIR="$RESULTS_ROOT/server_logs"
-mkdir -p "$SERVER_LOG_DIR"
+# launch_jet_workload.py retries unless torchrun's per-rank std*.log assets exist.
+ASSETS_ROOT="$(dirname "$RESULTS_ROOT")"
+TORCHRUN_LOG_DIR="$ASSETS_ROOT/logs/1"
+mkdir -p "$SERVER_LOG_DIR" "$TORCHRUN_LOG_DIR"
 # Clean any pre-existing results.json so this run starts fresh.
 rm -f "$RESULTS_JSON"
 
@@ -150,6 +153,9 @@ SERVER_COMMON_ARGS=(
         --nproc-per-node "$WORLD_SIZE" \
         --master_addr "$MASTER_ADDR" \
         --master_port "$MASTER_PORT" \
+        --log-dir "$TORCHRUN_LOG_DIR" \
+        --tee "0:3" \
+        --redirects "3" \
         -m tools.run_dynamic_text_generation_server \
         "${SERVER_COMMON_ARGS[@]}" \
         "${MODEL_ARGS[@]}" \


### PR DESCRIPTION
## Summary

- Restore torchrun per-rank log emission in the perf test harness.
- Create `{assets_dir}/logs/1` beside `{assets_dir}/perf_results` so `launch_jet_workload.py` can find `std*.log` assets.
- Fixes the `gpt_16b_perf` retry loop introduced when PR #4917 removed the torchrun log arguments.

## Test Plan

- `bash -n tests/performance_tests/shell_test_utils/run_perf_test.sh`
- `git diff --check -- tests/performance_tests/shell_test_utils/run_perf_test.sh`