### PR TITLE
Add advisory process group guidance to Claude reviews

### DIFF
--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -59,8 +59,10 @@ jobs:
             Mandatory workflow — never skip or reorder:
             1. Read the PR diff first (gh pr diff).
             2. Based on the changed files and areas, identify relevant skills from skills/<name>/SKILL.md.
-               Common skill names: build-and-dependency, testing, cicd, linting-and-formatting, run-on-slurm,
-               nightly-sync, create-issue, respond-to-issue, split-pr, onboard-gb200-1node-tests.
+               Common skill names: mcore-build-and-dependency, mcore-testing, mcore-cicd,
+               mcore-linting-and-formatting, mcore-run-on-slurm, nightly-sync,
+               mcore-create-issue, respond-to-issue, mcore-split-pr,
+               mcore-onboard-gb200-1node-tests.
             3. Read the SKILL.md files for all relevant areas using the Read tool.
             4. Only then perform the review using the skill context.
 
@@ -73,6 +75,13 @@ jobs:
               - If the PR adds a new feature or significant functionality without corresponding tests, suggest adding tests
               - If the PR fixes a bug that was not caught by an existing unit test, suggest adding a regression test to prevent recurrence
             - Outdated or inaccurate documentation affected by the changes
+            - New direct global process group access in `megatron/core` production code
+              - Flag added calls to `parallel_state.get_*_group()` or directly imported
+                `get_*_group()` helpers unless they are in `parallel_state.py`,
+                `process_groups_config.py`, initialization/bootstrap code that materializes a
+                `ProcessGroupCollection`, tests, docs, or an explicitly documented migration fallback
+              - Prefer passing a `ProcessGroupCollection` or explicit
+                `torch.distributed.ProcessGroup` from the caller
 
             Do NOT comment on:
             - Style preferences or formatting
@@ -152,8 +161,10 @@ jobs:
             Mandatory workflow — never skip or reorder:
             1. Read the PR diff first (gh pr diff).
             2. Based on the changed files and areas, identify relevant skills from skills/<name>/SKILL.md.
-               Common skill names: build-and-dependency, testing, cicd, linting-and-formatting, run-on-slurm,
-               nightly-sync, create-issue, respond-to-issue, split-pr, onboard-gb200-1node-tests.
+               Common skill names: mcore-build-and-dependency, mcore-testing, mcore-cicd,
+               mcore-linting-and-formatting, mcore-run-on-slurm, nightly-sync,
+               mcore-create-issue, respond-to-issue, mcore-split-pr,
+               mcore-onboard-gb200-1node-tests.
             3. Read the SKILL.md files for all relevant areas using the Read tool.
             4. Only then perform the review using the skill context.
 
@@ -211,6 +222,18 @@ jobs:
             - **Default value changes**: Changed defaults for training hyperparameters or parallelism settings — silently alters behavior for users relying on defaults
             - **API contract changes**: Changed function signatures, return types, or side effects in megatron/core/ without backward-compat shim
             - **Model architecture changes**: Altered layer ordering, initialization, or normalization placement — existing pretrained weights become incompatible
+
+            ### Megatron Core Process Group Usage
+            - In `megatron/core` production code, treat new direct reads of global process groups
+              from `parallel_state` as review findings unless they are clearly compatibility-only.
+            - Flag added calls to `parallel_state.get_*_group()` or directly imported
+              `get_*_group()` helpers when the surrounding code could instead receive a
+              `ProcessGroupCollection` or explicit `torch.distributed.ProcessGroup` from its caller.
+            - Do not flag `megatron/core/parallel_state.py`, `megatron/core/process_groups_config.py`,
+              tests, docs, initialization/bootstrap code that materializes a `ProcessGroupCollection`
+              from MPU globals, or explicitly documented migration fallbacks.
+            - This guidance is advisory and targets Megatron Core library code; do not apply it to
+              `megatron/training` or other training-loop code unless the PR opts into that migration.
 
             ### Mandatory Check: Unused New Variables / Arguments
             - For each changed file, list newly added identifiers (function args, config fields, locals).

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -59,10 +59,8 @@ jobs:
             Mandatory workflow — never skip or reorder:
             1. Read the PR diff first (gh pr diff).
             2. Based on the changed files and areas, identify relevant skills from skills/<name>/SKILL.md.
-               Common skill names: mcore-build-and-dependency, mcore-testing, mcore-cicd,
-               mcore-linting-and-formatting, mcore-run-on-slurm, nightly-sync,
-               mcore-create-issue, respond-to-issue, mcore-split-pr,
-               mcore-onboard-gb200-1node-tests.
+               Common skill names: build-and-dependency, testing, cicd, linting-and-formatting, run-on-slurm,
+               nightly-sync, create-issue, respond-to-issue, split-pr, onboard-gb200-1node-tests.
             3. Read the SKILL.md files for all relevant areas using the Read tool.
             4. Only then perform the review using the skill context.
 
@@ -161,10 +159,8 @@ jobs:
             Mandatory workflow — never skip or reorder:
             1. Read the PR diff first (gh pr diff).
             2. Based on the changed files and areas, identify relevant skills from skills/<name>/SKILL.md.
-               Common skill names: mcore-build-and-dependency, mcore-testing, mcore-cicd,
-               mcore-linting-and-formatting, mcore-run-on-slurm, nightly-sync,
-               mcore-create-issue, respond-to-issue, mcore-split-pr,
-               mcore-onboard-gb200-1node-tests.
+               Common skill names: build-and-dependency, testing, cicd, linting-and-formatting, run-on-slurm,
+               nightly-sync, create-issue, respond-to-issue, split-pr, onboard-gb200-1node-tests.
             3. Read the SKILL.md files for all relevant areas using the Read tool.
             4. Only then perform the review using the skill context.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,22 @@ skill keyword — infer it from the artifact you read.
 ### Code Quality
 
 - After editing imports in any Python files, always run `uv run isort` on those files to fix import order before committing.
+
+### Megatron Core Process Groups
+
+- In `megatron/core` production code, avoid adding new direct reads of global
+  process groups from `parallel_state` (for example,
+  `parallel_state.get_tensor_model_parallel_group()` or directly imported
+  `get_*_group()` helpers). Prefer accepting a `ProcessGroupCollection` or an
+  explicit `torch.distributed.ProcessGroup` from the caller and passing that
+  through.
+- Allowed compatibility points include `megatron/core/parallel_state.py`,
+  `megatron/core/process_groups_config.py`, initialization/bootstrap code that
+  materializes a `ProcessGroupCollection` from MPU globals, tests, docs, and
+  migration fallbacks with an explicit comment.
+- This guidance targets Megatron Core library code. Do not apply it to
+  `megatron/training` or other training-loop code unless the PR explicitly
+  opts into that migration.
+- In reviews, flag new direct `parallel_state.get_*_group()` usage in
+  `megatron/core` unless it is one of the compatibility points above. This is
+  advisory guidance, not a CI gate.


### PR DESCRIPTION
## What does this PR do?

Adds advisory guidance for agents and Claude reviews to discourage new direct reads of global process groups from `parallel_state` in `megatron/core` production code.

## Details

- Documents the preferred pattern in `AGENTS.md`: pass a `ProcessGroupCollection` or explicit `torch.distributed.ProcessGroup` from the caller.
- Calls out compatibility exceptions for `parallel_state.py`, `process_groups_config.py`, bootstrap code, tests, docs, and documented migration fallbacks.
- Updates the Claude light and strict review prompts to flag new direct `parallel_state.get_*_group()` or imported `get_*_group()` usages in `megatron/core`.
- Keeps this advisory-only. This PR does not add a CI gate or checker.
- Corrects the skill names listed in the Claude review prompt to match the checked-in `mcore-*` skill directories.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/claude_review.yml')"`