### PR TITLE
fix(tests): initialize num_microbatches calculator in vision cudagraph tests

### DIFF
--- a/tests/unit_tests/transformer/test_vision_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_vision_cuda_graphs.py
@@ -14,6 +14,10 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
 )
 from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.num_microbatches_calculator import (
+    destroy_num_microbatches_calculator,
+    init_num_microbatches_calculator,
+)
 from megatron.core.tensor_parallel.random import (
     HAVE_TE,
     initialize_rng_tracker,
@@ -274,10 +278,19 @@ class TestVisionTECudaGraphHelper:
         self.micro_batch_size = 2
 
     def teardown_method(self, method):
+        destroy_num_microbatches_calculator()
         Utils.destroy_model_parallel()
         gc.collect()
 
     def _make_helper(self, num_microbatches=1):
+        destroy_num_microbatches_calculator()
+        init_num_microbatches_calculator(
+            rank=0,
+            global_batch_size=self.micro_batch_size * num_microbatches,
+            micro_batch_size=self.micro_batch_size,
+            data_parallel_size=1,
+            decrease_batch_size_if_needed=False,
+        )
         return VisionTECudaGraphHelper(
             model=[self.llava_model],
             vision_config=self.vision_config,
@@ -354,8 +367,6 @@ class TestVisionTECudaGraphHelper:
         assert sample_kwargs_list == []
 
     # -- create_cudagraphs / delete_cuda_graphs lifecycle --
-    @pytest.mark.flaky
-    @pytest.mark.flaky_in_dev
     @pytest.mark.skipif(
         not (HAVE_TE_GRAPHS and is_te_min_version("2.7.0")),
         reason="TE CUDA graph capture requires TransformerEngine >= 2.7.0",
@@ -392,8 +403,6 @@ class TestVisionTECudaGraphHelper:
         not (HAVE_TE_GRAPHS and is_te_min_version("2.7.0")),
         reason="TE CUDA graph capture requires TransformerEngine >= 2.7.0",
     )
-    @pytest.mark.flaky
-    @pytest.mark.flaky_in_dev
     def test_create_cudagraphs_multi_microbatch(self):
         """Verify that graphs are created per-microbatch per-layer."""
         self.llava_model.cuda()


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Fixes #3802 (and closes its duplicate #3803, which was already closed manually).

## Bug

After the TE 2.13 bump (#3800) the vision-encoder CUDA graph unit tests started failing with:

```
megatron/core/num_microbatches_calculator.py:19: AttributeError
E       AttributeError: 'NoneType' object has no attribute 'get'
```

The call chain is:

`TestVisionTECudaGraphHelper.test_create_and_delete_cudagraphs`
→ `VisionTECudaGraphHelper.create_cudagraphs()`
→ `TECudaGraphHelper.create_cudagraphs()`
→ `_get_cuda_graph_input_data()`
→ `get_make_graphed_callables_kwargs()` (defined inline)
→ `get_num_microbatches()` (`megatron/core/transformer/cuda_graphs.py:2255`)

`get_num_microbatches()` does `_GLOBAL_NUM_MICROBATCHES_CALCULATOR.get()`, but the global calculator was never initialized in this unit test (only the model-parallel state is initialized in `setup_method`), so the global is `None`.

The follow-up `ci: Skip more tests in test_vision_cuda_graphs for LTS` (#3860) merely marked the two tests `@pytest.mark.flaky` / `@pytest.mark.flaky_in_dev`, masking the failure rather than fixing it. The PP2 variant tracked under #3804 is a separate hang and is left untouched here.

## Fix

In `tests/unit_tests/transformer/test_vision_cuda_graphs.py`:

1. Initialize the global `num_microbatches` calculator inside `TestVisionTECudaGraphHelper._make_helper` with the requested `num_microbatches`, matching the canonical pattern used in `tests/unit_tests/transformer/test_cuda_graphs.py`.
2. Destroy the calculator in `teardown_method` (and on each new `_make_helper` call) so the tests remain hermetic.
3. Drop the `@pytest.mark.flaky` / `@pytest.mark.flaky_in_dev` markers from `test_create_and_delete_cudagraphs` and `test_create_cudagraphs_multi_microbatch` so CI exercises the real code path again.

Minimal example of the fix shape:

```python
def _make_helper(self, num_microbatches=1):
    destroy_num_microbatches_calculator()
    init_num_microbatches_calculator(
        rank=0,
        global_batch_size=self.micro_batch_size * num_microbatches,
        micro_batch_size=self.micro_batch_size,
        data_parallel_size=1,
        decrease_batch_size_if_needed=False,
    )
    return VisionTECudaGraphHelper(...)
```

## Scope

PR scope is intentionally limited to the PP=1 `TestVisionTECudaGraphHelper`. The `TestVisionTECudaGraphHelperPP2` variant has the same uninitialized-calculator latent issue but also a separate hang tracked in #3804; it will be addressed when #3804 is fixed.

</details>
