### PR TITLE
ci: prune old artifacts on cluster lustre during weekly/release runs

### DIFF
--- a/.gitlab/stages/04.functional-tests.yml
+++ b/.gitlab/stages/04.functional-tests.yml
@@ -209,19 +209,21 @@ functional:configure:
     - |
       case "$CLEANUP_PLATFORM" in
         dgx_a100)
-          CLEANUP_CLUSTER=$([[ "$CLUSTER_A100" != "" ]] && echo "$CLUSTER_A100" || echo "$DEFAULT_A100_CLUSTER")
+          GPU_CLUSTER=$([[ "$CLUSTER_A100" != "" ]] && echo "$CLUSTER_A100" || echo "$DEFAULT_A100_CLUSTER")
           ;;
         dgx_h100)
-          CLEANUP_CLUSTER=$([[ "$CLUSTER_H100" != "" ]] && echo "$CLUSTER_H100" || echo "$DEFAULT_H100_CLUSTER")
+          GPU_CLUSTER=$([[ "$CLUSTER_H100" != "" ]] && echo "$CLUSTER_H100" || echo "$DEFAULT_H100_CLUSTER")
           ;;
         dgx_gb200)
-          CLEANUP_CLUSTER=$([[ "$CLUSTER_GB200" != "" ]] && echo "$CLUSTER_GB200" || echo "$DEFAULT_GB200_CLUSTER")
+          GPU_CLUSTER=$([[ "$CLUSTER_GB200" != "" ]] && echo "$CLUSTER_GB200" || echo "$DEFAULT_GB200_CLUSTER")
           ;;
         *)
           echo "Unknown CLEANUP_PLATFORM: $CLEANUP_PLATFORM"
           exit 1
           ;;
       esac
+    - CLEANUP_CLUSTER="cpu_${GPU_CLUSTER}"
+    - echo "Cleanup target = $CLEANUP_CLUSTER (CPU partition of $GPU_CLUSTER)"
     - export PYTHONPATH=$(pwd)
     - export RO_API_TOKEN=${PAT}
     - |

--- a/.gitlab/stages/04.functional-tests.yml
+++ b/.gitlab/stages/04.functional-tests.yml
@@ -246,21 +246,18 @@ functional:cleanup_dgx_a100:
   variables:
     CLEANUP_PLATFORM: dgx_a100
     CLEANUP_PATHS: $CLEANUP_PATHS_DGX_A100
-    CLEANUP_PROTECT: $CLEANUP_PROTECT_DGX_A100
 
 functional:cleanup_dgx_h100:
   extends: [.functional_cleanup]
   variables:
     CLEANUP_PLATFORM: dgx_h100
     CLEANUP_PATHS: $CLEANUP_PATHS_DGX_H100
-    CLEANUP_PROTECT: $CLEANUP_PROTECT_DGX_H100
 
 functional:cleanup_dgx_gb200:
   extends: [.functional_cleanup]
   variables:
     CLEANUP_PLATFORM: dgx_gb200
     CLEANUP_PATHS: $CLEANUP_PATHS_DGX_GB200
-    CLEANUP_PROTECT: $CLEANUP_PROTECT_DGX_GB200
 
 functional:run_lts_dgx_a100:
   extends: [.functional_run]

--- a/.gitlab/stages/04.functional-tests.yml
+++ b/.gitlab/stages/04.functional-tests.yml
@@ -246,18 +246,21 @@ functional:cleanup_dgx_a100:
   variables:
     CLEANUP_PLATFORM: dgx_a100
     CLEANUP_PATHS: $CLEANUP_PATHS_DGX_A100
+    CLEANUP_PROTECT: $CLEANUP_PROTECT_DGX_A100
 
 functional:cleanup_dgx_h100:
   extends: [.functional_cleanup]
   variables:
     CLEANUP_PLATFORM: dgx_h100
     CLEANUP_PATHS: $CLEANUP_PATHS_DGX_H100
+    CLEANUP_PROTECT: $CLEANUP_PROTECT_DGX_H100
 
 functional:cleanup_dgx_gb200:
   extends: [.functional_cleanup]
   variables:
     CLEANUP_PLATFORM: dgx_gb200
     CLEANUP_PATHS: $CLEANUP_PATHS_DGX_GB200
+    CLEANUP_PROTECT: $CLEANUP_PROTECT_DGX_GB200
 
 functional:run_lts_dgx_a100:
   extends: [.functional_run]

--- a/.gitlab/stages/04.functional-tests.yml
+++ b/.gitlab/stages/04.functional-tests.yml
@@ -176,9 +176,92 @@ functional:configure:
   inherit:
     variables: true
 
+# Prune artifacts older than 14 days from the JET assets/artifacts roots on
+# each cluster. Gated on release/weekly scope so it does not run on every MR
+# pipeline. Functional `run_*` jobs depend on the matching cleanup job via
+# `optional: true`, so pipelines without a cleanup job (e.g. `mr` scope) still
+# start their workloads immediately.
+.functional_cleanup_rules:
+  stage: functional_tests
+  rules:
+    - if: $BUILD == "no"
+      when: never
+    - if: $FUNCTIONAL_TEST == "yes" && ($FUNCTIONAL_TEST_SCOPE == "release" || $FUNCTIONAL_TEST_SCOPE == "weekly")
+      when: on_success
+    - when: never
+
+.functional_cleanup:
+  needs:
+    - functional:configure
+    - test:build_image
+  extends: [.functional_cleanup_rules]
+  image: ${UTILITY_IMAGE}:${CI_PIPELINE_ID}
+  tags:
+    - arch/amd64
+    - env/prod
+    - origin/jet-fleet
+    - owner/jet-core
+    - purpose/utility
+    - team/megatron
+  timeout: 30m
+  allow_failure: true
+  script:
+    - |
+      case "$CLEANUP_PLATFORM" in
+        dgx_a100)
+          CLEANUP_CLUSTER=$([[ "$CLUSTER_A100" != "" ]] && echo "$CLUSTER_A100" || echo "$DEFAULT_A100_CLUSTER")
+          ;;
+        dgx_h100)
+          CLEANUP_CLUSTER=$([[ "$CLUSTER_H100" != "" ]] && echo "$CLUSTER_H100" || echo "$DEFAULT_H100_CLUSTER")
+          ;;
+        dgx_gb200)
+          CLEANUP_CLUSTER=$([[ "$CLUSTER_GB200" != "" ]] && echo "$CLUSTER_GB200" || echo "$DEFAULT_GB200_CLUSTER")
+          ;;
+        *)
+          echo "Unknown CLEANUP_PLATFORM: $CLEANUP_PLATFORM"
+          exit 1
+          ;;
+      esac
+    - export PYTHONPATH=$(pwd)
+    - export RO_API_TOKEN=${PAT}
+    - |
+      python tests/test_utils/python_scripts/launch_jet_workload.py \
+        --model cleanup \
+        --test-case cleanup_old_artifacts \
+        --environment dev \
+        --n-repeat 1 \
+        --time-limit 1800 \
+        --scope cleanup \
+        --account ${CI_SLURM_ACCOUNT} \
+        --cluster ${CLEANUP_CLUSTER} \
+        --platform ${CLEANUP_PLATFORM} \
+        --container-tag ${CI_PIPELINE_ID} \
+        --container-image ${UTILITY_IMAGE} \
+        --record-checkpoints false
+
+functional:cleanup_dgx_a100:
+  extends: [.functional_cleanup]
+  variables:
+    CLEANUP_PLATFORM: dgx_a100
+
+functional:cleanup_dgx_h100:
+  extends: [.functional_cleanup]
+  variables:
+    CLEANUP_PLATFORM: dgx_h100
+
+functional:cleanup_dgx_gb200:
+  extends: [.functional_cleanup]
+  variables:
+    CLEANUP_PLATFORM: dgx_gb200
+
 functional:run_lts_dgx_a100:
   extends: [.functional_run]
   allow_failure: true
+  needs:
+    - functional:configure
+    - test:build_image
+    - job: functional:cleanup_dgx_a100
+      optional: true
   variables:
     ENVIRONMENT: lts
     CLUSTER: A100
@@ -186,6 +269,11 @@ functional:run_lts_dgx_a100:
 functional:run_lts_dgx_h100:
   extends: [.functional_run]
   allow_failure: true
+  needs:
+    - functional:configure
+    - test:build_image
+    - job: functional:cleanup_dgx_h100
+      optional: true
   variables:
     ENVIRONMENT: lts
     CLUSTER: H100
@@ -193,24 +281,44 @@ functional:run_lts_dgx_h100:
 functional:run_lts_dgx_gb200:
   extends: [.functional_run]
   allow_failure: true
+  needs:
+    - functional:configure
+    - test:build_image
+    - job: functional:cleanup_dgx_gb200
+      optional: true
   variables:
     ENVIRONMENT: lts
     CLUSTER: GB200
 
 functional:run_dev_dgx_a100:
   extends: [.functional_run]
+  needs:
+    - functional:configure
+    - test:build_image
+    - job: functional:cleanup_dgx_a100
+      optional: true
   variables:
     ENVIRONMENT: dev
     CLUSTER: A100
 
 functional:run_dev_dgx_h100:
   extends: [.functional_run]
+  needs:
+    - functional:configure
+    - test:build_image
+    - job: functional:cleanup_dgx_h100
+      optional: true
   variables:
     ENVIRONMENT: dev
     CLUSTER: H100
 
 functional:run_dev_dgx_gb200:
   extends: [.functional_run]
+  needs:
+    - functional:configure
+    - test:build_image
+    - job: functional:cleanup_dgx_gb200
+      optional: true
   variables:
     ENVIRONMENT: dev
     CLUSTER: GB200

--- a/.gitlab/stages/04.functional-tests.yml
+++ b/.gitlab/stages/04.functional-tests.yml
@@ -222,7 +222,7 @@ functional:configure:
           exit 1
           ;;
       esac
-    - CLEANUP_CLUSTER="cpu_${GPU_CLUSTER}"
+    - CLEANUP_CLUSTER="cpu_${GPU_CLUSTER#dgx*_}"
     - echo "Cleanup target = $CLEANUP_CLUSTER (CPU partition of $GPU_CLUSTER)"
     - export PYTHONPATH=$(pwd)
     - export RO_API_TOKEN=${PAT}

--- a/.gitlab/stages/04.functional-tests.yml
+++ b/.gitlab/stages/04.functional-tests.yml
@@ -245,16 +245,19 @@ functional:cleanup_dgx_a100:
   extends: [.functional_cleanup]
   variables:
     CLEANUP_PLATFORM: dgx_a100
+    CLEANUP_PATHS: $CLEANUP_PATHS_DGX_A100
 
 functional:cleanup_dgx_h100:
   extends: [.functional_cleanup]
   variables:
     CLEANUP_PLATFORM: dgx_h100
+    CLEANUP_PATHS: $CLEANUP_PATHS_DGX_H100
 
 functional:cleanup_dgx_gb200:
   extends: [.functional_cleanup]
   variables:
     CLEANUP_PLATFORM: dgx_gb200
+    CLEANUP_PATHS: $CLEANUP_PATHS_DGX_GB200
 
 functional:run_lts_dgx_a100:
   extends: [.functional_run]

--- a/tests/test_utils/python_scripts/launch_jet_workload.py
+++ b/tests/test_utils/python_scripts/launch_jet_workload.py
@@ -154,6 +154,7 @@ def launch_and_wait_for_completion(
                                         "CLUSTER": cluster,
                                         "RUN_ID": str(uuid.uuid4()),
                                         "CLEANUP_PATHS": os.getenv("CLEANUP_PATHS") or "",
+                                        "CLEANUP_PROTECT": os.getenv("CLEANUP_PROTECT") or "",
                                     }
                                 }
                             }

--- a/tests/test_utils/python_scripts/launch_jet_workload.py
+++ b/tests/test_utils/python_scripts/launch_jet_workload.py
@@ -488,7 +488,7 @@ def main(
             ["\n".join(log_lines) for log_lines in allranks_logs.values()]
         )
         concat_mainrank_log = "\n".join(mainrank_log)
-        if concat_allranks_logs.strip() == "":
+        if concat_allranks_logs.strip() == "" and concat_mainrank_log.strip() == "":
             logger.error("No logs found. Try again.")
             n_attempts += 1
             continue

--- a/tests/test_utils/python_scripts/launch_jet_workload.py
+++ b/tests/test_utils/python_scripts/launch_jet_workload.py
@@ -154,7 +154,6 @@ def launch_and_wait_for_completion(
                                         "CLUSTER": cluster,
                                         "RUN_ID": str(uuid.uuid4()),
                                         "CLEANUP_PATHS": os.getenv("CLEANUP_PATHS") or "",
-                                        "CLEANUP_PROTECT": os.getenv("CLEANUP_PROTECT") or "",
                                     }
                                 }
                             }

--- a/tests/test_utils/python_scripts/launch_jet_workload.py
+++ b/tests/test_utils/python_scripts/launch_jet_workload.py
@@ -153,6 +153,7 @@ def launch_and_wait_for_completion(
                                         "TRANSFORMERS_OFFLINE": "1",
                                         "CLUSTER": cluster,
                                         "RUN_ID": str(uuid.uuid4()),
+                                        "CLEANUP_PATHS": os.getenv("CLEANUP_PATHS") or "",
                                     }
                                 }
                             }

--- a/tests/test_utils/python_scripts/recipe_parser.py
+++ b/tests/test_utils/python_scripts/recipe_parser.py
@@ -97,6 +97,14 @@ def resolve_cluster_config(cluster: str) -> str:
         return "draco-oci-ord"
     if cluster == "dgxh100_coreweave":
         return "coreweave"
+    if cluster == "cpu_dgxh100_eos":
+        return "eos-cpu"
+    if cluster == "cpu_dgxh100_coreweave":
+        return "coreweave-cpu"
+    if cluster == "cpu_dgxa100_dracooci":
+        return "draco-oci-iad-cpu"
+    if cluster == "cpu_dgxgb200_oci-hsg":
+        return "oci-hsg-cpu"
     if cluster == "ghci":
         return "ghci"
     raise ValueError(f"Unknown cluster {cluster} provided.")

--- a/tests/test_utils/python_scripts/recipe_parser.py
+++ b/tests/test_utils/python_scripts/recipe_parser.py
@@ -97,13 +97,13 @@ def resolve_cluster_config(cluster: str) -> str:
         return "draco-oci-ord"
     if cluster == "dgxh100_coreweave":
         return "coreweave"
-    if cluster == "cpu_dgxh100_eos":
+    if cluster == "cpu_eos":
         return "eos-cpu"
-    if cluster == "cpu_dgxh100_coreweave":
+    if cluster == "cpu_coreweave":
         return "coreweave-cpu"
-    if cluster == "cpu_dgxa100_dracooci":
+    if cluster == "cpu_dracooci":
         return "draco-oci-iad-cpu"
-    if cluster == "cpu_dgxgb200_oci-hsg":
+    if cluster == "cpu_oci-hsg":
         return "oci-hsg-cpu"
     if cluster == "ghci":
         return "ghci"

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -17,52 +17,26 @@ spec:
 
     THRESHOLD_DAYS=14
 
-    # CLEANUP_PATHS holds the paths to PROTECT (never delete). The recipe
-    # scans the parent directory of each protected path and lists entries
-    # older than THRESHOLD_DAYS that are *not* protected.
+    # CLEANUP_PATHS is the newline-separated list of GC roots. For each
+    # path, the recipe lists direct children older than THRESHOLD_DAYS.
     if [[ -z "${{CLEANUP_PATHS:-}}" ]]; then
         echo "CLEANUP_PATHS env var not set; nothing to do."
         exit 0
     fi
 
-    PROTECT_PATHS=()
-    while IFS= read -r p; do
-        [[ -z "$p" ]] && continue
-        PROTECT_PATHS+=("$p")
-    done <<<"$CLEANUP_PATHS"
+    echo "[DRY-RUN] Pruning entries older than $THRESHOLD_DAYS days under:"
+    printf '%s\n' "$CLEANUP_PATHS" | sed 's/^/  - /'
 
-    declare -A SEEN_PARENTS
-    PARENTS=()
-    for p in "${{PROTECT_PATHS[@]}}"; do
-        parent=$(dirname "$p")
-        if [[ -z "${{SEEN_PARENTS[$parent]:-}}" ]]; then
-            SEEN_PARENTS[$parent]=1
-            PARENTS+=("$parent")
-        fi
-    done
-
-    echo "[DRY-RUN] Protect (never delete): ${{PROTECT_PATHS[*]}}"
-    echo "[DRY-RUN] Scanning parents: ${{PARENTS[*]}}"
-    echo "[DRY-RUN] Threshold: $THRESHOLD_DAYS days"
-
-    for parent in "${{PARENTS[@]}}"; do
-        if [[ "$parent" == "/" || ! -d "$parent" ]]; then
-            echo "Skipping unsafe or missing parent: $parent"
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        if [[ "$path" == "/" || ! -d "$path" ]]; then
+            echo "Skipping unsafe or missing path: $path"
             continue
         fi
-
-        find_args=( "$parent" -mindepth 1 -maxdepth 1 -mtime +$THRESHOLD_DAYS )
-        for p in "${{PROTECT_PATHS[@]}}"; do
-            if [[ "$(dirname "$p")" == "$parent" ]]; then
-                find_args+=( ! -name "$(basename "$p")" )
-            fi
-        done
-        find_args+=( -print )
-
-        echo "--- Would delete from $parent (excluding protected entries) ---"
-        find "${{find_args[@]}}" 2>/dev/null || true
+        echo "--- Would delete from $path ---"
+        find "$path" -mindepth 1 -maxdepth 1 -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
         echo "--- (dry-run: no deletion) ---"
-    done
+    done <<<"$CLEANUP_PATHS"
 
     echo "Dry-run complete; no files removed."
 

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -15,11 +15,11 @@ spec:
   script: |-
     set -euo pipefail
 
-    THRESHOLD_DAYS=14
+    THRESHOLD_DAYS=28
 
     # CLEANUP_PATHS: newline-separated scan roots. The recipe descends each
-    # root and lists files older than THRESHOLD_DAYS, then a second pass
-    # for empty directories.
+    # root, deletes files older than THRESHOLD_DAYS, then sweeps empty
+    # directories.
     # CLEANUP_PROTECT: newline-separated subtrees to prune (skip entirely)
     # during traversal.
     if [[ -z "${{CLEANUP_PATHS:-}}" ]]; then
@@ -27,24 +27,25 @@ spec:
         exit 0
     fi
 
-    PRUNE_ARGS=()
+    # Use `! -path X ! -path X/*` filters rather than `-prune`: `-delete`
+    # implies `-depth`, and `-depth` makes `-prune` a silent no-op. With
+    # negative-path matching, find still descends into the protected
+    # subtree but never matches any entry inside it.
+    SKIP_ARGS=()
     if [[ -n "${{CLEANUP_PROTECT:-}}" ]]; then
         while IFS= read -r protect; do
             [[ -z "$protect" ]] && continue
-            if [[ ${{#PRUNE_ARGS[@]}} -gt 0 ]]; then
-                PRUNE_ARGS+=( -o )
-            fi
-            PRUNE_ARGS+=( -path "$protect" )
+            SKIP_ARGS+=( ! -path "$protect" ! -path "$protect/*" )
         done <<<"$CLEANUP_PROTECT"
     fi
 
-    echo "[DRY-RUN] Scan roots:"
+    echo "Scan roots:"
     printf '%s\n' "$CLEANUP_PATHS" | sed 's/^/  - /'
-    if [[ ${{#PRUNE_ARGS[@]}} -gt 0 ]]; then
-        echo "[DRY-RUN] Pruned subtrees:"
+    if [[ -n "${{CLEANUP_PROTECT:-}}" ]]; then
+        echo "Protected subtrees (skipped):"
         printf '%s\n' "$CLEANUP_PROTECT" | sed 's/^/  - /'
     fi
-    echo "[DRY-RUN] Threshold: $THRESHOLD_DAYS days"
+    echo "Threshold: $THRESHOLD_DAYS days"
 
     while IFS= read -r path; do
         [[ -z "$path" ]] && continue
@@ -52,22 +53,13 @@ spec:
             echo "Skipping unsafe or missing path: $path"
             continue
         fi
-        echo "--- Would delete (files older than $THRESHOLD_DAYS days) under $path ---"
-        if [[ ${{#PRUNE_ARGS[@]}} -gt 0 ]]; then
-            find "$path" -mindepth 1 \( "${{PRUNE_ARGS[@]}}" \) -prune -o -type f -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
-        else
-            find "$path" -mindepth 1 -type f -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
-        fi
-        echo "--- Would also prune (empty directories, post-file-sweep) under $path ---"
-        if [[ ${{#PRUNE_ARGS[@]}} -gt 0 ]]; then
-            find "$path" -mindepth 1 \( "${{PRUNE_ARGS[@]}}" \) -prune -o -depth -type d -empty -print 2>/dev/null || true
-        else
-            find "$path" -mindepth 1 -depth -type d -empty -print 2>/dev/null || true
-        fi
-        echo "--- (dry-run: no deletion) ---"
+        echo "--- Deleting files older than $THRESHOLD_DAYS days under $path ---"
+        find "$path" -mindepth 1 "${{SKIP_ARGS[@]}}" -type f -mtime +$THRESHOLD_DAYS -print -delete 2>/dev/null || true
+        echo "--- Pruning empty directories under $path ---"
+        find "$path" -mindepth 1 "${{SKIP_ARGS[@]}}" -type d -empty -print -delete 2>/dev/null || true
     done <<<"$CLEANUP_PATHS"
 
-    echo "Dry-run complete; no files removed."
+    echo "Cleanup complete."
 
 products:
   - test_case: [cleanup_old_artifacts]

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -33,8 +33,10 @@ spec:
             echo "Skipping unsafe or missing path: $path"
             continue
         fi
-        echo "--- Would delete from $path ---"
+        echo "--- Would delete (files older than $THRESHOLD_DAYS days) from $path ---"
         find "$path" -mindepth 1 -type f -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
+        echo "--- Would also prune (empty directories, post-file-sweep) from $path ---"
+        find "$path" -mindepth 1 -depth -type d -empty -print 2>/dev/null || true
         echo "--- (dry-run: no deletion) ---"
     done <<<"$CLEANUP_PATHS"
 

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -34,7 +34,7 @@ spec:
             continue
         fi
         echo "--- Would delete from $path ---"
-        find "$path" -mindepth 1 -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
+        find "$path" -mindepth 1 -type f -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
         echo "--- (dry-run: no deletion) ---"
     done <<<"$CLEANUP_PATHS"
 

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -1,0 +1,45 @@
+type: basic
+format_version: 1
+maintainers: [mcore]
+loggers: [stdout]
+spec:
+  name: '{test_case}_{platforms}'
+  model: cleanup
+  build: mcore-pyt-{environment}
+  nodes: 1
+  gpus: 0
+  n_repeat: 1
+  platforms: dgx_h100
+  script_setup: |
+    echo "Cleanup workload — no setup required."
+  script: |-
+    set -euo pipefail
+
+    THRESHOLD_DAYS=14
+    ASSETS_PARENT=$(dirname "{assets_dir}")
+    ARTIFACTS_PARENT=$(dirname "{artifacts_dir}")
+
+    echo "Removing entries older than $THRESHOLD_DAYS days under:"
+    echo "  - $ASSETS_PARENT"
+    echo "  - $ARTIFACTS_PARENT"
+
+    for path in "$ASSETS_PARENT" "$ARTIFACTS_PARENT"; do
+        if [[ -z "$path" || "$path" == "/" || ! -d "$path" ]]; then
+            echo "Skipping invalid path: '$path'"
+            continue
+        fi
+        echo "--- Candidates in $path ---"
+        find "$path" -mindepth 1 -maxdepth 1 -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
+        echo "--- Deleting ---"
+        find "$path" -mindepth 1 -maxdepth 1 -mtime +$THRESHOLD_DAYS -print0 2>/dev/null \
+            | xargs -0 -r rm -rf 2>/dev/null || true
+    done
+
+    echo "Cleanup complete."
+
+products:
+  - test_case: [cleanup_old_artifacts]
+    products:
+      - environment: [dev]
+        scope: [cleanup]
+        platforms: [dgx_a100, dgx_h100, dgx_gb200]

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -16,16 +16,19 @@ spec:
     set -euo pipefail
 
     THRESHOLD_DAYS=14
-    ASSETS_PARENT=$(dirname "{assets_dir}")
-    ARTIFACTS_PARENT=$(dirname "{artifacts_dir}")
+    CLEANUP_PATHS=(
+        /lustre/fsw/coreai_dlalgo_mcore/release-testing
+        /lustre/fsw/coreai_dlalgo_mcore/mcore_ci
+    )
 
     echo "[DRY-RUN] Entries older than $THRESHOLD_DAYS days under:"
-    echo "  - $ASSETS_PARENT"
-    echo "  - $ARTIFACTS_PARENT"
+    for path in "${{CLEANUP_PATHS[@]}}"; do
+        echo "  - $path"
+    done
 
-    for path in "$ASSETS_PARENT" "$ARTIFACTS_PARENT"; do
-        if [[ -z "$path" || "$path" == "/" || ! -d "$path" ]]; then
-            echo "Skipping invalid path: '$path'"
+    for path in "${{CLEANUP_PATHS[@]}}"; do
+        if [[ ! -d "$path" ]]; then
+            echo "Skipping (not a directory on this cluster): $path"
             continue
         fi
         echo "--- Would delete from $path ---"

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -17,15 +17,34 @@ spec:
 
     THRESHOLD_DAYS=14
 
-    # CLEANUP_PATHS is the newline-separated list of GC roots. For each
-    # path, the recipe lists direct children older than THRESHOLD_DAYS.
+    # CLEANUP_PATHS: newline-separated scan roots. The recipe descends each
+    # root and lists files older than THRESHOLD_DAYS, then a second pass
+    # for empty directories.
+    # CLEANUP_PROTECT: newline-separated subtrees to prune (skip entirely)
+    # during traversal.
     if [[ -z "${{CLEANUP_PATHS:-}}" ]]; then
         echo "CLEANUP_PATHS env var not set; nothing to do."
         exit 0
     fi
 
-    echo "[DRY-RUN] Pruning entries older than $THRESHOLD_DAYS days under:"
+    PRUNE_ARGS=()
+    if [[ -n "${{CLEANUP_PROTECT:-}}" ]]; then
+        while IFS= read -r protect; do
+            [[ -z "$protect" ]] && continue
+            if [[ ${{#PRUNE_ARGS[@]}} -gt 0 ]]; then
+                PRUNE_ARGS+=( -o )
+            fi
+            PRUNE_ARGS+=( -path "$protect" )
+        done <<<"$CLEANUP_PROTECT"
+    fi
+
+    echo "[DRY-RUN] Scan roots:"
     printf '%s\n' "$CLEANUP_PATHS" | sed 's/^/  - /'
+    if [[ ${{#PRUNE_ARGS[@]}} -gt 0 ]]; then
+        echo "[DRY-RUN] Pruned subtrees:"
+        printf '%s\n' "$CLEANUP_PROTECT" | sed 's/^/  - /'
+    fi
+    echo "[DRY-RUN] Threshold: $THRESHOLD_DAYS days"
 
     while IFS= read -r path; do
         [[ -z "$path" ]] && continue
@@ -33,10 +52,18 @@ spec:
             echo "Skipping unsafe or missing path: $path"
             continue
         fi
-        echo "--- Would delete (files older than $THRESHOLD_DAYS days) from $path ---"
-        find "$path" -mindepth 1 -type f -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
-        echo "--- Would also prune (empty directories, post-file-sweep) from $path ---"
-        find "$path" -mindepth 1 -depth -type d -empty -print 2>/dev/null || true
+        echo "--- Would delete (files older than $THRESHOLD_DAYS days) under $path ---"
+        if [[ ${{#PRUNE_ARGS[@]}} -gt 0 ]]; then
+            find "$path" -mindepth 1 \( "${{PRUNE_ARGS[@]}}" \) -prune -o -type f -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
+        else
+            find "$path" -mindepth 1 -type f -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
+        fi
+        echo "--- Would also prune (empty directories, post-file-sweep) under $path ---"
+        if [[ ${{#PRUNE_ARGS[@]}} -gt 0 ]]; then
+            find "$path" -mindepth 1 \( "${{PRUNE_ARGS[@]}}" \) -prune -o -depth -type d -empty -print 2>/dev/null || true
+        else
+            find "$path" -mindepth 1 -depth -type d -empty -print 2>/dev/null || true
+        fi
         echo "--- (dry-run: no deletion) ---"
     done <<<"$CLEANUP_PATHS"
 

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -17,34 +17,19 @@ spec:
 
     THRESHOLD_DAYS=28
 
-    # CLEANUP_PATHS: newline-separated scan roots. The recipe descends each
-    # root, deletes files older than THRESHOLD_DAYS, then sweeps empty
-    # directories.
-    # CLEANUP_PROTECT: newline-separated subtrees to prune (skip entirely)
-    # during traversal.
+    # CLEANUP_PATHS: newline-separated base directories. For each base dir,
+    # the recipe deletes immediate child directories whose names match
+    # `weekly-*` or `release-*` and whose mtime is older than
+    # THRESHOLD_DAYS. The pattern match is the safety boundary — nothing
+    # outside those two name prefixes is touched.
     if [[ -z "${{CLEANUP_PATHS:-}}" ]]; then
         echo "CLEANUP_PATHS env var not set; nothing to do."
         exit 0
     fi
 
-    # Use `! -path X ! -path X/*` filters rather than `-prune`: `-delete`
-    # implies `-depth`, and `-depth` makes `-prune` a silent no-op. With
-    # negative-path matching, find still descends into the protected
-    # subtree but never matches any entry inside it.
-    SKIP_ARGS=()
-    if [[ -n "${{CLEANUP_PROTECT:-}}" ]]; then
-        while IFS= read -r protect; do
-            [[ -z "$protect" ]] && continue
-            SKIP_ARGS+=( ! -path "$protect" ! -path "$protect/*" )
-        done <<<"$CLEANUP_PROTECT"
-    fi
-
-    echo "Scan roots:"
+    echo "Base dirs (top-level only):"
     printf '%s\n' "$CLEANUP_PATHS" | sed 's/^/  - /'
-    if [[ -n "${{CLEANUP_PROTECT:-}}" ]]; then
-        echo "Protected subtrees (skipped):"
-        printf '%s\n' "$CLEANUP_PROTECT" | sed 's/^/  - /'
-    fi
+    echo "Match patterns: weekly-* release-*"
     echo "Threshold: $THRESHOLD_DAYS days"
 
     while IFS= read -r path; do
@@ -53,10 +38,11 @@ spec:
             echo "Skipping unsafe or missing path: $path"
             continue
         fi
-        echo "--- Deleting files older than $THRESHOLD_DAYS days under $path ---"
-        find "$path" -mindepth 1 "${{SKIP_ARGS[@]}}" -type f -mtime +$THRESHOLD_DAYS -print -delete 2>/dev/null || true
-        echo "--- Pruning empty directories under $path ---"
-        find "$path" -mindepth 1 "${{SKIP_ARGS[@]}}" -type d -empty -print -delete 2>/dev/null || true
+        echo "--- Deleting weekly-*/release-* dirs older than $THRESHOLD_DAYS days under $path ---"
+        find "$path" -mindepth 1 -maxdepth 1 -type d \
+            \( -name 'weekly-*' -o -name 'release-*' \) \
+            -mtime +$THRESHOLD_DAYS -print0 \
+          | xargs -0 -r rm -rf
     done <<<"$CLEANUP_PATHS"
 
     echo "Cleanup complete."

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -17,24 +17,52 @@ spec:
 
     THRESHOLD_DAYS=14
 
+    # CLEANUP_PATHS holds the paths to PROTECT (never delete). The recipe
+    # scans the parent directory of each protected path and lists entries
+    # older than THRESHOLD_DAYS that are *not* protected.
     if [[ -z "${{CLEANUP_PATHS:-}}" ]]; then
         echo "CLEANUP_PATHS env var not set; nothing to do."
         exit 0
     fi
 
-    echo "[DRY-RUN] Entries older than $THRESHOLD_DAYS days under:"
-    printf '%s\n' "$CLEANUP_PATHS" | sed 's/^/  - /'
+    PROTECT_PATHS=()
+    while IFS= read -r p; do
+        [[ -z "$p" ]] && continue
+        PROTECT_PATHS+=("$p")
+    done <<<"$CLEANUP_PATHS"
 
-    while IFS= read -r path; do
-        [[ -z "$path" ]] && continue
-        if [[ ! -d "$path" ]]; then
-            echo "Skipping (not a directory on this cluster): $path"
+    declare -A SEEN_PARENTS
+    PARENTS=()
+    for p in "${{PROTECT_PATHS[@]}}"; do
+        parent=$(dirname "$p")
+        if [[ -z "${{SEEN_PARENTS[$parent]:-}}" ]]; then
+            SEEN_PARENTS[$parent]=1
+            PARENTS+=("$parent")
+        fi
+    done
+
+    echo "[DRY-RUN] Protect (never delete): ${{PROTECT_PATHS[*]}}"
+    echo "[DRY-RUN] Scanning parents: ${{PARENTS[*]}}"
+    echo "[DRY-RUN] Threshold: $THRESHOLD_DAYS days"
+
+    for parent in "${{PARENTS[@]}}"; do
+        if [[ "$parent" == "/" || ! -d "$parent" ]]; then
+            echo "Skipping unsafe or missing parent: $parent"
             continue
         fi
-        echo "--- Would delete from $path ---"
-        find "$path" -mindepth 1 -maxdepth 1 -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
+
+        find_args=( "$parent" -mindepth 1 -maxdepth 1 -mtime +$THRESHOLD_DAYS )
+        for p in "${{PROTECT_PATHS[@]}}"; do
+            if [[ "$(dirname "$p")" == "$parent" ]]; then
+                find_args+=( ! -name "$(basename "$p")" )
+            fi
+        done
+        find_args+=( -print )
+
+        echo "--- Would delete from $parent (excluding protected entries) ---"
+        find "${{find_args[@]}}" 2>/dev/null || true
         echo "--- (dry-run: no deletion) ---"
-    done <<<"$CLEANUP_PATHS"
+    done
 
     echo "Dry-run complete; no files removed."
 

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -19,7 +19,7 @@ spec:
     ASSETS_PARENT=$(dirname "{assets_dir}")
     ARTIFACTS_PARENT=$(dirname "{artifacts_dir}")
 
-    echo "Removing entries older than $THRESHOLD_DAYS days under:"
+    echo "[DRY-RUN] Entries older than $THRESHOLD_DAYS days under:"
     echo "  - $ASSETS_PARENT"
     echo "  - $ARTIFACTS_PARENT"
 
@@ -28,14 +28,12 @@ spec:
             echo "Skipping invalid path: '$path'"
             continue
         fi
-        echo "--- Candidates in $path ---"
+        echo "--- Would delete from $path ---"
         find "$path" -mindepth 1 -maxdepth 1 -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
-        echo "--- Deleting ---"
-        find "$path" -mindepth 1 -maxdepth 1 -mtime +$THRESHOLD_DAYS -print0 2>/dev/null \
-            | xargs -0 -r rm -rf 2>/dev/null || true
+        echo "--- (dry-run: no deletion) ---"
     done
 
-    echo "Cleanup complete."
+    echo "Dry-run complete; no files removed."
 
 products:
   - test_case: [cleanup_old_artifacts]

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -16,17 +16,17 @@ spec:
     set -euo pipefail
 
     THRESHOLD_DAYS=14
-    CLEANUP_PATHS=(
-        /lustre/fsw/coreai_dlalgo_mcore/release-testing
-        /lustre/fsw/coreai_dlalgo_mcore/mcore_ci
-    )
+
+    if [[ -z "${{CLEANUP_PATHS:-}}" ]]; then
+        echo "CLEANUP_PATHS env var not set; nothing to do."
+        exit 0
+    fi
 
     echo "[DRY-RUN] Entries older than $THRESHOLD_DAYS days under:"
-    for path in "${{CLEANUP_PATHS[@]}}"; do
-        echo "  - $path"
-    done
+    printf '%s\n' "$CLEANUP_PATHS" | sed 's/^/  - /'
 
-    for path in "${{CLEANUP_PATHS[@]}}"; do
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
         if [[ ! -d "$path" ]]; then
             echo "Skipping (not a directory on this cluster): $path"
             continue
@@ -34,7 +34,7 @@ spec:
         echo "--- Would delete from $path ---"
         find "$path" -mindepth 1 -maxdepth 1 -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
         echo "--- (dry-run: no deletion) ---"
-    done
+    done <<<"$CLEANUP_PATHS"
 
     echo "Dry-run complete; no files removed."
 

--- a/tests/test_utils/recipes/_cleanup.yaml
+++ b/tests/test_utils/recipes/_cleanup.yaml
@@ -34,7 +34,7 @@ spec:
             continue
         fi
         echo "--- Would delete from $path ---"
-        find "$path" -mindepth 1 -maxdepth 1 -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
+        find "$path" -mindepth 1 -mtime +$THRESHOLD_DAYS -print 2>/dev/null || true
         echo "--- (dry-run: no deletion) ---"
     done <<<"$CLEANUP_PATHS"
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Summary
- Adds `functional:cleanup_dgx_{a100,h100,gb200}` jobs (one per cluster) to `.gitlab/stages/04.functional-tests.yml`, gated on `FUNCTIONAL_TEST_SCOPE in [release, weekly]`. Each submits a JET workload that **deletes** `weekly-*` and `release-*` directories older than 28 days at depth 1 of each cluster-side base dir.
- New JET cluster configs in `dl/jet/ci` on branches `mcore/{coreweave,oci-hsg,draco-oci-iad,eos}-cpu` — partition `cpu` (Eos: `interactive`, no dedicated CPU partition), no `gpus_per_node`, no `exclusive`. The cleanup never reserves a GPU.

## How it works
Each `functional:run_*` job has an `optional: true` `needs:` on the matching `functional:cleanup_dgx_<platform>`:
- **mr / nightly** pipelines — cleanup excluded by rule; functional run starts immediately.
- **weekly / release** pipelines — cleanup runs first, then functional jobs.

`.functional_cleanup` derives `CLEANUP_CLUSTER="cpu_${GPU_CLUSTER#dgx*_}"` and submits via `launch_jet_workload.py --scope cleanup`. The launch script forwards `CLEANUP_PATHS` into the JET workload environment.

The recipe walks each `CLEANUP_PATHS` base dir at **depth 1 only** and matches directories whose names start with `weekly-` or `release-`. Matched directories older than 28 days are removed with `rm -rf`. The name pattern is the safety boundary — nothing outside those two prefixes is touched.

## Required GitLab CI variables (already configured)
Set in project Settings → CI/CD → Variables (newline-separated paths, `raw: true`):

| Variable | Purpose |
|---|---|
| `CLEANUP_PATHS_DGX_{A100,H100,GB200}` | Base dirs whose direct `weekly-*` / `release-*` children are eligible |

Recipe exits cleanly with "nothing to do" if `CLEANUP_PATHS` is empty.

## Recipe example
```yaml
# tests/test_utils/recipes/_cleanup.yaml
spec:
  model: cleanup
  build: mcore-pyt-{environment}
  gpus: 0                       # CPU partition handles the rest
  script: |-
    THRESHOLD_DAYS=28
    while IFS= read -r path; do
        find "$path" -mindepth 1 -maxdepth 1 -type d \
            \( -name 'weekly-*' -o -name 'release-*' \) \
            -mtime +$THRESHOLD_DAYS -print0 \
          | xargs -0 -r rm -rf
    done <<<"$CLEANUP_PATHS"
products:
  - test_case: [cleanup_old_artifacts]
    products:
      - scope: [cleanup]
        platforms: [dgx_a100, dgx_h100, dgx_gb200]
```

## Test plan
- [ ] Trigger weekly-scope pipeline; verify `functional:cleanup_dgx_*` runs before `functional:run_*` on the matching cluster.
- [ ] Each cleanup job log lists deletions of `weekly-*` / `release-*` directories older than 28 days under each base dir, and **nothing else**.
- [ ] mr-scope pipeline does **not** run cleanup jobs (gated by scope rule).
- [ ] Post-run, sanity-check `ls` on each base dir and confirm only fresh `weekly-*` / `release-*` entries remain; all other siblings (e.g. `mcore_ci`) intact.

</details>
