### PR TITLE
fix: correct dsv4_hybrid Q-up FLOPs by using args.v_head_dim

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -573,7 +573,7 @@ def num_floating_point_operations(args, batch_size):
                 ## for in the dsv4_hybrid branch below.
                 q_term = args.q_lora_rank * (
                     args.hidden_size
-                    + args.num_attention_heads * (args.qk_head_dim + args.qk_pos_emb_head_dim)
+                    + args.num_attention_heads * args.v_head_dim
                     + 1  # q norm
                 )
                 kv_term = args.hidden_size * args.v_head_dim + args.v_head_dim  # kv proj + kv norm


### PR DESCRIPTION
## Summary

In `num_floating_point_operations` for `experimental_attention_variant == "dsv4_hybrid"`, the MLA Q-up term reads `args.qk_head_dim + args.qk_pos_emb_head_dim` — but in dsv4_hybrid mode `qk_head_dim` is derived from `v_head_dim` and `qk_pos_emb_head_dim` inside `MLATransformerConfig.__post_init__`, and that derivation only updates the `TransformerConfig` instance, never `args`. The FLOPs counter therefore uses the raw YAML/CLI `args.qk_head_dim`, under-counting the Q-up output per head.

By construction `qk_head_dim + qk_pos_emb_head_dim == v_head_dim` in dsv4_hybrid (already documented in the existing comment above this code). Read `args.v_head_dim` directly to avoid the stale-args path.

## Validation

DeepSeek-V4-Pro (61L + 1 MTP, hidden=7168, n_head=128, q_lora_rank=1536, qk_pos_emb_head_dim=64, v_head_dim=512, GBS=4096, 256 GPUs, iter5+ avg 22.26 s):

| | mcore-reported TF/s/GPU | external calibrator |
|---|---|---|
| Before fix | 882.7 | 957.0 |
| After fix  | 949.5 | 957.0 |

Closes ~92% of the gap (~68.9 TF/s/GPU recovered). Remaining ~7.5 TF/s/GPU is unrelated to this PR (router gating, mHC mapping_proj, mHC split eh-proj on multi-stream residual) and out of scope here.

## Scope

Only the `dsv4_hybrid` Q-term. No behavior change to non-`dsv4_hybrid` MLA or any other variant.