### PR TITLE
[mimo] Support bridge fan-out for variable modality tokens

### DIFF
--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -423,7 +423,7 @@ class MimoModel(MegatronModule):
                     raise RuntimeError(
                         f"{encoder_name} inputs are missing, but matching special tokens exist"
                     )
-                output = self._empty_encoder_output(submodule, input_ids)
+                output = self._empty_encoder_output(encoder_name)
 
             if output is not None:
                 self._attach_modality_split_sizes(output, input_ids, encoder_name)
@@ -476,9 +476,7 @@ class MimoModel(MegatronModule):
             return False
         return bool((input_ids == self.special_token_ids[encoder_name]).any().item())
 
-    def _empty_encoder_output(
-        self, submodule: torch.nn.Module, input_ids: Optional[torch.Tensor]
-    ) -> torch.Tensor:
+    def _empty_encoder_output(self, encoder_name: str) -> torch.Tensor:
         """Return the bridge payload for text-only non-colocated batches."""
         language_config = self.mimo_config.language_model_spec.params['config']
         hidden_size = getattr(language_config, 'hidden_size', None)
@@ -487,20 +485,13 @@ class MimoModel(MegatronModule):
                 "Language model config must define hidden_size for empty modality output"
             )
 
-        ref_tensor = next(submodule.parameters(), None)
-        if ref_tensor is None:
-            ref_tensor = next(submodule.buffers(), None)
-        if ref_tensor is not None:
-            device = ref_tensor.device
-        elif input_ids is not None:
-            device = input_ids.device
-        else:
-            device = torch.device("cuda", torch.cuda.current_device())
-        dtype = ref_tensor.dtype if ref_tensor is not None else self.config.params_dtype
-        if dtype is None:
-            dtype = torch.float32
-
-        return torch.empty((0, hidden_size), device=device, dtype=dtype, requires_grad=True)
+        encoder_config = self.mimo_config.modality_submodules_spec[encoder_name].params['config']
+        return torch.empty(
+            (0, hidden_size),
+            device=torch.cuda.current_device(),
+            dtype=encoder_config.params_dtype,
+            requires_grad=True,
+        )
 
     def _forward_language_module(
         self,

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -436,19 +436,28 @@ class MimoModel(MegatronModule):
     ) -> None:
         """Annotate flat modality outputs with per-sample split sizes for bridge fan-out.
 
-        Fan-out only (encoder DP <= LM DP): the encoder rank's local ``input_ids``
-        describe the samples it will send out. In fan-out the bridge splits this
-        local batch into N pieces for N LM peers on the sender side, consuming
-        ``_mimo_bridge_split_sizes``. The equal-DP case is one-to-one and the
-        metadata is a no-op.
+        Only attaches when per-sample token counts are non-uniform. Uniform counts
+        give equal splits, which the bridge's ``torch.tensor_split`` fallback
+        already produces, so the metadata would be a no-op.
 
-        TODO(mimo): fan-in (encoder DP > LM DP) is not supported. Multiple
-        encoder ranks contribute slices to a single LM peer, and the
-        receiver-side ``torch.cat`` path in BridgeCommunicator has no metadata
-        channel today, so per-sample boundaries are lost on the LM rank. Lift
-        this restriction by routing per-sample sizes through the bridge
+        TODO(mimo): non-uniform per-sample counts in fan-in (encoder DP > LM DP)
+        are not supported. Multiple encoder ranks contribute slices to a single
+        LM peer, and the receiver-side ``torch.cat`` path in BridgeCommunicator
+        has no metadata channel today, so per-sample boundaries are lost on the
+        LM rank. Lift this by routing per-sample sizes through the bridge
         alongside the activations and adding a sample-aligned concat path.
         """
+        token_id = self.special_token_ids.get(encoder_name)
+        if token_id is None or input_ids is None or output.ndim != 2 or input_ids.size(0) <= 1:
+            return
+
+        split_sizes = (input_ids == token_id).sum(dim=1).to(torch.long).tolist()
+        if sum(split_sizes) != output.size(0):
+            return
+        if len(set(split_sizes)) <= 1:
+            # Uniform counts — tensor_split fallback gives the same result.
+            return
+
         if self.role.mode is ModuleLayout.NON_COLOCATED:
             grid_map = self.mimo_config.module_to_grid_map
             encoder_grid = grid_map[encoder_name]
@@ -456,19 +465,14 @@ class MimoModel(MegatronModule):
             encoder_dp = encoder_grid.shape[encoder_grid.dim_names.index("dp")]
             language_dp = language_grid.shape[language_grid.dim_names.index("dp")]
             assert encoder_dp <= language_dp, (
-                f"Bridge fan-out split metadata only supports encoder DP <= LM DP "
-                f"(got encoder='{encoder_name}' DP={encoder_dp}, LM DP={language_dp}). "
-                f"Fan-in (encoder DP > LM DP) is not supported yet — see TODO in "
+                f"Bridge fan-out split metadata with non-uniform per-sample sizes "
+                f"requires encoder DP <= LM DP (got encoder='{encoder_name}' "
+                f"DP={encoder_dp}, LM DP={language_dp}). Fan-in with variable "
+                f"modality token counts is not supported yet — see TODO in "
                 f"_attach_modality_split_sizes."
             )
 
-        token_id = self.special_token_ids.get(encoder_name)
-        if token_id is None or input_ids is None or output.ndim != 2 or input_ids.size(0) <= 1:
-            return
-
-        split_sizes = (input_ids == token_id).sum(dim=1).to(torch.long).tolist()
-        if sum(split_sizes) == output.size(0):
-            output._mimo_bridge_split_sizes = split_sizes
+        output._mimo_bridge_split_sizes = split_sizes
 
     def _has_encoder_tokens(self, input_ids: Optional[torch.Tensor], encoder_name: str) -> bool:
         """Return whether the batch contains tokens for an encoder module."""

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -379,7 +379,7 @@ class MimoModel(MegatronModule):
 
         if self.role.mode == ModuleLayout.NON_COLOCATED:
             if self.role.has_modality_modules:
-                return self._forward_encoders(modality_inputs, input_tensors), loss_mask
+                return self._forward_encoders(input_ids, modality_inputs, input_tensors), loss_mask
 
             if self.role.has_language_module:
                 return (
@@ -395,6 +395,7 @@ class MimoModel(MegatronModule):
 
     def _forward_encoders(
         self,
+        input_ids: Optional[torch.Tensor],
         modality_inputs: Optional[Dict[str, Dict[str, Any]]],
         input_tensors: Optional[Dict[str, torch.Tensor]],
     ) -> Dict[str, torch.Tensor]:
@@ -414,15 +415,68 @@ class MimoModel(MegatronModule):
                 continue
 
             submodule = self.modality_submodules[encoder_name]
+            encoder_inputs = modality_inputs.get(encoder_name) if modality_inputs else None
+            hidden_states = input_tensors.get(encoder_name) if input_tensors else None
             output = submodule.forward(
-                encoder_inputs=modality_inputs.get(encoder_name) if modality_inputs else None,
-                hidden_states=input_tensors.get(encoder_name) if input_tensors else None,
+                encoder_inputs=encoder_inputs,
+                hidden_states=hidden_states,
             )
+            if output is None and encoder_inputs is None and hidden_states is None:
+                if self._has_encoder_tokens(input_ids, encoder_name):
+                    raise RuntimeError(
+                        f"{encoder_name} inputs are missing, but matching special tokens exist"
+                    )
+                output = self._empty_encoder_output(submodule, input_ids)
 
             if output is not None:
+                self._attach_modality_split_sizes(output, input_ids, encoder_name)
                 outputs[encoder_name] = output
 
         return outputs
+
+    def _attach_modality_split_sizes(
+        self, output: torch.Tensor, input_ids: Optional[torch.Tensor], encoder_name: str
+    ) -> None:
+        """Annotate flat modality outputs with per-sample split sizes for bridge fan-out."""
+        token_id = self.special_token_ids.get(encoder_name)
+        if token_id is None or input_ids is None or output.ndim != 2 or input_ids.size(0) <= 1:
+            return
+
+        split_sizes = (input_ids == token_id).sum(dim=1).to(torch.long).tolist()
+        if sum(split_sizes) == output.size(0):
+            output._mimo_bridge_split_sizes = split_sizes
+
+    def _has_encoder_tokens(self, input_ids: Optional[torch.Tensor], encoder_name: str) -> bool:
+        """Return whether the batch contains tokens for an encoder module."""
+        if input_ids is None or encoder_name not in self.special_token_ids:
+            return False
+        return bool((input_ids == self.special_token_ids[encoder_name]).any().item())
+
+    def _empty_encoder_output(
+        self, submodule: torch.nn.Module, input_ids: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        """Return the bridge payload for text-only non-colocated batches."""
+        language_config = self.mimo_config.language_model_spec.params['config']
+        hidden_size = getattr(language_config, 'hidden_size', None)
+        if hidden_size is None:
+            raise ValueError(
+                "Language model config must define hidden_size for empty modality output"
+            )
+
+        ref_tensor = next(submodule.parameters(), None)
+        if ref_tensor is None:
+            ref_tensor = next(submodule.buffers(), None)
+        if ref_tensor is not None:
+            device = ref_tensor.device
+        elif input_ids is not None:
+            device = input_ids.device
+        else:
+            device = torch.device("cuda", torch.cuda.current_device())
+        dtype = ref_tensor.dtype if ref_tensor is not None else self.config.params_dtype
+        if dtype is None:
+            dtype = torch.float32
+
+        return torch.empty((0, hidden_size), device=device, dtype=dtype, requires_grad=True)
 
     def _forward_language_module(
         self,

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -489,11 +489,11 @@ class MimoModel(MegatronModule):
                 "Language model config must define hidden_size for empty modality output"
             )
 
-        encoder_config = self.mimo_config.modality_submodules_spec[encoder_name].params['config']
+        output_dtype = getattr(language_config, 'params_dtype', None) or torch.float32
         return torch.empty(
             (0, hidden_size),
             device=torch.cuda.current_device(),
-            dtype=encoder_config.params_dtype,
+            dtype=output_dtype,
             requires_grad=True,
         )
 

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -434,7 +434,34 @@ class MimoModel(MegatronModule):
     def _attach_modality_split_sizes(
         self, output: torch.Tensor, input_ids: Optional[torch.Tensor], encoder_name: str
     ) -> None:
-        """Annotate flat modality outputs with per-sample split sizes for bridge fan-out."""
+        """Annotate flat modality outputs with per-sample split sizes for bridge fan-out.
+
+        Fan-out only (encoder DP <= LM DP): the encoder rank's local ``input_ids``
+        describe the samples it will send out. In fan-out the bridge splits this
+        local batch into N pieces for N LM peers on the sender side, consuming
+        ``_mimo_bridge_split_sizes``. The equal-DP case is one-to-one and the
+        metadata is a no-op.
+
+        TODO(mimo): fan-in (encoder DP > LM DP) is not supported. Multiple
+        encoder ranks contribute slices to a single LM peer, and the
+        receiver-side ``torch.cat`` path in BridgeCommunicator has no metadata
+        channel today, so per-sample boundaries are lost on the LM rank. Lift
+        this restriction by routing per-sample sizes through the bridge
+        alongside the activations and adding a sample-aligned concat path.
+        """
+        if self.role.mode is ModuleLayout.NON_COLOCATED:
+            grid_map = self.mimo_config.module_to_grid_map
+            encoder_grid = grid_map[encoder_name]
+            language_grid = grid_map[MIMO_LANGUAGE_MODULE_KEY]
+            encoder_dp = encoder_grid.shape[encoder_grid.dim_names.index("dp")]
+            language_dp = language_grid.shape[language_grid.dim_names.index("dp")]
+            assert encoder_dp <= language_dp, (
+                f"Bridge fan-out split metadata only supports encoder DP <= LM DP "
+                f"(got encoder='{encoder_name}' DP={encoder_dp}, LM DP={language_dp}). "
+                f"Fan-in (encoder DP > LM DP) is not supported yet — see TODO in "
+                f"_attach_modality_split_sizes."
+            )
+
         token_id = self.special_token_ids.get(encoder_name)
         if token_id is None or input_ids is None or output.ndim != 2 or input_ids.size(0) <= 1:
             return

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -417,10 +417,7 @@ class MimoModel(MegatronModule):
             submodule = self.modality_submodules[encoder_name]
             encoder_inputs = modality_inputs.get(encoder_name) if modality_inputs else None
             hidden_states = input_tensors.get(encoder_name) if input_tensors else None
-            output = submodule.forward(
-                encoder_inputs=encoder_inputs,
-                hidden_states=hidden_states,
-            )
+            output = submodule.forward(encoder_inputs=encoder_inputs, hidden_states=hidden_states)
             if output is None and encoder_inputs is None and hidden_states is None:
                 if self._has_encoder_tokens(input_ids, encoder_name):
                     raise RuntimeError(

--- a/megatron/core/pipeline_parallel/bridge_communicator.py
+++ b/megatron/core/pipeline_parallel/bridge_communicator.py
@@ -350,7 +350,7 @@ class BridgeCommunicator:
             num_sends = len(rank_info.send_to_ranks)
             if num_sends > 0:
                 tensor_splits = self._split_tensor_at_batch_dim(tensor_to_send, num_sends)
-                self._communicate_shapes(tensor_to_send_next=tensor_splits[0])
+                self._communicate_shapes(tensor_to_send_next=tensor_splits)
                 for dest_rank, tensor_split in zip(rank_info.send_to_ranks, tensor_splits):
                     logging.debug(
                         f"[Bridge Comunicator] [send_forward] Rank {self.current_rank} "
@@ -480,7 +480,7 @@ class BridgeCommunicator:
             # Send gradients back to source ranks
             num_receives = len(rank_info.recv_from_ranks)
             tensor_splits = self._split_tensor_at_batch_dim(grad_tensor, num_receives)
-            self._communicate_shapes(tensor_to_send_prev=tensor_splits[0])
+            self._communicate_shapes(tensor_to_send_prev=tensor_splits)
             if num_receives > 0:
                 for src_rank, tensor_split in zip(rank_info.recv_from_ranks, tensor_splits):
                     # Send the gradient split back to the source rank
@@ -618,7 +618,7 @@ class BridgeCommunicator:
             activation_splits = self._split_tensor_at_batch_dim(input_tensor, num_sends)
             # Communicate shapes for both directions (send forward, receive backward)
             recv_forward_shapes, recv_grad_shapes = self._communicate_shapes(
-                tensor_to_send_next=activation_splits[0], recv_next=True
+                tensor_to_send_next=activation_splits, recv_next=True
             )
             logging.debug(
                 f"[Bridge Communicator] [send_forward_recv_backward] Rank {self.current_rank} "
@@ -737,7 +737,7 @@ class BridgeCommunicator:
             gradient_splits = self._split_tensor_at_batch_dim(grad_tensor, num_receives)
             # Communicate shapes for both directions (send backward, receive forward)
             recv_forward_shapes, recv_grad_shapes = self._communicate_shapes(
-                tensor_to_send_prev=gradient_splits[0], recv_prev=True
+                tensor_to_send_prev=gradient_splits, recv_prev=True
             )
             logging.debug(
                 f"[Bridge Communicator] [send_backward_recv_backward] Rank {self.current_rank} "
@@ -848,8 +848,10 @@ class BridgeCommunicator:
         when dealing with variable sequence lengths or dynamic shapes.
 
         Args:
-            tensor_to_send_next: The tensor to send to the next rank (None if not sending)
-            tensor_to_send_prev: The tensor to send to the previous rank (None if not sending)
+            tensor_to_send_next: Tensor shape source for next ranks. Pass a single tensor when
+                every peer receives the same shape, or a list with one tensor per peer.
+            tensor_to_send_prev: Tensor shape source for previous ranks. Pass a single tensor when
+                every peer receives the same shape, or a list with one tensor per peer.
             recv_next: Whether to receive from the next rank (None if not receiving)
             recv_prev: Whether to receive from the previous rank (None if not receiving)
 
@@ -876,12 +878,14 @@ class BridgeCommunicator:
         if rank_info.role == CommRole.SENDER:
             # Prepare send operations for forward shapes
             if tensor_to_send_next is not None:
-                send_shape = tensor_to_send_next.shape
-                send_shape_tensor = torch.tensor(
-                    send_shape, device=torch.cuda.current_device(), dtype=torch.int64
+                tensors_to_send = self._as_per_peer_tensors(
+                    tensor_to_send_next, len(rank_info.send_to_ranks)
                 )
                 # Add send operations for each destination
-                for dest_rank in rank_info.send_to_ranks:
+                for dest_rank, tensor in zip(rank_info.send_to_ranks, tensors_to_send):
+                    send_shape_tensor = torch.tensor(
+                        tensor.shape, device=torch.cuda.current_device(), dtype=torch.int64
+                    )
                     ops.append(
                         torch.distributed.P2POp(
                             torch.distributed.isend, send_shape_tensor, dest_rank
@@ -918,12 +922,14 @@ class BridgeCommunicator:
             # If we need to send gradient shapes back, prepare send operations
             if tensor_to_send_prev is not None:
 
-                grad_shape = tensor_to_send_prev.shape
-                grad_shape_tensor = torch.tensor(
-                    grad_shape, device=torch.cuda.current_device(), dtype=torch.int64
+                tensors_to_send = self._as_per_peer_tensors(
+                    tensor_to_send_prev, len(rank_info.recv_from_ranks)
                 )
 
-                for src_rank in rank_info.recv_from_ranks:
+                for src_rank, tensor in zip(rank_info.recv_from_ranks, tensors_to_send):
+                    grad_shape_tensor = torch.tensor(
+                        tensor.shape, device=torch.cuda.current_device(), dtype=torch.int64
+                    )
                     ops.append(
                         torch.distributed.P2POp(
                             torch.distributed.isend, grad_shape_tensor, src_rank
@@ -947,6 +953,17 @@ class BridgeCommunicator:
 
         return recv_forward_shapes, recv_grad_shapes
 
+    @staticmethod
+    def _as_per_peer_tensors(tensors, expected_count: int) -> List[torch.Tensor]:
+        """Return one tensor per peer from either a shared tensor or a per-peer tensor list."""
+        if isinstance(tensors, torch.Tensor):
+            return [tensors for _ in range(expected_count)]
+        if len(tensors) != expected_count:
+            raise ValueError(
+                f"expected {expected_count} tensors for shape communication, got {len(tensors)}"
+            )
+        return list(tensors)
+
     def _split_tensor_at_batch_dim(
         self, aggregated_tensor: torch.Tensor, num_splits: int
     ) -> List[torch.Tensor]:
@@ -961,6 +978,34 @@ class BridgeCommunicator:
         """
         if num_splits <= 0:
             raise ValueError(f"num_splits must be positive, got {num_splits}")
+
+        split_sizes = getattr(aggregated_tensor, "_mimo_bridge_split_sizes", None)
+        if split_sizes is not None:
+            if num_splits == 1:
+                return [aggregated_tensor.contiguous()]
+            split_sizes = [int(size) for size in split_sizes]
+            if len(split_sizes) > num_splits and len(split_sizes) % num_splits == 0:
+                # Encoder metadata is per input sample; fan-out sends need one size per peer.
+                samples_per_split = len(split_sizes) // num_splits
+                split_sizes = [
+                    sum(split_sizes[i : i + samples_per_split])
+                    for i in range(0, len(split_sizes), samples_per_split)
+                ]
+            if len(split_sizes) != num_splits:
+                raise ValueError(
+                    f"bridge split metadata has {len(split_sizes)} entries, "
+                    f"but communication requires {num_splits} splits"
+                )
+            batch_dim_size = int(aggregated_tensor.shape[self._batch_dim])
+            if sum(split_sizes) != batch_dim_size:
+                raise ValueError(
+                    f"bridge split metadata sums to {sum(split_sizes)}, "
+                    f"but tensor batch dimension is {batch_dim_size}"
+                )
+            return [
+                split.contiguous()
+                for split in torch.split(aggregated_tensor, split_sizes, dim=self._batch_dim)
+            ]
 
         splits = torch.tensor_split(aggregated_tensor, num_splits, dim=self._batch_dim)
         # PyTorch p2p requires the tensors to be contiguous

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -532,6 +532,13 @@ def backward_step_multimodule(
     In multi-module pipelines, tensors are organized as dictionaries with
     module names as keys. Each module's backward pass is performed independently.
     """
+
+    def _unwrap_single_tensor_list(tensor):
+        if isinstance(tensor, list):
+            assert len(tensor) == 1, "expected a single tensor for multimodule backward"
+            return tensor[0]
+        return tensor
+
     # Retain gradients on all input tensors.
     for module_name, tensor in input_tensor.items():
         if isinstance(tensor, list):
@@ -550,13 +557,14 @@ def backward_step_multimodule(
 
     # Apply grad scaling if needed (for last stage only).
     for module_name in output_tensor.keys():
-        if output_tensor_grad[module_name] is None and config.grad_scale_func is not None:
+        output_tensor_grad_module = _unwrap_single_tensor_list(output_tensor_grad[module_name])
+        if output_tensor_grad_module is None and config.grad_scale_func is not None:
             output_tensor[module_name] = config.grad_scale_func(output_tensor[module_name])
 
     # Perform backward pass for each module.
     for module_name in output_tensor.keys():
-        output_tensor_module = output_tensor[module_name]
-        output_tensor_grad_module = output_tensor_grad[module_name]
+        output_tensor_module = _unwrap_single_tensor_list(output_tensor[module_name])
+        output_tensor_grad_module = _unwrap_single_tensor_list(output_tensor_grad[module_name])
 
         # In multi-modal models like VLM, some batches may not have images.
         # In such cases, skip backward while preserving zero gradients.

--- a/tests/unit_tests/models/test_mimo_model.py
+++ b/tests/unit_tests/models/test_mimo_model.py
@@ -5,6 +5,7 @@ WORLD_SIZE=1 LOCAL_RANK=0 python -m pytest tests/unit_tests/models/test_mimo_mod
 '''
 
 import math
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -731,8 +732,6 @@ class TestMimoModelFanoutHelpers:
 
     @staticmethod
     def _stub_model(special_token_ids):
-        from types import SimpleNamespace
-
         model = MimoModel.__new__(MimoModel)
         model.special_token_ids = special_token_ids
         # COLOCATED skips the fan-out DP assertion path; this fixture targets
@@ -774,3 +773,68 @@ class TestMimoModelFanoutHelpers:
         assert model._has_encoder_tokens(torch.tensor([[1, 2]]), "images") is False
         assert model._has_encoder_tokens(None, "images") is False
         assert model._has_encoder_tokens(torch.tensor([[1]]), "unknown") is False
+
+    @staticmethod
+    def _stub_language_config(hidden_size=8):
+        return SimpleNamespace(
+            language_model_spec=SimpleNamespace(
+                params={'config': SimpleNamespace(hidden_size=hidden_size)}
+            )
+        )
+
+    def test_set_input_tensor_unwraps_outer_list_and_forwards_to_language_model(self):
+        lm = MagicMock()
+        model = MimoModel.__new__(MimoModel)
+        model.language_model = lm
+        tensor = torch.zeros(2, 4)
+
+        model.set_input_tensor([tensor])
+
+        assert torch.equal(model.input_tensors, tensor)
+        lm.set_input_tensor.assert_called_once_with(tensor)
+
+    def test_set_input_tensor_dict_unwraps_single_element_value_lists(self):
+        model = MimoModel.__new__(MimoModel)
+        model.language_model = None
+        t_lang = torch.zeros(2, 4)
+        t_vision = torch.zeros(3, 4)
+
+        model.set_input_tensor({"language": [t_lang], "vision": t_vision})
+
+        assert torch.equal(model.input_tensors["language"], t_lang)
+        assert torch.equal(model.input_tensors["vision"], t_vision)
+
+    def test_empty_encoder_output_uses_submodule_param_dtype_and_device(self):
+        submodule = torch.nn.Linear(4, 8).to(torch.float16)
+        model = MimoModel.__new__(MimoModel)
+        model.mimo_config = self._stub_language_config(hidden_size=8)
+
+        output = model._empty_encoder_output(submodule, input_ids=None)
+
+        assert output.shape == (0, 8)
+        assert output.dtype is torch.float16
+        assert output.device == next(submodule.parameters()).device
+        assert output.requires_grad
+
+    def test_empty_encoder_output_falls_back_to_buffer_when_no_params(self):
+        class BufferOnly(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("scale", torch.zeros(1, dtype=torch.bfloat16))
+
+        model = MimoModel.__new__(MimoModel)
+        model.mimo_config = self._stub_language_config(hidden_size=4)
+
+        output = model._empty_encoder_output(BufferOnly(), input_ids=torch.zeros(1, 2))
+
+        assert output.shape == (0, 4)
+        assert output.dtype is torch.bfloat16
+
+    def test_empty_encoder_output_raises_when_hidden_size_missing(self):
+        model = MimoModel.__new__(MimoModel)
+        model.mimo_config = SimpleNamespace(
+            language_model_spec=SimpleNamespace(params={'config': SimpleNamespace()})
+        )
+
+        with pytest.raises(ValueError, match="hidden_size"):
+            model._empty_encoder_output(torch.nn.Linear(4, 4), input_ids=None)

--- a/tests/unit_tests/models/test_mimo_model.py
+++ b/tests/unit_tests/models/test_mimo_model.py
@@ -757,6 +757,16 @@ class TestMimoModelFanoutHelpers:
 
         assert not hasattr(output, "_mimo_bridge_split_sizes")
 
+    def test_attach_modality_split_sizes_skips_when_token_counts_uniform(self):
+        model = self._stub_model({"images": 50257})
+        # Two samples, two image tokens each — uniform per-sample counts.
+        input_ids = torch.tensor([[50257, 50257, 1, 2], [50257, 50257, 3, 4]])
+        output = torch.zeros(4, 8)
+
+        model._attach_modality_split_sizes(output, input_ids, "images")
+
+        assert not hasattr(output, "_mimo_bridge_split_sizes")
+
     def test_attach_modality_split_sizes_skips_for_single_sample_batch(self):
         model = self._stub_model({"images": 50257})
         input_ids = torch.tensor([[50257, 50257, 1]])

--- a/tests/unit_tests/models/test_mimo_model.py
+++ b/tests/unit_tests/models/test_mimo_model.py
@@ -785,14 +785,21 @@ class TestMimoModelFanoutHelpers:
         assert model._has_encoder_tokens(torch.tensor([[1]]), "unknown") is False
 
     @staticmethod
-    def _stub_mimo_config(*, hidden_size=8, encoder_dtype=torch.float16):
+    def _stub_mimo_config(
+        *,
+        hidden_size=8,
+        language_dtype=torch.float32,
+        include_language_dtype=True,
+        modality_params=None,
+    ):
+        language_config = SimpleNamespace(hidden_size=hidden_size)
+        if include_language_dtype:
+            language_config.params_dtype = language_dtype
         return SimpleNamespace(
-            language_model_spec=SimpleNamespace(
-                params={'config': SimpleNamespace(hidden_size=hidden_size)}
-            ),
+            language_model_spec=SimpleNamespace(params={'config': language_config}),
             modality_submodules_spec={
                 "images": SimpleNamespace(
-                    params={'config': SimpleNamespace(params_dtype=encoder_dtype)}
+                    params={} if modality_params is None else modality_params
                 )
             },
         )
@@ -819,15 +826,47 @@ class TestMimoModelFanoutHelpers:
         assert torch.equal(model.input_tensors["language"], t_lang)
         assert torch.equal(model.input_tensors["vision"], t_vision)
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for current_device")
-    def test_empty_encoder_output_uses_encoder_config_dtype_and_current_device(self):
+    def test_empty_encoder_output_uses_language_dtype_without_modality_config(self, monkeypatch):
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
         model = MimoModel.__new__(MimoModel)
-        model.mimo_config = self._stub_mimo_config(hidden_size=8, encoder_dtype=torch.bfloat16)
+        model.mimo_config = self._stub_mimo_config(
+            hidden_size=8,
+            language_dtype=torch.bfloat16,
+            modality_params={},
+        )
 
         output = model._empty_encoder_output("images")
 
         assert output.shape == (0, 8)
-        assert output.dtype is torch.bfloat16
+        assert output.dtype == torch.bfloat16
+        assert output.device.type == "cpu"
+        assert output.requires_grad
+
+    def test_empty_encoder_output_defaults_to_float32_without_language_dtype(self, monkeypatch):
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+        model = MimoModel.__new__(MimoModel)
+        model.mimo_config = self._stub_mimo_config(
+            hidden_size=8,
+            include_language_dtype=False,
+            modality_params={},
+        )
+
+        output = model._empty_encoder_output("images")
+
+        assert output.shape == (0, 8)
+        assert output.dtype == torch.float32
+        assert output.device.type == "cpu"
+        assert output.requires_grad
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for current_device")
+    def test_empty_encoder_output_uses_current_cuda_device(self):
+        model = MimoModel.__new__(MimoModel)
+        model.mimo_config = self._stub_mimo_config(hidden_size=8, language_dtype=torch.bfloat16)
+
+        output = model._empty_encoder_output("images")
+
+        assert output.shape == (0, 8)
+        assert output.dtype == torch.bfloat16
         assert output.device.type == "cuda"
         assert output.requires_grad
 

--- a/tests/unit_tests/models/test_mimo_model.py
+++ b/tests/unit_tests/models/test_mimo_model.py
@@ -775,11 +775,16 @@ class TestMimoModelFanoutHelpers:
         assert model._has_encoder_tokens(torch.tensor([[1]]), "unknown") is False
 
     @staticmethod
-    def _stub_language_config(hidden_size=8):
+    def _stub_mimo_config(*, hidden_size=8, encoder_dtype=torch.float16):
         return SimpleNamespace(
             language_model_spec=SimpleNamespace(
                 params={'config': SimpleNamespace(hidden_size=hidden_size)}
-            )
+            ),
+            modality_submodules_spec={
+                "images": SimpleNamespace(
+                    params={'config': SimpleNamespace(params_dtype=encoder_dtype)}
+                )
+            },
         )
 
     def test_set_input_tensor_unwraps_outer_list_and_forwards_to_language_model(self):
@@ -804,31 +809,17 @@ class TestMimoModelFanoutHelpers:
         assert torch.equal(model.input_tensors["language"], t_lang)
         assert torch.equal(model.input_tensors["vision"], t_vision)
 
-    def test_empty_encoder_output_uses_submodule_param_dtype_and_device(self):
-        submodule = torch.nn.Linear(4, 8).to(torch.float16)
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for current_device")
+    def test_empty_encoder_output_uses_encoder_config_dtype_and_current_device(self):
         model = MimoModel.__new__(MimoModel)
-        model.mimo_config = self._stub_language_config(hidden_size=8)
+        model.mimo_config = self._stub_mimo_config(hidden_size=8, encoder_dtype=torch.bfloat16)
 
-        output = model._empty_encoder_output(submodule, input_ids=None)
+        output = model._empty_encoder_output("images")
 
         assert output.shape == (0, 8)
-        assert output.dtype is torch.float16
-        assert output.device == next(submodule.parameters()).device
-        assert output.requires_grad
-
-    def test_empty_encoder_output_falls_back_to_buffer_when_no_params(self):
-        class BufferOnly(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.register_buffer("scale", torch.zeros(1, dtype=torch.bfloat16))
-
-        model = MimoModel.__new__(MimoModel)
-        model.mimo_config = self._stub_language_config(hidden_size=4)
-
-        output = model._empty_encoder_output(BufferOnly(), input_ids=torch.zeros(1, 2))
-
-        assert output.shape == (0, 4)
         assert output.dtype is torch.bfloat16
+        assert output.device.type == "cuda"
+        assert output.requires_grad
 
     def test_empty_encoder_output_raises_when_hidden_size_missing(self):
         model = MimoModel.__new__(MimoModel)
@@ -837,4 +828,4 @@ class TestMimoModelFanoutHelpers:
         )
 
         with pytest.raises(ValueError, match="hidden_size"):
-            model._empty_encoder_output(torch.nn.Linear(4, 4), input_ids=None)
+            model._empty_encoder_output("images")

--- a/tests/unit_tests/models/test_mimo_model.py
+++ b/tests/unit_tests/models/test_mimo_model.py
@@ -724,3 +724,48 @@ class TestMimoModelNonColocated:
         assert captured['input_ids'] is None
         assert captured['decoder_input'] is None
         torch.testing.assert_close(captured['position_ids'], position_ids)
+
+
+class TestMimoModelFanoutHelpers:
+    """CPU-only coverage for bridge-fanout helper methods on ``MimoModel``."""
+
+    @staticmethod
+    def _stub_model(special_token_ids):
+        model = MimoModel.__new__(MimoModel)
+        model.special_token_ids = special_token_ids
+        return model
+
+    def test_attach_modality_split_sizes_tags_output_with_per_sample_counts(self):
+        model = self._stub_model({"images": 50257})
+        input_ids = torch.tensor([[50257, 50257, 1, 2], [50257, 1, 2, 3]])
+        output = torch.zeros(3, 8)
+
+        model._attach_modality_split_sizes(output, input_ids, "images")
+
+        assert output._mimo_bridge_split_sizes == [2, 1]
+
+    def test_attach_modality_split_sizes_skips_when_total_mismatches(self):
+        model = self._stub_model({"images": 50257})
+        input_ids = torch.tensor([[50257, 1], [1, 1]])
+        output = torch.zeros(5, 8)
+
+        model._attach_modality_split_sizes(output, input_ids, "images")
+
+        assert not hasattr(output, "_mimo_bridge_split_sizes")
+
+    def test_attach_modality_split_sizes_skips_for_single_sample_batch(self):
+        model = self._stub_model({"images": 50257})
+        input_ids = torch.tensor([[50257, 50257, 1]])
+        output = torch.zeros(2, 8)
+
+        model._attach_modality_split_sizes(output, input_ids, "images")
+
+        assert not hasattr(output, "_mimo_bridge_split_sizes")
+
+    def test_has_encoder_tokens_detects_presence_and_absence(self):
+        model = self._stub_model({"images": 50257, "audio": 50258})
+
+        assert model._has_encoder_tokens(torch.tensor([[50257, 1]]), "images") is True
+        assert model._has_encoder_tokens(torch.tensor([[1, 2]]), "images") is False
+        assert model._has_encoder_tokens(None, "images") is False
+        assert model._has_encoder_tokens(torch.tensor([[1]]), "unknown") is False

--- a/tests/unit_tests/models/test_mimo_model.py
+++ b/tests/unit_tests/models/test_mimo_model.py
@@ -798,9 +798,7 @@ class TestMimoModelFanoutHelpers:
         return SimpleNamespace(
             language_model_spec=SimpleNamespace(params={'config': language_config}),
             modality_submodules_spec={
-                "images": SimpleNamespace(
-                    params={} if modality_params is None else modality_params
-                )
+                "images": SimpleNamespace(params={} if modality_params is None else modality_params)
             },
         )
 
@@ -830,9 +828,7 @@ class TestMimoModelFanoutHelpers:
         monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
         model = MimoModel.__new__(MimoModel)
         model.mimo_config = self._stub_mimo_config(
-            hidden_size=8,
-            language_dtype=torch.bfloat16,
-            modality_params={},
+            hidden_size=8, language_dtype=torch.bfloat16, modality_params={}
         )
 
         output = model._empty_encoder_output("images")
@@ -846,9 +842,7 @@ class TestMimoModelFanoutHelpers:
         monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
         model = MimoModel.__new__(MimoModel)
         model.mimo_config = self._stub_mimo_config(
-            hidden_size=8,
-            include_language_dtype=False,
-            modality_params={},
+            hidden_size=8, include_language_dtype=False, modality_params={}
         )
 
         output = model._empty_encoder_output("images")

--- a/tests/unit_tests/models/test_mimo_model.py
+++ b/tests/unit_tests/models/test_mimo_model.py
@@ -731,8 +731,13 @@ class TestMimoModelFanoutHelpers:
 
     @staticmethod
     def _stub_model(special_token_ids):
+        from types import SimpleNamespace
+
         model = MimoModel.__new__(MimoModel)
         model.special_token_ids = special_token_ids
+        # COLOCATED skips the fan-out DP assertion path; this fixture targets
+        # the metadata-tagging logic only.
+        model.role = SimpleNamespace(mode=ModuleLayout.COLOCATED)
         return model
 
     def test_attach_modality_split_sizes_tags_output_with_per_sample_counts(self):

--- a/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
+++ b/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
@@ -193,6 +193,45 @@ def get_transformer_block_and_grid(
     return block, grid
 
 
+class TestBridgeCommunicatorSplitMetadata:
+    """CPU-only checks for packed modality split metadata."""
+
+    @staticmethod
+    def _bridge():
+        bridge = BridgeCommunicator.__new__(BridgeCommunicator)
+        bridge.tensor_ndim = 2
+        bridge.dim_mapping = {'b': 0}
+        return bridge
+
+    def test_split_tensor_aggregates_per_sample_metadata_by_peer(self):
+        tensor = torch.arange(6).reshape(6, 1)
+        tensor._mimo_bridge_split_sizes = [0, 3, 1, 2]
+
+        splits = self._bridge()._split_tensor_at_batch_dim(tensor, num_splits=2)
+
+        assert [split.shape[0] for split in splits] == [3, 3]
+        torch.testing.assert_close(splits[0], tensor[:3])
+        torch.testing.assert_close(splits[1], tensor[3:])
+
+    def test_split_tensor_keeps_per_peer_metadata(self):
+        tensor = torch.arange(6).reshape(6, 1)
+        tensor._mimo_bridge_split_sizes = [1, 3, 2]
+
+        splits = self._bridge()._split_tensor_at_batch_dim(tensor, num_splits=3)
+
+        assert [split.shape[0] for split in splits] == [1, 3, 2]
+        torch.testing.assert_close(splits[0], tensor[:1])
+        torch.testing.assert_close(splits[1], tensor[1:4])
+        torch.testing.assert_close(splits[2], tensor[4:])
+
+    def test_split_tensor_rejects_non_divisible_sample_metadata(self):
+        tensor = torch.arange(6).reshape(6, 1)
+        tensor._mimo_bridge_split_sizes = [1, 2, 3]
+
+        with pytest.raises(ValueError, match="bridge split metadata has 3 entries"):
+            self._bridge()._split_tensor_at_batch_dim(tensor, num_splits=2)
+
+
 class TestBridgeCommunicator:
 
     @classmethod

--- a/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
+++ b/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
@@ -231,6 +231,43 @@ class TestBridgeCommunicatorSplitMetadata:
         with pytest.raises(ValueError, match="bridge split metadata has 3 entries"):
             self._bridge()._split_tensor_at_batch_dim(tensor, num_splits=2)
 
+    def test_split_tensor_rejects_metadata_sum_mismatch(self):
+        tensor = torch.arange(6).reshape(6, 1)
+        tensor._mimo_bridge_split_sizes = [2, 2]
+
+        with pytest.raises(ValueError, match="bridge split metadata sums to 4"):
+            self._bridge()._split_tensor_at_batch_dim(tensor, num_splits=2)
+
+    def test_split_tensor_short_circuits_metadata_for_single_split(self):
+        tensor = torch.arange(6).reshape(6, 1)
+        tensor._mimo_bridge_split_sizes = [1, 5]
+
+        splits = self._bridge()._split_tensor_at_batch_dim(tensor, num_splits=1)
+
+        assert len(splits) == 1
+        torch.testing.assert_close(splits[0], tensor)
+
+    def test_as_per_peer_tensors_broadcasts_single_tensor(self):
+        tensor = torch.zeros(2, 1)
+
+        peers = BridgeCommunicator._as_per_peer_tensors(tensor, expected_count=3)
+
+        assert len(peers) == 3
+        assert all(peer is tensor for peer in peers)
+
+    def test_as_per_peer_tensors_passes_through_list(self):
+        tensors = [torch.zeros(2, 1), torch.zeros(3, 1)]
+
+        peers = BridgeCommunicator._as_per_peer_tensors(tensors, expected_count=2)
+
+        assert peers == tensors
+
+    def test_as_per_peer_tensors_rejects_count_mismatch(self):
+        tensors = [torch.zeros(2, 1), torch.zeros(3, 1)]
+
+        with pytest.raises(ValueError, match="expected 3 tensors for shape communication, got 2"):
+            BridgeCommunicator._as_per_peer_tensors(tensors, expected_count=3)
+
 
 class TestBridgeCommunicator:
 


### PR DESCRIPTION
## Summary

Non-colocated bridge fan-out previously sent equal batch-dim slices to every peer. For VLM/AVLM data the per-sample modality-token counts vary, so the LLM received the wrong embeddings. Tag encoder outputs with per-sample split sizes and have the bridge honor them when fanning activations/gradients out.

  - `MimoModel._attach_modality_split_sizes` annotates flat encoder outputs with `_mimo_bridge_split_sizes` derived from  `special_token_ids`.
  - `MimoModel._empty_encoder_output` returns a `(0, hidden_size)` placeholder when a text-only sample reaches a non-colocated encoder rank; `_has_encoder_tokens` guards against silent loss of modality data.
  - `BridgeCommunicator._split_tensor_at_batch_dim` consumes `_mimo_bridge_split_sizes` (per-peer or per-sample) with sum/length checks.
  - `BridgeCommunicator._communicate_shapes` accepts a per-peer tensor list via the new `_as_per_peer_tensors` helper.
  - `schedules.backward_step_multimodule` unwraps single-element tensor lists so the per-peer paths feed back cleanly.

  ## Tests

  CPU-only unit tests added inside existing files:
  - `test_bridge_communicator.py::TestBridgeCommunicatorSplitMetadata` — `_split_tensor_at_batch_dim` sum-mismatch + `num_splits=1`short-circuit; `_as_per_peer_tensors` broadcast / pass-through / count-mismatch.
  - `test_mimo_model.py::TestMimoModelFanoutHelpers` — `_attach_modality_split_sizes` happy path + skip branches; `_has_encoder_tokens` presence/absence.