### PR TITLE
Add missing `os` import for `safe_get_rank()` fallback in megatron_fsdp/utils (fixes #4958)

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py
@@ -16,6 +16,7 @@ import contextlib
 import inspect
 import logging
 import operator
+import os
 from contextlib import nullcontext
 from functools import reduce
 from importlib.metadata import version


### PR DESCRIPTION
Fixes #4958.

## Bug

`safe_get_rank()` in `megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py` falls back to `int(os.environ.get("RANK", 0))` when `torch.distributed` is not initialized, but the module never imports `os`. The fallback raises `NameError: name 'os' is not defined` instead of returning the env rank (or `0` via the `except (ValueError, TypeError)` clause).

Reproducer (with no `torch.distributed.init_process_group` call beforehand):

```python
from megatron.core.distributed.fsdp.src.megatron_fsdp.utils import safe_get_rank
safe_get_rank()
# NameError: name 'os' is not defined
```

The sibling `safe_get_rank()` implementation at `megatron/core/_rank_utils.py` works correctly because that module already imports `os`.

## Fix

Add `import os` to the module's stdlib imports (alphabetical position after `operator`).

```diff
 import contextlib
 import inspect
 import logging
 import operator
+import os
 from contextlib import nullcontext
```

One-line change. No behavior change beyond removing the latent `NameError`.

## Verification

`ast.parse` confirms `os` is now in the top-level imports, and the existing `os.environ.get("RANK", 0)` usage on line 476 now resolves at runtime instead of raising.

## DCO

Commit is signed (`Signed-off-by: LeSingh1 <sshaurya914@gmail.com>`).