### PR TITLE
Cudagraphs: MCore local path training with variable-sized sequences

### DIFF
--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -20,9 +20,15 @@ def pad_cu_seqlens_for_cuda_graph(cu_seqlens: Tensor, target_num_seqs: int) -> O
     to `target_num_seqs + 1` entries by repeating the final cumulative value. The trailing
     repeated entries indicate zero-length segments which are handled by PackedSeqParams.
 
+    Any trailing padding-to-microbatch-size must already be folded into the last segment
+    of `cu_seqlens` before calling this helper. This is done in the SFT dataloader
+    (`megatron/training/datasets/sft_dataset.py` rewrites the last entry to `pack_length` when there
+    is trailing padding).
+
     Args:
         cu_seqlens: 1-D int32 cumulative sequence-length tensor of shape (K + 1,) where K is the
-            number of real documents.
+            number of real documents. `cu_seqlens[-1]` must equal the total token count of the
+            corresponding input tensor (see precondition above).
         target_num_seqs: Target document capacity (the value of --cuda-graph-max-packed-seqs).
 
     Returns:

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -39,8 +39,7 @@ def pad_cu_seqlens_for_cuda_graph(cu_seqlens: Tensor, target_num_seqs: int) -> O
         return cu_seqlens
 
     # Build the padded tensor without a GPU -> CPU sync: copy the real values, then
-    # broadcast-assign the final element into the tail. Both operations stay on
-    # the device that cu_seqlens lives on.
+    # broadcast-assign the final element into the tail.
     out = torch.empty((target_len,), dtype=cu_seqlens.dtype, device=cu_seqlens.device)
     out[:current_len] = cu_seqlens
     out[current_len:] = cu_seqlens[-1]

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -1,9 +1,49 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 from dataclasses import dataclass
+from typing import Optional
 
 import torch
 import torch.distributed as dist
 from torch import Tensor
+
+
+def pad_cu_seqlens_for_cuda_graph(cu_seqlens: Tensor, target_num_seqs: int) -> Optional[Tensor]:
+    """Pad a cu_seqlens tensor to a fixed shape for CUDA graph capture.
+
+    CUDA graphs require input tensor shapes to be stable across replays. Packed-sequence
+    training produces a variable number of documents per microbatch, so ``cu_seqlens``
+    (length = num_docs + 1) changes shape from step to step. This helper pads the tensor
+    to ``target_num_seqs + 1`` entries by repeating the final cumulative value, matching
+    the pattern used by ``megatron/rl/sequence_packing_utils.py``. The trailing
+    repeated entries describe zero-length phantom segments which are handled correctly
+    by ``PackedSeqParams.__post_init__`` (the seq_lengths diff has trailing zeros, which
+    its existing ``clamp(min=0)`` accepts).
+
+    Args:
+        cu_seqlens: 1-D int32 cumulative sequence-length tensor of shape ``(K + 1,)``
+            where ``K`` is the number of real documents.
+        target_num_seqs: Target document capacity (the value of
+            ``--cuda-graph-max-packed-seqs``).
+
+    Returns:
+        A new 1-D tensor of length ``target_num_seqs + 1`` on the same device and dtype
+        when ``K <= target_num_seqs``; ``None`` when ``K > target_num_seqs`` so the
+        caller can fall back to an eager (non-graphed) forward pass.
+    """
+    assert cu_seqlens.dim() == 1, f"cu_seqlens must be 1-D, got shape {cu_seqlens.shape}"
+    current_len = cu_seqlens.shape[0]
+    target_len = target_num_seqs + 1
+    if current_len > target_len:
+        return None
+    if current_len == target_len:
+        return cu_seqlens
+    # Build the padded tensor without a GPU->CPU sync: copy the real values, then
+    # broadcast-assign the final element into the tail. Both operations stay on
+    # the device that cu_seqlens lives on.
+    out = torch.empty((target_len,), dtype=cu_seqlens.dtype, device=cu_seqlens.device)
+    out[:current_len] = cu_seqlens
+    out[current_len:] = cu_seqlens[-1]
+    return out
 
 
 @dataclass

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -8,28 +8,28 @@ from torch import Tensor
 
 
 def pad_cu_seqlens_for_cuda_graph(cu_seqlens: Tensor, target_num_seqs: int) -> Optional[Tensor]:
-    """Pad a cu_seqlens tensor to a fixed shape for CUDA graph capture.
+    """Create PackedSeqParams for a single bin to enable proper attention masking in TE.
+    TODO(helenn/RL): unify with `create_packed_seq_params_for_bin` in rl/sequence_packing_utils.py.
 
-    CUDA graphs require input tensor shapes to be stable across replays. Packed-sequence
-    training produces a variable number of documents per microbatch, so ``cu_seqlens``
+    When using Transformer Engine with sequence packing, we need to provide cu_seqlens
+    (cumulative sequence lengths) so that TE knows the boundaries between sequences
+    within a packed bin. This prevents attention leakage between unrelated sequences.
+
+    Packed-sequence training produces a variable number of documents per microbatch, so `cu_seqlens`
     (length = num_docs + 1) changes shape from step to step. This helper pads the tensor
-    to ``target_num_seqs + 1`` entries by repeating the final cumulative value, matching
-    the pattern used by ``megatron/rl/sequence_packing_utils.py``. The trailing
-    repeated entries describe zero-length phantom segments which are handled correctly
-    by ``PackedSeqParams.__post_init__`` (the seq_lengths diff has trailing zeros, which
-    its existing ``clamp(min=0)`` accepts).
+    to `target_num_seqs + 1` entries by repeating the final cumulative value. The trailing
+    repeated entries indicate zero-length segments which are handled by PackedSeqParams.
 
     Args:
-        cu_seqlens: 1-D int32 cumulative sequence-length tensor of shape ``(K + 1,)``
-            where ``K`` is the number of real documents.
-        target_num_seqs: Target document capacity (the value of
-            ``--cuda-graph-max-packed-seqs``).
+        cu_seqlens: 1-D int32 cumulative sequence-length tensor of shape (K + 1,) where K is the
+            number of real documents.
+        target_num_seqs: Target document capacity (the value of --cuda-graph-max-packed-seqs).
 
     Returns:
-        A new 1-D tensor of length ``target_num_seqs + 1`` on the same device and dtype
-        when ``K <= target_num_seqs``; ``None`` when ``K > target_num_seqs`` so the
-        caller can fall back to an eager (non-graphed) forward pass.
+        A new 1-D tensor of length target_num_seqs + 1 when K <= target_num_seqs;
+        None when K > target_num_seqs so the caller can fall back to an eager forward pass.
     """
+
     assert cu_seqlens.dim() == 1, f"cu_seqlens must be 1-D, got shape {cu_seqlens.shape}"
     current_len = cu_seqlens.shape[0]
     target_len = target_num_seqs + 1
@@ -37,7 +37,8 @@ def pad_cu_seqlens_for_cuda_graph(cu_seqlens: Tensor, target_num_seqs: int) -> O
         return None
     if current_len == target_len:
         return cu_seqlens
-    # Build the padded tensor without a GPU->CPU sync: copy the real values, then
+
+    # Build the padded tensor without a GPU -> CPU sync: copy the real values, then
     # broadcast-assign the final element into the tail. Both operations stay on
     # the device that cu_seqlens lives on.
     out = torch.empty((target_len,), dtype=cu_seqlens.dtype, device=cu_seqlens.device)

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -120,9 +120,7 @@ _CUDA_GRAPH_SKIPPED = False
 
 
 def is_cuda_graph_skipped():
-    """Query whether CUDA graph dispatch is currently bypassed for the calling step.
-
-    Used by MegatronModule.__call__ to fall through to an eager forward pass when the caller has
+    """Used by MegatronModule.__call__ to fall through to an eager forward pass when the caller has
     wrapped a microbatch in disable_cuda_graphs_this_step. This enables the packed-sequence overflow
     fallback: when a microbatch contains more documents than `cuda_graph_max_packed_seqs`, that step
     bypasses graph replay so cu_seqlens shape mismatches do not crash capture.

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -116,41 +116,38 @@ def _set_warmup_end():
     _IS_GRAPH_WARMUP = False
 
 
-_CUDA_GRAPH_BYPASS = False
+_CUDA_GRAPH_SKIPPED = False
 
 
-def is_cuda_graph_bypass():
+def is_cuda_graph_skipped():
     """Query whether CUDA graph dispatch is currently bypassed for the calling step.
 
-    Used by ``MegatronModule.__call__`` to fall through to an eager forward pass when
-    the caller has wrapped a microbatch in ``disable_cuda_graphs_this_step``. This is
-    how the packed-sequence overflow fallback works: when a microbatch contains more
-    documents than ``cuda_graph_max_packed_seqs``, that step bypasses graph replay so
-    cu_seqlens shape mismatches do not crash capture.
+    Used by MegatronModule.__call__ to fall through to an eager forward pass when the caller has
+    wrapped a microbatch in disable_cuda_graphs_this_step. This enables the packed-sequence overflow
+    fallback: when a microbatch contains more documents than `cuda_graph_max_packed_seqs`, that step
+    bypasses graph replay so cu_seqlens shape mismatches do not crash capture.
     """
-    return _CUDA_GRAPH_BYPASS
+    return _CUDA_GRAPH_SKIPPED
 
 
 @contextlib.contextmanager
 def disable_cuda_graphs_this_step():
     """Bypass MCore-local CUDA graph dispatch for the duration of the context.
 
-    Mirrors the ``is_checkpointing()`` precedent: a thread-unsafe module-level flag
-    that the dispatch site in ``MegatronModule.__call__`` consults. Intended for
-    per-microbatch opt-outs (e.g. when a packed-sequence batch exceeds the configured
+    Intended for per-microbatch opt-outs (e.g. when a packed-sequence batch exceeds the configured
     cap and must run eagerly).
 
-    Note: during the recording phase of pipeline-parallel training, bypassing a
-    microbatch desynchronizes the per-microbatch runner store. Callers under
-    ``pipeline_model_parallel_size > 1`` should raise the cap rather than rely on this.
+    Note: during the recording phase of pipeline-parallel training, bypassing a microbatch
+    desynchronizes the per-microbatch runner store. Callers using
+    pipeline_model_parallel_size > 1 should raise the cap rather than rely on this fallback.
     """
-    global _CUDA_GRAPH_BYPASS
-    prev = _CUDA_GRAPH_BYPASS
-    _CUDA_GRAPH_BYPASS = True
+    global _CUDA_GRAPH_SKIPPED
+    prev = _CUDA_GRAPH_SKIPPED
+    _CUDA_GRAPH_SKIPPED = True
     try:
         yield
     finally:
-        _CUDA_GRAPH_BYPASS = prev
+        _CUDA_GRAPH_SKIPPED = prev
 
 
 @dataclass

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import contextlib
 import dataclasses
 import gc
 import inspect
@@ -113,6 +114,43 @@ def _set_warmup_end():
     """Set graph warmup has ended."""
     global _IS_GRAPH_WARMUP
     _IS_GRAPH_WARMUP = False
+
+
+_CUDA_GRAPH_BYPASS = False
+
+
+def is_cuda_graph_bypass():
+    """Query whether CUDA graph dispatch is currently bypassed for the calling step.
+
+    Used by ``MegatronModule.__call__`` to fall through to an eager forward pass when
+    the caller has wrapped a microbatch in ``disable_cuda_graphs_this_step``. This is
+    how the packed-sequence overflow fallback works: when a microbatch contains more
+    documents than ``cuda_graph_max_packed_seqs``, that step bypasses graph replay so
+    cu_seqlens shape mismatches do not crash capture.
+    """
+    return _CUDA_GRAPH_BYPASS
+
+
+@contextlib.contextmanager
+def disable_cuda_graphs_this_step():
+    """Bypass MCore-local CUDA graph dispatch for the duration of the context.
+
+    Mirrors the ``is_checkpointing()`` precedent: a thread-unsafe module-level flag
+    that the dispatch site in ``MegatronModule.__call__`` consults. Intended for
+    per-microbatch opt-outs (e.g. when a packed-sequence batch exceeds the configured
+    cap and must run eagerly).
+
+    Note: during the recording phase of pipeline-parallel training, bypassing a
+    microbatch desynchronizes the per-microbatch runner store. Callers under
+    ``pipeline_model_parallel_size > 1`` should raise the cap rather than rely on this.
+    """
+    global _CUDA_GRAPH_BYPASS
+    prev = _CUDA_GRAPH_BYPASS
+    _CUDA_GRAPH_BYPASS = True
+    try:
+        yield
+    finally:
+        _CUDA_GRAPH_BYPASS = prev
 
 
 @dataclass

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -340,7 +340,11 @@ class GraphableMegatronModule(MegatronModule):
 
     def __call__(self, *args, **kwargs):
         if self._should_call_local_cudagraph(*args, **kwargs):
-            return self.cudagraph_manager(self, args, kwargs)
+            from megatron.core.transformer.cuda_graphs import is_cuda_graph_bypass
+
+            if not is_cuda_graph_bypass():
+                return self.cudagraph_manager(self, args, kwargs)
+            # Bypass active: fall through to the eager super().__call__ below.
         elif self._should_call_te_cudagraph(*args, **kwargs):
             if not self.cuda_graphs:
                 # Do CUDA Graphs capture.

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -340,11 +340,11 @@ class GraphableMegatronModule(MegatronModule):
 
     def __call__(self, *args, **kwargs):
         if self._should_call_local_cudagraph(*args, **kwargs):
-            from megatron.core.transformer.cuda_graphs import is_cuda_graph_bypass
+            from megatron.core.transformer.cuda_graphs import is_cuda_graph_skipped
 
-            if not is_cuda_graph_bypass():
+            if not is_cuda_graph_skipped():
                 return self.cudagraph_manager(self, args, kwargs)
-            # Bypass active: fall through to the eager super().__call__ below.
+            # Skip cudagraphs this step: fall through to the eager call below.
         elif self._should_call_te_cudagraph(*args, **kwargs):
             if not self.cuda_graphs:
                 # Do CUDA Graphs capture.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -906,15 +906,13 @@ class TransformerConfig(ModelParallelConfig):
     """Number of warmup steps for CUDA graphs"""
 
     cuda_graph_max_packed_seqs: int = 0
-    """Maximum number of packed sequences per microbatch supported by CUDA graph capture
-    for packed-sequence (THD / variable-length) training. When > 0, cu_seqlens tensors
-    are padded to ``cuda_graph_max_packed_seqs + 1`` entries before being placed on
-    PackedSeqParams, so that the cudagraph input signature is stable across steps.
-    Microbatches that contain more than ``cuda_graph_max_packed_seqs`` documents fall
-    back to an eager (non-graphed) forward pass for that step. ``0`` (default) disables
-    padding entirely (the entire feature is off by default). The CLI flag
-    ``--cuda-graph-max-packed-seqs`` accepts no value to opt in with a default cap of
-    50, or an explicit value for fine-grained control. Only applies to
+    """Maximum number of packed sequences per microbatch supported by CUDA graph capture for 
+    packed-sequence (THD / variable-length) training. When > 0, cu_seqlens tensors are padded to 
+    `cuda_graph_max_packed_seqs + 1` entries before being placed on PackedSeqParams so that the 
+    cudagraph input signature is stable across steps. Microbatches that contain more than 
+    `cuda_graph_max_packed_seqs` documents fall back to an eager forward pass for that step. 
+    `0` disables padding entirely and the entire feature is off. If no value is passed then 
+    `--cuda-graph-max-packed-seqs` uses a default cap of 50. Only applies to
     cuda_graph_impl="local"."""
 
     external_cuda_graph: bool = False

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -905,6 +905,18 @@ class TransformerConfig(ModelParallelConfig):
     cuda_graph_warmup_steps: int = 3
     """Number of warmup steps for CUDA graphs"""
 
+    cuda_graph_max_packed_seqs: int = 0
+    """Maximum number of packed sequences per microbatch supported by CUDA graph capture
+    for packed-sequence (THD / variable-length) training. When > 0, cu_seqlens tensors
+    are padded to ``cuda_graph_max_packed_seqs + 1`` entries before being placed on
+    PackedSeqParams, so that the cudagraph input signature is stable across steps.
+    Microbatches that contain more than ``cuda_graph_max_packed_seqs`` documents fall
+    back to an eager (non-graphed) forward pass for that step. ``0`` (default) disables
+    padding entirely (the entire feature is off by default). The CLI flag
+    ``--cuda-graph-max-packed-seqs`` accepts no value to opt in with a default cap of
+    50, or an explicit value for fine-grained control. Only applies to
+    cuda_graph_impl="local"."""
+
     external_cuda_graph: bool = False
     """DEPRECATED and replaced by cuda_graph_impl.
     When set to true, TransformerLayer layers are swapped with user provided CUDA graphs."""

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1827,6 +1827,15 @@ def _add_inference_args(parser):
     group.add_argument('--cuda-graph-scope', nargs='+', type=_parse_cuda_graph_modules_arg,
                        default=None, dest='cuda_graph_scope_deprecated',
                        help=argparse.SUPPRESS)  # hidden; use --cuda-graph-modules instead
+    group.add_argument('--cuda-graph-max-packed-seqs', nargs='?', type=int, const=50, default=0,
+                       help='Maximum number of packed sequences per microbatch supported by '
+                       'CUDA graph capture for packed-sequence (THD / variable-length) training. '
+                       'When > 0, cu_seqlens tensors are padded to this many entries before being '
+                       'placed on PackedSeqParams so the cudagraph input signature is stable across '
+                       'steps. Microbatches that contain more documents than this fall back to an '
+                       'eager (non-graphed) forward pass for that step. Passing the flag without a '
+                       'value enables the feature with a default cap of 50. Defaults to 0 '
+                       '(feature off). Only applies when --cuda-graph-impl=local.')
     group.add_argument('--cuda-graph-modules', nargs='+', type=_parse_cuda_graph_modules_arg, default=[],
                        help='Selects training capture coverage within per-layer CUDA graphs '
                        '(local and transformer_engine implementations). '
@@ -2060,6 +2069,7 @@ def _add_network_size_args(parser):
         "moe_token_dropping",
         "cuda_graph_use_single_mempool",
         "cuda_graph_retain_backward_graph",
+        "cuda_graph_max_packed_seqs",
         "disable_parameter_transpose_cache",
         "inference_sampling_seed",
         "use_inference_optimized_layers",

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -18,6 +18,7 @@ if rank != 0:
     warnings.filterwarnings("ignore", category=UserWarning)
     warnings.filterwarnings("ignore", category=FutureWarning)
 
+import contextlib
 from functools import partial
 from typing import Any, List, Optional, Tuple
 
@@ -29,7 +30,8 @@ from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegat
 from megatron.core.datasets.gpt_dataset import GPTDataset, GPTDatasetConfig, MockGPTDataset
 from megatron.core.enums import ModelType
 from megatron.core.models.gpt import GPTModel
-from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.packed_seq_params import PackedSeqParams, pad_cu_seqlens_for_cuda_graph
+from megatron.core.transformer.cuda_graphs import disable_cuda_graphs_this_step
 from megatron.core.parallel_state import (
     get_context_parallel_group,
     get_hybrid_data_context_parallel_groups,
@@ -204,6 +206,7 @@ def forward_step(data_iterator, model: GPTModel, return_schedule_plan: bool = Fa
         ) = get_batch(data_iterator, vp_stage)
 
     packed_seq_params = None
+    cuda_graph_bypass = False
     if cu_seqlens is not None:
         # cu_seqlens / cu_seqlens_padded carry the dataloader's batch dim (1, n).
         # PackedSeqParams (and TE attention) expect 1-D, so squeeze before use.
@@ -214,6 +217,23 @@ def forward_step(data_iterator, model: GPTModel, return_schedule_plan: bool = Fa
         # attention only computes work for real tokens within each chunk.
         update_seqlen_stats_from_cu_seqlens(cu_seqlens)
         cu_seqlens_for_params = cu_seqlens_padded if cu_seqlens_padded is not None else cu_seqlens # TODO(asolergi-nv): Currently there is a bug forcing cu_seqlens to be cu_seqlens_padded
+
+        # Pad cu_seqlens to a fixed shape for CUDA-graph capture. Required for
+        # cuda_graph_impl="local" because the captured graph's input tensor shapes
+        # must be stable across replays. Falls back to eager forward when the actual
+        # number of documents exceeds the cap.
+        if config.cuda_graph_impl == "local" and config.cuda_graph_max_packed_seqs > 0:
+            max_seqs = config.cuda_graph_max_packed_seqs
+            padded_for_params = pad_cu_seqlens_for_cuda_graph(cu_seqlens_for_params, max_seqs)
+            if padded_for_params is None:
+                cuda_graph_bypass = True
+            else:
+                cu_seqlens_for_params = padded_for_params
+                if cu_seqlens_padded is not None:
+                    # Already-padded variant from the dataloader (CP / sequence-padding):
+                    # extend it to the same fixed length so the two tensors agree.
+                    cu_seqlens_padded = pad_cu_seqlens_for_cuda_graph(cu_seqlens_padded, max_seqs)
+
         packed_seq_params = PackedSeqParams(
             qkv_format="thd",
             cu_seqlens_q=cu_seqlens_for_params,
@@ -228,7 +248,8 @@ def forward_step(data_iterator, model: GPTModel, return_schedule_plan: bool = Fa
 
     timers('batch-generator').stop()
 
-    with stimer:
+    cuda_graph_ctx = disable_cuda_graphs_this_step() if cuda_graph_bypass else contextlib.nullcontext()
+    with stimer, cuda_graph_ctx:
         if return_schedule_plan:
             assert args.overlap_moe_expert_parallel_comm, \
                 "overlap_moe_expert_parallel_comm must be enabled to return the schedule plan"

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -219,10 +219,7 @@ def forward_step(data_iterator, model: GPTModel, return_schedule_plan: bool = Fa
         update_seqlen_stats_from_cu_seqlens(cu_seqlens)
         cu_seqlens_for_params = cu_seqlens_padded if cu_seqlens_padded is not None else cu_seqlens # TODO(asolergi-nv): Currently there is a bug forcing cu_seqlens to be cu_seqlens_padded
 
-        # Pad cu_seqlens to a fixed shape for CUDA-graph capture. Required for
-        # cuda_graph_impl="local" because the captured graph's input tensor shapes
-        # must be stable across replays. Falls back to eager forward when the actual
-        # number of documents exceeds the cap.
+        # Pad cu_seqlens to a fixed shape for CUDA-graph capture.
         if config.cuda_graph_impl == "local" and config.cuda_graph_max_packed_seqs > 0:
             max_seqs = config.cuda_graph_max_packed_seqs
             padded_for_params = pad_cu_seqlens_for_cuda_graph(cu_seqlens_for_params, max_seqs)

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -185,6 +185,7 @@ def forward_step(data_iterator, model: GPTModel, return_schedule_plan: bool = Fa
         return_schedule_plan (bool): Whether to return the schedule plan instead of the output tensor
     """
     args = get_args()
+    config = core_transformer_config_from_args(args)
     timers = get_timers()
 
     # Get the batch.
@@ -206,7 +207,7 @@ def forward_step(data_iterator, model: GPTModel, return_schedule_plan: bool = Fa
         ) = get_batch(data_iterator, vp_stage)
 
     packed_seq_params = None
-    cuda_graph_bypass = False
+    cuda_graph_skipped_this_step = False
     if cu_seqlens is not None:
         # cu_seqlens / cu_seqlens_padded carry the dataloader's batch dim (1, n).
         # PackedSeqParams (and TE attention) expect 1-D, so squeeze before use.
@@ -226,7 +227,7 @@ def forward_step(data_iterator, model: GPTModel, return_schedule_plan: bool = Fa
             max_seqs = config.cuda_graph_max_packed_seqs
             padded_for_params = pad_cu_seqlens_for_cuda_graph(cu_seqlens_for_params, max_seqs)
             if padded_for_params is None:
-                cuda_graph_bypass = True
+                cuda_graph_skipped_this_step = True
             else:
                 cu_seqlens_for_params = padded_for_params
                 if cu_seqlens_padded is not None:
@@ -248,7 +249,7 @@ def forward_step(data_iterator, model: GPTModel, return_schedule_plan: bool = Fa
 
     timers('batch-generator').stop()
 
-    cuda_graph_ctx = disable_cuda_graphs_this_step() if cuda_graph_bypass else contextlib.nullcontext()
+    cuda_graph_ctx = disable_cuda_graphs_this_step() if cuda_graph_skipped_this_step else contextlib.nullcontext()
     with stimer, cuda_graph_ctx:
         if return_schedule_plan:
             assert args.overlap_moe_expert_parallel_comm, \

--- a/pretrain_hybrid.py
+++ b/pretrain_hybrid.py
@@ -17,6 +17,7 @@ if rank != 0:
     warnings.filterwarnings("ignore", category=UserWarning)
     warnings.filterwarnings("ignore", category=FutureWarning)
 
+import contextlib
 from functools import partial
 from typing import Any, List, Optional, Tuple
 
@@ -28,7 +29,8 @@ from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegat
 from megatron.core.datasets.gpt_dataset import GPTDataset, GPTDatasetConfig, MockGPTDataset
 from megatron.core.enums import ModelType
 from megatron.core.models.hybrid.hybrid_model import HybridModel
-from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.packed_seq_params import PackedSeqParams, pad_cu_seqlens_for_cuda_graph
+from megatron.core.transformer.cuda_graphs import disable_cuda_graphs_this_step
 from megatron.core.parallel_state import (
     get_context_parallel_group,
     get_hybrid_data_context_parallel_groups,
@@ -175,6 +177,8 @@ def forward_step(data_iterator, model: HybridModel):
         data_iterator : Input data iterator
         model (HybridModel): The Hybrid Model
     """
+    args = get_args()
+    config = core_transformer_config_from_args(args)
     timers = get_timers()
 
     # Get the batch.
@@ -198,6 +202,7 @@ def forward_step(data_iterator, model: HybridModel):
         ) = get_batch(data_iterator, vp_stage)
 
     packed_seq_params = None
+    cuda_graph_bypass = False
     if cu_seqlens is not None:
         # cu_seqlens / cu_seqlens_padded carry the dataloader's batch dim (1, n).
         # PackedSeqParams (and TE attention) expect 1-D, so squeeze before use.
@@ -208,6 +213,20 @@ def forward_step(data_iterator, model: HybridModel):
         # attention only computes work for real tokens within each chunk.
         update_seqlen_stats_from_cu_seqlens(cu_seqlens)
         cu_seqlens_for_params = cu_seqlens_padded if cu_seqlens_padded is not None else cu_seqlens
+        total_tokens = int(cu_seqlens_for_params[-1].item())
+
+        # Pad cu_seqlens to a fixed shape for CUDA-graph capture. See pretrain_gpt.py
+        # for the rationale; falls back to eager forward when N_docs exceeds the cap.
+        if config.cuda_graph_impl == "local" and config.cuda_graph_max_packed_seqs > 0:
+            max_seqs = config.cuda_graph_max_packed_seqs
+            padded_for_params = pad_cu_seqlens_for_cuda_graph(cu_seqlens_for_params, max_seqs)
+            if padded_for_params is None:
+                cuda_graph_bypass = True
+            else:
+                cu_seqlens_for_params = padded_for_params
+                if cu_seqlens_padded is not None:
+                    cu_seqlens_padded = pad_cu_seqlens_for_cuda_graph(cu_seqlens_padded, max_seqs)
+
         packed_seq_params = PackedSeqParams(
             qkv_format="thd",
             cu_seqlens_q=cu_seqlens_for_params,
@@ -218,12 +237,13 @@ def forward_step(data_iterator, model: HybridModel):
             max_seqlen_kv=int(max_seqlen.item()),
             local_cp_size=int(local_cp_size.item()) if local_cp_size is not None else None,
             cp_group=hybrid_cp_group,
-            total_tokens=int(cu_seqlens_for_params[-1].item()),
+            total_tokens=total_tokens,
         )
 
     timers('batch-generator').stop()
 
-    with stimer:
+    cuda_graph_ctx = disable_cuda_graphs_this_step() if cuda_graph_bypass else contextlib.nullcontext()
+    with stimer, cuda_graph_ctx:
         output_tensor = model(
             tokens,
             position_ids,

--- a/pretrain_hybrid.py
+++ b/pretrain_hybrid.py
@@ -202,7 +202,7 @@ def forward_step(data_iterator, model: HybridModel):
         ) = get_batch(data_iterator, vp_stage)
 
     packed_seq_params = None
-    cuda_graph_bypass = False
+    cuda_graph_skipped_this_step = False
     if cu_seqlens is not None:
         # cu_seqlens / cu_seqlens_padded carry the dataloader's batch dim (1, n).
         # PackedSeqParams (and TE attention) expect 1-D, so squeeze before use.
@@ -221,7 +221,7 @@ def forward_step(data_iterator, model: HybridModel):
             max_seqs = config.cuda_graph_max_packed_seqs
             padded_for_params = pad_cu_seqlens_for_cuda_graph(cu_seqlens_for_params, max_seqs)
             if padded_for_params is None:
-                cuda_graph_bypass = True
+                cuda_graph_skipped_this_step = True
             else:
                 cu_seqlens_for_params = padded_for_params
                 if cu_seqlens_padded is not None:
@@ -242,7 +242,7 @@ def forward_step(data_iterator, model: HybridModel):
 
     timers('batch-generator').stop()
 
-    cuda_graph_ctx = disable_cuda_graphs_this_step() if cuda_graph_bypass else contextlib.nullcontext()
+    cuda_graph_ctx = disable_cuda_graphs_this_step() if cuda_graph_skipped_this_step else contextlib.nullcontext()
     with stimer, cuda_graph_ctx:
         output_tensor = model(
             tokens,

--- a/pretrain_hybrid.py
+++ b/pretrain_hybrid.py
@@ -215,8 +215,7 @@ def forward_step(data_iterator, model: HybridModel):
         cu_seqlens_for_params = cu_seqlens_padded if cu_seqlens_padded is not None else cu_seqlens
         total_tokens = int(cu_seqlens_for_params[-1].item())
 
-        # Pad cu_seqlens to a fixed shape for CUDA-graph capture. See pretrain_gpt.py
-        # for the rationale; falls back to eager forward when N_docs exceeds the cap.
+        # Pad cu_seqlens to a fixed shape for CUDA-graph capture.
         if config.cuda_graph_impl == "local" and config.cuda_graph_max_packed_seqs > 0:
             max_seqs = config.cuda_graph_max_packed_seqs
             padded_for_params = pad_cu_seqlens_for_cuda_graph(cu_seqlens_for_params, max_seqs)

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -807,11 +807,10 @@ class TestParallelHybridBlockCudagraphs:
 
 
 class TestPadCuSeqlensForCudaGraph:
-    """Unit tests for the pure-Python ``pad_cu_seqlens_for_cuda_graph`` helper.
+    """Unit tests for the `pad_cu_seqlens_for_cuda_graph` helper.
 
-    Verifies the contract used by the packed-sequence cudagraph wire-in: padding
-    repeats the final cumulative value so phantom segments are zero-length, and
-    returns None on overflow so the caller can fall back to eager.
+    Verifies that padding repeats the final cumulative value so phantom segments are zero-length,
+    and returns None on overflow so the caller can fall back to eager.
     """
 
     def test_short_input_pads_with_repeated_last_value(self):
@@ -842,12 +841,11 @@ class TestPadCuSeqlensForCudaGraph:
         assert pad_cu_seqlens_for_cuda_graph(cu_seqlens, target_num_seqs=3) is None
 
     def test_seq_idx_is_correct_under_padding(self):
-        """``PackedSeqParams.__post_init__`` builds ``seq_idx`` from the padded
-        cu_seqlens. Trailing repeated entries describe zero-length phantom segments
-        and contribute nothing. The tokens beyond ``cu_seqlens_padded[-1]`` (up to
-        ``total_tokens``) are accounted as one additional sequence whose index is
-        the position of the appended total-tokens sentinel — which under padding
-        is larger than under the unpadded form."""
+        """PackedSeqParams.__post_init__ builds seq_idx from the padded cu_seqlens.
+        Trailing repeated entries indicate zero-length segments which should not be used in the
+        attention computation. The tokens beyond `cu_seqlens_padded[-1]` (up to `total_tokens`) are
+        accounted as one additional sequence whose index is the position of the appended
+        total-tokens sentinel."""
         from megatron.core.packed_seq_params import PackedSeqParams, pad_cu_seqlens_for_cuda_graph
 
         cu_seqlens = torch.tensor([0, 5, 7, 11], dtype=torch.int32)
@@ -874,13 +872,13 @@ class TestPadCuSeqlensForCudaGraph:
 
 class TestParallelTransformerBlockCudagraphsPackedSeq:
     """End-to-end test of MCore-local cudagraph capture under packed-sequence
-    (THD / variable-length) training. Mirrors ``TestParallelTransformerBlockCudagraphs``
-    but feeds ``packed_seq_params`` and sets ``cuda_graph_max_packed_seqs``.
+    (THD / variable-length) training. Mirrors `TestParallelTransformerBlockCudagraphs`
+    but feeds `packed_seq_params` and sets `cuda_graph_max_packed_seqs`.
 
-    Verifies:
-      * the cudagraph captures with stable cu_seqlens shape (under-cap case);
-      * ``disable_cuda_graphs_this_step`` correctly bypasses capture (overflow case)
-        and still produces a valid forward output.
+    Checks:
+      * the cudagraph captures with stable cu_seqlens shape (under-cap case)
+      * `disable_cuda_graphs_this_step` correctly bypasses capture in the overflow case and still
+    produces a valid forward output.
     """
 
     def setup_method(self, method):
@@ -914,7 +912,7 @@ class TestParallelTransformerBlockCudagraphsPackedSeq:
 
     @staticmethod
     def _make_packed_seq_params(sequence_length, max_packed_seqs):
-        """Build a PackedSeqParams with 4 real docs, padded to ``max_packed_seqs``."""
+        """Build a PackedSeqParams with 4 real documents, padded to `max_packed_seqs`."""
         from megatron.core.packed_seq_params import PackedSeqParams, pad_cu_seqlens_for_cuda_graph
 
         cu_seqlens = torch.tensor([0, 6, 14, 22, sequence_length], dtype=torch.int32, device="cuda")

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -806,6 +806,292 @@ class TestParallelHybridBlockCudagraphs:
             del parallel_mamba_block.layers[_].cudagraph_manager.cudagraph_runners[0].fwd_graph
 
 
+class TestPadCuSeqlensForCudaGraph:
+    """Unit tests for the pure-Python ``pad_cu_seqlens_for_cuda_graph`` helper.
+
+    Verifies the contract used by the packed-sequence cudagraph wire-in: padding
+    repeats the final cumulative value so phantom segments are zero-length, and
+    returns None on overflow so the caller can fall back to eager.
+    """
+
+    def test_short_input_pads_with_repeated_last_value(self):
+        from megatron.core.packed_seq_params import pad_cu_seqlens_for_cuda_graph
+
+        cu_seqlens = torch.tensor([0, 5, 12, 19], dtype=torch.int32)
+        padded = pad_cu_seqlens_for_cuda_graph(cu_seqlens, target_num_seqs=6)
+        assert padded is not None
+        assert padded.shape == (7,)
+        assert padded.dtype == cu_seqlens.dtype
+        assert padded[:4].tolist() == [0, 5, 12, 19]
+        assert padded[4:].tolist() == [19, 19, 19]
+
+    def test_exact_fit_returns_input_unchanged(self):
+        from megatron.core.packed_seq_params import pad_cu_seqlens_for_cuda_graph
+
+        cu_seqlens = torch.tensor([0, 4, 9, 16], dtype=torch.int32)
+        padded = pad_cu_seqlens_for_cuda_graph(cu_seqlens, target_num_seqs=3)
+        assert padded is not None
+        assert padded.shape == (4,)
+        assert padded.tolist() == [0, 4, 9, 16]
+
+    def test_overflow_returns_none(self):
+        from megatron.core.packed_seq_params import pad_cu_seqlens_for_cuda_graph
+
+        cu_seqlens = torch.tensor([0, 3, 7, 11, 16, 22], dtype=torch.int32)
+        # 5 real documents > target_num_seqs=3 -> overflow
+        assert pad_cu_seqlens_for_cuda_graph(cu_seqlens, target_num_seqs=3) is None
+
+    def test_seq_idx_is_correct_under_padding(self):
+        """``PackedSeqParams.__post_init__`` builds ``seq_idx`` from the padded
+        cu_seqlens. Trailing repeated entries describe zero-length phantom segments
+        and contribute nothing. The tokens beyond ``cu_seqlens_padded[-1]`` (up to
+        ``total_tokens``) are accounted as one additional sequence whose index is
+        the position of the appended total-tokens sentinel — which under padding
+        is larger than under the unpadded form."""
+        from megatron.core.packed_seq_params import PackedSeqParams, pad_cu_seqlens_for_cuda_graph
+
+        cu_seqlens = torch.tensor([0, 5, 7, 11], dtype=torch.int32)
+        padded = pad_cu_seqlens_for_cuda_graph(cu_seqlens, target_num_seqs=8)
+        # padded == [0, 5, 7, 11, 11, 11, 11, 11, 11]  (length 9)
+        params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=padded,
+            cu_seqlens_kv=padded,
+            cu_seqlens_q_padded=padded,
+            cu_seqlens_kv_padded=padded,
+            max_seqlen_q=5,
+            max_seqlen_kv=5,
+            total_tokens=16,
+        )
+        # cu_seqlens_with_max = [0,5,7,11,11,11,11,11,11,16]
+        # seq_lengths = [5,2,4,0,0,0,0,0,5]
+        # seq_idx = [0]*5 + [1]*2 + [2]*4 + [3..7]*0 + [8]*5
+        assert params.seq_idx is not None
+        assert params.seq_idx.shape == (1, 16)
+        assert params.seq_idx.dtype == torch.int32
+        assert params.seq_idx[0].tolist() == ([0] * 5 + [1] * 2 + [2] * 4 + [8] * 5)
+
+
+class TestParallelTransformerBlockCudagraphsPackedSeq:
+    """End-to-end test of MCore-local cudagraph capture under packed-sequence
+    (THD / variable-length) training. Mirrors ``TestParallelTransformerBlockCudagraphs``
+    but feeds ``packed_seq_params`` and sets ``cuda_graph_max_packed_seqs``.
+
+    Verifies:
+      * the cudagraph captures with stable cu_seqlens shape (under-cap case);
+      * ``disable_cuda_graphs_this_step`` correctly bypasses capture (overflow case)
+        and still produces a valid forward output.
+    """
+
+    def setup_method(self, method):
+        initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+        # TP=1, PP=1 to keep the bypass test safe: under PP > 1 a recording-phase
+        # bypass desynchronizes the per-microbatch runner store.
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        model_parallel_cuda_manual_seed(123)
+
+        CudaGraphManager.global_mempool = None
+
+        self.transformer_config = TransformerConfig(
+            num_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            cuda_graph_impl="local",
+            cuda_graph_max_packed_seqs=8,
+        )
+        self.parallel_transformer_block = TransformerBlock(
+            self.transformer_config, get_gpt_layer_with_transformer_engine_spec()
+        )
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+        _CudagraphGlobalRecord.cudagraph_created = False
+        _CudagraphGlobalRecord.cudagraph_record = []
+        CudaGraphManager.global_mempool = None
+
+    @staticmethod
+    def _make_packed_seq_params(sequence_length, max_packed_seqs):
+        """Build a PackedSeqParams with 4 real docs, padded to ``max_packed_seqs``."""
+        from megatron.core.packed_seq_params import PackedSeqParams, pad_cu_seqlens_for_cuda_graph
+
+        cu_seqlens = torch.tensor([0, 6, 14, 22, sequence_length], dtype=torch.int32, device="cuda")
+        padded = pad_cu_seqlens_for_cuda_graph(cu_seqlens, max_packed_seqs)
+        return PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=padded,
+            cu_seqlens_kv=padded,
+            cu_seqlens_q_padded=padded,
+            cu_seqlens_kv_padded=padded,
+            max_seqlen_q=sequence_length,
+            max_seqlen_kv=sequence_length,
+            total_tokens=sequence_length,
+        )
+
+    @pytest.mark.skipif(
+        not (HAVE_TE and is_te_min_version("1.5.0")),
+        reason="use_te_rng_tracker requires TransformerEngine version >= 1.5",
+    )
+    def test_gpu_cudagraph_packed_seq_undercap(self):
+        block = self.parallel_transformer_block
+        block.cuda()
+
+        sequence_length = 32
+        # THD layout: [total_tokens, batch_size=1, hidden]
+        hidden_states = torch.ones(
+            (sequence_length, 1, self.transformer_config.hidden_size), device="cuda"
+        )
+        packed_seq_params = self._make_packed_seq_params(
+            sequence_length, self.transformer_config.cuda_graph_max_packed_seqs
+        )
+
+        # First call records the graph; subsequent calls replay.
+        out = block(
+            hidden_states=hidden_states, attention_mask=None, packed_seq_params=packed_seq_params
+        )
+        assert out.shape == hidden_states.shape
+
+        for layer in block.layers:
+            assert hasattr(layer, "cudagraph_manager")
+            assert len(layer.cudagraph_manager.cudagraph_runners) == 1
+            # Drop the captured graph so the test fixture does not retain the
+            # mempool past teardown.
+            del layer.cudagraph_manager.cudagraph_runners[0].fwd_graph
+
+    @pytest.mark.skipif(
+        not (HAVE_TE and is_te_min_version("1.5.0")),
+        reason="use_te_rng_tracker requires TransformerEngine version >= 1.5",
+    )
+    def test_overflow_bypass_runs_eagerly(self):
+        from megatron.core.transformer.cuda_graphs import disable_cuda_graphs_this_step
+
+        block = self.parallel_transformer_block
+        block.cuda()
+
+        sequence_length = 32
+        hidden_states = torch.ones(
+            (sequence_length, 1, self.transformer_config.hidden_size), device="cuda"
+        )
+
+        # 10 real docs > cap of 8 -> the padding helper would return None.
+        # Construct PackedSeqParams directly (skipping the helper) to simulate the
+        # overflow path inside forward_step, which falls back to eager via
+        # ``disable_cuda_graphs_this_step``.
+        from megatron.core.packed_seq_params import PackedSeqParams
+
+        cu_seqlens = torch.tensor(
+            [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, sequence_length], dtype=torch.int32, device="cuda"
+        )
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=sequence_length,
+            max_seqlen_kv=sequence_length,
+            total_tokens=sequence_length,
+        )
+
+        with disable_cuda_graphs_this_step():
+            out = block(
+                hidden_states=hidden_states,
+                attention_mask=None,
+                packed_seq_params=packed_seq_params,
+            )
+        assert out.shape == hidden_states.shape
+
+        # No cudagraph runner should have been created in the bypassed step.
+        for layer in block.layers:
+            assert hasattr(layer, "cudagraph_manager")
+            assert len(layer.cudagraph_manager.cudagraph_runners) == 0
+
+
+class TestParallelHybridBlockCudagraphsPackedSeq:
+    """End-to-end test of MCore-local cudagraph capture under packed-sequence
+    training for a hybrid Mamba-Transformer stack. Mirrors
+    ``TestParallelHybridBlockCudagraphs`` but feeds ``packed_seq_params``.
+    """
+
+    def setup_method(self, method):
+        initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        model_parallel_cuda_manual_seed(123)
+
+        CudaGraphManager.global_mempool = None
+
+        def get_pg_collection():
+            return ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'pp', 'cp'])
+
+        layer_type_list = validate_segment_layers("M-M*-")
+        transformer_config = TransformerConfig(
+            hidden_size=256,
+            num_layers=len(layer_type_list),
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            cuda_graph_impl="local",
+            cuda_graph_max_packed_seqs=8,
+        )
+        self.transformer_config = transformer_config
+        self.mamba_block = HybridStack(
+            transformer_config,
+            hybrid_stack_spec.submodules,
+            layer_type_list=layer_type_list,
+            pp_layer_offset=0,
+            pg_collection=get_pg_collection(),
+        )
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+        _CudagraphGlobalRecord.cudagraph_created = False
+        _CudagraphGlobalRecord.cudagraph_record = []
+        CudaGraphManager.global_mempool = None
+
+    @pytest.mark.skipif(
+        not (HAVE_TE and is_te_min_version("1.5.0")),
+        reason="use_te_rng_tracker requires TransformerEngine version >= 1.5",
+    )
+    def test_gpu_cudagraph_packed_seq_undercap(self):
+        from megatron.core.packed_seq_params import PackedSeqParams, pad_cu_seqlens_for_cuda_graph
+
+        block = self.mamba_block
+        block.cuda()
+
+        sequence_length = 32
+        hidden_states = torch.ones(
+            (sequence_length, 1, self.transformer_config.hidden_size), device="cuda"
+        )
+
+        cu_seqlens = torch.tensor([0, 6, 14, 22, sequence_length], dtype=torch.int32, device="cuda")
+        padded = pad_cu_seqlens_for_cuda_graph(
+            cu_seqlens, self.transformer_config.cuda_graph_max_packed_seqs
+        )
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=padded,
+            cu_seqlens_kv=padded,
+            cu_seqlens_q_padded=padded,
+            cu_seqlens_kv_padded=padded,
+            max_seqlen_q=sequence_length,
+            max_seqlen_kv=sequence_length,
+            total_tokens=sequence_length,
+        )
+
+        out = block(
+            hidden_states=hidden_states, attention_mask=None, packed_seq_params=packed_seq_params
+        )
+        assert out.shape == hidden_states.shape
+
+        for layer in block.layers:
+            assert hasattr(layer, "cudagraph_manager")
+            assert len(layer.cudagraph_manager.cudagraph_runners) == 1
+            del layer.cudagraph_manager.cudagraph_runners[0].fwd_graph
+
+
 # Global storage for comparing unique buffer counts across different num_microbatches,
 # keyed by (pp_size, vpp_size)
 _unique_buffer_counts = {}


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Adds CUDA graph capture/replay support for packed-sequence (THD / variable-length) training using the MCore-local cudagraph path.

`pad_cu_seqlens_for_cuda_graph()` pads `cu_seqlens` from `K+1` to `target_num_seqs+1` by repeating the final cumulative value, so the captured graph's input signature is stable across steps. 
`disable_cuda_graphs_this_step()` adds a per-step bypass context manager that `MegatronModule.__call__` consults at the single dispatch site. Falls back to eager when a microbatch has more docs than the cap.

`--cuda-graph-max-packed-seqs N` (default 0 = off). Passing the flag without a value enables it with a default of `50`. 

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
