### PR TITLE
Restore Greptile configuration

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,40 @@
+{
+    "labels": [],
+    "comment": "Disclaimer: This is AI-generated.",
+    "commentTypes": ["logic", "syntax", "style"],
+    "instructions": "Only comment if the PR description is unchanged from the default template, if a docstring is missing, or if there is a typo.",
+    "ignoreKeywords": "rename\nlinter\nprettier\ngreptile-ignor",
+    "ignorePatterns": "greptile.json\ntesting/**/*.py\n*.md\n*.txt\n*.json",
+    "patternRepositories": ["NVIDIA/Megatron-LM"],
+    "triggerOnUpdates": true,
+    "shouldUpdateDescription": false,
+    "disabledLabels": ["docs"],
+    "includeAuthors": [],
+    "excludeAuthors": ["github-actions"],
+    "strictness": 3,
+    "fixWithAI": false,
+    "includeBranches": ["main"],
+    "statusCheck": false,
+    "skipReview": "AUTOMATIC",
+    "summarySection": {
+      "included": false,
+      "collapsible": false,
+      "defaultOpen": false
+    },
+    "issuesTableSection": {
+      "included": false,
+      "collapsible": false,
+      "defaultOpen": false
+    },
+    "confidenceScoreSection": {
+      "included": false,
+      "collapsible": false,
+      "defaultOpen": false
+    },
+    "sequenceDiagramSection": {
+      "included": false,
+      "collapsible": false,
+      "defaultOpen": false
+    },
+    "statusCommentsEnabled": false
+  }

--- a/greptile.json
+++ b/greptile.json
@@ -2,7 +2,7 @@
     "labels": [],
     "comment": "Disclaimer: This is AI-generated.",
     "commentTypes": ["logic", "syntax", "style"],
-    "instructions": "Only comment if the PR description is unchanged from the default template, if a docstring is missing, or if there is a typo.",
+    "instructions": "Only comment if the PR description is unchanged from the default template, if a docstring is missing, if there is a typo, or if there is an important or critical bug.",
     "ignoreKeywords": "rename\nlinter\nprettier\ngreptile-ignor",
     "ignorePatterns": "greptile.json\ntesting/**/*.py\n*.md\n*.txt\n*.json",
     "patternRepositories": ["NVIDIA/Megatron-LM"],

--- a/greptile.json
+++ b/greptile.json
@@ -6,7 +6,6 @@
     "ignoreKeywords": "rename\nlinter\nprettier\ngreptile-ignor",
     "ignorePatterns": "greptile.json\ntesting/**/*.py\n*.md\n*.txt\n*.json",
     "patternRepositories": ["NVIDIA/Megatron-LM"],
-    "triggerOnUpdates": true,
     "shouldUpdateDescription": false,
     "disabledLabels": ["docs"],
     "includeAuthors": [],


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

Greptile was removed in https://github.com/NVIDIA/Megatron-LM/pull/5097 as part of a clean-up but there is still demand for it. Adding it back now.