### PR TITLE
fix(test): pin eval-global-batch-size on 15b gb200 release configs

### DIFF
--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_gb200/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_gb200/model_config.yaml
@@ -25,6 +25,7 @@ MODEL_ARGS:
   --disable-bias-linear: true
   --micro-batch-size: 4
   --step-batch-size-schedule: "0:384 200B:768 400B:1152"
+  --eval-global-batch-size: 1152
   --train-samples: 19531250
   --manual-gc: true
   --cross-entropy-loss-fusion: true

--- a/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm_gb200/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm_gb200/model_config.yaml
@@ -25,6 +25,7 @@ MODEL_ARGS:
   --disable-bias-linear: true
   --micro-batch-size: 4
   --step-batch-size-schedule: "0:384 200B:768 400B:1152"
+  --eval-global-batch-size: 1152
   --train-samples: 19531250
   --manual-gc: true
   --cross-entropy-loss-fusion: true


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Pin `--eval-global-batch-size: 1152` on the two PP=2 GB200 15B release configs:

- `tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_gb200/model_config.yaml`
- `tests/functional_tests/test_cases/gpt/gpt3_15b_8t_release_sm_gb200/model_config.yaml`

## Why

#4545 removed `--global-batch-size: 1152` from these configs because `--global-batch-size` is mutually exclusive with `--step-batch-size-schedule` (see `megatron/training/arguments.py:696-699`). With no explicit `--global-batch-size`, `arguments.py:700-707` defaults:

```text
args.global_batch_size      = micro_batch_size * data_parallel_size  =  4 * 32 = 128
args.eval_global_batch_size = args.global_batch_size                 = 128
eval_num_microbatches       = 128 / (4 * 32)                         = 1
```

The PP=2 configs use `--num-layers-per-virtual-pipeline-stage: 8` over 32 layers → 2 model chunks per PP stage → interleaved VPP schedule. Interleaved VPP requires:

```text
pipeline_parallel_size <= microbatch_group_size_per_vp_stage <= num_microbatches
```

With `num_microbatches = 1` and `pipeline_parallel_size = 2`, the range is empty and `forward_backward_pipelining_with_interleaving` raises during `evaluate()` (`megatron/core/pipeline_parallel/schedules.py:1052-1060`):

```text
ValueError: The number of contiguous micro-batches in a virtual pipeline stage
should range in [PP=2 , M=1]
```

## How

Adding `--eval-global-batch-size: 1152` (the value `--global-batch-size` held before #4545) on the two PP=2 configs gives `eval_num_microbatches = 1152 / (4 * 32) = 9`, satisfying the VPP constraint. The PP=1 release variants (`gpt3_15b_8t_release`, `gpt3_15b_8t_release_sm`) are unaffected — no interleaving, no constraint.

Example diff:

```yaml
  --micro-batch-size: 4
  --step-batch-size-schedule: "0:384 200B:768 400B:1152"
+ --eval-global-batch-size: 1152
  --train-samples: 19531250
```

</details>
