### PR TITLE
fix(layer_wise): tag MTP-stage word_embeddings as is_embedding_or_output_parameter

### DIFF
--- a/megatron/core/models/common/language_module/language_module.py
+++ b/megatron/core/models/common/language_module/language_module.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import logging
 import os
 from typing import Optional, Tuple
@@ -202,7 +202,12 @@ class LanguageModule(MegatronModule):
 
         # Mark embedding and output layer for decoupled_lr and other features.
         # This is the original Megatron attribute used by decoupled_lr, Muon, FSDP, etc.
-        if self.pre_process and hasattr(self, 'embedding'):
+        # Include MTP-stage embedding too: it is a duplicated copy of the pre_process
+        # embedding (kept in sync via cross-stage all-reduce). Without this tag, the
+        # LayerWise distributed optimizer routes it to its Muon-managed buffer and
+        # `_emit_bucket(shared_embedding=True)` replicates the (vocab x hidden) tensor
+        # across all dp_size shards, blowing up the chunk's buffer by ~8x.
+        if (self.pre_process or getattr(self, 'mtp_process', False)) and hasattr(self, 'embedding'):
             self.embedding.word_embeddings.weight.is_embedding_or_output_parameter = True
         if (
             self.post_process


### PR DESCRIPTION
## Summary

The MTP-stage duplicate of \`word_embeddings.weight\` is created in \`gpt_model.py\` whenever \`self.mtp_process\` is True (\`if self.pre_process or self.mtp_process: self.embedding = LanguageModelEmbedding(...)\`). Its weight is later tagged with \`shared_embedding = True\` in \`language_module.py:266\` so the cross-stage tied-embedding all-reduce can sync it with the \`pre_process\` copy.

However, \`is_embedding_or_output_parameter = True\` was only set on the \`pre_process\` copy (line 205-206), not on the MTP-stage one. \`LayerWiseDistributedOptimizer.is_managed_by_layer_wise_optimizer()\` (\`layer_wise_optimizer.py:35-50\`) reads only \`is_embedding_or_output_parameter\`, so it returns True for the MTP embedding (2D, no tag), routing it into the Muon-managed LayerWise buffer.

\`_compute_per_buffer_param_layout._emit_bucket(shared_embedding=True)\` (\`layer_wise_optimizer.py:189-197, 211, 222\`) then replicates the param across all DP shards via same-size padding, so the bucket numel = \`dp_size × vocab × hidden\`. On a DSv4 Flash Proxy / GB200 × 16 / TP1 PP2 EP8 run, this inflated PP-stage-1 chunk-3's Muon non-EP buffer from \`numel = 537 M\` (45 transformer linears) to \`numel = 4.77 B\` (45 + 1 MTP embedding × 8 shards), costing \`~22 GB\` extra (\`9 GB\` bf16 \`param_data\` + \`18 GB\` fp32 \`grad_data\`). Iter-2 fwd OOM'd on 184 GB GB200; without the fix the \`use_layer_wise_param_layout=True\` default path is unusable on this config.

The fix extends the \`is_embedding_or_output_parameter\` tag to the MTP-stage embedding too. Semantically the MTP embedding is the same tensor as the \`pre_process\` embedding (just a copy maintained via all-reduce), so it should follow the same routing: Adam, not Muon orthogonalization. After the fix, it lands in the DistOpt byte-level buffer where padding stays at bucket-end alignment only.

### Verified results (DSv4 Flash Proxy / MXFP8 / Muon / 4 × GB200 × 4 / TP1 PP2 EP8, no fp8 param gather, no precision-aware optimizer, no CUDA graph)

| | Before fix (default) | After fix (default) | Legacy (\`--no-use-layer-wise-param-layout\`) |
|---|---|---|---|
| chunk-3 Muon non-EP buffer \`numel\` | **4.77 B** | 537 M | n/a |
| chunk-3 total mem (pd+gd) | 44.2 GB | 23.0 GB | n/a |
| iter survival | iter-2 OOM | **60 iters (timeout)** | 60 iters (timeout) |
| TFLOP/s/GPU (median) | — | **241.4** | 240.4 |
| peak max_allocated rank 8 | OOM at 184 GB | 162.5 GB | 160.5 GB |

## Test plan

- [x] Cherry-picks cleanly on \`main\`
- [x] \`tools/autoformat.sh\` passes vs \`main\`
- [x] \`tools/check_copyright.py\` passes
- [x] DSv4 Flash Proxy MXFP8 Muon recipe runs 60 iterations at ~241 TFLOP/s/GPU on 4 × GB200 × 4 (used to OOM at iter 2)
- [ ] Functional tests (let CI run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)