### PR TITLE
build: cap pydantic<2.14 in transformer-engine dependency metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,10 @@ requires-dist = []
 name = "transformer-engine"
 version = "2.15.0+42b84005"
 requires-dist = [
-    "pydantic",
+    # Cap below 2.14: pydantic 2.14 breaks langchain_core's module-level
+    # RunnablePassthrough() instantiation, which is imported transitively in
+    # downstream consumers (e.g. Megatron-Bridge via nvidia-resiliency-ext).
+    "pydantic<2.14",
     "importlib-metadata>=1.0",
     "packaging",
     "torch>=2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ version = "1.0.0+9edee0c"
 [[manifest.dependency-metadata]]
 name = "transformer-engine"
 version = "2.15.0+42b84005"
-requires-dist = ["pydantic", "importlib-metadata>=1.0", "packaging", "torch>=2.1", "einops", "onnxscript", "onnx", "nvdlfw-inspect"]
+requires-dist = ["pydantic<2.14", "importlib-metadata>=1.0", "packaging", "torch>=2.1", "einops", "onnxscript", "onnx", "nvdlfw-inspect"]
 
 [[package]]
 name = "absl-py"


### PR DESCRIPTION
## Summary

Cap `pydantic<2.14` in the `transformer-engine` `[[tool.uv.dependency-metadata]]`
block in `pyproject.toml`.

## Why

#3026 added an **uncapped** `pydantic` to that dependency-metadata block. With no
upper bound, `uv` resolves the latest pydantic (`2.14`), which is incompatible
with `langchain_core`: `langchain_core/runnables/passthrough.py` instantiates a
module-level `RunnablePassthrough()` at import, and under pydantic 2.14 that fails:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for RunnablePassthrough
  name  Field required ...  https://errors.pydantic.dev/2.14/v/missing
```

Anything that transitively imports a langchain-based stack then crashes on import.

## Impact observed — MBridge downstream merge-queue tests

This broke the MCore→Megatron-Bridge downstream tests in the merge queue. The
first failing run was the first merge_group built **after #3026 merged** (10:49 → 11:03):

- ✅ pass: `gh-readonly-queue/main/pr-3026-…` (before merge)
- 🚨 fail: `pr-5063`, `pr-4846`, `pr-5047` (all after, all inheriting the uncapped lock)

Two unrelated model jobs (`L1_Launch_models_qwen2`, `L1_Launch_models_nemotron`)
failed with the *identical* import-time error — never reaching model code. Import
chain on the Bridge side:

```
tests/functional_tests/utils.py
  → megatron.bridge.training.state
    → megatron.bridge.training.nvrx_straggler
      → nvidia_resiliency_ext.attribution.straggler
        → ... → langchain_core → RunnablePassthrough()  → pydantic 2.14 ValidationError
```

Failed downstream run: https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/26840064744

## Note on why #3026's own gate was green

Classic uncapped-dependency time bomb: at the time #3026's merge_group ran, the
resolver still selected a pre-2.14 pydantic. Once 2.14 became the resolved version
on later container rebuilds, every downstream run failed with no code change —
which is also why re-running does not help.

## Companion change (defense-in-depth, Bridge side)

NVIDIA-NeMo/Megatron-Bridge#4124 broadens the optional `nvidia-resiliency-ext`
import guard so a transitive optional-dependency failure can never again crash
core `megatron.bridge.training` imports. This MCore PR fixes the version skew;
that PR prevents the whole class of breakage. They are complementary.

## Test

- `uv lock` resolves pydantic to `<2.14`; downstream langchain import succeeds.
