### PR TITLE
Fix Megatron-FSDP safe_get_rank fallback

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py
@@ -16,6 +16,7 @@ import contextlib
 import inspect
 import logging
 import operator
+import os
 from contextlib import nullcontext
 from functools import reduce
 from importlib.metadata import version

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mcore_tensor_parallelism_detect.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mcore_tensor_parallelism_detect.py
@@ -7,6 +7,7 @@ from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataPa
 from megatron.core.distributed.fsdp.src.megatron_fsdp.utils import (
     get_mcore_tensor_parallel_partition_dim,
     is_mcore_tensor_parallel_duplicated,
+    safe_get_rank,
     using_tensor_parallel,
 )
 
@@ -77,6 +78,22 @@ def test_using_tensor_parallel_false_when_mesh_size_one():
     # Mesh with 1 element -> no tensor parallel
     dist_index = DummyDistIndex(numel=1)
     assert using_tensor_parallel(dist_index) is False
+
+
+def test_safe_get_rank_falls_back_to_rank_env(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    monkeypatch.setenv("RANK", "7")
+
+    assert safe_get_rank() == 7
+
+
+def test_safe_get_rank_defaults_to_zero_without_valid_rank_env(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    monkeypatch.delenv("RANK", raising=False)
+    assert safe_get_rank() == 0
+
+    monkeypatch.setenv("RANK", "not-an-int")
+    assert safe_get_rank() == 0
 
 
 class DummyConfig:


### PR DESCRIPTION
## Summary
- import os in Megatron-FSDP utils so safe_get_rank() can read RANK when torch.distributed is not initialized
- add regression coverage for valid, missing, and invalid RANK fallback behavior

Fixes #4958

## Testing
- python -m py_compile megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py tests/unit_tests/distributed/megatron_fsdp/test_mcore_tensor_parallelism_detect.py
- git diff --check

Could not run the focused pytest locally because this environment is missing pytest and torch.