### PR TITLE
test: restrict iter-time comparison to steady-state window

### DIFF
--- a/tests/functional_tests/python_test_utils/common.py
+++ b/tests/functional_tests/python_test_utils/common.py
@@ -208,6 +208,19 @@ def pipeline(
                 ]
 
                 if metric_name == "iteration-time":
+                    # Restrict iter-time aggregation to the steady-state window
+                    # (steps 30-45) so the warmup step does not dominate the median.
+                    steady_window = range(30, 46)
+                    actual_value_list = [
+                        value
+                        for value_step, value in actual_values[metric_name].values.items()
+                        if value_step in golden_value.values.keys() and value_step in steady_window
+                    ]
+                    golden_value_list = [
+                        value
+                        for value_step, value in golden_value.values.items()
+                        if value_step in steady_window
+                    ]
                     actual_value_list = [
                         np.median([np.inf if type(v) is str else v for v in actual_value_list])
                     ]


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What does this PR do?

The functional-test pipeline aggregates iteration-time via `np.median` over **every** step in the golden values JSON, including step 2 — the warmup iteration. Step 2 typically runs an order of magnitude longer than steady-state (e.g. `deepseek_proxy_fsdp_ep2_fsdp2`: step 2 ≈ 13s, steady-state ≈ 0.07s). The median masks one outlier but biases the comparison on shorter runs and pollutes any downstream consumer that averages instead of medians (e.g. a Grafana panel computing a mean over the same array would read ~0.33s instead of ~0.07s).

This PR restricts iter-time aggregation to a steady-state window of **steps 30–45**, so the comparison reflects steady-state perf only.

## Example

For `deepseek_proxy_fsdp_ep2_fsdp2` golden values (step 2 = 12.9s warmup, steps 3–50 ≈ 0.07s each):

| Aggregation | Median | Mean |
|---|---|---|
| All steps (current) | 0.069s | 0.333s |
| Steps 30–45 (new) | 0.066s | 0.066s |

</details>
