### PR TITLE
Change distributed_backend init for CPU & CUDA

### DIFF
--- a/megatron/training/config/common_config.py
+++ b/megatron/training/config/common_config.py
@@ -71,7 +71,7 @@ class ProfilingConfig:
 class DistributedInitConfig:
     """Configuration settings for distributed training initialization."""
 
-    distributed_backend: Literal["nccl", "gloo"] = "nccl"
+    distributed_backend: str = "cpu:gloo,cuda:nccl"
     """Which backend to use for distributed training."""
 
     distributed_timeout_minutes: int = 10


### PR DESCRIPTION
Change the distributed_backend default from `nccl` to `cpu:gloo,cuda:nccl`, which is a multi-backend format introduced in
2024. This constructs both nccl and gloo PGs eagerly at `init_process_group`. Without this change, only the nccl backend is constructed, which defers the gloo backend construction to the first use. On a eight-node training job, this reduces the first checkpoint time from 24 seconds to 14 seconds.

- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Changes the default `distributed_backend` from `nccl` to `cpu:gloo,cuda:nccl`.

## Issue tracking

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests (N/A)
- [ ] I have added relevant functional tests (N/A)
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation (N/A)
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
