### PR TITLE
Fix `get_batch` return order to ignore BlendedDataset provenance fields

### DIFF
--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -105,7 +105,13 @@ def get_batch(data_iterator, vp_stage: Optional[int] = None):
     
     batch = get_batch_on_this_cp_rank(batch, is_hybrid_cp=is_hybrid_cp, cp_group=get_context_parallel_group(), hybrid_cp_group_func=get_hybrid_data_context_parallel_groups)
 
-    return [batch[key] for key in sorted(batch.keys())]
+    # Return values in BATCH_KEYS order so callers can unpack into the fixed
+    # names regardless of any provenance fields wrappers like BlendedDataset
+    # add (e.g. "dataset_id"). The for-loop above already populates every
+    # BATCH_KEYS entry on tp_rank 0; other tp_ranks receive a fresh dict from
+    # get_batch_on_this_tp_rank. BATCH_KEYS is already alphabetical, matching
+    # the historical sorted(batch.keys()) order.
+    return [batch[key] for key in BATCH_KEYS]
 
 
 # define spiky loss as a loss that's 10x the max loss observed

--- a/pretrain_hybrid.py
+++ b/pretrain_hybrid.py
@@ -104,7 +104,13 @@ def get_batch(data_iterator, vp_stage=None):
 
     batch = get_batch_on_this_cp_rank(batch, is_hybrid_cp=is_hybrid_cp, cp_group=get_context_parallel_group(), hybrid_cp_group_func=get_hybrid_data_context_parallel_groups)
 
-    return [batch[key] for key in sorted(batch.keys())]
+    # Return values in BATCH_KEYS order so callers can unpack into the fixed
+    # names regardless of any provenance fields wrappers like BlendedDataset
+    # add (e.g. "dataset_id"). The for-loop above already populates every
+    # BATCH_KEYS entry on tp_rank 0; other tp_ranks receive a fresh dict from
+    # get_batch_on_this_tp_rank. BATCH_KEYS is already alphabetical, matching
+    # the historical sorted(batch.keys()) order.
+    return [batch[key] for key in BATCH_KEYS]
 
 
 # define spiky loss as a loss that's 10x the max loss observed


### PR DESCRIPTION
## Summary

`get_batch` in [`pretrain_gpt.py`](https://github.com/NVIDIA/Megatron-LM/blob/f7f584d7a04c1891bc583a1213ebb1dbcac4e158/pretrain_gpt.py#L108) and [`pretrain_hybrid.py`](https://github.com/NVIDIA/Megatron-LM/blob/f7f584d7a04c1891bc583a1213ebb1dbcac4e158/pretrain_hybrid.py#L107) ended with `[batch[key] for key in sorted(batch.keys())]`, which returns one element per key actually present in the batch dict. The call sites at `forward_step` ([`pretrain_gpt.py:193-204`](https://github.com/NVIDIA/Megatron-LM/blob/f7f584d7a04c1891bc583a1213ebb1dbcac4e158/pretrain_gpt.py#L193-L204), [`pretrain_hybrid.py:187-198`](https://github.com/NVIDIA/Megatron-LM/blob/f7f584d7a04c1891bc583a1213ebb1dbcac4e158/pretrain_hybrid.py#L187-L198)) unpack into the 10 names in `BATCH_KEYS`.

[`BlendedDataset.__getitem__`](https://github.com/NVIDIA/Megatron-LM/blob/f7f584d7a04c1891bc583a1213ebb1dbcac4e158/megatron/core/datasets/blended_dataset.py#L108) returns `{"dataset_id": dataset_id, **self.datasets[dataset_id][dataset_sample_id]}` — i.e. it adds a `"dataset_id"` provenance key alongside the underlying dataset's fields. On **tp_rank 0** — which alone reads `next(data_iterator)` — that extra key survives `get_batch_on_this_tp_rank` (which mutates in place on rank 0) and `get_pretrain_batch_on_this_cp_rank` (no-op when cp_size == 1), so the return list has 11 items and unpacking raises `ValueError: too many values to unpack (expected 10)` on every `tp_rank == 0` rank.

Other tp_ranks construct a [fresh 10-key dict](https://github.com/NVIDIA/Megatron-LM/blob/f7f584d7a04c1891bc583a1213ebb1dbcac4e158/megatron/core/utils.py#L2235-L2246) so they unpack cleanly — which is why the failure is restricted to ranks where `rank % tp_size == 0`.

The fix: iterate `BATCH_KEYS` directly so the return shape is contractually 10 regardless of what wrappers the dataloader stack add. `BATCH_KEYS` is already alphabetical, matching the historical `sorted(batch.keys())` order.

This bug was introduced by #4103 (commit 5e4fc931ba, refactor consolidating `get_batch`).

## Test plan

- [x] Functional test on a multi-blend pretraining config with TP > 1 (this reliably reproduces the failure on `tp_rank == 0`).
- [x] Existing GPT/hybrid unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)