### PR TITLE
Fix error in deepseek parser

### DIFF
--- a/megatron/core/tokenizers/text/parsers/deepseek_r1_reasoning_parser.py
+++ b/megatron/core/tokenizers/text/parsers/deepseek_r1_reasoning_parser.py
@@ -12,6 +12,7 @@ class DeepSeekR1ReasoningParser(BaseParser):
         Only extracts the first set of think tags.
         If an initial <think> tag is not present but a </think> tag is,
         it will infer a <think> tag at the beginning of the text.
+        Any <think> appearing after the first </think> is treated as ordinary content.
 
         Args:
             text (str): The text to parse.
@@ -22,12 +23,13 @@ class DeepSeekR1ReasoningParser(BaseParser):
         """
 
         if "</think>" in text:
-            if "<think>" in text:
+            # Split on </think> first: everything before the first </think> is reasoning.
+            reasoning_content, remaining_text = text.split("</think>", maxsplit=1)
+            if "<think>" in reasoning_content:
                 # Strip the <think> prefix (it might not be present if it was part of the prompt)
-                pre_text, text = text.split("<think>", maxsplit=1)
+                pre_text, reasoning_content = reasoning_content.split("<think>", maxsplit=1)
             else:
                 pre_text = ""
-            reasoning_content, remaining_text = text.split("</think>", maxsplit=1)
             return pre_text + remaining_text, {'reasoning': reasoning_content}
         else:
             return text, {}

--- a/megatron/core/tokenizers/text/parsers/deepseek_r1_reasoning_parser.py
+++ b/megatron/core/tokenizers/text/parsers/deepseek_r1_reasoning_parser.py
@@ -12,7 +12,6 @@ class DeepSeekR1ReasoningParser(BaseParser):
         Only extracts the first set of think tags.
         If an initial <think> tag is not present but a </think> tag is,
         it will infer a <think> tag at the beginning of the text.
-        Any <think> appearing after the first </think> is treated as ordinary content.
 
         Args:
             text (str): The text to parse.
@@ -23,13 +22,12 @@ class DeepSeekR1ReasoningParser(BaseParser):
         """
 
         if "</think>" in text:
-            # Split on </think> first: everything before the first </think> is reasoning.
-            reasoning_content, remaining_text = text.split("</think>", maxsplit=1)
-            if "<think>" in reasoning_content:
+            if "<think>" in text:
                 # Strip the <think> prefix (it might not be present if it was part of the prompt)
-                pre_text, reasoning_content = reasoning_content.split("<think>", maxsplit=1)
+                pre_text, text = text.split("<think>", maxsplit=1)
             else:
                 pre_text = ""
+            reasoning_content, remaining_text = text.split("</think>", maxsplit=1)
             return pre_text + remaining_text, {'reasoning': reasoning_content}
         else:
             return text, {}

--- a/megatron/core/tokenizers/text/parsers/deepseek_r1_reasoning_parser.py
+++ b/megatron/core/tokenizers/text/parsers/deepseek_r1_reasoning_parser.py
@@ -7,11 +7,11 @@ class DeepSeekR1ReasoningParser(BaseParser):
 
     @staticmethod
     def parse(text: str, **kwargs) -> tuple[str, dict[str, str]]:
-        """
-        Extracts the reasoning content from the text using <think>...</think> tags.
-        Only extracts the first set of think tags.
-        If an initial <think> tag is not present but a </think> tag is,
-        it will infer a <think> tag at the beginning of the text.
+        """Extract reasoning content delimited by `<think>...</think>` tags.
+
+        Any text before the first `<think>` is discarded.
+        When no `</think>` follows, the model is still "thinking": all text is reasoning.
+        Otherwise the text is split at the first `</think>`.
 
         Args:
             text (str): The text to parse.
@@ -20,14 +20,15 @@ class DeepSeekR1ReasoningParser(BaseParser):
             tuple[str, dict[str, str]]: A tuple containing the unprocessed text
             and a dictionary with the extracted reasoning content.
         """
+        # Discard anything before the first `<think>`.
+        before, think_open, after = text.partition("<think>")
+        remaining = after if think_open else before
 
-        if "</think>" in text:
-            if "<think>" in text:
-                # Strip the <think> prefix (it might not be present if it was part of the prompt)
-                pre_text, text = text.split("<think>", maxsplit=1)
-            else:
-                pre_text = ""
-            reasoning_content, remaining_text = text.split("</think>", maxsplit=1)
-            return pre_text + remaining_text, {'reasoning': reasoning_content}
+        if "</think>" not in remaining:
+            # No closing tag: treat the remaining text as unterminated reasoning.
+            reasoning_content, content = remaining, ""
         else:
-            return text, {}
+            reasoning_content, _, content = remaining.partition("</think>")
+
+        info = {"reasoning": reasoning_content} if reasoning_content else {}
+        return content, info


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Comparison of vllm and Megatron-LM reasoning parser.

MLM path: https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/tokenizers/text/parsers/deepseek_r1_reasoning_parser.py
vllm paths: https://github.com/vllm-project/vllm/blob/main/vllm/reasoning/deepseek_r1_reasoning_parser.py https://github.com/vllm-project/vllm/blob/main/vllm/reasoning/basic_parsers.py

MLM code:
```
        if "</think>" in text:
            if "<think>" in text:
                # Strip the <think> prefix (it might not be present if it was part of the prompt)
                pre_text, text = text.split("<think>", maxsplit=1)
            else:
                pre_text = ""
            reasoning_content, remaining_text = text.split("</think>", maxsplit=1)
            return pre_text + remaining_text, {'reasoning': reasoning_content}
        else:
            return text, {}
```

vllm code:
```
        model_output_parts = model_output.partition(self.start_token)
        model_output = (
            model_output_parts[2] if model_output_parts[1] else model_output_parts[0]
        )

        # For models that may not generate start token,
        # assume the reasoning content is always at the start.
        if self.end_token not in model_output:
            return model_output, None
        else:
            reasoning, _, content = model_output.partition(self.end_token)
            # If generation stops right after end-of-think, return null content
            final_content = content or None
            return reasoning, final_content
```

NOTE: In this table, the tuple represents `(reasoning, content)`.
```
+---------------------------+--------------------+--------------------+-------+
| input                     |          vLLM      | Megatron-LM        |
+---------------------------+--------------------+--------------------+-------+
| 'answer'                  | ('answer', None)   | (None, 'answer')   |
| '<think>r'                | ('r', None)        | (None, '<think>r') |
| 'pre<think>r</think>post' | ('r', 'post')      | ('r', 'prepost')   |
| 'r</think>a<think>b'      | ('b', None)        | CRASH (ValueError) |
+---------------------------+--------------------+--------------------+-------+
```

In a nutshell:
 * vllm assumes that all rollouts that use a reasoning parser are CoT, and there is never a case where we will skip reasoning and go straight to non-reasoning content.
 * vllm throws away everything before the first explicit `<think>` tag.
 * vllm does not need an explicit `</think>` tag,

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
