### PR TITLE
Add named layouts to HyperCommGrid for heterogeneous parallelism

### DIFF
--- a/megatron/core/hyper_comm_grid.py
+++ b/megatron/core/hyper_comm_grid.py
@@ -1,18 +1,11 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 import os
-from operator import itemgetter
-from typing import Any, Optional, Tuple, Union
+from dataclasses import dataclass
+from typing import Any, Optional, Union
 
 import numpy as np
 import torch.distributed as dist
-
-try:
-    import einops
-
-    HAVE_EINOPS = True
-except ImportError:
-    HAVE_EINOPS = False
 
 try:
     from absl import logging
@@ -40,90 +33,17 @@ def _is_process_group_member(pg: Optional[dist.ProcessGroup]) -> bool:
     return pg is not None and pg is not non_member
 
 
-class GridLayout:
-    r"""An additional named factorization of a :class:`HyperCommGrid`'s ranks.
+_BASE_VIEW_NAME = "base"
 
-    Lets one rank span carry a second factorization (e.g. an expert
-    ``[expt_tp, ep, expt_dp, pp]`` alongside the dense base ``[tp, cp, dp, pp]``). Obtained from
-    :meth:`HyperCommGrid.register_layout`, retrieved with :meth:`HyperCommGrid.get_layout`; its
-    groups are reached only through this handle (the grid's own methods use the base layout). Dims
-    in ``shared_dims`` (e.g. ``pp``, which must match between dense and expert) reuse the base
-    grid's group rather than creating a duplicate.
-    """
 
-    def __init__(
-        self,
-        grid: "HyperCommGrid",
-        name: str,
-        shape: list[int],
-        dim_names: list[str],
-        shared_dims: list[str],
-    ) -> None:
-        # [:] insures a copy.
-        self._grid = grid
-        self.name = name
-        self.shape = shape[:]
-        self.dim_names = dim_names[:]
-        self.shared_dims = shared_dims[:]
+@dataclass
+class _RankViewSpec:
+    """A named rank factorization over the same rank span as the base grid."""
 
-    def _is_shared(self, ordered_dims: list[str]) -> bool:
-        """Whether ``ordered_dims`` spans only shared dims (so the group reuses the base grid's)."""
-        return all(d in self.shared_dims for d in ordered_dims)
-
-    def create_pg(self, dims: Union[str, list[str]], **kwargs: Any) -> dist.ProcessGroup | None:
-        """Create this layout's process group for ``dims`` (collective -- call on all ranks).
-
-        A group spanning only shared dims reuses the base grid's group; otherwise it is
-        layout-private. Not idempotent (re-creating raises ``KeyError``); retrieve with
-        :meth:`get_pg`. ``kwargs`` forward to ``dist.new_subgroups_by_enumeration``.
-        """
-        ordered_dims, _ = self._grid._order_dims_for(self.dim_names, dims)
-        if self._is_shared(ordered_dims):
-            # Shared dims must resolve to the *same* group as the base layout. Delegate to the
-            # base grid so the object is shared rather than duplicated.
-            return self._grid.create_pg(dims, **kwargs)
-
-        key = (self.name, tuple(ordered_dims))
-        if key in self._grid._pgs:
-            raise KeyError(
-                f"Process group {dims} for layout {self.name!r} has already been created. Because "
-                f"there is no way to check whether options to create process group matches the "
-                f"first, we error out instead of returning the process group that has already "
-                f"been created before."
-            )
-
-        rank_enum = self._grid._gen_rank_enum_for(self.shape, self.dim_names, ordered_dims)
-        pg, _ = dist.new_subgroups_by_enumeration(rank_enum, backend=self._grid.backend, **kwargs)
-
-        if dist.is_initialized() and dist.get_rank() == 0:
-            logging.info(
-                f"Generated process group for layout {self.name!r} {ordered_dims} with "
-                f"enumeration {rank_enum}"
-            )
-        self._grid._pgs[key] = pg
-        return pg
-
-    def get_pg(self, dims: Union[str, list[str]]) -> dist.ProcessGroup:
-        """Get this layout's previously-created group for ``dims`` (shared dims return the base group).
-
-        Raises ``KeyError`` if it has not been created yet.
-        """
-        ordered_dims, _ = self._grid._order_dims_for(self.dim_names, dims)
-        if self._is_shared(ordered_dims):
-            return self._grid.get_pg(dims)
-
-        key = (self.name, tuple(ordered_dims))
-        if key not in self._grid._pgs:
-            raise KeyError(
-                f"Process group {dims} for layout {self.name!r} hasn't been created. Call "
-                f"create_pg first."
-            )
-        return self._grid._pgs[key]
-
-    def get_rank_enum(self, dims: Union[str, list[str]]) -> list[list[int]]:
-        """Rank enumeration for ``dims`` under this layout (matches the base grid's for shared dims)."""
-        ordered_dims, _ = self._grid._order_dims_for(self.dim_names, dims)
-        return self._grid._gen_rank_enum_for(self.shape, self.dim_names, ordered_dims)
+    name: str
+    shape: list[int]
+    dim_names: list[str]
+    shared_dims: list[str]
 
 
 class HyperCommGrid:
@@ -137,12 +57,12 @@ class HyperCommGrid:
     For any combination of dimensions, a process group can only be created once.
     Creating process groups for the same combination with different options is not supported.
 
-    The grid's own :meth:`create_pg` / :meth:`get_pg` / :meth:`get_rank_enum` always operate on
-    the base factorization passed to the constructor. A rank span that admits more than one
+    The grid's own :meth:`create_pg` / :meth:`get_pg` / :meth:`get_rank_enum` operate on the base
+    factorization passed to the constructor by default. A rank span that admits more than one
     factorization (for example dense ``tp/cp/dp/pp`` groups alongside expert
-    ``expt_tp/ep/expt_dp/pp`` groups over the same ranks) can register an additional layout with
-    :meth:`register_layout`, which returns a :class:`GridLayout` handle. Layout-specific groups
-    are reached only through that handle; the base methods do not infer or route across layouts.
+    ``expt_tp/ep/expt_dp/pp`` groups over the same ranks) can register an additional rank view
+    with :meth:`register_view`. View-specific groups are still created and retrieved through this
+    root grid by passing ``view="..."``; process-group lifecycle is owned in exactly one place.
 
     Note:
         ``create_pg()`` over specific dims must be explicitly called to create a process group.
@@ -205,7 +125,7 @@ class HyperCommGrid:
                 "initialize torch.distributed before creating HyperCommGrid."
             )
         self.rank_offset = rank_offset
-        self.size = np.prod(shape)
+        self.size = int(np.prod(shape))
         if rank_offset < 0:
             raise ValueError(f"rank_offset must be non-negative, got {rank_offset}")
         if self.size > world_size - rank_offset:
@@ -218,59 +138,38 @@ class HyperCommGrid:
         self.shape = shape[:]
         self.dim_names = dim_names[:]
         self.backend = backend
-        # Base-layout groups are keyed by their dash-joined dim string (unchanged from the
-        # single-layout design); layout-private groups are keyed by ``(layout_name, dims_tuple)``.
-        self._pgs: dict[Union[str, Tuple[str, Tuple[str, ...]]], dist.ProcessGroup] = {}
-        self._layouts: dict[str, GridLayout] = {}
+        self._views: dict[str, _RankViewSpec] = {
+            _BASE_VIEW_NAME: _RankViewSpec(
+                _BASE_VIEW_NAME, self.shape[:], self.dim_names[:], shared_dims=[]
+            )
+        }
+        # Base-view groups are keyed by their dash-joined dim string (unchanged from the
+        # single-view design); view-private groups are keyed by ``(view_name, dims_tuple)``.
+        self._pgs: dict[Union[str, tuple[str, tuple[str, ...]]], dist.ProcessGroup] = {}
 
-    def register_layout(
+    def register_view(
         self,
         name: str,
         shape: list[int],
         dim_names: list[str],
         shared_dims: Optional[list[str]] = None,
-    ) -> GridLayout:
-        r"""Register an additional factorization over this grid's rank span.
+    ) -> None:
+        r"""Register an additional rank factorization over this grid's rank span.
 
-        Returns a :class:`GridLayout` handle through which the layout's process groups are
-        created and retrieved. The base layout (the constructor's ``shape``/``dim_names``) is
-        unaffected.
-
-        ``shared_dims`` names dims that are common to the base layout and must map to the *same*
-        process group across both. For example MCore requires the dense and expert pipeline
-        groups to be identical ranks, so ``"pp"`` is declared shared and a request for the
-        ``"pp"`` group through the handle reuses the base grid's group. Every shared dim must
-        exist in the base ``dim_names`` and must enumerate to the same ranks under both layouts,
-        otherwise registration raises.
-
-        Args:
-            name: Unique name for the layout.
-            shape: Shape of the layout. Its product must equal the grid size.
-            dim_names: Name of each dimension corresponding to ``shape``. Must have the same
-                length as ``shape``.
-            shared_dims: Dims shared with (and reused from) the base layout. Default ``None``
-                (no shared dims).
-
-        Returns:
-            GridLayout: A handle for creating/retrieving this layout's process groups.
-
-        Raises:
-            ValueError: If ``name`` is already registered, if ``shape`` and ``dim_names`` lengths
-                differ, if ``dim_names`` are not unique, if any ``shape`` entry is not a positive
-                int, if the layout size does not match the grid size, or if a shared dim is
-                missing from the base layout or enumerates to different ranks across layouts.
+        Shared dims must exist in both the base view and the new view, and must enumerate to the
+        same rank groups as the base view.
         """
-        if name in self._layouts:
-            raise ValueError(f"Layout {name!r} is already registered")
+        if name in self._views:
+            raise ValueError(f"View {name!r} is already registered")
         if len(shape) != len(dim_names):
             raise ValueError(f"len(shape) {shape} != len(dim_names) {dim_names}")
         if len(set(dim_names)) != len(dim_names):
-            raise ValueError(f"Layout {name!r} has duplicate dim_names: {dim_names}")
+            raise ValueError(f"View {name!r} has duplicate dim_names: {dim_names}")
         if any(not isinstance(s, int) or s <= 0 for s in shape):
-            raise ValueError(f"Layout {name!r} shape must be positive ints, got {shape}")
-        if np.prod(shape) != self.size:
+            raise ValueError(f"View {name!r} shape must be positive ints, got {shape}")
+        if int(np.prod(shape)) != self.size:
             raise ValueError(
-                f"Layout {name!r} shape {shape} has size {int(np.prod(shape))}, but the grid "
+                f"View {name!r} shape {shape} has size {int(np.prod(shape))}, but the grid "
                 f"size is {self.size}"
             )
 
@@ -278,45 +177,40 @@ class HyperCommGrid:
         for dim in shared_dims:
             if dim not in self.dim_names:
                 raise ValueError(
-                    f"Shared dim {dim!r} of layout {name!r} is not in the base layout "
+                    f"Shared dim {dim!r} of view {name!r} is not in the base view "
                     f"{self.dim_names}"
                 )
             if dim not in dim_names:
                 raise ValueError(
-                    f"Shared dim {dim!r} of layout {name!r} is not in the layout's dim_names "
+                    f"Shared dim {dim!r} of view {name!r} is not in the view's dim_names "
                     f"{dim_names}"
                 )
             base_dims, _ = self._order_dims_for(self.dim_names, dim)
             base_enum = self._gen_rank_enum_for(self.shape, self.dim_names, base_dims)
-            layout_dims, _ = self._order_dims_for(dim_names, dim)
-            layout_enum = self._gen_rank_enum_for(shape, dim_names, layout_dims)
-            if base_enum != layout_enum:
+            view_dims, _ = self._order_dims_for(dim_names, dim)
+            view_enum = self._gen_rank_enum_for(shape, dim_names, view_dims)
+            if base_enum != view_enum:
                 raise ValueError(
-                    f"Shared dim {dim!r} has different membership across layouts: base "
-                    f"enumeration {base_enum} != layout {name!r} enumeration {layout_enum}"
+                    f"Shared dim {dim!r} has different membership across views: base "
+                    f"enumeration {base_enum} != view {name!r} enumeration {view_enum}"
                 )
 
-        layout = GridLayout(self, name, shape, dim_names, shared_dims)
-        self._layouts[name] = layout
-        return layout
+        if len(shared_dims) > 1:
+            base_dims, _ = self._order_dims_for(self.dim_names, shared_dims)
+            base_enum = self._gen_rank_enum_for(self.shape, self.dim_names, base_dims)
+            view_dims, _ = self._order_dims_for(dim_names, shared_dims)
+            view_enum = self._gen_rank_enum_for(shape, dim_names, view_dims)
+            if base_enum != view_enum:
+                raise ValueError(
+                    f"Shared dims {shared_dims!r} have different membership across views: base "
+                    f"enumeration {base_enum} != view {name!r} enumeration {view_enum}"
+                )
 
-    def get_layout(self, name: str) -> GridLayout:
-        r"""Return the registered :class:`GridLayout` for ``name``.
+        self._views[name] = _RankViewSpec(name, shape[:], dim_names[:], shared_dims[:])
 
-        Args:
-            name: Name a layout was registered under via :meth:`register_layout`.
-
-        Raises:
-            KeyError: If no layout with that name is registered.
-        """
-        if name not in self._layouts:
-            raise KeyError(
-                f"Layout {name!r} is not registered. Registered layouts: "
-                f"{sorted(self._layouts)}"
-            )
-        return self._layouts[name]
-
-    def create_pg(self, dims: Union[str, list[str]], **kwargs: Any) -> dist.ProcessGroup | None:
+    def create_pg(
+        self, dims: Union[str, list[str]], view: Optional[str] = None, **kwargs: Any
+    ) -> dist.ProcessGroup | None:
         r"""Create a process group based on a list of dimension names
 
         Note: The unique key used to store the process group internally will follow the reversed
@@ -326,6 +220,7 @@ class HyperCommGrid:
 
         Args:
             dims: Name of leading dimensions to create process group
+            view: Optional registered rank view name. Defaults to the base view.
 
         Keyword arguments are directly passed into new_subgroups_by_enumeration(). The docstring
         is copied from new_subgroups_by_enumeration().
@@ -344,31 +239,48 @@ class HyperCommGrid:
         Raises:
             KeyError: If attempting to recreate a process group with an existing key.
         """
-        # ordered_dims and unique_group_key will follow the reversed order of self.dim_names
-        ordered_dims, unique_group_key = self._order_dims(dims)
+        view_spec = self._resolve_view(view)
+        ordered_dims, _ = self._order_dims_for_view(view_spec, dims)
+        unique_group_key, enum_view, enum_dims = self._canonical_pg_key_and_enum_view(
+            view_spec, ordered_dims
+        )
 
         if unique_group_key in self._pgs:
+            if self._is_base_pg_key(unique_group_key):
+                raise KeyError(
+                    f"Process group {dims} has already been created. Because there is no way "
+                    f"to check whether options to create process group matches the first, we "
+                    f"error out instead of returning the process group that has already been "
+                    f"created before."
+                )
             raise KeyError(
-                f"Process group {dims} has already been created. Because there is no way to check "
-                f"whether options to create process group matches the first, we error out instead "
-                f"of returning the process group that has already been created before."
+                f"Process group {dims} for view {view_spec.name!r} has already been created. "
+                f"Because there is no way to check whether options to create process group "
+                f"matches the first, we error out instead of returning the process group that "
+                f"has already been created before."
             )
 
-        rank_enum = self._gen_rank_enum(ordered_dims)
+        rank_enum = self._gen_rank_enum_for(enum_view.shape, enum_view.dim_names, enum_dims)
         pg, _ = dist.new_subgroups_by_enumeration(rank_enum, backend=self.backend, **kwargs)
 
         if dist.is_initialized() and dist.get_rank() == 0:
-            logging.info(
-                f"Generated process group for {unique_group_key} with enumeration {rank_enum}"
-            )
+            if view_spec.name == _BASE_VIEW_NAME:
+                logging.info(
+                    f"Generated process group for {unique_group_key} with enumeration {rank_enum}"
+                )
+            else:
+                logging.info(
+                    f"Generated process group for view {view_spec.name!r} {ordered_dims} with "
+                    f"enumeration {rank_enum}"
+                )
         self._pgs[unique_group_key] = pg
         return pg
 
     def destroy(self) -> None:
         """Destroy all process groups created by this grid that the current rank belongs to.
 
-        This includes base-layout groups and layout-private groups. A base group reused by a
-        layout for a shared dim is stored under a single key, so it is torn down exactly once.
+        This includes base-view groups and view-private groups. A base group reused by a
+        view for a shared dim is stored under a single key, so it is torn down exactly once.
         """
         destroyed: set[int] = set()
         for pg in self._pgs.values():
@@ -377,22 +289,33 @@ class HyperCommGrid:
                 destroyed.add(id(pg))
         self._pgs.clear()
 
-    def get_pg(self, dims: Union[str, list[str]]) -> dist.ProcessGroup:
+    def get_pg(self, dims: Union[str, list[str]], view: Optional[str] = None) -> dist.ProcessGroup:
         r"""Get a process group based on a list of dimension names
 
         Args:
             dims: Name of leading dimensions to create process group
+            view: Optional registered rank view name. Defaults to the base view.
         """
-        _, unique_group_key = self._order_dims(dims)
+        view_spec = self._resolve_view(view)
+        ordered_dims, _ = self._order_dims_for_view(view_spec, dims)
+        unique_group_key, _, _ = self._canonical_pg_key_and_enum_view(view_spec, ordered_dims)
 
         if unique_group_key not in self._pgs:
+            if self._is_base_pg_key(unique_group_key):
+                raise KeyError(
+                    f"Process group for {unique_group_key} hasn't been created. Call create_pg "
+                    f"first."
+                )
             raise KeyError(
-                f"Process group for {unique_group_key} hasn't been created. Call create_pg first."
+                f"Process group {dims} for view {view_spec.name!r} hasn't been created. Call "
+                f"create_pg first."
             )
 
         return self._pgs[unique_group_key]
 
-    def get_rank_enum(self, dims: Union[str, list[str]]) -> list[list[int]]:
+    def get_rank_enum(
+        self, dims: Union[str, list[str]], view: Optional[str] = None
+    ) -> list[list[int]]:
         r"""Get the rank enumeration for the requested dimension(s).
 
         This is the exact enumeration that would be used by create_pg for the same
@@ -401,12 +324,14 @@ class HyperCommGrid:
 
         Args:
             dims: Dimension name or list of dimension names.
+            view: Optional registered rank view name. Defaults to the base view.
 
         Returns:
             List of rank lists (one per subgroup).
         """
-        ordered_dims, _ = self._order_dims(dims)
-        return self._gen_rank_enum(ordered_dims)
+        view_spec = self._resolve_view(view)
+        ordered_dims, _ = self._order_dims_for_view(view_spec, dims)
+        return self._gen_rank_enum_for(view_spec.shape, view_spec.dim_names, ordered_dims)
 
     def _gen_rank_enum(self, dims: list[str]) -> list[list[int]]:
         r"""Generate rank enumeration before calling new_subgroups_by_enumeration
@@ -434,62 +359,87 @@ class HyperCommGrid:
     def _gen_rank_enum_for(
         self, shape: list[int], dim_names: list[str], dims: list[str]
     ) -> list[list[int]]:
-        r"""Generate rank enumeration for ``dims`` under an explicit ``shape``/``dim_names``.
-
-        Identical logic to :meth:`_gen_rank_enum` but parameterized by the factorization, so it
-        can serve both the base grid and a registered :class:`GridLayout` without any layout
-        inference. ``dims`` is assumed already ordered against the reversed ``dim_names``.
-        """
-        if not HAVE_EINOPS:
-            raise RuntimeError(
-                "einops is not installed. Please install it with `pip install einops`."
-            )
-
-        # Need to reverse order of dim_names to match MCore convention
+        r"""Generate rank enumeration for ``dims`` under an explicit ``shape``/``dim_names``."""
+        # Need to reverse order of dim_names to match MCore convention.
         dim_names_reverse = dim_names[::-1]
-
-        remaining_dims = []
-        for v in dim_names_reverse:
-            if v not in dims:
-                remaining_dims.append(v)
-
-        rearrange_str = (
-            f"({' '.join(dim_names_reverse)}) -> ({' '.join(remaining_dims)}) ({' '.join(dims)})"
-        )
-        logging.debug(rearrange_str)
-
         shape_dict = {d: s for d, s in zip(dim_names, shape)}
-        return einops.rearrange(
-            np.arange(self.rank_offset, self.rank_offset + self.size), rearrange_str, **shape_dict
-        ).tolist()
+        rank_tensor = np.arange(self.rank_offset, self.rank_offset + self.size).reshape(
+            [shape_dict[d] for d in dim_names_reverse]
+        )
 
-    def _order_dims(self, dims: Union[str, list[str]]) -> Tuple[list[str], str]:
+        source_axes = [dim_names_reverse.index(d) for d in dims]
+        target_axes = list(range(len(dim_names_reverse) - len(dims), len(dim_names_reverse)))
+        logging.debug(
+            "Moving axes %s to %s for dim_names=%s dims=%s",
+            source_axes,
+            target_axes,
+            dim_names,
+            dims,
+        )
+        rank_tensor = np.moveaxis(rank_tensor, source_axes, target_axes)
+
+        group_size = int(np.prod([shape_dict[d] for d in dims]))
+        return rank_tensor.reshape(-1, group_size).tolist()
+
+    def _order_dims(self, dims: Union[str, list[str]]) -> tuple[list[str], str]:
         r"""Reorder dims based on the order of self.dim_names"""
-        ordered_dims, _ = self._order_dims_for(self.dim_names, dims)
+        ordered_dims, _ = self._order_dims_for_view(self._views[_BASE_VIEW_NAME], dims)
         unique_group_key = "-".join(ordered_dims)
         return ordered_dims, unique_group_key
 
     def _order_dims_for(
         self, dim_names: list[str], dims: Union[str, list[str]]
-    ) -> Tuple[list[str], str]:
-        r"""Reorder ``dims`` against an explicit ``dim_names``.
-
-        Identical ordering logic to :meth:`_order_dims` but parameterized by the factorization's
-        ``dim_names``, so it serves both the base grid and a registered :class:`GridLayout`. The
-        returned dash-joined key is informational; callers build their own storage key.
-        """
+    ) -> tuple[list[str], str]:
+        r"""Reorder ``dims`` against an explicit ``dim_names``."""
         if not isinstance(dims, list):
             ordered_dims = [dims]
         else:
             dim_names_reverse = dim_names[::-1]
             indices = sorted([dim_names_reverse.index(d) for d in dims])
-            if len(indices) == 1:
-                ordered_dims = [dim_names_reverse[indices[0]]]
-            else:
-                ordered_dims = list(itemgetter(*indices)(dim_names_reverse))
+            ordered_dims = [dim_names_reverse[i] for i in indices]
 
         unique_group_key = "-".join(ordered_dims)
         return ordered_dims, unique_group_key
+
+    def _resolve_view(self, view: Optional[str]) -> _RankViewSpec:
+        r"""Return the requested rank view, defaulting to the base view."""
+        view_name = _BASE_VIEW_NAME if view is None else view
+        if view_name not in self._views:
+            raise KeyError(
+                f"View {view_name!r} is not registered. Registered views: {sorted(self._views)}"
+            )
+        return self._views[view_name]
+
+    def _order_dims_for_view(
+        self, view: _RankViewSpec, dims: Union[str, list[str]]
+    ) -> tuple[list[str], str]:
+        r"""Reorder ``dims`` against a registered view and report missing dims clearly."""
+        requested_dims = [dims] if not isinstance(dims, list) else dims
+        missing_dims = [d for d in requested_dims if d not in view.dim_names]
+        if missing_dims:
+            raise ValueError(
+                f"{missing_dims[0]!r} is not in view {view.name!r} with dim_names "
+                f"{view.dim_names}"
+            )
+        return self._order_dims_for(view.dim_names, dims)
+
+    def _canonical_pg_key_and_enum_view(
+        self, view: _RankViewSpec, ordered_dims: list[str]
+    ) -> tuple[Union[str, tuple[str, tuple[str, ...]]], _RankViewSpec, list[str]]:
+        r"""Return the storage key and rank view used to enumerate a process group."""
+        if view.name == _BASE_VIEW_NAME:
+            return "-".join(ordered_dims), view, ordered_dims
+
+        if all(d in view.shared_dims for d in ordered_dims):
+            base_view = self._views[_BASE_VIEW_NAME]
+            base_ordered_dims, base_key = self._order_dims_for_view(base_view, ordered_dims)
+            return base_key, base_view, base_ordered_dims
+
+        return (view.name, tuple(ordered_dims)), view, ordered_dims
+
+    def _is_base_pg_key(self, key: Union[str, tuple[str, tuple[str, ...]]]) -> bool:
+        r"""Whether a process-group key belongs to the base view namespace."""
+        return isinstance(key, str)
 
     def is_current_rank_in_grid(self) -> bool:
         """Check if the current rank belongs to this grid.

--- a/megatron/core/hyper_comm_grid.py
+++ b/megatron/core/hyper_comm_grid.py
@@ -30,6 +30,102 @@ except ImportError:
     HAVE_ABSL = False
 
 
+def _is_process_group_member(pg: Optional[dist.ProcessGroup]) -> bool:
+    """Whether the current rank belongs to ``pg``.
+
+    ``new_subgroups_by_enumeration`` returns the ``GroupMember.NON_GROUP_MEMBER``
+    sentinel (not ``None``) for non-member ranks, which must not be destroyed.
+    """
+    non_member = getattr(getattr(dist, "GroupMember", None), "NON_GROUP_MEMBER", None)
+    return pg is not None and pg is not non_member
+
+
+class GridLayout:
+    r"""An additional named factorization of a :class:`HyperCommGrid`'s ranks.
+
+    Lets one rank span carry a second factorization (e.g. an expert
+    ``[expt_tp, ep, expt_dp, pp]`` alongside the dense base ``[tp, cp, dp, pp]``). Obtained from
+    :meth:`HyperCommGrid.register_layout`, retrieved with :meth:`HyperCommGrid.get_layout`; its
+    groups are reached only through this handle (the grid's own methods use the base layout). Dims
+    in ``shared_dims`` (e.g. ``pp``, which must match between dense and expert) reuse the base
+    grid's group rather than creating a duplicate.
+    """
+
+    def __init__(
+        self,
+        grid: "HyperCommGrid",
+        name: str,
+        shape: list[int],
+        dim_names: list[str],
+        shared_dims: list[str],
+    ) -> None:
+        # [:] insures a copy.
+        self._grid = grid
+        self.name = name
+        self.shape = shape[:]
+        self.dim_names = dim_names[:]
+        self.shared_dims = shared_dims[:]
+
+    def _is_shared(self, ordered_dims: list[str]) -> bool:
+        """Whether ``ordered_dims`` spans only shared dims (so the group reuses the base grid's)."""
+        return all(d in self.shared_dims for d in ordered_dims)
+
+    def create_pg(self, dims: Union[str, list[str]], **kwargs: Any) -> dist.ProcessGroup | None:
+        """Create this layout's process group for ``dims`` (collective -- call on all ranks).
+
+        A group spanning only shared dims reuses the base grid's group; otherwise it is
+        layout-private. Not idempotent (re-creating raises ``KeyError``); retrieve with
+        :meth:`get_pg`. ``kwargs`` forward to ``dist.new_subgroups_by_enumeration``.
+        """
+        ordered_dims, _ = self._grid._order_dims_for(self.dim_names, dims)
+        if self._is_shared(ordered_dims):
+            # Shared dims must resolve to the *same* group as the base layout. Delegate to the
+            # base grid so the object is shared rather than duplicated.
+            return self._grid.create_pg(dims, **kwargs)
+
+        key = (self.name, tuple(ordered_dims))
+        if key in self._grid._pgs:
+            raise KeyError(
+                f"Process group {dims} for layout {self.name!r} has already been created. Because "
+                f"there is no way to check whether options to create process group matches the "
+                f"first, we error out instead of returning the process group that has already "
+                f"been created before."
+            )
+
+        rank_enum = self._grid._gen_rank_enum_for(self.shape, self.dim_names, ordered_dims)
+        pg, _ = dist.new_subgroups_by_enumeration(rank_enum, backend=self._grid.backend, **kwargs)
+
+        if dist.is_initialized() and dist.get_rank() == 0:
+            logging.info(
+                f"Generated process group for layout {self.name!r} {ordered_dims} with "
+                f"enumeration {rank_enum}"
+            )
+        self._grid._pgs[key] = pg
+        return pg
+
+    def get_pg(self, dims: Union[str, list[str]]) -> dist.ProcessGroup:
+        """Get this layout's previously-created group for ``dims`` (shared dims return the base group).
+
+        Raises ``KeyError`` if it has not been created yet.
+        """
+        ordered_dims, _ = self._grid._order_dims_for(self.dim_names, dims)
+        if self._is_shared(ordered_dims):
+            return self._grid.get_pg(dims)
+
+        key = (self.name, tuple(ordered_dims))
+        if key not in self._grid._pgs:
+            raise KeyError(
+                f"Process group {dims} for layout {self.name!r} hasn't been created. Call "
+                f"create_pg first."
+            )
+        return self._grid._pgs[key]
+
+    def get_rank_enum(self, dims: Union[str, list[str]]) -> list[list[int]]:
+        """Rank enumeration for ``dims`` under this layout (matches the base grid's for shared dims)."""
+        ordered_dims, _ = self._grid._order_dims_for(self.dim_names, dims)
+        return self._grid._gen_rank_enum_for(self.shape, self.dim_names, ordered_dims)
+
+
 class HyperCommGrid:
     r"""N-dimensional communication grid.
 
@@ -40,6 +136,13 @@ class HyperCommGrid:
 
     For any combination of dimensions, a process group can only be created once.
     Creating process groups for the same combination with different options is not supported.
+
+    The grid's own :meth:`create_pg` / :meth:`get_pg` / :meth:`get_rank_enum` always operate on
+    the base factorization passed to the constructor. A rank span that admits more than one
+    factorization (for example dense ``tp/cp/dp/pp`` groups alongside expert
+    ``expt_tp/ep/expt_dp/pp`` groups over the same ranks) can register an additional layout with
+    :meth:`register_layout`, which returns a :class:`GridLayout` handle. Layout-specific groups
+    are reached only through that handle; the base methods do not infer or route across layouts.
 
     Note:
         ``create_pg()`` over specific dims must be explicitly called to create a process group.
@@ -115,7 +218,103 @@ class HyperCommGrid:
         self.shape = shape[:]
         self.dim_names = dim_names[:]
         self.backend = backend
-        self._pgs: dict[str, dist.ProcessGroup] = {}
+        # Base-layout groups are keyed by their dash-joined dim string (unchanged from the
+        # single-layout design); layout-private groups are keyed by ``(layout_name, dims_tuple)``.
+        self._pgs: dict[Union[str, Tuple[str, Tuple[str, ...]]], dist.ProcessGroup] = {}
+        self._layouts: dict[str, GridLayout] = {}
+
+    def register_layout(
+        self,
+        name: str,
+        shape: list[int],
+        dim_names: list[str],
+        shared_dims: Optional[list[str]] = None,
+    ) -> GridLayout:
+        r"""Register an additional factorization over this grid's rank span.
+
+        Returns a :class:`GridLayout` handle through which the layout's process groups are
+        created and retrieved. The base layout (the constructor's ``shape``/``dim_names``) is
+        unaffected.
+
+        ``shared_dims`` names dims that are common to the base layout and must map to the *same*
+        process group across both. For example MCore requires the dense and expert pipeline
+        groups to be identical ranks, so ``"pp"`` is declared shared and a request for the
+        ``"pp"`` group through the handle reuses the base grid's group. Every shared dim must
+        exist in the base ``dim_names`` and must enumerate to the same ranks under both layouts,
+        otherwise registration raises.
+
+        Args:
+            name: Unique name for the layout.
+            shape: Shape of the layout. Its product must equal the grid size.
+            dim_names: Name of each dimension corresponding to ``shape``. Must have the same
+                length as ``shape``.
+            shared_dims: Dims shared with (and reused from) the base layout. Default ``None``
+                (no shared dims).
+
+        Returns:
+            GridLayout: A handle for creating/retrieving this layout's process groups.
+
+        Raises:
+            ValueError: If ``name`` is already registered, if ``shape`` and ``dim_names`` lengths
+                differ, if ``dim_names`` are not unique, if any ``shape`` entry is not a positive
+                int, if the layout size does not match the grid size, or if a shared dim is
+                missing from the base layout or enumerates to different ranks across layouts.
+        """
+        if name in self._layouts:
+            raise ValueError(f"Layout {name!r} is already registered")
+        if len(shape) != len(dim_names):
+            raise ValueError(f"len(shape) {shape} != len(dim_names) {dim_names}")
+        if len(set(dim_names)) != len(dim_names):
+            raise ValueError(f"Layout {name!r} has duplicate dim_names: {dim_names}")
+        if any(not isinstance(s, int) or s <= 0 for s in shape):
+            raise ValueError(f"Layout {name!r} shape must be positive ints, got {shape}")
+        if np.prod(shape) != self.size:
+            raise ValueError(
+                f"Layout {name!r} shape {shape} has size {int(np.prod(shape))}, but the grid "
+                f"size is {self.size}"
+            )
+
+        shared_dims = list(shared_dims) if shared_dims is not None else []
+        for dim in shared_dims:
+            if dim not in self.dim_names:
+                raise ValueError(
+                    f"Shared dim {dim!r} of layout {name!r} is not in the base layout "
+                    f"{self.dim_names}"
+                )
+            if dim not in dim_names:
+                raise ValueError(
+                    f"Shared dim {dim!r} of layout {name!r} is not in the layout's dim_names "
+                    f"{dim_names}"
+                )
+            base_dims, _ = self._order_dims_for(self.dim_names, dim)
+            base_enum = self._gen_rank_enum_for(self.shape, self.dim_names, base_dims)
+            layout_dims, _ = self._order_dims_for(dim_names, dim)
+            layout_enum = self._gen_rank_enum_for(shape, dim_names, layout_dims)
+            if base_enum != layout_enum:
+                raise ValueError(
+                    f"Shared dim {dim!r} has different membership across layouts: base "
+                    f"enumeration {base_enum} != layout {name!r} enumeration {layout_enum}"
+                )
+
+        layout = GridLayout(self, name, shape, dim_names, shared_dims)
+        self._layouts[name] = layout
+        return layout
+
+    def get_layout(self, name: str) -> GridLayout:
+        r"""Return the registered :class:`GridLayout` for ``name``.
+
+        Args:
+            name: Name a layout was registered under via :meth:`register_layout`.
+
+        Raises:
+            KeyError: If no layout with that name is registered.
+        """
+        if name not in self._layouts:
+            raise KeyError(
+                f"Layout {name!r} is not registered. Registered layouts: "
+                f"{sorted(self._layouts)}"
+            )
+        return self._layouts[name]
 
     def create_pg(self, dims: Union[str, list[str]], **kwargs: Any) -> dist.ProcessGroup | None:
         r"""Create a process group based on a list of dimension names
@@ -158,7 +357,7 @@ class HyperCommGrid:
         rank_enum = self._gen_rank_enum(ordered_dims)
         pg, _ = dist.new_subgroups_by_enumeration(rank_enum, backend=self.backend, **kwargs)
 
-        if dist.get_rank() == 0:
+        if dist.is_initialized() and dist.get_rank() == 0:
             logging.info(
                 f"Generated process group for {unique_group_key} with enumeration {rank_enum}"
             )
@@ -166,10 +365,16 @@ class HyperCommGrid:
         return pg
 
     def destroy(self) -> None:
-        """Destroy all process groups created by this grid."""
+        """Destroy all process groups created by this grid that the current rank belongs to.
+
+        This includes base-layout groups and layout-private groups. A base group reused by a
+        layout for a shared dim is stored under a single key, so it is torn down exactly once.
+        """
+        destroyed: set[int] = set()
         for pg in self._pgs.values():
-            if pg is not None:
+            if _is_process_group_member(pg) and id(pg) not in destroyed:
                 dist.destroy_process_group(pg)
+                destroyed.add(id(pg))
         self._pgs.clear()
 
     def get_pg(self, dims: Union[str, list[str]]) -> dist.ProcessGroup:
@@ -224,14 +429,24 @@ class HyperCommGrid:
         Although the function is lightweight enough to be inlined, a standalone one makes it
         easier to test against MCore's RankGenerator
         """
+        return self._gen_rank_enum_for(self.shape, self.dim_names, dims)
 
+    def _gen_rank_enum_for(
+        self, shape: list[int], dim_names: list[str], dims: list[str]
+    ) -> list[list[int]]:
+        r"""Generate rank enumeration for ``dims`` under an explicit ``shape``/``dim_names``.
+
+        Identical logic to :meth:`_gen_rank_enum` but parameterized by the factorization, so it
+        can serve both the base grid and a registered :class:`GridLayout` without any layout
+        inference. ``dims`` is assumed already ordered against the reversed ``dim_names``.
+        """
         if not HAVE_EINOPS:
             raise RuntimeError(
                 "einops is not installed. Please install it with `pip install einops`."
             )
 
         # Need to reverse order of dim_names to match MCore convention
-        dim_names_reverse = self.dim_names[::-1]
+        dim_names_reverse = dim_names[::-1]
 
         remaining_dims = []
         for v in dim_names_reverse:
@@ -243,17 +458,30 @@ class HyperCommGrid:
         )
         logging.debug(rearrange_str)
 
-        shape_dict = {d: s for d, s in zip(self.dim_names, self.shape)}
+        shape_dict = {d: s for d, s in zip(dim_names, shape)}
         return einops.rearrange(
             np.arange(self.rank_offset, self.rank_offset + self.size), rearrange_str, **shape_dict
         ).tolist()
 
     def _order_dims(self, dims: Union[str, list[str]]) -> Tuple[list[str], str]:
         r"""Reorder dims based on the order of self.dim_names"""
+        ordered_dims, _ = self._order_dims_for(self.dim_names, dims)
+        unique_group_key = "-".join(ordered_dims)
+        return ordered_dims, unique_group_key
+
+    def _order_dims_for(
+        self, dim_names: list[str], dims: Union[str, list[str]]
+    ) -> Tuple[list[str], str]:
+        r"""Reorder ``dims`` against an explicit ``dim_names``.
+
+        Identical ordering logic to :meth:`_order_dims` but parameterized by the factorization's
+        ``dim_names``, so it serves both the base grid and a registered :class:`GridLayout`. The
+        returned dash-joined key is informational; callers build their own storage key.
+        """
         if not isinstance(dims, list):
             ordered_dims = [dims]
         else:
-            dim_names_reverse = self.dim_names[::-1]
+            dim_names_reverse = dim_names[::-1]
             indices = sorted([dim_names_reverse.index(d) for d in dims])
             if len(indices) == 1:
                 ordered_dims = [dim_names_reverse[indices[0]]]

--- a/megatron/core/hyper_comm_grid.py
+++ b/megatron/core/hyper_comm_grid.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
+import numbers
 import os
 from dataclasses import dataclass
 from typing import Any, Optional, Union
@@ -165,7 +166,7 @@ class HyperCommGrid:
             raise ValueError(f"len(shape) {shape} != len(dim_names) {dim_names}")
         if len(set(dim_names)) != len(dim_names):
             raise ValueError(f"View {name!r} has duplicate dim_names: {dim_names}")
-        if any(not isinstance(s, int) or s <= 0 for s in shape):
+        if any(not isinstance(s, numbers.Integral) or s <= 0 for s in shape):
             raise ValueError(f"View {name!r} shape must be positive ints, got {shape}")
         if int(np.prod(shape)) != self.size:
             raise ValueError(
@@ -174,6 +175,8 @@ class HyperCommGrid:
             )
 
         shared_dims = list(shared_dims) if shared_dims is not None else []
+        if len(set(shared_dims)) != len(shared_dims):
+            raise ValueError(f"View {name!r} has duplicate shared_dims: {shared_dims}")
         for dim in shared_dims:
             if dim not in self.dim_names:
                 raise ValueError(
@@ -209,7 +212,7 @@ class HyperCommGrid:
         self._views[name] = _RankViewSpec(name, shape[:], dim_names[:], shared_dims[:])
 
     def create_pg(
-        self, dims: Union[str, list[str]], view: Optional[str] = None, **kwargs: Any
+        self, dims: Union[str, list[str]], *, view: Optional[str] = None, **kwargs: Any
     ) -> dist.ProcessGroup | None:
         r"""Create a process group based on a list of dimension names
 
@@ -264,7 +267,7 @@ class HyperCommGrid:
         pg, _ = dist.new_subgroups_by_enumeration(rank_enum, backend=self.backend, **kwargs)
 
         if dist.is_initialized() and dist.get_rank() == 0:
-            if view_spec.name == _BASE_VIEW_NAME:
+            if self._is_base_pg_key(unique_group_key):
                 logging.info(
                     f"Generated process group for {unique_group_key} with enumeration {rank_enum}"
                 )
@@ -289,7 +292,9 @@ class HyperCommGrid:
                 destroyed.add(id(pg))
         self._pgs.clear()
 
-    def get_pg(self, dims: Union[str, list[str]], view: Optional[str] = None) -> dist.ProcessGroup:
+    def get_pg(
+        self, dims: Union[str, list[str]], *, view: Optional[str] = None
+    ) -> dist.ProcessGroup:
         r"""Get a process group based on a list of dimension names
 
         Args:
@@ -314,7 +319,7 @@ class HyperCommGrid:
         return self._pgs[unique_group_key]
 
     def get_rank_enum(
-        self, dims: Union[str, list[str]], view: Optional[str] = None
+        self, dims: Union[str, list[str]], *, view: Optional[str] = None
     ) -> list[list[int]]:
         r"""Get the rank enumeration for the requested dimension(s).
 
@@ -363,7 +368,8 @@ class HyperCommGrid:
         # Need to reverse order of dim_names to match MCore convention.
         dim_names_reverse = dim_names[::-1]
         shape_dict = {d: s for d, s in zip(dim_names, shape)}
-        rank_tensor = np.arange(self.rank_offset, self.rank_offset + self.size).reshape(
+        size = int(np.prod(shape))
+        rank_tensor = np.arange(self.rank_offset, self.rank_offset + size).reshape(
             [shape_dict[d] for d in dim_names_reverse]
         )
 
@@ -380,12 +386,6 @@ class HyperCommGrid:
 
         group_size = int(np.prod([shape_dict[d] for d in dims]))
         return rank_tensor.reshape(-1, group_size).tolist()
-
-    def _order_dims(self, dims: Union[str, list[str]]) -> tuple[list[str], str]:
-        r"""Reorder dims based on the order of self.dim_names"""
-        ordered_dims, _ = self._order_dims_for_view(self._views[_BASE_VIEW_NAME], dims)
-        unique_group_key = "-".join(ordered_dims)
-        return ordered_dims, unique_group_key
 
     def _order_dims_for(
         self, dim_names: list[str], dims: Union[str, list[str]]

--- a/megatron/core/hyper_comm_grid.py
+++ b/megatron/core/hyper_comm_grid.py
@@ -25,11 +25,7 @@ except ImportError:
 
 
 def _is_process_group_member(pg: Optional[dist.ProcessGroup]) -> bool:
-    """Whether the current rank belongs to ``pg``.
-
-    ``new_subgroups_by_enumeration`` returns the ``GroupMember.NON_GROUP_MEMBER``
-    sentinel (not ``None``) for non-member ranks, which must not be destroyed.
-    """
+    """Whether the current rank belongs to ``pg`` (not the non-member sentinel)."""
     non_member = getattr(getattr(dist, "GroupMember", None), "NON_GROUP_MEMBER", None)
     return pg is not None and pg is not non_member
 
@@ -58,12 +54,8 @@ class HyperCommGrid:
     For any combination of dimensions, a process group can only be created once.
     Creating process groups for the same combination with different options is not supported.
 
-    The grid's own :meth:`create_pg` / :meth:`get_pg` / :meth:`get_rank_enum` operate on the base
-    factorization passed to the constructor by default. A rank span that admits more than one
-    factorization (for example dense ``tp/cp/dp/pp`` groups alongside expert
-    ``expt_tp/ep/expt_dp/pp`` groups over the same ranks) can register an additional rank view
-    with :meth:`register_view`. View-specific groups are still created and retrieved through this
-    root grid by passing ``view="..."``; process-group lifecycle is owned in exactly one place.
+    Methods default to the base factorization. Register additional factorizations of the same
+    rank span with :meth:`register_view` and target them via ``view="..."``.
 
     Note:
         ``create_pg()`` over specific dims must be explicitly called to create a process group.

--- a/tests/unit_tests/test_hyper_comm_grid.py
+++ b/tests/unit_tests/test_hyper_comm_grid.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
-from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.hyper_comm_grid import GridLayout, HyperCommGrid
 
 
 class TestHyperCommGrid:
@@ -309,6 +309,164 @@ class TestHyperCommGrid:
         expected_ab = [[0, 2, 1, 3], [4, 6, 5, 7]]
         assert rank_enum_ab == expected_ab
 
+    # ------------------------------------------------------------------
+    # register_layout / GridLayout validation (mock-based unit tests)
+    # ------------------------------------------------------------------
+
+    def test_register_layout_returns_handle(self):
+        """Test register_layout returns a GridLayout handle retrievable via get_layout."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
+
+        handle = grid.register_layout("expert", [4, 2], ["ep", "expt_dp"])
+
+        assert isinstance(handle, GridLayout)
+        assert handle.name == "expert"
+        # get_layout returns the same handle for a consumer in another module.
+        assert grid.get_layout("expert") is handle
+
+    def test_get_layout_unknown_error(self):
+        """Test get_layout raises a clear error for an unregistered layout."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
+
+        with pytest.raises(KeyError, match="Layout 'nope' is not registered"):
+            grid.get_layout("nope")
+
+    def test_register_layout_duplicate_name_error(self):
+        """Test register_layout rejects re-registering an existing layout name."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
+
+        grid.register_layout("expert", [2, 2, 2], ["expt_tp", "ep", "expt_dp"])
+        with pytest.raises(ValueError, match="is already registered"):
+            grid.register_layout("expert", [2, 4], ["ep", "expt_dp"])
+
+    def test_register_layout_length_mismatch_error(self):
+        """Test register_layout rejects shape/dim_names length mismatch."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
+
+        with pytest.raises(ValueError, match="len\\(shape\\).*!= len\\(dim_names\\)"):
+            grid.register_layout("expert", [2, 2, 2], ["ep", "expt_dp"])
+
+    def test_register_layout_duplicate_dim_names_error(self):
+        """Test register_layout rejects duplicate dim_names within a layout."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
+
+        with pytest.raises(ValueError, match="duplicate dim_names"):
+            grid.register_layout("expert", [2, 2, 2], ["ep", "ep", "expt_dp"])
+
+    def test_register_layout_size_mismatch_error(self):
+        """Test register_layout rejects a layout whose size differs from the grid."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])  # size 8
+
+        with pytest.raises(ValueError, match="but the grid size is 8"):
+            grid.register_layout("expert", [2, 2], ["ep", "expt_dp"])  # size 4
+
+    def test_register_layout_non_positive_shape_error(self):
+        """Test register_layout rejects shape entries that are not positive ints."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
+
+        with pytest.raises(ValueError, match="shape must be positive ints"):
+            grid.register_layout("expert", [8, 0], ["ep", "expt_dp"])
+        with pytest.raises(ValueError, match="shape must be positive ints"):
+            grid.register_layout("expert2", [-1, 8], ["ep", "expt_dp"])
+
+    def test_register_layout_success_copies_lists(self):
+        """Test a valid layout is registered and stored with copied data."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
+
+        shape = [4, 2]
+        dim_names = ["ep", "expt_dp"]
+        handle = grid.register_layout("expert", shape, dim_names)
+
+        # Stored layout must be a copy, not an alias of the caller's lists.
+        assert handle.shape == shape and handle.shape is not shape
+        assert handle.dim_names == dim_names and handle.dim_names is not dim_names
+
+    def test_register_layout_shared_dim_not_in_base_error(self):
+        """Test register_layout rejects a shared dim absent from the base layout."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
+
+        with pytest.raises(ValueError, match="Shared dim 'pp' .* is not in the base layout"):
+            grid.register_layout("expert", [4, 2], ["ep", "pp"], shared_dims=["pp"])
+
+    def test_register_layout_shared_dim_not_in_layout_error(self):
+        """Test register_layout rejects a shared dim absent from the layout's own dim_names."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "pp"])
+
+        with pytest.raises(ValueError, match="Shared dim 'pp' .* is not in the layout's dim_names"):
+            grid.register_layout("expert", [4, 2], ["ep", "expt_dp"], shared_dims=["pp"])
+
+    def test_register_layout_shared_dim_membership_mismatch_error(self):
+        """Test register_layout rejects a shared dim whose enumeration differs from base.
+
+        Here the base layout makes ``pp`` the trailing dim of the original order (strided ranks
+        ``[[0,4],[1,5],[2,6],[3,7]]``), but the expert layout makes ``pp`` the leading dim
+        (contiguous ranks ``[[0,1],[2,3],[4,5],[6,7]]``); the memberships differ, so the
+        shared-dim contract is violated and registration must raise.
+        """
+        # base: tp=2, dp=2, pp=2 -> pp trailing -> strided pp groups.
+        grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"])
+
+        with pytest.raises(ValueError, match="Shared dim 'pp' has different membership"):
+            # expert: pp=2, ep=4 -> pp leading -> contiguous pp groups, different membership.
+            grid.register_layout("expert", [2, 4], ["pp", "ep"], shared_dims=["pp"])
+
+    def test_register_layout_shared_dim_membership_match(self):
+        """Test register_layout accepts a shared dim that enumerates identically across layouts.
+
+        The base grid keeps ``pp`` as the trailing (outermost) dim, and the expert layout also
+        keeps ``pp`` trailing, so the ``pp`` groups are the same ranks.
+        """
+        # base: tp=2, dp=2, pp=2 -> reversed [dp, tp, ...]; pp trailing -> contiguous blocks.
+        grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"])
+        # expert: expt_tp=2, ep=2, pp=2 -> pp trailing -> same membership as base.
+        handle = grid.register_layout(
+            "expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"]
+        )
+
+        assert handle.shared_dims == ["pp"]
+        # Both layouts enumerate pp identically.
+        assert grid.get_rank_enum("pp") == handle.get_rank_enum("pp")
+
+    # ------------------------------------------------------------------
+    # GridLayout process-group creation (mock-based)
+    # ------------------------------------------------------------------
+
+    def test_layout_get_pg_not_created_error(self):
+        """Test get_pg on the handle raises when the group is absent."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
+        handle = grid.register_layout("expert", [4, 2], ["ep", "expt_dp"])
+
+        with pytest.raises(KeyError, match="for layout 'expert' hasn't been created"):
+            handle.get_pg("ep")
+
+    def test_destroy_skips_non_members(self):
+        """Test destroy only destroys groups the current rank is a member of."""
+        member_pg = MagicMock(spec=dist.ProcessGroup)
+        non_member = dist.GroupMember.NON_GROUP_MEMBER
+
+        grid = HyperCommGrid([2, 4], ["tp", "dp"])
+        grid._pgs = {"tp": member_pg, "dp": non_member, "cp": None}
+
+        with patch('torch.distributed.destroy_process_group') as mock_destroy:
+            grid.destroy()
+
+        # Only the real, member process group is destroyed.
+        mock_destroy.assert_called_once_with(member_pg)
+        assert grid._pgs == {}
+
+    @patch('torch.distributed.is_initialized', return_value=False)
+    @patch('torch.distributed.new_subgroups_by_enumeration')
+    def test_create_pg_skips_log_when_not_initialized(self, mock_new_subgroups, _mock_is_init):
+        """Test create_pg does not call get_rank when torch.distributed is not initialized."""
+        mock_pg = MagicMock(spec=dist.ProcessGroup)
+        mock_new_subgroups.return_value = (mock_pg, None)
+
+        grid = HyperCommGrid([2, 4], ["tp", "dp"])
+
+        # get_rank would raise if called before init; the is_initialized guard must short-circuit.
+        with patch('torch.distributed.get_rank', side_effect=AssertionError("get_rank called")):
+            grid.create_pg("tp")
+
 
 class TestHyperCommGridIntegration:
     """Integration tests for HyperCommGrid with real distributed initialization."""
@@ -542,3 +700,82 @@ class TestHyperCommGridIntegration:
             # Verify the sum is correct
             expected_sum = sum(tp_ranks)
             assert tensor.item() == expected_sum
+
+    def test_real_distributed_registered_layout(self):
+        """Verify a registered expert layout's groups with the real distributed backend.
+
+        On 8 ranks, build a base dense grid and register an expert layout that re-partitions the
+        same ranks, declaring ``pp`` as shared. Then assert:
+          * an expert-private group has the correct ACTUAL rank membership;
+          * the expert ``pp`` group IS the same object / same ranks as the base ``pp`` group
+            (shared-dim reuse);
+          * destroy() tears everything down once without double-freeing the reused group.
+        """
+        if not dist.is_initialized():
+            pytest.skip("Distributed not initialized")
+
+        world_size = dist.get_world_size()
+        if world_size != 8:
+            pytest.skip("This test specifically requires 8 GPUs")
+
+        # Base dense layout: tp=2, dp=2, pp=2. Reversed -> [pp(outer-most-on-left after reverse),
+        # dp, tp]; pp is the trailing dim of the original order, so pp groups are [[0,4],[1,5],
+        # [2,6],[3,7]] (strided by 4).
+        grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"], backend="nccl")
+
+        # Expert layout: expt_tp=2, ep=2, pp=2 over the same 8 ranks. pp kept trailing so its
+        # membership matches the base pp groups, satisfying the shared-dim contract.
+        expert = grid.register_layout(
+            "expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"]
+        )
+
+        # Base groups.
+        base_tp = grid.create_pg("tp")
+        base_pp = grid.create_pg("pp")
+
+        # Expert-private group spanning expt_tp + ep (the non-shared dims).
+        expert_te = expert.create_pg(["expt_tp", "ep"])
+        # Shared pp group via the handle must reuse the base object.
+        expert_pp = expert.get_pg("pp")
+
+        assert isinstance(base_tp, dist.ProcessGroup)
+        assert isinstance(base_pp, dist.ProcessGroup)
+        assert isinstance(expert_te, dist.ProcessGroup)
+
+        # Layout-private group is stored under a tuple key (no string namespacing) and is
+        # retrievable through the handle as the same object.
+        assert ("expert", ("ep", "expt_tp")) in grid._pgs
+        assert expert.get_pg(["expt_tp", "ep"]) is expert_te
+
+        # Shared-dim reuse: identical object AND identical ranks, and no layout-private duplicate
+        # was created for the shared dim.
+        assert expert_pp is base_pp
+        assert dist.get_process_group_ranks(expert_pp) == dist.get_process_group_ranks(base_pp)
+        assert ("expert", ("pp",)) not in grid._pgs
+
+        # Re-creating an already-created layout-private group must raise.
+        with pytest.raises(KeyError, match="for layout 'expert' has already been created"):
+            expert.create_pg(["expt_tp", "ep"])
+
+        # ACTUAL membership of the expert-private expt_tp-ep group. Reversed expert dim order is
+        # [pp, ep, expt_tp]; grouping by (ep, expt_tp) within each pp slice yields, per pp block
+        # of 4 contiguous ranks, the whole block. pp trailing => two blocks [0..3] and [4..7].
+        expected_te = [[0, 1, 2, 3], [4, 5, 6, 7]]
+        assert sorted(expert.get_rank_enum(["expt_tp", "ep"])) == sorted(expected_te)
+        my_te_ranks = sorted(dist.get_process_group_ranks(expert_te))
+        rank = dist.get_rank()
+        my_block = [b for b in expected_te if rank in b][0]
+        assert my_te_ranks == my_block
+
+        # Exercise real communication on the expert-private group.
+        device = torch.device(f"cuda:{rank % torch.cuda.device_count()}")
+        tensor = torch.tensor([rank], dtype=torch.float, device=device)
+        dist.all_reduce(tensor, group=expert_te)
+        assert tensor.item() == sum(my_block)
+
+        # destroy() must tear down base_tp, the shared pp group (once), and the expert-private
+        # group, without double-freeing the reused pp group. The pp group object is shared
+        # between base and expert under a single key, so it cannot be destroyed twice. After
+        # teardown the registry is empty.
+        grid.destroy()
+        assert grid._pgs == {}

--- a/tests/unit_tests/test_hyper_comm_grid.py
+++ b/tests/unit_tests/test_hyper_comm_grid.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
-from megatron.core.hyper_comm_grid import GridLayout, HyperCommGrid
+from megatron.core.hyper_comm_grid import HyperCommGrid
 
 
 class TestHyperCommGrid:
@@ -106,7 +106,7 @@ class TestHyperCommGrid:
         rank_enum = grid._gen_rank_enum(["tp", "cp"])
 
         # Should have 2 groups (for dp) with 4 ranks each (tp * cp)
-        expected = [[0, 2, 1, 3], [4, 6, 5, 7]]  # Updated to match actual einops rearrange result
+        expected = [[0, 2, 1, 3], [4, 6, 5, 7]]
         assert rank_enum == expected
 
     def test_gen_rank_enum_with_offset(self):
@@ -310,96 +310,97 @@ class TestHyperCommGrid:
         assert rank_enum_ab == expected_ab
 
     # ------------------------------------------------------------------
-    # register_layout / GridLayout validation (mock-based unit tests)
+    # register_view validation (mock-based unit tests)
     # ------------------------------------------------------------------
 
-    def test_register_layout_returns_handle(self):
-        """Test register_layout returns a GridLayout handle retrievable via get_layout."""
+    def test_register_view_stores_rank_view(self):
+        """Test register_view stores metadata without returning a PG-owning object."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
-        handle = grid.register_layout("expert", [4, 2], ["ep", "expt_dp"])
+        result = grid.register_view("expert", [4, 2], ["ep", "expt_dp"])
 
-        assert isinstance(handle, GridLayout)
-        assert handle.name == "expert"
-        # get_layout returns the same handle for a consumer in another module.
-        assert grid.get_layout("expert") is handle
+        assert result is None
+        assert grid._views["expert"].name == "expert"
+        assert grid._views["expert"].shape == [4, 2]
+        assert grid._views["expert"].dim_names == ["ep", "expt_dp"]
 
-    def test_get_layout_unknown_error(self):
-        """Test get_layout raises a clear error for an unregistered layout."""
+    def test_unknown_view_error(self):
+        """Test view-scoped APIs raise clearly for an unregistered view."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
-        with pytest.raises(KeyError, match="Layout 'nope' is not registered"):
-            grid.get_layout("nope")
+        with pytest.raises(KeyError, match="View 'nope' is not registered"):
+            grid.get_rank_enum("ep", view="nope")
 
-    def test_register_layout_duplicate_name_error(self):
-        """Test register_layout rejects re-registering an existing layout name."""
+    def test_register_view_duplicate_name_error(self):
+        """Test register_view rejects re-registering an existing view name."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
-        grid.register_layout("expert", [2, 2, 2], ["expt_tp", "ep", "expt_dp"])
+        grid.register_view("expert", [2, 2, 2], ["expt_tp", "ep", "expt_dp"])
         with pytest.raises(ValueError, match="is already registered"):
-            grid.register_layout("expert", [2, 4], ["ep", "expt_dp"])
+            grid.register_view("expert", [2, 4], ["ep", "expt_dp"])
 
-    def test_register_layout_length_mismatch_error(self):
-        """Test register_layout rejects shape/dim_names length mismatch."""
+    def test_register_view_length_mismatch_error(self):
+        """Test register_view rejects shape/dim_names length mismatch."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
         with pytest.raises(ValueError, match="len\\(shape\\).*!= len\\(dim_names\\)"):
-            grid.register_layout("expert", [2, 2, 2], ["ep", "expt_dp"])
+            grid.register_view("expert", [2, 2, 2], ["ep", "expt_dp"])
 
-    def test_register_layout_duplicate_dim_names_error(self):
-        """Test register_layout rejects duplicate dim_names within a layout."""
+    def test_register_view_duplicate_dim_names_error(self):
+        """Test register_view rejects duplicate dim_names within a view."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
         with pytest.raises(ValueError, match="duplicate dim_names"):
-            grid.register_layout("expert", [2, 2, 2], ["ep", "ep", "expt_dp"])
+            grid.register_view("expert", [2, 2, 2], ["ep", "ep", "expt_dp"])
 
-    def test_register_layout_size_mismatch_error(self):
-        """Test register_layout rejects a layout whose size differs from the grid."""
+    def test_register_view_size_mismatch_error(self):
+        """Test register_view rejects a view whose size differs from the grid."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])  # size 8
 
         with pytest.raises(ValueError, match="but the grid size is 8"):
-            grid.register_layout("expert", [2, 2], ["ep", "expt_dp"])  # size 4
+            grid.register_view("expert", [2, 2], ["ep", "expt_dp"])  # size 4
 
-    def test_register_layout_non_positive_shape_error(self):
-        """Test register_layout rejects shape entries that are not positive ints."""
+    def test_register_view_non_positive_shape_error(self):
+        """Test register_view rejects shape entries that are not positive ints."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
         with pytest.raises(ValueError, match="shape must be positive ints"):
-            grid.register_layout("expert", [8, 0], ["ep", "expt_dp"])
+            grid.register_view("expert", [8, 0], ["ep", "expt_dp"])
         with pytest.raises(ValueError, match="shape must be positive ints"):
-            grid.register_layout("expert2", [-1, 8], ["ep", "expt_dp"])
+            grid.register_view("expert2", [-1, 8], ["ep", "expt_dp"])
 
-    def test_register_layout_success_copies_lists(self):
-        """Test a valid layout is registered and stored with copied data."""
+    def test_register_view_success_copies_lists(self):
+        """Test a valid view is registered and stored with copied data."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
         shape = [4, 2]
         dim_names = ["ep", "expt_dp"]
-        handle = grid.register_layout("expert", shape, dim_names)
+        grid.register_view("expert", shape, dim_names)
+        view = grid._views["expert"]
 
-        # Stored layout must be a copy, not an alias of the caller's lists.
-        assert handle.shape == shape and handle.shape is not shape
-        assert handle.dim_names == dim_names and handle.dim_names is not dim_names
+        # Stored view must be a copy, not an alias of the caller's lists.
+        assert view.shape == shape and view.shape is not shape
+        assert view.dim_names == dim_names and view.dim_names is not dim_names
 
-    def test_register_layout_shared_dim_not_in_base_error(self):
-        """Test register_layout rejects a shared dim absent from the base layout."""
+    def test_register_view_shared_dim_not_in_base_error(self):
+        """Test register_view rejects a shared dim absent from the base view."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
-        with pytest.raises(ValueError, match="Shared dim 'pp' .* is not in the base layout"):
-            grid.register_layout("expert", [4, 2], ["ep", "pp"], shared_dims=["pp"])
+        with pytest.raises(ValueError, match="Shared dim 'pp' .* is not in the base view"):
+            grid.register_view("expert", [4, 2], ["ep", "pp"], shared_dims=["pp"])
 
-    def test_register_layout_shared_dim_not_in_layout_error(self):
-        """Test register_layout rejects a shared dim absent from the layout's own dim_names."""
+    def test_register_view_shared_dim_not_in_view_error(self):
+        """Test register_view rejects a shared dim absent from the view's own dim_names."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "pp"])
 
-        with pytest.raises(ValueError, match="Shared dim 'pp' .* is not in the layout's dim_names"):
-            grid.register_layout("expert", [4, 2], ["ep", "expt_dp"], shared_dims=["pp"])
+        with pytest.raises(ValueError, match="Shared dim 'pp' .* is not in the view's dim_names"):
+            grid.register_view("expert", [4, 2], ["ep", "expt_dp"], shared_dims=["pp"])
 
-    def test_register_layout_shared_dim_membership_mismatch_error(self):
-        """Test register_layout rejects a shared dim whose enumeration differs from base.
+    def test_register_view_shared_dim_membership_mismatch_error(self):
+        """Test register_view rejects a shared dim whose enumeration differs from base.
 
-        Here the base layout makes ``pp`` the trailing dim of the original order (strided ranks
-        ``[[0,4],[1,5],[2,6],[3,7]]``), but the expert layout makes ``pp`` the leading dim
+        Here the base view makes ``pp`` the trailing dim of the original order (strided ranks
+        ``[[0,4],[1,5],[2,6],[3,7]]``), but the expert view makes ``pp`` the leading dim
         (contiguous ranks ``[[0,1],[2,3],[4,5],[6,7]]``); the memberships differ, so the
         shared-dim contract is violated and registration must raise.
         """
@@ -408,36 +409,75 @@ class TestHyperCommGrid:
 
         with pytest.raises(ValueError, match="Shared dim 'pp' has different membership"):
             # expert: pp=2, ep=4 -> pp leading -> contiguous pp groups, different membership.
-            grid.register_layout("expert", [2, 4], ["pp", "ep"], shared_dims=["pp"])
+            grid.register_view("expert", [2, 4], ["pp", "ep"], shared_dims=["pp"])
 
-    def test_register_layout_shared_dim_membership_match(self):
-        """Test register_layout accepts a shared dim that enumerates identically across layouts.
+    def test_register_view_shared_dim_membership_match(self):
+        """Test register_view accepts a shared dim that enumerates identically across views.
 
-        The base grid keeps ``pp`` as the trailing (outermost) dim, and the expert layout also
+        The base grid keeps ``pp`` as the trailing (outermost) dim, and the expert view also
         keeps ``pp`` trailing, so the ``pp`` groups are the same ranks.
         """
         # base: tp=2, dp=2, pp=2 -> reversed [dp, tp, ...]; pp trailing -> contiguous blocks.
         grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"])
         # expert: expt_tp=2, ep=2, pp=2 -> pp trailing -> same membership as base.
-        handle = grid.register_layout(
+        grid.register_view(
             "expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"]
         )
 
-        assert handle.shared_dims == ["pp"]
+        assert grid._views["expert"].shared_dims == ["pp"]
         # Both layouts enumerate pp identically.
-        assert grid.get_rank_enum("pp") == handle.get_rank_enum("pp")
+        assert grid.get_rank_enum("pp") == grid.get_rank_enum("pp", view="expert")
 
     # ------------------------------------------------------------------
-    # GridLayout process-group creation (mock-based)
+    # Rank-view process-group creation (mock-based)
     # ------------------------------------------------------------------
 
-    def test_layout_get_pg_not_created_error(self):
-        """Test get_pg on the handle raises when the group is absent."""
+    def test_view_get_pg_not_created_error(self):
+        """Test get_pg with a view raises when the group is absent."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
-        handle = grid.register_layout("expert", [4, 2], ["ep", "expt_dp"])
+        grid.register_view("expert", [4, 2], ["ep", "expt_dp"])
 
-        with pytest.raises(KeyError, match="for layout 'expert' hasn't been created"):
-            handle.get_pg("ep")
+        with pytest.raises(KeyError, match="for view 'expert' hasn't been created"):
+            grid.get_pg("ep", view="expert")
+
+    @patch('torch.distributed.new_subgroups_by_enumeration')
+    def test_create_pg_with_view_uses_view_rank_order(self, mock_new_subgroups):
+        """Test view-scoped create_pg uses the selected view's rank generation order."""
+        mock_pg = MagicMock(spec=dist.ProcessGroup)
+        mock_new_subgroups.return_value = (mock_pg, None)
+
+        grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"])
+        grid.register_view("expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"])
+
+        result = grid.create_pg(["expt_tp", "ep"], view="expert")
+
+        assert result == mock_pg
+        assert ("expert", ("ep", "expt_tp")) in grid._pgs
+        args, _ = mock_new_subgroups.call_args
+        assert args[0] == [[0, 1, 2, 3], [4, 5, 6, 7]]
+
+    @patch('torch.distributed.new_subgroups_by_enumeration')
+    def test_shared_view_dim_reuses_base_process_group(self, mock_new_subgroups):
+        """Test fully-shared view dims canonicalize to the base process group."""
+        base_pp = MagicMock(spec=dist.ProcessGroup)
+        mock_new_subgroups.return_value = (base_pp, None)
+
+        grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"])
+        grid.register_view("expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"])
+
+        assert grid.create_pg("pp", view="expert") is base_pp
+        assert grid.get_pg("pp") is base_pp
+        assert grid.get_pg("pp", view="expert") is base_pp
+        assert "pp" in grid._pgs
+        assert ("expert", ("pp",)) not in grid._pgs
+
+    def test_view_dim_requires_explicit_view(self):
+        """Test view-private dims are not inferred from the base view."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"])
+        grid.register_view("expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"])
+
+        with pytest.raises(ValueError, match="'ep' is not in view 'base'"):
+            grid.get_rank_enum("ep")
 
     def test_destroy_skips_non_members(self):
         """Test destroy only destroys groups the current rank is a member of."""
@@ -701,10 +741,10 @@ class TestHyperCommGridIntegration:
             expected_sum = sum(tp_ranks)
             assert tensor.item() == expected_sum
 
-    def test_real_distributed_registered_layout(self):
-        """Verify a registered expert layout's groups with the real distributed backend.
+    def test_real_distributed_registered_view(self):
+        """Verify a registered expert view's groups with the real distributed backend.
 
-        On 8 ranks, build a base dense grid and register an expert layout that re-partitions the
+        On 8 ranks, build a base dense grid and register an expert view that re-partitions the
         same ranks, declaring ``pp`` as shared. Then assert:
           * an expert-private group has the correct ACTUAL rank membership;
           * the expert ``pp`` group IS the same object / same ranks as the base ``pp`` group
@@ -718,50 +758,48 @@ class TestHyperCommGridIntegration:
         if world_size != 8:
             pytest.skip("This test specifically requires 8 GPUs")
 
-        # Base dense layout: tp=2, dp=2, pp=2. Reversed -> [pp(outer-most-on-left after reverse),
+        # Base dense view: tp=2, dp=2, pp=2. Reversed -> [pp(outer-most-on-left after reverse),
         # dp, tp]; pp is the trailing dim of the original order, so pp groups are [[0,4],[1,5],
         # [2,6],[3,7]] (strided by 4).
         grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"], backend="nccl")
 
-        # Expert layout: expt_tp=2, ep=2, pp=2 over the same 8 ranks. pp kept trailing so its
+        # Expert view: expt_tp=2, ep=2, pp=2 over the same 8 ranks. pp kept trailing so its
         # membership matches the base pp groups, satisfying the shared-dim contract.
-        expert = grid.register_layout(
-            "expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"]
-        )
+        grid.register_view("expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"])
 
         # Base groups.
         base_tp = grid.create_pg("tp")
         base_pp = grid.create_pg("pp")
 
         # Expert-private group spanning expt_tp + ep (the non-shared dims).
-        expert_te = expert.create_pg(["expt_tp", "ep"])
-        # Shared pp group via the handle must reuse the base object.
-        expert_pp = expert.get_pg("pp")
+        expert_te = grid.create_pg(["expt_tp", "ep"], view="expert")
+        # Shared pp group via the expert view must reuse the base object.
+        expert_pp = grid.get_pg("pp", view="expert")
 
         assert isinstance(base_tp, dist.ProcessGroup)
         assert isinstance(base_pp, dist.ProcessGroup)
         assert isinstance(expert_te, dist.ProcessGroup)
 
-        # Layout-private group is stored under a tuple key (no string namespacing) and is
-        # retrievable through the handle as the same object.
+        # View-private group is stored under a tuple key (no string namespacing) and is
+        # retrievable through the root grid as the same object.
         assert ("expert", ("ep", "expt_tp")) in grid._pgs
-        assert expert.get_pg(["expt_tp", "ep"]) is expert_te
+        assert grid.get_pg(["expt_tp", "ep"], view="expert") is expert_te
 
-        # Shared-dim reuse: identical object AND identical ranks, and no layout-private duplicate
+        # Shared-dim reuse: identical object AND identical ranks, and no view-private duplicate
         # was created for the shared dim.
         assert expert_pp is base_pp
         assert dist.get_process_group_ranks(expert_pp) == dist.get_process_group_ranks(base_pp)
         assert ("expert", ("pp",)) not in grid._pgs
 
-        # Re-creating an already-created layout-private group must raise.
-        with pytest.raises(KeyError, match="for layout 'expert' has already been created"):
-            expert.create_pg(["expt_tp", "ep"])
+        # Re-creating an already-created view-private group must raise.
+        with pytest.raises(KeyError, match="for view 'expert' has already been created"):
+            grid.create_pg(["expt_tp", "ep"], view="expert")
 
         # ACTUAL membership of the expert-private expt_tp-ep group. Reversed expert dim order is
         # [pp, ep, expt_tp]; grouping by (ep, expt_tp) within each pp slice yields, per pp block
         # of 4 contiguous ranks, the whole block. pp trailing => two blocks [0..3] and [4..7].
         expected_te = [[0, 1, 2, 3], [4, 5, 6, 7]]
-        assert sorted(expert.get_rank_enum(["expt_tp", "ep"])) == sorted(expected_te)
+        assert sorted(grid.get_rank_enum(["expt_tp", "ep"], view="expert")) == sorted(expected_te)
         my_te_ranks = sorted(dist.get_process_group_ranks(expert_te))
         rank = dist.get_rank()
         my_block = [b for b in expected_te if rank in b][0]

--- a/tests/unit_tests/test_hyper_comm_grid.py
+++ b/tests/unit_tests/test_hyper_comm_grid.py
@@ -314,17 +314,6 @@ class TestHyperCommGrid:
     # register_view validation (mock-based unit tests)
     # ------------------------------------------------------------------
 
-    def test_register_view_stores_rank_view(self):
-        """Test register_view stores metadata without returning a PG-owning object."""
-        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
-
-        result = grid.register_view("expert", [4, 2], ["ep", "expt_dp"])
-
-        assert result is None
-        assert grid._views["expert"].name == "expert"
-        assert grid._views["expert"].shape == [4, 2]
-        assert grid._views["expert"].dim_names == ["ep", "expt_dp"]
-
     def test_unknown_view_error(self):
         """Test view-scoped APIs raise clearly for an unregistered view."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
@@ -388,15 +377,17 @@ class TestHyperCommGrid:
                 "expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp", "pp"]
             )
 
-    def test_register_view_success_copies_lists(self):
-        """Test a valid view is registered and stored with copied data."""
+    def test_register_view_success_stores_copied_metadata(self):
+        """Test a valid view is registered, returns None, and is stored with copied data."""
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
         shape = [4, 2]
         dim_names = ["ep", "expt_dp"]
-        grid.register_view("expert", shape, dim_names)
+        result = grid.register_view("expert", shape, dim_names)
         view = grid._views["expert"]
 
+        assert result is None
+        assert view.name == "expert"
         # Stored view must be a copy, not an alias of the caller's lists.
         assert view.shape == shape and view.shape is not shape
         assert view.dim_names == dim_names and view.dim_names is not dim_names

--- a/tests/unit_tests/test_hyper_comm_grid.py
+++ b/tests/unit_tests/test_hyper_comm_grid.py
@@ -430,9 +430,7 @@ class TestHyperCommGrid:
         # base: tp=2, dp=2, pp=2 -> reversed [dp, tp, ...]; pp trailing -> contiguous blocks.
         grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"])
         # expert: expt_tp=2, ep=2, pp=2 -> pp trailing -> same membership as base.
-        grid.register_view(
-            "expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"]
-        )
+        grid.register_view("expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"])
 
         assert grid._views["expert"].shared_dims == ["pp"]
         # Both layouts enumerate pp identically.

--- a/tests/unit_tests/test_hyper_comm_grid.py
+++ b/tests/unit_tests/test_hyper_comm_grid.py
@@ -3,6 +3,7 @@
 import os
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 import torch
 import torch.distributed as dist
@@ -58,7 +59,7 @@ class TestHyperCommGrid:
             [2, 2, 2], ["tp", "cp", "dp"]
         )  # Changed from [2, 3, 4] to fit world size
 
-        ordered_dims, unique_key = grid._order_dims("cp")
+        ordered_dims, unique_key = grid._order_dims_for(grid.dim_names, "cp")
 
         assert ordered_dims == ["cp"]
         assert unique_key == "cp"
@@ -70,7 +71,7 @@ class TestHyperCommGrid:
         )  # Changed from [2, 3, 4, 5] to fit world size
 
         # Should order according to reversed dim_names order
-        ordered_dims, unique_key = grid._order_dims(["dp", "tp"])
+        ordered_dims, unique_key = grid._order_dims_for(grid.dim_names, ["dp", "tp"])
 
         assert ordered_dims == [
             "dp",
@@ -84,7 +85,7 @@ class TestHyperCommGrid:
             [2, 2, 2], ["tp", "cp", "dp"]
         )  # Changed from [2, 3, 4] to fit world size
 
-        ordered_dims, unique_key = grid._order_dims(["dp", "cp", "tp"])
+        ordered_dims, unique_key = grid._order_dims_for(grid.dim_names, ["dp", "cp", "tp"])
 
         assert ordered_dims == ["dp", "cp", "tp"]  # Changed: reversed order
         assert unique_key == "dp-cp-tp"
@@ -238,7 +239,7 @@ class TestHyperCommGrid:
         assert grid.dim_names == ["tp", "cp", "pp", "dp"]
 
         # Test ordering of different dimension combinations
-        ordered_dims, key = grid._order_dims(["dp", "pp"])
+        ordered_dims, key = grid._order_dims_for(grid.dim_names, ["dp", "pp"])
         assert ordered_dims == ["dp", "pp"]  # Changed: actual order matches reversed dim_names
         assert key == "dp-pp"
 
@@ -368,6 +369,24 @@ class TestHyperCommGrid:
             grid.register_view("expert", [8, 0], ["ep", "expt_dp"])
         with pytest.raises(ValueError, match="shape must be positive ints"):
             grid.register_view("expert2", [-1, 8], ["ep", "expt_dp"])
+
+    def test_register_view_accepts_numpy_int_shape(self):
+        """Test register_view accepts numpy integer shape entries, like the base grid does."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
+
+        # Shapes derived programmatically are often numpy ints; they must be accepted.
+        shape = [np.int64(4), np.int64(2)]
+        grid.register_view("expert", shape, ["ep", "expt_dp"])
+        assert "expert" in grid._views
+
+    def test_register_view_duplicate_shared_dims_error(self):
+        """Test register_view rejects duplicate entries in shared_dims with a clear message."""
+        grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "pp"])
+
+        with pytest.raises(ValueError, match="duplicate shared_dims"):
+            grid.register_view(
+                "expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp", "pp"]
+            )
 
     def test_register_view_success_copies_lists(self):
         """Test a valid view is registered and stored with copied data."""


### PR DESCRIPTION
## What

Add named **views** to `HyperCommGrid`: one grid (a single rank span) can register extra factorizations beyond the implicit `base` view, then create / retrieve / enumerate process groups against any of them via a keyword-only `view=`.

- `register_view(name, shape, dim_names, shared_dims=None)` — register and validate a named factorization over the same ranks.
- `create_pg` / `get_pg` / `get_rank_enum` accept `view=` (defaults to `base`, so the single-view path is unchanged).
- Base-view group keys are byte-for-byte unchanged; view-private groups use namespaced keys, and dims listed in `shared_dims` reuse the base group instead of duplicating it.

## Why

Foundational for heterogeneous / non-colocated parallelism, where a dense (`tp/cp/dp/pp`) and an expert (`expt_tp/ep/expt_dp/pp`) factorization span the **same** ranks with different shapes. These are alternate tilings of one rank set — not orthogonal axes, so they can't be a single cube. `register_view` models each as a separate factorization that must agree on any `shared_dims`.

## How

- `_RankViewSpec` holds each factorization; the base view is auto-registered from the constructor args.
- Rank enumeration is generalized to any view's `shape`/`dim_names` via `np.moveaxis` + reshape (drops the einops dependency).
- `register_view` proves each `shared_dim` enumerates identically to the base view, so shared groups are reused rather than rebuilt.
- Robustness: `destroy()` skips groups this rank isn't a member of (`NON_GROUP_MEMBER` sentinel) and frees each shared group once; the rank-0 log is guarded by `is_initialized()`.

Fully backward compatible — all new params are optional and keyword-only. Covered by `tests/unit_tests/test_hyper_comm_grid.py`, including a real-distributed 8-GPU view test.
