### PR TITLE
Use ModelOpt megatron_generate in post_training examples (fixes #3311 NVFP4 PP OOM)

### DIFF
--- a/examples/post_training/modelopt/generate.py
+++ b/examples/post_training/modelopt/generate.py
@@ -8,21 +8,20 @@ import warnings
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
 
+import modelopt.torch.quantization as mtq
 import torch
 from datasets import load_dataset
+from modelopt.torch.utils.plugins import megatron_generate
+from utils import get_hf_tokenizer
 
 from megatron.post_training.arguments import add_modelopt_args
 from megatron.post_training.checkpointing import load_modelopt_checkpoint
-from megatron.post_training.generate import simple_generate
 from megatron.post_training.model_builder import modelopt_gpt_hybrid_builder
 from megatron.post_training.utils import report_current_memory_info, to_empty_if_meta
 from megatron.training import get_args, get_model, initialize_megatron
 from megatron.training.arguments import parse_and_validate_args
-from utils import get_hf_tokenizer
 from megatron.training.utils import print_rank_0, unwrap_model
 from model_provider import model_provider
-
-import modelopt.torch.quantization as mtq
 
 warnings.filterwarnings('once')
 
@@ -160,7 +159,7 @@ if __name__ == "__main__":
                     new_conversations, return_tensors="pt", add_generation_prompt=True
                 )
                 with torch.no_grad():
-                    output_ids = simple_generate(
+                    output_ids = megatron_generate(
                         unwrapped_model, input_ids.cuda(), osl=args.osl, disable_tqdm=args.disable_tqdm
                     )
                 output_texts = tokenizer.batch_decode(output_ids)[0]

--- a/examples/post_training/modelopt/mmlu.py
+++ b/examples/post_training/modelopt/mmlu.py
@@ -2,28 +2,29 @@
 
 """Sample Generate GPT."""
 import functools
+import logging
 import os
 import sys
 import warnings
+
 import datasets
-import logging
 import torch.distributed as dist
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
 
+import modelopt.torch.quantization as mtq
 import torch
 from diskcache import Cache
+from modelopt.torch.utils.plugins import megatron_generate
+from utils import get_hf_tokenizer
 
 from megatron.post_training.arguments import add_modelopt_args
 from megatron.post_training.checkpointing import load_modelopt_checkpoint
-from megatron.post_training.generate import simple_generate
 from megatron.post_training.model_builder import modelopt_gpt_hybrid_builder
 from megatron.post_training.utils import report_current_memory_info
 from megatron.training import get_args, get_model, initialize_megatron
 from megatron.training.arguments import parse_and_validate_args
-from utils import get_hf_tokenizer
 from megatron.training.utils import print_rank_0, unwrap_model
-import modelopt.torch.quantization as mtq
 from model_provider import model_provider
 
 logger = logging.getLogger(__name__)
@@ -206,7 +207,7 @@ if __name__ == "__main__":
             else:
                 tokens = tokenizer(prompt, return_tensors="pt")
                 with torch.no_grad():
-                    generated_ids = simple_generate(
+                    generated_ids = megatron_generate(
                         unwrapped_model, tokens.input_ids.cuda(), osl=2, disable_tqdm=disable_tqdm
                     )
                 predict = tokenizer.batch_decode(generated_ids)[0].strip()

--- a/examples/post_training/modelopt/quantize.py
+++ b/examples/post_training/modelopt/quantize.py
@@ -35,18 +35,16 @@ except ImportError:
     mtq_luts = None
     warnings.warn("luts is not installed. LUTs quantization configs will not be available.")
 
+from modelopt.torch.utils.plugins import megatron_generate, megatron_prefill
+from utils import get_hf_tokenizer
+
 from megatron.core.utils import get_batch_on_this_cp_rank
 from megatron.post_training.arguments import add_modelopt_args
 from megatron.post_training.checkpointing import load_modelopt_checkpoint
-from megatron.post_training.generate import simple_generate
 from megatron.post_training.model_builder import modelopt_gpt_hybrid_builder
-from megatron.post_training.utils import (
-    print_distributed_quant_summary,
-    report_current_memory_info,
-)
+from megatron.post_training.utils import print_distributed_quant_summary, report_current_memory_info
 from megatron.training import get_args, get_model, initialize_megatron
 from megatron.training.arguments import parse_and_validate_args
-from utils import get_hf_tokenizer
 from megatron.training.checkpointing import save_checkpoint
 from megatron.training.utils import print_rank_0, unwrap_model
 from model_provider import model_provider
@@ -393,7 +391,7 @@ if __name__ == "__main__":
 
         for idx, prompt in tqdm(enumerate(all_prompts), disable=torch.distributed.get_rank()):
             tokens = tokenizer(prompt, return_tensors="pt")
-            generated_ids = simple_generate(model, tokens.input_ids.cuda(), osl=32)
+            generated_ids = megatron_generate(model, tokens.input_ids.cuda(), osl=32)
             generated_texts = tokenizer.batch_decode(generated_ids)
             print_rank_0("{}".format(generated_texts))
             if all_references[idx] is not None:
@@ -410,7 +408,7 @@ if __name__ == "__main__":
         )
         for sample in tqdm(dataloader, disable=torch.distributed.get_rank()):
             sample = get_batch_on_this_cp_rank(sample)
-            simple_generate(model, sample["input_ids"], osl=1, calibration_mode=True)
+            megatron_prefill(model, sample["input_ids"], skip_return_logits=True)
 
     unwrapped_model = unwrap_model(model)[0]
 
@@ -451,5 +449,9 @@ if __name__ == "__main__":
     torch.cuda.empty_cache()
 
     # Do this after saving in case it causes issues
+    # Run under inference_mode: otherwise autograd pins a dequantized BF16 copy of
+    # every fake-quantized weight (incl. all MoE experts) for a backward that never
+    # runs, ~doubling weight memory and OOMing at PP=2 (see NVIDIA/Megatron-LM#3311).
     if not args.skip_generate:
-        _custom_prompt_forward_loop_func(unwrapped_model)
+        with torch.inference_mode():
+            _custom_prompt_forward_loop_func(unwrapped_model)


### PR DESCRIPTION
### What
Replace `simple_generate` with ModelOpt's maintained `megatron_generate` (and `megatron_prefill` for the calibration forward) in the modelopt post-training examples: `quantize.py`, `mmlu.py`, `generate.py`. Run the post-quant generate under `torch.inference_mode()`.

### Why (fixes #3311)
NVFP4 PTQ of `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` OOMs at `TP=1 PP=2`. Root cause (measured on 2×H100 80 GB):

- Parameters shard correctly: **31.1 GB/rank at PP=2** (15.7 GB at PP=4). Not a parameter problem.
- Calibration, amax, and the **quantized checkpoint save all succeed** (~35 GB peak) — calibration is already `@torch.no_grad()`.
- The OOM is in the **post-save generate**, which ran with autograd live. The linear backward pins a dequantized BF16 copy of every fake-quantized weight; with `SequentialMLP` over 128 experts × ~11 MoE layers/rank that's ~28 GB of pinned copies on top of the ~33 GB base → >79 GB.

### Result
| PP=2 full run | peak/rank | outcome |
|---|---|---|
| before | OOM (>79 GB) | dies in `fp4_fake_quant_block` |
| after | **~35 GB** | quantize + save + generate + MMLU all pass |

Validated end-to-end on 2×H100 80 GB: full quantize + `megatron_generate` + MMLU (passes the accuracy lower-bound) complete with exit 0.

### Notes
- `prune.py` left on `simple_generate` for now (separate script; can follow up).
- `megatron/post_training/generate.py::simple_generate` is kept — megatron core must not import `modelopt`.
- `megatron_generate` auto-disables KV-cache under `--sequence-parallel`.