### PR TITLE
Fix elastification unwrap_model import

### DIFF
--- a/megatron/elastification/loss_func.py
+++ b/megatron/elastification/loss_func.py
@@ -10,8 +10,8 @@ import torch
 
 from megatron.core import parallel_state
 from megatron.core.models.gpt import GPTModel
+from megatron.core.utils import unwrap_model
 from megatron.training import get_args
-from megatron.training.utils import unwrap_model
 
 
 def _mask_loss(output_tensor, loss_mask):

--- a/tests/unit_tests/elastification/test_loss_func.py
+++ b/tests/unit_tests/elastification/test_loss_func.py
@@ -16,11 +16,8 @@ import torch
 
 pytestmark = pytest.mark.flaky_in_dev
 
-try:
-    from megatron.elastification import loss_func as loss_func_module
-    from megatron.elastification.loss_func import _mask_loss, loss_func
-except ImportError as exc:
-    pytest.skip(f"megatron.elastification.loss_func unavailable: {exc}", allow_module_level=True)
+from megatron.elastification import loss_func as loss_func_module
+from megatron.elastification.loss_func import _mask_loss, loss_func
 
 
 def _stub_args(**overrides):


### PR DESCRIPTION
﻿- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Fixes the elastification loss function import so `tests/unit_tests/elastification/test_loss_func.py` can be collected again after `unwrap_model` stopped being exported from `megatron.training.utils`.

## Issue tracking

Linked issue: Fixes #4971

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Notes

This is a focused import-path fix plus the related test cleanup requested in review. Existing unit coverage already imports `megatron.elastification.loss_func` in `tests/unit_tests/elastification/test_loss_func.py`, which is the collection path reported in #4971.

Root cause: `megatron.elastification.loss_func` imported `unwrap_model` from `megatron.training.utils`, but `megatron/training/utils/__init__.py` no longer exports that symbol. The function is defined in `megatron.core.utils`, and current callers throughout the repository already import it from there.

The import guard in `tests/unit_tests/elastification/test_loss_func.py` has also been removed so future import regressions fail during collection instead of being hidden by a module-level skip.

Validation performed locally:

- `python -m py_compile megatron\elastification\loss_func.py tests\unit_tests\elastification\test_loss_func.py`
- `rg "pytest\.skip\(|try:|except ImportError|importorskip" tests\unit_tests\elastification\test_loss_func.py -n` returned no matches
- `git diff --check`

I could not run `pytest tests/unit_tests/elastification/test_loss_func.py` in this local checkout because the local Python environment is missing `pytest` and `torch`. CI should exercise the exact failing collection path.
