### PR TITLE
Add Megatron-FSDP weight prefetch for full recompute

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -251,9 +251,9 @@ class DistributedDataParallelConfig:
             assert self.fp8_param_gather, "Reuse grad buffer only when keeping params in MXFP8."
 
         if self.megatron_fsdp_prefetch_recompute_forward_weights:
-            assert self.use_megatron_fsdp, (
-                "megatron_fsdp_prefetch_recompute_forward_weights requires use_megatron_fsdp."
-            )
+            assert (
+                self.use_megatron_fsdp
+            ), "megatron_fsdp_prefetch_recompute_forward_weights requires use_megatron_fsdp."
             assert self.data_parallel_sharding_strategy == "optim_grads_params", (
                 "megatron_fsdp_prefetch_recompute_forward_weights is only supported with "
                 "data_parallel_sharding_strategy='optim_grads_params'."

--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from dataclasses import dataclass
 from typing import Optional, Tuple

--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -250,6 +250,15 @@ class DistributedDataParallelConfig:
         if self.reuse_grad_buf_for_mxfp8_param_ag:
             assert self.fp8_param_gather, "Reuse grad buffer only when keeping params in MXFP8."
 
+        if self.megatron_fsdp_prefetch_recompute_forward_weights:
+            assert self.use_megatron_fsdp, (
+                "megatron_fsdp_prefetch_recompute_forward_weights requires use_megatron_fsdp."
+            )
+            assert self.data_parallel_sharding_strategy == "optim_grads_params", (
+                "megatron_fsdp_prefetch_recompute_forward_weights is only supported with "
+                "data_parallel_sharding_strategy='optim_grads_params'."
+            )
+
         if self.nccl_ub and not is_torch_min_version("2.11.0a0"):
             if 'expandable_segments:True' in os.getenv('PYTORCH_CUDA_ALLOC_CONF', '').split(','):
                 raise ValueError(

--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -237,6 +237,12 @@ class DistributedDataParallelConfig:
       will be unsharded.
     """
 
+    megatron_fsdp_prefetch_recompute_forward_weights: bool = False
+    """If set to True, Megatron-FSDP prefetches rowwise weights needed by activation
+      recomputation during backward before prefetching backward transpose weights. This
+      also caches parameter bucket views to reduce repeated Python-side view setup.
+    """
+
     def __post_init__(self):
         import os
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
@@ -187,6 +187,12 @@ class DistributedDataParallelConfig:
         import os
 
         """Check the validity of the config."""
+        if self.megatron_fsdp_prefetch_recompute_forward_weights:
+            assert self.data_parallel_sharding_strategy == "optim_grads_params", (
+                "megatron_fsdp_prefetch_recompute_forward_weights is only supported with "
+                "data_parallel_sharding_strategy='optim_grads_params'."
+            )
+
         if self.nccl_ub and not is_torch_min_version("2.11.0a0"):
             if 'expandable_segments:True' in os.getenv('PYTORCH_CUDA_ALLOC_CONF', '').split(','):
                 raise ValueError(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from dataclasses import dataclass
 from typing import Optional

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
@@ -177,6 +177,12 @@ class DistributedDataParallelConfig:
       will be unsharded.
     """
 
+    megatron_fsdp_prefetch_recompute_forward_weights: bool = False
+    """If set to True, Megatron-FSDP prefetches rowwise weights needed by activation
+      recomputation during backward before prefetching backward transpose weights. This
+      also caches parameter bucket views to reduce repeated Python-side view setup.
+    """
+
     def __post_init__(self):
         import os
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py
@@ -364,6 +364,17 @@ def fully_shard_model(
             "Meta device initialization (init_model_with_meta_device=True) is not "
             "supported or necessary for the 'no_shard' / 0 sharding strategy."
         )
+    if prefetch_recompute_forward_weights:
+        if zero_dp_strategy != "optim_grads_params":
+            raise ValueError(
+                "prefetch_recompute_forward_weights is only supported with "
+                "zero_dp_strategy='optim_grads_params'."
+            )
+        if not fsdp_unit_modules:
+            raise ValueError(
+                "prefetch_recompute_forward_weights requires fsdp_unit_modules to define "
+                "the Megatron-FSDP unit-level backward prefetch order."
+            )
 
     # DDP Config for Megatron FSDP.
     ddp_config = DistributedDataParallelConfig(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import logging
 import types

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py
@@ -103,6 +103,7 @@ def fully_shard_model(
     fsdp_db_use_persist_buf_on_alloc_fail: bool = False,
     disable_symmetric_registration: bool = False,
     enable_fine_grained_param_gather: bool = False,
+    prefetch_recompute_forward_weights: bool = False,
     use_decoupled_grad: bool = False,
     cuda_graph_mode: bool = False,
 ) -> torch.nn.Module:
@@ -262,6 +263,11 @@ def fully_shard_model(
             unshards parameters per-Module instead of unsharding all sub-modules of an FSDP
             unit module simultaneously. Defaults to False.
 
+        prefetch_recompute_forward_weights (bool):
+            Whether to prefetch rowwise weights needed by activation recomputation during
+            backward before prefetching backward transpose weights. This also caches
+            parameter bucket views to reduce repeated Python-side view setup. Defaults to False.
+
         use_decoupled_grad (bool):
             If true, reduced gradients are installed into `Parameter.decoupled_grad` instead
             of `Parameter.grad`. Defaults to False.
@@ -371,6 +377,7 @@ def fully_shard_model(
         fsdp_double_buffer=fsdp_double_buffer or nccl_ub,
         fsdp_db_use_persist_buf_on_alloc_fail=fsdp_db_use_persist_buf_on_alloc_fail,
         disable_symmetric_registration=disable_symmetric_registration,
+        megatron_fsdp_prefetch_recompute_forward_weights=prefetch_recompute_forward_weights,
         megatron_fsdp_use_decoupled_grad=use_decoupled_grad,
         megatron_fsdp_cuda_graph_mode=cuda_graph_mode,
     )
@@ -678,6 +685,7 @@ def fully_shard(
     fsdp_db_use_persist_buf_on_alloc_fail: bool = False,
     disable_symmetric_registration: bool = False,
     enable_fine_grained_param_gather: bool = False,
+    prefetch_recompute_forward_weights: bool = False,
     use_decoupled_grad: bool = False,
     cuda_graph_mode: bool = False,
 ) -> tuple[MegatronFSDP, torch.optim.Optimizer]:
@@ -729,6 +737,7 @@ def fully_shard(
         fsdp_double_buffer=fsdp_double_buffer,
         fsdp_db_use_persist_buf_on_alloc_fail=fsdp_db_use_persist_buf_on_alloc_fail,
         disable_symmetric_registration=disable_symmetric_registration,
+        prefetch_recompute_forward_weights=prefetch_recompute_forward_weights,
         use_decoupled_grad=use_decoupled_grad,
         cuda_graph_mode=cuda_graph_mode,
     )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -3,7 +3,6 @@
 import functools
 import importlib
 import logging
-import os
 from contextlib import contextmanager
 from enum import Enum, auto
 from functools import partial
@@ -261,9 +260,9 @@ class MegatronFSDP(torch.nn.Module):
         self.enable_fine_grained_param_gather_backward_hook = (
             enable_fine_grained_param_gather_backward_hook
         )
-        self.prefetch_recompute_forward_weights = os.environ.get(
-            "MCORE_FSDP_PREFETCH_RECOMPUTE_FORWARD_WEIGHTS", "0"
-        ).lower() in ("1", "true", "yes", "on")
+        self.prefetch_recompute_forward_weights = (
+            self.ddp_config.megatron_fsdp_prefetch_recompute_forward_weights
+        )
         self.report_nan_in_param_grad = report_nan_in_param_grad
 
         # FSDPDistributedIndex stores the process groups and meshes used by Megatron-FSDP.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -15,6 +15,7 @@
 import functools
 import importlib
 import logging
+import os
 from contextlib import contextmanager
 from enum import Enum, auto
 from functools import partial
@@ -272,6 +273,9 @@ class MegatronFSDP(torch.nn.Module):
         self.enable_fine_grained_param_gather_backward_hook = (
             enable_fine_grained_param_gather_backward_hook
         )
+        self.prefetch_recompute_forward_weights = os.environ.get(
+            "MCORE_FSDP_PREFETCH_RECOMPUTE_FORWARD_WEIGHTS", "0"
+        ).lower() in ("1", "true", "yes", "on")
         self.report_nan_in_param_grad = report_nan_in_param_grad
 
         # FSDPDistributedIndex stores the process groups and meshes used by Megatron-FSDP.
@@ -879,9 +883,45 @@ class MegatronFSDP(torch.nn.Module):
                 param_list = list(module.parameters(recurse=False))
 
             # All-gather / unshard the module parameters before the backward pass.
-            self.all_gather_and_wait_parameters_ready(
-                param_list, prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER, bwd=True
-            )
+            if self.prefetch_recompute_forward_weights:
+                self.all_gather_and_wait_parameters_ready(
+                    param_list,
+                    prefetch=False,
+                    prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER,
+                    bwd=True,
+                )
+
+                outer_fsdp_group_param_gather = (
+                    self.dist_index.use_hybrid_fsdp
+                    and self.ddp_config.outer_dp_sharding_strategy != "no_shard"
+                    and (self.microbatch_count == 0 or self.model_auto_sync)
+                )
+                # During full activation recomputation, the next backward layer
+                # first reruns its forward path, so row-wise weights are more
+                # urgent than the column-wise transpose buffers used later in
+                # the same layer's backward path.
+                self.all_gather_pipeline.all_gather_params(
+                    params=param_list,
+                    prefetch=True,
+                    prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER,
+                    suggested_AG_prefetch_size=self.suggested_AG_prefetch_size,
+                    outer_fsdp_group_param_gather=outer_fsdp_group_param_gather,
+                    bwd=False,
+                    include_current=False,
+                )
+                self.all_gather_pipeline.all_gather_params(
+                    params=param_list,
+                    prefetch=True,
+                    prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER,
+                    suggested_AG_prefetch_size=self.suggested_AG_prefetch_size,
+                    outer_fsdp_group_param_gather=outer_fsdp_group_param_gather,
+                    bwd=True,
+                    include_current=False,
+                )
+            else:
+                self.all_gather_and_wait_parameters_ready(
+                    param_list, prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER, bwd=True
+                )
 
         self._root_pre_backward_hook_issued = False
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.import functools
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import functools
 import importlib

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -877,33 +877,17 @@ class MegatronFSDP(torch.nn.Module):
                     prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER,
                     bwd=True,
                 )
-
-                outer_fsdp_group_param_gather = (
-                    self.dist_index.use_hybrid_fsdp
-                    and self.ddp_config.outer_dp_sharding_strategy != "no_shard"
-                    and (self.microbatch_count == 0 or self.model_auto_sync)
-                )
-                # During full activation recomputation, the next backward layer
-                # first reruns its forward path, so row-wise weights are more
-                # urgent than the column-wise transpose buffers used later in
-                # the same layer's backward path.
-                self.all_gather_pipeline.all_gather_params(
-                    params=param_list,
+                self.all_gather_and_wait_parameters_ready(
+                    param_list,
                     prefetch=True,
                     prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER,
-                    suggested_AG_prefetch_size=self.suggested_AG_prefetch_size,
-                    outer_fsdp_group_param_gather=outer_fsdp_group_param_gather,
                     bwd=False,
-                    include_current=False,
                 )
-                self.all_gather_pipeline.all_gather_params(
-                    params=param_list,
+                self.all_gather_and_wait_parameters_ready(
+                    param_list,
                     prefetch=True,
                     prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER,
-                    suggested_AG_prefetch_size=self.suggested_AG_prefetch_size,
-                    outer_fsdp_group_param_gather=outer_fsdp_group_param_gather,
                     bwd=True,
-                    include_current=False,
                 )
             else:
                 self.all_gather_and_wait_parameters_ready(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -21,6 +21,7 @@ import gc
 import inspect
 import logging
 import math
+import os
 import traceback
 import warnings
 from collections import defaultdict, namedtuple
@@ -57,6 +58,22 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").lower() in ("1", "true", "yes", "on")
+
+
+def _same_tensor_view(a: Optional[torch.Tensor], b: torch.Tensor) -> bool:
+    if a is None:
+        return False
+    return (
+        a.data_ptr() == b.data_ptr()
+        and a.dtype == b.dtype
+        and a.shape == b.shape
+        and a.stride() == b.stride()
+        and a.storage_offset() == b.storage_offset()
+    )
 
 
 try:
@@ -924,6 +941,8 @@ class DataParallelBuffer:
 
         # Count all parameters in this buffer and store their enumerated index.
         self.param_idx = {p: i for i, p in enumerate(self.params)}
+        self.cache_param_bucket_views = _env_flag("MCORE_FSDP_CACHE_PARAM_BUCKET_VIEWS")
+        self._param_bucket_view_cache = {}
 
     def init_data(self, data: torch.Tensor):
         """Allocate a buffer Tensor to persistently store the data for this
@@ -970,15 +989,49 @@ class DataParallelBuffer:
 
         # Need to set parameter data after resize model weight buffer data-storage.
         if set_param_data:
-            for p in self.params:
-                item_id = self.param_idx[p]
-                p = to_local_if_dtensor(p)
-                data = self.get_item_from_bucket(bucket, item_id).view(p.shape)
-                if is_float8tensor(p):
-                    fp8_set_raw_data(p, data, self.is_transpose_buffer)
-                else:
-                    p.data = data
+            self.set_param_data_from_bucket(bucket)
         return bucket
+
+    def _bucket_view_cache_key(self, bucket: Bucket):
+        return (
+            bucket.data.data_ptr(),
+            bucket.data.numel(),
+            bucket.data.dtype,
+            str(bucket.data.device),
+            self.is_transpose_buffer,
+        )
+
+    def _build_param_bucket_view_entries(self, bucket: Bucket):
+        entries = []
+        for p in self.params:
+            item_id = self.param_idx[p]
+            p = to_local_if_dtensor(p)
+            data = self.get_item_from_bucket(bucket, item_id).view(p.shape)
+            entries.append((p, data, is_float8tensor(p)))
+        return entries
+
+    def set_param_data_from_bucket(self, bucket: Bucket) -> None:
+        """Attach module parameter tensors to their views in an all-gather bucket."""
+        entries = None
+        if self.cache_param_bucket_views:
+            cache_key = self._bucket_view_cache_key(bucket)
+            entries = self._param_bucket_view_cache.get(cache_key)
+            if entries is None:
+                entries = self._build_param_bucket_view_entries(bucket)
+                self._param_bucket_view_cache[cache_key] = entries
+        else:
+            entries = self._build_param_bucket_view_entries(bucket)
+
+        for p, data, is_fp8 in entries:
+            if is_fp8:
+                old_data = fp8_get_raw_data(p, self.is_transpose_buffer)
+                if self.cache_param_bucket_views and _same_tensor_view(old_data, data):
+                    continue
+                fp8_set_raw_data(p, data, self.is_transpose_buffer)
+            else:
+                if self.cache_param_bucket_views and _same_tensor_view(p.data, data):
+                    continue
+                p.data = data
 
     def allocate_bucket_storage(
         self,
@@ -3887,6 +3940,8 @@ class AllGatherPipeline:
         for i in range(self.buffer.num_buckets):
             for bwd in [False, True]:
                 self.bucket_can_be_released[self.get_bucket_key(i, bwd)] = False
+        self.defer_param_bucket_view_setup = _env_flag("MCORE_FSDP_DEFER_PARAM_VIEW_SETUP")
+        self.deferred_param_bucket_views = {}
 
         # Map each bucket to the bucket group it belongs to by enumerated ID.
         # Made to collect a subset of buckets in the same bucket group.
@@ -4148,6 +4203,10 @@ class AllGatherPipeline:
                         # into an allocated bucket containing unsharded weights.
                         self.async_bucket_gather(bucket_id, bwd)
 
+            if self.defer_param_bucket_view_setup:
+                for bucket_id in buckets:
+                    self.set_deferred_param_bucket_views(bucket_id, bwd)
+
             # Replace the parameter all-gather event with coalescing event.
             for bucket_id in buckets:
                 bucket_key = self.get_bucket_key(bucket_id, bwd)
@@ -4244,6 +4303,15 @@ class AllGatherPipeline:
                 self.release_bucket(bucket_id, is_transpose_weight)
                 self.bucket_can_be_released[bucket_key] = False
 
+    def set_deferred_param_bucket_views(self, bucket_id: int, bwd: bool) -> None:
+        """Attach parameter views after the all-gather has been enqueued."""
+        bucket_key = self.get_bucket_key(bucket_id, bwd)
+        pending = self.deferred_param_bucket_views.pop(bucket_key, None)
+        if pending is None:
+            return
+        wbuf, bucket = pending
+        wbuf.set_param_data_from_bucket(bucket)
+
     def get_fsdp_buffer(self, bucket_id: int, bwd=False) -> DataParallelBuffer:
         """
         Get the FSDP / DP-Shard buffer with the given bucket ID.
@@ -4282,7 +4350,9 @@ class AllGatherPipeline:
         self.recycle_unused_buckets()
 
         # Allocate an empty bucket to store the module weights.
-        bucket = wbuf.fetch_bucket(set_param_data=True)
+        bucket = wbuf.fetch_bucket(set_param_data=not self.defer_param_bucket_view_setup)
+        if self.defer_param_bucket_view_setup:
+            self.deferred_param_bucket_views[bucket_key] = (wbuf, bucket)
 
         # All-gather the module weights in each buffer shard into the allocated bucket.
         # Now each rank will have a copy of this FSDP unit module's weights.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -4141,6 +4141,11 @@ class AllGatherPipeline:
                 bucket_id for bucket_id in ag_buckets if bucket_id not in current_ag_bucket_set
             ]
 
+        # Do not release the buckets that are requested by this call, even if
+        # they are already ready and do not need a new all-gather.
+        for bucket_id in ag_buckets:
+            self.bucket_can_be_released[self.get_bucket_key(bucket_id, bwd)] = False
+
         # Only all-gather on buckets that have not been allocated yet or whose
         # persistent storage was preserved but is not ready for use.
         ag_buckets = [
@@ -4151,10 +4156,6 @@ class AllGatherPipeline:
         ]
         if len(ag_buckets) == 0:
             return
-
-        # Do not release the buckets that are being all-gathered.
-        for bucket_id in ag_buckets:
-            self.bucket_can_be_released[self.get_bucket_key(bucket_id, bwd)] = False
 
         # Divide buckets into aggregate groups. We need to reconstruct the bucket groups
         # because the all-gather parameter groups may be a subset of the buckets.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -4037,15 +4037,12 @@ class AllGatherPipeline:
         if len(params) == 0:
             return
 
-        current_ag_buckets = [self.buffer.param_to_param_group[item] for item in params]
-        current_ag_buckets = list(
-            sorted(set(current_ag_buckets))
-        )  # Sort in order of unique bucket ID.
-        ag_buckets = list(current_ag_buckets)
+        ag_buckets = [self.buffer.param_to_param_group[item] for item in params]
+        ag_buckets = list(sorted(set(ag_buckets)))  # Sort in order of unique bucket ID.
         parameter_groups = self.buffer.parameter_groups
         if self.buffer.ddp_config.fsdp_double_buffer:
             double_buf_units = set()
-            for bucket_id in current_ag_buckets:
+            for bucket_id in ag_buckets:
                 fsdp_unit_id = parameter_groups[bucket_id].fsdp_unit_id
                 if fsdp_unit_id in self.buffer.double_buf_units:
                     double_buf_units.add(fsdp_unit_id)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 # TODO: Split this file into smaller files.
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -4017,7 +4017,6 @@ class AllGatherPipeline:
         async_param_gather: bool = True,
         outer_fsdp_group_param_gather: bool = False,
         bwd: bool = False,
-        include_current: bool = True,
     ):
         """All-gather the params. If prefetch is enabled, prefetch next buckets
         in the order of `prefetch_order`.
@@ -4034,9 +4033,6 @@ class AllGatherPipeline:
             bwd (bool, optional):
                 Whether to all-gather column-wise parameters instead of row-wise parameters
                 for the backward pass for formats that require a transpose buffer like MXFP8.
-            include_current (bool, optional):
-                Whether to all-gather the buckets that contain ``params``. If False,
-                only the prefetch buckets adjacent to the current buckets are issued.
         """
         if len(params) == 0:
             return
@@ -4127,12 +4123,6 @@ class AllGatherPipeline:
                 # Re-sort and find the next bucket not in the list.
                 ag_buckets = list(sorted(set(ag_buckets)))
                 bucket_id = next_bucket_id(ag_buckets)
-
-        if not include_current:
-            current_ag_bucket_set = set(current_ag_buckets)
-            ag_buckets = [
-                bucket_id for bucket_id in ag_buckets if bucket_id not in current_ag_bucket_set
-            ]
 
         # Do not release the buckets that are requested by this call, even if
         # they are already ready and do not need a new all-gather.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -9,7 +9,6 @@ import gc
 import inspect
 import logging
 import math
-import os
 import traceback
 import warnings
 from collections import defaultdict, namedtuple
@@ -46,10 +45,6 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _env_flag(name: str) -> bool:
-    return os.environ.get(name, "").lower() in ("1", "true", "yes", "on")
 
 
 def _same_tensor_view(a: Optional[torch.Tensor], b: torch.Tensor) -> bool:
@@ -929,7 +924,9 @@ class DataParallelBuffer:
 
         # Count all parameters in this buffer and store their enumerated index.
         self.param_idx = {p: i for i, p in enumerate(self.params)}
-        self.cache_param_bucket_views = _env_flag("MCORE_FSDP_CACHE_PARAM_BUCKET_VIEWS")
+        self.cache_param_bucket_views = (
+            ddp_config.megatron_fsdp_prefetch_recompute_forward_weights
+        )
         self._param_bucket_view_cache = {}
 
     def init_data(self, data: torch.Tensor):
@@ -3928,8 +3925,6 @@ class AllGatherPipeline:
         for i in range(self.buffer.num_buckets):
             for bwd in [False, True]:
                 self.bucket_can_be_released[self.get_bucket_key(i, bwd)] = False
-        self.defer_param_bucket_view_setup = _env_flag("MCORE_FSDP_DEFER_PARAM_VIEW_SETUP")
-        self.deferred_param_bucket_views = {}
 
         # Map each bucket to the bucket group it belongs to by enumerated ID.
         # Made to collect a subset of buckets in the same bucket group.
@@ -4205,10 +4200,6 @@ class AllGatherPipeline:
                         # into an allocated bucket containing unsharded weights.
                         self.async_bucket_gather(bucket_id, bwd)
 
-            if self.defer_param_bucket_view_setup:
-                for bucket_id in buckets:
-                    self.set_deferred_param_bucket_views(bucket_id, bwd)
-
             # Replace the parameter all-gather event with coalescing event.
             for bucket_id in buckets:
                 bucket_key = self.get_bucket_key(bucket_id, bwd)
@@ -4305,15 +4296,6 @@ class AllGatherPipeline:
                 self.release_bucket(bucket_id, is_transpose_weight)
                 self.bucket_can_be_released[bucket_key] = False
 
-    def set_deferred_param_bucket_views(self, bucket_id: int, bwd: bool) -> None:
-        """Attach parameter views after the all-gather has been enqueued."""
-        bucket_key = self.get_bucket_key(bucket_id, bwd)
-        pending = self.deferred_param_bucket_views.pop(bucket_key, None)
-        if pending is None:
-            return
-        wbuf, bucket = pending
-        wbuf.set_param_data_from_bucket(bucket)
-
     def get_fsdp_buffer(self, bucket_id: int, bwd=False) -> DataParallelBuffer:
         """
         Get the FSDP / DP-Shard buffer with the given bucket ID.
@@ -4352,9 +4334,7 @@ class AllGatherPipeline:
         self.recycle_unused_buckets()
 
         # Allocate an empty bucket to store the module weights.
-        bucket = wbuf.fetch_bucket(set_param_data=not self.defer_param_bucket_view_setup)
-        if self.defer_param_bucket_view_setup:
-            self.deferred_param_bucket_views[bucket_key] = (wbuf, bucket)
+        bucket = wbuf.fetch_bucket(set_param_data=True)
 
         # All-gather the module weights in each buffer shard into the allocated bucket.
         # Now each rank will have a copy of this FSDP unit module's weights.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -924,9 +924,7 @@ class DataParallelBuffer:
 
         # Count all parameters in this buffer and store their enumerated index.
         self.param_idx = {p: i for i, p in enumerate(self.params)}
-        self.cache_param_bucket_views = (
-            ddp_config.megatron_fsdp_prefetch_recompute_forward_weights
-        )
+        self.cache_param_bucket_views = ddp_config.megatron_fsdp_prefetch_recompute_forward_weights
         self._param_bucket_view_cache = {}
 
     def init_data(self, data: torch.Tensor):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -4036,6 +4036,7 @@ class AllGatherPipeline:
         async_param_gather: bool = True,
         outer_fsdp_group_param_gather: bool = False,
         bwd: bool = False,
+        include_current: bool = True,
     ):
         """All-gather the params. If prefetch is enabled, prefetch next buckets
         in the order of `prefetch_order`.
@@ -4052,16 +4053,22 @@ class AllGatherPipeline:
             bwd (bool, optional):
                 Whether to all-gather column-wise parameters instead of row-wise parameters
                 for the backward pass for formats that require a transpose buffer like MXFP8.
+            include_current (bool, optional):
+                Whether to all-gather the buckets that contain ``params``. If False,
+                only the prefetch buckets adjacent to the current buckets are issued.
         """
         if len(params) == 0:
             return
 
-        ag_buckets = [self.buffer.param_to_param_group[item] for item in params]
-        ag_buckets = list(sorted(set(ag_buckets)))  # Sort in order of unique bucket ID.
+        current_ag_buckets = [self.buffer.param_to_param_group[item] for item in params]
+        current_ag_buckets = list(
+            sorted(set(current_ag_buckets))
+        )  # Sort in order of unique bucket ID.
+        ag_buckets = list(current_ag_buckets)
         parameter_groups = self.buffer.parameter_groups
         if self.buffer.ddp_config.fsdp_double_buffer:
             double_buf_units = set()
-            for bucket_id in ag_buckets:
+            for bucket_id in current_ag_buckets:
                 fsdp_unit_id = parameter_groups[bucket_id].fsdp_unit_id
                 if fsdp_unit_id in self.buffer.double_buf_units:
                     double_buf_units.add(fsdp_unit_id)
@@ -4070,10 +4077,6 @@ class AllGatherPipeline:
                     f"{double_buf_units} FSDP units were requested, "
                     "but double buffers can support no more than 2 FSDP units."
                 )
-
-        # Do not release the buckets that are being all-gathered.
-        for bucket_id in ag_buckets:
-            self.bucket_can_be_released[self.get_bucket_key(bucket_id, bwd)] = False
 
         # If prefetch is enabled, we will add prefetch buckets to ag_buckets.
         if prefetch:
@@ -4144,6 +4147,12 @@ class AllGatherPipeline:
                 ag_buckets = list(sorted(set(ag_buckets)))
                 bucket_id = next_bucket_id(ag_buckets)
 
+        if not include_current:
+            current_ag_bucket_set = set(current_ag_buckets)
+            ag_buckets = [
+                bucket_id for bucket_id in ag_buckets if bucket_id not in current_ag_bucket_set
+            ]
+
         # Only all-gather on buckets that have not been allocated yet or whose
         # persistent storage was preserved but is not ready for use.
         ag_buckets = [
@@ -4154,6 +4163,10 @@ class AllGatherPipeline:
         ]
         if len(ag_buckets) == 0:
             return
+
+        # Do not release the buckets that are being all-gathered.
+        for bucket_id in ag_buckets:
+            self.bucket_can_be_released[self.get_bucket_key(bucket_id, bwd)] = False
 
         # Divide buckets into aggregate groups. We need to reconstruct the bucket groups
         # because the all-gather parameter groups may be a subset of the buckets.

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1141,6 +1141,20 @@ def validate_args(args, defaults={}):
 
         assert args.ckpt_format == "fsdp_dtensor", \
             "Megatron-FSDP requires the `fsdp_dtensor` checkpointing format."
+
+        if args.megatron_fsdp_prefetch_recompute_forward_weights:
+            assert args.data_parallel_sharding_strategy == "optim_grads_params", (
+                "--megatron-fsdp-prefetch-recompute-forward-weights is only supported "
+                'with --data-parallel-sharding-strategy optim_grads_params.'
+            )
+            assert args.recompute_granularity == "full", (
+                "--megatron-fsdp-prefetch-recompute-forward-weights is only supported "
+                "with full activation recomputation."
+            )
+            assert not args.overlap_moe_expert_parallel_comm, (
+                "--megatron-fsdp-prefetch-recompute-forward-weights is not supported "
+                "with --overlap-moe-expert-parallel-comm."
+            )
     
         if args.nccl_ub:
             # In Megatron-LM, required implementation for manual registration is already provided.
@@ -1153,6 +1167,12 @@ def validate_args(args, defaults={}):
                 "Meta device initialization (init_model_with_meta_device=True) is not "
                 "supported or necessary for the 'no_shard' / 0 sharding strategy."
             )
+
+    else:
+        assert not args.megatron_fsdp_prefetch_recompute_forward_weights, (
+            "--megatron-fsdp-prefetch-recompute-forward-weights requires "
+            "--use-megatron-fsdp."
+        )
 
     if args.fsdp_manual_registration:
         assert args.use_megatron_fsdp, "FSDP manual registration is only supported with Megatron FSDP."

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -3325,6 +3325,18 @@ def _add_experimental_args(parser):
                 'recomputation will be unsharded.'
             ),
         )
+    group.add_argument(
+            '--megatron-fsdp-prefetch-recompute-forward-weights',
+            action='store_true',
+            default=False,
+            dest='megatron_fsdp_prefetch_recompute_forward_weights',
+            help=(
+                'If set, Megatron-FSDP prefetches rowwise weights needed by activation '
+                'recomputation during backward before prefetching backward transpose '
+                'weights. This also caches parameter bucket views to reduce repeated '
+                'Python-side view setup.'
+            ),
+        )
 
     return parser
 


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds an opt-in Megatron-FSDP path to prefetch the row-wise parameter buckets needed by the recompute forward pass during backward when full activation recomputation is enabled. This moves the recompute-forward all-gather earlier in the backward pass so the second forward has fewer parameter-gather stalls on the critical path.

The feature is exposed through `--megatron-fsdp-prefetch-recompute-forward-weights` and the corresponding DDP config / standalone `fully_shard` API flag. It is intentionally scoped to Megatron-FSDP with `optim_grads_params` sharding and full activation recomputation. Unsupported combinations, including selective recomputation and `--overlap-moe-expert-parallel-comm`, fail during argument/config validation instead of entering the FSDP runtime path.

## Key changes

- Adds the CLI, DDP config, and standalone `fully_shard(..., prefetch_recompute_forward_weights=...)` flag for recompute-forward weight prefetch.
- During backward, prefetches adjacent row-wise forward buckets before the transpose / column-wise buckets used later by the same layer's backward path.
- Caches per-bucket parameter views while this optimization is enabled, avoiding repeated tensor view setup and redundant `param.data` reassignment.
- Adds `include_current=False` support to FSDP all-gather scheduling so prefetch calls can request only adjacent buckets.
- Keeps requested buckets protected from release even when they are already in `READY_TO_USE` state.
- Adds early validation for unsupported flag combinations in CLI argument validation, DDP config construction, and the standalone `fully_shard_model()` entrypoint.

## Issue tracking

Linked issue: N/A

## Validation

- `git diff --check`
- `/home/hongbinl/.local/bin/python3.12 -m py_compile megatron/core/distributed/distributed_data_parallel_config.py megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py megatron/training/arguments.py`

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
