### PR TITLE
ci: treat docker container-removal conflict as flaky

### DIFF
--- a/tests/test_utils/python_scripts/launch_nemo_run_workload.py
+++ b/tests/test_utils/python_scripts/launch_nemo_run_workload.py
@@ -42,6 +42,9 @@ def is_flaky_failure(concat_allranks_logs: str) -> bool:
         or "free(): corrupted unsorted chunks" in concat_allranks_logs
         or "Segfault encountered" in concat_allranks_logs
         or "The following metrics failed" in concat_allranks_logs
+        or "removal of container" in concat_allranks_logs
+        or "is already in progress" in concat_allranks_logs
+        or "Error deleting container" in concat_allranks_logs
     )
 
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

### Background / motivation
- A functional-test job whose training run **succeeded** (`+ exit 0`, `finished: SUCCEEDED`) still surfaced cleanup noise in the NeMo-Run launcher logs:
  ```
  3-task-1-0/0 + exit 0
  3-task-1-0/0 ERROR: driverInitFileInfo 578 result=11ERROR: init 664 result=11ERROR: init 250 result=11
  [19:12:25] INFO     Job task-1-fz21bbt4chnj5 finished: SUCCEEDED launcher.py:186
             WARNING  Error deleting container task-1-fz21bbt4chnj5: docker.py:323
                      409 Client Error ... Conflict ("removal of container ... is already in progress")
  ```
- The `driverInitFileInfo ... result=11` lines are benign NVML init noise on a passing job.
- The real resilience gap: NeMo-Run's `DockerExecutor` double-removes the same container during cleanup, producing a `409 Conflict "removal ... already in progress"` race. This is harmless and must never trip or pollute a job.
- `nemo_run`'s `docker.py` is an external dependency, so the fix belongs in this repo's launcher.

### What changed
- Classify the docker container-removal-conflict signatures as flaky in `is_flaky_failure`, so the launcher retries instead of treating the race as a fatal failure.

### Details
- `tests/test_utils/python_scripts/launch_nemo_run_workload.py` — added three substrings to `is_flaky_failure`:
  - `"removal of container"`
  - `"is already in progress"`
  - `"Error deleting container"`
- These match the `409 Conflict` cleanup race emitted by `nemo_run/.../docker.py:323`. The launcher already exits 0 on a `SUCCEEDED` status; this extends the flaky-retry net to the failure path so a job tripped purely by this cleanup race is retried rather than failed.

### Note on overlap with #5118
- PR #5118 (`ko3n1g/ci/resilient-network-timeouts`) independently extends the same `is_flaky_failure` function with network-timeout patterns (`TimeoutError`, `Read timed out`, ...) plus a `_collect_failure_logs` helper. This PR is branched off `main` to keep the diff clean and independent; the two will overlap logically in the same function and should merge with a trivial conflict at most.

### Tested
- `ruff check` — All checks passed.
- `isort --check` — clean.
- `black --check` (repo config, line-length 100) — unchanged.
- `python -m py_compile` — OK.

</details>
