### PR TITLE
Sync overlap-param-gather between optimizer and ddp config

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -721,6 +721,17 @@ def check_config_overrides_consistency(
     return True
 
 
+def _sync_overlap_param_gather_from_ddp_config(
+    config: OptimizerConfig, model_chunks: List[MegatronModule]
+) -> None:
+    """Sync optimizer overlap_param_gather from the model chunk's DDP config."""
+    for model_chunk in model_chunks:
+        ddp_config = getattr(model_chunk, 'ddp_config', None)
+        if ddp_config is not None:
+            config.overlap_param_gather = ddp_config.overlap_param_gather
+            return
+
+
 def _get_megatron_emerging_optimizer(
     config: OptimizerConfig,
     model_chunks: List[MegatronModule],
@@ -994,6 +1005,7 @@ def get_megatron_optimizer(
     if config_overrides is None:
         config_overrides = get_standard_config_overrides(config)
 
+    _sync_overlap_param_gather_from_ddp_config(config, model_chunks)
     check_config_overrides_consistency(config, config_overrides)
 
     # TODO: the standard and emerging optimizer paths handle pg_collection differently;

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +20,7 @@ from megatron.core.optimizer import (
     ParamKey,
     ParamPredicate,
     _get_param_groups,
+    _sync_overlap_param_gather_from_ddp_config,
     check_config_overrides_consistency,
     get_megatron_optimizer,
     get_standard_config_overrides,
@@ -114,6 +116,16 @@ def test_get_param_groups_default_overrides(mock_get_world_size):
     pg0, pg1 = param_groups
     wd_mults = {pg0['wd_mult'], pg1['wd_mult']}
     assert wd_mults == {1.0, 0.0}
+
+
+def test_optimizer_config_overlap_param_gather_syncs_from_ddp_config():
+    ddp_config = DistributedDataParallelConfig(overlap_param_gather=True)
+    model_chunk = SimpleNamespace(ddp_config=ddp_config)
+    opt_config = OptimizerConfig(optimizer='adam', lr=0.01, overlap_param_gather=False)
+
+    _sync_overlap_param_gather_from_ddp_config(opt_config, [model_chunk])
+
+    assert opt_config.overlap_param_gather is True
 
 
 @patch('torch.distributed.get_world_size', return_value=1)


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Force-sync OptimizerConfig.overlap_param_gather from the DDP config for consistency. If this flag is not set to be the same in two configs, the mxfp8 behavior will be affected.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
