### PR TITLE
test: re-enable paged stashing MoE tests

### DIFF
--- a/tests/unit_tests/transformer/moe/test_paged_stashing.py
+++ b/tests/unit_tests/transformer/moe/test_paged_stashing.py
@@ -208,7 +208,6 @@ class TestPagedStashing:
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
 
-    @pytest.mark.flaky_in_dev
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @pytest.mark.internal
     def test_forward_backward_4_layers(self):
@@ -298,7 +297,6 @@ class TestPagedStashingOverBudget:
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
 
-    @pytest.mark.flaky_in_dev
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @pytest.mark.internal
     def test_overload_factor_and_over_budget(self):

--- a/tests/unit_tests/transformer/moe/test_paged_stashing.py
+++ b/tests/unit_tests/transformer/moe/test_paged_stashing.py
@@ -196,6 +196,19 @@ _TE_GROUPED_MLP_OP_FUSER_SKIP_REASON = (
 )
 
 
+def _is_mxfp8_supported() -> bool:
+    """MXFP8 quantization in TE requires compute capability >= 10.0 (Blackwell)."""
+    if not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability()[0] >= 10
+
+
+_MXFP8_SKIP_REASON = (
+    "MXFP8 (tests configure fp8_recipe='mxfp8') requires compute capability >= 10.0 (Blackwell)"
+)
+
+
+@pytest.mark.skipif(not _is_mxfp8_supported(), reason=_MXFP8_SKIP_REASON)
 @pytest.mark.skipif(
     not _te_grouped_mlp_op_fuser_environment_supported(),
     reason=_TE_GROUPED_MLP_OP_FUSER_SKIP_REASON,
@@ -285,6 +298,7 @@ class TestPagedStashing:
             ), f"tokens_per_expert != ref: max diff = {(tpe_f - ref_f).abs().max().item()}"
 
 
+@pytest.mark.skipif(not _is_mxfp8_supported(), reason=_MXFP8_SKIP_REASON)
 @pytest.mark.skipif(
     not _te_grouped_mlp_op_fuser_environment_supported(),
     reason=_TE_GROUPED_MLP_OP_FUSER_SKIP_REASON,


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Removes the `@pytest.mark.flaky_in_dev` markers from both paged-stashing MoE tests and replaces them with an explicit SM100 (Blackwell) skip, so the tests run on Blackwell CI and skip cleanly on H100/A100 instead of failing with a TE runtime error.

## Why the original markers were wrong

`flaky_in_dev` was added in #4931 to keep CI green, but the failures were not flaky — they were a missing hardware gate. Both classes configure `fp8_recipe='mxfp8'`; TE rejects this on devices below compute capability 10.0 with:

```
RuntimeError: Device compute capability 10.0 or higher required for MXFP8 execution.
  at .../transformer_engine/pytorch/quantization.py:143
```

H100 CI is SM90, so the tests can never have run there. The previous `flaky_in_dev` marker hid this fact in the `dev` environment.

## Change

```python
def _is_mxfp8_supported() -> bool:
    """MXFP8 quantization in TE requires compute capability >= 10.0 (Blackwell)."""
    if not torch.cuda.is_available():
        return False
    return torch.cuda.get_device_capability()[0] >= 10


@pytest.mark.skipif(not _is_mxfp8_supported(), reason=_MXFP8_SKIP_REASON)
@pytest.mark.skipif(not _te_grouped_mlp_op_fuser_environment_supported(), ...)
@pytest.mark.skipif(not is_hybrid_ep_available(), reason="Hybrid EP are not available")
class TestPagedStashing: ...

@pytest.mark.skipif(not _is_mxfp8_supported(), reason=_MXFP8_SKIP_REASON)
@pytest.mark.skipif(not _te_grouped_mlp_op_fuser_environment_supported(), ...)
@pytest.mark.skipif(not is_hybrid_ep_available(), reason="Hybrid EP are not available")
class TestPagedStashingOverBudget: ...
```

Same pattern already used in `tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py:983` and `tests/unit_tests/inference/test_mxfp8_utils.py:349`.

## Affected tests

- `tests/unit_tests/transformer/moe/test_paged_stashing.py::TestPagedStashing::test_forward_backward_4_layers`
- `tests/unit_tests/transformer/moe/test_paged_stashing.py::TestPagedStashingOverBudget::test_overload_factor_and_over_budget`

Closes #4935.

</details>