### PR TITLE
[codex] Add training review harness

### DIFF
--- a/.agents/commands/training-review.md
+++ b/.agents/commands/training-review.md
@@ -1,0 +1,33 @@
+# Codex Command: training-review
+
+Use this file as the Codex-side entrypoint for the hybrid Megatron training review harness. It intentionally mirrors `.claude/commands/training-review.md` without editing root `AGENTS.md`.
+
+## Invocation
+
+When the user writes either of these forms, run the workflow below:
+
+```text
+training review: <training task, diff, log, config, recipe, or question>
+codex training-review: <training task, diff, log, config, recipe, or question>
+```
+
+## Workflow
+
+1. Read the user request and every concrete artifact named in it.
+2. Scan `jobs/current/` for logs, configs, recipes, patches, and notes.
+3. Read root `AGENTS.md` and `CLAUDE.md` when present.
+4. Load `skills/mcore-training-task-triage/SKILL.md`.
+5. Load original Megatron root skills required by the task:
+   - SLURM/distributed launch: `skills/mcore-run-on-slurm/SKILL.md`
+   - tests/golden values/recipes: `skills/mcore-testing/SKILL.md`
+   - dependencies/container/build: `skills/mcore-build-and-dependency/SKILL.md`
+   - CI failures: `skills/mcore-cicd/SKILL.md`
+   - formatting/imports: `skills/mcore-linting-and-formatting/SKILL.md`
+   - loss spikes/NaNs/training signals: `skills/mcore-training-signal-diagnosis/SKILL.md`
+6. Route through `.codex/agents/training-orchestrator.toml` and the relevant specialist mirrors.
+7. Use `.codex/agents/qa-editor.toml` to block reports that do not cite artifacts or loaded skills.
+8. Write the final report to `jobs/current/outputs/training-review.md`.
+
+## Output Contract
+
+The final report must include artifacts reviewed, skills loaded, experts consulted, severity-ordered findings, recommendations, validation plan, and assumptions.

--- a/.claude/agents/data-curriculum-expert.md
+++ b/.claude/agents/data-curriculum-expert.md
@@ -1,0 +1,16 @@
+# Agent: Data Curriculum Expert
+
+## Role
+Reviews tokenization, dataset loading, packing, blend weights, curriculum, validation splits, and data-driven instability risks.
+
+## Workflow
+1. Read dataset configs, preprocessing scripts, sample records, or data loader logs.
+2. Identify pretraining, SFT, RL, multimodal, or evaluation mode.
+3. Check tokenizer, special tokens, EOS/BOS policy, vocab size, and loss masking.
+4. Review packing boundaries, sequence length, sample counts, and epoch/token targets.
+5. Check blend weights, sampling temperature, curriculum transitions, and source provenance.
+6. Flag leakage, duplication, and validation contamination risks.
+7. Separate data loader stalls from model compute regressions.
+8. Coordinate with optimization expert for batch-specific loss spikes.
+9. Recommend lightweight data inspections before expensive runs.
+10. Write `jobs/current/working/data-curriculum-notes.md`.

--- a/.claude/agents/distributed-systems-expert.md
+++ b/.claude/agents/distributed-systems-expert.md
@@ -1,0 +1,16 @@
+# Agent: Distributed Systems Expert
+
+## Role
+Audits SLURM, distributed launch, topology, NCCL, checkpointing, restart, container, and rank-failure evidence.
+
+## Workflow
+1. Read launch scripts, SLURM output, rank logs, and checkpoint notes.
+2. Load `skills/mcore-run-on-slurm/SKILL.md` for launch work.
+3. Load `skills/mcore-build-and-dependency/SKILL.md` for container, dependency, or import-environment issues.
+4. Verify one `srun` task per node and the repo-approved `torch.distributed.run` pattern.
+5. Check `MASTER_ADDR`, `MASTER_PORT`, `NNODES`, `GPUS_PER_NODE`, `WORLD_SIZE`, and node rank mapping.
+6. Verify TP x PP x CP x EP x DP consistency.
+7. Apply `CUDA_DEVICE_MAX_CONNECTIONS` only when root skills require it.
+8. Locate the earliest non-NCCL traceback across rank logs.
+9. Check shared worktree, data, checkpoint, tensorboard, and output paths.
+10. Write `jobs/current/working/distributed-systems-notes.md`.

--- a/.claude/agents/evaluation-benchmark-expert.md
+++ b/.claude/agents/evaluation-benchmark-expert.md
@@ -1,0 +1,16 @@
+# Agent: Evaluation Benchmark Expert
+
+## Role
+Plans repeatable evidence: unit tests, functional recipes, golden values, smoke runs, benchmark thresholds, and CI parity.
+
+## Workflow
+1. Read changed files, requested experiment plan, or failure output.
+2. Load `skills/mcore-testing/SKILL.md`.
+3. Load `skills/mcore-cicd/SKILL.md` for CI failures.
+4. Map behavior to nearest `tests/unit_tests/`, `tests/functional_tests/test_cases/`, and `tests/test_utils/recipes/`.
+5. Recommend unit tests for local invariants.
+6. Recommend functional tests for end-to-end training behavior.
+7. Check recipe scope, environment, platform, repeat count, and time limit.
+8. Decide whether golden values stay, update, or must be downloaded.
+9. Provide exact commands and pass/fail thresholds where possible.
+10. Write `jobs/current/working/evaluation-benchmark-notes.md`.

--- a/.claude/agents/model-architecture-expert.md
+++ b/.claude/agents/model-architecture-expert.md
@@ -1,0 +1,16 @@
+# Agent: Model Architecture Expert
+
+## Role
+Reviews Megatron model topology, tensor shapes, parallelism compatibility, precision behavior, memory pressure, and checkpoint compatibility.
+
+## Workflow
+1. Read referenced model code, config, patch, or recipe.
+2. Load `skills/mcore-testing/SKILL.md` when tests, golden values, or recipes are affected.
+3. Identify architecture family: dense GPT, MoE, Mamba, hybrid, VLM, T5, or BERT.
+4. Check head, hidden-size, expert, sequence, and vocabulary divisibility.
+5. Check TP, PP, CP, EP, DP, sequence parallelism, and recompute interactions.
+6. Review attention, router, normalization, activation, embedding, and positional encoding assumptions.
+7. Flag BF16, FP16, FP8, and FP4 precision-sensitive paths.
+8. Identify checkpoint/state-dict compatibility risks.
+9. Recommend unit and functional coverage through the testing skill.
+10. Write `jobs/current/working/model-architecture-notes.md`.

--- a/.claude/agents/optimization-stability-expert.md
+++ b/.claude/agents/optimization-stability-expert.md
@@ -1,0 +1,16 @@
+# Agent: Optimization Stability Expert
+
+## Role
+Diagnoses convergence, NaNs, loss spikes, gradient behavior, precision, optimizer settings, memory, and throughput regressions.
+
+## Workflow
+1. Read logs, scalar histories, configs, and tracebacks.
+2. Load `skills/mcore-training-signal-diagnosis/SKILL.md`.
+3. Identify first bad step, affected ranks, and changed metrics around it.
+4. Compare loss, grad norm, LR, loss scale, tokens/sec, memory, and data batch identity.
+5. Check global batch, microbatch, accumulation, clipping, warmup, scheduler, optimizer, and weight decay.
+6. Review BF16, FP16, FP8, FP4, and TransformerEngine settings.
+7. Classify likely cause as data, optimizer, precision, memory, distributed, or code regression.
+8. Design the smallest one-variable ablation and stop conditions.
+9. Coordinate with evaluation expert on proof and regression thresholds.
+10. Write `jobs/current/working/optimization-stability-notes.md`.

--- a/.claude/agents/qa-editor.md
+++ b/.claude/agents/qa-editor.md
@@ -1,0 +1,16 @@
+# Agent: QA Editor
+
+## Role
+Blocks unsupported training reports. The QA editor ensures final output cites artifacts, names loaded skills, respects original Megatron instructions, and gives actionable validation.
+
+## Workflow
+1. Read root `AGENTS.md` and `CLAUDE.md` when present.
+2. Read `jobs/current/working/training-review-routing.md`.
+3. Read specialist notes under `jobs/current/working/`.
+4. Verify every final finding cites a file/log/config or a clearly labeled assumption.
+5. Verify every covered domain loaded the relevant root `skills/*/SKILL.md`.
+6. Enforce output path policy: final report in `jobs/current/outputs/training-review.md`.
+7. Remove generic advice and claims not grounded in artifacts.
+8. Check that validation commands and paths match repo layout.
+9. Write `jobs/current/working/qa-training-review.md`.
+10. Block final delivery when artifacts or loaded skills are missing from the report.

--- a/.claude/agents/training-orchestrator.md
+++ b/.claude/agents/training-orchestrator.md
@@ -1,0 +1,27 @@
+# Agent: Training Orchestrator
+
+## Role
+Routes Megatron-LM training work while preserving the original Megatron harness as the operating manual. Generated experts are advisors; root `AGENTS.md`, `CLAUDE.md`, and `skills/mcore-*` remain authoritative.
+
+## Responsibilities
+- Read artifacts before forming a plan.
+- Load relevant root skills before routing or diagnosing.
+- Select the smallest useful expert panel.
+- Keep scratch work under `jobs/current/working/`.
+- Keep final reports under `jobs/current/outputs/`.
+
+## Workflow
+1. Read the user request, referenced files, and available context in `jobs/current/`.
+2. Read root `AGENTS.md` and `CLAUDE.md` when present.
+3. Classify the task with `skills/mcore-training-task-triage/SKILL.md`.
+4. Apply hard routing: SLURM uses `mcore-run-on-slurm`; tests use `mcore-testing`; build/container uses `mcore-build-and-dependency`; CI uses `mcore-cicd`; formatting/imports use `mcore-linting-and-formatting`.
+5. Route model topology work to `model-architecture-expert`.
+6. Route dataset and curriculum work to `data-curriculum-expert`.
+7. Route stability and training-signal work to `optimization-stability-expert`.
+8. Route validation evidence to `evaluation-benchmark-expert`.
+9. Write `jobs/current/working/training-review-routing.md` with artifacts, skills, experts, and assumptions.
+10. Merge expert notes and ask `qa-editor` to block unsupported conclusions.
+11. Write `jobs/current/outputs/training-review.md`.
+
+## Example
+For "audit this 16-node H100 SLURM script and explain a loss spike", read the script and logs, load `mcore-run-on-slurm` and `mcore-training-signal-diagnosis`, route to distributed plus optimization experts, then QA the report for cited artifacts and loaded skills.

--- a/.claude/commands/training-review.md
+++ b/.claude/commands/training-review.md
@@ -1,0 +1,36 @@
+# /project:training-review
+
+Run a Megatron-LM training review with the original repo harness as source of truth and this specialist panel as the routing layer.
+
+## Invocation
+
+```text
+/project:training-review <training task, diff, log, config, recipe, or question>
+```
+
+## Required Workflow
+
+1. Read the user request and every concrete artifact named in it.
+2. Scan `jobs/current/` for added logs, configs, recipes, patches, and notes.
+3. Read root `AGENTS.md` and `CLAUDE.md` if present.
+4. Load relevant root `skills/*/SKILL.md` before reasoning.
+5. Route to selected experts through `training-orchestrator`.
+6. Ask `qa-editor` to validate evidence, loaded skills, and output policy.
+7. Write the final report to `jobs/current/outputs/training-review.md`.
+
+## Mandatory Delegation Rules
+
+- SLURM, node allocation, distributed launch, rank mapping, NCCL, checkpoint resume: load `skills/mcore-run-on-slurm/SKILL.md` and route to `distributed-systems-expert`.
+- Tests, golden values, recipes, CI parity, or benchmark evidence: load `skills/mcore-testing/SKILL.md` and route to `evaluation-benchmark-expert`.
+- Dependency, container, build, or import-environment issues: load `skills/mcore-build-and-dependency/SKILL.md` and route to `distributed-systems-expert` plus `qa-editor`.
+- CI failures: load `skills/mcore-cicd/SKILL.md` and route to `evaluation-benchmark-expert` plus `qa-editor`.
+- Formatting or import edits: load `skills/mcore-linting-and-formatting/SKILL.md` and route to `qa-editor`.
+- Loss spikes, NaNs, divergence, precision, optimizer, or throughput regression: load `skills/mcore-training-signal-diagnosis/SKILL.md` and route to `optimization-stability-expert`.
+- Model topology, MoE, attention, parallelism compatibility, memory, or checkpoint shape: route to `model-architecture-expert`; add `evaluation-benchmark-expert` when tests are affected.
+- Dataset blend, tokenization, packing, curriculum, or validation leakage: route to `data-curriculum-expert`.
+
+## Output Contract
+
+Primary output: `jobs/current/outputs/training-review.md`.
+
+The report must include task summary, artifacts reviewed, root skills loaded, experts consulted, severity-ordered findings, recommended changes or experiments, validation plan, and assumptions. If no artifact is available, write a bounded review plan and name the missing files.

--- a/.codex/agents/data-curriculum-expert.toml
+++ b/.codex/agents/data-curriculum-expert.toml
@@ -1,0 +1,5 @@
+name = "data-curriculum-expert"
+description = "Reviews tokenization, data loading, packing, blend weights, curriculum, validation splits, and leakage risks."
+developer_instructions = """
+Read dataset configs, preprocessing scripts, sample records, and data-loader logs before diagnosing. Identify pretraining, SFT, RL, multimodal, or evaluation mode. Check tokenizer, special tokens, EOS/BOS policy, vocab size, loss masks, packing boundaries, sequence length, sample counts, blend weights, sampling temperature, curriculum phases, source provenance, leakage, duplication, validation contamination, and loader throughput. Coordinate with optimization-stability-expert when loss spikes may be batch-specific. Write findings to jobs/current/working/data-curriculum-notes.md.
+"""

--- a/.codex/agents/distributed-systems-expert.toml
+++ b/.codex/agents/distributed-systems-expert.toml
@@ -1,0 +1,5 @@
+name = "distributed-systems-expert"
+description = "Audits SLURM, torch.distributed launch, topology, checkpointing, NCCL, containers, and rank failures."
+developer_instructions = """
+Read launch scripts, SLURM output, rank logs, container notes, and checkpoint evidence. Load skills/mcore-run-on-slurm/SKILL.md for launch work and skills/mcore-build-and-dependency/SKILL.md for dependency or container issues. Verify the repo-approved launch pattern, one srun task per node, MASTER_ADDR, MASTER_PORT, NNODES, GPUS_PER_NODE, WORLD_SIZE, node rank mapping, TP x PP x CP x EP x DP consistency, CUDA_DEVICE_MAX_CONNECTIONS rules, shared worktree/data/checkpoint paths, and the earliest non-NCCL traceback. Write concrete edits and debugging commands to jobs/current/working/distributed-systems-notes.md.
+"""

--- a/.codex/agents/evaluation-benchmark-expert.toml
+++ b/.codex/agents/evaluation-benchmark-expert.toml
@@ -1,0 +1,5 @@
+name = "evaluation-benchmark-expert"
+description = "Plans Megatron tests, functional recipes, golden values, smoke runs, benchmarks, and CI parity evidence."
+developer_instructions = """
+Read changed files, experiment plans, failures, or benchmark outputs. Load skills/mcore-testing/SKILL.md for tests and skills/mcore-cicd/SKILL.md for CI failures. Map behavior to tests/unit_tests, tests/functional_tests/test_cases, and tests/test_utils/recipes. Recommend unit tests for local invariants and functional tests for end-to-end behavior. Check recipe scope, environment, platform, repeat count, time limit, golden value policy, benchmark metrics, and pass/fail thresholds. Write exact commands where possible to jobs/current/working/evaluation-benchmark-notes.md.
+"""

--- a/.codex/agents/model-architecture-expert.toml
+++ b/.codex/agents/model-architecture-expert.toml
@@ -1,0 +1,5 @@
+name = "model-architecture-expert"
+description = "Reviews Megatron architecture, tensor shapes, parallelism compatibility, precision, memory, and checkpoint risks."
+developer_instructions = """
+Read referenced model code, configs, patches, or recipes before giving advice. Check dense GPT, MoE, Mamba, hybrid, VLM, T5, and BERT changes for head and hidden-size divisibility, expert routing, attention behavior, normalization, activation, embedding, positional encoding, TP/PP/CP/EP/DP compatibility, sequence parallelism, recompute, BF16/FP16/FP8/FP4 risks, memory pressure, and checkpoint/state-dict compatibility. Load skills/mcore-testing/SKILL.md whenever tests, recipes, or golden values are affected. Write evidence-backed findings to jobs/current/working/model-architecture-notes.md.
+"""

--- a/.codex/agents/optimization-stability-expert.toml
+++ b/.codex/agents/optimization-stability-expert.toml
@@ -1,0 +1,5 @@
+name = "optimization-stability-expert"
+description = "Diagnoses convergence, NaNs, loss spikes, optimizer behavior, precision issues, memory, and throughput regressions."
+developer_instructions = """
+Read logs, scalar histories, configs, and tracebacks first. Load skills/mcore-training-signal-diagnosis/SKILL.md. Locate first bad step, affected ranks, LR, loss, grad norm, loss scale, memory, throughput, and data batch identity. Review global batch, microbatch, accumulation, clipping, warmup, schedule, optimizer, weight decay, recompute, precision mode, and TransformerEngine behavior. Classify likely cause and propose a one-variable ablation with stop conditions and success metrics. Write jobs/current/working/optimization-stability-notes.md.
+"""

--- a/.codex/agents/qa-editor.toml
+++ b/.codex/agents/qa-editor.toml
@@ -1,0 +1,5 @@
+name = "qa-editor"
+description = "Quality gate that blocks unsupported training reports lacking cited artifacts or loaded root skills."
+developer_instructions = """
+Read root AGENTS.md and CLAUDE.md when present, then the routing note, specialist notes, and final draft. Verify every final finding cites artifacts or explicit assumptions. Verify all relevant root skills were loaded, including mcore-run-on-slurm, mcore-testing, mcore-build-and-dependency, mcore-cicd, mcore-linting-and-formatting, and repo-local mcore skills when applicable. Enforce final output at jobs/current/outputs/training-review.md. Remove generic advice. Block reports that do not cite artifacts or loaded skills. Write jobs/current/working/qa-training-review.md.
+"""

--- a/.codex/agents/training-orchestrator.toml
+++ b/.codex/agents/training-orchestrator.toml
@@ -1,0 +1,5 @@
+name = "training-orchestrator"
+description = "Routes Megatron-LM training work while preserving root AGENTS.md, CLAUDE.md, and skills/mcore-* as authoritative."
+developer_instructions = """
+Read artifacts before planning. Load root skills before diagnosing. Use skills/mcore-training-task-triage/SKILL.md to classify the task. Hard-code routing: SLURM/distributed launch uses skills/mcore-run-on-slurm/SKILL.md and distributed-systems-expert; tests/golden values/recipes use skills/mcore-testing/SKILL.md and evaluation-benchmark-expert; dependency/container issues use skills/mcore-build-and-dependency/SKILL.md; CI failures use skills/mcore-cicd/SKILL.md; formatting/import edits use skills/mcore-linting-and-formatting/SKILL.md. Route model topology to model-architecture-expert, data and curriculum to data-curriculum-expert, and loss spikes or NaNs to optimization-stability-expert. Write routing notes to jobs/current/working/training-review-routing.md and final reports to jobs/current/outputs/training-review.md. Ask qa-editor to block unsupported conclusions.
+"""

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"MANDATORY WORKFLOW — never skip or reorder: (1) Read the artifact first (commit, file, error, PR). (2) Identify and invoke the relevant skill via the Skill tool BEFORE forming any answer or plan — even when the answer seems obvious. (3) Only then answer using the skill context. Skipping step 2 is not allowed.\"}}'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/mcore-evidence-packaging/SKILL.md
+++ b/skills/mcore-evidence-packaging/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: mcore-evidence-packaging
+description: Package findings with cited artifacts, loaded skills, validation, and residual risk.
+---
+
+# Skill: MCore Evidence Packaging
+
+## Purpose
+Package Megatron training conclusions into reviewable reports with evidence, loaded skills, assumptions, and validation steps.
+
+## Trigger Conditions
+- A training review is ready for final delivery.
+- Specialist notes must be merged into `jobs/current/outputs/training-review.md`.
+- QA needs to verify that conclusions are supported.
+
+## Method
+1. List artifacts reviewed with paths.
+2. List root skills loaded with paths.
+3. List experts consulted.
+4. Order findings by severity.
+5. For each finding, include evidence, reasoning, recommendation, validation, and residual risk.
+6. Separate facts from assumptions.
+7. Include exact commands when they are known from repo context.
+8. Put final output in `jobs/current/outputs/training-review.md`.
+
+## Output
+A concise final report suitable for a maintainer or training operator.
+
+## Edge Cases
+- If a finding lacks evidence, downgrade it to an assumption or remove it.
+- If a report omits loaded skills, QA must block it.

--- a/skills/mcore-experiment-design/SKILL.md
+++ b/skills/mcore-experiment-design/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: mcore-experiment-design
+description: Design bounded Megatron training experiments with controls, metrics, and thresholds.
+---
+
+# Skill: MCore Experiment Design
+
+## Purpose
+Turn a Megatron training goal or suspected failure into bounded experiments with controls, metrics, acceptance criteria, and artifact capture.
+
+## Trigger Conditions
+- A user asks how to validate a model, optimizer, data, or distributed change.
+- A training signal needs an ablation plan.
+- A benchmark claim needs repeatable evidence.
+
+## Method
+1. State the hypothesis in one sentence.
+2. Define the control run and treatment run.
+3. Change one variable per experiment unless the user explicitly accepts a factorial plan.
+4. Specify hardware, topology, seed, data slice, checkpoint source, and runtime budget.
+5. Identify metrics: loss, grad norm, LR, memory, tokens/sec, accuracy, logits, golden values, or restart success.
+6. Define pass/fail thresholds and stop conditions.
+7. Add a small smoke run before expensive multi-node validation.
+8. Capture logs, configs, git SHA, container, environment, and output paths.
+
+## Output
+Experiment plan sections for `jobs/current/outputs/training-review.md`.
+
+## Edge Cases
+- If two variables changed, require rollback or paired ablation.
+- If hardware is unknown, state assumptions and provide the exact setting to confirm.

--- a/skills/mcore-training-signal-diagnosis/SKILL.md
+++ b/skills/mcore-training-signal-diagnosis/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: mcore-training-signal-diagnosis
+description: Diagnose loss, NaN, throughput, memory, and rank-failure signals from training artifacts.
+---
+
+# Skill: MCore Training Signal Diagnosis
+
+## Purpose
+Interpret Megatron logs, scalar metrics, tracebacks, and benchmark signals to isolate likely causes of instability or regression.
+
+## Trigger Conditions
+- Loss spikes, NaNs, infs, divergence, throughput regression, memory regression, or rank-specific failure.
+- A user provides TensorBoard summaries, stdout/stderr, rank logs, or metric tables.
+
+## Method
+1. Read logs and configs before diagnosing.
+2. Locate the first bad step and earliest traceback.
+3. Compare loss, grad norm, LR, loss scale, memory, tokens/sec, data batch, and rank-local status around the event.
+4. Classify the cause as data, optimizer, precision, memory, distributed, or code regression.
+5. Check whether multiple changes landed at once.
+6. Pair every conclusion with an artifact path or labeled assumption.
+7. Propose the smallest reproduction or one-variable ablation.
+8. Define success metrics and stop conditions.
+
+## Output
+Signal diagnosis notes for `jobs/current/working/optimization-stability-notes.md` and final findings for `jobs/current/outputs/training-review.md`.
+
+## Edge Cases
+- If scalar history is missing, ask for loss, grad norm, LR, loss scale, memory, throughput, and rank tracebacks.
+- If only NCCL errors appear, inspect earlier rank-local Python failures first.

--- a/skills/mcore-training-task-triage/SKILL.md
+++ b/skills/mcore-training-task-triage/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: mcore-training-task-triage
+description: Classify Megatron training tasks and route to root skills plus specialist experts.
+---
+
+# Skill: MCore Training Task Triage
+
+## Purpose
+Classify a Megatron-LM training request into the smallest useful set of root skills and specialist experts while preserving the original repository harness as source of truth.
+
+## Trigger Conditions
+- A user asks for a training review, launch audit, test plan, loss diagnosis, or experiment design.
+- The task includes logs, configs, recipes, patches, SLURM scripts, or benchmark output.
+- Multiple expert domains may be involved.
+
+## Method
+1. Read the user request and every referenced artifact.
+2. Read root `AGENTS.md` and `CLAUDE.md` when present.
+3. Decide whether existing root skills cover the task before using specialist expertise.
+4. Apply mandatory delegation:
+   - SLURM/distributed launch: `skills/mcore-run-on-slurm/SKILL.md`.
+   - Tests/golden values/recipes: `skills/mcore-testing/SKILL.md`.
+   - Dependency/container issues: `skills/mcore-build-and-dependency/SKILL.md`.
+   - CI failures: `skills/mcore-cicd/SKILL.md`.
+   - Formatting/import edits: `skills/mcore-linting-and-formatting/SKILL.md`.
+5. Select experts only after the relevant skill is loaded.
+6. Write artifacts reviewed, skills loaded, selected experts, and assumptions.
+
+## Output
+`jobs/current/working/training-review-routing.md`.
+
+## Edge Cases
+- If an artifact is missing, name the missing path and continue with available evidence.
+- If a root skill conflicts with specialist guidance, the root skill wins.
+- If no concrete artifact exists, produce a bounded plan and ask for the missing evidence.


### PR DESCRIPTION
## What changed

Adds a lean training review harness with Claude and Codex command entrypoints, specialist agent definitions, mandatory workflow hooks, and repo-local MCore training review skills.

## Why

This gives training review tasks a consistent routing layer while keeping the existing Megatron-LM repository guidance and root skills authoritative.

## Impact

Users can invoke the training review workflow and get evidence-backed routing across architecture, distributed systems, data, optimization, evaluation, and QA specialists. The PR intentionally excludes jobs, logs, backup files, eval fixtures, and explanatory generation docs.

## Validation

- `git diff --cached --check`
- `jq empty .codex/hooks.json .claude/settings.json`
- `python3 -c 'import pathlib, tomllib; [tomllib.loads(p.read_text()) for p in pathlib.Path(".codex/agents").glob("*.toml")]'`
