### PR TITLE
test(release): skip golden comparison on intermediate resume windows

### DIFF
--- a/tests/functional_tests/shell_test_utils/run_ci_test.sh
+++ b/tests/functional_tests/shell_test_utils/run_ci_test.sh
@@ -335,6 +335,25 @@ for i in $(seq 1 $N_REPEAT); do
         echo $((TRAIN_ITERS / 2)) >$CHECKPOINT_SAVE_PATH/latest_checkpointed_iteration.txt
     fi
 
+    # Release tests span multiple SLURM windows via checkpoint resume.
+    # Only compare against golden values once training has reached the
+    # configured exit interval; otherwise a partial-trajectory window
+    # would false-positive-fail the goldens check and block the
+    # orchestration's resumable retrigger.
+    if [[ "$TEST_TYPE" == "release" ]]; then
+        TRACKER_FILE="$CHECKPOINT_SAVE_PATH/latest_checkpointed_iteration.txt"
+        LATEST_ITER=0
+        if [[ -f "$TRACKER_FILE" ]]; then
+            LATEST_ITER=$(tr -d '[:space:]' <"$TRACKER_FILE" 2>/dev/null || echo 0)
+            [[ "$LATEST_ITER" =~ ^[0-9]+$ ]] || LATEST_ITER=0
+        fi
+        if (( LATEST_ITER < TRAIN_ITERS )); then
+            echo "Release intermediate window: latest checkpointed iter $LATEST_ITER < $TRAIN_ITERS; skipping golden-value comparison so the orchestration can resume."
+            continue
+        fi
+        echo "Release run reached iter $LATEST_ITER >= $TRAIN_ITERS; running golden-value comparison."
+    fi
+
     if [[ ${RECORD_CHECKPOINTS} == "true" ]]; then
         echo "Skipping Pytest during checkpoint recording."
         SKIP_PYTEST=1


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

<details><summary>Claude summary</summary>

Stop release tests from false-positive-failing the golden-value check on intermediate checkpoint-resume windows.

## Why

Release tests train past the 4 h SLURM cap by checkpoint-resuming across many `sbatch` windows until `--exit-interval` is hit. Today every intermediate window also runs the golden-value pytest against a partial-trajectory tensorboard, which fails the goldens check because the recorded trajectory does not yet span steps 1…`--exit-interval`. The "failure" blocks the orchestration's resumable retrigger, even though the run is healthy and on track.

## How

Megatron writes `latest_checkpointed_iteration.txt` (`megatron/training/checkpointing.py:312-316`) on every save, and exits cleanly at every `--exit-interval` boundary (`megatron/training/training.py:3040-3060`). The shell already reads `--exit-interval` into `TRAIN_ITERS` for release tests (`run_ci_test.sh:124-125`). So the "is this the final window?" signal is just:

```
$(cat $CHECKPOINT_SAVE_PATH/latest_checkpointed_iteration.txt) >= $TRAIN_ITERS
```

The gate sits between the resume-handling block and the eval section. On intermediate windows the script logs the skip reason and `continue`s the `N_REPEAT` loop, so the orchestration sees a clean exit and re-triggers. On the final window the goldens are checked exactly once, as today.

```bash
if [[ "$TEST_TYPE" == "release" ]]; then
    TRACKER_FILE="$CHECKPOINT_SAVE_PATH/latest_checkpointed_iteration.txt"
    LATEST_ITER=0
    if [[ -f "$TRACKER_FILE" ]]; then
        LATEST_ITER=$(tr -d '[:space:]' <"$TRACKER_FILE" 2>/dev/null || echo 0)
        [[ "$LATEST_ITER" =~ ^[0-9]+$ ]] || LATEST_ITER=0
    fi
    if (( LATEST_ITER < TRAIN_ITERS )); then
        echo "Release intermediate window: latest checkpointed iter $LATEST_ITER < $TRAIN_ITERS; skipping golden-value comparison so the orchestration can resume."
        continue
    fi
    echo "Release run reached iter $LATEST_ITER >= $TRAIN_ITERS; running golden-value comparison."
fi
```

## Robustness notes

- All ranks read the same lustre file → unanimous `continue` decision → no barrier desync.
- Missing tracker file or non-integer contents are treated as `LATEST_ITER=0`, so the very first window (no prior save) cleanly takes the "intermediate" path.
- `--exit-interval` writes the checkpoint **before** exiting (`training.py:3048-3057`), so `LATEST_ITER >= TRAIN_ITERS` is reached on the same attempt that hits the boundary — no off-by-one loss of the final comparison.
- Non-release tests are untouched: the gate is scoped to `TEST_TYPE == "release"`.

</details>

## Issue tracking

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
