### PR TITLE
Add transactional async scheduling for dynamic inference

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/nvrx.py
+++ b/megatron/core/dist_checkpointing/strategies/nvrx.py
@@ -41,9 +41,8 @@ def has_nvrx_async_support() -> bool:
         getattr(state_dict_saver, "save_state_dict_async_finalize", None),
         getattr(state_dict_saver, "save_state_dict_async_plan", None),
     )
-    assert (
-        is_nvrx_min_version()
-    ), f"Minimum required nvidia-resiliency-ext package version is {NVRX_MIN_VERSION}."
+    if not is_nvrx_min_version():
+        return False
 
     return all(symbol is not None for symbol in required_symbols) and hasattr(
         filesystem_async, "_results_queue"

--- a/megatron/core/inference/async_stream.py
+++ b/megatron/core/inference/async_stream.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 # Copyright 2025 The vLLM authors.
 #
-# This code was adopted from https://github.com/vllm-project/vllm/
+# This code was derived from https://github.com/vllm-project/vllm/
 # This source code is licensed under the Apache license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -14,7 +14,7 @@ import zlib
 from collections import Counter, deque
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Deque, Iterable, Optional, Sequence
+from typing import Any, Callable, Deque, Iterable, Optional, Sequence
 
 import torch
 
@@ -252,7 +252,7 @@ class StepTxn:
     request_ids: Sequence[int]
     slot_id: int = 0
     decode_only: bool = True
-    cuda_graph_key: Optional[tuple] = None
+    cuda_graph_key: Optional[Any] = None
     h2d_done_event: object = None
     forward_done_event: object = None
     forward_timing_start_event: object = None
@@ -336,7 +336,7 @@ class StepTxn:
         *,
         terminal_request_ids: Iterable[int] = (),
         decode_only: bool = True,
-        cuda_graph_key: Optional[tuple] = None,
+        cuda_graph_key: Optional[Any] = None,
     ) -> bool:
         """Check the no-reject-after-launch adoption invariant.
 
@@ -456,13 +456,6 @@ class AsyncDecodeSlot:
         self.forward_done_event = self._record_event_if_cuda()
         return self.forward_done_event
 
-    def cuda_graph_key(self, base_key: Optional[tuple]) -> Optional[tuple]:
-        """Attach slot pointer identity to a CUDA graph key."""
-
-        if base_key is None:
-            return None
-        return (*base_key, ("decode_slot", self.slot_id, self.pointer_signature()))
-
     def _record_event_if_cuda(self, stream: object = None) -> object:
         buf = getattr(self.gpu_view, "_buf", None)
         if buf is None or not getattr(buf, "is_cuda", False):
@@ -470,22 +463,6 @@ class AsyncDecodeSlot:
         event = torch.cuda.Event()
         event.record(stream or torch.cuda.current_stream(buf.device))
         return event
-
-    def pointer_signature(self) -> tuple[int, ...]:
-        """Return stable pointer identity for graph-key safety checks."""
-
-        pointers = []
-        for name in (
-            "_buf",
-            "token_to_input_ids",
-            "token_to_pos_ids",
-            "token_to_block_idx",
-            "mha_block_table",
-        ):
-            tensor = getattr(self.gpu_view, name, None)
-            if tensor is not None and hasattr(tensor, "data_ptr"):
-                pointers.append(int(tensor.data_ptr()))
-        return tuple(pointers)
 
 
 class AsyncDecodeSlotRing:

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -65,6 +65,11 @@ class AsyncTxnDiagnostics:
     child_prestage_duration_us: float = 0.0
     ep_handoff_duration_us: float = 0.0
     child_graph_shape_duration_us: float = 0.0
+    controller_wall_us: float = 0.0
+    sampling_block_us: float = 0.0
+    engine_forward_wall_us: float = 0.0
+    engine_bookkeep_wall_us: float = 0.0
+    engine_postprocess_us: float = 0.0
     retire_queue_depth: int = 0
     eligibility_skip_reasons: Counter = field(default_factory=Counter)
 
@@ -108,6 +113,26 @@ class AsyncTxnDiagnostics:
     def record_child_graph_shape_duration(self, duration_us: float) -> None:
         if self.enabled:
             self.child_graph_shape_duration_us = max(0.0, float(duration_us))
+
+    def record_controller_wall_duration(self, duration_us: float) -> None:
+        if self.enabled:
+            self.controller_wall_us = max(0.0, float(duration_us))
+
+    def record_sampling_block_duration(self, duration_us: float) -> None:
+        if self.enabled:
+            self.sampling_block_us = max(0.0, float(duration_us))
+
+    def record_engine_forward_wall_duration(self, duration_us: float) -> None:
+        if self.enabled:
+            self.engine_forward_wall_us = max(0.0, float(duration_us))
+
+    def record_engine_bookkeep_wall_duration(self, duration_us: float) -> None:
+        if self.enabled:
+            self.engine_bookkeep_wall_us = max(0.0, float(duration_us))
+
+    def record_engine_postprocess_duration(self, duration_us: float) -> None:
+        if self.enabled:
+            self.engine_postprocess_us = max(0.0, float(duration_us))
 
     def record_sync_step(self, reason: AsyncTxnSkipReason | str) -> None:
         if not self.enabled:
@@ -159,6 +184,11 @@ class AsyncTxnDiagnostics:
             "child_prestage_duration_us": self.child_prestage_duration_us,
             "ep_handoff_duration_us": self.ep_handoff_duration_us,
             "child_graph_shape_duration_us": self.child_graph_shape_duration_us,
+            "controller_wall_us": self.controller_wall_us,
+            "sampling_block_us": self.sampling_block_us,
+            "engine_forward_wall_us": self.engine_forward_wall_us,
+            "engine_bookkeep_wall_us": self.engine_bookkeep_wall_us,
+            "engine_postprocess_us": self.engine_postprocess_us,
             "retire_queue_depth": self.retire_queue_depth,
             "eligibility_skip_reasons": dict(self.eligibility_skip_reasons),
             "top_skip_reason": self.top_skip_reason(),

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -58,6 +58,9 @@ class AsyncTxnDiagnostics:
     barrier_skips: int = 0
     retired: int = 0
     guard_failures: int = 0
+    chain_attempts: int = 0
+    chain_launches: int = 0
+    presampled_commits: int = 0
     prepare_under_forward: int = 0
     h2d_ready_before_sampling: int = 0
     sample_to_launch_latency_us: float = 0.0
@@ -155,6 +158,17 @@ class AsyncTxnDiagnostics:
         if self.enabled:
             self.guard_failures += 1
 
+    def record_chain_attempt(self, *, launched: bool = False) -> None:
+        if not self.enabled:
+            return
+        self.chain_attempts += 1
+        if launched:
+            self.chain_launches += 1
+
+    def record_presampled_commit(self) -> None:
+        if self.enabled:
+            self.presampled_commits += 1
+
     def record_retired(self, count: int = 1) -> None:
         if self.enabled:
             self.retired += count
@@ -182,6 +196,9 @@ class AsyncTxnDiagnostics:
             "barrier_skips": self.barrier_skips,
             "retired": self.retired,
             "guard_failures": self.guard_failures,
+            "chain_attempts": self.chain_attempts,
+            "chain_launches": self.chain_launches,
+            "presampled_commits": self.presampled_commits,
             "prepare_under_forward": self.prepare_under_forward,
             "h2d_ready_before_sampling": self.h2d_ready_before_sampling,
             "sample_to_launch_latency_us": self.sample_to_launch_latency_us,

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -33,6 +33,9 @@ class AsyncTxnSkipReason(str, Enum):
     RESUME_BARRIER = "resume_barrier"
     EVICT_BARRIER = "evict_barrier"
     FORCE_PAUSE_BARRIER = "force_pause_barrier"
+    CHILD_SLOT_BUSY = "child_slot_busy"
+    HYBRID_PRESTAGE_DEFERRED = "hybrid_prestage_deferred"
+    BOUNDARY_PRESTAGE_DEFERRED = "boundary_prestage_deferred"
     SERIAL_WRAPPED = "serial_wrapped"
     UNKNOWN_BARRIER = "unknown_barrier"
 

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -149,6 +149,18 @@ def _event_done(event) -> bool:
 
 
 @dataclass
+class KVBlockLease:
+    """A KV block reserved for a request before an async child launches."""
+
+    request_id: int
+    block_column: int
+    block_id: int
+
+    def key(self) -> tuple[int, int]:
+        return (int(self.request_id), int(self.block_column))
+
+
+@dataclass
 class StepTxn:
     """Ownership record for one decode forward step."""
 
@@ -161,17 +173,68 @@ class StepTxn:
     forward_done_event: object = None
     sample_done_event: object = None
     kv_block_ids: tuple[int, ...] = ()
+    kv_block_leases: tuple[KVBlockLease, ...] = ()
     mamba_slot_ids: tuple[int, ...] = ()
+    terminal_request_ids: tuple[int, ...] = ()
+    committed_request_ids: tuple[int, ...] = ()
     launched: bool = False
     adopted: bool = False
     retired: bool = False
 
     def __post_init__(self) -> None:
         self.request_ids = tuple(int(r) for r in self.request_ids)
+        self.kv_block_leases = tuple(
+            lease
+            if isinstance(lease, KVBlockLease)
+            else KVBlockLease(
+                request_id=int(lease[0]), block_column=int(lease[1]), block_id=int(lease[2])
+            )
+            for lease in self.kv_block_leases
+        )
+        self.terminal_request_ids = tuple(int(r) for r in self.terminal_request_ids)
+        self.committed_request_ids = tuple(int(r) for r in self.committed_request_ids)
 
     @property
     def request_id_set(self) -> set[int]:
         return set(self.request_ids)
+
+    @property
+    def terminal_request_id_set(self) -> set[int]:
+        return set(self.terminal_request_ids)
+
+    @property
+    def kv_lease_map(self) -> dict[tuple[int, int], int]:
+        return {lease.key(): int(lease.block_id) for lease in self.kv_block_leases}
+
+    def get_kv_lease(self, request_id: int, block_column: int) -> Optional[int]:
+        """Return a reserved block for ``(request_id, block_column)``, if any."""
+
+        return self.kv_lease_map.get((int(request_id), int(block_column)))
+
+    def mark_committed(
+        self,
+        committed_request_ids: Iterable[int],
+        *,
+        terminal_request_ids: Iterable[int] = (),
+    ) -> None:
+        """Record CPU commit results keyed by request id."""
+
+        self.committed_request_ids = tuple(int(r) for r in committed_request_ids)
+        self.terminal_request_ids = tuple(int(r) for r in terminal_request_ids)
+
+    def unused_kv_leases(self) -> tuple[KVBlockLease, ...]:
+        """Return leased blocks that did not become part of committed survivors."""
+
+        if not self.kv_block_leases:
+            return ()
+        committed = set(self.committed_request_ids)
+        return tuple(lease for lease in self.kv_block_leases if lease.request_id not in committed)
+
+    def committed_row_indices(self, committed_request_ids: Iterable[int]) -> tuple[int, ...]:
+        """Map committed request ids back to launched row indices."""
+
+        row_by_request_id = {request_id: row for row, request_id in enumerate(self.request_ids)}
+        return tuple(row_by_request_id[int(request_id)] for request_id in committed_request_ids)
 
     def h2d_ready(self) -> bool:
         return _event_done(self.h2d_done_event)

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -370,6 +370,7 @@ class AsyncDecodeSlot:
 
     slot_id: int
     gpu_view: object
+    cpu_bookkeeping_buf: object = None
     h2d_done_event: object = None
     forward_done_event: object = None
 

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -273,6 +273,36 @@ class AsyncDecodeSlot:
     def can_reuse(self) -> bool:
         return _event_done(self.h2d_done_event) and _event_done(self.forward_done_event)
 
+    def copy_bookkeeping_from_cpu(
+        self, cpu_bookkeeping_buf: torch.Tensor, *, non_blocking: bool = True
+    ) -> object:
+        """Copy CPU bookkeeping into this slot and record the H2D dependency."""
+
+        self.gpu_view._buf.copy_(cpu_bookkeeping_buf, non_blocking=non_blocking)
+        self.h2d_done_event = self._record_event_if_cuda()
+        return self.h2d_done_event
+
+    def record_forward_done(self) -> object:
+        """Record the forward completion dependency for this slot."""
+
+        self.forward_done_event = self._record_event_if_cuda()
+        return self.forward_done_event
+
+    def cuda_graph_key(self, base_key: Optional[tuple]) -> Optional[tuple]:
+        """Attach slot pointer identity to a CUDA graph key."""
+
+        if base_key is None:
+            return None
+        return (*base_key, ("decode_slot", self.slot_id, self.pointer_signature()))
+
+    def _record_event_if_cuda(self) -> object:
+        buf = getattr(self.gpu_view, "_buf", None)
+        if buf is None or not getattr(buf, "is_cuda", False):
+            return None
+        event = torch.cuda.Event()
+        event.record(torch.cuda.current_stream(buf.device))
+        return event
+
     def pointer_signature(self) -> tuple[int, ...]:
         """Return stable pointer identity for graph-key safety checks."""
 
@@ -298,6 +328,10 @@ class AsyncDecodeSlotRing:
             raise ValueError("async decode transaction ring requires exactly two slots")
         self._slots = tuple(slots)
         self.current_index = 0
+
+    @property
+    def slots(self) -> tuple[AsyncDecodeSlot, AsyncDecodeSlot]:
+        return self._slots
 
     @property
     def current(self) -> AsyncDecodeSlot:

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -378,12 +378,21 @@ class AsyncDecodeSlot:
         return _event_done(self.h2d_done_event) and _event_done(self.forward_done_event)
 
     def copy_bookkeeping_from_cpu(
-        self, cpu_bookkeeping_buf: torch.Tensor, *, non_blocking: bool = True
+        self,
+        cpu_bookkeeping_buf: torch.Tensor,
+        *,
+        non_blocking: bool = True,
+        stream: object = None,
     ) -> object:
         """Copy CPU bookkeeping into this slot and record the H2D dependency."""
 
-        self.gpu_view._buf.copy_(cpu_bookkeeping_buf, non_blocking=non_blocking)
-        self.h2d_done_event = self._record_event_if_cuda()
+        if stream is not None and getattr(self.gpu_view._buf, "is_cuda", False):
+            with torch.cuda.stream(stream):
+                self.gpu_view._buf.copy_(cpu_bookkeeping_buf, non_blocking=non_blocking)
+            self.h2d_done_event = self._record_event_if_cuda(stream=stream)
+        else:
+            self.gpu_view._buf.copy_(cpu_bookkeeping_buf, non_blocking=non_blocking)
+            self.h2d_done_event = self._record_event_if_cuda()
         return self.h2d_done_event
 
     def record_forward_done(self) -> object:
@@ -399,12 +408,12 @@ class AsyncDecodeSlot:
             return None
         return (*base_key, ("decode_slot", self.slot_id, self.pointer_signature()))
 
-    def _record_event_if_cuda(self) -> object:
+    def _record_event_if_cuda(self, stream: object = None) -> object:
         buf = getattr(self.gpu_view, "_buf", None)
         if buf is None or not getattr(buf, "is_cuda", False):
             return None
         event = torch.cuda.Event()
-        event.record(torch.cuda.current_stream(buf.device))
+        event.record(stream or torch.cuda.current_stream(buf.device))
         return event
 
     def pointer_signature(self) -> tuple[int, ...]:

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -10,6 +10,7 @@ and when they may be reused.
 
 from __future__ import annotations
 
+import zlib
 from collections import Counter, deque
 from dataclasses import dataclass, field
 from enum import Enum
@@ -433,6 +434,173 @@ class AsyncLaunchEligibility:
     reason: Optional[AsyncTxnSkipReason] = None
     boundary_request_ids: tuple[int, ...] = ()
     required_boundary_blocks: int = 0
+
+
+def _group_size(group) -> int:
+    if group is None:
+        return 1
+    if hasattr(group, "size"):
+        return int(group.size())
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        return int(torch.distributed.get_world_size(group))
+    return 1
+
+
+def _group_rank(group) -> int:
+    if group is None:
+        return 0
+    if hasattr(group, "rank"):
+        return int(group.rank())
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        return int(torch.distributed.get_rank(group))
+    return 0
+
+
+def _global_src_rank(group, src_group_rank: int) -> int:
+    if (
+        group is not None
+        and torch.distributed.is_available()
+        and torch.distributed.is_initialized()
+        and hasattr(torch.distributed, "get_process_group_ranks")
+    ):
+        return int(torch.distributed.get_process_group_ranks(group)[src_group_rank])
+    return int(src_group_rank)
+
+
+def _broadcast_tensor(tensor: torch.Tensor, group, src_group_rank: int, broadcast_fn=None) -> None:
+    if _group_size(group) <= 1:
+        return
+    src_rank = _global_src_rank(group, src_group_rank)
+    if broadcast_fn is None:
+        broadcast_fn = torch.distributed.broadcast
+    broadcast_fn(tensor, src=src_rank, group=group)
+
+
+def broadcast_ep_sampled_tokens(
+    sampled_tokens: torch.Tensor,
+    active_request_count: int,
+    group,
+    *,
+    src_group_rank: int = 0,
+    broadcast_fn=None,
+) -> torch.Tensor:
+    """Broadcast canonical sampled tokens across an EP group.
+
+    Only row-ordered token values are exchanged. Request ids, row maps, KV block
+    ids, and Mamba slot ids remain local.
+    """
+
+    if sampled_tokens is None or int(active_request_count) <= 0:
+        return sampled_tokens
+    token_slice = sampled_tokens[: int(active_request_count)]
+    _broadcast_tensor(token_slice, group, src_group_rank, broadcast_fn=broadcast_fn)
+    return sampled_tokens
+
+
+def broadcast_ep_stop_word_finished_ids(
+    active_request_ids: Sequence[int] | torch.Tensor,
+    finished_request_ids: Iterable[int],
+    group,
+    *,
+    src_group_rank: int = 0,
+    device: Optional[torch.device | int | str] = None,
+    broadcast_fn=None,
+) -> set[int]:
+    """Broadcast stop-word finishes as an active-row mask.
+
+    The mask lets every EP rank derive its local finished-id set without
+    exchanging request ids.
+    """
+
+    if isinstance(active_request_ids, torch.Tensor):
+        request_id_list = [int(request_id) for request_id in active_request_ids.tolist()]
+    else:
+        request_id_list = [int(request_id) for request_id in active_request_ids]
+    active_count = len(request_id_list)
+    if active_count == 0:
+        return set()
+
+    if device is None:
+        device = (
+            active_request_ids.device
+            if isinstance(active_request_ids, torch.Tensor)
+            else torch.device("cpu")
+        )
+    finished_set = {int(request_id) for request_id in finished_request_ids}
+    mask = torch.tensor(
+        [1 if request_id in finished_set else 0 for request_id in request_id_list],
+        dtype=torch.int32,
+        device=device,
+    )
+    _broadcast_tensor(mask, group, src_group_rank, broadcast_fn=broadcast_fn)
+    mask_cpu = mask.cpu()
+    return {
+        request_id
+        for request_id, finished in zip(request_id_list, mask_cpu.tolist())
+        if int(finished) != 0
+    }
+
+
+def broadcast_ep_accepted_counts(
+    accepted_counts: torch.Tensor,
+    active_request_count: int,
+    group,
+    *,
+    src_group_rank: int = 0,
+    broadcast_fn=None,
+) -> torch.Tensor:
+    """Broadcast canonical MTP accepted-count rows across an EP group."""
+
+    if accepted_counts is None or int(active_request_count) <= 0:
+        return accepted_counts
+    counts_slice = accepted_counts[: int(active_request_count)]
+    _broadcast_tensor(counts_slice, group, src_group_rank, broadcast_fn=broadcast_fn)
+    return accepted_counts
+
+
+def _phase_code(phase: str) -> int:
+    return zlib.adler32(phase.encode("utf-8")) & 0x7FFFFFFF
+
+
+def assert_ep_phase_tag(
+    phase: str,
+    step_id: int,
+    active_request_count: int,
+    group,
+    *,
+    device: Optional[torch.device | int | str] = None,
+    all_gather_fn=None,
+) -> torch.Tensor:
+    """Verify that EP ranks enter the same phase and active shape.
+
+    This is a debug/proof hook. It exchanges only ``(phase, step_id,
+    active_count)`` tags and raises a clear error instead of letting skew hang in
+    a later collective.
+    """
+
+    if device is None:
+        device = torch.cuda.current_device() if torch.cuda.is_available() else torch.device("cpu")
+    local = torch.tensor(
+        [_phase_code(phase), int(step_id), int(active_request_count)],
+        dtype=torch.int64,
+        device=device,
+    )
+    size = _group_size(group)
+    if size <= 1:
+        return local
+    gathered = [torch.empty_like(local) for _ in range(size)]
+    if all_gather_fn is None:
+        all_gather_fn = torch.distributed.all_gather
+    all_gather_fn(gathered, local, group=group)
+    expected = gathered[0]
+    mismatched = [idx for idx, tag in enumerate(gathered) if not torch.equal(tag, expected)]
+    if mismatched:
+        tags = [tag.cpu().tolist() for tag in gathered]
+        raise RuntimeError(
+            "EP async transaction phase mismatch: "
+            f"phase={phase!r}, local_tag={local.cpu().tolist()}, gathered_tags={tags}"
+        )
+    return local
 
 
 def boundary_crossing_request_ids(context) -> tuple[int, ...]:

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -65,6 +65,7 @@ class AsyncTxnDiagnostics:
     child_prestage_duration_us: float = 0.0
     ep_handoff_duration_us: float = 0.0
     child_graph_shape_duration_us: float = 0.0
+    child_forward_gpu_us: float = 0.0
     controller_wall_us: float = 0.0
     sampling_block_us: float = 0.0
     engine_forward_wall_us: float = 0.0
@@ -113,6 +114,10 @@ class AsyncTxnDiagnostics:
     def record_child_graph_shape_duration(self, duration_us: float) -> None:
         if self.enabled:
             self.child_graph_shape_duration_us = max(0.0, float(duration_us))
+
+    def record_child_forward_gpu_duration(self, duration_us: float) -> None:
+        if self.enabled:
+            self.child_forward_gpu_us = max(0.0, float(duration_us))
 
     def record_controller_wall_duration(self, duration_us: float) -> None:
         if self.enabled:
@@ -184,6 +189,7 @@ class AsyncTxnDiagnostics:
             "child_prestage_duration_us": self.child_prestage_duration_us,
             "ep_handoff_duration_us": self.ep_handoff_duration_us,
             "child_graph_shape_duration_us": self.child_graph_shape_duration_us,
+            "child_forward_gpu_us": self.child_forward_gpu_us,
             "controller_wall_us": self.controller_wall_us,
             "sampling_block_us": self.sampling_block_us,
             "engine_forward_wall_us": self.engine_forward_wall_us,
@@ -232,6 +238,8 @@ class StepTxn:
     cuda_graph_key: Optional[tuple] = None
     h2d_done_event: object = None
     forward_done_event: object = None
+    forward_timing_start_event: object = None
+    forward_timing_done_event: object = None
     sample_done_event: object = None
     cpu_bookkeeping_buf: Optional[torch.Tensor] = None
     kv_block_ids: tuple[int, ...] = ()

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -72,16 +72,27 @@ class AsyncTxnDiagnostics:
         if under_forward:
             self.prepare_under_forward += 1
 
-    def record_launched(self, *, h2d_ready_before_sampling: bool = False) -> None:
+    def record_launched(
+        self,
+        *,
+        h2d_ready_before_sampling: bool = False,
+        sample_to_launch_latency_us: Optional[float] = None,
+    ) -> None:
         if not self.enabled:
             return
         self.launched += 1
         if h2d_ready_before_sampling:
             self.h2d_ready_before_sampling += 1
+        if sample_to_launch_latency_us is not None:
+            self.sample_to_launch_latency_us = max(0.0, float(sample_to_launch_latency_us))
 
     def record_adopted(self) -> None:
         if self.enabled:
             self.adopted += 1
+
+    def record_commit_duration(self, duration_us: float) -> None:
+        if self.enabled:
+            self.commit_duration_us = max(0.0, float(duration_us))
 
     def record_sync_step(self, reason: AsyncTxnSkipReason | str) -> None:
         if not self.enabled:

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -193,6 +193,7 @@ class StepTxn:
         )
         self.terminal_request_ids = tuple(int(r) for r in self.terminal_request_ids)
         self.committed_request_ids = tuple(int(r) for r in self.committed_request_ids)
+        self.mamba_slot_ids = tuple(int(slot_id) for slot_id in self.mamba_slot_ids)
 
     @property
     def request_id_set(self) -> set[int]:

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -1,0 +1,429 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Async decode transaction primitives.
+
+This module intentionally contains only small, explicit ownership objects.  The
+dynamic engine remains the source of truth for request scheduling and persistent
+CPU state; these helpers describe which GPU-side resources are tied to a forward
+and when they may be reused.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Deque, Iterable, Optional, Sequence
+
+import torch
+
+
+class AsyncTxnSkipReason(str, Enum):
+    """Concrete reasons a decode child was not eligible for async launch."""
+
+    ASYNC_DISABLED = "async_disabled"
+    NOT_DECODE_ONLY = "not_decode_only"
+    MTP_ACTIVE = "mtp_active"
+    CHUNKED_PREFILL = "chunked_prefill"
+    PENDING_ADMISSION = "pending_admission"
+    PAUSED_REQUESTS = "paused_requests"
+    KV_RESERVATION_UNAVAILABLE = "kv_reservation_unavailable"
+    GRAPH_RECAPTURE_BARRIER = "graph_recapture_barrier"
+    LOG_INTERVAL_BARRIER = "log_interval_barrier"
+    RESUME_BARRIER = "resume_barrier"
+    EVICT_BARRIER = "evict_barrier"
+    FORCE_PAUSE_BARRIER = "force_pause_barrier"
+    SERIAL_WRAPPED = "serial_wrapped"
+    UNKNOWN_BARRIER = "unknown_barrier"
+
+
+@dataclass
+class AsyncTxnDiagnostics:
+    """Low-overhead counters for async transaction decisions."""
+
+    enabled: bool = False
+    prepared: int = 0
+    launched: int = 0
+    adopted: int = 0
+    sync_steps: int = 0
+    barrier_skips: int = 0
+    retired: int = 0
+    guard_failures: int = 0
+    prepare_under_forward: int = 0
+    h2d_ready_before_sampling: int = 0
+    sample_to_launch_latency_us: float = 0.0
+    commit_duration_us: float = 0.0
+    retire_queue_depth: int = 0
+    eligibility_skip_reasons: Counter = field(default_factory=Counter)
+
+    def record_prepared(self, *, under_forward: bool = False) -> None:
+        if not self.enabled:
+            return
+        self.prepared += 1
+        if under_forward:
+            self.prepare_under_forward += 1
+
+    def record_launched(self, *, h2d_ready_before_sampling: bool = False) -> None:
+        if not self.enabled:
+            return
+        self.launched += 1
+        if h2d_ready_before_sampling:
+            self.h2d_ready_before_sampling += 1
+
+    def record_adopted(self) -> None:
+        if self.enabled:
+            self.adopted += 1
+
+    def record_sync_step(self, reason: AsyncTxnSkipReason | str) -> None:
+        if not self.enabled:
+            return
+        self.sync_steps += 1
+        self.record_skip(reason)
+
+    def record_barrier_skip(self, reason: AsyncTxnSkipReason | str) -> None:
+        if not self.enabled:
+            return
+        self.barrier_skips += 1
+        self.record_skip(reason)
+
+    def record_guard_failure(self) -> None:
+        if self.enabled:
+            self.guard_failures += 1
+
+    def record_retired(self, count: int = 1) -> None:
+        if self.enabled:
+            self.retired += count
+
+    def record_skip(self, reason: AsyncTxnSkipReason | str) -> None:
+        if not self.enabled:
+            return
+        key = reason.value if isinstance(reason, AsyncTxnSkipReason) else str(reason)
+        self.eligibility_skip_reasons[key] += 1
+
+    def top_skip_reason(self) -> Optional[str]:
+        if not self.eligibility_skip_reasons:
+            return None
+        return self.eligibility_skip_reasons.most_common(1)[0][0]
+
+    def snapshot(self) -> dict:
+        """Return a plain dict suitable for logging or assertions."""
+
+        return {
+            "enabled": self.enabled,
+            "prepared": self.prepared,
+            "launched": self.launched,
+            "adopted": self.adopted,
+            "sync_steps": self.sync_steps,
+            "barrier_skips": self.barrier_skips,
+            "retired": self.retired,
+            "guard_failures": self.guard_failures,
+            "prepare_under_forward": self.prepare_under_forward,
+            "h2d_ready_before_sampling": self.h2d_ready_before_sampling,
+            "sample_to_launch_latency_us": self.sample_to_launch_latency_us,
+            "commit_duration_us": self.commit_duration_us,
+            "retire_queue_depth": self.retire_queue_depth,
+            "eligibility_skip_reasons": dict(self.eligibility_skip_reasons),
+            "top_skip_reason": self.top_skip_reason(),
+        }
+
+
+def _event_done(event) -> bool:
+    """Return whether a CUDA-like event is complete.
+
+    Tests use tiny fake events with a ``query()`` method.  ``None`` means there
+    is no outstanding GPU dependency.
+    """
+
+    if event is None:
+        return True
+    if hasattr(event, "query"):
+        return bool(event.query())
+    return bool(event)
+
+
+@dataclass
+class StepTxn:
+    """Ownership record for one decode forward step."""
+
+    step_id: int
+    request_ids: Sequence[int]
+    slot_id: int = 0
+    decode_only: bool = True
+    cuda_graph_key: Optional[tuple] = None
+    h2d_done_event: object = None
+    forward_done_event: object = None
+    sample_done_event: object = None
+    kv_block_ids: tuple[int, ...] = ()
+    mamba_slot_ids: tuple[int, ...] = ()
+    launched: bool = False
+    adopted: bool = False
+    retired: bool = False
+
+    def __post_init__(self) -> None:
+        self.request_ids = tuple(int(r) for r in self.request_ids)
+
+    @property
+    def request_id_set(self) -> set[int]:
+        return set(self.request_ids)
+
+    def h2d_ready(self) -> bool:
+        return _event_done(self.h2d_done_event)
+
+    def forward_done(self) -> bool:
+        return _event_done(self.forward_done_event)
+
+    def guard_adoption(
+        self,
+        current_request_ids: Iterable[int],
+        *,
+        terminal_request_ids: Iterable[int] = (),
+        decode_only: bool = True,
+        cuda_graph_key: Optional[tuple] = None,
+    ) -> bool:
+        """Check the no-reject-after-launch adoption invariant.
+
+        Survivors must be a subset of launched rows.  Any launched row that is
+        missing from the current committed set must be terminal; no non-terminal
+        survivor may disappear after child launch.
+        """
+
+        if not self.launched:
+            return False
+        if self.decode_only and not decode_only:
+            return False
+        if self.cuda_graph_key is not None and cuda_graph_key is not None:
+            if self.cuda_graph_key != cuda_graph_key:
+                return False
+
+        current = set(int(r) for r in current_request_ids)
+        terminal = set(int(r) for r in terminal_request_ids)
+        launched = self.request_id_set
+        if not current.issubset(launched):
+            return False
+        missing = launched - current
+        return missing.issubset(terminal)
+
+
+@dataclass
+class _RetireItem:
+    event: object
+    callback: Callable[[], None]
+    label: str = ""
+
+
+class TxnRetireQueue:
+    """FIFO retire queue for resources owned by in-flight forwards."""
+
+    def __init__(self, diagnostics: Optional[AsyncTxnDiagnostics] = None) -> None:
+        self._items: Deque[_RetireItem] = deque()
+        self._diagnostics = diagnostics
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def enqueue(self, event, callback: Callable[[], None], *, label: str = "") -> None:
+        self._items.append(_RetireItem(event=event, callback=callback, label=label))
+        self._update_depth()
+
+    def drain_ready(self) -> int:
+        """Run callbacks for completed items at the queue head."""
+
+        retired = 0
+        while self._items and _event_done(self._items[0].event):
+            item = self._items.popleft()
+            item.callback()
+            retired += 1
+        if retired and self._diagnostics is not None:
+            self._diagnostics.record_retired(retired)
+        self._update_depth()
+        return retired
+
+    def drain_all_ready(self) -> int:
+        """Drain all ready items, including ready entries behind pending ones."""
+
+        kept: Deque[_RetireItem] = deque()
+        retired = 0
+        while self._items:
+            item = self._items.popleft()
+            if _event_done(item.event):
+                item.callback()
+                retired += 1
+            else:
+                kept.append(item)
+        self._items = kept
+        if retired and self._diagnostics is not None:
+            self._diagnostics.record_retired(retired)
+        self._update_depth()
+        return retired
+
+    def _update_depth(self) -> None:
+        if self._diagnostics is not None and self._diagnostics.enabled:
+            self._diagnostics.retire_queue_depth = len(self._items)
+
+
+@dataclass
+class AsyncDecodeSlot:
+    """One GPU metadata slot in the decode ring."""
+
+    slot_id: int
+    gpu_view: object
+    h2d_done_event: object = None
+    forward_done_event: object = None
+
+    def can_reuse(self) -> bool:
+        return _event_done(self.h2d_done_event) and _event_done(self.forward_done_event)
+
+    def pointer_signature(self) -> tuple[int, ...]:
+        """Return stable pointer identity for graph-key safety checks."""
+
+        pointers = []
+        for name in (
+            "_buf",
+            "token_to_input_ids",
+            "token_to_pos_ids",
+            "token_to_block_idx",
+            "mha_block_table",
+        ):
+            tensor = getattr(self.gpu_view, name, None)
+            if tensor is not None and hasattr(tensor, "data_ptr"):
+                pointers.append(int(tensor.data_ptr()))
+        return tuple(pointers)
+
+
+class AsyncDecodeSlotRing:
+    """Depth-2 decode metadata slot owner."""
+
+    def __init__(self, slots: Sequence[AsyncDecodeSlot]):
+        if len(slots) != 2:
+            raise ValueError("async decode transaction ring requires exactly two slots")
+        self._slots = tuple(slots)
+        self.current_index = 0
+
+    @property
+    def current(self) -> AsyncDecodeSlot:
+        return self._slots[self.current_index]
+
+    @property
+    def child(self) -> AsyncDecodeSlot:
+        return self._slots[1 - self.current_index]
+
+    def promote_child(self) -> AsyncDecodeSlot:
+        if not self.child.can_reuse():
+            raise RuntimeError("cannot promote child slot before its prior work has retired")
+        self.current_index = 1 - self.current_index
+        return self.current
+
+
+@dataclass(frozen=True)
+class AsyncLaunchEligibility:
+    """Result of the child-launch gate."""
+
+    eligible: bool
+    reason: Optional[AsyncTxnSkipReason] = None
+    boundary_request_ids: tuple[int, ...] = ()
+    required_boundary_blocks: int = 0
+
+
+def boundary_crossing_request_ids(context) -> tuple[int, ...]:
+    """Return active request ids that require one more KV block next decode step."""
+
+    active_count = context.total_request_count - context.paused_request_count
+    if active_count <= 0:
+        return ()
+    start = context.paused_request_count
+    end = context.total_request_count
+    offsets = context.request_last_kv_block_offset[start:end]
+    threshold = context.block_size_tokens - 1 - context.num_speculative_tokens
+    mask = offsets >= threshold
+    if not bool(mask.any()):
+        return ()
+    req_ids = context.request_ids[start:end][mask]
+    return tuple(int(r) for r in req_ids.tolist())
+
+
+def classify_decode_child_launch(
+    context,
+    *,
+    async_enabled: bool,
+    pending_admission: bool = False,
+    graph_recapture_barrier: bool = False,
+    log_interval_barrier: bool = False,
+    resume_barrier: bool = False,
+    evict_barrier: bool = False,
+    force_pause_barrier: bool = False,
+    mtp_active: Optional[bool] = None,
+) -> AsyncLaunchEligibility:
+    """Classify whether the next plain-decode child may be launched."""
+
+    if not async_enabled:
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.ASYNC_DISABLED)
+    if mtp_active is None:
+        mtp_active = getattr(context, "num_speculative_tokens", 0) > 0
+    if mtp_active:
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.MTP_ACTIVE)
+    if not context.is_decode_only():
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.NOT_DECODE_ONLY)
+    if getattr(context, "chunked_prefill_request_id", -1) != -1:
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.CHUNKED_PREFILL)
+    if pending_admission:
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.PENDING_ADMISSION)
+    if getattr(context, "paused_request_count", 0) > 0:
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.PAUSED_REQUESTS)
+    if graph_recapture_barrier:
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.GRAPH_RECAPTURE_BARRIER)
+    if log_interval_barrier:
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.LOG_INTERVAL_BARRIER)
+    if resume_barrier:
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.RESUME_BARRIER)
+    if evict_barrier:
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.EVICT_BARRIER)
+    if force_pause_barrier:
+        return AsyncLaunchEligibility(False, AsyncTxnSkipReason.FORCE_PAUSE_BARRIER)
+
+    boundary_ids = boundary_crossing_request_ids(context)
+    required = len(boundary_ids)
+    if required and not context.kv_block_allocator.is_memory_available(required):
+        return AsyncLaunchEligibility(
+            False,
+            AsyncTxnSkipReason.KV_RESERVATION_UNAVAILABLE,
+            boundary_request_ids=boundary_ids,
+            required_boundary_blocks=required,
+        )
+
+    return AsyncLaunchEligibility(
+        True, boundary_request_ids=boundary_ids, required_boundary_blocks=required
+    )
+
+
+class RequestRNGStore:
+    """Request-id keyed RNG store for stochastic decode sampling."""
+
+    def __init__(self, base_seed: int, *, device: Optional[torch.device | int | str] = None):
+        self.base_seed = int(base_seed)
+        self.device = device
+        self._generators: dict[int, torch.Generator] = {}
+
+    def get(self, request_id: int) -> torch.Generator:
+        request_id = int(request_id)
+        generator = self._generators.get(request_id)
+        if generator is None:
+            generator = torch.Generator(device=self.device)
+            generator.manual_seed(self._seed_for(request_id))
+            self._generators[request_id] = generator
+        return generator
+
+    def remove(self, request_id: int) -> None:
+        self._generators.pop(int(request_id), None)
+
+    def remove_many(self, request_ids: Iterable[int]) -> None:
+        for request_id in request_ids:
+            self.remove(int(request_id))
+
+    def _seed_for(self, request_id: int) -> int:
+        # SplitMix64-style integer mixing keeps nearby request ids from sharing
+        # nearby RNG streams while staying deterministic across processes.
+        x = (self.base_seed + 0x9E3779B97F4A7C15 + int(request_id)) & 0xFFFFFFFFFFFFFFFF
+        x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9 & 0xFFFFFFFFFFFFFFFF
+        x = (x ^ (x >> 27)) * 0x94D049BB133111EB & 0xFFFFFFFFFFFFFFFF
+        x = x ^ (x >> 31)
+        return int(x % (2**63 - 1))

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -62,6 +62,9 @@ class AsyncTxnDiagnostics:
     h2d_ready_before_sampling: int = 0
     sample_to_launch_latency_us: float = 0.0
     commit_duration_us: float = 0.0
+    child_prestage_duration_us: float = 0.0
+    ep_handoff_duration_us: float = 0.0
+    child_graph_shape_duration_us: float = 0.0
     retire_queue_depth: int = 0
     eligibility_skip_reasons: Counter = field(default_factory=Counter)
 
@@ -93,6 +96,18 @@ class AsyncTxnDiagnostics:
     def record_commit_duration(self, duration_us: float) -> None:
         if self.enabled:
             self.commit_duration_us = max(0.0, float(duration_us))
+
+    def record_child_prestage_duration(self, duration_us: float) -> None:
+        if self.enabled:
+            self.child_prestage_duration_us = max(0.0, float(duration_us))
+
+    def record_ep_handoff_duration(self, duration_us: float) -> None:
+        if self.enabled:
+            self.ep_handoff_duration_us = max(0.0, float(duration_us))
+
+    def record_child_graph_shape_duration(self, duration_us: float) -> None:
+        if self.enabled:
+            self.child_graph_shape_duration_us = max(0.0, float(duration_us))
 
     def record_sync_step(self, reason: AsyncTxnSkipReason | str) -> None:
         if not self.enabled:
@@ -141,6 +156,9 @@ class AsyncTxnDiagnostics:
             "h2d_ready_before_sampling": self.h2d_ready_before_sampling,
             "sample_to_launch_latency_us": self.sample_to_launch_latency_us,
             "commit_duration_us": self.commit_duration_us,
+            "child_prestage_duration_us": self.child_prestage_duration_us,
+            "ep_handoff_duration_us": self.ep_handoff_duration_us,
+            "child_graph_shape_duration_us": self.child_graph_shape_duration_us,
             "retire_queue_depth": self.retire_queue_depth,
             "eligibility_skip_reasons": dict(self.eligibility_skip_reasons),
             "top_skip_reason": self.top_skip_reason(),

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -448,6 +448,15 @@ class AsyncLaunchEligibility:
     required_boundary_blocks: int = 0
 
 
+@dataclass(frozen=True)
+class EPDecodeBroadcastPlan:
+    """Rank-uniform source and shape for EP decode post-forward collectives."""
+
+    active_request_count: int
+    src_group_rank: int
+    has_real_work: bool
+
+
 def _group_size(group) -> int:
     if group is None:
         return 1
@@ -486,6 +495,67 @@ def _broadcast_tensor(tensor: torch.Tensor, group, src_group_rank: int, broadcas
     if broadcast_fn is None:
         broadcast_fn = torch.distributed.broadcast
     broadcast_fn(tensor, src=src_rank, group=group)
+
+
+def resolve_ep_decode_broadcast_plan(
+    active_request_count: int,
+    group,
+    *,
+    has_real_work: bool,
+    sync_all_reduce_max_fn=None,
+) -> EPDecodeBroadcastPlan:
+    """Resolve the one real EP source rank that owns decode sampling results.
+
+    Coordinator EP mode has one rank with persistent request state and peer ranks
+    running dummy model work to satisfy MoE collectives. Post-forward collectives
+    must still be entered by every EP rank with an identical source rank and
+    tensor shape. This CPU-side plan keeps that contract explicit before the
+    NCCL broadcast is issued.
+    """
+
+    local_count = int(active_request_count) if has_real_work else 0
+    group_size = _group_size(group)
+    if group_size <= 1:
+        return EPDecodeBroadcastPlan(
+            active_request_count=local_count,
+            src_group_rank=0,
+            has_real_work=local_count > 0,
+        )
+
+    if sync_all_reduce_max_fn is None:
+        return EPDecodeBroadcastPlan(
+            active_request_count=int(active_request_count),
+            src_group_rank=0,
+            has_real_work=local_count > 0,
+        )
+
+    group_rank = _group_rank(group)
+    local_src_max = group_rank if local_count > 0 else -1
+    local_neg_src_min = -group_rank if local_count > 0 else -(group_size + 1)
+    global_count, max_src, neg_min_src = sync_all_reduce_max_fn(
+        local_count, local_src_max, local_neg_src_min
+    )
+    global_count = int(global_count)
+    max_src = int(max_src)
+    min_src = -int(neg_min_src)
+
+    if global_count <= 0:
+        return EPDecodeBroadcastPlan(
+            active_request_count=0,
+            src_group_rank=0,
+            has_real_work=False,
+        )
+    if max_src != min_src:
+        raise RuntimeError(
+            "EP decode broadcast requires exactly one real source rank per EP group; "
+            f"got min/max real source ranks {min_src}/{max_src}"
+        )
+
+    return EPDecodeBroadcastPlan(
+        active_request_count=global_count,
+        src_group_rank=max_src,
+        has_real_work=True,
+    )
 
 
 def broadcast_ep_sampled_tokens(

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -36,6 +36,10 @@ class AsyncTxnSkipReason(str, Enum):
     CHILD_SLOT_BUSY = "child_slot_busy"
     HYBRID_PRESTAGE_DEFERRED = "hybrid_prestage_deferred"
     BOUNDARY_PRESTAGE_DEFERRED = "boundary_prestage_deferred"
+    TERMINAL_CHECK_REQUIRED = "terminal_check_required"
+    LOGPROBS_DEFERRED = "logprobs_deferred"
+    CUDA_GRAPH_DEFERRED = "cuda_graph_deferred"
+    MOE_EP_DEFERRED = "moe_ep_deferred"
     SERIAL_WRAPPED = "serial_wrapped"
     UNKNOWN_BARRIER = "unknown_barrier"
 
@@ -347,6 +351,12 @@ class AsyncDecodeSlotRing:
     def promote_child(self) -> AsyncDecodeSlot:
         if not self.child.can_reuse():
             raise RuntimeError("cannot promote child slot before its prior work has retired")
+        self.current_index = 1 - self.current_index
+        return self.current
+
+    def adopt_child(self) -> AsyncDecodeSlot:
+        """Mark the prepared child slot as the current in-flight forward slot."""
+
         self.current_index = 1 - self.current_index
         return self.current
 

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -41,8 +41,9 @@ class AsyncTxnSkipReason(str, Enum):
     LOGPROBS_DEFERRED = "logprobs_deferred"
     CUDA_GRAPH_DEFERRED = "cuda_graph_deferred"
     MOE_EP_DEFERRED = "moe_ep_deferred"
+    SKIP_BOOKKEEPING = "skip_bookkeeping"
+    ACTIVE_COUNT_CHANGED = "active_count_changed"
     SERIAL_WRAPPED = "serial_wrapped"
-    UNKNOWN_BARRIER = "unknown_barrier"
 
 
 @dataclass

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -325,7 +325,7 @@ class StepTxn:
         return tuple(row_by_request_id[int(request_id)] for request_id in committed_request_ids)
 
     def h2d_ready(self) -> bool:
-        return _event_done(self.h2d_done_event)
+        return self.cpu_bookkeeping_buf is None and _event_done(self.h2d_done_event)
 
     def forward_done(self) -> bool:
         return _event_done(self.forward_done_event)

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -53,14 +53,14 @@ class AsyncTxnDiagnostics:
     enabled: bool = False
     prepared: int = 0
     launched: int = 0
-    adopted: int = 0
+    consumed: int = 0
     sync_steps: int = 0
     barrier_skips: int = 0
     retired: int = 0
     guard_failures: int = 0
     chain_attempts: int = 0
     chain_launches: int = 0
-    presampled_commits: int = 0
+    deferred_sample_commits: int = 0
     prepare_under_forward: int = 0
     h2d_ready_before_sampling: int = 0
     sample_to_launch_latency_us: float = 0.0
@@ -98,9 +98,9 @@ class AsyncTxnDiagnostics:
         if sample_to_launch_latency_us is not None:
             self.sample_to_launch_latency_us = max(0.0, float(sample_to_launch_latency_us))
 
-    def record_adopted(self) -> None:
+    def record_consumed(self) -> None:
         if self.enabled:
-            self.adopted += 1
+            self.consumed += 1
 
     def record_commit_duration(self, duration_us: float) -> None:
         if self.enabled:
@@ -165,9 +165,9 @@ class AsyncTxnDiagnostics:
         if launched:
             self.chain_launches += 1
 
-    def record_presampled_commit(self) -> None:
+    def record_deferred_sample_commit(self) -> None:
         if self.enabled:
-            self.presampled_commits += 1
+            self.deferred_sample_commits += 1
 
     def record_retired(self, count: int = 1) -> None:
         if self.enabled:
@@ -191,14 +191,14 @@ class AsyncTxnDiagnostics:
             "enabled": self.enabled,
             "prepared": self.prepared,
             "launched": self.launched,
-            "adopted": self.adopted,
+            "consumed": self.consumed,
             "sync_steps": self.sync_steps,
             "barrier_skips": self.barrier_skips,
             "retired": self.retired,
             "guard_failures": self.guard_failures,
             "chain_attempts": self.chain_attempts,
             "chain_launches": self.chain_launches,
-            "presampled_commits": self.presampled_commits,
+            "deferred_sample_commits": self.deferred_sample_commits,
             "prepare_under_forward": self.prepare_under_forward,
             "h2d_ready_before_sampling": self.h2d_ready_before_sampling,
             "sample_to_launch_latency_us": self.sample_to_launch_latency_us,
@@ -265,7 +265,7 @@ class StepTxn:
     terminal_request_ids: tuple[int, ...] = ()
     committed_request_ids: tuple[int, ...] = ()
     launched: bool = False
-    adopted: bool = False
+    consumed: bool = False
     retired: bool = False
 
     def __post_init__(self) -> None:
@@ -330,7 +330,7 @@ class StepTxn:
     def forward_done(self) -> bool:
         return _event_done(self.forward_done_event)
 
-    def guard_adoption(
+    def is_consumable_after_commit(
         self,
         current_request_ids: Iterable[int],
         *,
@@ -338,7 +338,7 @@ class StepTxn:
         decode_only: bool = True,
         cuda_graph_key: Optional[Any] = None,
     ) -> bool:
-        """Check the no-reject-after-launch adoption invariant.
+        """Check the no-reject-after-launch consumption invariant.
 
         Survivors must be a subset of launched rows.  Any launched row that is
         missing from the current committed set must be terminal; no non-terminal
@@ -492,7 +492,7 @@ class AsyncDecodeSlotRing:
         self.current_index = 1 - self.current_index
         return self.current
 
-    def adopt_child(self) -> AsyncDecodeSlot:
+    def mark_child_current(self) -> AsyncDecodeSlot:
         """Mark the prepared child slot as the current in-flight forward slot."""
 
         self.current_index = 1 - self.current_index

--- a/megatron/core/inference/async_txn.py
+++ b/megatron/core/inference/async_txn.py
@@ -185,6 +185,7 @@ class StepTxn:
     h2d_done_event: object = None
     forward_done_event: object = None
     sample_done_event: object = None
+    cpu_bookkeeping_buf: Optional[torch.Tensor] = None
     kv_block_ids: tuple[int, ...] = ()
     kv_block_leases: tuple[KVBlockLease, ...] = ()
     mamba_slot_ids: tuple[int, ...] = ()

--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -17,6 +17,15 @@ import torch
 from megatron.core.utils import get_pg_size, round_up_to_nearest_multiple
 
 
+def _sync_all_reduce_max_with_phase(communicator, phase: str, *values: int):
+    """Run a tiny CPU MAX reduction, tagging it when the communicator supports phases."""
+
+    try:
+        return communicator.sync_all_reduce_max(*values, phase=phase)
+    except TypeError:
+        return communicator.sync_all_reduce_max(*values)
+
+
 @dataclass(order=True, frozen=True)
 class InferenceBatchDimensions:
     """Batch dimensions for dynamic inference.
@@ -175,8 +184,11 @@ class InferenceBatchDimensions:
         if ep_zmq_communicator is not None:
             # CPU-only sync via ZMQ: avoids a NCCL AllReduce kernel on the
             # compute stream plus the H2D/D2H pair that sandwiches it.
-            (max_token_count, max_is_non_decode) = ep_zmq_communicator.sync_all_reduce_max(
-                local_batch_dims.token_count, int(is_non_decode)
+            (max_token_count, max_is_non_decode) = _sync_all_reduce_max_with_phase(
+                ep_zmq_communicator,
+                "ep_graph_shape",
+                local_batch_dims.token_count,
+                int(is_non_decode),
             )
         else:
             sync_tensor = torch.tensor(

--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -14,6 +14,7 @@ from typing import List, Optional, Tuple
 
 import torch
 
+from megatron.core.inference.ep_async_protocol import EPAsyncPhase
 from megatron.core.utils import get_pg_size, round_up_to_nearest_multiple
 
 
@@ -153,6 +154,7 @@ class InferenceBatchDimensions:
         local_batch_dims,
         ep_group: Optional[torch.distributed.ProcessGroup] = None,
         ep_zmq_communicator=None,
+        ep_async_protocol=None,
     ) -> Optional["InferenceBatchDimensions"]:
         """Adjust CUDA graph batch dimensions for expert parallelism.
 
@@ -181,7 +183,16 @@ class InferenceBatchDimensions:
 
         is_non_decode = local_batch_dims.prefill_req_count > 0
 
-        if ep_zmq_communicator is not None:
+        if ep_async_protocol is not None and ep_async_protocol.enabled:
+            # CPU-only sync via the EP async protocol: uses the active EP work
+            # step id so dummy and real child forwards cannot drift by one
+            # decode iteration and still match the same phase string.
+            (max_token_count, max_is_non_decode) = ep_async_protocol.sync_all_reduce_max(
+                EPAsyncPhase.GRAPH_SHAPE,
+                local_batch_dims.token_count,
+                int(is_non_decode),
+            )
+        elif ep_zmq_communicator is not None:
             # CPU-only sync via ZMQ: avoids a NCCL AllReduce kernel on the
             # compute stream plus the H2D/D2H pair that sandwiches it.
             (max_token_count, max_is_non_decode) = _sync_all_reduce_max_with_phase(
@@ -637,6 +648,7 @@ class CUDAGraphBatchDimensionBuilder:
         strict: bool = False,
         ep_group: Optional[torch.distributed.ProcessGroup] = None,
         ep_zmq_communicator=None,
+        ep_async_protocol=None,
         match_ep_token_counts: bool = True,
     ) -> Optional[InferenceBatchDimensions]:
         """
@@ -673,7 +685,10 @@ class CUDAGraphBatchDimensionBuilder:
             # NCCL dispatcher: all EP ranks must select the same CUDA graph. Sync batch dims
             # across the EP group so graph selection is consistent.
             adjusted_batch_dim = InferenceBatchDimensions.adjust_batch_dims_for_expert_parallelism(
-                real_batch_dim, ep_group=ep_group, ep_zmq_communicator=ep_zmq_communicator
+                real_batch_dim,
+                ep_group=ep_group,
+                ep_zmq_communicator=ep_zmq_communicator,
+                ep_async_protocol=ep_async_protocol,
             )
 
             if adjusted_batch_dim is None:

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -338,6 +338,9 @@ class InferenceConfig:
     sampling_backend: Literal['torch', 'flashinfer'] = 'torch'
     """Which sampling kernels to use during inference."""
 
+    async_scheduling: bool = False
+    """Enable transactional async scheduling for dynamic decode."""
+
     request_metadata_types: Optional[List[Tuple[str, torch.dtype]]] = None
     """
     A list of the per-request metadata types to track. Each entry is a tuple

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -341,6 +341,9 @@ class InferenceConfig:
     async_scheduling: bool = False
     """Enable transactional async scheduling for dynamic decode."""
 
+    async_chain_scheduling: bool = True
+    """Enable chained sampling plus child-forward launch for async decode."""
+
     request_metadata_types: Optional[List[Tuple[str, torch.dtype]]] = None
     """
     A list of the per-request metadata types to track. Each entry is a tuple

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -14,7 +14,12 @@ class MambaMetadata:
     """Manages the metadata tensors required for Mamba layers during inference."""
 
     def __init__(
-        self, max_requests: int, max_tokens: int, mamba_chunk_size: int = 128, d_conv: int = 0
+        self,
+        max_requests: int,
+        max_tokens: int,
+        mamba_chunk_size: int = 128,
+        d_conv: int = 0,
+        state_bank_count: int = 1,
     ):
         """
         Initializes the Mamba slot allocator.
@@ -25,11 +30,13 @@ class MambaMetadata:
             mamba_chunk_size (int): The chunk size used by the Mamba SSM Triton kernels.
             d_conv (int): Convolution window size (from mamba_conv_states_shape[-1]).
                 Used for vectorized conv state extraction at intermediate offsets.
+            state_bank_count (int): Number of flattened state banks per logical request slot.
         """
         self.max_requests = max_requests
         self.max_tokens = max_tokens
         self.mamba_chunk_size = mamba_chunk_size
         self.d_conv = d_conv
+        self.state_bank_count = state_bank_count
         self.device = torch.cuda.current_device()
 
         # Maximum possible chunks across all batch configurations
@@ -39,10 +46,16 @@ class MambaMetadata:
         self.request_to_mamba_state_idx = torch.full(
             (self.max_requests,), -1, dtype=torch.int32, device='cpu'
         )
+        self.request_to_mamba_state_bank = torch.zeros(
+            (self.max_requests,), dtype=torch.int32, device='cpu'
+        )
 
-        # Map from requests to slots in the static Mamba state buffer for active decode requests.
-        # int64 so selective_state_update can index directly without a per-layer upcast kernel;
+        # Maps from requests to slots in the static Mamba state buffer for active decode requests.
+        # int64 so selective_state_update can index directly without a per-layer upcast kernel.
         self._batch_indices_decode_buffer = torch.full(
+            (self.max_requests,), -1, dtype=torch.int64, device=self.device
+        )
+        self._batch_indices_decode_write_buffer = torch.full(
             (self.max_requests,), -1, dtype=torch.int64, device=self.device
         )
 
@@ -138,6 +151,7 @@ class MambaMetadata:
         Resets all Mamba states and frees all allocated slots.
         """
         self.request_to_mamba_state_idx.fill_(-1)
+        self.request_to_mamba_state_bank.zero_()
 
         self.reset_varlen_metadata()
 
@@ -150,6 +164,7 @@ class MambaMetadata:
     def reset_varlen_metadata(self) -> None:
         """Resets varlen metadata."""
         self.batch_indices_decode = None
+        self.batch_indices_decode_write = None
         self.batch_indices_prefill = None
         self.cu_seqlens = None
         self.seq_idx = None
@@ -182,6 +197,7 @@ class MambaMetadata:
         enable_chunked_prefill: bool,
         intermediate_offsets_gpu: Optional[torch.Tensor] = None,
         intermediate_counts_gpu: Optional[torch.Tensor] = None,
+        active_mamba_write_indices: Optional[torch.Tensor] = None,
     ) -> None:
         """
         Updates the dedicated CUDA graph mapping tensor with the indices
@@ -190,6 +206,8 @@ class MambaMetadata:
         Args:
             active_mamba_indices (Tensor): Tensor containing the Mamba slot indices
                                            for active requests.
+            active_mamba_write_indices (Tensor): Optional decode-state destination slots.
+                                                Defaults to active_mamba_indices.
             token_to_request_idx (Tensor): Map from token index to request index.
             cu_seqlens (Tensor): Cumulative sequence lengths.
             batch_dimensions (InferenceBatchDimensions): Dimensions of the current batch.
@@ -211,9 +229,20 @@ class MambaMetadata:
             self._batch_indices_decode_buffer[:real_decode_count].copy_(
                 active_mamba_indices[:real_decode_count]
             )
+            if active_mamba_write_indices is None:
+                active_mamba_write_indices = active_mamba_indices
+            self._batch_indices_decode_write_buffer[:real_decode_count].copy_(
+                active_mamba_write_indices[:real_decode_count]
+            )
             if padded_decode_count > real_decode_count:
                 self._batch_indices_decode_buffer[real_decode_count:padded_decode_count] = -1
+                self._batch_indices_decode_write_buffer[
+                    real_decode_count:padded_decode_count
+                ] = -1
             self.batch_indices_decode = self._batch_indices_decode_buffer[:padded_decode_count]
+            self.batch_indices_decode_write = self._batch_indices_decode_write_buffer[
+                :padded_decode_count
+            ]
 
         if padded_prefill_count > 0:
             # Update prefill indices (all prefill requests go through varlen)
@@ -482,6 +511,7 @@ class MambaMetadata:
         enable_chunked_prefill: bool,
         intermediate_offsets_gpu: Optional[torch.Tensor] = None,
         intermediate_counts_gpu: Optional[torch.Tensor] = None,
+        active_mamba_write_indices: Optional[torch.Tensor] = None,
     ) -> dict:
         """Compute all Mamba metadata on CPU, writing directly into the bound
         pinned CPU views.
@@ -493,6 +523,7 @@ class MambaMetadata:
 
         Args:
             active_mamba_indices: CPU tensor of Mamba slot indices for active requests.
+            active_mamba_write_indices: Optional CPU tensor of decode-state destination slots.
             token_to_request_idx: CPU tensor mapping tokens to request indices.
             cpu_cu_query: CPU cumulative query lengths from MHA metadata computation.
             batch_dimensions: Dimensions of the current batch.
@@ -524,8 +555,14 @@ class MambaMetadata:
             bufs['batch_indices_decode'][:real_decode_count] = active_mamba_indices[
                 :real_decode_count
             ]
+            if active_mamba_write_indices is None:
+                active_mamba_write_indices = active_mamba_indices
+            bufs['batch_indices_decode_write'][:real_decode_count] = active_mamba_write_indices[
+                :real_decode_count
+            ]
             if padded_decode_count > real_decode_count:
                 bufs['batch_indices_decode'][real_decode_count:padded_decode_count] = -1
+                bufs['batch_indices_decode_write'][real_decode_count:padded_decode_count] = -1
 
         # Prefill batch indices, seq_idx, cu_seqlens, chunk/conv metadata.
         if padded_prefill_count > 0:
@@ -660,6 +697,9 @@ class MambaMetadata:
 
         if padded_decode_count > 0:
             self.batch_indices_decode = v.mamba_batch_indices_decode[:padded_decode_count]
+            self.batch_indices_decode_write = v.mamba_batch_indices_decode_write[
+                :padded_decode_count
+            ]
 
         if padded_prefill_count > 0:
             self.batch_indices_prefill = v.mamba_batch_indices_prefill[:padded_prefill_count]
@@ -749,6 +789,7 @@ class MambaMetadata:
 
         # Invalidate the Mamba state index for the finished requests
         self.request_to_mamba_state_idx[request_indices] = -1
+        self.request_to_mamba_state_bank[request_indices] = 0
 
     def free_slot_ids(self, mamba_indices: torch.Tensor) -> None:
         """Return already-detached Mamba slot ids to the free pool."""

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -749,3 +749,18 @@ class MambaMetadata:
 
         # Invalidate the Mamba state index for the finished requests
         self.request_to_mamba_state_idx[request_indices] = -1
+
+    def free_slot_ids(self, mamba_indices: torch.Tensor) -> None:
+        """Return already-detached Mamba slot ids to the free pool."""
+
+        mamba_indices = mamba_indices[mamba_indices != -1]
+        num_to_free = len(mamba_indices)
+        if num_to_free == 0:
+            return
+
+        start_idx = self.mamba_state_free_slot_count
+        end_idx = start_idx + num_to_free
+        self.mamba_state_free_slots[start_idx:end_idx] = mamba_indices.to(
+            dtype=self.mamba_state_free_slots.dtype, device=self.mamba_state_free_slots.device
+        )
+        self.mamba_state_free_slot_count = end_idx

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1601,7 +1601,7 @@ class DynamicInferenceContext(BaseInferenceContext):
     def plain_decode_child_needs_terminal_check(
         self, active_request_count: Optional[int] = None
     ) -> bool:
-        """Return whether same-step finish detection could affect child adoption."""
+        """Return whether same-step finish detection could affect child consumption."""
 
         if active_request_count is None:
             active_request_count = self.total_request_count - self.paused_request_count
@@ -1626,7 +1626,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         This covers ordinary non-hybrid decode, including requests that cross a
         KV-block boundary. Boundary blocks are reserved before launch and
-        adopted during the later CPU commit by request id.
+        consumed during the later CPU commit by request id.
         """
 
         if not self.async_scheduling or self.async_decode_slot_ring is None:
@@ -3737,7 +3737,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
 
     def retire_unused_async_kv_leases(self, txn: Optional[StepTxn]) -> None:
-        """Retire reserved KV blocks that were not adopted by committed survivors."""
+        """Retire reserved KV blocks that were not consumed by committed survivors."""
 
         if txn is None:
             return

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1485,7 +1485,12 @@ class DynamicInferenceContext(BaseInferenceContext):
         max_sequence_lengths = self.get_max_sequence_lengths()[:active_request_count]
         return bool(torch.ge(active_sequence_lengths + 1, max_sequence_lengths).any())
 
-    def prepare_child_from_committed_decode_state(self) -> Optional[StepTxn]:
+    def prepare_child_from_committed_decode_state(
+        self,
+        *,
+        target_slot: Optional[AsyncDecodeSlot] = None,
+        defer_h2d: bool = False,
+    ) -> Optional[StepTxn]:
         """Prestage deterministic plain-decode child metadata into the free slot.
 
         This covers ordinary non-hybrid decode, including requests that cross a
@@ -1502,8 +1507,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.async_txn_diagnostics.record_barrier_skip(eligibility.reason)
             return None
 
-        child_slot = self.async_decode_slot_ring.child
-        if not child_slot.can_reuse():
+        child_slot = target_slot or self.async_decode_slot_ring.child
+        if child_slot is not self.async_decode_slot_ring.current and not child_slot.can_reuse():
             self.async_txn_diagnostics.record_barrier_skip(AsyncTxnSkipReason.CHILD_SLOT_BUSY)
             return None
 
@@ -1535,13 +1540,16 @@ class DynamicInferenceContext(BaseInferenceContext):
         self._patch_plain_decode_child_bookkeeping(
             child_cpu_buf, active_request_count, kv_block_leases=kv_block_leases
         )
-        h2d_done_event = child_slot.copy_bookkeeping_from_cpu(child_cpu_buf, non_blocking=True)
+        h2d_done_event = None
+        if not defer_h2d:
+            h2d_done_event = child_slot.copy_bookkeeping_from_cpu(child_cpu_buf, non_blocking=True)
         self.async_txn_diagnostics.record_prepared(under_forward=True)
         return StepTxn(
             step_id=self.step_count + 1,
             request_ids=request_ids,
             slot_id=child_slot.slot_id,
             h2d_done_event=h2d_done_event,
+            cpu_bookkeeping_buf=child_cpu_buf if defer_h2d else None,
             kv_block_leases=kv_block_leases,
             mamba_slot_ids=mamba_slot_ids,
             cuda_graph_key=child_slot.cuda_graph_key(

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1459,18 +1459,13 @@ class DynamicInferenceContext(BaseInferenceContext):
         return self._using_cuda_graph_this_step
 
     def cuda_graph_cache_key(self):
-        """Return the CUDA graph cache key for the currently bound metadata slot."""
+        """Return the CUDA graph cache key for the active padded shape.
 
-        if (
-            self.async_scheduling
-            and self.async_decode_slot_ring is not None
-            and self.using_cuda_graph_this_step()
-            and self.is_decode_only()
-        ):
-            slot = self.active_decode_slot()
-            return slot.cuda_graph_key(
-                ("decode", self.padded_active_request_count, self.padded_active_token_count)
-            )
+        Async decode slots are transactional metadata owners, not graph-cache
+        dimensions. Keeping this shape-only matches the main inference path and
+        avoids opt-in async CUDA graph capture.
+        """
+
         return self.padded_batch_dimensions
 
     def async_launch_eligibility(self, **kwargs):
@@ -1600,8 +1595,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             cpu_bookkeeping_buf=child_cpu_buf if defer_h2d else None,
             kv_block_leases=kv_block_leases,
             mamba_slot_ids=mamba_slot_ids,
-            cuda_graph_key=child_slot.cuda_graph_key(
-                ("decode", self.padded_active_request_count, self.padded_active_token_count)
+            cuda_graph_key=(
+                self.padded_batch_dimensions if self.using_cuda_graph_this_step() else None
             ),
         )
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1251,10 +1251,32 @@ class DynamicInferenceContext(BaseInferenceContext):
                 device=torch.cuda.current_device(),
                 max_mamba_chunks=self._max_mamba_chunks,
             )
+            slot_cpu_bookkeeping_bufs = (
+                torch.empty(
+                    self._cpu_bookkeeping_buf.shape,
+                    dtype=self._cpu_bookkeeping_buf.dtype,
+                    device="cpu",
+                    pin_memory=True,
+                ),
+                torch.empty(
+                    self._cpu_bookkeeping_buf.shape,
+                    dtype=self._cpu_bookkeeping_buf.dtype,
+                    device="cpu",
+                    pin_memory=True,
+                ),
+            )
             self.async_decode_slot_ring = AsyncDecodeSlotRing(
                 (
-                    AsyncDecodeSlot(slot_id=0, gpu_view=self.gpu_view),
-                    AsyncDecodeSlot(slot_id=1, gpu_view=child_gpu_view),
+                    AsyncDecodeSlot(
+                        slot_id=0,
+                        gpu_view=self.gpu_view,
+                        cpu_bookkeeping_buf=slot_cpu_bookkeeping_bufs[0],
+                    ),
+                    AsyncDecodeSlot(
+                        slot_id=1,
+                        gpu_view=child_gpu_view,
+                        cpu_bookkeeping_buf=slot_cpu_bookkeeping_bufs[1],
+                    ),
                 )
             )
 
@@ -1552,8 +1574,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
             return None
 
-        child_cpu_buf = self._cpu_bookkeeping_buf.clone()
-        self._patch_plain_decode_child_bookkeeping(
+        child_cpu_buf = self._async_child_cpu_bookkeeping_buf(child_slot)
+        self._build_plain_decode_child_bookkeeping(
             child_cpu_buf, active_request_count, kv_block_leases=kv_block_leases
         )
         h2d_done_event = None
@@ -1606,18 +1628,51 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
         return tuple(leases)
 
-    def _patch_plain_decode_child_bookkeeping(
+    def _async_child_cpu_bookkeeping_buf(self, child_slot: AsyncDecodeSlot) -> Tensor:
+        """Return this slot's pinned CPU staging buffer for child metadata."""
+
+        child_cpu_buf = getattr(child_slot, "cpu_bookkeeping_buf", None)
+        if child_cpu_buf is None:
+            child_cpu_buf = torch.empty(
+                self._cpu_bookkeeping_buf.shape,
+                dtype=self._cpu_bookkeeping_buf.dtype,
+                device="cpu",
+                pin_memory=self._cpu_bookkeeping_buf.is_pinned(),
+            )
+            child_slot.cpu_bookkeeping_buf = child_cpu_buf
+        return child_cpu_buf
+
+    def _build_plain_decode_child_bookkeeping(
         self,
         child_cpu_buf: Tensor,
         active_request_count: int,
         *,
         kv_block_leases: Sequence[KVBlockLease] = (),
     ) -> None:
-        """Patch a CPU bookkeeping clone from current decode to child decode."""
+        """Build the child CPU metadata snapshot by active slices only.
+
+        The full bookkeeping layout contains the max-request block table, which
+        is large for long-context graphs.  Child decode differs from committed
+        decode only in active rows plus any newly reserved boundary blocks, so
+        avoid cloning inactive rows that the child graph will never read.
+        """
 
         token_count = active_request_count
+        padded_token_count = max(token_count, self.padded_active_token_count)
+        padded_active = max(active_request_count, self.padded_active_request_count)
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+
+        child_token_to_input_ids = self._cpu_bookkeeping_clone_view(
+            self.token_to_input_ids, child_cpu_buf
+        )
         child_token_to_pos_ids = self._cpu_bookkeeping_clone_view(
             self.token_to_pos_ids, child_cpu_buf
+        )
+        child_token_to_block_idx = self._cpu_bookkeeping_clone_view(
+            self.token_to_block_idx, child_cpu_buf
+        )
+        child_token_to_request_idx = self._cpu_bookkeeping_clone_view(
+            self.token_to_request_idx, child_cpu_buf
         )
         child_token_to_position = self._cpu_bookkeeping_clone_view(
             self.token_to_position_in_request, child_cpu_buf
@@ -1625,8 +1680,28 @@ class DynamicInferenceContext(BaseInferenceContext):
         child_token_to_local = self._cpu_bookkeeping_clone_view(
             self.token_to_local_position_within_kv_block, child_cpu_buf
         )
+        child_staging_prefill = self._cpu_bookkeeping_clone_view(
+            self._staging_request_in_prefill_status, child_cpu_buf
+        )
+        child_staging_query_lengths = self._cpu_bookkeeping_clone_view(
+            self._staging_request_query_lengths, child_cpu_buf
+        )
         child_staging_kv_offsets = self._cpu_bookkeeping_clone_view(
             self._staging_request_kv_length_offsets, child_cpu_buf
+        )
+        child_temperature = self._cpu_bookkeeping_clone_view(
+            self._staging_temperature, child_cpu_buf
+        )
+        child_top_k = self._cpu_bookkeeping_clone_view(self._staging_top_k, child_cpu_buf)
+        child_top_p = self._cpu_bookkeeping_clone_view(self._staging_top_p, child_cpu_buf)
+        child_last_token_idxs = self._cpu_bookkeeping_clone_view(
+            self.active_request_last_token_idxs, child_cpu_buf
+        )
+        child_mha_query_lengths = self._cpu_bookkeeping_clone_view(
+            self._cpu_mha_query_lengths, child_cpu_buf
+        )
+        child_mha_cu_query_lengths = self._cpu_bookkeeping_clone_view(
+            self._cpu_mha_cu_query_seq_lengths, child_cpu_buf
         )
         child_mha_kv_lengths = self._cpu_bookkeeping_clone_view(
             self._cpu_mha_kv_seq_lengths, child_cpu_buf
@@ -1634,21 +1709,63 @@ class DynamicInferenceContext(BaseInferenceContext):
         child_mha_cu_kv_lengths = self._cpu_bookkeeping_clone_view(
             self._cpu_mha_cu_kv_seq_lengths, child_cpu_buf
         )
-        child_token_to_block_idx = self._cpu_bookkeeping_clone_view(
-            self.token_to_block_idx, child_cpu_buf
-        )
         child_mha_block_table = self._cpu_bookkeeping_clone_view(
             self._cpu_mha_block_table, child_cpu_buf
         )
 
+        child_token_to_input_ids[:token_count].copy_(self.token_to_input_ids[:token_count])
+        child_token_to_pos_ids[:token_count].copy_(self.token_to_pos_ids[:token_count])
         child_token_to_pos_ids[:token_count].add_(1)
+        child_token_to_block_idx[:token_count].copy_(self.token_to_block_idx[:token_count])
+        child_token_to_request_idx[:token_count].copy_(self.token_to_request_idx[:token_count])
+        child_token_to_position[:token_count].copy_(
+            self.token_to_position_in_request[:token_count]
+        )
         child_token_to_position[:token_count].add_(1)
+        child_token_to_local[:token_count].copy_(
+            self.token_to_local_position_within_kv_block[:token_count]
+        )
         child_token_to_local[:token_count].add_(1)
         child_token_to_local[:token_count].remainder_(self.block_size_tokens)
+
+        if token_count < padded_token_count:
+            pad_slice = slice(token_count, padded_token_count)
+            child_token_to_input_ids[pad_slice] = 0
+            child_token_to_pos_ids[pad_slice] = 0
+            child_token_to_block_idx[pad_slice] = self.kv_block_allocator.dummy_block_idx
+            child_token_to_request_idx[pad_slice] = -1
+            child_token_to_position[pad_slice] = 0
+            child_token_to_local[pad_slice] = 0
+
+        child_staging_prefill[:active_request_count] = 0
+        child_staging_query_lengths[:active_request_count].copy_(
+            self.request_query_lengths[active_slice]
+        )
+        child_staging_kv_offsets[:active_request_count].copy_(
+            self.request_kv_length_offsets[active_slice]
+        )
         child_staging_kv_offsets[:active_request_count].add_(1)
+        child_temperature[:padded_active].copy_(
+            self.active_request_metadata["temperature"][:padded_active]
+        )
+        child_top_k[:padded_active].copy_(self.active_request_metadata["top_k"][:padded_active])
+        child_top_p[:padded_active].copy_(self.active_request_metadata["top_p"][:padded_active])
+        child_last_token_idxs[:padded_active].copy_(
+            self.active_request_last_token_idxs[:padded_active]
+        )
+        if active_request_count < padded_active:
+            pad_slice = slice(active_request_count, padded_active)
+            child_staging_prefill[pad_slice] = 0
+            child_staging_query_lengths[pad_slice] = 0
+            child_staging_kv_offsets[pad_slice] = 0
 
         real_bs = self.batch_dimensions.req_count
         padded_bs = self.padded_batch_dimensions.req_count
+        child_mha_query_lengths[:padded_bs].copy_(self._cpu_mha_query_lengths[:padded_bs])
+        child_mha_cu_query_lengths[: padded_bs + 1].copy_(
+            self._cpu_mha_cu_query_seq_lengths[: padded_bs + 1]
+        )
+        child_mha_kv_lengths[:real_bs].copy_(self._cpu_mha_kv_seq_lengths[:real_bs])
         child_mha_kv_lengths[:real_bs].add_(1)
         child_mha_cu_kv_lengths[0] = 0
         if real_bs > 0:
@@ -1659,6 +1776,10 @@ class DynamicInferenceContext(BaseInferenceContext):
             child_mha_cu_kv_lengths[real_bs + 1 : padded_bs + 1] = child_mha_cu_kv_lengths[
                 real_bs
             ]
+            child_mha_kv_lengths[real_bs:padded_bs] = 0
+        child_mha_block_table[:real_bs].copy_(self._cpu_mha_block_table[:real_bs])
+        if real_bs < padded_bs:
+            child_mha_block_table[real_bs:padded_bs] = -1
 
         if kv_block_leases:
             active_request_ids = self.request_ids[
@@ -1671,6 +1792,16 @@ class DynamicInferenceContext(BaseInferenceContext):
                 row = request_id_to_row[int(lease.request_id)]
                 child_token_to_block_idx[row] = int(lease.block_id)
                 child_mha_block_table[row, int(lease.block_column)] = int(lease.block_id)
+
+        if self.is_hybrid_model:
+            child_mamba_decode = self._cpu_bookkeeping_clone_view(
+                self._cpu_mamba_batch_indices_decode, child_cpu_buf
+            )
+            child_mamba_decode[:padded_active].copy_(
+                self._cpu_mamba_batch_indices_decode[:padded_active]
+            )
+            if active_request_count < padded_active:
+                child_mamba_decode[active_request_count:padded_active] = -1
 
     def _cpu_bookkeeping_clone_view(self, source: Tensor, child_cpu_buf: Tensor) -> Tensor:
         """Return the matching typed view inside a cloned CPU bookkeeping buffer."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -290,6 +290,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Engine step counter (used for logging, metrics, and event tracking)
         self.step_count = 0
         self.async_scheduling = inference_config.async_scheduling
+        self.async_chain_scheduling = inference_config.async_chain_scheduling
         self.async_txn_diagnostics = AsyncTxnDiagnostics(enabled=self.async_scheduling)
         self.async_txn_retire_queue = TxnRetireQueue(self.async_txn_diagnostics)
         self.async_decode_slot_ring: Optional[AsyncDecodeSlotRing] = None

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2025,6 +2025,45 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         self._ep_zmq_communicator = communicator
 
+    def sync_ep_child_graph_shape(self) -> None:
+        """Enter the EP graph-shape sync for a prepared async child forward.
+
+        The real async child path launches from pre-staged metadata and therefore
+        does not call initialize_attention_state().  EP dummy ranks do call
+        initialize_attention_state() before their matching child forward, which
+        runs the CUDA-graph shape consensus.  This method lets the real rank
+        participate in that same consensus without rebuilding or copying
+        metadata that was already prepared transactionally.
+        """
+
+        if get_pg_size(self.expert_model_parallel_group) <= 1:
+            return
+        if not self.cuda_graph_batch_dimensions_list:
+            return
+
+        batch_dimensions = InferenceBatchDimensions(
+            token_count=self.active_token_count,
+            prefill_req_count=self.num_prefill_requests,
+            decode_req_count=self.num_decode_requests,
+        )
+        best_graph = CUDAGraphBatchDimensionBuilder.match_graph_config(
+            batch_dimensions,
+            self.cuda_graph_batch_dimensions_list,
+            strict=self.is_hybrid_model,
+            ep_group=self.expert_model_parallel_group,
+            match_ep_token_counts=self._nccl_ep_dispatcher or self._training_ep_dispatcher,
+            ep_zmq_communicator=self._ep_zmq_communicator,
+        )
+        if (best_graph is not None) != self._using_cuda_graph_this_step:
+            raise RuntimeError(
+                "EP async child graph-shape consensus diverged from the prepared decode step"
+            )
+        if best_graph is not None and best_graph != self.padded_batch_dimensions:
+            raise RuntimeError(
+                "EP async child graph shape does not match the prepared decode metadata: "
+                f"expected {self.padded_batch_dimensions}, got {best_graph}"
+            )
+
     def reset_attention_state(self) -> None:
         """Reset state used within attention, after each step."""
         # Attention metadata reset is now handled by MHAMetadata.reset()

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -4,7 +4,7 @@ import logging
 import math
 import operator
 import warnings
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from typing import Dict, List, Optional, Sequence, Tuple
 
 import torch  # type: ignore
@@ -1458,6 +1458,23 @@ class DynamicInferenceContext(BaseInferenceContext):
         """Returns True if cuda graphs are being used for this step."""
         return self._using_cuda_graph_this_step
 
+    @contextmanager
+    def async_child_forward_eager_scope(self):
+        """Temporarily force async child forwards onto the eager model path.
+
+        Full-iteration CUDA graphs are captured for the committed context
+        metadata. Async child forwards use transient transactional metadata
+        buffers, so they must not replay the committed-step graph unless a
+        separate async graph design is explicitly added.
+        """
+
+        previous = self._using_cuda_graph_this_step
+        self._using_cuda_graph_this_step = False
+        try:
+            yield
+        finally:
+            self._using_cuda_graph_this_step = previous
+
     def cuda_graph_cache_key(self):
         """Return the CUDA graph cache key for the active padded shape.
 
@@ -1595,9 +1612,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             cpu_bookkeeping_buf=child_cpu_buf if defer_h2d else None,
             kv_block_leases=kv_block_leases,
             mamba_slot_ids=mamba_slot_ids,
-            cuda_graph_key=(
-                self.padded_batch_dimensions if self.using_cuda_graph_this_step() else None
-            ),
+            cuda_graph_key=None,
         )
 
     def _reserve_async_boundary_blocks(

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1433,6 +1433,21 @@ class DynamicInferenceContext(BaseInferenceContext):
         """Returns True if cuda graphs are being used for this step."""
         return self._using_cuda_graph_this_step
 
+    def cuda_graph_cache_key(self):
+        """Return the CUDA graph cache key for the currently bound metadata slot."""
+
+        if (
+            self.async_scheduling
+            and self.async_decode_slot_ring is not None
+            and self.using_cuda_graph_this_step()
+            and self.is_decode_only()
+        ):
+            slot = self.active_decode_slot()
+            return slot.cuda_graph_key(
+                ("decode", self.padded_active_request_count, self.padded_active_token_count)
+            )
+        return self.padded_batch_dimensions
+
     def async_launch_eligibility(self, **kwargs):
         """Classify whether the next decode child may be launched asynchronously."""
         return classify_decode_child_launch(

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1515,9 +1515,35 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.non_graph_attn_metadata["mha_metadata"].bind_gpu_buffers(self.gpu_view)
             if self.is_hybrid_model and hasattr(self, "mamba_metadata"):
                 self.mamba_metadata.bind_gpu_buffers(self.gpu_view)
+            self._refresh_active_metadata_views_for_bound_slot()
         if changed and hasattr(self, "_input_position_views"):
             self._input_position_views.clear()
         return slot
+
+    def _refresh_active_metadata_views_for_bound_slot(self) -> None:
+        """Rebuild active per-step metadata slices after switching decode slots."""
+
+        if self.active_attn_metadata is not None:
+            mha = self.active_attn_metadata["mha_metadata"]
+            if getattr(mha, "state_data", None):
+                mha.set_state_data(
+                    padded_active_request_count=self.padded_active_request_count,
+                    max_seqlen_q=mha.state_data["max_seqlen_q"],
+                    max_seqlen_k=mha.state_data["max_seqlen_k"],
+                )
+
+        if (
+            self.is_hybrid_model
+            and hasattr(self, "mamba_metadata")
+            and self.mamba_metadata is not None
+            and self.is_decode_only()
+            and self.padded_batch_dimensions.decode_req_count > 0
+        ):
+            self.mamba_metadata.batch_indices_decode = (
+                self.gpu_view.mamba_batch_indices_decode[
+                    : self.padded_batch_dimensions.decode_req_count
+                ]
+            )
 
     def active_decode_slot(self) -> Optional[AsyncDecodeSlot]:
         """Return the slot currently bound to forward metadata."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1458,40 +1458,31 @@ class DynamicInferenceContext(BaseInferenceContext):
         """Returns True if cuda graphs are being used for this step."""
         return self._using_cuda_graph_this_step
 
+    def replay_cuda_graph_this_step(self) -> bool:
+        """Return whether module-level CUDA graph replay is allowed now."""
+
+        return self._using_cuda_graph_this_step and not getattr(
+            self, "_disable_cuda_graph_replay_this_scope", False
+        )
+
     @contextmanager
-    def async_child_forward_eager_scope(self):
-        """Temporarily force async child forwards onto the eager model path.
+    def async_child_forward_graph_replay_disabled_scope(self):
+        """Temporarily disable module-level graph replay for async child forwards.
 
         Full-iteration CUDA graphs are captured for the committed context
         metadata. Async child forwards use transient transactional metadata
         buffers, so they must not replay the committed-step graph unless a
-        separate async graph design is explicitly added. The scope also makes
-        the child slot's non-graph attention metadata active for the eager
-        forward.
+        separate async graph design is explicitly added. The graph-mode metadata
+        flag remains true, so the child still uses the same padded graph metadata
+        and optimized kernels as the committed decode path.
         """
 
-        previous_cuda_graph = self._using_cuda_graph_this_step
-        previous_attn_metadata = self.active_attn_metadata
-        self._using_cuda_graph_this_step = False
-        self.active_attn_metadata = self.non_graph_attn_metadata  # type: ignore[assignment]
-        real_bs = self.batch_dimensions.req_count
-        padded_bs = self.padded_batch_dimensions.req_count
-        if real_bs > 0:
-            max_seqlen_q = int(self._cpu_mha_query_lengths[:real_bs].max().item())
-            max_seqlen_k = int((self._cpu_mha_kv_seq_lengths[:real_bs] + 1).max().item())
-        else:
-            max_seqlen_q = self.num_speculative_tokens + 1
-            max_seqlen_k = 1
-        self.non_graph_attn_metadata["mha_metadata"].set_state_data(
-            padded_active_request_count=padded_bs,
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_k=max_seqlen_k,
-        )
+        previous = getattr(self, "_disable_cuda_graph_replay_this_scope", False)
+        self._disable_cuda_graph_replay_this_scope = True
         try:
             yield
         finally:
-            self.active_attn_metadata = previous_attn_metadata
-            self._using_cuda_graph_this_step = previous_cuda_graph
+            self._disable_cuda_graph_replay_this_scope = previous
 
     def cuda_graph_cache_key(self):
         """Return the CUDA graph cache key for the active padded shape.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -385,6 +385,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.num_attention_layers = len(attention_layer_map) + len(dsa_layer_map)
             self.num_mamba_layers = len(mamba_layer_map)
             self.layer_map = attention_layer_map | dsa_layer_map | mamba_layer_map
+            self.mamba_state_bank_count = 2 if self.async_scheduling else 1
         else:
             # The layer map is the identity function for pure Transformer models.
             # Use the same per-PP-rank layer count as TransformerBlock (handles
@@ -409,6 +410,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.num_mamba_layers = 0
             (self.mamba_conv_states_shape, self.mamba_ssm_states_shape) = (None, None)
             self.layer_map = {i: i for i in range(self.num_attention_layers)}
+            self.mamba_state_bank_count = 1
 
         if self.num_attention_layers == 0:
             raise NotImplementedError(
@@ -447,6 +449,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                 math.prod(self.mamba_ssm_states_shape) * self.mamba_ssm_states_dtype.itemsize
             )
             mamba_states_memory_per_request *= self.num_mamba_layers
+            mamba_states_memory_per_request *= self.mamba_state_bank_count
             if self.num_speculative_tokens > 0:
                 # Add memory for intermediate conv and SSM states
                 intermediate_memory_per_request = (
@@ -839,6 +842,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                 max_tokens=self.max_tokens,
                 mamba_chunk_size=self.mamba_chunk_size,
                 d_conv=self.mamba_conv_states_shape[-1],
+                state_bank_count=self.mamba_state_bank_count,
             )
             # Bind the unified CPU/GPU buffers so the per-step Mamba metadata
             # fields ride along with the single coalesced H2D in
@@ -846,6 +850,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata.bind_cpu_buffers(
                 {
                     "batch_indices_decode": self._cpu_mamba_batch_indices_decode,
+                    "batch_indices_decode_write": self._cpu_mamba_batch_indices_decode_write,
                     "batch_indices_prefill": self._cpu_mamba_batch_indices_prefill,
                     "seq_idx": self._cpu_mamba_seq_idx,
                     "cu_seqlens": self._cpu_mamba_cu_seqlens,
@@ -858,12 +863,14 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
             self.mamba_metadata.bind_gpu_buffers(self.gpu_view)
             self.mamba_conv_states = torch.empty(
-                (self.num_mamba_layers, self.max_requests) + self.mamba_conv_states_shape,
+                (self.num_mamba_layers, self.max_requests * self.mamba_state_bank_count)
+                + self.mamba_conv_states_shape,
                 dtype=self.mamba_conv_states_dtype,
                 device=torch.cuda.current_device(),
             )
             self.mamba_ssm_states = torch.empty(
-                (self.num_mamba_layers, self.max_requests) + self.mamba_ssm_states_shape,
+                (self.num_mamba_layers, self.max_requests * self.mamba_state_bank_count)
+                + self.mamba_ssm_states_shape,
                 dtype=self.mamba_ssm_states_dtype,
                 device=torch.cuda.current_device(),
             )
@@ -1035,12 +1042,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
         # Mamba section (hybrid models only). Must match the MambaMetadata
         # shapes (mirrors the layout documented in ContextGPUView).
-        # batch_indices_decode is int64; all other fields are int32.
+        # batch_indices_decode and batch_indices_decode_write are int64;
+        # all other fields are int32.
         if self.is_hybrid_model:
             # mamba_batch_indices_decode is int64; pad to 8-byte alignment.
             _mamba_align_pad = (8 - _pre_mamba_bytes % 8) % 8
             self._max_mamba_chunks = self.max_tokens // self.mamba_chunk_size + self.max_requests
             _mamba_batch_indices_decode_bytes = self.max_requests * 8
+            _mamba_batch_indices_decode_write_bytes = self.max_requests * 8
             _mamba_batch_indices_prefill_bytes = self.max_requests * 4
             _mamba_seq_idx_bytes = self.max_tokens * 4
             _mamba_cu_seqlens_bytes = (self.max_requests + 1) * 4
@@ -1053,6 +1062,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             _mamba_align_pad = 0
             self._max_mamba_chunks = 0
             _mamba_batch_indices_decode_bytes = 0
+            _mamba_batch_indices_decode_write_bytes = 0
             _mamba_batch_indices_prefill_bytes = 0
             _mamba_seq_idx_bytes = 0
             _mamba_cu_seqlens_bytes = 0
@@ -1065,6 +1075,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             _pre_mamba_bytes
             + _mamba_align_pad
             + _mamba_batch_indices_decode_bytes
+            + _mamba_batch_indices_decode_write_bytes
             + _mamba_batch_indices_prefill_bytes
             + _mamba_seq_idx_bytes
             + _mamba_cu_seqlens_bytes
@@ -1198,6 +1209,10 @@ class DynamicInferenceContext(BaseInferenceContext):
                 _off : _off + _mamba_batch_indices_decode_bytes
             ].view(torch.int64)
             _off += _mamba_batch_indices_decode_bytes
+            self._cpu_mamba_batch_indices_decode_write = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_batch_indices_decode_write_bytes
+            ].view(torch.int64)
+            _off += _mamba_batch_indices_decode_write_bytes
             self._cpu_mamba_batch_indices_prefill = self._cpu_bookkeeping_buf[
                 _off : _off + _mamba_batch_indices_prefill_bytes
             ].view(torch.int32)
@@ -1567,6 +1582,11 @@ class DynamicInferenceContext(BaseInferenceContext):
                     : self.padded_batch_dimensions.decode_req_count
                 ]
             )
+            self.mamba_metadata.batch_indices_decode_write = (
+                self.gpu_view.mamba_batch_indices_decode_write[
+                    : self.padded_batch_dimensions.decode_req_count
+                ]
+            )
 
     def active_decode_slot(self) -> Optional[AsyncDecodeSlot]:
         """Return the slot currently bound to forward metadata."""
@@ -1875,11 +1895,19 @@ class DynamicInferenceContext(BaseInferenceContext):
             child_mamba_decode = self._cpu_bookkeeping_clone_view(
                 self._cpu_mamba_batch_indices_decode, child_cpu_buf
             )
-            child_mamba_decode[:padded_active].copy_(
-                self._cpu_mamba_batch_indices_decode[:padded_active]
+            child_mamba_decode_write = self._cpu_bookkeeping_clone_view(
+                self._cpu_mamba_batch_indices_decode_write, child_cpu_buf
             )
+            active_slice = slice(self.paused_request_count, self.total_request_count)
+            child_mamba_decode[:active_request_count] = self._mamba_flat_indices(active_slice).to(
+                dtype=child_mamba_decode.dtype
+            )
+            child_mamba_decode_write[:active_request_count] = self._mamba_flat_indices(
+                active_slice, use_candidate_bank=True
+            ).to(dtype=child_mamba_decode_write.dtype)
             if active_request_count < padded_active:
                 child_mamba_decode[active_request_count:padded_active] = -1
+                child_mamba_decode_write[active_request_count:padded_active] = -1
 
     def _cpu_bookkeeping_clone_view(self, source: Tensor, child_cpu_buf: Tensor) -> Tensor:
         """Return the matching typed view inside a cloned CPU bookkeeping buffer."""
@@ -2073,6 +2101,60 @@ class DynamicInferenceContext(BaseInferenceContext):
             ssm_state = self.mamba_ssm_states[mamba_layer_number]
 
         return (conv_state, ssm_state)
+
+    def _mamba_flat_indices(
+        self, request_slice: slice, *, use_candidate_bank: bool = False
+    ) -> Tensor:
+        """Return flattened Mamba state rows for the selected request rows."""
+        assert self.is_hybrid_model, "Only hybrid models have Mamba state tensors"
+        base_indices = self.mamba_metadata.request_to_mamba_state_idx[request_slice].to(
+            dtype=torch.int32
+        )
+        bank_indices = self.mamba_metadata.request_to_mamba_state_bank[request_slice].to(
+            dtype=torch.int32
+        )
+        if use_candidate_bank and self.mamba_state_bank_count > 1:
+            bank_indices = 1 - bank_indices
+        return base_indices * self.mamba_state_bank_count + bank_indices
+
+    def _mamba_flat_indices_from_request_idxs(
+        self, request_idxs: Tensor, *, use_candidate_bank: bool = False
+    ) -> Tensor:
+        """Return flattened Mamba state rows for explicit request rows."""
+        assert self.is_hybrid_model, "Only hybrid models have Mamba state tensors"
+        base_indices = self.mamba_metadata.request_to_mamba_state_idx[request_idxs].to(
+            dtype=torch.int32
+        )
+        bank_indices = self.mamba_metadata.request_to_mamba_state_bank[request_idxs].to(
+            dtype=torch.int32
+        )
+        if use_candidate_bank and self.mamba_state_bank_count > 1:
+            bank_indices = 1 - bank_indices
+        return base_indices * self.mamba_state_bank_count + bank_indices
+
+    def accept_async_mamba_state(self, request_ids: Sequence[int] | Tensor) -> None:
+        """Commit candidate Mamba banks for accepted async-forward requests."""
+        if not self.is_hybrid_model or self.mamba_state_bank_count == 1:
+            return
+        if isinstance(request_ids, torch.Tensor):
+            if request_ids.numel() == 0:
+                return
+            request_id_list = [int(request_id) for request_id in request_ids.tolist()]
+        else:
+            request_id_list = [int(request_id) for request_id in request_ids]
+            if not request_id_list:
+                return
+
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        active_request_ids = self.request_ids[active_slice]
+        for request_id in request_id_list:
+            matches = torch.nonzero(active_request_ids == request_id, as_tuple=True)[0]
+            if matches.numel() == 0:
+                continue
+            request_idx = self.paused_request_count + int(matches[0].item())
+            self.mamba_metadata.request_to_mamba_state_bank[request_idx] = (
+                1 - self.mamba_metadata.request_to_mamba_state_bank[request_idx]
+            )
 
     # =========================================================================
     # Mamba prefix cache infrastructure
@@ -2444,6 +2526,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                     )
                 self._pending_mamba_zeros.append(mamba_idx)
                 self.mamba_metadata.request_to_mamba_state_idx[request_idx] = mamba_idx
+                self.mamba_metadata.request_to_mamba_state_bank[request_idx] = 0
 
         self.active_token_count = token_end
         self.total_request_count = end_request_idx
@@ -2582,6 +2665,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata.request_to_mamba_state_idx[0:N] = (
                 self.mamba_metadata.batch_allocate_slots(N)
             )
+            self.mamba_metadata.request_to_mamba_state_bank[0:N] = 0
 
     def initialize_attention_state(
         self,
@@ -2809,7 +2893,8 @@ class DynamicInferenceContext(BaseInferenceContext):
                     self.mamba_slot_allocator.get_intermediate_cpu_data()
                 )
             self._pending_mamba_transfer = self.mamba_metadata.compute_cpu_metadata(
-                active_mamba_indices=self.mamba_metadata.request_to_mamba_state_idx[active_slice],
+                active_mamba_indices=self._mamba_flat_indices(active_slice),
+                active_mamba_write_indices=self._mamba_flat_indices(active_slice),
                 token_to_request_idx=self.token_to_request_idx[: self.active_token_count],
                 cpu_cu_query=self._cpu_mha_cu_query_seq_lengths,
                 batch_dimensions=attn_dimensions,
@@ -2863,7 +2948,12 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Batch-zero newly allocated Mamba slots.
         if self._pending_mamba_zeros:
             device = self.mamba_conv_states.device
-            indices = torch.tensor(self._pending_mamba_zeros, dtype=torch.long, device=device)
+            base_indices = torch.tensor(self._pending_mamba_zeros, dtype=torch.long, device=device)
+            if self.mamba_state_bank_count > 1:
+                banks = torch.arange(self.mamba_state_bank_count, dtype=torch.long, device=device)
+                indices = (base_indices[:, None] * self.mamba_state_bank_count + banks).flatten()
+            else:
+                indices = base_indices
             self.mamba_conv_states[:, indices] = 0.0
             self.mamba_ssm_states[:, indices] = 0.0
             self._pending_mamba_zeros.clear()
@@ -3450,6 +3540,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             if mamba_idx is None:
                 raise ContextOverflowError(req.request_id, "No Mamba slots available")
             self.mamba_metadata.request_to_mamba_state_idx[self.total_request_count] = mamba_idx
+            self.mamba_metadata.request_to_mamba_state_bank[self.total_request_count] = 0
 
             # Restore Mamba state from the block corresponding to prefix_skip_tokens
             restore_block_count = prefix_skip_tokens // self.block_size_tokens
@@ -3509,6 +3600,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata.request_to_mamba_state_idx[dst_idxs] = (
                 self.mamba_metadata.request_to_mamba_state_idx[src_idxs]
             )
+            self.mamba_metadata.request_to_mamba_state_bank[dst_idxs] = (
+                self.mamba_metadata.request_to_mamba_state_bank[src_idxs]
+            )
 
     def _swap_book_keeping_tensors(
         self, src_idxs, dst_idxs, next_tokens=None, new_speculative_tokens=None
@@ -3539,6 +3633,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         if self.is_hybrid_model:
             tensor_swap(self.mamba_metadata.request_to_mamba_state_idx, src_idxs, dst_idxs)
+            tensor_swap(self.mamba_metadata.request_to_mamba_state_bank, src_idxs, dst_idxs)
 
     def get_index_of_chunked_prefill_request(self, safe: bool = True) -> int:
         """
@@ -3591,9 +3686,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         # tensor.
         self.request_to_kv_block_ids[request_indexes] = -1
 
-        # Free Mamba slots. Async-launched hybrid decode uses single-bank Mamba
-        # state, so finished slots cannot return to the free pool until the
-        # launched child forward has retired.
+        # Free logical Mamba slots. Async-launched hybrid decode may still own
+        # one physical bank until its forward retires, so defer returning the
+        # logical slot when requested.
         if self.is_hybrid_model:
             if defer_release:
                 mamba_slot_ids = self.mamba_metadata.request_to_mamba_state_idx[
@@ -3606,6 +3701,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                     label="finished_request_mamba",
                 )
                 self.mamba_metadata.request_to_mamba_state_idx[request_indexes] = -1
+                self.mamba_metadata.request_to_mamba_state_bank[request_indexes] = 0
             else:
                 self.mamba_metadata.free_slots(request_indexes)
 
@@ -3875,6 +3971,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_to_kv_block_ids[evict_slice] = -1
         if self.is_hybrid_model:
             self.mamba_metadata.request_to_mamba_state_idx[evict_slice] = -1
+            self.mamba_metadata.request_to_mamba_state_bank[evict_slice] = 0
 
         return evict_request_ids
 
@@ -4041,6 +4138,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                 self.request_to_kv_block_ids[active_idxs_on_right] = -1
                 if self.is_hybrid_model:
                     self.mamba_metadata.request_to_mamba_state_idx[active_idxs_on_right] = -1
+                    self.mamba_metadata.request_to_mamba_state_bank[active_idxs_on_right] = 0
 
         # 5. We identify requests that require a new block and add them to the paused requests (i.e move them left) :-
         #       a) Put requests that have filled their current block and  require a new one in a pause state temporarily

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1464,6 +1464,24 @@ class DynamicInferenceContext(BaseInferenceContext):
                 return slot
         raise RuntimeError(f"active decode slot {self.active_decode_slot_id} is not in the ring")
 
+    def plain_decode_child_needs_terminal_check(
+        self, active_request_count: Optional[int] = None
+    ) -> bool:
+        """Return whether same-step finish detection could affect child adoption."""
+
+        if active_request_count is None:
+            active_request_count = self.total_request_count - self.paused_request_count
+        if active_request_count <= 0:
+            return True
+
+        termination_ids = self.active_request_metadata["termination_id"][:active_request_count]
+        if bool((termination_ids >= 0).any()):
+            return True
+
+        active_sequence_lengths = self.get_active_sequence_lengths()[:active_request_count]
+        max_sequence_lengths = self.get_max_sequence_lengths()[:active_request_count]
+        return bool(torch.ge(active_sequence_lengths + 1, max_sequence_lengths).any())
+
     def prepare_child_from_committed_decode_state(self) -> Optional[StepTxn]:
         """Prestage deterministic plain-decode child metadata into the free slot.
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -288,6 +288,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.async_scheduling = inference_config.async_scheduling
         self.async_txn_diagnostics = AsyncTxnDiagnostics(enabled=self.async_scheduling)
         self.async_decode_slot_ring: Optional[AsyncDecodeSlotRing] = None
+        self.active_decode_slot_id = 0
         self.request_rng_store = (
             RequestRNGStore(
                 model_config.inference_sampling_seed,
@@ -1432,6 +1433,35 @@ class DynamicInferenceContext(BaseInferenceContext):
             self, async_enabled=self.async_scheduling, **kwargs
         )
 
+    def bind_decode_slot(self, slot: Optional[AsyncDecodeSlot] = None) -> Optional[AsyncDecodeSlot]:
+        """Bind GPU metadata views to the selected async decode slot."""
+
+        if not self.async_scheduling:
+            return None
+        assert self.async_decode_slot_ring is not None
+        slot = slot or self.async_decode_slot_ring.current
+        changed = self.gpu_view is not slot.gpu_view
+        self.gpu_view = slot.gpu_view
+        self.active_decode_slot_id = slot.slot_id
+        if changed:
+            self.graph_attn_metadata["mha_metadata"].bind_gpu_buffers(self.gpu_view)
+            self.non_graph_attn_metadata["mha_metadata"].bind_gpu_buffers(self.gpu_view)
+            if self.is_hybrid_model and hasattr(self, "mamba_metadata"):
+                self.mamba_metadata.bind_gpu_buffers(self.gpu_view)
+        if changed and hasattr(self, "_input_position_views"):
+            self._input_position_views.clear()
+        return slot
+
+    def active_decode_slot(self) -> Optional[AsyncDecodeSlot]:
+        """Return the slot currently bound to forward metadata."""
+
+        if not self.async_scheduling or self.async_decode_slot_ring is None:
+            return None
+        for slot in self.async_decode_slot_ring.slots:
+            if slot.slot_id == self.active_decode_slot_id:
+                return slot
+        raise RuntimeError(f"active decode slot {self.active_decode_slot_id} is not in the ring")
+
     def has_unfinished_requests(self) -> bool:
         """Test if any requests remain."""
         return self.total_request_count > 0
@@ -2097,6 +2127,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Launch deferred Mamba GPU ops first (state zeroing/restore) so they
         # overlap with the CPU work below.  These are non-blocking GPU kernels.
         self._execute_pending_mamba_ops()
+        self.bind_decode_slot()
 
         self.is_creating_cuda_graphs = construct_graph_dimensions is not None
         assert not (
@@ -2361,7 +2392,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_ssm_states[:, indices] = 0.0
             self._pending_mamba_zeros.clear()
 
-    def transfer_bookkeeping_to_gpu(self) -> None:
+    def transfer_bookkeeping_to_gpu(self, slot: Optional[AsyncDecodeSlot] = None) -> None:
         """Batch transfer CPU bookkeeping state to GPU staging buffers.
 
         Called after initialize_attention_state() and before the forward pass.
@@ -2374,6 +2405,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         tensors immediately before the H2D (GPU reads them at `[:n_active]`
         while CPU bookkeeping keeps them at `[paused_count:total_count)`).
         """
+        slot = self.bind_decode_slot(slot)
         n_active = self.total_request_count - self.paused_request_count
         active_slice = slice(self.paused_request_count, self.total_request_count)
         padded_active = max(n_active, self.padded_active_request_count)
@@ -2410,7 +2442,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Copying the whole (max_tokens + max_requests)-sized buffer including
         # unused slots is cheap (~71 KB total, ~3-5 us on PCIe Gen4) and saves
         # 8 redundant launch overheads vs. the prior per-field copies.
-        self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+        if slot is None:
+            self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+        else:
+            slot.copy_bookkeeping_from_cpu(self._cpu_bookkeeping_buf, non_blocking=True)
 
         # MHA metadata GPU views were already bound to state_data in
         # initialize_attention_state(); the H2D above populates the underlying

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1520,6 +1520,29 @@ class DynamicInferenceContext(BaseInferenceContext):
             self._input_position_views.clear()
         return slot
 
+    def bind_decode_slot_for_forward(
+        self, slot: Optional[AsyncDecodeSlot] = None
+    ) -> Optional[AsyncDecodeSlot]:
+        """Bind a decode slot and make per-step metadata ready for a forward.
+
+        Async child forwards can be launched from transactionally prepared GPU
+        bookkeeping without re-running initialize_attention_state() on every
+        participating rank. Slot binding therefore owns the final forward-time
+        invariant: active MHA/Mamba metadata must point at the bound slot and at
+        the graph/non-graph metadata family selected by the prepared shape.
+        """
+
+        slot = self.bind_decode_slot(slot)
+        if slot is None:
+            return None
+        self.active_attn_metadata = (
+            self.graph_attn_metadata  # type: ignore[assignment]
+            if self.using_cuda_graph_this_step()
+            else self.non_graph_attn_metadata  # type: ignore[assignment]
+        )
+        self._refresh_active_metadata_views_for_bound_slot()
+        return slot
+
     def _refresh_active_metadata_views_for_bound_slot(self) -> None:
         """Rebuild active per-step metadata slices after switching decode slots."""
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -12,6 +12,13 @@ import torch.nn.functional as F  # type: ignore
 from torch import Tensor  # type: ignore
 
 from megatron.core import parallel_state
+from megatron.core.inference.async_txn import (
+    AsyncDecodeSlot,
+    AsyncDecodeSlotRing,
+    AsyncTxnDiagnostics,
+    RequestRNGStore,
+    classify_decode_child_launch,
+)
 from megatron.core.inference.batch_dimensions_utils import (
     CUDAGraphBatchDimensionBuilder,
     InferenceBatchDimensions,
@@ -278,6 +285,17 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # Engine step counter (used for logging, metrics, and event tracking)
         self.step_count = 0
+        self.async_scheduling = inference_config.async_scheduling
+        self.async_txn_diagnostics = AsyncTxnDiagnostics(enabled=self.async_scheduling)
+        self.async_decode_slot_ring: Optional[AsyncDecodeSlotRing] = None
+        self.request_rng_store = (
+            RequestRNGStore(
+                model_config.inference_sampling_seed,
+                device=torch.device("cuda", torch.cuda.current_device()),
+            )
+            if self.async_scheduling
+            else None
+        )
 
         self.cache_mla_latent = (
             isinstance(model_config, MLATransformerConfig) and model_config.cache_mla_latents
@@ -1218,6 +1236,20 @@ class DynamicInferenceContext(BaseInferenceContext):
             device=torch.cuda.current_device(),
             max_mamba_chunks=self._max_mamba_chunks,
         )
+        if self.async_scheduling:
+            child_gpu_view = ContextGPUView(
+                max_requests=self.max_requests,
+                max_tokens=self.max_tokens,
+                max_kv_blocks=self.max_kv_block_count,
+                device=torch.cuda.current_device(),
+                max_mamba_chunks=self._max_mamba_chunks,
+            )
+            self.async_decode_slot_ring = AsyncDecodeSlotRing(
+                (
+                    AsyncDecodeSlot(slot_id=0, gpu_view=self.gpu_view),
+                    AsyncDecodeSlot(slot_id=1, gpu_view=child_gpu_view),
+                )
+            )
 
         # Cache of (input_ids_view, pos_ids_view) keyed by num_tokens. Instead of slicing and
         # unsqueezing on every new inference step (constructing new TensorImpls at 30-60 us),
@@ -1393,6 +1425,12 @@ class DynamicInferenceContext(BaseInferenceContext):
     def using_cuda_graph_this_step(self) -> bool:
         """Returns True if cuda graphs are being used for this step."""
         return self._using_cuda_graph_this_step
+
+    def async_launch_eligibility(self, **kwargs):
+        """Classify whether the next decode child may be launched asynchronously."""
+        return classify_decode_child_launch(
+            self, async_enabled=self.async_scheduling, **kwargs
+        )
 
     def has_unfinished_requests(self) -> bool:
         """Test if any requests remain."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1243,6 +1243,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             device=torch.cuda.current_device(),
             max_mamba_chunks=self._max_mamba_chunks,
         )
+        self._bookkeeping_h2d_done_event = torch.cuda.Event()
         if self.async_scheduling:
             child_gpu_view = ContextGPUView(
                 max_requests=self.max_requests,
@@ -2798,7 +2799,12 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_ssm_states[:, indices] = 0.0
             self._pending_mamba_zeros.clear()
 
-    def transfer_bookkeeping_to_gpu(self, slot: Optional[AsyncDecodeSlot] = None) -> None:
+    def transfer_bookkeeping_to_gpu(
+        self,
+        slot: Optional[AsyncDecodeSlot] = None,
+        *,
+        record_done_event: bool = False,
+    ) -> Optional[torch.cuda.Event]:
         """Batch transfer CPU bookkeeping state to GPU staging buffers.
 
         Called after initialize_attention_state() and before the forward pass.
@@ -2852,6 +2858,10 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
         else:
             slot.copy_bookkeeping_from_cpu(self._cpu_bookkeeping_buf, non_blocking=True)
+        done_event = None
+        if record_done_event:
+            done_event = self._bookkeeping_h2d_done_event
+            done_event.record(torch.cuda.current_stream())
 
         # MHA metadata GPU views were already bound to state_data in
         # initialize_attention_state(); the H2D above populates the underlying
@@ -2861,6 +2871,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         if hasattr(self, '_pending_mamba_transfer') and self._pending_mamba_transfer is not None:
             self.mamba_metadata.load_from_cpu(self._pending_mamba_transfer)
             self._pending_mamba_transfer = None
+
+        return done_event
 
     def reset_tensors(self) -> None:
         """Fill all bookkeeping tensors with sentinel values."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -16,7 +16,9 @@ from megatron.core.inference.async_txn import (
     AsyncDecodeSlot,
     AsyncDecodeSlotRing,
     AsyncTxnDiagnostics,
+    AsyncTxnSkipReason,
     RequestRNGStore,
+    StepTxn,
     classify_decode_child_launch,
 )
 from megatron.core.inference.batch_dimensions_utils import (
@@ -1461,6 +1463,113 @@ class DynamicInferenceContext(BaseInferenceContext):
             if slot.slot_id == self.active_decode_slot_id:
                 return slot
         raise RuntimeError(f"active decode slot {self.active_decode_slot_id} is not in the ring")
+
+    def prepare_child_from_committed_decode_state(self) -> Optional[StepTxn]:
+        """Prestage deterministic plain-decode child metadata into the free slot.
+
+        This covers the ordinary non-hybrid, no-boundary decode case. Later
+        commits extend the same slot ownership to boundary reservations and
+        Mamba metadata; until then those cases are explicit sync gates.
+        """
+
+        if not self.async_scheduling or self.async_decode_slot_ring is None:
+            return None
+
+        eligibility = self.async_launch_eligibility()
+        if not eligibility.eligible:
+            self.async_txn_diagnostics.record_barrier_skip(eligibility.reason)
+            return None
+        if self.is_hybrid_model:
+            self.async_txn_diagnostics.record_barrier_skip(
+                AsyncTxnSkipReason.HYBRID_PRESTAGE_DEFERRED
+            )
+            return None
+        if eligibility.required_boundary_blocks:
+            self.async_txn_diagnostics.record_barrier_skip(
+                AsyncTxnSkipReason.BOUNDARY_PRESTAGE_DEFERRED
+            )
+            return None
+
+        child_slot = self.async_decode_slot_ring.child
+        if not child_slot.can_reuse():
+            self.async_txn_diagnostics.record_barrier_skip(AsyncTxnSkipReason.CHILD_SLOT_BUSY)
+            return None
+
+        active_request_count = self.total_request_count - self.paused_request_count
+        if active_request_count <= 0 or self.active_token_count != active_request_count:
+            self.async_txn_diagnostics.record_barrier_skip(AsyncTxnSkipReason.NOT_DECODE_ONLY)
+            return None
+
+        child_cpu_buf = self._cpu_bookkeeping_buf.clone()
+        self._patch_plain_decode_child_bookkeeping(child_cpu_buf, active_request_count)
+        h2d_done_event = child_slot.copy_bookkeeping_from_cpu(child_cpu_buf, non_blocking=True)
+        request_ids = self.request_ids[
+            self.paused_request_count : self.total_request_count
+        ].tolist()
+        self.async_txn_diagnostics.record_prepared(under_forward=True)
+        return StepTxn(
+            step_id=self.step_count + 1,
+            request_ids=request_ids,
+            slot_id=child_slot.slot_id,
+            h2d_done_event=h2d_done_event,
+            cuda_graph_key=child_slot.cuda_graph_key(
+                ("decode", self.padded_active_request_count, self.padded_active_token_count)
+            ),
+        )
+
+    def _patch_plain_decode_child_bookkeeping(
+        self, child_cpu_buf: Tensor, active_request_count: int
+    ) -> None:
+        """Patch a CPU bookkeeping clone from current decode to child decode."""
+
+        token_count = active_request_count
+        child_token_to_pos_ids = self._cpu_bookkeeping_clone_view(
+            self.token_to_pos_ids, child_cpu_buf
+        )
+        child_token_to_position = self._cpu_bookkeeping_clone_view(
+            self.token_to_position_in_request, child_cpu_buf
+        )
+        child_token_to_local = self._cpu_bookkeeping_clone_view(
+            self.token_to_local_position_within_kv_block, child_cpu_buf
+        )
+        child_staging_kv_offsets = self._cpu_bookkeeping_clone_view(
+            self._staging_request_kv_length_offsets, child_cpu_buf
+        )
+        child_mha_kv_lengths = self._cpu_bookkeeping_clone_view(
+            self._cpu_mha_kv_seq_lengths, child_cpu_buf
+        )
+        child_mha_cu_kv_lengths = self._cpu_bookkeeping_clone_view(
+            self._cpu_mha_cu_kv_seq_lengths, child_cpu_buf
+        )
+
+        child_token_to_pos_ids[:token_count].add_(1)
+        child_token_to_position[:token_count].add_(1)
+        child_token_to_local[:token_count].add_(1)
+        child_staging_kv_offsets[:active_request_count].add_(1)
+
+        real_bs = self.batch_dimensions.req_count
+        padded_bs = self.padded_batch_dimensions.req_count
+        child_mha_kv_lengths[:real_bs].add_(1)
+        child_mha_cu_kv_lengths[0] = 0
+        if real_bs > 0:
+            child_mha_cu_kv_lengths[1 : real_bs + 1] = torch.cumsum(
+                child_mha_kv_lengths[:real_bs], dim=0
+            )
+        if real_bs < padded_bs:
+            child_mha_cu_kv_lengths[real_bs + 1 : padded_bs + 1] = child_mha_cu_kv_lengths[
+                real_bs
+            ]
+
+    def _cpu_bookkeeping_clone_view(self, source: Tensor, child_cpu_buf: Tensor) -> Tensor:
+        """Return the matching typed view inside a cloned CPU bookkeeping buffer."""
+
+        byte_offset = source.data_ptr() - self._cpu_bookkeeping_buf.data_ptr()
+        byte_count = source.numel() * source.element_size()
+        if byte_offset < 0 or byte_offset + byte_count > child_cpu_buf.numel():
+            raise RuntimeError("source tensor is not backed by the CPU bookkeeping buffer")
+        return child_cpu_buf[byte_offset : byte_offset + byte_count].view(source.dtype).view(
+            source.shape
+        )
 
     def has_unfinished_requests(self) -> bool:
         """Test if any requests remain."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1279,6 +1279,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                     ),
                 )
             )
+            self._async_child_h2d_stream = torch.cuda.Stream()
 
         # Cache of (input_ids_view, pos_ids_view) keyed by num_tokens. Instead of slicing and
         # unsqueezing on every new inference step (constructing new TensorImpls at 30-60 us),
@@ -1580,7 +1581,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
         h2d_done_event = None
         if not defer_h2d:
-            h2d_done_event = child_slot.copy_bookkeeping_from_cpu(child_cpu_buf, non_blocking=True)
+            h2d_stream = (
+                getattr(self, "_async_child_h2d_stream", None)
+                if child_slot is not self.async_decode_slot_ring.current
+                else None
+            )
+            h2d_done_event = child_slot.copy_bookkeeping_from_cpu(
+                child_cpu_buf, non_blocking=True, stream=h2d_stream
+            )
         self.async_txn_diagnostics.record_prepared(under_forward=True)
         return StepTxn(
             step_id=self.step_count + 1,

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -17,8 +17,10 @@ from megatron.core.inference.async_txn import (
     AsyncDecodeSlotRing,
     AsyncTxnDiagnostics,
     AsyncTxnSkipReason,
+    KVBlockLease,
     RequestRNGStore,
     StepTxn,
+    TxnRetireQueue,
     classify_decode_child_launch,
 )
 from megatron.core.inference.batch_dimensions_utils import (
@@ -289,6 +291,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.step_count = 0
         self.async_scheduling = inference_config.async_scheduling
         self.async_txn_diagnostics = AsyncTxnDiagnostics(enabled=self.async_scheduling)
+        self.async_txn_retire_queue = TxnRetireQueue(self.async_txn_diagnostics)
         self.async_decode_slot_ring: Optional[AsyncDecodeSlotRing] = None
         self.active_decode_slot_id = 0
         self.request_rng_store = (
@@ -1485,13 +1488,14 @@ class DynamicInferenceContext(BaseInferenceContext):
     def prepare_child_from_committed_decode_state(self) -> Optional[StepTxn]:
         """Prestage deterministic plain-decode child metadata into the free slot.
 
-        This covers the ordinary non-hybrid, no-boundary decode case. Later
-        commits extend the same slot ownership to boundary reservations and
-        Mamba metadata; until then those cases are explicit sync gates.
+        This covers ordinary non-hybrid decode, including requests that cross a
+        KV-block boundary. Boundary blocks are reserved before launch and
+        adopted during the later CPU commit by request id.
         """
 
         if not self.async_scheduling or self.async_decode_slot_ring is None:
             return None
+        self.async_txn_retire_queue.drain_ready()
 
         eligibility = self.async_launch_eligibility()
         if not eligibility.eligible:
@@ -1500,11 +1504,6 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.is_hybrid_model:
             self.async_txn_diagnostics.record_barrier_skip(
                 AsyncTxnSkipReason.HYBRID_PRESTAGE_DEFERRED
-            )
-            return None
-        if eligibility.required_boundary_blocks:
-            self.async_txn_diagnostics.record_barrier_skip(
-                AsyncTxnSkipReason.BOUNDARY_PRESTAGE_DEFERRED
             )
             return None
 
@@ -1518,25 +1517,72 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.async_txn_diagnostics.record_barrier_skip(AsyncTxnSkipReason.NOT_DECODE_ONLY)
             return None
 
-        child_cpu_buf = self._cpu_bookkeeping_buf.clone()
-        self._patch_plain_decode_child_bookkeeping(child_cpu_buf, active_request_count)
-        h2d_done_event = child_slot.copy_bookkeeping_from_cpu(child_cpu_buf, non_blocking=True)
         request_ids = self.request_ids[
             self.paused_request_count : self.total_request_count
         ].tolist()
+        kv_block_leases = self._reserve_async_boundary_blocks(eligibility.boundary_request_ids)
+        if kv_block_leases is None:
+            self.async_txn_diagnostics.record_barrier_skip(
+                AsyncTxnSkipReason.KV_RESERVATION_UNAVAILABLE
+            )
+            return None
+
+        child_cpu_buf = self._cpu_bookkeeping_buf.clone()
+        self._patch_plain_decode_child_bookkeeping(
+            child_cpu_buf, active_request_count, kv_block_leases=kv_block_leases
+        )
+        h2d_done_event = child_slot.copy_bookkeeping_from_cpu(child_cpu_buf, non_blocking=True)
         self.async_txn_diagnostics.record_prepared(under_forward=True)
         return StepTxn(
             step_id=self.step_count + 1,
             request_ids=request_ids,
             slot_id=child_slot.slot_id,
             h2d_done_event=h2d_done_event,
+            kv_block_leases=kv_block_leases,
             cuda_graph_key=child_slot.cuda_graph_key(
                 ("decode", self.padded_active_request_count, self.padded_active_token_count)
             ),
         )
 
+    def _reserve_async_boundary_blocks(
+        self, boundary_request_ids: Sequence[int]
+    ) -> Optional[tuple[KVBlockLease, ...]]:
+        """Reserve one next-column KV block for each boundary-crossing request."""
+
+        if not boundary_request_ids:
+            return ()
+
+        num_blocks = len(boundary_request_ids)
+        block_ids = self.kv_block_allocator.allocate_memory_blocks(num_blocks)
+        if block_ids is None or block_ids.numel() != num_blocks:
+            return None
+
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        active_request_ids = self.request_ids[active_slice].tolist()
+        request_id_to_row = {
+            int(request_id): row for row, request_id in enumerate(active_request_ids)
+        }
+        leases = []
+        for request_id, block_id in zip(boundary_request_ids, block_ids.tolist()):
+            row = request_id_to_row[int(request_id)]
+            block_column = int(
+                self.request_kv_block_counts[self.paused_request_count + row].item()
+            )
+            leases.append(
+                KVBlockLease(
+                    request_id=int(request_id),
+                    block_column=block_column,
+                    block_id=int(block_id),
+                )
+            )
+        return tuple(leases)
+
     def _patch_plain_decode_child_bookkeeping(
-        self, child_cpu_buf: Tensor, active_request_count: int
+        self,
+        child_cpu_buf: Tensor,
+        active_request_count: int,
+        *,
+        kv_block_leases: Sequence[KVBlockLease] = (),
     ) -> None:
         """Patch a CPU bookkeeping clone from current decode to child decode."""
 
@@ -1559,10 +1605,17 @@ class DynamicInferenceContext(BaseInferenceContext):
         child_mha_cu_kv_lengths = self._cpu_bookkeeping_clone_view(
             self._cpu_mha_cu_kv_seq_lengths, child_cpu_buf
         )
+        child_token_to_block_idx = self._cpu_bookkeeping_clone_view(
+            self.token_to_block_idx, child_cpu_buf
+        )
+        child_mha_block_table = self._cpu_bookkeeping_clone_view(
+            self._cpu_mha_block_table, child_cpu_buf
+        )
 
         child_token_to_pos_ids[:token_count].add_(1)
         child_token_to_position[:token_count].add_(1)
         child_token_to_local[:token_count].add_(1)
+        child_token_to_local[:token_count].remainder_(self.block_size_tokens)
         child_staging_kv_offsets[:active_request_count].add_(1)
 
         real_bs = self.batch_dimensions.req_count
@@ -1577,6 +1630,18 @@ class DynamicInferenceContext(BaseInferenceContext):
             child_mha_cu_kv_lengths[real_bs + 1 : padded_bs + 1] = child_mha_cu_kv_lengths[
                 real_bs
             ]
+
+        if kv_block_leases:
+            active_request_ids = self.request_ids[
+                self.paused_request_count : self.total_request_count
+            ].tolist()
+            request_id_to_row = {
+                int(request_id): row for row, request_id in enumerate(active_request_ids)
+            }
+            for lease in kv_block_leases:
+                row = request_id_to_row[int(lease.request_id)]
+                child_token_to_block_idx[row] = int(lease.block_id)
+                child_mha_block_table[row, int(lease.block_column)] = int(lease.block_id)
 
     def _cpu_bookkeeping_clone_view(self, source: Tensor, child_cpu_buf: Tensor) -> Tensor:
         """Return the matching typed view inside a cloned CPU bookkeeping buffer."""
@@ -3206,7 +3271,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         """Returns whether chunked prefill is enabled."""
         return self.enable_chunked_prefill
 
-    def release_memory_blocks_from_request_indexes(self, request_indexes) -> None:
+    def release_memory_blocks_from_request_indexes(
+        self, request_indexes, *, retire_event=None, defer_release: bool = False
+    ) -> None:
         """Release memory blocks used by the given request idxs.
 
         Args:
@@ -3215,7 +3282,12 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         kv_blocks_assigned = self.request_to_kv_block_ids[request_indexes]
         non_zero_values_in_kv_memory = kv_blocks_assigned[kv_blocks_assigned != -1]
-        self.kv_block_allocator.release_memory_blocks(non_zero_values_in_kv_memory)
+        self.release_kv_blocks(
+            non_zero_values_in_kv_memory,
+            retire_event=retire_event,
+            defer_release=defer_release,
+            label="finished_request_kv",
+        )
 
         # Reset the KV blocks for finished requests.
         # Note: do not use fill_() (or add_() and similar inplace ops) here.
@@ -3235,6 +3307,45 @@ class DynamicInferenceContext(BaseInferenceContext):
             sa._intermediate_offsets_cpu[request_indexes] = 0
             sa._intermediate_block_ids_cpu[request_indexes] = -1
             sa._eos_cache_block_id_cpu[request_indexes] = -1
+
+    def release_kv_blocks(
+        self,
+        block_ids: Tensor,
+        *,
+        retire_event=None,
+        defer_release: bool = False,
+        label: str = "kv",
+    ) -> None:
+        """Release KV blocks now or after a transaction-owned forward event."""
+
+        if block_ids.numel() == 0:
+            return
+        block_ids = block_ids.to(device='cpu', dtype=torch.int32).clone()
+        if not defer_release:
+            self.kv_block_allocator.release_memory_blocks(block_ids)
+            return
+
+        self.async_txn_retire_queue.enqueue(
+            retire_event,
+            lambda block_ids=block_ids: self.kv_block_allocator.release_memory_blocks(block_ids),
+            label=label,
+        )
+
+    def retire_unused_async_kv_leases(self, txn: Optional[StepTxn]) -> None:
+        """Retire reserved KV blocks that were not adopted by committed survivors."""
+
+        if txn is None:
+            return
+        unused = txn.unused_kv_leases()
+        if not unused:
+            return
+        block_ids = torch.tensor([lease.block_id for lease in unused], dtype=torch.int32)
+        self.release_kv_blocks(
+            block_ids,
+            retire_event=txn.forward_done_event,
+            defer_release=txn.launched,
+            label="unused_async_kv_lease",
+        )
 
     def resume_paused_requests(
         self, active_request_count: int, newly_paused_request_ids: torch.Tensor
@@ -3438,6 +3549,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         active_requests_mask: Tensor,
         new_tokens: Tensor,
         new_speculative_tokens: Tensor = None,
+        async_txn: Optional[StepTxn] = None,
     ) -> Tensor:
         """Update context state after calling engine.step().
 
@@ -3491,6 +3603,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             new_tokens = new_tokens.cpu()
         if new_speculative_tokens is not None and new_speculative_tokens.is_cuda:
             new_speculative_tokens = new_speculative_tokens.cpu()
+        defer_finished_release = async_txn is not None and async_txn.launched
+        retire_event = async_txn.forward_done_event if defer_finished_release else None
 
         self.num_prefill_requests = 0  # all turns to decode
         # All request that were in prefill become decode requests.
@@ -3529,7 +3643,11 @@ class DynamicInferenceContext(BaseInferenceContext):
                     torch.nonzero(active_requests_mask == 0, as_tuple=True)[0]
                     + self.paused_request_count
                 )
-                self.release_memory_blocks_from_request_indexes(finished_idxs)
+                self.release_memory_blocks_from_request_indexes(
+                    finished_idxs,
+                    retire_event=retire_event,
+                    defer_release=defer_finished_release,
+                )
 
             # Reset request/token counts.
             self.request_to_kv_block_ids.fill_(-1)
@@ -3559,7 +3677,11 @@ class DynamicInferenceContext(BaseInferenceContext):
                 torch.nonzero(active_requests_mask == 0, as_tuple=True)[0]
                 + self.paused_request_count
             )
-            self.release_memory_blocks_from_request_indexes(finished_idxs)
+            self.release_memory_blocks_from_request_indexes(
+                finished_idxs,
+                retire_event=retire_event,
+                defer_release=defer_finished_release,
+            )
 
             if active_request_count > 0:
                 finished_idxs_on_left = (
@@ -3598,6 +3720,22 @@ class DynamicInferenceContext(BaseInferenceContext):
             active_requests_requiring_new_block = (
                 num_tokens_in_last_block >= self.block_size_tokens - 1 - self.num_speculative_tokens
             ).byte()
+
+            if async_txn is not None and async_txn.kv_block_leases:
+                requiring_relative_idxs = torch.nonzero(
+                    active_requests_requiring_new_block, as_tuple=True
+                )[0]
+                for relative_idx in requiring_relative_idxs.tolist():
+                    row_idx = self.paused_request_count + relative_idx
+                    request_id = int(self.request_ids[row_idx].item())
+                    block_column = int(self.request_kv_block_counts[row_idx].item())
+                    block_id = async_txn.get_kv_lease(request_id, block_column)
+                    if block_id is None:
+                        continue
+                    self.request_to_kv_block_ids[row_idx, block_column] = block_id
+                    self.request_kv_block_counts[row_idx] += 1
+                    self.request_last_kv_block_id[row_idx] = block_id
+                    active_requests_requiring_new_block[relative_idx] = 0
 
             # Find the id in request_ids that is the chunked_prefill_request_id. Only one request should be chunked.
             if (

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1501,11 +1501,6 @@ class DynamicInferenceContext(BaseInferenceContext):
         if not eligibility.eligible:
             self.async_txn_diagnostics.record_barrier_skip(eligibility.reason)
             return None
-        if self.is_hybrid_model:
-            self.async_txn_diagnostics.record_barrier_skip(
-                AsyncTxnSkipReason.HYBRID_PRESTAGE_DEFERRED
-            )
-            return None
 
         child_slot = self.async_decode_slot_ring.child
         if not child_slot.can_reuse():
@@ -1520,6 +1515,15 @@ class DynamicInferenceContext(BaseInferenceContext):
         request_ids = self.request_ids[
             self.paused_request_count : self.total_request_count
         ].tolist()
+        mamba_slot_ids = ()
+        if self.is_hybrid_model:
+            assert self.mamba_metadata is not None
+            mamba_slot_ids = tuple(
+                int(slot)
+                for slot in self.mamba_metadata.request_to_mamba_state_idx[
+                    self.paused_request_count : self.total_request_count
+                ].tolist()
+            )
         kv_block_leases = self._reserve_async_boundary_blocks(eligibility.boundary_request_ids)
         if kv_block_leases is None:
             self.async_txn_diagnostics.record_barrier_skip(
@@ -1539,6 +1543,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             slot_id=child_slot.slot_id,
             h2d_done_event=h2d_done_event,
             kv_block_leases=kv_block_leases,
+            mamba_slot_ids=mamba_slot_ids,
             cuda_graph_key=child_slot.cuda_graph_key(
                 ("decode", self.padded_active_request_count, self.padded_active_token_count)
             ),
@@ -3296,9 +3301,23 @@ class DynamicInferenceContext(BaseInferenceContext):
         # tensor.
         self.request_to_kv_block_ids[request_indexes] = -1
 
-        # Free Mamba slots.
+        # Free Mamba slots. Async-launched hybrid decode uses single-bank Mamba
+        # state, so finished slots cannot return to the free pool until the
+        # launched child forward has retired.
         if self.is_hybrid_model:
-            self.mamba_metadata.free_slots(request_indexes)
+            if defer_release:
+                mamba_slot_ids = self.mamba_metadata.request_to_mamba_state_idx[
+                    request_indexes
+                ].clone()
+                self.release_mamba_slots(
+                    mamba_slot_ids,
+                    retire_event=retire_event,
+                    defer_release=True,
+                    label="finished_request_mamba",
+                )
+                self.mamba_metadata.request_to_mamba_state_idx[request_indexes] = -1
+            else:
+                self.mamba_metadata.free_slots(request_indexes)
 
         # Clear intermediate offset entries for released requests (CPU writes).
         if self.mamba_slot_allocator is not None:
@@ -3345,6 +3364,31 @@ class DynamicInferenceContext(BaseInferenceContext):
             retire_event=txn.forward_done_event,
             defer_release=txn.launched,
             label="unused_async_kv_lease",
+        )
+
+    def release_mamba_slots(
+        self,
+        mamba_slot_ids: Tensor,
+        *,
+        retire_event=None,
+        defer_release: bool = False,
+        label: str = "mamba",
+    ) -> None:
+        """Release Mamba slots now or after a transaction-owned forward event."""
+
+        if mamba_slot_ids.numel() == 0:
+            return
+        mamba_slot_ids = mamba_slot_ids.to(device='cpu', dtype=torch.int32).clone()
+        if not defer_release:
+            self.mamba_metadata.free_slot_ids(mamba_slot_ids)
+            return
+
+        self.async_txn_retire_queue.enqueue(
+            retire_event,
+            lambda mamba_slot_ids=mamba_slot_ids: self.mamba_metadata.free_slot_ids(
+                mamba_slot_ids
+            ),
+            label=label,
         )
 
     def resume_paused_requests(

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -357,6 +357,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # match_graph_config() uses this to perform the MAX reduction on the
         # CPU, avoiding a per-step NCCL AllReduce kernel on the compute stream.
         self._ep_zmq_communicator = None
+        self._ep_async_protocol = None
 
         # Mamba states.
         mamba_inference_state_config = inference_config.mamba_inference_state_config
@@ -2025,6 +2026,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         self._ep_zmq_communicator = communicator
 
+    def set_ep_async_protocol(self, protocol) -> None:
+        """Attach the EP async step protocol for tagged, step-scoped CPU sync."""
+
+        self._ep_async_protocol = protocol
+
     def sync_ep_child_graph_shape(self) -> None:
         """Enter the EP graph-shape sync for a prepared async child forward.
 
@@ -2053,6 +2059,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             ep_group=self.expert_model_parallel_group,
             match_ep_token_counts=self._nccl_ep_dispatcher or self._training_ep_dispatcher,
             ep_zmq_communicator=self._ep_zmq_communicator,
+            ep_async_protocol=self._ep_async_protocol,
         )
         if (best_graph is not None) != self._using_cuda_graph_this_step:
             raise RuntimeError(
@@ -2406,6 +2413,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             ep_group=self.expert_model_parallel_group,
             match_ep_token_counts=self._nccl_ep_dispatcher or self._training_ep_dispatcher,
             ep_zmq_communicator=self._ep_zmq_communicator,
+            ep_async_protocol=self._ep_async_protocol,
         )
         self._using_cuda_graph_this_step = best_graph is not None
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1465,15 +1465,33 @@ class DynamicInferenceContext(BaseInferenceContext):
         Full-iteration CUDA graphs are captured for the committed context
         metadata. Async child forwards use transient transactional metadata
         buffers, so they must not replay the committed-step graph unless a
-        separate async graph design is explicitly added.
+        separate async graph design is explicitly added. The scope also makes
+        the child slot's non-graph attention metadata active for the eager
+        forward.
         """
 
-        previous = self._using_cuda_graph_this_step
+        previous_cuda_graph = self._using_cuda_graph_this_step
+        previous_attn_metadata = self.active_attn_metadata
         self._using_cuda_graph_this_step = False
+        self.active_attn_metadata = self.non_graph_attn_metadata  # type: ignore[assignment]
+        real_bs = self.batch_dimensions.req_count
+        padded_bs = self.padded_batch_dimensions.req_count
+        if real_bs > 0:
+            max_seqlen_q = int(self._cpu_mha_query_lengths[:real_bs].max().item())
+            max_seqlen_k = int((self._cpu_mha_kv_seq_lengths[:real_bs] + 1).max().item())
+        else:
+            max_seqlen_q = self.num_speculative_tokens + 1
+            max_seqlen_k = 1
+        self.non_graph_attn_metadata["mha_metadata"].set_state_data(
+            padded_active_request_count=padded_bs,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+        )
         try:
             yield
         finally:
-            self._using_cuda_graph_this_step = previous
+            self.active_attn_metadata = previous_attn_metadata
+            self._using_cuda_graph_this_step = previous_cuda_graph
 
     def cuda_graph_cache_key(self):
         """Return the CUDA graph cache key for the active padded shape.

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -60,15 +60,16 @@ class ContextGPUView:
         mha_block_table_bytes = max_bs * max_kv_blocks * 4
 
         # Mamba section, only present for hybrid models.
-        #   mamba_batch_indices_decode    int64 (max_bs,)
-        #   mamba_batch_indices_prefill   int32 (max_bs,)
-        #   mamba_seq_idx                 int32 (1, max_tokens)
-        #   mamba_cu_seqlens              int32 (max_bs + 1,)
-        #   mamba_cu_chunk_seqlens        int32 (max_mamba_chunks + 1,)
-        #   mamba_last_chunk_indices      int32 (max_bs,)
-        #   mamba_seq_idx_for_varlen      int32 (max_mamba_chunks,)
-        #   mamba_conv_seq_idx            int32 (max_tokens,)
-        #   mamba_conv_seq_start          int32 (max_tokens,)
+        #   mamba_batch_indices_decode       int64 (max_bs,)
+        #   mamba_batch_indices_decode_write int64 (max_bs,)
+        #   mamba_batch_indices_prefill      int32 (max_bs,)
+        #   mamba_seq_idx                    int32 (1, max_tokens)
+        #   mamba_cu_seqlens                 int32 (max_bs + 1,)
+        #   mamba_cu_chunk_seqlens           int32 (max_mamba_chunks + 1,)
+        #   mamba_last_chunk_indices         int32 (max_bs,)
+        #   mamba_seq_idx_for_varlen         int32 (max_mamba_chunks,)
+        #   mamba_conv_seq_idx               int32 (max_tokens,)
+        #   mamba_conv_seq_start             int32 (max_tokens,)
         # Bytes before the Mamba section (needed to compute alignment padding).
         pre_mamba_bytes = (
             3 * tok_int64_bytes
@@ -85,6 +86,7 @@ class ContextGPUView:
             # mamba_batch_indices_decode is int64; pad to 8-byte alignment.
             mamba_align_pad = (8 - pre_mamba_bytes % 8) % 8
             mamba_batch_indices_decode_bytes = max_bs * 8
+            mamba_batch_indices_decode_write_bytes = max_bs * 8
             mamba_batch_indices_prefill_bytes = max_bs * 4
             mamba_seq_idx_bytes = max_tokens * 4
             mamba_cu_seqlens_bytes = (max_bs + 1) * 4
@@ -96,6 +98,7 @@ class ContextGPUView:
         else:
             mamba_align_pad = 0
             mamba_batch_indices_decode_bytes = 0
+            mamba_batch_indices_decode_write_bytes = 0
             mamba_batch_indices_prefill_bytes = 0
             mamba_seq_idx_bytes = 0
             mamba_cu_seqlens_bytes = 0
@@ -109,6 +112,7 @@ class ContextGPUView:
             pre_mamba_bytes
             + mamba_align_pad
             + mamba_batch_indices_decode_bytes
+            + mamba_batch_indices_decode_write_bytes
             + mamba_batch_indices_prefill_bytes
             + mamba_seq_idx_bytes
             + mamba_cu_seqlens_bytes
@@ -194,6 +198,10 @@ class ContextGPUView:
                 off : off + mamba_batch_indices_decode_bytes
             ].view(torch.int64)
             off += mamba_batch_indices_decode_bytes
+            self.mamba_batch_indices_decode_write = self._buf[
+                off : off + mamba_batch_indices_decode_write_bytes
+            ].view(torch.int64)
+            off += mamba_batch_indices_decode_write_bytes
             self.mamba_batch_indices_prefill = self._buf[
                 off : off + mamba_batch_indices_prefill_bytes
             ].view(torch.int32)
@@ -226,6 +234,7 @@ class ContextGPUView:
             off += mamba_conv_seq_start_bytes
         else:
             self.mamba_batch_indices_decode = None
+            self.mamba_batch_indices_decode_write = None
             self.mamba_batch_indices_prefill = None
             self.mamba_seq_idx = None
             self.mamba_cu_seqlens = None

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -320,6 +320,16 @@ class MambaSlotAllocator:
         self.ssm_states[layer_idx, slot].copy_(ssm_state)
         self.conv_states[layer_idx, slot].copy_(conv_state)
 
+    def _live_mamba_indices(self, request_indices: list, device: torch.device) -> Tensor:
+        """Return flattened live Mamba-state rows for the given context request indices."""
+        req_tensor_cpu = torch.tensor(request_indices, dtype=torch.int64)
+        base_indices = self.context.mamba_metadata.request_to_mamba_state_idx[req_tensor_cpu]
+        state_bank_count = getattr(self.context, "mamba_state_bank_count", 1)
+        if state_bank_count > 1:
+            bank_indices = self.context.mamba_metadata.request_to_mamba_state_bank[req_tensor_cpu]
+            base_indices = base_indices * state_bank_count + bank_indices
+        return base_indices.to(device=device, dtype=torch.int64)
+
     def store_from_live_batch(self, slots: list, request_indices: list) -> None:
         """Copy all layers from live per-request buffers to cache slots.
 
@@ -331,12 +341,7 @@ class MambaSlotAllocator:
             return
         device = self.conv_states.device
         slot_tensor = torch.tensor(slots, dtype=torch.int64, device=device)
-        # Lookup mamba indices from CPU bookkeeping, then move to GPU for state copy.
-        req_tensor_cpu = torch.tensor(request_indices, dtype=torch.int64)
-        mamba_indices = self.context.mamba_metadata.request_to_mamba_state_idx[
-            req_tensor_cpu
-        ].tolist()
-        mamba_idx_tensor = torch.tensor(mamba_indices, dtype=torch.int64, device=device)
+        mamba_idx_tensor = self._live_mamba_indices(request_indices, device)
         # Fancy-indexed copy (2 kernel launches instead of 2E)
         self.conv_states[:, slot_tensor] = self.context.mamba_conv_states[:, mamba_idx_tensor]
         self.ssm_states[:, slot_tensor] = self.context.mamba_ssm_states[:, mamba_idx_tensor]
@@ -354,7 +359,7 @@ class MambaSlotAllocator:
         slot = self.block_to_slot[block_id].item()
         if slot < 0:
             return False
-        mamba_idx = self.context.mamba_metadata.request_to_mamba_state_idx[request_idx].item()
+        mamba_idx = self._live_mamba_indices([request_idx], self.conv_states.device)[0].item()
         self.context.mamba_conv_states[:, mamba_idx].copy_(self.conv_states[:, slot])
         self.context.mamba_ssm_states[:, mamba_idx].copy_(self.ssm_states[:, slot])
         return True

--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -17,6 +17,15 @@ except ImportError:
     HAVE_ZMQ = False
 
 
+_SETUP_MAGIC = b"AZQS"
+_DATA_MAGIC = b"AZQD"
+_ERROR_MAGIC = b"AZQE"
+
+
+class ZMQCollectiveError(RuntimeError):
+    """Raised when a tagged ZMQ collective observes a protocol mismatch."""
+
+
 class AsyncZMQCommunicator:
     """
     An asyncio-friendly communicator abstraction using ZMQ.
@@ -46,6 +55,9 @@ class AsyncZMQCommunicator:
         self.is_leader = self.rank == 0
         # Get the global rank of the leader (first rank in the process group)
         src_rank = dist.get_process_group_ranks(process_group)[0]
+        self._async_collective_step = 0
+        self._sync_collective_step = 0
+        self.protocol_mismatch_count = 0
 
         if self.is_leader:
             local_ip = hostname or socket.gethostname()
@@ -53,26 +65,148 @@ class AsyncZMQCommunicator:
             self.gather_sock.bind_to_random_port(f"tcp://{local_ip}")
             gather_socket_addr = self.gather_sock.getsockopt_string(zmq.LAST_ENDPOINT)
 
-            self.bcast_sock = zmq_context.socket(zmq.PUB)
-            self.bcast_sock.bind_to_random_port(f"tcp://{local_ip}")
-            bcast_socket_addr = self.bcast_sock.getsockopt_string(zmq.LAST_ENDPOINT)
-
             # Share the socket addresses with all peers
-            dist.broadcast_object_list(
-                [gather_socket_addr, bcast_socket_addr], src=src_rank, group=process_group
-            )
+            dist.broadcast_object_list([gather_socket_addr], src=src_rank, group=process_group)
+
+            self.result_push_socks = {}
+            while len(self.result_push_socks) < self.world_size - 1:
+                peer_rank, result_socket_addr = self._unpack_setup_message(self.gather_sock.recv())
+                result_push_sock = zmq_context.socket(zmq.PUSH)
+                result_push_sock.connect(result_socket_addr)
+                self.result_push_socks[peer_rank] = result_push_sock
 
         else:
-            bcast_output = [None, None]
+            bcast_output = [None]
             dist.broadcast_object_list(bcast_output, src=src_rank, group=process_group)
-            gather_socket_addr, bcast_socket_addr = bcast_output
+            [gather_socket_addr] = bcast_output
             self.gather_sock = zmq_context.socket(zmq.PUSH)
             self.gather_sock.connect(gather_socket_addr)
-            self.bcast_sock = zmq_context.socket(zmq.SUB)
-            self.bcast_sock.connect(bcast_socket_addr)
-            self.bcast_sock.setsockopt_string(zmq.SUBSCRIBE, "")
+            local_ip = hostname or socket.gethostname()
+            self.result_recv_sock = zmq_context.socket(zmq.PULL)
+            self.result_recv_sock.bind_to_random_port(f"tcp://{local_ip}")
+            result_socket_addr = self.result_recv_sock.getsockopt_string(zmq.LAST_ENDPOINT)
+            self.gather_sock.send(self._pack_setup_message(self.rank, result_socket_addr))
 
-    async def all_reduce_max(self, *local_vals: int, async_op=True) -> int | tuple[int, ...]:
+        # Prevent a fast peer from sending the first collective before the leader has collected
+        # all per-rank result sockets. ZMQ preserves per-peer ordering, not global ordering.
+        dist.barrier(group=process_group)
+
+    @staticmethod
+    def _pack_setup_message(rank: int, socket_addr: str) -> bytes:
+        addr = socket_addr.encode("utf-8")
+        return struct.pack(f"!4siH{len(addr)}s", _SETUP_MAGIC, rank, len(addr), addr)
+
+    @staticmethod
+    def _unpack_setup_message(msg: bytes) -> tuple[int, str]:
+        magic, rank, addr_len = struct.unpack("!4siH", msg[:10])
+        if magic != _SETUP_MAGIC:
+            raise ZMQCollectiveError("Unexpected ZMQ communicator setup message")
+        addr = struct.unpack(f"!{addr_len}s", msg[10 : 10 + addr_len])[0].decode("utf-8")
+        return rank, addr
+
+    @staticmethod
+    def _pack_values_message(phase: str, step_id: int, values: tuple[int, ...]) -> bytes:
+        phase_bytes = phase.encode("utf-8")
+        n = len(values)
+        return struct.pack(
+            f"!4sHqH{len(phase_bytes)}s{n}i",
+            _DATA_MAGIC,
+            len(phase_bytes),
+            step_id,
+            n,
+            phase_bytes,
+            *values,
+        )
+
+    @staticmethod
+    def _unpack_values_message(
+        msg: bytes, *, expected_phase: str, expected_step_id: int, expected_count: int
+    ) -> tuple[int, ...]:
+        if len(msg) < 16:
+            raise ZMQCollectiveError("Malformed ZMQ collective message")
+
+        magic = msg[:4]
+        if magic == _ERROR_MAGIC:
+            raise ZMQCollectiveError(AsyncZMQCommunicator._unpack_error_message(msg))
+        if magic != _DATA_MAGIC:
+            raise ZMQCollectiveError("Unexpected ZMQ collective message type")
+
+        _, phase_len, step_id, value_count = struct.unpack("!4sHqH", msg[:16])
+        phase_start = 16
+        phase_end = phase_start + phase_len
+        phase = struct.unpack(f"!{phase_len}s", msg[phase_start:phase_end])[0].decode("utf-8")
+        if phase != expected_phase:
+            raise ZMQCollectiveError(
+                f"ZMQ collective phase mismatch: expected {expected_phase}, got {phase}"
+            )
+        if step_id != expected_step_id:
+            raise ZMQCollectiveError(
+                f"ZMQ collective step mismatch for {phase}: "
+                f"expected {expected_step_id}, got {step_id}"
+            )
+        if value_count != expected_count:
+            raise ZMQCollectiveError(
+                f"ZMQ collective value_count mismatch for {phase} step {step_id}: "
+                f"expected {expected_count}, got {value_count}"
+            )
+
+        values_start = phase_end
+        values_end = values_start + (4 * value_count)
+        if len(msg) != values_end:
+            raise ZMQCollectiveError(
+                f"Malformed ZMQ collective payload for {phase} step {step_id}: "
+                f"expected {values_end} bytes, got {len(msg)}"
+            )
+        return struct.unpack(f"!{value_count}i", msg[values_start:values_end])
+
+    def _unpack_collective_values_message(
+        self, msg: bytes, *, expected_phase: str, expected_step_id: int, expected_count: int
+    ) -> tuple[int, ...]:
+        try:
+            return self._unpack_values_message(
+                msg,
+                expected_phase=expected_phase,
+                expected_step_id=expected_step_id,
+                expected_count=expected_count,
+            )
+        except ZMQCollectiveError:
+            self.protocol_mismatch_count += 1
+            raise
+
+    @staticmethod
+    def _pack_error_message(message: str) -> bytes:
+        encoded = message.encode("utf-8")
+        return struct.pack(f"!4sI{len(encoded)}s", _ERROR_MAGIC, len(encoded), encoded)
+
+    @staticmethod
+    def _unpack_error_message(msg: bytes) -> str:
+        _, message_len = struct.unpack("!4sI", msg[:8])
+        return struct.unpack(f"!{message_len}s", msg[8 : 8 + message_len])[0].decode("utf-8")
+
+    def _next_collective_tag(
+        self, *, phase: str | None, step_id: int | None, sync: bool
+    ) -> tuple[str, int]:
+        if phase is None:
+            phase = "sync_all_reduce_max" if sync else "all_reduce_max"
+        if step_id is None:
+            if sync:
+                step_id = self._sync_collective_step
+                self._sync_collective_step += 1
+            else:
+                step_id = self._async_collective_step
+                self._async_collective_step += 1
+        return phase, step_id
+
+    def _send_result_to_peers(self, msg: bytes) -> None:
+        for peer_rank in sorted(self.result_push_socks):
+            self.result_push_socks[peer_rank].send(msg)
+
+    def _send_error_to_peers(self, error: Exception) -> None:
+        self._send_result_to_peers(self._pack_error_message(str(error)))
+
+    async def all_reduce_max(
+        self, *local_vals: int, async_op=True, phase: str | None = None, step_id: int | None = None
+    ) -> int | tuple[int, ...]:
         """Element-wise all-reduce max of one or more integers.
 
         Packs all values into a single message so the communication cost
@@ -87,8 +221,8 @@ class AsyncZMQCommunicator:
         if self.world_size <= 1:
             return local_vals[0] if n == 1 else local_vals
 
-        fmt = f'!{n}i'
-        payload = struct.pack(fmt, *local_vals)
+        phase, step_id = self._next_collective_tag(phase=phase, step_id=step_id, sync=False)
+        payload = self._pack_values_message(phase, step_id, local_vals)
 
         if self.is_leader:
             rows = [local_vals]
@@ -99,12 +233,19 @@ class AsyncZMQCommunicator:
                         msg = self.gather_sock.recv(flags=zmq.NOBLOCK)
                     else:
                         msg = self.gather_sock.recv()
-                    rows.append(struct.unpack(fmt, msg))
+                    rows.append(
+                        self._unpack_collective_values_message(
+                            msg, expected_phase=phase, expected_step_id=step_id, expected_count=n
+                        )
+                    )
                 except zmq.Again:
                     await asyncio.sleep(0.001)
+                except Exception as error:
+                    self._send_error_to_peers(error)
+                    raise
 
             maxes = tuple(max(row[i] for row in rows) for i in range(n))
-            self.bcast_sock.send(struct.pack(fmt, *maxes))
+            self._send_result_to_peers(self._pack_values_message(phase, step_id, maxes))
             if not async_op:
                 await asyncio.sleep(
                     0
@@ -118,10 +259,12 @@ class AsyncZMQCommunicator:
             while True:
                 try:
                     if async_op:
-                        msg = self.bcast_sock.recv(flags=zmq.NOBLOCK)
+                        msg = self.result_recv_sock.recv(flags=zmq.NOBLOCK)
                     else:
-                        msg = self.bcast_sock.recv()
-                    result = struct.unpack(fmt, msg)
+                        msg = self.result_recv_sock.recv()
+                    result = self._unpack_collective_values_message(
+                        msg, expected_phase=phase, expected_step_id=step_id, expected_count=n
+                    )
                     if not async_op:
                         await asyncio.sleep(
                             0
@@ -131,7 +274,9 @@ class AsyncZMQCommunicator:
                 except zmq.Again:
                     await asyncio.sleep(0.001)
 
-    def sync_all_reduce_max(self, *local_vals: int) -> int | tuple[int, ...]:
+    def sync_all_reduce_max(
+        self, *local_vals: int, phase: str | None = None, step_id: int | None = None
+    ) -> int | tuple[int, ...]:
         """Synchronous (non-asyncio) variant of all_reduce_max.
 
         Uses blocking ZMQ sends/recvs so it can be called from synchronous
@@ -153,21 +298,31 @@ class AsyncZMQCommunicator:
         if self.world_size <= 1:
             return local_vals[0] if n == 1 else local_vals
 
-        fmt = f'!{n}i'
-        payload = struct.pack(fmt, *local_vals)
+        phase, step_id = self._next_collective_tag(phase=phase, step_id=step_id, sync=True)
+        payload = self._pack_values_message(phase, step_id, local_vals)
 
         if self.is_leader:
             rows = [local_vals]
-            while len(rows) < self.world_size:
-                msg = self.gather_sock.recv()
-                rows.append(struct.unpack(fmt, msg))
+            try:
+                while len(rows) < self.world_size:
+                    msg = self.gather_sock.recv()
+                    rows.append(
+                        self._unpack_collective_values_message(
+                            msg, expected_phase=phase, expected_step_id=step_id, expected_count=n
+                        )
+                    )
+            except Exception as error:
+                self._send_error_to_peers(error)
+                raise
             maxes = tuple(max(row[i] for row in rows) for i in range(n))
-            self.bcast_sock.send(struct.pack(fmt, *maxes))
+            self._send_result_to_peers(self._pack_values_message(phase, step_id, maxes))
             return maxes[0] if n == 1 else maxes
         else:
             self.gather_sock.send(payload)
-            msg = self.bcast_sock.recv()
-            result = struct.unpack(fmt, msg)
+            msg = self.result_recv_sock.recv()
+            result = self._unpack_collective_values_message(
+                msg, expected_phase=phase, expected_step_id=step_id, expected_count=n
+            )
             return result[0] if n == 1 else result
 
     def close(self):
@@ -177,4 +332,8 @@ class AsyncZMQCommunicator:
         # linger=0: discard unsent messages immediately on close rather than blocking until sent.
         # The ZMQ default is to not allow `close` until all messages have been successfully sent.
         self.gather_sock.close(linger=0)
-        self.bcast_sock.close(linger=0)
+        if self.is_leader:
+            for sock in self.result_push_socks.values():
+                sock.close(linger=0)
+        else:
+            self.result_recv_sock.close(linger=0)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -427,90 +427,59 @@ class DynamicInferenceEngine(AbstractEngine):
         if HAVE_TQDM:
             tbar = tqdm(tbar, total=len(context.cuda_graph_batch_dimensions_list))
         for tbar_idx, cuda_graph_batch_dimension in tbar:
-            capture_slots = (None,)
-            if (
-                context.async_scheduling
-                and context.async_decode_slot_ring is not None
-                and cuda_graph_batch_dimension.prefill_req_count == 0
-            ):
-                capture_slots = context.async_decode_slot_ring.slots
-
-            saved_slot_index = (
-                context.async_decode_slot_ring.current_index
-                if context.async_decode_slot_ring is not None
-                else None
+            input_ids, position_ids = self.controller._dynamic_step_context_init(
+                construct_graph_dimensions=cuda_graph_batch_dimension
             )
-            try:
-                for capture_slot_index, capture_slot in enumerate(capture_slots):
-                    if capture_slot is not None:
-                        context.async_decode_slot_ring.current_index = capture_slot_index
-                        context.bind_decode_slot(capture_slot)
+            # Progress.
+            tbar_str = f"cuda graph warmup - {cuda_graph_batch_dimension}"
+            if HAVE_TQDM:
+                tbar.set_description(tbar_str)
+            else:
+                logging.info(
+                    f"{tbar_idx}/{len(context.cuda_graph_batch_dimensions_list)}. {tbar_str}"
+                )
 
-                    input_ids, position_ids = self.controller._dynamic_step_context_init(
-                        construct_graph_dimensions=cuda_graph_batch_dimension
-                    )
-                    # Progress.
-                    slot_suffix = (
-                        f" slot {capture_slot.slot_id}" if capture_slot is not None else ""
-                    )
-                    tbar_str = f"cuda graph warmup - {cuda_graph_batch_dimension}{slot_suffix}"
-                    if HAVE_TQDM:
-                        tbar.set_description(tbar_str)
+            # Enable routing recording during warmup if routing replay is enabled.
+            # This ensures the record_indices copy operation is captured in the CUDA graph.
+            if model_config.moe_enable_routing_replay:
+                RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+
+            # Forward pass -> logits.
+            with torch.inference_mode():
+                controller._dynamic_step_forward_logits(input_ids, position_ids)
+
+                if controller._sampling_backend == "flashinfer":
+                    if controller.num_speculative_tokens > 0:
+                        controller._dynamic_step_sample_logits_and_verify_tokens(input_ids)
                     else:
-                        logging.info(
-                            f"{tbar_idx}/{len(context.cuda_graph_batch_dimensions_list)}. "
-                            f"{tbar_str}"
-                        )
+                        controller._dynamic_step_sample_logits()
 
-                    # Enable routing recording during warmup if routing replay is enabled.
-                    # This ensures the record_indices copy operation is captured in the CUDA graph.
-                    if model_config.moe_enable_routing_replay:
-                        RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+                # MTP CUDA graph warmup for this batch dimension.
+                if mtp_warmup_enabled:
+                    n = cuda_graph_batch_dimension.req_count
+                    # pylint: disable-next=possibly-used-before-assignment
+                    if sp_enabled:
+                        n = round_up_to_nearest_multiple(n, tp_size)
+                    # pylint: disable-next=possibly-used-before-assignment
+                    if n > 0 and n not in mtp_seen_batch_sizes:
+                        mtp_seen_batch_sizes.add(n)
+                        device = torch.cuda.current_device()
+                        batch_dim = n // tp_size if sp_enabled else n
+                        # Use zeros (not empty) — garbage token IDs cause OOB embedding lookups during graph capture/replay.
+                        for depth in mtp_warmup_depths:
+                            unwrapped.compute_mtp_single_step(
+                                hidden_states=torch.zeros(
+                                    (batch_dim, 1, model_config.hidden_size),
+                                    device=device,
+                                    dtype=model_config.params_dtype,
+                                ),
+                                next_token_ids=torch.zeros((1, n), device=device, dtype=torch.long),
+                                position_ids=torch.zeros((1, n), device=device, dtype=torch.int64),
+                                depth=depth,
+                                cache_key=("mtp", n, depth),
+                            )
 
-                    # Forward pass -> logits.
-                    with torch.inference_mode():
-                        controller._dynamic_step_forward_logits(input_ids, position_ids)
-
-                        if controller._sampling_backend == "flashinfer":
-                            if controller.num_speculative_tokens > 0:
-                                controller._dynamic_step_sample_logits_and_verify_tokens(input_ids)
-                            else:
-                                controller._dynamic_step_sample_logits()
-
-                        # MTP CUDA graph warmup for this batch dimension.
-                        if mtp_warmup_enabled:
-                            n = cuda_graph_batch_dimension.req_count
-                            # pylint: disable-next=possibly-used-before-assignment
-                            if sp_enabled:
-                                n = round_up_to_nearest_multiple(n, tp_size)
-                            # pylint: disable-next=possibly-used-before-assignment
-                            if n > 0 and n not in mtp_seen_batch_sizes:
-                                mtp_seen_batch_sizes.add(n)
-                                device = torch.cuda.current_device()
-                                batch_dim = n // tp_size if sp_enabled else n
-                                # Use zeros (not empty) — garbage token IDs cause OOB embedding lookups during graph capture/replay.
-                                for depth in mtp_warmup_depths:
-                                    unwrapped.compute_mtp_single_step(
-                                        hidden_states=torch.zeros(
-                                            (batch_dim, 1, model_config.hidden_size),
-                                            device=device,
-                                            dtype=model_config.params_dtype,
-                                        ),
-                                        next_token_ids=torch.zeros(
-                                            (1, n), device=device, dtype=torch.long
-                                        ),
-                                        position_ids=torch.zeros(
-                                            (1, n), device=device, dtype=torch.int64
-                                        ),
-                                        depth=depth,
-                                        cache_key=("mtp", n, depth),
-                                    )
-
-                        context.reset()
-            finally:
-                if saved_slot_index is not None:
-                    context.async_decode_slot_ring.current_index = saved_slot_index
-                    context.bind_decode_slot(context.async_decode_slot_ring.current)
+                context.reset()
 
             # Per-iteration memory accounting, scoped to the CUDA-graph mempool.
             # This isolates pool growth from process-wide scratch churn (KV cache,

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -2167,7 +2167,10 @@ class DynamicInferenceEngine(AbstractEngine):
                 output_str += (
                     " ... async txn: prepared %(prepared)d, launched %(launched)d, "
                     "adopted %(adopted)d, retired %(retired)d, sync %(sync_steps)d, "
-                    "barrier %(barrier_skips)d, top-skip %(top_skip_reason)s"
+                    "barrier %(barrier_skips)d, h2d-ready %(h2d_ready_before_sampling)d, "
+                    "sample-launch %(sample_to_launch_latency_us).1f us, "
+                    "commit %(commit_duration_us).1f us, retire-depth %(retire_queue_depth)d, "
+                    "top-skip %(top_skip_reason)s"
                 ) % async_diag
             if context_state["is_decode_only"]:
                 output_str = f"\033[94m{output_str}\033[0m"

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -268,6 +268,9 @@ class DynamicInferenceEngine(AbstractEngine):
         self.controller.set_stop_word_finished_ids_callback(
             self._get_and_clear_stop_word_finished_ids
         )
+        self.controller.set_stop_word_constraints_callback(
+            self._has_stop_word_constraints
+        )
 
         # Configure wandb to use separate step counter for inference metrics (only once)
         if self.logging_step_interval > 0 and self.metrics_writer is not None:
@@ -1573,6 +1576,20 @@ class DynamicInferenceEngine(AbstractEngine):
         self.stop_word_finished_request_ids -= result
         return result
 
+    def _has_stop_word_constraints(self, active_request_ids: list[int]) -> bool:
+        """Return whether active requests have stop-word state that can affect scheduling."""
+
+        active_ids = set(int(request_id) for request_id in active_request_ids)
+        if self.stop_word_finished_request_ids & active_ids:
+            return True
+        if self.stop_word_being_finished_ids & active_ids:
+            return True
+        for request_id in active_ids:
+            entry = self.requests.get(request_id)
+            if entry is not None and entry.record[-1].stop_word_ids:
+                return True
+        return False
+
     def _check_stop_words_for_request_post_append(
         self, request: DynamicInferenceRequest
     ) -> Tuple[bool, int]:
@@ -2325,6 +2342,8 @@ class DynamicInferenceEngine(AbstractEngine):
                     " ... async txn: prepared %(prepared)d, launched %(launched)d, "
                     "adopted %(adopted)d, retired %(retired)d, sync %(sync_steps)d, "
                     "barrier %(barrier_skips)d, h2d-ready %(h2d_ready_before_sampling)d, "
+                    "chain %(chain_launches)d/%(chain_attempts)d, "
+                    "presampled %(presampled_commits)d, "
                     "sample-launch %(sample_to_launch_latency_us).1f us, "
                     "commit %(commit_duration_us).1f us, "
                     "prestage %(child_prestage_duration_us).1f us, "

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -19,6 +19,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 from torch import Tensor
 
+from megatron.core.inference.async_txn import AsyncTxnSkipReason
 from megatron.core.inference.config import KVCacheManagementMode
 from megatron.core.inference.contexts.dynamic_context import (
     BlockOverflowError,
@@ -332,6 +333,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self._pending_signals = deque()
 
         self.resume_request_ids = None
+        self._next_async_launch_barrier_reason: Optional[AsyncTxnSkipReason] = None
 
         # Speculative decoding acceptance tracking (per-position).
         # Each tensor has length num_speculative_tokens; index i tracks position i+1
@@ -515,6 +517,9 @@ class DynamicInferenceEngine(AbstractEngine):
         )
 
         self.capture_stats = capture_stats
+        self._request_next_async_launch_barrier(
+            AsyncTxnSkipReason.GRAPH_RECAPTURE_BARRIER
+        )
 
     @internal_api
     async def start_listening_to_data_parallel_coordinator(
@@ -788,6 +793,7 @@ class DynamicInferenceEngine(AbstractEngine):
         if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
             return
 
+        self._drain_async_transactions(drop_launched=True)
         InferenceMode.unset_active()
 
         # Deallocate context tensors.
@@ -887,6 +893,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 )
             )
         )
+        self._request_next_async_launch_barrier(AsyncTxnSkipReason.RESUME_BARRIER)
 
         # If we are not using the inference coordinator, we need to manually handle state.
         if not self.use_coordinator:
@@ -895,6 +902,41 @@ class DynamicInferenceEngine(AbstractEngine):
             self._loop.call_soon_threadsafe(
                 asyncio.create_task, self._notify_cond_for_new_request()
             )
+
+    def _request_next_async_launch_barrier(self, reason: AsyncTxnSkipReason) -> None:
+        """Force the next async child-launch decision through a sync boundary."""
+
+        if getattr(self.context, "async_scheduling", False):
+            self._next_async_launch_barrier_reason = reason
+
+    def _drain_async_transactions(self, *, drop_launched: bool = False) -> None:
+        """Drain async controller work when the controller supports it."""
+
+        drain = getattr(self.controller, "drain_async_transactions", None)
+        if drain is not None:
+            drain(drop_launched=drop_launched)
+
+    def _consume_async_launch_barrier_reason(
+        self,
+        *,
+        admitted_requests: bool,
+        will_log_this_step: bool,
+    ) -> Optional[AsyncTxnSkipReason]:
+        """Return the one-step async barrier reason for the current step, if any."""
+
+        reason = self._next_async_launch_barrier_reason
+        if reason is not None:
+            self._next_async_launch_barrier_reason = None
+            return reason
+        if self.state == EngineState.PAUSING:
+            return AsyncTxnSkipReason.FORCE_PAUSE_BARRIER
+        if getattr(self.context, "chunked_prefill_request_id", -1) != -1:
+            return AsyncTxnSkipReason.CHUNKED_PREFILL
+        if admitted_requests:
+            return AsyncTxnSkipReason.PENDING_ADMISSION
+        if will_log_this_step:
+            return AsyncTxnSkipReason.LOG_INTERVAL_BARRIER
+        return None
 
     @trace_async_exceptions
     async def _notify_cond_for_new_request(self):
@@ -1563,10 +1605,17 @@ class DynamicInferenceEngine(AbstractEngine):
                 return i + 1
         return 0
 
-    def schedule_waiting_requests(self):
-        """Tries to schedule any requests in the waiting pool."""
+    def schedule_waiting_requests(self) -> bool:
+        """Tries to schedule any requests in the waiting pool.
+
+        Returns:
+            Whether the call actually admitted request work into the context.
+        """
         # Keep track of which requests get scheduled.
         waiting_before = set(self.waiting_request_ids)
+        waiting_count_before = len(self.waiting_request_ids)
+        total_request_count_before = self.context.total_request_count
+        active_token_count_before = self.context.active_token_count
         if self.enable_chunked_prefill:
             self.schedule_chunked_prefill()
         else:
@@ -1579,6 +1628,12 @@ class DynamicInferenceEngine(AbstractEngine):
                 req = self.get_request(request_id)
                 if req.kv_cache_epoch is None:
                     req.kv_cache_epoch = [(0, self._generation_epoch)]
+
+        return (
+            len(self.waiting_request_ids) < waiting_count_before
+            or self.context.total_request_count > total_request_count_before
+            or self.context.active_token_count > active_token_count_before
+        )
 
     def schedule_non_chunked_prefill(self):
         """
@@ -1780,7 +1835,7 @@ class DynamicInferenceEngine(AbstractEngine):
             raise EngineSuspendedError(self.context.step_count)
 
         # schedule requests
-        self.schedule_waiting_requests()
+        admitted_requests = self.schedule_waiting_requests()
 
         # The print block (async_bookkeep) and metrics block both fire on this
         # condition after step_count is incremented. Predict it up-front so we
@@ -1792,6 +1847,10 @@ class DynamicInferenceEngine(AbstractEngine):
         )
 
         is_decode_only = self.context.is_decode_only()
+        async_launch_barrier_reason = self._consume_async_launch_barrier_reason(
+            admitted_requests=admitted_requests,
+            will_log_this_step=will_log_this_step,
+        )
         if will_log_this_step:
             pre_step_context_state = {
                 "is_decode_only": is_decode_only,
@@ -1817,7 +1876,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
         if will_log_this_step:
             self.step_start_event.record()
-        result = await self.controller.async_generate_output_tokens_dynamic_batch()
+        result = await self.controller.async_generate_output_tokens_dynamic_batch(
+            async_launch_barrier_reason=async_launch_barrier_reason
+        )
         if will_log_this_step:
             self.step_end_event.record()
             self.step_end_event.synchronize()
@@ -1887,6 +1948,11 @@ class DynamicInferenceEngine(AbstractEngine):
             top_n_logprobs_by_request_id = step_result.get("top_n_logprobs_by_request_id")
             finished_routing_block_ids = step_result.get("finished_routing_block_ids", None)
             cuda_graph_request_count = step_result["cuda_graph_request_count"]
+
+            if newly_paused_request_ids is not None and len(newly_paused_request_ids) > 0:
+                self._request_next_async_launch_barrier(AsyncTxnSkipReason.FORCE_PAUSE_BARRIER)
+            if evict_request_ids is not None and len(evict_request_ids) > 0:
+                self._request_next_async_launch_barrier(AsyncTxnSkipReason.EVICT_BARRIER)
 
             # Add paused events.
             if newly_paused_request_ids is not None and self.track_paused_request_events:
@@ -2291,6 +2357,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
             if header == Headers.PAUSE:
                 if self.state == EngineState.RUNNING:
+                    self._request_next_async_launch_barrier(
+                        AsyncTxnSkipReason.FORCE_PAUSE_BARRIER
+                    )
                     self.state = EngineState.PAUSING
                     self._state_events[EngineState.RUNNING].clear()
                 # Any other state can safely ignore PAUSE.
@@ -2331,6 +2400,7 @@ class DynamicInferenceEngine(AbstractEngine):
         Called from the engine loop's finally block after the loop exits.
         """
         self.state = EngineState.STOPPED
+        self._drain_async_transactions(drop_launched=True)
 
         # Cleanup the request futures.
         for entry in self.requests.values():
@@ -2477,6 +2547,7 @@ class DynamicInferenceEngine(AbstractEngine):
                         # rank, so when there is no local work we run dummy_forward()
                         # rather than sleeping. Sleeping here would deadlock EP > 1.
                         if self.state == EngineState.PAUSING:
+                            self._drain_async_transactions()
                             await self._world_barrier()
                             self.state = EngineState.PAUSED
                             self._state_events[EngineState.PAUSED].set()
@@ -2516,6 +2587,7 @@ class DynamicInferenceEngine(AbstractEngine):
 
                     if all_pausing:
                         # All EP peers are PAUSING: pause immediately.
+                        self._drain_async_transactions()
                         await self._world_barrier()
                         self.state = EngineState.PAUSED
                         self._state_events[EngineState.PAUSED].set()
@@ -2551,6 +2623,7 @@ class DynamicInferenceEngine(AbstractEngine):
                     self._last_ep_consensus = (0, False)
 
                 elif self.state == EngineState.SUSPENDING:
+                    self._drain_async_transactions(drop_launched=True)
                     await self._world_barrier()
                     self.state = EngineState.SUSPENDED
                     self._state_events[EngineState.SUSPENDED].set()
@@ -2564,6 +2637,7 @@ class DynamicInferenceEngine(AbstractEngine):
                     self._state_events[EngineState.RESUMED].set()
 
                 elif self.state == EngineState.STOPPING:
+                    self._drain_async_transactions(drop_launched=True)
                     await self._world_barrier()
                     if self.rank == 0:
                         logging.info("Stopping engine.")

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -2263,7 +2263,11 @@ class DynamicInferenceEngine(AbstractEngine):
                     "adopted %(adopted)d, retired %(retired)d, sync %(sync_steps)d, "
                     "barrier %(barrier_skips)d, h2d-ready %(h2d_ready_before_sampling)d, "
                     "sample-launch %(sample_to_launch_latency_us).1f us, "
-                    "commit %(commit_duration_us).1f us, retire-depth %(retire_queue_depth)d, "
+                    "commit %(commit_duration_us).1f us, "
+                    "prestage %(child_prestage_duration_us).1f us, "
+                    "ep-handoff %(ep_handoff_duration_us).1f us, "
+                    "child-graph %(child_graph_shape_duration_us).1f us, "
+                    "retire-depth %(retire_queue_depth)d, "
                     "top-skip %(top_skip_reason)s"
                 ) % async_diag
             if context_state["is_decode_only"]:

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -805,7 +805,7 @@ class DynamicInferenceEngine(AbstractEngine):
         if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
             return
 
-        self._drain_async_transactions(drop_launched=True)
+        self._drain_async_transactions(clear_launched=True)
         InferenceMode.unset_active()
 
         # Deallocate context tensors.
@@ -921,12 +921,12 @@ class DynamicInferenceEngine(AbstractEngine):
         if getattr(self.context, "async_scheduling", False):
             self._next_async_launch_barrier_reason = reason
 
-    def _drain_async_transactions(self, *, drop_launched: bool = False) -> None:
+    def _drain_async_transactions(self, *, clear_launched: bool = False) -> None:
         """Drain async controller work when the controller supports it."""
 
         drain = getattr(self.controller, "drain_async_transactions", None)
         if drain is not None:
-            drain(drop_launched=drop_launched)
+            drain(clear_launched=clear_launched)
 
     def _consume_async_launch_barrier_reason(
         self,
@@ -1856,9 +1856,12 @@ class DynamicInferenceEngine(AbstractEngine):
                 step_time (float): How long this step took.
         """
 
+        async_diag = getattr(self.context, "async_txn_diagnostics", None)
         forward_wall_started_at = (
             time.perf_counter()
-            if self.context.async_scheduling and self.context.async_txn_diagnostics.enabled
+            if self.context.async_scheduling
+            and async_diag is not None
+            and async_diag.enabled
             else None
         )
 
@@ -2309,10 +2312,10 @@ class DynamicInferenceEngine(AbstractEngine):
                 async_diag = self.context.async_txn_diagnostics.snapshot()
                 output_str += (
                     " ... async txn: prepared %(prepared)d, launched %(launched)d, "
-                    "adopted %(adopted)d, retired %(retired)d, sync %(sync_steps)d, "
+                    "consumed %(consumed)d, retired %(retired)d, sync %(sync_steps)d, "
                     "barrier %(barrier_skips)d, h2d-ready %(h2d_ready_before_sampling)d, "
                     "chain %(chain_launches)d/%(chain_attempts)d, "
-                    "presampled %(presampled_commits)d, "
+                    "deferred_sample %(deferred_sample_commits)d, "
                     "sample-launch %(sample_to_launch_latency_us).1f us, "
                     "commit %(commit_duration_us).1f us, "
                     "prestage %(child_prestage_duration_us).1f us, "
@@ -2564,7 +2567,7 @@ class DynamicInferenceEngine(AbstractEngine):
         Called from the engine loop's finally block after the loop exits.
         """
         self.state = EngineState.STOPPED
-        self._drain_async_transactions(drop_launched=True)
+        self._drain_async_transactions(clear_launched=True)
         await self._drain_coordinator_reply_tasks()
         if self._coordinator_reply_executor is not None:
             self._coordinator_reply_executor.shutdown(wait=False, cancel_futures=True)
@@ -2808,7 +2811,7 @@ class DynamicInferenceEngine(AbstractEngine):
                     self._last_ep_consensus = (0, False)
 
                 elif self.state == EngineState.SUSPENDING:
-                    self._drain_async_transactions(drop_launched=True)
+                    self._drain_async_transactions(clear_launched=True)
                     await self._world_barrier()
                     self.state = EngineState.SUSPENDED
                     self._state_events[EngineState.SUSPENDED].set()
@@ -2822,7 +2825,7 @@ class DynamicInferenceEngine(AbstractEngine):
                     self._state_events[EngineState.RESUMED].set()
 
                 elif self.state == EngineState.STOPPING:
-                    self._drain_async_transactions(drop_launched=True)
+                    self._drain_async_transactions(clear_launched=True)
                     await self._world_barrier()
                     if self.rank == 0:
                         logging.info("Stopping engine.")

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -30,6 +30,7 @@ from megatron.core.inference.contexts.dynamic_context import (
 from megatron.core.inference.data_parallel_inference_coordinator import (
     DataParallelInferenceCoordinator,
 )
+from megatron.core.inference.ep_async_protocol import EPAsyncStepProtocol
 from megatron.core.inference.engines.abstract_engine import AbstractEngine
 from megatron.core.inference.headers import Headers, UnknownHeaderError
 from megatron.core.inference.inference_request import (
@@ -317,6 +318,8 @@ class DynamicInferenceEngine(AbstractEngine):
         self.stop_word_finished_request_ids: set[int] = set()
         # Track requests currently being finished due to stop words (to skip extra token)
         self.stop_word_being_finished_ids: set[int] = set()
+        self._coordinator_reply_tasks = set()
+        self._coordinator_reply_executor = None
 
         # Timing and logging variables.
         self.rank = torch.distributed.get_rank()
@@ -692,16 +695,22 @@ class DynamicInferenceEngine(AbstractEngine):
         # initialize zmq-based EP communicator
         self.ep_rank = get_pg_rank(self.pg_collection.ep)
         self.ep_world_size = get_pg_size(self.pg_collection.ep)
+        self.ep_async_step_protocol = EPAsyncStepProtocol()
         self._ep_consensus_loop_counter = 0
         self._last_ep_consensus: tuple[int, bool] = (0, False)
         if self.ep_world_size > 1:
             self.expert_parallel_zmq_communicator = AsyncZMQCommunicator(
                 self.zmq_context, process_group=self.pg_collection.ep, hostname=hostname
             )
+            self.ep_async_step_protocol = EPAsyncStepProtocol(self.expert_parallel_zmq_communicator)
             # Give the context a CPU-side MAX-reduction primitive so
             # match_graph_config() can avoid a per-step NCCL AllReduce kernel.
             if hasattr(self.context, "set_ep_zmq_communicator"):
                 self.context.set_ep_zmq_communicator(self.expert_parallel_zmq_communicator)
+            if hasattr(self.context, "set_ep_async_protocol"):
+                self.context.set_ep_async_protocol(self.ep_async_step_protocol)
+            if hasattr(self.controller, "set_ep_async_protocol"):
+                self.controller.set_ep_async_protocol(self.ep_async_step_protocol)
 
         # initialize zmq-based world communicator for consensus barriers
         total_world_size = torch.distributed.get_world_size()
@@ -1914,8 +1923,103 @@ class DynamicInferenceEngine(AbstractEngine):
 
         return result, context_state, step_time
 
+    def _send_finished_records_to_coordinator(
+        self, finished_request_records: list[DynamicInferenceRequestRecord]
+    ) -> None:
+        """Queue completed request records for the data-parallel coordinator."""
+
+        if not self.use_coordinator or not self.is_mp_coordinator:
+            return
+
+        records_to_send = [
+            r for r in finished_request_records if r.requests[-1].status != Status.FAILED
+        ]
+        if not records_to_send:
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            payload = self._pack_finished_records_for_coordinator(records_to_send)
+            self._send_coordinator_reply_payload(payload)
+            return
+
+        task = loop.create_task(self._send_finished_records_to_coordinator_async(records_to_send))
+        self._coordinator_reply_tasks.add(task)
+        task.add_done_callback(self._coordinator_reply_done)
+
+    @staticmethod
+    def _pack_finished_records_for_coordinator(
+        records_to_send: list[DynamicInferenceRequestRecord],
+    ) -> bytes:
+        """Serialize finished request records for a coordinator reply."""
+
+        nvtx_range_push("coordinator_reply_pack")
+        try:
+            return msgpack.packb(
+                [Headers.ENGINE_REPLY.value, [r.merge().serialize() for r in records_to_send]],
+                use_bin_type=True,
+            )
+        finally:
+            nvtx_range_pop("coordinator_reply_pack")
+
+    def _get_coordinator_reply_executor(self) -> concurrent.futures.ThreadPoolExecutor:
+        """Return the single-worker executor used for coordinator reply packing."""
+
+        executor = self._coordinator_reply_executor
+        if executor is None:
+            executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="coordinator-reply"
+            )
+            self._coordinator_reply_executor = executor
+        return executor
+
+    def _send_coordinator_reply_payload(self, payload: bytes) -> None:
+        """Send an already-packed coordinator reply payload."""
+
+        nvtx_range_push("coordinator_reply_send")
+        try:
+            self.socket_for_receiving_requests.send(payload)
+        finally:
+            nvtx_range_pop("coordinator_reply_send")
+
+    async def _send_finished_records_to_coordinator_async(
+        self, records_to_send: list[DynamicInferenceRequestRecord]
+    ) -> None:
+        """Pack a coordinator reply off the engine loop, then send it on the loop."""
+
+        loop = asyncio.get_running_loop()
+        payload = await loop.run_in_executor(
+            self._get_coordinator_reply_executor(),
+            self._pack_finished_records_for_coordinator,
+            records_to_send,
+        )
+        self._send_coordinator_reply_payload(payload)
+
+    def _coordinator_reply_done(self, task: asyncio.Task) -> None:
+        """Drop completed reply tasks and surface unexpected failures."""
+
+        self._coordinator_reply_tasks.discard(task)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logging.exception("Failed to send coordinator reply")
+
+    async def _drain_coordinator_reply_tasks(self) -> None:
+        """Wait for all queued coordinator replies to be sent."""
+
+        if self._coordinator_reply_tasks:
+            await asyncio.gather(*list(self._coordinator_reply_tasks), return_exceptions=True)
+
     async def async_bookkeep(
-        self, step_result: Optional[Dict], context_state: Dict, step_time: float
+        self,
+        step_result: Optional[Dict],
+        context_state: Dict,
+        step_time: float,
+        *,
+        send_coordinator_replies: bool = True,
     ):
         """Uses `asyncio` for continuous bookkeeping.
 
@@ -2016,18 +2120,8 @@ class DynamicInferenceEngine(AbstractEngine):
         # Handle necessary ZMQ DP coordinator communication.
         # Failed request replies were already sent in _handle_failed_request,
         # so only send completed records here.
-        if self.use_coordinator and self.is_mp_coordinator:
-            records_to_send = [
-                r for r in finished_request_records if r.requests[-1].status != Status.FAILED
-            ]
-            if records_to_send:
-                nvtx_range_push("coordinator_communication")
-                payload = msgpack.packb(
-                    [Headers.ENGINE_REPLY.value, [r.merge().serialize() for r in records_to_send]],
-                    use_bin_type=True,
-                )
-                self.socket_for_receiving_requests.send(payload)
-                nvtx_range_pop("coordinator_communication")
+        if send_coordinator_replies:
+            self._send_finished_records_to_coordinator(finished_request_records)
 
         # Drain prefix cache hit counters from context into engine accumulators.
         if self.context.enable_prefix_caching:
@@ -2186,7 +2280,7 @@ class DynamicInferenceEngine(AbstractEngine):
         }
 
     async def async_step(
-        self,
+        self, *, send_coordinator_replies: bool = True
     ) -> Tuple[List[DynamicInferenceRequest], List[DynamicInferenceRequest], float]:
         """
         Wrapper for controller.generate_output_tokens_dynamic_batch(), to
@@ -2200,7 +2294,9 @@ class DynamicInferenceEngine(AbstractEngine):
                 3. The step time in seconds.
         """
         last_step_data = await self.async_forward()
-        ret = await self.async_bookkeep(*last_step_data)
+        ret = await self.async_bookkeep(
+            *last_step_data, send_coordinator_replies=send_coordinator_replies
+        )
         # Keep for compatibility with current test suite.
         return ret
 
@@ -2404,6 +2500,10 @@ class DynamicInferenceEngine(AbstractEngine):
         """
         self.state = EngineState.STOPPED
         self._drain_async_transactions(drop_launched=True)
+        await self._drain_coordinator_reply_tasks()
+        if self._coordinator_reply_executor is not None:
+            self._coordinator_reply_executor.shutdown(wait=False, cancel_futures=True)
+            self._coordinator_reply_executor = None
 
         # Cleanup the request futures.
         for entry in self.requests.values():
@@ -2476,8 +2576,6 @@ class DynamicInferenceEngine(AbstractEngine):
         """
         nvtx_range_push("_ep_establish_consensus")
 
-        consensus_val = -1 if signal_consensus else 0
-
         # Signals can be received asynchronously on EP ranks.
         # We do not want a rank to pause prematurely if its peers have yet to receive the signal.
         # So this is an *attempt* to process the signal. This rank has received the signal
@@ -2486,21 +2584,49 @@ class DynamicInferenceEngine(AbstractEngine):
         # will be zero and we will defer processing the signal.
         # When all ranks receive the signal, global consensus will be -1 and we can process.
 
-        if self.ep_world_size > 1:
-            # Note that it is important to use a non-blocking asyncio-friendly all-reduce here.
-            # The user may have other tasks running in the event loop that need to be serviced.
-            # Do not using a torch.distributed blocking all-reduce here using nccl/gloo.
-            # We have tried that and it blocks the event loop in megatron-rl.
-            global_work, global_consensus = (
-                await self.expert_parallel_zmq_communicator.all_reduce_max(
-                    local_work, consensus_val, async_op=(not self.use_synchronous_zmq_collectives)
-                )
-            )
-        else:
-            global_work, global_consensus = local_work, consensus_val
+        consensus = await self.ep_async_step_protocol.establish_work_consensus(
+            local_work,
+            signal_consensus,
+            async_op=(not self.use_synchronous_zmq_collectives),
+        )
 
         nvtx_range_pop("_ep_establish_consensus")
-        return global_work, global_consensus == -1
+        return consensus.global_work, consensus.all_pausing
+
+    async def _ep_complete_work_step(self) -> None:
+        """Keep real and dummy EP ranks aligned before the next work consensus."""
+
+        if self.ep_world_size > 1:
+            nvtx_range_push("_ep_complete_work_step")
+            await self.ep_async_step_protocol.complete_work_step(
+                async_op=(not self.use_synchronous_zmq_collectives)
+            )
+            nvtx_range_pop("_ep_complete_work_step")
+        else:
+            self.ep_async_step_protocol.complete_idle_step()
+
+    async def _run_ep_work_step(self, local_pending: int) -> None:
+        """Run one coordinator-driven EP work step and close it before external replies."""
+
+        self.ep_async_step_protocol.ensure_work_step()
+        finished_request_records = None
+        if local_pending > 0:
+            step_result = await self.async_step(send_coordinator_replies=False)
+            finished_request_records = step_result["finished_request_records"]
+        else:
+            self.step_start_event.record()
+            nvtx_range_push("EP-dummy-forward")
+            self.controller.dummy_forward()
+            self.step_end_event.record()
+            self.step_end_event.synchronize()
+            nvtx_range_pop("EP-dummy-forward")
+            self.context.step_count += 1
+            self.context.prefix_cache_lru_clock += 1
+
+        await self._ep_complete_work_step()
+
+        if finished_request_records is not None:
+            self._send_finished_records_to_coordinator(finished_request_records)
 
     async def _world_barrier(self):
         """World-wide ZMQ all-reduce barrier for global rank consensus.
@@ -2590,26 +2716,17 @@ class DynamicInferenceEngine(AbstractEngine):
 
                     if all_pausing:
                         # All EP peers are PAUSING: pause immediately.
+                        self.ep_async_step_protocol.complete_idle_step()
                         self._drain_async_transactions()
                         await self._world_barrier()
                         self.state = EngineState.PAUSED
                         self._state_events[EngineState.PAUSED].set()
                     elif global_work > 0:
                         # At least one EP peer has work: all must participate.
-                        if local_pending > 0:
-                            await self.async_step()
-                        else:
-                            # Dummy forward to participate in the EP collective.
-                            self.step_start_event.record()
-                            nvtx_range_push("EP-dummy-forward")
-                            self.controller.dummy_forward()
-                            self.step_end_event.record()
-                            self.step_end_event.synchronize()
-                            nvtx_range_pop("EP-dummy-forward")
-                            self.context.step_count += 1
-                            self.context.prefix_cache_lru_clock += 1
+                        await self._run_ep_work_step(local_pending)
                     else:
                         # No work, but not all pausing: idle.
+                        self.ep_async_step_protocol.complete_idle_step()
                         await asyncio.sleep(0.02)
 
                 elif self.state == EngineState.PAUSED:

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1138,6 +1138,10 @@ class DynamicInferenceEngine(AbstractEngine):
         accepted_tokens: torch.Tensor,
         log_probs: torch.Tensor,
         top_n_logprobs: Optional[Dict[int, List[Tuple[torch.Tensor, torch.Tensor]]]] = None,
+        log_probs_by_request_id: Optional[Dict[int, List[float]]] = None,
+        top_n_logprobs_by_request_id: Optional[
+            Dict[int, List[Tuple[torch.Tensor, torch.Tensor]]]
+        ] = None,
         pre_fwd_active_token_count: Optional[int] = None,
         pre_fwd_step_count: Optional[int] = None,
         finished_routing_block_ids: Optional[Dict[int, list[int]]] = None,
@@ -1155,6 +1159,8 @@ class DynamicInferenceEngine(AbstractEngine):
             log_probs: (List): Log probs for each request
             top_n_logprobs: (Dict): Top-n log probs for each request. Maps request_idx to
                 list of (top_n_logprobs, top_n_indices) tuples.
+            log_probs_by_request_id: Log probs keyed by request id after commit.
+            top_n_logprobs_by_request_id: Top-n log probs keyed by request id after commit.
             finished_routing_block_ids: (Dict[int, List[int]]): Block IDs for
                 finished requests, saved before update_requests released them.
                 Used for per-block routing reconstruction.
@@ -1169,8 +1175,14 @@ class DynamicInferenceEngine(AbstractEngine):
         if evict_request_ids is not None:
             self.evicted_request_count += evict_request_ids.numel()
 
-        log_probs_iter = log_probs if log_probs else repeat(None)
         block_allocator = self.context.kv_block_allocator
+        request_id_list = request_ids.tolist()
+        if log_probs_by_request_id is not None:
+            log_probs_iter = (
+                log_probs_by_request_id.get(int(request_id)) for request_id in request_id_list
+            )
+        else:
+            log_probs_iter = log_probs if log_probs else repeat(None)
 
         # Pre-compute step-level block stats (before the per-request loop)
         if self.track_generated_token_events:
@@ -1190,8 +1202,14 @@ class DynamicInferenceEngine(AbstractEngine):
             self._spec_steps += 1
 
         for req_idx, (request_id, tokens, accepted_tokens_list, request_log_probs) in enumerate(
-            zip(request_ids.tolist(), sample.tolist(), accepted_tokens_iter, log_probs_iter)
+            zip(request_id_list, sample.tolist(), accepted_tokens_iter, log_probs_iter)
         ):
+            request_id = int(request_id)
+            request_top_n_logprobs = None
+            if top_n_logprobs_by_request_id is not None:
+                request_top_n_logprobs = top_n_logprobs_by_request_id.get(request_id)
+            elif top_n_logprobs is not None and req_idx in top_n_logprobs:
+                request_top_n_logprobs = top_n_logprobs[req_idx]
 
             # Ensure tokens is always a list for consistent handling
             if not isinstance(tokens, list):
@@ -1226,8 +1244,8 @@ class DynamicInferenceEngine(AbstractEngine):
                     # Trim log probs / top-n to match so the counts stay in sync.
                     if request_log_probs is not None:
                         request_log_probs = request_log_probs[:keep]
-                    if top_n_logprobs is not None and req_idx in top_n_logprobs:
-                        top_n_logprobs[req_idx] = top_n_logprobs[req_idx][:keep]
+                    if request_top_n_logprobs is not None:
+                        request_top_n_logprobs = request_top_n_logprobs[:keep]
                 if request_id not in self.stop_word_being_finished_ids:
                     is_first_token = len(request.generated_tokens) == 0
                     request.generated_tokens += tokens
@@ -1339,8 +1357,8 @@ class DynamicInferenceEngine(AbstractEngine):
             if num_stop_word_trim > 0:
                 if request_log_probs is not None:
                     request_log_probs = request_log_probs[:-num_stop_word_trim]
-                if top_n_logprobs is not None and req_idx in top_n_logprobs:
-                    top_n_logprobs[req_idx] = top_n_logprobs[req_idx][:-num_stop_word_trim]
+                if request_top_n_logprobs is not None:
+                    request_top_n_logprobs = request_top_n_logprobs[:-num_stop_word_trim]
 
             # Process log_probs if available (unified for both regular and chunked prefill)
             # Skip for requests being finished due to stop words — tokens are not
@@ -1384,8 +1402,7 @@ class DynamicInferenceEngine(AbstractEngine):
             # Process top_n_logprobs if available (unified for both regular and chunked prefill)
             # Same stop-word guard as log probs above.
             if (
-                top_n_logprobs is not None
-                and req_idx in top_n_logprobs
+                request_top_n_logprobs is not None
                 and request_id not in self.stop_word_being_finished_ids
             ):
                 # Initialize lists if they don't exist
@@ -1394,7 +1411,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 if request.generated_top_n_logprobs is None:
                     request.generated_top_n_logprobs = []
 
-                top_n_data_list = top_n_logprobs[req_idx]
+                top_n_data_list = request_top_n_logprobs
                 prompt_length = len(request.prompt_tokens)
 
                 # Process each token's top-n logprobs
@@ -1858,6 +1875,8 @@ class DynamicInferenceEngine(AbstractEngine):
             accepted_tokens = step_result["accepted_tokens"]
             log_probs = step_result["log_probs"]
             top_n_logprobs = step_result.get("top_n_logprobs", None)
+            log_probs_by_request_id = step_result.get("log_probs_by_request_id")
+            top_n_logprobs_by_request_id = step_result.get("top_n_logprobs_by_request_id")
             finished_routing_block_ids = step_result.get("finished_routing_block_ids", None)
             cuda_graph_request_count = step_result["cuda_graph_request_count"]
 
@@ -1876,6 +1895,8 @@ class DynamicInferenceEngine(AbstractEngine):
                 accepted_tokens,
                 log_probs,
                 top_n_logprobs,
+                log_probs_by_request_id=log_probs_by_request_id,
+                top_n_logprobs_by_request_id=top_n_logprobs_by_request_id,
                 pre_fwd_active_token_count=context_state.get("active_token_count"),
                 pre_fwd_step_count=context_state.get("step_count"),
                 finished_routing_block_ids=finished_routing_block_ids,

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1922,8 +1922,13 @@ class DynamicInferenceEngine(AbstractEngine):
 
         if will_log_this_step:
             self.step_start_event.record()
+        profile_async_child_forward = (
+            self.logging_step_interval > 0
+            and (self.context.step_count + 2) % self.logging_step_interval == 0
+        )
         result = await self.controller.async_generate_output_tokens_dynamic_batch(
-            async_launch_barrier_reason=async_launch_barrier_reason
+            async_launch_barrier_reason=async_launch_barrier_reason,
+            profile_async_child_forward=profile_async_child_forward,
         )
         if will_log_this_step:
             self.step_end_event.record()
@@ -2325,6 +2330,7 @@ class DynamicInferenceEngine(AbstractEngine):
                     "prestage %(child_prestage_duration_us).1f us, "
                     "ep-handoff %(ep_handoff_duration_us).1f us, "
                     "child-graph %(child_graph_shape_duration_us).1f us, "
+                    "child-fwd-gpu %(child_forward_gpu_us).1f us, "
                     "sample-block %(sampling_block_us).1f us, "
                     "eng-fwd %(engine_forward_wall_us).1f us, "
                     "eng-book %(engine_bookkeep_wall_us).1f us, "

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -424,59 +424,90 @@ class DynamicInferenceEngine(AbstractEngine):
         if HAVE_TQDM:
             tbar = tqdm(tbar, total=len(context.cuda_graph_batch_dimensions_list))
         for tbar_idx, cuda_graph_batch_dimension in tbar:
-            input_ids, position_ids = self.controller._dynamic_step_context_init(
-                construct_graph_dimensions=cuda_graph_batch_dimension
+            capture_slots = (None,)
+            if (
+                context.async_scheduling
+                and context.async_decode_slot_ring is not None
+                and cuda_graph_batch_dimension.prefill_req_count == 0
+            ):
+                capture_slots = context.async_decode_slot_ring.slots
+
+            saved_slot_index = (
+                context.async_decode_slot_ring.current_index
+                if context.async_decode_slot_ring is not None
+                else None
             )
-            # Progress.
-            tbar_str = f"cuda graph warmup - {cuda_graph_batch_dimension}"
-            if HAVE_TQDM:
-                tbar.set_description(tbar_str)
-            else:
-                logging.info(
-                    f"{tbar_idx}/{len(context.cuda_graph_batch_dimensions_list)}. {tbar_str}"
-                )
+            try:
+                for capture_slot_index, capture_slot in enumerate(capture_slots):
+                    if capture_slot is not None:
+                        context.async_decode_slot_ring.current_index = capture_slot_index
+                        context.bind_decode_slot(capture_slot)
 
-            # Enable routing recording during warmup if routing replay is enabled.
-            # This ensures the record_indices copy operation is captured in the CUDA graph.
-            if model_config.moe_enable_routing_replay:
-                RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
-
-            # Forward pass -> logits.
-            with torch.inference_mode():
-                controller._dynamic_step_forward_logits(input_ids, position_ids)
-
-                if controller._sampling_backend == "flashinfer":
-                    if controller.num_speculative_tokens > 0:
-                        controller._dynamic_step_sample_logits_and_verify_tokens(input_ids)
+                    input_ids, position_ids = self.controller._dynamic_step_context_init(
+                        construct_graph_dimensions=cuda_graph_batch_dimension
+                    )
+                    # Progress.
+                    slot_suffix = (
+                        f" slot {capture_slot.slot_id}" if capture_slot is not None else ""
+                    )
+                    tbar_str = f"cuda graph warmup - {cuda_graph_batch_dimension}{slot_suffix}"
+                    if HAVE_TQDM:
+                        tbar.set_description(tbar_str)
                     else:
-                        controller._dynamic_step_sample_logits()
+                        logging.info(
+                            f"{tbar_idx}/{len(context.cuda_graph_batch_dimensions_list)}. "
+                            f"{tbar_str}"
+                        )
 
-                # MTP CUDA graph warmup for this batch dimension.
-                if mtp_warmup_enabled:
-                    n = cuda_graph_batch_dimension.req_count
-                    # pylint: disable-next=possibly-used-before-assignment
-                    if sp_enabled:
-                        n = round_up_to_nearest_multiple(n, tp_size)
-                    # pylint: disable-next=possibly-used-before-assignment
-                    if n > 0 and n not in mtp_seen_batch_sizes:
-                        mtp_seen_batch_sizes.add(n)
-                        device = torch.cuda.current_device()
-                        batch_dim = n // tp_size if sp_enabled else n
-                        # Use zeros (not empty) — garbage token IDs cause OOB embedding lookups during graph capture/replay.
-                        for depth in mtp_warmup_depths:
-                            unwrapped.compute_mtp_single_step(
-                                hidden_states=torch.zeros(
-                                    (batch_dim, 1, model_config.hidden_size),
-                                    device=device,
-                                    dtype=model_config.params_dtype,
-                                ),
-                                next_token_ids=torch.zeros((1, n), device=device, dtype=torch.long),
-                                position_ids=torch.zeros((1, n), device=device, dtype=torch.int64),
-                                depth=depth,
-                                cache_key=("mtp", n, depth),
-                            )
+                    # Enable routing recording during warmup if routing replay is enabled.
+                    # This ensures the record_indices copy operation is captured in the CUDA graph.
+                    if model_config.moe_enable_routing_replay:
+                        RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
 
-                context.reset()
+                    # Forward pass -> logits.
+                    with torch.inference_mode():
+                        controller._dynamic_step_forward_logits(input_ids, position_ids)
+
+                        if controller._sampling_backend == "flashinfer":
+                            if controller.num_speculative_tokens > 0:
+                                controller._dynamic_step_sample_logits_and_verify_tokens(input_ids)
+                            else:
+                                controller._dynamic_step_sample_logits()
+
+                        # MTP CUDA graph warmup for this batch dimension.
+                        if mtp_warmup_enabled:
+                            n = cuda_graph_batch_dimension.req_count
+                            # pylint: disable-next=possibly-used-before-assignment
+                            if sp_enabled:
+                                n = round_up_to_nearest_multiple(n, tp_size)
+                            # pylint: disable-next=possibly-used-before-assignment
+                            if n > 0 and n not in mtp_seen_batch_sizes:
+                                mtp_seen_batch_sizes.add(n)
+                                device = torch.cuda.current_device()
+                                batch_dim = n // tp_size if sp_enabled else n
+                                # Use zeros (not empty) — garbage token IDs cause OOB embedding lookups during graph capture/replay.
+                                for depth in mtp_warmup_depths:
+                                    unwrapped.compute_mtp_single_step(
+                                        hidden_states=torch.zeros(
+                                            (batch_dim, 1, model_config.hidden_size),
+                                            device=device,
+                                            dtype=model_config.params_dtype,
+                                        ),
+                                        next_token_ids=torch.zeros(
+                                            (1, n), device=device, dtype=torch.long
+                                        ),
+                                        position_ids=torch.zeros(
+                                            (1, n), device=device, dtype=torch.int64
+                                        ),
+                                        depth=depth,
+                                        cache_key=("mtp", n, depth),
+                                    )
+
+                        context.reset()
+            finally:
+                if saved_slot_index is not None:
+                    context.async_decode_slot_ring.current_index = saved_slot_index
+                    context.bind_decode_slot(context.async_decode_slot_ring.current)
 
             # Per-iteration memory accounting, scoped to the CUDA-graph mempool.
             # This isolates pool growth from process-wide scratch churn (KV cache,

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -257,6 +257,10 @@ class DynamicInferenceEngine(AbstractEngine):
         self.cuda_graph_modules = model_config.cuda_graph_modules
         # Initialize engine.
         self.reset()
+        logging.info(
+            "> dynamic async scheduling: %s",
+            "enabled" if inference_config.async_scheduling else "disabled",
+        )
 
         # Set callback for getting stop word finished request IDs
         self.controller.set_stop_word_finished_ids_callback(
@@ -2062,6 +2066,13 @@ class DynamicInferenceEngine(AbstractEngine):
                     self._prefix_cache_hits,
                     self._prefix_cache_blocks_matched,
                 )
+            if self.context.async_scheduling:
+                async_diag = self.context.async_txn_diagnostics.snapshot()
+                output_str += (
+                    " ... async txn: prepared %(prepared)d, launched %(launched)d, "
+                    "adopted %(adopted)d, retired %(retired)d, sync %(sync_steps)d, "
+                    "barrier %(barrier_skips)d, top-skip %(top_skip_reason)s"
+                ) % async_diag
             if context_state["is_decode_only"]:
                 output_str = f"\033[94m{output_str}\033[0m"
             logging.info(output_str)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1138,6 +1138,7 @@ class DynamicInferenceEngine(AbstractEngine):
         accepted_tokens: torch.Tensor,
         log_probs: torch.Tensor,
         top_n_logprobs: Optional[Dict[int, List[Tuple[torch.Tensor, torch.Tensor]]]] = None,
+        accepted_tokens_by_request_id: Optional[Dict[int, List[int]]] = None,
         log_probs_by_request_id: Optional[Dict[int, List[float]]] = None,
         top_n_logprobs_by_request_id: Optional[
             Dict[int, List[Tuple[torch.Tensor, torch.Tensor]]]
@@ -1159,6 +1160,7 @@ class DynamicInferenceEngine(AbstractEngine):
             log_probs: (List): Log probs for each request
             top_n_logprobs: (Dict): Top-n log probs for each request. Maps request_idx to
                 list of (top_n_logprobs, top_n_indices) tuples.
+            accepted_tokens_by_request_id: Accepted speculative tokens keyed by request id.
             log_probs_by_request_id: Log probs keyed by request id after commit.
             top_n_logprobs_by_request_id: Top-n log probs keyed by request id after commit.
             finished_routing_block_ids: (Dict[int, List[int]]): Block IDs for
@@ -1195,8 +1197,14 @@ class DynamicInferenceEngine(AbstractEngine):
                 blocks_ref_count = None
 
         # When accepted_tokens is None (no speculative decoding), use repeat([]) to provide
-        # empty lists for each request, so the zip produces the correct number of iterations
-        accepted_tokens_iter = repeat([]) if accepted_tokens is None else accepted_tokens.tolist()
+        # empty lists for each request, so the zip produces the correct number of iterations.
+        if accepted_tokens_by_request_id is not None:
+            accepted_tokens_iter = (
+                accepted_tokens_by_request_id.get(int(request_id), [])
+                for request_id in request_id_list
+            )
+        else:
+            accepted_tokens_iter = repeat([]) if accepted_tokens is None else accepted_tokens.tolist()
 
         if self.num_speculative_tokens > 0 and accepted_tokens is not None:
             self._spec_steps += 1
@@ -1895,6 +1903,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 accepted_tokens,
                 log_probs,
                 top_n_logprobs,
+                accepted_tokens_by_request_id=step_result.get("accepted_tokens_by_request_id"),
                 log_probs_by_request_id=log_probs_by_request_id,
                 top_n_logprobs_by_request_id=top_n_logprobs_by_request_id,
                 pre_fwd_active_token_count=context_state.get("active_token_count"),

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1870,6 +1870,12 @@ class DynamicInferenceEngine(AbstractEngine):
                 step_time (float): How long this step took.
         """
 
+        forward_wall_started_at = (
+            time.perf_counter()
+            if self.context.async_scheduling and self.context.async_txn_diagnostics.enabled
+            else None
+        )
+
         # If suspended, no stepping.
         if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
             raise EngineSuspendedError(self.context.step_count)
@@ -1951,6 +1957,11 @@ class DynamicInferenceEngine(AbstractEngine):
             # Keep kv_stats=None so the metrics-block gate at `async_bookkeep`
             # (`if context_state["kv_stats"] is not None`) remains well-typed.
             context_state = {**pre_step_context_state, "kv_stats": None}
+
+        if forward_wall_started_at is not None:
+            self.context.async_txn_diagnostics.record_engine_forward_wall_duration(
+                (time.perf_counter() - forward_wall_started_at) * 1_000_000
+            )
 
         return result, context_state, step_time
 
@@ -2066,6 +2077,11 @@ class DynamicInferenceEngine(AbstractEngine):
                 step_time (float): The step time in seconds.
                 cuda_graph_request_count (int): The CUDA graph batch size matching this step.
         """
+        bookkeep_wall_started_at = (
+            time.perf_counter()
+            if self.context.async_scheduling and self.context.async_txn_diagnostics.enabled
+            else None
+        )
         # Increment finished_request_count.
         nvtx_range_push("bookkeeping")
         cuda_graph_request_count = None
@@ -2095,22 +2111,33 @@ class DynamicInferenceEngine(AbstractEngine):
                 [self.get_request(i).add_event_pause() for i in newly_paused_request_ids]
 
             # Process finished requests (adds FINISH events and returns records).
-            (active_request_ids, finished_request_records) = self.post_process_requests(
-                active_request_ids,
-                finished_request_ids,
-                evict_request_ids,
-                step_time,
-                sample,
-                accepted_tokens,
-                log_probs,
-                top_n_logprobs,
-                accepted_tokens_by_request_id=step_result.get("accepted_tokens_by_request_id"),
-                log_probs_by_request_id=log_probs_by_request_id,
-                top_n_logprobs_by_request_id=top_n_logprobs_by_request_id,
-                pre_fwd_active_token_count=context_state.get("active_token_count"),
-                pre_fwd_step_count=context_state.get("step_count"),
-                finished_routing_block_ids=finished_routing_block_ids,
+            postprocess_started_at = (
+                time.perf_counter()
+                if self.context.async_scheduling and self.context.async_txn_diagnostics.enabled
+                else None
             )
+            try:
+                (active_request_ids, finished_request_records) = self.post_process_requests(
+                    active_request_ids,
+                    finished_request_ids,
+                    evict_request_ids,
+                    step_time,
+                    sample,
+                    accepted_tokens,
+                    log_probs,
+                    top_n_logprobs,
+                    accepted_tokens_by_request_id=step_result.get("accepted_tokens_by_request_id"),
+                    log_probs_by_request_id=log_probs_by_request_id,
+                    top_n_logprobs_by_request_id=top_n_logprobs_by_request_id,
+                    pre_fwd_active_token_count=context_state.get("active_token_count"),
+                    pre_fwd_step_count=context_state.get("step_count"),
+                    finished_routing_block_ids=finished_routing_block_ids,
+                )
+            finally:
+                if postprocess_started_at is not None:
+                    self.context.async_txn_diagnostics.record_engine_postprocess_duration(
+                        (time.perf_counter() - postprocess_started_at) * 1_000_000
+                    )
 
         else:
             active_request_ids: list[int] = []
@@ -2298,6 +2325,10 @@ class DynamicInferenceEngine(AbstractEngine):
                     "prestage %(child_prestage_duration_us).1f us, "
                     "ep-handoff %(ep_handoff_duration_us).1f us, "
                     "child-graph %(child_graph_shape_duration_us).1f us, "
+                    "sample-block %(sampling_block_us).1f us, "
+                    "eng-fwd %(engine_forward_wall_us).1f us, "
+                    "eng-book %(engine_bookkeep_wall_us).1f us, "
+                    "post %(engine_postprocess_us).1f us, "
                     "retire-depth %(retire_queue_depth)d, "
                     "top-skip %(top_skip_reason)s"
                 ) % async_diag
@@ -2306,6 +2337,11 @@ class DynamicInferenceEngine(AbstractEngine):
             logging.info(output_str)
 
         nvtx_range_pop("console_logging")
+
+        if bookkeep_wall_started_at is not None:
+            self.context.async_txn_diagnostics.record_engine_bookkeep_wall_duration(
+                (time.perf_counter() - bookkeep_wall_started_at) * 1_000_000
+            )
 
         return {
             "active_request_ids": active_request_ids,

--- a/megatron/core/inference/ep_async_protocol.py
+++ b/megatron/core/inference/ep_async_protocol.py
@@ -16,6 +16,7 @@ class EPAsyncPhase(str, Enum):
     GRAPH_SHAPE = "ep_graph_shape"
     DECODE_POST_FORWARD = "ep_decode_post_forward"
     ASYNC_CHILD_HANDOFF = "ep_async_child_handoff"
+    ASYNC_CHAIN_HANDOFF = "ep_async_chain_handoff"
 
 
 @dataclass(frozen=True)

--- a/megatron/core/inference/ep_async_protocol.py
+++ b/megatron/core/inference/ep_async_protocol.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class EPAsyncPhase(str, Enum):
+    """Tagged collective phases owned by the EP async protocol."""
+
+    WORK_CONSENSUS = "ep_work_consensus"
+    WORK_CONSENSUS_ACK = "ep_work_consensus_ack"
+    STEP_COMPLETE = "ep_step_complete"
+    STEP_COMPLETE_ACK = "ep_step_complete_ack"
+    GRAPH_SHAPE = "ep_graph_shape"
+    DECODE_POST_FORWARD = "ep_decode_post_forward"
+    ASYNC_CHILD_HANDOFF = "ep_async_child_handoff"
+
+
+@dataclass(frozen=True)
+class EPWorkConsensus:
+    """EP-wide work and state-transition consensus for one engine-loop iteration."""
+
+    step_id: int
+    global_work: int
+    all_pausing: bool
+
+
+class EPAsyncStepProtocol:
+    """Owns tagged EP async collectives and their per-step ordering."""
+
+    def __init__(self, communicator=None):
+        self.communicator = communicator
+        self._phase_step_ids: dict[EPAsyncPhase, int] = {phase: 0 for phase in EPAsyncPhase}
+        self._next_ep_step_id = 0
+        self._active_ep_step_id: int | None = None
+        self._work_consensus_count = 0
+        self._work_completion_count = 0
+        self._idle_completion_count = 0
+        self._collective_error_count = 0
+
+    @property
+    def enabled(self) -> bool:
+        """Whether this rank participates in multi-rank EP protocol collectives."""
+
+        return self.communicator is not None and self.communicator.world_size > 1
+
+    def diagnostics(self) -> dict[str, int | bool | None]:
+        """Return protocol counters for tests and benchmark logs."""
+
+        return {
+            "enabled": self.enabled,
+            "active_step_id": self._active_ep_step_id,
+            "next_step_id": self._next_ep_step_id,
+            "work_consensus": self._work_consensus_count,
+            "work_completions": self._work_completion_count,
+            "idle_completions": self._idle_completion_count,
+            "collective_errors": self._collective_error_count,
+            "phase_mismatches": getattr(self.communicator, "protocol_mismatch_count", 0),
+        }
+
+    def _next_step_id(self, phase: EPAsyncPhase) -> int:
+        step_id = self._phase_step_ids[phase]
+        self._phase_step_ids[phase] = step_id + 1
+        return step_id
+
+    def _begin_ep_step(self) -> int:
+        if self._active_ep_step_id is not None:
+            raise RuntimeError(f"EP protocol step {self._active_ep_step_id} is still active")
+        step_id = self._next_ep_step_id
+        self._next_ep_step_id += 1
+        self._active_ep_step_id = step_id
+        return step_id
+
+    def _finish_ep_step(self) -> None:
+        self._active_ep_step_id = None
+
+    def ensure_work_step(self) -> int:
+        """Ensure that the current engine-loop work iteration has a protocol step id."""
+
+        if self._active_ep_step_id is None:
+            return self._begin_ep_step()
+        return self._active_ep_step_id
+
+    def _step_id_for_phase(self, phase: EPAsyncPhase) -> int:
+        if self._active_ep_step_id is not None:
+            return self._active_ep_step_id
+        return self._next_step_id(phase)
+
+    async def _all_reduce_max_at_step(
+        self, phase: EPAsyncPhase, step_id: int, *local_vals: int, async_op: bool = True
+    ) -> int | tuple[int, ...]:
+        if not self.enabled:
+            return local_vals[0] if len(local_vals) == 1 else local_vals
+        try:
+            return await self.communicator.all_reduce_max(
+                *local_vals, async_op=async_op, phase=phase.value, step_id=step_id
+            )
+        except Exception:
+            self._collective_error_count += 1
+            raise
+
+    async def _ack_at_step(
+        self, phase: EPAsyncPhase, step_id: int, *, async_op: bool = True
+    ) -> None:
+        await self._all_reduce_max_at_step(phase, step_id, 1, async_op=async_op)
+
+    def _sync_all_reduce_max_at_step(
+        self, phase: EPAsyncPhase, step_id: int, *local_vals: int
+    ) -> int | tuple[int, ...]:
+        if not self.enabled:
+            return local_vals[0] if len(local_vals) == 1 else local_vals
+        try:
+            return self.communicator.sync_all_reduce_max(
+                *local_vals, phase=phase.value, step_id=step_id
+            )
+        except Exception:
+            self._collective_error_count += 1
+            raise
+
+    def sync_all_reduce_max(
+        self, phase: EPAsyncPhase, *local_vals: int
+    ) -> int | tuple[int, ...]:
+        """Run a tagged EP MAX collective for a synchronous call site."""
+
+        if len(local_vals) == 0:
+            raise ValueError("EP async protocol sync_all_reduce_max requires at least one value")
+        step_id = self._step_id_for_phase(phase)
+        return self._sync_all_reduce_max_at_step(phase, step_id, *local_vals)
+
+    async def establish_work_consensus(
+        self, local_work: int, signal_consensus: bool, *, async_op: bool = True
+    ) -> EPWorkConsensus:
+        """Share pending work and pause intent across EP ranks."""
+
+        consensus_val = -1 if signal_consensus else 0
+        step_id = self._begin_ep_step()
+        global_work, global_consensus = await self._all_reduce_max_at_step(
+            EPAsyncPhase.WORK_CONSENSUS, step_id, local_work, consensus_val, async_op=async_op
+        )
+        await self._ack_at_step(EPAsyncPhase.WORK_CONSENSUS_ACK, step_id, async_op=async_op)
+        self._work_consensus_count += 1
+
+        return EPWorkConsensus(
+            step_id=step_id, global_work=global_work, all_pausing=(global_consensus == -1)
+        )
+
+    async def complete_work_step(self, *, async_op: bool = True) -> None:
+        """Close the active EP work step after real and dummy ranks have finished it."""
+
+        if self._active_ep_step_id is None:
+            return
+        step_id = self._active_ep_step_id
+        try:
+            await self._all_reduce_max_at_step(
+                EPAsyncPhase.STEP_COMPLETE, step_id, 1, async_op=async_op
+            )
+            await self._ack_at_step(EPAsyncPhase.STEP_COMPLETE_ACK, step_id, async_op=async_op)
+            self._work_completion_count += 1
+        finally:
+            self._finish_ep_step()
+
+    def complete_idle_step(self) -> None:
+        """Close an EP step that ended at consensus without model work."""
+
+        if self._active_ep_step_id is not None:
+            self._idle_completion_count += 1
+        self._finish_ep_step()

--- a/megatron/core/inference/ep_async_protocol.py
+++ b/megatron/core/inference/ep_async_protocol.py
@@ -34,8 +34,8 @@ class EPStepBeginDecision:
 
     step_id: int
     has_real_work: bool
-    reuse_pending_forward: bool
-    discard_pending_forward: bool
+    consume_launched_forward: bool
+    launched_forward_invariant_failed: bool
 
 
 class EPAsyncStepProtocol:
@@ -50,7 +50,7 @@ class EPAsyncStepProtocol:
         self._work_completion_count = 0
         self._idle_completion_count = 0
         self._step_begin_reuse_count = 0
-        self._step_begin_discard_count = 0
+        self._step_begin_invariant_failure_count = 0
         self._collective_error_count = 0
 
     @property
@@ -70,7 +70,7 @@ class EPAsyncStepProtocol:
             "work_completions": self._work_completion_count,
             "idle_completions": self._idle_completion_count,
             "step_begin_reuses": self._step_begin_reuse_count,
-            "step_begin_discards": self._step_begin_discard_count,
+            "step_begin_invariant_failures": self._step_begin_invariant_failure_count,
             "collective_errors": self._collective_error_count,
             "phase_mismatches": getattr(self.communicator, "protocol_mismatch_count", 0),
         }
@@ -187,50 +187,52 @@ class EPAsyncStepProtocol:
         self,
         *,
         has_real_work: bool,
-        has_pending_forward: bool,
-        pending_forward_reusable: bool,
+        has_launched_forward: bool,
+        launched_forward_consumable: bool,
     ) -> EPStepBeginDecision:
         """Synchronize whether this EP work step reuses a prior async child forward."""
 
         step_id = self._step_id_for_phase(EPAsyncPhase.STEP_BEGIN)
         local_real = int(has_real_work)
-        local_pending_forward = int(has_pending_forward)
-        local_reusable = int(has_pending_forward and pending_forward_reusable)
-        local_discard = int(has_pending_forward and not pending_forward_reusable)
-        local_real_missing_forward = int(has_real_work and not has_pending_forward)
+        local_launched_forward = int(has_launched_forward)
+        local_reusable = int(has_launched_forward and launched_forward_consumable)
+        local_invariant_failure = int(has_launched_forward and not launched_forward_consumable)
+        local_real_missing_forward = int(has_real_work and not has_launched_forward)
 
         (
             any_real,
-            any_pending_forward,
+            any_launched_forward,
             any_reusable,
-            any_discard,
+            any_invariant_failure,
             any_real_missing_forward,
         ) = self._sync_all_reduce_max_at_step(
             EPAsyncPhase.STEP_BEGIN,
             step_id,
             local_real,
-            local_pending_forward,
+            local_launched_forward,
             local_reusable,
-            local_discard,
+            local_invariant_failure,
             local_real_missing_forward,
         )
         self._sync_all_reduce_max_at_step(EPAsyncPhase.STEP_BEGIN_ACK, step_id, 1)
 
-        reuse_pending_forward = bool(
-            any_pending_forward
+        consume_launched_forward = bool(
+            any_launched_forward
             and any_reusable
-            and not any_discard
+            and not any_invariant_failure
             and not any_real_missing_forward
         )
-        discard_pending_forward = bool(any_pending_forward and not reuse_pending_forward)
-        if reuse_pending_forward:
+        launched_forward_invariant_failed = bool(
+            any_launched_forward and not consume_launched_forward
+        )
+        if consume_launched_forward:
             self._step_begin_reuse_count += 1
-        if discard_pending_forward:
-            self._step_begin_discard_count += 1
+        if launched_forward_invariant_failed:
+            self._step_begin_invariant_failure_count += 1
 
         return EPStepBeginDecision(
             step_id=step_id,
             has_real_work=bool(any_real),
-            reuse_pending_forward=reuse_pending_forward,
-            discard_pending_forward=discard_pending_forward,
+            consume_launched_forward=consume_launched_forward,
+            launched_forward_invariant_failed=launched_forward_invariant_failed,
         )

--- a/megatron/core/inference/ep_async_protocol.py
+++ b/megatron/core/inference/ep_async_protocol.py
@@ -11,6 +11,8 @@ class EPAsyncPhase(str, Enum):
     WORK_CONSENSUS_ACK = "ep_work_consensus_ack"
     STEP_COMPLETE = "ep_step_complete"
     STEP_COMPLETE_ACK = "ep_step_complete_ack"
+    STEP_BEGIN = "ep_step_begin"
+    STEP_BEGIN_ACK = "ep_step_begin_ack"
     GRAPH_SHAPE = "ep_graph_shape"
     DECODE_POST_FORWARD = "ep_decode_post_forward"
     ASYNC_CHILD_HANDOFF = "ep_async_child_handoff"
@@ -25,6 +27,16 @@ class EPWorkConsensus:
     all_pausing: bool
 
 
+@dataclass(frozen=True)
+class EPStepBeginDecision:
+    """EP-wide decision for GPU work already launched by the previous step."""
+
+    step_id: int
+    has_real_work: bool
+    reuse_pending_forward: bool
+    discard_pending_forward: bool
+
+
 class EPAsyncStepProtocol:
     """Owns tagged EP async collectives and their per-step ordering."""
 
@@ -36,6 +48,8 @@ class EPAsyncStepProtocol:
         self._work_consensus_count = 0
         self._work_completion_count = 0
         self._idle_completion_count = 0
+        self._step_begin_reuse_count = 0
+        self._step_begin_discard_count = 0
         self._collective_error_count = 0
 
     @property
@@ -54,6 +68,8 @@ class EPAsyncStepProtocol:
             "work_consensus": self._work_consensus_count,
             "work_completions": self._work_completion_count,
             "idle_completions": self._idle_completion_count,
+            "step_begin_reuses": self._step_begin_reuse_count,
+            "step_begin_discards": self._step_begin_discard_count,
             "collective_errors": self._collective_error_count,
             "phase_mismatches": getattr(self.communicator, "protocol_mismatch_count", 0),
         }
@@ -165,3 +181,55 @@ class EPAsyncStepProtocol:
         if self._active_ep_step_id is not None:
             self._idle_completion_count += 1
         self._finish_ep_step()
+
+    def decide_step_begin(
+        self,
+        *,
+        has_real_work: bool,
+        has_pending_forward: bool,
+        pending_forward_reusable: bool,
+    ) -> EPStepBeginDecision:
+        """Synchronize whether this EP work step reuses a prior async child forward."""
+
+        step_id = self._step_id_for_phase(EPAsyncPhase.STEP_BEGIN)
+        local_real = int(has_real_work)
+        local_pending_forward = int(has_pending_forward)
+        local_reusable = int(has_pending_forward and pending_forward_reusable)
+        local_discard = int(has_pending_forward and not pending_forward_reusable)
+        local_real_missing_forward = int(has_real_work and not has_pending_forward)
+
+        (
+            any_real,
+            any_pending_forward,
+            any_reusable,
+            any_discard,
+            any_real_missing_forward,
+        ) = self._sync_all_reduce_max_at_step(
+            EPAsyncPhase.STEP_BEGIN,
+            step_id,
+            local_real,
+            local_pending_forward,
+            local_reusable,
+            local_discard,
+            local_real_missing_forward,
+        )
+        self._sync_all_reduce_max_at_step(EPAsyncPhase.STEP_BEGIN_ACK, step_id, 1)
+
+        reuse_pending_forward = bool(
+            any_pending_forward
+            and any_reusable
+            and not any_discard
+            and not any_real_missing_forward
+        )
+        discard_pending_forward = bool(any_pending_forward and not reuse_pending_forward)
+        if reuse_pending_forward:
+            self._step_begin_reuse_count += 1
+        if discard_pending_forward:
+            self._step_begin_discard_count += 1
+
+        return EPStepBeginDecision(
+            step_id=step_id,
+            has_real_work=bool(any_real),
+            reuse_pending_forward=reuse_pending_forward,
+            discard_pending_forward=discard_pending_forward,
+        )

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-# Some of this code was adopted from https://github.com/vllm-project/vllm.
+# Some of this code was derived from https://github.com/vllm-project/vllm.
 # This source code is licensed under the Apache license found in the
 # LICENSE file in the root directory of this source tree.
 """vLLM-style Triton fused MoE kernel (BF16) for Megatron inference.

--- a/megatron/core/inference/sampling/torch_sampling.py
+++ b/megatron/core/inference/sampling/torch_sampling.py
@@ -142,6 +142,11 @@ class TorchSampling(Sampling):
             logits = logits[gather_indices[:n], :]
 
         output = torch.empty(n, device=logits.device, dtype=torch.int64)
+        request_rng_store = getattr(context, "request_rng_store", None)
+        request_ids_cpu = None
+        if request_rng_store is not None:
+            active_slice = slice(context.paused_request_count, context.total_request_count)
+            request_ids_cpu = context.request_ids[active_slice].tolist()
         token_list = []
         indices_list = []
         for idx_tensor, (_, temp, top_k, top_p) in zip(bucket_index_tensors, buckets):
@@ -149,6 +154,23 @@ class TorchSampling(Sampling):
                 row_indices = idx_tensor
             else:
                 row_indices = torch.where(torch.isin(token_to_request_index, idx_tensor))[0]
+            if request_rng_store is not None:
+                assert request_ids_cpu is not None
+                for row_index in row_indices.tolist():
+                    if token_to_request_index is None:
+                        request_index = row_index
+                    else:
+                        request_index = int(token_to_request_index[row_index].item())
+                    generator = request_rng_store.get(request_ids_cpu[request_index])
+                    output[row_index] = TorchSampling.sample_from_logits(
+                        logits[row_index : row_index + 1, :],
+                        temp,
+                        top_k,
+                        top_p,
+                        generator=generator,
+                        vocab_size=self._vocab_size,
+                    )[0]
+                continue
             token_list.append(
                 TorchSampling.sample_from_logits(
                     logits[row_indices, :],
@@ -160,6 +182,9 @@ class TorchSampling(Sampling):
                 )
             )
             indices_list.append(row_indices)
+
+        if request_rng_store is not None:
+            return output
 
         sampled_tokens = torch.cat(token_list, dim=0)
         sampled_indices = torch.cat(indices_list, dim=0)

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -6,6 +6,7 @@ import copy
 import functools
 import time
 from collections import defaultdict
+from contextlib import nullcontext
 from typing import Any, Dict, Iterable, List, Optional, OrderedDict, Tuple, Union
 
 import numpy as np
@@ -719,13 +720,16 @@ class TextGenerationController:
             self._all_logits_cuda = logits
 
     def _async_decode_cuda_graph_key(self, slot=None) -> Optional[Any]:
-        """Return the active decode graph shape key, if CUDA graphs are active."""
+        """Return the graph key used to guard async child adoption.
 
-        context = self.inference_wrapped_model.inference_context
+        Async child forwards intentionally run outside the full-iteration CUDA graph
+        cache. The cache is keyed by the committed step shape, but the child path
+        owns separate transient metadata buffers and must not depend on a replayed
+        graph captured for the persistent context.
+        """
+
         del slot
-        if not context.using_cuda_graph_this_step():
-            return None
-        return context.padded_batch_dimensions
+        return None
 
     def _async_active_request_ids(self) -> tuple[int, ...]:
         """Return committed active request ids as plain ints."""
@@ -985,7 +989,9 @@ class TextGenerationController:
         if profile_child_forward:
             child_txn.forward_timing_start_event = torch.cuda.Event(enable_timing=True)
             child_txn.forward_timing_start_event.record(torch.cuda.current_stream())
-        self._dynamic_step_forward_logits(input_ids, position_ids)
+        eager_child_scope = getattr(context, "async_child_forward_eager_scope", None)
+        with eager_child_scope() if eager_child_scope is not None else nullcontext():
+            self._dynamic_step_forward_logits(input_ids, position_ids)
         if profile_child_forward:
             child_txn.forward_timing_done_event = torch.cuda.Event(enable_timing=True)
             child_txn.forward_timing_done_event.record(torch.cuda.current_stream())

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -989,8 +989,14 @@ class TextGenerationController:
         if profile_child_forward:
             child_txn.forward_timing_start_event = torch.cuda.Event(enable_timing=True)
             child_txn.forward_timing_start_event.record(torch.cuda.current_stream())
-        eager_child_scope = getattr(context, "async_child_forward_eager_scope", None)
-        with eager_child_scope() if eager_child_scope is not None else nullcontext():
+        disable_child_graph_replay = getattr(
+            context, "async_child_forward_graph_replay_disabled_scope", None
+        )
+        with (
+            disable_child_graph_replay()
+            if disable_child_graph_replay is not None
+            else nullcontext()
+        ):
             self._dynamic_step_forward_logits(input_ids, position_ids)
         if profile_child_forward:
             child_txn.forward_timing_done_event = torch.cuda.Event(enable_timing=True)

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -15,6 +15,7 @@ from torch.cuda.nvtx import range_pop, range_push
 
 from megatron.core import parallel_state
 from megatron.core.inference.async_stream import AsyncStream
+from megatron.core.inference.async_txn import AsyncTxnSkipReason, StepTxn
 from megatron.core.inference.communication_utils import (
     broadcast_from_last_pipeline_stage,
     is_pipeline_last_stage,
@@ -132,6 +133,9 @@ class TextGenerationController:
         if self.inference_wrapped_model.inference_context.is_dynamic_batching():
             self._init_dynamic_sampling_tensors()
 
+        self._async_prepared_child_txn: Optional[StepTxn] = None
+        self._async_launched_child_txn: Optional[StepTxn] = None
+
     def set_stop_word_finished_ids_callback(self, callback):
         """Set a callback to get request IDs that should be marked as finished due to stop words.
 
@@ -176,6 +180,14 @@ class TextGenerationController:
         #     - `self._sampled_tokens_cuda` is rebound to the output of `sample_kernel`,
         #     which uses CudaGraphManager syntactic sugar to keep it as a static tensor.
         self._sampled_tokens_cuda = None
+        self._async_sampled_tokens_cpu = (
+            torch.empty(max_requests, dtype=torch.int64, pin_memory=True)
+            if context.async_scheduling
+            else None
+        )
+        self._async_sample_transfer_stream = None
+        self._async_sample_transfer_done_event = None
+        self._async_sample_transfer_count = 0
 
         # Sampling backend: provides the sampling kernel.
         if self._sampling_backend == "flashinfer":
@@ -666,6 +678,174 @@ class TextGenerationController:
             self._all_logits_cuda[:, :logits_seq_len, :].copy_(logits[:, :logits_seq_len, :])
         else:
             self._all_logits_cuda = logits
+
+    def _async_decode_cuda_graph_key(self, slot=None) -> Optional[tuple]:
+        """Return the decode graph key for the currently active shape and slot."""
+
+        context = self.inference_wrapped_model.inference_context
+        slot = slot or context.active_decode_slot()
+        if slot is None:
+            return None
+        return slot.cuda_graph_key(
+            ("decode", context.padded_active_request_count, context.padded_active_token_count)
+        )
+
+    def _async_active_request_ids(self) -> tuple[int, ...]:
+        """Return committed active request ids as plain ints."""
+
+        context = self.inference_wrapped_model.inference_context
+        active_slice = slice(context.paused_request_count, context.total_request_count)
+        return tuple(int(request_id) for request_id in context.request_ids[active_slice].tolist())
+
+    def _try_adopt_async_child_logits(self) -> bool:
+        """Consume logits from a previously launched child forward if still valid."""
+
+        child_txn = self._async_launched_child_txn
+        if child_txn is None:
+            return False
+
+        context = self.inference_wrapped_model.inference_context
+        if not context.async_scheduling:
+            self._async_launched_child_txn = None
+            return False
+
+        if not child_txn.guard_adoption(
+            self._async_active_request_ids(),
+            decode_only=context.is_decode_only(),
+            cuda_graph_key=self._async_decode_cuda_graph_key(),
+        ):
+            context.async_txn_diagnostics.record_guard_failure()
+            self._async_launched_child_txn = None
+            raise RuntimeError("async decode child adoption invariant failed")
+
+        child_txn.adopted = True
+        self._async_launched_child_txn = None
+        context.async_txn_diagnostics.record_adopted()
+        return True
+
+    def _async_child_launch_skip_reason(
+        self,
+        child_txn: Optional[StepTxn],
+        *,
+        return_log_probs: bool,
+        return_top_n_logprobs: bool,
+        skip_bookkeeping: bool,
+    ) -> Optional[AsyncTxnSkipReason]:
+        """Return the reason the prepared plain-decode child cannot be launched."""
+
+        if child_txn is None:
+            return None
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = context.total_request_count - context.paused_request_count
+        if skip_bookkeeping:
+            return AsyncTxnSkipReason.UNKNOWN_BARRIER
+        if self.num_speculative_tokens > 0:
+            return AsyncTxnSkipReason.MTP_ACTIVE
+        if context.is_hybrid_model:
+            return AsyncTxnSkipReason.HYBRID_PRESTAGE_DEFERRED
+        if self._enable_cuda_graph or context.using_cuda_graph_this_step():
+            return AsyncTxnSkipReason.CUDA_GRAPH_DEFERRED
+        if (
+            getattr(self.model_config, "expert_model_parallel_size", 1) > 1
+            or getattr(self.model_config, "num_moe_experts", None) is not None
+        ):
+            return AsyncTxnSkipReason.MOE_EP_DEFERRED
+        if self._get_stop_word_finished_ids_callback is not None:
+            return AsyncTxnSkipReason.TERMINAL_CHECK_REQUIRED
+        if return_log_probs or return_top_n_logprobs:
+            return AsyncTxnSkipReason.LOGPROBS_DEFERRED
+        if active_request_count != len(child_txn.request_ids):
+            return AsyncTxnSkipReason.UNKNOWN_BARRIER
+        if context.plain_decode_child_needs_terminal_check(active_request_count):
+            return AsyncTxnSkipReason.TERMINAL_CHECK_REQUIRED
+        return None
+
+    def _launch_async_decode_child(self, child_txn: StepTxn) -> None:
+        """Scatter sampled tokens into the prepared child slot and launch it."""
+
+        context = self.inference_wrapped_model.inference_context
+        assert context.async_decode_slot_ring is not None
+        child_slot = context.async_decode_slot_ring.child
+        if child_slot.slot_id != child_txn.slot_id:
+            raise RuntimeError("prepared async child slot no longer matches ring child")
+
+        h2d_ready_before_sampling = child_txn.h2d_ready()
+        if child_txn.h2d_done_event is not None:
+            torch.cuda.current_stream(child_slot.gpu_view._buf.device).wait_event(
+                child_txn.h2d_done_event
+            )
+
+        active_request_count = context.total_request_count - context.paused_request_count
+        child_slot.gpu_view.token_to_input_ids[:active_request_count].copy_(
+            self._sampled_tokens_cuda[:active_request_count], non_blocking=True
+        )
+
+        context.bind_decode_slot(child_slot)
+        input_ids, position_ids = context.current_input_and_position_ids()
+
+        range_push("async_child_forward")
+        self._dynamic_step_forward_logits(input_ids, position_ids)
+        child_txn.forward_done_event = child_slot.record_forward_done()
+        range_pop()
+
+        child_txn.launched = True
+        context.async_decode_slot_ring.adopt_child()
+        self._async_launched_child_txn = child_txn
+        self._async_prepared_child_txn = None
+        context.async_txn_diagnostics.record_launched(
+            h2d_ready_before_sampling=h2d_ready_before_sampling
+        )
+
+    def _record_async_sample_ready_event(self):
+        """Record an event immediately after sampling for side-stream D2H."""
+
+        if self._sampled_tokens_cuda is None or not self._sampled_tokens_cuda.is_cuda:
+            return None
+        event = torch.cuda.Event()
+        event.record(torch.cuda.current_stream(self._sampled_tokens_cuda.device))
+        return event
+
+    def _start_async_sample_transfer(self, active_request_count: int, sample_ready_event) -> None:
+        """Start sampled-token D2H after child launch without waiting on child forward."""
+
+        if (
+            sample_ready_event is None
+            or self._async_sampled_tokens_cpu is None
+            or self._sampled_tokens_cuda is None
+            or not self._sampled_tokens_cuda.is_cuda
+        ):
+            self._async_sample_transfer_done_event = None
+            self._async_sample_transfer_count = 0
+            return
+
+        device = self._sampled_tokens_cuda.device
+        if self._async_sample_transfer_stream is None:
+            self._async_sample_transfer_stream = torch.cuda.Stream(device=device)
+
+        with torch.cuda.stream(self._async_sample_transfer_stream):
+            self._async_sample_transfer_stream.wait_event(sample_ready_event)
+            self._async_sampled_tokens_cpu[:active_request_count].copy_(
+                self._sampled_tokens_cuda[:active_request_count], non_blocking=True
+            )
+            self._async_sample_transfer_done_event = torch.cuda.Event()
+            self._async_sample_transfer_done_event.record(self._async_sample_transfer_stream)
+            self._async_sample_transfer_count = active_request_count
+
+    def _consume_async_sample_transfer(self, active_request_count: int) -> Optional[Tensor]:
+        """Return sampled tokens copied by the async side stream, if available."""
+
+        if (
+            self._async_sample_transfer_done_event is None
+            or self._async_sample_transfer_count != active_request_count
+            or self._async_sampled_tokens_cpu is None
+        ):
+            return None
+
+        self._async_sample_transfer_done_event.synchronize()
+        sampled_tokens_cpu = self._async_sampled_tokens_cpu[:active_request_count].clone()
+        self._async_sample_transfer_done_event = None
+        self._async_sample_transfer_count = 0
+        return sampled_tokens_cpu
 
     def _rewind_kv_cache(self) -> tuple:
         """Update the KV cache bookkeeping for speculative decoding.
@@ -1600,7 +1780,11 @@ class TextGenerationController:
             sampled_mtp_tokens_cpu = None
         return sampled_tokens_cpu, sampled_mtp_tokens_cpu
 
-    def _dynamic_step_context_bookkeeping(self) -> Dict[str, Tensor]:
+    def _dynamic_step_context_bookkeeping(
+        self,
+        sampled_tokens_cpu: Optional[Tensor] = None,
+        sampled_mtp_tokens_cpu: Optional[Tensor] = None,
+    ) -> Dict[str, Tensor]:
         """Update the dynamic inference context after sampling.
 
         Args:
@@ -1619,12 +1803,13 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
-        # Batch GPU-to-CPU transfer of all sampled tokens.
-        range_push("transfer_samples_to_cpu")
-        sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
-            active_request_count
-        )
-        range_pop()
+        if sampled_tokens_cpu is None:
+            # Batch GPU-to-CPU transfer of all sampled tokens.
+            range_push("transfer_samples_to_cpu")
+            sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
+                active_request_count
+            )
+            range_pop()
 
         range_push("active_request_mask")
         # Everything below is 100% CPU.
@@ -1722,14 +1907,12 @@ class TextGenerationController:
             return None
 
         with torch.inference_mode():
-            input_ids, position_ids = self._dynamic_step_context_init()
-            async_eligibility = None
-            if context.async_scheduling:
-                async_eligibility = context.async_launch_eligibility()
-                if async_eligibility.eligible:
-                    context.async_txn_diagnostics.record_prepared(under_forward=False)
-                else:
-                    context.async_txn_diagnostics.record_barrier_skip(async_eligibility.reason)
+            adopted_child = self._try_adopt_async_child_logits()
+            input_ids = None
+            position_ids = None
+
+            if not adopted_child:
+                input_ids, position_ids = self._dynamic_step_context_init()
 
             cuda_graph_request_count = (
                 context.padded_active_request_count
@@ -1737,30 +1920,36 @@ class TextGenerationController:
                 else None
             )
 
-            # Enable routing recording before forward pass if routing replay is enabled
-            config = self.inference_wrapped_model.model.config
-            if config.moe_enable_routing_replay:
-                RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+            if not adopted_child:
+                # Enable routing recording before forward pass if routing replay is enabled
+                config = self.inference_wrapped_model.model.config
+                if config.moe_enable_routing_replay:
+                    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
 
-            # Forward pass produces only base logits. When speculative decoding is
-            # active, MTP logits are computed serially after verification.
-            range_push("forward_pass")
-            self._dynamic_step_forward_logits(input_ids, position_ids)
+                # Forward pass produces only base logits. When speculative decoding is
+                # active, MTP logits are computed serially after verification.
+                range_push("forward_pass")
+                self._dynamic_step_forward_logits(input_ids, position_ids)
 
-            # Commit Mamba intermediate states before update_requests, which
-            # may swap request indices. The Python lists tracking EOS block IDs
-            # and intermediate offsets are not swapped along with tensors, so
-            # commit must run while indices are still valid.
-            if context.is_hybrid_model and context.mamba_slot_allocator is not None:
-                context.mamba_slot_allocator.commit_intermediate_states()
+                # Commit Mamba intermediate states before update_requests, which
+                # may swap request indices. The Python lists tracking EOS block IDs
+                # and intermediate offsets are not swapped along with tensors, so
+                # commit must run while indices are still valid.
+                if context.is_hybrid_model and context.mamba_slot_allocator is not None:
+                    context.mamba_slot_allocator.commit_intermediate_states()
 
-            # Collect flat routing indices and scatter them into per-block storage.
-            # Must be done before update_requests while token-to-block mappings are valid.
-            # Reconstruction happens from blocks at request completion.
-            context.kv_block_allocator.store_routing_per_block(self._router_record_bookkeeping())
-            if context.async_scheduling and context.async_decode_slot_ring is not None:
-                context.async_decode_slot_ring.current.record_forward_done()
-            range_pop()
+                # Collect flat routing indices and scatter them into per-block storage.
+                # Must be done before update_requests while token-to-block mappings are valid.
+                # Reconstruction happens from blocks at request completion.
+                context.kv_block_allocator.store_routing_per_block(
+                    self._router_record_bookkeeping()
+                )
+                if context.async_scheduling and context.async_decode_slot_ring is not None:
+                    context.async_decode_slot_ring.current.record_forward_done()
+                    self._async_prepared_child_txn = (
+                        context.prepare_child_from_committed_decode_state()
+                    )
+                range_pop()
 
         # This is the best place to yield control back to event loop.
         # At this point we have enqueued FW pass GPU kernels asynchronously.
@@ -1774,6 +1963,18 @@ class TextGenerationController:
         with torch.inference_mode():
             range_push("sampling")
             return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
+            launched_child_txn = None
+            child_launch_skip_reason = None
+            if context.async_scheduling:
+                child_launch_skip_reason = self._async_child_launch_skip_reason(
+                    self._async_prepared_child_txn,
+                    return_log_probs=return_log_probs,
+                    return_top_n_logprobs=return_top_n_logprobs,
+                    skip_bookkeeping=skip_bookkeeping,
+                )
+                if child_launch_skip_reason is not None:
+                    context.async_txn_diagnostics.record_barrier_skip(child_launch_skip_reason)
+                    self._async_prepared_child_txn = None
 
             if self.num_speculative_tokens > 0:
                 # Phase 1: Verify speculative tokens using base logits only.
@@ -1804,6 +2005,16 @@ class TextGenerationController:
 
             log_probs = None
             top_n_logprobs = None
+            if (
+                context.async_scheduling
+                and child_launch_skip_reason is None
+                and self._async_prepared_child_txn is not None
+            ):
+                launched_child_txn = self._async_prepared_child_txn
+                sample_ready_event = self._record_async_sample_ready_event()
+                self._launch_async_decode_child(launched_child_txn)
+                self._start_async_sample_transfer(active_request_count, sample_ready_event)
+
             if return_log_probs or return_top_n_logprobs:
                 if self.num_speculative_tokens > 0:
                     log_probs, log_probs_tensor = (
@@ -1839,7 +2050,18 @@ class TextGenerationController:
             else:
                 # request_bookkeeping supplies "sample" as the already-CPU
                 # tensor produced by _transfer_samples_to_cpu.
-                request_bookkeeping = self._dynamic_step_context_bookkeeping()
+                sampled_tokens_cpu = (
+                    self._consume_async_sample_transfer(active_request_count)
+                    if launched_child_txn is not None
+                    else None
+                )
+                request_bookkeeping = self._dynamic_step_context_bookkeeping(
+                    sampled_tokens_cpu=sampled_tokens_cpu
+                )
+                if launched_child_txn is not None:
+                    self._async_prepared_child_txn = (
+                        context.prepare_child_from_committed_decode_state()
+                    )
 
             ret = {
                 "accepted_tokens": (
@@ -1855,7 +2077,7 @@ class TextGenerationController:
             if self.num_speculative_tokens > 0:
                 self._accepted_tokens_per_request.fill_(-1)
                 self._accepted_token_counts_per_request.fill_(0)
-            if context.async_scheduling:
+            if context.async_scheduling and not adopted_child:
                 context.async_txn_diagnostics.record_adopted()
                 context.async_txn_diagnostics.record_sync_step("serial_wrapped")
             ret.update(request_bookkeeping)

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -146,8 +146,8 @@ class TextGenerationController:
 
         self._async_prepared_child_txn: Optional[StepTxn] = None
         self._async_launched_child_txn: Optional[StepTxn] = None
-        self._async_presampled_txn: Optional[StepTxn] = None
-        self._async_presampled_cuda_graph_request_count: Optional[int] = None
+        self._async_deferred_sample_txn: Optional[StepTxn] = None
+        self._async_deferred_sample_cuda_graph_request_count: Optional[int] = None
         self._ep_decode_broadcast_plan: Optional[EPDecodeBroadcastPlan] = None
         self._ep_async_protocol = None
         self._ep_step_begin_decision: Optional[EPStepBeginDecision] = None
@@ -720,7 +720,7 @@ class TextGenerationController:
             self._all_logits_cuda = logits
 
     def _async_decode_cuda_graph_key(self, slot=None) -> Optional[Any]:
-        """Return the graph key used to guard async child adoption.
+        """Return the graph key used to guard async child consumption.
 
         CUDA-graph child forwards replay the normal committed-step graph by
         staging the next-step metadata into the current decode slot after
@@ -742,7 +742,7 @@ class TextGenerationController:
         active_slice = slice(context.paused_request_count, context.total_request_count)
         return tuple(int(request_id) for request_id in context.request_ids[active_slice].tolist())
 
-    def _pending_async_child_reusable(self) -> bool:
+    def _launched_async_child_consumable(self) -> bool:
         """Return whether the launched child transaction can be this step's forward."""
 
         child_txn = self._async_launched_child_txn
@@ -751,7 +751,7 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         if not context.async_scheduling:
             return False
-        return child_txn.guard_adoption(
+        return child_txn.is_consumable_after_commit(
             self._async_active_request_ids(),
             terminal_request_ids=child_txn.terminal_request_ids,
             decode_only=context.is_decode_only(),
@@ -761,22 +761,22 @@ class TextGenerationController:
     def _decide_ep_step_begin(self, *, has_real_work: bool) -> EPStepBeginDecision:
         """Synchronize whether this EP step reuses the previous async child forward."""
 
-        has_pending_forward = self._async_launched_child_txn is not None
-        pending_forward_reusable = (
-            self._pending_async_child_reusable() if has_pending_forward else False
+        has_launched_forward = self._async_launched_child_txn is not None
+        launched_forward_consumable = (
+            self._launched_async_child_consumable() if has_launched_forward else False
         )
         if self._ep_async_protocol is not None and self._ep_async_protocol.enabled:
             decision = self._ep_async_protocol.decide_step_begin(
                 has_real_work=has_real_work,
-                has_pending_forward=has_pending_forward,
-                pending_forward_reusable=pending_forward_reusable,
+                has_launched_forward=has_launched_forward,
+                launched_forward_consumable=launched_forward_consumable,
             )
         else:
             decision = EPStepBeginDecision(
                 step_id=-1,
                 has_real_work=has_real_work,
-                reuse_pending_forward=bool(has_pending_forward and pending_forward_reusable),
-                discard_pending_forward=bool(has_pending_forward and not pending_forward_reusable),
+                consume_launched_forward=bool(has_launched_forward and launched_forward_consumable),
+                launched_forward_invariant_failed=bool(has_launched_forward and not launched_forward_consumable),
             )
         self._ep_step_begin_decision = decision
         return decision
@@ -784,7 +784,7 @@ class TextGenerationController:
     def _clear_ep_step_begin_decision(self) -> None:
         self._ep_step_begin_decision = None
 
-    def _try_adopt_async_child_logits(self) -> bool:
+    def _consume_async_child_logits(self) -> bool:
         """Consume logits from a previously launched child forward if still valid."""
 
         child_txn = self._async_launched_child_txn
@@ -796,9 +796,9 @@ class TextGenerationController:
             self._async_launched_child_txn = None
             return False
 
-        range_push("async_txn_adopt")
+        range_push("async_txn_consume_child")
         try:
-            if not child_txn.guard_adoption(
+            if not child_txn.is_consumable_after_commit(
                 self._async_active_request_ids(),
                 terminal_request_ids=child_txn.terminal_request_ids,
                 decode_only=context.is_decode_only(),
@@ -806,11 +806,11 @@ class TextGenerationController:
             ):
                 context.async_txn_diagnostics.record_guard_failure()
                 self._async_launched_child_txn = None
-                raise RuntimeError("async decode child adoption invariant failed")
+                raise RuntimeError("async decode child consumption invariant failed")
 
             if context.is_hybrid_model:
                 context.accept_async_mamba_state(child_txn.request_ids)
-            child_txn.adopted = True
+            child_txn.consumed = True
             self._async_launched_child_txn = None
             if (
                 child_txn.forward_timing_start_event is not None
@@ -823,7 +823,7 @@ class TextGenerationController:
                     )
                     * 1000.0
                 )
-            context.async_txn_diagnostics.record_adopted()
+            context.async_txn_diagnostics.record_consumed()
             return True
         finally:
             range_pop()
@@ -839,14 +839,14 @@ class TextGenerationController:
         elif hasattr(event, "query") and not event.query() and torch.cuda.is_available():
             torch.cuda.synchronize()
 
-    def drain_async_transactions(self, *, drop_launched: bool = False) -> None:
+    def drain_async_transactions(self, *, clear_launched: bool = False) -> None:
         """Drain in-flight async work before external pause/suspend/shutdown observation."""
 
         child_txn = self._async_launched_child_txn
         if child_txn is not None:
             self._synchronize_async_event(child_txn.forward_done_event)
             self._synchronize_async_event(child_txn.sample_done_event)
-            if drop_launched:
+            if clear_launched:
                 self._async_launched_child_txn = None
 
         self._async_prepared_child_txn = None
@@ -1033,7 +1033,7 @@ class TextGenerationController:
 
         child_txn.launched = True
         if child_slot is context.async_decode_slot_ring.child:
-            context.async_decode_slot_ring.adopt_child()
+            context.async_decode_slot_ring.mark_child_current()
         else:
             context.bind_decode_slot(child_slot)
         self._async_launched_child_txn = child_txn
@@ -1199,8 +1199,8 @@ class TextGenerationController:
             sample_completed_at=sample_completed_at,
             profile_child_forward=profile_child_forward,
         )
-        self._async_presampled_txn = parent_txn
-        self._async_presampled_cuda_graph_request_count = (
+        self._async_deferred_sample_txn = parent_txn
+        self._async_deferred_sample_cuda_graph_request_count = (
             context.padded_active_request_count if context.using_cuda_graph_this_step() else None
         )
         return True
@@ -1679,7 +1679,7 @@ class TextGenerationController:
         # Logit indices for tokens that need sampling.
         # Padded under graph capture so the captured `gather_indices` input has a stable shape.
         # Padded slots resolve to row 0; verify and prepare-next read only the actual prefix,
-        # so the padded-row samples produced by the captured kernel are discarded.
+        # so the padded-row samples produced by the captured kernel are ignored.
         nvtx_range_push("mtp-spec-decoding/verify/logit-indices")
         # Use pre-allocated buffer for CUDA graph compatibility.
         logits = self._all_logits_cuda
@@ -2282,7 +2282,7 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         step_begin_decision = self._decide_ep_step_begin(has_real_work=False)
 
-        if not step_begin_decision.reuse_pending_forward:
+        if not step_begin_decision.consume_launched_forward:
             # attempt to use cuda-graph if possible
             input_ids, position_ids = self._dynamic_step_context_init(is_dummy_forward=True)
             self._dynamic_step_forward_logits(input_ids, position_ids)
@@ -2597,7 +2597,7 @@ class TextGenerationController:
             "top_n_logprobs_by_request_id": top_n_logprobs_by_request_id,
         }
 
-    async def _async_generate_presampled_plain_decode(
+    async def _async_generate_deferred_sample_plain_decode(
         self,
         *,
         skip_bookkeeping: bool = False,
@@ -2607,18 +2607,20 @@ class TextGenerationController:
 
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
-        presampled_txn = self._async_presampled_txn
-        if presampled_txn is None:
+        deferred_sample_txn = self._async_deferred_sample_txn
+        if deferred_sample_txn is None:
             return None
 
-        context.async_txn_diagnostics.record_presampled_commit()
-        self._async_presampled_txn = None
-        cuda_graph_request_count = self._async_presampled_cuda_graph_request_count
-        self._async_presampled_cuda_graph_request_count = None
+        context.async_txn_diagnostics.record_deferred_sample_commit()
+        self._async_deferred_sample_txn = None
+        cuda_graph_request_count = self._async_deferred_sample_cuda_graph_request_count
+        self._async_deferred_sample_cuda_graph_request_count = None
 
         ep_step_begin_decision = self._decide_ep_step_begin(has_real_work=True)
-        if ep_step_begin_decision.discard_pending_forward:
-            self._async_launched_child_txn = None
+        if ep_step_begin_decision.launched_forward_invariant_failed:
+            raise RuntimeError(
+                "async decode launched-child invariant failed before deferred-sample commit"
+            )
         if context.async_scheduling and self.num_speculative_tokens == 0:
             ep_child_launch_plan = self._sync_ep_async_child_launch_plan(
                 active_request_count,
@@ -2627,7 +2629,7 @@ class TextGenerationController:
             if self._ep_async_child_launches(ep_child_launch_plan):
                 raise RuntimeError(
                     "EP async child launch plan selected a normal child while this rank "
-                    "is consuming a presampled decode step"
+                    "is consuming a deferred_sample decode step"
                 )
 
         with torch.inference_mode():
@@ -2648,10 +2650,10 @@ class TextGenerationController:
                     range_push("async_txn_cpu_commit")
                 try:
                     if context.is_hybrid_model:
-                        context.accept_async_mamba_state(presampled_txn.request_ids)
+                        context.accept_async_mamba_state(deferred_sample_txn.request_ids)
                     request_bookkeeping = self._dynamic_step_context_bookkeeping(
                         sampled_tokens_cpu=sampled_tokens_cpu,
-                        async_txn=presampled_txn,
+                        async_txn=deferred_sample_txn,
                     )
                 finally:
                     if commit_range_active:
@@ -2731,29 +2733,29 @@ class TextGenerationController:
         if context.active_token_count == 0 and active_request_count == 0:
             return None
 
-        if context.async_scheduling and self._async_presampled_txn is not None:
-            return await self._async_generate_presampled_plain_decode(
+        if context.async_scheduling and self._async_deferred_sample_txn is not None:
+            return await self._async_generate_deferred_sample_plain_decode(
                 skip_bookkeeping=bool(skip_bookkeeping),
                 profile_async_child_forward=profile_async_child_forward,
             )
 
         ep_step_begin_decision = self._decide_ep_step_begin(has_real_work=True)
-        local_pending_child = self._async_launched_child_txn is not None
-        if ep_step_begin_decision.discard_pending_forward:
-            self._async_launched_child_txn = None
+        local_launched_child = self._async_launched_child_txn is not None
+        if ep_step_begin_decision.launched_forward_invariant_failed:
+            raise RuntimeError("async decode launched-child invariant failed at step begin")
 
         with torch.inference_mode():
-            adopted_child = self._try_adopt_async_child_logits()
+            consumed_child = self._consume_async_child_logits()
             if (
-                local_pending_child
-                and ep_step_begin_decision.reuse_pending_forward
-                and not adopted_child
+                local_launched_child
+                and ep_step_begin_decision.consume_launched_forward
+                and not consumed_child
             ):
-                raise RuntimeError("EP step-begin selected async child adoption, but adoption failed")
+                raise RuntimeError("EP step-begin selected async child consumption, but consumption failed")
             input_ids = None
             position_ids = None
 
-            if not adopted_child:
+            if not consumed_child:
                 input_ids, position_ids = self._dynamic_step_context_init()
 
             cuda_graph_request_count = (
@@ -2762,7 +2764,7 @@ class TextGenerationController:
                 else None
             )
 
-            if not adopted_child:
+            if not consumed_child:
                 # Enable routing recording before forward pass if routing replay is enabled
                 config = self.inference_wrapped_model.model.config
                 if config.moe_enable_routing_replay:
@@ -3014,8 +3016,8 @@ class TextGenerationController:
             if self.num_speculative_tokens > 0:
                 self._accepted_tokens_per_request.fill_(-1)
                 self._accepted_token_counts_per_request.fill_(0)
-            if context.async_scheduling and not adopted_child:
-                context.async_txn_diagnostics.record_adopted()
+            if context.async_scheduling and not consumed_child:
+                context.async_txn_diagnostics.record_consumed()
                 context.async_txn_diagnostics.record_sync_step("serial_wrapped")
             ret.update(request_bookkeeping)
             self._clear_ep_decode_broadcast_plan()

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -796,6 +796,17 @@ class TextGenerationController:
 
             child_txn.adopted = True
             self._async_launched_child_txn = None
+            if (
+                child_txn.forward_timing_start_event is not None
+                and child_txn.forward_timing_done_event is not None
+            ):
+                child_txn.forward_timing_done_event.synchronize()
+                context.async_txn_diagnostics.record_child_forward_gpu_duration(
+                    child_txn.forward_timing_start_event.elapsed_time(
+                        child_txn.forward_timing_done_event
+                    )
+                    * 1000.0
+                )
             context.async_txn_diagnostics.record_adopted()
             return True
         finally:
@@ -916,6 +927,7 @@ class TextGenerationController:
         *,
         h2d_ready_before_sampling: bool = False,
         sample_completed_at: Optional[float] = None,
+        profile_child_forward: bool = False,
     ) -> None:
         """Scatter sampled tokens into the prepared child slot and launch it."""
 
@@ -964,7 +976,13 @@ class TextGenerationController:
 
         range_push("async_txn_launch_child")
         range_push("async_child_forward")
+        if profile_child_forward:
+            child_txn.forward_timing_start_event = torch.cuda.Event(enable_timing=True)
+            child_txn.forward_timing_start_event.record(torch.cuda.current_stream())
         self._dynamic_step_forward_logits(input_ids, position_ids)
+        if profile_child_forward:
+            child_txn.forward_timing_done_event = torch.cuda.Event(enable_timing=True)
+            child_txn.forward_timing_done_event.record(torch.cuda.current_stream())
         child_txn.forward_done_event = child_slot.record_forward_done()
         range_pop()
         range_pop()
@@ -2420,6 +2438,7 @@ class TextGenerationController:
         skip_bookkeeping: Optional[bool] = False,
         *,
         async_launch_barrier_reason: Optional[AsyncTxnSkipReason] = None,
+        profile_async_child_forward: bool = False,
     ) -> Optional[Dict]:
         """Forward step the model and update the inference context.
 
@@ -2604,6 +2623,7 @@ class TextGenerationController:
                     launched_child_txn,
                     h2d_ready_before_sampling=h2d_ready_before_sampling,
                     sample_completed_at=sample_completed_at,
+                    profile_child_forward=profile_async_child_forward,
                 )
                 self._start_async_sample_transfer(active_request_count, sample_ready_event)
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -749,10 +749,6 @@ class TextGenerationController:
             or getattr(self.model_config, "num_moe_experts", None) is not None
         ):
             return AsyncTxnSkipReason.MOE_EP_DEFERRED
-        if self._get_stop_word_finished_ids_callback is not None:
-            return AsyncTxnSkipReason.TERMINAL_CHECK_REQUIRED
-        if return_log_probs or return_top_n_logprobs:
-            return AsyncTxnSkipReason.LOGPROBS_DEFERRED
         if active_request_count != len(child_txn.request_ids):
             return AsyncTxnSkipReason.UNKNOWN_BARRIER
         return None
@@ -1887,6 +1883,55 @@ class TextGenerationController:
             **(update_result or {}),
         }
 
+    def _dynamic_step_publication_by_request_id(
+        self,
+        request_ids: Tensor,
+        sample: Tensor,
+        accepted_tokens: Optional[Tensor],
+        log_probs: Optional[List[List[float]]],
+        top_n_logprobs: Optional[Dict[int, List[Tuple[Tensor, Tensor]]]],
+    ) -> Dict[str, Dict[int, Any]]:
+        """Build post-commit publication artifacts keyed by request id.
+
+        The hot path consumes tensors in row order, but anything externally
+        visible must survive compaction. These maps are built after
+        ``update_requests`` so row indices are translated once at the publication
+        boundary and downstream code can address artifacts by request id.
+        """
+
+        request_id_list = [int(request_id) for request_id in request_ids.tolist()]
+
+        sample_by_request_id = {
+            request_id: tokens for request_id, tokens in zip(request_id_list, sample.tolist())
+        }
+
+        accepted_tokens_by_request_id = {}
+        if accepted_tokens is not None:
+            accepted_tokens_by_request_id = {
+                request_id: tokens
+                for request_id, tokens in zip(request_id_list, accepted_tokens.tolist())
+            }
+
+        log_probs_by_request_id = {}
+        if log_probs is not None:
+            log_probs_by_request_id = {
+                request_id: request_log_probs
+                for request_id, request_log_probs in zip(request_id_list, log_probs)
+            }
+
+        top_n_logprobs_by_request_id = {}
+        if top_n_logprobs is not None:
+            for row_idx, request_top_n in top_n_logprobs.items():
+                if row_idx < len(request_id_list):
+                    top_n_logprobs_by_request_id[request_id_list[row_idx]] = request_top_n
+
+        return {
+            "sample_by_request_id": sample_by_request_id,
+            "accepted_tokens_by_request_id": accepted_tokens_by_request_id,
+            "log_probs_by_request_id": log_probs_by_request_id,
+            "top_n_logprobs_by_request_id": top_n_logprobs_by_request_id,
+        }
+
     async def async_generate_output_tokens_dynamic_batch(
         self, skip_bookkeeping: Optional[bool] = False
     ) -> Optional[Dict]:
@@ -2069,17 +2114,28 @@ class TextGenerationController:
                         context.prepare_child_from_committed_decode_state()
                     )
 
+            accepted_tokens_result = (
+                # Clone needed: .fill_(-1) below would corrupt the returned value.
+                self._accepted_tokens_per_request.clone()
+                if self.num_speculative_tokens > 0 and num_decode_requests > 0
+                else None
+            )
             ret = {
-                "accepted_tokens": (
-                    # Clone needed: .fill_(-1) below would corrupt the returned value.
-                    self._accepted_tokens_per_request.clone()
-                    if self.num_speculative_tokens > 0 and num_decode_requests > 0
-                    else None
-                ),
+                "accepted_tokens": accepted_tokens_result,
                 "log_probs": log_probs,
                 "top_n_logprobs": top_n_logprobs,
                 "cuda_graph_request_count": cuda_graph_request_count,
             }
+            if "active_request_ids" in request_bookkeeping:
+                ret.update(
+                    self._dynamic_step_publication_by_request_id(
+                        request_bookkeeping["active_request_ids"],
+                        request_bookkeeping["sample"],
+                        accepted_tokens_result,
+                        log_probs,
+                        top_n_logprobs,
+                    )
+                )
             if self.num_speculative_tokens > 0:
                 self._accepted_tokens_per_request.fill_(-1)
                 self._accepted_token_counts_per_request.fill_(0)

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -153,6 +153,7 @@ class TextGenerationController:
         self._ep_dummy_sampled_tokens_cuda: Optional[Tensor] = None
         self._ep_dummy_accepted_counts_cuda: Optional[Tensor] = None
         self._dummy_context_h2d_done_event = None
+        self._has_stop_word_constraints_callback = None
 
     def set_stop_word_finished_ids_callback(self, callback):
         """Set a callback to get request IDs that should be marked as finished due to stop words.
@@ -164,6 +165,11 @@ class TextGenerationController:
             callback: Function that returns request IDs to mark as finished.
         """
         self._get_stop_word_finished_ids_callback = callback
+
+    def set_stop_word_constraints_callback(self, callback):
+        """Set a callback that reports whether stop-word state can affect active requests."""
+
+        self._has_stop_word_constraints_callback = callback
 
     def set_ep_async_protocol(self, protocol) -> None:
         """Attach the EP async step protocol for tagged, step-scoped CPU sync."""
@@ -1073,7 +1079,10 @@ class TextGenerationController:
             return False
         if self.num_speculative_tokens > 0:
             return False
-        if self._get_stop_word_finished_ids_callback is not None:
+        if (
+            self._has_stop_word_constraints_callback is not None
+            and self._has_stop_word_constraints_callback(list(parent_txn.request_ids))
+        ):
             return False
         if parent_txn.terminal_request_ids:
             return False
@@ -1115,9 +1124,12 @@ class TextGenerationController:
         )
         ep_chain_plan = self._sync_ep_chain_handoff(active_request_count, can_chain)
         if not (can_chain and self._ep_async_child_launches(ep_chain_plan)):
+            context = self.inference_wrapped_model.inference_context
+            context.async_txn_diagnostics.record_chain_attempt(launched=False)
             return False
 
         context = self.inference_wrapped_model.inference_context
+        context.async_txn_diagnostics.record_chain_attempt(launched=True)
         sampling_started_at = (
             time.perf_counter()
             if context.async_scheduling and context.async_txn_diagnostics.enabled
@@ -2554,6 +2566,7 @@ class TextGenerationController:
         if presampled_txn is None:
             return None
 
+        context.async_txn_diagnostics.record_presampled_commit()
         self._async_presampled_txn = None
         cuda_graph_request_count = self._async_presampled_cuda_graph_request_count
         self._async_presampled_cuda_graph_request_count = None

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1073,7 +1073,11 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         if parent_txn is None or child_txn is None:
             return False
-        if not context.async_scheduling or context.async_decode_slot_ring is None:
+        if (
+            not context.async_scheduling
+            or not getattr(context, "async_chain_scheduling", True)
+            or context.async_decode_slot_ring is None
+        ):
             return False
         if skip_bookkeeping or return_log_probs or return_top_n_logprobs:
             return False

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -150,6 +150,7 @@ class TextGenerationController:
         self._ep_step_begin_decision: Optional[EPStepBeginDecision] = None
         self._ep_dummy_sampled_tokens_cuda: Optional[Tensor] = None
         self._ep_dummy_accepted_counts_cuda: Optional[Tensor] = None
+        self._dummy_context_h2d_done_event = None
 
     def set_stop_word_finished_ids_callback(self, callback):
         """Set a callback to get request IDs that should be marked as finished due to stop words.
@@ -591,7 +592,11 @@ class TextGenerationController:
 
         # Single batch CPU-to-GPU transfer of bookkeeping state.
         range_push("transfer_bookkeeping_to_gpu")
-        context.transfer_bookkeeping_to_gpu()
+        h2d_done_event = context.transfer_bookkeeping_to_gpu(
+            record_done_event=is_dummy_forward
+        )
+        if is_dummy_forward:
+            self._dummy_context_h2d_done_event = h2d_done_event
         range_pop()
 
         set_moe_metadata_sync(unwrapped_model)
@@ -1216,6 +1221,15 @@ class TextGenerationController:
             list(range(plan.active_request_count)),
             finished_request_ids=(),
         )
+
+    def _wait_for_dummy_context_h2d(self) -> None:
+        """Fence dummy metadata H2D before reusing its pinned CPU source buffer."""
+
+        h2d_done_event = self._dummy_context_h2d_done_event
+        if h2d_done_event is None:
+            return
+        h2d_done_event.synchronize()
+        self._dummy_context_h2d_done_event = None
 
     def _rewind_kv_cache(self) -> tuple:
         """Update the KV cache bookkeeping for speculative decoding.
@@ -2064,6 +2078,7 @@ class TextGenerationController:
         finally:
             self._clear_ep_decode_broadcast_plan()
             self._clear_ep_step_begin_decision()
+            self._wait_for_dummy_context_h2d()
             # clear the context of any temporary state from the dummy forward
             context.reset()
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1112,6 +1112,11 @@ class TextGenerationController:
             src_group_rank=self._ep_broadcast_source_rank(),
         )
 
+    def _ep_decode_results_need_collectives(self) -> bool:
+        """Whether decode result tensors have an EP peer consumer this step."""
+
+        return self.num_speculative_tokens > 0
+
     def _ensure_ep_dummy_sampled_tokens(self, active_request_count: int) -> Tensor:
         device = self._ep_decode_collective_device()
         needs_alloc = (
@@ -1153,22 +1158,13 @@ class TextGenerationController:
         if plan is None or not plan.has_real_work or plan.active_request_count <= 0:
             return
 
-        if self.num_speculative_tokens > 0:
-            accepted_counts = self._ensure_ep_dummy_accepted_counts(plan.active_request_count)
-            broadcast_ep_accepted_counts(
-                accepted_counts,
-                plan.active_request_count,
-                group,
-                src_group_rank=plan.src_group_rank,
-            )
-        else:
-            sampled_tokens = self._ensure_ep_dummy_sampled_tokens(plan.active_request_count)
-            broadcast_ep_sampled_tokens(
-                sampled_tokens,
-                plan.active_request_count,
-                group,
-                src_group_rank=plan.src_group_rank,
-            )
+        accepted_counts = self._ensure_ep_dummy_accepted_counts(plan.active_request_count)
+        broadcast_ep_accepted_counts(
+            accepted_counts,
+            plan.active_request_count,
+            group,
+            src_group_rank=plan.src_group_rank,
+        )
 
     def _dummy_decode_stop_word_collective_tail(self) -> None:
         """Mirror the stop-word EP collective after dummy MTP work."""
@@ -1587,8 +1583,9 @@ class TextGenerationController:
             eager=not use_graph,
             cache_key=("sample", n) if use_graph else None,
         )
-        self._sync_ep_decode_broadcast_plan(active_request_count, has_real_work=True)
-        self._ep_broadcast_sampled_tokens(active_request_count)
+        if self._ep_decode_results_need_collectives():
+            self._sync_ep_decode_broadcast_plan(active_request_count, has_real_work=True)
+            self._ep_broadcast_sampled_tokens(active_request_count)
 
     def _dynamic_step_log_probs_bookkeeping(self) -> Tuple[bool, bool]:
         """Perform bookkeeping necessary to compute log probs for dynamic batching.
@@ -2014,10 +2011,11 @@ class TextGenerationController:
                 set_decode_expert_padding(unwrapped_model, False)
 
         try:
-            # The real EP rank performs decode sampling/verification after the
-            # main forward. Dummy ranks must enter the same post-forward
-            # collective phase before any MTP collectives are issued.
-            self._dummy_decode_sample_collective()
+            # The real EP rank performs MTP verification after the main forward.
+            # Dummy ranks only need to mirror decode-result collectives when a
+            # later GPU phase consumes those results on peer ranks.
+            if self._ep_decode_results_need_collectives():
+                self._dummy_decode_sample_collective()
             if self.num_speculative_tokens == 0:
                 self._dummy_decode_async_child_forward_if_planned()
 
@@ -2029,7 +2027,6 @@ class TextGenerationController:
             self._dummy_serial_mtp_forward()
             if self.num_speculative_tokens > 0:
                 self._dummy_decode_async_child_forward_if_planned()
-            self._dummy_decode_stop_word_collective_tail()
         finally:
             self._clear_ep_decode_broadcast_plan()
             self._clear_ep_step_begin_decision()
@@ -2206,9 +2203,6 @@ class TextGenerationController:
         if self._get_stop_word_finished_ids_callback is not None:
             request_ids_list = active_request_ids.tolist()
             stop_word_finished_ids = self._get_stop_word_finished_ids_callback(request_ids_list)
-            stop_word_finished_ids = self._ep_broadcast_stop_word_finished_ids(
-                request_ids_list, stop_word_finished_ids
-            )
             if stop_word_finished_ids:
                 for idx, request_id in enumerate(request_ids_list):
                     if request_id in stop_word_finished_ids:

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -5,7 +5,7 @@ import concurrent
 import copy
 import functools
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, OrderedDict, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, OrderedDict, Tuple, Union
 
 import numpy as np
 import torch
@@ -15,7 +15,13 @@ from torch.cuda.nvtx import range_pop, range_push
 
 from megatron.core import parallel_state
 from megatron.core.inference.async_stream import AsyncStream
-from megatron.core.inference.async_txn import AsyncTxnSkipReason, StepTxn
+from megatron.core.inference.async_txn import (
+    AsyncTxnSkipReason,
+    StepTxn,
+    broadcast_ep_accepted_counts,
+    broadcast_ep_sampled_tokens,
+    broadcast_ep_stop_word_finished_ids,
+)
 from megatron.core.inference.communication_utils import (
     broadcast_from_last_pipeline_stage,
     is_pipeline_last_stage,
@@ -840,6 +846,40 @@ class TextGenerationController:
         self._async_sample_transfer_count = 0
         return sampled_tokens_cpu
 
+    def _expert_parallel_group(self):
+        context = self.inference_wrapped_model.inference_context
+        return getattr(context, "expert_model_parallel_group", None)
+
+    def _ep_broadcast_sampled_tokens(self, active_request_count: int) -> None:
+        group = self._expert_parallel_group()
+        if get_pg_size(group) <= 1:
+            return
+        broadcast_ep_sampled_tokens(self._sampled_tokens_cuda, active_request_count, group)
+
+    def _ep_broadcast_stop_word_finished_ids(
+        self, request_ids: List[int], finished_request_ids: Iterable[int]
+    ) -> set[int]:
+        group = self._expert_parallel_group()
+        if get_pg_size(group) <= 1:
+            return {int(request_id) for request_id in finished_request_ids}
+        device = torch.cuda.current_device() if torch.cuda.is_available() else torch.device("cpu")
+        return broadcast_ep_stop_word_finished_ids(
+            request_ids,
+            finished_request_ids,
+            group,
+            device=device,
+        )
+
+    def _ep_broadcast_mtp_accepted_counts(self, active_request_count: int) -> None:
+        group = self._expert_parallel_group()
+        if get_pg_size(group) <= 1 or self._accepted_token_counts_per_request is None:
+            return
+        broadcast_ep_accepted_counts(
+            self._accepted_token_counts_per_request,
+            active_request_count,
+            group,
+        )
+
     def _rewind_kv_cache(self) -> tuple:
         """Update the KV cache bookkeeping for speculative decoding.
 
@@ -1172,6 +1212,7 @@ class TextGenerationController:
             accepted_tokens_mask,
             input_tokens_required,
         )
+        self._ep_broadcast_mtp_accepted_counts(active_request_count)
         nvtx_range_pop("mtp-spec-decoding/verify/prepare-next")
 
     def _prepare_speculative_tokens_for_next_forward_pass(
@@ -1238,6 +1279,7 @@ class TextGenerationController:
             eager=not use_graph,
             cache_key=("sample", n) if use_graph else None,
         )
+        self._ep_broadcast_sampled_tokens(active_request_count)
 
     def _dynamic_step_log_probs_bookkeeping(self) -> Tuple[bool, bool]:
         """Perform bookkeeping necessary to compute log probs for dynamic batching.
@@ -1830,6 +1872,9 @@ class TextGenerationController:
         if self._get_stop_word_finished_ids_callback is not None:
             request_ids_list = active_request_ids.tolist()
             stop_word_finished_ids = self._get_stop_word_finished_ids_callback(request_ids_list)
+            stop_word_finished_ids = self._ep_broadcast_stop_word_finished_ids(
+                request_ids_list, stop_word_finished_ids
+            )
             if stop_word_finished_ids:
                 for idx, request_id in enumerate(request_ids_list):
                     if request_id in stop_word_finished_ids:

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -18,10 +18,12 @@ from megatron.core import parallel_state
 from megatron.core.inference.async_stream import AsyncStream
 from megatron.core.inference.async_txn import (
     AsyncTxnSkipReason,
+    EPDecodeBroadcastPlan,
     StepTxn,
     broadcast_ep_accepted_counts,
     broadcast_ep_sampled_tokens,
     broadcast_ep_stop_word_finished_ids,
+    resolve_ep_decode_broadcast_plan,
 )
 from megatron.core.inference.communication_utils import (
     broadcast_from_last_pipeline_stage,
@@ -142,6 +144,9 @@ class TextGenerationController:
 
         self._async_prepared_child_txn: Optional[StepTxn] = None
         self._async_launched_child_txn: Optional[StepTxn] = None
+        self._ep_decode_broadcast_plan: Optional[EPDecodeBroadcastPlan] = None
+        self._ep_dummy_sampled_tokens_cuda: Optional[Tensor] = None
+        self._ep_dummy_accepted_counts_cuda: Optional[Tensor] = None
 
     def set_stop_word_finished_ids_callback(self, callback):
         """Set a callback to get request IDs that should be marked as finished due to stop words.
@@ -899,11 +904,55 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         return getattr(context, "expert_model_parallel_group", None)
 
+    def _sync_ep_decode_broadcast_plan(
+        self, active_request_count: int, *, has_real_work: bool
+    ) -> Optional[EPDecodeBroadcastPlan]:
+        """Synchronize source rank and shape for EP decode post-forward collectives."""
+
+        group = self._expert_parallel_group()
+        if get_pg_size(group) <= 1:
+            self._ep_decode_broadcast_plan = None
+            return None
+
+        context = self.inference_wrapped_model.inference_context
+        communicator = getattr(context, "_ep_zmq_communicator", None)
+        plan = resolve_ep_decode_broadcast_plan(
+            active_request_count,
+            group,
+            has_real_work=has_real_work,
+            sync_all_reduce_max_fn=(
+                communicator.sync_all_reduce_max if communicator is not None else None
+            ),
+        )
+        self._ep_decode_broadcast_plan = plan
+        return plan
+
+    def _clear_ep_decode_broadcast_plan(self) -> None:
+        self._ep_decode_broadcast_plan = None
+
+    def _ep_broadcast_source_rank(self) -> int:
+        if self._ep_decode_broadcast_plan is not None:
+            return self._ep_decode_broadcast_plan.src_group_rank
+        return 0
+
+    def _ep_decode_collective_device(self) -> torch.device:
+        if torch.cuda.is_available():
+            return torch.device("cuda", torch.cuda.current_device())
+        return torch.device("cpu")
+
     def _ep_broadcast_sampled_tokens(self, active_request_count: int) -> None:
         group = self._expert_parallel_group()
         if get_pg_size(group) <= 1:
             return
-        broadcast_ep_sampled_tokens(self._sampled_tokens_cuda, active_request_count, group)
+        plan = self._ep_decode_broadcast_plan
+        if plan is not None:
+            active_request_count = plan.active_request_count
+        broadcast_ep_sampled_tokens(
+            self._sampled_tokens_cuda,
+            active_request_count,
+            group,
+            src_group_rank=self._ep_broadcast_source_rank(),
+        )
 
     def _ep_broadcast_stop_word_finished_ids(
         self, request_ids: List[int], finished_request_ids: Iterable[int]
@@ -911,22 +960,102 @@ class TextGenerationController:
         group = self._expert_parallel_group()
         if get_pg_size(group) <= 1:
             return {int(request_id) for request_id in finished_request_ids}
-        device = torch.cuda.current_device() if torch.cuda.is_available() else torch.device("cpu")
+        device = self._ep_decode_collective_device()
         return broadcast_ep_stop_word_finished_ids(
             request_ids,
             finished_request_ids,
             group,
             device=device,
+            src_group_rank=self._ep_broadcast_source_rank(),
         )
 
     def _ep_broadcast_mtp_accepted_counts(self, active_request_count: int) -> None:
         group = self._expert_parallel_group()
         if get_pg_size(group) <= 1 or self._accepted_token_counts_per_request is None:
             return
+        plan = self._ep_decode_broadcast_plan
+        if plan is not None:
+            active_request_count = plan.active_request_count
         broadcast_ep_accepted_counts(
             self._accepted_token_counts_per_request,
             active_request_count,
             group,
+            src_group_rank=self._ep_broadcast_source_rank(),
+        )
+
+    def _ensure_ep_dummy_sampled_tokens(self, active_request_count: int) -> Tensor:
+        device = self._ep_decode_collective_device()
+        needs_alloc = (
+            self._ep_dummy_sampled_tokens_cuda is None
+            or self._ep_dummy_sampled_tokens_cuda.numel() < active_request_count
+            or self._ep_dummy_sampled_tokens_cuda.device != device
+        )
+        if needs_alloc:
+            self._ep_dummy_sampled_tokens_cuda = torch.zeros(
+                active_request_count, dtype=torch.int64, device=device
+            )
+        else:
+            self._ep_dummy_sampled_tokens_cuda[:active_request_count].zero_()
+        return self._ep_dummy_sampled_tokens_cuda
+
+    def _ensure_ep_dummy_accepted_counts(self, active_request_count: int) -> Tensor:
+        device = self._ep_decode_collective_device()
+        needs_alloc = (
+            self._ep_dummy_accepted_counts_cuda is None
+            or self._ep_dummy_accepted_counts_cuda.numel() < active_request_count
+            or self._ep_dummy_accepted_counts_cuda.device != device
+        )
+        if needs_alloc:
+            self._ep_dummy_accepted_counts_cuda = torch.zeros(
+                active_request_count, dtype=torch.int64, device=device
+            )
+        else:
+            self._ep_dummy_accepted_counts_cuda[:active_request_count].zero_()
+        return self._ep_dummy_accepted_counts_cuda
+
+    def _dummy_decode_sample_collective(self) -> None:
+        """Mirror the decode sampling/verification EP collective on dummy ranks."""
+
+        group = self._expert_parallel_group()
+        if get_pg_size(group) <= 1:
+            return
+
+        plan = self._sync_ep_decode_broadcast_plan(0, has_real_work=False)
+        if plan is None or not plan.has_real_work or plan.active_request_count <= 0:
+            return
+
+        if self.num_speculative_tokens > 0:
+            accepted_counts = self._ensure_ep_dummy_accepted_counts(plan.active_request_count)
+            broadcast_ep_accepted_counts(
+                accepted_counts,
+                plan.active_request_count,
+                group,
+                src_group_rank=plan.src_group_rank,
+            )
+        else:
+            sampled_tokens = self._ensure_ep_dummy_sampled_tokens(plan.active_request_count)
+            broadcast_ep_sampled_tokens(
+                sampled_tokens,
+                plan.active_request_count,
+                group,
+                src_group_rank=plan.src_group_rank,
+            )
+
+    def _dummy_decode_stop_word_collective_tail(self) -> None:
+        """Mirror the stop-word EP collective after dummy MTP work."""
+
+        plan = self._ep_decode_broadcast_plan
+        if (
+            plan is None
+            or not plan.has_real_work
+            or plan.active_request_count <= 0
+            or self._get_stop_word_finished_ids_callback is None
+        ):
+            return
+
+        self._ep_broadcast_stop_word_finished_ids(
+            list(range(plan.active_request_count)),
+            finished_request_ids=(),
         )
 
     def _rewind_kv_cache(self) -> tuple:
@@ -1261,6 +1390,7 @@ class TextGenerationController:
             accepted_tokens_mask,
             input_tokens_required,
         )
+        self._sync_ep_decode_broadcast_plan(active_request_count, has_real_work=True)
         self._ep_broadcast_mtp_accepted_counts(active_request_count)
         nvtx_range_pop("mtp-spec-decoding/verify/prepare-next")
 
@@ -1328,6 +1458,7 @@ class TextGenerationController:
             eager=not use_graph,
             cache_key=("sample", n) if use_graph else None,
         )
+        self._sync_ep_decode_broadcast_plan(active_request_count, has_real_work=True)
         self._ep_broadcast_sampled_tokens(active_request_count)
 
     def _dynamic_step_log_probs_bookkeeping(self) -> Tuple[bool, bool]:
@@ -1751,15 +1882,23 @@ class TextGenerationController:
                 unwrapped_model = unwrap_model(self.inference_wrapped_model.model)
                 set_decode_expert_padding(unwrapped_model, False)
 
-        # When speculative decoding is active, the real EP ranks perform serial
-        # MTP forward passes after the main forward pass. MTP layers may contain
-        # MoE sublayers (inherited from the decoder spec), which require EP
-        # all-to-all collectives. The dummy rank must participate in these
-        # collectives to avoid a hang.
-        self._dummy_serial_mtp_forward()
+        try:
+            # The real EP rank performs decode sampling/verification after the
+            # main forward. Dummy ranks must enter the same post-forward
+            # collective phase before any MTP collectives are issued.
+            self._dummy_decode_sample_collective()
 
-        # clear the context of any temporary state from the dummy forward
-        context.reset()
+            # When speculative decoding is active, the real EP ranks perform serial
+            # MTP forward passes after the main forward pass. MTP layers may contain
+            # MoE sublayers (inherited from the decoder spec), which require EP
+            # all-to-all collectives. The dummy rank must participate in these
+            # collectives to avoid a hang.
+            self._dummy_serial_mtp_forward()
+            self._dummy_decode_stop_word_collective_tail()
+        finally:
+            self._clear_ep_decode_broadcast_plan()
+            # clear the context of any temporary state from the dummy forward
+            context.reset()
 
     @torch.inference_mode()
     def _dummy_serial_mtp_forward(self):
@@ -2277,6 +2416,7 @@ class TextGenerationController:
                 context.async_txn_diagnostics.record_adopted()
                 context.async_txn_diagnostics.record_sync_step("serial_wrapped")
             ret.update(request_bookkeeping)
+            self._clear_ep_decode_broadcast_plan()
             return ret
 
     @torch.inference_mode()

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -808,6 +808,8 @@ class TextGenerationController:
                 self._async_launched_child_txn = None
                 raise RuntimeError("async decode child adoption invariant failed")
 
+            if context.is_hybrid_model:
+                context.accept_async_mamba_state(child_txn.request_ids)
             child_txn.adopted = True
             self._async_launched_child_txn = None
             if (
@@ -2645,6 +2647,8 @@ class TextGenerationController:
                 if commit_range_active:
                     range_push("async_txn_cpu_commit")
                 try:
+                    if context.is_hybrid_model:
+                        context.accept_async_mamba_state(presampled_txn.request_ids)
                     request_bookkeeping = self._dynamic_step_context_bookkeeping(
                         sampled_tokens_cpu=sampled_tokens_cpu,
                         async_txn=presampled_txn,

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -718,16 +718,14 @@ class TextGenerationController:
         else:
             self._all_logits_cuda = logits
 
-    def _async_decode_cuda_graph_key(self, slot=None) -> Optional[tuple]:
-        """Return the decode graph key for the currently active shape and slot."""
+    def _async_decode_cuda_graph_key(self, slot=None) -> Optional[Any]:
+        """Return the active decode graph shape key, if CUDA graphs are active."""
 
         context = self.inference_wrapped_model.inference_context
-        slot = slot or context.active_decode_slot()
-        if slot is None:
+        del slot
+        if not context.using_cuda_graph_this_step():
             return None
-        return slot.cuda_graph_key(
-            ("decode", context.padded_active_request_count, context.padded_active_token_count)
-        )
+        return context.padded_batch_dimensions
 
     def _async_active_request_ids(self) -> tuple[int, ...]:
         """Return committed active request ids as plain ints."""

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -2502,14 +2502,11 @@ class TextGenerationController:
                         range_pop()
                 range_pop()
 
-        # This is the best place to yield control back to event loop.
-        # At this point we have enqueued FW pass GPU kernels asynchronously.
-        # While they are running, we can do other useful CPU work.
-        # Note: This can be moved further ahead if sampling can be made
-        # asynchronous.
-        # Todo [Siddharth]: Can we condition the sleep on a cuda event?
-        # NOTE [TDE]: This will be moved once CPU and GPU methods are separated.
-        await asyncio.sleep(0)
+        # Yield only when there is no async child ready to chain. With an async
+        # child staged, the lowest-gap decode path is to immediately enqueue
+        # sampling and the child forward behind the current forward.
+        if not (context.async_scheduling and self._async_prepared_child_txn is not None):
+            await asyncio.sleep(0)
 
         with torch.inference_mode():
             range_push("sampling")

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -201,6 +201,12 @@ class TextGenerationController:
         #     - `self._sampled_tokens_cuda` is rebound to the output of `sample_kernel`,
         #     which uses CudaGraphManager syntactic sugar to keep it as a static tensor.
         self._sampled_tokens_cuda = None
+        self._greedy_sample_values_cuda = torch.empty(
+            max_requests, dtype=logits_dtype, device=device
+        )
+        self._greedy_sampled_tokens_cuda = torch.empty(
+            max_requests, dtype=torch.int64, device=device
+        )
         self._async_sampled_tokens_cpu = (
             torch.empty(max_requests, dtype=torch.int64, pin_memory=True)
             if context.async_scheduling
@@ -1601,6 +1607,54 @@ class TextGenerationController:
         # Expose the active slice so downstream code sees the right length.
         self._last_accepted_seq_indices = self._last_accepted_seq_indices_buf[:active_request_count]
 
+    def _active_requests_use_greedy_sampling(
+        self, active_request_count: Optional[int] = None
+    ) -> bool:
+        """Return whether active requests are deterministic greedy requests."""
+
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+            if active_request_count is None
+            else active_request_count
+        )
+        if active_request_count <= 0:
+            return True
+
+        active_metadata = context.active_request_metadata
+        active_slice = slice(0, active_request_count)
+        return bool(
+            (active_metadata["top_k"][active_slice] == 1).all()
+            and (active_metadata["top_p"][active_slice] == 0.0).all()
+        )
+
+    def _dynamic_step_required_token_logits(self) -> Tensor:
+        """Return the per-active-request logits consumed by normal decode sampling."""
+
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = context.total_request_count - context.paused_request_count
+        if context.config.materialize_only_last_token_logits:
+            return self._all_logits_cuda.squeeze(0)[:active_request_count, :]
+        return context.last_token_logits(
+            self._all_logits_cuda[:, : context.padded_active_token_count, :]
+        )
+
+    def _dynamic_step_sample_logits_greedy(self) -> None:
+        """Greedy-sample logits into the stable sampled-token buffer."""
+
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = context.total_request_count - context.paused_request_count
+        required_token_logits = self._dynamic_step_required_token_logits()
+        torch.max(
+            required_token_logits[:active_request_count],
+            dim=-1,
+            out=(
+                self._greedy_sample_values_cuda[:active_request_count],
+                self._greedy_sampled_tokens_cuda[:active_request_count],
+            ),
+        )
+        self._sampled_tokens_cuda = self._greedy_sampled_tokens_cuda
+
     def _dynamic_step_sample_logits(self):
         """Sample tokens from logits for dynamic batching."""
         # TODO(ksanthanam): Evaluate whether it makes more sense to sample on 1 rank
@@ -1608,6 +1662,13 @@ class TextGenerationController:
 
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
+        if self._active_requests_use_greedy_sampling(active_request_count):
+            self._dynamic_step_sample_logits_greedy()
+            if self._ep_decode_results_need_collectives():
+                self._sync_ep_decode_broadcast_plan(active_request_count, has_real_work=True)
+                self._ep_broadcast_sampled_tokens(active_request_count)
+            return
+
         use_graph = (
             self._sampling_backend == "flashinfer"
             and self._enable_cuda_graph

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1758,6 +1758,8 @@ class TextGenerationController:
             # Must be done before update_requests while token-to-block mappings are valid.
             # Reconstruction happens from blocks at request completion.
             context.kv_block_allocator.store_routing_per_block(self._router_record_bookkeeping())
+            if context.async_scheduling and context.async_decode_slot_ring is not None:
+                context.async_decode_slot_ring.current.record_forward_done()
             range_pop()
 
         # This is the best place to yield control back to event loop.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -145,6 +145,8 @@ class TextGenerationController:
 
         self._async_prepared_child_txn: Optional[StepTxn] = None
         self._async_launched_child_txn: Optional[StepTxn] = None
+        self._async_presampled_txn: Optional[StepTxn] = None
+        self._async_presampled_cuda_graph_request_count: Optional[int] = None
         self._ep_decode_broadcast_plan: Optional[EPDecodeBroadcastPlan] = None
         self._ep_async_protocol = None
         self._ep_step_begin_decision: Optional[EPStepBeginDecision] = None
@@ -1050,6 +1052,102 @@ class TextGenerationController:
         self._async_sample_transfer_count = 0
         return sampled_tokens_cpu
 
+    def _can_chain_plain_decode_child(
+        self,
+        parent_txn: Optional[StepTxn],
+        child_txn: Optional[StepTxn],
+        *,
+        active_request_count: int,
+        return_log_probs: bool,
+        return_top_n_logprobs: bool,
+        skip_bookkeeping: bool,
+    ) -> bool:
+        """Return whether sampling+next-forward may be enqueued without CPU observation."""
+
+        context = self.inference_wrapped_model.inference_context
+        if parent_txn is None or child_txn is None:
+            return False
+        if not context.async_scheduling or context.async_decode_slot_ring is None:
+            return False
+        if skip_bookkeeping or return_log_probs or return_top_n_logprobs:
+            return False
+        if self.num_speculative_tokens > 0:
+            return False
+        if self._get_stop_word_finished_ids_callback is not None:
+            return False
+        if parent_txn.terminal_request_ids:
+            return False
+        if active_request_count != len(parent_txn.request_ids):
+            return False
+        if context.plain_decode_child_needs_terminal_check(active_request_count):
+            return False
+        return True
+
+    def _sync_ep_chain_handoff(self, active_request_count: int, can_chain: bool) -> EPDecodeBroadcastPlan:
+        """Synchronize the optional chained child launch across EP peers."""
+
+        return self._sync_ep_async_child_launch_plan(
+            active_request_count if can_chain else 0,
+            can_launch_real_child=can_chain,
+            phase=EPAsyncPhase.ASYNC_CHAIN_HANDOFF,
+        )
+
+    def _try_chain_plain_decode_child(
+        self,
+        parent_txn: Optional[StepTxn],
+        child_txn: Optional[StepTxn],
+        *,
+        active_request_count: int,
+        return_log_probs: bool = False,
+        return_top_n_logprobs: bool = False,
+        skip_bookkeeping: bool = False,
+        profile_child_forward: bool = False,
+    ) -> bool:
+        """Enqueue parent sampling and the prepared child forward as one GPU chain."""
+
+        can_chain = self._can_chain_plain_decode_child(
+            parent_txn,
+            child_txn,
+            active_request_count=active_request_count,
+            return_log_probs=return_log_probs,
+            return_top_n_logprobs=return_top_n_logprobs,
+            skip_bookkeeping=skip_bookkeeping,
+        )
+        ep_chain_plan = self._sync_ep_chain_handoff(active_request_count, can_chain)
+        if not (can_chain and self._ep_async_child_launches(ep_chain_plan)):
+            return False
+
+        context = self.inference_wrapped_model.inference_context
+        sampling_started_at = (
+            time.perf_counter()
+            if context.async_scheduling and context.async_txn_diagnostics.enabled
+            else None
+        )
+        range_push("async_txn_chain_sample")
+        try:
+            self._dynamic_step_sample_logits()
+        finally:
+            range_pop()
+        sample_completed_at = time.perf_counter()
+        if sampling_started_at is not None:
+            context.async_txn_diagnostics.record_sampling_block_duration(
+                (sample_completed_at - sampling_started_at) * 1_000_000
+            )
+
+        sample_ready_event = self._record_async_sample_ready_event()
+        self._launch_async_decode_child(
+            child_txn,
+            h2d_ready_before_sampling=child_txn.h2d_ready(),
+            sample_completed_at=sample_completed_at,
+            profile_child_forward=profile_child_forward,
+        )
+        self._start_async_sample_transfer(active_request_count, sample_ready_event)
+        self._async_presampled_txn = parent_txn
+        self._async_presampled_cuda_graph_request_count = (
+            context.padded_active_request_count if context.using_cuda_graph_this_step() else None
+        )
+        return True
+
     def _expert_parallel_group(self):
         context = self.inference_wrapped_model.inference_context
         return getattr(context, "expert_model_parallel_group", None)
@@ -1076,7 +1174,11 @@ class TextGenerationController:
         return plan
 
     def _sync_ep_async_child_launch_plan(
-        self, active_request_count: int, *, can_launch_real_child: bool
+        self,
+        active_request_count: int,
+        *,
+        can_launch_real_child: bool,
+        phase: EPAsyncPhase = EPAsyncPhase.ASYNC_CHILD_HANDOFF,
     ) -> EPDecodeBroadcastPlan:
         """Synchronize whether the EP group will enter an async child forward phase."""
 
@@ -1104,9 +1206,7 @@ class TextGenerationController:
                 ),
                 has_real_work=bool(can_launch_real_child),
                 group=group,
-                sync_all_reduce_max_fn=self._ep_sync_all_reduce_max_fn(
-                    EPAsyncPhase.ASYNC_CHILD_HANDOFF
-                ),
+                sync_all_reduce_max_fn=self._ep_sync_all_reduce_max_fn(phase),
             )
             return plan
         finally:
@@ -2145,6 +2245,9 @@ class TextGenerationController:
                 self._dummy_decode_sample_collective()
             if self.num_speculative_tokens == 0:
                 self._dummy_decode_async_child_forward_if_planned()
+                self._dummy_decode_async_child_forward_if_planned(
+                    phase=EPAsyncPhase.ASYNC_CHAIN_HANDOFF
+                )
 
             # When speculative decoding is active, the real EP ranks perform serial
             # MTP forward passes after the main forward pass. MTP layers may contain
@@ -2161,10 +2264,14 @@ class TextGenerationController:
             # clear the context of any temporary state from the dummy forward
             context.reset()
 
-    def _dummy_decode_async_child_forward_if_planned(self) -> None:
+    def _dummy_decode_async_child_forward_if_planned(
+        self, *, phase: EPAsyncPhase = EPAsyncPhase.ASYNC_CHILD_HANDOFF
+    ) -> None:
         """Mirror a real EP rank's async child forward phase on dummy ranks."""
 
-        plan = self._sync_ep_async_child_launch_plan(0, can_launch_real_child=False)
+        plan = self._sync_ep_async_child_launch_plan(
+            0, can_launch_real_child=False, phase=phase
+        )
         if not self._ep_async_child_launches(plan):
             return
 
@@ -2433,6 +2540,99 @@ class TextGenerationController:
             "top_n_logprobs_by_request_id": top_n_logprobs_by_request_id,
         }
 
+    async def _async_generate_presampled_plain_decode(
+        self,
+        *,
+        skip_bookkeeping: bool = False,
+        profile_async_child_forward: bool = False,
+    ) -> Optional[Dict]:
+        """Commit a decode token whose sampling was already enqueued behind a child forward."""
+
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = context.total_request_count - context.paused_request_count
+        presampled_txn = self._async_presampled_txn
+        if presampled_txn is None:
+            return None
+
+        self._async_presampled_txn = None
+        cuda_graph_request_count = self._async_presampled_cuda_graph_request_count
+        self._async_presampled_cuda_graph_request_count = None
+
+        ep_step_begin_decision = self._decide_ep_step_begin(has_real_work=True)
+        if ep_step_begin_decision.discard_pending_forward:
+            self._async_launched_child_txn = None
+
+        with torch.inference_mode():
+            sampled_tokens_cpu = self._consume_async_sample_transfer(active_request_count)
+            if sampled_tokens_cpu is None:
+                sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
+
+            if skip_bookkeeping:
+                request_bookkeeping = {"sample": sampled_tokens_cpu}
+                if context.async_scheduling and self.num_speculative_tokens == 0:
+                    self._sync_ep_chain_handoff(active_request_count, False)
+            else:
+                commit_started_at = (
+                    time.perf_counter() if context.async_txn_diagnostics.enabled else None
+                )
+                commit_range_active = context.async_scheduling
+                if commit_range_active:
+                    range_push("async_txn_cpu_commit")
+                try:
+                    request_bookkeeping = self._dynamic_step_context_bookkeeping(
+                        sampled_tokens_cpu=sampled_tokens_cpu,
+                        async_txn=presampled_txn,
+                    )
+                finally:
+                    if commit_range_active:
+                        range_pop()
+                    if commit_started_at is not None:
+                        context.async_txn_diagnostics.record_commit_duration(
+                            (time.perf_counter() - commit_started_at) * 1_000_000
+                        )
+
+                if self._async_launched_child_txn is not None:
+                    range_push("async_txn_child_prestage")
+                    try:
+                        self._async_prepared_child_txn = (
+                            self._prepare_async_child_from_committed_decode_state()
+                        )
+                    finally:
+                        range_pop()
+
+                if context.async_scheduling and self.num_speculative_tokens == 0:
+                    next_active_request_count = (
+                        context.total_request_count - context.paused_request_count
+                    )
+                    self._try_chain_plain_decode_child(
+                        self._async_launched_child_txn,
+                        self._async_prepared_child_txn,
+                        active_request_count=next_active_request_count,
+                        skip_bookkeeping=skip_bookkeeping,
+                        profile_child_forward=profile_async_child_forward,
+                    )
+
+            ret = {
+                "accepted_tokens": None,
+                "log_probs": None,
+                "top_n_logprobs": None,
+                "cuda_graph_request_count": cuda_graph_request_count,
+            }
+            if "active_request_ids" in request_bookkeeping:
+                ret.update(
+                    self._dynamic_step_publication_by_request_id(
+                        request_bookkeeping["active_request_ids"],
+                        request_bookkeeping["sample"],
+                        None,
+                        None,
+                        None,
+                    )
+                )
+            ret.update(request_bookkeeping)
+            self._clear_ep_decode_broadcast_plan()
+            self._clear_ep_step_begin_decision()
+            return ret
+
     async def async_generate_output_tokens_dynamic_batch(
         self,
         skip_bookkeeping: Optional[bool] = False,
@@ -2460,6 +2660,12 @@ class TextGenerationController:
         # No tokens and no active requests?
         if context.active_token_count == 0 and active_request_count == 0:
             return None
+
+        if context.async_scheduling and self._async_presampled_txn is not None:
+            return await self._async_generate_presampled_plain_decode(
+                skip_bookkeeping=bool(skip_bookkeeping),
+                profile_async_child_forward=profile_async_child_forward,
+            )
 
         ep_step_begin_decision = self._decide_ep_step_begin(has_real_work=True)
         local_pending_child = self._async_launched_child_txn is not None
@@ -2663,6 +2869,8 @@ class TextGenerationController:
                 request_bookkeeping = {
                     "sample": self._sampled_tokens_cuda[:active_request_count].cpu()
                 }
+                if context.async_scheduling and self.num_speculative_tokens == 0:
+                    self._sync_ep_chain_handoff(active_request_count, False)
             else:
                 # request_bookkeeping supplies "sample" as the already-CPU
                 # tensor produced by _transfer_samples_to_cpu.
@@ -2697,6 +2905,19 @@ class TextGenerationController:
                         )
                     finally:
                         range_pop()
+                if context.async_scheduling and self.num_speculative_tokens == 0:
+                    next_active_request_count = (
+                        context.total_request_count - context.paused_request_count
+                    )
+                    self._try_chain_plain_decode_child(
+                        launched_child_txn,
+                        self._async_prepared_child_txn,
+                        active_request_count=next_active_request_count,
+                        return_log_probs=return_log_probs,
+                        return_top_n_logprobs=return_top_n_logprobs,
+                        skip_bookkeeping=skip_bookkeeping,
+                        profile_child_forward=profile_async_child_forward,
+                    )
 
             accepted_tokens_result = (
                 # Clone needed: .fill_(-1) below would corrupt the returned value.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -31,7 +31,7 @@ from megatron.core.inference.communication_utils import (
 )
 from megatron.core.inference.contexts.dynamic_context import MaxSequenceLengthOverflowError
 from megatron.core.inference.contexts.static_context import StaticInferenceContext
-from megatron.core.inference.ep_async_protocol import EPAsyncPhase
+from megatron.core.inference.ep_async_protocol import EPAsyncPhase, EPStepBeginDecision
 from megatron.core.inference.inference_request import InferenceRequest, Status
 from megatron.core.inference.model_inference_wrappers.abstract_model_inference_wrapper import (
     AbstractModelInferenceWrapper,
@@ -147,6 +147,7 @@ class TextGenerationController:
         self._async_launched_child_txn: Optional[StepTxn] = None
         self._ep_decode_broadcast_plan: Optional[EPDecodeBroadcastPlan] = None
         self._ep_async_protocol = None
+        self._ep_step_begin_decision: Optional[EPStepBeginDecision] = None
         self._ep_dummy_sampled_tokens_cuda: Optional[Tensor] = None
         self._ep_dummy_accepted_counts_cuda: Optional[Tensor] = None
 
@@ -715,6 +716,48 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         active_slice = slice(context.paused_request_count, context.total_request_count)
         return tuple(int(request_id) for request_id in context.request_ids[active_slice].tolist())
+
+    def _pending_async_child_reusable(self) -> bool:
+        """Return whether the launched child transaction can be this step's forward."""
+
+        child_txn = self._async_launched_child_txn
+        if child_txn is None:
+            return False
+        context = self.inference_wrapped_model.inference_context
+        if not context.async_scheduling:
+            return False
+        return child_txn.guard_adoption(
+            self._async_active_request_ids(),
+            terminal_request_ids=child_txn.terminal_request_ids,
+            decode_only=context.is_decode_only(),
+            cuda_graph_key=self._async_decode_cuda_graph_key(),
+        )
+
+    def _decide_ep_step_begin(self, *, has_real_work: bool) -> EPStepBeginDecision:
+        """Synchronize whether this EP step reuses the previous async child forward."""
+
+        has_pending_forward = self._async_launched_child_txn is not None
+        pending_forward_reusable = (
+            self._pending_async_child_reusable() if has_pending_forward else False
+        )
+        if self._ep_async_protocol is not None and self._ep_async_protocol.enabled:
+            decision = self._ep_async_protocol.decide_step_begin(
+                has_real_work=has_real_work,
+                has_pending_forward=has_pending_forward,
+                pending_forward_reusable=pending_forward_reusable,
+            )
+        else:
+            decision = EPStepBeginDecision(
+                step_id=-1,
+                has_real_work=has_real_work,
+                reuse_pending_forward=bool(has_pending_forward and pending_forward_reusable),
+                discard_pending_forward=bool(has_pending_forward and not pending_forward_reusable),
+            )
+        self._ep_step_begin_decision = decision
+        return decision
+
+    def _clear_ep_step_begin_decision(self) -> None:
+        self._ep_step_begin_decision = None
 
     def _try_adopt_async_child_logits(self) -> bool:
         """Consume logits from a previously launched child forward if still valid."""
@@ -1956,10 +1999,12 @@ class TextGenerationController:
         on ranks that do not have any real requests. It may run in eager mode."""
 
         context = self.inference_wrapped_model.inference_context
+        step_begin_decision = self._decide_ep_step_begin(has_real_work=False)
 
-        # attempt to use cuda-graph if possible
-        input_ids, position_ids = self._dynamic_step_context_init(is_dummy_forward=True)
-        self._dynamic_step_forward_logits(input_ids, position_ids)
+        if not step_begin_decision.reuse_pending_forward:
+            # attempt to use cuda-graph if possible
+            input_ids, position_ids = self._dynamic_step_context_init(is_dummy_forward=True)
+            self._dynamic_step_forward_logits(input_ids, position_ids)
 
         # Disable MoE padding for MTP computation, unless CUDA graphs
         # are active (the graphs were captured with padding enabled).
@@ -1987,6 +2032,7 @@ class TextGenerationController:
             self._dummy_decode_stop_word_collective_tail()
         finally:
             self._clear_ep_decode_broadcast_plan()
+            self._clear_ep_step_begin_decision()
             # clear the context of any temporary state from the dummy forward
             context.reset()
 
@@ -2292,8 +2338,19 @@ class TextGenerationController:
         if context.active_token_count == 0 and active_request_count == 0:
             return None
 
+        ep_step_begin_decision = self._decide_ep_step_begin(has_real_work=True)
+        local_pending_child = self._async_launched_child_txn is not None
+        if ep_step_begin_decision.discard_pending_forward:
+            self._async_launched_child_txn = None
+
         with torch.inference_mode():
             adopted_child = self._try_adopt_async_child_logits()
+            if (
+                local_pending_child
+                and ep_step_begin_decision.reuse_pending_forward
+                and not adopted_child
+            ):
+                raise RuntimeError("EP step-begin selected async child adoption, but adoption failed")
             input_ids = None
             position_ids = None
 
@@ -2540,6 +2597,7 @@ class TextGenerationController:
                 context.async_txn_diagnostics.record_sync_step("serial_wrapped")
             ret.update(request_bookkeeping)
             self._clear_ep_decode_broadcast_plan()
+            self._clear_ep_step_begin_decision()
             return ret
 
     @torch.inference_mode()

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1017,7 +1017,12 @@ class TextGenerationController:
         return event
 
     def _start_async_sample_transfer(self, active_request_count: int, sample_ready_event) -> None:
-        """Start sampled-token D2H after child launch without waiting on child forward."""
+        """Start sampled-token D2H at the sample boundary.
+
+        The copy stream waits only for sampling, not for the child forward. This keeps the
+        transaction accept path from paying for sampled-token D2H after the child forward
+        has already been launched.
+        """
 
         if (
             sample_ready_event is None
@@ -1151,13 +1156,13 @@ class TextGenerationController:
             )
 
         sample_ready_event = self._record_async_sample_ready_event()
+        self._start_async_sample_transfer(active_request_count, sample_ready_event)
         self._launch_async_decode_child(
             child_txn,
             h2d_ready_before_sampling=child_txn.h2d_ready(),
             sample_completed_at=sample_completed_at,
             profile_child_forward=profile_child_forward,
         )
-        self._start_async_sample_transfer(active_request_count, sample_ready_event)
         self._async_presampled_txn = parent_txn
         self._async_presampled_cuda_graph_request_count = (
             context.padded_active_request_count if context.using_cuda_graph_this_step() else None
@@ -2852,13 +2857,13 @@ class TextGenerationController:
             ):
                 launched_child_txn = self._async_prepared_child_txn
                 sample_ready_event = self._record_async_sample_ready_event()
+                self._start_async_sample_transfer(active_request_count, sample_ready_event)
                 self._launch_async_decode_child(
                     launched_child_txn,
                     h2d_ready_before_sampling=h2d_ready_before_sampling,
                     sample_completed_at=sample_completed_at,
                     profile_child_forward=profile_async_child_forward,
                 )
-                self._start_async_sample_transfer(active_request_count, sample_ready_event)
 
             if return_log_probs or return_top_n_logprobs:
                 if self.num_speculative_tokens > 0:

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1681,6 +1681,8 @@ class TextGenerationController:
         update_result = context.update_requests(
             active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
         )
+        if context.request_rng_store is not None and finished_request_ids.numel() > 0:
+            context.request_rng_store.remove_many(finished_request_ids.tolist())
         range_pop()
 
         return {
@@ -1721,6 +1723,13 @@ class TextGenerationController:
 
         with torch.inference_mode():
             input_ids, position_ids = self._dynamic_step_context_init()
+            async_eligibility = None
+            if context.async_scheduling:
+                async_eligibility = context.async_launch_eligibility()
+                if async_eligibility.eligible:
+                    context.async_txn_diagnostics.record_prepared(under_forward=False)
+                else:
+                    context.async_txn_diagnostics.record_barrier_skip(async_eligibility.reason)
 
             cuda_graph_request_count = (
                 context.padded_active_request_count
@@ -1844,6 +1853,9 @@ class TextGenerationController:
             if self.num_speculative_tokens > 0:
                 self._accepted_tokens_per_request.fill_(-1)
                 self._accepted_token_counts_per_request.fill_(0)
+            if context.async_scheduling:
+                context.async_txn_diagnostics.record_adopted()
+                context.async_txn_diagnostics.record_sync_step("serial_wrapped")
             ret.update(request_bookkeeping)
             return ret
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -977,7 +977,11 @@ class TextGenerationController:
         )
         range_pop()
 
-        context.bind_decode_slot(child_slot)
+        bind_slot_for_forward = getattr(context, "bind_decode_slot_for_forward", None)
+        if bind_slot_for_forward is not None:
+            bind_slot_for_forward(child_slot)
+        else:
+            context.bind_decode_slot(child_slot)
         input_ids, position_ids = context.current_input_and_position_ids()
 
         sample_to_launch_latency_us = None

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -722,13 +722,17 @@ class TextGenerationController:
     def _async_decode_cuda_graph_key(self, slot=None) -> Optional[Any]:
         """Return the graph key used to guard async child adoption.
 
-        Async child forwards intentionally run outside the full-iteration CUDA graph
-        cache. The cache is keyed by the committed step shape, but the child path
-        owns separate transient metadata buffers and must not depend on a replayed
-        graph captured for the persistent context.
+        CUDA-graph child forwards replay the normal committed-step graph by
+        staging the next-step metadata into the current decode slot after
+        sampling. Separate child-slot forwards intentionally do not use this key,
+        because they cannot safely replay a graph captured with current-slot
+        tensor addresses.
         """
 
         del slot
+        context = self.inference_wrapped_model.inference_context
+        if context.using_cuda_graph_this_step() and context.replay_cuda_graph_this_step():
+            return context.cuda_graph_cache_key()
         return None
 
     def _async_active_request_ids(self) -> tuple[int, ...]:
@@ -897,7 +901,19 @@ class TextGenerationController:
     def _prepare_async_child_from_committed_decode_state_impl(self, context) -> Optional[StepTxn]:
         """Implementation for child transaction preparation, wrapped for diagnostics."""
 
-        return context.prepare_child_from_committed_decode_state()
+        target_slot = None
+        defer_h2d = False
+        if context.using_cuda_graph_this_step() and context.replay_cuda_graph_this_step():
+            target_slot = context.async_decode_slot_ring.current
+            defer_h2d = True
+
+        child_txn = context.prepare_child_from_committed_decode_state(
+            target_slot=target_slot,
+            defer_h2d=defer_h2d,
+        )
+        if child_txn is not None:
+            child_txn.cuda_graph_key = self._async_decode_cuda_graph_key()
+        return child_txn
 
     def _decode_slot_for_txn(self, child_txn: StepTxn):
         context = self.inference_wrapped_model.inference_context
@@ -944,6 +960,10 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         assert context.async_decode_slot_ring is not None
         child_slot = self._decode_slot_for_txn(child_txn)
+        current_slot_replay = (
+            child_slot is context.async_decode_slot_ring.current
+            and context.replay_cuda_graph_this_step()
+        )
 
         if hasattr(context, "sync_ep_child_graph_shape"):
             graph_shape_started_at = (
@@ -996,11 +1016,11 @@ class TextGenerationController:
         disable_child_graph_replay = getattr(
             context, "async_child_forward_graph_replay_disabled_scope", None
         )
-        with (
-            disable_child_graph_replay()
-            if disable_child_graph_replay is not None
-            else nullcontext()
-        ):
+        if current_slot_replay or disable_child_graph_replay is None:
+            child_forward_scope = nullcontext()
+        else:
+            child_forward_scope = disable_child_graph_replay()
+        with child_forward_scope:
             self._dynamic_step_forward_logits(input_ids, position_ids)
         if profile_child_forward:
             child_txn.forward_timing_done_event = torch.cuda.Event(enable_timing=True)

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -2574,6 +2574,16 @@ class TextGenerationController:
         ep_step_begin_decision = self._decide_ep_step_begin(has_real_work=True)
         if ep_step_begin_decision.discard_pending_forward:
             self._async_launched_child_txn = None
+        if context.async_scheduling and self.num_speculative_tokens == 0:
+            ep_child_launch_plan = self._sync_ep_async_child_launch_plan(
+                active_request_count,
+                can_launch_real_child=False,
+            )
+            if self._ep_async_child_launches(ep_child_launch_plan):
+                raise RuntimeError(
+                    "EP async child launch plan selected a normal child while this rank "
+                    "is consuming a presampled decode step"
+                )
 
         with torch.inference_mode():
             sampled_tokens_cpu = self._consume_async_sample_transfer(active_request_count)

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -2508,6 +2508,12 @@ class TextGenerationController:
         if not (context.async_scheduling and self._async_prepared_child_txn is not None):
             await asyncio.sleep(0)
 
+        sampling_started_at = (
+            time.perf_counter()
+            if context.async_scheduling and context.async_txn_diagnostics.enabled
+            else None
+        )
+
         with torch.inference_mode():
             range_push("sampling")
             return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
@@ -2617,6 +2623,10 @@ class TextGenerationController:
                             log_probs_tensor
                         )
             range_pop()
+            if sampling_started_at is not None:
+                context.async_txn_diagnostics.record_sampling_block_duration(
+                    (time.perf_counter() - sampling_started_at) * 1_000_000
+                )
 
             # Capture before update_requests (called by _dynamic_step_context_bookkeeping)
             # resets num_prefill_requests to 0, which would make num_decode_requests

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -742,8 +742,6 @@ class TextGenerationController:
             return AsyncTxnSkipReason.UNKNOWN_BARRIER
         if self.num_speculative_tokens > 0:
             return AsyncTxnSkipReason.MTP_ACTIVE
-        if context.is_hybrid_model:
-            return AsyncTxnSkipReason.HYBRID_PRESTAGE_DEFERRED
         if self._enable_cuda_graph or context.using_cuda_graph_this_step():
             return AsyncTxnSkipReason.CUDA_GRAPH_DEFERRED
         if (

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -711,6 +711,7 @@ class TextGenerationController:
 
         if not child_txn.guard_adoption(
             self._async_active_request_ids(),
+            terminal_request_ids=child_txn.terminal_request_ids,
             decode_only=context.is_decode_only(),
             cuda_graph_key=self._async_decode_cuda_graph_key(),
         ):
@@ -756,8 +757,6 @@ class TextGenerationController:
             return AsyncTxnSkipReason.LOGPROBS_DEFERRED
         if active_request_count != len(child_txn.request_ids):
             return AsyncTxnSkipReason.UNKNOWN_BARRIER
-        if context.plain_decode_child_needs_terminal_check(active_request_count):
-            return AsyncTxnSkipReason.TERMINAL_CHECK_REQUIRED
         return None
 
     def _launch_async_decode_child(self, child_txn: StepTxn) -> None:
@@ -1784,6 +1783,7 @@ class TextGenerationController:
         self,
         sampled_tokens_cpu: Optional[Tensor] = None,
         sampled_mtp_tokens_cpu: Optional[Tensor] = None,
+        async_txn: Optional[StepTxn] = None,
     ) -> Dict[str, Tensor]:
         """Update the dynamic inference context after sampling.
 
@@ -1864,8 +1864,15 @@ class TextGenerationController:
 
         range_push("update_requests")
         update_result = context.update_requests(
-            active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
+            active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu, async_txn=async_txn
         )
+        if async_txn is not None:
+            committed_slice = slice(context.paused_request_count, context.total_request_count)
+            async_txn.mark_committed(
+                context.request_ids[committed_slice].tolist(),
+                terminal_request_ids=finished_request_ids.tolist(),
+            )
+            context.retire_unused_async_kv_leases(async_txn)
         if context.request_rng_store is not None and finished_request_ids.numel() > 0:
             context.request_rng_store.remove_many(finished_request_ids.tolist())
         range_pop()
@@ -2056,7 +2063,8 @@ class TextGenerationController:
                     else None
                 )
                 request_bookkeeping = self._dynamic_step_context_bookkeeping(
-                    sampled_tokens_cpu=sampled_tokens_cpu
+                    sampled_tokens_cpu=sampled_tokens_cpu,
+                    async_txn=launched_child_txn,
                 )
                 if launched_child_txn is not None:
                     self._async_prepared_child_txn = (

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -788,16 +788,35 @@ class TextGenerationController:
             return AsyncTxnSkipReason.SKIP_BOOKKEEPING
         if self.num_speculative_tokens > 0:
             return AsyncTxnSkipReason.MTP_ACTIVE
-        if self._enable_cuda_graph or context.using_cuda_graph_this_step():
-            return AsyncTxnSkipReason.CUDA_GRAPH_DEFERRED
-        if (
-            getattr(self.model_config, "expert_model_parallel_size", 1) > 1
-            or getattr(self.model_config, "num_moe_experts", None) is not None
-        ):
-            return AsyncTxnSkipReason.MOE_EP_DEFERRED
         if active_request_count != len(child_txn.request_ids):
             return AsyncTxnSkipReason.ACTIVE_COUNT_CHANGED
         return None
+
+    def _prepare_async_child_from_committed_decode_state(self) -> Optional[StepTxn]:
+        """Prepare the next plain-decode transaction with graph-safe slot ownership."""
+
+        context = self.inference_wrapped_model.inference_context
+        if not context.async_scheduling or context.async_decode_slot_ring is None:
+            return None
+
+        if context.using_cuda_graph_this_step():
+            # CUDA graphs capture metadata pointer addresses.  Reuse the currently
+            # captured slot and defer the H2D until after sampling, when the prior
+            # forward/sampling work has finished using those buffers.
+            return context.prepare_child_from_committed_decode_state(
+                target_slot=context.async_decode_slot_ring.current,
+                defer_h2d=True,
+            )
+
+        return context.prepare_child_from_committed_decode_state()
+
+    def _decode_slot_for_txn(self, child_txn: StepTxn):
+        context = self.inference_wrapped_model.inference_context
+        assert context.async_decode_slot_ring is not None
+        for slot in context.async_decode_slot_ring.slots:
+            if slot.slot_id == child_txn.slot_id:
+                return slot
+        raise RuntimeError(f"prepared async child slot {child_txn.slot_id} is not in the ring")
 
     def _launch_async_decode_child(
         self,
@@ -810,11 +829,14 @@ class TextGenerationController:
 
         context = self.inference_wrapped_model.inference_context
         assert context.async_decode_slot_ring is not None
-        child_slot = context.async_decode_slot_ring.child
-        if child_slot.slot_id != child_txn.slot_id:
-            raise RuntimeError("prepared async child slot no longer matches ring child")
+        child_slot = self._decode_slot_for_txn(child_txn)
 
-        if child_txn.h2d_done_event is not None:
+        if child_txn.cpu_bookkeeping_buf is not None:
+            child_txn.h2d_done_event = child_slot.copy_bookkeeping_from_cpu(
+                child_txn.cpu_bookkeeping_buf, non_blocking=True
+            )
+            child_txn.cpu_bookkeeping_buf = None
+        elif child_txn.h2d_done_event is not None:
             torch.cuda.current_stream(child_slot.gpu_view._buf.device).wait_event(
                 child_txn.h2d_done_event
             )
@@ -841,7 +863,10 @@ class TextGenerationController:
         range_pop()
 
         child_txn.launched = True
-        context.async_decode_slot_ring.adopt_child()
+        if child_slot is context.async_decode_slot_ring.child:
+            context.async_decode_slot_ring.adopt_child()
+        else:
+            context.bind_decode_slot(child_slot)
         self._async_launched_child_txn = child_txn
         self._async_prepared_child_txn = None
         context.async_txn_diagnostics.record_launched(
@@ -926,6 +951,36 @@ class TextGenerationController:
         )
         self._ep_decode_broadcast_plan = plan
         return plan
+
+    def _sync_ep_async_child_launch_plan(
+        self, active_request_count: int, *, can_launch_real_child: bool
+    ) -> EPDecodeBroadcastPlan:
+        """Synchronize whether the EP group will enter an async child forward phase."""
+
+        group = self._expert_parallel_group()
+        if get_pg_size(group) <= 1:
+            return EPDecodeBroadcastPlan(
+                active_request_count=(
+                    int(active_request_count) if can_launch_real_child else 0
+                ),
+                src_group_rank=0,
+                has_real_work=bool(can_launch_real_child),
+            )
+
+        context = self.inference_wrapped_model.inference_context
+        communicator = getattr(context, "_ep_zmq_communicator", None)
+        return resolve_ep_decode_broadcast_plan(
+            active_request_count,
+            group,
+            has_real_work=can_launch_real_child,
+            sync_all_reduce_max_fn=(
+                communicator.sync_all_reduce_max if communicator is not None else None
+            ),
+        )
+
+    @staticmethod
+    def _ep_async_child_launches(plan: EPDecodeBroadcastPlan) -> bool:
+        return bool(plan.has_real_work and plan.active_request_count > 0)
 
     def _clear_ep_decode_broadcast_plan(self) -> None:
         self._ep_decode_broadcast_plan = None
@@ -1887,6 +1942,8 @@ class TextGenerationController:
             # main forward. Dummy ranks must enter the same post-forward
             # collective phase before any MTP collectives are issued.
             self._dummy_decode_sample_collective()
+            if self.num_speculative_tokens == 0:
+                self._dummy_decode_async_child_forward_if_planned()
 
             # When speculative decoding is active, the real EP ranks perform serial
             # MTP forward passes after the main forward pass. MTP layers may contain
@@ -1894,11 +1951,23 @@ class TextGenerationController:
             # all-to-all collectives. The dummy rank must participate in these
             # collectives to avoid a hang.
             self._dummy_serial_mtp_forward()
+            if self.num_speculative_tokens > 0:
+                self._dummy_decode_async_child_forward_if_planned()
             self._dummy_decode_stop_word_collective_tail()
         finally:
             self._clear_ep_decode_broadcast_plan()
             # clear the context of any temporary state from the dummy forward
             context.reset()
+
+    def _dummy_decode_async_child_forward_if_planned(self) -> None:
+        """Mirror a real EP rank's async child forward phase on dummy ranks."""
+
+        plan = self._sync_ep_async_child_launch_plan(0, can_launch_real_child=False)
+        if not self._ep_async_child_launches(plan):
+            return
+
+        input_ids, position_ids = self._dynamic_step_context_init(is_dummy_forward=True)
+        self._dynamic_step_forward_logits(input_ids, position_ids)
 
     @torch.inference_mode()
     def _dummy_serial_mtp_forward(self):
@@ -2235,7 +2304,7 @@ class TextGenerationController:
                     range_push("async_txn_child_prestage")
                     try:
                         self._async_prepared_child_txn = (
-                            context.prepare_child_from_committed_decode_state()
+                            self._prepare_async_child_from_committed_decode_state()
                         )
                     finally:
                         range_pop()
@@ -2306,10 +2375,33 @@ class TextGenerationController:
 
             log_probs = None
             top_n_logprobs = None
-            if (
+            local_can_launch_child = (
                 context.async_scheduling
                 and child_launch_skip_reason is None
                 and self._async_prepared_child_txn is not None
+            )
+            ep_child_launch_plan = None
+            if context.async_scheduling:
+                ep_child_launch_plan = self._sync_ep_async_child_launch_plan(
+                    active_request_count,
+                    can_launch_real_child=local_can_launch_child,
+                )
+                if local_can_launch_child and not self._ep_async_child_launches(
+                    ep_child_launch_plan
+                ):
+                    raise RuntimeError("EP async child launch plan dropped the real child launch")
+                if (
+                    self._ep_async_child_launches(ep_child_launch_plan)
+                    and not local_can_launch_child
+                ):
+                    raise RuntimeError(
+                        "EP async child launch plan selected a source rank without a local child"
+                    )
+
+            if (
+                local_can_launch_child
+                and ep_child_launch_plan is not None
+                and self._ep_async_child_launches(ep_child_launch_plan)
             ):
                 launched_child_txn = self._async_prepared_child_txn
                 sample_ready_event = self._record_async_sample_ready_event()
@@ -2382,7 +2474,7 @@ class TextGenerationController:
                     range_push("async_txn_child_prestage")
                     try:
                         self._async_prepared_child_txn = (
-                            context.prepare_child_from_committed_decode_state()
+                            self._prepare_async_child_from_committed_decode_state()
                         )
                     finally:
                         range_pop()

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -31,6 +31,7 @@ from megatron.core.inference.communication_utils import (
 )
 from megatron.core.inference.contexts.dynamic_context import MaxSequenceLengthOverflowError
 from megatron.core.inference.contexts.static_context import StaticInferenceContext
+from megatron.core.inference.ep_async_protocol import EPAsyncPhase
 from megatron.core.inference.inference_request import InferenceRequest, Status
 from megatron.core.inference.model_inference_wrappers.abstract_model_inference_wrapper import (
     AbstractModelInferenceWrapper,
@@ -145,6 +146,7 @@ class TextGenerationController:
         self._async_prepared_child_txn: Optional[StepTxn] = None
         self._async_launched_child_txn: Optional[StepTxn] = None
         self._ep_decode_broadcast_plan: Optional[EPDecodeBroadcastPlan] = None
+        self._ep_async_protocol = None
         self._ep_dummy_sampled_tokens_cuda: Optional[Tensor] = None
         self._ep_dummy_accepted_counts_cuda: Optional[Tensor] = None
 
@@ -158,6 +160,11 @@ class TextGenerationController:
             callback: Function that returns request IDs to mark as finished.
         """
         self._get_stop_word_finished_ids_callback = callback
+
+    def set_ep_async_protocol(self, protocol) -> None:
+        """Attach the EP async step protocol for tagged, step-scoped CPU sync."""
+
+        self._ep_async_protocol = protocol
 
     def _init_dynamic_sampling_tensors(self):
         """Initialize tensors needed for dynamic sampling."""
@@ -825,6 +832,23 @@ class TextGenerationController:
         except TypeError:
             return communicator.sync_all_reduce_max(*values)
 
+    def _sync_ep_protocol_all_reduce_max(self, phase: EPAsyncPhase, *values: int):
+        if self._ep_async_protocol is not None and self._ep_async_protocol.enabled:
+            return self._ep_async_protocol.sync_all_reduce_max(phase, *values)
+        context = self.inference_wrapped_model.inference_context
+        communicator = getattr(context, "_ep_zmq_communicator", None)
+        if communicator is None:
+            return None
+        return self._sync_all_reduce_max_with_phase(communicator, phase.value, *values)
+
+    def _ep_sync_all_reduce_max_fn(self, phase: EPAsyncPhase):
+        if self._ep_async_protocol is not None and self._ep_async_protocol.enabled:
+            return functools.partial(self._sync_ep_protocol_all_reduce_max, phase)
+        context = self.inference_wrapped_model.inference_context
+        if getattr(context, "_ep_zmq_communicator", None) is None:
+            return None
+        return functools.partial(self._sync_ep_protocol_all_reduce_max, phase)
+
     def _launch_async_decode_child(
         self,
         child_txn: StepTxn,
@@ -949,20 +973,12 @@ class TextGenerationController:
             self._ep_decode_broadcast_plan = None
             return None
 
-        context = self.inference_wrapped_model.inference_context
-        communicator = getattr(context, "_ep_zmq_communicator", None)
         plan = resolve_ep_decode_broadcast_plan(
             active_request_count,
             group,
             has_real_work=has_real_work,
-            sync_all_reduce_max_fn=(
-                functools.partial(
-                    self._sync_all_reduce_max_with_phase,
-                    communicator,
-                    "ep_decode_post_forward",
-                )
-                if communicator is not None
-                else None
+            sync_all_reduce_max_fn=self._ep_sync_all_reduce_max_fn(
+                EPAsyncPhase.DECODE_POST_FORWARD
             ),
         )
         self._ep_decode_broadcast_plan = plan
@@ -983,22 +999,15 @@ class TextGenerationController:
                 has_real_work=bool(can_launch_real_child),
             )
 
-        context = self.inference_wrapped_model.inference_context
-        communicator = getattr(context, "_ep_zmq_communicator", None)
-        return resolve_ep_decode_broadcast_plan(
+        plan = resolve_ep_decode_broadcast_plan(
             active_request_count,
             group,
             has_real_work=can_launch_real_child,
-            sync_all_reduce_max_fn=(
-                functools.partial(
-                    self._sync_all_reduce_max_with_phase,
-                    communicator,
-                    "ep_async_child_handoff",
-                )
-                if communicator is not None
-                else None
+            sync_all_reduce_max_fn=self._ep_sync_all_reduce_max_fn(
+                EPAsyncPhase.ASYNC_CHILD_HANDOFF
             ),
         )
+        return plan
 
     @staticmethod
     def _ep_async_child_launches(plan: EPDecodeBroadcastPlan) -> bool:

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -730,6 +730,33 @@ class TextGenerationController:
         context.async_txn_diagnostics.record_adopted()
         return True
 
+    @staticmethod
+    def _synchronize_async_event(event) -> None:
+        """Synchronize a CUDA-like event when a sync boundary needs a drain."""
+
+        if event is None:
+            return
+        if hasattr(event, "synchronize"):
+            event.synchronize()
+        elif hasattr(event, "query") and not event.query() and torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+    def drain_async_transactions(self, *, drop_launched: bool = False) -> None:
+        """Drain in-flight async work before external pause/suspend/shutdown observation."""
+
+        child_txn = self._async_launched_child_txn
+        if child_txn is not None:
+            self._synchronize_async_event(child_txn.forward_done_event)
+            self._synchronize_async_event(child_txn.sample_done_event)
+            if drop_launched:
+                self._async_launched_child_txn = None
+
+        self._async_prepared_child_txn = None
+        context = self.inference_wrapped_model.inference_context
+        retire_queue = getattr(context, "async_txn_retire_queue", None)
+        if retire_queue is not None:
+            retire_queue.drain_all_ready()
+
     def _async_child_launch_skip_reason(
         self,
         child_txn: Optional[StepTxn],
@@ -737,9 +764,12 @@ class TextGenerationController:
         return_log_probs: bool,
         return_top_n_logprobs: bool,
         skip_bookkeeping: bool,
+        async_launch_barrier_reason: Optional[AsyncTxnSkipReason] = None,
     ) -> Optional[AsyncTxnSkipReason]:
         """Return the reason the prepared plain-decode child cannot be launched."""
 
+        if async_launch_barrier_reason is not None:
+            return async_launch_barrier_reason
         if child_txn is None:
             return None
         context = self.inference_wrapped_model.inference_context
@@ -1978,7 +2008,10 @@ class TextGenerationController:
         }
 
     async def async_generate_output_tokens_dynamic_batch(
-        self, skip_bookkeeping: Optional[bool] = False
+        self,
+        skip_bookkeeping: Optional[bool] = False,
+        *,
+        async_launch_barrier_reason: Optional[AsyncTxnSkipReason] = None,
     ) -> Optional[Dict]:
         """Forward step the model and update the inference context.
 
@@ -2066,6 +2099,7 @@ class TextGenerationController:
                     return_log_probs=return_log_probs,
                     return_top_n_logprobs=return_top_n_logprobs,
                     skip_bookkeeping=skip_bookkeeping,
+                    async_launch_barrier_reason=async_launch_barrier_reason,
                 )
                 if child_launch_skip_reason is not None:
                     context.async_txn_diagnostics.record_barrier_skip(child_launch_skip_reason)

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -848,6 +848,22 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         if not context.async_scheduling or context.async_decode_slot_ring is None:
             return None
+        prepare_started_at = (
+            time.perf_counter()
+            if getattr(context, "async_txn_diagnostics", None) is not None
+            and context.async_txn_diagnostics.enabled
+            else None
+        )
+        try:
+            return self._prepare_async_child_from_committed_decode_state_impl(context)
+        finally:
+            if prepare_started_at is not None:
+                context.async_txn_diagnostics.record_child_prestage_duration(
+                    (time.perf_counter() - prepare_started_at) * 1_000_000
+                )
+
+    def _prepare_async_child_from_committed_decode_state_impl(self, context) -> Optional[StepTxn]:
+        """Implementation for child transaction preparation, wrapped for diagnostics."""
 
         if context.using_cuda_graph_this_step():
             # CUDA graphs capture metadata pointer addresses.  Reuse the currently
@@ -906,7 +922,19 @@ class TextGenerationController:
         child_slot = self._decode_slot_for_txn(child_txn)
 
         if hasattr(context, "sync_ep_child_graph_shape"):
-            context.sync_ep_child_graph_shape()
+            graph_shape_started_at = (
+                time.perf_counter()
+                if getattr(context, "async_txn_diagnostics", None) is not None
+                and context.async_txn_diagnostics.enabled
+                else None
+            )
+            try:
+                context.sync_ep_child_graph_shape()
+            finally:
+                if graph_shape_started_at is not None:
+                    context.async_txn_diagnostics.record_child_graph_shape_duration(
+                        (time.perf_counter() - graph_shape_started_at) * 1_000_000
+                    )
 
         if child_txn.cpu_bookkeeping_buf is not None:
             child_txn.h2d_done_event = child_slot.copy_bookkeeping_from_cpu(
@@ -1032,25 +1060,40 @@ class TextGenerationController:
     ) -> EPDecodeBroadcastPlan:
         """Synchronize whether the EP group will enter an async child forward phase."""
 
+        context = self.inference_wrapped_model.inference_context
+        sync_started_at = (
+            time.perf_counter()
+            if getattr(context, "async_txn_diagnostics", None) is not None
+            and context.async_txn_diagnostics.enabled
+            else None
+        )
         group = self._expert_parallel_group()
-        if get_pg_size(group) <= 1:
-            return EPDecodeBroadcastPlan(
+        try:
+            if get_pg_size(group) <= 1:
+                return EPDecodeBroadcastPlan(
+                    active_request_count=(
+                        int(active_request_count) if can_launch_real_child else 0
+                    ),
+                    src_group_rank=0,
+                    has_real_work=bool(can_launch_real_child),
+                )
+
+            plan = resolve_ep_decode_broadcast_plan(
                 active_request_count=(
                     int(active_request_count) if can_launch_real_child else 0
                 ),
-                src_group_rank=0,
                 has_real_work=bool(can_launch_real_child),
+                group=group,
+                sync_all_reduce_max_fn=self._ep_sync_all_reduce_max_fn(
+                    EPAsyncPhase.ASYNC_CHILD_HANDOFF
+                ),
             )
-
-        plan = resolve_ep_decode_broadcast_plan(
-            active_request_count,
-            group,
-            has_real_work=can_launch_real_child,
-            sync_all_reduce_max_fn=self._ep_sync_all_reduce_max_fn(
-                EPAsyncPhase.ASYNC_CHILD_HANDOFF
-            ),
-        )
-        return plan
+            return plan
+        finally:
+            if sync_started_at is not None:
+                context.async_txn_diagnostics.record_ep_handoff_duration(
+                    (time.perf_counter() - sync_started_at) * 1_000_000
+                )
 
     @staticmethod
     def _ep_async_child_launches(plan: EPDecodeBroadcastPlan) -> bool:

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -865,15 +865,6 @@ class TextGenerationController:
     def _prepare_async_child_from_committed_decode_state_impl(self, context) -> Optional[StepTxn]:
         """Implementation for child transaction preparation, wrapped for diagnostics."""
 
-        if context.using_cuda_graph_this_step():
-            # CUDA graphs capture metadata pointer addresses.  Reuse the currently
-            # captured slot and defer the H2D until after sampling, when the prior
-            # forward/sampling work has finished using those buffers.
-            return context.prepare_child_from_committed_decode_state(
-                target_slot=context.async_decode_slot_ring.current,
-                defer_h2d=True,
-            )
-
         return context.prepare_child_from_committed_decode_state()
 
     def _decode_slot_for_txn(self, child_txn: StepTxn):

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -818,6 +818,13 @@ class TextGenerationController:
                 return slot
         raise RuntimeError(f"prepared async child slot {child_txn.slot_id} is not in the ring")
 
+    @staticmethod
+    def _sync_all_reduce_max_with_phase(communicator, phase: str, *values: int):
+        try:
+            return communicator.sync_all_reduce_max(*values, phase=phase)
+        except TypeError:
+            return communicator.sync_all_reduce_max(*values)
+
     def _launch_async_decode_child(
         self,
         child_txn: StepTxn,
@@ -830,6 +837,9 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         assert context.async_decode_slot_ring is not None
         child_slot = self._decode_slot_for_txn(child_txn)
+
+        if hasattr(context, "sync_ep_child_graph_shape"):
+            context.sync_ep_child_graph_shape()
 
         if child_txn.cpu_bookkeeping_buf is not None:
             child_txn.h2d_done_event = child_slot.copy_bookkeeping_from_cpu(
@@ -946,7 +956,13 @@ class TextGenerationController:
             group,
             has_real_work=has_real_work,
             sync_all_reduce_max_fn=(
-                communicator.sync_all_reduce_max if communicator is not None else None
+                functools.partial(
+                    self._sync_all_reduce_max_with_phase,
+                    communicator,
+                    "ep_decode_post_forward",
+                )
+                if communicator is not None
+                else None
             ),
         )
         self._ep_decode_broadcast_plan = plan
@@ -974,7 +990,13 @@ class TextGenerationController:
             group,
             has_real_work=can_launch_real_child,
             sync_all_reduce_max_fn=(
-                communicator.sync_all_reduce_max if communicator is not None else None
+                functools.partial(
+                    self._sync_all_reduce_max_with_phase,
+                    communicator,
+                    "ep_async_child_handoff",
+                )
+                if communicator is not None
+                else None
             ),
         )
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -4,6 +4,7 @@ import asyncio
 import concurrent
 import copy
 import functools
+import time
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, OrderedDict, Tuple, Union
 
@@ -715,20 +716,24 @@ class TextGenerationController:
             self._async_launched_child_txn = None
             return False
 
-        if not child_txn.guard_adoption(
-            self._async_active_request_ids(),
-            terminal_request_ids=child_txn.terminal_request_ids,
-            decode_only=context.is_decode_only(),
-            cuda_graph_key=self._async_decode_cuda_graph_key(),
-        ):
-            context.async_txn_diagnostics.record_guard_failure()
-            self._async_launched_child_txn = None
-            raise RuntimeError("async decode child adoption invariant failed")
+        range_push("async_txn_adopt")
+        try:
+            if not child_txn.guard_adoption(
+                self._async_active_request_ids(),
+                terminal_request_ids=child_txn.terminal_request_ids,
+                decode_only=context.is_decode_only(),
+                cuda_graph_key=self._async_decode_cuda_graph_key(),
+            ):
+                context.async_txn_diagnostics.record_guard_failure()
+                self._async_launched_child_txn = None
+                raise RuntimeError("async decode child adoption invariant failed")
 
-        child_txn.adopted = True
-        self._async_launched_child_txn = None
-        context.async_txn_diagnostics.record_adopted()
-        return True
+            child_txn.adopted = True
+            self._async_launched_child_txn = None
+            context.async_txn_diagnostics.record_adopted()
+            return True
+        finally:
+            range_pop()
 
     @staticmethod
     def _synchronize_async_event(event) -> None:
@@ -789,7 +794,13 @@ class TextGenerationController:
             return AsyncTxnSkipReason.ACTIVE_COUNT_CHANGED
         return None
 
-    def _launch_async_decode_child(self, child_txn: StepTxn) -> None:
+    def _launch_async_decode_child(
+        self,
+        child_txn: StepTxn,
+        *,
+        h2d_ready_before_sampling: bool = False,
+        sample_completed_at: Optional[float] = None,
+    ) -> None:
         """Scatter sampled tokens into the prepared child slot and launch it."""
 
         context = self.inference_wrapped_model.inference_context
@@ -798,23 +809,30 @@ class TextGenerationController:
         if child_slot.slot_id != child_txn.slot_id:
             raise RuntimeError("prepared async child slot no longer matches ring child")
 
-        h2d_ready_before_sampling = child_txn.h2d_ready()
         if child_txn.h2d_done_event is not None:
             torch.cuda.current_stream(child_slot.gpu_view._buf.device).wait_event(
                 child_txn.h2d_done_event
             )
 
         active_request_count = context.total_request_count - context.paused_request_count
+        range_push("async_txn_scatter_to_child_input")
         child_slot.gpu_view.token_to_input_ids[:active_request_count].copy_(
             self._sampled_tokens_cuda[:active_request_count], non_blocking=True
         )
+        range_pop()
 
         context.bind_decode_slot(child_slot)
         input_ids, position_ids = context.current_input_and_position_ids()
 
+        sample_to_launch_latency_us = None
+        if sample_completed_at is not None:
+            sample_to_launch_latency_us = (time.perf_counter() - sample_completed_at) * 1_000_000
+
+        range_push("async_txn_launch_child")
         range_push("async_child_forward")
         self._dynamic_step_forward_logits(input_ids, position_ids)
         child_txn.forward_done_event = child_slot.record_forward_done()
+        range_pop()
         range_pop()
 
         child_txn.launched = True
@@ -822,7 +840,8 @@ class TextGenerationController:
         self._async_launched_child_txn = child_txn
         self._async_prepared_child_txn = None
         context.async_txn_diagnostics.record_launched(
-            h2d_ready_before_sampling=h2d_ready_before_sampling
+            h2d_ready_before_sampling=h2d_ready_before_sampling,
+            sample_to_launch_latency_us=sample_to_launch_latency_us,
         )
 
     def _record_async_sample_ready_event(self):
@@ -2074,9 +2093,13 @@ class TextGenerationController:
                 )
                 if context.async_scheduling and context.async_decode_slot_ring is not None:
                     context.async_decode_slot_ring.current.record_forward_done()
-                    self._async_prepared_child_txn = (
-                        context.prepare_child_from_committed_decode_state()
-                    )
+                    range_push("async_txn_child_prestage")
+                    try:
+                        self._async_prepared_child_txn = (
+                            context.prepare_child_from_committed_decode_state()
+                        )
+                    finally:
+                        range_pop()
                 range_pop()
 
         # This is the best place to yield control back to event loop.
@@ -2093,6 +2116,7 @@ class TextGenerationController:
             return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
             launched_child_txn = None
             child_launch_skip_reason = None
+            h2d_ready_before_sampling = False
             if context.async_scheduling:
                 child_launch_skip_reason = self._async_child_launch_skip_reason(
                     self._async_prepared_child_txn,
@@ -2104,6 +2128,8 @@ class TextGenerationController:
                 if child_launch_skip_reason is not None:
                     context.async_txn_diagnostics.record_barrier_skip(child_launch_skip_reason)
                     self._async_prepared_child_txn = None
+                elif self._async_prepared_child_txn is not None:
+                    h2d_ready_before_sampling = self._async_prepared_child_txn.h2d_ready()
 
             if self.num_speculative_tokens > 0:
                 # Phase 1: Verify speculative tokens using base logits only.
@@ -2130,7 +2156,14 @@ class TextGenerationController:
                 # data-dependent boolean-mask sync overlaps with MTP GPU work.
                 context.kv_block_allocator.release_memory_blocks(blocks_to_release[remove_mask])
             else:
-                self._dynamic_step_sample_logits()
+                if context.async_scheduling:
+                    range_push("async_txn_sample")
+                try:
+                    self._dynamic_step_sample_logits()
+                finally:
+                    if context.async_scheduling:
+                        range_pop()
+            sample_completed_at = time.perf_counter() if context.async_scheduling else None
 
             log_probs = None
             top_n_logprobs = None
@@ -2141,7 +2174,11 @@ class TextGenerationController:
             ):
                 launched_child_txn = self._async_prepared_child_txn
                 sample_ready_event = self._record_async_sample_ready_event()
-                self._launch_async_decode_child(launched_child_txn)
+                self._launch_async_decode_child(
+                    launched_child_txn,
+                    h2d_ready_before_sampling=h2d_ready_before_sampling,
+                    sample_completed_at=sample_completed_at,
+                )
                 self._start_async_sample_transfer(active_request_count, sample_ready_event)
 
             if return_log_probs or return_top_n_logprobs:
@@ -2179,19 +2216,37 @@ class TextGenerationController:
             else:
                 # request_bookkeeping supplies "sample" as the already-CPU
                 # tensor produced by _transfer_samples_to_cpu.
-                sampled_tokens_cpu = (
-                    self._consume_async_sample_transfer(active_request_count)
-                    if launched_child_txn is not None
-                    else None
+                commit_started_at = (
+                    time.perf_counter() if context.async_txn_diagnostics.enabled else None
                 )
-                request_bookkeeping = self._dynamic_step_context_bookkeeping(
-                    sampled_tokens_cpu=sampled_tokens_cpu,
-                    async_txn=launched_child_txn,
-                )
-                if launched_child_txn is not None:
-                    self._async_prepared_child_txn = (
-                        context.prepare_child_from_committed_decode_state()
+                commit_range_active = context.async_scheduling
+                if commit_range_active:
+                    range_push("async_txn_cpu_commit")
+                try:
+                    sampled_tokens_cpu = (
+                        self._consume_async_sample_transfer(active_request_count)
+                        if launched_child_txn is not None
+                        else None
                     )
+                    request_bookkeeping = self._dynamic_step_context_bookkeeping(
+                        sampled_tokens_cpu=sampled_tokens_cpu,
+                        async_txn=launched_child_txn,
+                    )
+                finally:
+                    if commit_range_active:
+                        range_pop()
+                    if commit_started_at is not None:
+                        context.async_txn_diagnostics.record_commit_duration(
+                            (time.perf_counter() - commit_started_at) * 1_000_000
+                        )
+                if launched_child_txn is not None:
+                    range_push("async_txn_child_prestage")
+                    try:
+                        self._async_prepared_child_txn = (
+                            context.prepare_child_from_committed_decode_state()
+                        )
+                    finally:
+                        range_pop()
 
             accepted_tokens_result = (
                 # Clone needed: .fill_(-1) below would corrupt the returned value.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -775,7 +775,7 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
         if skip_bookkeeping:
-            return AsyncTxnSkipReason.UNKNOWN_BARRIER
+            return AsyncTxnSkipReason.SKIP_BOOKKEEPING
         if self.num_speculative_tokens > 0:
             return AsyncTxnSkipReason.MTP_ACTIVE
         if self._enable_cuda_graph or context.using_cuda_graph_this_step():
@@ -786,7 +786,7 @@ class TextGenerationController:
         ):
             return AsyncTxnSkipReason.MOE_EP_DEFERRED
         if active_request_count != len(child_txn.request_ids):
-            return AsyncTxnSkipReason.UNKNOWN_BARRIER
+            return AsyncTxnSkipReason.ACTIVE_COUNT_CHANGED
         return None
 
     def _launch_async_decode_child(self, child_txn: StepTxn) -> None:

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -388,6 +388,8 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         ):
             if kwargs['inference_context'].is_static_batching():
                 using_cuda_graph = kwargs['inference_context'].is_decode_only()
+            elif hasattr(kwargs['inference_context'], 'replay_cuda_graph_this_step'):
+                using_cuda_graph = kwargs['inference_context'].replay_cuda_graph_this_step()
             else:
                 using_cuda_graph = kwargs['inference_context'].using_cuda_graph_this_step()
 

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -538,8 +538,10 @@ class MambaMixer(MegatronModule):
                 conv_state,
                 ssm_state,
                 batch_indices=context.mamba_metadata.batch_indices_decode,
+                write_batch_indices=context.mamba_metadata.batch_indices_decode_write,
                 intermediate_conv_state=int_conv_state,
                 intermediate_ssm_state=int_ssm_state,
+                state_bank_count=context.mamba_metadata.state_bank_count,
             )
 
             # Flatten back to [N*S, 1, d] to match merge logic
@@ -1081,8 +1083,10 @@ class MambaMixer(MegatronModule):
         conv_state: torch.Tensor,
         ssm_state: torch.Tensor,
         batch_indices: Optional[torch.Tensor] = None,
+        write_batch_indices: Optional[torch.Tensor] = None,
         intermediate_conv_state: Optional[torch.Tensor] = None,
         intermediate_ssm_state: Optional[torch.Tensor] = None,
+        state_bank_count: int = 1,
     ) -> torch.Tensor:
         """
         Performs SSM computation for inference decode step.
@@ -1094,10 +1098,13 @@ class MambaMixer(MegatronModule):
             conv_state: The convolution state tensor for inference.
             ssm_state: The selective scan state tensor for inference.
             batch_indices: A map from batch id to position in the Mamba state tensors.
+            write_batch_indices: A map from batch id to destination position in the Mamba
+                state tensors. Defaults to ``batch_indices``.
             intermediate_conv_state: Optional buffer for storing conv state at each
                 sequence step (for speculative decoding rollback).
             intermediate_ssm_state: Optional buffer for storing SSM state at each
                 sequence step (for speculative decoding rollback).
+            state_bank_count: Number of flattened banks per logical request slot.
 
         Returns:
             The output tensor of shape (b, s, d).
@@ -1139,7 +1146,9 @@ class MambaMixer(MegatronModule):
                 self.conv1d_bias.to(conv_state.dtype),
                 self.activation,
                 conv_state_indices=batch_indices,
+                conv_state_write_indices=write_batch_indices,
                 intermediate_conv_states=intermediate_conv_state,
+                state_bank_count=state_bank_count,
             ).to(xBC_dtype)
 
         x, B, C = torch.split(
@@ -1236,7 +1245,9 @@ class MambaMixer(MegatronModule):
                 dt_bias=dt_bias,
                 dt_softplus=True,
                 state_batch_indices=batch_indices,
+                state_batch_write_indices=write_batch_indices,
                 intermediate_ssm_states=intermediate_ssm_state,  # SSM only
+                state_bank_count=state_bank_count,
             )
             y = rearrange(y, "b s h p -> b s (h p)")
 

--- a/megatron/core/ssm/ops/causal_conv1d_triton.py
+++ b/megatron/core/ssm/ops/causal_conv1d_triton.py
@@ -47,6 +47,7 @@ def causal_conv1d_update_kernel(
     out_s_stride,
     out_c_stride,
     conv_state_indices_ptr,
+    conv_state_write_indices_ptr,
     batch,
     seq_len,
     dim,
@@ -55,7 +56,9 @@ def causal_conv1d_update_kernel(
     BLOCK_DIM: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     HAS_STATE_INDICES: tl.constexpr,
+    HAS_WRITE_STATE_INDICES: tl.constexpr,
     HAS_INT_STATE: tl.constexpr,
+    STATE_BANK_COUNT: tl.constexpr,
     SILU_ACTIVATION: tl.constexpr,
 ):
     """Triton implementation of causal_conv1d_update (kernel)."""
@@ -70,6 +73,10 @@ def causal_conv1d_update_kernel(
         state_batch_coord = tl.load(conv_state_indices_ptr + batch_id)
     else:
         state_batch_coord = batch_id
+    if HAS_WRITE_STATE_INDICES:
+        write_state_batch_coord = tl.load(conv_state_write_indices_ptr + batch_id)
+    else:
+        write_state_batch_coord = state_batch_coord
 
     # Base Pointers
     conv_state_ptrs = (
@@ -77,10 +84,15 @@ def causal_conv1d_update_kernel(
         + state_batch_coord * conv_state_b_stride
         + channel_offsets * conv_state_c_stride
     )
+    conv_state_write_ptrs = (
+        conv_state_ptr
+        + write_state_batch_coord * conv_state_b_stride
+        + channel_offsets * conv_state_c_stride
+    )
     weight_ptrs = weight_ptr + channel_offsets * weight_c_stride
 
     # Skip padding tokens (block-level uniform condition)
-    if state_batch_coord < 0:
+    if state_batch_coord < 0 or write_state_batch_coord < 0:
         for s in range(seq_len):
             out_ptrs = (
                 out_ptr
@@ -149,37 +161,44 @@ def causal_conv1d_update_kernel(
         # state_len > WIDTH the leading positions are untouched by compute; fall
         # through to the explicit load+store shift.
         if state_len == WIDTH:
-            out_dtype = conv_state_ptrs.dtype.element_ty
+            out_dtype = conv_state_write_ptrs.dtype.element_ty
             if WIDTH >= 2:
                 tl.store(
-                    conv_state_ptrs + 0 * conv_state_l_stride, x_val_0.to(out_dtype), mask=mask
+                    conv_state_write_ptrs + 0 * conv_state_l_stride,
+                    x_val_0.to(out_dtype),
+                    mask=mask,
                 )
             if WIDTH >= 3:
                 tl.store(
-                    conv_state_ptrs + 1 * conv_state_l_stride, x_val_1.to(out_dtype), mask=mask
+                    conv_state_write_ptrs + 1 * conv_state_l_stride,
+                    x_val_1.to(out_dtype),
+                    mask=mask,
                 )
             if WIDTH >= 4:
                 tl.store(
-                    conv_state_ptrs + 2 * conv_state_l_stride, x_val_2.to(out_dtype), mask=mask
+                    conv_state_write_ptrs + 2 * conv_state_l_stride,
+                    x_val_2.to(out_dtype),
+                    mask=mask,
                 )
         else:
             i = 0
             while i < state_len - 1:
                 val = tl.load(conv_state_ptrs + (i + 1) * conv_state_l_stride, mask=mask)
-                tl.store(conv_state_ptrs + i * conv_state_l_stride, val, mask=mask)
+                tl.store(conv_state_write_ptrs + i * conv_state_l_stride, val, mask=mask)
                 i += 1
 
         # Store the new token at the end of the linear state buffer
-        tl.store(conv_state_ptrs + (state_len - 1) * conv_state_l_stride, x_val, mask=mask)
+        tl.store(conv_state_write_ptrs + (state_len - 1) * conv_state_l_stride, x_val, mask=mask)
 
         # Write out to the intermediate state buffer if requested. Reuse the
         # register values from the shift above (and x_val for the new tail
         # position) when state_len == WIDTH, instead of re-reading from HBM.
         if HAS_INT_STATE:
+            int_state_batch_coord = state_batch_coord // STATE_BANK_COUNT
             if state_len == WIDTH:
                 int_base = (
                     int_state_ptr
-                    + state_batch_coord * int_state_b_stride
+                    + int_state_batch_coord * int_state_b_stride
                     + s * int_state_s_stride
                     + channel_offsets * int_state_c_stride
                 )
@@ -194,10 +213,10 @@ def causal_conv1d_update_kernel(
             else:
                 i = 0
                 while i < state_len:
-                    val = tl.load(conv_state_ptrs + i * conv_state_l_stride, mask=mask)
+                    val = tl.load(conv_state_write_ptrs + i * conv_state_l_stride, mask=mask)
                     int_ptr = (
                         int_state_ptr
-                        + state_batch_coord * int_state_b_stride
+                        + int_state_batch_coord * int_state_b_stride
                         + s * int_state_s_stride
                         + channel_offsets * int_state_c_stride
                         + i * int_state_l_stride
@@ -227,6 +246,7 @@ def causal_conv1d_update_kernel(
             out_val = out_val * tl.sigmoid(out_val)
 
         tl.store(out_ptrs, out_val.to(out_ptrs.dtype.element_ty), mask=mask)
+        conv_state_ptrs = conv_state_write_ptrs
 
 
 def causal_conv1d_update(
@@ -236,7 +256,9 @@ def causal_conv1d_update(
     bias: torch.Tensor | None,
     silu_activation: bool,
     conv_state_indices: torch.Tensor | None,
+    conv_state_write_indices: torch.Tensor | None = None,
     intermediate_conv_states: torch.Tensor | None = None,
+    state_bank_count: int = 1,
 ) -> torch.Tensor:
     """Triton implementation of causal_conv1d_update (entrypoint)."""
 
@@ -263,6 +285,11 @@ def causal_conv1d_update(
     else:
         conv_state_indices = x  # Dummy pointer
         has_state_indices = False
+    if conv_state_write_indices is not None:
+        has_write_state_indices = True
+    else:
+        conv_state_write_indices = x  # Dummy pointer
+        has_write_state_indices = False
 
     # Extract intermediate state strides if provided
     if intermediate_conv_states is not None:
@@ -307,6 +334,7 @@ def causal_conv1d_update(
         out.stride(1),
         out.stride(2),
         conv_state_indices,
+        conv_state_write_indices,
         batch,
         seq_len,
         dim,
@@ -315,7 +343,9 @@ def causal_conv1d_update(
         BLOCK_DIM=BLOCK_DIM,
         HAS_BIAS=has_bias,
         HAS_STATE_INDICES=has_state_indices,
+        HAS_WRITE_STATE_INDICES=has_write_state_indices,
         HAS_INT_STATE=has_int_state,
+        STATE_BANK_COUNT=state_bank_count,
         SILU_ACTIVATION=silu_activation == "silu",
     )
 

--- a/megatron/core/ssm/ops/mamba_ssm.py
+++ b/megatron/core/ssm/ops/mamba_ssm.py
@@ -74,6 +74,7 @@ def _selective_scan_update_kernel(
     z_ptr,
     out_ptr,
     state_batch_indices_ptr,
+    state_batch_write_indices_ptr,
     int_state_ptr,
     # Matrix dimensions
     batch,
@@ -131,7 +132,9 @@ def _selective_scan_update_kernel(
     HAS_D: tl.constexpr,
     HAS_Z: tl.constexpr,
     HAS_STATE_BATCH_INDICES: tl.constexpr,
+    HAS_STATE_BATCH_WRITE_INDICES: tl.constexpr,
     HAS_INT_STATE: tl.constexpr,
+    STATE_BANK_COUNT: tl.constexpr,
     BLOCK_SIZE_DSTATE: tl.constexpr,
 ):
     pid_m = tl.program_id(axis=0)
@@ -148,17 +151,26 @@ def _selective_scan_update_kernel(
     if HAS_STATE_BATCH_INDICES:
         state_batch_indices_ptr += pid_b
         state_batch_idx = tl.load(state_batch_indices_ptr)
+        if HAS_STATE_BATCH_WRITE_INDICES:
+            state_batch_write_indices_ptr += pid_b
+            state_batch_write_idx = tl.load(state_batch_write_indices_ptr)
+        else:
+            state_batch_write_idx = state_batch_idx
         # Skip padding tokens (e.g. from graph capture or inactive slots)
-        if state_batch_idx < 0:
+        if state_batch_idx < 0 or state_batch_write_idx < 0:
             for s in range(seq_len):
                 out_s_ptrs = out_ptrs + s * stride_out_seq
                 tl.store(out_s_ptrs, 0.0, mask=offs_m < dim)
             return
         state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
+        state_write_ptr = state_ptr + (state_batch_write_idx - state_batch_idx) * stride_state_batch
         if HAS_INT_STATE:
-            int_state_ptr += state_batch_idx * stride_int_batch + pid_h * stride_int_head
+            int_state_ptr += (
+                state_batch_idx // STATE_BANK_COUNT
+            ) * stride_int_batch + pid_h * stride_int_head
     else:
         state_ptr += pid_b * stride_state_batch + pid_h * stride_state_head
+        state_write_ptr = state_ptr
         if HAS_INT_STATE:
             int_state_ptr += pid_b * stride_int_batch + pid_h * stride_int_head
 
@@ -176,6 +188,9 @@ def _selective_scan_update_kernel(
 
     # Constant offsets (A, D, and bias do not have a sequence dimension)
     state_ptrs = state_ptr + (
+        offs_m[:, None] * stride_state_dim + offs_n[None, :] * stride_state_dstate
+    )
+    state_write_ptrs = state_write_ptr + (
         offs_m[:, None] * stride_state_dim + offs_n[None, :] * stride_state_dstate
     )
     if HAS_INT_STATE:
@@ -279,7 +294,7 @@ def _selective_scan_update_kernel(
         tl.store(out_s_ptrs, out, mask=offs_m < dim)
 
     # After processing all sequence steps, persist the final state back to HBM
-    tl.store(state_ptrs, state, mask=(offs_m[:, None] < dim) & (offs_n[None, :] < dstate))
+    tl.store(state_write_ptrs, state, mask=(offs_m[:, None] < dim) & (offs_n[None, :] < dstate))
 
 
 def selective_state_update(
@@ -294,7 +309,9 @@ def selective_state_update(
     dt_bias=None,
     dt_softplus=False,
     state_batch_indices=None,
+    state_batch_write_indices=None,
     intermediate_ssm_states=None,
+    state_bank_count: int = 1,
 ):
     """
     Argument:
@@ -308,8 +325,11 @@ def selective_state_update(
         D: (dim,) or (nheads, dim)
         z: Matches x
         dt_bias: (dim,) or (nheads, dim)
+        state_batch_indices: Optional read-state slot index for each batch row.
+        state_batch_write_indices: Optional write-state slot index for each batch row.
         intermediate_ssm_states: Optional buffer of shape (batch, seqlen, nheads, dim, dstate)
                                  or (batch, seqlen, dim, dstate)
+        state_bank_count: Number of flattened state banks per logical request slot.
     Return:
         out: shape matches x
     """
@@ -378,6 +398,9 @@ def selective_state_update(
     z_strides = (
         (z.stride(0), z.stride(1), z.stride(2), z.stride(3)) if z is not None else (0, 0, 0, 0)
     )
+    has_state_batch_write_indices = state_batch_write_indices is not None
+    if state_batch_write_indices is None:
+        state_batch_write_indices = state_batch_indices
 
     is_blackwell = torch.cuda.get_device_capability(x.device)[0] >= 10
 
@@ -417,6 +440,7 @@ def selective_state_update(
             z,
             out,
             state_batch_indices,
+            state_batch_write_indices,
             intermediate_ssm_states,
             batch,
             seq_len,
@@ -461,6 +485,8 @@ def selective_state_update(
             dt_softplus,
             tie_hdim,
             BLOCK_SIZE_M,
+            HAS_STATE_BATCH_WRITE_INDICES=has_state_batch_write_indices,
+            STATE_BANK_COUNT=state_bank_count,
             num_warps=num_warps,
         )
 

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1624,6 +1624,8 @@ class CudaGraphManager(torch.nn.Module):
             if inference_context.is_static_batching():
                 batch_size = kwargs['hidden_states'].shape[0]
                 cache_key = (batch_size, inference_context.is_decode_only())
+            elif hasattr(inference_context, "cuda_graph_cache_key"):
+                cache_key = inference_context.cuda_graph_cache_key()
             else:
                 cache_key = inference_context.padded_batch_dimensions
         is_in_checkpoint_fwd = is_checkpointing()
@@ -1665,6 +1667,7 @@ class CudaGraphManager(torch.nn.Module):
                                     getattr(r[0].base_module, 'layer_number', None)
                                     == runner.base_module.layer_number - 1
                                     and r[0].fwd_graph is not None
+                                    and (len(r) < 5 or r[4] == cache_key)
                                     and ArgMetadata(r[3]['hidden_states'])
                                     == ArgMetadata(kwargs['hidden_states'])
                                 )
@@ -1685,7 +1688,7 @@ class CudaGraphManager(torch.nn.Module):
 
                     # Record this to the global execution record
                     _CudagraphGlobalRecord.cudagraph_inference_record.append(
-                        (runner, "fwd", args, kwargs)
+                        (runner, "fwd", args, kwargs, cache_key)
                     )
 
                 # Now replay the graph

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -463,6 +463,8 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         ):
             if kwargs['inference_context'].is_static_batching():
                 using_cuda_graph = kwargs['inference_context'].is_decode_only()
+            elif hasattr(kwargs['inference_context'], 'replay_cuda_graph_this_step'):
+                using_cuda_graph = kwargs['inference_context'].replay_cuda_graph_this_step()
             else:
                 using_cuda_graph = kwargs['inference_context'].using_cuda_graph_this_step()
 

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1332,6 +1332,8 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         ):
             if kwargs['inference_context'].is_static_batching():
                 using_cuda_graph = kwargs['inference_context'].is_decode_only()
+            elif hasattr(kwargs['inference_context'], 'replay_cuda_graph_this_step'):
+                using_cuda_graph = kwargs['inference_context'].replay_cuda_graph_this_step()
             else:
                 # it can happen that non-decode steps have a token count greater than the max
                 # supported cuda graph token count. In that case this flag will be set to

--- a/megatron/inference/utils.py
+++ b/megatron/inference/utils.py
@@ -384,6 +384,7 @@ def get_inference_config_from_model_and_args(model: MegatronModule, args):
         disable_ep_consensus=args.inference_disable_ep_consensus,
         sampling_backend=args.inference_dynamic_batching_sampling_backend,
         async_scheduling=args.inference_dynamic_batching_async_scheduling,
+        async_chain_scheduling=args.inference_dynamic_batching_async_chain_scheduling,
     )
 
 

--- a/megatron/inference/utils.py
+++ b/megatron/inference/utils.py
@@ -4,6 +4,7 @@ import logging
 from argparse import ArgumentParser
 from functools import partial
 from typing import Optional
+
 import torch
 
 from gpt_builders import gpt_builder
@@ -382,6 +383,7 @@ def get_inference_config_from_model_and_args(model: MegatronModule, args):
         use_synchronous_zmq_collectives=args.inference_use_synchronous_zmq_collectives,
         disable_ep_consensus=args.inference_disable_ep_consensus,
         sampling_backend=args.inference_dynamic_batching_sampling_backend,
+        async_scheduling=args.inference_dynamic_batching_async_scheduling,
     )
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -6,18 +6,24 @@ import argparse
 import dataclasses
 import json
 import os
-from pathlib import Path
 import re
 import types
+from pathlib import Path
 
 import torch
 import torch.nn.functional as F
 from packaging.version import Version as PkgVersion
 
+from megatron.core.activations import squared_relu
 from megatron.core.dist_checkpointing.validation import StrictHandling
+from megatron.core.fusions.fused_bias_geglu import quick_gelu
+from megatron.core.msc_utils import MultiStorageClientFeature
+from megatron.core.quantization.utils import (
+    kitchen_quantization_recipe_config,
+    load_quantization_recipe,
+)
 from megatron.core.rerun_state_machine import RerunStateMachine
 from megatron.core.transformer import MLATransformerConfig, TransformerConfig
-from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.transformer.cuda_graph_config import (
     ALLOWED_INFERENCE_SCOPES,
     get_deprecated_cuda_graph_modules_migration,
@@ -30,29 +36,22 @@ from megatron.core.transformer.heterogeneous.heterogeneous_config import (
     HeterogeneousTransformerConfig,
     MLPConfig,
 )
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.utils import (
     get_torch_version,
     is_flashinfer_min_version,
     is_te_min_version,
     is_torch_min_version,
 )
-from megatron.core.activations import squared_relu
-from megatron.core.fusions.fused_bias_geglu import quick_gelu
+from megatron.training.argument_utils import ArgumentGroupFactory, core_transformer_config_from_args
 from megatron.training.global_vars import set_global_variables
 from megatron.training.utils import (
     get_device_arch_version,
-    update_use_dist_ckpt,
     print_rank_0,
+    update_use_dist_ckpt,
     warn_rank_0,
 )
-from megatron.core.msc_utils import MultiStorageClientFeature
 
-from megatron.core.quantization.utils import (
-    kitchen_quantization_recipe_config,
-    load_quantization_recipe,
-)
-
-from megatron.training.argument_utils import ArgumentGroupFactory, core_transformer_config_from_args
 
 def add_megatron_arguments(parser: argparse.ArgumentParser):
     """"Add Megatron-LM arguments to the given parser."""
@@ -409,8 +408,9 @@ def validate_args(args, defaults={}):
         'Currently only global and local checkpoints are supported'
     if args.non_persistent_ckpt_type == 'local':
         try:
-            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import \
-                LocalCheckpointManager
+            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import (
+                LocalCheckpointManager,
+            )
         except ModuleNotFoundError as e:
             raise RuntimeError('nvidia_resiliency_ext is required for local checkpointing') from e
 
@@ -756,8 +756,10 @@ def validate_args(args, defaults={}):
         )
 
     from megatron.core.models.hybrid.hybrid_layer_allocation import (
-        Symbols, parse_hybrid_pattern, get_hybrid_total_layer_count,
+        Symbols,
+        get_hybrid_total_layer_count,
         get_hybrid_total_pipeline_segment_count,
+        parse_hybrid_pattern,
     )
     sep = Symbols.MTP_SEPARATOR
 
@@ -1990,6 +1992,10 @@ def _add_inference_args(parser):
                        help='Which sampling kernels to use during inference. '
                             'Falls back to "torch" with a warning if "flashinfer" '
                             'is requested but the package is not installed.')
+    group.add_argument('--inference-dynamic-batching-async-scheduling',
+                       action=argparse.BooleanOptionalAction,
+                       default=False,
+                       help='Enable transactional async scheduling for dynamic decode.')
     group.add_argument('--inference-logging-step-interval', type=int, default=0,
                        help='Step interval for logging inference metrics. '
                             'Default to 0 to disable inference logging.')
@@ -2517,8 +2523,7 @@ def _add_rl_args(parser):
     return parser
 
 def _add_training_args(parser):
-    from megatron.training.config import TrainingConfig
-    from megatron.training.config import ProfilingConfig
+    from megatron.training.config import ProfilingConfig, TrainingConfig
 
     prof_factory = ArgumentGroupFactory(ProfilingConfig)
     prof_group = prof_factory.build_group(parser, "profiling")
@@ -3354,7 +3359,7 @@ def _add_kitchen_quantization_arguments(parser: argparse.ArgumentParser):
     If kitchen isn't available, nothing to do here, return unchanged parser
     """
     try:
-        from megatron.core.extensions.kitchen import KitchenSpecProvider, HAVE_KITCHEN
+        from megatron.core.extensions.kitchen import HAVE_KITCHEN, KitchenSpecProvider
 
     except (ImportError, ModuleNotFoundError):
         HAVE_KITCHEN = False

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1996,6 +1996,10 @@ def _add_inference_args(parser):
                        action=argparse.BooleanOptionalAction,
                        default=False,
                        help='Enable transactional async scheduling for dynamic decode.')
+    group.add_argument('--inference-dynamic-batching-async-chain-scheduling',
+                       action=argparse.BooleanOptionalAction,
+                       default=True,
+                       help='Enable chained sampling plus child-forward launch for async decode.')
     group.add_argument('--inference-logging-step-interval', type=int, default=0,
                        help='Step interval for logging inference metrics. '
                             'Default to 0 to disable inference logging.')

--- a/tests/unit_tests/dist_checkpointing/test_async_save.py
+++ b/tests/unit_tests/dist_checkpointing/test_async_save.py
@@ -129,7 +129,7 @@ _NVRX_SUBMODULES = [
 
 
 class TestHasNvrxAsyncSupport:
-    """Tests for has_nvrx_async_support, focusing on the minimum-version assertion."""
+    """Tests for has_nvrx_async_support, focusing on the minimum-version gate."""
 
     def _fake_modules(self):
         """MagicMock modules that satisfy every symbol and hasattr check in has_nvrx_async_support."""
@@ -150,7 +150,7 @@ class TestHasNvrxAsyncSupport:
             assert has_nvrx_async_support() is True
 
     def test_version_check_fails(self):
-        """Raises AssertionError when all NVRx symbols are present but version is too old."""
+        """Returns False when all NVRx symbols are present but version is too old."""
         with (
             mock.patch(
                 'megatron.core.dist_checkpointing.strategies.nvrx.import_module',
@@ -161,5 +161,4 @@ class TestHasNvrxAsyncSupport:
                 return_value=False,
             ),
         ):
-            with pytest.raises(AssertionError, match="Minimum required nvidia-resiliency-ext"):
-                has_nvrx_async_support()
+            assert has_nvrx_async_support() is False

--- a/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
+++ b/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
@@ -100,6 +100,7 @@ class TestMambaMetadata:
 
         expected_decode = torch.arange(4, dtype=torch.int32, device=metadata_context.device)
         assert torch.equal(metadata_context.batch_indices_decode, expected_decode)
+        assert torch.equal(metadata_context.batch_indices_decode_write, expected_decode)
 
         assert metadata_context.batch_indices_prefill is None
         assert metadata_context.device_decode_prefill is None
@@ -124,9 +125,33 @@ class TestMambaMetadata:
             [0, 1, -1, -1], dtype=torch.int32, device=metadata_context.device
         )
         assert torch.equal(metadata_context.batch_indices_decode, expected_decode)
+        assert torch.equal(metadata_context.batch_indices_decode_write, expected_decode)
 
         assert metadata_context.batch_indices_prefill is None
         assert metadata_context.device_decode_prefill is None
+
+    @pytest.mark.internal
+    def test_update_decode_write_indices_can_target_candidate_bank(self, metadata_context):
+        """Decode reads may come from committed slots while writes target candidate slots."""
+        dims = InferenceBatchDimensions(token_count=2, prefill_req_count=0, decode_req_count=2)
+        padded_dims = InferenceBatchDimensions(token_count=4, prefill_req_count=0, decode_req_count=4)
+        read_indices = torch.tensor([4, 9], dtype=torch.int32, device=metadata_context.device)
+        write_indices = torch.tensor([5, 8], dtype=torch.int32, device=metadata_context.device)
+        token_to_req = torch.tensor([0, 1], dtype=torch.int32, device=metadata_context.device)
+        cu_seqlens = torch.tensor([0, 1, 2], dtype=torch.int32, device=metadata_context.device)
+
+        metadata_context.update(
+            active_mamba_indices=read_indices,
+            token_to_request_idx=token_to_req,
+            cu_seqlens=cu_seqlens,
+            batch_dimensions=dims,
+            padded_batch_dimensions=padded_dims,
+            enable_chunked_prefill=False,
+            active_mamba_write_indices=write_indices,
+        )
+
+        assert metadata_context.batch_indices_decode.tolist() == [4, 9, -1, -1]
+        assert metadata_context.batch_indices_decode_write.tolist() == [5, 8, -1, -1]
 
     @pytest.mark.internal
     def test_update_chunked_enabled_no_prefill_reqs(self, metadata_context):

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -407,6 +407,54 @@ class TestDynamicContext:
 
     @pytest.mark.internal
     @rounder_override(64)
+    def test_bind_decode_slot_for_forward_restores_active_graph_metadata(self):
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=2,
+            kv_channels=64,
+            num_attention_heads=8,
+            max_sequence_length=128,
+            buffer_size_gb=0.1,
+            block_size_tokens=128,
+            max_tokens=None,
+            num_cuda_graphs=-1,
+            async_scheduling=True,
+        )
+        dynamic_context.add_request(
+            DynamicInferenceRequest(
+                request_id=42,
+                prompt_tokens=torch.tensor([5], dtype=torch.long, device='cpu'),
+                sampling_params=SamplingParams(num_tokens_to_generate=8),
+            )
+        )
+        dynamic_context.update_requests(
+            active_requests_mask=torch.tensor([1], dtype=torch.int32),
+            new_tokens=torch.tensor([7], dtype=torch.int64),
+        )
+        dynamic_context.initialize_attention_state()
+        assert dynamic_context.using_cuda_graph_this_step()
+
+        child_txn = dynamic_context.prepare_child_from_committed_decode_state()
+        assert child_txn is not None
+        if child_txn.h2d_done_event is not None:
+            child_txn.h2d_done_event.synchronize()
+
+        child_slot = dynamic_context.async_decode_slot_ring.child
+        dynamic_context.reset_attention_state()
+        assert dynamic_context.active_attn_metadata is None
+
+        dynamic_context.bind_decode_slot_for_forward(child_slot)
+
+        assert dynamic_context.active_attn_metadata is dynamic_context.graph_attn_metadata
+        block_table = dynamic_context.active_attn_metadata["mha_metadata"].state_data[
+            "block_table"
+        ]
+        assert block_table.data_ptr() == child_slot.gpu_view.mha_block_table.data_ptr()
+        _, _, kv_block_table = dynamic_context.key_value_cache(layer_number=1)
+        assert kv_block_table.data_ptr() == child_slot.gpu_view.mha_block_table.data_ptr()
+
+    @pytest.mark.internal
+    @rounder_override(64)
     @pytest.mark.parametrize("is_hybrid_model", [False, True])
     def test_reset(self, is_hybrid_model: bool):
 

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -77,6 +77,7 @@ class TestDynamicContext:
         num_speculative_tokens=0,
         enable_chunked_prefill: bool = False,
         max_requests: int = None,
+        async_scheduling: bool = False,
     ):
         if is_hybrid_model:
             if layer_type_list is None:
@@ -117,6 +118,7 @@ class TestDynamicContext:
                 unified_memory_level=0,  # unit tests currently broken with UVM
                 enable_chunked_prefill=enable_chunked_prefill,
                 max_requests=max_requests,
+                async_scheduling=async_scheduling,
             ),
         )
         return dynamic_context
@@ -296,6 +298,60 @@ class TestDynamicContext:
         assert refreshed_pos_ids is pos_ids_view
         assert torch.equal(refreshed_input_ids.squeeze(0), new_input_ids)
         assert torch.equal(refreshed_pos_ids.squeeze(0), new_pos_ids)
+
+    @pytest.mark.internal
+    @rounder_override(64)
+    def test_prepare_child_from_committed_decode_state_uses_child_slot(self):
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=2,
+            kv_channels=64,
+            num_attention_heads=8,
+            max_sequence_length=128,
+            buffer_size_gb=0.1,
+            block_size_tokens=128,
+            max_tokens=None,
+            async_scheduling=True,
+        )
+        dynamic_context.add_request(
+            DynamicInferenceRequest(
+                request_id=42,
+                prompt_tokens=torch.tensor([5], dtype=torch.long, device='cpu'),
+                sampling_params=SamplingParams(num_tokens_to_generate=8),
+            )
+        )
+        dynamic_context.update_requests(
+            active_requests_mask=torch.tensor([1], dtype=torch.int32),
+            new_tokens=torch.tensor([7], dtype=torch.int64),
+        )
+        dynamic_context.initialize_attention_state()
+
+        committed_pos_ids = dynamic_context.token_to_pos_ids[:1].clone()
+        committed_kv_offsets = dynamic_context.request_kv_length_offsets[:1].clone()
+        child_txn = dynamic_context.prepare_child_from_committed_decode_state()
+
+        assert child_txn is not None
+        assert child_txn.request_ids == (42,)
+        assert child_txn.slot_id == dynamic_context.async_decode_slot_ring.child.slot_id
+        assert dynamic_context.active_decode_slot_id == dynamic_context.async_decode_slot_ring.current.slot_id
+        if child_txn.h2d_done_event is not None:
+            child_txn.h2d_done_event.synchronize()
+
+        child_view = dynamic_context.async_decode_slot_ring.child.gpu_view
+        assert child_view.token_to_input_ids[0].item() == 7
+        assert child_view.token_to_pos_ids[0].item() == committed_pos_ids[0].item() + 1
+        assert child_view.token_to_position_in_request[0].item() == committed_pos_ids[0].item() + 1
+        assert child_view.token_to_local_position_within_kv_block[0].item() == (
+            committed_pos_ids[0].item() + 1
+        )
+        assert child_view.request_kv_length_offsets[0].item() == (
+            committed_kv_offsets[0].item() + 1
+        )
+        assert child_view.mha_kv_seq_lengths[0].item() == (
+            dynamic_context.gpu_view.mha_kv_seq_lengths[0].item() + 1
+        )
+        assert torch.equal(dynamic_context.token_to_pos_ids[:1], committed_pos_ids)
+        assert torch.equal(dynamic_context.request_kv_length_offsets[:1], committed_kv_offsets)
 
     @pytest.mark.internal
     @rounder_override(64)

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -365,6 +365,7 @@ class TestDynamicContext:
             buffer_size_gb=0.1,
             block_size_tokens=128,
             max_tokens=None,
+            num_cuda_graphs=-1,
             async_scheduling=True,
         )
         dynamic_context.add_request(
@@ -379,6 +380,9 @@ class TestDynamicContext:
             new_tokens=torch.tensor([7], dtype=torch.int64),
         )
         dynamic_context.initialize_attention_state()
+        assert dynamic_context.using_cuda_graph_this_step()
+        assert dynamic_context.active_attn_metadata is dynamic_context.graph_attn_metadata
+
         child_txn = dynamic_context.prepare_child_from_committed_decode_state()
         assert child_txn is not None
         if child_txn.h2d_done_event is not None:
@@ -387,7 +391,6 @@ class TestDynamicContext:
         child_slot = dynamic_context.async_decode_slot_ring.child
         dynamic_context.bind_decode_slot(child_slot)
         previous_attn_metadata = dynamic_context.active_attn_metadata
-        dynamic_context._using_cuda_graph_this_step = True
 
         with dynamic_context.async_child_forward_graph_replay_disabled_scope():
             assert dynamic_context.using_cuda_graph_this_step()

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -355,7 +355,7 @@ class TestDynamicContext:
 
     @pytest.mark.internal
     @rounder_override(64)
-    def test_async_child_forward_eager_scope_activates_child_non_graph_metadata(self):
+    def test_async_child_forward_scope_disables_replay_but_keeps_graph_metadata(self):
         dynamic_context = self._get_dynamic_context(
             params_dtype=torch.float32,
             num_layers=2,
@@ -389,15 +389,17 @@ class TestDynamicContext:
         previous_attn_metadata = dynamic_context.active_attn_metadata
         dynamic_context._using_cuda_graph_this_step = True
 
-        with dynamic_context.async_child_forward_eager_scope():
-            assert not dynamic_context.using_cuda_graph_this_step()
-            assert dynamic_context.active_attn_metadata is dynamic_context.non_graph_attn_metadata
+        with dynamic_context.async_child_forward_graph_replay_disabled_scope():
+            assert dynamic_context.using_cuda_graph_this_step()
+            assert not dynamic_context.replay_cuda_graph_this_step()
+            assert dynamic_context.active_attn_metadata is previous_attn_metadata
             block_table = dynamic_context.active_attn_metadata["mha_metadata"].state_data[
                 "block_table"
             ]
             assert block_table.data_ptr() == child_slot.gpu_view.mha_block_table.data_ptr()
 
         assert dynamic_context.using_cuda_graph_this_step()
+        assert dynamic_context.replay_cuda_graph_this_step()
         assert dynamic_context.active_attn_metadata is previous_attn_metadata
 
     @pytest.mark.internal

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -355,6 +355,53 @@ class TestDynamicContext:
 
     @pytest.mark.internal
     @rounder_override(64)
+    def test_async_child_forward_eager_scope_activates_child_non_graph_metadata(self):
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=2,
+            kv_channels=64,
+            num_attention_heads=8,
+            max_sequence_length=128,
+            buffer_size_gb=0.1,
+            block_size_tokens=128,
+            max_tokens=None,
+            async_scheduling=True,
+        )
+        dynamic_context.add_request(
+            DynamicInferenceRequest(
+                request_id=42,
+                prompt_tokens=torch.tensor([5], dtype=torch.long, device='cpu'),
+                sampling_params=SamplingParams(num_tokens_to_generate=8),
+            )
+        )
+        dynamic_context.update_requests(
+            active_requests_mask=torch.tensor([1], dtype=torch.int32),
+            new_tokens=torch.tensor([7], dtype=torch.int64),
+        )
+        dynamic_context.initialize_attention_state()
+        child_txn = dynamic_context.prepare_child_from_committed_decode_state()
+        assert child_txn is not None
+        if child_txn.h2d_done_event is not None:
+            child_txn.h2d_done_event.synchronize()
+
+        child_slot = dynamic_context.async_decode_slot_ring.child
+        dynamic_context.bind_decode_slot(child_slot)
+        previous_attn_metadata = dynamic_context.active_attn_metadata
+        dynamic_context._using_cuda_graph_this_step = True
+
+        with dynamic_context.async_child_forward_eager_scope():
+            assert not dynamic_context.using_cuda_graph_this_step()
+            assert dynamic_context.active_attn_metadata is dynamic_context.non_graph_attn_metadata
+            block_table = dynamic_context.active_attn_metadata["mha_metadata"].state_data[
+                "block_table"
+            ]
+            assert block_table.data_ptr() == child_slot.gpu_view.mha_block_table.data_ptr()
+
+        assert dynamic_context.using_cuda_graph_this_step()
+        assert dynamic_context.active_attn_metadata is previous_attn_metadata
+
+    @pytest.mark.internal
+    @rounder_override(64)
     @pytest.mark.parametrize("is_hybrid_model", [False, True])
     def test_reset(self, is_hybrid_model: bool):
 

--- a/tests/unit_tests/inference/contexts/test_gpu_view.py
+++ b/tests/unit_tests/inference/contexts/test_gpu_view.py
@@ -26,7 +26,7 @@ REQUEST_VIEWS_INT32 = (
     "active_request_last_token_idxs",
 )
 REQUEST_VIEWS_FLOAT32 = ("temperature", "top_p")
-MAMBA_VIEWS_INT64 = ("mamba_batch_indices_decode",)
+MAMBA_VIEWS_INT64 = ("mamba_batch_indices_decode", "mamba_batch_indices_decode_write")
 MAMBA_VIEWS_INT32 = (
     "mamba_batch_indices_prefill",
     "mamba_seq_idx",

--- a/tests/unit_tests/inference/test_async_txn_barriers.py
+++ b/tests/unit_tests/inference/test_async_txn_barriers.py
@@ -59,8 +59,9 @@ class FakeController:
         self.barrier_reasons = []
 
     async def async_generate_output_tokens_dynamic_batch(
-        self, *, async_launch_barrier_reason=None
+        self, *, async_launch_barrier_reason=None, profile_async_child_forward=False
     ):
+        del profile_async_child_forward
         self.barrier_reasons.append(async_launch_barrier_reason)
         return None
 
@@ -209,7 +210,7 @@ def test_async_forward_passes_pending_admission_barrier_to_controller():
     assert controller.barrier_reasons == [AsyncTxnSkipReason.PENDING_ADMISSION]
 
 
-def test_drain_synchronizes_inflight_forward_and_keeps_adoptable_child_by_default():
+def test_drain_synchronizes_inflight_forward_and_keeps_consumable_child_by_default():
     diagnostics = AsyncTxnDiagnostics(enabled=True)
     retire_queue = TxnRetireQueue(diagnostics)
     released = []
@@ -236,6 +237,6 @@ def test_drain_synchronizes_inflight_forward_and_keeps_adoptable_child_by_defaul
     assert controller._async_prepared_child_txn is None
     assert controller._async_launched_child_txn is launched
 
-    controller.drain_async_transactions(drop_launched=True)
+    controller.drain_async_transactions(clear_launched=True)
 
     assert controller._async_launched_child_txn is None

--- a/tests/unit_tests/inference/test_async_txn_barriers.py
+++ b/tests/unit_tests/inference/test_async_txn_barriers.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.inference.async_txn import (
+    AsyncTxnDiagnostics,
+    AsyncTxnSkipReason,
+    StepTxn,
+    TxnRetireQueue,
+    classify_decode_child_launch,
+)
+from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine, EngineState
+from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+    TextGenerationController,
+)
+
+
+class FakeEvent:
+    def __init__(self, *, done: bool = True):
+        self.done = done
+        self.synchronized = 0
+
+    def query(self) -> bool:
+        return self.done
+
+    def synchronize(self) -> None:
+        self.synchronized += 1
+        self.done = True
+
+
+class FakeLaunchContext:
+    def __init__(
+        self,
+        *,
+        decode_only: bool = True,
+        chunked_prefill_request_id: int = -1,
+        paused_request_count: int = 0,
+    ):
+        self._decode_only = decode_only
+        self.chunked_prefill_request_id = chunked_prefill_request_id
+        self.paused_request_count = paused_request_count
+        self.total_request_count = 1
+        self.num_speculative_tokens = 0
+        self.block_size_tokens = 4
+        self.request_last_kv_block_offset = torch.tensor([0], dtype=torch.int32)
+        self.request_ids = torch.tensor([101], dtype=torch.int32)
+        self.kv_block_allocator = SimpleNamespace(is_memory_available=lambda count: True)
+
+    def is_decode_only(self) -> bool:
+        return self._decode_only
+
+
+class FakeController:
+    def __init__(self):
+        self.barrier_reasons = []
+
+    async def async_generate_output_tokens_dynamic_batch(
+        self, *, async_launch_barrier_reason=None
+    ):
+        self.barrier_reasons.append(async_launch_barrier_reason)
+        return None
+
+
+class FakeAsyncForwardContext:
+    def __init__(self):
+        self.async_scheduling = True
+        self.step_count = 0
+        self.prefix_cache_lru_clock = 0
+        self.max_requests = 8
+        self.total_request_count = 1
+        self.paused_request_count = 0
+        self.active_token_count = 1
+
+    def is_decode_only(self) -> bool:
+        return True
+
+
+def _make_controller(context):
+    controller = object.__new__(TextGenerationController)
+    controller.num_speculative_tokens = 0
+    controller._enable_cuda_graph = False
+    controller.model_config = SimpleNamespace(expert_model_parallel_size=1, num_moe_experts=None)
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
+    return controller
+
+
+def _make_engine_for_barriers(context=None):
+    engine = object.__new__(DynamicInferenceEngine)
+    engine.context = context or SimpleNamespace(
+        async_scheduling=True, chunked_prefill_request_id=-1
+    )
+    engine.state = EngineState.RUNNING
+    engine._next_async_launch_barrier_reason = None
+    return engine
+
+
+def test_admission_defers_child_launch_even_without_prepared_child():
+    context = FakeLaunchContext()
+    controller = _make_controller(context)
+
+    reason = controller._async_child_launch_skip_reason(
+        None,
+        return_log_probs=False,
+        return_top_n_logprobs=False,
+        skip_bookkeeping=False,
+        async_launch_barrier_reason=AsyncTxnSkipReason.PENDING_ADMISSION,
+    )
+
+    assert reason == AsyncTxnSkipReason.PENDING_ADMISSION
+
+
+def test_chunked_prefill_disables_and_reenables_async_barrier():
+    context = SimpleNamespace(async_scheduling=True, chunked_prefill_request_id=77)
+    engine = _make_engine_for_barriers(context)
+
+    reason = DynamicInferenceEngine._consume_async_launch_barrier_reason(
+        engine, admitted_requests=False, will_log_this_step=False
+    )
+    context.chunked_prefill_request_id = -1
+    resumed_reason = DynamicInferenceEngine._consume_async_launch_barrier_reason(
+        engine, admitted_requests=False, will_log_this_step=False
+    )
+
+    assert reason == AsyncTxnSkipReason.CHUNKED_PREFILL
+    assert resumed_reason is None
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        AsyncTxnSkipReason.RESUME_BARRIER,
+        AsyncTxnSkipReason.EVICT_BARRIER,
+        AsyncTxnSkipReason.FORCE_PAUSE_BARRIER,
+        AsyncTxnSkipReason.GRAPH_RECAPTURE_BARRIER,
+    ],
+)
+def test_explicit_barrier_reasons_are_consumed_once(reason):
+    engine = _make_engine_for_barriers()
+
+    DynamicInferenceEngine._request_next_async_launch_barrier(engine, reason)
+    first = DynamicInferenceEngine._consume_async_launch_barrier_reason(
+        engine, admitted_requests=False, will_log_this_step=False
+    )
+    second = DynamicInferenceEngine._consume_async_launch_barrier_reason(
+        engine, admitted_requests=False, will_log_this_step=False
+    )
+
+    assert first == reason
+    assert second is None
+
+
+def test_log_interval_barrier_skips_only_the_intended_step():
+    engine = _make_engine_for_barriers()
+
+    first = DynamicInferenceEngine._consume_async_launch_barrier_reason(
+        engine, admitted_requests=False, will_log_this_step=True
+    )
+    second = DynamicInferenceEngine._consume_async_launch_barrier_reason(
+        engine, admitted_requests=False, will_log_this_step=False
+    )
+
+    assert first == AsyncTxnSkipReason.LOG_INTERVAL_BARRIER
+    assert second is None
+
+
+def test_resume_evict_and_overflow_pause_are_concrete_launch_gates():
+    paused_context = FakeLaunchContext(paused_request_count=1)
+    launchable_context = FakeLaunchContext()
+
+    paused = classify_decode_child_launch(paused_context, async_enabled=True)
+    resume = classify_decode_child_launch(
+        launchable_context, async_enabled=True, resume_barrier=True
+    )
+    evict = classify_decode_child_launch(
+        launchable_context, async_enabled=True, evict_barrier=True
+    )
+    force_pause = classify_decode_child_launch(
+        launchable_context, async_enabled=True, force_pause_barrier=True
+    )
+
+    assert paused.reason == AsyncTxnSkipReason.PAUSED_REQUESTS
+    assert resume.reason == AsyncTxnSkipReason.RESUME_BARRIER
+    assert evict.reason == AsyncTxnSkipReason.EVICT_BARRIER
+    assert force_pause.reason == AsyncTxnSkipReason.FORCE_PAUSE_BARRIER
+
+
+def test_async_forward_passes_pending_admission_barrier_to_controller():
+    context = FakeAsyncForwardContext()
+    controller = FakeController()
+    engine = _make_engine_for_barriers(context)
+    engine.controller = controller
+    engine.schedule_waiting_requests = lambda: True
+    engine.logging_step_interval = 0
+    engine.is_decode_only = None
+
+    result, context_state, step_time = asyncio.run(
+        DynamicInferenceEngine.async_forward(engine)
+    )
+
+    assert result is None
+    assert context_state["active_token_count"] == 1
+    assert step_time == 0.0
+    assert context.step_count == 1
+    assert context.prefix_cache_lru_clock == 1
+    assert controller.barrier_reasons == [AsyncTxnSkipReason.PENDING_ADMISSION]
+
+
+def test_drain_synchronizes_inflight_forward_and_keeps_adoptable_child_by_default():
+    diagnostics = AsyncTxnDiagnostics(enabled=True)
+    retire_queue = TxnRetireQueue(diagnostics)
+    released = []
+    retire_queue.enqueue(FakeEvent(done=True), lambda: released.append("retired"))
+    context = SimpleNamespace(async_txn_retire_queue=retire_queue)
+    controller = _make_controller(context)
+    forward_event = FakeEvent(done=False)
+    sample_event = FakeEvent(done=False)
+    launched = StepTxn(
+        step_id=9,
+        request_ids=(101,),
+        forward_done_event=forward_event,
+        sample_done_event=sample_event,
+        launched=True,
+    )
+    controller._async_launched_child_txn = launched
+    controller._async_prepared_child_txn = StepTxn(step_id=10, request_ids=(101,))
+
+    controller.drain_async_transactions()
+
+    assert forward_event.synchronized == 1
+    assert sample_event.synchronized == 1
+    assert released == ["retired"]
+    assert controller._async_prepared_child_txn is None
+    assert controller._async_launched_child_txn is launched
+
+    controller.drain_async_transactions(drop_launched=True)
+
+    assert controller._async_launched_child_txn is None

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -81,12 +81,12 @@ def test_cuda_graph_cache_key_stays_shape_only_for_async_decode():
     assert key == context.padded_batch_dimensions
 
 
-def test_async_decode_child_adoption_is_not_graph_keyed():
+def test_async_decode_child_adoption_uses_current_slot_graph_key():
     context = _make_graph_key_context(active_slot_id=1)
     controller = object.__new__(TextGenerationController)
     controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
 
-    assert controller._async_decode_cuda_graph_key() is None
+    assert controller._async_decode_cuda_graph_key() == context.padded_batch_dimensions
 
 
 def test_cuda_graph_cache_key_stays_shape_only_for_non_decode_or_non_async():

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -81,7 +81,7 @@ def test_cuda_graph_cache_key_stays_shape_only_for_async_decode():
     assert key == context.padded_batch_dimensions
 
 
-def test_async_decode_child_adoption_uses_current_slot_graph_key():
+def test_async_decode_child_consumption_uses_current_slot_graph_key():
     context = _make_graph_key_context(active_slot_id=1)
     controller = object.__new__(TextGenerationController)
     controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
@@ -235,7 +235,7 @@ def _make_dummy_controller(*, num_speculative_tokens):
         inference_context=SimpleNamespace(reset=lambda: calls.append("reset"))
     )
     controller._decide_ep_step_begin = lambda has_real_work: SimpleNamespace(
-        reuse_pending_forward=True
+        consume_launched_forward=True
     )
     controller._dynamic_step_context_init = lambda is_dummy_forward=False: (_ for _ in ()).throw(
         AssertionError("non-MTP reuse should not run a base dummy forward")
@@ -432,31 +432,31 @@ def test_ep_async_step_protocol_keeps_child_phases_in_active_work_step():
     asyncio.run(run_test())
 
 
-def test_ep_async_step_protocol_reuse_pending_forward_skips_dummy_base_forward():
+def test_ep_async_step_protocol_consume_launched_forward_skips_dummy_base_forward():
     communicator = FakeStepCommunicator()
     protocol = EPAsyncStepProtocol(communicator)
     protocol.ensure_work_step()
 
     decision = protocol.decide_step_begin(
         has_real_work=True,
-        has_pending_forward=True,
-        pending_forward_reusable=True,
+        has_launched_forward=True,
+        launched_forward_consumable=True,
     )
 
-    assert decision.reuse_pending_forward is True
-    assert decision.discard_pending_forward is False
+    assert decision.consume_launched_forward is True
+    assert decision.launched_forward_invariant_failed is False
     assert communicator.sync_calls == [
         ("ep_step_begin", 0, (1, 1, 1, 0, 0)),
         ("ep_step_begin_ack", 0, (1,)),
     ]
 
 
-def test_ep_async_step_protocol_discards_pending_forward_if_real_rank_missing_child():
+def test_ep_async_step_protocol_reports_launched_forward_invariant_failure_if_real_rank_missing_child():
     class MissingChildCommunicator(FakeStepCommunicator):
         def sync_all_reduce_max(self, *values, phase=None, step_id=None):
             self.sync_calls.append((phase, step_id, values))
             if phase == "ep_step_begin":
-                # Some EP rank has a pending child, but a real rank is missing it.
+                # Some EP rank has a launched child, but a real rank is missing it.
                 return (1, 1, 1, 0, 1)
             return values[0] if len(values) == 1 else values
 
@@ -466,12 +466,12 @@ def test_ep_async_step_protocol_discards_pending_forward_if_real_rank_missing_ch
 
     decision = protocol.decide_step_begin(
         has_real_work=True,
-        has_pending_forward=False,
-        pending_forward_reusable=False,
+        has_launched_forward=False,
+        launched_forward_consumable=False,
     )
 
-    assert decision.reuse_pending_forward is False
-    assert decision.discard_pending_forward is True
+    assert decision.consume_launched_forward is False
+    assert decision.launched_forward_invariant_failed is True
 
 
 def test_ep_work_step_sends_coordinator_reply_after_step_completion():

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.inference.async_txn import (
+    assert_ep_phase_tag,
+    broadcast_ep_accepted_counts,
+    broadcast_ep_sampled_tokens,
+    broadcast_ep_stop_word_finished_ids,
+)
+
+
+class FakeEPGroup:
+    def __init__(self, *, size=2, rank=1):
+        self._size = size
+        self._rank = rank
+
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
+
+
+def test_token_broadcast_gives_identical_survivor_set_across_ranks():
+    local_tokens = torch.tensor([99, 4, 99], dtype=torch.int64)
+    canonical_tokens = torch.tensor([5, 4, 7], dtype=torch.int64)
+    termination_id = torch.tensor([7, 7, 7], dtype=torch.int64)
+
+    def broadcast(tensor, src, group):
+        assert src == 0
+        assert group.rank() == 1
+        tensor.copy_(canonical_tokens)
+
+    broadcast_ep_sampled_tokens(local_tokens, 3, FakeEPGroup(), broadcast_fn=broadcast)
+
+    assert local_tokens.tolist() == [5, 4, 7]
+    assert (local_tokens != termination_id).tolist() == [True, True, False]
+
+
+def test_stop_word_id_broadcast_gives_identical_finish_mask():
+    active_request_ids = [101, 102, 103]
+    canonical_finish_mask = torch.tensor([0, 1, 0], dtype=torch.int32)
+
+    def broadcast(tensor, src, group):
+        tensor.copy_(canonical_finish_mask)
+
+    finished_ids = broadcast_ep_stop_word_finished_ids(
+        active_request_ids,
+        finished_request_ids=set(),
+        group=FakeEPGroup(),
+        broadcast_fn=broadcast,
+    )
+
+    assert finished_ids == {102}
+
+
+def test_forced_argmax_tie_uses_canonical_sampled_tokens():
+    local_tie_break = torch.tensor([31, 32], dtype=torch.int64)
+    canonical_tie_break = torch.tensor([41, 41], dtype=torch.int64)
+
+    def broadcast(tensor, src, group):
+        tensor.copy_(canonical_tie_break)
+
+    broadcast_ep_sampled_tokens(local_tie_break, 2, FakeEPGroup(), broadcast_fn=broadcast)
+
+    assert local_tie_break.tolist() == [41, 41]
+
+
+def test_mtp_accepted_count_broadcast_gives_identical_speculative_prefix():
+    local_counts = torch.tensor([0, 2, 1, 9], dtype=torch.int64)
+    canonical_counts = torch.tensor([2, 1, 0], dtype=torch.int64)
+
+    def broadcast(tensor, src, group):
+        tensor.copy_(canonical_counts)
+
+    broadcast_ep_accepted_counts(local_counts, 3, FakeEPGroup(), broadcast_fn=broadcast)
+
+    assert local_counts.tolist() == [2, 1, 0, 9]
+
+
+def test_dummy_rank_mirrors_sync_replacement_and_mtp_phase_collectives():
+    calls = []
+
+    def broadcast(tensor, src, group):
+        calls.append((src, tensor.dtype, tensor.numel()))
+
+    broadcast_ep_sampled_tokens(
+        torch.tensor([11, 12], dtype=torch.int64), 2, FakeEPGroup(), broadcast_fn=broadcast
+    )
+    broadcast_ep_stop_word_finished_ids(
+        [101, 102], {102}, FakeEPGroup(), broadcast_fn=broadcast
+    )
+    broadcast_ep_accepted_counts(
+        torch.tensor([1, 0], dtype=torch.int64), 2, FakeEPGroup(), broadcast_fn=broadcast
+    )
+
+    assert calls == [
+        (0, torch.int64, 2),
+        (0, torch.int32, 2),
+        (0, torch.int64, 2),
+    ]
+
+
+def test_ep_protocol_does_not_exchange_layout_identifiers():
+    request_ids = {101, 102}
+    kv_block_ids = {909, 910}
+    mamba_slots = {808, 809}
+    captured = []
+
+    def broadcast(tensor, src, group):
+        captured.append(tensor.clone())
+
+    broadcast_ep_sampled_tokens(
+        torch.tensor([11, 12], dtype=torch.int64), 2, FakeEPGroup(), broadcast_fn=broadcast
+    )
+    broadcast_ep_stop_word_finished_ids(
+        [101, 102], {102}, FakeEPGroup(), broadcast_fn=broadcast
+    )
+    broadcast_ep_accepted_counts(
+        torch.tensor([1, 0], dtype=torch.int64), 2, FakeEPGroup(), broadcast_fn=broadcast
+    )
+
+    exchanged_values = set()
+    for tensor in captured:
+        exchanged_values.update(int(value) for value in tensor.tolist())
+
+    assert exchanged_values.isdisjoint(request_ids)
+    assert exchanged_values.isdisjoint(kv_block_ids)
+    assert exchanged_values.isdisjoint(mamba_slots)
+
+
+def test_phase_tag_mismatch_raises_explicit_error_instead_of_hanging():
+    def all_gather(gathered, local, group):
+        gathered[0].copy_(local)
+        gathered[1].copy_(torch.tensor([local[0] + 1, local[1], local[2]], dtype=local.dtype))
+
+    with pytest.raises(RuntimeError, match="EP async transaction phase mismatch"):
+        assert_ep_phase_tag(
+            "sample",
+            step_id=4,
+            active_request_count=2,
+            group=FakeEPGroup(),
+            device=torch.device("cpu"),
+            all_gather_fn=all_gather,
+        )

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -10,6 +10,13 @@ from megatron.core.inference.async_txn import (
     broadcast_ep_stop_word_finished_ids,
     resolve_ep_decode_broadcast_plan,
 )
+from megatron.core.inference.engines.async_zmq_communicator import (
+    AsyncZMQCommunicator,
+    ZMQCollectiveError,
+)
+from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+    TextGenerationController,
+)
 
 
 class FakeEPGroup:
@@ -218,3 +225,31 @@ def test_phase_tag_mismatch_raises_explicit_error_instead_of_hanging():
             device=torch.device("cpu"),
             all_gather_fn=all_gather,
         )
+
+
+def test_zmq_collective_payload_rejects_wrong_phase():
+    msg = AsyncZMQCommunicator._pack_values_message("ep_graph_shape", 4, (1, 0))
+
+    with pytest.raises(ZMQCollectiveError, match="phase mismatch"):
+        AsyncZMQCommunicator._unpack_values_message(
+            msg,
+            expected_phase="ep_async_child_handoff",
+            expected_step_id=4,
+            expected_count=2,
+        )
+
+
+def test_controller_ep_sync_helper_uses_named_phase_when_supported():
+    calls = []
+
+    class PhaseAwareCommunicator:
+        def sync_all_reduce_max(self, *values, phase=None):
+            calls.append((phase, values))
+            return values
+
+    result = TextGenerationController._sync_all_reduce_max_with_phase(
+        PhaseAwareCommunicator(), "ep_async_child_handoff", 1, 3
+    )
+
+    assert result == (1, 3)
+    assert calls == [("ep_async_child_handoff", (1, 3))]

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -179,6 +180,54 @@ def test_ep_decode_broadcast_plan_rejects_multiple_real_sources():
             has_real_work=True,
             sync_all_reduce_max_fn=sync_all_reduce_max,
         )
+
+
+def _make_dummy_controller(*, num_speculative_tokens):
+    calls = []
+    controller = object.__new__(TextGenerationController)
+    controller.num_speculative_tokens = num_speculative_tokens
+    controller.model_config = SimpleNamespace(moe_pad_experts_for_cuda_graph_inference=False)
+    controller.inference_wrapped_model = SimpleNamespace(
+        inference_context=SimpleNamespace(reset=lambda: calls.append("reset"))
+    )
+    controller._decide_ep_step_begin = lambda has_real_work: SimpleNamespace(
+        reuse_pending_forward=True
+    )
+    controller._dynamic_step_context_init = lambda is_dummy_forward=False: (_ for _ in ()).throw(
+        AssertionError("non-MTP reuse should not run a base dummy forward")
+    )
+    controller._dynamic_step_forward_logits = lambda input_ids, position_ids: calls.append(
+        "forward"
+    )
+    controller._dummy_decode_sample_collective = lambda: calls.append("decode_result_collective")
+    controller._dummy_decode_async_child_forward_if_planned = lambda: calls.append("child_forward")
+    controller._dummy_serial_mtp_forward = lambda: calls.append("serial_mtp")
+    controller._clear_ep_decode_broadcast_plan = lambda: calls.append("clear_plan")
+    controller._clear_ep_step_begin_decision = lambda: calls.append("clear_step")
+    return controller, calls
+
+
+def test_non_mtp_dummy_reuse_skips_decode_result_collective():
+    controller, calls = _make_dummy_controller(num_speculative_tokens=0)
+
+    controller.dummy_forward()
+
+    assert calls == ["child_forward", "serial_mtp", "clear_plan", "clear_step", "reset"]
+
+
+def test_mtp_dummy_reuse_keeps_decode_result_collective_before_mtp_and_child():
+    controller, calls = _make_dummy_controller(num_speculative_tokens=2)
+
+    controller.dummy_forward()
+
+    assert calls == [
+        "decode_result_collective",
+        "serial_mtp",
+        "child_forward",
+        "clear_plan",
+        "clear_step",
+        "reset",
+    ]
 
 
 def test_dummy_rank_mirrors_sync_replacement_and_mtp_phase_collectives():

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -13,6 +13,8 @@ from megatron.core.inference.async_txn import (
     broadcast_ep_stop_word_finished_ids,
     resolve_ep_decode_broadcast_plan,
 )
+from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensions
+from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
 from megatron.core.inference.engines.async_zmq_communicator import (
     AsyncZMQCommunicator,
     ZMQCollectiveError,
@@ -51,6 +53,48 @@ class FakeStepCommunicator:
     def sync_all_reduce_max(self, *values, phase=None, step_id=None):
         self.sync_calls.append((phase, step_id, values))
         return values[0] if len(values) == 1 else values
+
+
+class FakeGraphSlot:
+    def __init__(self, slot_id):
+        self.slot_id = slot_id
+
+    def cuda_graph_key(self, base_key):
+        return (*base_key, ("slot", self.slot_id))
+
+
+def _make_graph_key_context(*, async_scheduling=True, decode_only=True, active_slot_id=1):
+    context = object.__new__(DynamicInferenceContext)
+    context.async_scheduling = async_scheduling
+    context._using_cuda_graph_this_step = True
+    context.padded_active_request_count = 1
+    context.padded_active_token_count = 1
+    context.padded_batch_dimensions = InferenceBatchDimensions(
+        token_count=1,
+        prefill_req_count=0 if decode_only else 1,
+        decode_req_count=1,
+    )
+    context.async_decode_slot_ring = SimpleNamespace(
+        slots=(FakeGraphSlot(0), FakeGraphSlot(1))
+    )
+    context.active_decode_slot_id = active_slot_id
+    return context
+
+
+def test_cuda_graph_cache_key_includes_active_async_decode_slot():
+    context = _make_graph_key_context(active_slot_id=1)
+
+    key = DynamicInferenceContext.cuda_graph_cache_key(context)
+
+    assert key == ("decode", 1, 1, ("slot", 1))
+
+
+def test_cuda_graph_cache_key_stays_shape_only_for_non_decode_or_non_async():
+    non_decode = _make_graph_key_context(decode_only=False)
+    non_async = _make_graph_key_context(async_scheduling=False)
+
+    assert DynamicInferenceContext.cuda_graph_cache_key(non_decode) == non_decode.padded_batch_dimensions
+    assert DynamicInferenceContext.cuda_graph_cache_key(non_async) == non_async.padded_batch_dimensions
 
 
 def test_token_broadcast_gives_identical_survivor_set_across_ranks():

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import asyncio
+
 import pytest
 import torch
 
@@ -14,6 +16,8 @@ from megatron.core.inference.engines.async_zmq_communicator import (
     AsyncZMQCommunicator,
     ZMQCollectiveError,
 )
+from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
+from megatron.core.inference.ep_async_protocol import EPAsyncPhase, EPAsyncStepProtocol
 from megatron.core.inference.text_generation_controllers.text_generation_controller import (
     TextGenerationController,
 )
@@ -29,6 +33,23 @@ class FakeEPGroup:
 
     def rank(self):
         return self._rank
+
+
+class FakeStepCommunicator:
+    world_size = 4
+    protocol_mismatch_count = 0
+
+    def __init__(self):
+        self.async_calls = []
+        self.sync_calls = []
+
+    async def all_reduce_max(self, *values, async_op=True, phase=None, step_id=None):
+        self.async_calls.append((phase, step_id, values))
+        return values[0] if len(values) == 1 else values
+
+    def sync_all_reduce_max(self, *values, phase=None, step_id=None):
+        self.sync_calls.append((phase, step_id, values))
+        return values[0] if len(values) == 1 else values
 
 
 def test_token_broadcast_gives_identical_survivor_set_across_ranks():
@@ -253,3 +274,102 @@ def test_controller_ep_sync_helper_uses_named_phase_when_supported():
 
     assert result == (1, 3)
     assert calls == [("ep_async_child_handoff", (1, 3))]
+
+
+def test_ep_async_step_protocol_keeps_child_phases_in_active_work_step():
+    async def run_test():
+        communicator = FakeStepCommunicator()
+        protocol = EPAsyncStepProtocol(communicator)
+
+        consensus = await protocol.establish_work_consensus(1, False, async_op=False)
+        decode_result = protocol.sync_all_reduce_max(EPAsyncPhase.DECODE_POST_FORWARD, 1, 2, -2)
+        handoff_result = protocol.sync_all_reduce_max(EPAsyncPhase.ASYNC_CHILD_HANDOFF, 1, 2, -2)
+        graph_result = protocol.sync_all_reduce_max(EPAsyncPhase.GRAPH_SHAPE, 1, 0)
+        await protocol.complete_work_step(async_op=False)
+
+        assert consensus.step_id == 0
+        assert decode_result == (1, 2, -2)
+        assert handoff_result == (1, 2, -2)
+        assert graph_result == (1, 0)
+        assert communicator.sync_calls == [
+            ("ep_decode_post_forward", 0, (1, 2, -2)),
+            ("ep_async_child_handoff", 0, (1, 2, -2)),
+            ("ep_graph_shape", 0, (1, 0)),
+        ]
+        assert communicator.async_calls == [
+            ("ep_work_consensus", 0, (1, 0)),
+            ("ep_work_consensus_ack", 0, (1,)),
+            ("ep_step_complete", 0, (1,)),
+            ("ep_step_complete_ack", 0, (1,)),
+        ]
+
+    asyncio.run(run_test())
+
+
+def test_ep_work_step_sends_coordinator_reply_after_step_completion():
+    async def run_test():
+        events = []
+        engine = object.__new__(DynamicInferenceEngine)
+        engine.ep_world_size = 4
+        engine.use_synchronous_zmq_collectives = True
+
+        class Protocol:
+            def ensure_work_step(self):
+                events.append("ensure")
+
+            async def complete_work_step(self, *, async_op=True):
+                events.append(("complete", async_op))
+
+        async def async_step(*, send_coordinator_replies=True):
+            events.append(("step", send_coordinator_replies))
+            return {"finished_request_records": ["record"]}
+
+        engine.ep_async_step_protocol = Protocol()
+        engine.async_step = async_step
+        engine._send_finished_records_to_coordinator = lambda records: events.append(
+            ("reply", records)
+        )
+
+        await DynamicInferenceEngine._run_ep_work_step(engine, local_pending=1)
+
+        assert events == [
+            "ensure",
+            ("step", False),
+            ("complete", False),
+            ("reply", ["record"]),
+        ]
+
+    asyncio.run(run_test())
+
+
+def test_controller_ep_sync_helper_prefers_step_protocol_when_available():
+    calls = []
+    controller = object.__new__(TextGenerationController)
+
+    class Protocol:
+        enabled = True
+
+        def sync_all_reduce_max(self, phase, *values):
+            calls.append((phase, values))
+            return values
+
+    controller._ep_async_protocol = Protocol()
+
+    result = TextGenerationController._sync_ep_protocol_all_reduce_max(
+        controller, EPAsyncPhase.ASYNC_CHILD_HANDOFF, 1, 3
+    )
+
+    assert result == (1, 3)
+    assert calls == [(EPAsyncPhase.ASYNC_CHILD_HANDOFF, (1, 3))]
+
+
+def test_ep_async_step_protocol_starts_cached_consensus_work_steps():
+    communicator = FakeStepCommunicator()
+    protocol = EPAsyncStepProtocol(communicator)
+
+    step_id = protocol.ensure_work_step()
+    result = protocol.sync_all_reduce_max(EPAsyncPhase.ASYNC_CHILD_HANDOFF, 1, 0, 0)
+
+    assert step_id == 0
+    assert result == (1, 0, 0)
+    assert communicator.sync_calls == [("ep_async_child_handoff", 0, (1, 0, 0))]

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -306,6 +306,48 @@ def test_ep_async_step_protocol_keeps_child_phases_in_active_work_step():
     asyncio.run(run_test())
 
 
+def test_ep_async_step_protocol_reuse_pending_forward_skips_dummy_base_forward():
+    communicator = FakeStepCommunicator()
+    protocol = EPAsyncStepProtocol(communicator)
+    protocol.ensure_work_step()
+
+    decision = protocol.decide_step_begin(
+        has_real_work=True,
+        has_pending_forward=True,
+        pending_forward_reusable=True,
+    )
+
+    assert decision.reuse_pending_forward is True
+    assert decision.discard_pending_forward is False
+    assert communicator.sync_calls == [
+        ("ep_step_begin", 0, (1, 1, 1, 0, 0)),
+        ("ep_step_begin_ack", 0, (1,)),
+    ]
+
+
+def test_ep_async_step_protocol_discards_pending_forward_if_real_rank_missing_child():
+    class MissingChildCommunicator(FakeStepCommunicator):
+        def sync_all_reduce_max(self, *values, phase=None, step_id=None):
+            self.sync_calls.append((phase, step_id, values))
+            if phase == "ep_step_begin":
+                # Some EP rank has a pending child, but a real rank is missing it.
+                return (1, 1, 1, 0, 1)
+            return values[0] if len(values) == 1 else values
+
+    communicator = MissingChildCommunicator()
+    protocol = EPAsyncStepProtocol(communicator)
+    protocol.ensure_work_step()
+
+    decision = protocol.decide_step_begin(
+        has_real_work=True,
+        has_pending_forward=False,
+        pending_forward_reusable=False,
+    )
+
+    assert decision.reuse_pending_forward is False
+    assert decision.discard_pending_forward is True
+
+
 def test_ep_work_step_sends_coordinator_reply_after_step_completion():
     async def run_test():
         events = []

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -81,6 +81,14 @@ def test_cuda_graph_cache_key_stays_shape_only_for_async_decode():
     assert key == context.padded_batch_dimensions
 
 
+def test_async_decode_child_adoption_is_not_graph_keyed():
+    context = _make_graph_key_context(active_slot_id=1)
+    controller = object.__new__(TextGenerationController)
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
+
+    assert controller._async_decode_cuda_graph_key() is None
+
+
 def test_cuda_graph_cache_key_stays_shape_only_for_non_decode_or_non_async():
     non_decode = _make_graph_key_context(decode_only=False)
     non_async = _make_graph_key_context(async_scheduling=False)

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -248,6 +248,7 @@ def _make_dummy_controller(*, num_speculative_tokens):
     controller._dummy_serial_mtp_forward = lambda: calls.append("serial_mtp")
     controller._clear_ep_decode_broadcast_plan = lambda: calls.append("clear_plan")
     controller._clear_ep_step_begin_decision = lambda: calls.append("clear_step")
+    controller._dummy_context_h2d_done_event = None
     return controller, calls
 
 
@@ -272,6 +273,28 @@ def test_mtp_dummy_reuse_keeps_decode_result_collective_before_mtp_and_child():
         "clear_step",
         "reset",
     ]
+
+
+def test_dummy_forward_fences_metadata_h2d_before_context_reset():
+    controller, calls = _make_dummy_controller(num_speculative_tokens=0)
+
+    class Event:
+        def synchronize(self):
+            calls.append("h2d_wait")
+
+    controller._dummy_context_h2d_done_event = Event()
+
+    controller.dummy_forward()
+
+    assert calls == [
+        "child_forward",
+        "serial_mtp",
+        "clear_plan",
+        "clear_step",
+        "h2d_wait",
+        "reset",
+    ]
+    assert controller._dummy_context_h2d_done_event is None
 
 
 def test_dummy_rank_mirrors_sync_replacement_and_mtp_phase_collectives():

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -8,6 +8,7 @@ from megatron.core.inference.async_txn import (
     broadcast_ep_accepted_counts,
     broadcast_ep_sampled_tokens,
     broadcast_ep_stop_word_finished_ids,
+    resolve_ep_decode_broadcast_plan,
 )
 
 
@@ -78,6 +79,78 @@ def test_mtp_accepted_count_broadcast_gives_identical_speculative_prefix():
     broadcast_ep_accepted_counts(local_counts, 3, FakeEPGroup(), broadcast_fn=broadcast)
 
     assert local_counts.tolist() == [2, 1, 0, 9]
+
+
+def test_ep_decode_broadcast_plan_selects_nonzero_real_source_rank():
+    group = FakeEPGroup(size=4, rank=3)
+
+    def sync_all_reduce_max(local_count, local_src_max, local_neg_src_min):
+        assert (local_count, local_src_max, local_neg_src_min) == (1, 3, -3)
+        # Ranks 0-2 are dummy ranks and rank 3 owns the real coordinator state.
+        values_by_rank = [
+            (0, -1, -5),
+            (0, -1, -5),
+            (0, -1, -5),
+            (local_count, local_src_max, local_neg_src_min),
+        ]
+        return tuple(max(values[index] for values in values_by_rank) for index in range(3))
+
+    plan = resolve_ep_decode_broadcast_plan(
+        1,
+        group,
+        has_real_work=True,
+        sync_all_reduce_max_fn=sync_all_reduce_max,
+    )
+
+    assert plan.active_request_count == 1
+    assert plan.src_group_rank == 3
+    assert plan.has_real_work is True
+
+
+def test_ep_decode_broadcast_plan_gives_dummy_same_source_and_count():
+    group = FakeEPGroup(size=4, rank=0)
+
+    def sync_all_reduce_max(local_count, local_src_max, local_neg_src_min):
+        assert (local_count, local_src_max, local_neg_src_min) == (0, -1, -5)
+        values_by_rank = [
+            (local_count, local_src_max, local_neg_src_min),
+            (0, -1, -5),
+            (0, -1, -5),
+            (2, 3, -3),
+        ]
+        return tuple(max(values[index] for values in values_by_rank) for index in range(3))
+
+    plan = resolve_ep_decode_broadcast_plan(
+        0,
+        group,
+        has_real_work=False,
+        sync_all_reduce_max_fn=sync_all_reduce_max,
+    )
+
+    assert plan.active_request_count == 2
+    assert plan.src_group_rank == 3
+    assert plan.has_real_work is True
+
+
+def test_ep_decode_broadcast_plan_rejects_multiple_real_sources():
+    group = FakeEPGroup(size=4, rank=1)
+
+    def sync_all_reduce_max(local_count, local_src_max, local_neg_src_min):
+        values_by_rank = [
+            (0, -1, -5),
+            (local_count, local_src_max, local_neg_src_min),
+            (0, -1, -5),
+            (1, 3, -3),
+        ]
+        return tuple(max(values[index] for values in values_by_rank) for index in range(3))
+
+    with pytest.raises(RuntimeError, match="exactly one real source rank"):
+        resolve_ep_decode_broadcast_plan(
+            1,
+            group,
+            has_real_work=True,
+            sync_all_reduce_max_fn=sync_all_reduce_max,
+        )
 
 
 def test_dummy_rank_mirrors_sync_replacement_and_mtp_phase_collectives():

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -55,14 +55,6 @@ class FakeStepCommunicator:
         return values[0] if len(values) == 1 else values
 
 
-class FakeGraphSlot:
-    def __init__(self, slot_id):
-        self.slot_id = slot_id
-
-    def cuda_graph_key(self, base_key):
-        return (*base_key, ("slot", self.slot_id))
-
-
 def _make_graph_key_context(*, async_scheduling=True, decode_only=True, active_slot_id=1):
     context = object.__new__(DynamicInferenceContext)
     context.async_scheduling = async_scheduling
@@ -75,18 +67,18 @@ def _make_graph_key_context(*, async_scheduling=True, decode_only=True, active_s
         decode_req_count=1,
     )
     context.async_decode_slot_ring = SimpleNamespace(
-        slots=(FakeGraphSlot(0), FakeGraphSlot(1))
+        slots=(SimpleNamespace(slot_id=0), SimpleNamespace(slot_id=1))
     )
     context.active_decode_slot_id = active_slot_id
     return context
 
 
-def test_cuda_graph_cache_key_includes_active_async_decode_slot():
+def test_cuda_graph_cache_key_stays_shape_only_for_async_decode():
     context = _make_graph_key_context(active_slot_id=1)
 
     key = DynamicInferenceContext.cuda_graph_cache_key(context)
 
-    assert key == ("decode", 1, 1, ("slot", 1))
+    assert key == context.padded_batch_dimensions
 
 
 def test_cuda_graph_cache_key_stays_shape_only_for_non_decode_or_non_async():

--- a/tests/unit_tests/inference/test_async_txn_ep.py
+++ b/tests/unit_tests/inference/test_async_txn_ep.py
@@ -244,7 +244,9 @@ def _make_dummy_controller(*, num_speculative_tokens):
         "forward"
     )
     controller._dummy_decode_sample_collective = lambda: calls.append("decode_result_collective")
-    controller._dummy_decode_async_child_forward_if_planned = lambda: calls.append("child_forward")
+    controller._dummy_decode_async_child_forward_if_planned = (
+        lambda *args, **kwargs: calls.append("child_forward")
+    )
     controller._dummy_serial_mtp_forward = lambda: calls.append("serial_mtp")
     controller._clear_ep_decode_broadcast_plan = lambda: calls.append("clear_plan")
     controller._clear_ep_step_begin_decision = lambda: calls.append("clear_step")
@@ -257,7 +259,14 @@ def test_non_mtp_dummy_reuse_skips_decode_result_collective():
 
     controller.dummy_forward()
 
-    assert calls == ["child_forward", "serial_mtp", "clear_plan", "clear_step", "reset"]
+    assert calls == [
+        "child_forward",
+        "child_forward",
+        "serial_mtp",
+        "clear_plan",
+        "clear_step",
+        "reset",
+    ]
 
 
 def test_mtp_dummy_reuse_keeps_decode_result_collective_before_mtp_and_child():
@@ -287,6 +296,7 @@ def test_dummy_forward_fences_metadata_h2d_before_context_reset():
     controller.dummy_forward()
 
     assert calls == [
+        "child_forward",
         "child_forward",
         "serial_mtp",
         "clear_plan",

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -174,6 +174,9 @@ def _make_controller(context):
     controller._accepted_tokens_per_request = None
     controller._accepted_token_counts_per_request = None
     controller._sampled_tokens_cuda = torch.tensor([5], dtype=torch.int64)
+    controller._async_sampled_tokens_cpu = torch.empty(4, dtype=torch.int64)
+    controller._async_sample_transfer_done_event = None
+    controller._async_sample_transfer_count = 0
 
     def context_init():
         order.append("init")
@@ -191,8 +194,34 @@ def _make_controller(context):
 
     def transfer(active_request_count):
         order.append("transfer")
-        assert "child_forward" in order
         return controller._sampled_tokens_cuda[:active_request_count].cpu(), None
+
+    def record_sample_ready():
+        order.append("sample_ready")
+        return object()
+
+    def start_async_transfer(active_request_count, sample_ready_event):
+        order.append("transfer_start")
+        assert sample_ready_event is not None
+        assert "sample" in order
+        assert "child_forward" not in order
+        controller._async_sampled_tokens_cpu[:active_request_count].copy_(
+            controller._sampled_tokens_cuda[:active_request_count]
+        )
+        controller._async_sample_transfer_done_event = sample_ready_event
+        controller._async_sample_transfer_count = active_request_count
+
+    def consume_async_transfer(active_request_count):
+        if (
+            controller._async_sample_transfer_done_event is None
+            or controller._async_sample_transfer_count != active_request_count
+        ):
+            return None
+        order.append("transfer")
+        sampled_tokens_cpu = controller._async_sampled_tokens_cpu[:active_request_count].clone()
+        controller._async_sample_transfer_done_event = None
+        controller._async_sample_transfer_count = 0
+        return sampled_tokens_cpu
 
     controller._dynamic_step_context_init = context_init
     controller._dynamic_step_forward_logits = forward
@@ -202,6 +231,9 @@ def _make_controller(context):
     controller._dynamic_step_calculate_top_n_logprobs = lambda log_probs_tensor: None
     controller._router_record_bookkeeping = lambda: None
     controller._transfer_samples_to_cpu = transfer
+    controller._record_async_sample_ready_event = record_sample_ready
+    controller._start_async_sample_transfer = start_async_transfer
+    controller._consume_async_sample_transfer = consume_async_transfer
     return controller, order
 
 
@@ -257,13 +289,15 @@ def test_dynamic_sample_logits_keeps_generic_sampler_for_non_greedy_requests():
     assert controller._sampled_tokens_cuda is sampled
 
 
-def test_child_launch_occurs_before_cpu_sample_transfer():
+def test_cpu_sample_transfer_starts_before_child_launch():
     context = FakeContext()
     controller, order = _make_controller(context)
 
     result = asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
 
     assert result["sample"].tolist() == [7]
+    assert order.index("sample") < order.index("transfer_start")
+    assert order.index("transfer_start") < order.index("child_forward")
     assert order.index("child_forward") < order.index("transfer")
     assert context.async_txn_diagnostics.launched == 1
     assert context.async_txn_diagnostics.prepared == 2

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -455,7 +455,7 @@ def test_cuda_graph_child_launch_replays_current_slot_after_deferred_h2d():
     assert context.child_forward_graph_flags == [(True, True)]
     assert context.using_cuda_graph_this_step()
     assert context.replay_cuda_graph_this_step()
-    assert context.deferred_h2d_prepares == 1
+    assert context.deferred_h2d_prepares == 2
     assert context.async_txn_diagnostics.h2d_ready_before_sampling == 0
     assert context.async_txn_diagnostics.launched == 1
 

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -34,7 +34,7 @@ class FakeKVAllocator:
 
 
 class FakeContext:
-    def __init__(self, *, async_scheduling=True, termination_id=-1):
+    def __init__(self, *, async_scheduling=True, termination_id=-1, use_cuda_graph=False):
         self.async_scheduling = async_scheduling
         self.async_txn_diagnostics = AsyncTxnDiagnostics(enabled=async_scheduling)
         self.async_decode_slot_ring = AsyncDecodeSlotRing(
@@ -63,12 +63,14 @@ class FakeContext:
         self.request_rng_store = None
         self.prepared = 0
         self.updated = 0
+        self.use_cuda_graph = use_cuda_graph
+        self.deferred_h2d_prepares = 0
 
     def is_decode_only(self):
         return True
 
     def using_cuda_graph_this_step(self):
-        return False
+        return self.use_cuda_graph
 
     def active_decode_slot(self):
         return self.async_decode_slot_ring.current
@@ -83,16 +85,19 @@ class FakeContext:
         view = self.async_decode_slot_ring.current.gpu_view
         return view.token_to_input_ids[:1].unsqueeze(0), view.token_to_pos_ids[:1].unsqueeze(0)
 
-    def prepare_child_from_committed_decode_state(self):
+    def prepare_child_from_committed_decode_state(self, *, target_slot=None, defer_h2d=False):
         if not self.async_scheduling:
             return None
         self.prepared += 1
-        child = self.async_decode_slot_ring.child
+        child = target_slot or self.async_decode_slot_ring.child
+        if defer_h2d:
+            self.deferred_h2d_prepares += 1
         self.async_txn_diagnostics.record_prepared(under_forward=True)
         return StepTxn(
             step_id=self.prepared,
             request_ids=(17,),
             slot_id=child.slot_id,
+            cpu_bookkeeping_buf=torch.zeros_like(child.gpu_view._buf) if defer_h2d else None,
             cuda_graph_key=child.cuda_graph_key(("decode", 1, 1)),
         )
 
@@ -238,6 +243,20 @@ def test_child_launch_allows_ordinary_terminal_rows():
     asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
 
     assert "child_forward" in order
+    assert context.async_txn_diagnostics.launched == 1
+
+
+def test_cuda_graph_child_launch_reuses_current_slot_with_deferred_h2d():
+    context = FakeContext(use_cuda_graph=True)
+    controller, order = _make_controller(context)
+    controller._enable_cuda_graph = True
+
+    asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
+
+    assert "child_forward" in order
+    assert context.active_decode_slot_id == 0
+    assert controller._async_launched_child_txn.slot_id == 0
+    assert context.deferred_h2d_prepares >= 1
     assert context.async_txn_diagnostics.launched == 1
 
 

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -157,6 +157,7 @@ def _make_controller(context):
     controller.num_speculative_tokens = 0
     controller.model_is_pipeline_parallel = False
     controller._enable_cuda_graph = False
+    controller._ep_async_protocol = None
     controller._get_stop_word_finished_ids_callback = None
     controller._async_prepared_child_txn = None
     controller._async_launched_child_txn = None

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -193,8 +193,8 @@ def _make_controller(context):
     controller._has_stop_word_constraints_callback = lambda request_ids: True
     controller._async_prepared_child_txn = None
     controller._async_launched_child_txn = None
-    controller._async_presampled_txn = None
-    controller._async_presampled_cuda_graph_request_count = None
+    controller._async_deferred_sample_txn = None
+    controller._async_deferred_sample_cuda_graph_request_count = None
     controller._accepted_tokens_per_request = None
     controller._accepted_token_counts_per_request = None
     controller._sampled_tokens_cuda = torch.tensor([5], dtype=torch.int64)
@@ -413,7 +413,7 @@ def test_chain_plain_decode_defers_active_stop_words():
     )
 
 
-def test_consecutive_decode_steps_adopt_launched_children():
+def test_consecutive_decode_steps_consume_launched_children():
     context = FakeContext()
     controller, order = _make_controller(context)
 
@@ -424,7 +424,7 @@ def test_consecutive_decode_steps_adopt_launched_children():
     assert "init" not in order
     assert "forward" not in order
     assert order.index("sample") < order.index("child_forward")
-    assert context.async_txn_diagnostics.adopted >= 1
+    assert context.async_txn_diagnostics.consumed >= 1
     assert context.async_txn_diagnostics.launched == 2
 
 

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -166,7 +166,7 @@ def _make_controller(context):
     controller._enable_cuda_graph = False
     controller._ep_async_protocol = None
     controller._get_stop_word_finished_ids_callback = None
-    controller._has_stop_word_constraints_callback = None
+    controller._has_stop_word_constraints_callback = lambda request_ids: True
     controller._async_prepared_child_txn = None
     controller._async_launched_child_txn = None
     controller._async_presampled_txn = None

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -270,6 +270,22 @@ def test_child_launch_occurs_before_cpu_sample_transfer():
     assert controller._async_launched_child_txn is not None
 
 
+def test_prepared_async_child_path_does_not_yield_before_launch(monkeypatch):
+    context = FakeContext()
+    controller, _ = _make_controller(context)
+    sleeps = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
+
+    assert sleeps == []
+    assert context.async_txn_diagnostics.launched == 1
+
+
 def test_child_launch_enters_graph_shape_sync_before_forward():
     context = FakeContext()
     controller, order = _make_controller(context)

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -192,6 +192,9 @@ def test_child_launch_occurs_before_cpu_sample_transfer():
     assert order.index("child_forward") < order.index("transfer")
     assert context.async_txn_diagnostics.launched == 1
     assert context.async_txn_diagnostics.prepared == 2
+    assert context.async_txn_diagnostics.h2d_ready_before_sampling == 1
+    assert context.async_txn_diagnostics.sample_to_launch_latency_us > 0.0
+    assert context.async_txn_diagnostics.commit_duration_us > 0.0
     assert controller._async_launched_child_txn is not None
 
 

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import asyncio
+from types import SimpleNamespace
+
+import torch
+
+from megatron.core.inference.async_txn import (
+    AsyncDecodeSlot,
+    AsyncDecodeSlotRing,
+    AsyncTxnDiagnostics,
+    AsyncTxnSkipReason,
+    StepTxn,
+)
+from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+    TextGenerationController,
+)
+
+
+class FakeGPUView:
+    def __init__(self):
+        self._buf = torch.zeros(32, dtype=torch.uint8)
+        self.token_to_input_ids = torch.zeros(4, dtype=torch.int64)
+        self.token_to_pos_ids = torch.arange(4, dtype=torch.int64)
+        self.token_to_block_idx = torch.zeros(4, dtype=torch.int64)
+        self.mha_block_table = torch.zeros((2, 2), dtype=torch.int32)
+
+
+class FakeKVAllocator:
+    block_routing = False
+
+    def store_routing_per_block(self, routing):
+        return None
+
+
+class FakeContext:
+    def __init__(self, *, async_scheduling=True, termination_id=-1):
+        self.async_scheduling = async_scheduling
+        self.async_txn_diagnostics = AsyncTxnDiagnostics(enabled=async_scheduling)
+        self.async_decode_slot_ring = AsyncDecodeSlotRing(
+            (AsyncDecodeSlot(0, FakeGPUView()), AsyncDecodeSlot(1, FakeGPUView()))
+        )
+        self.active_decode_slot_id = 0
+        self.total_request_count = 1
+        self.paused_request_count = 0
+        self.active_token_count = 1
+        self.padded_active_request_count = 1
+        self.padded_active_token_count = 1
+        self.num_decode_requests = 1
+        self.request_ids = torch.tensor([17], dtype=torch.int64)
+        self.request_kv_length_offsets = torch.tensor([1], dtype=torch.int32)
+        self.request_query_lengths = torch.tensor([1], dtype=torch.int32)
+        self.request_output_lengths = torch.tensor([16], dtype=torch.int32)
+        self.active_request_metadata = {
+            "termination_id": torch.tensor([termination_id], dtype=torch.int64),
+            "return_log_probs": torch.tensor([False], dtype=torch.bool),
+            "top_n_logprobs": torch.tensor([0], dtype=torch.int32),
+        }
+        self.config = SimpleNamespace(materialize_only_last_token_logits=True)
+        self.is_hybrid_model = False
+        self.mamba_slot_allocator = None
+        self.kv_block_allocator = FakeKVAllocator()
+        self.request_rng_store = None
+        self.prepared = 0
+        self.updated = 0
+
+    def is_decode_only(self):
+        return True
+
+    def using_cuda_graph_this_step(self):
+        return False
+
+    def active_decode_slot(self):
+        return self.async_decode_slot_ring.current
+
+    def bind_decode_slot(self, slot=None):
+        if slot is None:
+            slot = self.async_decode_slot_ring.current
+        self.active_decode_slot_id = slot.slot_id
+        return slot
+
+    def current_input_and_position_ids(self):
+        view = self.async_decode_slot_ring.current.gpu_view
+        return view.token_to_input_ids[:1].unsqueeze(0), view.token_to_pos_ids[:1].unsqueeze(0)
+
+    def prepare_child_from_committed_decode_state(self):
+        if not self.async_scheduling:
+            return None
+        self.prepared += 1
+        child = self.async_decode_slot_ring.child
+        self.async_txn_diagnostics.record_prepared(under_forward=True)
+        return StepTxn(
+            step_id=self.prepared,
+            request_ids=(17,),
+            slot_id=child.slot_id,
+            cuda_graph_key=child.cuda_graph_key(("decode", 1, 1)),
+        )
+
+    def plain_decode_child_needs_terminal_check(self, active_request_count=None):
+        active_request_count = active_request_count or 1
+        if bool((self.active_request_metadata["termination_id"][:active_request_count] >= 0).any()):
+            return True
+        return bool(
+            torch.ge(
+                self.get_active_sequence_lengths()[:active_request_count] + 1,
+                self.get_max_sequence_lengths()[:active_request_count],
+            ).any()
+        )
+
+    def get_active_sequence_lengths(self):
+        return self.request_kv_length_offsets + self.request_query_lengths
+
+    def get_max_sequence_lengths(self):
+        return self.request_output_lengths
+
+    def update_requests(self, active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu=None):
+        self.updated += 1
+        self.request_kv_length_offsets.add_(1)
+        return {}
+
+
+def _make_controller(context):
+    order = []
+    controller = object.__new__(TextGenerationController)
+    controller.model_config = SimpleNamespace(
+        cuda_graph_impl="none",
+        expert_model_parallel_size=1,
+        moe_enable_routing_replay=False,
+        num_moe_experts=None,
+    )
+    controller.inference_wrapped_model = SimpleNamespace(
+        inference_context=context,
+        model=SimpleNamespace(config=controller.model_config),
+        config=SimpleNamespace(params_dtype=torch.float32),
+    )
+    controller.num_speculative_tokens = 0
+    controller.model_is_pipeline_parallel = False
+    controller._enable_cuda_graph = False
+    controller._get_stop_word_finished_ids_callback = None
+    controller._async_prepared_child_txn = None
+    controller._async_launched_child_txn = None
+    controller._accepted_tokens_per_request = None
+    controller._accepted_token_counts_per_request = None
+    controller._sampled_tokens_cuda = torch.tensor([5], dtype=torch.int64)
+
+    def context_init():
+        order.append("init")
+        return context.current_input_and_position_ids()
+
+    def forward(input_ids, position_ids):
+        if "sample" in order:
+            order.append("child_forward")
+        else:
+            order.append("forward")
+
+    def sample():
+        order.append("sample")
+        controller._sampled_tokens_cuda = torch.tensor([7], dtype=torch.int64)
+
+    def transfer(active_request_count):
+        order.append("transfer")
+        assert "child_forward" in order
+        return controller._sampled_tokens_cuda[:active_request_count].cpu(), None
+
+    controller._dynamic_step_context_init = context_init
+    controller._dynamic_step_forward_logits = forward
+    controller._dynamic_step_sample_logits = sample
+    controller._dynamic_step_log_probs_bookkeeping = lambda: (False, False)
+    controller._dynamic_step_calculate_log_probs = lambda: (None, None)
+    controller._dynamic_step_calculate_top_n_logprobs = lambda log_probs_tensor: None
+    controller._router_record_bookkeeping = lambda: None
+    controller._transfer_samples_to_cpu = transfer
+    return controller, order
+
+
+def test_child_launch_occurs_before_cpu_sample_transfer():
+    context = FakeContext()
+    controller, order = _make_controller(context)
+
+    result = asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
+
+    assert result["sample"].tolist() == [7]
+    assert order.index("child_forward") < order.index("transfer")
+    assert context.async_txn_diagnostics.launched == 1
+    assert context.async_txn_diagnostics.prepared == 2
+    assert controller._async_launched_child_txn is not None
+
+
+def test_bookkeeping_uses_supplied_async_cpu_sample_without_default_transfer():
+    context = FakeContext()
+    controller, _ = _make_controller(context)
+    controller._transfer_samples_to_cpu = lambda active_request_count: (_ for _ in ()).throw(
+        AssertionError("_transfer_samples_to_cpu should not run for async sample handoff")
+    )
+
+    result = controller._dynamic_step_context_bookkeeping(
+        sampled_tokens_cpu=torch.tensor([7], dtype=torch.int64)
+    )
+
+    assert result["sample"].tolist() == [7]
+    assert context.updated == 1
+
+
+def test_consecutive_decode_steps_adopt_launched_children():
+    context = FakeContext()
+    controller, order = _make_controller(context)
+
+    asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
+    order.clear()
+    asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
+
+    assert "init" not in order
+    assert "forward" not in order
+    assert order.index("sample") < order.index("child_forward")
+    assert context.async_txn_diagnostics.adopted >= 1
+    assert context.async_txn_diagnostics.launched == 2
+
+
+def test_child_launch_skips_when_terminal_detection_is_needed():
+    context = FakeContext(termination_id=7)
+    controller, order = _make_controller(context)
+    controller._transfer_samples_to_cpu = lambda active_request_count: (
+        order.append("transfer") or (controller._sampled_tokens_cuda[:active_request_count], None)
+    )
+
+    asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
+
+    assert "child_forward" not in order
+    assert context.async_txn_diagnostics.launched == 0
+    assert (
+        context.async_txn_diagnostics.eligibility_skip_reasons[
+            AsyncTxnSkipReason.TERMINAL_CHECK_REQUIRED.value
+        ]
+        == 1
+    )
+
+
+def test_async_disabled_path_does_not_prepare_or_launch():
+    context = FakeContext(async_scheduling=False)
+    controller, order = _make_controller(context)
+    controller._transfer_samples_to_cpu = lambda active_request_count: (
+        order.append("transfer") or (controller._sampled_tokens_cuda[:active_request_count], None)
+    )
+
+    asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
+
+    assert "child_forward" not in order
+    assert context.prepared == 0
+    assert context.async_txn_diagnostics.snapshot()["launched"] == 0

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -79,6 +79,7 @@ class FakeContext:
         self.child_graph_shape_syncs = 0
         self.child_graph_shape_order = None
         self.child_forward_graph_flags = []
+        self._disable_cuda_graph_replay_this_scope = False
 
     def is_decode_only(self):
         return True
@@ -86,14 +87,17 @@ class FakeContext:
     def using_cuda_graph_this_step(self):
         return self.use_cuda_graph
 
+    def replay_cuda_graph_this_step(self):
+        return self.use_cuda_graph and not self._disable_cuda_graph_replay_this_scope
+
     @contextmanager
-    def async_child_forward_eager_scope(self):
-        previous = self.use_cuda_graph
-        self.use_cuda_graph = False
+    def async_child_forward_graph_replay_disabled_scope(self):
+        previous = self._disable_cuda_graph_replay_this_scope
+        self._disable_cuda_graph_replay_this_scope = True
         try:
             yield
         finally:
-            self.use_cuda_graph = previous
+            self._disable_cuda_graph_replay_this_scope = previous
 
     def last_token_logits(self, logits):
         return logits.squeeze(0)[: self.total_request_count - self.paused_request_count]
@@ -202,7 +206,12 @@ def _make_controller(context):
     def forward(input_ids, position_ids):
         if "sample" in order:
             order.append("child_forward")
-            context.child_forward_graph_flags.append(context.using_cuda_graph_this_step())
+            context.child_forward_graph_flags.append(
+                (
+                    context.using_cuda_graph_this_step(),
+                    context.replay_cuda_graph_this_step(),
+                )
+            )
         else:
             order.append("forward")
 
@@ -439,8 +448,9 @@ def test_cuda_graph_child_launch_uses_child_slot_without_deferred_h2d():
     assert "child_forward" in order
     assert context.active_decode_slot_id == 1
     assert controller._async_launched_child_txn.slot_id == 1
-    assert context.child_forward_graph_flags == [False]
+    assert context.child_forward_graph_flags == [(True, False)]
     assert context.using_cuda_graph_this_step()
+    assert context.replay_cuda_graph_this_step()
     assert context.deferred_h2d_prepares == 0
     assert context.async_txn_diagnostics.launched == 1
 

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -52,11 +52,15 @@ class FakeContext:
         self.request_query_lengths = torch.tensor([1], dtype=torch.int32)
         self.request_output_lengths = torch.tensor([16], dtype=torch.int32)
         self.active_request_metadata = {
-            "termination_id": torch.tensor([termination_id], dtype=torch.int64),
-            "return_log_probs": torch.tensor([False], dtype=torch.bool),
-            "top_n_logprobs": torch.tensor([0], dtype=torch.int32),
+            "termination_id": torch.tensor([termination_id, -1, -1, -1], dtype=torch.int64),
+            "return_log_probs": torch.tensor([False, False, False, False], dtype=torch.bool),
+            "top_n_logprobs": torch.tensor([0, 0, 0, 0], dtype=torch.int32),
+            "top_k": torch.tensor([1, 1, 1, 1], dtype=torch.int32),
+            "top_p": torch.tensor([0.0, 0.0, 0.0, 0.0], dtype=torch.float32),
         }
-        self.config = SimpleNamespace(materialize_only_last_token_logits=True)
+        self.config = SimpleNamespace(
+            materialize_only_last_token_logits=True, sampling_backend="flashinfer"
+        )
         self.is_hybrid_model = False
         self.mamba_slot_allocator = None
         self.kv_block_allocator = FakeKVAllocator()
@@ -73,6 +77,9 @@ class FakeContext:
 
     def using_cuda_graph_this_step(self):
         return self.use_cuda_graph
+
+    def last_token_logits(self, logits):
+        return logits.squeeze(0)[: self.total_request_count - self.paused_request_count]
 
     def active_decode_slot(self):
         return self.async_decode_slot_ring.current
@@ -193,6 +200,58 @@ def _make_controller(context):
     controller._router_record_bookkeeping = lambda: None
     controller._transfer_samples_to_cpu = transfer
     return controller, order
+
+
+def _make_sampling_controller(context):
+    controller = object.__new__(TextGenerationController)
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
+    controller.num_speculative_tokens = 0
+    controller._sampling_backend = "flashinfer"
+    controller._enable_cuda_graph = False
+    controller._greedy_sample_values_cuda = torch.empty(4, dtype=torch.float32)
+    controller._greedy_sampled_tokens_cuda = torch.empty(4, dtype=torch.int64)
+    controller._sampled_tokens_cuda = None
+    return controller
+
+
+def test_dynamic_sample_logits_uses_argmax_for_greedy_requests():
+    context = FakeContext()
+    context.total_request_count = 2
+    controller = _make_sampling_controller(context)
+    controller._sampling = SimpleNamespace(
+        sample_kernel=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("greedy requests should not use the generic sampler")
+        )
+    )
+    controller._all_logits_cuda = torch.tensor(
+        [[[1.0, 7.0, 3.0, 0.5], [4.0, 2.0, 9.0, 1.0]]], dtype=torch.float32
+    )
+
+    controller._dynamic_step_sample_logits()
+
+    assert controller._sampled_tokens_cuda is controller._greedy_sampled_tokens_cuda
+    assert controller._sampled_tokens_cuda[:2].tolist() == [1, 2]
+
+
+def test_dynamic_sample_logits_keeps_generic_sampler_for_non_greedy_requests():
+    context = FakeContext()
+    context.total_request_count = 2
+    context.active_request_metadata["top_p"][1] = 0.8
+    controller = _make_sampling_controller(context)
+    sampled = torch.tensor([3, 4], dtype=torch.int64)
+    calls = []
+
+    def sample_kernel(*args, **kwargs):
+        calls.append((args, kwargs))
+        return sampled
+
+    controller._sampling = SimpleNamespace(sample_kernel=sample_kernel)
+    controller._all_logits_cuda = torch.zeros((1, 2, 4), dtype=torch.float32)
+
+    controller._dynamic_step_sample_logits()
+
+    assert calls
+    assert controller._sampled_tokens_cuda is sampled
 
 
 def test_child_launch_occurs_before_cpu_sample_transfer():

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -44,6 +44,12 @@ class FakeContext:
         self.total_request_count = 1
         self.paused_request_count = 0
         self.active_token_count = 1
+        self.padded_batch_dimensions = SimpleNamespace(
+            token_count=1,
+            prefill_req_count=0,
+            decode_req_count=1,
+            req_count=1,
+        )
         self.padded_active_request_count = 1
         self.padded_active_token_count = 1
         self.num_decode_requests = 1
@@ -112,7 +118,7 @@ class FakeContext:
             request_ids=(17,),
             slot_id=child.slot_id,
             cpu_bookkeeping_buf=torch.zeros_like(child.gpu_view._buf) if defer_h2d else None,
-            cuda_graph_key=child.cuda_graph_key(("decode", 1, 1)),
+            cuda_graph_key=self.padded_batch_dimensions if self.use_cuda_graph else None,
         )
 
     def plain_decode_child_needs_terminal_check(self, active_request_count=None):

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import asyncio
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import torch
@@ -77,12 +78,22 @@ class FakeContext:
         self.deferred_h2d_prepares = 0
         self.child_graph_shape_syncs = 0
         self.child_graph_shape_order = None
+        self.child_forward_graph_flags = []
 
     def is_decode_only(self):
         return True
 
     def using_cuda_graph_this_step(self):
         return self.use_cuda_graph
+
+    @contextmanager
+    def async_child_forward_eager_scope(self):
+        previous = self.use_cuda_graph
+        self.use_cuda_graph = False
+        try:
+            yield
+        finally:
+            self.use_cuda_graph = previous
 
     def last_token_logits(self, logits):
         return logits.squeeze(0)[: self.total_request_count - self.paused_request_count]
@@ -118,7 +129,7 @@ class FakeContext:
             request_ids=(17,),
             slot_id=child.slot_id,
             cpu_bookkeeping_buf=torch.zeros_like(child.gpu_view._buf) if defer_h2d else None,
-            cuda_graph_key=self.padded_batch_dimensions if self.use_cuda_graph else None,
+            cuda_graph_key=None,
         )
 
     def plain_decode_child_needs_terminal_check(self, active_request_count=None):
@@ -191,6 +202,7 @@ def _make_controller(context):
     def forward(input_ids, position_ids):
         if "sample" in order:
             order.append("child_forward")
+            context.child_forward_graph_flags.append(context.using_cuda_graph_this_step())
         else:
             order.append("forward")
 
@@ -427,6 +439,8 @@ def test_cuda_graph_child_launch_uses_child_slot_without_deferred_h2d():
     assert "child_forward" in order
     assert context.active_decode_slot_id == 1
     assert controller._async_launched_child_txn.slot_id == 1
+    assert context.child_forward_graph_flags == [False]
+    assert context.using_cuda_graph_this_step()
     assert context.deferred_h2d_prepares == 0
     assert context.async_txn_diagnostics.launched == 1
 

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -113,10 +113,19 @@ class FakeContext:
     def get_max_sequence_lengths(self):
         return self.request_output_lengths
 
-    def update_requests(self, active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu=None):
+    def update_requests(
+        self, active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu=None, async_txn=None
+    ):
         self.updated += 1
         self.request_kv_length_offsets.add_(1)
+        if async_txn is not None:
+            survivors = self.request_ids[active_request_mask.bool()].tolist()
+            terminals = self.request_ids[~active_request_mask.bool()].tolist()
+            async_txn.mark_committed(survivors, terminal_request_ids=terminals)
         return {}
+
+    def retire_unused_async_kv_leases(self, async_txn):
+        return None
 
 
 def _make_controller(context):
@@ -216,7 +225,7 @@ def test_consecutive_decode_steps_adopt_launched_children():
     assert context.async_txn_diagnostics.launched == 2
 
 
-def test_child_launch_skips_when_terminal_detection_is_needed():
+def test_child_launch_allows_ordinary_terminal_rows():
     context = FakeContext(termination_id=7)
     controller, order = _make_controller(context)
     controller._transfer_samples_to_cpu = lambda active_request_count: (
@@ -225,14 +234,8 @@ def test_child_launch_skips_when_terminal_detection_is_needed():
 
     asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
 
-    assert "child_forward" not in order
-    assert context.async_txn_diagnostics.launched == 0
-    assert (
-        context.async_txn_diagnostics.eligibility_skip_reasons[
-            AsyncTxnSkipReason.TERMINAL_CHECK_REQUIRED.value
-        ]
-        == 1
-    )
+    assert "child_forward" in order
+    assert context.async_txn_diagnostics.launched == 1
 
 
 def test_async_disabled_path_does_not_prepare_or_launch():

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -264,7 +264,7 @@ def test_child_launch_allows_ordinary_terminal_rows():
     assert context.async_txn_diagnostics.launched == 1
 
 
-def test_cuda_graph_child_launch_reuses_current_slot_with_deferred_h2d():
+def test_cuda_graph_child_launch_uses_child_slot_without_deferred_h2d():
     context = FakeContext(use_cuda_graph=True)
     controller, order = _make_controller(context)
     controller._enable_cuda_graph = True
@@ -272,9 +272,9 @@ def test_cuda_graph_child_launch_reuses_current_slot_with_deferred_h2d():
     asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
 
     assert "child_forward" in order
-    assert context.active_decode_slot_id == 0
-    assert controller._async_launched_child_txn.slot_id == 0
-    assert context.deferred_h2d_prepares >= 1
+    assert context.active_decode_slot_id == 1
+    assert controller._async_launched_child_txn.slot_id == 1
+    assert context.deferred_h2d_prepares == 0
     assert context.async_txn_diagnostics.launched == 1
 
 

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -90,6 +90,9 @@ class FakeContext:
     def replay_cuda_graph_this_step(self):
         return self.use_cuda_graph and not self._disable_cuda_graph_replay_this_scope
 
+    def cuda_graph_cache_key(self):
+        return self.padded_batch_dimensions
+
     @contextmanager
     def async_child_forward_graph_replay_disabled_scope(self):
         previous = self._disable_cuda_graph_replay_this_scope
@@ -438,7 +441,7 @@ def test_child_launch_allows_ordinary_terminal_rows():
     assert context.async_txn_diagnostics.launched == 1
 
 
-def test_cuda_graph_child_launch_uses_child_slot_without_deferred_h2d():
+def test_cuda_graph_child_launch_replays_current_slot_after_deferred_h2d():
     context = FakeContext(use_cuda_graph=True)
     controller, order = _make_controller(context)
     controller._enable_cuda_graph = True
@@ -446,12 +449,14 @@ def test_cuda_graph_child_launch_uses_child_slot_without_deferred_h2d():
     asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
 
     assert "child_forward" in order
-    assert context.active_decode_slot_id == 1
-    assert controller._async_launched_child_txn.slot_id == 1
-    assert context.child_forward_graph_flags == [(True, False)]
+    assert context.active_decode_slot_id == 0
+    assert controller._async_launched_child_txn.slot_id == 0
+    assert controller._async_launched_child_txn.cpu_bookkeeping_buf is None
+    assert context.child_forward_graph_flags == [(True, True)]
     assert context.using_cuda_graph_this_step()
     assert context.replay_cuda_graph_this_step()
-    assert context.deferred_h2d_prepares == 0
+    assert context.deferred_h2d_prepares == 1
+    assert context.async_txn_diagnostics.h2d_ready_before_sampling == 0
     assert context.async_txn_diagnostics.launched == 1
 
 

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -166,8 +166,11 @@ def _make_controller(context):
     controller._enable_cuda_graph = False
     controller._ep_async_protocol = None
     controller._get_stop_word_finished_ids_callback = None
+    controller._has_stop_word_constraints_callback = None
     controller._async_prepared_child_txn = None
     controller._async_launched_child_txn = None
+    controller._async_presampled_txn = None
+    controller._async_presampled_cuda_graph_request_count = None
     controller._accepted_tokens_per_request = None
     controller._accepted_token_counts_per_request = None
     controller._sampled_tokens_cuda = torch.tensor([5], dtype=torch.int64)
@@ -310,6 +313,40 @@ def test_bookkeeping_uses_supplied_async_cpu_sample_without_default_transfer():
 
     assert result["sample"].tolist() == [7]
     assert context.updated == 1
+
+
+def test_chain_plain_decode_allows_empty_stop_word_state():
+    context = FakeContext()
+    controller, _ = _make_controller(context)
+    controller._has_stop_word_constraints_callback = lambda request_ids: False
+    parent_txn = StepTxn(step_id=1, request_ids=(17,), slot_id=0)
+    child_txn = StepTxn(step_id=2, request_ids=(17,), slot_id=1)
+
+    assert controller._can_chain_plain_decode_child(
+        parent_txn,
+        child_txn,
+        active_request_count=1,
+        return_log_probs=False,
+        return_top_n_logprobs=False,
+        skip_bookkeeping=False,
+    )
+
+
+def test_chain_plain_decode_defers_active_stop_words():
+    context = FakeContext()
+    controller, _ = _make_controller(context)
+    controller._has_stop_word_constraints_callback = lambda request_ids: True
+    parent_txn = StepTxn(step_id=1, request_ids=(17,), slot_id=0)
+    child_txn = StepTxn(step_id=2, request_ids=(17,), slot_id=1)
+
+    assert not controller._can_chain_plain_decode_child(
+        parent_txn,
+        child_txn,
+        active_request_count=1,
+        return_log_probs=False,
+        return_top_n_logprobs=False,
+        skip_bookkeeping=False,
+    )
 
 
 def test_consecutive_decode_steps_adopt_launched_children():

--- a/tests/unit_tests/inference/test_async_txn_fast_path.py
+++ b/tests/unit_tests/inference/test_async_txn_fast_path.py
@@ -65,6 +65,8 @@ class FakeContext:
         self.updated = 0
         self.use_cuda_graph = use_cuda_graph
         self.deferred_h2d_prepares = 0
+        self.child_graph_shape_syncs = 0
+        self.child_graph_shape_order = None
 
     def is_decode_only(self):
         return True
@@ -84,6 +86,11 @@ class FakeContext:
     def current_input_and_position_ids(self):
         view = self.async_decode_slot_ring.current.gpu_view
         return view.token_to_input_ids[:1].unsqueeze(0), view.token_to_pos_ids[:1].unsqueeze(0)
+
+    def sync_ep_child_graph_shape(self):
+        self.child_graph_shape_syncs += 1
+        if self.child_graph_shape_order is not None:
+            self.child_graph_shape_order.append("child_graph_shape_sync")
 
     def prepare_child_from_committed_decode_state(self, *, target_slot=None, defer_h2d=False):
         if not self.async_scheduling:
@@ -201,6 +208,17 @@ def test_child_launch_occurs_before_cpu_sample_transfer():
     assert context.async_txn_diagnostics.sample_to_launch_latency_us > 0.0
     assert context.async_txn_diagnostics.commit_duration_us > 0.0
     assert controller._async_launched_child_txn is not None
+
+
+def test_child_launch_enters_graph_shape_sync_before_forward():
+    context = FakeContext()
+    controller, order = _make_controller(context)
+    context.child_graph_shape_order = order
+
+    asyncio.run(controller.async_generate_output_tokens_dynamic_batch())
+
+    assert context.child_graph_shape_syncs == 1
+    assert order.index("child_graph_shape_sync") < order.index("child_forward")
 
 
 def test_bookkeeping_uses_supplied_async_cpu_sample_without_default_transfer():

--- a/tests/unit_tests/inference/test_async_txn_mamba.py
+++ b/tests/unit_tests/inference/test_async_txn_mamba.py
@@ -36,6 +36,7 @@ class FakeKVAllocator:
 class FakeMambaMetadata:
     def __init__(self):
         self.request_to_mamba_state_idx = torch.tensor([5, 7, -1], dtype=torch.int32)
+        self.request_to_mamba_state_bank = torch.tensor([0, 0, 0], dtype=torch.int32)
         self.freed_slot_ids = []
         self.free_slot_request_indices = []
 
@@ -46,6 +47,7 @@ class FakeMambaMetadata:
         self.free_slot_request_indices.extend(int(idx) for idx in request_indices.tolist())
         self.free_slot_ids(self.request_to_mamba_state_idx[request_indices])
         self.request_to_mamba_state_idx[request_indices] = -1
+        self.request_to_mamba_state_bank[request_indices] = 0
 
 
 class FakeLaunchContext:
@@ -115,7 +117,7 @@ def test_finished_hybrid_row_mamba_slot_is_not_reused_before_retire():
     assert context.mamba_metadata.freed_slot_ids == [5]
 
 
-def test_immediate_hybrid_release_uses_existing_single_bank_free_path():
+def test_immediate_hybrid_release_uses_existing_logical_slot_free_path():
     context = _make_release_context()
 
     DynamicInferenceContext.release_memory_blocks_from_request_indexes(
@@ -151,8 +153,34 @@ def test_hybrid_pause_pressure_still_forces_sync_before_child_launch():
     assert eligibility.reason == AsyncTxnSkipReason.PAUSED_REQUESTS
 
 
-def test_step_txn_records_single_bank_mamba_slots_without_candidate_bank():
+def test_step_txn_records_logical_mamba_slots_without_bank_internals():
     txn = StepTxn(step_id=3, request_ids=[101, 102], mamba_slot_ids=(5, 7))
 
     assert txn.mamba_slot_ids == (5, 7)
     assert not hasattr(txn, "candidate_mamba_slot_ids")
+
+
+def test_async_mamba_bank_accept_flips_only_matching_active_requests():
+    context = object.__new__(DynamicInferenceContext)
+    context.is_hybrid_model = True
+    context.mamba_state_bank_count = 2
+    context.paused_request_count = 1
+    context.total_request_count = 4
+    context.request_ids = torch.tensor([900, 101, 102, 103], dtype=torch.int32)
+    context.mamba_metadata = SimpleNamespace(
+        request_to_mamba_state_idx=torch.tensor([90, 5, 7, 9], dtype=torch.int32),
+        request_to_mamba_state_bank=torch.tensor([0, 0, 1, 0], dtype=torch.int32),
+    )
+
+    assert DynamicInferenceContext._mamba_flat_indices(
+        context, slice(context.paused_request_count, context.total_request_count)
+    ).tolist() == [10, 15, 18]
+    assert DynamicInferenceContext._mamba_flat_indices(
+        context,
+        slice(context.paused_request_count, context.total_request_count),
+        use_candidate_bank=True,
+    ).tolist() == [11, 14, 19]
+
+    DynamicInferenceContext.accept_async_mamba_state(context, (102, 999, 101))
+
+    assert context.mamba_metadata.request_to_mamba_state_bank.tolist() == [0, 1, 0, 0]

--- a/tests/unit_tests/inference/test_async_txn_mamba.py
+++ b/tests/unit_tests/inference/test_async_txn_mamba.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import torch
+
+from megatron.core.inference.async_txn import (
+    AsyncTxnDiagnostics,
+    AsyncTxnSkipReason,
+    StepTxn,
+    TxnRetireQueue,
+    classify_decode_child_launch,
+)
+from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
+from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+    TextGenerationController,
+)
+
+
+class FakeEvent:
+    def __init__(self, done: bool = False):
+        self.done = done
+
+    def query(self) -> bool:
+        return self.done
+
+
+class FakeKVAllocator:
+    def __init__(self):
+        self.released = []
+
+    def release_memory_blocks(self, block_ids: torch.Tensor) -> None:
+        self.released.extend(int(block_id) for block_id in block_ids.tolist())
+
+
+class FakeMambaMetadata:
+    def __init__(self):
+        self.request_to_mamba_state_idx = torch.tensor([5, 7, -1], dtype=torch.int32)
+        self.freed_slot_ids = []
+        self.free_slot_request_indices = []
+
+    def free_slot_ids(self, slot_ids: torch.Tensor) -> None:
+        self.freed_slot_ids.extend(int(slot_id) for slot_id in slot_ids.tolist() if slot_id != -1)
+
+    def free_slots(self, request_indices: torch.Tensor) -> None:
+        self.free_slot_request_indices.extend(int(idx) for idx in request_indices.tolist())
+        self.free_slot_ids(self.request_to_mamba_state_idx[request_indices])
+        self.request_to_mamba_state_idx[request_indices] = -1
+
+
+class FakeLaunchContext:
+    def __init__(self, *, paused_request_count=0):
+        self.total_request_count = 2
+        self.paused_request_count = paused_request_count
+        self.is_hybrid_model = True
+        self.chunked_prefill_request_id = -1
+        self.num_speculative_tokens = 0
+        self.block_size_tokens = 4
+        self.request_last_kv_block_offset = torch.tensor([0, 0], dtype=torch.int32)
+        self.request_ids = torch.tensor([101, 102], dtype=torch.int32)
+        self.kv_block_allocator = SimpleNamespace(is_memory_available=lambda count: True)
+
+    def is_decode_only(self) -> bool:
+        return True
+
+    def using_cuda_graph_this_step(self) -> bool:
+        return False
+
+
+def _make_release_context() -> DynamicInferenceContext:
+    context = object.__new__(DynamicInferenceContext)
+    context.is_hybrid_model = True
+    context.mamba_metadata = FakeMambaMetadata()
+    context.mamba_slot_allocator = None
+    context.kv_block_allocator = FakeKVAllocator()
+    context.async_txn_diagnostics = AsyncTxnDiagnostics(enabled=True)
+    context.async_txn_retire_queue = TxnRetireQueue(context.async_txn_diagnostics)
+    context.request_to_kv_block_ids = torch.tensor(
+        [[10, -1], [20, -1], [-1, -1]], dtype=torch.int32
+    )
+    return context
+
+
+def _make_controller(context):
+    controller = object.__new__(TextGenerationController)
+    controller.num_speculative_tokens = 0
+    controller._enable_cuda_graph = False
+    controller._get_stop_word_finished_ids_callback = None
+    controller.model_config = SimpleNamespace(
+        expert_model_parallel_size=1,
+        num_moe_experts=None,
+    )
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
+    return controller
+
+
+def test_finished_hybrid_row_mamba_slot_is_not_reused_before_retire():
+    context = _make_release_context()
+    event = FakeEvent(done=False)
+
+    DynamicInferenceContext.release_memory_blocks_from_request_indexes(
+        context,
+        torch.tensor([0], dtype=torch.int64),
+        retire_event=event,
+        defer_release=True,
+    )
+
+    assert context.kv_block_allocator.released == []
+    assert context.mamba_metadata.freed_slot_ids == []
+    assert context.mamba_metadata.request_to_mamba_state_idx.tolist() == [-1, 7, -1]
+
+    event.done = True
+    assert context.async_txn_retire_queue.drain_ready() == 2
+    assert context.kv_block_allocator.released == [10]
+    assert context.mamba_metadata.freed_slot_ids == [5]
+
+
+def test_immediate_hybrid_release_uses_existing_single_bank_free_path():
+    context = _make_release_context()
+
+    DynamicInferenceContext.release_memory_blocks_from_request_indexes(
+        context, torch.tensor([1], dtype=torch.int64)
+    )
+
+    assert context.kv_block_allocator.released == [20]
+    assert context.mamba_metadata.free_slot_request_indices == [1]
+    assert context.mamba_metadata.freed_slot_ids == [7]
+
+
+def test_hybrid_child_launch_is_not_rejected_when_no_mutation_gate_applies():
+    context = FakeLaunchContext()
+    controller = _make_controller(context)
+    child_txn = StepTxn(step_id=3, request_ids=[101, 102], mamba_slot_ids=(5, 7))
+
+    reason = controller._async_child_launch_skip_reason(
+        child_txn,
+        return_log_probs=False,
+        return_top_n_logprobs=False,
+        skip_bookkeeping=False,
+    )
+
+    assert reason is None
+
+
+def test_hybrid_pause_pressure_still_forces_sync_before_child_launch():
+    context = FakeLaunchContext(paused_request_count=1)
+
+    eligibility = classify_decode_child_launch(context, async_enabled=True)
+
+    assert not eligibility.eligible
+    assert eligibility.reason == AsyncTxnSkipReason.PAUSED_REQUESTS
+
+
+def test_step_txn_records_single_bank_mamba_slots_without_candidate_bank():
+    txn = StepTxn(step_id=3, request_ids=[101, 102], mamba_slot_ids=(5, 7))
+
+    assert txn.mamba_slot_ids == (5, 7)
+    assert not hasattr(txn, "candidate_mamba_slot_ids")

--- a/tests/unit_tests/inference/test_async_txn_mtp.py
+++ b/tests/unit_tests/inference/test_async_txn_mtp.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import torch
+
+from megatron.core.inference.async_txn import AsyncTxnSkipReason, StepTxn
+from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
+from megatron.core.inference.inference_request import (
+    DynamicInferenceRequest,
+    DynamicInferenceRequestRecord,
+    Status,
+)
+from megatron.core.inference.sampling_params import SamplingParams
+from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+    TextGenerationController,
+)
+
+
+class FakeFuture:
+    def __init__(self):
+        self.result = None
+
+    def set_result(self, result):
+        self.result = result
+
+
+class FakeTokenizer:
+    def detokenize(self, tokens):
+        return "".join(str(int(token)) for token in tokens)
+
+
+class FakeKVAllocator:
+    total_count = 8
+    total_avail = 4
+    enable_prefix_caching = False
+
+    def reconstruct_routing_from_blocks(self, block_ids, total_routing_tokens):
+        return None
+
+
+class FakeContext:
+    chunked_prefill_request_id = -1
+    kv_block_allocator = FakeKVAllocator()
+
+
+class FakeLaunchContext:
+    total_request_count = 1
+    paused_request_count = 0
+
+    def using_cuda_graph_this_step(self):
+        return False
+
+
+def _make_request(request_id: int) -> DynamicInferenceRequest:
+    request = DynamicInferenceRequest(
+        request_id=request_id,
+        prompt_tokens=torch.tensor([1], dtype=torch.int64),
+        sampling_params=SamplingParams(num_tokens_to_generate=5),
+        status=Status.ACTIVE_AND_GENERATING_TOKENS,
+    )
+    request.add_event_add_engine()
+    return request
+
+
+def _make_engine(request_ids, *, num_speculative_tokens=2):
+    engine = object.__new__(DynamicInferenceEngine)
+    engine.context = FakeContext()
+    engine.controller = SimpleNamespace(tokenizer=FakeTokenizer())
+    engine.requests = {
+        request_id: SimpleNamespace(
+            record=DynamicInferenceRequestRecord.from_request(_make_request(request_id)),
+            future=FakeFuture(),
+        )
+        for request_id in request_ids
+    }
+    engine.finished_request_count = 0
+    engine.evicted_request_count = 0
+    engine.track_generated_token_events = False
+    engine.stop_word_finished_request_ids = set()
+    engine.stop_word_being_finished_ids = set()
+    engine.num_speculative_tokens = num_speculative_tokens
+    engine._spec_steps = 0
+    engine._spec_tokens_proposed_per_pos = torch.zeros(num_speculative_tokens, dtype=torch.int64)
+    engine._spec_tokens_accepted_per_pos = torch.zeros(num_speculative_tokens, dtype=torch.int64)
+    engine._check_stop_words_for_request_post_append = lambda request: (False, 0)
+    return engine
+
+
+def test_mtp_accepted_tokens_publish_by_request_id_after_middle_finish():
+    engine = _make_engine([101, 102, 103])
+
+    active_request_ids, finished_records = DynamicInferenceEngine.post_process_requests(
+        engine,
+        torch.tensor([101, 102, 103], dtype=torch.int64),
+        torch.tensor([102], dtype=torch.int64),
+        evict_request_ids=None,
+        step_time=0.0,
+        sample=torch.tensor([11, 22, 33], dtype=torch.int64),
+        accepted_tokens=torch.tensor([[91, 92], [93, 94], [95, 96]], dtype=torch.int64),
+        log_probs=None,
+        accepted_tokens_by_request_id={
+            103: [77, 78],
+            101: [44, -1],
+            102: [55, 56],
+        },
+    )
+
+    assert active_request_ids == [101, 103]
+    assert engine.get_request(101).generated_tokens == [44, 11]
+    assert engine.get_request(103).generated_tokens == [77, 78, 33]
+    assert finished_records[0][-1].request_id == 102
+    assert finished_records[0][-1].generated_tokens == [55, 56, 22]
+
+
+def test_mtp_rejected_speculative_suffix_is_not_published():
+    engine = _make_engine([101])
+
+    DynamicInferenceEngine.post_process_requests(
+        engine,
+        torch.tensor([101], dtype=torch.int64),
+        torch.tensor([], dtype=torch.int64),
+        evict_request_ids=None,
+        step_time=0.0,
+        sample=torch.tensor([11], dtype=torch.int64),
+        accepted_tokens=torch.tensor([[91, 92]], dtype=torch.int64),
+        log_probs=None,
+        accepted_tokens_by_request_id={101: [-1, -1]},
+    )
+
+    assert engine.get_request(101).generated_tokens == [11]
+    assert engine._spec_tokens_accepted_per_pos.tolist() == [0, 0]
+
+
+def test_mtp_publication_helper_maps_accepted_tokens_by_request_id():
+    controller = object.__new__(TextGenerationController)
+
+    publication = controller._dynamic_step_publication_by_request_id(
+        torch.tensor([102, 101], dtype=torch.int64),
+        torch.tensor([22, 11], dtype=torch.int64),
+        accepted_tokens=torch.tensor([[5, -1], [6, 7]], dtype=torch.int64),
+        log_probs=None,
+        top_n_logprobs=None,
+    )
+
+    assert publication["accepted_tokens_by_request_id"] == {102: [5, -1], 101: [6, 7]}
+
+
+def test_mtp_child_launch_is_gated_instead_of_rejecting_after_launch():
+    controller = object.__new__(TextGenerationController)
+    controller.num_speculative_tokens = 2
+    controller._enable_cuda_graph = False
+    controller.model_config = SimpleNamespace(expert_model_parallel_size=1, num_moe_experts=None)
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=FakeLaunchContext())
+
+    reason = controller._async_child_launch_skip_reason(
+        StepTxn(step_id=4, request_ids=(101,)),
+        return_log_probs=False,
+        return_top_n_logprobs=False,
+        skip_bookkeeping=False,
+    )
+
+    assert reason == AsyncTxnSkipReason.MTP_ACTIVE

--- a/tests/unit_tests/inference/test_async_txn_no_regressions.py
+++ b/tests/unit_tests/inference/test_async_txn_no_regressions.py
@@ -30,9 +30,9 @@ def _core_inference_source() -> str:
     [
         "AsyncDecodeLifecyclePlan",
         "_AsyncPendingForwardView",
-        "pending_forward_signature",
-        "_validate_pending_forward",
-        "_consume_pending_forward",
+        "launched_forward_signature",
+        "_validate_launched_forward",
+        "_consume_previous_forward",
         "full_layout_signature",
         "row_map",
         "rowmap",
@@ -45,7 +45,7 @@ def test_prediction_and_reconciliation_symbols_are_absent(symbol):
     assert symbol not in _core_inference_source()
 
 
-class _AdoptionContext:
+class _ConsumptionContext:
     async_scheduling = True
     paused_request_count = 0
     total_request_count = 1
@@ -70,20 +70,20 @@ class _AdoptionContext:
         return False
 
 
-def test_guard_failure_drops_launched_child_without_plain_decode_rerun():
-    context = _AdoptionContext()
+def test_guard_failure_clears_launched_child_without_plain_decode_rerun():
+    context = _ConsumptionContext()
     controller = object.__new__(TextGenerationController)
     controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
     controller._async_launched_child_txn = StepTxn(
         step_id=1, request_ids=(10,), launched=True
     )
 
-    with pytest.raises(RuntimeError, match="async decode child adoption invariant failed"):
-        controller._try_adopt_async_child_logits()
+    with pytest.raises(RuntimeError, match="async decode child consumption invariant failed"):
+        controller._consume_async_child_logits()
 
     assert controller._async_launched_child_txn is None
     assert context.async_txn_diagnostics.guard_failures == 1
-    assert context.async_txn_diagnostics.adopted == 0
+    assert context.async_txn_diagnostics.consumed == 0
 
 
 def test_step_txn_tracks_logical_mamba_slots_without_bank_internals():
@@ -170,7 +170,7 @@ def test_diagnostics_show_compact_transaction_lifecycle():
 
     diagnostics.record_prepared(under_forward=True)
     diagnostics.record_launched(h2d_ready_before_sampling=True)
-    diagnostics.record_adopted()
+    diagnostics.record_consumed()
     retire_queue.enqueue(None, lambda: released.append("retired"))
     retire_queue.drain_ready()
     diagnostics.record_barrier_skip(AsyncTxnSkipReason.SKIP_BOOKKEEPING)
@@ -179,7 +179,7 @@ def test_diagnostics_show_compact_transaction_lifecycle():
     assert released == ["retired"]
     assert snapshot["prepared"] == 1
     assert snapshot["launched"] == 1
-    assert snapshot["adopted"] == 1
+    assert snapshot["consumed"] == 1
     assert snapshot["retired"] == 1
     assert snapshot["prepare_under_forward"] == 1
     assert snapshot["h2d_ready_before_sampling"] == 1

--- a/tests/unit_tests/inference/test_async_txn_no_regressions.py
+++ b/tests/unit_tests/inference/test_async_txn_no_regressions.py
@@ -142,6 +142,23 @@ def test_plain_decode_launch_gate_uses_concrete_local_reasons():
     assert active_count_reason == AsyncTxnSkipReason.ACTIVE_COUNT_CHANGED
 
 
+def test_cuda_graph_and_ep_are_not_blanket_async_skip_reasons():
+    controller = _make_launch_gate_controller()
+    controller._enable_cuda_graph = True
+    controller.model_config.expert_model_parallel_size = 4
+    controller.model_config.num_moe_experts = 128
+    child_txn = StepTxn(step_id=1, request_ids=(101, 102))
+
+    reason = controller._async_child_launch_skip_reason(
+        child_txn,
+        return_log_probs=False,
+        return_top_n_logprobs=False,
+        skip_bookkeeping=False,
+    )
+
+    assert reason is None
+
+
 def test_diagnostics_show_compact_transaction_lifecycle():
     diagnostics = AsyncTxnDiagnostics(enabled=True)
     released = []

--- a/tests/unit_tests/inference/test_async_txn_no_regressions.py
+++ b/tests/unit_tests/inference/test_async_txn_no_regressions.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from dataclasses import fields
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.inference.async_txn import (
+    AsyncTxnDiagnostics,
+    AsyncTxnSkipReason,
+    StepTxn,
+    TxnRetireQueue,
+)
+from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+    TextGenerationController,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CORE_INFERENCE_ROOT = REPO_ROOT / "megatron" / "core" / "inference"
+
+
+def _core_inference_source() -> str:
+    return "\n".join(path.read_text() for path in CORE_INFERENCE_ROOT.rglob("*.py"))
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    [
+        "AsyncDecodeLifecyclePlan",
+        "_AsyncPendingForwardView",
+        "pending_forward_signature",
+        "_validate_pending_forward",
+        "_consume_pending_forward",
+        "full_layout_signature",
+        "row_map",
+        "rowmap",
+        "candidate_bank",
+        "candidate_mamba",
+        "mamba_candidate",
+        "four_vote",
+        "four-vote",
+        "vote_protocol",
+    ],
+)
+def test_prediction_and_reconciliation_symbols_are_absent(symbol):
+    assert symbol not in _core_inference_source()
+
+
+class _AdoptionContext:
+    async_scheduling = True
+    paused_request_count = 0
+    total_request_count = 1
+    padded_active_request_count = 1
+    padded_active_token_count = 1
+
+    def __init__(self):
+        self.async_txn_diagnostics = AsyncTxnDiagnostics(enabled=True)
+        self.request_ids = torch.tensor([11], dtype=torch.int64)
+
+    def active_decode_slot(self):
+        return None
+
+    def is_decode_only(self):
+        return True
+
+
+def test_guard_failure_drops_launched_child_without_plain_decode_rerun():
+    context = _AdoptionContext()
+    controller = object.__new__(TextGenerationController)
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
+    controller._async_launched_child_txn = StepTxn(
+        step_id=1, request_ids=(10,), launched=True
+    )
+
+    with pytest.raises(RuntimeError, match="async decode child adoption invariant failed"):
+        controller._try_adopt_async_child_logits()
+
+    assert controller._async_launched_child_txn is None
+    assert context.async_txn_diagnostics.guard_failures == 1
+    assert context.async_txn_diagnostics.adopted == 0
+
+
+def test_step_txn_tracks_single_bank_mamba_slots_without_candidate_state():
+    step_txn_fields = {field.name for field in fields(StepTxn)}
+
+    assert "mamba_slot_ids" in step_txn_fields
+    assert not any("candidate" in field_name for field_name in step_txn_fields)
+    assert not any("bank" in field_name for field_name in step_txn_fields)
+
+
+def test_async_skip_reasons_are_concrete():
+    reason_values = {reason.value for reason in AsyncTxnSkipReason}
+
+    assert "unknown_barrier" not in reason_values
+    assert "skip_bookkeeping" in reason_values
+    assert "active_count_changed" in reason_values
+    assert not any("unknown" in value for value in reason_values)
+
+
+class _LaunchGateContext:
+    total_request_count = 2
+    paused_request_count = 0
+
+    def using_cuda_graph_this_step(self):
+        return False
+
+
+def _make_launch_gate_controller():
+    controller = object.__new__(TextGenerationController)
+    controller.model_config = SimpleNamespace(
+        expert_model_parallel_size=1,
+        num_moe_experts=None,
+    )
+    controller.inference_wrapped_model = SimpleNamespace(
+        inference_context=_LaunchGateContext()
+    )
+    controller.num_speculative_tokens = 0
+    controller._enable_cuda_graph = False
+    return controller
+
+
+def test_plain_decode_launch_gate_uses_concrete_local_reasons():
+    controller = _make_launch_gate_controller()
+    child_txn = StepTxn(step_id=1, request_ids=(101,))
+
+    skip_bookkeeping_reason = controller._async_child_launch_skip_reason(
+        child_txn,
+        return_log_probs=False,
+        return_top_n_logprobs=False,
+        skip_bookkeeping=True,
+    )
+    active_count_reason = controller._async_child_launch_skip_reason(
+        child_txn,
+        return_log_probs=False,
+        return_top_n_logprobs=False,
+        skip_bookkeeping=False,
+    )
+
+    assert skip_bookkeeping_reason == AsyncTxnSkipReason.SKIP_BOOKKEEPING
+    assert active_count_reason == AsyncTxnSkipReason.ACTIVE_COUNT_CHANGED
+
+
+def test_diagnostics_show_compact_transaction_lifecycle():
+    diagnostics = AsyncTxnDiagnostics(enabled=True)
+    released = []
+    retire_queue = TxnRetireQueue(diagnostics)
+
+    diagnostics.record_prepared(under_forward=True)
+    diagnostics.record_launched(h2d_ready_before_sampling=True)
+    diagnostics.record_adopted()
+    retire_queue.enqueue(None, lambda: released.append("retired"))
+    retire_queue.drain_ready()
+    diagnostics.record_barrier_skip(AsyncTxnSkipReason.SKIP_BOOKKEEPING)
+
+    snapshot = diagnostics.snapshot()
+    assert released == ["retired"]
+    assert snapshot["prepared"] == 1
+    assert snapshot["launched"] == 1
+    assert snapshot["adopted"] == 1
+    assert snapshot["retired"] == 1
+    assert snapshot["prepare_under_forward"] == 1
+    assert snapshot["h2d_ready_before_sampling"] == 1
+    assert snapshot["top_skip_reason"] == AsyncTxnSkipReason.SKIP_BOOKKEEPING.value

--- a/tests/unit_tests/inference/test_async_txn_no_regressions.py
+++ b/tests/unit_tests/inference/test_async_txn_no_regressions.py
@@ -36,9 +36,6 @@ def _core_inference_source() -> str:
         "full_layout_signature",
         "row_map",
         "rowmap",
-        "candidate_bank",
-        "candidate_mamba",
-        "mamba_candidate",
         "four_vote",
         "four-vote",
         "vote_protocol",
@@ -54,6 +51,7 @@ class _AdoptionContext:
     total_request_count = 1
     padded_active_request_count = 1
     padded_active_token_count = 1
+    is_hybrid_model = False
 
     def __init__(self):
         self.async_txn_diagnostics = AsyncTxnDiagnostics(enabled=True)
@@ -64,6 +62,12 @@ class _AdoptionContext:
 
     def is_decode_only(self):
         return True
+
+    def using_cuda_graph_this_step(self):
+        return False
+
+    def replay_cuda_graph_this_step(self):
+        return False
 
 
 def test_guard_failure_drops_launched_child_without_plain_decode_rerun():
@@ -82,7 +86,7 @@ def test_guard_failure_drops_launched_child_without_plain_decode_rerun():
     assert context.async_txn_diagnostics.adopted == 0
 
 
-def test_step_txn_tracks_single_bank_mamba_slots_without_candidate_state():
+def test_step_txn_tracks_logical_mamba_slots_without_bank_internals():
     step_txn_fields = {field.name for field in fields(StepTxn)}
 
     assert "mamba_slot_ids" in step_txn_fields

--- a/tests/unit_tests/inference/test_async_txn_prestage.py
+++ b/tests/unit_tests/inference/test_async_txn_prestage.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.inference.async_txn import (
+    AsyncTxnSkipReason,
+    boundary_crossing_request_ids,
+    classify_decode_child_launch,
+)
+
+
+class FakeKVAllocator:
+    def __init__(self, available: int):
+        self.available = available
+
+    def is_memory_available(self, num_blocks: int) -> bool:
+        return num_blocks <= self.available
+
+
+class FakeContext:
+    def __init__(
+        self,
+        *,
+        decode_only: bool = True,
+        paused_request_count: int = 0,
+        total_request_count: int = 2,
+        offsets=(0, 1),
+        available_blocks: int = 10,
+        chunked_prefill_request_id: int = -1,
+        num_speculative_tokens: int = 0,
+        block_size_tokens: int = 4,
+    ):
+        self._decode_only = decode_only
+        self.paused_request_count = paused_request_count
+        self.total_request_count = total_request_count
+        self.request_last_kv_block_offset = torch.tensor(offsets, dtype=torch.int32)
+        self.request_ids = torch.arange(10, 10 + len(offsets), dtype=torch.int32)
+        self.kv_block_allocator = FakeKVAllocator(available_blocks)
+        self.chunked_prefill_request_id = chunked_prefill_request_id
+        self.num_speculative_tokens = num_speculative_tokens
+        self.block_size_tokens = block_size_tokens
+
+    def is_decode_only(self) -> bool:
+        return self._decode_only
+
+
+def test_boundary_crosser_requires_exactly_one_block_per_request():
+    context = FakeContext(offsets=(0, 3, 2), block_size_tokens=4, total_request_count=3)
+
+    assert boundary_crossing_request_ids(context) == (11,)
+    result = classify_decode_child_launch(context, async_enabled=True)
+    assert result.eligible
+    assert result.boundary_request_ids == (11,)
+    assert result.required_boundary_blocks == 1
+
+
+def test_unavailable_kv_prevents_preparation():
+    context = FakeContext(offsets=(3, 3), block_size_tokens=4, available_blocks=1)
+
+    result = classify_decode_child_launch(context, async_enabled=True)
+
+    assert not result.eligible
+    assert result.reason == AsyncTxnSkipReason.KV_RESERVATION_UNAVAILABLE
+    assert result.required_boundary_blocks == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs,reason",
+    [
+        ({"async_enabled": False}, AsyncTxnSkipReason.ASYNC_DISABLED),
+        ({"async_enabled": True, "mtp_active": True}, AsyncTxnSkipReason.MTP_ACTIVE),
+        ({"async_enabled": True, "pending_admission": True}, AsyncTxnSkipReason.PENDING_ADMISSION),
+        (
+            {"async_enabled": True, "graph_recapture_barrier": True},
+            AsyncTxnSkipReason.GRAPH_RECAPTURE_BARRIER,
+        ),
+        (
+            {"async_enabled": True, "log_interval_barrier": True},
+            AsyncTxnSkipReason.LOG_INTERVAL_BARRIER,
+        ),
+        ({"async_enabled": True, "resume_barrier": True}, AsyncTxnSkipReason.RESUME_BARRIER),
+        ({"async_enabled": True, "evict_barrier": True}, AsyncTxnSkipReason.EVICT_BARRIER),
+        (
+            {"async_enabled": True, "force_pause_barrier": True},
+            AsyncTxnSkipReason.FORCE_PAUSE_BARRIER,
+        ),
+    ],
+)
+def test_launch_gate_reports_concrete_skip_reasons(kwargs, reason):
+    context = FakeContext()
+
+    result = classify_decode_child_launch(context, **kwargs)
+
+    assert not result.eligible
+    assert result.reason == reason
+
+
+def test_decode_only_and_chunked_prefill_are_static_gates():
+    non_decode = FakeContext(decode_only=False)
+    chunked = FakeContext(chunked_prefill_request_id=17)
+    paused = FakeContext(paused_request_count=1, total_request_count=2)
+
+    assert (
+        classify_decode_child_launch(non_decode, async_enabled=True).reason
+        == AsyncTxnSkipReason.NOT_DECODE_ONLY
+    )
+    assert (
+        classify_decode_child_launch(chunked, async_enabled=True).reason
+        == AsyncTxnSkipReason.CHUNKED_PREFILL
+    )
+    assert (
+        classify_decode_child_launch(paused, async_enabled=True).reason
+        == AsyncTxnSkipReason.PAUSED_REQUESTS
+    )

--- a/tests/unit_tests/inference/test_async_txn_primitives.py
+++ b/tests/unit_tests/inference/test_async_txn_primitives.py
@@ -68,23 +68,14 @@ def test_diagnostics_are_noop_when_disabled():
     diagnostics.record_launched(sample_to_launch_latency_us=12.0)
     diagnostics.record_commit_duration(34.0)
 
-    assert diagnostics.snapshot() == {
-        "enabled": False,
-        "prepared": 0,
-        "launched": 0,
-        "adopted": 0,
-        "sync_steps": 0,
-        "barrier_skips": 0,
-        "retired": 0,
-        "guard_failures": 0,
-        "prepare_under_forward": 0,
-        "h2d_ready_before_sampling": 0,
-        "sample_to_launch_latency_us": 0.0,
-        "commit_duration_us": 0.0,
-        "retire_queue_depth": 0,
-        "eligibility_skip_reasons": {},
-        "top_skip_reason": None,
-    }
+    snapshot = diagnostics.snapshot()
+    assert snapshot["enabled"] is False
+    assert snapshot["eligibility_skip_reasons"] == {}
+    assert snapshot["top_skip_reason"] is None
+    for key, value in snapshot.items():
+        if key in {"enabled", "eligibility_skip_reasons", "top_skip_reason"}:
+            continue
+        assert value == 0
 
 
 def test_serial_wrapped_diagnostics_are_cheap_dict_counters():

--- a/tests/unit_tests/inference/test_async_txn_primitives.py
+++ b/tests/unit_tests/inference/test_async_txn_primitives.py
@@ -24,6 +24,11 @@ def test_step_txn_owns_request_snapshot_and_events():
     event.done = True
     assert txn.h2d_ready()
 
+    txn.cpu_bookkeeping_buf = torch.empty(1, dtype=torch.uint8)
+    assert not txn.h2d_ready()
+    txn.cpu_bookkeeping_buf = None
+    assert txn.h2d_ready()
+
 
 def test_step_txn_guard_allows_only_terminal_disappearances():
     txn = StepTxn(step_id=1, request_ids=[1, 2, 3], cuda_graph_key=("decode", 4))

--- a/tests/unit_tests/inference/test_async_txn_primitives.py
+++ b/tests/unit_tests/inference/test_async_txn_primitives.py
@@ -34,11 +34,11 @@ def test_step_txn_guard_allows_only_terminal_disappearances():
     txn = StepTxn(step_id=1, request_ids=[1, 2, 3], cuda_graph_key=("decode", 4))
     txn.launched = True
 
-    assert txn.guard_adoption([1, 3], terminal_request_ids=[2], cuda_graph_key=("decode", 4))
-    assert not txn.guard_adoption([1, 3], terminal_request_ids=[], cuda_graph_key=("decode", 4))
-    assert not txn.guard_adoption([1, 4], terminal_request_ids=[2], cuda_graph_key=("decode", 4))
-    assert not txn.guard_adoption([1, 3], terminal_request_ids=[2], cuda_graph_key=("decode", 8))
-    assert not txn.guard_adoption([1, 3], terminal_request_ids=[2], decode_only=False)
+    assert txn.is_consumable_after_commit([1, 3], terminal_request_ids=[2], cuda_graph_key=("decode", 4))
+    assert not txn.is_consumable_after_commit([1, 3], terminal_request_ids=[], cuda_graph_key=("decode", 4))
+    assert not txn.is_consumable_after_commit([1, 4], terminal_request_ids=[2], cuda_graph_key=("decode", 4))
+    assert not txn.is_consumable_after_commit([1, 3], terminal_request_ids=[2], cuda_graph_key=("decode", 8))
+    assert not txn.is_consumable_after_commit([1, 3], terminal_request_ids=[2], decode_only=False)
 
 
 def test_retire_queue_releases_only_after_event_completion():
@@ -65,7 +65,7 @@ def test_diagnostics_are_noop_when_disabled():
     diagnostics = AsyncTxnDiagnostics(enabled=False)
     diagnostics.record_prepared(under_forward=True)
     diagnostics.record_launched(h2d_ready_before_sampling=True)
-    diagnostics.record_adopted()
+    diagnostics.record_consumed()
     diagnostics.record_sync_step("serial_wrapped")
     diagnostics.record_barrier_skip("not_decode_only")
     diagnostics.record_retired()
@@ -86,12 +86,12 @@ def test_diagnostics_are_noop_when_disabled():
 def test_serial_wrapped_diagnostics_are_cheap_dict_counters():
     diagnostics = AsyncTxnDiagnostics(enabled=True)
     diagnostics.record_prepared()
-    diagnostics.record_adopted()
+    diagnostics.record_consumed()
     diagnostics.record_sync_step("serial_wrapped")
 
     snapshot = diagnostics.snapshot()
     assert snapshot["prepared"] == 1
-    assert snapshot["adopted"] == 1
+    assert snapshot["consumed"] == 1
     assert snapshot["sync_steps"] == 1
     assert snapshot["eligibility_skip_reasons"] == {"serial_wrapped": 1}
     assert torch.tensor(snapshot["prepared"]).item() == 1

--- a/tests/unit_tests/inference/test_async_txn_primitives.py
+++ b/tests/unit_tests/inference/test_async_txn_primitives.py
@@ -65,6 +65,8 @@ def test_diagnostics_are_noop_when_disabled():
     diagnostics.record_barrier_skip("not_decode_only")
     diagnostics.record_retired()
     diagnostics.record_guard_failure()
+    diagnostics.record_launched(sample_to_launch_latency_us=12.0)
+    diagnostics.record_commit_duration(34.0)
 
     assert diagnostics.snapshot() == {
         "enabled": False,
@@ -97,3 +99,18 @@ def test_serial_wrapped_diagnostics_are_cheap_dict_counters():
     assert snapshot["sync_steps"] == 1
     assert snapshot["eligibility_skip_reasons"] == {"serial_wrapped": 1}
     assert torch.tensor(snapshot["prepared"]).item() == 1
+
+
+def test_diagnostics_record_latest_latency_samples():
+    diagnostics = AsyncTxnDiagnostics(enabled=True)
+
+    diagnostics.record_launched(
+        h2d_ready_before_sampling=True, sample_to_launch_latency_us=7.25
+    )
+    diagnostics.record_commit_duration(11.5)
+
+    snapshot = diagnostics.snapshot()
+    assert snapshot["launched"] == 1
+    assert snapshot["h2d_ready_before_sampling"] == 1
+    assert snapshot["sample_to_launch_latency_us"] == 7.25
+    assert snapshot["commit_duration_us"] == 11.5

--- a/tests/unit_tests/inference/test_async_txn_primitives.py
+++ b/tests/unit_tests/inference/test_async_txn_primitives.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import torch
+
+from megatron.core.inference.async_txn import AsyncTxnDiagnostics, StepTxn, TxnRetireQueue
+
+
+class FakeEvent:
+    def __init__(self, done: bool = False):
+        self.done = done
+
+    def query(self) -> bool:
+        return self.done
+
+
+def test_step_txn_owns_request_snapshot_and_events():
+    ids = [7, 8]
+    event = FakeEvent(done=False)
+    txn = StepTxn(step_id=3, request_ids=ids, h2d_done_event=event)
+    ids.append(9)
+
+    assert txn.request_ids == (7, 8)
+    assert not txn.h2d_ready()
+    event.done = True
+    assert txn.h2d_ready()
+
+
+def test_step_txn_guard_allows_only_terminal_disappearances():
+    txn = StepTxn(step_id=1, request_ids=[1, 2, 3], cuda_graph_key=("decode", 4))
+    txn.launched = True
+
+    assert txn.guard_adoption([1, 3], terminal_request_ids=[2], cuda_graph_key=("decode", 4))
+    assert not txn.guard_adoption([1, 3], terminal_request_ids=[], cuda_graph_key=("decode", 4))
+    assert not txn.guard_adoption([1, 4], terminal_request_ids=[2], cuda_graph_key=("decode", 4))
+    assert not txn.guard_adoption([1, 3], terminal_request_ids=[2], cuda_graph_key=("decode", 8))
+    assert not txn.guard_adoption([1, 3], terminal_request_ids=[2], decode_only=False)
+
+
+def test_retire_queue_releases_only_after_event_completion():
+    released = []
+    first = FakeEvent(done=False)
+    second = FakeEvent(done=True)
+    diagnostics = AsyncTxnDiagnostics(enabled=True)
+    queue = TxnRetireQueue(diagnostics)
+
+    queue.enqueue(first, lambda: released.append("first"))
+    queue.enqueue(second, lambda: released.append("second"))
+    assert queue.drain_ready() == 0
+    assert released == []
+    assert diagnostics.retire_queue_depth == 2
+
+    first.done = True
+    assert queue.drain_ready() == 2
+    assert released == ["first", "second"]
+    assert diagnostics.retired == 2
+    assert diagnostics.retire_queue_depth == 0
+
+
+def test_diagnostics_are_noop_when_disabled():
+    diagnostics = AsyncTxnDiagnostics(enabled=False)
+    diagnostics.record_prepared(under_forward=True)
+    diagnostics.record_launched(h2d_ready_before_sampling=True)
+    diagnostics.record_adopted()
+    diagnostics.record_sync_step("serial_wrapped")
+    diagnostics.record_barrier_skip("not_decode_only")
+    diagnostics.record_retired()
+    diagnostics.record_guard_failure()
+
+    assert diagnostics.snapshot() == {
+        "enabled": False,
+        "prepared": 0,
+        "launched": 0,
+        "adopted": 0,
+        "sync_steps": 0,
+        "barrier_skips": 0,
+        "retired": 0,
+        "guard_failures": 0,
+        "prepare_under_forward": 0,
+        "h2d_ready_before_sampling": 0,
+        "sample_to_launch_latency_us": 0.0,
+        "commit_duration_us": 0.0,
+        "retire_queue_depth": 0,
+        "eligibility_skip_reasons": {},
+        "top_skip_reason": None,
+    }
+
+
+def test_serial_wrapped_diagnostics_are_cheap_dict_counters():
+    diagnostics = AsyncTxnDiagnostics(enabled=True)
+    diagnostics.record_prepared()
+    diagnostics.record_adopted()
+    diagnostics.record_sync_step("serial_wrapped")
+
+    snapshot = diagnostics.snapshot()
+    assert snapshot["prepared"] == 1
+    assert snapshot["adopted"] == 1
+    assert snapshot["sync_steps"] == 1
+    assert snapshot["eligibility_skip_reasons"] == {"serial_wrapped": 1}
+    assert torch.tensor(snapshot["prepared"]).item() == 1

--- a/tests/unit_tests/inference/test_async_txn_publication.py
+++ b/tests/unit_tests/inference/test_async_txn_publication.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.inference.async_txn import StepTxn
+from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
+from megatron.core.inference.inference_request import (
+    DynamicInferenceRequest,
+    DynamicInferenceRequestRecord,
+    Status,
+)
+from megatron.core.inference.sampling_params import SamplingParams
+from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+    TextGenerationController,
+)
+
+
+class FakeFuture:
+    def __init__(self):
+        self.result = None
+
+    def set_result(self, result):
+        self.result = result
+
+    def done(self):
+        return self.result is not None
+
+
+class FakeTokenizer:
+    def detokenize(self, tokens):
+        return "".join(f"T{int(token)}" for token in tokens)
+
+
+class FakeKVAllocator:
+    total_count = 8
+    total_avail = 4
+    enable_prefix_caching = False
+
+    def reconstruct_routing_from_blocks(self, block_ids, total_routing_tokens):
+        return None
+
+
+class FakeContext:
+    chunked_prefill_request_id = -1
+    kv_block_allocator = FakeKVAllocator()
+
+
+class FakeLaunchContext:
+    def __init__(self):
+        self.total_request_count = 2
+        self.paused_request_count = 0
+
+    def using_cuda_graph_this_step(self):
+        return False
+
+
+def _make_request(request_id: int, *, top_n_logprobs: int = 2) -> DynamicInferenceRequest:
+    request = DynamicInferenceRequest(
+        request_id=request_id,
+        prompt_tokens=torch.tensor([1], dtype=torch.int64),
+        sampling_params=SamplingParams(
+            num_tokens_to_generate=2,
+            return_log_probs=True,
+            skip_prompt_log_probs=True,
+            top_n_logprobs=top_n_logprobs,
+        ),
+        status=Status.ACTIVE_AND_GENERATING_TOKENS,
+    )
+    request.add_event_add_engine()
+    return request
+
+
+def _make_engine(request_ids):
+    engine = object.__new__(DynamicInferenceEngine)
+    engine.context = FakeContext()
+    engine.controller = SimpleNamespace(tokenizer=FakeTokenizer())
+    engine.requests = {
+        request_id: SimpleNamespace(
+            record=DynamicInferenceRequestRecord.from_request(_make_request(request_id)),
+            future=FakeFuture(),
+        )
+        for request_id in request_ids
+    }
+    engine.finished_request_count = 0
+    engine.evicted_request_count = 0
+    engine.track_generated_token_events = False
+    engine.stop_word_finished_request_ids = set()
+    engine.stop_word_being_finished_ids = set()
+    engine.num_speculative_tokens = 0
+    engine._check_stop_words_for_request_post_append = lambda request: (False, 0)
+    return engine
+
+
+def test_publication_maps_generated_artifacts_by_request_id_after_compaction():
+    controller = object.__new__(TextGenerationController)
+    top_n = {
+        0: [(torch.tensor([-0.11, -1.1]), torch.tensor([11, 1]))],
+        1: [(torch.tensor([-0.22, -2.2]), torch.tensor([22, 2]))],
+        2: [(torch.tensor([-0.33, -3.3]), torch.tensor([33, 3]))],
+    }
+
+    publication = controller._dynamic_step_publication_by_request_id(
+        torch.tensor([101, 102, 103], dtype=torch.int64),
+        torch.tensor([11, 22, 33], dtype=torch.int64),
+        accepted_tokens=None,
+        log_probs=[[-0.11], [-0.22], [-0.33]],
+        top_n_logprobs=top_n,
+    )
+
+    assert publication["sample_by_request_id"] == {101: 11, 102: 22, 103: 33}
+    assert publication["log_probs_by_request_id"] == {
+        101: [-0.11],
+        102: [-0.22],
+        103: [-0.33],
+    }
+    assert publication["top_n_logprobs_by_request_id"][103] is top_n[2]
+
+
+def test_post_process_prefers_request_id_publication_for_logprobs_and_top_n():
+    engine = _make_engine([101, 102, 103])
+
+    active_request_ids, finished_records = DynamicInferenceEngine.post_process_requests(
+        engine,
+        torch.tensor([101, 102, 103], dtype=torch.int64),
+        torch.tensor([102], dtype=torch.int64),
+        evict_request_ids=None,
+        step_time=0.0,
+        sample=torch.tensor([11, 22, 33], dtype=torch.int64),
+        accepted_tokens=None,
+        log_probs=[[-9.01], [-9.02], [-9.03]],
+        top_n_logprobs={
+            0: [(torch.tensor([-9.01]), torch.tensor([91]))],
+            1: [(torch.tensor([-9.02]), torch.tensor([92]))],
+            2: [(torch.tensor([-9.03]), torch.tensor([93]))],
+        },
+        log_probs_by_request_id={103: [-0.33], 101: [-0.11], 102: [-0.22]},
+        top_n_logprobs_by_request_id={
+            103: [(torch.tensor([-0.33]), torch.tensor([33]))],
+            101: [(torch.tensor([-0.11]), torch.tensor([11]))],
+            102: [(torch.tensor([-0.22]), torch.tensor([22]))],
+        },
+    )
+
+    assert active_request_ids == [101, 103]
+    assert len(finished_records) == 1
+    assert engine.get_request(101).generated_log_probs == [-0.11]
+    assert engine.get_request(103).generated_log_probs == [-0.33]
+    assert finished_records[0][-1].request_id == 102
+    assert finished_records[0][-1].generated_log_probs == [-0.22]
+    assert engine.get_request(101).generated_top_n_logprobs[0]["T11"] == pytest.approx(-0.11)
+    assert engine.get_request(103).generated_top_n_logprobs[0]["T33"] == pytest.approx(-0.33)
+    assert finished_records[0][-1].generated_top_n_logprobs[0]["T22"] == pytest.approx(-0.22)
+
+
+def test_no_logprob_publication_keeps_logprob_maps_empty():
+    controller = object.__new__(TextGenerationController)
+
+    publication = controller._dynamic_step_publication_by_request_id(
+        torch.tensor([101], dtype=torch.int64),
+        torch.tensor([11], dtype=torch.int64),
+        accepted_tokens=None,
+        log_probs=None,
+        top_n_logprobs=None,
+    )
+
+    assert publication["log_probs_by_request_id"] == {}
+    assert publication["top_n_logprobs_by_request_id"] == {}
+
+
+def test_logprobs_and_stop_words_do_not_force_serial_child_launch():
+    controller = object.__new__(TextGenerationController)
+    controller.num_speculative_tokens = 0
+    controller._enable_cuda_graph = False
+    controller._get_stop_word_finished_ids_callback = lambda request_ids: set()
+    controller.model_config = SimpleNamespace(expert_model_parallel_size=1, num_moe_experts=None)
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=FakeLaunchContext())
+
+    reason = controller._async_child_launch_skip_reason(
+        StepTxn(step_id=4, request_ids=(101, 102)),
+        return_log_probs=True,
+        return_top_n_logprobs=True,
+        skip_bookkeeping=False,
+    )
+
+    assert reason is None

--- a/tests/unit_tests/inference/test_async_txn_rng.py
+++ b/tests/unit_tests/inference/test_async_txn_rng.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.inference.async_txn import RequestRNGStore
+from megatron.core.inference.sampling.torch_sampling import TorchSampling
+
+
+class FakeContext:
+    def __init__(self, request_ids, rng_store):
+        self.total_request_count = len(request_ids)
+        self.paused_request_count = 0
+        self.request_ids = torch.tensor(request_ids, dtype=torch.int32, device='cpu')
+        self.request_rng_store = rng_store
+        self.active_request_metadata = {
+            "temperature": torch.ones(len(request_ids), dtype=torch.float32, pin_memory=True),
+            "top_k": torch.zeros(len(request_ids), dtype=torch.int32, pin_memory=True),
+            "top_p": torch.zeros(len(request_ids), dtype=torch.float32, pin_memory=True),
+        }
+
+
+def test_request_rng_store_is_keyed_by_request_id():
+    store_a = RequestRNGStore(123, device='cpu')
+    store_b = RequestRNGStore(123, device='cpu')
+
+    first = torch.rand(3, generator=store_a.get(7))
+    second = torch.rand(3, generator=store_b.get(7))
+    other = torch.rand(3, generator=store_b.get(8))
+
+    assert torch.equal(first, second)
+    assert not torch.equal(first, other)
+
+
+def test_removing_finished_request_does_not_reset_survivor_rng():
+    store = RequestRNGStore(123, device='cpu')
+    expected_first = torch.rand(1, generator=store.get(2))
+    store.remove(1)
+    expected_second = torch.rand(1, generator=store.get(2))
+
+    replay = RequestRNGStore(123, device='cpu')
+    replay_first = torch.rand(1, generator=replay.get(2))
+    replay_second = torch.rand(1, generator=replay.get(2))
+
+    assert torch.equal(expected_first, replay_first)
+    assert torch.equal(expected_second, replay_second)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA sampling test requires GPU")
+def test_torch_sampling_uses_request_rng_when_store_is_present():
+    device = torch.device("cuda", torch.cuda.current_device())
+    store_a = RequestRNGStore(555, device=device)
+    store_b = RequestRNGStore(555, device=device)
+    context = FakeContext([101, 202], store_a)
+    sampler = TorchSampling(torch.Generator(device=device), vocab_size=5)
+    logits = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5], [0.5, 0.4, 0.3, 0.2, 0.1]], device='cuda')
+
+    first = sampler.sample_kernel(logits, 2, context)
+    context_reordered = FakeContext([202, 101], store_b)
+    second = sampler.sample_kernel(logits.flip(0), 2, context_reordered)
+
+    assert first[0].item() == second[1].item()
+    assert first[1].item() == second[0].item()

--- a/tests/unit_tests/inference/test_async_txn_slots.py
+++ b/tests/unit_tests/inference/test_async_txn_slots.py
@@ -46,6 +46,18 @@ def test_graph_key_changes_when_slot_pointers_differ():
     slot_b = AsyncDecodeSlot(slot_id=1, gpu_view=FakeGPUView())
 
     assert slot_a.pointer_signature() != slot_b.pointer_signature()
+    assert slot_a.cuda_graph_key(("decode", 4)) != slot_b.cuda_graph_key(("decode", 4))
+
+
+def test_slot_copies_cpu_bookkeeping_into_its_gpu_view():
+    slot = AsyncDecodeSlot(slot_id=1, gpu_view=FakeGPUView())
+    cpu_bookkeeping = torch.arange(slot.gpu_view._buf.numel(), dtype=torch.uint8)
+
+    event = slot.copy_bookkeeping_from_cpu(cpu_bookkeeping, non_blocking=False)
+
+    assert event is None
+    assert slot.h2d_done_event is None
+    assert torch.equal(slot.gpu_view._buf, cpu_bookkeeping)
 
 
 def test_ring_promotes_only_reusable_child_slot():

--- a/tests/unit_tests/inference/test_async_txn_slots.py
+++ b/tests/unit_tests/inference/test_async_txn_slots.py
@@ -41,12 +41,12 @@ def test_slot_cannot_reuse_before_forward_event_retires():
     assert slot.can_reuse()
 
 
-def test_graph_key_changes_when_slot_pointers_differ():
+def test_slots_own_distinct_metadata_buffers():
     slot_a = AsyncDecodeSlot(slot_id=0, gpu_view=FakeGPUView())
     slot_b = AsyncDecodeSlot(slot_id=1, gpu_view=FakeGPUView())
 
-    assert slot_a.pointer_signature() != slot_b.pointer_signature()
-    assert slot_a.cuda_graph_key(("decode", 4)) != slot_b.cuda_graph_key(("decode", 4))
+    assert slot_a.gpu_view is not slot_b.gpu_view
+    assert slot_a.gpu_view._buf.data_ptr() != slot_b.gpu_view._buf.data_ptr()
 
 
 def test_slot_copies_cpu_bookkeeping_into_its_gpu_view():

--- a/tests/unit_tests/inference/test_async_txn_slots.py
+++ b/tests/unit_tests/inference/test_async_txn_slots.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.inference.async_txn import AsyncDecodeSlot, AsyncDecodeSlotRing
+
+
+class FakeEvent:
+    def __init__(self, done: bool):
+        self.done = done
+
+    def query(self) -> bool:
+        return self.done
+
+
+class FakeGPUView:
+    def __init__(self):
+        self._buf = torch.zeros(16, dtype=torch.uint8)
+        self.token_to_input_ids = torch.zeros(4, dtype=torch.int64)
+        self.token_to_pos_ids = torch.zeros(4, dtype=torch.int64)
+        self.token_to_block_idx = torch.zeros(4, dtype=torch.int64)
+        self.mha_block_table = torch.zeros((2, 2), dtype=torch.int32)
+
+
+def test_slot_cannot_reuse_before_h2d_event_retires():
+    h2d = FakeEvent(False)
+    slot = AsyncDecodeSlot(slot_id=1, gpu_view=FakeGPUView(), h2d_done_event=h2d)
+
+    assert not slot.can_reuse()
+    h2d.done = True
+    assert slot.can_reuse()
+
+
+def test_slot_cannot_reuse_before_forward_event_retires():
+    forward = FakeEvent(False)
+    slot = AsyncDecodeSlot(slot_id=1, gpu_view=FakeGPUView(), forward_done_event=forward)
+
+    assert not slot.can_reuse()
+    forward.done = True
+    assert slot.can_reuse()
+
+
+def test_graph_key_changes_when_slot_pointers_differ():
+    slot_a = AsyncDecodeSlot(slot_id=0, gpu_view=FakeGPUView())
+    slot_b = AsyncDecodeSlot(slot_id=1, gpu_view=FakeGPUView())
+
+    assert slot_a.pointer_signature() != slot_b.pointer_signature()
+
+
+def test_ring_promotes_only_reusable_child_slot():
+    current = AsyncDecodeSlot(slot_id=0, gpu_view=FakeGPUView())
+    child = AsyncDecodeSlot(
+        slot_id=1,
+        gpu_view=FakeGPUView(),
+        h2d_done_event=FakeEvent(True),
+        forward_done_event=FakeEvent(False),
+    )
+    ring = AsyncDecodeSlotRing((current, child))
+
+    with pytest.raises(RuntimeError):
+        ring.promote_child()
+
+    child.forward_done_event.done = True
+    assert ring.promote_child().slot_id == 1

--- a/tests/unit_tests/inference/test_async_txn_survivors.py
+++ b/tests/unit_tests/inference/test_async_txn_survivors.py
@@ -65,11 +65,15 @@ def _make_bookkeeping_context() -> DynamicInferenceContext:
     context.block_size_tokens = 4
     context.paused_request_count = 0
     context.total_request_count = 2
+    context.padded_active_request_count = 2
+    context.padded_active_token_count = 2
+    context.is_hybrid_model = False
     context.request_ids = torch.tensor([101, 102], dtype=torch.int32)
     context.batch_dimensions = SimpleNamespace(req_count=2)
     context.padded_batch_dimensions = SimpleNamespace(req_count=2)
+    context.kv_block_allocator = SimpleNamespace(dummy_block_idx=-1)
 
-    buf = torch.zeros(512, dtype=torch.uint8)
+    buf = torch.zeros(2048, dtype=torch.uint8)
     context._cpu_bookkeeping_buf = buf
     offset = 0
 
@@ -84,17 +88,41 @@ def _make_bookkeeping_context() -> DynamicInferenceContext:
         offset += count * element_size
         return out
 
+    context.token_to_input_ids = view(torch.int64, (4,))
     context.token_to_pos_ids = view(torch.int64, (4,))
+    context.token_to_request_idx = view(torch.int32, (4,))
     context.token_to_position_in_request = view(torch.int32, (4,))
     context.token_to_local_position_within_kv_block = view(torch.int32, (4,))
+    context._staging_request_in_prefill_status = view(torch.int32, (4,))
+    context._staging_request_query_lengths = view(torch.int32, (4,))
     context._staging_request_kv_length_offsets = view(torch.int32, (4,))
+    context._staging_temperature = view(torch.float32, (4,))
+    context._staging_top_k = view(torch.int32, (4,))
+    context._staging_top_p = view(torch.float32, (4,))
+    context.active_request_last_token_idxs = view(torch.int32, (4,))
+    context._cpu_mha_query_lengths = view(torch.int32, (2,))
+    context._cpu_mha_cu_query_seq_lengths = view(torch.int32, (3,))
     context._cpu_mha_kv_seq_lengths = view(torch.int32, (4,))
     context._cpu_mha_cu_kv_seq_lengths = view(torch.int32, (5,))
     context.token_to_block_idx = view(torch.int64, (4,))
     context._cpu_mha_block_table = view(torch.int32, (2, 2))
 
+    context.token_to_input_ids[:2] = torch.tensor([11, 22])
+    context.token_to_pos_ids[:2] = torch.tensor([1, 3])
+    context.token_to_request_idx[:2] = torch.tensor([0, 1])
+    context.token_to_position_in_request[:2] = torch.tensor([1, 3])
     context.token_to_local_position_within_kv_block[:2] = torch.tensor([1, 3])
     context.token_to_block_idx[:2] = torch.tensor([10, 20])
+    context.request_query_lengths = torch.ones(2, dtype=torch.int32)
+    context.request_kv_length_offsets = torch.tensor([1, 3], dtype=torch.int32)
+    context.active_request_metadata = {
+        "temperature": torch.ones(4, dtype=torch.float32),
+        "top_k": torch.ones(4, dtype=torch.int32),
+        "top_p": torch.zeros(4, dtype=torch.float32),
+    }
+    context.active_request_last_token_idxs[:2] = torch.tensor([0, 1])
+    context._cpu_mha_query_lengths[:2] = torch.ones(2, dtype=torch.int32)
+    context._cpu_mha_cu_query_seq_lengths[:3] = torch.tensor([0, 1, 2], dtype=torch.int32)
     context._cpu_mha_block_table[:] = torch.tensor([[10, -1], [20, -1]], dtype=torch.int32)
     context._cpu_mha_kv_seq_lengths[:2] = torch.tensor([2, 4], dtype=torch.int32)
     context._cpu_mha_cu_kv_seq_lengths[:3] = torch.tensor([0, 2, 6], dtype=torch.int32)
@@ -147,7 +175,7 @@ def test_finish_in_middle_accepts_survivors():
     txn.launched = True
     txn.mark_committed([101, 103], terminal_request_ids=[102])
 
-    assert txn.guard_adoption([101, 103], terminal_request_ids=txn.terminal_request_ids)
+    assert txn.is_consumable_after_commit([101, 103], terminal_request_ids=txn.terminal_request_ids)
 
 
 def test_compaction_changes_row_order_but_survivor_outputs_follow_request_ids():
@@ -175,7 +203,7 @@ def test_terminal_ignored_row_kv_blocks_are_not_reused_before_retire():
     assert context.kv_block_allocator.released == [10]
 
 
-def test_boundary_crosser_adopts_reserved_block():
+def test_boundary_crosser_uses_reserved_block():
     context = _make_update_context()
     txn = StepTxn(
         step_id=4,
@@ -218,7 +246,7 @@ def test_guard_failure_after_launch_does_not_accept_nonterminal_disappearance():
     txn.launched = True
     txn.mark_committed([101], terminal_request_ids=[])
 
-    assert not txn.guard_adoption([101], terminal_request_ids=txn.terminal_request_ids)
+    assert not txn.is_consumable_after_commit([101], terminal_request_ids=txn.terminal_request_ids)
 
 
 def test_patch_plain_decode_child_uses_reserved_boundary_block():
@@ -226,7 +254,7 @@ def test_patch_plain_decode_child_uses_reserved_boundary_block():
     child = context._cpu_bookkeeping_buf.clone()
     lease = KVBlockLease(request_id=102, block_column=1, block_id=77)
 
-    DynamicInferenceContext._patch_plain_decode_child_bookkeeping(
+    DynamicInferenceContext._build_plain_decode_child_bookkeeping(
         context, child, 2, kv_block_leases=(lease,)
     )
     child_block_idx = DynamicInferenceContext._cpu_bookkeeping_clone_view(

--- a/tests/unit_tests/inference/test_async_txn_survivors.py
+++ b/tests/unit_tests/inference/test_async_txn_survivors.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import torch
+
+from megatron.core.inference.async_txn import (
+    AsyncTxnDiagnostics,
+    KVBlockLease,
+    StepTxn,
+    TxnRetireQueue,
+    classify_decode_child_launch,
+)
+from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
+
+
+class FakeEvent:
+    def __init__(self, done: bool = False):
+        self.done = done
+
+    def query(self) -> bool:
+        return self.done
+
+
+class FakeKVAllocator:
+    block_routing = {}
+    paused_count = 0
+    total_avail = 0
+
+    def __init__(self, available: int = 0):
+        self.available = available
+        self.active_count = 16
+        self.released = []
+
+    def is_memory_available(self, num_blocks: int) -> bool:
+        return num_blocks <= self.available
+
+    def release_memory_blocks(self, block_ids: torch.Tensor) -> None:
+        self.released.extend(int(block_id) for block_id in block_ids.tolist())
+
+    def get_active_avail(self) -> int:
+        return self.active_count
+
+    def get_paused_used(self) -> int:
+        return 0
+
+
+class FakeLaunchContext:
+    def __init__(self, *, offsets=(3,), available_blocks=0):
+        self.paused_request_count = 0
+        self.total_request_count = len(offsets)
+        self.request_last_kv_block_offset = torch.tensor(offsets, dtype=torch.int32)
+        self.request_ids = torch.arange(100, 100 + len(offsets), dtype=torch.int32)
+        self.block_size_tokens = 4
+        self.num_speculative_tokens = 0
+        self.kv_block_allocator = FakeKVAllocator(available_blocks)
+        self.chunked_prefill_request_id = -1
+
+    def is_decode_only(self) -> bool:
+        return True
+
+
+def _make_bookkeeping_context() -> DynamicInferenceContext:
+    context = object.__new__(DynamicInferenceContext)
+    context.block_size_tokens = 4
+    context.paused_request_count = 0
+    context.total_request_count = 2
+    context.request_ids = torch.tensor([101, 102], dtype=torch.int32)
+    context.batch_dimensions = SimpleNamespace(req_count=2)
+    context.padded_batch_dimensions = SimpleNamespace(req_count=2)
+
+    buf = torch.zeros(512, dtype=torch.uint8)
+    context._cpu_bookkeeping_buf = buf
+    offset = 0
+
+    def view(dtype, shape):
+        nonlocal offset
+        element_size = torch.tensor([], dtype=dtype).element_size()
+        offset += (element_size - offset % element_size) % element_size
+        count = 1
+        for dim in shape:
+            count *= dim
+        out = buf[offset : offset + count * element_size].view(dtype).view(shape)
+        offset += count * element_size
+        return out
+
+    context.token_to_pos_ids = view(torch.int64, (4,))
+    context.token_to_position_in_request = view(torch.int32, (4,))
+    context.token_to_local_position_within_kv_block = view(torch.int32, (4,))
+    context._staging_request_kv_length_offsets = view(torch.int32, (4,))
+    context._cpu_mha_kv_seq_lengths = view(torch.int32, (4,))
+    context._cpu_mha_cu_kv_seq_lengths = view(torch.int32, (5,))
+    context.token_to_block_idx = view(torch.int64, (4,))
+    context._cpu_mha_block_table = view(torch.int32, (2, 2))
+
+    context.token_to_local_position_within_kv_block[:2] = torch.tensor([1, 3])
+    context.token_to_block_idx[:2] = torch.tensor([10, 20])
+    context._cpu_mha_block_table[:] = torch.tensor([[10, -1], [20, -1]], dtype=torch.int32)
+    context._cpu_mha_kv_seq_lengths[:2] = torch.tensor([2, 4], dtype=torch.int32)
+    context._cpu_mha_cu_kv_seq_lengths[:3] = torch.tensor([0, 2, 6], dtype=torch.int32)
+    return context
+
+
+def _make_update_context() -> DynamicInferenceContext:
+    context = object.__new__(DynamicInferenceContext)
+    context.num_speculative_tokens = 0
+    context.num_prefill_requests = 0
+    context.paused_request_count = 0
+    context.total_request_count = 2
+    context.active_token_count = 2
+    context.max_requests = 4
+    context.max_tokens = 4
+    context.block_size_tokens = 4
+    context.chunked_prefill_request_id = -1
+    context.paused_tokens = None
+    context.paused_speculative_tokens = None
+    context.is_hybrid_model = False
+    context.mamba_slot_allocator = None
+    context.kv_block_allocator = FakeKVAllocator()
+    context.async_txn_diagnostics = AsyncTxnDiagnostics(enabled=True)
+    context.async_txn_retire_queue = TxnRetireQueue(context.async_txn_diagnostics)
+
+    context.request_ids = torch.tensor([101, 102, -1, -1], dtype=torch.int32)
+    context.request_kv_length_offsets = torch.tensor([3, 1, 0, 0], dtype=torch.int32)
+    context.request_in_prefill_status_tensor = torch.zeros(4, dtype=torch.int32)
+    context.request_query_lengths = torch.ones(4, dtype=torch.int32)
+    context.request_output_lengths = torch.full((4,), 99, dtype=torch.int32)
+    context.request_to_kv_block_ids = torch.tensor(
+        [[10, -1], [20, -1], [-1, -1], [-1, -1]], dtype=torch.int32
+    )
+    context.request_kv_block_counts = torch.tensor([1, 1, 0, 0], dtype=torch.int32)
+    context.request_last_kv_block_id = torch.tensor([10, 20, -1, -1], dtype=torch.int32)
+    context.request_last_kv_block_offset = torch.tensor([3, 1, 0, 0], dtype=torch.int32)
+    context.request_metadata = {}
+    context.token_to_input_ids = torch.zeros(8, dtype=torch.int64)
+    context.token_to_pos_ids = torch.zeros(8, dtype=torch.int64)
+    context.token_to_request_idx = torch.zeros(8, dtype=torch.int32)
+    context.token_to_position_in_request = torch.zeros(8, dtype=torch.int64)
+    context.token_to_local_position_within_kv_block = torch.zeros(8, dtype=torch.int32)
+    context.token_to_block_idx = torch.zeros(8, dtype=torch.int64)
+    context.reset_attention_state = lambda: None
+    return context
+
+
+def test_finish_in_middle_accepts_survivors():
+    txn = StepTxn(step_id=4, request_ids=[101, 102, 103])
+    txn.launched = True
+    txn.mark_committed([101, 103], terminal_request_ids=[102])
+
+    assert txn.guard_adoption([101, 103], terminal_request_ids=txn.terminal_request_ids)
+
+
+def test_compaction_changes_row_order_but_survivor_outputs_follow_request_ids():
+    txn = StepTxn(step_id=4, request_ids=[101, 102, 103])
+    row_ordered_samples = torch.tensor([11, 22, 33])
+    committed_request_ids = [103, 101]
+
+    row_idxs = txn.committed_row_indices(committed_request_ids)
+
+    assert row_ordered_samples[list(row_idxs)].tolist() == [33, 11]
+
+
+def test_terminal_ignored_row_kv_blocks_are_not_reused_before_retire():
+    context = _make_update_context()
+    event = FakeEvent(done=False)
+    txn = StepTxn(step_id=4, request_ids=[101, 102], forward_done_event=event, launched=True)
+
+    DynamicInferenceContext.update_requests(
+        context, torch.tensor([0, 1], dtype=torch.uint8), torch.tensor([7, 8]), async_txn=txn
+    )
+
+    assert context.kv_block_allocator.released == []
+    event.done = True
+    assert context.async_txn_retire_queue.drain_ready() == 1
+    assert context.kv_block_allocator.released == [10]
+
+
+def test_boundary_crosser_adopts_reserved_block():
+    context = _make_update_context()
+    txn = StepTxn(
+        step_id=4,
+        request_ids=[101, 102],
+        kv_block_leases=(KVBlockLease(request_id=101, block_column=1, block_id=30),),
+        launched=True,
+    )
+
+    result = DynamicInferenceContext.update_requests(
+        context, torch.tensor([1, 1], dtype=torch.uint8), torch.tensor([7, 8]), async_txn=txn
+    )
+
+    assert result["newly_paused_request_ids"] is None
+    assert context.paused_request_count == 0
+    assert context.request_to_kv_block_ids[0, 1].item() == 30
+    assert context.request_last_kv_block_id[0].item() == 30
+    assert context.token_to_block_idx[:2].tolist() == [30, 20]
+
+
+def test_missing_reservation_prevents_launch_instead_of_post_launch_pause():
+    context = FakeLaunchContext(offsets=(3,), available_blocks=0)
+
+    result = classify_decode_child_launch(context, async_enabled=True)
+
+    assert not result.eligible
+    assert result.required_boundary_blocks == 1
+
+
+def test_missing_reservation_ignores_same_step_terminal_free_headroom():
+    context = FakeLaunchContext(offsets=(3, 1), available_blocks=0)
+
+    result = classify_decode_child_launch(context, async_enabled=True)
+
+    assert not result.eligible
+    assert result.required_boundary_blocks == 1
+
+
+def test_guard_failure_after_launch_does_not_accept_nonterminal_disappearance():
+    txn = StepTxn(step_id=4, request_ids=[101, 102])
+    txn.launched = True
+    txn.mark_committed([101], terminal_request_ids=[])
+
+    assert not txn.guard_adoption([101], terminal_request_ids=txn.terminal_request_ids)
+
+
+def test_patch_plain_decode_child_uses_reserved_boundary_block():
+    context = _make_bookkeeping_context()
+    child = context._cpu_bookkeeping_buf.clone()
+    lease = KVBlockLease(request_id=102, block_column=1, block_id=77)
+
+    DynamicInferenceContext._patch_plain_decode_child_bookkeeping(
+        context, child, 2, kv_block_leases=(lease,)
+    )
+    child_block_idx = DynamicInferenceContext._cpu_bookkeeping_clone_view(
+        context, context.token_to_block_idx, child
+    )
+    child_local = DynamicInferenceContext._cpu_bookkeeping_clone_view(
+        context, context.token_to_local_position_within_kv_block, child
+    )
+    child_block_table = DynamicInferenceContext._cpu_bookkeeping_clone_view(
+        context, context._cpu_mha_block_table, child
+    )
+
+    assert child_local[:2].tolist() == [2, 0]
+    assert child_block_idx[:2].tolist() == [10, 77]
+    assert child_block_table[1, 1].item() == 77


### PR DESCRIPTION
## Summary

This PR implements a transactional async scheduling architecture for dynamic inference decode. The goal is to keep the GPU busy in ordinary decode steady state by alternating forward and sampling work without inserting CPU bookkeeping gaps:

```text
forward_K -> sampling_K -> forward_K+1 -> sampling_K+1
```

The design intentionally avoids speculative layout prediction and reject/rerun behavior for plain decode. Instead, a child decode forward is launched only when the next step is known to be safe under a no-reject-after-launch invariant. Terminal rows may be ignored after launch, but surviving non-terminal rows must be accepted.

## Architecture Plan

The full implementation plan covers:

- Transaction primitives, retire queues, diagnostics, and explicit async enablement.
- Two GPU metadata slots so child metadata can be pre-staged while the current forward is running.
- Request-id-keyed sampling RNG so compaction and deferred admission do not perturb stochastic outputs.
- Pre-staged deterministic decode child metadata, including KV boundary reservations before launch.
- Launch-before-commit plain decode fast path with GPU token scatter plus immediate child replay/launch after sampling.
- Closed-survivor-set handling for finishes, row compaction, KV leases, and block-boundary adoption.
- Single-bank hybrid/Mamba safety based on the no-reject invariant, with Mamba slot retirement delayed until relevant forwards retire.
- Request-id-keyed publication for generated logprobs, top-n logprobs, stop-word handling, routing records, and coordinator replies.
- MTP correctness as a nested transaction, while explicitly deferring MTP no-gap performance optimization to a later plan.
- EP deterministic behavior through cheap canonical broadcasts and dummy-rank mirroring, without PR-4604-style per-step layout voting.
- Sync gates for admission, resume, eviction, chunked prefill, graph recapture, logging/benchmark barriers, prefix cache, shutdown, and drain.
- Cleanup to prevent prediction/reconciliation machinery from reappearing under new names.
- Low-overhead diagnostics and HSG benchmark validation for async prepared/launched/adopted/retired steady-state steps.

## Correctness Contract

The key contract is that a launched plain-decode child is never rejected for a surviving request. The launch gate must prove that any post-sampling mutation is either terminal/absorbable or deferred to a sync step before the child is launched. If a non-terminal row could be admitted, resumed, paused, evicted, force-paused, graph-recaptured, or otherwise layout-mutated, async child launch is skipped for that step.

This contract keeps hybrid/Mamba single-bank and in-place for ordinary decode. Rollback remains scoped to MTP validation only.

## Validation Plan

Focused tests are planned across each implementation commit for:

- transaction primitives and diagnostics
- metadata slot lifetime and graph pointer safety
- per-request RNG determinism
- child prestage eligibility and KV boundary reservation
- launch-before-commit ordering
- survivor compaction and KV leasing
- single-bank Mamba correctness
- request-id publication/logprobs/stop words/routing
- MTP accepted-token/KV/Mamba correctness
- EP token/stop-word/accepted-count broadcast behavior
- admission, chunked prefill, resume/evict, graph/log barriers, prefix cache, and shutdown drain
- no-regression checks against prediction/rejection machinery

Performance validation will use HSG inference-bench for mcore nanov3, including printed-arg verification that async scheduling is enabled, steady-state diagnostics, and nsys evidence that ordinary non-MTP decode has no inter-forward GPU gap.

## Status

Draft while implementation proceeds on `async-sched-txn-codex`. The PR description intentionally describes the complete plan, not only the currently pushed commits.