### PR TITLE
Avoid offsetting functional test master port

### DIFF
--- a/tests/functional_tests/shell_test_utils/_run_training.sh
+++ b/tests/functional_tests/shell_test_utils/_run_training.sh
@@ -175,10 +175,6 @@ LAST_RANK=$((GPUS_PER_NODE - 1))
 export LOG_DIR=$OUTPUT_PATH/logs/$REPEAT
 mkdir -p $LOG_DIR
 
-if [[ -n "${RUN_CI_PHASE_INDEX:-}" ]]; then
-    MASTER_PORT=$((MASTER_PORT + RUN_CI_PHASE_INDEX))
-fi
-
 # Read launcher type from model config (default: torchrun)
 LAUNCHER=$(/usr/local/bin/yq '.LAUNCHER // "torchrun"' "$TRAINING_PARAMS_PATH")
 


### PR DESCRIPTION
Summary:
- Remove the phase-based MASTER_PORT offset from functional test training launches.
- Keep multi-node phase barriers and exit-code synchronization intact.
- Avoid binding to unchecked derived ports that can already be in use.

Validation:
- bash -n tests/functional_tests/shell_test_utils/_run_training.sh
- bash -n tests/functional_tests/shell_test_utils/run_ci_test.sh
- git diff --check