### PR TITLE
fix(mHC): make HybridStack mHC wrapper CUDA-graph capturable

### DIFF
--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -24,12 +24,13 @@ from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import CheckpointManager
 from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.hyper_connection import (
     HyperConnectionModule,
     learned_output_contract,
 )
 from megatron.core.transformer.identity_op import IdentityOp
-from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.module import GraphableMegatronModule, MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.transformer.utils import (
@@ -55,7 +56,7 @@ class HybridStackSubmodules:
     mtp_block_spec: Optional[ModuleSpec] = None
 
 
-class HyperConnectionHybridLayer(MegatronModule):
+class HyperConnectionHybridLayer(GraphableMegatronModule):
     """Layer-boundary mHC wrapper for HybridStack layers.
 
     Hybrid layers already own their local residual paths. For this initial
@@ -74,6 +75,17 @@ class HyperConnectionHybridLayer(MegatronModule):
     migration. Note: this differs from `HyperConnectionTransformerLayer`,
     which subclasses `TransformerLayer` and only adds new sibling fields,
     keeping all base keys stable.
+
+    CUDA graphs: this wrapper subclasses ``GraphableMegatronModule`` so that, with
+    ``cuda_graph_impl="transformer_engine"``, the whole wrapper forward (mHC
+    aggregate + inner layer + n-stream BDA) is captured as one per-layer graph —
+    mirroring ``HyperConnectionTransformerLayer`` on the GPT path. Without this,
+    the TE graph discovery (``_layer_is_graphable``) only inspects the top-level
+    layer type and silently skips every wrapped layer, so an mHC-enabled
+    HybridStack would run entirely eager. The inner layer's own ``__call__`` graph
+    routing is bypassed during capture (see ``_call_inner_layer``) to avoid nested
+    capture; the inner layer's params are still covered by the wrapper graph's
+    manual hooks because ``_get_submodules_under_cudagraphs`` returns ``[self]``.
     """
 
     def __init__(self, config: TransformerConfig, layer: MegatronModule) -> None:
@@ -85,6 +97,50 @@ class HyperConnectionHybridLayer(MegatronModule):
             self.hyper_connection.to(dtype=config.params_dtype)
         if hasattr(layer, 'tp_group'):
             self.tp_group = layer.tp_group
+
+    def get_layer_static_inputs(self, seq_length, micro_batch_size):
+        """Override to produce n-stream hidden_states of shape [s, b, n*C].
+
+        CUDA graph capture allocates static buffers sized by this method. The base
+        returns [s, b, C], but mHC layers carry n-stream hidden states [s, b, n*C].
+        Mirrors ``HyperConnectionTransformerLayer.get_layer_static_inputs``.
+        """
+        static_inputs = super().get_layer_static_inputs(seq_length, micro_batch_size)
+        hs = static_inputs["hidden_states"]
+        n = self.config.num_residual_streams
+        static_inputs["hidden_states"] = torch.ones(
+            (hs.shape[0], hs.shape[1], n * self.config.hidden_size),
+            dtype=hs.dtype,
+            requires_grad=hs.requires_grad,
+            device=hs.device,
+        )
+        return static_inputs
+
+    def _te_cuda_graph_capture(self, *args, **kwargs):
+        """Capture the whole wrapper forward as one graph.
+
+        The wrapper forward returns ``(hidden_states, context)``; ``context`` is
+        ``None`` for the hybrid layer types that participate in graphing (no
+        cross-attention), so it is dropped from the captured outputs — a tuple
+        containing ``None`` cannot be a CUDA-graph output. Mirrors the
+        ``context is not None`` handling in ``TransformerLayer._te_cuda_graph_capture``.
+        """
+        hidden_states, context = self.forward(*args, **kwargs)
+        cuda_graph_outputs = [hidden_states]
+        if context is not None:
+            cuda_graph_outputs.append(context)
+        return tuple(cuda_graph_outputs)
+
+    def _te_cuda_graph_replay(self, *args, **kwargs):
+        """Replay the captured wrapper graph and restore the (hidden_states, context) contract.
+
+        The whole wrapper forward is captured as one graph whose only output is the
+        layer's n-stream hidden_states (``context`` is ``None`` for the graphed
+        hybrid layer types, so it was dropped at capture). The HybridStack forward
+        loop unpacks ``hidden_states, _ = layer(...)``, so re-append ``None`` here.
+        """
+        cuda_graph_output = list(super()._te_cuda_graph_replay(*args, **kwargs))
+        return cuda_graph_output[0], None
 
     def mamba_state_shapes_per_request(self) -> Optional[Tuple[Tuple[int], Tuple[int]]]:
         """Delegate Mamba inference state shape requests to the wrapped layer."""
@@ -102,8 +158,18 @@ class HyperConnectionHybridLayer(MegatronModule):
         packed_seq_params: Optional[PackedSeqParams],
         padding_mask: Optional[Tensor],
     ) -> Tuple[Tensor, Optional[Tensor]]:
+        # When this wrapper is itself being CUDA-graph captured, the inner layer
+        # must run as a plain forward: routing through its ``__call__`` would
+        # trigger nested TE graph capture (the inner layer is also a
+        # GraphableMegatronModule). During eager steps we keep ``__call__`` so the
+        # inner layer's forward pre-hooks (e.g. param all-gather) fire normally;
+        # under graph replay these are driven by the wrapper's manual hooks.
+        from megatron.core.transformer.cuda_graphs import is_graph_capturing
+
+        inner = self.inner_layer.forward if is_graph_capturing() else self.inner_layer
+
         if isinstance(self.inner_layer, TransformerLayer):
-            output = self.inner_layer(
+            output = inner(
                 hidden_states=hidden_states,
                 attention_mask=attention_mask,
                 inference_context=inference_context,
@@ -120,7 +186,7 @@ class HyperConnectionHybridLayer(MegatronModule):
             # rotary_pos_emb / sequence_len_offset / padding_mask — pass only
             # the common arguments. New layer types that consume any of these
             # must add explicit handling here.
-            output = self.inner_layer(
+            output = inner(
                 hidden_states=hidden_states,
                 attention_mask=attention_mask,
                 inference_context=inference_context,
@@ -135,7 +201,7 @@ class HyperConnectionHybridLayer(MegatronModule):
     def forward(
         self,
         hidden_states: Tensor,
-        attention_mask: Tensor,
+        attention_mask: Optional[Tensor] = None,
         inference_context: Optional[BaseInferenceContext] = None,
         rotary_pos_emb: Optional[Tensor] = None,
         sequence_len_offset: Optional[Tensor] = None,
@@ -143,7 +209,13 @@ class HyperConnectionHybridLayer(MegatronModule):
         padding_mask: Optional[Tensor] = None,
         mhc_recompute_manager=None,
     ) -> Tuple[Tensor, Optional[Tensor]]:
-        """Run the wrapped hybrid layer through one layer-boundary mHC update."""
+        """Run the wrapped hybrid layer through one layer-boundary mHC update.
+
+        ``attention_mask`` defaults to ``None`` so that CUDA-graph capture, which
+        calls this forward with only the static ``hidden_states`` input, does not
+        fail on a missing positional argument (causal masking is inferred by the
+        attention backend when the mask is ``None``).
+        """
         residual = hidden_states
         aggregated, h_res, h_post = self.hyper_connection(
             hidden_states, mhc_recompute_manager=mhc_recompute_manager

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1703,11 +1703,31 @@ def _layer_is_graphable(layer, config):
         return True
 
     # import modules here to avoid a circular import
+    from megatron.core.models.hybrid.hybrid_block import HyperConnectionHybridLayer
     from megatron.core.ssm.mamba_layer import MambaLayer
     from megatron.core.transformer.identity_op import IdentityOp
     from megatron.core.transformer.mlp import MLP
     from megatron.core.transformer.moe.moe_layer import MoELayer
     from megatron.core.transformer.transformer_layer import TransformerLayer
+
+    # mHC wrapper: the whole wrapper forward (mHC aggregate + inner layer + BDA) is
+    # captured as one graph, so graphability is decided by the inner layer's
+    # type/scope. MoE inner layers are excluded: a whole-layer capture would try to
+    # graph the expert all-to-all, which is not graph-safe (the GPT path graphs only
+    # moe_router/moe_preprocess and runs experts eagerly). Those wrappers stay eager.
+    if isinstance(layer, HyperConnectionHybridLayer):
+        inner = layer.inner_layer
+        if isinstance(inner, MambaLayer) and CudaGraphModule.mamba in config.cuda_graph_modules:
+            return True
+        if isinstance(inner, TransformerLayer) and not isinstance(inner.mlp, MoELayer):
+            if CudaGraphModule.attn in config.cuda_graph_modules and not (
+                isinstance(inner.self_attention, IdentityOp)
+                and isinstance(inner.cross_attention, IdentityOp)
+            ):
+                return True
+            if CudaGraphModule.mlp in config.cuda_graph_modules and isinstance(inner.mlp, MLP):
+                return True
+        return False
 
     if isinstance(layer, MambaLayer) and CudaGraphModule.mamba in config.cuda_graph_modules:
         # mamba layer.

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -15,7 +15,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_mtp_block_spec,
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
-from megatron.core.models.hybrid.hybrid_block import HybridStack
+from megatron.core.models.hybrid.hybrid_block import HybridStack, HyperConnectionHybridLayer
 from megatron.core.models.hybrid.hybrid_layer_allocation import validate_segment_layers
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.num_microbatches_calculator import (
@@ -33,9 +33,10 @@ from megatron.core.transformer.cuda_graphs import (
     CudaGraphManager,
     TECudaGraphHelper,
     _CudagraphGlobalRecord,
+    _layer_is_graphable,
 )
 from megatron.core.transformer.enums import CudaGraphModule, CudaGraphScope, InferenceCudaGraphScope
-from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.module import GraphableMegatronModule, MegatronModule
 from megatron.core.transformer.moe.fused_a2a import reset_hybrid_ep_buffer
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -799,6 +800,50 @@ class TestParallelHybridBlockCudagraphs:
             assert len(parallel_mamba_block.layers[0].cudagraph_manager.cudagraph_runners) == 1
 
             del parallel_mamba_block.layers[_].cudagraph_manager.cudagraph_runners[0].fwd_graph
+
+    def test_mhc_hybrid_layers_are_te_cudagraph_capturable(self):
+        """Regression: a mHC-enabled HybridStack must expose graph-capturable layers.
+
+        When ``enable_hyper_connections=True``, ``HybridStack`` wraps every layer in
+        ``HyperConnectionHybridLayer``. That wrapper must subclass
+        ``GraphableMegatronModule`` and be recognized by ``_layer_is_graphable`` so TE
+        cuda-graph discovery finds the wrapped layers. Before the fix the wrapper
+        subclassed plain ``MegatronModule``, so discovery rejected every layer (0
+        graphable) and CUDA graph capture was silently skipped for the whole hybrid
+        model -- making the mHC hybrid run fully eager (several times slower than the
+        graphed GPT mHC path). This test fails on the pre-fix code via both assertions.
+        """
+        # The wrapper must be graph-capturable by construction.
+        assert issubclass(HyperConnectionHybridLayer, GraphableMegatronModule)
+
+        layer_type_list = validate_segment_layers("M-M*-")  # mamba / mlp / attention mix
+        config = TransformerConfig(
+            hidden_size=256,
+            num_layers=len(layer_type_list),
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            cuda_graph_impl="transformer_engine",
+            enable_hyper_connections=True,
+            num_residual_streams=4,
+            cuda_graph_modules=[CudaGraphModule.attn, CudaGraphModule.mamba, CudaGraphModule.mlp],
+        )
+        block = HybridStack(
+            config,
+            hybrid_stack_spec.submodules,
+            layer_type_list=layer_type_list,
+            pp_layer_offset=0,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=["tp", "pp", "cp"]
+            ),
+        )
+
+        # Every layer is wrapped, and the wrappers are discoverable as graphable.
+        assert all(isinstance(layer, HyperConnectionHybridLayer) for layer in block.layers)
+        graphable = [layer for layer in block.layers if _layer_is_graphable(layer, config)]
+        assert len(graphable) > 0, (
+            "mHC HybridStack produced 0 graphable layers -- TE cuda-graph capture would "
+            "be silently skipped for the entire model (the pre-fix bug)."
+        )
 
 
 # Global storage for comparing unique buffer counts across different num_microbatches,


### PR DESCRIPTION
## Problem

With `--cuda-graph-impl transformer_engine`, an mHC-enabled **HybridModel** silently ran with **CUDA graphs disabled for the entire model** — making it several times slower than the GPT mHC path at scale (fully eager / launch-bound).

## Root cause

When `enable_hyper_connections=True`, `HybridStack` wraps every layer in `HyperConnectionHybridLayer`. That wrapper subclassed plain `MegatronModule`, so the TE cuda-graph discovery gate `_layer_is_graphable` (which requires `GraphableMegatronModule`) rejected **all** wrapped layers → `0 graphable layers` → `TECudaGraphHelper: No graphable layers found. Skipping CUDA graph capture.` Discovery inspects only the top-level layer type and does not recurse into the wrapper.

The GPT path is unaffected because `HyperConnectionTransformerLayer` subclasses `TransformerLayer` (already a `GraphableMegatronModule`). The bug only manifests with CUDA graphs on, which is why compile/lint and graph-off tests missed it.

## Fix

Mirror the GPT path so the wrapper participates in TE graph capture:
- `HyperConnectionHybridLayer` now subclasses `GraphableMegatronModule`.
- `get_layer_static_inputs` returns n-stream `[s, b, n*C]` static buffers.
- The whole wrapper forward (mHC aggregate + inner layer + n-stream BDA) is captured as one per-layer graph; `_te_cuda_graph_capture` drops the `None` context and `_te_cuda_graph_replay` restores the `(hidden_states, context)` contract.
- `_call_inner_layer` routes the inner layer through `.forward` during capture to avoid nested graph capture of the (also-graphable) inner layer.
- `attention_mask` defaults to `None` so capture (hidden_states-only) doesn't fail.
- `_layer_is_graphable` recognizes the wrapper and delegates the scope/type decision to `inner_layer`, **excluding MoE inner layers** (a whole-layer capture would graph the expert all-to-all, which is not graph-safe — matching the GPT path that graphs only `moe_router`/`moe_preprocess` and runs experts eagerly).

## Validation

- **Unit test** (added): `tests/unit_tests/transformer/test_cuda_graphs.py::TestParallelHybridBlockCudagraphs::test_mhc_hybrid_layers_are_te_cudagraph_capturable` — asserts the wrapper is a `GraphableMegatronModule` and that a mHC `HybridStack` exposes graph-capturable layers (`>0`). Fails on pre-fix code, passes with the fix.
- **Generic hybrid (attn+MLP), 1×H100**: graphable layers `0 → 8`, capture succeeds, **per-iteration loss bit-identical** to the eager run.
- **Real DSv4 hybrid (MLA + DSA + MoE + MTP), 1×GB200 smoke**: graphable `0 → 8`, capture succeeds, loss bit-identical to eager, step time matches the GPT mHC path.

## Note (out of scope)

During DSv4 validation I also hit a separate, pre-existing capture-safety bug in the unfused DSA path (`csa.py`: `torch.tensor(-1, device=x.device)` is a host→device copy, illegal during graph capture). That is unrelated to mHC and is **not** included here; it affects the GPT path too when graphing the unfused DSA attention and is worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
