### PR TITLE
Hybrid recipe loading and lowering

### DIFF
--- a/megatron/core/models/hybrid/__init__.py
+++ b/megatron/core/models/hybrid/__init__.py
@@ -12,6 +12,20 @@ from megatron.core.models.hybrid.layer_configs import (
     MLPLayerConfig,
     MoELayerConfig,
 )
+from megatron.core.models.hybrid.layer_pattern import (
+    RECIPE_ENTRY_POINT,
+    flatten_decoder_pattern,
+    load_recipe,
+)
+
+
+def __getattr__(name):
+    if name == "HybridModelConfig":
+        from megatron.training.models.hybrid import HybridModelConfig
+
+        return HybridModelConfig
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "AttentionLayerConfig",
@@ -20,8 +34,11 @@ __all__ = [
     "DSALayerConfig",
     "EmbeddingLayerConfig",
     "GDNLayerConfig",
+    "HybridModelConfig",
     "LayerConfig",
     "MambaLayerConfig",
     "MLPLayerConfig",
     "MoELayerConfig",
+    "RECIPE_ENTRY_POINT",
+    "load_recipe",
 ]

--- a/megatron/core/models/hybrid/layer_pattern.py
+++ b/megatron/core/models/hybrid/layer_pattern.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Pattern-flattening and recipe-loading helpers for the HybridModel DSL.
+
+The Python DSL composes a model from a (possibly nested) list of
+:class:`LayerConfig` instances. :func:`flatten_decoder_pattern` flattens the
+*decoder body* (i.e. between the :class:`EmbeddingLayerConfig` and
+:class:`CrossEntropyLayerConfig` markers) into a flat list of layer configs.
+:func:`load_recipe` resolves a recipe spec — either a dotted Python module
+path or a filesystem path, with an optional ``:func`` suffix — and returns
+the :class:`HybridModelConfig` ready to feed into :class:`HybridModel` via
+``HybridModel(config=recipe)``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+
+from megatron.core.models.hybrid.layer_configs import (
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    LayerConfig,
+)
+
+if TYPE_CHECKING:
+    from megatron.training.models.hybrid import HybridModelConfig
+
+# Canonical recipe entry point. When a recipe module / file omits the
+# ``:func`` suffix, this function name is preferred as the default recipe.
+RECIPE_ENTRY_POINT = "make_recipe"
+
+
+def flatten_decoder_pattern(pattern: Any) -> List[LayerConfig]:
+    """Recursively flatten the decoder portion of a layer pattern.
+
+    The decoder body is everything between the :class:`EmbeddingLayerConfig`
+    and :class:`CrossEntropyLayerConfig` markers. Lists and tuples are
+    descended into; every leaf must be a :class:`LayerConfig` (Mamba,
+    Attention, MoE, MLP, GDN, DSA). Embedding / loss markers at this
+    point are an error — they should have been handled earlier.
+
+    Raises :class:`TypeError` (with the offending index path) on
+    non-conforming leaves.
+    """
+    flat: List[LayerConfig] = []
+    _flatten_into(pattern, flat, path=())
+    return flat
+
+
+def _flatten_into(node: Any, out: List[LayerConfig], path: tuple) -> None:
+    if isinstance(node, LayerConfig):
+        out.append(node)
+        return
+    if isinstance(node, (EmbeddingLayerConfig, CrossEntropyLayerConfig)):
+        raise TypeError(
+            f"Encountered {type(node).__name__} at path {list(path)} inside the "
+            f"decoder body; embedding/loss markers may only appear at the "
+            f"start/end of layer_pattern."
+        )
+    if isinstance(node, (list, tuple)):
+        for i, child in enumerate(node):
+            _flatten_into(child, out, path + (i,))
+        return
+    raise TypeError(
+        f"layer_pattern leaf at path {list(path)} has unsupported type "
+        f"{type(node).__name__!r}; expected a LayerConfig instance or a "
+        f"nested list/tuple of LayerConfigs."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Recipe loading
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _split_spec(spec: str) -> Tuple[str, Optional[str]]:
+    """Split ``module-or-path[:func]`` into ``(module-or-path, func or None)``.
+
+    Special-cases Windows drive letters in file paths (``C:/foo``) so the
+    drive-letter colon isn't confused with the function-name separator.
+    """
+    if ":" not in spec:
+        return spec, None
+    head, tail = spec.rsplit(":", 1)
+    # Windows drive-letter check: ``C:/foo`` or ``C:\foo`` would have a
+    # one-char head and a tail that starts with ``/`` or ``\``.
+    if len(head) == 1 and tail.startswith(("/", "\\")):
+        return spec, None
+    return head, tail or None
+
+
+def _is_file_path(s: str) -> bool:
+    """Heuristic: treat ``s`` as a filesystem path when it ends in ``.py`` or
+    contains a path separator."""
+    return s.endswith(".py") or os.sep in s or "/" in s
+
+
+def _import_from_spec(spec: str):
+    """Import a module from either a dotted path or a filesystem path."""
+    if _is_file_path(spec):
+        path = Path(spec).expanduser().resolve()
+        if not path.is_file():
+            raise ImportError(f"--model-recipe file path {spec!r} does not exist or is not a file.")
+        # Use a unique synthetic module name so multiple recipes loaded by
+        # path don't collide in ``sys.modules``. SHA-1 of the absolute path is
+        # stable across processes and avoids the per-process randomization of
+        # builtin ``hash()``.
+        digest = hashlib.sha1(str(path).encode("utf-8")).hexdigest()[:16]
+        module_name = f"_megatron_recipe_{digest}"
+        cached = sys.modules.get(module_name)
+        if cached is not None:
+            return cached
+        spec_obj = importlib.util.spec_from_file_location(module_name, path)
+        if spec_obj is None or spec_obj.loader is None:
+            raise ImportError(f"could not build import spec for {path}")
+        module = importlib.util.module_from_spec(spec_obj)
+        sys.modules[module_name] = module
+        spec_obj.loader.exec_module(module)
+        return module
+    try:
+        return importlib.import_module(spec)
+    except ImportError as e:
+        raise ImportError(
+            f"--model-recipe {spec!r} could not be imported. Ensure the module "
+            f"path is correct and on PYTHONPATH (or pass a filesystem path "
+            f"ending in ``.py``). Underlying error: {e}"
+        ) from e
+
+
+def _resolve_recipe_object(module, func_name: Optional[str], origin: str) -> HybridModelConfig:
+    """Find the :class:`HybridModelConfig` to compile.
+
+    Resolution order, given a loaded module:
+
+    1. If ``func_name`` is given (i.e. the user wrote ``--model-recipe foo:bar``),
+       call that function and return its result.
+    2. Otherwise call :data:`RECIPE_ENTRY_POINT`, the canonical recipe
+       convention.
+    """
+    # 1. Explicit :func selection
+    if func_name is not None:
+        if not hasattr(module, func_name):
+            raise AttributeError(
+                f"--model-recipe {origin!r}: module has no attribute " f"{func_name!r}."
+            )
+        return _call_recipe_function(getattr(module, func_name), origin, source=func_name)
+
+    # 2. Canonical default: a function literally named ``make_recipe``.
+    if hasattr(module, RECIPE_ENTRY_POINT):
+        return _call_recipe_function(
+            getattr(module, RECIPE_ENTRY_POINT), origin, source=RECIPE_ENTRY_POINT
+        )
+    raise AttributeError(
+        f"--model-recipe {origin!r}: no {RECIPE_ENTRY_POINT}() function found. "
+        f"Define {RECIPE_ENTRY_POINT}() in the recipe module, or pass an "
+        f"explicit function with ``--model-recipe {origin}:<func_name>``."
+    )
+
+
+def _call_recipe_function(fn, origin: str, source: str) -> HybridModelConfig:
+    if not callable(fn):
+        raise TypeError(f"--model-recipe {origin!r}: {source!r} is not callable.")
+    return _ensure_hybrid_model_config(fn(), origin, source=source)
+
+
+def _ensure_hybrid_model_config(value, origin: str, source: str) -> HybridModelConfig:
+    from megatron.training.models.hybrid import HybridModelConfig
+
+    if not isinstance(value, HybridModelConfig):
+        raise TypeError(
+            f"--model-recipe {origin!r}: {source!r} returned "
+            f"{type(value).__name__}, not HybridModelConfig."
+        )
+    return value
+
+
+def load_recipe(spec: str) -> HybridModelConfig:
+    """Resolve a recipe spec and return its :class:`HybridModelConfig`.
+
+    The recipe is the public contract: pass it directly to
+    :class:`HybridModel` via ``HybridModel(config=recipe)`` or to the
+    ``--model-recipe`` argparse adapter, both of which own the lowering
+    internally.
+
+    ``spec`` accepts three forms:
+
+    1. Dotted Python path::
+
+           --model-recipe examples.nemotron3.nano
+
+    2. Dotted path with explicit function selection::
+
+           --model-recipe examples.nemotron3.nano:make_recipe
+
+    3. Filesystem path (anywhere on disk; no PYTHONPATH manipulation needed),
+       with optional ``:func`` suffix::
+
+           --model-recipe /home/me/recipes/qwen3_next.py
+           --model-recipe /home/me/recipes/qwen3_next.py:my_pretrain_recipe
+
+    When no ``:func`` is given, the loader calls ``make_recipe()``.
+
+    Raises:
+        ImportError: if the module / file cannot be loaded.
+        AttributeError: if the selected recipe function is missing.
+        TypeError: if the resolved value is not a :class:`HybridModelConfig`.
+    """
+    module_or_path, func_name = _split_spec(spec)
+    module = _import_from_spec(module_or_path)
+    return _resolve_recipe_object(module, func_name, origin=spec)

--- a/megatron/training/models/hybrid.py
+++ b/megatron/training/models/hybrid.py
@@ -1,54 +1,108 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
+import dataclasses
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable, ClassVar, Literal, override
+from typing import Any, Callable, ClassVar, List, Literal, Tuple
+
+from typing_extensions import override
 
 from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
 from megatron.core.enums import ModelType
+from megatron.core.models.hybrid.common_layer_config import CommonLayerConfig
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_inference_stack_spec
 from megatron.core.models.hybrid.hybrid_layer_specs import (
     hybrid_stack_spec as default_hybrid_stack_spec,
-    hybrid_inference_stack_spec,
 )
 from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.models.hybrid.layer_configs import (
+    AttentionLayerConfig,
+    CrossEntropyLayerConfig,
+    DSALayerConfig,
+    EmbeddingLayerConfig,
+    LayerConfig,
+    MoELayerConfig,
+)
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
 from megatron.core.post_training.modelopt.hybrid.model_specs import get_hybrid_stack_modelopt_spec
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import Float16Module, MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.training.models.base import (
-    ModelBuilder,
-    ModelConfig,
-    compose_hooks,
-)
+from megatron.training.models.base import ModelBuilder, ModelConfig, compose_hooks
 from megatron.training.models.dist_utils import unimodal_build_distributed_models
 from megatron.training.vocab_utils import calculate_padded_vocab_size
 
 logger = logging.getLogger(__name__)
 
+# YARN scaling parameters that HybridModel reads via getattr when
+# position_embedding_type == "yarn" (see hybrid_model.py around the
+# YarnRotaryEmbedding construction). They are not currently
+# TransformerConfig dataclass fields; _lower() applies them via setattr to
+# match the existing legacy-path pattern.
+_YARN_FIELDS = (
+    "yarn_rotary_scaling_factor",
+    "yarn_original_max_position_embeddings",
+    "yarn_beta_fast",
+    "yarn_beta_slow",
+    "yarn_mscale",
+    "yarn_mscale_all_dim",
+    "yarn_correction_range_round_to_int",
+)
+
 
 @dataclass(kw_only=True)
 class HybridModelConfig(ModelConfig):
-    """Configuration for a Megatron Core Hybrid model.
+    """A complete HybridModel recipe.
 
-    This is purely a configuration object. All model construction
-    logic lives in ``HybridModelBuilder``.
-
-    Contains a ``TransformerConfig`` alongside Hybrid-specific parameters. Attributes
-    on the embedded ``transformer`` config are accessible directly on this object
-    via ``__getattr__``/``__setattr__`` proxying.
-
-    Supports hybrid architectures via ``hybrid_layer_pattern``
-
-    Note:
-        ``vocab_size`` must be set before passing this config to ``HybridModelBuilder``.
-        ``hybrid_attention_ratio``,``hybrid_mlp_ratio``, and
-        ``hybrid_override_pattern`` are deprecated and will be removed in a future release.
+    Returned by a recipe module's ``make_recipe()`` entry point. Pass an
+    instance directly to :class:`HybridModel` via ``HybridModel(config=recipe)``;
+    the ``--model-recipe`` adapter loads the recipe and projects its fields
+    onto the legacy launcher namespace using the public query methods on
+    this class (no lowering object is exposed to callers).
     """
 
+    # TODO(recipe-api): two follow-ups deferred from the Phase 1 review:
+    #   (1) Add a public ``validate(self) -> None`` method that runs the
+    #       structural / parallelism / attention-geometry checks
+    #       independently of ``_lower()`` so users can sanity-check a
+    #       recipe from a non-distributed script (no TC construction, no
+    #       process groups). The checks already fire inside ``_lower()``
+    #       before any process-group setup, so this is ergonomic, not
+    #       blocking.
+    #   (2) Document the polarity flip on
+    #       :attr:`untie_embeddings_and_output_weights`: the recipe
+    #       default is ``False`` (i.e., tied / shared by default), but
+    #       :class:`HybridModel`'s legacy default is
+    #       ``share_embeddings_and_output_weights=False`` (i.e., NOT
+    #       shared). Recipe authors migrating from a legacy bash launcher
+    #       must set ``untie_embeddings_and_output_weights=True`` to
+    #       reproduce the legacy default. A migration-note docstring on
+    #       the field would help people not silently drift from their
+    #       legacy baseline.
+
     builder: ClassVar[str] = "megatron.training.models.hybrid.HybridModelBuilder"
-    transformer: TransformerConfig
+
+    common_config: CommonLayerConfig | None = None
+    """Model-wide defaults shared by every layer."""
+
+    layer_pattern: list | None = None
+    """The layer pattern. Must begin with an :class:`EmbeddingLayerConfig`,
+    contain at least one decoder :class:`LayerConfig`, and end with a
+    :class:`CrossEntropyLayerConfig`. Decoder layers may be nested in any
+    list/tuple structure; :meth:`flatten_decoder` flattens them. Pipeline
+    parallelism is not part of the recipe DSL — recipes that need PP must
+    use the legacy ``hybrid_layer_pattern`` string DSL."""
+
+    untie_embeddings_and_output_weights: bool = False
+    """Untie input embedding and output projection weights."""
+
+    # === Legacy / argparse-derived construction path ===
+    # These fields preserve the existing training-config API while the
+    # recipe API becomes the canonical surface. When ``common_config`` /
+    # ``layer_pattern`` are set, the recipe path owns model definition and
+    # these legacy architecture fields are ignored by ``HybridModelBuilder``.
+    transformer: TransformerConfig | None = None
     fp16_lm_cross_entropy: bool = False
     parallel_output: bool = True
     share_embeddings_and_output_weights: bool = False
@@ -57,8 +111,8 @@ class HybridModelConfig(ModelConfig):
     hybrid_override_pattern: str | None = None
     hybrid_layer_pattern: str | None = None
     seq_length: int = 8192
-    # HybridModel with no attention has no need for position embeddings, so none is default
-    position_embedding_type: Literal["learned_absolute", "rope", "none"] = "none"
+    # HybridModel with no attention has no need for position embeddings.
+    position_embedding_type: Literal["learned_absolute", "rope", "yarn", "none"] = "none"
     rotary_percent: float = 1.0
     rotary_base: int = 10000
     seq_len_interpolation_factor: float | None = None
@@ -66,6 +120,61 @@ class HybridModelConfig(ModelConfig):
     hybrid_stack_spec: ModuleSpec | None = None
     vocab_size: int | None = None
     should_pad_vocab: bool = False
+
+    # === Model-level parallelism ===
+    # These live here (not on :class:`CommonLayerConfig`) because they are
+    # job-/model-level concerns: process groups are constructed once, not
+    # per-layer, and they cannot meaningfully vary per layer. ``_lower()``
+    # injects them into every per-layer TransformerConfig and the
+    # stack-level TC. PP is intentionally absent — the recipe DSL is
+    # PP-free; recipes that need PP must use the legacy string DSL.
+    #
+    # All four default to ``None``, meaning "do not pin from the recipe".
+    # When unset, the launcher's args projection skips writing them onto
+    # ``args``, so launcher CLI flags (``--tensor-model-parallel-size`` etc.)
+    # win. Recipes for topology-bound models (e.g. Nemotron-3 Nano needs
+    # TP=4/EP=8 to fit) should pin these explicitly; ad-hoc / debugging
+    # recipes can leave them unset and let the launcher decide.
+    tensor_model_parallel_size: int | None = None
+    """Tensor-model-parallel world size; ``None`` = use ``--tensor-model-parallel-size``."""
+
+    context_parallel_size: int | None = None
+    """Context-parallel world size; ``None`` = use ``--context-parallel-size``."""
+
+    expert_model_parallel_size: int | None = None
+    """Expert-model-parallel world size (used by MoE layers); ``None`` = use
+    ``--expert-model-parallel-size``."""
+
+    expert_tensor_parallel_size: int | None = None
+    """Expert tensor-parallel size; ``None`` = use ``--expert-tensor-parallel-size``
+    (which itself defaults to ``tensor_model_parallel_size``)."""
+
+    # === Stack-level MoE metadata override (heterogeneous-MoE recipes only) ===
+    # The stack-level TransformerConfig carries one ``num_moe_experts`` /
+    # ``moe_ffn_hidden_size`` pair. With homogeneous MoE the value is
+    # unambiguous; with heterogeneous MoE there is no single right answer.
+    # Two consumers read these fields from the stack TC: MTP's MoE body and
+    # the inference text-generation capacity-factor calculation. Recipes
+    # that mix MoE shapes must pin the values they want those consumers to
+    # see — :meth:`derived_moe_metadata` raises if MoE is heterogeneous and
+    # these are unset.
+    stack_moe_num_experts: int | None = None
+    """Stack-level ``num_moe_experts`` for heterogeneous-MoE recipes.
+    Required when MoE layers disagree on ``num_experts``; ignored otherwise."""
+
+    stack_moe_ffn_hidden_size: int | None = None
+    """Stack-level ``moe_ffn_hidden_size`` for heterogeneous-MoE recipes.
+    Required when MoE layers disagree on ``ffn_hidden_size``; ignored
+    otherwise. ``None`` falls through to ``ffn_hidden_size``."""
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Compatibility / builder helpers
+    # ──────────────────────────────────────────────────────────────────────
+
+    @property
+    def is_recipe_config(self) -> bool:
+        """Whether this config uses the Python recipe surface."""
+        return self.common_config is not None or self.layer_pattern is not None
 
     @property
     def mamba_stack_spec(self):
@@ -84,7 +193,7 @@ class HybridModelConfig(ModelConfig):
             transformer = object.__getattribute__(self, "transformer")
         except AttributeError:
             raise AttributeError(f"HybridModelConfig has no attribute '{name}'")
-        if hasattr(transformer, name):
+        if transformer is not None and hasattr(transformer, name):
             return getattr(transformer, name)
         raise AttributeError(f"Neither HybridModelConfig nor TransformerConfig has any attribute '{name}'.")
 
@@ -98,16 +207,603 @@ class HybridModelConfig(ModelConfig):
             # `transformer` not yet initialised; store the attribute on self.
             super().__setattr__(name, value)
             return
-        if hasattr(transformer, name):
+        if transformer is not None and hasattr(transformer, name):
             setattr(transformer, name, value)
         else:
             super().__setattr__(name, value)
 
     def finalize(self) -> None:
         """One time validation to run once config is ready to be used by builder."""
-
+        if self.is_recipe_config:
+            self._lower()
+            return
+        if self.transformer is None:
+            raise ValueError(
+                "HybridModelConfig requires either common_config/layer_pattern "
+                "for the recipe path or transformer for the legacy path."
+            )
         if hasattr(self.transformer, "finalize") and callable(self.transformer.finalize):
             self.transformer.finalize()
+
+    def get_transformer_config(self) -> TransformerConfig:
+        """Return the stack-level TransformerConfig used to build/wrap the model."""
+        if self.is_recipe_config:
+            stack_config, _, _ = self._lower()
+            return stack_config
+        if self.transformer is None:
+            raise ValueError(
+                "HybridModelConfig requires a transformer config on the legacy path."
+            )
+        return self.transformer
+
+    # Public queries
+    #
+    # These are TC-free observations on the recipe itself. The launcher's
+    # args projection reads them to populate ``args.num_layers``,
+    # ``args.num_experts``, etc., without going through ``_lower()``. They
+    # also let tests assert recipe semantics without depending on the
+    # lowering's output shape.
+    # ──────────────────────────────────────────────────────────────────────
+
+    @property
+    def embedding_marker(self) -> EmbeddingLayerConfig:
+        """The :class:`EmbeddingLayerConfig` at the start of ``layer_pattern``.
+
+        Validates pattern structure on access.
+        """
+        self._require_recipe_fields()
+        embedding, _, _ = _split_pattern(self.layer_pattern)
+        return embedding
+
+    @property
+    def loss_marker(self) -> CrossEntropyLayerConfig:
+        """The :class:`CrossEntropyLayerConfig` at the end of ``layer_pattern``.
+
+        Validates pattern structure on access.
+        """
+        self._require_recipe_fields()
+        _, _, loss = _split_pattern(self.layer_pattern)
+        return loss
+
+    def flatten_decoder(self) -> List[LayerConfig]:
+        """Return the decoder body as a flat list of :class:`LayerConfig`.
+
+        Walks the (possibly nested) ``layer_pattern[1:-1]`` and flattens it
+        into a single ordered list. Useful for the launcher and for tests
+        that need to inspect "what layers does this recipe contain".
+        """
+        from megatron.core.models.hybrid.layer_pattern import flatten_decoder_pattern
+
+        self._require_recipe_fields()
+        _, decoder_body, _ = _split_pattern(self.layer_pattern)
+        return flatten_decoder_pattern(decoder_body)
+
+    @property
+    def num_layers(self) -> int:
+        """Number of decoder layers, derived from ``layer_pattern``."""
+        return len(self.flatten_decoder())
+
+    @property
+    def has_multi_latent_attention(self) -> bool:
+        """Whether the recipe uses MLA (any :class:`DSALayerConfig` in the decoder).
+
+        Surfaced as a query because the launcher needs it to set
+        ``args.multi_latent_attention`` *before* any process-group / config
+        wiring happens, i.e. before lowering can run.
+        """
+        return any(isinstance(lc, DSALayerConfig) for lc in self.flatten_decoder())
+
+    def derived_moe_metadata(self) -> tuple[int | None, int | None]:
+        """Return ``(num_moe_experts, moe_ffn_hidden_size)`` for stack-level
+        MoE consumers (MTP body construction, inference capacity-factor calc).
+
+        Three cases:
+
+        1. No :class:`MoELayerConfig` in the decoder → ``(None, None)``.
+        2. Homogeneous MoE → that value.
+        3. Heterogeneous MoE → the recipe must pin :attr:`stack_moe_num_experts`
+           (and optionally :attr:`stack_moe_ffn_hidden_size`); raises otherwise.
+        """
+        return _derive_stack_moe_metadata(
+            self.flatten_decoder(),
+            override_num_experts=self.stack_moe_num_experts,
+            override_ffn_hidden_size=self.stack_moe_ffn_hidden_size,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Internal lowering
+    #
+    # Do not call from outside the hybrid package. ``HybridModel.__init__``
+    # invokes this when constructed with ``config: HybridModelConfig``; it
+    # returns the three pieces HybridModel still needs as TransformerConfig:
+    # the stack-level TC, the per-layer symbol list, and the per-layer TC
+    # list. Embedding-marker fields (vocab_size, position_embedding_type,
+    # …) and loss-marker fields (fp16_lm_cross_entropy, parallel_output)
+    # are NOT included — read them directly from
+    # :attr:`embedding_marker` and :attr:`loss_marker`. This method's
+    # signature and return shape are implementation details that will
+    # change when TC / TransformerLayer are retired.
+    # ──────────────────────────────────────────────────────────────────────
+
+    def _lower(self) -> Tuple[TransformerConfig, List[str], List[TransformerConfig]]:
+        """Lower this recipe into ``(stack_tc, layer_symbols, layer_tcs)``.
+
+        The three returned pieces are exactly what :class:`HybridModel`
+        consumes when constructed with a :class:`HybridModelConfig`.
+        Marker-derived fields (vocab_size, max_sequence_length,
+        position_embedding_type, rotary_*, fp16_lm_cross_entropy,
+        parallel_output, …) are not in the return value — read them
+        directly from :attr:`embedding_marker` and :attr:`loss_marker`.
+        """
+        self._require_recipe_fields()
+        embedding, decoder_leaves, loss = _split_pattern(self.layer_pattern)
+
+        # Auto-inherit the recipe's common_config into any layer/marker that
+        # was constructed without an explicit ``common_config=`` argument.
+        # Without this, a layer like ``MambaLayerConfig(head_dim=64)`` carries
+        # a default-constructed CommonLayerConfig with ``hidden_size=0``,
+        # silently producing an invalid model.
+        embedding = _inherit_common_if_default(embedding, self.common_config)
+        loss = _inherit_common_if_default(loss, self.common_config)
+        decoder_leaves = _inherit_common_in_pattern(decoder_leaves, self.common_config)
+
+        from megatron.core.models.hybrid.layer_pattern import flatten_decoder_pattern
+
+        decoder_flat: List[LayerConfig] = flatten_decoder_pattern(decoder_leaves)
+        if not decoder_flat:
+            raise ValueError(
+                "layer_pattern has no decoder layers between the EmbeddingLayerConfig "
+                "and CrossEntropyLayerConfig markers."
+            )
+
+        num_layers = len(decoder_flat)
+
+        # ─────────────────────────────────────────────────────────────────
+        # Glue between the DSL surface and the underlying TransformerConfig
+        # machinery. ``parallelism`` carries the universal job-level
+        # settings (TP/PP/CP) that flow into every per-layer config.
+        # ``expert_parallelism`` carries EP/ETP, which are MoE-only and
+        # therefore only flow into MoE per-layer TCs (and the stack-level
+        # TC for the model-wide topology snapshot). ``placeholders`` carries
+        # values that exist solely to satisfy
+        # ``TransformerConfig.__post_init__`` invariants on layers that
+        # don't naturally set them (e.g. ``num_attention_heads`` is
+        # required for the kv_channels derivation even on Mamba layers).
+        #
+        # When the layer infrastructure is rewritten with dedicated
+        # per-layer config classes, neither the placeholder logic nor the
+        # split parallelism dicts will be needed — the new layers won't
+        # share a single config type and won't impose cross-layer
+        # invariants. The DSL's user-facing surface stays the same; only
+        # this glue block changes.
+        # ─────────────────────────────────────────────────────────────────
+
+        # Topology fields default to ``None`` on the recipe (= "let the
+        # launcher decide"). For per-layer TC construction we still need
+        # concrete values, so substitute TC defaults (1 / TP) here. The
+        # ``None``-ness is preserved on the recipe itself so the launcher's
+        # args projection only writes to ``args.<field>`` when the recipe
+        # pinned a value.
+        tp = self.tensor_model_parallel_size if self.tensor_model_parallel_size is not None else 1
+        cp = self.context_parallel_size if self.context_parallel_size is not None else 1
+        ep = self.expert_model_parallel_size if self.expert_model_parallel_size is not None else 1
+        etp = (
+            self.expert_tensor_parallel_size if self.expert_tensor_parallel_size is not None else tp
+        )
+
+        # Universal parallelism — flows into every per-layer TC. PP is
+        # intentionally absent: the recipe DSL is PP-free. ``is_hybrid_model``
+        # is implicit for any HybridModelConfig recipe; force it on every TC
+        # so users don't carry a redundant ``=True``.
+        parallelism: dict = {
+            "tensor_model_parallel_size": tp,
+            "context_parallel_size": cp,
+            "is_hybrid_model": True,
+        }
+
+        # MoE-only parallelism — applied to MoE per-layer TCs (after their
+        # base build) and to the stack-level TC. Non-MoE per-layer TCs do
+        # not receive these fields; TransformerConfig's defaults
+        # (``expert_model_parallel_size=1``, ``expert_tensor_parallel_size``
+        # auto-derived from TP) take over, which is correct because those
+        # layers don't participate in expert parallelism.
+        expert_parallelism: dict = {
+            "expert_model_parallel_size": ep,
+            "expert_tensor_parallel_size": etp,
+        }
+
+        # ``placeholders`` only fill if absent, so a recipe author's
+        # ``common.extra={...}`` or per-layer override wins.
+        # ``num_attention_heads % tensor_model_parallel_size == 0`` is
+        # required by TC; setting the placeholder to TP satisfies the
+        # check trivially on non-attention layers. Attention layers override
+        # with their real value via ``_layer_specific_kwargs``.
+        attention_metadata = _infer_uniform_attention_metadata(decoder_flat)
+
+        # Heterogeneous attention geometry under RoPE/YARN is not supported:
+        # HybridModel builds one global rotary embedding from the stack TC
+        # and passes it to every attention layer. If layers disagree on
+        # ``num_attention_heads`` / ``num_query_groups`` / ``kv_channels``,
+        # the rotary tensor is sized for the placeholder value and at
+        # runtime layers with different geometry hit shape mismatches.
+        # Reject at lowering time until per-layer rotary lands.
+        if embedding.position_embedding_type in ("rope", "yarn"):
+            _reject_heterogeneous_attention_geometry(decoder_flat, attention_metadata)
+
+        placeholders: dict = {"num_attention_heads": max(1, tp)}
+        # If the recipe contains a uniform attention geometry, use it as the
+        # semantic placeholder for non-attention layer TransformerConfigs.
+        # This keeps recipe authors out of TransformerConfig compatibility
+        # details like "Mamba still needs num_attention_heads to satisfy
+        # TC.__post_init__".
+        placeholders.update(attention_metadata)
+
+        layer_type_list = [type(lc).SYMBOL for lc in decoder_flat]
+        layer_config_list: List[TransformerConfig] = []
+        for lc in decoder_flat:
+            # Only MoE layers carry expert parallelism; non-MoE TCs default
+            # to EP=1 (TC default), which is what they actually consume at
+            # runtime. Merging into the initial kwargs (rather than via a
+            # follow-up dataclasses.replace) keeps TC.__post_init__'s MoE
+            # cross-checks (e.g. ``add_bias_linear`` requires ``ETP==1``)
+            # validating against the right ETP value the first time around.
+            layer_parallelism = parallelism
+            if isinstance(lc, MoELayerConfig):
+                layer_parallelism = {**parallelism, **expert_parallelism}
+            tc = lc.to_transformer_config(
+                num_layers, parallelism=layer_parallelism, placeholders=placeholders
+            )
+            layer_config_list.append(tc)
+
+        # Reuse the existing pattern validator for the Attention/DSA mix rule.
+        from megatron.core.models.hybrid.hybrid_layer_allocation import _validate_pattern
+
+        _validate_pattern("".join(layer_type_list), "main", allow_pipe=False)
+
+        # Stack-level config: a model-wide topology snapshot used for the
+        # final norm, embedding init, inference capacity sizing, and the
+        # launcher's args projection. Carries EP/ETP because it represents
+        # the global topology, even though non-MoE per-layer TCs do not.
+        stack_kwargs = embedding.common_config.to_transformer_config_kwargs()
+        stack_kwargs.update(parallelism)
+        stack_kwargs.update(expert_parallelism)
+        for k, v in attention_metadata.items():
+            stack_kwargs.setdefault(k, v)
+        for k, v in placeholders.items():
+            stack_kwargs.setdefault(k, v)
+        for k, v in _infer_uniform_moe_metadata(decoder_flat).items():
+            stack_kwargs.setdefault(k, v)
+        # Derive stack-level MoE metadata from the recipe's actual MoE
+        # configs rather than using a placeholder. Two consumers read these
+        # fields semantically: the MTP block construction path (when a body
+        # symbol contains ``E``, the MoE layer inside MTP is built from the
+        # stack TC) and the inference capacity-factor calculation
+        # (``capacity_factor = num_moe_experts / moe_router_topk``).
+        stack_moe_experts, stack_moe_ffn_hidden_size = _derive_stack_moe_metadata(
+            decoder_flat,
+            override_num_experts=self.stack_moe_num_experts,
+            override_ffn_hidden_size=self.stack_moe_ffn_hidden_size,
+        )
+        if stack_moe_experts is not None:
+            stack_kwargs["num_moe_experts"] = stack_moe_experts
+            if stack_moe_ffn_hidden_size is not None:
+                stack_kwargs["moe_ffn_hidden_size"] = stack_moe_ffn_hidden_size
+        elif ep > 1:
+            raise ValueError(
+                "expert_model_parallel_size > 1 requires at least one "
+                "MoELayerConfig in the layer_pattern; the recipe has none. "
+                "Either drop expert parallelism, or add MoE layers."
+            )
+        # DSA / MLA layers carry their own decoupled RoPE; HybridModel uses
+        # ``self.config.multi_latent_attention`` (the stack TC) to decide
+        # whether to construct the global RoPE embedding. Without this flag
+        # promoted to the stack, recipes containing DSALayerConfig get a
+        # global rotary built and passed in alongside the MLA-internal one.
+        if any(isinstance(lc, DSALayerConfig) for lc in decoder_flat):
+            stack_kwargs["multi_latent_attention"] = True
+        stack_kwargs["num_layers"] = num_layers
+        stack_kwargs["cross_entropy_loss_fusion"] = loss.loss_fusion
+        stack_kwargs["cross_entropy_fusion_impl"] = loss.fusion_impl
+        stack_kwargs["calculate_per_token_loss"] = loss.calculate_per_token_loss
+        # Marker-level passthroughs: Embedding and CrossEntropy markers may
+        # set TransformerConfig fields the curated DSL surface doesn't cover.
+        # Same shadowing rule as CommonLayerConfig.extra and LayerConfig.extra:
+        # ``extra`` cannot name a curated field on the same marker.
+        from megatron.core.models.hybrid.common_layer_config import validate_extra_kwargs
+
+        if embedding.extra:
+            validate_extra_kwargs(embedding.extra, "EmbeddingLayerConfig.extra")
+            curated = {
+                f.name
+                for f in dataclasses.fields(embedding)
+                if f.name not in ("common_config", "extra")
+            }
+            shadowed = sorted(set(embedding.extra) & curated)
+            if shadowed:
+                raise ValueError(
+                    f"EmbeddingLayerConfig.extra cannot name curated fields: {shadowed}. "
+                    f"Set them on the dataclass attribute directly."
+                )
+            stack_kwargs.update(embedding.extra)
+        if loss.extra:
+            validate_extra_kwargs(loss.extra, "CrossEntropyLayerConfig.extra")
+            # CrossEntropy's curated fields are renamed when projected onto
+            # TransformerConfig (``loss_fusion`` → ``cross_entropy_loss_fusion``
+            # etc.); reject both the recipe-side dataclass names and the
+            # TC-side names ``_lower`` writes into ``stack_kwargs`` above.
+            curated = {f.name for f in dataclasses.fields(loss) if f.name != "extra"} | {
+                "cross_entropy_loss_fusion",
+                "cross_entropy_fusion_impl",
+                "calculate_per_token_loss",
+            }
+            shadowed = sorted(set(loss.extra) & curated)
+            if shadowed:
+                raise ValueError(
+                    f"CrossEntropyLayerConfig.extra cannot name curated fields: {shadowed}. "
+                    f"Set them on the dataclass attribute directly."
+                )
+            stack_kwargs.update(loss.extra)
+        stack_kwargs = {k: v for k, v in stack_kwargs.items() if v is not None}
+        stack_config = TransformerConfig(**stack_kwargs)
+
+        # YARN parameters are not TransformerConfig dataclass fields today
+        # (see model_builder.py:196-201 and tests/.../test_hybrid_model.py for
+        # the existing setattr pattern). HybridModel.__init__ reads them via
+        # getattr when position_embedding_type == "yarn"; mirror that
+        # convention here so recipe-built models support YARN without forcing
+        # the recipe author to monkey-patch the config.
+        if embedding.yarn:
+            unknown = set(embedding.yarn) - set(_YARN_FIELDS)
+            if unknown:
+                raise ValueError(
+                    f"EmbeddingLayerConfig.yarn has unknown keys {sorted(unknown)}; "
+                    f"valid keys are {sorted(_YARN_FIELDS)}."
+                )
+            if embedding.position_embedding_type == "yarn":
+                for name, value in embedding.yarn.items():
+                    setattr(stack_config, name, value)
+
+        return stack_config, layer_type_list, layer_config_list
+
+    def _require_recipe_fields(self) -> None:
+        if self.common_config is None or self.layer_pattern is None:
+            raise ValueError(
+                "HybridModelConfig recipe path requires both common_config "
+                "and layer_pattern. The legacy path requires transformer "
+                "and hybrid_layer_pattern instead."
+            )
+
+
+# --- pattern-structure helpers --------------------------------------------
+
+
+def _inherit_common_if_default(node: Any, recipe_common: CommonLayerConfig) -> Any:
+    """If ``node`` carries no explicit common_config (left as ``None``),
+    substitute ``recipe_common`` via :func:`dataclasses.replace`. An
+    explicit :class:`CommonLayerConfig` (even a default-constructed one)
+    is preserved — recipe authors who write ``CommonLayerConfig()``
+    intentionally get the default values they asked for. Applies to
+    LayerConfig instances and pattern markers."""
+    if not hasattr(node, "common_config"):
+        return node
+    if node.common_config is None:
+        return dataclasses.replace(node, common_config=recipe_common)
+    return node
+
+
+def _inherit_common_in_pattern(node: Any, recipe_common: CommonLayerConfig) -> Any:
+    """Recursive variant: walks lists/tuples and applies
+    :func:`_inherit_common_if_default` to every leaf."""
+    if isinstance(node, list):
+        return [_inherit_common_in_pattern(child, recipe_common) for child in node]
+    if isinstance(node, tuple):
+        return tuple(_inherit_common_in_pattern(child, recipe_common) for child in node)
+    return _inherit_common_if_default(node, recipe_common)
+
+
+def _split_pattern(pattern: list):
+    """Split ``[Embedding, ...decoder..., Loss]`` into its three pieces.
+
+    The returned tuple is ``(embedding, decoder_body, loss)``.
+
+    Validates that exactly one :class:`EmbeddingLayerConfig` appears at the
+    start and exactly one :class:`CrossEntropyLayerConfig` at the end. MTP
+    and pipeline parallelism are intentionally not part of the recipe DSL;
+    recipes that need either should use the legacy ``hybrid_layer_pattern``
+    string DSL.
+    """
+    if not isinstance(pattern, list) or not pattern:
+        raise TypeError("layer_pattern must be a non-empty list.")
+
+    if not isinstance(pattern[0], EmbeddingLayerConfig):
+        raise TypeError(
+            "layer_pattern must begin with an EmbeddingLayerConfig; got "
+            f"{type(pattern[0]).__name__}."
+        )
+    if not isinstance(pattern[-1], CrossEntropyLayerConfig):
+        raise TypeError(
+            "layer_pattern must end with a CrossEntropyLayerConfig; got "
+            f"{type(pattern[-1]).__name__}."
+        )
+
+    body = pattern[1:-1]
+
+    # Embedding/Loss in the decoder body → wrong slot.
+    def _walk(node):
+        if isinstance(node, (EmbeddingLayerConfig, CrossEntropyLayerConfig)):
+            raise TypeError(
+                "EmbeddingLayerConfig / CrossEntropyLayerConfig may only appear "
+                "at the start / end of layer_pattern, never in the body."
+            )
+        if isinstance(node, (list, tuple)):
+            for child in node:
+                _walk(child)
+
+    for entry in body:
+        _walk(entry)
+
+    return pattern[0], body, pattern[-1]
+
+
+def _infer_uniform_attention_metadata(decoder_flat: List[LayerConfig]) -> dict[str, Any]:
+    """Infer model-wide attention geometry from attention-like layers.
+
+    ``TransformerConfig`` still requires attention-shaped fields even for
+    non-attention layer configs. Those requirements are an implementation
+    artifact of the current lowering target, not DSL concepts recipe authors
+    should have to spell in ``CommonLayerConfig.extra``.
+
+    When all attention/DSA layers in the pattern agree on a field, expose that
+    value to the lowering as a private placeholder. If attention layers are
+    heterogeneous, return only the fields that are actually uniform; the
+    remaining TransformerConfig invariants fall back to minimal placeholders.
+    """
+
+    attention_layers = [
+        lc for lc in decoder_flat if isinstance(lc, (AttentionLayerConfig, DSALayerConfig))
+    ]
+    if not attention_layers:
+        return {}
+
+    candidate_fields = ("num_attention_heads", "num_query_groups", "kv_channels")
+    metadata: dict[str, Any] = {}
+    for field_name in candidate_fields:
+        values = [getattr(lc, field_name) for lc in attention_layers]
+        if any(v is None for v in values):
+            continue
+        first = values[0]
+        if all(v == first for v in values[1:]):
+            metadata[field_name] = first
+    return metadata
+
+
+def _derive_stack_moe_metadata(
+    decoder_flat: List[LayerConfig],
+    override_num_experts: int | None,
+    override_ffn_hidden_size: int | None,
+) -> tuple[int | None, int | None]:
+    """Derive ``(num_moe_experts, moe_ffn_hidden_size)`` for the stack-level TC.
+
+    The stack TC is a model-wide topology snapshot, not a per-layer config,
+    but two consumers read its MoE fields semantically:
+    :class:`MultiTokenPredictionBlock` (when a body symbol contains ``E``,
+    the MoE layer inside MTP is built from the stack TC) and the inference
+    text-generation controller's capacity-factor calculation. Three cases:
+
+    1. No MoELayerConfig in the decoder → ``(None, None)``. The stack TC is
+       dense; the caller is responsible for raising on ``EP > 1``.
+    2. Homogeneous MoE → that value. The stack TC matches what every MoE
+       layer in the recipe actually uses.
+    3. Heterogeneous MoE → recipe must pin
+       :attr:`HybridModelConfig.stack_moe_num_experts` (and optionally
+       :attr:`stack_moe_ffn_hidden_size`). Without the pin we raise rather
+       than silently picking a "max"-shaped value: MTP and the inference
+       capacity-factor calc would otherwise consume a config that matches
+       no actual layer, and per-consumer wrongness is hard to debug after
+       the fact.
+    """
+    moe_layers = [lc for lc in decoder_flat if isinstance(lc, MoELayerConfig)]
+    if not moe_layers:
+        return None, None
+
+    distinct_experts = {lc.num_experts for lc in moe_layers}
+    distinct_ffn = {lc.ffn_hidden_size for lc in moe_layers if lc.ffn_hidden_size is not None}
+
+    if len(distinct_experts) == 1:
+        num_experts = next(iter(distinct_experts))
+    elif override_num_experts is not None:
+        num_experts = override_num_experts
+    else:
+        raise ValueError(
+            f"Heterogeneous MoE recipe (num_experts values: {sorted(distinct_experts)}) "
+            f"requires HybridModelConfig.stack_moe_num_experts to pin the value the "
+            f"stack-level TransformerConfig should expose. The stack TC is read by "
+            f"MTP and by the inference capacity-factor calculation; without an "
+            f"explicit pin those consumers would see a config that matches no "
+            f"actual MoE layer."
+        )
+
+    if len(distinct_ffn) <= 1:
+        # Homogeneous (or all None) — pick the matching layer's value, or fall
+        # through to ``ffn_hidden_size`` when every MoE layer leaves it unset.
+        ffn_hidden_size = next(
+            (
+                lc.ffn_hidden_size
+                for lc in moe_layers
+                if lc.num_experts == num_experts and lc.ffn_hidden_size is not None
+            ),
+            None,
+        )
+    elif override_ffn_hidden_size is not None:
+        ffn_hidden_size = override_ffn_hidden_size
+    else:
+        raise ValueError(
+            f"Heterogeneous MoE recipe (ffn_hidden_size values: {sorted(distinct_ffn)}) "
+            f"requires HybridModelConfig.stack_moe_ffn_hidden_size to pin the value the "
+            f"stack-level TransformerConfig should expose."
+        )
+
+    return num_experts, ffn_hidden_size
+
+
+def _infer_uniform_moe_metadata(decoder_flat: List[LayerConfig]) -> dict[str, Any]:
+    """Infer stack-level MoE metadata from homogeneous MoE layer configs.
+
+    The stack TC is still read by a few model-wide consumers. When every
+    MoE layer agrees on a MoE TransformerConfig field, expose that value on
+    the stack TC so recipe authors do not need to duplicate MoE router /
+    dispatcher settings through marker ``extra`` passthroughs.
+    """
+    moe_layers = [lc for lc in decoder_flat if isinstance(lc, MoELayerConfig)]
+    if not moe_layers:
+        return {}
+
+    layer_kwargs = [lc._layer_specific_kwargs() for lc in moe_layers]
+    candidate_fields = set().union(*(kwargs.keys() for kwargs in layer_kwargs))
+    metadata: dict[str, Any] = {}
+    for field_name in candidate_fields:
+        values = [kwargs.get(field_name) for kwargs in layer_kwargs]
+        if any(v is None for v in values):
+            continue
+        first = values[0]
+        if all(v == first for v in values[1:]):
+            metadata[field_name] = first
+    return metadata
+
+
+def _reject_heterogeneous_attention_geometry(
+    decoder_flat: List[LayerConfig], attention_metadata: dict[str, Any]
+) -> None:
+    """Raise if attention layers under RoPE/YARN disagree on rotary geometry.
+
+    HybridModel builds a single global rotary embedding from the stack TC's
+    ``num_attention_heads`` / ``kv_channels``. When per-layer attention
+    configs diverge on those fields, the rotary tensor is sized for the
+    placeholder and runtime hits shape mismatches. Until per-layer rotary
+    lands, force recipes under RoPE/YARN to use uniform attention geometry.
+    """
+
+    attention_layers = [
+        lc for lc in decoder_flat if isinstance(lc, (AttentionLayerConfig, DSALayerConfig))
+    ]
+    if not attention_layers:
+        return
+    for field_name in ("num_attention_heads", "num_query_groups", "kv_channels"):
+        # If inference produced this field, all layers agree; skip.
+        if field_name in attention_metadata:
+            continue
+        values = [getattr(lc, field_name) for lc in attention_layers]
+        non_none = {v for v in values if v is not None}
+        if len(non_none) > 1:
+            raise NotImplementedError(
+                f"Heterogeneous attention geometry under RoPE/YARN is not "
+                f"supported: attention layers disagree on {field_name!r} "
+                f"(values: {sorted(non_none)}). HybridModel builds one global "
+                f"rotary embedding from the stack TC and passes it to every "
+                f"attention layer; per-layer rotary support is a follow-up. "
+                f"Use uniform attention geometry, or position_embedding_type="
+                f"\"none\" / \"learned_absolute\"."
+            )
 
 
 class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
@@ -148,9 +844,10 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
         Note:
             Virtual pipeline model parallelism is not supported for Hybrid models.
         """
+        transformer_config = self._model_config.get_transformer_config()
         hybrid_stack_spec = self._model_config.hybrid_stack_spec
         if hybrid_stack_spec is None:
-            if self._model_config.transformer.transformer_impl == "inference_optimized":
+            if transformer_config.transformer_impl == "inference_optimized":
                 hybrid_stack_spec = hybrid_inference_stack_spec
             elif self._model_config.restore_modelopt_state:
                 hybrid_stack_spec = get_hybrid_stack_modelopt_spec(
@@ -161,19 +858,31 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
                 hybrid_stack_spec = default_hybrid_stack_spec
 
         assert (
-            getattr(self._model_config.transformer, "virtual_pipeline_model_parallel_size", None) is None
+            getattr(transformer_config, "virtual_pipeline_model_parallel_size", None) is None
             and vp_stage is None
         ), (
             "Virtual pipeline model parallelism is temporarily unsupported in Hybrid "
             "models due to upstream MCore HybridModel API dependency"
         )
 
+        if self._model_config.is_recipe_config:
+            pre_process = pre_process if pre_process is not None else is_pp_first_stage(pg_collection.pp)
+            post_process = post_process if post_process is not None else is_pp_last_stage(pg_collection.pp)
+            return HybridModel(
+                config=self._model_config,
+                hybrid_stack_spec=hybrid_stack_spec,
+                pre_process=pre_process,
+                post_process=post_process,
+                pg_collection=pg_collection,
+                vp_stage=vp_stage,
+            )
+
         assert self._model_config.vocab_size is not None, "vocab_size must be configured before calling build_model()"
         if self._model_config.should_pad_vocab:
             padded_vocab_size = calculate_padded_vocab_size(
                 self._model_config.vocab_size,
                 self._model_config.make_vocab_size_divisible_by,
-                self._model_config.transformer.tensor_model_parallel_size,
+                transformer_config.tensor_model_parallel_size,
             )
         else:
             padded_vocab_size = self._model_config.vocab_size
@@ -181,7 +890,7 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
         pre_process = pre_process if pre_process is not None else is_pp_first_stage(pg_collection.pp)
         post_process = post_process if post_process is not None else is_pp_last_stage(pg_collection.pp)
         return HybridModel(
-            config=self._model_config.transformer,
+            config=transformer_config,
             hybrid_stack_spec=hybrid_stack_spec,
             vocab_size=padded_vocab_size,
             max_sequence_length=self._model_config.seq_length,
@@ -228,7 +937,7 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
         Returns:
             List of model stages.
         """
-        transformer_config = self._model_config.transformer
+        transformer_config = self._model_config.get_transformer_config()
         composed_pre_wrap_hook = compose_hooks(self._model_config.pre_wrap_hooks)
         model_list = unimodal_build_distributed_models(
             self.build_model,

--- a/tests/unit_tests/models/hybrid/test_layer_pattern.py
+++ b/tests/unit_tests/models/hybrid/test_layer_pattern.py
@@ -1,0 +1,1152 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the HybridModel Python layer-pattern DSL primitives.
+
+These tests exercise pure-Python composition logic and do not require a
+distributed initialization or a CUDA device.
+"""
+
+import dataclasses
+from collections import namedtuple
+
+import pytest
+import torch
+
+from megatron.core.models.hybrid.common_layer_config import CommonLayerConfig, validate_extra_kwargs
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.layer_configs import (
+    AttentionLayerConfig,
+    CrossEntropyLayerConfig,
+    DSALayerConfig,
+    EmbeddingLayerConfig,
+    GDNLayerConfig,
+    LayerConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+    MoELayerConfig,
+)
+from megatron.core.models.hybrid.layer_pattern import flatten_decoder_pattern
+from megatron.core.transformer import MLATransformerConfig
+from megatron.training.models.hybrid import HybridModelConfig
+
+# ``HybridModelConfig._lower()`` now returns a 3-tuple
+# ``(stack_tc, layer_symbols, layer_tcs)``; the previous ``_RecipeLowering``
+# named-attribute struct went away when the recipe-API refactor inlined the
+# lowering into ``HybridModel.__init__``. Tests in this module use
+# ``compiled.config`` / ``.layer_type_list`` / ``.layer_config_list`` style
+# access purely for readability — wrap the tuple here so existing
+# assertions stay legible without coupling the production code to a
+# named-attribute return type.
+_Lowered = namedtuple("_Lowered", ["config", "layer_type_list", "layer_config_list"])
+
+
+def _lower(recipe: HybridModelConfig) -> _Lowered:
+    return _Lowered(*recipe._lower())
+
+
+def _make_common(**overrides) -> CommonLayerConfig:
+    """Build a minimal valid CommonLayerConfig for unit tests."""
+    base = dict(hidden_size=256, use_cpu_initialization=True)
+    base.update(overrides)
+    return CommonLayerConfig(**base)
+
+
+@pytest.mark.internal
+class TestCommonLayerConfig:
+
+    COMMON_FIELD_LAYER_COVERAGE = {
+        "hidden_size": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "ffn_hidden_size": ("mlp", "moe"),
+        "mixed_precision_dtype": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "params_dtype": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "first_last_layers_bf16": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "sequence_parallel": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "init_method_std": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "perform_initialization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "use_cpu_initialization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "normalization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "layernorm_epsilon": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "layernorm_zero_centered_gamma": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "add_bias_linear": ("attention", "dsa", "mlp", "moe"),
+        "gated_linear_unit": ("mlp", "moe"),
+        "activation_func": ("gdn", "mlp", "moe"),
+        "hidden_dropout": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp32_residual_connection": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "apply_rope_fusion": ("attention", "dsa"),
+        "persist_layer_norm": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "transformer_impl": ("attention", "mlp", "moe"),
+        "cuda_graph_impl": ("mamba", "attention", "mlp", "moe"),
+        "cuda_graph_scope": ("mamba", "attention", "mlp", "moe"),
+        "cuda_graph_warmup_steps": ("mamba", "attention", "mlp", "moe"),
+        # TransformerLayer-level wiring — applies wherever the per-layer
+        # type is wrapped in a TransformerLayer (i.e. everywhere).
+        "apply_residual_connection_post_layernorm": (
+            "mamba",
+            "attention",
+            "dsa",
+            "gdn",
+            "mlp",
+            "moe",
+        ),
+        # FP8/FP4/recompute clusters — TC-level concerns that affect every
+        # layer family the recipe builds.
+        "fp8": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_recipe": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_param": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_margin": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_amax_history_len": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_dot_product_attention": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4_recipe": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4_param": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_granularity": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_method": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_num_layers": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "distribute_saved_activations": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+    }
+
+    NON_SHARED_FIELDS = {
+        "attention_dropout",
+        "attention_softmax_in_fp32",
+        "apply_query_key_layer_scaling",
+        "add_qkv_bias",
+        "masked_softmax_fusion",
+        "use_fused_weighted_squared_relu",
+    }
+
+    def test_common_fields_are_explicitly_audited_as_shared(self):
+        common_fields = {f.name for f in dataclasses.fields(CommonLayerConfig) if f.name != "extra"}
+        assert common_fields == set(self.COMMON_FIELD_LAYER_COVERAGE)
+        for field_name, layer_families in self.COMMON_FIELD_LAYER_COVERAGE.items():
+            assert len(layer_families) >= 2, field_name
+
+    def test_non_shared_fields_are_not_common_fields(self):
+        common_fields = {f.name for f in dataclasses.fields(CommonLayerConfig)}
+        assert common_fields.isdisjoint(self.NON_SHARED_FIELDS)
+
+    def test_update_returns_new_instance(self):
+        common = _make_common()
+        updated = common.update(hidden_size=512)
+        assert updated is not common
+        assert common.hidden_size == 256
+        assert updated.hidden_size == 512
+
+    def test_mixed_precision_dtype_bf16_maps_to_bf16_true(self):
+        common = _make_common(mixed_precision_dtype=torch.bfloat16)
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.bf16 is True
+        assert tc.fp16 is False
+
+    def test_params_dtype_auto_derives_from_mixed_precision_when_unset(self):
+        """Setting ``mixed_precision_dtype=torch.bfloat16`` without overriding
+        ``params_dtype`` should produce a TC whose
+        params live in bf16 — matching the legacy --bf16 CLI flag's
+        behaviour."""
+        common = _make_common(mixed_precision_dtype=torch.bfloat16)
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.params_dtype == torch.bfloat16
+
+    def test_explicit_params_dtype_override_preserved(self):
+        """An explicit ``params_dtype`` from the recipe author wins over the
+        auto-derive. Useful when a recipe wants bf16 mixed precision but
+        keeps params in fp32 (e.g. for fp32 master-weight workflows)."""
+        common = _make_common(
+            mixed_precision_dtype=torch.bfloat16,
+            params_dtype=torch.float16,
+        )
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.params_dtype == torch.float16
+
+    def test_invalid_mixed_precision_dtype_raises(self):
+        common = _make_common(mixed_precision_dtype="nope")
+        with pytest.raises(TypeError, match="mixed_precision_dtype"):
+            common.to_transformer_config_kwargs()
+
+    def test_invalid_activation_func_raises(self):
+        common = _make_common(activation_func="not_a_real_activation")
+        with pytest.raises(ValueError, match="activation"):
+            common.to_transformer_config_kwargs()
+
+    def test_attention_specific_fields_live_on_attention_layer_config(self):
+        common = _make_common()
+        layer = AttentionLayerConfig(
+            common_config=common,
+            num_attention_heads=4,
+            attention_dropout=0.25,
+            attention_softmax_in_fp32=False,
+            add_qkv_bias=True,
+            masked_softmax_fusion=True,
+            # Niche legacy fp16-stability knob; reachable via ``extra`` rather
+            # than as a curated AttentionLayerConfig field.
+            extra={"apply_query_key_layer_scaling": False},
+        )
+
+        tc = layer.to_transformer_config(num_layers=2)
+
+        assert tc.attention_dropout == 0.25
+        assert tc.attention_softmax_in_fp32 is False
+        assert tc.apply_query_key_layer_scaling is False
+        assert tc.add_qkv_bias is True
+        assert tc.masked_softmax_fusion is True
+
+    def test_moe_specific_fields_live_on_moe_layer_config(self):
+        common = _make_common(activation_func="squared_relu")
+        layer = MoELayerConfig(
+            common_config=common, num_experts=8, top_k=2, use_fused_weighted_squared_relu=True
+        )
+
+        tc = layer.to_transformer_config(num_layers=2)
+
+        assert tc.use_fused_weighted_squared_relu is True
+
+    def test_fp8_cluster_propagates(self):
+        """FP8 cluster on CommonLayerConfig flows through to per-layer TC."""
+        common = _make_common(
+            fp8="hybrid",
+            fp8_recipe="delayed",
+            fp8_param=True,
+            fp8_margin=2,
+            fp8_amax_history_len=1024,
+            fp8_dot_product_attention=True,
+        )
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.fp8 == "hybrid"
+        assert tc.fp8_recipe == "delayed"
+        assert tc.fp8_param is True
+        assert tc.fp8_margin == 2
+        assert tc.fp8_amax_history_len == 1024
+        assert tc.fp8_dot_product_attention is True
+
+    def test_recompute_cluster_propagates(self):
+        common = _make_common(
+            recompute_granularity="full", recompute_method="uniform", recompute_num_layers=4
+        )
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=8)
+        assert tc.recompute_granularity == "full"
+        assert tc.recompute_method == "uniform"
+        assert tc.recompute_num_layers == 4
+
+    def test_apply_residual_connection_post_layernorm_propagates(self):
+        common = _make_common(apply_residual_connection_post_layernorm=True)
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.apply_residual_connection_post_layernorm is True
+
+    def test_dsa_add_qkv_bias_curated(self):
+        """``add_qkv_bias`` is curated on :class:`DSALayerConfig` (parity with
+        :class:`AttentionLayerConfig`); it should not require ``extra``."""
+        common = _make_common()
+        layer = DSALayerConfig(common_config=common, num_attention_heads=4, add_qkv_bias=True)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.add_qkv_bias is True
+
+    def test_dsa_mla_knobs_curated(self):
+        """The MLA-defining knobs are curated on :class:`DSALayerConfig` so
+        DeepSeek-style models don't need ``extra={...}`` for every field.
+        Each is ``None`` by default and falls through to the underlying
+        :class:`TransformerConfig` MLA defaults; setting them explicitly
+        overrides those defaults."""
+        common = _make_common()
+        # DeepSeek-V3-style values (representative — not the exact card).
+        layer = DSALayerConfig(
+            common_config=common,
+            num_attention_heads=128,
+            q_lora_rank=1536,
+            kv_lora_rank=512,
+            qk_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            v_head_dim=128,
+            rope_type="yarn",
+            rotary_base=1000000.0,
+            rotary_percent=1.0,
+            rotary_scaling_factor=40.0,
+            original_max_position_embeddings=4096,
+            beta_fast=32.0,
+            beta_slow=1.0,
+            mscale=1.0,
+            mscale_all_dim=0.0,
+            cache_mla_latents=True,
+            mla_down_proj_fusion=True,
+            dsa_indexer_n_heads=8,
+            dsa_indexer_head_dim=64,
+            dsa_indexer_topk=32,
+            dsa_indexer_loss_coeff=0.1,
+            dsa_indexer_use_sparse_loss=True,
+        )
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.multi_latent_attention is True
+        assert tc.experimental_attention_variant == "dsa"
+        assert tc.q_lora_rank == 1536
+        assert tc.kv_lora_rank == 512
+        assert tc.qk_head_dim == 128
+        assert tc.qk_pos_emb_head_dim == 64
+        assert tc.v_head_dim == 128
+        assert tc.rope_type == "yarn"
+        assert tc.rotary_base == 1000000.0
+        assert tc.rotary_percent == 1.0
+        assert tc.rotary_scaling_factor == 40.0
+        assert tc.original_max_position_embeddings == 4096
+        assert tc.beta_fast == 32.0
+        assert tc.beta_slow == 1.0
+        assert tc.mscale == 1.0
+        assert tc.mscale_all_dim == 0.0
+        assert tc.cache_mla_latents is True
+        assert tc.mla_down_proj_fusion is True
+        assert tc.dsa_indexer_n_heads == 8
+        assert tc.dsa_indexer_head_dim == 64
+        assert tc.dsa_indexer_topk == 32
+        assert tc.dsa_indexer_loss_coeff == 0.1
+        assert tc.dsa_indexer_use_sparse_loss is True
+
+    def test_dsa_mla_knobs_default_to_transformer_config_defaults(self):
+        """Unset MLA knobs on :class:`DSALayerConfig` fall through to the
+        underlying TransformerConfig defaults — recipe authors don't have
+        to repeat the model-card defaults to opt in."""
+        common = _make_common()
+        layer = DSALayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=2)
+        # TC's MLA defaults (transformer_config.py around line 2297+).
+        assert tc.q_lora_rank == 512
+        assert tc.kv_lora_rank == 512
+        assert tc.qk_head_dim == 128
+        assert tc.qk_pos_emb_head_dim == 64
+        assert tc.v_head_dim == 128
+        assert tc.rotary_scaling_factor == 40
+        assert tc.experimental_attention_variant == "dsa"
+
+
+@pytest.mark.internal
+class TestLayerConfigSymbols:
+    """Each LayerConfig subclass binds the correct hybrid-allocation symbol."""
+
+    def test_symbol_assignments(self):
+        assert MambaLayerConfig.SYMBOL == Symbols.MAMBA
+        assert GDNLayerConfig.SYMBOL == Symbols.GDN
+        assert AttentionLayerConfig.SYMBOL == Symbols.ATTENTION
+        assert DSALayerConfig.SYMBOL == Symbols.DS_ATTENTION
+        assert MLPLayerConfig.SYMBOL == Symbols.MLP
+        assert MoELayerConfig.SYMBOL == Symbols.MOE
+
+    def test_symbols_are_valid(self):
+        for cls in (
+            MambaLayerConfig,
+            GDNLayerConfig,
+            AttentionLayerConfig,
+            DSALayerConfig,
+            MLPLayerConfig,
+            MoELayerConfig,
+        ):
+            assert cls.SYMBOL in Symbols.VALID_LAYERS
+
+    def test_mlp_layer_compiles_and_emits_dash_symbol(self):
+        """The recipe-DSL ``MLPLayerConfig`` produces the same ``-`` symbol
+        the legacy string DSL writes, and yields a per-layer TC with the
+        author-specified ``ffn_hidden_size``. This proves the MLP path is
+        not dead code in the recipe pipeline."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(common_config=common, vocab_size=32, max_sequence_length=8)
+        m = MambaLayerConfig(common_config=common)
+        mlp = MLPLayerConfig(common_config=common, ffn_hidden_size=192)
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common, layer_pattern=[emb, m, mlp, loss]
+        )._lower()
+        assert compiled.layer_type_list == [Symbols.MAMBA, Symbols.MLP]
+        assert compiled.layer_config_list[1].ffn_hidden_size == 192
+
+    def test_gdn_layer_compiles_and_emits_g_symbol(self):
+        """The recipe-DSL ``GDNLayerConfig`` produces the same ``G`` symbol
+        the legacy string DSL writes, and yields a per-layer TC carrying
+        the author-specified attention-head count. This proves the GDN
+        path is not dead code in the recipe pipeline."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(common_config=common, vocab_size=32, max_sequence_length=8)
+        g = GDNLayerConfig(common_config=common, num_attention_heads=8)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, g, loss]))
+        assert compiled.layer_type_list == [Symbols.GDN]
+        assert compiled.layer_config_list[0].num_attention_heads == 8
+
+
+@pytest.mark.internal
+class TestLayerConfigToTransformerConfig:
+
+    def test_mamba_layer_config(self):
+        common = _make_common()
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.mamba_head_dim == 64
+        assert tc.mamba_state_dim == 128
+        assert tc.mamba_num_groups == 8
+        assert tc.num_layers == 4
+
+    def test_attention_layer_config(self):
+        common = _make_common()
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=32)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.num_attention_heads == 32
+        # num_query_groups auto-derived to num_attention_heads when not set.
+        assert tc.num_query_groups == 32
+        # kv_channels auto-derived to hidden_size // num_attention_heads.
+        assert tc.kv_channels == common.hidden_size // 32
+        assert tc.num_layers == 4
+
+    def test_moe_layer_config(self):
+        common = _make_common()
+        layer = MoELayerConfig(common_config=common, num_experts=8, top_k=2)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.num_moe_experts == 8
+        assert tc.moe_router_topk == 2
+        assert tc.num_layers == 4
+
+
+@pytest.mark.internal
+class TestFlatten:
+
+    def test_flat_with_repeat_block(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        e = MoELayerConfig(common_config=common, num_experts=4, top_k=2)
+        # [Mamba, [Att, MoE] * 3] → length 1 + 2*3 = 7
+        result = flatten_decoder_pattern([m, [a, e] * 3])
+        assert len(result) == 7
+        assert result == [m, a, e, a, e, a, e]
+
+    def test_tuples_treated_as_lists(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        result = flatten_decoder_pattern([m, (a, m)])
+        assert result == [m, a, m]
+
+    def test_non_layerconfig_leaf_rejected(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        with pytest.raises(TypeError, match="path"):
+            flatten_decoder_pattern([m, "M", m])
+
+    def test_embedding_in_body_rejected(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        emb = EmbeddingLayerConfig(common_config=common)
+        with pytest.raises(TypeError, match="start/end"):
+            flatten_decoder_pattern([m, emb, m])
+
+    def test_loss_in_body_rejected(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        loss = CrossEntropyLayerConfig()
+        with pytest.raises(TypeError, match="start/end"):
+            flatten_decoder_pattern([m, loss, m])
+
+
+@pytest.mark.internal
+class TestHybridModelConfigLowering:
+
+    def _embedding(self, common, **overrides):
+        kwargs = dict(
+            common_config=common,
+            vocab_size=32000,
+            max_sequence_length=2048,
+            position_embedding_type="rope",
+        )
+        kwargs.update(overrides)
+        return EmbeddingLayerConfig(**kwargs)
+
+    def test_lower_returns_stack_tc_and_per_layer_tcs(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        m = MambaLayerConfig(common_config=common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, m, a, m, a, loss])
+        compiled = _lower(recipe)
+        # The lowering produces the stack TC, per-layer symbol list, and
+        # per-layer TC list — exactly what HybridModel needs in addition to
+        # what it reads directly from the recipe's markers.
+        assert compiled.layer_type_list == ["M", "*", "M", "*"]
+        assert len(compiled.layer_config_list) == 4
+        # Marker-derived fields are NOT in the lowering output any more —
+        # they're read directly from the recipe at the call site.
+        assert recipe.embedding_marker.vocab_size == 32000
+        assert recipe.embedding_marker.max_sequence_length == 2048
+        assert recipe.embedding_marker.position_embedding_type == "rope"
+        # Default untie=False → share=True at the call site.
+        assert recipe.untie_embeddings_and_output_weights is False
+        assert recipe.num_layers == 4
+
+    def test_recipe_topology_defaults_to_none(self):
+        """``HybridModelConfig`` topology fields default to ``None`` — the
+        launcher's args projection reads these directly off the recipe to
+        decide whether to overwrite a CLI flag, so the default is part of
+        the public contract."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss])
+        assert recipe.tensor_model_parallel_size is None
+        assert recipe.context_parallel_size is None
+        assert recipe.expert_model_parallel_size is None
+        assert recipe.expert_tensor_parallel_size is None
+
+    def test_lower_substitutes_concrete_topology_into_stack_tc(self):
+        """When the recipe leaves topology unset, ``_lower`` substitutes
+        TC defaults (1 / TP) into the stack TC and per-layer TCs because
+        ``TransformerConfig`` cannot accept ``None`` for those fields. The
+        ``None``-ness on the recipe itself (verified above) is what the
+        launcher reads — the substituted concrete value is purely an
+        implementation detail of the current TC backend."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.tensor_model_parallel_size == 1
+
+    def test_recipe_topology_pin_propagates_through_lowering(self):
+        """When the recipe pins a topology field, the recipe itself carries
+        the pin (for the launcher) and the lowering's stack TC carries it
+        too (for downstream TC consumers)."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, loss],
+            tensor_model_parallel_size=4,
+            context_parallel_size=2,
+        )
+        assert recipe.tensor_model_parallel_size == 4
+        assert recipe.context_parallel_size == 2
+        assert recipe.expert_model_parallel_size is None
+        assert recipe.expert_tensor_parallel_size is None
+        compiled = _lower(recipe)
+        assert compiled.config.tensor_model_parallel_size == 4
+        assert compiled.config.context_parallel_size == 2
+
+    def test_common_config_auto_inherited_into_layers_without_explicit_common(self):
+        """A recipe author who omits ``common_config=common`` on a layer
+        should still get the recipe's common_config injected — otherwise the
+        layer compiles with ``hidden_size=0`` and silently produces an
+        invalid model."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(
+            vocab_size=1024, max_sequence_length=512, position_embedding_type="rope"
+        )
+        m = MambaLayerConfig()  # No common_config — should auto-inherit.
+        a = AttentionLayerConfig(num_attention_heads=4)  # Same.
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, m, a, loss]))
+        # All per-layer TCs see the recipe's hidden_size, not 0.
+        for tc in compiled.layer_config_list:
+            assert tc.hidden_size == common.hidden_size
+
+    def test_common_config_explicit_override_preserved(self):
+        """An explicit non-default ``common_config`` on a layer wins over
+        the auto-inherit path — auto-inherit only fills in defaults."""
+        common = _make_common(hidden_size=256)
+        other_common = _make_common(hidden_size=512)
+        emb = self._embedding(common)
+        # Layer carries an explicit, non-default common_config.
+        m = MambaLayerConfig(common_config=other_common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, m, a, loss]))
+        # Mamba layer (idx 0) keeps its explicit hidden_size=512.
+        assert compiled.layer_config_list[0].hidden_size == 512
+        # Attention layer (idx 1) uses the recipe common's 256.
+        assert compiled.layer_config_list[1].hidden_size == 256
+
+    def test_lower_infers_uniform_attention_metadata(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        m = MambaLayerConfig(common_config=common)
+        a = AttentionLayerConfig(
+            common_config=common, num_attention_heads=8, num_query_groups=2, kv_channels=16
+        )
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common, layer_pattern=[emb, m, a, m, loss], tensor_model_parallel_size=2
+        )
+
+        compiled = _lower(recipe)
+        assert compiled.config.num_attention_heads == 8
+        assert compiled.config.num_query_groups == 2
+        assert compiled.config.kv_channels == 16
+        # The Mamba layer still lowers to TransformerConfig today, but the
+        # recipe author does not have to pass attention fields through
+        # CommonLayerConfig.extra just to satisfy TransformerConfig invariants.
+        mamba_tc = compiled.layer_config_list[0]
+        assert mamba_tc.num_attention_heads == 8
+        assert mamba_tc.num_query_groups == 2
+        assert mamba_tc.kv_channels == 16
+
+    def test_untie_disables_sharing(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, loss],
+            untie_embeddings_and_output_weights=True,
+        )
+        # ``untie_embeddings_and_output_weights`` is a recipe-level field;
+        # callers (HybridModel.__init__, the launcher) read it directly off
+        # the recipe rather than going through ``_lower``.
+        _lower(recipe)  # smoke-test: lowering succeeds with this setting.
+        assert recipe.untie_embeddings_and_output_weights is True
+
+    def test_missing_embedding_raises(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[m, loss])
+        with pytest.raises(TypeError, match="EmbeddingLayerConfig"):
+            recipe._lower()
+
+    def test_missing_loss_raises(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        m = MambaLayerConfig(common_config=common)
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, m])
+        with pytest.raises(TypeError, match="CrossEntropyLayerConfig"):
+            recipe._lower()
+
+    def test_no_decoder_layers_raises(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, loss])
+        with pytest.raises(ValueError, match="no decoder layers"):
+            recipe._lower()
+
+    def test_attention_dsa_mix_rejected(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        d = DSALayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, a, d, loss])
+        with pytest.raises(ValueError, match="Attention.*MLA/DSA|MLA/DSA.*Attention"):
+            recipe._lower()
+
+    def test_dsa_recipe_promotes_multi_latent_attention_to_stack(self):
+        """DSA / MLA layers use their own decoupled RoPE.
+        ``HybridModel.__init__`` skips global RoPE construction when
+        ``self.config.multi_latent_attention`` (stack TC) is True. Compile
+        must promote the flag whenever the decoder contains any DSA layer."""
+        common = _make_common()
+        emb = self._embedding(common)
+        d = DSALayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, d, loss]))
+        assert compiled.config.multi_latent_attention is True
+
+    def test_no_dsa_layers_keeps_multi_latent_attention_default(self):
+        """A recipe without DSA must not flip the stack-level flag — that
+        would silently disable global RoPE construction for ordinary
+        Attention layers."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.multi_latent_attention is False
+
+    def test_heterogeneous_attention_under_rope_rejected(self):
+        """Two attention layers with different ``num_attention_heads`` under
+        RoPE produce a single global rotary sized for a placeholder; the
+        layer with the non-matching head count would hit shape mismatches
+        at runtime. Reject at compile time until per-layer rotary lands."""
+        common = _make_common()
+        emb = self._embedding(common, position_embedding_type="rope")
+        a1 = AttentionLayerConfig(common_config=common, num_attention_heads=8)
+        a2 = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, a1, a2, loss])
+        with pytest.raises(NotImplementedError, match="[Hh]eterogeneous attention geometry"):
+            recipe._lower()
+
+    def test_heterogeneous_attention_under_none_position_embedding_allowed(self):
+        """Without RoPE/YARN, no global rotary is built — heterogeneous
+        attention geometry is fine."""
+        common = _make_common()
+        emb = self._embedding(common, position_embedding_type="none")
+        a1 = AttentionLayerConfig(common_config=common, num_attention_heads=8)
+        a2 = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common, layer_pattern=[emb, a1, a2, loss]
+        )._lower()
+        assert compiled.layer_config_list[0].num_attention_heads == 8
+        assert compiled.layer_config_list[1].num_attention_heads == 4
+
+
+@pytest.mark.internal
+class TestHeterogeneousMoE:
+    """Two distinct MoELayerConfig instances in one recipe must produce two
+    per-layer TransformerConfigs whose MoE fields actually differ. This is
+    the headline DSL capability the legacy single-character pattern can't
+    express."""
+
+    def _embedding(self, common):
+        return EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="rope",
+        )
+
+    def test_two_moe_configs_produce_distinct_tcs(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        dense = MoELayerConfig(common_config=common, num_experts=8, top_k=4, ffn_hidden_size=256)
+        sparse = MoELayerConfig(common_config=common, num_experts=4, top_k=2, ffn_hidden_size=128)
+        loss = CrossEntropyLayerConfig()
+        # Pattern: [emb, a, dense, a, sparse, loss] — 4 decoder layers, 2 MoE.
+        # Heterogeneous MoE requires explicit stack-TC pins.
+        compiled = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, dense, a, sparse, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+            stack_moe_num_experts=8,
+            stack_moe_ffn_hidden_size=256,
+        )._lower()
+        tcs = compiled.layer_config_list
+        # Decoder indices: 0=att, 1=dense MoE, 2=att, 3=sparse MoE.
+        dense_tc, sparse_tc = tcs[1], tcs[3]
+        assert dense_tc.num_moe_experts == 8 and sparse_tc.num_moe_experts == 4
+        assert dense_tc.moe_router_topk == 4 and sparse_tc.moe_router_topk == 2
+        assert dense_tc.moe_ffn_hidden_size == 256 and sparse_tc.moe_ffn_hidden_size == 128
+        # And the two are not the same Python object (no aliasing).
+        assert dense_tc is not sparse_tc
+
+    def test_two_moe_configs_share_global_ep(self):
+        """EP is a model-wide topology fact — both MoE TCs must agree on it
+        regardless of any per-layer-config differences."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        dense = MoELayerConfig(common_config=common, num_experts=8, top_k=2)
+        sparse = MoELayerConfig(common_config=common, num_experts=4, top_k=2)
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, dense, a, sparse, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+            stack_moe_num_experts=8,
+        )._lower()
+        dense_tc, sparse_tc = compiled.layer_config_list[1], compiled.layer_config_list[3]
+        assert dense_tc.expert_model_parallel_size == 2
+        assert sparse_tc.expert_model_parallel_size == 2
+
+    def test_non_moe_tcs_carry_no_expert_parallelism(self):
+        """The other half of the EP-only-on-MoE invariant: non-MoE TCs in a
+        heterogeneous-MoE recipe default to EP=1 and ``num_moe_experts=None``,
+        which is what the runtime layer construction actually consumes."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        dense = MoELayerConfig(common_config=common, num_experts=8, top_k=2)
+        sparse = MoELayerConfig(common_config=common, num_experts=4, top_k=2)
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, dense, a, sparse, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+            stack_moe_num_experts=8,
+        )._lower()
+        # Indices 0 and 2 are attention layers in the pattern above.
+        att_tc_0, att_tc_2 = compiled.layer_config_list[0], compiled.layer_config_list[2]
+        for tc in (att_tc_0, att_tc_2):
+            assert tc.expert_model_parallel_size == 1
+            assert tc.num_moe_experts is None
+
+    def test_homogeneous_moe_stack_num_experts_matches_recipe(self):
+        """Stack TC's ``num_moe_experts`` reflects the recipe's actual MoE
+        configuration — not a magic placeholder. MTP block construction and
+        inference capacity sizing both read this value semantically."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        moe = MoELayerConfig(
+            common_config=common,
+            num_experts=128,
+            top_k=6,
+            router_score_function="sigmoid",
+            router_topk_scaling_factor=2.5,
+        )
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, moe, a, moe, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+        )._lower()
+        assert compiled.config.num_moe_experts == 128
+        assert compiled.config.moe_router_topk == 6
+        assert compiled.config.moe_router_score_function == "sigmoid"
+        assert compiled.config.moe_router_topk_scaling_factor == 2.5
+
+    def test_heterogeneous_moe_without_override_raises(self):
+        """Heterogeneous MoE without an explicit ``stack_moe_num_experts``
+        pin is rejected: the stack TC is read by MTP and the inference
+        capacity-factor calc, and silently picking a value that matches
+        no actual layer would mislead both consumers."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        dense = MoELayerConfig(common_config=common, num_experts=128, top_k=2)
+        sparse = MoELayerConfig(common_config=common, num_experts=64, top_k=2)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, dense, a, sparse, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+        )
+        with pytest.raises(ValueError, match="stack_moe_num_experts"):
+            recipe._lower()
+
+    def test_heterogeneous_moe_with_override_uses_pinned_num_experts(self):
+        """An explicit ``stack_moe_num_experts`` pins the stack-TC value
+        for MTP / inference consumers in a heterogeneous-MoE recipe."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        dense = MoELayerConfig(common_config=common, num_experts=128, top_k=2)
+        sparse = MoELayerConfig(common_config=common, num_experts=64, top_k=2)
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, dense, a, sparse, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+            stack_moe_num_experts=128,
+        )._lower()
+        assert compiled.config.num_moe_experts == 128
+
+    def test_heterogeneous_moe_ffn_hidden_size_requires_override(self):
+        """Same rule for ``moe_ffn_hidden_size``: heterogeneous values
+        require an explicit pin."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        wide = MoELayerConfig(common_config=common, num_experts=128, top_k=2, ffn_hidden_size=1024)
+        narrow = MoELayerConfig(common_config=common, num_experts=128, top_k=2, ffn_hidden_size=512)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, wide, a, narrow, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+        )
+        with pytest.raises(ValueError, match="stack_moe_ffn_hidden_size"):
+            recipe._lower()
+        # With both overrides set, compile succeeds with the pinned values.
+        recipe.stack_moe_ffn_hidden_size = 1024
+        compiled = _lower(recipe)
+        assert compiled.config.num_moe_experts == 128
+        assert compiled.config.moe_ffn_hidden_size == 1024
+
+    def test_no_moe_no_ep_keeps_num_experts_none(self):
+        """A dense recipe (no MoE, EP=1) must leave ``num_moe_experts``
+        unset on the stack TC — TC defaults take over."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.num_moe_experts is None
+
+    def test_ep_gt_1_without_moe_layers_rejected(self):
+        """Setting ``expert_model_parallel_size > 1`` without any MoE layer
+        is a recipe misconfiguration — surface it loudly rather than
+        silently filling in a placeholder."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+        )
+        with pytest.raises(ValueError, match="requires at least one MoELayerConfig"):
+            recipe._lower()
+
+
+@pytest.mark.internal
+class TestExtraPassthrough:
+    """Every config exposes an ``extra: dict`` escape hatch for any
+    TransformerConfig field not in the curated DSL surface."""
+
+    def _embedding(self, common, **kwargs):
+        base = dict(
+            common_config=common,
+            vocab_size=32000,
+            max_sequence_length=2048,
+            position_embedding_type="rope",
+        )
+        base.update(kwargs)
+        return EmbeddingLayerConfig(**base)
+
+    def test_common_extra_propagates_to_layer_tc(self):
+        # qk_layernorm is a real TransformerConfig field but isn't curated
+        # on CommonLayerConfig — the passthrough should set it.
+        common = _make_common(extra={"qk_layernorm": True})
+        layer = MambaLayerConfig(common_config=common)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.qk_layernorm is True
+
+    def test_layer_extra_overrides_common_extra(self):
+        common = _make_common(extra={"qk_layernorm": False})
+        layer = AttentionLayerConfig(
+            common_config=common, num_attention_heads=4, extra={"qk_layernorm": True}
+        )
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.qk_layernorm is True
+
+    def test_common_extra_unknown_field_raises(self):
+        common = _make_common(extra={"definitely_not_a_real_tc_field": 7})
+        with pytest.raises(ValueError, match="not TransformerConfig fields"):
+            common.to_transformer_config_kwargs()
+
+    def test_layer_extra_unknown_field_raises(self):
+        common = _make_common()
+        layer = MambaLayerConfig(common_config=common, extra={"another_typo_field": 1.0})
+        with pytest.raises(ValueError, match="MambaLayerConfig.extra"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_extra_validation_can_target_mla_transformer_config(self):
+        """The low-level escape-hatch validator can target a TC subclass, so
+        MLATransformerConfig-only fields are not rejected as typos."""
+        validate_extra_kwargs(
+            {"mla_down_proj_fusion": True}, "DSALayerConfig.extra", MLATransformerConfig
+        )
+
+    def test_layer_extra_cannot_shadow_parallelism(self):
+        """Per-layer ``extra`` cannot override model-wide topology fields —
+        process groups are global and a per-layer disagreement would be
+        invalid sharding."""
+        common = _make_common()
+        a = AttentionLayerConfig(
+            common_config=common,
+            num_attention_heads=4,
+            extra={"tensor_model_parallel_size": 8},  # Conflicts with TP=2 below.
+        )
+        emb = self._embedding(common)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common, layer_pattern=[emb, a, loss], tensor_model_parallel_size=2
+        )
+        with pytest.raises(ValueError, match="tensor_model_parallel_size"):
+            recipe._lower()
+
+    def test_embedding_extra_propagates_to_stack_tc(self):
+        common = _make_common()
+        emb = self._embedding(common, extra={"qk_layernorm": True})
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.qk_layernorm is True
+
+    def test_loss_extra_propagates_to_stack_tc(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig(extra={"qk_layernorm": True})
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.qk_layernorm is True
+
+    def test_embedding_extra_unknown_field_raises(self):
+        common = _make_common()
+        emb = self._embedding(common, extra={"made_up_field": 1})
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        with pytest.raises(ValueError, match="EmbeddingLayerConfig.extra"):
+            HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss])._lower()
+
+    def test_loss_extra_cannot_shadow_curated_field(self):
+        """``CrossEntropyLayerConfig.extra`` may not name a curated field that
+        the marker already exposes (e.g. ``loss_fusion``). Such an entry would
+        silently override the marker's value otherwise."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig(loss_fusion=True, extra={"cross_entropy_loss_fusion": False})
+        with pytest.raises(ValueError, match="cross_entropy_loss_fusion"):
+            HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss])._lower()
+
+    def test_common_extra_cannot_shadow_curated_field(self):
+        """Same shadowing rule across all four ``extra`` sites: ``extra`` may
+        not name a curated dataclass field on the same config."""
+        common = _make_common(extra={"hidden_size": 999})
+        with pytest.raises(ValueError, match="hidden_size"):
+            common.to_transformer_config_kwargs()
+
+    def test_common_extra_cannot_shadow_curated_transformer_config_key(self):
+        """Curated fields may lower to differently named TC fields; those
+        lowered names are reserved too. ``mixed_precision_dtype`` owns
+        ``bf16`` / ``fp16``."""
+        common = _make_common(mixed_precision_dtype=torch.bfloat16, extra={"bf16": False})
+        with pytest.raises(ValueError, match="bf16"):
+            common.to_transformer_config_kwargs()
+
+    def test_layer_extra_cannot_shadow_curated_field(self):
+        common = _make_common()
+        layer = AttentionLayerConfig(
+            common_config=common, num_attention_heads=4, extra={"num_attention_heads": 8}
+        )
+        with pytest.raises(ValueError, match="num_attention_heads"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_layer_extra_cannot_shadow_curated_transformer_config_key(self):
+        common = _make_common()
+        layer = MoELayerConfig(common_config=common, num_experts=8, extra={"num_moe_experts": 4})
+        with pytest.raises(ValueError, match="num_moe_experts"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_embedding_extra_cannot_shadow_curated_field(self):
+        common = _make_common()
+        emb = self._embedding(common, vocab_size=100, extra={"vocab_size": 999})
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        with pytest.raises(ValueError, match="vocab_size"):
+            HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss])._lower()
+
+
+@pytest.mark.internal
+class TestYarnEmbedding:
+    """``EmbeddingLayerConfig`` exposes curated YARN fields that
+    :meth:`HybridModelConfig.compile` attaches to the stack-level
+    :class:`TransformerConfig` when ``position_embedding_type == "yarn"``.
+    This mirrors the existing setattr pattern in ``model_builder.py`` and
+    matches the ``getattr`` lookups in :class:`HybridModel.__init__`."""
+
+    def _attention_loss(self, common):
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        return a, CrossEntropyLayerConfig()
+
+    def test_yarn_fields_attached_when_position_embedding_is_yarn(self):
+        common = _make_common()
+        emb = EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="yarn",
+            yarn={
+                "yarn_rotary_scaling_factor": 32.0,
+                "yarn_original_max_position_embeddings": 131072,
+                "yarn_beta_fast": 32.0,
+                "yarn_beta_slow": 1.0,
+                "yarn_mscale": 1.0,
+                "yarn_mscale_all_dim": 0.0,
+                "yarn_correction_range_round_to_int": True,
+            },
+        )
+        a, loss = self._attention_loss(common)
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.yarn_rotary_scaling_factor == 32.0
+        assert compiled.config.yarn_original_max_position_embeddings == 131072
+        assert compiled.config.yarn_beta_fast == 32.0
+        assert compiled.config.yarn_beta_slow == 1.0
+        assert compiled.config.yarn_mscale == 1.0
+        assert compiled.config.yarn_mscale_all_dim == 0.0
+        assert compiled.config.yarn_correction_range_round_to_int is True
+
+    def test_yarn_fields_not_attached_when_position_embedding_is_rope(self):
+        """When ``position_embedding_type != "yarn"``, the yarn block is
+        silently unused — a no-op rather than an error so a recipe author
+        can toggle the embedding type without removing the yarn block."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="rope",
+            yarn={"yarn_rotary_scaling_factor": 32.0},
+        )
+        a, loss = self._attention_loss(common)
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert not hasattr(compiled.config, "yarn_rotary_scaling_factor")
+
+    def test_yarn_partial_dict_only_stamps_provided_keys(self):
+        """A partial yarn dict stamps only the keys the recipe author
+        provided; absent keys are not stamped, so missing-required-attribute
+        bugs in HybridModel.__init__ surface clearly via AttributeError."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="yarn",
+            yarn={"yarn_rotary_scaling_factor": 32.0},
+        )
+        a, loss = self._attention_loss(common)
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.yarn_rotary_scaling_factor == 32.0
+        assert not hasattr(compiled.config, "yarn_beta_fast")
+
+    def test_yarn_unknown_key_rejected(self):
+        """Typos in the yarn dict raise at compile time."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="yarn",
+            yarn={"yarn_typo_field": 1.0},
+        )
+        a, loss = self._attention_loss(common)
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss])
+        with pytest.raises(ValueError, match="unknown keys"):
+            recipe._lower()
+
+
+@pytest.mark.internal
+class TestNumLayersDerived:
+    """The recipe author never sets num_layers; compile derives it."""
+
+    def test_num_layers_from_flattened_count(self):
+        common = _make_common()
+        # The recipe author never sets num_layers anywhere; CommonLayerConfig
+        # does not even have a num_layers field.
+        assert not hasattr(common, "num_layers")
+        emb = EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=32000,
+            max_sequence_length=2048,
+            position_embedding_type="rope",
+        )
+        m = MambaLayerConfig(common_config=common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        # 5 decoder layers.
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, m, a, m, a, m, loss])
+        compiled = _lower(recipe)
+        assert len(compiled.layer_config_list) == 5
+        for tc in compiled.layer_config_list:
+            assert tc.num_layers == 5

--- a/tests/unit_tests/models/hybrid/test_load_recipe.py
+++ b/tests/unit_tests/models/hybrid/test_load_recipe.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the recipe loader behind the ``--model-recipe`` flag.
+
+The loader accepts three spec forms (see :func:`load_recipe`):
+
+1. Dotted Python path (``foo.bar``)
+2. Dotted path with explicit function selection (``foo.bar:func_name``)
+3. Filesystem path to a ``.py`` file (with optional ``:func`` suffix)
+
+When ``:func`` is omitted, the loader calls the module's ``make_recipe()``
+function. These tests use synthetic in-memory modules for dotted-path loading
+and temporary files for filesystem-path loading.
+"""
+
+import sys
+import textwrap
+import types
+from pathlib import Path
+
+import pytest
+
+from megatron.core.models.hybrid.common_layer_config import CommonLayerConfig
+from megatron.core.models.hybrid.layer_configs import (
+    AttentionLayerConfig,
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    MambaLayerConfig,
+)
+from megatron.core.models.hybrid.layer_pattern import RECIPE_ENTRY_POINT, load_recipe
+from megatron.training.models.hybrid import HybridModelConfig
+
+
+def _make_common(**overrides) -> CommonLayerConfig:
+    base = dict(hidden_size=128, use_cpu_initialization=True)
+    base.update(overrides)
+    return CommonLayerConfig(**base)
+
+
+def _make_valid_pattern(common):
+    return [
+        EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="rope",
+        ),
+        AttentionLayerConfig(common_config=common, num_attention_heads=4),
+        AttentionLayerConfig(common_config=common, num_attention_heads=4),
+        CrossEntropyLayerConfig(),
+    ]
+
+
+def _register_synthetic_module(monkeypatch, name: str, **attrs) -> types.ModuleType:
+    """Build a fresh :class:`types.ModuleType` with the requested attributes
+    and inject into ``sys.modules`` for the test's lifetime."""
+    module = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(module, k, v)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def test_recipe_entry_point_constant():
+    """The canonical entry-point name is the documented public constant."""
+    assert RECIPE_ENTRY_POINT == "make_recipe"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Resolution form 1 — module:func explicit selection
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.internal
+class TestExplicitFuncSelection:
+
+    def test_module_colon_func_selects_named_function(self, monkeypatch):
+        common = _make_common()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+
+        def my_pretrain_recipe() -> HybridModelConfig:
+            return recipe
+
+        # Other (non-recipe) module attrs should be ignored.
+        def helper(x):
+            return x + 1
+
+        _register_synthetic_module(
+            monkeypatch,
+            "tests._explicit_func_recipe",
+            my_pretrain_recipe=my_pretrain_recipe,
+            helper=helper,
+        )
+        loaded = load_recipe("tests._explicit_func_recipe:my_pretrain_recipe")
+        assert isinstance(loaded, HybridModelConfig)
+        assert loaded is recipe
+
+    def test_module_colon_func_missing_function(self, monkeypatch):
+        _register_synthetic_module(monkeypatch, "tests._explicit_func_missing")
+        with pytest.raises(AttributeError, match="missing_func"):
+            load_recipe("tests._explicit_func_missing:missing_func")
+
+    def test_module_colon_func_returning_wrong_type(self, monkeypatch):
+        def bad() -> HybridModelConfig:
+            return 42  # type: ignore[return-value]
+
+        _register_synthetic_module(monkeypatch, "tests._explicit_func_wrong_type", bad=bad)
+        with pytest.raises(TypeError, match="HybridModelConfig"):
+            load_recipe("tests._explicit_func_wrong_type:bad")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Resolution form 2 — canonical ``make_recipe``
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.internal
+class TestMakeRecipeDefault:
+
+    def test_make_recipe_used_when_no_other_resolution(self, monkeypatch):
+        common = _make_common()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+
+        def make_recipe():
+            return recipe
+
+        _register_synthetic_module(
+            monkeypatch, "tests._make_recipe_convention", make_recipe=make_recipe
+        )
+        loaded = load_recipe("tests._make_recipe_convention")
+        assert isinstance(loaded, HybridModelConfig)
+        assert loaded is recipe
+
+    def test_make_recipe_used_even_when_other_functions_exist(self, monkeypatch):
+        common = _make_common()
+        default_recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=_make_valid_pattern(common),
+            tensor_model_parallel_size=2,
+        )
+        variant_recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=_make_valid_pattern(common),
+            tensor_model_parallel_size=4,
+        )
+
+        def make_recipe() -> HybridModelConfig:
+            return default_recipe
+
+        def debug_recipe() -> HybridModelConfig:
+            return variant_recipe
+
+        _register_synthetic_module(
+            monkeypatch,
+            "tests._make_recipe_default",
+            make_recipe=make_recipe,
+            debug_recipe=debug_recipe,
+        )
+        loaded = load_recipe("tests._make_recipe_default")
+        assert loaded.tensor_model_parallel_size == 2
+        explicit = load_recipe("tests._make_recipe_default:debug_recipe")
+        assert explicit.tensor_model_parallel_size == 4
+
+    def test_make_recipe_must_be_callable(self, monkeypatch):
+        common = _make_common()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+        _register_synthetic_module(monkeypatch, "tests._non_callable_recipe", make_recipe=recipe)
+        with pytest.raises(TypeError, match="not callable"):
+            load_recipe("tests._non_callable_recipe")
+
+    def test_module_with_nothing_resolvable_errors(self, monkeypatch):
+        _register_synthetic_module(monkeypatch, "tests._empty_recipe")
+        with pytest.raises(AttributeError, match="no make_recipe"):
+            load_recipe("tests._empty_recipe")
+
+    def test_unimportable_module_raises(self):
+        with pytest.raises(ImportError, match="could not be imported"):
+            load_recipe("definitely.does.not.exist.module")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Filesystem-path form
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.internal
+class TestFilesystemPath:
+
+    def _write_recipe_file(self, tmp_path: Path, body: str) -> Path:
+        path = tmp_path / "my_recipe.py"
+        path.write_text(textwrap.dedent(body))
+        return path
+
+    def test_file_path_with_make_recipe(self, tmp_path):
+        path = self._write_recipe_file(
+            tmp_path,
+            """
+            from megatron.core.models.hybrid import (
+                AttentionLayerConfig, CommonLayerConfig, CrossEntropyLayerConfig,
+                EmbeddingLayerConfig,
+            )
+            from megatron.training.models.hybrid import HybridModelConfig
+            def make_recipe() -> HybridModelConfig:
+                common = CommonLayerConfig(hidden_size=128, use_cpu_initialization=True)
+                return HybridModelConfig(
+                    common_config=common,
+                    layer_pattern=[
+                        EmbeddingLayerConfig(common_config=common, vocab_size=1024,
+                                             max_sequence_length=512, position_embedding_type="rope"),
+                        AttentionLayerConfig(common_config=common, num_attention_heads=4),
+                        CrossEntropyLayerConfig(),
+                    ],
+                )
+            """,
+        )
+        loaded = load_recipe(str(path))
+        assert isinstance(loaded, HybridModelConfig)
+
+    def test_file_path_with_explicit_func(self, tmp_path):
+        path = self._write_recipe_file(
+            tmp_path,
+            """
+            from megatron.core.models.hybrid import (
+                AttentionLayerConfig, CommonLayerConfig, CrossEntropyLayerConfig,
+                EmbeddingLayerConfig,
+            )
+            from megatron.training.models.hybrid import HybridModelConfig
+            def my_pretrain_config() -> HybridModelConfig:
+                common = CommonLayerConfig(hidden_size=128, use_cpu_initialization=True)
+                return HybridModelConfig(
+                    common_config=common,
+                    layer_pattern=[
+                        EmbeddingLayerConfig(common_config=common, vocab_size=1024,
+                                             max_sequence_length=512, position_embedding_type="rope"),
+                        AttentionLayerConfig(common_config=common, num_attention_heads=4),
+                        CrossEntropyLayerConfig(),
+                    ],
+                )
+            """,
+        )
+        loaded = load_recipe(f"{path}:my_pretrain_config")
+        assert isinstance(loaded, HybridModelConfig)
+
+    def test_file_path_does_not_exist(self, tmp_path):
+        path = tmp_path / "nope.py"
+        with pytest.raises(ImportError, match="does not exist"):
+            load_recipe(str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pattern-validation errors surface on first use
+#
+# ``load_recipe`` is now a pure loader — it returns the unmodified
+# :class:`HybridModelConfig`. Pattern-shape validation runs lazily, the
+# first time a consumer queries the recipe (``embedding_marker``,
+# ``flatten_decoder``, lowering inside ``HybridModel.from_recipe``, etc.).
+# That keeps loading cheap and pushes validation to the call site that
+# actually depends on the malformed field.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.internal
+class TestPatternValidation:
+
+    def test_bad_pattern_validates_on_first_use(self, monkeypatch):
+        common = _make_common()
+        bad = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[MambaLayerConfig(common_config=common), CrossEntropyLayerConfig()],
+        )
+
+        def make_recipe() -> HybridModelConfig:
+            return bad
+
+        _register_synthetic_module(
+            monkeypatch, "tests._bad_pattern_recipe", make_recipe=make_recipe
+        )
+        loaded = load_recipe("tests._bad_pattern_recipe")
+        assert isinstance(loaded, HybridModelConfig)
+        with pytest.raises(TypeError, match="EmbeddingLayerConfig"):
+            loaded.flatten_decoder()
+
+
+def _has_apply_model_recipe_to_args() -> bool:
+    try:
+        from megatron.training.arguments import _apply_model_recipe_to_args  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(
+    not _has_apply_model_recipe_to_args(),
+    reason="--model-recipe argparse adapter lives in the CLI follow-up PR; auto-enables once it lands.",
+)
+class TestRecipeArgProjection:
+    """The launcher should learn model-shape/topology args from --model-recipe.
+
+    This keeps recipe authors from passing dummy legacy shape flags whose
+    values are ignored later by hybrid_builder.
+    """
+
+    def test_apply_model_recipe_to_args_sets_legacy_namespace_fields(self, monkeypatch):
+        from megatron.training.arguments import _apply_model_recipe_to_args
+
+        common = _make_common()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=_make_valid_pattern(common),
+            tensor_model_parallel_size=2,
+        )
+        _register_synthetic_module(
+            monkeypatch, "tests._args_projection_recipe", make_recipe=lambda: recipe
+        )
+        args = types.SimpleNamespace(
+            model_recipe="tests._args_projection_recipe",
+            num_layers=None,
+            hidden_size=None,
+            num_attention_heads=None,
+            max_position_embeddings=None,
+            padded_vocab_size=None,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=None,
+            position_embedding_type=None,
+            rotary_percent=None,
+            rotary_base=None,
+            rotary_seq_len_interpolation_factor=None,
+            untie_embeddings_and_output_weights=False,
+            fp16_lm_cross_entropy=False,
+            mtp_num_layers=None,
+            encoder_num_layers=123,
+            num_experts=None,
+        )
+
+        _apply_model_recipe_to_args(args)
+
+        # ``args._model_recipe`` carries the loaded HybridModelConfig itself —
+        # not a lowered intermediate. The launcher and ``hybrid_builder``
+        # both consume it via the public recipe surface (queries on
+        # HybridModelConfig + ``HybridModel.from_recipe``).
+        assert isinstance(args._model_recipe, HybridModelConfig)
+        assert args._model_recipe.num_layers == 2
+        assert args.num_layers == 2
+        assert args.encoder_num_layers is None
+        assert args.hidden_size == common.hidden_size
+        assert args.num_attention_heads == 4
+        assert args.max_position_embeddings == 512
+        assert args.padded_vocab_size == 1024
+        assert args.tensor_model_parallel_size == 2


### PR DESCRIPTION
Adds HybridModelConfig recipe loading, validation, and lowering on top of #4537.

This PR keeps the recipe object and layer-pattern construction separate from HybridModel integration. Follow-up #5031 wires recipes into HybridModel as a first-class constructor path. Existing stack PRs #4538 and #4539 sit above #5031.