### PR TITLE
fix(test): skip scalar-less tensorboard event files in resume checks

### DIFF
--- a/tests/functional_tests/python_test_utils/common.py
+++ b/tests/functional_tests/python_test_utils/common.py
@@ -92,6 +92,32 @@ class SkipMetricError(Exception):
     """Raised if metric shall be skipped"""
 
 
+def _load_event_accumulators_with_scalars(
+    files: List[str],
+) -> List[event_accumulator.EventAccumulator]:
+    """Loads event-file accumulators that contain scalar data, preserving order.
+
+    A resumed training phase can emit a header-only TensorBoard event file with
+    zero scalars before the file that holds the actual metrics (for example when
+    the fault-tolerance launcher initializes a SummaryWriter ahead of logging).
+    Dropping scalar-less files keeps positional ``index`` selection aligned with
+    real run data instead of latching onto an empty file and yielding no metrics.
+
+    Args:
+        files: Event-file paths, ordered oldest-first.
+
+    Returns:
+        Reloaded accumulators that expose at least one scalar tag, in input order.
+    """
+    accumulators = []
+    for event_file in files:
+        ea = event_accumulator.EventAccumulator(event_file, size_guidance=SIZE_GUIDANCE)
+        ea.Reload()
+        if ea.Tags()["scalars"]:
+            accumulators.append(ea)
+    return accumulators
+
+
 def read_tb_logs_as_list(
     path, index: int = 0, train_iters: int = 50, start_idx: int = 1, step_size: int = 5
 ) -> Optional[Dict[str, GoldenValueMetric]]:
@@ -113,18 +139,21 @@ def read_tb_logs_as_list(
         return None
 
     files.sort(key=lambda x: os.path.getmtime(os.path.join(path, pathlib.Path(x).name)))
-    accumulators = []
 
-    if index == -1:
-        for event_file in files:
-            ea = event_accumulator.EventAccumulator(event_file, size_guidance=SIZE_GUIDANCE)
-            ea.Reload()
-            accumulators.append(ea)
-    else:
-        event_file = files[index]
-        ea = event_accumulator.EventAccumulator(event_file, size_guidance=SIZE_GUIDANCE)
-        ea.Reload()
-        accumulators.append(ea)
+    accumulators = _load_event_accumulators_with_scalars(files)
+
+    if not accumulators:
+        logger.error(f"No event file with scalar data found at: {path}")
+        return None
+
+    if index != -1:
+        if index >= len(accumulators):
+            logger.error(
+                f"Requested event-file index {index} but only {len(accumulators)} "
+                f"event file(s) with scalar data found at: {path}"
+            )
+            return None
+        accumulators = [accumulators[index]]
 
     summaries = {}
     for ea in accumulators:


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- `moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_multi_dist_optimizer_instances` failed in the merge queue. Training **passed** (exit 0); the failure was in the golden-value comparison at fixture setup:
  ```
  pydantic_core.ValidationError: 1 validation error for GoldenValues
    Input should be a valid dictionary [type=dict_type, input_value=PydanticUndefined]
  common.py:168: ValidationError
  ```
- Root cause: the resumed (2nd) run's extracted metrics file `*_2nd.json` was literally `{}`. `GoldenValues(**{})` then leaves `root` undefined → the cryptic `dict_type` error.
- **Why it was empty:** `#5074` isolates each ckpt-resume phase into its own tensorboard subdir (`run_1`/`run_2`) and reads the resumed run via `read_tb_logs_as_list(run_2, index=0)`. But the resumed run emits a **header-only 88-byte event file with zero scalars *before*** the file that holds the real metrics. `index=0` selects the oldest-by-mtime file — the empty one — so extraction yields `{}`.

Verified directly against the failing run's artifact:
```
run_2/  events…1780434660…  size=    88  scalar_tags=0   <- index=0 picked this -> {}
        events…1780434689…  size=125950  scalar_tags=19  (lm loss, num-zeros, …)
```

## What changed

- **`common.py`** — new `_load_event_accumulators_with_scalars()` filters globbed event files down to those carrying ≥1 scalar tag, *before* positional `index` selection. `read_tb_logs_as_list` now indexes into that filtered list, so `index=0` lands on real run data. Returns `None` (with a clear log) when no scalar-bearing file exists or the requested index is out of range, instead of silently emitting `{}`.

This complements `#5074` (per-phase tensorboard isolation): that fixed the directory layout; this fixes the empty leading event file inside it.

## Details

- `tests/functional_tests/python_test_utils/common.py` — `read_tb_logs_as_list` selection block replaced; `index == -1` (convergence) still aggregates all scalar-bearing files.

## Tested

- Reproduced against the failing run's artifact (`run_2`):
  - **before** — `files[0]` = 88-byte file, 0 scalars → `{}`.
  - **after** — empty file skipped → `lm loss` (steps 1–100), `num-zeros`, `iteration-time`, `mem-allocated-bytes`, `mem-max-allocated-bytes` all extracted; `_2nd.json` non-empty.
  - `run_1` extraction unchanged.
- `ruff check`, `isort --check`, `black==24.4.2 --check`, `py_compile` — all pass.
