### PR TITLE
Fix ModelOpt parameters typo

### DIFF
--- a/examples/post_training/modelopt/README.md
+++ b/examples/post_training/modelopt/README.md
@@ -63,7 +63,7 @@ provide `${EXPORT_DIR}` to `export.sh`.
 > **📙 NOTE:** ModelOpt supports different quantization formats which are listed in the [ModelOpt quant configs](https://github.com/NVIDIA/Model-Optimizer/blob/7971fff05882da7eae16eae6bc927d1481dcd63f/modelopt/torch/quantization/config.py#L626).
 > The quant config is specified by the full config name in all-caps, e.g. NVFP4_DEFAULT_CFG.
 > By default, we simulate the low-precision numerical behavior (fake-quant) which can be run on GPUs with compute > 80.
-> Real low-precision paramters (e.g. `E4M3` or `E2M1`)
+> Real low-precision parameters (e.g. `E4M3` or `E2M1`)
 > and low-precision compute (e.g. `FP8Linear`) are also supported depending on GPU compute capability.
 > **See [Advanced Topics](./ADVANCED.md) for details**.
 


### PR DESCRIPTION
## Summary
- Fix a typo in the ModelOpt post-training README: `paramters` -> `parameters`.

## Validation
- `git diff --check`
- `! grep -R "paramters" -n examples/post_training/modelopt/README.md`

Category: docs typo
Confidence: 82/100