### PR TITLE
fix(fsdp): import os in safe_get_rank fallback

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py
@@ -16,6 +16,7 @@ import contextlib
 import inspect
 import logging
 import operator
+import os
 from contextlib import nullcontext
 from functools import reduce
 from importlib.metadata import version

--- a/tests/unit_tests/distributed/mfsdp_v1/test_mcore_tensor_parallelism_detect.py
+++ b/tests/unit_tests/distributed/mfsdp_v1/test_mcore_tensor_parallelism_detect.py
@@ -7,6 +7,7 @@ from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataPa
 from megatron.core.distributed.fsdp.src.megatron_fsdp.utils import (
     get_mcore_tensor_parallel_partition_dim,
     is_mcore_tensor_parallel_duplicated,
+    safe_get_rank,
     using_tensor_parallel,
 )
 
@@ -77,6 +78,13 @@ def test_using_tensor_parallel_false_when_mesh_size_one():
     # Mesh with 1 element -> no tensor parallel
     dist_index = DummyDistIndex(numel=1)
     assert using_tensor_parallel(dist_index) is False
+
+
+def test_safe_get_rank_should_fall_back_to_rank_env_if_distributed_is_not_initialized(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    monkeypatch.setenv("RANK", "7")
+
+    assert safe_get_rank() == 7
 
 
 class DummyConfig:


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/Megatron-LM/issues/4958.

## Summary
- add the missing `os` import in Megatron-FSDP utils
- add a focused regression test for `safe_get_rank()` env fallback

## Root cause
`safe_get_rank()` falls back to `os.environ["RANK"]` when `torch.distributed` is not initialized, but `megatron_fsdp/utils.py` did not import `os`, so that fallback path raised `NameError`.

## Validation
- direct function-level validation: loading `megatron_fsdp/utils.py` and verifying `safe_get_rank()` returns `7` when `RANK=7` and `torch.distributed.is_initialized()` is mocked to `False`
- attempted targeted pytest for `tests/unit_tests/distributed/megatron_fsdp/test_mcore_tensor_parallelism_detect.py -k safe_get_rank`
- local test harness is currently blocked by missing optional dependencies in this environment (`pytest` on the system interpreter, then `triton` during repo `conftest` import)

## Notes
- scope is intentionally minimal: one import fix plus one regression test