### PR TITLE
build: add managed = true to [tool.uv]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ ci = ["python-gitlab", "slack-sdk", "pandas"]
 no_pypi_wheels = ["flash_mla", "emerging_optimizers"]
 
 [tool.uv]
+managed = true
 default-groups = ["linting", "build", "test"]
 no-build-isolation-package = [
     "causal-conv1d",


### PR DESCRIPTION
## Summary
- Adds `managed = true` to `[tool.uv]` in `pyproject.toml`, declaring that uv manages this project's environment

## Test plan
- No functional change; CI passes as-is