### PR TITLE
test(elastification): quarantine flaky test_gumbel_determinism as flaky_in_dev

### DIFF
--- a/tests/unit_tests/elastification/test_hybrid_flex_router.py
+++ b/tests/unit_tests/elastification/test_hybrid_flex_router.py
@@ -157,9 +157,17 @@ class TestFlextronRouter:
         assert logits.numel() == len(config.emb_int_list)
         assert choice in config.emb_int_list
 
+    @pytest.mark.flaky_in_dev
     def test_gumbel_determinism(self):
         """Two routers at the same config + iteration + fwd_pass_count should
-        produce identical Gumbel-softmax samples."""
+        produce identical Gumbel-softmax samples.
+
+        Quarantined as flaky_in_dev (#5155): ``FlextronRouter.forward`` draws
+        ``hard_sample`` from Python's un-seeded global ``random``, which is not
+        covered by the Gumbel ``torch.manual_seed``, so the two routers
+        intermittently disagree on the hard/soft branch and the bit-exact
+        ``assert_close`` fails.
+        """
         config = _router_config()
         config.curr_iteration = 0
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

### Background / motivation

- `tests/unit_tests/elastification/test_hybrid_flex_router.py::TestFlextronRouter::test_gumbel_determinism` is flaky and intermittently reds the default unit-test pipeline.
- First observed in run [26937673156](https://github.com/NVIDIA/Megatron-LM/actions/runs/26937673156) (rank 3 failed while all 1460 tests passed on rank 0). Tracked in #5155.

### What changed

- Mark `test_gumbel_determinism` with `@pytest.mark.flaky_in_dev` to quarantine it from the default (dev) pipeline until the root cause is fixed.

### Details

- The test asserts two routers produce **bit-identical** Gumbel logits (`assert_close(atol=0, rtol=0)`).
- The Gumbel sample is deterministic (`_dp_gumbel_softmax` wraps `F.gumbel_softmax` in `torch.manual_seed` + RNG save/restore), but `FlextronRouter.forward` draws a separate flag from Python's **un-seeded global** RNG:
  ```python
  # megatron/elastification/router/hybrid_flex_router.py:545
  hard_sample = random.random() > self.hard_sample_th   # th = 0.996
  ```
- ~0.4% of the time the two routers land on different hard/soft branches (one-hot vs soft) → divergent logits → the `atol=0, rtol=0` assert fails (`Mismatched 2/2, abs diff ~0.42, rel diff inf`). It surfaces on an arbitrary rank because each rank's global Python-RNG state differs at test time.
- This PR only quarantines. The proposed fix (seed Python `random` identically before each forward) is documented in #5155 for the elastification owner.

### Tested

- `python -c "import ast; ast.parse(open('tests/unit_tests/elastification/test_hybrid_flex_router.py').read())"` → parses.
- Marker `flaky_in_dev` is registered in `pyproject.toml` and consumed by `tests/unit_tests/run_ci_test.sh` (`-m "... and not flaky_in_dev"` in the dev environment).

Closes #5155 once the follow-up fix lands; quarantine keeps CI green in the interim.

</details>