### PR TITLE
ci(notify): mention mcore-oncall and philipp on critical CI events

### DIFF
--- a/tests/test_utils/python_scripts/notify.py
+++ b/tests/test_utils/python_scripts/notify.py
@@ -87,7 +87,9 @@ def main(pipeline_id: int, check_for: str, pipeline_context: str, pipeline_creat
             f":doctorge: <https://{GITLAB_ENDPOINT}/ADLR/megatron-lm/-/pipelines/{pipeline_id}|Report - {pipeline_created_at_day} - {pipeline_context} - {bridge_name}>: {len(unsuccessful_jobs)} of {total_num_jobs} failed."
         )
         if TAG_TEAM:
-            messages.append(f"cc {TEAM_SLUG}: Critical event, please react as soon as possible.")
+            messages.append(
+                f"cc {TEAM_SLUG} <!subteam^S0A7B4U1T3P> <@U09TX0DHZ97>: Critical event, please react as soon as possible."
+            )
 
         for job in unsuccessful_jobs:
             messages.append(


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- On `main`, the CI notifier (`tests/test_utils/python_scripts/notify.py`) posts a "Critical event, please react as soon as possible." Slack message when a pipeline bridge has failing jobs.
- Today it only `cc`s `$SLACK_ADMIN` (`TEAM_SLUG`). We want the mcore-oncall rotation and Philipp paged on these events too, so critical failures get faster eyes.

## What changed

- Add the `mcore-oncall` Slack usergroup and Philipp's user mention to the critical-event alert.

## Details

- `tests/test_utils/python_scripts/notify.py:90` — appended `<!subteam^S0A7B4U1T3P>` (usergroup `mcore-oncall`) and `<@U09TX0DHZ97>` (Philipp) to the message, after the existing `{TEAM_SLUG}`.
- Mention syntax is Slack mrkdwn for the incoming-webhook send path: `<!subteam^…>` for the usergroup (matching the format already used in `.github/workflows/*`), `<@…>` for the user.
- Unchanged gating: the message is still only emitted when `TAG_TEAM=1`, which the GitLab CI sets only on `CI_COMMIT_BRANCH == "main"` (`.gitlab/stages/02.test.yml`, `.gitlab/stages/04.functional-tests.yml`). PR/feature pipelines are unaffected.

```python
if TAG_TEAM:
    messages.append(
        f"cc {TEAM_SLUG} <!subteam^S0A7B4U1T3P> <@U09TX0DHZ97>: Critical event, please react as soon as possible."
    )
```

## Tested

- String/format-only change; no behavior path beyond the message text. Verified the mention IDs map to the intended targets (`S…` → usergroup `mcore-oncall`, `U…` → Philipp) and the `<!subteam^…>` form matches the repo's existing webhook usergroup mentions.
- Live verification requires a failing `main` pipeline (where `TAG_TEAM=1`); not reproduced here.

</details>
