### PR TITLE
Apply MIMO SP/CP sharding with explicit groups and enable THD in non-colocated path

### DIFF
--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -2,7 +2,7 @@
 
 import logging
 import warnings
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 
@@ -77,8 +77,11 @@ class MimoModel(MegatronModule):
         max_seq_len = mimo_config.language_model_spec.params.get('max_sequence_length', 4096)
 
         self.partition_adapter: Optional[PartitionAdapter] = None
-        # Create partition adapter only if parallelism is enabled
-        if language_config.context_parallel_size > 1 or language_config.sequence_parallel:
+        # Only on language-module ranks: encoder-only ranks never shard and would read
+        # process groups they do not own.
+        if self.role.has_language_module and (
+            language_config.context_parallel_size > 1 or language_config.sequence_parallel
+        ):
             partition_config = PartitionConfig.from_mp_config(
                 mp=language_config,
                 max_seq_len=max_seq_len,
@@ -307,10 +310,24 @@ class MimoModel(MegatronModule):
         else:
             position_ids_text = position_ids[batch_idx, seq_idx].unsqueeze(0)
 
-        text_embeddings = (
-            unwrap_model(self.language_model)
-            .embedding(input_ids=input_ids_text, position_ids=position_ids_text)
-            .squeeze(1)
+        embedding_layer = unwrap_model(self.language_model).embedding
+        # Combined embeddings are SP-scattered later in PartitionAdapter; a second scatter
+        # here would split the flat text tokens across TP ranks before alignment.
+        if (
+            self.partition_adapter is not None
+            and self.partition_adapter.cfg.seq_parallel
+            and getattr(embedding_layer, 'scatter_to_sequence_parallel', False)
+        ):
+            raise RuntimeError(
+                "MIMO sequence parallelism requires the language embedding scatter to be "
+                "disabled; pass scatter_embedding_sequence_parallel=False when constructing "
+                "the language model."
+            )
+
+        text_embeddings = embedding_layer(
+            input_ids=input_ids_text, position_ids=position_ids_text
+        ).squeeze(
+            1
         )  # Shape: [num_text_tokens, hidden_dim]
         return text_embeddings
 
@@ -382,11 +399,14 @@ class MimoModel(MegatronModule):
                 return self._forward_encoders(input_ids, modality_inputs, input_tensors), loss_mask
 
             if self.role.has_language_module:
-                return (
-                    self._forward_language_module(
-                        input_ids, position_ids, attention_mask, labels, input_tensors
-                    ),
+                return self._forward_language_module(
+                    input_ids,
+                    position_ids,
+                    attention_mask,
                     loss_mask,
+                    labels,
+                    input_tensors,
+                    packing_kwargs,
                 )
 
             raise RuntimeError(f"Rank has no modules assigned in role: {self.role}")
@@ -497,27 +517,85 @@ class MimoModel(MegatronModule):
             requires_grad=True,
         )
 
+    def _build_packed_seq_params(self, packing_kwargs: Optional[dict]) -> Optional[PackedSeqParams]:
+        """Build THD ``PackedSeqParams`` from ``packing_kwargs`` (None if not packing)."""
+        if packing_kwargs is None:
+            return None
+        for key in packing_kwargs:
+            if 'cu_seqlens' in key and packing_kwargs[key] is not None:
+                packing_kwargs[key] = packing_kwargs[key].to(dtype=torch.int32)
+        packed_seq_params = PackedSeqParams(**packing_kwargs)
+        packed_seq_params.qkv_format = 'thd'
+        return packed_seq_params
+
+    def _shard_language_inputs(
+        self,
+        embeddings: Optional[torch.Tensor],
+        labels: Optional[torch.Tensor],
+        loss_mask: Optional[torch.Tensor],
+        packed_seq_params: Optional[PackedSeqParams] = None,
+    ) -> Tuple[
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[PackedSeqParams],
+    ]:
+        """Apply CP/SP sharding via the partition adapter, or pass through if inactive.
+
+        ``embeddings`` are sequence-first ``(S, B, H)`` (``None`` on non-first PP stages)
+        and come back in ``(S/(cp*tp), B, H)``; labels/loss_mask are ``(B, S)``.
+        """
+        if self.partition_adapter is None:
+            return embeddings, labels, loss_mask, packed_seq_params
+
+        return self.partition_adapter.shard(
+            embeddings=embeddings,
+            labels=labels,
+            loss_mask=loss_mask,
+            packed_seq_params=packed_seq_params,
+        )
+
     def _forward_language_module(
         self,
         input_ids: torch.Tensor,
         position_ids: Optional[torch.Tensor],
         attention_mask: Optional[torch.Tensor],
+        loss_mask: Optional[torch.Tensor],
         labels: Optional[torch.Tensor],
         input_tensors: Optional[Dict[str, torch.Tensor]],
-    ) -> torch.Tensor:
+        packing_kwargs: Optional[dict] = None,
+    ) -> Tuple[Any, Optional[torch.Tensor]]:
         """Forward pass for language module on this rank.
 
         Args:
             input_ids: Token IDs
             position_ids: Position IDs
-            attention_mask: Attention mask
+            attention_mask: Attention mask. Must be ``None`` under context parallelism
+                (CP-local hidden states cannot line up with a dense mask); mask via a
+                causal ``attn_mask_type`` or ``packed_seq_params`` instead.
+            loss_mask: Loss mask for per-token loss normalization
             labels: Labels for loss computation
             input_tensors: Hidden states or embeddings from previous stage
+            packing_kwargs: Optional kwargs to construct packed (THD) sequence params.
 
         Returns:
-            Language model output (hidden states, logits, or loss depending on stage)
+            Tuple of (language model output, possibly CP-sharded loss mask). The
+            output is hidden states, logits, or loss depending on the stage.
         """
         lang_name = MIMO_LANGUAGE_MODULE_KEY
+
+        if (
+            self.partition_adapter is not None
+            and self.partition_adapter.cfg.use_cp
+            and attention_mask is not None
+        ):
+            raise RuntimeError(
+                "MIMO context parallelism requires attention_mask=None; mask via a causal "
+                "attn_mask_type or packed_seq_params (a dense mask cannot line up with the "
+                "CP-sharded sequence)."
+            )
+
+        packed_seq_params = self._build_packed_seq_params(packing_kwargs)
 
         if self.role.is_first_stage(lang_name):
             # First stage: receive encoder embeddings, combine with text, pass to LM
@@ -534,11 +612,19 @@ class MimoModel(MegatronModule):
             )
             modality_embeddings["text"] = text_embeddings
 
-            # Combine all embeddings
+            # Combine all embeddings ([S, B, H])
             combined_embeddings = self.align_embeddings_by_token_positions(
                 modality_embeddings=modality_embeddings,
                 input_ids=input_ids,
                 special_token_ids=self.special_token_ids,
+            )
+
+            # Apply CP/SP sharding; combined_embeddings returns in [S/(cp*tp), B, H].
+            combined_embeddings, labels, loss_mask, packed_seq_params = self._shard_language_inputs(
+                embeddings=combined_embeddings,
+                labels=labels,
+                loss_mask=loss_mask,
+                packed_seq_params=packed_seq_params,
             )
 
             lm_output = self.language_model(
@@ -550,9 +636,19 @@ class MimoModel(MegatronModule):
                 decoder_input=combined_embeddings,
                 labels=labels,
                 attention_mask=attention_mask,
+                packed_seq_params=packed_seq_params,
             )
         else:
-            # Non-first stage: receive hidden states from previous LM stage
+            # Non-first stage: receive hidden states from previous LM stage.
+            # Labels/loss_mask still need CP sharding so the loss on the last stage
+            # lines up with the CP-local hidden states.
+            _, labels, loss_mask, packed_seq_params = self._shard_language_inputs(
+                embeddings=None,
+                labels=labels,
+                loss_mask=loss_mask,
+                packed_seq_params=packed_seq_params,
+            )
+
             hidden_states = input_tensors.get(lang_name) if input_tensors else None
 
             # Set input tensor on language model for PP (unwrap DDP to reach GPTModel)
@@ -569,13 +665,14 @@ class MimoModel(MegatronModule):
                 decoder_input=None,
                 labels=labels,
                 attention_mask=attention_mask,
+                packed_seq_params=packed_seq_params,
             )
 
         # Key output for non-last stages so schedule can route to next LM stage
         if not self.role.is_last_stage(lang_name):
-            return {lang_name: lm_output}
+            return {lang_name: lm_output}, loss_mask
 
-        return lm_output
+        return lm_output, loss_mask
 
     def _build_colocated_communicators(self):
         grid_map = self.mimo_config.module_to_grid_map
@@ -632,16 +729,7 @@ class MimoModel(MegatronModule):
 
         This is the original behavior, preserved for backward compatibility.
         """
-        # If packing_kwargs is provided, construct PackedSeqParams
-        packed_seq_params = None
-        if packing_kwargs is not None:
-            # Ensure correct dtype for seqlens tensors
-            for key in packing_kwargs:
-                if 'cu_seqlens' in key and packing_kwargs[key] is not None:
-                    packing_kwargs[key] = packing_kwargs[key].to(dtype=torch.int32)
-            packed_seq_params = PackedSeqParams(**packing_kwargs)
-            packed_seq_params.qkv_format = 'thd'
-            logger.debug(f"Packed sequence parameters: {packed_seq_params}")
+        packed_seq_params = self._build_packed_seq_params(packing_kwargs)
 
         # 1. Process each modality to get embeddings
         modality_embeddings = {}
@@ -679,25 +767,14 @@ class MimoModel(MegatronModule):
         )
         logger.debug(f"Combined embeddings shape: {combined_embeddings.shape}")
 
-        # 3. If sharding is needed, apply PartitionAdapter.
-        # combined_embeddings is [S, B, H]; transpose to [B, S, H] for shard() which expects
-        # batch-first layout (required by get_batch_on_this_cp_rank). After CP sharding each
-        # rank holds [B, S/cp, H]; transpose back to [S/cp, B, H] for the language model.
-        if self.partition_adapter is not None:
-            combined_embeddings = combined_embeddings.transpose(0, 1).contiguous()  # [B, S, H]
-            combined_embeddings, labels, loss_mask, _, packed_seq_params = (
-                self.partition_adapter.shard(
-                    embeddings=combined_embeddings,
-                    labels=labels,
-                    loss_mask=loss_mask,
-                    attention_mask=attention_mask,
-                    packed_seq_params=packed_seq_params,
-                )
-            )
-            # shard() returns embeddings in [B, S/cp, H]; transpose to [S/cp, B, H]
-            # which is what the language model expects.
-            if combined_embeddings is not None:
-                combined_embeddings = combined_embeddings.transpose(0, 1).contiguous()
+        # 3. Apply CP/SP sharding. combined_embeddings is [S, B, H] and returns
+        # [S/(cp*tp), B, H] for the LM (the adapter handles the CP batch-first transpose).
+        combined_embeddings, labels, loss_mask, packed_seq_params = self._shard_language_inputs(
+            embeddings=combined_embeddings,
+            labels=labels,
+            loss_mask=loss_mask,
+            packed_seq_params=packed_seq_params,
+        )
 
         # 5. Forward pass through language model
         lm_output = self.language_model(

--- a/megatron/core/models/mimo/partition/utils.py
+++ b/megatron/core/models/mimo/partition/utils.py
@@ -50,11 +50,6 @@ class PartitionConfig:
     cp_group: Optional[ProcessGroup] = None
     tp_group: Optional[ProcessGroup] = None
 
-    @property
-    def is_partitioning_enabled(self) -> bool:
-        """Returns True if context parallelism or sequence parallelism is active."""
-        return self.use_cp or self.seq_parallel
-
     @classmethod
     def from_mp_config(
         cls,
@@ -89,7 +84,7 @@ class PartitionConfig:
 
 
 class PartitionAdapter:
-    """Shard batch-first embeddings & label tensors for Context and Sequence Parallelism."""
+    """Shard MIMO sequence inputs (CP/SP) and return language-model-ready embeddings."""
 
     def __init__(self, cfg: PartitionConfig):
         """Initialize the partition adapter.
@@ -100,97 +95,83 @@ class PartitionAdapter:
 
     def shard(
         self,
-        embeddings: torch.Tensor,
-        labels: torch.Tensor,
-        loss_mask: torch.Tensor,
-        attention_mask: torch.Tensor,
+        embeddings: Optional[torch.Tensor],
+        labels: Optional[torch.Tensor],
+        loss_mask: Optional[torch.Tensor],
         packed_seq_params: Optional[PackedSeqParams] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, Optional[PackedSeqParams]]:
+    ) -> Tuple[
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[PackedSeqParams],
+    ]:
+        """Apply context- (CP) and sequence-parallel (SP) sharding along the sequence.
+
+        Inputs:
+            - embeddings: sequence-first ``(S, B, H)``, or ``None`` on non-first PP stages.
+            - labels / loss_mask: batch-first ``(B, S)``.
+
+        Returns ``(embeddings, labels, loss_mask, packed_seq_params)`` with embeddings in
+        ``(S/(cp*tp), B, H)`` language-model layout. CP shards every tensor along the
+        sequence; SP additionally scatters only the embeddings -- labels/loss_mask are not
+        SP-scattered because the loss runs after the TP all-gather on the full CP-local
+        sequence. A dense ``[B, S]`` attention mask is intentionally not handled: under CP
+        it cannot line up with the sharded sequence, so MIMO masks via a causal
+        ``attn_mask_type`` or ``packed_seq_params`` (THD) instead.
         """
-        Apply context parallel (CP) and sequence parallel (SP) sharding to input tensors.
-
-        All input tensors must be in batch-first layout:
-            - embeddings: (B, S, H)
-            - labels / loss_mask / attention_mask: (B, S)
-
-        After this call embeddings are still in (B, S/cp, H) batch-first layout.
-        The caller is responsible for transposing to (S/cp, B, H) if the language model
-        requires sequence-first tensors.
-
-        Args:
-            embeddings (torch.Tensor):
-                Input embeddings tensor. Shape: (B, S, H)
-            labels (torch.Tensor):
-                Labels tensor. Shape: (B, S)
-            loss_mask (torch.Tensor):
-                Loss mask tensor. Shape: (B, S)
-            attention_mask (torch.Tensor):
-                Attention mask tensor. Shape: (B, S)
-            packed_seq_params (PackedSeqParams, optional):
-                Packed sequence parameters. Defaults to None.
-
-        Returns:
-            Tuple containing:
-                - embeddings (torch.Tensor): Sharded embeddings. Shape: (B, S/cp, H)
-                - labels (torch.Tensor): Possibly sharded labels. Shape: (B, S/cp)
-                - loss_mask (torch.Tensor): Possibly sharded loss mask. Shape: (B, S/cp)
-                - attention_mask (torch.Tensor): Possibly sharded attention mask. Shape: (B, S/cp)
-                - packed_seq_params (PackedSeqParams, optional): Updated packed sequence parameters.
-        """
-        if not (self.cfg.use_cp or self.cfg.seq_parallel):
-            return embeddings, labels, loss_mask, attention_mask, packed_seq_params
-
-        # Sanity-check the sequence length before any sharding happens.
+        # Sanity-check the sequence length before sharding. Embeddings are sequence-first,
+        # so the token sequence is dim 0.
         if embeddings is not None:
             shard_factor = None
-            seq_dim = None  # which dimension holds the token sequence
 
             if self.cfg.use_cp and self.cfg.seq_parallel:
                 shard_factor = get_pg_size(self.cfg.tp_group) * get_pg_size(self.cfg.cp_group) * 2
-                seq_dim = 1  # embeddings shape: [B, S, H]
             elif self.cfg.use_cp:
                 shard_factor = get_pg_size(self.cfg.cp_group) * 2
-                seq_dim = 1
             elif self.cfg.seq_parallel:
                 shard_factor = get_pg_size(self.cfg.tp_group)
-                seq_dim = 0  # embeddings shape: [S, B, H]
 
             if shard_factor is not None and (
                 packed_seq_params is None
                 or getattr(packed_seq_params, 'qkv_format', 'sbhd') == 'sbhd'
             ):
-                assert embeddings.shape[seq_dim] % shard_factor == 0, (
+                assert embeddings.shape[0] % shard_factor == 0, (
                     f"Sequence length should be divisible by {shard_factor} "
                     "for Sequence/Context parallelism"
                 )
 
                 if self.cfg.seq_parallel and self.cfg.tp_comm_overlap:
-                    assert embeddings.shape[seq_dim] == self.cfg.max_seq_len, (
+                    assert embeddings.shape[0] == self.cfg.max_seq_len, (
                         "TP Comm overlap requires Vision+Text token length "
                         "== language_max_sequence_length"
                     )
 
         if self.cfg.use_cp:
-            embeddings, labels, loss_mask, attention_mask, packed_seq_params = (
-                self._apply_context_parallel(
-                    embeddings, labels, loss_mask, attention_mask, packed_seq_params
-                )
+            # CP shards batch-first (get_batch_on_this_cp_rank requirement): transpose
+            # (S, B, H) -> (B, S, H) in, then the CP-local result back to (S/cp, B, H).
+            if embeddings is not None:
+                embeddings = embeddings.transpose(0, 1).contiguous()
+            embeddings, labels, loss_mask, packed_seq_params = self._apply_context_parallel(
+                embeddings, labels, loss_mask, packed_seq_params
+            )
+            if embeddings is not None:
+                embeddings = embeddings.transpose(0, 1).contiguous()
+
+        # SP scatters the sequence (dim 0); the SP-only path needs no transpose.
+        if self.cfg.seq_parallel and embeddings is not None:
+            embeddings = tensor_parallel.scatter_to_sequence_parallel_region(
+                embeddings, group=self.cfg.tp_group
             )
 
-        if self.cfg.seq_parallel and embeddings is not None:
-            embeddings = tensor_parallel.scatter_to_sequence_parallel_region(embeddings)
-
-        return embeddings, labels, loss_mask, attention_mask, packed_seq_params
+        return embeddings, labels, loss_mask, packed_seq_params
 
     def _apply_context_parallel(
         self,
         embeddings: Optional[torch.Tensor],
         labels: Optional[torch.Tensor],
         loss_mask: Optional[torch.Tensor],
-        attention_mask: Optional[torch.Tensor],
         packed_seq_params: Optional[PackedSeqParams],
     ) -> Tuple[
-        Optional[torch.Tensor],
         Optional[torch.Tensor],
         Optional[torch.Tensor],
         Optional[torch.Tensor],
@@ -206,8 +187,6 @@ class PartitionAdapter:
                 Labels tensor. Shape: (B, S)
             loss_mask (Optional[torch.Tensor]):
                 Loss mask tensor. Shape: (B, S)
-            attention_mask (Optional[torch.Tensor]):
-                Attention mask tensor. Shape: (B, S)
             packed_seq_params (PackedSeqParams, optional):
                 Packed sequence parameters. Defaults to None.
 
@@ -216,12 +195,10 @@ class PartitionAdapter:
                 - embeddings (Optional[torch.Tensor]): Sharded embeddings. Shape: (B, S/cp, H)
                 - labels (Optional[torch.Tensor]): Possibly sharded labels. Shape: (B, S/cp)
                 - loss_mask (Optional[torch.Tensor]): Possibly sharded loss mask. Shape: (B, S/cp)
-                - attention_mask (Optional[torch.Tensor]): Possibly sharded attention mask.
-                                                           Shape: (B, S/cp)
                 - packed_seq_params (PackedSeqParams, optional): Updated packed sequence parameters.
         """
         if not self.cfg.use_cp:
-            return embeddings, labels, loss_mask, attention_mask, packed_seq_params
+            return embeddings, labels, loss_mask, packed_seq_params
 
         # Distribute sequence across CP ranks
         batch = dict()
@@ -231,8 +208,6 @@ class PartitionAdapter:
             batch["labels"] = labels
         if loss_mask is not None:
             batch["loss_mask"] = loss_mask
-        if attention_mask is not None:
-            batch["attention_mask"] = attention_mask
 
         if packed_seq_params is None or getattr(packed_seq_params, 'qkv_format', 'sbhd') == 'sbhd':
             batch = get_batch_on_this_cp_rank(batch, is_hybrid_cp=False, cp_group=self.cfg.cp_group)
@@ -250,11 +225,10 @@ class PartitionAdapter:
                 )
                 batch[key] = data.index_select(1, index)
 
-        # Extract sharded tensors; embeddings remain in [B, S/cp, H] — the caller
-        # is responsible for transposing to [S/cp, B, H] for the language model.
+        # Extract sharded tensors; embeddings stay in [B, S/cp, H]. shard() transposes
+        # them to language-model layout [S/cp, B, H] after CP and before optional SP.
         embeddings = batch.get("embeddings", None)
         labels = batch.get("labels", None)
         loss_mask = batch.get("loss_mask", None)
-        attention_mask = batch.get("attention_mask", None)
 
-        return embeddings, labels, loss_mask, attention_mask, packed_seq_params
+        return embeddings, labels, loss_mask, packed_seq_params

--- a/tests/unit_tests/models/mimo/test_mimo_model.py
+++ b/tests/unit_tests/models/mimo/test_mimo_model.py
@@ -449,17 +449,25 @@ class TestMimoModel:
         assert packed_seq_params.cu_seqlens_kv.dtype == torch.int32
 
     def test_forward_with_partition_adapter(self):
-        """Test that partition_adapter.shard() is called and embeddings are transposed correctly."""
+        """shard() receives sequence-first embeddings and returns LM-layout [S/cp, B, H].
+
+        The caller no longer transposes around shard(): it passes the sequence-first
+        ``(S, B, H)`` combined embeddings straight in, and shard()'s LM-layout output
+        flows straight into the language model as ``decoder_input``.
+        """
         mimo_model = self._make_vlm()
         input_ids = self._make_input_ids()
         position_ids = self._make_position_ids()
+        loss_mask = torch.ones(self.batch_size, self.seq_len, device=self.device)
 
         sharded_seq_len = self.seq_len // 2
+        # shard() returns LM-layout [S/cp, B, H] and a (CP-sharded) loss mask.
         sharded_emb = torch.zeros(
-            self.batch_size, sharded_seq_len, self.hidden_size, device=self.device
+            sharded_seq_len, self.batch_size, self.hidden_size, device=self.device
         )
+        sharded_loss_mask = torch.ones(self.batch_size, sharded_seq_len, device=self.device)
         mock_adapter = MagicMock()
-        mock_adapter.shard.return_value = (sharded_emb, None, None, None, None)
+        mock_adapter.shard.return_value = (sharded_emb, None, sharded_loss_mask, None)
         mimo_model.partition_adapter = mock_adapter
 
         text_emb = torch.zeros(self.batch_size * self.seq_len, self.hidden_size, device=self.device)
@@ -482,16 +490,88 @@ class TestMimoModel:
             ),
             patch.object(mimo_model.language_model, 'forward', side_effect=capture_lm_forward),
         ):
-            mimo_model(input_ids=input_ids, position_ids=position_ids, modality_inputs=None)
+            _, out_loss_mask = mimo_model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                loss_mask=loss_mask,
+                modality_inputs=None,
+            )
 
         mock_adapter.shard.assert_called_once()
         shard_kwargs = mock_adapter.shard.call_args[1]
-        assert shard_kwargs['embeddings'].shape == (self.batch_size, self.seq_len, self.hidden_size)
+        # The helper passes sequence-first [S, B, H] embeddings straight to shard().
+        assert shard_kwargs['embeddings'].shape == (self.seq_len, self.batch_size, self.hidden_size)
+        assert shard_kwargs['loss_mask'] is loss_mask
+        # shard()'s LM-layout output flows straight into the LM (no extra transpose).
         assert captured['decoder_input'].shape == (
             sharded_seq_len,
             self.batch_size,
             self.hidden_size,
         )
+        # forward() returns the (possibly sharded) loss mask from shard().
+        assert out_loss_mask is sharded_loss_mask
+
+    def test_get_text_embeddings_raises_when_sp_and_embedding_scatter_enabled(self):
+        """SP must not double-scatter: if the LM embedding still scatters, raise.
+
+        With sequence parallelism active, PartitionAdapter scatters the combined
+        embeddings. If the language embedding also scattered, the flat text tokens
+        would be split across TP ranks before alignment. ``get_text_embeddings``
+        must reject that configuration.
+        """
+        mimo_model = self._make_vlm()
+        input_ids = self._make_input_ids()
+        position_ids = self._make_position_ids()
+
+        sp_adapter = MagicMock()
+        sp_adapter.cfg.seq_parallel = True
+        mimo_model.partition_adapter = sp_adapter
+        # Embedding layer reports it would scatter for sequence parallelism.
+        mimo_model.language_model.embedding.scatter_to_sequence_parallel = True
+
+        with pytest.raises(RuntimeError, match="embedding scatter to be disabled"):
+            mimo_model.get_text_embeddings(input_ids, position_ids, self.special_token_ids)
+
+    def test_get_text_embeddings_ok_when_sp_and_embedding_scatter_disabled(self):
+        """SP with embedding scatter disabled is the supported configuration."""
+        mimo_model = self._make_vlm()
+        input_ids = self._make_input_ids()
+        position_ids = self._make_position_ids()
+
+        sp_adapter = MagicMock()
+        sp_adapter.cfg.seq_parallel = True
+        mimo_model.partition_adapter = sp_adapter
+        mimo_model.language_model.embedding.scatter_to_sequence_parallel = False
+
+        text_embeddings = mimo_model.get_text_embeddings(
+            input_ids, position_ids, self.special_token_ids
+        )
+        assert text_embeddings.shape == (self.batch_size * self.seq_len, self.hidden_size)
+
+    def test_forward_language_module_rejects_attention_mask_under_cp(self):
+        """A dense attention_mask is rejected under context parallelism.
+
+        Under CP the hidden states are CP-local, so a dense [B, S] mask cannot line up
+        with the sharded sequence; _forward_language_module must fail fast.
+        """
+        mimo_model = self._make_vlm()
+        input_ids = self._make_input_ids()
+        position_ids = self._make_position_ids()
+        attention_mask = torch.ones(self.batch_size, self.seq_len, device=self.device)
+
+        cp_adapter = MagicMock()
+        cp_adapter.cfg.use_cp = True
+        mimo_model.partition_adapter = cp_adapter
+
+        with pytest.raises(RuntimeError, match="context parallelism requires attention_mask=None"):
+            mimo_model._forward_language_module(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                loss_mask=None,
+                labels=None,
+                input_tensors=None,
+            )
 
 
 class MockProcessGroup:
@@ -714,10 +794,11 @@ class TestMimoModelNonColocated:
             patch.object(model.role, 'is_last_stage', return_value=True),
             patch.object(model.language_model, 'forward', side_effect=capture_lm_forward),
         ):
-            model._forward_language_module(
+            lm_output, _ = model._forward_language_module(
                 input_ids=input_ids,
                 position_ids=position_ids,
                 attention_mask=None,
+                loss_mask=None,
                 labels=None,
                 input_tensors={MIMO_LANGUAGE_MODULE_KEY: hidden_states},
             )

--- a/tests/unit_tests/models/mimo/test_mimo_partition.py
+++ b/tests/unit_tests/models/mimo/test_mimo_partition.py
@@ -6,42 +6,21 @@ WORLD_SIZE=1 LOCAL_RANK=0 python -m torch.distributed.run \
     tests/unit_tests/models/mimo/test_mimo_partition.py -v
 '''
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
 
+from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.models.mimo.partition.utils import PartitionAdapter, PartitionConfig
 from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
 
 
 @pytest.mark.experimental
 class TestPartitionConfig:
     """Tests for PartitionConfig dataclass and factory method."""
-
-    def test_is_partitioning_enabled_cp_only(self):
-        cfg = PartitionConfig(
-            seq_parallel=False, use_cp=True, tp_comm_overlap=False, max_seq_len=128
-        )
-        assert cfg.is_partitioning_enabled is True
-
-    def test_is_partitioning_enabled_sp_only(self):
-        cfg = PartitionConfig(
-            seq_parallel=True, use_cp=False, tp_comm_overlap=False, max_seq_len=128
-        )
-        assert cfg.is_partitioning_enabled is True
-
-    def test_is_partitioning_enabled_both(self):
-        cfg = PartitionConfig(
-            seq_parallel=True, use_cp=True, tp_comm_overlap=False, max_seq_len=128
-        )
-        assert cfg.is_partitioning_enabled is True
-
-    def test_is_partitioning_enabled_neither(self):
-        cfg = PartitionConfig(
-            seq_parallel=False, use_cp=False, tp_comm_overlap=False, max_seq_len=128
-        )
-        assert cfg.is_partitioning_enabled is False
 
     def test_from_mp_config_invalid_type_raises(self):
         with pytest.raises(TypeError, match="mp must be a ModelParallelConfig instance"):
@@ -151,117 +130,40 @@ class TestPartitionAdapterShard:
         )
 
     def _make_tensors(self, B=2, S=8, H=16):
-        embeddings = torch.rand(B, S, H)
+        # Embeddings are sequence-first (S, B, H); labels/loss_mask are (B, S).
+        embeddings = torch.rand(S, B, H)
         labels = torch.randint(0, 100, (B, S))
         loss_mask = torch.ones(B, S)
-        attention_mask = torch.ones(B, S)
-        return embeddings, labels, loss_mask, attention_mask
+        return embeddings, labels, loss_mask
 
     def test_noop_when_both_disabled(self):
-        """No sharding when neither CP nor SP is enabled — inputs returned as-is."""
+        """With neither CP nor SP active, shard() is a pure passthrough.
+
+        Production never constructs a PartitionAdapter unless CP or SP is enabled.
+        Embeddings are already sequence-first (S, B, H), so with no collectives the
+        inputs are returned untouched (no transpose, no sharding).
+        """
         cfg = self._make_cfg(use_cp=False, seq_parallel=False)
         adapter = PartitionAdapter(cfg)
-        embeddings, labels, loss_mask, attention_mask = self._make_tensors()
-        out = adapter.shard(embeddings, labels, loss_mask, attention_mask)
+        embeddings, labels, loss_mask = self._make_tensors(B=2, S=8, H=16)
+        out = adapter.shard(embeddings, labels, loss_mask)
         assert out[0] is embeddings
         assert out[1] is labels
         assert out[2] is loss_mask
-        assert out[3] is attention_mask
-        assert out[4] is None
-
-    def test_cp_only_shards_sequence(self):
-        mock_cp_group = MagicMock()
-        cfg = self._make_cfg(use_cp=True, max_seq_len=8, cp_group=mock_cp_group)
-        adapter = PartitionAdapter(cfg)
-        embeddings, labels, loss_mask, attention_mask = self._make_tensors(B=2, S=8, H=16)
-        sharded = {
-            'embeddings': embeddings[:, :4, :],
-            'labels': labels[:, :4],
-            'loss_mask': loss_mask[:, :4],
-            'attention_mask': attention_mask[:, :4],
-        }
-        with (
-            patch('megatron.core.models.mimo.partition.utils.get_pg_size', return_value=2),
-            patch(
-                'megatron.core.models.mimo.partition.utils.get_batch_on_this_cp_rank',
-                return_value=sharded,
-            ),
-        ):
-            out = adapter.shard(embeddings, labels, loss_mask, attention_mask)
-        assert out[0].shape == (2, 4, 16)
-        assert out[1].shape == (2, 4)
-
-    def test_sp_only_scatters(self):
-        mock_tp_group = MagicMock()
-        cfg = self._make_cfg(seq_parallel=True, max_seq_len=8, tp_group=mock_tp_group)
-        adapter = PartitionAdapter(cfg)
-        # SP uses seq_dim=0: embeddings shape [S, B, H]
-        embeddings = torch.rand(8, 2, 16)
-        labels = torch.randint(0, 100, (2, 8))
-        loss_mask = torch.ones(2, 8)
-        attention_mask = torch.ones(2, 8)
-        scattered = torch.rand(4, 2, 16)
-        with (
-            patch('megatron.core.models.mimo.partition.utils.get_pg_size', return_value=2),
-            patch(
-                'megatron.core.models.mimo.partition.utils.tensor_parallel.scatter_to_sequence_parallel_region',
-                return_value=scattered,
-            ),
-        ):
-            out = adapter.shard(embeddings, labels, loss_mask, attention_mask)
-        assert out[0].shape == (4, 2, 16)
-
-    def test_cp_and_sp_combined(self):
-        mock_cp_group = MagicMock()
-        mock_tp_group = MagicMock()
-        cfg = self._make_cfg(
-            use_cp=True,
-            seq_parallel=True,
-            max_seq_len=16,
-            cp_group=mock_cp_group,
-            tp_group=mock_tp_group,
-        )
-        adapter = PartitionAdapter(cfg)
-        # cp_size=2, tp_size=2 → shard_factor = 2*2*2 = 8; S=16 is divisible
-        embeddings = torch.rand(2, 16, 16)
-        labels = torch.randint(0, 100, (2, 16))
-        loss_mask = torch.ones(2, 16)
-        attention_mask = torch.ones(2, 16)
-        cp_sharded = {
-            'embeddings': embeddings[:, :8, :],
-            'labels': labels[:, :8],
-            'loss_mask': loss_mask[:, :8],
-            'attention_mask': attention_mask[:, :8],
-        }
-        scattered = torch.rand(2, 4, 16)
-
-        with (
-            patch('megatron.core.models.mimo.partition.utils.get_pg_size', return_value=2),
-            patch(
-                'megatron.core.models.mimo.partition.utils.get_batch_on_this_cp_rank',
-                return_value=cp_sharded,
-            ),
-            patch(
-                'megatron.core.models.mimo.partition.utils.tensor_parallel.scatter_to_sequence_parallel_region',
-                return_value=scattered,
-            ),
-        ):
-            out = adapter.shard(embeddings, labels, loss_mask, attention_mask)
-        assert out[0].shape == (2, 4, 16)
+        assert out[3] is None
 
     def test_seq_not_divisible_raises(self):
         mock_cp_group = MagicMock()
         cfg = self._make_cfg(use_cp=True, max_seq_len=7, cp_group=mock_cp_group)
         adapter = PartitionAdapter(cfg)
-        embeddings = torch.rand(2, 7, 16)  # 7 % (2*2) != 0
+        embeddings = torch.rand(7, 2, 16)  # seq-first [S, B, H]; 7 % (2*2) != 0
         labels = torch.randint(0, 100, (2, 7))
         loss_mask = torch.ones(2, 7)
-        attention_mask = torch.ones(2, 7)
         with (
             patch('megatron.core.models.mimo.partition.utils.get_pg_size', return_value=2),
             pytest.raises(AssertionError, match="divisible"),
         ):
-            adapter.shard(embeddings, labels, loss_mask, attention_mask)
+            adapter.shard(embeddings, labels, loss_mask)
 
     def test_tp_comm_overlap_seq_len_assertion(self):
         mock_tp_group = MagicMock()
@@ -269,16 +171,15 @@ class TestPartitionAdapterShard:
             seq_parallel=True, tp_comm_overlap=True, max_seq_len=16, tp_group=mock_tp_group
         )
         adapter = PartitionAdapter(cfg)
-        # S=8 but max_seq_len=16 → assertion fires
-        embeddings = torch.rand(8, 2, 16)  # [S, B, H] for SP
+        # S=8 (seq-first [S, B, H]) but max_seq_len=16 → assertion fires
+        embeddings = torch.rand(8, 2, 16)
         labels = torch.randint(0, 100, (2, 8))
         loss_mask = torch.ones(2, 8)
-        attention_mask = torch.ones(2, 8)
         with (
             patch('megatron.core.models.mimo.partition.utils.get_pg_size', return_value=2),
             pytest.raises(AssertionError, match="TP Comm overlap"),
         ):
-            adapter.shard(embeddings, labels, loss_mask, attention_mask)
+            adapter.shard(embeddings, labels, loss_mask)
 
     def test_thd_format_skips_divisibility_check(self):
         """PackedSeqParams with qkv_format='thd' bypasses the divisibility assertion."""
@@ -287,10 +188,9 @@ class TestPartitionAdapterShard:
         mock_cp_group = MagicMock()
         cfg = self._make_cfg(use_cp=True, max_seq_len=7, cp_group=mock_cp_group)
         adapter = PartitionAdapter(cfg)
-        embeddings = torch.rand(2, 7, 16)  # seq_len=7 not divisible by cp*2, but THD skips check
+        embeddings = torch.rand(7, 2, 16)  # seq-first; len=7 not divisible by cp*2, THD skips check
         labels = torch.randint(0, 100, (2, 7))
         loss_mask = torch.ones(2, 7)
-        attention_mask = torch.ones(2, 7)
         packed_seq_params = MagicMock(spec=PackedSeqParams)
         packed_seq_params.qkv_format = 'thd'
         packed_seq_params.cu_seqlens_q_padded = torch.tensor([0, 4, 7], dtype=torch.int32)
@@ -304,22 +204,17 @@ class TestPartitionAdapterShard:
         ):
             mock_tex.thd_get_partitioned_indices.return_value = fake_index
             # Should NOT raise AssertionError about divisibility
-            out = adapter.shard(embeddings, labels, loss_mask, attention_mask, packed_seq_params)
+            out = adapter.shard(embeddings, labels, loss_mask, packed_seq_params)
         assert out[0] is not None
 
     def test_none_embeddings_skips_shard_factor_check(self):
-        """When embeddings is None, the divisibility check is skipped."""
+        """When embeddings is None, the divisibility check is skipped (non-first PP stage)."""
         mock_cp_group = MagicMock()
         cfg = self._make_cfg(use_cp=True, max_seq_len=7, cp_group=mock_cp_group)
         adapter = PartitionAdapter(cfg)
         labels = torch.randint(0, 100, (2, 7))
         loss_mask = torch.ones(2, 7)
-        attention_mask = torch.ones(2, 7)
-        cp_sharded = {
-            'labels': labels[:, :4],
-            'loss_mask': loss_mask[:, :4],
-            'attention_mask': attention_mask[:, :4],
-        }
+        cp_sharded = {'labels': labels[:, :4], 'loss_mask': loss_mask[:, :4]}
         with (
             patch('megatron.core.models.mimo.partition.utils.get_pg_size', return_value=2),
             patch(
@@ -327,8 +222,10 @@ class TestPartitionAdapterShard:
                 return_value=cp_sharded,
             ),
         ):
-            out = adapter.shard(None, labels, loss_mask, attention_mask)
+            out = adapter.shard(None, labels, loss_mask)
         assert out[0] is None
+        assert out[1].shape == (2, 4)
+        assert out[2].shape == (2, 4)
 
 
 @pytest.mark.experimental
@@ -350,12 +247,11 @@ class TestPartitionAdapterApplyContextParallel:
         embeddings = torch.rand(2, 8, 16)
         labels = torch.randint(0, 100, (2, 8))
         loss_mask = torch.ones(2, 8)
-        attention_mask = torch.ones(2, 8)
-        out = adapter._apply_context_parallel(embeddings, labels, loss_mask, attention_mask, None)
+        out = adapter._apply_context_parallel(embeddings, labels, loss_mask, None)
         assert out[0] is embeddings
         assert out[1] is labels
         assert out[2] is loss_mask
-        assert out[3] is attention_mask
+        assert out[3] is None
 
     def test_sbhd_path_calls_get_batch_on_this_cp_rank(self):
         mock_cp_group = MagicMock()
@@ -364,21 +260,18 @@ class TestPartitionAdapterApplyContextParallel:
         embeddings = torch.rand(2, 8, 16)
         labels = torch.randint(0, 100, (2, 8))
         loss_mask = torch.ones(2, 8)
-        attention_mask = torch.ones(2, 8)
         sharded = {
             'embeddings': embeddings[:, :4, :],
             'labels': labels[:, :4],
             'loss_mask': loss_mask[:, :4],
-            'attention_mask': attention_mask[:, :4],
         }
         with patch(
             'megatron.core.models.mimo.partition.utils.get_batch_on_this_cp_rank',
             return_value=sharded,
         ) as mock_fn:
-            out = adapter._apply_context_parallel(
-                embeddings, labels, loss_mask, attention_mask, None
-            )
+            out = adapter._apply_context_parallel(embeddings, labels, loss_mask, None)
             mock_fn.assert_called_once()
+        # _apply_context_parallel keeps batch-first [B, S/cp, H]; shard() transposes later.
         assert out[0].shape == (2, 4, 16)
         assert out[1].shape == (2, 4)
 
@@ -389,8 +282,8 @@ class TestPartitionAdapterApplyContextParallel:
         with patch(
             'megatron.core.models.mimo.partition.utils.get_batch_on_this_cp_rank', return_value={}
         ):
-            out = adapter._apply_context_parallel(None, None, None, None, None)
-        assert all(v is None for v in out[:4])
+            out = adapter._apply_context_parallel(None, None, None, None)
+        assert all(v is None for v in out[:3])
 
     def test_only_non_none_tensors_added_to_batch(self):
         """None tensors must not appear in the batch dict passed to get_batch_on_this_cp_rank."""
@@ -409,7 +302,7 @@ class TestPartitionAdapterApplyContextParallel:
             'megatron.core.models.mimo.partition.utils.get_batch_on_this_cp_rank',
             side_effect=mock_fn,
         ):
-            out = adapter._apply_context_parallel(embeddings, None, None, None, None)
+            out = adapter._apply_context_parallel(embeddings, None, None, None)
 
         assert 'embeddings' in captured
         assert 'labels' not in captured
@@ -431,4 +324,189 @@ class TestPartitionAdapterApplyContextParallel:
             patch('megatron.core.models.mimo.partition.utils._HAVE_TEX', False),
             pytest.raises(AssertionError, match="Transformer Engine"),
         ):
-            adapter._apply_context_parallel(embeddings, None, None, None, packed_seq_params)
+            adapter._apply_context_parallel(embeddings, None, None, packed_seq_params)
+
+
+def _expected_cp_zigzag_shard(tensor: torch.Tensor, cp_size: int, cp_rank: int) -> torch.Tensor:
+    """Reconstruct the CP zigzag shard of ``tensor`` along the sequence dim (dim 1).
+
+    Mirrors ``get_pretrain_batch_on_this_cp_rank``: the sequence is split into
+    ``2 * cp_size`` equal chunks and rank ``r`` keeps chunks ``r`` and
+    ``2*cp_size - r - 1`` (concatenated in that order). Implemented independently
+    here so the real-distributed assertions do not lean on the production helper.
+    """
+    if cp_size == 1:
+        return tensor
+    chunks = list(torch.chunk(tensor, 2 * cp_size, dim=1))
+    return torch.cat([chunks[cp_rank], chunks[2 * cp_size - cp_rank - 1]], dim=1)
+
+
+@pytest.mark.experimental
+@pytest.mark.skipif(
+    int(os.environ.get('WORLD_SIZE', '1')) != 8,
+    reason="Real MIMO CP/SP sharding tests require an 8-GPU world",
+)
+class TestPartitionAdapterShardRealDistributed:
+    """Real 8-GPU tests for ``PartitionAdapter.shard()``.
+
+    These exercise the genuine collectives (CP zigzag chunking via
+    ``get_batch_on_this_cp_rank`` and the SP scatter via
+    ``scatter_to_sequence_parallel_region``) against process groups built from a
+    real ``HyperCommGrid``. They assert the actual per-rank output shapes *and*
+    content rather than that a mock was invoked.
+
+    Run with::
+
+        WORLD_SIZE=8 python -m torch.distributed.run --nproc-per-node 8 -m pytest \
+            tests/unit_tests/models/mimo/test_mimo_partition.py -m experimental \
+            --experimental -k RealDistributed
+    """
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @staticmethod
+    def _build_grid(tp_size, cp_size):
+        """Build a real HyperCommGrid spanning all 8 ranks (remainder folded into dp)."""
+        Utils.initialize_distributed()
+        world_size = torch.distributed.get_world_size()
+        assert world_size == 8, f"expected an 8-GPU world, got {world_size}"
+        dp_size = world_size // (tp_size * cp_size)
+        # Order tp-cp-...-dp so tp is the fastest-varying (contiguous SP shards).
+        grid = HyperCommGrid([tp_size, cp_size, 1, 1, dp_size], ["tp", "cp", "ep", "pp", "dp"])
+        return grid
+
+    @staticmethod
+    def _make_inputs(B, S, H):
+        """Deterministic, rank-identical inputs so every rank shards the same tensor.
+
+        Embeddings are sequence-first ``(S, B, H)`` and encode their (sequence, hidden)
+        coordinates so a shard's content can be checked positionally; labels/loss_mask
+        are ``(B, S)`` and encode the absolute sequence index.
+        """
+        torch.manual_seed(1234)
+        seq = torch.arange(S, dtype=torch.float32)
+        hid = torch.arange(H, dtype=torch.float32)
+        # [S, B, H] where entry [s, b, h] = s * 1000 + h + b (unique per position).
+        embeddings = (
+            seq.view(S, 1, 1) * 1000.0
+            + hid.view(1, 1, H)
+            + torch.arange(B, dtype=torch.float32).view(1, B, 1)
+        ).cuda()
+        labels = torch.arange(S, dtype=torch.long).view(1, S).expand(B, S).contiguous().cuda()
+        loss_mask = torch.arange(S, dtype=torch.float32).view(1, S).expand(B, S).contiguous().cuda()
+        return embeddings, labels, loss_mask
+
+    def test_sp_only_scatters_sequence_real(self):
+        """SP-only: [S, B, H] -> [S/tp, B, H], contiguous sequence shard on this TP rank."""
+        tp_size, cp_size = 8, 1
+        B, S, H = 2, 64, 16
+        grid = self._build_grid(tp_size, cp_size)
+        tp_group = grid.create_pg("tp")
+
+        cfg = PartitionConfig(
+            use_cp=False,
+            seq_parallel=True,
+            tp_comm_overlap=False,
+            max_seq_len=S,
+            cp_group=None,
+            tp_group=tp_group,
+        )
+        adapter = PartitionAdapter(cfg)
+        embeddings, labels, loss_mask = self._make_inputs(B, S, H)
+
+        out_emb, out_labels, out_loss_mask, _ = adapter.shard(
+            embeddings.clone(), labels.clone(), loss_mask.clone()
+        )
+
+        tp_rank = tp_group.rank()
+        shard = S // tp_size
+        # SP scatter is a contiguous split along the sequence dim 0; no transpose for SP-only.
+        assert out_emb.shape == (shard, B, H)
+        expected = embeddings[tp_rank * shard : (tp_rank + 1) * shard]
+        torch.testing.assert_close(out_emb, expected.contiguous())
+        # Labels / loss_mask are NOT SP-scattered: full sequence comes back unchanged.
+        assert out_labels.shape == (B, S)
+        torch.testing.assert_close(out_labels, labels)
+        assert out_loss_mask.shape == (B, S)
+        torch.testing.assert_close(out_loss_mask, loss_mask)
+
+    def test_cp_only_shards_sequence_real(self):
+        """CP-only: embeddings -> [S/cp, B, H]; labels/loss_mask CP-sharded (zigzag), not scattered."""
+        tp_size, cp_size = 1, 8
+        B, S, H = 2, 64, 16
+        grid = self._build_grid(tp_size, cp_size)
+        cp_group = grid.create_pg("cp")
+
+        cfg = PartitionConfig(
+            use_cp=True,
+            seq_parallel=False,
+            tp_comm_overlap=False,
+            max_seq_len=S,
+            cp_group=cp_group,
+            tp_group=None,
+        )
+        adapter = PartitionAdapter(cfg)
+        embeddings, labels, loss_mask = self._make_inputs(B, S, H)
+
+        out_emb, out_labels, out_loss_mask, _ = adapter.shard(
+            embeddings.clone(), labels.clone(), loss_mask.clone()
+        )
+
+        cp_rank = cp_group.rank()
+        shard = S // cp_size
+        # Embeddings: transpose to batch-first for the zigzag, then back to [S/cp, B, H].
+        assert out_emb.shape == (shard, B, H)
+        emb_bshd = embeddings.transpose(0, 1)  # [S, B, H] -> [B, S, H]
+        expected_emb = _expected_cp_zigzag_shard(emb_bshd, cp_size, cp_rank).transpose(0, 1)
+        torch.testing.assert_close(out_emb, expected_emb.contiguous())
+        # Labels / loss_mask: CP-sharded (zigzag) but NOT SP-scattered -> [B, S/cp].
+        assert out_labels.shape == (B, shard)
+        torch.testing.assert_close(out_labels, _expected_cp_zigzag_shard(labels, cp_size, cp_rank))
+        assert out_loss_mask.shape == (B, shard)
+        torch.testing.assert_close(
+            out_loss_mask, _expected_cp_zigzag_shard(loss_mask, cp_size, cp_rank)
+        )
+
+    def test_cp_and_sp_combined_real(self):
+        """CP+SP: embeddings -> [S/(cp*tp), B, H]; labels/loss_mask only CP-sharded [B, S/cp]."""
+        tp_size, cp_size = 2, 2  # 2*2 = 4; remaining factor of 2 goes to dp (spans all 8 ranks).
+        B, S, H = 2, 64, 16
+        grid = self._build_grid(tp_size, cp_size)
+        tp_group = grid.create_pg("tp")
+        cp_group = grid.create_pg("cp")
+
+        cfg = PartitionConfig(
+            use_cp=True,
+            seq_parallel=True,
+            tp_comm_overlap=False,
+            max_seq_len=S,
+            cp_group=cp_group,
+            tp_group=tp_group,
+        )
+        adapter = PartitionAdapter(cfg)
+        embeddings, labels, loss_mask = self._make_inputs(B, S, H)
+
+        out_emb, out_labels, out_loss_mask, _ = adapter.shard(
+            embeddings.clone(), labels.clone(), loss_mask.clone()
+        )
+
+        cp_rank = cp_group.rank()
+        tp_rank = tp_group.rank()
+        cp_shard = S // cp_size
+        final_shard = S // (cp_size * tp_size)
+
+        # Embeddings: transpose to batch-first, CP zigzag, back to [S/cp, B, H], SP scatter dim 0.
+        assert out_emb.shape == (final_shard, B, H)
+        emb_bshd = embeddings.transpose(0, 1)  # [S, B, H] -> [B, S, H]
+        cp_emb = _expected_cp_zigzag_shard(emb_bshd, cp_size, cp_rank).transpose(0, 1)
+        expected_emb = cp_emb[tp_rank * final_shard : (tp_rank + 1) * final_shard]
+        torch.testing.assert_close(out_emb, expected_emb.contiguous())
+
+        # Labels / loss_mask: CP-sharded only (no SP scatter) -> [B, S/cp].
+        assert out_labels.shape == (B, cp_shard)
+        torch.testing.assert_close(out_labels, _expected_cp_zigzag_shard(labels, cp_size, cp_rank))
+        assert out_loss_mask.shape == (B, cp_shard)
+        torch.testing.assert_close(
+            out_loss_mask, _expected_cp_zigzag_shard(loss_mask, cp_size, cp_rank)
+        )


### PR DESCRIPTION
## What

Make MIMO language-model input sharding correct for **non-colocated / heterogeneous** parallelism, where the LM owns its own process-group grid.

`PartitionAdapter.shard()` owns the layout contract — sequence-first `(S, B, H)` in and out:

- **Explicit TP group** for the SP scatter (was the global `parallel_state` group).
- **Correct SP dim**: scatters the *sequence*; CP transposes to batch-first only internally (for `get_batch_on_this_cp_rank`), and SP-only does no transpose. Previously the SP path scattered `[B, S, H]` along the batch dim.
- **`loss_mask` and `packed_seq_params` threaded** through the LM forward and CP-sharded, so per-token loss and packed/THD sequences line up with the CP-local output on the non-colocated path.
- **No dense `attention_mask` in the adapter**; fast-fail if a dense mask is combined with CP (mask via a causal `attn_mask_type` / `packed_seq_params`).

`shard()` returns `(embeddings[S/(cp*tp),B,H], labels[B,S/cp], loss_mask[B,S/cp], packed_seq_params)`. Single in-core caller (`MimoModel`).

## Backward compatibility

Colocated path unchanged (still returns `(output, loss_mask)`). Under CP, `position_ids` are passed full-length — the rotary module shards them internally, so MIMO must not.

## Testing

Real 8-GPU tests assert per-rank shape **and** content for SP-only / CP-only / CP+SP, plus loss-mask CP-sharding and the attention-mask-under-CP guard. **122 passed, 2 skipped** on 1 node × 8 GPUs.

No new direct `parallel_state.get_*_group()` reads.
