### PR TITLE
ci(test): isolate ckpt-resume tensorboard per phase

### DIFF
--- a/tests/functional_tests/python_test_utils/get_test_results_from_tensorboard_logs.py
+++ b/tests/functional_tests/python_test_utils/get_test_results_from_tensorboard_logs.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import os
 
 os.environ["OPENBLAS_NUM_THREADS"] = "1"

--- a/tests/functional_tests/python_test_utils/get_test_results_from_tensorboard_logs.py
+++ b/tests/functional_tests/python_test_utils/get_test_results_from_tensorboard_logs.py
@@ -22,27 +22,13 @@ logger = logging.getLogger(__name__)
     help="Use first or all tensorboard logs",
     default=False,
 )
-@click.option(
-    "--is-second-run/--is-not-second-run",
-    type=bool,
-    help="Use second run of tensorboard logs",
-    default=False,
-)
 @click.option("--step-size", required=False, default=5, type=int, help="Step size of sampling")
 def collect_train_test_metrics(
-    logs_dir: str,
-    train_iters: str,
-    output_path: str,
-    is_convergence_test: bool,
-    is_second_run: bool,
-    step_size: int,
+    logs_dir: str, train_iters: str, output_path: str, is_convergence_test: bool, step_size: int
 ):
-    if is_convergence_test and is_second_run:
-        raise ValueError("Convergence test cannot be run on second run of tensorboard logs")
-
     summaries = common.read_tb_logs_as_list(
         logs_dir,
-        index=(-1 if is_convergence_test else (1 if is_second_run else 0)),
+        index=(-1 if is_convergence_test else 0),
         train_iters=train_iters,
         start_idx=1,
         step_size=step_size,

--- a/tests/functional_tests/shell_test_utils/run_ci_test.sh
+++ b/tests/functional_tests/shell_test_utils/run_ci_test.sh
@@ -226,6 +226,11 @@ for i in $(seq 1 $N_REPEAT); do
     FILE=$(basename "$_TENSORBOARD_PATH")
     export TENSORBOARD_PATH=$DIR/$i/$FILE
     mkdir -p $(dirname $TENSORBOARD_PATH)
+    # Per-repeat base; for ckpt-resume / frozen-resume tests each training
+    # phase writes to its own ${_REPEAT_TENSORBOARD_PATH}/run_N subdir so the
+    # analyzer can read by explicit path rather than guessing phase from
+    # mtime-sorted glob order.
+    _REPEAT_TENSORBOARD_PATH=$TENSORBOARD_PATH
     export REPEAT=$i
 
     wait_for_all_nodes "repeat_${REPEAT}_start"
@@ -294,6 +299,10 @@ for i in $(seq 1 $N_REPEAT); do
         done
     else
         # The standard single-run test that otherwise runs
+        if [[ "$TEST_TYPE" == "ckpt-resume" || "$TEST_TYPE" == "frozen-resume" ]]; then
+            export TENSORBOARD_PATH="$_REPEAT_TENSORBOARD_PATH/run_${RUN_NUMBER}"
+            mkdir -p "$TENSORBOARD_PATH"
+        fi
         run_training_phase "repeat_${REPEAT}_run_${RUN_NUMBER}"
     fi
 
@@ -316,6 +325,8 @@ for i in $(seq 1 $N_REPEAT); do
         echo $((TRAIN_ITERS / 2)) >$CHECKPOINT_LOAD_PATH/latest_checkpointed_iteration.txt
 
         export RUN_NUMBER=2
+        export TENSORBOARD_PATH="$_REPEAT_TENSORBOARD_PATH/run_${RUN_NUMBER}"
+        mkdir -p "$TENSORBOARD_PATH"
         run_training_phase "repeat_${REPEAT}_run_${RUN_NUMBER}"
     fi
 
@@ -326,6 +337,8 @@ for i in $(seq 1 $N_REPEAT); do
         export CHECKPOINT_SAVE_PATH=/tmp/checkpoints/
 
         export RUN_NUMBER=2
+        export TENSORBOARD_PATH="$_REPEAT_TENSORBOARD_PATH/run_${RUN_NUMBER}"
+        mkdir -p "$TENSORBOARD_PATH"
         run_training_phase "repeat_${REPEAT}_run_${RUN_NUMBER}"
 
         export CHECKPOINT_SAVE_PATH=$_CHECKPOINT_SAVE_PATH
@@ -371,8 +384,13 @@ for i in $(seq 1 $N_REPEAT); do
         # Read test values from Tensorboard for non-inference tests.
         # Inference tests will load from JSON instead.
         if [[ "$MODE" == "pretraining" ]]; then
+            if [[ "$TEST_TYPE" == "ckpt-resume" || "$TEST_TYPE" == "frozen-resume" ]]; then
+                FIRST_RUN_TENSORBOARD_PATH="$_REPEAT_TENSORBOARD_PATH/run_1"
+            else
+                FIRST_RUN_TENSORBOARD_PATH="$TENSORBOARD_PATH"
+            fi
             uv run --no-sync python $ROOT_DIR/tests/functional_tests/python_test_utils/get_test_results_from_tensorboard_logs.py \
-                --logs-dir $TENSORBOARD_PATH \
+                --logs-dir $FIRST_RUN_TENSORBOARD_PATH \
                 --train-iters $TRAIN_ITERS \
                 --output-path ${OUTPUT_PATH}/$(basename $GOLDEN_VALUES_PATH) \
                 "${EXTRACT_ARGS[@]}"
@@ -424,10 +442,9 @@ for i in $(seq 1 $N_REPEAT); do
 
                 if [[ "$TEST_TYPE" == "ckpt-resume" || "$TEST_TYPE" == "frozen-resume" ]]; then
                     uv run --no-sync python $ROOT_DIR/tests/functional_tests/python_test_utils/get_test_results_from_tensorboard_logs.py \
-                        --logs-dir $TENSORBOARD_PATH \
+                        --logs-dir "$_REPEAT_TENSORBOARD_PATH/run_2" \
                         --train-iters $TRAIN_ITERS \
                         --output-path "${OUTPUT_PATH}/$(basename $GOLDEN_VALUES_PATH .json)_2nd.json" \
-                        --is-second-run \
                         "${EXTRACT_ARGS[@]}"
                             
                     echo "Running pytest 1st vs 2nd run comparison"


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

`ckpt-resume` and `frozen-resume` functional tests previously wrote tensorboard events from **both** training phases into the same `$TENSORBOARD_PATH` directory and relied on `files[1]` (mtime-sorted glob `index=1`) to identify the resume run's data. That assumption is racy:

- if only one events file lands in the dir → `IndexError` (the failure mode in #4903),
- if the indexed file happens to have no scalar events flushed yet, or is some unrelated extra file → `read_tb_logs_as_list` returns `{}`, the `_2nd.json` file is written as `{}`, and the resume pytest fails in fixture setup with a pydantic `ValidationError: input_value=PydanticUndefined` out of `read_golden_values_from_json` at `tests/functional_tests/python_test_utils/common.py:168` — the latest h100 incarnation observed on the `gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_multi_dist_optimizer_instances` test case (same test enumerated in #4903).

This PR removes the glob-ordering dependency by giving each phase its own directory.

## How

`run_ci_test.sh`

- Snapshot the per-repeat tensorboard base into `_REPEAT_TENSORBOARD_PATH`.
- For `ckpt-resume` / `frozen-resume`, before each training phase set:
  ```sh
  export TENSORBOARD_PATH="$_REPEAT_TENSORBOARD_PATH/run_${RUN_NUMBER}"
  mkdir -p "$TENSORBOARD_PATH"
  ```
  Training picks up the new path via the existing `--tensorboard-dir: ${TENSORBOARD_PATH}` in the recipe YAML.
- First-run analyzer now points at `${_REPEAT_TENSORBOARD_PATH}/run_1` for resume tests (unchanged for everything else).
- Second-run analyzer points at `${_REPEAT_TENSORBOARD_PATH}/run_2` and no longer passes `--is-second-run`.

`get_test_results_from_tensorboard_logs.py`

- The `--is-second-run` flag and the `index=1` branch it controlled are removed. The single caller now passes an explicit per-phase `--logs-dir`, so the script always reads `files[0]`.

## Layout, before / after

```text
# before (both phases collide; resume analyzer guesses via mtime sort)
$TENSORBOARD_PATH/
  events.out.tfevents.<ts1>.<host>.<pid1>    ← run 1
  events.out.tfevents.<ts2>.<host>.<pid2>    ← run 2 (analyzer: files[1])

# after (per-phase isolation; analyzer reads explicit subdir)
$TENSORBOARD_PATH/
  run_1/events.out.tfevents.<...>
  run_2/events.out.tfevents.<...>
```

## Scope

- Behavior unchanged for `frozen-start`, `release`, `checkpoint-consistency`, inference, and RL modes — they don't write to per-run subdirs.
- No change to golden values; same scalars, same metric filter list.

## Related

- Same failure family as the closed #4903 (gb200 `IndexError` variant). The multi-node sync fix in #4924 didn't address single-node h100 because the underlying cause is the analyzer's index-into-sorted-glob, not multi-node phase ordering.
</details>
