### PR TITLE
Fix NameError in is_flashinfer_min_version when check_equality=False

### DIFF
--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -484,7 +484,7 @@ def is_flashinfer_min_version(version, check_equality=True):
         return False
     if check_equality:
         return flashinfer_version >= PkgVersion(version)
-    return flashinver_version > PkgVersion(version)
+    return flashinfer_version > PkgVersion(version)
 
 
 def accepts_parameter(func: Callable, name: str) -> bool:

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -52,6 +52,24 @@ def test_divide_improperly():
         util.divide(4, 5)
 
 
+@pytest.mark.skipif(not util.HAVE_PACKAGING, reason="packaging is not installed")
+@pytest.mark.parametrize("check_equality", [True, False])
+def test_is_flashinfer_min_version(check_equality):
+    from packaging.version import Version as PkgVersion
+
+    with patch.object(util, "get_flashinfer_version", return_value=PkgVersion("0.6.5")):
+        # check_equality=False exercised the path that used to reference an
+        # undefined name and raise NameError instead of returning a bool.
+        assert util.is_flashinfer_min_version("0.6.4", check_equality=check_equality) is True
+        assert util.is_flashinfer_min_version("0.7.0", check_equality=check_equality) is False
+        assert (
+            util.is_flashinfer_min_version("0.6.5", check_equality=check_equality) is check_equality
+        )
+
+    with patch.object(util, "get_flashinfer_version", return_value=None):
+        assert util.is_flashinfer_min_version("0.6.4", check_equality=check_equality) is False
+
+
 def test_experimental_cls_init():
     with patch.object(config, 'ENABLE_EXPERIMENTAL', True):
         # Check that initialization works


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Fixes a `NameError` in `is_flashinfer_min_version` (`megatron/core/utils.py`). The `check_equality=False` branch returns `flashinver_version > PkgVersion(version)`, but no such name exists; the walrus operator a few lines above binds `flashinfer_version`. So any call with `check_equality=False` raises `NameError: name 'flashinver_version' is not defined` instead of comparing versions.

```python
def is_flashinfer_min_version(version, check_equality=True):
    ...
    if (flashinfer_version := get_flashinfer_version()) is None:
        return False
    if check_equality:
        return flashinfer_version >= PkgVersion(version)
    return flashinver_version > PkgVersion(version)   # NameError when check_equality=False
```

Repro (with flashinfer installed):

```python
from megatron.core.utils import is_flashinfer_min_version
is_flashinfer_min_version("0.6.4", check_equality=False)
# NameError: name 'flashinver_version' is not defined
```

The fix is to use the correct `flashinfer_version`, matching the sibling helpers `is_te_min_version` / `is_torch_min_version`. Added a unit test in `tests/unit_tests/test_utils.py` that patches `get_flashinfer_version` and exercises both `check_equality` values (and the `None` case), so the broken branch is now covered.

## Issue tracking

Linked issue: none (small bug fix).

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
