### PR TITLE
[dev] fix: use global RoPE length for DeepSeek V4 CP attention

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -103,6 +103,11 @@ def _apply_rope(
         total_seq_len = rotary_seq_len
     else:
         total_seq_len = rotary_seq_len * ratio
+    if cp_group is not None and cp_group.size() > 1:
+        # Inputs are already local zigzag CP chunks. Request the full sequence
+        # length, then let RotaryEmbedding select this rank's CP slice before
+        # optional compression-ratio sampling.
+        total_seq_len *= cp_group.size()
     mscale = 1.0
     rotary_pos_cos = None
     rotary_pos_sin = None

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -314,6 +314,11 @@ class DSv4HybridAttention(Attention):
         else:
             cu_seqlens_kv = None
             rope_seqlen = seq_len
+            if self.config.context_parallel_size > 1:
+                # ``core_attn_out`` is local to this CP rank. Request the full
+                # sequence RoPE table so RotaryEmbedding can take its normal
+                # zigzag CP slice, yielding local global-position frequencies.
+                rope_seqlen *= self.config.context_parallel_size
         mscale = 1.0
         rotary_pos_cos = None
         rotary_pos_sin = None


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Fixes DeepSeek V4 CSA/hybrid attention RoPE generation under context parallelism by requesting full-sequence RoPE tables before applying the existing CP slice.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Details

When `context_parallel_size > 1`, DeepSeek V4 attention receives local zigzag CP chunks, but `RotaryEmbedding` still needs the full sequence length so it can select the correct CP-local   
position slice. Passing only the local chunk length can produce RoPE frequencies for local positions instead of global positions.                                                           
                                                                                                                                                                                            
This PR updates:                                                                                                                                                                            
                                                                                                                                                                                            
- `experimental_attention_variant/csa.py`                                                                                                                                                   
  - Scale `total_seq_len` by `cp_group.size()` before RoPE generation when CP is enabled.                                                                                                   
                                                                                                                                                                                            
- `experimental_attention_variant/deepseek_v4_hybrid_attention.py`                                                                                                                          
  - Scale `rope_seqlen` by `context_parallel_size` before RoPE generation for non-packed sequence DSv4 hybrid attention.

## Validation                                                                                                                                                                               
                                                                                                                                                                                              
Validated indirectly through a 16-node DeepSeek-V4-Flash GRPO run from verl using Megatron actor/ref workers with context parallelism enabled:                                              
                                                                                                                                                                                            
- `MAX_RESPONSE_LENGTH=10240`                                                                                                                                                               
- `ACTOR_CP=2`, `REF_CP=2`                                                                                                                                                                  
- Job completed successfully                                                                                                                                                                

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
