### PR TITLE
perf(parallel_state): speed up process group init with local sync

### DIFF
--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -120,6 +120,7 @@ _HYBRID_DP_CP_GROUPS = {}
 
 # Data parallel group information with context parallel combined.
 _DATA_PARALLEL_GROUP_WITH_CP = None
+_DATA_PARALLEL_GROUP_WITH_CP_AG = None
 _DATA_PARALLEL_GROUP_WITH_CP_GLOO = None
 _DATA_PARALLEL_GLOBAL_RANKS_WITH_CP = None
 
@@ -394,23 +395,25 @@ def create_hierarchical_groups(
             l=int(np.prod(hierarchical_group_sizes[level + 1 :])),
         ).tolist()
         for sub_ranks in rearranged_ranks:
-            sub_group = create_group(
-                sub_ranks,
-                timeout=timeout,
-                pg_options=pg_options[level],
-                group_desc=f"HIERARCHICAL_{group_desc}_L{level}",
-            )
-            if create_gloo_process_groups:
-                sub_group_gloo = create_group(
+            if rank in sub_ranks:
+                sub_group = create_group(
                     sub_ranks,
                     timeout=timeout,
-                    backend="gloo",
                     pg_options=pg_options[level],
-                    group_desc=f"HIERARCHICAL_{group_desc}_GLOO_L{level}",
+                    use_local_synchronization=True,
+                    group_desc=f"HIERARCHICAL_{group_desc}_L{level}",
                 )
-            else:
-                sub_group_gloo = None
-            if rank in sub_ranks:
+                if create_gloo_process_groups:
+                    sub_group_gloo = create_group(
+                        sub_ranks,
+                        timeout=timeout,
+                        backend="gloo",
+                        pg_options=pg_options[level],
+                        use_local_synchronization=True,
+                        group_desc=f"HIERARCHICAL_{group_desc}_GLOO_L{level}",
+                    )
+                else:
+                    sub_group_gloo = None
                 hierarchical_groups.append(sub_group)
                 hierarchical_groups_gloo.append(sub_group_gloo)
     assert rank not in ranks or len(hierarchical_groups) == len(hierarchical_group_sizes)
@@ -430,12 +433,14 @@ def create_hybrid_dp_cp_groups(rank, ranks, pg_options):
     group_sizes = [2**i for i in range(int(log2(len(ranks))))][1:]
     for group_size in group_sizes:
         for i in range(0, len(ranks), group_size):
-            group = create_group(
-                ranks[i : i + group_size],
-                pg_options=pg_options,
-                group_desc=f"HYBRID_DP_CP_GROUP_{group_size}",
-            )
-            if rank in ranks[i : i + group_size]:
+            sub_ranks = ranks[i : i + group_size]
+            if rank in sub_ranks:
+                group = create_group(
+                    sub_ranks,
+                    pg_options=pg_options,
+                    use_local_synchronization=True,
+                    group_desc=f"HYBRID_DP_CP_GROUP_{group_size}",
+                )
                 assert (
                     group_size not in hybrid_dp_cp_groups
                 ), f"Rank {rank} appears in multiple Hybrid DP CP groups of size {group_size}"
@@ -564,6 +569,7 @@ def initialize_model_parallel(
     create_gloo_process_groups: bool = True,
     high_priority_stream_groups: Optional[List[str]] = None,
     sharp_enabled_group: Optional[str] = None,
+    create_all_gather_group: Optional[bool] = False,
     rank_offset: int = 0,
     local_world_size: Optional[int] = None,
 ) -> None:
@@ -679,6 +685,13 @@ def initialize_model_parallel(
             This option is only valid when use_sharp is True.
             By default (None), it is enabled from dp group.
             Available options (choose one): [dp, dp_replica]
+
+        create_all_gather_group (bool, default = False):
+            Create a separate process group for all-gather operations to avoid
+            head-of-line blocking with reduce-scatter operations. When enabled,
+            creates an additional NCCL communicator with identical ranks as the
+            dp-cp group but with independent progress engines for better communication
+            overlap.
 
     Let's say we have a total of 16 GPUs denoted by g0 ... g15 and we
     use 2 GPUs to parallelize the model tensor, and 4 GPUs to parallelize
@@ -818,6 +831,7 @@ def initialize_model_parallel(
     global _DATA_PARALLEL_GROUP_GLOO
     global _DATA_PARALLEL_GLOBAL_RANKS
     global _DATA_PARALLEL_GROUP_WITH_CP
+    global _DATA_PARALLEL_GROUP_WITH_CP_AG
     global _DATA_PARALLEL_GROUP_WITH_CP_GLOO
     global _DATA_PARALLEL_GLOBAL_RANKS_WITH_CP
     global _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP
@@ -843,23 +857,39 @@ def initialize_model_parallel(
     # Therefore, dp-cp group, which potentially requires SHARP-enablement,
     # need to be created before all the other groups
     for ranks_with_cp in decoder_rank_generator.get_ranks('dp-cp'):
-        group_with_cp = create_group(
-            ranks_with_cp,
-            timeout=timeout,
-            pg_options=get_nccl_options("dp_cp", nccl_comm_cfgs),
-            group_desc="DATA_PARALLEL_GROUP_WITH_CP",
-        )
         if create_gloo_process_groups:
-            group_with_cp_gloo = create_group(
-                ranks_with_cp,
-                timeout=timeout,
-                backend="gloo",
-                group_desc="DATA_PARALLEL_GROUP_WITH_CP_GLOO",
-            )
+            if rank in ranks_with_cp:
+                group_with_cp_gloo = create_group(
+                    ranks_with_cp,
+                    timeout=timeout,
+                    backend="gloo",
+                    use_local_synchronization=True,
+                    group_desc="DATA_PARALLEL_GROUP_WITH_CP_GLOO",
+                )
+            else:
+                group_with_cp_gloo = None
         else:
             group_with_cp_gloo = None
         if rank in ranks_with_cp:
+            group_with_cp = create_group(
+                ranks_with_cp,
+                timeout=timeout,
+                pg_options=get_nccl_options("dp_cp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="DATA_PARALLEL_GROUP_WITH_CP",
+            )
+            if create_all_gather_group:
+                group_with_cp_ag = create_group(
+                    ranks_with_cp,
+                    timeout=timeout,
+                    pg_options=get_nccl_options("dp_cp", nccl_comm_cfgs),
+                    use_local_synchronization=True,
+                    group_desc="DATA_PARALLEL_GROUP_WITH_CP_AG",
+                )
+            else:
+                group_with_cp_ag = None
             _DATA_PARALLEL_GROUP_WITH_CP = group_with_cp
+            _DATA_PARALLEL_GROUP_WITH_CP_AG = group_with_cp_ag
             _DATA_PARALLEL_GROUP_WITH_CP_GLOO = group_with_cp_gloo
             _DATA_PARALLEL_GLOBAL_RANKS_WITH_CP = ranks_with_cp
 
@@ -871,22 +901,24 @@ def initialize_model_parallel(
                         (i + 1) * intra_partial_data_parallel_size
                     )
                 ]
-                intra_partial_dp_group_with_cp = create_group(
-                    intra_partial_dp_ranks_with_cp,
-                    timeout=timeout,
-                    pg_options=get_nccl_options("intra_dp_cp", nccl_comm_cfgs),
-                    group_desc="INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP",
-                )
-                if create_gloo_process_groups:
-                    intra_partial_dp_group_with_cp_gloo = create_group(
+                if rank in intra_partial_dp_ranks_with_cp:
+                    intra_partial_dp_group_with_cp = create_group(
                         intra_partial_dp_ranks_with_cp,
                         timeout=timeout,
-                        backend="gloo",
-                        group_desc="INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_GLOO",
+                        pg_options=get_nccl_options("intra_dp_cp", nccl_comm_cfgs),
+                        use_local_synchronization=True,
+                        group_desc="INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP",
                     )
-                else:
-                    intra_partial_dp_group_with_cp_gloo = None
-                if rank in intra_partial_dp_ranks_with_cp:
+                    if create_gloo_process_groups:
+                        intra_partial_dp_group_with_cp_gloo = create_group(
+                            intra_partial_dp_ranks_with_cp,
+                            timeout=timeout,
+                            backend="gloo",
+                            use_local_synchronization=True,
+                            group_desc="INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_GLOO",
+                        )
+                    else:
+                        intra_partial_dp_group_with_cp_gloo = None
                     _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = intra_partial_dp_group_with_cp
                     _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_GLOO = (
                         intra_partial_dp_group_with_cp_gloo
@@ -933,19 +965,27 @@ def initialize_model_parallel(
         # TODO: Are gloo groups needed for hybrid cp?
 
     for ranks in decoder_rank_generator.get_ranks('dp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("dp", nccl_comm_cfgs),
-            group_desc="DATA_PARALLEL_GROUP",
-        )
         if create_gloo_process_groups:
-            group_gloo = create_group(
-                ranks, timeout=timeout, backend="gloo", group_desc="DATA_PARALLEL_GROUP_GLOO"
-            )
+            if rank in ranks:
+                group_gloo = create_group(
+                    ranks,
+                    timeout=timeout,
+                    backend="gloo",
+                    use_local_synchronization=True,
+                    group_desc="DATA_PARALLEL_GROUP_GLOO",
+                )
+            else:
+                group_gloo = None
         else:
             group_gloo = None
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("dp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="DATA_PARALLEL_GROUP",
+            )
             _DATA_PARALLEL_GROUP = group
             _DATA_PARALLEL_GROUP_GLOO = group_gloo
             _DATA_PARALLEL_GLOBAL_RANKS = ranks
@@ -955,28 +995,29 @@ def initialize_model_parallel(
     global _CONTEXT_PARALLEL_GLOBAL_RANKS
     assert _CONTEXT_PARALLEL_GROUP is None, 'context parallel group is already initialized'
     for ranks in decoder_rank_generator.get_ranks('cp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("cp", nccl_comm_cfgs),
-            group_desc="CONTEXT_PARALLEL_GROUP",
-        )
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("cp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="CONTEXT_PARALLEL_GROUP",
+            )
             _CONTEXT_PARALLEL_GROUP = group
             _CONTEXT_PARALLEL_GLOBAL_RANKS = ranks
         if hierarchical_context_parallel_sizes:
             assert np.prod(hierarchical_context_parallel_sizes) == context_parallel_size
-            global _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS
-            hierarchical_groups, _ = create_hierarchical_groups(
-                rank,
-                ranks,
-                hierarchical_context_parallel_sizes,
-                create_gloo_process_groups=False,
-                pg_options=get_nccl_options("hcp", nccl_comm_cfgs),
-                timeout=timeout,
-                group_desc="CONTEXT_PARALLEL_GROUP",
-            )
             if rank in ranks:
+                global _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS
+                hierarchical_groups, _ = create_hierarchical_groups(
+                    rank,
+                    ranks,
+                    hierarchical_context_parallel_sizes,
+                    create_gloo_process_groups=False,
+                    pg_options=get_nccl_options("hcp", nccl_comm_cfgs),
+                    timeout=timeout,
+                    group_desc="CONTEXT_PARALLEL_GROUP",
+                )
                 _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS = hierarchical_groups
 
     # Build the model-parallel groups.
@@ -984,13 +1025,14 @@ def initialize_model_parallel(
     global _MODEL_PARALLEL_GLOBAL_RANKS
     assert _MODEL_PARALLEL_GROUP is None, 'model parallel group is already initialized'
     for ranks in decoder_rank_generator.get_ranks('tp-pp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("mp", nccl_comm_cfgs),
-            group_desc="MODEL_PARALLEL_GROUP",
-        )
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("mp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="MODEL_PARALLEL_GROUP",
+            )
             _MODEL_PARALLEL_GROUP = group
             _MODEL_PARALLEL_GLOBAL_RANKS = ranks
 
@@ -1001,13 +1043,14 @@ def initialize_model_parallel(
         _TENSOR_MODEL_PARALLEL_GROUP is None
     ), 'tensor model parallel group is already initialized'
     for ranks in decoder_rank_generator.get_ranks('tp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp", nccl_comm_cfgs),
-            group_desc="TENSOR_MODEL_PARALLEL_GROUP",
-        )
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("tp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="TENSOR_MODEL_PARALLEL_GROUP",
+            )
             _TENSOR_MODEL_PARALLEL_GROUP = group
             _TENSOR_MODEL_PARALLEL_GLOBAL_RANKS = ranks
 
@@ -1077,17 +1120,6 @@ def initialize_model_parallel(
         os.environ["UCC_CL_BASIC_TLS"] = "^sharp,nccl"
 
     for ranks in decoder_rank_generator.get_ranks('pp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            backend=pipeline_model_parallel_comm_backend,
-            pg_options=(
-                None
-                if pipeline_model_parallel_comm_backend == "ucc"
-                else get_nccl_options("pp", nccl_comm_cfgs)
-            ),
-            group_desc="PIPELINE_MODEL_PARALLEL_GROUP",
-        )
         assert (
             pipeline_model_parallel_comm_backend == None
             or pipeline_model_parallel_comm_backend == "nccl"
@@ -1095,6 +1127,18 @@ def initialize_model_parallel(
         ), f'"{pipeline_model_parallel_comm_backend}" backend for PP communication is currently not supported'
 
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                backend=pipeline_model_parallel_comm_backend,
+                pg_options=(
+                    None
+                    if pipeline_model_parallel_comm_backend == "ucc"
+                    else get_nccl_options("pp", nccl_comm_cfgs)
+                ),
+                use_local_synchronization=True,
+                group_desc="PIPELINE_MODEL_PARALLEL_GROUP",
+            )
             if _PIPELINE_MODEL_PARALLEL_GROUP is None:
                 _PIPELINE_MODEL_PARALLEL_GROUP = group
                 _PIPELINE_GLOBAL_RANKS = ranks
@@ -1106,24 +1150,26 @@ def initialize_model_parallel(
                 _PIPELINE_GLOBAL_RANKS = [_PIPELINE_GLOBAL_RANKS, ranks]
 
         embedding_ranks = get_embedding_ranks(ranks)
-        group = create_group(
-            embedding_ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("embd", nccl_comm_cfgs),
-            group_desc="EMBEDDING_GROUP",
-        )
         if rank in embedding_ranks:
+            group = create_group(
+                embedding_ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("embd", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="EMBEDDING_GROUP",
+            )
             _EMBEDDING_GROUP = group
             _EMBEDDING_GLOBAL_RANKS = embedding_ranks
 
         position_embedding_ranks = get_position_embedding_ranks(ranks)
-        group = create_group(
-            position_embedding_ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("pos_embd", nccl_comm_cfgs),
-            group_desc="POSITION_EMBEDDING_GROUP",
-        )
         if rank in position_embedding_ranks:
+            group = create_group(
+                position_embedding_ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("pos_embd", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="POSITION_EMBEDDING_GROUP",
+            )
             _POSITION_EMBEDDING_GROUP = group
             _POSITION_EMBEDDING_GLOBAL_RANKS = position_embedding_ranks
 
@@ -1134,22 +1180,24 @@ def initialize_model_parallel(
         _TENSOR_AND_DATA_PARALLEL_GROUP is None
     ), 'Tensor + data parallel group is already initialized'
     for ranks in decoder_rank_generator.get_ranks('tp-dp-cp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp_dp_cp", nccl_comm_cfgs),
-            group_desc="TENSOR_AND_DATA_PARALLEL_GROUP_WITH_CP",
-        )
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("tp_dp_cp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="TENSOR_AND_DATA_PARALLEL_GROUP_WITH_CP",
+            )
             _TENSOR_AND_DATA_PARALLEL_GROUP_WITH_CP = group
     for ranks in decoder_rank_generator.get_ranks('tp-dp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp_dp", nccl_comm_cfgs),
-            group_desc="TENSOR_AND_DATA_PARALLEL_GROUP",
-        )
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("tp_dp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="TENSOR_AND_DATA_PARALLEL_GROUP",
+            )
             _TENSOR_AND_DATA_PARALLEL_GROUP = group
 
     global _TENSOR_AND_CONTEXT_PARALLEL_GROUP
@@ -1157,13 +1205,14 @@ def initialize_model_parallel(
         _TENSOR_AND_CONTEXT_PARALLEL_GROUP is None
     ), 'Tensor + context parallel group is already initialized'
     for ranks in decoder_rank_generator.get_ranks('tp-cp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp_cp", nccl_comm_cfgs),
-            group_desc="TENSOR_AND_CONTEXT_PARALLEL_GROUP",
-        )
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("tp_cp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="TENSOR_AND_CONTEXT_PARALLEL_GROUP",
+            )
             _TENSOR_AND_CONTEXT_PARALLEL_GROUP = group
 
     ### Expert-related parallel groups initialization
@@ -1171,13 +1220,14 @@ def initialize_model_parallel(
     global _EXPERT_MODEL_PARALLEL_GROUP, _EXPERT_MODEL_PARALLEL_RANKS
     assert _EXPERT_MODEL_PARALLEL_GROUP is None, 'Expert parallel group is already initialized'
     for ranks in expert_decoder_rank_generator.get_ranks('ep'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("ep", nccl_comm_cfgs),
-            group_desc="EXPERT_MODEL_PARALLEL_GROUP",
-        )
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("ep", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="EXPERT_MODEL_PARALLEL_GROUP",
+            )
             _EXPERT_MODEL_PARALLEL_GROUP = group
             _EXPERT_MODEL_PARALLEL_RANKS = ranks
 
@@ -1187,13 +1237,14 @@ def initialize_model_parallel(
         _EXPERT_TENSOR_PARALLEL_GROUP is None
     ), 'Expert tensor model parallel group is already initialized'
     for ranks in expert_decoder_rank_generator.get_ranks('tp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("ep_tp", nccl_comm_cfgs),
-            group_desc="EXPERT_TENSOR_PARALLEL_GROUP",
-        )
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("ep_tp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="EXPERT_TENSOR_PARALLEL_GROUP",
+            )
             _EXPERT_TENSOR_PARALLEL_GROUP = group
 
     # Build the tensor + expert parallel groups
@@ -1202,13 +1253,14 @@ def initialize_model_parallel(
         _EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP is None
     ), 'Expert tensor + model parallel group is already initialized'
     for ranks in expert_decoder_rank_generator.get_ranks('tp-ep'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp_ep_mp", nccl_comm_cfgs),
-            group_desc="EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP",
-        )
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("tp_ep_mp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP",
+            )
             _EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP = group
 
     # Build the expert+tensor+pipeline parallel groups
@@ -1217,13 +1269,14 @@ def initialize_model_parallel(
         _EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP is None
     ), 'The expert_tensor_model_pipeline parallel group is already initialized'
     for ranks in expert_decoder_rank_generator.get_ranks('tp-ep-pp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp_ep_pp", nccl_comm_cfgs),
-            group_desc="EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP",
-        )
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("tp_ep_pp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP",
+            )
             _EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP = group
 
     # Build the expert data parallel group
@@ -1252,19 +1305,26 @@ def initialize_model_parallel(
     )
 
     for ranks in expert_decoder_rank_generator.get_ranks('dp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("ep_dp", nccl_comm_cfgs),
-            group_desc="EXPERT_DATA_PARALLEL_GROUP",
-        )
         if create_gloo_process_groups:
-            group_gloo = create_group(
-                ranks, backend="gloo", group_desc="EXPERT_DATA_PARALLEL_GROUP_GLOO"
-            )
+            if rank in ranks:
+                group_gloo = create_group(
+                    ranks,
+                    backend="gloo",
+                    use_local_synchronization=True,
+                    group_desc="EXPERT_DATA_PARALLEL_GROUP_GLOO",
+                )
+            else:
+                group_gloo = None
         else:
             group_gloo = None
         if rank in ranks:
+            group = create_group(
+                ranks,
+                timeout=timeout,
+                pg_options=get_nccl_options("ep_dp", nccl_comm_cfgs),
+                use_local_synchronization=True,
+                group_desc="EXPERT_DATA_PARALLEL_GROUP",
+            )
             _EXPERT_DATA_PARALLEL_GROUP = group
             _EXPERT_DATA_PARALLEL_GROUP_GLOO = group_gloo
 
@@ -1321,13 +1381,14 @@ def initialize_model_parallel(
         model_parallel_group_id += 1
         intra_dist_opt_ranks.extend(ranks)
         if model_parallel_group_id % intra_partial_expert_data_parallel_size == 0:
-            intra_dist_opt_instance_group = create_group(
-                intra_dist_opt_ranks,
-                timeout=timeout,
-                pg_options=get_nccl_options("intra_dist_opt_instance", nccl_comm_cfgs),
-                group_desc="INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP",
-            )
             if rank in intra_dist_opt_ranks:
+                intra_dist_opt_instance_group = create_group(
+                    intra_dist_opt_ranks,
+                    timeout=timeout,
+                    pg_options=get_nccl_options("intra_dist_opt_instance", nccl_comm_cfgs),
+                    use_local_synchronization=True,
+                    group_desc="INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP",
+                )
                 _INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP = intra_dist_opt_instance_group
             intra_dist_opt_ranks = []
 
@@ -1385,13 +1446,14 @@ def create_all_gather_groups(for_expert_parallelism=False, timeout=None, nccl_co
     )
 
     for ranks_with_cp in decoder_rank_gen.get_ranks('dp-cp'):
-        group_with_cp_ag = create_group(
-            ranks_with_cp,
-            timeout=timeout,
-            pg_options=get_nccl_options('dp_cp', nccl_comm_cfgs or {}),
-            group_desc='DATA_PARALLEL_GROUP_WITH_CP_AG',
-        )
         if rank in ranks_with_cp:
+            group_with_cp_ag = create_group(
+                ranks_with_cp,
+                timeout=timeout,
+                pg_options=get_nccl_options('dp_cp', nccl_comm_cfgs or {}),
+                use_local_synchronization=True,
+                group_desc='DATA_PARALLEL_GROUP_WITH_CP_AG',
+            )
             dp_cp_ag_group = group_with_cp_ag
 
     # Create expert DP all-gather group if requested
@@ -1411,13 +1473,14 @@ def create_all_gather_groups(for_expert_parallelism=False, timeout=None, nccl_co
         )
 
         for expert_dp_ranks in expert_rank_gen.get_ranks('dp'):
-            expert_dp_ag = create_group(
-                expert_dp_ranks,
-                timeout=timeout,
-                pg_options=get_nccl_options("ep_dp", nccl_comm_cfgs or {}),
-                group_desc='EXPERT_DATA_PARALLEL_GROUP_AG',
-            )
             if rank in expert_dp_ranks:
+                expert_dp_ag = create_group(
+                    expert_dp_ranks,
+                    timeout=timeout,
+                    pg_options=get_nccl_options("ep_dp", nccl_comm_cfgs or {}),
+                    use_local_synchronization=True,
+                    group_desc='EXPERT_DATA_PARALLEL_GROUP_AG',
+                )
                 expt_dp_ag_group = expert_dp_ag
 
     return dp_cp_ag_group, expt_dp_ag_group
@@ -1464,7 +1527,9 @@ def get_pipeline_model_parallel_group(check_initialized=True):
     return _PIPELINE_MODEL_PARALLEL_GROUP
 
 
-def get_data_parallel_group(with_context_parallel=False, partial_data_parallel=False):
+def get_data_parallel_group(
+    with_context_parallel=False, partial_data_parallel=False, independent_all_gather=False
+):
     """Get the data-parallel group the caller rank belongs to."""
     if with_context_parallel:
         if partial_data_parallel:
@@ -1472,6 +1537,11 @@ def get_data_parallel_group(with_context_parallel=False, partial_data_parallel=F
                 _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP is not None
             ), "Intra partial data parallel group is not initialized"
             return _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP
+        if independent_all_gather:
+            assert (
+                _DATA_PARALLEL_GROUP_WITH_CP_AG is not None
+            ), "data parallel group with context parallel AG is not initialized"
+            return _DATA_PARALLEL_GROUP_WITH_CP_AG
         assert (
             _DATA_PARALLEL_GROUP_WITH_CP is not None
         ), "data parallel group with context parallel combined is not initialized"
@@ -1480,6 +1550,15 @@ def get_data_parallel_group(with_context_parallel=False, partial_data_parallel=F
         assert _DATA_PARALLEL_GROUP is not None, "data parallel group is not initialized"
         assert partial_data_parallel == False, "Partial DP for Optimizer needs to include CP"
         return _DATA_PARALLEL_GROUP
+
+
+def has_separate_all_gather_group() -> bool:
+    """Check if a separate all-gather process group has been created.
+
+    Returns True if a dedicated all-gather process group exists for improved
+    communication overlap, False otherwise.
+    """
+    return _DATA_PARALLEL_GROUP_WITH_CP_AG is not None
 
 
 def get_data_parallel_group_gloo(with_context_parallel=False, partial_data_parallel=False):
@@ -2106,6 +2185,9 @@ def destroy_model_parallel():
 
     global _DATA_PARALLEL_GROUP_WITH_CP
     _DATA_PARALLEL_GROUP_WITH_CP = None
+
+    global _DATA_PARALLEL_GROUP_WITH_CP_AG
+    _DATA_PARALLEL_GROUP_WITH_CP_AG = None
 
     global _CONTEXT_PARALLEL_GROUP
     _CONTEXT_PARALLEL_GROUP = None


### PR DESCRIPTION
- Call create_group only from ranks that belong to each group
- Pass use_local_synchronization=True for NCCL/gloo new_group paths
- Apply to hierarchical CP, hybrid DP-CP helpers, and all MPU groups
- Rebased on latest main and resolved conflicts
