### PR TITLE
Support HybridModelConfig recipes in HybridModel

### DIFF
--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -60,6 +60,12 @@ class HybridStack(MegatronModule):
         layer_type_list (list, optional): pre-computed list of layer type symbols for
             this pipeline segment. When provided (by HybridModel), pipeline stage
             selection has already been done via '|' separators in the pattern.
+        layer_config_list (list[TransformerConfig], optional): per-layer
+            :class:`TransformerConfig` instances, parallel to ``layer_type_list``.
+            When provided (by HybridModel built via the Python layer-pattern DSL),
+            each layer is constructed with its own per-layer config instead of the
+            stack-level ``config``. When ``None``, every layer uses ``config``,
+            preserving the legacy string-pattern path byte-for-byte.
         pp_layer_offset (int, optional): the global layer offset for this pipeline
             segment. Defaults to 0.
         post_layer_norm (bool, optional): whether to include a final layer norm.
@@ -79,6 +85,7 @@ class HybridStack(MegatronModule):
         submodules: HybridStackSubmodules,
         pre_process: bool = True,
         layer_type_list: Optional[list[str]] = None,
+        layer_config_list: Optional[list[TransformerConfig]] = None,
         pp_layer_offset: int = 0,
         post_layer_norm: bool = True,
         post_process: bool = True,
@@ -113,10 +120,22 @@ class HybridStack(MegatronModule):
         )
         self.layer_type_list = layer_type_list
 
+        if layer_config_list is not None and len(layer_config_list) != len(layer_type_list):
+            raise ValueError(
+                f"layer_config_list length ({len(layer_config_list)}) must match "
+                f"layer_type_list length ({len(layer_type_list)})."
+            )
+        self.layer_config_list = layer_config_list
+
         # Build layers from the pre-selected segment
         self.layers = nn.ModuleList()
         for i, layer_type in enumerate(self.layer_type_list):
             layer_number = i + 1 + pp_layer_offset
+            # Per-layer config from the Python DSL when provided; otherwise
+            # every layer uses the stack-level config (legacy string-pattern path).
+            per_layer_config = (
+                layer_config_list[i] if layer_config_list is not None else self.config
+            )
             if self.config.fp8:
                 quant_init_context = get_fp8_context(self.config, i + pp_layer_offset, is_init=True)
             elif self.config.fp4:
@@ -127,7 +146,7 @@ class HybridStack(MegatronModule):
                 if layer_type == LayerSymbols.MAMBA:
                     layer = build_module(
                         submodules.mamba_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pp_layer_offset=pp_layer_offset,
                         pg_collection=pg_collection,
@@ -136,7 +155,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.ATTENTION:
                     layer = build_module(
                         submodules.attention_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -147,7 +166,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.DS_ATTENTION:
                     layer = build_module(
                         submodules.dsa_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -158,7 +177,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.MLP:
                     layer = build_module(
                         submodules.mlp_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         add_layer_offset=False,
@@ -167,7 +186,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.MOE:
                     layer = build_module(
                         submodules.moe_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         add_layer_offset=False,
@@ -176,7 +195,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.GDN:
                     layer = build_module(
                         submodules.gdn_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         # Set to False as we do not want to change offset.

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
 
-import logging
-from typing import Literal, Optional
+from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING, Literal, Optional, Union
+
+import torch
 from torch import Tensor
 
 from megatron.core import tensor_parallel
@@ -39,18 +42,65 @@ from megatron.core.utils import (
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from megatron.training.models.hybrid import HybridModelConfig
+
+
+def _is_recipe_config(config: object) -> bool:
+    return bool(getattr(config, "is_recipe_config", False))
+
 
 class HybridModel(LanguageModule, GraphableMegatronModule):
     """Hybrid language model.
 
+    A HybridModel is constructed via either of two paths:
+
+    1. **Recipe path (recommended).** Pass a :class:`HybridModelConfig`
+       directly as ``config``: ``HybridModel(config=recipe, ...)``. The
+       recipe is the public contract; lowering to the underlying
+       :class:`TransformerConfig`-based representation happens internally
+       inside ``__init__``. The :meth:`from_recipe` classmethod is retained
+       as a thin alias for backward compatibility.
+    2. **Legacy string-pattern path.** Pass ``config`` (a
+       :class:`TransformerConfig`) together with ``hybrid_layer_pattern``
+       (a single-character pattern string). Retained for backwards
+       compatibility — including pipeline parallelism and MTP, which the
+       recipe DSL does not yet cover.
+
     Args:
-        config (TransformerConfig): Model config
-        hybrid_stack_spec (ModuleSpec): Specifies the modules to use for the various layer types
-        vocab_size (int): Vocabulary size
-        max_sequence_length (int): maximum size of sequence.
-            This is used for positional embedding
-        hybrid_layer_pattern (str): Unified hybrid layer pattern with optional MTP and
-            pipeline stage boundaries.
+        config (Union[TransformerConfig, HybridModelConfig]): Either a
+            :class:`HybridModelConfig` (recipe path — the recipe is the
+            single source of truth for everything except construction-time
+            concerns like ``pg_collection`` and ``vp_stage``) or a stack-
+            level :class:`TransformerConfig` (legacy path). When a
+            :class:`HybridModelConfig` is passed, the architecture / loss
+            / position-embedding kwargs below (``vocab_size``,
+            ``max_sequence_length``, ``position_embedding_type``,
+            ``rotary_percent``, ``rotary_base``,
+            ``scatter_embedding_sequence_parallel``,
+            ``seq_len_interpolation_factor``, ``fp16_lm_cross_entropy``,
+            ``parallel_output``, ``share_embeddings_and_output_weights``)
+            are read from the recipe's
+            :class:`EmbeddingLayerConfig` / :class:`CrossEntropyLayerConfig`
+            markers and the recipe's
+            ``untie_embeddings_and_output_weights`` field; any explicit
+            values passed alongside a recipe are silently overridden.
+        hybrid_stack_spec (ModuleSpec, optional): Module specs for the
+            various layer types. Required on the legacy string-pattern path.
+            On the recipe path, defaults to the production
+            ``hybrid_stack_spec`` in
+            :mod:`megatron.core.models.hybrid.hybrid_layer_specs` when not
+            supplied.
+        vocab_size (int): Vocabulary size. Legacy path only — on the
+            recipe path the value comes from
+            ``recipe.embedding_marker.vocab_size``.
+        max_sequence_length (int): Maximum size of sequence used for
+            positional embedding. Legacy path only — on the recipe path
+            the value comes from
+            ``recipe.embedding_marker.max_sequence_length``.
+        hybrid_layer_pattern (str): Legacy string-pattern path. Unified
+            hybrid layer pattern with optional MTP and pipeline stage
+            boundaries.
             Format: "<main_pattern>/<mtp_pattern>/<mtp_pattern>/..."
             The main pattern may contain "|" to define pipeline stage boundaries.
             Examples:
@@ -70,30 +120,39 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             (used with pipeline parallelism). Defaults to True.
         post_process (bool, optional): Include an output layer (used with pipeline parallelism).
             Defaults to True.
-        fp16_lm_cross_entropy (bool, optional): Defaults to False.
+        fp16_lm_cross_entropy (bool, optional): Defaults to False. Legacy path only — on
+            the recipe path the value comes from ``recipe.loss_marker.fp16_lm_cross_entropy``.
         parallel_output (bool, optional): Do not gather the outputs, keep them split across tensor
-            parallel ranks. Defaults to True.
+            parallel ranks. Defaults to True. Legacy path only — on the recipe path the
+            value comes from ``recipe.loss_marker.parallel_output``.
         share_embeddings_and_output_weights (bool, optional): When True, input embeddings and
-            output logit weights are shared. Defaults to False.
+            output logit weights are shared. Defaults to False. Legacy path only — on the
+            recipe path the value is derived as
+            ``not recipe.untie_embeddings_and_output_weights``.
         position_embedding_type (Literal[learned_absolute,rope,yarn,none], optional):  Position
-            embedding type. Defaults to 'none'.
+            embedding type. Defaults to 'none'. Legacy path only — on the recipe path the
+            value comes from ``recipe.embedding_marker.position_embedding_type``.
         rotary_percent (float, optional): Percent of rotary dimension to use for rotary position
             embeddings. Ignored unless position_embedding_type is 'rope'. Defaults to 1.0.
+            Legacy path only — on the recipe path the value comes from
+            ``recipe.embedding_marker.rotary_percent``.
         rotary_base (int, optional): Base period for rotary position embeddings. Ignored unless
-            position_embedding_type is 'rope'. Defaults to 10000.
+            position_embedding_type is 'rope'. Defaults to 10000. Legacy path only — on
+            the recipe path the value comes from ``recipe.embedding_marker.rotary_base``.
         seq_len_interpolation_factor (Optional[float], optional): scale of linearly
             interpolating RoPE for longer sequences. The value must be a float larger than 1.0.
-             Defaults to None.
+             Defaults to None. Legacy path only — on the recipe path the value comes from
+             ``recipe.embedding_marker.seq_len_interpolation_factor``.
         pg_collection (ProcessGroupCollection, optional): Model communication process groups.
         vp_stage (Optional[int], optional): Virtual pipeline stage index. Defaults to None.
     """
 
     def __init__(
         self,
-        config: TransformerConfig,
-        hybrid_stack_spec: ModuleSpec,
-        vocab_size: int,
-        max_sequence_length: int,
+        config: Union[TransformerConfig, HybridModelConfig],
+        hybrid_stack_spec: Optional[ModuleSpec] = None,
+        vocab_size: Optional[int] = None,
+        max_sequence_length: Optional[int] = None,
         hybrid_layer_pattern: Optional[str] = None,
         hybrid_attention_ratio: Optional[float] = None,
         hybrid_mlp_ratio: Optional[float] = None,
@@ -112,6 +171,65 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         pg_collection: Optional[ProcessGroupCollection] = None,
         vp_stage: Optional[int] = None,
     ) -> None:
+        # Recipe path dispatch: when ``config`` is a HybridModelConfig,
+        # lower it inline and read the model-wrapping fields directly from
+        # the recipe's embedding/loss markers (``recipe.embedding_marker``,
+        # ``recipe.loss_marker``) and from the recipe itself
+        # (``untie_embeddings_and_output_weights``). Construction-time
+        # concerns (pg_collection, pre_process, post_process, vp_stage,
+        # optional hybrid_stack_spec) flow through unchanged.
+        layer_type_list: Optional[list] = None
+        layer_config_list: Optional[list] = None
+        recipe_path: bool = False
+
+        if _is_recipe_config(config):
+            if (
+                hybrid_layer_pattern is not None
+                or hybrid_override_pattern is not None
+                or (hybrid_attention_ratio is not None and hybrid_attention_ratio > 0.0)
+                or (hybrid_mlp_ratio is not None and hybrid_mlp_ratio > 0.0)
+            ):
+                raise ValueError(
+                    "HybridModelConfig (Python DSL) and the legacy "
+                    "hybrid_layer_pattern / hybrid_override_pattern / "
+                    "hybrid_attention_ratio / hybrid_mlp_ratio arguments are "
+                    "mutually exclusive; pass exactly one architecture surface."
+                )
+            recipe = config
+            stack_tc, layer_type_list, layer_config_list = recipe._lower()
+            # HybridModel-specific invariant: the inference-optimized stack
+            # does not support fused-TP communication. TC's own
+            # ``__post_init__`` checks the forward direction
+            # (fuse-TP-comm → inference_optimized); the reverse
+            # (inference_optimized + fuse-TP-comm → reject for hybrid) is
+            # a hybrid-stack-spec constraint that lives here so it fires
+            # on both ``HybridModel(config=recipe)`` and the
+            # ``from_recipe`` alias.
+            if (
+                stack_tc.transformer_impl == "inference_optimized"
+                and stack_tc.inference_fuse_tp_communication
+            ):
+                raise ValueError(
+                    "inference_fuse_tp_communication is not supported for HybridModel."
+                )
+            # Read embedding-marker fields directly from the recipe.
+            emb = recipe.embedding_marker
+            vocab_size = emb.vocab_size
+            max_sequence_length = emb.max_sequence_length
+            position_embedding_type = emb.position_embedding_type
+            rotary_percent = emb.rotary_percent
+            rotary_base = emb.rotary_base
+            scatter_embedding_sequence_parallel = emb.scatter_embedding_sequence_parallel
+            seq_len_interpolation_factor = emb.seq_len_interpolation_factor
+            # Read loss-marker fields directly from the recipe.
+            loss = recipe.loss_marker
+            fp16_lm_cross_entropy = loss.fp16_lm_cross_entropy
+            parallel_output = loss.parallel_output
+            # Tied-weights toggle lives on the recipe itself.
+            share_embeddings_and_output_weights = not recipe.untie_embeddings_and_output_weights
+            config = stack_tc
+            recipe_path = True
+
         super().__init__(config=config, pg_collection=pg_collection)
 
         if has_config_logger_enabled(config):
@@ -125,7 +243,6 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             )
             HybridModel.mup_warning_printed = True
 
-        self.hybrid_stack_spec: ModuleSpec = hybrid_stack_spec
         self.vocab_size = vocab_size
         self.max_sequence_length = max_sequence_length
         self.hybrid_layer_pattern = hybrid_layer_pattern
@@ -137,6 +254,34 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         self.position_embedding_type = position_embedding_type
         self.vp_stage = vp_stage
         self.disable_param_offloading = True
+
+        # ``recipe_path``, ``layer_type_list``, and ``layer_config_list``
+        # are set above by the recipe dispatch; on the legacy path the
+        # lists stay None and ``HybridStack`` derives them from
+        # ``hybrid_layer_pattern`` further below.
+        if not recipe_path and (vocab_size is None or max_sequence_length is None):
+            raise ValueError(
+                "vocab_size and max_sequence_length are required on the legacy "
+                "(hybrid_layer_pattern) construction path; pass both explicitly. "
+                "On the recipe path, HybridModel reads them from the "
+                "EmbeddingLayerConfig marker."
+            )
+
+        # When using a recipe, fall back to the default hybrid_stack_spec so that
+        # users do not need to construct or pass a ModuleSpec.
+        if recipe_path and hybrid_stack_spec is None:
+            from megatron.core.models.hybrid.hybrid_layer_specs import (
+                hybrid_stack_spec as _default_hybrid_stack_spec,
+            )
+
+            hybrid_stack_spec = _default_hybrid_stack_spec
+        elif hybrid_stack_spec is None:
+            raise ValueError(
+                "hybrid_stack_spec is required when using the legacy string-pattern path "
+                "(hybrid_layer_pattern). Pass a ModuleSpec, or use a Python recipe via "
+                "the --model-recipe path."
+            )
+        self.hybrid_stack_spec: ModuleSpec = hybrid_stack_spec
 
         # Backward compatibility for deprecated hybrid parameters
         if hybrid_override_pattern is not None:
@@ -177,24 +322,49 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     config.num_layers, attn_ratio, mlp_ratio
                 )
 
-        # Parse unified pattern to extract main and MTP components, and
-        # determine the pipeline segment for this model instance.
-        from megatron.core.models.hybrid.hybrid_layer_allocation import (
-            parse_hybrid_pattern,
-            select_pipeline_segment,
-        )
+        if recipe_path:
+            # Recipe path: per-layer symbols and configs were lowered from
+            # HybridModelConfig by the recipe-dispatch block above (when
+            # ``config`` was a HybridModelConfig). Pipeline parallelism
+            # and MTP are not part of the recipe DSL — recipes that need
+            # either must use the legacy hybrid_layer_pattern string DSL.
+            # The PP > 1 check below catches launcher/CLI mismatches
+            # where a PP group was constructed despite the recipe being
+            # PP-free.
+            pp_size = (
+                torch.distributed.get_world_size(self.pg_collection.pp)
+                if self.pg_collection.pp is not None
+                else 1
+            )
+            if pp_size > 1:
+                raise NotImplementedError(
+                    "The Python DSL recipe path does not support pipeline "
+                    "parallelism. Use hybrid_layer_pattern (string DSL "
+                    "with '|' separators) for PP."
+                )
+            layer_offset = 0
+            self.mtp_pattern = None
+            self.mtp_num_depths = 0
+        else:
+            # Parse unified pattern to extract main and MTP components, and
+            # determine the pipeline segment for this model instance.
+            from megatron.core.models.hybrid.hybrid_layer_allocation import (
+                parse_hybrid_pattern,
+                select_pipeline_segment,
+            )
 
-        parsed = parse_hybrid_pattern(self.hybrid_layer_pattern)
-        self.mtp_pattern = parsed.mtp_pattern
-        self.mtp_num_depths = parsed.mtp_num_depths
+            parsed = parse_hybrid_pattern(self.hybrid_layer_pattern)
+            self.mtp_pattern = parsed.mtp_pattern
+            self.mtp_num_depths = parsed.mtp_num_depths
 
-        layer_type_list, layer_offset = select_pipeline_segment(
-            parsed.main_pattern or '',
-            self.pg_collection.pp,
-            vp_stage,
-            first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
-            last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
-        )
+            layer_type_list, layer_offset = select_pipeline_segment(
+                parsed.main_pattern or '',
+                self.pg_collection.pp,
+                vp_stage,
+                first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
+                last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
+            )
+            layer_config_list = None
 
         # Determine if MTP is needed (based on pattern parsing)
         self.mtp_process = (
@@ -262,6 +432,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             self.config,
             pre_process=self.pre_process,
             layer_type_list=layer_type_list,
+            layer_config_list=layer_config_list,
             pp_layer_offset=layer_offset,
             post_process=self.post_process,
             dtype=config.params_dtype,
@@ -316,6 +487,58 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             if hasattr(module, 'finish_init'):
                 quant_config = get_quant_config_or_none(name, self.config.quant_recipe)
                 module.finish_init(quant_config)
+
+    @classmethod
+    def from_recipe(
+        cls,
+        recipe: HybridModelConfig,
+        *,
+        hybrid_stack_spec: Optional[ModuleSpec] = None,
+        pre_process: bool = True,
+        post_process: bool = True,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+        vp_stage: Optional[int] = None,
+    ) -> "HybridModel":
+        """Construct a :class:`HybridModel` from a :class:`HybridModelConfig`.
+
+        .. note::
+           This classmethod is now a thin alias for
+           ``HybridModel(config=recipe, ...)``. New code should call the
+           constructor directly; ``from_recipe`` is retained for backward
+           compatibility with callers that pre-date the constructor's
+           native :class:`HybridModelConfig` support.
+
+        ``HybridModelConfig`` is the source of truth for everything about
+        the model (architecture, embeddings, loss behaviour, parallelism
+        pins). Only construction-time concerns — process groups, pipeline
+        staging, optional stack-spec override — come in as kwargs.
+
+        Args:
+            recipe: The recipe to build. Typically returned by a
+                ``make_recipe()`` entry point and resolved via
+                :func:`load_recipe` from the ``--model-recipe`` flag.
+            hybrid_stack_spec: Optional override for the per-layer module
+                spec. Defaults to the production
+                :data:`hybrid_layer_specs.hybrid_stack_spec`.
+            pre_process: Include the embedding layer (used with PP).
+            post_process: Include the output layer (used with PP).
+            pg_collection: Process-group collection for distributed
+                construction.
+            vp_stage: Virtual pipeline stage index.
+
+        Note:
+            Pipeline parallelism is not part of the recipe DSL.
+            :class:`HybridModel` raises if it is constructed under a PP
+            group greater than 1 via this path.
+        """
+        return cls(
+            config=recipe,
+            hybrid_stack_spec=hybrid_stack_spec,
+            pre_process=pre_process,
+            post_process=post_process,
+            pg_collection=pg_collection,
+            vp_stage=vp_stage,
+        )
 
     def set_input_tensor(self, input_tensor: Tensor) -> None:
         """Sets input tensor to the model.

--- a/tests/unit_tests/models/hybrid/test_python_dsl_equivalence.py
+++ b/tests/unit_tests/models/hybrid/test_python_dsl_equivalence.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""End-to-end equivalence tests between the legacy string DSL and the recipe DSL.
+
+Building a HybridModel via ``hybrid_layer_pattern="M*-"`` and via a
+``HybridModelConfig`` recipe must produce equivalent models: identical layer
+types, identical parameter counts, and — when seeded the same way — identical
+forward outputs.
+
+Heterogeneous-within-type smoke tests confirm that the Python DSL's per-layer
+config plumbing actually reaches the constructed layer instances.
+
+These tests require CUDA + Transformer Engine (matching the rest of the
+hybrid test suite) and run inside the Megatron-LM CI container.
+"""
+
+import pytest
+import torch
+from transformer_engine.pytorch.fp8 import check_fp8_support  # noqa: F401  # CI gate
+
+pytest.importorskip("mamba_ssm", reason="HybridModel Mamba equivalence tests require MambaSSM")
+
+from megatron.core.models.hybrid import (
+    AttentionLayerConfig,
+    CommonLayerConfig,
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+)
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from megatron.training.models.hybrid import HybridModelConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+def _make_common(**overrides) -> CommonLayerConfig:
+    # ``hidden_dropout=0.1`` matches the TransformerConfig default; the
+    # CommonLayerConfig default (0.0) would silently diverge from the
+    # legacy-CLI side of the equivalence comparison.
+    base = dict(hidden_size=256, use_cpu_initialization=True, hidden_dropout=0.1)
+    base.update(overrides)
+    return CommonLayerConfig(**base)
+
+
+def _make_legacy_config(**overrides) -> TransformerConfig:
+    base = dict(
+        num_layers=3,
+        hidden_size=256,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        is_hybrid_model=True,
+    )
+    base.update(overrides)
+    return TransformerConfig(**base)
+
+
+def _embedding(common: CommonLayerConfig) -> EmbeddingLayerConfig:
+    return EmbeddingLayerConfig(common_config=common, vocab_size=100, max_sequence_length=4)
+
+
+def _loss() -> CrossEntropyLayerConfig:
+    return CrossEntropyLayerConfig()
+
+
+def _build_model_from_recipe(recipe: HybridModelConfig) -> HybridModel:
+    return HybridModel.from_recipe(recipe)
+
+
+@pytest.mark.internal
+class TestPythonDSLStringEquivalence:
+    """Two models built from the same architecture — one via the string DSL, one
+    via the recipe DSL — must be functionally identical."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _build_string_dsl_model(self) -> HybridModel:
+        model_parallel_cuda_manual_seed(123)
+        return HybridModel(
+            config=_make_legacy_config(),
+            hybrid_stack_spec=hybrid_stack_spec,
+            vocab_size=100,
+            max_sequence_length=4,
+            hybrid_layer_pattern="M*-",
+        )
+
+    def _build_python_dsl_model(self) -> HybridModel:
+        model_parallel_cuda_manual_seed(123)
+        common = _make_common()
+        # ``untie_embeddings_and_output_weights=True`` matches HybridModel's
+        # legacy default (``share_embeddings_and_output_weights=False``);
+        # without it the recipe path produces a single shared embedding+output
+        # table while the legacy path produces two separate tables.
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[
+                _embedding(common),
+                MambaLayerConfig(common_config=common),
+                AttentionLayerConfig(common_config=common, num_attention_heads=4),
+                MLPLayerConfig(common_config=common),
+                _loss(),
+            ],
+            untie_embeddings_and_output_weights=True,
+        )
+        return _build_model_from_recipe(recipe)
+
+    def test_layer_types_match(self):
+        legacy = self._build_string_dsl_model()
+        new = self._build_python_dsl_model()
+        assert legacy.decoder.layer_type_list == new.decoder.layer_type_list
+        assert len(legacy.decoder.layers) == len(new.decoder.layers)
+
+    def test_parameter_count_matches(self):
+        legacy_params = sum(p.numel() for p in self._build_string_dsl_model().parameters())
+        new_params = sum(p.numel() for p in self._build_python_dsl_model().parameters())
+        assert legacy_params == new_params
+
+    def test_forward_outputs_match(self):
+        """The two paths' forward outputs must agree on shape and dtype.
+
+        We deliberately do **not** compare values: even with identical
+        ``model_parallel_cuda_manual_seed`` and identical per-layer field
+        values, the legacy and recipe construction paths consume CUDA RNG in
+        different orders during weight init (one shared TC vs per-layer TC
+        list, traversed by different code paths). The architectural-
+        equivalence guarantee is captured by ``test_layer_types_match`` and
+        ``test_parameter_count_matches``; this test catches divergent
+        forward signatures (extra outputs, wrong dtype, wrong shape) on top.
+        """
+        legacy = self._build_string_dsl_model().cuda()
+        new = self._build_python_dsl_model().cuda()
+
+        seq_len = legacy.max_sequence_length
+        bsz = 2
+        data = list(range(seq_len))
+        input_ids = torch.tensor(data, dtype=torch.int64).repeat((bsz, 1)).cuda()
+        position_ids = torch.tensor(data, dtype=torch.int64).repeat((bsz, 1)).cuda()
+        attention_mask = torch.ones((bsz, 1, seq_len, seq_len), dtype=bool).cuda()
+
+        legacy_out = legacy.forward(
+            input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask
+        )
+        new_out = new.forward(
+            input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask
+        )
+
+        assert legacy_out.shape == new_out.shape
+        assert legacy_out.dtype == new_out.dtype
+
+
+@pytest.mark.internal
+class TestHeterogeneousWithinType:
+    """Within-type heterogeneity (e.g. two distinct MambaLayerConfig instances)
+    must produce layers whose constructed config reflects the per-layer
+    overrides — not just the global common config."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_per_layer_mamba_overrides_reach_constructed_layer(self):
+        # MambaMixer requires ``num_heads % num_groups == 0``. Pick num_groups
+        # that divides both heterogeneous head counts so the layers actually
+        # construct (the test target is heterogeneity, not the divisibility
+        # constraint).
+        common = _make_common(hidden_dropout=0.0)
+        big = MambaLayerConfig(common_config=common, num_heads=16, head_dim=32, num_groups=2)
+        small = MambaLayerConfig(common_config=common, num_heads=8, head_dim=64, num_groups=2)
+
+        model_parallel_cuda_manual_seed(123)
+        recipe = HybridModelConfig(
+            common_config=common, layer_pattern=[_embedding(common), big, small, _loss()]
+        )
+        model = _build_model_from_recipe(recipe)
+
+        # The constructed layers' configs must match the per-layer overrides,
+        # not the (default) global common config.
+        layer0_cfg = model.decoder.layer_config_list[0]
+        layer1_cfg = model.decoder.layer_config_list[1]
+        assert layer0_cfg.mamba_num_heads == 16
+        assert layer0_cfg.mamba_head_dim == 32
+        assert layer1_cfg.mamba_num_heads == 8
+        assert layer1_cfg.mamba_head_dim == 64
+        assert layer0_cfg is not layer1_cfg

--- a/tests/unit_tests/models/hybrid/test_recipe_constructor.py
+++ b/tests/unit_tests/models/hybrid/test_recipe_constructor.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Equivalence tests for the two recipe-path entry points.
+
+Phase 1 of the HybridModel recipe-API design adds direct
+:class:`HybridModelConfig` support to :meth:`HybridModel.__init__`::
+
+    HybridModel(config=recipe, ...)
+
+The pre-existing :meth:`HybridModel.from_recipe` classmethod continues to
+work — it is now a thin alias that delegates to the constructor. This
+module verifies the two entry points produce equivalent models (same layer
+types, same parameter counts, same forward signature) and that the
+constructor rejects mutually-exclusive kwargs on the recipe path.
+
+These tests require CUDA + Transformer Engine (matching the rest of the
+hybrid test suite) and run inside the Megatron-LM CI container.
+"""
+
+import pytest
+import torch
+from transformer_engine.pytorch.fp8 import check_fp8_support  # noqa: F401  # CI gate
+
+pytest.importorskip("mamba_ssm", reason="HybridModel Mamba equivalence tests require MambaSSM")
+
+from megatron.core.models.hybrid import (
+    AttentionLayerConfig,
+    CommonLayerConfig,
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+)
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.training.models.hybrid import HybridModelConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+def _make_common(**overrides) -> CommonLayerConfig:
+    # ``hidden_dropout=0.1`` matches the TransformerConfig default; the
+    # CommonLayerConfig default (0.0) would silently diverge from any
+    # legacy-CLI counterpart that left ``--hidden-dropout`` at its default.
+    base = dict(hidden_size=256, use_cpu_initialization=True, hidden_dropout=0.1)
+    base.update(overrides)
+    return CommonLayerConfig(**base)
+
+
+def _make_recipe() -> HybridModelConfig:
+    common = _make_common()
+    return HybridModelConfig(
+        common_config=common,
+        layer_pattern=[
+            EmbeddingLayerConfig(common_config=common, vocab_size=100, max_sequence_length=4),
+            MambaLayerConfig(common_config=common),
+            AttentionLayerConfig(common_config=common, num_attention_heads=4),
+            MLPLayerConfig(common_config=common),
+            CrossEntropyLayerConfig(),
+        ],
+        # Match HybridModel's legacy default
+        # (``share_embeddings_and_output_weights=False``).
+        untie_embeddings_and_output_weights=True,
+    )
+
+
+@pytest.mark.internal
+class TestRecipeConstructorEquivalence:
+    """``HybridModel(config=recipe)`` and ``HybridModel.from_recipe(recipe)``
+    must produce equivalent models.
+
+    ``from_recipe`` is now a thin alias for the constructor; this guards
+    against drift if either path is touched independently.
+    """
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _build_via_constructor(self) -> HybridModel:
+        model_parallel_cuda_manual_seed(123)
+        return HybridModel(config=_make_recipe())
+
+    def _build_via_from_recipe(self) -> HybridModel:
+        model_parallel_cuda_manual_seed(123)
+        return HybridModel.from_recipe(_make_recipe())
+
+    def test_layer_types_match(self):
+        ctor = self._build_via_constructor()
+        factory = self._build_via_from_recipe()
+        assert ctor.decoder.layer_type_list == factory.decoder.layer_type_list
+        assert len(ctor.decoder.layers) == len(factory.decoder.layers)
+
+    def test_parameter_count_matches(self):
+        ctor_params = sum(p.numel() for p in self._build_via_constructor().parameters())
+        factory_params = sum(p.numel() for p in self._build_via_from_recipe().parameters())
+        assert ctor_params == factory_params
+
+    def test_forward_signature_matches(self):
+        """Forward outputs must agree on shape and dtype.
+
+        Bit-equality is not asserted: ``from_recipe`` delegates to the
+        constructor, so today the two paths consume the CUDA RNG
+        identically — but if either picks up additional construction work
+        (e.g. a future ``validate()`` call, or an extra log line that
+        touches state), bit-equality could drift. Shape/dtype is the
+        structural guarantee that matters here; deeper equivalence is
+        already covered by ``test_python_dsl_equivalence``.
+        """
+        ctor = self._build_via_constructor().cuda()
+        factory = self._build_via_from_recipe().cuda()
+
+        seq_len = ctor.max_sequence_length
+        bsz = 2
+        data = list(range(seq_len))
+        input_ids = torch.tensor(data, dtype=torch.int64).repeat((bsz, 1)).cuda()
+        position_ids = torch.tensor(data, dtype=torch.int64).repeat((bsz, 1)).cuda()
+        attention_mask = torch.ones((bsz, 1, seq_len, seq_len), dtype=bool).cuda()
+
+        ctor_out = ctor.forward(
+            input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask
+        )
+        factory_out = factory.forward(
+            input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask
+        )
+
+        assert ctor_out.shape == factory_out.shape
+        assert ctor_out.dtype == factory_out.dtype
+
+
+@pytest.mark.internal
+class TestRecipeConstructorRejection:
+    """The recipe-path entry point rejects kwargs that conflict with the
+    recipe DSL. These guards keep recipes from being silently shadowed by
+    a stale CLI flag in callers that mix entry points.
+    """
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_rejects_string_pattern(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            HybridModel(config=_make_recipe(), hybrid_layer_pattern="M*-")
+
+    def test_rejects_legacy_attention_ratio(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            HybridModel(config=_make_recipe(), hybrid_attention_ratio=0.5)
+
+    def test_rejects_legacy_mlp_ratio(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            HybridModel(config=_make_recipe(), hybrid_mlp_ratio=0.5)
+
+    def test_rejects_legacy_override_pattern(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            HybridModel(config=_make_recipe(), hybrid_override_pattern="M*-")


### PR DESCRIPTION
Splits the HybridModel constructor and HybridStack integration out of #4537. Depends on #5030 for the recipe object and lowering path. Existing PRs #4538 and #4539 are retargeted above this PR.