### PR TITLE
Align TEGroupedMLP fused support checks with TE requirements

### DIFF
--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import inspect
@@ -313,32 +313,48 @@ class TEGroupedMLP(MegatronModule):
         )
 
     def _is_fused_impl_supported(self) -> bool:
-        """Check if the TE op fuser supports implementing this module."""
+        """Check if the TE op fuser supports implementing this module.
+
+        Logs a warning for each unsatisfied condition to aid debugging
+        (e.g. when CUDA graph fails because the CuTe DSL fused kernel
+        was not activated and GroupedLinear falls back to tolist()).
+        """
+
+        def _unsupported(reason):
+            logger.warning("TE fused GroupedMLP not available: %s", reason)
+            return False
+
+        def _activation_name():
+            return getattr(
+                self.config.activation_func, "__name__", str(self.config.activation_func)
+            )
 
         # Check Transformer Engine installation
         if not HAVE_TE:
-            return False  # Transformer Engine is not available
+            return _unsupported("Transformer Engine is not installed")
         try:
-            from transformer_engine.pytorch.ops import GroupedLinear, ScaledSwiGLU
+            from transformer_engine.pytorch import ops as te_ops
         except ImportError:
-            return False  # Transformer Engine version is too old
+            return _unsupported("TE too old (missing pytorch.ops)")
+        if not hasattr(te_ops, "GroupedLinear") or not hasattr(te_ops, "ScaledSwiGLU"):
+            return _unsupported("TE too old (missing GroupedLinear/ScaledSwiGLU ops)")
 
         if not is_te_min_version("2.14.0"):
-            return False
+            return _unsupported("TE version < 2.14.0")
 
         # Check for unsupported features
         if self.tp_group.size() > 1:
-            return False  # Tensor parallelism is not supported
+            return _unsupported(f"expert TP > 1 (tp_size={self.tp_group.size()})")
         if self.offload_expert_fc1 or self.offload_moe_act:
-            return False  # Fine-grained activation offloading is not supported
+            return _unsupported("fine-grained activation offloading enabled")
         if self.config.moe_apply_probs_on_input:
-            return False  # Pre-multiplying probs is not supported
+            return _unsupported("moe_apply_probs_on_input enabled")
 
         # Check grouped linear modules
-        if not isinstance(self.linear_fc1, te.pytorch.GroupedLinear):
-            return False
-        if not isinstance(self.linear_fc2, te.pytorch.GroupedLinear):
-            return False
+        if not isinstance(self.linear_fc1, te_ops.GroupedLinear):
+            return _unsupported(f"linear_fc1 is {type(self.linear_fc1).__name__}")
+        if not isinstance(self.linear_fc2, te_ops.GroupedLinear):
+            return _unsupported(f"linear_fc2 is {type(self.linear_fc2).__name__}")
 
         # Check activation: SwiGLU, quick GEGLU, or weighted squared ReLU.
         # Use config.activation_func instead of self.activation_func because when
@@ -353,23 +369,35 @@ class TEGroupedMLP(MegatronModule):
             and not self.config.gated_linear_unit
         )
         if not (use_glu_fusion or use_srelu_fusion):
-            return False
+            return _unsupported(
+                f"unsupported activation {_activation_name()} "
+                f"(gated_linear_unit={self.config.gated_linear_unit}, "
+                f"use_fused_weighted_squared_relu={self.config.use_fused_weighted_squared_relu})"
+            )
         if self.config.activation_func == F.silu:
-            return True
-        if self.config.activation_func == quick_gelu:
-            try:
-                from transformer_engine.pytorch.ops import ScaledClampedQGeGLU  # noqa: F401
-            except ImportError:
-                return False
-            return True
-        if self.config.activation_func == squared_relu:
-            try:
-                from transformer_engine.pytorch.ops import ScaledSReLU  # noqa: F401
-            except ImportError:
-                return False
-            return True
+            pass  # SwiGLU is covered by the ScaledSwiGLU availability check above.
+        elif self.config.activation_func == quick_gelu:
+            if not hasattr(te_ops, "ScaledClampedQGeGLU"):
+                return _unsupported("quick_gelu needs TE >= 2.15")
+        elif self.config.activation_func == squared_relu:
+            if not hasattr(te_ops, "ScaledSReLU"):
+                return _unsupported("weighted squared_relu needs ScaledSReLU")
 
-        return False
+        # Check TE CuTe DSL fused kernel conditions (must match TE's
+        # fuse_grouped_mlp_ops matching logic).
+        import os
+
+        if int(os.environ.get("NVTE_CUTEDSL_FUSED_GROUPED_MLP", "0")) <= 0:
+            return _unsupported(
+                "NVTE_CUTEDSL_FUSED_GROUPED_MLP not set; CuTe DSL fused kernel disabled"
+            )
+        if use_glu_fusion and self.config.moe_mlp_glu_interleave_size != 32:
+            return _unsupported(
+                f"moe_mlp_glu_interleave_size={self.config.moe_mlp_glu_interleave_size} "
+                f"(CuTe DSL GLU fusion requires 32)"
+            )
+
+        return True
 
     def _make_fused_ops(self) -> torch.nn.Module:
         """Construct fused module for FC1, activation, and FC2."""

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -351,9 +351,9 @@ class TEGroupedMLP(MegatronModule):
             return _unsupported("moe_apply_probs_on_input enabled")
 
         # Check grouped linear modules
-        if not isinstance(self.linear_fc1, te_ops.GroupedLinear):
+        if not isinstance(self.linear_fc1, te.pytorch.GroupedLinear):
             return _unsupported(f"linear_fc1 is {type(self.linear_fc1).__name__}")
-        if not isinstance(self.linear_fc2, te_ops.GroupedLinear):
+        if not isinstance(self.linear_fc2, te.pytorch.GroupedLinear):
             return _unsupported(f"linear_fc2 is {type(self.linear_fc2).__name__}")
 
         # Check activation: SwiGLU, quick GEGLU, or weighted squared ReLU.

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp1_pp1_te_4experts_groupedGEMM_op_fuser/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp1_pp1_te_4experts_groupedGEMM_op_fuser/model_config.yaml
@@ -45,6 +45,7 @@ MODEL_ARGS:
   --expert-model-parallel-size: 1
   --moe-grouped-gemm: true
   --use-transformer-engine-op-fuser: true
+  --moe-mlp-glu-interleave-size: 32
   --disable-bias-linear: true
   --num-experts: 4
   --moe-router-load-balancing-type: sinkhorn

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import argparse
 import sys
@@ -552,7 +552,12 @@ def _install_fake_te_ops_modules(
 
 
 def _make_fused_impl_support_module(
-    FakeGroupedLinear, *, activation_func, gated_linear_unit, use_fused_weighted_squared_relu=False
+    FakeGroupedLinear,
+    *,
+    activation_func,
+    gated_linear_unit,
+    use_fused_weighted_squared_relu=False,
+    moe_mlp_glu_interleave_size=32,
 ):
     module = TEGroupedMLP.__new__(TEGroupedMLP)
     torch.nn.Module.__init__(module)
@@ -560,6 +565,7 @@ def _make_fused_impl_support_module(
         activation_func=activation_func,
         gated_linear_unit=gated_linear_unit,
         use_fused_weighted_squared_relu=use_fused_weighted_squared_relu,
+        moe_mlp_glu_interleave_size=moe_mlp_glu_interleave_size,
         moe_apply_probs_on_input=False,
     )
     module.activation_func = object()
@@ -591,12 +597,53 @@ def test_is_fused_impl_supported_uses_config_activation_for_swiglu(monkeypatch):
     assert module._is_fused_impl_supported() is True
 
 
+def test_is_fused_impl_supported_requires_cutedsl_env(monkeypatch):
+    fake_te, FakeGroupedLinear = _make_fake_te_namespace()
+    monkeypatch.setattr(experts_module, "te", fake_te)
+    monkeypatch.setattr(experts_module, "HAVE_TE", True)
+    monkeypatch.setattr(experts_module, "is_te_min_version", lambda _: True)
+    monkeypatch.delenv("NVTE_CUTEDSL_FUSED_GROUPED_MLP", raising=False)
+    _install_fake_te_ops_modules(monkeypatch, fake_te)
+
+    module = _make_fused_impl_support_module(
+        FakeGroupedLinear, activation_func=F.silu, gated_linear_unit=True
+    )
+
+    assert module._is_fused_impl_supported() is False
+
+
+def test_is_fused_impl_supported_requires_glu_interleave_32(monkeypatch):
+    fake_te, FakeGroupedLinear = _make_fake_te_namespace()
+    monkeypatch.setattr(experts_module, "te", fake_te)
+    monkeypatch.setattr(experts_module, "HAVE_TE", True)
+    monkeypatch.setattr(experts_module, "is_te_min_version", lambda _: True)
+    _install_fake_te_ops_modules(monkeypatch, fake_te)
+
+    module = _make_fused_impl_support_module(
+        FakeGroupedLinear,
+        activation_func=F.silu,
+        gated_linear_unit=True,
+        moe_mlp_glu_interleave_size=16,
+    )
+
+    assert module._is_fused_impl_supported() is False
+
+
 @pytest.mark.parametrize(
-    ("use_fused_weighted_squared_relu", "gated_linear_unit", "expected"),
-    [(True, False, True), (False, False, False), (True, True, False)],
+    (
+        "use_fused_weighted_squared_relu",
+        "gated_linear_unit",
+        "moe_mlp_glu_interleave_size",
+        "expected",
+    ),
+    [(True, False, None, True), (False, False, None, False), (True, True, 32, False)],
 )
 def test_is_fused_impl_supported_gates_scaled_srelu_on_weighted_flag_and_non_glu(
-    monkeypatch, use_fused_weighted_squared_relu, gated_linear_unit, expected
+    monkeypatch,
+    use_fused_weighted_squared_relu,
+    gated_linear_unit,
+    moe_mlp_glu_interleave_size,
+    expected,
 ):
     fake_te, FakeGroupedLinear = _make_fake_te_namespace()
     monkeypatch.setattr(experts_module, "te", fake_te)
@@ -609,6 +656,7 @@ def test_is_fused_impl_supported_gates_scaled_srelu_on_weighted_flag_and_non_glu
         activation_func=squared_relu,
         gated_linear_unit=gated_linear_unit,
         use_fused_weighted_squared_relu=use_fused_weighted_squared_relu,
+        moe_mlp_glu_interleave_size=moe_mlp_glu_interleave_size,
     )
 
     assert module._is_fused_impl_supported() is expected
@@ -962,6 +1010,7 @@ class TestTEGroupedMLP:
             moe_router_topk=1,
             moe_grouped_gemm=True,
             use_transformer_engine_op_fuser=True,
+            moe_mlp_glu_interleave_size=32,
         )
         _set_random_seed(seed_=123, data_parallel_random_init=False)
         submodules = get_submodules(
@@ -1049,6 +1098,7 @@ class TestTEGroupedMLP:
             moe_router_topk=1,
             moe_grouped_gemm=True,
             use_transformer_engine_op_fuser=True,
+            moe_mlp_glu_interleave_size=32,
         )
         _set_random_seed(seed_=123, data_parallel_random_init=False)
         submodules = get_submodules(


### PR DESCRIPTION
## Summary
- Add diagnostic warnings for each unsupported TEGroupedMLP op-fuser condition.
- Require `NVTE_CUTEDSL_FUSED_GROUPED_MLP` before enabling the fused implementation, and require `moe_mlp_glu_interleave_size=32` for GLU fusion to match TE's CuTe DSL grouped MLP matching rules.
- Preserve the existing main-branch ScaledSReLU fused path and update unit/functional tests to cover the new gates.

## Test plan
- `uv run --project /project/agentic-mcore-dev python -m py_compile megatron/core/transformer/moe/experts.py tests/unit_tests/transformer/moe/test_grouped_mlp.py`
- `CHECK_ONLY=true BASE_REF=main uv run --project /project/agentic-mcore-dev --extra mcore-lint -- bash tools/autoformat.sh`
- `uv run --project /project/agentic-mcore-dev --extra mcore-lint -- python tools/check_copyright.py megatron/core/transformer/moe/experts.py tests/unit_tests/transformer/moe/test_grouped_mlp.py`

Note: local pytest could not start in this checkout because the local uv environment does not have `torch` installed.

Generated with Codex.