### PR TITLE
Add VPP training simulation framework

### DIFF
--- a/docs/user-guide/features/index.md
+++ b/docs/user-guide/features/index.md
@@ -23,6 +23,7 @@ dist_optimizer
 optimizer_cpu_offload
 paged_stash
 pipeline_parallel_layout
+vpp_simulation
 tokenizers
 megatron_energon
 megatron_rl

--- a/docs/user-guide/features/vpp_simulation.md
+++ b/docs/user-guide/features/vpp_simulation.md
@@ -1,0 +1,134 @@
+<!---
+   Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+   NVIDIA CORPORATION and its licensors retain all intellectual property
+   and proprietary rights in and to this software, related documentation
+   and any modifications thereto. Any use, reproduction, disclosure or
+   distribution of this software and related documentation without an express
+   license agreement from NVIDIA CORPORATION is strictly prohibited.
+-->
+
+# VPP Training Simulation
+
+VPP training simulation estimates one global-batch step for an interleaved
+pipeline-parallel training recipe without launching the full pipeline world. It
+is intended for performance sampling and schedule analysis of large PP/VPP
+models when running the complete trainer is expensive.
+
+## Execution Model
+
+Simulation launches an executor world and folds pipeline parallelism out during
+initialization. After Megatron initialization, the simulator restores the target
+pipeline layout and sequentially samples the work that would have run on each
+virtual pipeline rank.
+
+For a target recipe with `PP = pipeline_model_parallel_size`, the executor
+world is typically the target world with PP removed:
+
+```text
+executor_world_size = launched WORLD_SIZE
+vtrainer_world_size = executor_world_size * PP
+```
+
+For example, a 256-GPU target recipe with `TP2/PP8/CP1` can be sampled on
+32 executor GPUs. The simulator restores `PP=8`, samples all PP stages, and
+reconstructs a full 256-GPU global-batch timeline.
+
+## Data Parallel Size
+
+Megatron derives the non-expert data-parallel size from the full virtual
+trainer shape:
+
+```text
+data_parallel_size = vtrainer_world_size / (TP * PP * CP)
+```
+
+During simulation initialization, `PP` is temporarily set to 1 so the smaller
+executor world can initialize process groups. After initialization, simulation
+restores the original PP layout and expands `data_parallel_size` by the
+restored PP size. The global-batch microbatch count therefore follows the
+target trainer:
+
+```text
+num_microbatches = global_batch_size / (micro_batch_size * data_parallel_size)
+```
+
+MoE expert data parallelism is a separate expert-group dimension. It is derived
+from the expert tensor/pipeline/expert-parallel shape and should not be confused
+with the non-expert `data_parallel_size`.
+
+## Task DAG And Timing
+
+The simulator builds forward and backward tasks for every tuple of
+`(pp_rank, microbatch_id, model_chunk_id)`. Dependencies are created from:
+
+* the pipeline schedule for each PP rank,
+* forward-to-backward dependencies for the same microbatch and chunk,
+* cross-PP forward and backward edges.
+
+Each task stores a measured duration in milliseconds. The analyzer computes the
+global-batch time from the reconstructed DAG:
+
+```text
+gbs_time = latest_task_end_time - earliest_task_start_time
+```
+
+The primary throughput metric is normalized by the full virtual trainer size,
+because the reconstructed time models the target full-world global-batch step:
+
+```text
+throughput_per_gpu = FLOPs(one GBS) / (gbs_time * 1e12 * vtrainer_world_size)
+```
+
+The executor-normalized throughput is also reported as a sampling diagnostic:
+
+```text
+executor_normalized_throughput =
+    FLOPs(one GBS) / (gbs_time * 1e12 * executor_world_size)
+```
+
+## Memory And Allocator Lifetime
+
+Simulation should time the same compute region that the full trainer executes.
+Per-repeat cleanup must not include allocator-level cache eviction. In
+particular, `torch.cuda.empty_cache()` is kept at model-chunk teardown
+boundaries but is not part of the per-repeat timing release path.
+
+Gradient tensors are also kept allocated across timing repeats and zeroed
+instead of being set to `None`. This keeps the CUDA caching allocator and CUDA
+graph pools stable after warmup, avoiding repeated large allocations and making
+sampled chunk timing closer to full training.
+
+## Unsupported Features
+
+Simulation currently samples individual forward and backward tasks directly
+instead of running the full training loop's CUDA graph capture and replay
+lifecycle. It therefore rejects CUDA graph modes while `--simulate-global-step`
+is enabled:
+
+* `--cuda-graph-impl` values other than `none`,
+* non-empty `--cuda-graph-modules`,
+* `--optimizer-cuda-graph`.
+
+These guards prevent reporting eager task timings as if they were equivalent to
+full training with captured CUDA graphs. CUDA graph support should be added only
+after the simulator can run the same warmup, capture, and replay lifecycle as
+the corresponding training path.
+
+## Unit Test Coverage
+
+`tests/unit_tests/simulation/test_vpp_simulator_e2e.py` is a single-node E2E
+smoke test. It initializes the real NCCL process group on the local ranks and
+uses a tiny MCore GPT model to run the simulator's real forward/backward timing
+functions:
+
+* task creation and scheduling,
+* model creation and static-memory collection,
+* warmup and measured CUDA task execution,
+* result serialization,
+* analyzer load and throughput reporting.
+
+The test is expected to run under the regular Megatron unit-test launcher with
+one node and eight processes. All ranks exercise the simulator execution path,
+and rank 0 validates the saved result files, positive measured task durations,
+and the `executor_world_size` versus `vtrainer_world_size` throughput
+accounting.

--- a/examples/simulation/simulate_deepseek_v3.sh
+++ b/examples/simulation/simulate_deepseek_v3.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# Simulate DeepSeek v3
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export NCCL_DEBUG=WARN
+
+GPUS_PER_NODE=8
+# Change for multinode config
+MASTER_ADDR=localhost
+MASTER_PORT=29527
+NUM_NODES=1
+NODE_RANK=0
+WORLD_SIZE=$(($GPUS_PER_NODE*$NUM_NODES))
+
+export TIME_STAMP=$(date '+%Y%m%d-%H%M')
+
+BASEDIR="${SIMULATION_OUTPUT_DIR:-./simulation_results}"
+LOG_PATH="${BASEDIR}/simulate_deepseek_v3/${TIME_STAMP}/logs"
+OUTPUT_PATH="${BASEDIR}/simulate_deepseek_v3/${TIME_STAMP}/outputs"
+mkdir -p $LOG_PATH
+mkdir -p $OUTPUT_PATH
+
+# Backup script to log directory
+if [[ $NODE_RANK -eq 0 ]]; then
+    cp -r ${0} ${LOG_PATH}
+fi
+
+CHECKPOINT_PATH=$1 #<Specify path>
+TENSORBOARD_LOGS_PATH=$2 #<Specify path>
+VOCAB_FILE=$3 #<Specify path to file>/gpt2-vocab.json
+MERGE_FILE=$4 #<Specify path to file>/gpt2-merges.txt
+DATA_PATH=$5 #<Specify path and file prefix>_text_document
+
+DISTRIBUTED_ARGS=(
+    --nproc_per_node $GPUS_PER_NODE
+    --nnodes $NUM_NODES
+    --master_addr $MASTER_ADDR
+    --master_port $MASTER_PORT
+)
+
+DEEPSEEK_MODEL=(
+    --num-layers 14
+    --seq-length 4096
+    --max-position-embeddings 4096
+    --max-position-embeddings 4096
+    --hidden-size 7168
+    --ffn-hidden-size 18432
+    --num-attention-heads 128
+    --kv-channels 128
+
+    --position-embedding-type rope
+    --rotary-base 10000
+    --make-vocab-size-divisible-by 3232
+    --attention-backend fused # Can use (flash/fused/unfused/local)
+    --moe-router-load-balancing-type seq_aux_loss
+    --moe-router-topk 8
+    --moe-grouped-gemm
+    --moe-aux-loss-coeff 1e-4
+    --moe-router-group-topk 4
+    --moe-router-num-groups 8
+    --moe-router-pre-softmax
+    #--moe-router-padding-for-quantization
+    --moe-router-topk-scaling-factor 2.5
+    --moe-router-score-function sigmoid
+    --moe-router-enable-expert-bias
+    --moe-router-bias-update-rate 1e-3
+    --moe-router-dtype fp32
+    #--moe-permute-fusion
+    #--moe-router-fusion
+    --q-lora-rank 1536
+    --kv-lora-rank 512
+    --qk-head-dim 128
+    --qk-pos-emb-head-dim 64
+    --v-head-dim 128
+    --disable-bias-linear
+
+    --num-experts 256
+    --moe-layer-freq "[0]*1+[1]*13"
+    --moe-ffn-hidden-size 2048
+    --moe-shared-expert-intermediate-size 2048
+
+    --normalization RMSNorm
+    --norm-epsilon 1e-6
+    --swiglu
+    --untie-embeddings-and-output-weights
+    --multi-latent-attention
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+)
+
+TRAINING_ARGS=(
+    --micro-batch-size 1
+    --global-batch-size 384
+    --train-iters 500000
+    --weight-decay 0.1
+    --adam-beta1 0.9
+    --adam-beta2 0.95
+    --init-method-std 0.006
+    --clip-grad 1.0
+    --bf16
+    --lr 6.0e-5
+    --lr-decay-style cosine
+    --min-lr 6.0e-6
+    --lr-warmup-fraction .001
+    --lr-decay-iters 430000
+)
+
+MODEL_PARALLEL_ARGS=(
+	--tensor-model-parallel-size 1
+	--pipeline-model-parallel-size 4
+    --expert-model-parallel-size 8
+    --expert-tensor-parallel-size 1
+    --pipeline-model-parallel-layout "Ett|(tt|)*6L"
+    --moe-token-dispatcher-type flex
+    --moe-flex-dispatcher-backend deepep
+    --sequence-parallel
+)
+
+DATA_ARGS=(
+    --mock-data
+    --tokenizer-type NullTokenizer
+    --vocab-size 128256
+)
+
+COMPUTE_ARGS=(
+    --use-distributed-optimizer
+    --overlap-grad-reduce
+    --overlap-param-gather
+    --use-mcore-models
+
+    --no-save-optim
+    --no-check-for-nan-in-loss-and-grad
+    --cross-entropy-loss-fusion
+    --cross-entropy-fusion-impl te
+    --manual-gc
+    --manual-gc-interval 10
+    --enable-experimental
+    --transformer-impl transformer_engine
+
+    # --fp8-recipe mxfp8
+    # --fp8-format e4m3
+    # --fp8-param-gather
+    # --reuse-grad-buf-for-mxfp8-param-ag
+)
+
+SIMULATE_ARGS=(
+    --simulate-global-step
+    --execute-mode "router_balanced"
+    --simulate-result-dir ${OUTPUT_PATH}
+)
+
+# SIMULATE_ARGS=(
+#     --simulate-global-step
+#     --skip-execute
+#     --load-result-dir /dnn_training_sys/users/lisiyuan.li/autolab/workspace/simulation/simulate_deepseek_v3/20251213-2025/outputs
+# )
+
+CMD="torchrun ${DISTRIBUTED_ARGS[@]} pretrain_gpt.py \
+    ${DEEPSEEK_MODEL[@]} \
+    ${TRAINING_ARGS[@]} \
+    ${COMPUTE_ARGS[@]} \
+    ${MODEL_PARALLEL_ARGS[@]} \
+    ${DATA_ARGS[@]} \
+    ${SIMULATE_ARGS[@]}"
+
+$CMD 2>&1 | tee ${LOG_PATH}/log_${NODE_RANK}.log

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Megatron arguments."""
 
@@ -2020,6 +2020,19 @@ def validate_args(args, defaults={}):
 
     # Validate simulate-result-dir when simulate-global-step is enabled
     if args.simulate_global_step:
+        assert args.cuda_graph_impl == "none", (
+            "VPP simulation does not support CUDA graph capture/replay yet. "
+            "Disable --cuda-graph-impl when using --simulate-global-step."
+        )
+        assert not args.cuda_graph_modules, (
+            "VPP simulation does not support --cuda-graph-modules yet. "
+            "Disable CUDA graph module capture when using --simulate-global-step."
+        )
+        assert not args.optimizer_cuda_graph, (
+            "VPP simulation does not support --optimizer-cuda-graph because simulation "
+            "does not execute optimizer steps."
+        )
+
         # Validate skip-execute and load-result-dir dependencies
         if args.skip_execute:
             assert args.load_result_dir is not None, \
@@ -2029,6 +2042,14 @@ def validate_args(args, defaults={}):
         else:
             assert args.simulate_result_dir is not None, \
                 "When --simulate-global-step is enabled (without --skip-execute), --simulate-result-dir must be provided."
+            assert args.simulation_warmup_times >= 0, \
+                "--simulation-warmup-times must be non-negative."
+            assert args.simulation_measure_times > 0, \
+                "--simulation-measure-times must be positive."
+            assert args.simulation_measure_skip_times >= 0, \
+                "--simulation-measure-skip-times must be non-negative."
+            assert args.simulation_measure_times > args.simulation_measure_skip_times, \
+                "--simulation-measure-times must be greater than --simulation-measure-skip-times."
 
         # Auto-disable incompatible options in simulation mode
         if args.overlap_grad_reduce:
@@ -4913,5 +4934,11 @@ def _add_simulation_args(parser):
     group.add_argument('--load-result-dir', type=str, required=False, default=None,
                        help='Directory path to load previously saved simulation results. '
                        'Used with --skip-execute to reanalyze existing results without re-execution.')
+    group.add_argument('--simulation-warmup-times', type=int, required=False, default=15,
+                       help='Number of warmup iterations for each executed simulation task.')
+    group.add_argument('--simulation-measure-times', type=int, required=False, default=10,
+                       help='Number of measured iterations for each executed simulation task.')
+    group.add_argument('--simulation-measure-skip-times', type=int, required=False, default=5,
+                       help='Number of measured simulation iterations to skip when averaging.')
 
     return parser

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -89,6 +89,7 @@ def add_megatron_arguments(parser: argparse.ArgumentParser):
     parser = _add_msc_args(parser)
     parser = _add_kitchen_quantization_arguments(parser)
     parser = _add_sft_args(parser)
+    parser = _add_simulation_args(parser)
 
     parser = _add_fault_injector_args(parser)
 
@@ -2006,6 +2007,41 @@ def validate_args(args, defaults={}):
         assert (
             args.num_experts is not None
         ), "MoE latent projections are applicable only for MoE models."
+
+    # Simulation execute mode validation
+    if args.execute_mode is not None:
+        if args.execute_mode == 'router_balanced':
+            # Automatically enable force load balancing for router_balanced mode
+            args.moe_router_force_load_balancing = True
+        elif args.execute_mode == 'load_router_map':
+            # Validate that router_map_path is provided for load_router_map mode
+            assert args.router_map_path is not None, \
+                "When execute-mode is 'load_router_map', --router-map-path must be provided."
+
+    # Validate simulate-result-dir when simulate-global-step is enabled
+    if args.simulate_global_step:
+        # Validate skip-execute and load-result-dir dependencies
+        if args.skip_execute:
+            assert args.load_result_dir is not None, \
+                "When --skip-execute is enabled, --load-result-dir must be provided to load previous results."
+            if args.rank == 0:
+                print(f"Skip-execute mode enabled, will load results from: {args.load_result_dir}", flush=True)
+        else:
+            assert args.simulate_result_dir is not None, \
+                "When --simulate-global-step is enabled (without --skip-execute), --simulate-result-dir must be provided."
+
+        # Auto-disable incompatible options in simulation mode
+        if args.overlap_grad_reduce:
+            if args.rank == 0:
+                print("WARNING: --overlap-grad-reduce is incompatible with --simulate-global-step, "
+                      "automatically disabling it.", flush=True)
+            args.overlap_grad_reduce = False
+
+        if args.overlap_param_gather:
+            if args.rank == 0:
+                print("WARNING: --overlap-param-gather is incompatible with --simulate-global-step, "
+                      "automatically disabling it.", flush=True)
+            args.overlap_param_gather = False
 
     # Print arguments.
     _print_args("arguments", args)
@@ -4854,4 +4890,28 @@ def _add_fault_injector_args(parser):
     from megatron.training.config import FaultInjectorConfig
 
     ArgumentGroupFactory(FaultInjectorConfig).build_group(parser, "fault injector")
+    return parser
+
+def _add_simulation_args(parser):
+    group = parser.add_argument_group(title='simulation')
+    group.add_argument('--simulate-global-step', action="store_true",
+                       help='If True, simulate global step with only ep size gpus')
+    group.add_argument('--execute-mode', type=str, required=False, default='router_balanced',
+                       choices=['router_balanced', 'load_router_map'],
+                       help='Execution mode for simulation. '
+                       'router_balanced: force load-balanced routing by enabling moe-router-force-load-balancing. '
+                       'load_router_map: load routing map from a precomputed file dumped from inference.')
+    group.add_argument('--router-map-path', type=str, required=False, default=None,
+                       help='Path to the routing map file (required when execute-mode is load_router_map). '
+                       'This file should contain the routing map dumped from inference.')
+    group.add_argument('--simulate-result-dir', type=str, required=False, default=None,
+                       help='Directory path to store all profile results. '
+                       'Required when simulate-global-step is enabled.')
+    group.add_argument('--skip-execute', action='store_true',
+                       help='Skip actual model execution and load results from a previous run. '
+                       'When enabled, requires --load-result-dir to be specified.')
+    group.add_argument('--load-result-dir', type=str, required=False, default=None,
+                       help='Directory path to load previously saved simulation results. '
+                       'Used with --skip-execute to reanalyze existing results without re-execution.')
+
     return parser

--- a/megatron/training/simulation/__init__.py
+++ b/megatron/training/simulation/__init__.py
@@ -1,0 +1,2 @@
+from .vpp_simulate import VppSimulator
+from .utils import SimulationArgsOverride

--- a/megatron/training/simulation/__init__.py
+++ b/megatron/training/simulation/__init__.py
@@ -1,2 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 from .vpp_simulate import VppSimulator
 from .utils import SimulationArgsOverride

--- a/megatron/training/simulation/analyzer.py
+++ b/megatron/training/simulation/analyzer.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Analysis tools for VPP Training Simulation
+
+This module provides comprehensive analysis capabilities for VPP training simulation:
+- Timeline visualization (Chrome Trace format)
+- Throughput statistics (TFLOPS, tokens/day)
+- Memory usage analysis and visualization
+
+Functions are adapted from ATorch centralized scheduler implementation.
+"""
+
+import json
+import logging
+import os
+import pickle
+import re
+from typing import Any, Dict, List, Optional, Tuple
+from megatron.training.utils import print_rank_0
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Utility Functions
+# =============================================================================
+
+def parse_task_id(task_id: str) -> Dict[str, Any]:
+    """
+    Parse task_id string to extract task information
+
+    Expected format: pp_{pp_rank}-mbs_{microbatch_id}-model_chunk_{model_chunk_id}-task_type_{task_type}
+    Example: pp_0-mbs_0-model_chunk_0-task_type_forward
+
+    Args:
+        task_id: Task ID string to parse
+
+    Returns:
+        Dict containing:
+            - task_type: str (e.g., "forward", "backward")
+            - pp_rank: int (pipeline parallel rank)
+            - vpp_rank: int (virtual pipeline parallel rank, same as model_chunk_id)
+            - microbatch_id: int (microbatch ID)
+            - model_chunk_id: int (model chunk ID, same as vpp_rank)
+
+    Raises:
+        ValueError: If task_id format is invalid
+    """
+    # Regular expression pattern to match the task_id format
+    pattern = r'^pp_(\d+)-mbs_(\d+)-model_chunk_(\d+)-task_type_(.+)$'
+
+    match = re.match(pattern, task_id)
+    if not match:
+        raise ValueError(
+            f"Invalid task_id format: {task_id}. "
+            f"Expected format: pp_{{pp_rank}}-mbs_{{microbatch_id}}-model_chunk_{{model_chunk_id}}-task_type_{{task_type}}"
+        )
+
+    pp_rank = int(match.group(1))
+    microbatch_id = int(match.group(2))
+    model_chunk_id = int(match.group(3))
+    task_type = match.group(4)
+
+    return {
+        'task_type': task_type,
+        'pp_rank': pp_rank,
+        'vpp_rank': model_chunk_id,  # vpp_rank is the same as model_chunk_id
+        'microbatch_id': microbatch_id,
+        'model_chunk_id': model_chunk_id
+    }
+
+
+
+def token_per_day(gbs: int, gbs_time: float, seq_length: int, world_size: int) -> float:
+    """Calculate tokens per day per GPU
+
+    Args:
+        gbs: Global batch size
+        gbs_time: Time for one global batch step (seconds)
+        seq_length: Sequence length
+        world_size: Total number of GPUs
+
+    Returns:
+        Tokens per day per GPU (in billions)
+    """
+    seconds_per_day = 24 * 60 * 60
+    steps_per_day = seconds_per_day / gbs_time
+    tokens_per_day_value = gbs * seq_length * steps_per_day / world_size
+    # Return in billions
+    return tokens_per_day_value / 1e9
+
+
+# =============================================================================
+# Throughput Statistics
+# =============================================================================
+
+def display_gbs_statistics(pp_finished_task_queue_dict: Dict, pipeline_parallel_size: int,
+                          num_microbatches: int, num_model_chunks: int,
+                          args, task_type_enum):
+    """
+    Display global batch step statistics including throughput and timing
+
+    Args:
+        pp_finished_task_queue_dict: Dict of finished tasks per PP rank {pp_rank: [tasks]}
+        pipeline_parallel_size: Number of pipeline parallel stages
+        num_microbatches: Number of microbatches
+        num_model_chunks: Number of model chunks
+        args: Training arguments (containing batch sizes, world size, etc.)
+        task_type_enum: TaskType enum class for type checking
+    """
+    # Collect all finished tasks
+    all_finished_tasks = []
+    t_id_task_dict = {}
+    for pp_rank in range(pipeline_parallel_size):
+        if pp_rank in pp_finished_task_queue_dict:
+            all_finished_tasks.extend(pp_finished_task_queue_dict[pp_rank])
+    for task in all_finished_tasks:
+        t_id_task_dict[task.task_id] = task
+
+    if not all_finished_tasks:
+        logger.warning("No finished tasks found, cannot calculate GBS statistics")
+        return
+
+    # Filter tasks based on execute mode
+    execute_mode = getattr(args, 'execute_mode', 'router_balanced')
+    if execute_mode == 'load_router_map':
+        # For load_router_map mode, only use tasks from microbatch_id=0
+        filtered_tasks = [task for task in all_finished_tasks if task.microbatch_id == 0]
+        logger.info(
+            f"load_router_map mode: using {len(filtered_tasks)} tasks from mbs=0 "
+            f"out of {len(all_finished_tasks)} total tasks"
+        )
+    else:
+        # For router_balanced mode, use all tasks
+        filtered_tasks = all_finished_tasks
+
+    if not filtered_tasks:
+        logger.warning("No filtered tasks found for statistics calculation")
+        return
+
+    # Calculate each task's start and end time
+    task_timing = {}  # {task_id: {'start_time': float, 'end_time': float}}
+
+    def calculate_task_start_time(task_id: str) -> float:
+        """Recursively calculate task start time (in milliseconds)"""
+        if task_id in task_timing:
+            return task_timing[task_id]['start_time']
+
+        if task_id not in t_id_task_dict:
+            logger.error(f"[TIMELINE] ❌ Task {task_id} not found in t_id_task_dict")
+            return 0.0
+
+        task = t_id_task_dict[task_id]
+
+        # If no dependencies, start time is 0
+        if not task.dependencies:
+            start_time = 0.0
+            logger.debug(f"[TIMELINE] Task {task_id} has no dependencies, start_time=0.0")
+        else:
+            # Start time = max end time of all dependency tasks (milliseconds)
+            logger.debug(f"[TIMELINE] Task {task_id} has {len(task.dependencies)} dependencies: {task.dependencies}")
+            max_dep_end_time = 0.0
+            for dep_task_id in task.dependencies:
+                # Check if dependency task exists (some tasks may not have been executed)
+                if dep_task_id not in t_id_task_dict:
+                    logger.error(f"[TIMELINE] ❌ MISSING DEPENDENCY: Task {task_id} depends on {dep_task_id}, but it's not in t_id_task_dict!")
+                    logger.error(f"[TIMELINE]    This will cause incorrect start_time calculation!")
+                    continue
+                dep_end_time = calculate_task_start_time(dep_task_id) + t_id_task_dict[dep_task_id].duration
+                logger.debug(f"[TIMELINE]   Dependency {dep_task_id} ends at {dep_end_time:.3f}ms")
+                max_dep_end_time = max(max_dep_end_time, dep_end_time)
+            start_time = max_dep_end_time
+
+        # Record timing info (milliseconds)
+        task_timing[task_id] = {
+            'start_time': start_time,
+            'end_time': start_time + task.duration
+        }
+
+        logger.debug(f"[TIMELINE] Task {task_id}: start={start_time:.3f}ms, duration={task.duration:.3f}ms, end={start_time + task.duration:.3f}ms")
+
+        return start_time
+
+    # Calculate timing for filtered_tasks
+    for task in filtered_tasks:
+        calculate_task_start_time(task.task_id)
+
+    if not task_timing:
+        logger.warning("No task timing information available")
+        return
+
+    # Calculate single mbs time (based on filtered_tasks)
+    earliest_start_time = min(timing['start_time'] for timing in task_timing.values())
+    latest_end_time = max(timing['end_time'] for timing in task_timing.values())
+    single_mbs_time_ms = latest_end_time - earliest_start_time
+
+    # For load_router_map mode, multiply by num_microbatches to get total GBS time
+    if execute_mode == 'load_router_map':
+        total_gbs_time_ms = single_mbs_time_ms * num_microbatches
+        total_gbs_time_seconds = total_gbs_time_ms / 1000.0
+        logger.info(
+            f"load_router_map mode: single_mbs_time = {single_mbs_time_ms:.3f}ms, "
+            f"total_gbs_time = {total_gbs_time_ms:.3f}ms (x{num_microbatches} mbs)"
+        )
+    else:
+        total_gbs_time_ms = single_mbs_time_ms
+        total_gbs_time_seconds = total_gbs_time_ms / 1000.0
+
+    # Calculate TFLOPS
+    from megatron.training.training import num_floating_point_operations
+
+    global_batch_size = getattr(args, 'global_batch_size')
+    flops = num_floating_point_operations(args, global_batch_size)
+
+    # VTrainer world size = args.world_size * pipeline_parallel_size
+    # because we're simulating PP ranks on a single GPU
+    vtrainer_world_size = args.world_size * pipeline_parallel_size
+
+    throughput = flops / (total_gbs_time_seconds * 10**12 * vtrainer_world_size)
+
+    # Count task types
+    forward_tasks = [task for task in all_finished_tasks if task.task_type == task_type_enum.FORWARD]
+    backward_tasks = [task for task in all_finished_tasks if task.task_type == task_type_enum.BACKWARD]
+
+    # Calculate average execution time
+    avg_forward_time = sum(task.duration for task in forward_tasks) / len(forward_tasks) if forward_tasks else 0
+    avg_backward_time = sum(task.duration for task in backward_tasks) / len(backward_tasks) if backward_tasks else 0
+
+    # Output statistics
+    output_lines = []
+    output_lines.append("=" * 80)
+    output_lines.append("GBS Execution Statistics")
+    output_lines.append("=" * 80)
+    output_lines.append(f"Configuration:")
+    output_lines.append(f"  VTrainer World Size: {vtrainer_world_size}")
+    output_lines.append(f"  World Size: {args.world_size}")
+    output_lines.append(f"  Pipeline Parallel Size: {pipeline_parallel_size}")
+    output_lines.append(f"  Num Microbatches: {num_microbatches}")
+    output_lines.append(f"  Num Model Chunks: {num_model_chunks}")
+    output_lines.append(f"  Global Batch Size: {global_batch_size}")
+    output_lines.append(f"  Micro Batch Size: {getattr(args, 'micro_batch_size')}")
+    output_lines.append("-" * 80)
+
+    output_lines.append(f"Timing Statistics:")
+    output_lines.append(f"  First task start time: {earliest_start_time:.3f}ms")
+    output_lines.append(f"  Last task end time: {latest_end_time:.3f}ms")
+    output_lines.append("-" * 80)
+
+    output_lines.append(f"Performance Metrics:")
+    output_lines.append(f"  GBS time: {total_gbs_time_seconds:.3f}s")
+    flops_as_tera = flops / 10**12
+    output_lines.append(f"  FLOPs for one GBS: {flops_as_tera:.3f} TFLOPs")
+    output_lines.append(f"  Throughput: {throughput:.3f} TFLOPS per GPU")
+
+    # Calculate tokens per day per GPU
+    seq_length = getattr(args, 'seq_length')
+    tokens_per_day_per_gpu = token_per_day(
+        gbs=global_batch_size,
+        gbs_time=total_gbs_time_seconds,
+        seq_length=seq_length,
+        world_size=vtrainer_world_size
+    )
+    output_lines.append(f"  Tokens per day per GPU: {tokens_per_day_per_gpu:.3f} B tokens/day")
+
+    output_lines.append("=" * 80)
+
+    # Print all info
+    print_rank_0('\n'.join(output_lines))

--- a/megatron/training/simulation/analyzer.py
+++ b/megatron/training/simulation/analyzer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Analysis tools for VPP Training Simulation
 
@@ -214,11 +214,18 @@ def display_gbs_statistics(pp_finished_task_queue_dict: Dict, pipeline_parallel_
     global_batch_size = getattr(args, 'global_batch_size')
     flops = num_floating_point_operations(args, global_batch_size)
 
-    # VTrainer world size = args.world_size * pipeline_parallel_size
-    # because we're simulating PP ranks on a single GPU
+    # VTrainer world size = args.world_size * pipeline_parallel_size because
+    # each executor rank samples every virtual PP rank sequentially. The GBS
+    # time below is reconstructed for the full virtual pipeline, so the primary
+    # per-GPU throughput must be normalized by the virtual/full trainer size.
+    # The executor-normalized value is only a sampling diagnostic.
+    executor_world_size = args.world_size
     vtrainer_world_size = args.world_size * pipeline_parallel_size
 
     throughput = flops / (total_gbs_time_seconds * 10**12 * vtrainer_world_size)
+    executor_normalized_throughput = (
+        flops / (total_gbs_time_seconds * 10**12 * executor_world_size)
+    )
 
     # Count task types
     forward_tasks = [task for task in all_finished_tasks if task.task_type == task_type_enum.FORWARD]
@@ -234,8 +241,8 @@ def display_gbs_statistics(pp_finished_task_queue_dict: Dict, pipeline_parallel_
     output_lines.append("GBS Execution Statistics")
     output_lines.append("=" * 80)
     output_lines.append(f"Configuration:")
+    output_lines.append(f"  Executor World Size: {executor_world_size}")
     output_lines.append(f"  VTrainer World Size: {vtrainer_world_size}")
-    output_lines.append(f"  World Size: {args.world_size}")
     output_lines.append(f"  Pipeline Parallel Size: {pipeline_parallel_size}")
     output_lines.append(f"  Num Microbatches: {num_microbatches}")
     output_lines.append(f"  Num Model Chunks: {num_model_chunks}")
@@ -253,6 +260,10 @@ def display_gbs_statistics(pp_finished_task_queue_dict: Dict, pipeline_parallel_
     flops_as_tera = flops / 10**12
     output_lines.append(f"  FLOPs for one GBS: {flops_as_tera:.3f} TFLOPs")
     output_lines.append(f"  Throughput: {throughput:.3f} TFLOPS per GPU")
+    output_lines.append(
+        f"  Executor-normalized sampled throughput: "
+        f"{executor_normalized_throughput:.3f} TFLOPS per executor GPU"
+    )
 
     # Calculate tokens per day per GPU
     seq_length = getattr(args, 'seq_length')

--- a/megatron/training/simulation/model_executor.py
+++ b/megatron/training/simulation/model_executor.py
@@ -1,0 +1,473 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Model Executor Utilities for VPP Training Simulation"""
+
+import logging
+import os
+import time
+import torch
+import torch.distributed
+
+from contextlib import nullcontext
+from functools import partial
+
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core import parallel_state
+from megatron.core.utils import get_model_config, get_attr_wrapped_model, log_single_rank
+from megatron.training.global_vars import get_args
+from megatron.core.pipeline_parallel.schedules import forward_step
+from megatron.training.utils import print_rank_0
+from megatron.training.simulation.utils import MockPipelineProcessGroup
+
+logger = logging.getLogger(__name__)
+
+
+def get_pg_collection_for_simulation(pp_rank: int, pp_size: int):
+    """Create ProcessGroupCollection for simulation mode.
+
+    In simulation mode, we use fewer physical GPUs (EP GPUs) to simulate
+    a larger configuration (EP × PP GPUs). The PP process group is mocked
+    to return virtual size and rank, while all other groups use real
+    process groups from parallel_state.
+
+    Args:
+        pp_rank: Virtual pipeline parallel rank (0 to pp_size-1)
+        pp_size: Virtual pipeline parallel world size (e.g., 4)
+
+    Returns:
+        ProcessGroupCollection with mocked PP group and real other groups
+
+    """
+    # Start with real process groups from parallel_state
+    pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+    # Replace PP group with mock
+    pg_collection.pp = MockPipelineProcessGroup(size=pp_size, rank=pp_rank)
+
+    return pg_collection
+
+
+def create_model(pp_rank, model_provider):
+    """Create model for specified pipeline rank in simulation mode.
+
+    Args:
+        pp_rank: Virtual pipeline parallel rank (0 to pp_size-1)
+        model_provider: Function to create model
+
+    Returns:
+        model: Created model (list of model chunks for VPP)
+    """
+    # Reset MTP embedding for second MTP build
+    from megatron.training import get_model
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    #from megatron.core.transformer.multi_token_prediction import MTPEmbeddingHelper
+    #MTPEmbeddingHelper.set_embedding(None)
+
+    # Set pipeline rank and world size for correct is_last_stage calculation
+    args = get_args()
+    parallel_state.set_pipeline_model_parallel_rank(pp_rank)
+    parallel_state.set_pipeline_model_parallel_world_size(args.pipeline_model_parallel_size)
+
+    # Create simulation-specific ProcessGroupCollection with mocked PP group
+    # This allows build_model() to see virtual PP size/rank without code changes
+    pg_collection = get_pg_collection_for_simulation(
+        pp_rank=pp_rank,
+        pp_size=args.pipeline_model_parallel_size
+    )
+    # Pass the simulation pg_collection to get_model
+    model = get_model(model_provider, pg_collection=pg_collection)
+
+    return model
+
+
+def clear_model_mem(model):
+    """Clear model memory including DDP buffers
+
+    Args:
+        model: model to clear (can be a list for VPP)
+    """
+    from megatron.core import DistributedDataParallel
+    import gc
+
+    def _clear_single_model(single_model):
+        """Clear a single model chunk"""
+        if isinstance(single_model, DistributedDataParallel):
+            def _clear_buffer(buffer):
+                # Clear param_data
+                if buffer.param_data is not None:
+                    buffer.param_data.untyped_storage().resize_(0)
+                    buffer.param_data = None
+
+                # Clear grad_data
+                if buffer.grad_data is not None:
+                    buffer.grad_data.untyped_storage().resize_(0)
+                    buffer.grad_data = None
+
+            # Clear standard buffers
+            if hasattr(single_model, 'buffers'):
+                for buffer in single_model.buffers:
+                    _clear_buffer(buffer)
+
+            # Clear expert parallel buffers
+            if hasattr(single_model, 'expert_parallel_buffers'):
+                for buffer in single_model.expert_parallel_buffers:
+                    _clear_buffer(buffer)
+
+    # Handle list of model chunks (VPP)
+    if isinstance(model, list):
+        for model_chunk in model:
+            _clear_single_model(model_chunk)
+    else:
+        _clear_single_model(model)
+
+    # Delete model reference
+    del model
+
+    # Clear GPU cache
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+    # Force garbage collection
+    gc.collect()
+
+
+def prepare_input_tensor(pp_rank, vpp_rank, microbatch_id, task_output_tensor_dict):
+    """Prepare input tensor for forward pass
+
+    Args:
+        pp_rank: pipeline parallel rank
+        vpp_rank: virtual pipeline rank (model_chunk_id)
+        microbatch_id: microbatch id
+        task_output_tensor_dict: dictionary storing task output tensors
+
+    Returns:
+        input_tensor: input tensor for forward pass (None for first stage)
+    """
+    # First stage gets data from data_iterator
+    if pp_rank == 0 and vpp_rank == 0 and microbatch_id == 0:
+        return None
+
+    # Other stages get input from previous stage output
+    cache_key = (0, 0, 0)  # Always use output from pp0_vpp0
+
+    if cache_key in task_output_tensor_dict:
+        input_tensor = task_output_tensor_dict[cache_key]
+        return input_tensor
+    else:
+        raise KeyError(f"Input tensor not found for pp_rank={pp_rank}, vpp_rank={vpp_rank}, "
+                      f"microbatch_id={microbatch_id}. Cache key: {cache_key} not in task_output_tensor_dict")
+
+
+def execute_forward_with_timing(
+    model,
+    vpp_rank,
+    input_tensor,
+    data_iterator,
+    forward_step_func,
+    args,
+    microbatch_id,
+    warmup_times=15,
+    measure_times=10
+):
+    """Execute forward pass with timing measurement
+
+    Args:
+        model: model to execute (list of model chunks)
+        vpp_rank: virtual pipeline rank (model_chunk_id)
+        input_tensor: input tensor
+        data_iterator: training data iterator
+        forward_step_func: forward step function to use
+        args: training arguments
+        microbatch_id: microbatch id
+        warmup_times: number of warmup iterations (default 15)
+        measure_times: number of measurement iterations (default 10)
+
+    Returns:
+        output_tensor: output tensor from forward pass
+        avg_forward_time: average forward time in milliseconds
+    """
+    # Get ranks for profiling
+    pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+    global_rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+
+    # Get profiling configuration
+    simulate_result_dir = args.simulate_result_dir
+    # Prepare forward step parameters
+    num_microbatches = args.global_batch_size // parallel_state.get_data_parallel_world_size()
+    forward_data_store = []
+    collect_non_loss_data = False
+    config = get_model_config(model[0])
+    checkpoint_activations_microbatch = None
+    cp_group_size = parallel_state.get_context_parallel_world_size()
+
+    # Determine if this is the last pipeline stage (both PP and VPP)
+    pipeline_parallel_size = parallel_state.get_pipeline_model_parallel_world_size()
+    is_last_stage = (pp_rank == pipeline_parallel_size - 1 and vpp_rank == len(model) - 1)
+
+    # Warmup phase with profiling
+    for i in range(warmup_times):
+        output_tensor, num_tokens = forward_step(
+            forward_step_func,
+            data_iterator,
+            model[vpp_rank],
+            num_microbatches,
+            input_tensor,
+            forward_data_store,
+            config,
+            cp_group_size,
+            collect_non_loss_data=collect_non_loss_data,
+            checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+            is_first_microbatch=False,
+            current_microbatch=microbatch_id,
+            vp_stage=vpp_rank,
+            is_last_stage=is_last_stage,
+        )
+        torch.cuda.synchronize()
+        torch.distributed.barrier()
+        forward_data_store = []
+
+    # Measurement phase - measure time with CUDA events
+    total_forward_time = 0
+    measure_skip_times = 5  # Skip first few measurements
+
+    for i in range(measure_times):
+        forward_start = torch.cuda.Event(enable_timing=True)
+        forward_end = torch.cuda.Event(enable_timing=True)
+
+        forward_start.record()
+        output_tensor, num_tokens = forward_step(
+            forward_step_func,
+            data_iterator,
+            model[vpp_rank],
+            num_microbatches,
+            input_tensor,
+            forward_data_store,
+            config,
+            cp_group_size,
+            collect_non_loss_data=collect_non_loss_data,
+            checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+            is_first_microbatch=False,
+            current_microbatch=microbatch_id,
+            vp_stage=vpp_rank,
+            is_last_stage=is_last_stage,
+        )
+        forward_end.record()
+        forward_data_store = []
+
+        torch.cuda.synchronize()
+        torch.distributed.barrier()
+
+        forward_time = forward_start.elapsed_time(forward_end)
+        if i >= measure_skip_times:
+            total_forward_time += forward_time
+
+    # Calculate average time
+    torch.cuda.synchronize()
+    measured_iterations = measure_times - measure_skip_times
+    avg_forward_time = total_forward_time / measured_iterations
+
+    return output_tensor, avg_forward_time
+
+
+def prepare_output_grad_tensor(pp_rank, vpp_rank, microbatch_id, task_input_tensor_grad_dict, num_model_chunks, forward_output_tensor=None):
+    """Prepare output gradient tensor for backward pass
+
+    Args:
+        pp_rank: pipeline parallel rank
+        vpp_rank: virtual pipeline rank (model_chunk_id)
+        microbatch_id: microbatch id
+        task_input_tensor_grad_dict: dictionary storing task input gradient tensors
+        num_model_chunks: number of model chunks (for VPP)
+        forward_output_tensor: forward output tensor for generating mock gradient if needed
+
+    Returns:
+        output_tensor_grad: output gradient tensor for backward pass (None for last stage)
+    """
+    # Debug: Log pipeline stage information
+    vpp_world_size = parallel_state.get_virtual_pipeline_model_parallel_world_size()
+    print_rank_0(f"[DEBUG prepare_output_grad_tensor] pp_rank={pp_rank}, vpp_rank={vpp_rank}, "
+                f"microbatch_id={microbatch_id}, vpp_world_size={vpp_world_size}")
+
+    # Last stage has no output gradient
+    is_last = parallel_state.is_pipeline_last_stage(ignore_virtual=False, vp_stage=vpp_rank)
+    print_rank_0(f"[DEBUG prepare_output_grad_tensor] is_pipeline_last_stage={is_last}")
+
+    if is_last:
+        return None
+
+    # Other stages get gradient from next stage
+    # Assuming the gradient comes from the last pp stage's output
+    # Use pp=-1, vpp=-1 to get the last stage's output
+    last_pp_rank = parallel_state.get_pipeline_model_parallel_world_size() - 1
+    last_vpp_rank = num_model_chunks - 1
+    cache_key = (last_pp_rank, last_vpp_rank, microbatch_id)
+
+    if cache_key in task_input_tensor_grad_dict:
+        output_tensor_grad = task_input_tensor_grad_dict[cache_key]
+        return output_tensor_grad
+    else:
+        # If not found, generate mock gradient for simulation
+        # This is needed for performance profiling when tasks are executed out of dependency order
+        if forward_output_tensor is not None:
+            print_rank_0(f"Warning: Gradient not found for pp_rank={pp_rank}, vpp_rank={vpp_rank}, "
+                        f"microbatch_id={microbatch_id}. Generating mock gradient.")
+            return torch.ones_like(forward_output_tensor)
+        else:
+            return None
+
+
+def execute_backward_with_timing(
+    model,
+    vpp_rank,
+    input_tensor,
+    data_iterator,
+    forward_step_func,
+    args,
+    microbatch_id,
+    num_model_chunks,
+    task_input_tensor_grad_dict,
+    warmup_times=15,
+    measure_times=10
+):
+    """Execute backward pass with timing measurement
+
+    Args:
+        model: model to execute (list of model chunks)
+        vpp_rank: virtual pipeline rank (model_chunk_id)
+        input_tensor: input tensor (requires_grad=True for gradient computation)
+        data_iterator: training data iterator
+        forward_step_func: forward step function to use
+        args: training arguments
+        microbatch_id: microbatch id
+        num_model_chunks: number of model chunks (for VPP)
+        task_input_tensor_grad_dict: dictionary storing task input gradient tensors
+        warmup_times: number of warmup iterations (default 15)
+        measure_times: number of measurement iterations (default 10)
+
+    Returns:
+        input_tensor_grad: input gradient tensor for upstream stage
+        avg_backward_time: average backward time in milliseconds
+    """
+    from megatron.core.pipeline_parallel.schedules import backward_step
+    from megatron.core.utils import get_model_type
+
+    # Get ranks for profiling
+    pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+    global_rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+
+    # Get profiling configuration
+    simulate_result_dir = getattr(args, 'simulate_result_dir', None)
+
+    # Prepare forward step parameters
+    num_microbatches = args.global_batch_size // parallel_state.get_data_parallel_world_size()
+    forward_data_store = []
+    collect_non_loss_data = False
+    config = get_model_config(model[0])
+    checkpoint_activations_microbatch = None
+    model_type = get_model_type(model[0])
+    cp_group_size = parallel_state.get_context_parallel_world_size()
+
+    # Determine if this is the last pipeline stage (both PP and VPP)
+    pipeline_parallel_size = parallel_state.get_pipeline_model_parallel_world_size()
+    is_last_stage = (pp_rank == pipeline_parallel_size - 1 and vpp_rank == len(model) - 1)
+
+    # Save original config setting and temporarily disable deallocate
+    original_deallocate = config.deallocate_pipeline_outputs
+    config.deallocate_pipeline_outputs = False
+
+    # Warmup phase with profiling
+    for i in range(warmup_times):
+        # Forward pass to build autograd graph
+        output_tensor, num_tokens = forward_step(
+            forward_step_func,
+            data_iterator,
+            model[vpp_rank],
+            num_microbatches,
+            input_tensor,
+            forward_data_store,
+            config,
+            cp_group_size,
+            collect_non_loss_data=collect_non_loss_data,
+            checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+            is_first_microbatch=False,
+            current_microbatch=microbatch_id,
+            vp_stage=vpp_rank,
+            is_last_stage=is_last_stage,
+        )
+        forward_data_store = []
+        torch.cuda.synchronize()
+        torch.distributed.barrier()
+
+        # Prepare output gradient tensor (with mock gradient generation if needed)
+        output_tensor_grad = prepare_output_grad_tensor(
+            pp_rank, vpp_rank, microbatch_id, task_input_tensor_grad_dict, num_model_chunks,
+            forward_output_tensor=output_tensor
+        )
+
+
+        # Backward pass
+        input_tensor_grad = backward_step(
+            input_tensor, output_tensor, output_tensor_grad, model_type, config
+        )
+        torch.cuda.synchronize()
+        torch.distributed.barrier()
+
+    # Measurement phase - measure backward time with CUDA events
+    total_backward_time = 0
+    measure_skip_times = 5  # Skip first few measurements
+
+    for i in range(measure_times):
+        backward_start = torch.cuda.Event(enable_timing=True)
+        backward_end = torch.cuda.Event(enable_timing=True)
+
+        # Forward pass (not measured)
+        output_tensor, num_tokens = forward_step(
+            forward_step_func,
+            data_iterator,
+            model[vpp_rank],
+            num_microbatches,
+            input_tensor,
+            forward_data_store,
+            config,
+            cp_group_size,
+            collect_non_loss_data=collect_non_loss_data,
+            checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+            is_first_microbatch=False,
+            current_microbatch=microbatch_id,
+            vp_stage=vpp_rank,
+            is_last_stage=is_last_stage,
+        )
+        forward_data_store = []
+        torch.cuda.synchronize()
+        torch.distributed.barrier()
+
+        # Prepare output gradient tensor (with mock gradient generation if needed)
+        output_tensor_grad = prepare_output_grad_tensor(
+            pp_rank, vpp_rank, microbatch_id, task_input_tensor_grad_dict, num_model_chunks,
+            forward_output_tensor=output_tensor
+        )
+
+        # Backward pass (measured)
+        backward_start.record()
+        input_tensor_grad = backward_step(
+            input_tensor, output_tensor, output_tensor_grad, model_type, config
+        )
+        backward_end.record()
+
+        torch.cuda.synchronize()
+        torch.distributed.barrier()
+
+        backward_time = backward_start.elapsed_time(backward_end)
+        if i >= measure_skip_times:
+            total_backward_time += backward_time
+
+    # Restore original config setting
+    config.deallocate_pipeline_outputs = original_deallocate
+
+    # Calculate average time
+    torch.cuda.synchronize()
+    measured_iterations = measure_times - measure_skip_times
+    avg_backward_time = total_backward_time / measured_iterations
+
+    return input_tensor_grad, avg_backward_time

--- a/megatron/training/simulation/model_executor.py
+++ b/megatron/training/simulation/model_executor.py
@@ -1,18 +1,20 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Model Executor Utilities for VPP Training Simulation"""
 
 import logging
+import gc
 import os
 import time
 import torch
 import torch.distributed
 
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from functools import partial
 
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core import parallel_state
+from megatron.core.rerun_state_machine import RerunMode, get_rerun_state_machine
 from megatron.core.utils import get_model_config, get_attr_wrapped_model, log_single_rank
 from megatron.training.global_vars import get_args
 from megatron.core.pipeline_parallel.schedules import forward_step
@@ -20,6 +22,98 @@ from megatron.training.utils import print_rank_0
 from megatron.training.simulation.utils import MockPipelineProcessGroup
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _maybe_profile_simulation_task(
+    args,
+    *,
+    task_type,
+    pp_rank,
+    vpp_rank,
+    microbatch_id,
+    measure_index,
+):
+    """Optionally export a PyTorch chrome trace for one sampled simulator task."""
+    if os.getenv("MCORE_SIM_TRACE", "0") != "1":
+        yield
+        return
+
+    global_rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    target_rank = int(os.getenv("MCORE_SIM_TRACE_RANK", "0"))
+    target_pp = int(os.getenv("MCORE_SIM_TRACE_PP", "0"))
+    target_vpp = int(os.getenv("MCORE_SIM_TRACE_VPP", "0"))
+    target_microbatch = int(os.getenv("MCORE_SIM_TRACE_MICROBATCH", "0"))
+    target_measure_index = int(os.getenv("MCORE_SIM_TRACE_MEASURE_INDEX", "0"))
+    target_types = {
+        item.strip()
+        for item in os.getenv("MCORE_SIM_TRACE_TYPES", "forward,backward").split(",")
+        if item.strip()
+    }
+
+    should_profile = (
+        global_rank == target_rank
+        and pp_rank == target_pp
+        and vpp_rank == target_vpp
+        and microbatch_id == target_microbatch
+        and measure_index == target_measure_index
+        and task_type in target_types
+    )
+    if not should_profile:
+        yield
+        return
+
+    trace_dir = os.getenv(
+        "MCORE_SIM_TRACE_DIR",
+        os.path.join(args.simulate_result_dir, "torch_profile"),
+    )
+    os.makedirs(trace_dir, exist_ok=True)
+    trace_path = os.path.join(
+        trace_dir,
+        (
+            f"rank-{global_rank}-pp-{pp_rank}-vpp-{vpp_rank}-mb-{microbatch_id}-"
+            f"{task_type}-measure-{measure_index}.json"
+        ),
+    )
+    activities = [torch.profiler.ProfilerActivity.CPU]
+    if torch.cuda.is_available():
+        activities.append(torch.profiler.ProfilerActivity.CUDA)
+
+    with torch.profiler.profile(
+        activities=activities,
+        record_shapes=True,
+        with_stack=False,
+    ) as profiler:
+        yield
+        profiler.step()
+
+    profiler.export_chrome_trace(trace_path)
+    print_rank_0(f"[SIM_TRACE] exported {task_type} trace to {trace_path}")
+
+
+@contextmanager
+def _simulation_forward_backward_state():
+    """Enter the rerun state expected by loss/gradient validation helpers.
+
+    Simulation times individual forward/backward tasks directly instead of using
+    Megatron's full forward_backward_func wrapper. Validation hooks in loss and
+    grad code still expect the rerun state machine to be inside a
+    forward-backward pass, so provide that state while disabling rerun/replay
+    behavior that is not meaningful for sampled simulator tasks.
+    """
+    rerun_state_machine = get_rerun_state_machine()
+    original_mode = rerun_state_machine.get_mode()
+    rerun_state_machine.set_mode(RerunMode.DISABLED)
+    entered = rerun_state_machine.should_run_forward_backward(None)
+    if not entered:
+        rerun_state_machine.set_mode(original_mode)
+        raise RuntimeError("Unable to enter rerun state for simulation task execution")
+
+    try:
+        yield
+    finally:
+        rerun_state_machine.should_run_forward_backward(None)
+        rerun_state_machine.set_mode(original_mode)
 
 
 def get_pg_collection_for_simulation(pp_rank: int, pp_size: int):
@@ -132,6 +226,63 @@ def clear_model_mem(model):
     gc.collect()
 
 
+def clear_model_grad_state(model):
+    """Clear model gradient state at simulator model-chunk boundaries."""
+    model_chunks = model if isinstance(model, list) else [model]
+
+    for model_chunk in model_chunks:
+        if hasattr(model_chunk, "zero_grad_buffer"):
+            model_chunk.zero_grad_buffer()
+        if hasattr(model_chunk, "zero_grad"):
+            try:
+                model_chunk.zero_grad(set_to_none=False)
+            except TypeError:
+                model_chunk.zero_grad()
+
+        for param in model_chunk.parameters():
+            if param.grad is not None:
+                param.grad.zero_()
+            if hasattr(param, "grad_added_to_main_grad"):
+                param.grad_added_to_main_grad = False
+
+
+def _release_timing_iteration(model, input_tensor):
+    """Release per-repeat autograd state before the next simulator timing repeat."""
+    _clear_tensor_grad(input_tensor)
+    gc.collect()
+
+
+def _clear_tensor_grad(tensor_or_tensors):
+    """Drop retained input gradients from tensors reused across timing repeats."""
+    if tensor_or_tensors is None:
+        return
+    if isinstance(tensor_or_tensors, torch.Tensor):
+        tensor_or_tensors.grad = None
+        return
+    if isinstance(tensor_or_tensors, dict):
+        for tensor in tensor_or_tensors.values():
+            _clear_tensor_grad(tensor)
+        return
+    if isinstance(tensor_or_tensors, (list, tuple)):
+        for tensor in tensor_or_tensors:
+            _clear_tensor_grad(tensor)
+
+
+def _detach_tensor_tree(tensor_or_tensors):
+    """Detach tensors while preserving container structure."""
+    if tensor_or_tensors is None:
+        return None
+    if isinstance(tensor_or_tensors, torch.Tensor):
+        return tensor_or_tensors.detach()
+    if isinstance(tensor_or_tensors, dict):
+        return {key: _detach_tensor_tree(value) for key, value in tensor_or_tensors.items()}
+    if isinstance(tensor_or_tensors, tuple):
+        return tuple(_detach_tensor_tree(tensor) for tensor in tensor_or_tensors)
+    if isinstance(tensor_or_tensors, list):
+        return [_detach_tensor_tree(tensor) for tensor in tensor_or_tensors]
+    return tensor_or_tensors
+
+
 def prepare_input_tensor(pp_rank, vpp_rank, microbatch_id, task_output_tensor_dict):
     """Prepare input tensor for forward pass
 
@@ -168,7 +319,8 @@ def execute_forward_with_timing(
     args,
     microbatch_id,
     warmup_times=15,
-    measure_times=10
+    measure_times=10,
+    measure_skip_times=5,
 ):
     """Execute forward pass with timing measurement
 
@@ -182,6 +334,7 @@ def execute_forward_with_timing(
         microbatch_id: microbatch id
         warmup_times: number of warmup iterations (default 15)
         measure_times: number of measurement iterations (default 10)
+        measure_skip_times: number of measurement iterations to skip in average (default 5)
 
     Returns:
         output_tensor: output tensor from forward pass
@@ -207,58 +360,76 @@ def execute_forward_with_timing(
 
     # Warmup phase with profiling
     for i in range(warmup_times):
-        output_tensor, num_tokens = forward_step(
-            forward_step_func,
-            data_iterator,
-            model[vpp_rank],
-            num_microbatches,
-            input_tensor,
-            forward_data_store,
-            config,
-            cp_group_size,
-            collect_non_loss_data=collect_non_loss_data,
-            checkpoint_activations_microbatch=checkpoint_activations_microbatch,
-            is_first_microbatch=False,
-            current_microbatch=microbatch_id,
-            vp_stage=vpp_rank,
-            is_last_stage=is_last_stage,
-        )
+        _clear_tensor_grad(input_tensor)
+        with _simulation_forward_backward_state():
+            output_tensor, num_tokens = forward_step(
+                forward_step_func,
+                data_iterator,
+                model[vpp_rank],
+                num_microbatches,
+                input_tensor,
+                forward_data_store,
+                config,
+                cp_group_size,
+                collect_non_loss_data=collect_non_loss_data,
+                checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+                is_first_microbatch=False,
+                current_microbatch=microbatch_id,
+                vp_stage=vpp_rank,
+                is_last_stage=is_last_stage,
+            )
         torch.cuda.synchronize()
         torch.distributed.barrier()
         forward_data_store = []
+        del output_tensor
+        _release_timing_iteration(model, input_tensor)
+        torch.distributed.barrier()
 
-    # Measurement phase - measure time with CUDA events
+    # Measurement phase - measure only the sampled forward task. Cleanup stays
+    # outside the timed region and a barrier before timing prevents prior
+    # cleanup skew from being charged to the next collective.
     total_forward_time = 0
-    measure_skip_times = 5  # Skip first few measurements
-
+    measured_output_tensor = None
     for i in range(measure_times):
-        forward_start = torch.cuda.Event(enable_timing=True)
-        forward_end = torch.cuda.Event(enable_timing=True)
-
-        forward_start.record()
-        output_tensor, num_tokens = forward_step(
-            forward_step_func,
-            data_iterator,
-            model[vpp_rank],
-            num_microbatches,
-            input_tensor,
-            forward_data_store,
-            config,
-            cp_group_size,
-            collect_non_loss_data=collect_non_loss_data,
-            checkpoint_activations_microbatch=checkpoint_activations_microbatch,
-            is_first_microbatch=False,
-            current_microbatch=microbatch_id,
-            vp_stage=vpp_rank,
-            is_last_stage=is_last_stage,
-        )
-        forward_end.record()
+        _clear_tensor_grad(input_tensor)
+        torch.distributed.barrier()
+        with _simulation_forward_backward_state():
+            torch.cuda.synchronize()
+            forward_start = time.perf_counter()
+            with _maybe_profile_simulation_task(
+                args,
+                task_type="forward",
+                pp_rank=pp_rank,
+                vpp_rank=vpp_rank,
+                microbatch_id=microbatch_id,
+                measure_index=i,
+            ):
+                output_tensor, num_tokens = forward_step(
+                    forward_step_func,
+                    data_iterator,
+                    model[vpp_rank],
+                    num_microbatches,
+                    input_tensor,
+                    forward_data_store,
+                    config,
+                    cp_group_size,
+                    collect_non_loss_data=collect_non_loss_data,
+                    checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+                    is_first_microbatch=False,
+                    current_microbatch=microbatch_id,
+                    vp_stage=vpp_rank,
+                    is_last_stage=is_last_stage,
+                )
+            torch.cuda.synchronize()
+            forward_time = (time.perf_counter() - forward_start) * 1000.0
         forward_data_store = []
 
-        torch.cuda.synchronize()
         torch.distributed.barrier()
-
-        forward_time = forward_start.elapsed_time(forward_end)
+        if i == measure_times - 1:
+            measured_output_tensor = _detach_tensor_tree(output_tensor)
+        del output_tensor
+        _release_timing_iteration(model, input_tensor)
+        torch.distributed.barrier()
         if i >= measure_skip_times:
             total_forward_time += forward_time
 
@@ -267,7 +438,7 @@ def execute_forward_with_timing(
     measured_iterations = measure_times - measure_skip_times
     avg_forward_time = total_forward_time / measured_iterations
 
-    return output_tensor, avg_forward_time
+    return measured_output_tensor, avg_forward_time
 
 
 def prepare_output_grad_tensor(pp_rank, vpp_rank, microbatch_id, task_input_tensor_grad_dict, num_model_chunks, forward_output_tensor=None):
@@ -328,7 +499,8 @@ def execute_backward_with_timing(
     num_model_chunks,
     task_input_tensor_grad_dict,
     warmup_times=15,
-    measure_times=10
+    measure_times=10,
+    measure_skip_times=5,
 ):
     """Execute backward pass with timing measurement
 
@@ -344,13 +516,13 @@ def execute_backward_with_timing(
         task_input_tensor_grad_dict: dictionary storing task input gradient tensors
         warmup_times: number of warmup iterations (default 15)
         measure_times: number of measurement iterations (default 10)
+        measure_skip_times: number of measurement iterations to skip in average (default 5)
 
     Returns:
         input_tensor_grad: input gradient tensor for upstream stage
         avg_backward_time: average backward time in milliseconds
     """
     from megatron.core.pipeline_parallel.schedules import backward_step
-    from megatron.core.utils import get_model_type
 
     # Get ranks for profiling
     pp_rank = parallel_state.get_pipeline_model_parallel_rank()
@@ -365,7 +537,6 @@ def execute_backward_with_timing(
     collect_non_loss_data = False
     config = get_model_config(model[0])
     checkpoint_activations_microbatch = None
-    model_type = get_model_type(model[0])
     cp_group_size = parallel_state.get_context_parallel_world_size()
 
     # Determine if this is the last pipeline stage (both PP and VPP)
@@ -378,87 +549,99 @@ def execute_backward_with_timing(
 
     # Warmup phase with profiling
     for i in range(warmup_times):
-        # Forward pass to build autograd graph
-        output_tensor, num_tokens = forward_step(
-            forward_step_func,
-            data_iterator,
-            model[vpp_rank],
-            num_microbatches,
-            input_tensor,
-            forward_data_store,
-            config,
-            cp_group_size,
-            collect_non_loss_data=collect_non_loss_data,
-            checkpoint_activations_microbatch=checkpoint_activations_microbatch,
-            is_first_microbatch=False,
-            current_microbatch=microbatch_id,
-            vp_stage=vpp_rank,
-            is_last_stage=is_last_stage,
-        )
-        forward_data_store = []
+        _clear_tensor_grad(input_tensor)
+        with _simulation_forward_backward_state():
+            # Forward pass to build autograd graph
+            output_tensor, num_tokens = forward_step(
+                forward_step_func,
+                data_iterator,
+                model[vpp_rank],
+                num_microbatches,
+                input_tensor,
+                forward_data_store,
+                config,
+                cp_group_size,
+                collect_non_loss_data=collect_non_loss_data,
+                checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+                is_first_microbatch=False,
+                current_microbatch=microbatch_id,
+                vp_stage=vpp_rank,
+                is_last_stage=is_last_stage,
+            )
+            forward_data_store = []
+            torch.cuda.synchronize()
+            torch.distributed.barrier()
+
+            # Prepare output gradient tensor (with mock gradient generation if needed)
+            output_tensor_grad = prepare_output_grad_tensor(
+                pp_rank, vpp_rank, microbatch_id, task_input_tensor_grad_dict, num_model_chunks,
+                forward_output_tensor=output_tensor
+            )
+
+            # Backward pass
+            input_tensor_grad = backward_step(input_tensor, output_tensor, output_tensor_grad, config)
         torch.cuda.synchronize()
         torch.distributed.barrier()
-
-        # Prepare output gradient tensor (with mock gradient generation if needed)
-        output_tensor_grad = prepare_output_grad_tensor(
-            pp_rank, vpp_rank, microbatch_id, task_input_tensor_grad_dict, num_model_chunks,
-            forward_output_tensor=output_tensor
-        )
-
-
-        # Backward pass
-        input_tensor_grad = backward_step(
-            input_tensor, output_tensor, output_tensor_grad, model_type, config
-        )
-        torch.cuda.synchronize()
+        del output_tensor, output_tensor_grad, input_tensor_grad
+        _release_timing_iteration(model, input_tensor)
         torch.distributed.barrier()
 
-    # Measurement phase - measure backward time with CUDA events
+    # Measurement phase - measure only the sampled backward task. The setup
+    # forward and cleanup are excluded from the timed region.
     total_backward_time = 0
-    measure_skip_times = 5  # Skip first few measurements
-
+    measured_input_tensor_grad = None
     for i in range(measure_times):
-        backward_start = torch.cuda.Event(enable_timing=True)
-        backward_end = torch.cuda.Event(enable_timing=True)
+        _clear_tensor_grad(input_tensor)
+        with _simulation_forward_backward_state():
+            # Forward pass (not measured)
+            output_tensor, num_tokens = forward_step(
+                forward_step_func,
+                data_iterator,
+                model[vpp_rank],
+                num_microbatches,
+                input_tensor,
+                forward_data_store,
+                config,
+                cp_group_size,
+                collect_non_loss_data=collect_non_loss_data,
+                checkpoint_activations_microbatch=checkpoint_activations_microbatch,
+                is_first_microbatch=False,
+                current_microbatch=microbatch_id,
+                vp_stage=vpp_rank,
+                is_last_stage=is_last_stage,
+            )
+            forward_data_store = []
+            torch.cuda.synchronize()
+            torch.distributed.barrier()
 
-        # Forward pass (not measured)
-        output_tensor, num_tokens = forward_step(
-            forward_step_func,
-            data_iterator,
-            model[vpp_rank],
-            num_microbatches,
-            input_tensor,
-            forward_data_store,
-            config,
-            cp_group_size,
-            collect_non_loss_data=collect_non_loss_data,
-            checkpoint_activations_microbatch=checkpoint_activations_microbatch,
-            is_first_microbatch=False,
-            current_microbatch=microbatch_id,
-            vp_stage=vpp_rank,
-            is_last_stage=is_last_stage,
-        )
-        forward_data_store = []
-        torch.cuda.synchronize()
+            # Prepare output gradient tensor (with mock gradient generation if needed)
+            output_tensor_grad = prepare_output_grad_tensor(
+                pp_rank, vpp_rank, microbatch_id, task_input_tensor_grad_dict, num_model_chunks,
+                forward_output_tensor=output_tensor
+            )
+
+            # Backward pass (measured)
+            torch.distributed.barrier()
+            torch.cuda.synchronize()
+            backward_start = time.perf_counter()
+            with _maybe_profile_simulation_task(
+                args,
+                task_type="backward",
+                pp_rank=pp_rank,
+                vpp_rank=vpp_rank,
+                microbatch_id=microbatch_id,
+                measure_index=i,
+            ):
+                input_tensor_grad = backward_step(input_tensor, output_tensor, output_tensor_grad, config)
+            torch.cuda.synchronize()
+            backward_time = (time.perf_counter() - backward_start) * 1000.0
+
         torch.distributed.barrier()
-
-        # Prepare output gradient tensor (with mock gradient generation if needed)
-        output_tensor_grad = prepare_output_grad_tensor(
-            pp_rank, vpp_rank, microbatch_id, task_input_tensor_grad_dict, num_model_chunks,
-            forward_output_tensor=output_tensor
-        )
-
-        # Backward pass (measured)
-        backward_start.record()
-        input_tensor_grad = backward_step(
-            input_tensor, output_tensor, output_tensor_grad, model_type, config
-        )
-        backward_end.record()
-
-        torch.cuda.synchronize()
+        if i == measure_times - 1:
+            measured_input_tensor_grad = _detach_tensor_tree(input_tensor_grad)
+        del output_tensor, output_tensor_grad, input_tensor_grad
+        _release_timing_iteration(model, input_tensor)
         torch.distributed.barrier()
-
-        backward_time = backward_start.elapsed_time(backward_end)
         if i >= measure_skip_times:
             total_backward_time += backward_time
 
@@ -470,4 +653,4 @@ def execute_backward_with_timing(
     measured_iterations = measure_times - measure_skip_times
     avg_backward_time = total_backward_time / measured_iterations
 
-    return input_tensor_grad, avg_backward_time
+    return measured_input_tensor_grad, avg_backward_time

--- a/megatron/training/simulation/task.py
+++ b/megatron/training/simulation/task.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 from typing import Any, Dict, List, Optional, Callable, Type
 from dataclasses import dataclass, asdict
 from enum import Enum

--- a/megatron/training/simulation/task.py
+++ b/megatron/training/simulation/task.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict, List, Optional, Callable, Type
+from dataclasses import dataclass, asdict
+from enum import Enum
+
+
+class TaskType(Enum):
+    FORWARD = "forward"
+    BACKWARD = "backward"
+    SEND = "send"
+    RECV = "recv"
+    GBS_FINISH = "gbs_finish"
+
+
+@dataclass
+class Task:
+    """Base task class for pipeline operations"""
+    # Required fields (no default values)
+    task_type: TaskType
+    pp_rank: int
+    microbatch_id: int
+    model_chunk_id: int # local vpp id
+
+    # Optional fields (with default values)
+    task_id: str = None # '{pp_rank}_{microbatch_id}_{model_chunk_id}_{forward/backward}'
+    dependencies: List[str] = None # [task_id]
+
+    finished: bool = False
+    duration: float = None
+
+    def __post_init__(self):
+        if self.dependencies is None:
+            self.dependencies = []
+        if self.task_type == TaskType.GBS_FINISH:
+            self.task_id = f"finish_task"
+        else:
+            self.task_id = f"pp_{self.pp_rank}-mbs_{self.microbatch_id}-model_chunk_{self.model_chunk_id}-task_type_{self.task_type.value}"
+
+    def to_dict(self) -> Dict:
+        """Convert Task to dictionary for JSON serialization"""
+        data = asdict(self)
+        # Convert enum to string
+        data['task_type'] = self.task_type.value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'Task':
+        """Create Task from dictionary (JSON deserialization)"""
+        # Convert string back to enum
+        if isinstance(data['task_type'], str):
+            data['task_type'] = TaskType(data['task_type'])
+        return cls(**data)

--- a/megatron/training/simulation/utils.py
+++ b/megatron/training/simulation/utils.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Utility functions for VPP training simulation."""
+
+import logging
+
+from megatron.core import parallel_state
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
+from megatron.core.utils import log_single_rank
+from megatron.training.global_vars import get_args
+
+logger = logging.getLogger(__name__)
+
+
+class SimulationArgsOverride:
+    """
+    Context manager for temporarily overriding pipeline parallelism arguments
+    during simulation initialization.
+
+    In simulation mode, we use EP GPUs to simulate a model that normally requires
+    EP×PP GPUs. To make the network initialization succeed with fewer GPUs, we
+    temporarily set PP=1 and clear the pipeline layout. After initialization, we
+    restore the user-defined PP configuration for simulation logic to use.
+
+    Args:
+        parsed_args: The parsed arguments object from parse_args()
+        enable (bool): Whether to enable parameter override (typically args.simulate_global_step)
+
+    Usage:
+        >>> with SimulationArgsOverride(parsed_args, enable=args.simulate_global_step):
+        ...     initialize_megatron(parsed_args=parsed_args)
+        ...     args = get_args()
+        ...     timers = get_timers()
+    """
+
+    def __init__(self, parsed_args, enable=True):
+        self.parsed_args = parsed_args
+        self.enable = enable
+
+        # Store original values
+        self.original_pp_size = None
+        self.original_pp_layout = None
+
+    def __enter__(self):
+        """Override pipeline parallelism arguments for simulation initialization."""
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] SimulationArgsOverride.__enter__ called, enable={self.enable}")
+
+        if not self.enable:
+            return self
+
+        # Debug: Log original parsed args
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] Parsed args before override:")
+        log_single_rank(logger, logging.DEBUG, f"  - pipeline_model_parallel_size: {self.parsed_args.pipeline_model_parallel_size}")
+        log_single_rank(logger, logging.DEBUG, f"  - pipeline_model_parallel_layout type: {type(self.parsed_args.pipeline_model_parallel_layout)}")
+        log_single_rank(logger, logging.DEBUG, f"  - pipeline_model_parallel_layout: {self.parsed_args.pipeline_model_parallel_layout}")
+
+        # Save original user-defined values
+        self.original_pp_size = self.parsed_args.pipeline_model_parallel_size
+        self.original_pp_layout = PipelineParallelLayerLayout.from_str(
+            layout=self.parsed_args.pipeline_model_parallel_layout,
+            pipeline_model_parallel_size=self.parsed_args.pipeline_model_parallel_size
+        )
+
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] Saved original values:")
+        log_single_rank(logger, logging.DEBUG, f"  - original_pp_size: {self.original_pp_size}")
+        log_single_rank(logger, logging.DEBUG, f"  - original_pp_layout type: {type(self.original_pp_layout)}")
+        log_single_rank(logger, logging.DEBUG, f"  - original_pp_layout: {self.original_pp_layout}")
+
+        # Override with simulation values to enable initialization with fewer GPUs
+        # Set PP=1 to allow network initialization with only EP GPUs
+        self.parsed_args.pipeline_model_parallel_size = 1
+        self.parsed_args.pipeline_model_parallel_layout = None
+
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] After override for simulation:")
+        log_single_rank(logger, logging.DEBUG, f"  - pipeline_model_parallel_size: {self.parsed_args.pipeline_model_parallel_size}")
+        log_single_rank(logger, logging.DEBUG, f"  - pipeline_model_parallel_layout: {self.parsed_args.pipeline_model_parallel_layout}")
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Restore original pipeline parallelism configuration."""
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] SimulationArgsOverride.__exit__ called, enable={self.enable}")
+
+        if not self.enable:
+            return False
+
+        # Debug: Log saved original values
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] Original saved values:")
+        log_single_rank(logger, logging.DEBUG, f"  - original_pp_size: {self.original_pp_size}")
+        log_single_rank(logger, logging.DEBUG, f"  - original_pp_layout type: {type(self.original_pp_layout)}")
+        log_single_rank(logger, logging.DEBUG, f"  - original_pp_layout: {self.original_pp_layout}")
+
+        # Get global args object and restore user-defined PP configuration
+        args = get_args()
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] Before restoration:")
+        log_single_rank(logger, logging.DEBUG, f"  - args.pipeline_model_parallel_size: {args.pipeline_model_parallel_size}")
+        log_single_rank(logger, logging.DEBUG, f"  - args.pipeline_model_parallel_layout: {args.pipeline_model_parallel_layout}")
+        log_single_rank(logger, logging.DEBUG, f"  - args.virtual_pipeline_model_parallel_size: {getattr(args, 'virtual_pipeline_model_parallel_size', 'NOT SET')}")
+
+        args.pipeline_model_parallel_size = self.original_pp_size
+        args.pipeline_model_parallel_layout = self.original_pp_layout
+
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] After restoration:")
+        log_single_rank(logger, logging.DEBUG, f"  - args.pipeline_model_parallel_size: {args.pipeline_model_parallel_size}")
+        log_single_rank(logger, logging.DEBUG, f"  - args.pipeline_model_parallel_layout: {args.pipeline_model_parallel_layout}")
+
+        # Recalculate virtual_pipeline_model_parallel_size from restored layout
+        # This is necessary because during __enter__(), layout was set to None,
+        # causing virtual_pipeline_model_parallel_size to be set to None in arguments.py
+        if args.pipeline_model_parallel_layout is not None:
+            log_single_rank(logger, logging.DEBUG, f"[DEBUG] Calculating virtual_pipeline_model_parallel_size:")
+            layout_str = str(args.pipeline_model_parallel_layout)
+            log_single_rank(logger, logging.DEBUG, f"  - layout_str: {layout_str}")
+
+            num_stages = PipelineParallelLayerLayout.get_num_stages_from_str(layout_str)
+            log_single_rank(logger, logging.DEBUG, f"  - num_stages: {num_stages}")
+            log_single_rank(logger, logging.DEBUG, f"  - pp_size: {args.pipeline_model_parallel_size}")
+
+            assert num_stages % args.pipeline_model_parallel_size == 0, (
+                f"The length of pipeline_model_parallel_layout must be divisible"
+                f" by pipeline_model_parallel_size ({num_stages=},"
+                f" {args.pipeline_model_parallel_size=})"
+            )
+            args.virtual_pipeline_model_parallel_size = num_stages // args.pipeline_model_parallel_size
+            log_single_rank(logger, logging.DEBUG, f"  - calculated virtual_pipeline_model_parallel_size: {args.virtual_pipeline_model_parallel_size}")
+
+            if args.virtual_pipeline_model_parallel_size == 1:
+                args.virtual_pipeline_model_parallel_size = None
+                log_single_rank(logger, logging.DEBUG, f"  - set to None because it's 1")
+        else:
+            args.virtual_pipeline_model_parallel_size = None
+            log_single_rank(logger, logging.DEBUG, f"[DEBUG] pipeline_model_parallel_layout is None, setting virtual_pipeline_model_parallel_size to None")
+
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] Final virtual_pipeline_model_parallel_size: {args.virtual_pipeline_model_parallel_size}")
+
+        # IMPORTANT: Update the global variable in parallel_state module
+        # This is critical because is_pipeline_last_stage() checks the global variable,
+        # not args.virtual_pipeline_model_parallel_size
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] Before updating parallel_state global variable:")
+        log_single_rank(logger, logging.DEBUG, f"  - parallel_state._VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE: {parallel_state._VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE}")
+
+        parallel_state._VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE = args.virtual_pipeline_model_parallel_size
+
+        log_single_rank(logger, logging.DEBUG, f"[DEBUG] After updating parallel_state global variable:")
+        log_single_rank(logger, logging.DEBUG, f"  - parallel_state._VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE: {parallel_state._VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE}")
+        log_single_rank(logger, logging.DEBUG, f"  - get_virtual_pipeline_model_parallel_world_size(): {parallel_state.get_virtual_pipeline_model_parallel_world_size()}")
+
+        # prepare for data build
+        args.iteration = 0
+        args.num_floating_point_operations_so_far = 0
+        args.eval_interval = args.train_iters
+        return False
+
+
+class MockPipelineProcessGroup:
+    """Mock ProcessGroup for simulation mode.
+
+    In simulation mode, we use fewer physical GPUs than the model requires.
+    This mock allows us to simulate a larger pipeline parallel configuration
+    without actual distributed process groups.
+
+    Args:
+        size: Virtual world size (e.g., 4 for PP=4)
+        rank: Virtual rank in the group (0 to size-1)
+
+    Example:
+        # Simulate PP=4 with rank 2
+        mock_pp = MockProcessGroup(size=4, rank=2)
+        assert mock_pp.size() == 4
+        assert mock_pp.rank() == 2
+    """
+
+    def __init__(self, size: int = 1, rank: int = 0):
+        """Initialize MockProcessGroup with virtual size and rank."""
+        self._size = size
+        self._rank = rank
+
+    def size(self) -> int:
+        """Return the virtual world size of the process group."""
+        return self._size
+
+    def rank(self) -> int:
+        """Return the virtual rank of the current process in the group."""
+        return self._rank
+
+    def __repr__(self):
+        return f"MockProcessGroup(size={self._size}, rank={self._rank})"
+
+
+__all__ = ['SimulationArgsOverride', 'MockPipelineProcessGroup']

--- a/megatron/training/simulation/utils.py
+++ b/megatron/training/simulation/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Utility functions for VPP training simulation."""
 
@@ -40,6 +40,8 @@ class SimulationArgsOverride:
         # Store original values
         self.original_pp_size = None
         self.original_pp_layout = None
+        self.original_vpp_size = None
+        self.original_data_parallel_size = None
 
     def __enter__(self):
         """Override pipeline parallelism arguments for simulation initialization."""
@@ -56,6 +58,8 @@ class SimulationArgsOverride:
 
         # Save original user-defined values
         self.original_pp_size = self.parsed_args.pipeline_model_parallel_size
+        self.original_vpp_size = self.parsed_args.virtual_pipeline_model_parallel_size
+        self.original_data_parallel_size = self.parsed_args.data_parallel_size
         self.original_pp_layout = PipelineParallelLayerLayout.from_str(
             layout=self.parsed_args.pipeline_model_parallel_layout,
             pipeline_model_parallel_size=self.parsed_args.pipeline_model_parallel_size
@@ -67,13 +71,15 @@ class SimulationArgsOverride:
         log_single_rank(logger, logging.DEBUG, f"  - original_pp_layout: {self.original_pp_layout}")
 
         # Override with simulation values to enable initialization with fewer GPUs
-        # Set PP=1 to allow network initialization with only EP GPUs
+        # Set PP=1 and disable VPP to allow network initialization with only EP GPUs.
         self.parsed_args.pipeline_model_parallel_size = 1
         self.parsed_args.pipeline_model_parallel_layout = None
+        self.parsed_args.virtual_pipeline_model_parallel_size = None
 
         log_single_rank(logger, logging.DEBUG, f"[DEBUG] After override for simulation:")
         log_single_rank(logger, logging.DEBUG, f"  - pipeline_model_parallel_size: {self.parsed_args.pipeline_model_parallel_size}")
         log_single_rank(logger, logging.DEBUG, f"  - pipeline_model_parallel_layout: {self.parsed_args.pipeline_model_parallel_layout}")
+        log_single_rank(logger, logging.DEBUG, f"  - virtual_pipeline_model_parallel_size: {self.parsed_args.virtual_pipeline_model_parallel_size}")
 
         return self
 
@@ -99,10 +105,13 @@ class SimulationArgsOverride:
 
         args.pipeline_model_parallel_size = self.original_pp_size
         args.pipeline_model_parallel_layout = self.original_pp_layout
+        args.virtual_pipeline_model_parallel_size = self.original_vpp_size
+        args.data_parallel_size = self.original_data_parallel_size * self.original_pp_size
 
         log_single_rank(logger, logging.DEBUG, f"[DEBUG] After restoration:")
         log_single_rank(logger, logging.DEBUG, f"  - args.pipeline_model_parallel_size: {args.pipeline_model_parallel_size}")
         log_single_rank(logger, logging.DEBUG, f"  - args.pipeline_model_parallel_layout: {args.pipeline_model_parallel_layout}")
+        log_single_rank(logger, logging.DEBUG, f"  - args.data_parallel_size: {args.data_parallel_size}")
 
         # Recalculate virtual_pipeline_model_parallel_size from restored layout
         # This is necessary because during __enter__(), layout was set to None,
@@ -144,6 +153,23 @@ class SimulationArgsOverride:
         log_single_rank(logger, logging.DEBUG, f"[DEBUG] After updating parallel_state global variable:")
         log_single_rank(logger, logging.DEBUG, f"  - parallel_state._VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE: {parallel_state._VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE}")
         log_single_rank(logger, logging.DEBUG, f"  - get_virtual_pipeline_model_parallel_world_size(): {parallel_state.get_virtual_pipeline_model_parallel_world_size()}")
+
+        from megatron.core.num_microbatches_calculator import reconfigure_num_microbatches_calculator
+
+        reconfigure_num_microbatches_calculator(
+            rank=args.rank,
+            global_batch_size=args.global_batch_size,
+            micro_batch_size=args.micro_batch_size,
+            data_parallel_size=args.data_parallel_size,
+            decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
+            step_batch_size_schedule=args.step_batch_size_schedule,
+            seq_length=args.seq_length,
+        )
+        log_single_rank(
+            logger,
+            logging.INFO,
+            f"Simulation restored virtual data_parallel_size={args.data_parallel_size}",
+        )
 
         # prepare for data build
         args.iteration = 0

--- a/megatron/training/simulation/vpp_simulate.py
+++ b/megatron/training/simulation/vpp_simulate.py
@@ -1,0 +1,1036 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""VPP Training Simulation for Performance Profiling"""
+import itertools
+import logging
+import os
+import time
+import json
+from contextlib import contextmanager
+from typing import Dict, List, Tuple
+
+import torch
+import torch.distributed
+
+from megatron.core import parallel_state
+from megatron.core.pipeline_parallel.schedules import get_schedule_table, get_pp_rank_microbatches
+from megatron.core.num_microbatches_calculator import get_num_microbatches
+from megatron.core.utils import log_single_rank
+from megatron.training.global_vars import get_args
+from megatron.training.simulation.task import Task, TaskType
+from megatron.core.transformer.enums import LayerType
+from megatron.core.pipeline_parallel.schedules import forward_step
+from megatron.training.simulation.model_executor import (
+    create_model,
+    clear_model_mem,
+    prepare_input_tensor,
+    execute_forward_with_timing,
+    execute_backward_with_timing,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _preserve_pipeline_parallel_state():
+    """Context manager to preserve and restore pipeline parallel state
+
+    This context manager saves the original pipeline parallel state on entry
+    and restores it on exit. The actual state modification is done manually
+    inside the context.
+
+    This is used in VPP simulation where we use EP GPUs to simulate PP*EP GPUs.
+    We need to temporarily set PP rank/size to call functions that depend on
+    parallel_state, but restore the original state afterwards.
+    """
+    # Save original state
+    original_pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+    original_pp_size = parallel_state.get_pipeline_model_parallel_world_size()
+
+    try:
+        yield
+    finally:
+        # Restore original state (guaranteed even if exception occurs)
+        parallel_state.set_pipeline_model_parallel_rank(original_pp_rank)
+        parallel_state.set_pipeline_model_parallel_world_size(original_pp_size)
+
+
+class VppSimulator(object):
+    """
+    Simulate VPP training for performance profiling.
+
+    This function executes a complete global batch step across all pipeline ranks,
+    measures execution time for each forward/backward pass, and generates:
+    - Timeline trace (Chrome trace format)
+    - Memory usage profile
+    - Performance statistics
+
+    Args:
+        train_data_iterator: training data iterator
+        model_provider: function to create model
+
+    Execution flow:
+        1. Iterate through each PP rank and create corresponding model chunks
+        2. Execute forward/backward passes based on execution granularity
+        3. Collect timeline and memory information
+        4. Rank 0 merges all results and generates reports
+    """
+    def __init__(self, train_data_iterator, model_provider, forward_step_func):
+        self.train_data_iterator = train_data_iterator
+        self.model_provider = model_provider
+        self.forward_step_func = forward_step_func
+        self._initialize()
+
+    def _initialize(self):
+        args = get_args()
+        self.pipeline_parallel_size = args.pipeline_model_parallel_size
+
+        self.num_microbatches = get_num_microbatches()
+        self.num_model_chunks = parallel_state.get_virtual_pipeline_model_parallel_world_size()
+        if self.num_model_chunks is None:
+            self.num_model_chunks = 1
+        self.total_num_microbatches = self.num_microbatches * self.num_model_chunks
+
+        # Get schedule table
+        # Use 'or' to handle None case: getattr returns None when arg exists but is None
+        self.microbatch_group_size_per_vp_stage = getattr(args, 'microbatch_group_size_per_vp_stage', None) or self.pipeline_parallel_size
+        self.schedule_table = get_schedule_table(
+            self.num_microbatches,
+            self.num_model_chunks,
+            self.microbatch_group_size_per_vp_stage
+        )
+
+        self.microbatch_id_table, self.model_chunk_id_table = zip(*self.schedule_table)
+
+        # create tasks
+        self.pp_mbid_mcid_fb_task_dict = {}
+        self.task_num_count = 0
+
+        # Create forward tasks
+        for pp_rank, model_chunk_id, micro_batch_id in self.forward_task_iter():
+            self.pp_mbid_mcid_fb_task_dict[(pp_rank, micro_batch_id, model_chunk_id, TaskType.FORWARD)] = Task(
+                task_type=TaskType.FORWARD,
+                pp_rank=pp_rank,
+                microbatch_id=micro_batch_id,
+                model_chunk_id=model_chunk_id,
+            )
+            self.task_num_count += 1
+
+        # Create backward tasks
+        for pp_rank, model_chunk_id, micro_batch_id in self.backward_task_iter():
+            self.pp_mbid_mcid_fb_task_dict[(pp_rank, micro_batch_id, model_chunk_id, TaskType.BACKWARD)] = Task(
+                task_type=TaskType.BACKWARD,
+                pp_rank=pp_rank,
+                microbatch_id=micro_batch_id,
+                model_chunk_id=model_chunk_id,
+            )
+            self.task_num_count += 1
+
+        # Task execution order for each PP rank {pp_rank: [task_id1, task_id2, ...]}
+        # Must be initialized BEFORE _create_task_dependencies() is called
+        self.pp_rank_execution_order = {}
+
+        self._create_task_dependencies()
+
+        # create task execution time recorder
+        self.task_recorder = {}
+
+        # Model caching for reuse across tasks
+        self.current_model = None
+        self.current_model_pp_rank = None
+        self.current_model_vpp_rank = None
+
+        # Task output tensor storage
+        self.task_output_tensor_dict = {}
+
+        # Task input gradient tensor storage for backward
+        self.task_input_tensor_grad_dict = {}
+
+        # Static memory info for each PP rank {pp_rank: (params_gb, grads_gb)}
+        self.pp_static_memory_dict = {}
+
+        # DEBUG: Print schedule_table for debugging
+        log_single_rank(logger, logging.DEBUG, "\n" + "="*80)
+        log_single_rank(logger, logging.DEBUG, "DEBUG: Schedule Table Information")
+        log_single_rank(logger, logging.DEBUG, "="*80)
+        log_single_rank(logger, logging.DEBUG, f"num_microbatches: {self.num_microbatches}")
+        log_single_rank(logger, logging.DEBUG, f"num_model_chunks: {self.num_model_chunks}")
+        log_single_rank(logger, logging.DEBUG, f"total_num_microbatches: {self.total_num_microbatches}")
+        log_single_rank(logger, logging.DEBUG, f"microbatch_group_size_per_vp_stage: {self.microbatch_group_size_per_vp_stage}")
+        log_single_rank(logger, logging.DEBUG, f"\nSchedule table (first 10 entries):")
+        for i, (mb_id, mc_id) in enumerate(self.schedule_table[:10]):
+            log_single_rank(logger, logging.DEBUG, f"  virtual_mb_id {i}: (microbatch_id={mb_id}, model_chunk_id={mc_id})")
+        log_single_rank(logger, logging.DEBUG, "="*80 + "\n")
+
+    def _create_task_dependencies(self):
+        for pp_rank in range(self.pipeline_parallel_size):
+            for micro_batch_id in range(self.num_microbatches):
+                for model_chunk_id in range(self.num_model_chunks):
+                    backward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, micro_batch_id, model_chunk_id, TaskType.BACKWARD)]
+                    forward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, micro_batch_id, model_chunk_id, TaskType.FORWARD)]
+                    backward_task.dependencies.append(forward_task.task_id)
+
+        self._create_cross_pp_rank_dependencies()
+
+        # Use context manager to preserve and restore original parallel_state
+        # Inside the loop, we manually set the state for each PP rank simulation
+        with _preserve_pipeline_parallel_state():
+            for pp_rank in range(self.pipeline_parallel_size):
+                self._create_pp_rank_schedule_dependencies(pp_rank)
+
+    def _create_cross_pp_rank_dependencies(self):
+        """Create cross-PP rank pipeline dependencies
+
+        Forward pipeline: PP rank i depends on PP rank i-1 for the same microbatch
+        Backward pipeline: PP rank i depends on PP rank i+1 for the same microbatch
+        """
+        for micro_batch_id in range(self.num_microbatches):
+            for model_chunk_id in range(self.num_model_chunks):
+                # Forward pipeline dependency: forward tasks at pp_rank > 0 depend on forward tasks from the previous pp_rank
+                for pp_rank in range(1, self.pipeline_parallel_size):
+                    current_forward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, micro_batch_id, model_chunk_id, TaskType.FORWARD)]
+                    prev_forward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank-1, micro_batch_id, model_chunk_id, TaskType.FORWARD)]
+                    current_forward_task.dependencies.append(prev_forward_task.task_id)
+
+                # Backward pipeline dependency: backward tasks at pp_rank < pipeline_parallel_size-1 depend on backward tasks from the next pp_rank
+                for pp_rank in range(self.pipeline_parallel_size-1):
+                    current_backward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, micro_batch_id, model_chunk_id, TaskType.BACKWARD)]
+                    next_backward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank+1, micro_batch_id, model_chunk_id, TaskType.BACKWARD)]
+                    current_backward_task.dependencies.append(next_backward_task.task_id)
+
+    def _get_pp_rank_microbatches(self, pp_rank: int):
+        """Get microbatch distribution for a specific PP rank
+
+        This function replaces the previous hardcoded logic by directly calling
+        get_pp_rank_microbatches from schedules.py. It assumes parallel_state
+        has been set to the correct pp_rank before calling (via context manager).
+
+        Args:
+            pp_rank: Pipeline parallel rank (for documentation; actual value from parallel_state)
+
+        Returns:
+            Tuple of (total_num_microbatches, are_all_microbatches_in_warmup,
+                      num_warmup_microbatches, num_microbatches_remaining)
+        """
+        args = get_args()
+        # Set parallel_state for this PP rank to simulate its behavior
+        parallel_state.set_pipeline_model_parallel_rank(pp_rank)
+        parallel_state.set_pipeline_model_parallel_world_size(self.pipeline_parallel_size)
+
+        # Call the original function from schedules.py
+        # The pp_rank is read from parallel_state inside get_pp_rank_microbatches
+        return get_pp_rank_microbatches(
+            num_microbatches=self.num_microbatches,
+            num_model_chunks=self.num_model_chunks,
+            microbatch_group_size_per_vp_stage=self.microbatch_group_size_per_vp_stage,
+            forward_only=False,
+            overlap_moe_expert_parallel_comm=getattr(args, 'overlap_moe_expert_parallel_comm', False),
+            p2p_communicator=None
+        )
+
+    def _get_microbatch_id_in_model_chunk(self, virtual_microbatch_id: int, forward: bool):
+        if forward:
+            microbatch_id = self.microbatch_id_table[virtual_microbatch_id % self.total_num_microbatches]
+        else:
+            # Use the same microbatch_id for backward pass
+            microbatch_id = self.microbatch_id_table[virtual_microbatch_id % self.total_num_microbatches]
+        return microbatch_id
+
+    def _get_model_chunk_id(self, virtual_microbatch_id: int, forward: bool):
+        model_chunk_id = self.model_chunk_id_table[virtual_microbatch_id % self.total_num_microbatches]
+        original_chunk_id = model_chunk_id
+        if not forward:
+            model_chunk_id = self.num_model_chunks - model_chunk_id - 1
+            # DEBUG: Print reversal logic for backward at virtual_mb_id=0
+            if virtual_microbatch_id == 0:
+                log_single_rank(logger, logging.DEBUG, f"      [_get_model_chunk_id] virtual_mb_id={virtual_microbatch_id}, forward={forward}")
+                log_single_rank(logger, logging.DEBUG, f"      [_get_model_chunk_id] original_chunk_id={original_chunk_id}, reversed_chunk_id={model_chunk_id}")
+        return model_chunk_id
+
+    def _create_pp_rank_schedule_dependencies(self, pp_rank: int):
+        # Initialize execution order list for this PP rank
+        self.pp_rank_execution_order[pp_rank] = []
+
+        # Get microbatch distribution for this PP rank
+        (
+            total_num_microbatches,
+            are_all_microbatches_in_warmup,
+            num_warmup_microbatches,
+            num_microbatches_remaining,
+        ) = self._get_pp_rank_microbatches(pp_rank)
+
+        # Create schedule dependencies for each virtual microbatch
+        prev_task_id = None
+
+        # Phase 1: Warmup phase - forward tasks only
+        for k in range(num_warmup_microbatches):
+            model_chunk_id = self._get_model_chunk_id(k, forward=True)
+            microbatch_id = self._get_microbatch_id_in_model_chunk(k, forward=True)
+
+            forward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, microbatch_id, model_chunk_id, TaskType.FORWARD)]
+
+            # Record execution order
+            self.pp_rank_execution_order[pp_rank].append(forward_task.task_id)
+
+            # Sequential dependencies within the same PP rank
+            if prev_task_id is not None:
+                forward_task.dependencies.append(prev_task_id)
+
+            prev_task_id = forward_task.task_id
+
+        # Phase 2: Steady state phase - 1F1B
+        for k in range(num_microbatches_remaining):
+            # Forward task
+            forward_k = k + num_warmup_microbatches
+            f_model_chunk_id = self._get_model_chunk_id(forward_k, forward=True)
+            f_microbatch_id = self._get_microbatch_id_in_model_chunk(forward_k, forward=True)
+
+            forward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, f_microbatch_id, f_model_chunk_id, TaskType.FORWARD)]
+
+            # Backward task
+            backward_k = k
+
+            # DEBUG: Print backward task calculation for first iteration and specific pp_rank
+            if k == 0 and pp_rank in [0, 3]:
+                log_single_rank(logger, logging.DEBUG, f"\n>>> DEBUG 1F1B Phase (pp_rank={pp_rank}, k={k}):")
+                log_single_rank(logger, logging.DEBUG, f"    backward_k = {backward_k}")
+                # Get raw values from schedule table
+                raw_mb_id = self.microbatch_id_table[backward_k % self.total_num_microbatches]
+                raw_mc_id = self.model_chunk_id_table[backward_k % self.total_num_microbatches]
+                log_single_rank(logger, logging.DEBUG, f"    schedule_table[{backward_k}] = (mb_id={raw_mb_id}, mc_id={raw_mc_id})")
+
+            b_model_chunk_id = self._get_model_chunk_id(backward_k, forward=False)
+            b_microbatch_id = self._get_microbatch_id_in_model_chunk(backward_k, forward=False)
+
+            # DEBUG: Print results after get functions
+            if k == 0 and pp_rank in [0, 3]:
+                log_single_rank(logger, logging.DEBUG, f"    After _get_model_chunk_id(backward_k={backward_k}, forward=False):")
+                log_single_rank(logger, logging.DEBUG, f"      b_model_chunk_id = {b_model_chunk_id} (should be reversed!)")
+                log_single_rank(logger, logging.DEBUG, f"      b_microbatch_id = {b_microbatch_id}")
+                log_single_rank(logger, logging.DEBUG, f"    num_model_chunks = {self.num_model_chunks}")
+
+            backward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, b_microbatch_id, b_model_chunk_id, TaskType.BACKWARD)]
+
+            # DEBUG: Print task_id
+            if k == 0 and pp_rank in [0, 3]:
+                log_single_rank(logger, logging.DEBUG, f"    backward_task.task_id = {backward_task.task_id}\n")
+
+            # Correct dependency order for 1F1B phase: execute forward first, then backward
+            # 1. Forward task depends on the previous task
+            if prev_task_id is not None:
+                forward_task.dependencies.append(prev_task_id)
+
+            # Record execution order: forward first
+            self.pp_rank_execution_order[pp_rank].append(forward_task.task_id)
+
+            # Update prev_task_id to current forward task
+            prev_task_id = forward_task.task_id
+
+            # 2. Backward task depends on the previous task (the just-completed forward)
+            if prev_task_id is not None:
+                backward_task.dependencies.append(prev_task_id)
+
+            # Record execution order: backward second
+            self.pp_rank_execution_order[pp_rank].append(backward_task.task_id)
+
+            # 3. Next iteration's task will depend on current backward task
+            prev_task_id = backward_task.task_id
+
+        # Phase 3: Cooldown phase - backward tasks only
+        if not are_all_microbatches_in_warmup:
+            for k in range(num_microbatches_remaining, total_num_microbatches):
+                model_chunk_id = self._get_model_chunk_id(k, forward=False)
+                microbatch_id = self._get_microbatch_id_in_model_chunk(k, forward=False)
+
+                backward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, microbatch_id, model_chunk_id, TaskType.BACKWARD)]
+
+                # Record execution order
+                self.pp_rank_execution_order[pp_rank].append(backward_task.task_id)
+
+                # Sequential dependencies within the same PP rank
+                if prev_task_id is not None:
+                    backward_task.dependencies.append(prev_task_id)
+
+                prev_task_id = backward_task.task_id
+
+    def forward_task_iter(self):
+        """Iterate all forward tasks in order: microbatch -> vpp_rank -> pp_rank"""
+        for micro_batch_id in range(self.num_microbatches):
+            for model_chunk_id in range(self.num_model_chunks):
+                for pp_rank in range(self.pipeline_parallel_size):
+                    yield (pp_rank, model_chunk_id, micro_batch_id)
+
+    def backward_task_iter(self):
+        """Iterate all backward tasks in reverse order: microbatch -> vpp_rank(reversed) -> pp_rank(reversed)"""
+        for micro_batch_id in range(self.num_microbatches):
+            for model_chunk_id in range(self.num_model_chunks - 1, -1, -1):
+                for pp_rank in range(self.pipeline_parallel_size - 1, -1, -1):
+                    yield (pp_rank, model_chunk_id, micro_batch_id)
+
+    def _get_moe_pattern_for_chunk(self, pp_rank, vpp_rank, base_layout):
+        """
+        Determine MoE/Dense pattern for decoder layers in the current chunk
+
+        Returns:
+            list: pattern like ['dense', 'moe', 'moe'] for each decoder layer in chunk
+        """
+
+        args = get_args()
+
+        layer_offset = 0
+        for _vp_rank in range(vpp_rank + 1):
+            for _pp_rank in range(
+                args.pipeline_model_parallel_size if _vp_rank < vpp_rank else pp_rank
+            ):
+                layer_offset += args.pipeline_model_parallel_layout.layout[_pp_rank][_vp_rank].count(LayerType.decoder)
+
+        num_decoder_layers = base_layout.count(LayerType.decoder)
+
+        if num_decoder_layers == 0:
+            return []
+
+        # Get MoE frequency configuration
+        moe_layer_freq = getattr(args, 'moe_layer_freq', None)
+        total_layers = getattr(args, 'num_layers', 0)
+
+        assert isinstance(moe_layer_freq, list)
+
+        pattern = []
+        for i in range(num_decoder_layers):
+            global_layer_idx = layer_offset + i
+            if global_layer_idx < len(moe_layer_freq):
+                is_moe = moe_layer_freq[global_layer_idx] == 1
+                pattern.append('moe' if is_moe else 'dense')
+            else:
+                raise ValueError(f"Global layer index {global_layer_idx} out of range for moe_layer_freq at pp_rank {pp_rank}, vpp_rank {vpp_rank}")
+
+        return pattern
+
+    def _get_enhanced_layout_key(self, pp_rank, model_chunk_id):
+        args = get_args()
+
+        current_model_chunk_layout = tuple(args.pipeline_model_parallel_layout.layout[pp_rank][model_chunk_id])
+
+        # Get MoE pattern for decoder layers in this chunk
+        moe_pattern_list = self._get_moe_pattern_for_chunk(pp_rank, model_chunk_id, current_model_chunk_layout)
+
+        # Get attention type (sigmoid/softmax)
+        attn_pattern_list = ["softmax" for _ in moe_pattern_list]
+
+        # Build simplified key
+        enhanced_layout = []
+        decoder_idx = 0  # Separate index for decoder layers only
+
+        for layer_idx, layer_type in enumerate(current_model_chunk_layout):
+            # Handle LayerType enum cases
+            if layer_type == LayerType.embedding:
+                enhanced_layout.append('embedding')
+            elif layer_type == LayerType.loss:
+                enhanced_layout.append('loss')
+            elif layer_type == LayerType.encoder:
+                enhanced_layout.append('encoder')
+            elif layer_type == LayerType.mtp:
+                enhanced_layout.append('mtp')
+            elif layer_type == LayerType.decoder:
+                # Use decoder_idx to access decoder-specific patterns
+                if decoder_idx < len(attn_pattern_list) and decoder_idx < len(moe_pattern_list):
+                    attn_type = f"attn_{attn_pattern_list[decoder_idx]}"
+                    mlp_type = f"mlp_{moe_pattern_list[decoder_idx]}"
+                    enhanced_layout.append(('decoder_layer', attn_type, mlp_type))
+                    decoder_idx += 1  # Increment decoder index
+                else:
+                    enhanced_layout.append(('decoder_layer', 'attn_softmax', 'mlp_dense'))  # Default fallback
+                    decoder_idx += 1
+            else:
+                raise ValueError(f"Unknown layer type {layer_type} at pp_rank {pp_rank}, vpp_rank {model_chunk_id}")
+
+        return tuple(enhanced_layout)
+
+    def does_need_to_execute_task(self, now_task):
+        args = get_args()
+        now_enhanced_layout = self._get_enhanced_layout_key(now_task.pp_rank, now_task.model_chunk_id)
+        if args.execute_mode == 'router_balanced':
+            task_key = (now_enhanced_layout, now_task.task_type)
+        elif args.execute_mode == 'load_router_map':
+            task_key = (now_enhanced_layout, now_task.microbatch_id, now_task.task_type)
+        else:
+            raise ValueError(f'Unknown execute_mode: {args.execute_mode}')
+        if task_key in self.task_recorder:
+            return False
+        else:
+            return True
+
+    def record_task(self, task):
+        args = get_args()
+        now_enhanced_layout = self._get_enhanced_layout_key(task.pp_rank, task.model_chunk_id)
+        if args.execute_mode == 'router_balanced':
+            task_key = (now_enhanced_layout, task.task_type)
+        elif args.execute_mode == 'load_router_map':
+            task_key = (now_enhanced_layout, task.microbatch_id, task.task_type)
+        else:
+            raise ValueError(f'Unknown execute_mode: {args.execute_mode}')
+        self.task_recorder[task_key] = task.duration
+
+    def _assign_task_duration(self, task):
+        """
+        Assign duration to task from task_recorder and mark as finished.
+
+        This is used when a task doesn't need actual execution (same layout already executed).
+
+        Args:
+            task: Task object to assign duration to
+
+        Returns:
+            task: Updated task with duration and finished=True
+        """
+        args = get_args()
+        now_enhanced_layout = self._get_enhanced_layout_key(task.pp_rank, task.model_chunk_id)
+
+        if args.execute_mode == 'router_balanced':
+            task_key = (now_enhanced_layout, task.task_type)
+        elif args.execute_mode == 'load_router_map':
+            task_key = (now_enhanced_layout, task.microbatch_id, task.task_type)
+        else:
+            raise ValueError(f'Unknown execute_mode: {args.execute_mode}')
+
+        if task_key in self.task_recorder:
+            task.duration = self.task_recorder[task_key]
+            task.finished = True
+            log_single_rank(logger, logging.INFO, f'\tAssigned duration from recorded task: {task.duration:.2f}ms')
+        else:
+            raise RuntimeError(
+                f'Task key {task_key} not found in task_recorder. '
+                f'This should not happen - make sure a task with the same layout was executed first.'
+            )
+
+        return task
+
+    def run_global_step(self):
+        args = get_args()
+
+        # Check if we should skip execution and load from previous results
+        if args.skip_execute:
+            log_single_rank(logger, logging.INFO, "\n" + "="*80)
+            log_single_rank(logger, logging.INFO, "SKIP EXECUTE MODE: Loading Previous Simulation Results")
+            log_single_rank(logger, logging.INFO, "="*80)
+            log_single_rank(logger, logging.INFO, f"Loading results from: {args.load_result_dir}")
+
+            # Skip Phase 1 and Phase 2, directly go to Phase 3 with loaded data
+            # Only rank 0 performs analysis to avoid file I/O conflicts
+            if torch.distributed.get_rank() == 0:
+                log_single_rank(logger, logging.INFO, "\n" + "="*80)
+                log_single_rank(logger, logging.INFO, "PHASE 3: Analyzing Global Batch Results (from loaded data)")
+                log_single_rank(logger, logging.INFO, "="*80)
+                self.analyze_global_batch(load_from_dir=args.load_result_dir)
+            return
+
+        # Normal execution path
+        # Phase 1: Execute all forward tasks
+        log_single_rank(logger, logging.INFO, "\n" + "="*80)
+        log_single_rank(logger, logging.INFO, "PHASE 1: Executing Forward Tasks")
+        log_single_rank(logger, logging.INFO, "="*80)
+        for pp_rank, model_chunk_id, micro_batch_id in self.forward_task_iter():
+            now_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, micro_batch_id, model_chunk_id, TaskType.FORWARD)]
+            log_single_rank(logger, logging.INFO, "'During run_global_step. Prepare to run FORWARD task. \n"
+                         f"\tpp_rank: {pp_rank}; model_chunk_id: {model_chunk_id}; micro_batch_id: {micro_batch_id}")
+
+            # Determine execution requirements
+            need_execute_task = self.does_need_to_execute_task(now_task)
+            need_create_model = (pp_rank not in self.pp_static_memory_dict)
+
+            # Execute task if needed (for timing or static memory collection)
+            if need_execute_task or need_create_model:
+                if need_execute_task:
+                    log_single_rank(logger, logging.INFO, f'\tExecuting task for timing')
+                else:
+                    log_single_rank(logger, logging.INFO, f'\tCreating model for static memory collection only')
+
+                # Execute task (may skip computation if only collecting static memory)
+                now_task = self._execute_forward_task(
+                    now_task,
+                    self.train_data_iterator,
+                    execute_task=need_execute_task
+                )
+
+                # Handle task completion
+                if need_execute_task:
+                    # Task was actually executed - record duration
+                    self.record_task(now_task)
+                else:
+                    # Model was created but task not executed - assign duration from recorder
+                    now_task = self._assign_task_duration(now_task)
+            else:
+                # No execution or model creation needed - assign duration from recorder
+                log_single_rank(logger, logging.INFO, f'\tSkipping task execution')
+                now_task = self._assign_task_duration(now_task)
+
+        # Phase 2: Execute all backward tasks
+        log_single_rank(logger, logging.INFO, "\n" + "="*80)
+        log_single_rank(logger, logging.INFO, "PHASE 2: Executing Backward Tasks")
+        log_single_rank(logger, logging.INFO, "="*80)
+        for pp_rank, model_chunk_id, micro_batch_id in self.backward_task_iter():
+            now_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, micro_batch_id, model_chunk_id, TaskType.BACKWARD)]
+            log_single_rank(logger, logging.INFO, "'During run_global_step. Prepare to run BACKWARD task. \n"
+                         f"\tpp_rank: {pp_rank}; model_chunk_id: {model_chunk_id}; micro_batch_id: {micro_batch_id}")
+
+            # Check if backward task needs execution
+            need_execute_task = self.does_need_to_execute_task(now_task)
+
+            # Ensure corresponding forward task is finished (dependency requirement)
+            if need_execute_task:
+                forward_task = self.pp_mbid_mcid_fb_task_dict[(pp_rank, micro_batch_id, model_chunk_id, TaskType.FORWARD)]
+                if not forward_task.finished:
+                    log_single_rank(logger, logging.INFO, f'\tCorresponding forward task not finished, executing it first...')
+                    forward_task = self._execute_forward_task(forward_task, self.train_data_iterator, execute_task=True)
+                    self.record_task(forward_task)
+                    log_single_rank(logger, logging.INFO, f'\tForced forward execution completed for backward dependency')
+
+            # Execute or assign duration
+            if need_execute_task:
+                log_single_rank(logger, logging.INFO, f'\tExecuting backward task for timing')
+                now_task = self._execute_backward_task(now_task, self.train_data_iterator)
+                self.record_task(now_task)
+            else:
+                log_single_rank(logger, logging.INFO, f'\tSkipping backward task execution')
+                now_task = self._assign_task_duration(now_task)
+
+        # Phase 3: Collect and save results
+        # Only rank 0 performs file I/O operations to avoid conflicts
+        if torch.distributed.get_rank() == 0:
+            log_single_rank(logger, logging.INFO, "\n" + "="*80)
+            log_single_rank(logger, logging.INFO, "PHASE 3: Collecting and Saving Results")
+            log_single_rank(logger, logging.INFO, "="*80)
+            self._collect_and_save_results()
+
+            # Phase 4: Analyze and generate reports
+            log_single_rank(logger, logging.INFO, "\n" + "="*80)
+            log_single_rank(logger, logging.INFO, "PHASE 4: Analyzing Global Batch Results")
+            log_single_rank(logger, logging.INFO, "="*80)
+            self.analyze_global_batch(load_from_dir=args.simulate_result_dir)
+
+    def _collect_and_save_results(self):
+        """Collect finished tasks from execution and save auxiliary files
+
+        This method is called after Phase 2 (backward execution) in execute mode.
+        It collects all finished tasks from the execution and saves them along with
+        auxiliary files (task orders, VPP layouts, memory info, etc.) to simulate_result_dir.
+        """
+        args = get_args()
+
+        # Ensure simulate_result_dir is specified
+        simulate_result_dir = getattr(args, 'simulate_result_dir', None)
+        if simulate_result_dir is None:
+            raise ValueError("--simulate-result-dir must be specified in execute mode")
+
+        log_single_rank(logger, logging.INFO, f"Collecting results and saving to: {simulate_result_dir}")
+
+        # Collect finished tasks from current execution
+        # IMPORTANT: Collect tasks in execution order (not dict iteration order)
+        from megatron.training.simulation.analyzer import parse_task_id
+
+        pp_finished_task_queue_dict = {}
+        for pp_rank in range(self.pipeline_parallel_size):
+            pp_finished_task_queue_dict[pp_rank] = []
+
+            # Use execution_order to collect tasks in correct order
+            for task_id in self.pp_rank_execution_order[pp_rank]:
+                # Parse task_id to get task information
+                task_info = parse_task_id(task_id)
+
+                # Build task_key to lookup task object
+                task_type_enum = TaskType.FORWARD if task_info['task_type'] == 'forward' else TaskType.BACKWARD
+                task_key = (
+                    task_info['pp_rank'],
+                    task_info['microbatch_id'],
+                    task_info['model_chunk_id'],
+                    task_type_enum
+                )
+
+                # Get task object from dict
+                if task_key in self.pp_mbid_mcid_fb_task_dict:
+                    task = self.pp_mbid_mcid_fb_task_dict[task_key]
+                    if task.finished:
+                        pp_finished_task_queue_dict[pp_rank].append(task)
+                else:
+                    log_single_rank(logger, logging.WARNING, f"Warning: task {task_id} not found in task dict")
+
+        # Count total finished tasks
+        total_finished_tasks = sum(len(tasks) for tasks in pp_finished_task_queue_dict.values())
+        log_single_rank(logger, logging.INFO, f"Collected {total_finished_tasks} finished tasks across {self.pipeline_parallel_size} PP ranks")
+
+        # Verification: Print task collection order for debugging
+        log_single_rank(logger, logging.DEBUG, "\n" + "=" * 80)
+        log_single_rank(logger, logging.DEBUG, "Task Collection Order Verification:")
+        log_single_rank(logger, logging.DEBUG, "=" * 80)
+        for pp_rank in range(min(2, self.pipeline_parallel_size)):  # Print first 2 PP ranks
+            log_single_rank(logger, logging.DEBUG, f"PP Rank {pp_rank}: {len(pp_finished_task_queue_dict[pp_rank])} tasks collected")
+            for i, task in enumerate(pp_finished_task_queue_dict[pp_rank][:5]):  # Print first 5 tasks
+                log_single_rank(logger, logging.DEBUG, f"  [{i}] {task.task_id}")
+        log_single_rank(logger, logging.DEBUG, "=" * 80 + "\n")
+
+        # Save auxiliary files
+        self._save_auxiliary_files(pp_finished_task_queue_dict, simulate_result_dir)
+
+        log_single_rank(logger, logging.INFO, "✅ Results collection and saving complete!")
+
+    def analyze_global_batch(self, load_from_dir):
+        """Analyze complete global batch execution including timeline, throughput, and memory
+
+        This function performs comprehensive analysis of the completed global batch step:
+        1. Load finished tasks from load_from_dir
+        2. Generate timeline visualization (Chrome Trace format)
+        3. Calculate throughput statistics (TFLOPS, tokens/day)
+        4. Analyze memory usage and create visualization charts
+
+        Args:
+            load_from_dir: Directory to load finished tasks and auxiliary files from.
+                          In execute mode: load from simulate_result_dir
+                          In skip-execute mode: load from load_result_dir
+        """
+        args = get_args()
+
+        log_single_rank(logger, logging.INFO, "=" * 80)
+        log_single_rank(logger, logging.INFO, "Starting Global Batch Analysis")
+        log_single_rank(logger, logging.INFO, "=" * 80)
+
+        # Step 1: Load finished tasks from directory
+        log_single_rank(logger, logging.INFO, f"Loading finished tasks from: {load_from_dir}")
+        pp_finished_task_queue_dict = self._load_finished_tasks(load_from_dir)
+
+        # Use load_from_dir as the analysis directory
+        analysis_dir = load_from_dir
+
+        # Step 2: Generate timeline visualization
+        log_single_rank(logger, logging.INFO, "\n" + "-" * 80)
+        log_single_rank(logger, logging.INFO, "Generating timeline visualization...")
+        log_single_rank(logger, logging.INFO, "-" * 80)
+        from megatron.training.simulation import analyzer
+        from megatron.training.simulation.task import TaskType
+
+
+        analyzer.display_gbs_statistics(
+            pp_finished_task_queue_dict=pp_finished_task_queue_dict,
+            pipeline_parallel_size=self.pipeline_parallel_size,
+            num_microbatches=self.num_microbatches,
+            num_model_chunks=self.num_model_chunks,
+            args=args,
+            task_type_enum=TaskType
+        )
+
+        log_single_rank(logger, logging.INFO, "\n" + "=" * 80)
+        log_single_rank(logger, logging.INFO, "✅ Global Batch Analysis Complete!")
+        log_single_rank(logger, logging.INFO, "=" * 80)
+        log_single_rank(logger, logging.INFO, f"Analysis results from: {analysis_dir}")
+
+    def _load_finished_tasks(self, load_result_dir):
+        """Load finished tasks from a previous simulation run
+
+        Args:
+            load_result_dir: Directory containing saved simulation results
+
+        Returns:
+            pp_finished_task_queue_dict: Dictionary of finished tasks per PP rank
+        """
+        finished_tasks_path = os.path.join(load_result_dir, 'finished_tasks.json')
+
+        if not os.path.exists(finished_tasks_path):
+            raise FileNotFoundError(
+                f"Cannot find finished_tasks.json in {load_result_dir}. "
+                "Please ensure the directory contains results from a previous simulation run."
+            )
+
+        log_single_rank(logger, logging.INFO, f"Loading finished tasks from: {finished_tasks_path}")
+        with open(finished_tasks_path, 'r') as f:
+            finished_tasks_json = json.load(f)
+
+        # Reconstruct Task objects from JSON
+        pp_finished_task_queue_dict = {}
+        for pp_rank_str, task_list in finished_tasks_json.items():
+            pp_rank = int(pp_rank_str)
+            pp_finished_task_queue_dict[pp_rank] = [Task.from_dict(task_dict) for task_dict in task_list]
+
+        # Count total tasks loaded
+        total_tasks = sum(len(tasks) for tasks in pp_finished_task_queue_dict.values())
+        log_single_rank(logger, logging.INFO, f"Loaded {total_tasks} finished tasks from {len(pp_finished_task_queue_dict)} PP ranks")
+
+        return pp_finished_task_queue_dict
+
+    def _save_auxiliary_files(self, pp_finished_task_queue_dict, simulate_result_dir):
+        """Save auxiliary files needed for analysis
+
+        Args:
+            pp_finished_task_queue_dict: Dictionary of finished tasks per PP rank
+            simulate_result_dir: Directory to save files
+        """
+        # Ensure directory exists
+        os.makedirs(simulate_result_dir, exist_ok=True)
+
+        # 1. Save pp_task_orders.json using recorded execution order
+        pp_task_orders = {}
+        for pp_rank in range(self.pipeline_parallel_size):
+            # Use the execution order recorded during schedule creation
+            pp_task_orders[pp_rank] = self.pp_rank_execution_order[pp_rank]
+
+        pp_task_orders_path = os.path.join(simulate_result_dir, 'pp_task_orders.json')
+        with open(pp_task_orders_path, 'w') as f:
+            json.dump(pp_task_orders, f, indent=2)
+        log_single_rank(logger, logging.INFO, f"Saved task orders to: {pp_task_orders_path}")
+
+        # 2. Save all_pp_vpp_layout.json
+        all_pp_vpp_layout = {}
+        for pp_rank in range(self.pipeline_parallel_size):
+            vpp_layout = {}
+            for vpp_rank in range(self.num_model_chunks):
+                # Get enhanced layout key for this pp_rank and vpp_rank
+                enhanced_layout = self._get_enhanced_layout_key(pp_rank, vpp_rank)
+                # Convert tuple to list for JSON serialization
+                vpp_layout[vpp_rank] = list(enhanced_layout) if isinstance(enhanced_layout, tuple) else enhanced_layout
+            all_pp_vpp_layout[pp_rank] = vpp_layout
+
+        vpp_layout_path = os.path.join(simulate_result_dir, 'all_pp_vpp_layout.json')
+        with open(vpp_layout_path, 'w') as f:
+            json.dump(all_pp_vpp_layout, f, indent=2)
+        log_single_rank(logger, logging.INFO, f"Saved VPP layouts to: {vpp_layout_path}")
+
+        # 3. Save static_memory_info.json with actual model memory info
+        static_memory_info = {
+            "executor_0": {}
+        }
+
+        for pp_rank in range(self.pipeline_parallel_size):
+            # Use actual static memory if available, otherwise use 0.0
+            if pp_rank in self.pp_static_memory_dict:
+                params_gb = self.pp_static_memory_dict[pp_rank]['params_memory_gb']
+                grads_gb = self.pp_static_memory_dict[pp_rank]['grads_memory_gb']
+            else:
+                # This should not happen in normal simulation, but provide fallback
+                params_gb = 0.0
+                grads_gb = 0.0
+                log_single_rank(logger, logging.WARNING, f"Warning: PP rank {pp_rank} static memory not collected, using 0.0")
+
+            static_memory_info["executor_0"][str(pp_rank)] = {
+                "static": {
+                    "params_memory_gb": params_gb,
+                    "grads_memory_gb": grads_gb
+                },
+                "dynamic": {}
+            }
+
+        static_memory_path = os.path.join(simulate_result_dir, 'static_memory_info.json')
+        with open(static_memory_path, 'w') as f:
+            json.dump(static_memory_info, f, indent=2)
+        log_single_rank(logger, logging.INFO, f"Saved static memory info to: {static_memory_path}")
+
+        # 4. Save finished_tasks.json - complete task objects for re-analysis
+        finished_tasks_json = {}
+        for pp_rank in range(self.pipeline_parallel_size):
+            finished_tasks_json[str(pp_rank)] = [task.to_dict() for task in pp_finished_task_queue_dict[pp_rank]]
+
+        finished_tasks_path = os.path.join(simulate_result_dir, 'finished_tasks.json')
+        with open(finished_tasks_path, 'w') as f:
+            json.dump(finished_tasks_json, f, indent=2)
+        log_single_rank(logger, logging.INFO, f"Saved finished tasks to: {finished_tasks_path}")
+
+        # 5. Save task_durations.json - human-readable task duration records
+        task_durations = {}
+        for pp_rank in range(self.pipeline_parallel_size):
+            for task in pp_finished_task_queue_dict[pp_rank]:
+                task_durations[task.task_id] = {
+                    'duration_ms': task.duration,
+                    'pp_rank': task.pp_rank,
+                    'microbatch_id': task.microbatch_id,
+                    'model_chunk_id': task.model_chunk_id,
+                    'task_type': task.task_type.value
+                }
+
+        task_durations_path = os.path.join(simulate_result_dir, 'task_durations.json')
+        with open(task_durations_path, 'w') as f:
+            json.dump(task_durations, f, indent=2)
+        log_single_rank(logger, logging.INFO, f"Saved task durations to: {task_durations_path}")
+
+    def _execute_forward_task(self, task: Task, data_iterator, execute_task: bool = True):
+        """Execute forward task with actual computation
+
+        Args:
+            task: Task object containing pp_rank, vpp_rank (model_chunk_id), microbatch_id
+            data_iterator: training data iterator
+            execute_task: If True, execute actual forward computation for timing.
+                         If False, only create model and collect static memory.
+
+        Returns:
+            task: Updated task with duration and finished status
+        """
+        args = get_args()
+        pp_rank = task.pp_rank
+        vpp_rank = task.model_chunk_id
+        microbatch_id = task.microbatch_id
+
+        global_rank = torch.distributed.get_rank()
+
+        # Determine if model needs to be recreated
+        need_recreate = (
+            self.current_model is None or
+            self.current_model_pp_rank != pp_rank
+        )
+
+        if need_recreate:
+            # Clear old model if exists
+            if self.current_model is not None:
+                if global_rank == 0:
+                    log_single_rank(logger, logging.INFO, f"Clearing old model: pp_rank={self.current_model_pp_rank}, "
+                                f"vpp_rank={self.current_model_vpp_rank}")
+                clear_model_mem(self.current_model)
+                self.current_model = None
+
+            # Create new model
+            if global_rank == 0:
+                log_single_rank(logger, logging.INFO, f"Creating new model for pp_rank={pp_rank}, vpp_rank={vpp_rank}")
+            self.current_model = create_model(pp_rank, self.model_provider)
+            self.current_model_pp_rank = pp_rank
+            self.current_model_vpp_rank = vpp_rank
+
+        else:
+            if global_rank == 0:
+                log_single_rank(logger, logging.INFO, f"Reusing existing model for pp_rank={pp_rank}, vpp_rank={vpp_rank}")
+
+        # If we don't need to execute the task (only collecting static memory), return early
+        if not execute_task:
+            if global_rank == 0:
+                log_single_rank(logger, logging.INFO, f"Skipping forward execution (static memory collected)")
+            # Mark task as finished with 0 duration (will be filled from task_recorder later)
+            task.duration = 0.0
+            task.finished = False  # Not actually executed
+            return task
+
+        # Prepare input tensor
+        input_tensor = prepare_input_tensor(
+            pp_rank, vpp_rank, microbatch_id, self.task_output_tensor_dict
+        )
+
+        input_info = f"shape: {input_tensor.shape}" if input_tensor is not None else "None"
+        log_single_rank(logger, logging.DEBUG, f"Forward task Before execute. - pp_rank: {pp_rank}, vpp_rank: {vpp_rank}, "
+                    f"microbatch_id: {microbatch_id}, input_tensor: {input_info}")
+
+        # Execute forward with timing
+        output_tensor, avg_forward_time = execute_forward_with_timing(
+            model=self.current_model,
+            vpp_rank=vpp_rank,
+            input_tensor=input_tensor,
+            data_iterator=data_iterator,
+            forward_step_func=self.forward_step_func,
+            args=args,
+            microbatch_id=microbatch_id,
+            warmup_times=15,
+            measure_times=10,
+        )
+
+        # Cache output tensor for downstream stages
+        log_single_rank(logger, logging.DEBUG, f"Forward task After execute. - pp_rank: {pp_rank}, vpp_rank: {vpp_rank}, "
+                    f"microbatch_id: {microbatch_id}, output_tensor: {output_tensor}")
+        cache_key = (pp_rank, vpp_rank, microbatch_id)
+        self.task_output_tensor_dict[cache_key] = output_tensor.detach().clone()
+
+        if global_rank == 0:
+            output_info = f"shape: {output_tensor.shape}" if output_tensor is not None else "None"
+            log_single_rank(logger, logging.DEBUG, f"Forward task completed - output_tensor: {output_info}, "
+                        f"duration: {avg_forward_time:.2f}ms")
+
+        # Update task
+        task.duration = avg_forward_time
+        task.finished = True
+
+        # Clean up output tensor reference (keep cached version only)
+        del output_tensor
+
+        return task
+
+    def _execute_backward_task(self, task: Task, data_iterator):
+        """Execute backward task with actual computation
+
+        Args:
+            task: Task object containing pp_rank, vpp_rank (model_chunk_id), microbatch_id
+            data_iterator: training data iterator
+
+        Returns:
+            task: Updated task with duration and finished status
+        """
+        args = get_args()
+        pp_rank = task.pp_rank
+        vpp_rank = task.model_chunk_id
+        microbatch_id = task.microbatch_id
+
+        global_rank = torch.distributed.get_rank()
+
+        # Determine if model needs to be recreated
+        need_recreate = (
+            self.current_model is None or
+            self.current_model_pp_rank != pp_rank
+        )
+
+        if need_recreate:
+            # Clear old model if exists
+            if self.current_model is not None:
+                if global_rank == 0:
+                    log_single_rank(logger, logging.INFO, f"Clearing old model: pp_rank={self.current_model_pp_rank}, "
+                                f"vpp_rank={self.current_model_vpp_rank}")
+                clear_model_mem(self.current_model)
+                self.current_model = None
+
+            # Create new model
+            if global_rank == 0:
+                log_single_rank(logger, logging.INFO, f"Creating new model for pp_rank={pp_rank}, vpp_rank={vpp_rank}")
+            self.current_model = create_model(pp_rank, self.model_provider)
+            self.current_model_pp_rank = pp_rank
+            self.current_model_vpp_rank = vpp_rank
+            # Note: Static memory is already collected in forward task, no need to recalculate here
+        else:
+            if global_rank == 0:
+                log_single_rank(logger, logging.INFO, f"Reusing existing model for pp_rank={pp_rank}, vpp_rank={vpp_rank}")
+
+        # Prepare input tensor from forward pass output
+        input_tensor = prepare_input_tensor(
+            pp_rank, vpp_rank, microbatch_id, self.task_output_tensor_dict
+        )
+
+        # Clone and enable gradient for backward
+        if input_tensor is not None:
+            input_tensor = input_tensor.clone().detach().requires_grad_(True)
+
+        if global_rank == 0:
+            input_info = f"shape: {input_tensor.shape}" if input_tensor is not None else "None"
+            log_single_rank(logger, logging.DEBUG, f"Backward task - pp_rank: {pp_rank}, vpp_rank: {vpp_rank}, "
+                        f"microbatch_id: {microbatch_id}, input_tensor: {input_info}")
+
+        # Execute backward with timing (output_tensor_grad will be prepared inside)
+        input_tensor_grad, avg_backward_time = execute_backward_with_timing(
+            model=self.current_model,
+            vpp_rank=vpp_rank,
+            input_tensor=input_tensor,
+            data_iterator=data_iterator,
+            forward_step_func=self.forward_step_func,
+            args=args,
+            microbatch_id=microbatch_id,
+            num_model_chunks=self.num_model_chunks,
+            task_input_tensor_grad_dict=self.task_input_tensor_grad_dict,
+            warmup_times=15,
+            measure_times=10,
+        )
+
+        # Cache input gradient tensor for upstream stages
+        if input_tensor_grad is not None:
+            cache_key = (pp_rank, vpp_rank, microbatch_id)
+            self.task_input_tensor_grad_dict[cache_key] = input_tensor_grad.detach().clone()
+
+        if global_rank == 0:
+            input_grad_info = f"shape: {input_tensor_grad.shape}" if input_tensor_grad is not None else "None"
+            log_single_rank(logger, logging.DEBUG, f"Backward task completed - input_tensor_grad: {input_grad_info}, "
+                        f"duration: {avg_backward_time:.2f}ms")
+
+        # Update task
+        task.duration = avg_backward_time
+        task.finished = True
+
+        # Clean up gradient reference (keep cached version only)
+        del input_tensor_grad
+
+        return task

--- a/megatron/training/simulation/vpp_simulate.py
+++ b/megatron/training/simulation/vpp_simulate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """VPP Training Simulation for Performance Profiling"""
 import itertools
@@ -23,6 +23,7 @@ from megatron.core.pipeline_parallel.schedules import forward_step
 from megatron.training.simulation.model_executor import (
     create_model,
     clear_model_mem,
+    clear_model_grad_state,
     prepare_input_tensor,
     execute_forward_with_timing,
     execute_backward_with_timing,
@@ -161,6 +162,81 @@ class VppSimulator(object):
         for i, (mb_id, mc_id) in enumerate(self.schedule_table[:10]):
             log_single_rank(logger, logging.DEBUG, f"  virtual_mb_id {i}: (microbatch_id={mb_id}, model_chunk_id={mc_id})")
         log_single_rank(logger, logging.DEBUG, "="*80 + "\n")
+
+    def _clear_grad_state_on_model_chunk_switch(self, pp_rank: int, vpp_rank: int):
+        """Clear model gradient state when simulator execution moves to another VPP chunk."""
+        if self.current_model is None:
+            return
+
+        if self.current_model_vpp_rank is None:
+            self.current_model_vpp_rank = vpp_rank
+            return
+
+        if self.current_model_vpp_rank == vpp_rank:
+            return
+
+        log_single_rank(
+            logger,
+            logging.DEBUG,
+            "Clearing model grad state on model chunk switch: "
+            f"pp_rank={pp_rank}, old_vpp_rank={self.current_model_vpp_rank}, "
+            f"new_vpp_rank={vpp_rank}",
+        )
+        clear_model_grad_state(self.current_model)
+        self.current_model_vpp_rank = vpp_rank
+
+    def _record_static_memory(self, pp_rank: int, model):
+        """Record static model memory once for a simulated PP rank."""
+        if pp_rank in self.pp_static_memory_dict:
+            return
+
+        params_bytes = 0
+        grads_bytes = 0
+
+        def _add_buffer_memory(buffer):
+            nonlocal params_bytes, grads_bytes
+            param_data = getattr(buffer, 'param_data', None)
+            grad_data = getattr(buffer, 'grad_data', None)
+            if param_data is not None:
+                params_bytes += param_data.numel() * param_data.element_size()
+            if grad_data is not None:
+                grads_bytes += grad_data.numel() * grad_data.element_size()
+
+        def _record_chunk(chunk):
+            nonlocal params_bytes, grads_bytes
+            used_ddp_buffers = False
+            for attr_name in ('buffers', 'expert_parallel_buffers'):
+                buffers = getattr(chunk, attr_name, None)
+                if callable(buffers):
+                    buffers = None
+                for buffer in buffers or []:
+                    _add_buffer_memory(buffer)
+                    used_ddp_buffers = True
+
+            if not used_ddp_buffers:
+                for param in chunk.parameters():
+                    params_bytes += param.numel() * param.element_size()
+                    if param.grad is not None:
+                        grads_bytes += param.grad.numel() * param.grad.element_size()
+
+        if isinstance(model, list):
+            for model_chunk in model:
+                _record_chunk(model_chunk)
+        else:
+            _record_chunk(model)
+
+        self.pp_static_memory_dict[pp_rank] = {
+            'params_memory_gb': params_bytes / (1024 ** 3),
+            'grads_memory_gb': grads_bytes / (1024 ** 3),
+        }
+
+        log_single_rank(
+            logger,
+            logging.INFO,
+            f"Collected static memory for pp_rank={pp_rank}: "
+            f"params={self.pp_static_memory_dict[pp_rank]['params_memory_gb']:.2f}GB, "
+            f"grads={self.pp_static_memory_dict[pp_rank]['grads_memory_gb']:.2f}GB",
+        )
 
     def _create_task_dependencies(self):
         for pp_rank in range(self.pipeline_parallel_size):
@@ -367,6 +443,27 @@ class VppSimulator(object):
                 for pp_rank in range(self.pipeline_parallel_size - 1, -1, -1):
                     yield (pp_rank, model_chunk_id, micro_batch_id)
 
+    def _get_moe_layer_pattern(self):
+        args = get_args()
+        moe_layer_freq = getattr(args, 'moe_layer_freq', None)
+        total_layers = getattr(args, 'num_layers', 0)
+
+        if isinstance(moe_layer_freq, int):
+            if moe_layer_freq <= 0:
+                raise ValueError(f"Invalid moe_layer_freq: {moe_layer_freq}")
+            return [
+                1 if (layer_idx % moe_layer_freq == 0) else 0
+                for layer_idx in range(total_layers)
+            ]
+        if isinstance(moe_layer_freq, list):
+            if len(moe_layer_freq) != total_layers:
+                raise ValueError(
+                    f"Invalid length of moe_layer_freq: {len(moe_layer_freq)}, "
+                    f"expected {total_layers}"
+                )
+            return moe_layer_freq
+        raise ValueError(f"Invalid moe_layer_freq: {type(moe_layer_freq)}, {moe_layer_freq}")
+
     def _get_moe_pattern_for_chunk(self, pp_rank, vpp_rank, base_layout):
         """
         Determine MoE/Dense pattern for decoder layers in the current chunk
@@ -389,20 +486,19 @@ class VppSimulator(object):
         if num_decoder_layers == 0:
             return []
 
-        # Get MoE frequency configuration
-        moe_layer_freq = getattr(args, 'moe_layer_freq', None)
-        total_layers = getattr(args, 'num_layers', 0)
-
-        assert isinstance(moe_layer_freq, list)
+        moe_layer_pattern = self._get_moe_layer_pattern()
 
         pattern = []
         for i in range(num_decoder_layers):
             global_layer_idx = layer_offset + i
-            if global_layer_idx < len(moe_layer_freq):
-                is_moe = moe_layer_freq[global_layer_idx] == 1
+            if global_layer_idx < len(moe_layer_pattern):
+                is_moe = moe_layer_pattern[global_layer_idx] == 1
                 pattern.append('moe' if is_moe else 'dense')
             else:
-                raise ValueError(f"Global layer index {global_layer_idx} out of range for moe_layer_freq at pp_rank {pp_rank}, vpp_rank {vpp_rank}")
+                raise ValueError(
+                    f"Global layer index {global_layer_idx} out of range for "
+                    f"moe_layer_freq at pp_rank {pp_rank}, vpp_rank {vpp_rank}"
+                )
 
         return pattern
 
@@ -888,6 +984,7 @@ class VppSimulator(object):
             self.current_model = create_model(pp_rank, self.model_provider)
             self.current_model_pp_rank = pp_rank
             self.current_model_vpp_rank = vpp_rank
+            self._record_static_memory(pp_rank, self.current_model)
 
         else:
             if global_rank == 0:
@@ -901,6 +998,8 @@ class VppSimulator(object):
             task.duration = 0.0
             task.finished = False  # Not actually executed
             return task
+
+        self._clear_grad_state_on_model_chunk_switch(pp_rank, vpp_rank)
 
         # Prepare input tensor
         input_tensor = prepare_input_tensor(
@@ -920,8 +1019,9 @@ class VppSimulator(object):
             forward_step_func=self.forward_step_func,
             args=args,
             microbatch_id=microbatch_id,
-            warmup_times=15,
-            measure_times=10,
+            warmup_times=args.simulation_warmup_times,
+            measure_times=args.simulation_measure_times,
+            measure_skip_times=args.simulation_measure_skip_times,
         )
 
         # Cache output tensor for downstream stages
@@ -982,10 +1082,13 @@ class VppSimulator(object):
             self.current_model = create_model(pp_rank, self.model_provider)
             self.current_model_pp_rank = pp_rank
             self.current_model_vpp_rank = vpp_rank
+            self._record_static_memory(pp_rank, self.current_model)
             # Note: Static memory is already collected in forward task, no need to recalculate here
         else:
             if global_rank == 0:
                 log_single_rank(logger, logging.INFO, f"Reusing existing model for pp_rank={pp_rank}, vpp_rank={vpp_rank}")
+
+        self._clear_grad_state_on_model_chunk_switch(pp_rank, vpp_rank)
 
         # Prepare input tensor from forward pass output
         input_tensor = prepare_input_tensor(
@@ -1012,8 +1115,9 @@ class VppSimulator(object):
             microbatch_id=microbatch_id,
             num_model_chunks=self.num_model_chunks,
             task_input_tensor_grad_dict=self.task_input_tensor_grad_dict,
-            warmup_times=15,
-            measure_times=10,
+            warmup_times=args.simulation_warmup_times,
+            measure_times=args.simulation_measure_times,
+            measure_skip_times=args.simulation_measure_skip_times,
         )
 
         # Cache input gradient tensor for upstream stages

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Pretrain utilities."""
 import argparse

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -172,6 +172,7 @@ from megatron.training.checkpointing import (
     save_checkpoint,
     save_grads,
 )
+from megatron.training.simulation import SimulationArgsOverride, VppSimulator
 
 try:
     from megatron.core.distributed import TorchFullyShardedDataParallel as torch_FSDP
@@ -1033,6 +1034,25 @@ def preprocess_common_state_dict(common_state_dict):
     return preprocessed_common_state_dict
 
 
+def simulate_global_step(
+    train_valid_test_dataset_provider,
+    model_provider,
+    forward_step_func,
+):
+
+    train_data_iterator, valid_data_iterator, test_data_iterator = (
+        build_train_valid_test_data_iterators(train_valid_test_dataset_provider)
+    )
+
+    vpp_simulator = VppSimulator(
+        train_data_iterator,
+        model_provider,
+        forward_step_func,
+    )
+
+    vpp_simulator.run_global_step()
+
+
 def pretrain(
     cfg_container: PretrainConfigContainer,
     train_valid_test_dataset_provider,
@@ -1091,24 +1111,27 @@ def pretrain(
     # Capture timestamp right at top of pretrain, before initialize_megatron
     global _STARTUP_TIMESTAMPS
     _STARTUP_TIMESTAMPS['pretrain_entry'] = time.time()
+    args = get_args()
 
-    if inprocess_call_wrapper is not None:
-        iteration = inprocess_call_wrapper.iteration
-        store = torch.distributed.PrefixStore(str(iteration), store)
+    # Temporarily override PP args for simulation initialization
+    with SimulationArgsOverride(args, enable=getattr(args, 'simulate_global_step', False)):
+        if inprocess_call_wrapper is not None:
+            iteration = inprocess_call_wrapper.iteration
+            store = torch.distributed.PrefixStore(str(iteration), store)
 
-    timestamp_after_inprocess_setup = time.time()
+        timestamp_after_inprocess_setup = time.time()
 
-    # Early fault tolerance setup - must be done before initialize_megatron
-    # to enable monitoring of the initialization process
-    ft_integration.setup()
-    timestamp_after_in_job_setup = time.time()
+        # Early fault tolerance setup - must be done before initialize_megatron
+        # to enable monitoring of the initialization process
+        ft_integration.setup()
+        timestamp_after_in_job_setup = time.time()
 
-    # Initalize and get arguments, timers, and Tensorboard writer.
-    initialize_megatron(
-        get_embedding_ranks=get_embedding_ranks,
-        get_position_embedding_ranks=get_position_embedding_ranks,
-        store=store,
-    )
+        # Initialize Megatron with PP=1 in simulation mode.
+        initialize_megatron(
+            get_embedding_ranks=get_embedding_ranks,
+            get_position_embedding_ranks=get_position_embedding_ranks,
+            store=store,
+        )
 
     timestamp_after_initialize_megatron = time.time()
 
@@ -1215,6 +1238,14 @@ def pretrain(
 
     # Track E2E metrics on pretrain start
     one_logger_utils.on_pretrain_start()
+
+    if args.simulate_global_step:
+        simulate_global_step(
+            train_valid_test_dataset_provider,
+            model_provider,
+            forward_step_func,
+        )
+        return
 
     # Context used for persisting some state between checkpoint saves.
     if cfg_container.checkpoint.non_persistent_ckpt_type == 'local':

--- a/tests/unit_tests/simulation/__init__.py
+++ b/tests/unit_tests/simulation/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.

--- a/tests/unit_tests/simulation/__init__.py
+++ b/tests/unit_tests/simulation/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.

--- a/tests/unit_tests/simulation/conftest.py
+++ b/tests/unit_tests/simulation/conftest.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""
+Local conftest for simulation tests.
+Overrides the ensure_test_data fixture to skip data download.
+"""
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_test_data():
+    """Override parent fixture - simulation tests use mock data, no download needed."""
+    # Do nothing - simulation tests use mock data
+    pass

--- a/tests/unit_tests/simulation/conftest.py
+++ b/tests/unit_tests/simulation/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """
 Local conftest for simulation tests.

--- a/tests/unit_tests/simulation/test_vpp_simulation_args.py
+++ b/tests/unit_tests/simulation/test_vpp_simulation_args.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import sys
+
+import pytest
+
+from megatron.core.num_microbatches_calculator import destroy_num_microbatches_calculator
+from megatron.core.transformer.enums import CudaGraphModule
+from megatron.training import arguments as training_arguments
+from megatron.training.arguments import parse_args, validate_args
+from megatron.training.global_vars import destroy_global_vars
+
+
+def _validate_simulation_args(monkeypatch, tmp_path, cli_args=None, **overrides):
+    destroy_global_vars()
+    destroy_num_microbatches_calculator()
+
+    monkeypatch.setattr(training_arguments, "warn_rank_0", lambda *args, **kwargs: None)
+    monkeypatch.setattr(training_arguments, "print_rank_0", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "test_vpp_simulation_args.py",
+            "--simulate-global-step",
+            "--simulate-result-dir",
+            str(tmp_path),
+            *(cli_args or []),
+        ],
+    )
+
+    args = parse_args()
+    args.num_layers = 2
+    args.vocab_size = 256
+    args.hidden_size = 64
+    args.num_attention_heads = 4
+    args.max_position_embeddings = 128
+    args.seq_length = 128
+    args.micro_batch_size = 1
+
+    for key, value in overrides.items():
+        setattr(args, key, value)
+
+    return validate_args(args)
+
+
+def test_simulation_rejects_cuda_graph_impl(monkeypatch, tmp_path):
+    with pytest.raises(
+        AssertionError,
+        match="VPP simulation does not support CUDA graph capture/replay yet",
+    ):
+        _validate_simulation_args(monkeypatch, tmp_path, ["--cuda-graph-impl", "local"])
+
+
+def test_simulation_rejects_cuda_graph_modules(monkeypatch, tmp_path):
+    with pytest.raises(
+        AssertionError,
+        match="VPP simulation does not support --cuda-graph-modules yet",
+    ):
+        _validate_simulation_args(
+            monkeypatch,
+            tmp_path,
+            cuda_graph_modules=[CudaGraphModule.attn],
+        )
+
+
+def test_simulation_rejects_optimizer_cuda_graph(monkeypatch, tmp_path):
+    with pytest.raises(
+        AssertionError,
+        match="VPP simulation does not support --optimizer-cuda-graph",
+    ):
+        _validate_simulation_args(monkeypatch, tmp_path, ["--optimizer-cuda-graph"])

--- a/tests/unit_tests/simulation/test_vpp_simulator.py
+++ b/tests/unit_tests/simulation/test_vpp_simulator.py
@@ -1,0 +1,507 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""
+Unit tests for VppSimulator.run_global_step functionality.
+
+Tests the simulation of Pipeline Parallel (PP) and Virtual Pipeline Parallel (VPP)
+training under different configurations, using mocked execution functions to avoid
+actual GPU computation.
+"""
+
+import os
+import json
+import pytest
+import torch
+from pathlib import Path
+from types import SimpleNamespace
+
+from megatron.training.simulation.vpp_simulate import VppSimulator
+from megatron.training.simulation.task import TaskType
+from megatron.training.global_vars import set_args
+from megatron.core.num_microbatches_calculator import (
+    init_num_microbatches_calculator,
+    destroy_num_microbatches_calculator
+)
+from megatron.core.transformer.pipeline_parallel_layer_layout import (
+    PipelineParallelLayerLayout
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+class TestVppSimulatorBasic:
+    """Test VppSimulator basic functionality - run_global_step under different PP/VPP configs"""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        """Setup and teardown for each test"""
+        # Setup: Initialize minimal parallel environment
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1
+        )
+        yield
+        # Teardown: Clean up
+        destroy_num_microbatches_calculator()
+        Utils.destroy_model_parallel()
+
+    @pytest.fixture
+    def mock_args(self, tmp_path):
+        """Mock args object with all necessary simulation parameters"""
+        # Use SimpleNamespace instead of MagicMock to avoid type issues
+        args = SimpleNamespace()
+
+        # PP configuration
+        args.pipeline_model_parallel_size = 2
+        args.virtual_pipeline_model_parallel_size = None
+        # Create a simple pipeline layout - will be updated per test
+        # Format: list of lists, each inner list is layers for one PP stage
+        # For now, create a simple 2-stage layout with decoder layers
+        args.pipeline_model_parallel_layout = None  # Will be set per test
+
+        # Model configuration
+        args.num_layers = 4
+        args.hidden_size = 64
+        args.num_attention_heads = 4
+        args.seq_length = 128
+        args.max_position_embeddings = 128
+
+        # Training configuration
+        args.micro_batch_size = 2
+        args.global_batch_size = 8
+        args.data_parallel_size = 1
+
+        # Simulation configuration
+        args.simulate_result_dir = str(tmp_path / "sim_results")
+        args.execute_mode = 'router_balanced'
+        args.skip_execute = False
+        args.microbatch_group_size_per_vp_stage = None
+
+        # Other required parameters
+        args.rank = 0
+        # MoE configuration - all layers are dense (no MoE)
+        # moe_layer_freq is a list where 0=dense, 1=moe
+        args.moe_layer_freq = [0] * args.num_layers  # All dense layers
+        args.use_cpu_initialization = True
+        args.perform_initialization = True
+        args.fp16 = False
+        args.bf16 = False
+
+        # Data configuration - use mock data to avoid downloads
+        args.mock_data = True
+        args.tokenizer_type = 'NullTokenizer'
+        args.vocab_size = 128256
+        args.data_path = None
+
+        # DDP/FSDP configuration - disable to avoid complex distributed setup
+        args.use_distributed_optimizer = False
+        args.ddp_bucket_size = None
+        args.ddp_num_buckets = None
+        args.ddp_average_in_collective = False
+        args.overlap_grad_reduce = False
+        args.overlap_param_gather = False
+        args.use_torch_fsdp2 = False
+        args.torch_fsdp2_reshard_after_forward = True  # bool, not MagicMock
+        args.nccl_ub = False
+        args.accumulate_allreduce_grads_in_fp32 = False
+        args.check_for_nan_in_loss_and_grad = False
+        args.check_for_large_grads = False
+
+        # Create result directory
+        os.makedirs(args.simulate_result_dir, exist_ok=True)
+
+        return args
+
+    @pytest.fixture
+    def simple_model_provider(self):
+        """Simple model provider returning minimal test model"""
+        def provider(pre_process=True, post_process=True, **kwargs):
+            """
+            Model provider function for testing
+
+            Accepts all standard model_provider arguments:
+            - pre_process, post_process: bool flags
+            - config: TransformerConfig (optional)
+            - pg_collection: ProcessGroupCollection (optional)
+            - vp_stage: int (optional, for VPP)
+
+            Returns a list of models (VPP format)
+            """
+            class SimpleTestModel(torch.nn.Module):
+                """Minimal model for testing"""
+                def __init__(self, config):
+                    super().__init__()
+                    self.config = config  # Required by Megatron
+                    self.linear = torch.nn.Linear(64, 64)
+
+                def forward(self, hidden_states):
+                    return self.linear(hidden_states)
+
+            # Create a minimal TransformerConfig for the model
+            # Use config from kwargs if provided, otherwise create a simple one
+            config = kwargs.get('config', None)
+            if config is None:
+                config = TransformerConfig(
+                    num_layers=4,
+                    hidden_size=64,
+                    num_attention_heads=4,
+                    use_cpu_initialization=True
+                )
+
+            # Return single model object (get_model will wrap in list if needed for VPP)
+            return SimpleTestModel(config)
+
+        return provider
+
+    @pytest.fixture
+    def mock_data_iterator(self, mock_args):
+        """Mock data iterator"""
+        class MockDataIterator:
+            def __init__(self, args):
+                self.args = args
+
+            def __next__(self):
+                batch_size = self.args.micro_batch_size
+                seq_length = self.args.seq_length
+                return {
+                    'tokens': torch.randint(0, 1000, (batch_size, seq_length)),
+                    'labels': torch.randint(0, 1000, (batch_size, seq_length)),
+                    'loss_mask': torch.ones(batch_size, seq_length),
+                    'attention_mask': torch.ones(batch_size, 1, seq_length, seq_length)
+                }
+
+            def __iter__(self):
+                return self
+
+        return MockDataIterator(mock_args)
+
+    @pytest.fixture
+    def forward_step_func(self):
+        """Simplified forward step function"""
+        def forward_step(data_iterator, model, num_microbatches, input_tensor, **kwargs):
+            """
+            Simplified forward step for testing
+            Returns output_tensor and loss_func
+            """
+            batch_size = 2
+            seq_length = 128
+            hidden_size = 64
+
+            # Create fake output_tensor
+            if input_tensor is None:
+                # First stage - create new tensor
+                output_tensor = torch.randn(batch_size, seq_length, hidden_size)
+            else:
+                # Middle stage - create output based on input
+                output_tensor = torch.randn_like(input_tensor)
+
+            # Simple loss_func
+            def loss_func(output_tensor, non_loss_data):
+                loss = torch.tensor(1.0)
+                return loss, {'lm loss': loss}
+
+            return output_tensor, loss_func
+
+        return forward_step
+
+    @pytest.fixture
+    def mock_execute_functions(self, monkeypatch):
+        """Mock forward and backward execution functions to return fixed duration"""
+
+        def fake_execute_forward(*args, **kwargs):
+            """
+            Mock execute_forward_with_timing
+            Returns (output_tensor, duration)
+            """
+            batch_size = 2
+            seq_length = 128
+            hidden_size = 64
+            output_tensor = torch.randn(batch_size, seq_length, hidden_size)
+            duration = 10.0  # Fixed 10ms
+            return output_tensor, duration
+
+        def fake_execute_backward(*args, **kwargs):
+            """
+            Mock execute_backward_with_timing
+            Returns (input_tensor_grad, duration)
+            """
+            batch_size = 2
+            seq_length = 128
+            hidden_size = 64
+            input_tensor_grad = torch.randn(batch_size, seq_length, hidden_size)
+            duration = 15.0  # Fixed 15ms
+            return input_tensor_grad, duration
+
+        # Patch execution functions
+        # CRITICAL: Patch the references in vpp_simulate, not model_executor!
+        # vpp_simulate.py imports: from model_executor import execute_forward_with_timing, execute_backward_with_timing
+        monkeypatch.setattr(
+            'megatron.training.simulation.vpp_simulate.execute_forward_with_timing',
+            fake_execute_forward
+        )
+        monkeypatch.setattr(
+            'megatron.training.simulation.vpp_simulate.execute_backward_with_timing',
+            fake_execute_backward
+        )
+
+    @pytest.fixture
+    def mock_model_creation(self, monkeypatch, mock_args):
+        """Mock create_model to avoid calling get_model() which requires complete args"""
+
+        def fake_create_model(pp_rank, model_provider):
+            """
+            Mock create_model to return a simple fake model without calling get_model()
+
+            Args:
+                pp_rank: Pipeline parallel rank
+                model_provider: Model provider function (not used in mock)
+
+            Returns:
+                List of fake models (VPP format)
+            """
+            from types import SimpleNamespace
+
+            class FakeModel(torch.nn.Module):
+                """Minimal fake model for testing VppSimulator scheduling logic"""
+
+                def __init__(self, hidden_size=64):
+                    super().__init__()
+                    self.linear = torch.nn.Linear(hidden_size, hidden_size)
+
+                    # Required attributes for VppSimulator
+                    self.config = SimpleNamespace(
+                        hidden_size=hidden_size,
+                        sequence_parallel=False,
+                        context_parallel_size=1,
+                        num_layers=mock_args.num_layers,
+                    )
+
+                def forward(self, x):
+                    return self.linear(x)
+
+            # Determine number of VPP chunks
+            vpp_size = mock_args.virtual_pipeline_model_parallel_size or 1
+
+            # Return list of models (VPP format)
+            return [FakeModel(hidden_size=mock_args.hidden_size) for _ in range(vpp_size)]
+
+        # Patch create_model function
+        # CRITICAL: Patch the reference in vpp_simulate, not model_executor!
+        # vpp_simulate.py imports: from model_executor import create_model
+        # So we need to patch vpp_simulate.create_model, not model_executor.create_model
+        monkeypatch.setattr(
+            'megatron.training.simulation.vpp_simulate.create_model',
+            fake_create_model
+        )
+
+    @pytest.fixture
+    def mock_performance_analysis(self, monkeypatch):
+        """Mock analyze_global_batch to skip performance analysis in tests"""
+
+        def fake_analyze_global_batch(self, load_from_dir=None):
+            """
+            No-op replacement for analyze_global_batch
+
+            The test only needs to verify scheduling logic works correctly,
+            not to compute actual performance metrics (TFLOPs, throughput, etc.)
+            """
+            pass
+
+        # Patch the analyze_global_batch method on VppSimulator class
+        monkeypatch.setattr(
+            'megatron.training.simulation.vpp_simulate.VppSimulator.analyze_global_batch',
+            fake_analyze_global_batch
+        )
+
+    @pytest.mark.parametrize("pp_size,vpp_size,num_microbatches", [
+        (1, None, 4),   # No Pipeline
+        (2, None, 4),   # 2-stage Pipeline
+        (4, None, 8),   # 4-stage Pipeline
+        (2, 2, 8),      # PP=2, VPP=2
+        (4, 2, 8),      # PP=4, VPP=2
+    ])
+    def test_run_global_step_completes(
+        self,
+        pp_size,
+        vpp_size,
+        num_microbatches,
+        mock_args,
+        simple_model_provider,
+        mock_data_iterator,
+        forward_step_func,
+        mock_execute_functions,
+        mock_model_creation,
+        mock_performance_analysis,
+        monkeypatch
+    ):
+        """Test that run_global_step completes successfully under different PP/VPP configs"""
+
+        # 1. Configure args for this test
+        mock_args.pipeline_model_parallel_size = pp_size
+        mock_args.virtual_pipeline_model_parallel_size = vpp_size
+        mock_args.global_batch_size = num_microbatches * mock_args.micro_batch_size
+
+        # Create a simple pipeline layout based on pp_size and vpp_size
+        # Format: "t" = decoder layer, "E" = embedding, "L" = loss
+        # For simplicity, use a uniform layout with decoder layers
+        num_model_chunks = vpp_size if vpp_size else 1
+
+        # Adjust num_layers to ensure enough layers for all stages
+        # When total_stages > original num_layers, we need more layers to avoid index errors
+        if pp_size > 1 and num_model_chunks > 1:
+            total_stages = pp_size * num_model_chunks
+            if total_stages > mock_args.num_layers:
+                # Expand num_layers and moe_layer_freq to match total_stages
+                mock_args.num_layers = total_stages
+                mock_args.moe_layer_freq = [0] * total_stages
+
+        # Calculate layers_per_chunk to ensure total decoder layers match num_layers
+        # This keeps moe_layer_freq consistent with the actual layout
+        if pp_size == 1:
+            # Single PP stage: all layers in one or distributed across VPP chunks
+            layers_per_chunk = mock_args.num_layers // num_model_chunks
+        else:
+            if num_model_chunks == 1:
+                # No VPP: distribute layers evenly across PP ranks
+                # Total decoder layers = pp_size * layers_per_chunk
+                layers_per_chunk = max(1, mock_args.num_layers // pp_size)
+            else:
+                # With VPP: total stages = pp_size * num_model_chunks
+                # Each stage should have layers_per_chunk decoder layers
+                total_stages = pp_size * num_model_chunks
+                layers_per_chunk = max(1, mock_args.num_layers // total_stages)
+
+        if pp_size == 1:
+            # Single PP stage
+            if num_model_chunks == 1:
+                # No VPP: "EttL" (Embedding + 2 decoder + Loss)
+                layout_str = f"E{'t' * layers_per_chunk}L"
+            else:
+                # With VPP: "E(tt|)*N-1 tt L" where N is num_model_chunks
+                # E.g., for vpp_size=2: "Ett|ttL"
+                vpp_parts = []
+                for i in range(num_model_chunks):
+                    if i == 0:
+                        vpp_parts.append("E" + "t" * layers_per_chunk)
+                    elif i == num_model_chunks - 1:
+                        vpp_parts.append("t" * layers_per_chunk + "L")
+                    else:
+                        vpp_parts.append("t" * layers_per_chunk)
+                layout_str = "|".join(vpp_parts)
+        else:
+            # Multiple PP stages
+            if num_model_chunks == 1:
+                # No VPP: distribute layers across PP stages
+                # E.g., for pp_size=2: "Ett|ttL"
+                # E.g., for pp_size=4: "Et|t|t|tL"
+                pp_parts = []
+                for i in range(pp_size):
+                    if i == 0:
+                        pp_parts.append("E" + "t" * layers_per_chunk)
+                    elif i == pp_size - 1:
+                        pp_parts.append("t" * layers_per_chunk + "L")
+                    else:
+                        pp_parts.append("t" * layers_per_chunk)
+                layout_str = "|".join(pp_parts)
+            else:
+                # With VPP: create individual stages for each PP rank and VPP chunk
+                # Total stages = pp_size * vpp_size
+                # E.g., for pp_size=2, vpp_size=2, layers_per_chunk=1: "Et|t|t|tL"
+                total_stages = pp_size * num_model_chunks
+                stage_parts = []
+                for stage_idx in range(total_stages):
+                    if stage_idx == 0:
+                        # First stage: embedding + layers
+                        stage_parts.append("E" + "t" * layers_per_chunk)
+                    elif stage_idx == total_stages - 1:
+                        # Last stage: layers + loss
+                        stage_parts.append("t" * layers_per_chunk + "L")
+                    else:
+                        # Middle stages: just layers
+                        stage_parts.append("t" * layers_per_chunk)
+                layout_str = "|".join(stage_parts)
+
+        mock_args.pipeline_model_parallel_layout = PipelineParallelLayerLayout(
+            layout=layout_str,
+            pipeline_model_parallel_size=pp_size
+        )
+
+        # 2. Mock parallel_state to return correct VPP size
+        # VppSimulator uses parallel_state.get_virtual_pipeline_model_parallel_world_size()
+        # to determine num_model_chunks, but in single-process test environment it returns None
+        from megatron.core import parallel_state
+        original_get_vpp_size = parallel_state.get_virtual_pipeline_model_parallel_world_size
+
+        def mock_get_vpp_size():
+            return vpp_size
+
+        monkeypatch.setattr(
+            'megatron.core.parallel_state.get_virtual_pipeline_model_parallel_world_size',
+            mock_get_vpp_size
+        )
+
+        # 3. Set global args and initialize num_microbatches_calculator
+        set_args(mock_args)
+        # Destroy any existing calculator first
+        destroy_num_microbatches_calculator()
+        init_num_microbatches_calculator(
+            rank=0,
+            rampup_batch_size=None,
+            global_batch_size=mock_args.global_batch_size,
+            micro_batch_size=mock_args.micro_batch_size,
+            data_parallel_size=mock_args.data_parallel_size
+        )
+
+        # 4. Create VppSimulator
+        simulator = VppSimulator(
+            mock_data_iterator,
+            simple_model_provider,
+            forward_step_func
+        )
+
+        # 5. Execute run_global_step
+        simulator.run_global_step()
+
+        # 6. Verify: Task count is correct
+        num_model_chunks = vpp_size if vpp_size else 1
+        expected_task_count = pp_size * num_microbatches * num_model_chunks * 2
+        assert simulator.task_num_count == expected_task_count, \
+            f"Expected {expected_task_count} tasks, got {simulator.task_num_count}"
+
+        # 7. Verify: All tasks are finished
+        for task_key, task in simulator.pp_mbid_mcid_fb_task_dict.items():
+            assert task.finished, \
+                f"Task {task.task_id} not finished"
+            assert task.duration is not None and task.duration > 0, \
+                f"Task {task.task_id} has invalid duration: {task.duration}"
+
+        # 8. Verify: Result files created (only rank 0)
+        if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
+            result_dir = Path(mock_args.simulate_result_dir)
+            required_files = [
+                'finished_tasks.json',
+                'pp_task_orders.json',
+                'static_memory_info.json',
+                'all_pp_vpp_layout.json',
+                'task_durations.json'
+            ]
+
+            for filename in required_files:
+                filepath = result_dir / filename
+                assert filepath.exists(), \
+                    f"Expected result file not found: {filename}"
+        elif not torch.distributed.is_initialized():
+            # Single-process mode - should still create files
+            result_dir = Path(mock_args.simulate_result_dir)
+            required_files = [
+                'finished_tasks.json',
+                'pp_task_orders.json',
+                'static_memory_info.json',
+                'all_pp_vpp_layout.json',
+                'task_durations.json'
+            ]
+
+            for filename in required_files:
+                filepath = result_dir / filename
+                assert filepath.exists(), \
+                    f"Expected result file not found: {filename}"

--- a/tests/unit_tests/simulation/test_vpp_simulator.py
+++ b/tests/unit_tests/simulation/test_vpp_simulator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """
 Unit tests for VppSimulator.run_global_step functionality.
@@ -8,24 +8,23 @@ training under different configurations, using mocked execution functions to avo
 actual GPU computation.
 """
 
-import os
 import json
-import pytest
-import torch
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
-from megatron.training.simulation.vpp_simulate import VppSimulator
-from megatron.training.simulation.task import TaskType
-from megatron.training.global_vars import set_args
+import pytest
+import torch
+
 from megatron.core.num_microbatches_calculator import (
+    destroy_num_microbatches_calculator,
     init_num_microbatches_calculator,
-    destroy_num_microbatches_calculator
 )
-from megatron.core.transformer.pipeline_parallel_layer_layout import (
-    PipelineParallelLayerLayout
-)
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.training.global_vars import set_args
+from megatron.training.simulation.task import TaskType
+from megatron.training.simulation.vpp_simulate import VppSimulator
 from tests.unit_tests.test_utilities import Utils
 
 
@@ -37,8 +36,7 @@ class TestVppSimulatorBasic:
         """Setup and teardown for each test"""
         # Setup: Initialize minimal parallel environment
         Utils.initialize_model_parallel(
-            tensor_model_parallel_size=1,
-            pipeline_model_parallel_size=1
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
         )
         yield
         # Teardown: Clean up
@@ -115,6 +113,7 @@ class TestVppSimulatorBasic:
     @pytest.fixture
     def simple_model_provider(self):
         """Simple model provider returning minimal test model"""
+
         def provider(pre_process=True, post_process=True, **kwargs):
             """
             Model provider function for testing
@@ -127,8 +126,10 @@ class TestVppSimulatorBasic:
 
             Returns a list of models (VPP format)
             """
+
             class SimpleTestModel(torch.nn.Module):
                 """Minimal model for testing"""
+
                 def __init__(self, config):
                     super().__init__()
                     self.config = config  # Required by Megatron
@@ -142,10 +143,7 @@ class TestVppSimulatorBasic:
             config = kwargs.get('config', None)
             if config is None:
                 config = TransformerConfig(
-                    num_layers=4,
-                    hidden_size=64,
-                    num_attention_heads=4,
-                    use_cpu_initialization=True
+                    num_layers=4, hidden_size=64, num_attention_heads=4, use_cpu_initialization=True
                 )
 
             # Return single model object (get_model will wrap in list if needed for VPP)
@@ -156,6 +154,7 @@ class TestVppSimulatorBasic:
     @pytest.fixture
     def mock_data_iterator(self, mock_args):
         """Mock data iterator"""
+
         class MockDataIterator:
             def __init__(self, args):
                 self.args = args
@@ -167,7 +166,7 @@ class TestVppSimulatorBasic:
                     'tokens': torch.randint(0, 1000, (batch_size, seq_length)),
                     'labels': torch.randint(0, 1000, (batch_size, seq_length)),
                     'loss_mask': torch.ones(batch_size, seq_length),
-                    'attention_mask': torch.ones(batch_size, 1, seq_length, seq_length)
+                    'attention_mask': torch.ones(batch_size, 1, seq_length, seq_length),
                 }
 
             def __iter__(self):
@@ -178,6 +177,7 @@ class TestVppSimulatorBasic:
     @pytest.fixture
     def forward_step_func(self):
         """Simplified forward step function"""
+
         def forward_step(data_iterator, model, num_microbatches, input_tensor, **kwargs):
             """
             Simplified forward step for testing
@@ -237,11 +237,11 @@ class TestVppSimulatorBasic:
         # vpp_simulate.py imports: from model_executor import execute_forward_with_timing, execute_backward_with_timing
         monkeypatch.setattr(
             'megatron.training.simulation.vpp_simulate.execute_forward_with_timing',
-            fake_execute_forward
+            fake_execute_forward,
         )
         monkeypatch.setattr(
             'megatron.training.simulation.vpp_simulate.execute_backward_with_timing',
-            fake_execute_backward
+            fake_execute_backward,
         )
 
     @pytest.fixture
@@ -290,8 +290,7 @@ class TestVppSimulatorBasic:
         # vpp_simulate.py imports: from model_executor import create_model
         # So we need to patch vpp_simulate.create_model, not model_executor.create_model
         monkeypatch.setattr(
-            'megatron.training.simulation.vpp_simulate.create_model',
-            fake_create_model
+            'megatron.training.simulation.vpp_simulate.create_model', fake_create_model
         )
 
     @pytest.fixture
@@ -310,16 +309,19 @@ class TestVppSimulatorBasic:
         # Patch the analyze_global_batch method on VppSimulator class
         monkeypatch.setattr(
             'megatron.training.simulation.vpp_simulate.VppSimulator.analyze_global_batch',
-            fake_analyze_global_batch
+            fake_analyze_global_batch,
         )
 
-    @pytest.mark.parametrize("pp_size,vpp_size,num_microbatches", [
-        (1, None, 4),   # No Pipeline
-        (2, None, 4),   # 2-stage Pipeline
-        (4, None, 8),   # 4-stage Pipeline
-        (2, 2, 8),      # PP=2, VPP=2
-        (4, 2, 8),      # PP=4, VPP=2
-    ])
+    @pytest.mark.parametrize(
+        "pp_size,vpp_size,num_microbatches",
+        [
+            (1, None, 4),  # No Pipeline
+            (2, None, 4),  # 2-stage Pipeline
+            (4, None, 8),  # 4-stage Pipeline
+            (2, 2, 8),  # PP=2, VPP=2
+            (4, 2, 8),  # PP=4, VPP=2
+        ],
+    )
     def test_run_global_step_completes(
         self,
         pp_size,
@@ -332,7 +334,7 @@ class TestVppSimulatorBasic:
         mock_execute_functions,
         mock_model_creation,
         mock_performance_analysis,
-        monkeypatch
+        monkeypatch,
     ):
         """Test that run_global_step completes successfully under different PP/VPP configs"""
 
@@ -422,14 +424,14 @@ class TestVppSimulatorBasic:
                 layout_str = "|".join(stage_parts)
 
         mock_args.pipeline_model_parallel_layout = PipelineParallelLayerLayout(
-            layout=layout_str,
-            pipeline_model_parallel_size=pp_size
+            layout=layout_str, pipeline_model_parallel_size=pp_size
         )
 
         # 2. Mock parallel_state to return correct VPP size
         # VppSimulator uses parallel_state.get_virtual_pipeline_model_parallel_world_size()
         # to determine num_model_chunks, but in single-process test environment it returns None
         from megatron.core import parallel_state
+
         original_get_vpp_size = parallel_state.get_virtual_pipeline_model_parallel_world_size
 
         def mock_get_vpp_size():
@@ -437,7 +439,7 @@ class TestVppSimulatorBasic:
 
         monkeypatch.setattr(
             'megatron.core.parallel_state.get_virtual_pipeline_model_parallel_world_size',
-            mock_get_vpp_size
+            mock_get_vpp_size,
         )
 
         # 3. Set global args and initialize num_microbatches_calculator
@@ -449,15 +451,11 @@ class TestVppSimulatorBasic:
             rampup_batch_size=None,
             global_batch_size=mock_args.global_batch_size,
             micro_batch_size=mock_args.micro_batch_size,
-            data_parallel_size=mock_args.data_parallel_size
+            data_parallel_size=mock_args.data_parallel_size,
         )
 
         # 4. Create VppSimulator
-        simulator = VppSimulator(
-            mock_data_iterator,
-            simple_model_provider,
-            forward_step_func
-        )
+        simulator = VppSimulator(mock_data_iterator, simple_model_provider, forward_step_func)
 
         # 5. Execute run_global_step
         simulator.run_global_step()
@@ -465,15 +463,16 @@ class TestVppSimulatorBasic:
         # 6. Verify: Task count is correct
         num_model_chunks = vpp_size if vpp_size else 1
         expected_task_count = pp_size * num_microbatches * num_model_chunks * 2
-        assert simulator.task_num_count == expected_task_count, \
-            f"Expected {expected_task_count} tasks, got {simulator.task_num_count}"
+        assert (
+            simulator.task_num_count == expected_task_count
+        ), f"Expected {expected_task_count} tasks, got {simulator.task_num_count}"
 
         # 7. Verify: All tasks are finished
         for task_key, task in simulator.pp_mbid_mcid_fb_task_dict.items():
-            assert task.finished, \
-                f"Task {task.task_id} not finished"
-            assert task.duration is not None and task.duration > 0, \
-                f"Task {task.task_id} has invalid duration: {task.duration}"
+            assert task.finished, f"Task {task.task_id} not finished"
+            assert (
+                task.duration is not None and task.duration > 0
+            ), f"Task {task.task_id} has invalid duration: {task.duration}"
 
         # 8. Verify: Result files created (only rank 0)
         if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
@@ -483,13 +482,12 @@ class TestVppSimulatorBasic:
                 'pp_task_orders.json',
                 'static_memory_info.json',
                 'all_pp_vpp_layout.json',
-                'task_durations.json'
+                'task_durations.json',
             ]
 
             for filename in required_files:
                 filepath = result_dir / filename
-                assert filepath.exists(), \
-                    f"Expected result file not found: {filename}"
+                assert filepath.exists(), f"Expected result file not found: {filename}"
         elif not torch.distributed.is_initialized():
             # Single-process mode - should still create files
             result_dir = Path(mock_args.simulate_result_dir)
@@ -498,10 +496,9 @@ class TestVppSimulatorBasic:
                 'pp_task_orders.json',
                 'static_memory_info.json',
                 'all_pp_vpp_layout.json',
-                'task_durations.json'
+                'task_durations.json',
             ]
 
             for filename in required_files:
                 filepath = result_dir / filename
-                assert filepath.exists(), \
-                    f"Expected result file not found: {filename}"
+                assert filepath.exists(), f"Expected result file not found: {filename}"

--- a/tests/unit_tests/simulation/test_vpp_simulator_e2e.py
+++ b/tests/unit_tests/simulation/test_vpp_simulator_e2e.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Single-node E2E smoke tests for VPP simulation."""
+
+import json
+import os
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core import parallel_state
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.num_microbatches_calculator import (
+    destroy_num_microbatches_calculator,
+    init_num_microbatches_calculator,
+)
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.enums import AttnBackend
+from megatron.core.transformer.pipeline_parallel_layer_layout import (
+    PipelineParallelLayerLayout,
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.training.global_vars import set_args
+from megatron.training.simulation.model_executor import get_pg_collection_for_simulation
+from megatron.training.simulation.vpp_simulate import VppSimulator
+from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.fixture(autouse=True)
+def cleanup_parallel_state():
+    yield
+    destroy_num_microbatches_calculator()
+    Utils.destroy_model_parallel()
+
+
+def _build_args(tmp_path):
+    rank = int(os.getenv("RANK", "0"))
+    world_size = int(os.getenv("WORLD_SIZE", "1"))
+    return SimpleNamespace(
+        rank=rank,
+        world_size=world_size,
+        pipeline_model_parallel_size=2,
+        virtual_pipeline_model_parallel_size=None,
+        pipeline_model_parallel_layout=PipelineParallelLayerLayout(
+            layout="Et|tL",
+            pipeline_model_parallel_size=2,
+        ),
+        num_layers=2,
+        hidden_size=16,
+        num_attention_heads=4,
+        ffn_hidden_size=64,
+        seq_length=8,
+        vocab_size=32,
+        micro_batch_size=1,
+        global_batch_size=world_size,
+        data_parallel_size=world_size,
+        decrease_batch_size_if_needed=False,
+        step_batch_size_schedule=None,
+        execute_mode="router_balanced",
+        skip_execute=False,
+        simulate_result_dir=str(tmp_path / "simulation_results"),
+        simulation_warmup_times=1,
+        simulation_measure_times=1,
+        simulation_measure_skip_times=0,
+        microbatch_group_size_per_vp_stage=None,
+        moe_layer_freq=[0, 0],
+    )
+
+
+def _build_gpt_model(args, pp_rank):
+    config = TransformerConfig(
+        num_layers=args.num_layers,
+        hidden_size=args.hidden_size,
+        num_attention_heads=args.num_attention_heads,
+        ffn_hidden_size=args.ffn_hidden_size,
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=args.pipeline_model_parallel_size,
+        pipeline_dtype=torch.float32,
+        context_parallel_size=1,
+        pipeline_model_parallel_layout=args.pipeline_model_parallel_layout,
+        sequence_parallel=False,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        attention_backend=AttnBackend.local,
+        use_cpu_initialization=True,
+    )
+    return GPTModel(
+        config=config,
+        transformer_layer_spec=get_gpt_layer_local_spec(),
+        vocab_size=args.vocab_size,
+        max_sequence_length=args.seq_length,
+        pre_process=pp_rank == 0,
+        post_process=pp_rank == args.pipeline_model_parallel_size - 1,
+        parallel_output=True,
+        share_embeddings_and_output_weights=False,
+        position_embedding_type="learned_absolute",
+        pg_collection=get_pg_collection_for_simulation(
+            pp_rank=pp_rank,
+            pp_size=args.pipeline_model_parallel_size,
+        ),
+    ).cuda()
+
+
+def _build_gpt_batch(args):
+    device = torch.cuda.current_device()
+    tokens = torch.arange(args.seq_length, dtype=torch.long, device=device).unsqueeze(0)
+    input_ids = tokens.repeat(args.micro_batch_size, 1) % args.vocab_size
+    labels = (input_ids + 1) % args.vocab_size
+    position_ids = tokens.repeat(args.micro_batch_size, 1)
+    attention_mask = torch.ones(
+        args.micro_batch_size,
+        1,
+        args.seq_length,
+        args.seq_length,
+        dtype=torch.bool,
+        device=device,
+    )
+    return input_ids, labels, position_ids, attention_mask
+
+
+def test_single_node_simulation_e2e_writes_results_and_reports_virtual_world_size(
+    tmp_path, monkeypatch, capsys
+):
+    if not torch.cuda.is_available():
+        pytest.skip("VPP simulation E2E test requires CUDA")
+
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+    )
+
+    args = _build_args(tmp_path)
+    args.rank = torch.distributed.get_rank()
+    args.world_size = torch.distributed.get_world_size()
+    set_args(args)
+    init_num_microbatches_calculator(
+        rank=args.rank,
+        rampup_batch_size=None,
+        global_batch_size=args.global_batch_size,
+        micro_batch_size=args.micro_batch_size,
+        data_parallel_size=args.data_parallel_size,
+    )
+
+    model_parallel_cuda_manual_seed(123)
+
+    def fake_create_model(pp_rank, model_provider):
+        parallel_state.set_pipeline_model_parallel_rank(pp_rank)
+        parallel_state.set_pipeline_model_parallel_world_size(args.pipeline_model_parallel_size)
+        return [_build_gpt_model(args, pp_rank)]
+
+    def gpt_forward_step(data_iterator, model):
+        input_ids, labels, position_ids, attention_mask = _build_gpt_batch(args)
+        output = model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            labels=labels,
+        )
+
+        def loss_func(output_tensor, non_loss_data=False):
+            loss = output_tensor.float().mean()
+            if non_loss_data:
+                return {"loss": loss.detach()}
+            return loss, {"loss": loss.detach()}
+
+        return output, loss_func
+
+    monkeypatch.setattr(
+        "megatron.training.simulation.vpp_simulate.create_model",
+        fake_create_model,
+    )
+    monkeypatch.setattr(
+        "megatron.training.training.num_floating_point_operations",
+        lambda parsed_args, batch_size: 1000000000000,
+    )
+
+    simulator = VppSimulator(
+        train_data_iterator=iter(()),
+        model_provider=lambda **_: _build_gpt_model(args, 0),
+        forward_step_func=gpt_forward_step,
+    )
+    simulator.run_global_step()
+
+    if args.rank != 0:
+        return
+
+    result_dir = Path(args.simulate_result_dir)
+    finished_tasks = json.loads((result_dir / "finished_tasks.json").read_text())
+    task_durations = json.loads((result_dir / "task_durations.json").read_text())
+
+    assert set(finished_tasks) == {"0", "1"}
+    num_microbatches = args.global_batch_size // (
+        args.micro_batch_size * args.data_parallel_size
+    )
+    max_task_count = args.pipeline_model_parallel_size * num_microbatches * 2
+    assert 0 < len(task_durations) <= max_task_count
+    assert all(task["duration_ms"] > 0 for task in task_durations.values())
+    assert {task["task_type"] for task in task_durations.values()} == {
+        "forward",
+        "backward",
+    }
+    assert {task["pp_rank"] for task in task_durations.values()} == {
+        0,
+        1,
+    }
+
+    output = capsys.readouterr().out
+    assert "GBS Execution Statistics" in output
+    assert f"Executor World Size: {args.world_size}" in output
+    assert (
+        f"VTrainer World Size: {args.world_size * args.pipeline_model_parallel_size}"
+        in output
+    )
+    assert "Pipeline Parallel Size: 2" in output
+
+    throughput_match = re.search(r"Throughput: ([0-9.]+) TFLOPS per GPU", output)
+    executor_throughput_match = re.search(
+        r"Executor-normalized sampled throughput: ([0-9.]+) TFLOPS per executor GPU",
+        output,
+    )
+    assert throughput_match is not None
+    assert executor_throughput_match is not None
+    throughput = float(throughput_match.group(1))
+    executor_throughput = float(executor_throughput_match.group(1))
+    assert executor_throughput == pytest.approx(
+        throughput * args.pipeline_model_parallel_size,
+        rel=1e-3,
+    )


### PR DESCRIPTION
## Summary

- Squash the original VPP training simulation framework from #3138 onto `dev`.
- Add follow-up fixes for simulator argument restoration, virtual-world-size throughput accounting, sampling controls, timing placement, allocator cleanup, rerun state, and chunk-scoped model/grad cleanup.
- Add validation guards for CUDA graph modes that the simulator does not faithfully model yet.
- Add VppSimulator scheduling unit tests, a single-node GPU E2E smoke test, simulation argument validation tests, and VPP simulation design documentation.

## Validation

- `git diff --check origin/dev..HEAD`: pass.
- `uv run python -m py_compile megatron/training/arguments.py tests/unit_tests/simulation/test_vpp_simulation_args.py`: pass.
- `CHECK_ONLY=true BASE_REF=dev uv run --project /project/agentic-mcore-dev/.claude/worktrees/pr-3138-qwen3-235b-sim --extra mcore-lint -- bash tools/autoformat.sh`: pass. The local lint env still prints mypy import-not-found messages for `pytest` and `torch`, but the repository script exits successfully after black/isort/pylint/ruff pass.
- `tools/check_copyright.py` over changed `megatron/` and `tests/` Python files: pass.
- `uv run unit-test run tests/unit_tests/simulation/test_vpp_simulator_e2e.py --cluster cw --environment dev --platform h100 --nodes 1 --nproc-per-node 8 --time-limit 0:30:00`: pass, SLURM `12451405`, `torchrun --nproc_per_node 8`, tiny MCore GPTModel with real forward/backward simulation timing.
- `uv run unit-test run tests/unit_tests/simulation/test_vpp_simulation_args.py --cluster cw --environment dev --platform h100 --nodes 1 --nproc-per-node 8 --time-limit 0:20:00`: pass, SLURM `12452542`, `torchrun --nproc_per_node 8`, validates CUDA graph simulation guardrails.

## Current CUDA Graph Limitation

The simulator samples individual forward/backward tasks directly and does not run the full training loop's CUDA graph warmup, capture, and replay lifecycle. The PR now rejects `--cuda-graph-impl != none`, non-empty `--cuda-graph-modules`, and `--optimizer-cuda-graph` while `--simulate-global-step` is enabled. CUDA graph support should be added only after the simulator can enter the same capture/replay path as full training.

## Historical Qwen H100 Comparison From Investigation

The following measurements were collected while debugging timing and throughput parity before adding the CUDA graph guard above. They are kept as investigation context, not as currently supported simulation recipes.

| Model | Mode / shape | Full training | Simulation | Delta |
| --- | --- | --- | --- | --- |
| Qwen3-30B-A3B | A2A dispatcher + TE partial CUDA graph, 32 GPUs / TP1 PP4 EP8, GBS=128, MBS=1 | `20260601-232318-0ce5`: median `165.4 TFLOPS/GPU`, median iter `2279.4ms` after 2 warmup iters | `20260602-044119-0dbf`: `163.809 TFLOPS/GPU`, GBS time `2.301s`; 8 executor GPUs simulating 32 virtual GPUs | `-1.0%` throughput |
| Qwen3-235B | no-overlap + TE partial CUDA graph, 256 GPUs / TP2 PP8 EP32, GBS=256, MBS=1 | `20260601-190227-d993`: median `207.8 TFLOPS/GPU`, median iter `2922.3ms` after 8 warmup iters | `20260602-044538-1fe6`: `215.745 TFLOPS/GPU`, GBS time `2.810s`; 32 executor GPUs simulating 256 virtual GPUs | `+3.8%` throughput |

### Qwen3-30B H100 A2A Investigation

- Simulation job: `20260602-044119-0dbf` / SLURM `12431334`.
- Simulation recipe/run: `Qwen3-30B-TP1PP4EP8-MBS1GBS128-simulation-trace-a2a-cg`.
- Simulation shape: 8 executor GPUs simulating 32 virtual GPUs, TP1/PP4/EP8, GBS=128, MBS=1, A2A dispatcher.
- CUDA graph: `cuda_graph_impl=transformer_engine`, `cuda_graph_scope=[moe_router, moe_preprocess]`.
- Simulation result directory: `/lustre/fsw/portfolios/coreai/users/denliu/benchmarking/simulation/qwen3_30b/20260602_044158`.
- Simulation result: GBS time `2.301s`, throughput `163.809 TFLOPS/GPU`.
- Full-training comparison job: `20260601-232318-0ce5` / SLURM `12422589`, 32 GPUs, TP1/PP4/EP8, GBS=128, MBS=1, A2A dispatcher.
- Full-training result after skipping 2 warmup iterations: median iteration time `2279.4ms`, median throughput `165.4 TFLOPS/GPU`.
- Outcome: the investigative A2A + CUDA graph simulation was within about `1.0%` of the full-training throughput. A profiled full A2A control (`20260601-234939-b611`) reported median `161.0 TFLOPS/GPU` after skipping 8 warmup iterations.

### Qwen3-235B H100 No-Overlap Investigation

- Simulation job: `20260602-044538-1fe6` / SLURM `12431383`.
- Simulation recipe: `bf16_32GPU_TP2PP8EP32_simulation_no_overlap_pr3138_sampling`.
- Simulation shape: 32 executor GPUs simulating 256 virtual GPUs, TP2/PP8/EP32, GBS=256, MBS=1, sampling 15 warmup / 10 timing / 5 skip, force load balancing enabled.
- CUDA graph: `cuda_graph_impl=transformer_engine`, `cuda_graph_scope=[moe_router, moe_preprocess]`.
- Simulation result: GBS time `2.810s`, throughput `215.745 TFLOPS/GPU`.
- Full-training comparison job: `20260601-190227-d993`, 256 GPUs, TP2/PP8/EP32, GBS=256, MBS=1, no-overlap, force load balancing enabled.
- Full-training result after skipping 8 warmup iterations: median iteration time `2922.3ms`, median throughput `207.8 TFLOPS/GPU`.
- Outcome: the investigative no-overlap + CUDA graph simulation was within about `3.8%` of the full-training throughput.

## Known Limitation From Overlap Controls

- The overlap + delayed expert wgrad simulation path is not validated by this PR.
- `overlap_moe_expert_parallel_comm=True` + delayed expert wgrad control with sampling 8/8/3 completed but under-reported throughput at `49.038 TFLOPS/GPU` (`20260602-022435-7c8d` / SLURM `12428630`).
- Original-PR-style sampling 15/10/5 for the same overlap path OOMed during backward timing setup at `GroupedLinear.forward -> torch.empty(130 MiB)` (`20260602-030946-5028`, `20260602-031821-ee43`, and no-CUDA-graph control `20260602-032436-b68d`).
- Current conclusion: isolated chunk sampling does not yet faithfully model the full delayed-wgrad overlap schedule, while the no-overlap path matched the full-training experiment closely during investigation.
