### PR TITLE
[Dev] fix non-boundary vpp rank data iterator under thd format

### DIFF
--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -304,7 +304,10 @@ def is_dataset_built_on_rank(vp_stage=None, is_packed_sequence=False):
     config = core_transformer_config_from_args(args)
     if parallel_state.get_tensor_model_parallel_rank() != 0:
         return False
-    elif is_packed_sequence:
+    elif is_packed_sequence and (
+        args.virtual_pipeline_model_parallel_size is None
+        or args.sequence_packing_scheduler is None
+    ):
         return True
     return is_first_or_last_pipeline_stage(vp_stage) or mtp_on_this_rank(
         config, ignore_virtual=False, vp_stage=vp_stage


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

Fix THD sequence packing with virtual pipeline parallelism when `sequence_packing_scheduler` is enabled.

  Previously, packed sequence training built full data iterators for every virtual pipeline chunk. With VPP, non-boundary virtual chunks only need sequence metadata, but they
  could receive and mutate shared full batch samples by clearing fields such as `tokens`, `labels`, and `loss_mask`. A later boundary chunk could then observe `labels=None`
  and fail in the last-stage forward path.

  This change keeps the old behavior for:
  - packed sequence without VPP
  - packed sequence with VPP but without `sequence_packing_scheduler`

  When both VPP and `sequence_packing_scheduler` are enabled, dataset construction now follows the existing first/last virtual pipeline stage predicate, so only boundary
  chunks build full data iterators while non-boundary chunks use metadata-only iterator behavior.

  ## Testing

  Validated locally with THD + VPP sequence packing smoke coverage before reset:
  - scheduler + VPP boundary/non-boundary behavior
  - distributed dataloader wrapping
  - dense THD+VPP training smoke with dynamic global batch size


:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
