### PR TITLE
Fix bugs in re-sharding `DistributedOptimizer` state in `torch_dist` checkpoint

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1709,10 +1709,21 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 # Note: for NVFP4, param_index_map uses unpacked (full numel)
                 # offsets, which is correct here since optimizer states
                 # (fp32_param, exp_avg, exp_avg_sq) are in unpacked space.
+
+                # Compute cumulative bucket-end padding stripped before each bucket.
+                # world_tensors has bucket-end padding stripped, but param_index_map
+                # indices include bucket-end padding. We need to adjust indices.
+                cumulative_padding_stripped = [0]  # For bucket 0, no prior padding stripped
+                for bucket in buffer.buckets[:-1]:  # All but last bucket
+                    bucket_padding = bucket.grad_data.numel() - bucket.numel_unpadded
+                    cumulative_padding_stripped.append(
+                        cumulative_padding_stripped[-1] + bucket_padding
+                    )
+
                 for model_param, (
                     param_world_start,
                     param_world_end,
-                    _,
+                    bucket_id,
                 ) in buffer.param_index_map.items():
                     try:
                         sharded_metadata = param_to_sharded_metadata[model_param]
@@ -1728,6 +1739,13 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     # Note: replica_id is exactly the same as in the model param
                     replica_id = sharded_metadata.replica_id
 
+                    # Adjust indices to account for stripped bucket-end padding.
+                    # param_world_start/end are indices in the buffer (with padding),
+                    # but world_tensors has the bucket-end padding stripped.
+                    padding_adjustment = cumulative_padding_stripped[bucket_id]
+                    adjusted_start = param_world_start - padding_adjustment
+                    adjusted_end = param_world_end - padding_adjustment
+
                     tensors = {}
                     for state_key in world_tensor_keys:
                         if state_key == 'step' or state_key == 'numel' or state_key == 'numel_unpadded':
@@ -1735,7 +1753,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                             # specifically and is read from param_groups.
                             # numel and numel_unpadded are not needed.
                             continue
-                        state_ten = world_tensors[state_key][param_world_start:param_world_end]
+                        state_ten = world_tensors[state_key][adjusted_start:adjusted_end]
 
                         assert len(state_ten) == (param_world_end - param_world_start), (
                             len(state_ten),

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1261,9 +1261,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 world_tensors = {}
                 if data_parallel_rank == 0 or return_on_all_ranks:
                     world_tensors = {
-                        key: torch.zeros(
-                            (buffer_numel,), dtype=torch.float32, device="cpu"
-                        )
+                        key: torch.zeros((buffer_numel,), dtype=torch.float32, device="cpu")
                         for key in ("param", "exp_avg", "exp_avg_sq")
                     }
                     world_tensors["numel"] = buffer_numel
@@ -1748,7 +1746,11 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                     tensors = {}
                     for state_key in world_tensor_keys:
-                        if state_key == 'step' or state_key == 'numel' or state_key == 'numel_unpadded':
+                        if (
+                            state_key == 'step'
+                            or state_key == 'numel'
+                            or state_key == 'numel_unpadded'
+                        ):
                             # The optimizer state of STEP is handled
                             # specifically and is read from param_groups.
                             # numel and numel_unpadded are not needed.

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1255,16 +1255,18 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             dtype_state = {}
             assert len(gbuf_range_maps) == 1, "single dtype supported, for now."
             for dtype, gbuf_range_map_for_all_buckets in gbuf_range_maps.items():
+                buffer_numel = self.buffers[gbuf_idx].numel
                 buffer_numel_unpadded = self.buffers[gbuf_idx].numel_unpadded
                 # Create coalesced tensors for all state related to parameters in this buffer.
                 world_tensors = {}
                 if data_parallel_rank == 0 or return_on_all_ranks:
                     world_tensors = {
                         key: torch.zeros(
-                            (buffer_numel_unpadded,), dtype=torch.float32, device="cpu"
+                            (buffer_numel,), dtype=torch.float32, device="cpu"
                         )
                         for key in ("param", "exp_avg", "exp_avg_sq")
                     }
+                    world_tensors["numel"] = buffer_numel
                     world_tensors["numel_unpadded"] = buffer_numel_unpadded
 
                 if not empty_data:
@@ -1728,30 +1730,14 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                     tensors = {}
                     for state_key in world_tensor_keys:
-                        if state_key == 'step' or state_key == 'numel_unpadded':
+                        if state_key == 'step' or state_key == 'numel' or state_key == 'numel_unpadded':
                             # The optimizer state of STEP is handled
                             # specifically and is read from param_groups.
-                            # Numel unpadded is not needed.
+                            # numel and numel_unpadded are not needed.
                             continue
                         state_ten = world_tensors[state_key][param_world_start:param_world_end]
-                        missing_elems_num = (param_world_end - param_world_start) - len(state_ten)
 
-                        if missing_elems_num > 0:
-                            # `state_ten` is shorter than the slice which means the world_tensor
-                            # is shorter than `param_world_end` - this is a bug in the param ranges
-                            # logic. Here we can only pad this with zeros as a workaround.
-                            # TODO: this assert shouldn't hold and indicates a bug, see issue #504
-                            assert param_world_end > buffer.numel_unpadded
-
-                            logger.warning(
-                                f"'{sharded_metadata.key}' param range exceeds"
-                                f" unpadded buffer by {missing_elems_num} elements."
-                                f" It will be padded with zeros which can lead to"
-                                f" data corruption."
-                            )
-                            state_ten = torch.nn.functional.pad(state_ten, (0, missing_elems_num))
-
-                        assert len(state_ten) == param_world_end - param_world_start, (
+                        assert len(state_ten) == (param_world_end - param_world_start), (
                             len(state_ten),
                             param_world_end - param_world_start,
                         )

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1309,16 +1309,18 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             dtype_state = {}
             assert len(gbuf_range_maps) == 1, "single dtype supported, for now."
             for dtype, gbuf_range_map_for_all_buckets in gbuf_range_maps.items():
-                buffer_numel = self.buffers[gbuf_idx].numel
                 buffer_numel_unpadded = self.buffers[gbuf_idx].numel_unpadded
                 # Create coalesced tensors for all state related to parameters in this buffer.
+                # These are sized to the compact (bucket-end padding stripped) layout, which is
+                # exactly what the loop below fills and what the load paths read back.
                 world_tensors = {}
                 if data_parallel_rank == 0 or return_on_all_ranks:
                     world_tensors = {
-                        key: torch.zeros((buffer_numel,), dtype=torch.float32, device="cpu")
+                        key: torch.zeros(
+                            (buffer_numel_unpadded,), dtype=torch.float32, device="cpu"
+                        )
                         for key in ("param",) + self.optimizer_state_keys
                     }
-                    world_tensors["numel"] = buffer_numel
                     world_tensors["numel_unpadded"] = buffer_numel_unpadded
 
                 if not empty_data:
@@ -1800,15 +1802,17 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                     tensors = {}
                     for state_key in world_tensor_keys:
-                        if (
-                            state_key == 'step'
-                            or state_key == 'numel'
-                            or state_key == 'numel_unpadded'
-                        ):
+                        if state_key == 'step' or state_key == 'numel_unpadded':
                             # The optimizer state of STEP is handled
                             # specifically and is read from param_groups.
-                            # numel and numel_unpadded are not needed.
+                            # Numel unpadded is not needed.
                             continue
+                        assert adjusted_end <= world_tensors[state_key].numel(), (
+                            f"'{sharded_metadata.key}' range [{adjusted_start}, {adjusted_end})"
+                            f" runs past the coalesced buffer"
+                            f" ({world_tensors[state_key].numel()} elements);"
+                            f" bucket-padding adjustment is wrong."
+                        )
                         state_ten = world_tensors[state_key][adjusted_start:adjusted_end]
 
                         assert len(state_ten) == (param_world_end - param_world_start), (

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1763,10 +1763,21 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 # Note: for NVFP4, param_index_map uses unpacked (full numel)
                 # offsets, which is correct here since optimizer states
                 # (fp32_param, exp_avg, exp_avg_sq) are in unpacked space.
+
+                # Compute cumulative bucket-end padding stripped before each bucket.
+                # world_tensors has bucket-end padding stripped, but param_index_map
+                # indices include bucket-end padding. We need to adjust indices.
+                cumulative_padding_stripped = [0]  # For bucket 0, no prior padding stripped
+                for bucket in buffer.buckets[:-1]:  # All but last bucket
+                    bucket_padding = bucket.grad_data.numel() - bucket.numel_unpadded
+                    cumulative_padding_stripped.append(
+                        cumulative_padding_stripped[-1] + bucket_padding
+                    )
+
                 for model_param, (
                     param_world_start,
                     param_world_end,
-                    _,
+                    bucket_id,
                 ) in buffer.param_index_map.items():
                     try:
                         sharded_metadata = param_to_sharded_metadata[model_param]
@@ -1782,6 +1793,13 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     # Note: replica_id is exactly the same as in the model param
                     replica_id = sharded_metadata.replica_id
 
+                    # Adjust indices to account for stripped bucket-end padding.
+                    # param_world_start/end are indices in the buffer (with padding),
+                    # but world_tensors has the bucket-end padding stripped.
+                    padding_adjustment = cumulative_padding_stripped[bucket_id]
+                    adjusted_start = param_world_start - padding_adjustment
+                    adjusted_end = param_world_end - padding_adjustment
+
                     tensors = {}
                     for state_key in world_tensor_keys:
                         if state_key == 'step' or state_key == 'numel' or state_key == 'numel_unpadded':
@@ -1789,7 +1807,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                             # specifically and is read from param_groups.
                             # numel and numel_unpadded are not needed.
                             continue
-                        state_ten = world_tensors[state_key][param_world_start:param_world_end]
+                        state_ten = world_tensors[state_key][adjusted_start:adjusted_end]
 
                         assert len(state_ten) == (param_world_end - param_world_start), (
                             len(state_ten),

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1309,16 +1309,18 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             dtype_state = {}
             assert len(gbuf_range_maps) == 1, "single dtype supported, for now."
             for dtype, gbuf_range_map_for_all_buckets in gbuf_range_maps.items():
+                buffer_numel = self.buffers[gbuf_idx].numel
                 buffer_numel_unpadded = self.buffers[gbuf_idx].numel_unpadded
                 # Create coalesced tensors for all state related to parameters in this buffer.
                 world_tensors = {}
                 if data_parallel_rank == 0 or return_on_all_ranks:
                     world_tensors = {
                         key: torch.zeros(
-                            (buffer_numel_unpadded,), dtype=torch.float32, device="cpu"
+                            (buffer_numel,), dtype=torch.float32, device="cpu"
                         )
                         for key in ("param",) + self.optimizer_state_keys
                     }
+                    world_tensors["numel"] = buffer_numel
                     world_tensors["numel_unpadded"] = buffer_numel_unpadded
 
                 if not empty_data:
@@ -1782,30 +1784,14 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                     tensors = {}
                     for state_key in world_tensor_keys:
-                        if state_key == 'step' or state_key == 'numel_unpadded':
+                        if state_key == 'step' or state_key == 'numel' or state_key == 'numel_unpadded':
                             # The optimizer state of STEP is handled
                             # specifically and is read from param_groups.
-                            # Numel unpadded is not needed.
+                            # numel and numel_unpadded are not needed.
                             continue
                         state_ten = world_tensors[state_key][param_world_start:param_world_end]
-                        missing_elems_num = (param_world_end - param_world_start) - len(state_ten)
 
-                        if missing_elems_num > 0:
-                            # `state_ten` is shorter than the slice which means the world_tensor
-                            # is shorter than `param_world_end` - this is a bug in the param ranges
-                            # logic. Here we can only pad this with zeros as a workaround.
-                            # TODO: this assert shouldn't hold and indicates a bug, see issue #504
-                            assert param_world_end > buffer.numel_unpadded
-
-                            logger.warning(
-                                f"'{sharded_metadata.key}' param range exceeds"
-                                f" unpadded buffer by {missing_elems_num} elements."
-                                f" It will be padded with zeros which can lead to"
-                                f" data corruption."
-                            )
-                            state_ten = torch.nn.functional.pad(state_ten, (0, missing_elems_num))
-
-                        assert len(state_ten) == param_world_end - param_world_start, (
+                        assert len(state_ten) == (param_world_end - param_world_start), (
                             len(state_ten),
                             param_world_end - param_world_start,
                         )

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1315,9 +1315,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 world_tensors = {}
                 if data_parallel_rank == 0 or return_on_all_ranks:
                     world_tensors = {
-                        key: torch.zeros(
-                            (buffer_numel,), dtype=torch.float32, device="cpu"
-                        )
+                        key: torch.zeros((buffer_numel,), dtype=torch.float32, device="cpu")
                         for key in ("param",) + self.optimizer_state_keys
                     }
                     world_tensors["numel"] = buffer_numel
@@ -1802,7 +1800,11 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                     tensors = {}
                     for state_key in world_tensor_keys:
-                        if state_key == 'step' or state_key == 'numel' or state_key == 'numel_unpadded':
+                        if (
+                            state_key == 'step'
+                            or state_key == 'numel'
+                            or state_key == 'numel_unpadded'
+                        ):
                             # The optimizer state of STEP is handled
                             # specifically and is read from param_groups.
                             # numel and numel_unpadded are not needed.

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -19,9 +19,7 @@ from megatron.core.dist_checkpointing.optimizer import (
 )
 from megatron.core.dist_checkpointing.utils import add_prefix_for_sharding, extract_sharded_tensors
 from megatron.core.dist_checkpointing.validation import StrictHandling
-from megatron.core.models.gpt.gpt_layer_specs import (
-    get_gpt_decoder_block_spec,
-)
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_spec as gpt_te_spec,
 )

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -19,7 +19,9 @@ from megatron.core.dist_checkpointing.optimizer import (
 )
 from megatron.core.dist_checkpointing.utils import add_prefix_for_sharding, extract_sharded_tensors
 from megatron.core.dist_checkpointing.validation import StrictHandling
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_decoder_block_spec,
+)
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_spec as gpt_te_spec,
 )
@@ -176,6 +178,41 @@ class SwigluFactoryModel(torch.nn.Module):
         return sharded_state_dict
 
 
+class MultiBucketModel(torch.nn.Module):
+    """Model with enough separate params for the grad buffer to split into several buckets.
+
+    Param sizes are deliberately not multiples of the bucket-end divisor, so every bucket
+    but the last picks up nonzero DP-divisibility padding. That padding is what the
+    reshardable-checkpoint index math has to compensate for: `param_index_map` offsets
+    include it, the coalesced world tensors do not.
+    """
+
+    def __init__(self, num_layers: int = 6):
+        super().__init__()
+        self.layers = torch.nn.ModuleList(
+            torch.nn.Linear(70, 130, bias=True) for _ in range(num_layers)
+        )
+        self.config = TransformerConfig(
+            hidden_size=8, num_attention_heads=1, num_layers=1, bf16=True
+        )
+
+    def sharded_state_dict(self):
+        # The model is replicated rather than sharded; every rank holds the same tensor,
+        # which keeps this test focused on bucket index math instead of TP/PP resharding.
+        sharded_state_dict = self.state_dict(keep_vars=True)
+        for key, tensor in sharded_state_dict.items():
+            sharded_state_dict[key] = ShardedTensor.from_rank_offsets(
+                key,
+                tensor,
+                replica_id=(
+                    parallel_state.get_pipeline_model_parallel_rank(),
+                    parallel_state.get_tensor_model_parallel_rank(),
+                    parallel_state.get_data_parallel_rank(with_context_parallel=True),
+                ),
+            )
+        return sharded_state_dict
+
+
 class Model1dFlattenTensor(torch.nn.Module):
     """This model is used to test whether a 1d flatten tensor can be correctly
     transformed into torch dist-ckpt form
@@ -328,6 +365,13 @@ def initialize_pp_agnostic_model(pre_process=True, post_process=True, seed=0, **
 
 def initialize_pp_agnostic_gpt_model(pre_process=True, post_process=True, seed=0, **config_kwargs):
     return initialize_gpt_model(False, False, seed=seed, **config_kwargs)
+
+
+def initialize_multi_bucket_model(pre_process=True, post_process=True, seed=0, **config_kwargs):
+    torch.manual_seed(seed)
+    model_parallel_cuda_manual_seed(seed)
+
+    return MultiBucketModel()
 
 
 def initialize_small_model(pre_process=True, post_process=True, seed=0, **config_kwargs):
@@ -882,6 +926,144 @@ class TestDistributedOptimizer:
             assert self.check_equal_dp_zero_state(
                 dp_zero_optim_A, dp_zero_optim_B, same_dp_group, raise_if_different=True
             )
+
+    @staticmethod
+    def _unwrap_distributed_optimizer(optimizer):
+        if isinstance(optimizer, ChainedOptimizer):
+            assert len(optimizer.chained_optimizers) == 1
+            return optimizer.chained_optimizers[0]
+        return optimizer
+
+    @staticmethod
+    def _bucket_end_paddings(buffer):
+        """Bucket-end padding stripped from the coalesced world tensors, per bucket."""
+        return [bucket.grad_data.numel() - bucket.numel_unpadded for bucket in buffer.buckets[:-1]]
+
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.6a0"),
+        reason="fully_reshardable requires PyTorch 2.6a0 or later",
+    )
+    @pytest.mark.parametrize(('num_buckets', 'pad_buckets'), [(2, False), (3, False), (3, True)])
+    def test_fully_reshardable_multi_bucket_save_load(
+        self, tmp_path_dist_ckpt, num_buckets, pad_buckets
+    ):
+        """Round-trip fully-reshardable optimizer state across a multi-bucket grad buffer.
+
+        `sharded_param_state_fully_reshardable` slices the coalesced world tensors using
+        `param_index_map` offsets, which include each bucket's end padding, while the world
+        tensors are packed with that padding stripped. Without the per-bucket adjustment,
+        every param past the first bucket is saved from the wrong offset. Existing coverage
+        misses this because the default bucket size puts the whole buffer in one bucket,
+        where the adjustment is always zero.
+        """
+        Utils.initialize_model_parallel(1, 1)
+        metadata = {
+            'distrib_optim_sharding_type': 'fully_reshardable',
+            'distrib_optim_fully_reshardable_mem_efficient': False,
+        }
+        setup_kwargs = dict(
+            tp=1,
+            pp=1,
+            bf16=True,
+            dist_opt=True,
+            initialize_fn=initialize_multi_bucket_model,
+            ddp_num_buckets=num_buckets,
+            ddp_pad_buckets_for_high_nccl_busbw=pad_buckets,
+        )
+
+        with TempNamedDir(
+            tmp_path_dist_ckpt / 'test_fully_reshardable_multi_bucket_save_load', sync=True
+        ) as ckpt_dir:
+            model_A, optimizer_A = setup_model_and_optimizer(seed=2, **setup_kwargs)
+
+            # Guard against the test silently degenerating into the single-bucket case that
+            # already passes, or into buckets that happen to need no padding.
+            for buffer in self._unwrap_distributed_optimizer(optimizer_A).buffers:
+                assert len(buffer.buckets) == num_buckets, (
+                    f"expected {num_buckets} buckets, got {len(buffer.buckets)}; "
+                    f"the bucket-padding adjustment is a no-op with a single bucket"
+                )
+                paddings = self._bucket_end_paddings(buffer)
+                assert any(padding > 0 for padding in paddings), (
+                    f"no bucket-end padding to strip ({paddings}); this test cannot "
+                    f"distinguish adjusted from unadjusted indices"
+                )
+
+            optim_sd = optimizer_A.sharded_state_dict(
+                model_A[0].sharded_state_dict(), metadata=metadata
+            )
+            save(optim_sd, ckpt_dir)
+            dp_zero_optim_A = get_param_state_dp_zero(optimizer_A)
+
+            # A different seed, so an unloaded optimizer B is guaranteed to differ from A.
+            model_B, optimizer_B = setup_model_and_optimizer(seed=3, **setup_kwargs)
+            dp_zero_optim_B = get_param_state_dp_zero(optimizer_B)
+            assert not self.check_equal_dp_zero_state(
+                dp_zero_optim_A, dp_zero_optim_B, same_dp_group=True
+            )
+
+            load_sharded_state_dict = optimizer_B.sharded_state_dict(
+                model_B[0].sharded_state_dict(), metadata=metadata, is_loading=True
+            )
+            state_dict, _, unexpected_keys = load(
+                load_sharded_state_dict, ckpt_dir, strict=StrictHandling.RETURN_ALL
+            )
+            assert not unexpected_keys
+            optimizer_B.load_state_dict(state_dict)
+
+            dp_zero_optim_B = get_param_state_dp_zero(optimizer_B)
+            assert self.check_equal_dp_zero_state(
+                dp_zero_optim_A, dp_zero_optim_B, same_dp_group=True, raise_if_different=True
+            )
+
+    @pytest.mark.parametrize('pad_buckets', [False, True])
+    def test_coalesced_world_tensors_are_compact(self, pad_buckets):
+        """The coalesced world tensors are sized to exactly what the fill and read paths use.
+
+        `get_parameter_state_dp_zero` packs bucket-by-bucket with bucket-end padding stripped,
+        so `numel_unpadded` is both the last element written and the last element read once
+        `param_index_map` offsets are rebased. Oversizing them would append a zero tail to
+        every dp_zero_gather_scatter and legacy checkpoint, and would let an out-of-range
+        slice still satisfy the length assert in the reshardable save path.
+        """
+        Utils.initialize_model_parallel(1, 1)
+        _, optimizer = setup_model_and_optimizer(
+            seed=2,
+            tp=1,
+            pp=1,
+            bf16=True,
+            dist_opt=True,
+            initialize_fn=initialize_multi_bucket_model,
+            ddp_num_buckets=3,
+            ddp_pad_buckets_for_high_nccl_busbw=pad_buckets,
+        )
+        distributed_optimizer = self._unwrap_distributed_optimizer(optimizer)
+        state = distributed_optimizer.get_parameter_state_dp_zero(use_gloo_comm=False)
+        if parallel_state.get_data_parallel_rank(with_context_parallel=True) != 0:
+            return
+
+        for gbuf_idx, buffer in enumerate(distributed_optimizer.buffers):
+            assert any(padding > 0 for padding in self._bucket_end_paddings(buffer))
+
+            for world_tensors in state[gbuf_idx].values():
+                for key, tensor in world_tensors.items():
+                    if not isinstance(tensor, torch.Tensor):
+                        continue
+                    assert tensor.numel() == buffer.numel_unpadded, (
+                        f"world tensor '{key}' is {tensor.numel()} elements, expected the "
+                        f"compact {buffer.numel_unpadded}"
+                    )
+
+            # The rebased ranges must end exactly at numel_unpadded: any less and the
+            # compact allocation would be wasteful, any more and it would truncate.
+            cumulative_padding_stripped = [0]
+            for padding in self._bucket_end_paddings(buffer):
+                cumulative_padding_stripped.append(cumulative_padding_stripped[-1] + padding)
+            adjusted_ends = [
+                param_world_end - cumulative_padding_stripped[bucket_id]
+                for _, param_world_end, bucket_id in buffer.param_index_map.values()
+            ]
+            assert max(adjusted_ends) == buffer.numel_unpadded
 
     def check_equal_dp_zero_state(
         self, dp_zero_state_A, dp_zero_state_B, same_dp_group, raise_if_different=False

--- a/tests/unit_tests/dist_checkpointing/utils.py
+++ b/tests/unit_tests/dist_checkpointing/utils.py
@@ -190,6 +190,8 @@ def setup_model_and_optimizer(
     ep=1,
     etp=1,
     use_megatron_fsdp=False,
+    ddp_num_buckets=None,
+    ddp_pad_buckets_for_high_nccl_busbw=False,
 ):
     optimizer_type = optimizer
     use_layer_wise = False
@@ -210,6 +212,12 @@ def setup_model_and_optimizer(
     mock_args = parse_args(ignore_unknown_args=True)
     with mock.patch('megatron.training.training.get_args', new=lambda: mock_args):
         init_basic_mock_args(mock_args, tp, pp, bf16=bf16)
+        if ddp_num_buckets is not None:
+            # resolve_ddp_bucket_size() forces a single bucket unless grad reduction
+            # overlaps, so both knobs are needed to actually split the grad buffer.
+            mock_args.ddp_num_buckets = ddp_num_buckets
+            mock_args.overlap_grad_reduce = True
+        mock_args.ddp_pad_buckets_for_high_nccl_busbw = ddp_pad_buckets_for_high_nccl_busbw
         mock_args.context_parallel_size = cp
         mock_args.expert_model_parallel_size = ep
         mock_args.expert_tensor_parallel_size = etp


### PR DESCRIPTION
## Summary

Fixes optimizer state corruption when saving a `torch_dist` checkpoint with `--dist-ckpt-optim-fully-reshardable` and a grad buffer split across more than one bucket.

`get_parameter_state_dp_zero()` packs the coalesced world tensors bucket by bucket with each bucket's end padding stripped, but `sharded_param_state_fully_reshardable()` slices into them using raw `param_index_map` offsets, which still include that padding. Every parameter past the first bucket is read from the wrong offset; the overshoot ran off the end of the world tensor and was silently zero-padded with a warning, so the saved state for those params was partly zeros.

The fix computes the cumulative bucket-end padding stripped before each bucket and subtracts it before indexing. The world tensors stay sized to `buffer_numel_unpadded`, which is exactly what the rebased offsets need, and an explicit bound check on the adjusted end replaces the zero-padding workaround so a future indexing error fails loudly instead of writing zeros.

The bug is invisible with a single bucket, where the adjustment is identically zero, and that is the only configuration existing tests covered.

## Tests

`tests/unit_tests/dist_checkpointing/test_optimizer.py`:

- `test_fully_reshardable_multi_bucket_save_load` - save/load round trip over 2 and 3 buckets, plus one case with `pad_buckets_for_high_nccl_busbw`. The load path reads `state_dict[param_idx]` by key rather than re-slicing `world_tensors`, so a wrong save offset does not cancel out on load.
- `test_coalesced_world_tensors_are_compact` - the world tensors stay at `numel_unpadded` and every rebased param range ends exactly there.

Both assert up front that the buffer really split into N buckets and that the non-final buckets carry nonzero padding, so neither can silently degenerate into the single-bucket case it exists to cover.

Supporting changes: a `MultiBucketModel` fixture, and `ddp_num_buckets` / `ddp_pad_buckets_for_high_nccl_busbw` knobs on `setup_model_and_optimizer`. Both knobs are needed because `resolve_ddp_bucket_size()` forces a single bucket unless `overlap_grad_reduce` is on.

## Test plan

- [ ] `tests/unit_tests/dist_checkpointing/test_optimizer.py -k "multi_bucket or compact"` on 8 GPUs. **Not yet run.**
- [ ] CI: `Run functional tests` label (touches the optimizer code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
