### PR TITLE
[dev] feat(moe): Decouple activation clamp value of the shared expert for Step-3.5-Flash

### DIFF
--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -278,7 +278,7 @@ class SharedExpertMLP(MLP):
                         intermediate_parallel,
                         bias_parallel,
                         self.config.activation_func_fp8_input_store,
-                        clamp_value=self.config.activation_func_clamp_value,
+                        clamp_value=self.config.activation_func_clamp_value_shared_expert,
                     )
                 else:
                     raise ValueError("Only support fusion of gelu and swiglu")
@@ -289,7 +289,7 @@ class SharedExpertMLP(MLP):
 
                     def glu(x):
                         x_glu, x_linear = torch.chunk(x, 2, dim=-1)
-                        if (val := self.config.activation_func_clamp_value) is not None:
+                        if (val := self.config.activation_func_clamp_value_shared_expert) is not None:
                             x_glu = x_glu.clamp(min=None, max=val)
                             x_linear = x_linear.clamp(min=-val, max=val)
                         return self.config.activation_func(x_glu) * (

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -183,7 +183,23 @@ class SharedExpertMLP(MLP):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Forward function"""
-        output, _ = super().forward(hidden_states)
+        # ``MLP.forward`` (called via ``super().forward``) reads
+        # ``self.config.activation_func_clamp_value``. To honor
+        # ``activation_func_clamp_value_shared_expert`` for the shared expert (and
+        # the documented fallback to ``activation_func_clamp_value`` when it is
+        # None), temporarily override the field on this instance's config (which
+        # is a private deepcopy and is not shared with routed experts) and
+        # restore it after ``super().forward`` returns.
+        shared_clamp = self.config.activation_func_clamp_value_shared_expert
+        if shared_clamp is not None:
+            original_clamp = self.config.activation_func_clamp_value
+            self.config.activation_func_clamp_value = shared_clamp
+            try:
+                output, _ = super().forward(hidden_states)
+            finally:
+                self.config.activation_func_clamp_value = original_clamp
+        else:
+            output, _ = super().forward(hidden_states)
         if self.use_shared_expert_gate:
             logits = torch.nn.functional.linear(hidden_states, self.gate_weight)
             gate_score = torch.nn.functional.sigmoid(logits)
@@ -289,7 +305,9 @@ class SharedExpertMLP(MLP):
 
                     def glu(x):
                         x_glu, x_linear = torch.chunk(x, 2, dim=-1)
-                        if (val := self.config.activation_func_clamp_value_shared_expert) is not None:
+                        if (
+                            val := self.config.activation_func_clamp_value_shared_expert
+                        ) is not None:
                             x_glu = x_glu.clamp(min=None, max=val)
                             x_linear = x_linear.clamp(min=-val, max=val)
                         return self.config.activation_func(x_glu) * (

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -216,6 +216,11 @@ class TransformerConfig(ModelParallelConfig):
     """Clamp the output of the linear_fc1 in the activation function. Only used when activation_func
     is quick_gelu or weighted SwiGLU (MoE only)."""
 
+    activation_func_clamp_value_shared_expert: Optional[float] = None
+    """Clamp the output of the linear_fc1 in the activation function for shared expert. Only used
+    when activation_func is SwiGLU (MoE only). When not None, it will override the
+    activation_func_clamp_value for shared expert, otherwise use the activation_func_clamp_value."""
+
     num_moe_experts: Optional[int] = None
     """Number of experts to use for MoE layer. When set, it replaces MLP with MoE layer. Set to None
     for no MoE."""
@@ -2212,6 +2217,24 @@ class TransformerConfig(ModelParallelConfig):
                     raise ValueError(
                         "use_transformer_engine_op_fuser must be False "
                         "when activation_func_clamp_value is not None for SwiGLU"
+                    )
+
+        if self.activation_func_clamp_value_shared_expert is not None:
+            # swiglu
+            if self.activation_func == F.silu and self.gated_linear_unit:
+                if self.num_moe_experts is None:
+                    raise ValueError(
+                        "activation_func_clamp_value_shared_expert for SwiGLU is only supported with MoE."
+                    )
+                if self.use_te_activation_func:
+                    raise ValueError(
+                        "use_te_activation_func must be False "
+                        "when activation_func_clamp_value_shared_expert is not None for SwiGLU"
+                    )
+                if self.use_transformer_engine_op_fuser:
+                    raise ValueError(
+                        "use_transformer_engine_op_fuser must be False "
+                        "when activation_func_clamp_value_shared_expert is not None for SwiGLU"
                     )
 
         if self.apply_rope_fusion:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2224,7 +2224,8 @@ class TransformerConfig(ModelParallelConfig):
             if self.activation_func == F.silu and self.gated_linear_unit:
                 if self.num_moe_experts is None:
                     raise ValueError(
-                        "activation_func_clamp_value_shared_expert for SwiGLU is only supported with MoE."
+                        "activation_func_clamp_value_shared_expert for SwiGLU is only "
+                        "supported with MoE."
                     )
                 if self.use_te_activation_func:
                     raise ValueError(

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -192,3 +192,120 @@ class TestSharedExperts:
             "Clamping had no observable effect on shared-expert output; "
             "activation_func_clamp_value may not be plumbed through."
         )
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("bias_activation_fusion", [True, False])
+    def test_shared_expert_clamp_value_shared_expert_swiglu(self, bias_activation_fusion):
+        """
+        Verifies that ``activation_func_clamp_value_shared_expert`` independently
+        controls clamping of the shared expert's SwiGLU activation, in both the
+        overlapped and non-overlapped paths, and in both the
+        ``bias_activation_fusion`` and manual-glu code paths.
+        """
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, expert_model_parallel_size=1)
+
+        clamp_value = 1.0
+
+        # Create MoE layer with shared expert overlap enabled.
+        model_parallel_cuda_manual_seed(123)
+        moe_layer_overlap = self.get_moe_layer(
+            moe_shared_expert_overlap=True,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value_shared_expert=clamp_value,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+
+        # Create MoE layer with shared expert overlap disabled, sharing weights.
+        model_parallel_cuda_manual_seed(123)
+        moe_layer_no_overlap = self.get_moe_layer(
+            moe_shared_expert_overlap=False,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value_shared_expert=clamp_value,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+        moe_layer_no_overlap.load_state_dict(moe_layer_overlap.state_dict())
+
+        # Use a large input range to ensure the clamp actually triggers.
+        hidden_states = (
+            torch.randn((32, 2, self.config.hidden_size), device="cuda", dtype=torch.bfloat16) * 5.0
+        )
+        hidden_states = hidden_states.detach().requires_grad_(True)
+        hidden_states_no_overlap = hidden_states.detach().clone().requires_grad_(True)
+
+        output_overlap, _ = moe_layer_overlap(hidden_states)
+        output_no_overlap, _ = moe_layer_no_overlap(hidden_states_no_overlap)
+
+        cos_out = torch.nn.functional.cosine_similarity(
+            output_overlap.flatten().unsqueeze(0).float(),
+            output_no_overlap.flatten().unsqueeze(0).float(),
+        ).item()
+        assert cos_out > 0.999, (
+            f"shared-expert clamp_value_shared_expert output mismatch "
+            f"(fusion={bias_activation_fusion}): cos sim = {cos_out:.6f}"
+        )
+
+        output_overlap.mean().backward()
+        output_no_overlap.mean().backward()
+
+        for p_overlap, p_no_overlap in zip(
+            moe_layer_overlap.parameters(), moe_layer_no_overlap.parameters()
+        ):
+            assert torch.allclose(p_overlap.grad, p_no_overlap.grad), (
+                f"shared-expert clamp_value_shared_expert grad mismatch "
+                f"(fusion={bias_activation_fusion}); "
+                f"max diff: {torch.max(torch.abs(p_overlap.grad - p_no_overlap.grad))}"
+            )
+
+        # Verify clamping has an observable effect on the shared-expert output.
+        model_parallel_cuda_manual_seed(123)
+        moe_layer_unclamped = self.get_moe_layer(
+            moe_shared_expert_overlap=False,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value_shared_expert=None,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+        moe_layer_unclamped.load_state_dict(moe_layer_overlap.state_dict())
+
+        hidden_states_unclamped = hidden_states.clone().detach().requires_grad_(True)
+        output_unclamped, _ = moe_layer_unclamped(hidden_states_unclamped)
+        assert not torch.allclose(output_no_overlap, output_unclamped), (
+            "Clamping had no observable effect on shared-expert output; "
+            "activation_func_clamp_value_shared_expert may not be plumbed through."
+        )
+
+        # Verify activation_func_clamp_value (routed-expert setting) does NOT clamp
+        # the shared expert when activation_func_clamp_value_shared_expert is None.
+        # The shared-expert outputs should match between the unclamped run above
+        # and a run that sets only the routed-expert clamp.
+        model_parallel_cuda_manual_seed(123)
+        moe_layer_routed_only = self.get_moe_layer(
+            moe_shared_expert_overlap=False,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value=clamp_value,
+            activation_func_clamp_value_shared_expert=None,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+        moe_layer_routed_only.load_state_dict(moe_layer_overlap.state_dict())
+
+        se_input = (
+            torch.randn((4, 2, self.config.hidden_size), device="cuda", dtype=torch.bfloat16) * 5.0
+        )
+        se_out_unclamped = moe_layer_unclamped.shared_experts(se_input)
+        se_out_routed_only = moe_layer_routed_only.shared_experts(se_input)
+        torch.testing.assert_close(
+            se_out_unclamped,
+            se_out_routed_only,
+            msg=(
+                "activation_func_clamp_value should not affect shared experts when "
+                "activation_func_clamp_value_shared_expert is None."
+            ),
+        )
+
+        # And conversely, setting only activation_func_clamp_value_shared_expert
+        # should change the shared-expert output relative to the fully-unclamped run.
+        se_out_se_clamp = moe_layer_no_overlap.shared_experts(se_input)
+        assert not torch.allclose(se_out_unclamped, se_out_se_clamp), (
+            "activation_func_clamp_value_shared_expert had no observable effect on "
+            "shared-expert output when set in isolation."
+        )

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -274,10 +274,10 @@ class TestSharedExperts:
             "activation_func_clamp_value_shared_expert may not be plumbed through."
         )
 
-        # Verify activation_func_clamp_value (routed-expert setting) does NOT clamp
-        # the shared expert when activation_func_clamp_value_shared_expert is None.
-        # The shared-expert outputs should match between the unclamped run above
-        # and a run that sets only the routed-expert clamp.
+        # When activation_func_clamp_value_shared_expert is None, the shared expert
+        # should fall back to activation_func_clamp_value (per the field's docstring).
+        # A layer with shared=clamp_value should therefore produce the same shared-
+        # expert output as a layer with shared=None and routed=clamp_value.
         model_parallel_cuda_manual_seed(123)
         moe_layer_routed_only = self.get_moe_layer(
             moe_shared_expert_overlap=False,
@@ -291,21 +291,37 @@ class TestSharedExperts:
         se_input = (
             torch.randn((4, 2, self.config.hidden_size), device="cuda", dtype=torch.bfloat16) * 5.0
         )
-        se_out_unclamped = moe_layer_unclamped.shared_experts(se_input)
-        se_out_routed_only = moe_layer_routed_only.shared_experts(se_input)
+        se_out_shared_clamp = moe_layer_no_overlap.shared_experts(se_input)
+        se_out_routed_fallback = moe_layer_routed_only.shared_experts(se_input)
         torch.testing.assert_close(
-            se_out_unclamped,
-            se_out_routed_only,
+            se_out_shared_clamp,
+            se_out_routed_fallback,
             msg=(
-                "activation_func_clamp_value should not affect shared experts when "
-                "activation_func_clamp_value_shared_expert is None."
+                "activation_func_clamp_value_shared_expert=None should fall back to "
+                "activation_func_clamp_value for the shared expert."
             ),
         )
 
-        # And conversely, setting only activation_func_clamp_value_shared_expert
-        # should change the shared-expert output relative to the fully-unclamped run.
-        se_out_se_clamp = moe_layer_no_overlap.shared_experts(se_input)
-        assert not torch.allclose(se_out_unclamped, se_out_se_clamp), (
-            "activation_func_clamp_value_shared_expert had no observable effect on "
-            "shared-expert output when set in isolation."
+        # When both are set, activation_func_clamp_value_shared_expert must override
+        # activation_func_clamp_value for the shared expert: a layer with only the
+        # shared clamp set should match a layer that additionally sets the routed
+        # clamp to a much larger (essentially no-op) value.
+        model_parallel_cuda_manual_seed(123)
+        moe_layer_override = self.get_moe_layer(
+            moe_shared_expert_overlap=False,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value=100.0,
+            activation_func_clamp_value_shared_expert=clamp_value,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+        moe_layer_override.load_state_dict(moe_layer_overlap.state_dict())
+
+        se_out_override = moe_layer_override.shared_experts(se_input)
+        torch.testing.assert_close(
+            se_out_shared_clamp,
+            se_out_override,
+            msg=(
+                "activation_func_clamp_value_shared_expert should override "
+                "activation_func_clamp_value for the shared expert when both are set."
+            ),
         )


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->
Decouple the SwiGLU activation clamp value of the shared expert from the routed-expert clamp by introducing a new config field ``activation_func_clamp_value_shared_expert``. When unset, the shared expert is unclamped; when set, it overrides the routed-expert clamp value for the shared expert only.

Adds a unit test that covers both ``bias_activation_fusion`` paths and both overlap / non-overlap shared-expert paths, plus an independence check against ``activation_func_clamp_value``.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
