### PR TITLE
fix(megatron-fsdp): reduce padding for grouped expert weights

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -1404,11 +1404,28 @@ def _get_parameter_groups(
 
     is_expert_parameter = lambda n, p: ".experts." in n
 
-    def _get_csf_base(group: ParameterGroup, param: torch.nn.Parameter) -> int:
-        shape = to_local_if_dtensor(param).shape
-        if group.is_expert_param and len(shape) > 1:
-            return shape[-1]
-        return shape[1:].numel()
+    def _should_split_from_grouped_expert_bucket(
+        is_expert_param: bool,
+        param: torch.nn.Parameter,
+        param_chunk_size_factor: int,
+        chunk_size_factor: int,
+        same_factor_params: List[torch.nn.Parameter],
+    ) -> bool:
+        """
+        Split grouped expert (>=3D) tensors with heterogeneous chunk size
+        factors into separate buckets to avoid LCM-inflated bucket alignment
+        padding.
+        """
+        # Non-expert groups keep the original LCM/fragment merge.
+        if not is_expert_param:
+            return False
+        # Param already aligns with bucket chunk size factor (always true for
+        # the first param after sort); no split needed.
+        if param_chunk_size_factor == chunk_size_factor:
+            return False
+        return to_local_if_dtensor(param).dim() >= 3 or any(
+            to_local_if_dtensor(p).dim() >= 3 for p in same_factor_params
+        )
 
     # Step 1: Group the parameters according to their execution order and attributes.
     # FSDP unit module parameters are split into multiple parameter sub-groups.
@@ -1500,25 +1517,36 @@ def _get_parameter_groups(
     # Step 3: Split parameter groups to meet communication segmentation requirements.
     new_bucket_groups = []
     for group in bucket_groups:
-        params = sorted(group.params, key=lambda p: _get_csf_base(group, p), reverse=True)
+        params = sorted(
+            group.params, key=lambda p: to_local_if_dtensor(p).shape[1:].numel(), reverse=True
+        )
         while len(params) > 0:
-            chunk_size_factor = _get_csf_base(group, params[0])
+            chunk_size_factor = to_local_if_dtensor(params[0]).shape[1:].numel()
             same_factor_params = []
             remaining_params = []
             for param in params:
                 param_shape = to_local_if_dtensor(param).shape
-                param_csf_base = _get_csf_base(group, param)
+                param_chunk_size_factor = param_shape[1:].numel()
+                if _should_split_from_grouped_expert_bucket(
+                    group.is_expert_param,
+                    param,
+                    param_chunk_size_factor,
+                    chunk_size_factor,
+                    same_factor_params,
+                ):
+                    remaining_params.append(param)
+                    continue
                 if (
-                    param_csf_base == chunk_size_factor
+                    param_chunk_size_factor == chunk_size_factor
                     or (
-                        chunk_size_factor % param_csf_base == 0
+                        chunk_size_factor % param_chunk_size_factor == 0
                         and param_shape.numel() % chunk_size_factor == 0
                     )
                     or (param_shape.numel() < chunk_size_factor)
                 ):
                     same_factor_params.append(param)
                 else:
-                    lcm_chunk_size_factor = math.lcm(chunk_size_factor, param_csf_base)
+                    lcm_chunk_size_factor = math.lcm(chunk_size_factor, param_chunk_size_factor)
                     chunk_size_factor = lcm_chunk_size_factor
                     same_factor_params.append(param)
             # Create a new parameter group with the same chunk size factor.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -1404,6 +1404,12 @@ def _get_parameter_groups(
 
     is_expert_parameter = lambda n, p: ".experts." in n
 
+    def _get_csf_base(group: ParameterGroup, param: torch.nn.Parameter) -> int:
+        shape = to_local_if_dtensor(param).shape
+        if group.is_expert_param and len(shape) > 1:
+            return shape[-1]
+        return shape[1:].numel()
+
     # Step 1: Group the parameters according to their execution order and attributes.
     # FSDP unit module parameters are split into multiple parameter sub-groups.
     # All parameters in the module are assigned a parameter group, even non-FSDP modules.
@@ -1494,26 +1500,25 @@ def _get_parameter_groups(
     # Step 3: Split parameter groups to meet communication segmentation requirements.
     new_bucket_groups = []
     for group in bucket_groups:
-        params = sorted(
-            group.params, key=lambda p: to_local_if_dtensor(p).shape[1:].numel(), reverse=True
-        )
+        params = sorted(group.params, key=lambda p: _get_csf_base(group, p), reverse=True)
         while len(params) > 0:
-            chunk_size_factor = to_local_if_dtensor(params[0]).shape[1:].numel()
+            chunk_size_factor = _get_csf_base(group, params[0])
             same_factor_params = []
             remaining_params = []
             for param in params:
                 param_shape = to_local_if_dtensor(param).shape
+                param_csf_base = _get_csf_base(group, param)
                 if (
-                    param_shape[1:].numel() == chunk_size_factor
+                    param_csf_base == chunk_size_factor
                     or (
-                        chunk_size_factor % param_shape[1:].numel() == 0
+                        chunk_size_factor % param_csf_base == 0
                         and param_shape.numel() % chunk_size_factor == 0
                     )
                     or (param_shape.numel() < chunk_size_factor)
                 ):
                     same_factor_params.append(param)
                 else:
-                    lcm_chunk_size_factor = math.lcm(chunk_size_factor, param_shape[1:].numel())
+                    lcm_chunk_size_factor = math.lcm(chunk_size_factor, param_csf_base)
                     chunk_size_factor = lcm_chunk_size_factor
                     same_factor_params.append(param)
             # Create a new parameter group with the same chunk size factor.

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mfsdp_param_and_grad_buffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mfsdp_param_and_grad_buffer.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import math
+
+import torch
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer import (
+    BucketingPolicy,
+    _get_parameter_groups,
+)
+
+
+class _ExpertTestModule(torch.nn.Module):
+    """
+    Mock module whose params are routed under `.experts.` to trigger
+    is_expert_param=True. The outer `layer` attribute puts a dot before
+    `experts` in the parameter path (e.g. `layer.experts.linear_fc1`).
+    """
+
+    def __init__(self, shapes):
+        super().__init__()
+        self.layer = torch.nn.Module()
+        self.layer.experts = torch.nn.ParameterDict(
+            {name: torch.nn.Parameter(torch.empty(shape)) for name, shape in shapes.items()}
+        )
+
+
+def _get_bucket_signatures(module):
+    bucket_groups, _, _ = _get_parameter_groups(
+        module, BucketingPolicy(suggested_bucket_size=None), meta_device_init_fp8_params={}
+    )
+    param_to_name = {param: name for name, param in module.named_parameters()}
+    return [
+        {
+            "chunk_size_factor": group.chunk_size_factor,
+            "params": [(param_to_name[param], tuple(param.shape)) for param in group.params],
+        }
+        for group in bucket_groups
+    ]
+
+
+def test_grouped_expert_weights_split_when_chunk_size_factors_differ():
+    """Grouped expert weights with mismatched chunk size factors get routed to separate buckets."""
+    num_local_experts = 4
+    hidden_size = 12
+    moe_ffn_hidden_size = 8
+    shapes = {
+        "linear_fc1": (num_local_experts, 2 * moe_ffn_hidden_size, hidden_size),
+        "linear_fc2": (num_local_experts, hidden_size, moe_ffn_hidden_size),
+    }
+    module = _ExpertTestModule(shapes)
+
+    assert _get_bucket_signatures(module) == [
+        {
+            "chunk_size_factor": torch.Size(shapes["linear_fc1"])[1:].numel(),
+            "params": [("layer.experts.linear_fc1", shapes["linear_fc1"])],
+        },
+        {
+            "chunk_size_factor": torch.Size(shapes["linear_fc2"])[1:].numel(),
+            "params": [("layer.experts.linear_fc2", shapes["linear_fc2"])],
+        },
+    ]
+
+
+def test_per_expert_2d_weights_merge_via_lcm():
+    """Per-expert 2D weights merge into a single bucket via LCM chunk size factor."""
+    hidden_size = 12
+    moe_ffn_hidden_size = 8
+    shapes = {
+        "linear_fc1": (2 * moe_ffn_hidden_size, hidden_size),
+        "linear_fc2": (hidden_size, moe_ffn_hidden_size),
+    }
+    module = _ExpertTestModule(shapes)
+
+    assert _get_bucket_signatures(module) == [
+        {
+            "chunk_size_factor": math.lcm(
+                torch.Size(shapes["linear_fc1"])[1:].numel(),
+                torch.Size(shapes["linear_fc2"])[1:].numel(),
+            ),
+            "params": [
+                ("layer.experts.linear_fc1", shapes["linear_fc1"]),
+                ("layer.experts.linear_fc2", shapes["linear_fc2"]),
+            ],
+        }
+    ]


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
MFSDP computes a chunk size factor (CSF) for each bucket as `shape[1:].numel()`, which flattens all dimensions except the first one.

For per-expert 2D expert weights:

- `linear_fc1: (2 * moe_ffn_hidden_size, hidden_size)`
- `linear_fc2: (hidden_size, moe_ffn_hidden_size)`

`shape[1:].numel()` is just the last dimension, so the CSF stays small.

For grouped 3D expert weights:

- `linear_fc1: (num_local_experts, 2 * moe_ffn_hidden_size, hidden_size)`
- `linear_fc2: (num_local_experts, hidden_size, moe_ffn_hidden_size)`

`shape[1:].numel()` becomes the full per-expert matrix size. This can make the CSF much larger than the equivalent per-expert 2D layout. When multiple expert weights share a bucket, MFSDP uses divisibility/LCM logic to choose a common CSF. The oversized CSF can force the bucket size to be padded to a much larger alignment unit, increasing AllGather traffic. In the reported configuration this matched the observed ~33% communication increase, corresponding to ~25% bucket padding.

This PR routes grouped expert weights with heterogeneous CSFs into separate buckets via a new `_should_split_from_grouped_expert_bucket` helper, while keeping the 2D / non-expert paths unchanged.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
