### PR TITLE
ci(unit-tests): split slow unit-test buckets over 15min SLA

### DIFF
--- a/tests/test_utils/recipes/h100/unit-tests.yaml
+++ b/tests/test_utils/recipes/h100/unit-tests.yaml
@@ -172,6 +172,13 @@ products:
         scope: [unit-tests]
         n_repeat: [1]
         time_limit: [1800]
+  - test_case: [tests/unit_tests/ssm/test_gated_delta_net.py]
+    products:
+      - environment: [lts, dev]
+        tag: [latest]
+        scope: [unit-tests]
+        n_repeat: [1]
+        time_limit: [1800]
   - test_case: [tests/unit_tests/ssm/**/*.py]
     products:
       - environment: [lts, dev]
@@ -190,6 +197,13 @@ products:
     products:
       - environment: [lts, dev]
         tag: [latest]
+        scope: [unit-tests]
+        n_repeat: [1]
+        time_limit: [1800]
+  - test_case: [tests/unit_tests/a2a_overlap/**/*.py]
+    products:
+      - environment: [lts, dev]
+        tag: [latest, legacy]
         scope: [unit-tests]
         n_repeat: [1]
         time_limit: [1800]

--- a/tests/test_utils/recipes/h100/unit-tests.yaml
+++ b/tests/test_utils/recipes/h100/unit-tests.yaml
@@ -130,6 +130,20 @@ products:
         scope: [unit-tests]
         n_repeat: [1]
         time_limit: [1800]
+  - test_case: [tests/unit_tests/inference/engines/test_dynamic_engine.py]
+    products:
+      - environment: [lts, dev]
+        tag: [latest, legacy]
+        scope: [unit-tests]
+        n_repeat: [1]
+        time_limit: [1800]
+  - test_case: [tests/unit_tests/inference/test_hybrid_moe.py]
+    products:
+      - environment: [lts, dev]
+        tag: [latest]
+        scope: [unit-tests]
+        n_repeat: [1]
+        time_limit: [1800]
   - test_case: [tests/unit_tests/inference/**/*.py]
     products:
       - environment: [lts, dev]


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- Several H100 unit-test buckets exceeded the **15 min** per-bucket ceiling in [run 26849297427](https://github.com/NVIDIA/Megatron-LM/actions/runs/26849297427):

  | Bucket | Runtime |
  |---|---|
  | `ssm/**/*.py` | 20.9m |
  | `tests/unit_tests/**/*.py` (catch-all) | 19.0m |
  | `inference/**/*.py` | 17.5m |

- Per-file wall time (reconstructed from rank-0 timestamp deltas) showed each bucket's cost concentrated in a few files.

## What changed

- Carve each bucket's hotspot(s) into dedicated buckets in `tests/test_utils/recipes/h100/unit-tests.yaml`. The parent globs auto-shed the carved files via `find_test_cases.py`'s `--ignore` mechanism — no test loss, no double-run.

## Details

| New bucket | Test time | + ~2.5–3m fixed | Tags |
|---|---|---|---|
| `inference/engines/test_dynamic_engine.py` | ~6.5m | **~9m** | latest, legacy |
| `inference/test_hybrid_moe.py` | ~3.3m | **~6m** | latest |
| `inference/**/*.py` (remainder) | ~5m | **~8m** | latest, legacy |
| `ssm/test_gated_delta_net.py` | ~11.1m | **~13.8m** | latest |
| `ssm/**/*.py` (remainder) | ~7m | **~10m** | latest, legacy |
| `a2a_overlap/**/*.py` | ~8m | **~11m** | latest, legacy |
| `tests/unit_tests/**/*.py` (catch-all remainder) | ~8m | **~11m** | latest, legacy |

- **File-granularity floor**: the framework splits at *file* level (not test-class), so a single heavy file is the hard floor for any bucket containing it — `test_dynamic_engine.py` (6.5m) and `test_gated_delta_net.py` (11.1m). `test_gated_delta_net.py` lands at ~13.8m; getting it well below ~12m would require refactoring the test file itself (it is an 11-min single file).
- **`find_test_cases.py` is tag-agnostic**, so child buckets must mirror the parent's tag matrix, and a single-file/dir bucket tagged `legacy` errors if the path is absent in the `core_r0.14.0` legacy suite. Verified presence in `core_r0.14.0`:
  - present → keep `legacy`: `engines/test_dynamic_engine.py`, `a2a_overlap/`
  - absent → `latest`-only: `test_hybrid_moe.py`, `ssm/test_gated_delta_net.py`

```mermaid
flowchart LR
    subgraph Before["Before — 3 jobs over SLA"]
        A1["inference/**/*.py<br/>17.5m"]
        A2["ssm/**/*.py<br/>20.9m"]
        A3["catch-all **/*.py<br/>19m"]
    end
    subgraph After["After — all ≤ ~14m"]
        B1["engines/test_dynamic_engine.py ~9m"]
        B2["test_hybrid_moe.py ~6m"]
        B3["inference remainder ~8m"]
        B4["ssm/test_gated_delta_net.py ~13.8m"]
        B5["ssm remainder ~10m"]
        B6["a2a_overlap/**/*.py ~11m"]
        B7["catch-all remainder ~11m"]
    end
    A1 --> B1 & B2 & B3
    A2 --> B4 & B5
    A3 --> B6 & B7
```

## Tested

- `yq` matrix command from `cicd-main.yml` emits all new buckets (20 → 24 total).
- `find_test_cases.py` on each parent → `--ignore`s exactly the carved files; on each new bucket → resolves to its own path with no spurious ignores.
- Global `tests/unit_tests/**/*.py` still sheds every carved file (verified: 6 `a2a_overlap` files + both single files) — no double-run, no lost coverage.
- CI on this PR will confirm wall-clock per bucket.

## Out of scope

Per request, only buckets **> 15 min** were split. These remain within the 10–15 min band and were left untouched: `transformer/moe/**` (14.8m), `distributed/megatron_fsdp/**` (13.2m), `dist_checkpointing/**` (12.9m), `transformer/**` (11.8m), `dist_checkpointing/test_optimizer.py` (10.9m).

</details>
