### PR TITLE
fix(test): widen iter-time steady-state window for short tests

### DIFF
--- a/tests/functional_tests/python_test_utils/common.py
+++ b/tests/functional_tests/python_test_utils/common.py
@@ -208,9 +208,8 @@ def pipeline(
                 ]
 
                 if metric_name == "iteration-time":
-                    # Restrict iter-time aggregation to the steady-state window
-                    # (steps 30-45) so the warmup step does not dominate the median.
-                    steady_window = range(30, 46)
+                    max_golden_step = max(golden_value.values.keys()) if golden_value.values else 0
+                    steady_window = range(5, 21) if max_golden_step <= 25 else range(30, 46)
                     actual_value_list = [
                         value
                         for value_step, value in actual_values[metric_name].values.items()


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Make the iter-time steady-state window adaptive so it does not break tests that run fewer than 30 steps.

## Why

[`#5010`](https://github.com/NVIDIA/Megatron-LM/pull/5010) (commit `71223d5`) hard-coded the iter-time aggregation window to `range(30, 46)` to avoid the warmup step dominating the median. For tests that train for only ~25 steps (e.g. `gpt3_7b_tp1_pp4_memory_speed`, which sets `--train-iters: 25` and `--exit-interval: 25`), no step lands in that window, so both `actual_value_list` and `golden_value_list` end up empty. `np.median([])` returns `NaN`, `np.isclose(NaN, NaN)` is `False`, and the test fails with no useful diagnostic.

## How

In `tests/functional_tests/python_test_utils/common.py:pipeline`, derive the window from the highest step present in the golden values:

```python
max_golden_step = max(golden_value.values.keys()) if golden_value.values else 0
steady_window = range(5, 21) if max_golden_step <= 25 else range(30, 46)
```

- Short tests (≤25 logged steps) → `range(5, 21)` — skips the first warmup step, averages over ~15 measured points.
- Everything else → `range(30, 46)` — original behaviour, untouched.

## Test plan

- [ ] Functional CI green on `gpt3_7b_tp1_pp4_memory_speed`.
- [ ] No regression on long iter-time tests (median identical to pre-change, since `range(30, 46)` path is taken).

</details>
