### PR TITLE
Async decode scheduling: a minimal transactional GPU/CPU contract (GPU-100%-busy)

### DIFF
--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -275,6 +275,16 @@ class InferenceConfig:
     enable_chunked_prefill: bool = False
     """Whether to enable chunked prefill."""
 
+    enable_async_scheduling: bool = False
+    """Whether to enable transactional async scheduling for dynamic-batching decode.
+
+    When True, the dynamic engine overlaps CPU scheduling/bookkeeping work with the GPU
+    forward (launch-before-commit pipeline) so that steady-state decode keeps the GPU
+    busy. Opt-in; defaults to False. When False, the decode step is byte-for-byte
+    identical to the legacy serial path. Mapped from the Megatron argument
+    ``--inference-dynamic-batching-async-scheduling``.
+    """
+
     num_speculative_tokens: int = 0
     """The number of speculative tokens to generate for decode steps."""
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -5,7 +5,7 @@ import math
 import operator
 import warnings
 from contextlib import nullcontext
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import torch  # type: ignore
 import torch.nn.functional as F  # type: ignore
@@ -263,6 +263,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Transactional async scheduling (launch-before-commit) opt-in. When False,
         # the decode step is byte-for-byte identical to the legacy serial path.
         self.enable_async_scheduling = inference_config.enable_async_scheduling
+
+        # C4: whether the authoritative next-step decode input ids currently live on
+        # the single GPU metadata buffer (placed there by an in-place GPU token scatter
+        # rather than a CPU write + H2D). When True, the upcoming coalesced H2D excludes
+        # the leading token_to_input_ids region so it does not clobber the scattered ids.
+        # Only ever set on the async path for clean steady-state decode transitions;
+        # always False (so the H2D is full, exactly as on main) when async is disabled.
+        self._decode_token_ids_live_on_gpu = False
 
         # Prefix caching configuration
         self.enable_prefix_caching = inference_config.enable_prefix_caching
@@ -1241,6 +1249,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         # commits.
         self.decode_metadata_buffer: Optional[DecodeMetadataBuffer] = None
         self.cpu_staging_ring: Optional[DepthTwoRing] = None
+        # Byte span of the leading token_to_input_ids field (offset 0, int64 x max_tokens)
+        # within the coalesced buffer. The token-excluded H2D (C4) copies _buf[this:]
+        # only, leaving the GPU-scattered token ids intact.
+        self._token_ids_byte_count = self.max_tokens * 8
         if self.enable_async_scheduling:
             self.decode_metadata_buffer = DecodeMetadataBuffer(gpu_view=self.gpu_view)
             # Pinned mirror (matches `_cpu_bookkeeping_buf`) so the staging->GPU H2D is a
@@ -1251,6 +1263,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.cpu_staging_ring = DepthTwoRing.of(
                 self._cpu_bookkeeping_buf, self._cpu_staging_buf
             )
+            # Reusable CUDA event recorded after each coalesced H2D into the single GPU
+            # buffer (the buffer's h2d_done_event). Allocated lazily on first transfer.
+            self._h2d_done_event: Optional[Any] = None
 
         # Cache of (input_ids_view, pos_ids_view) keyed by num_tokens. Instead of slicing and
         # unsqueezing on every new inference step (constructing new TensorImpls at 30-60 us),
@@ -2356,7 +2371,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_ssm_states[:, indices] = 0.0
             self._pending_mamba_zeros.clear()
 
-    def transfer_bookkeeping_to_gpu(self) -> None:
+    def transfer_bookkeeping_to_gpu(self, include_token_to_input_ids: Optional[bool] = None) -> None:
         """Batch transfer CPU bookkeeping state to GPU staging buffers.
 
         Called after initialize_attention_state() and before the forward pass.
@@ -2368,7 +2383,20 @@ class DynamicInferenceContext(BaseInferenceContext):
         Request-level staging slots are refreshed from the persistent CPU
         tensors immediately before the H2D (GPU reads them at `[:n_active]`
         while CPU bookkeeping keeps them at `[paused_count:total_count)`).
+
+        Args:
+            include_token_to_input_ids (Optional[bool]): Whether to include the leading
+                ``token_to_input_ids`` region in the H2D. ``None`` (the default) derives
+                it from context state: the region is EXCLUDED only on the async path
+                when the next step's input ids already live on the single GPU buffer via
+                an in-place token scatter (C4) and this is a decode-only step -- so the
+                H2D never clobbers the scattered ids. When async is disabled this is
+                always ``True``, i.e. the H2D is the same full copy as on main.
         """
+        if include_token_to_input_ids is None:
+            include_token_to_input_ids = not (
+                self._decode_token_ids_live_on_gpu and self.is_decode_only()
+            )
         n_active = self.total_request_count - self.paused_request_count
         active_slice = slice(self.paused_request_count, self.total_request_count)
         padded_active = max(n_active, self.padded_active_request_count)
@@ -2405,7 +2433,27 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Copying the whole (max_tokens + max_requests)-sized buffer including
         # unused slots is cheap (~71 KB total, ~3-5 us on PCIe Gen4) and saves
         # 8 redundant launch overheads vs. the prior per-field copies.
-        self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+        #
+        # C4: when the next-step input ids already live on the single GPU buffer
+        # (placed there by an in-place token scatter), exclude the leading
+        # token_to_input_ids region (`_token_ids_byte_count` bytes at offset 0) so
+        # the copy does not clobber them. The remainder of the buffer -- pos ids,
+        # block idx, request staging, MHA metadata, and (hybrid) mamba metadata --
+        # is still a single contiguous cudaMemcpyAsync.
+        if include_token_to_input_ids:
+            self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+        else:
+            tib = self._token_ids_byte_count
+            self.gpu_view._buf[tib:].copy_(self._cpu_bookkeeping_buf[tib:], non_blocking=True)
+
+        # Record the H2D completion fence on the single decode metadata buffer (async
+        # only). C4 only records it; the launch-before-commit pipeline (C5) is what
+        # waits on it (before reusing the pinned buffer / before relaunching).
+        if self.decode_metadata_buffer is not None:
+            if self._h2d_done_event is None:
+                self._h2d_done_event = torch.cuda.Event()
+            self._h2d_done_event.record()
+            self.decode_metadata_buffer.h2d_done_event = self._h2d_done_event
 
         # MHA metadata GPU views were already bound to state_data in
         # initialize_attention_state(); the H2D above populates the underlying
@@ -2416,8 +2464,93 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata.load_from_cpu(self._pending_mamba_transfer)
             self._pending_mamba_transfer = None
 
+    def scatter_decode_tokens_to_gpu(self, sampled_tokens_cuda: Tensor) -> None:
+        """In-place GPU scatter of the just-sampled ids into ``token_to_input_ids``.
+
+        For a plain (``num_speculative_tokens == 0``) steady-state decode transition,
+        the next step's input ids are exactly this step's sampled tokens, one per active
+        request in identity order -- the same values ``update_requests`` writes into the
+        CPU ``token_to_input_ids[:active_token_count]``. This writes them directly into
+        the single GPU metadata buffer with NO device->host round trip, so the next
+        step's coalesced H2D can exclude the token-id region (see
+        ``transfer_bookkeeping_to_gpu``). The buffer's captured graph reads
+        ``token_to_input_ids`` at its absolute address, which this scatter writes in
+        place; the buffer is never moved.
+
+        The caller is responsible for gating this to the clean steady-state decode case
+        (no finishes, no paused requests, decode-only, plain decode). For all other
+        transitions the legacy CPU write + full H2D path is used unchanged.
+        """
+        assert self.decode_metadata_buffer is not None, "scatter requires async scheduling"
+        assert self.num_speculative_tokens == 0, "C4 token scatter is plain-decode only"
+        n = self.active_token_count
+        dst = self.gpu_view.token_to_input_ids
+        # Identity scatter of the active rows; .copy_() handles the dtype cast (sampled
+        # ids may be int32/int64 while token_to_input_ids is int64). No .cpu() anywhere.
+        dst[:n].copy_(sampled_tokens_cuda[:n])
+
+    @staticmethod
+    def advance_decode_metadata_in_place(
+        *,
+        bs: int,
+        prev_kv_seq_lengths: Tensor,
+        committed_block_table: Tensor,
+        out_query_lengths: Tensor,
+        out_cu_query: Tensor,
+        out_kv_seq_lengths: Tensor,
+        out_cu_kv: Tensor,
+        out_block_table: Tensor,
+    ) -> None:
+        """Advance one plain decode step's MHA metadata IN PLACE (no full rebuild).
+
+        ``initialize_attention_state`` rebuilds the flash-attention MHA metadata from
+        scratch every step. For a plain (``num_speculative_tokens == 0``) decode step
+        whose active set and graph bucket are unchanged, the same result is reachable by
+        a cheap incremental advance of the *previous* step's metadata:
+
+        * ``query_lengths`` are all ``1`` and ``cu_query`` is ``[0, 1, 2, ...]`` -- both
+          invariant across plain decode steps.
+        * each request's ``kv_seq_length`` grows by exactly its (unit) query length, so
+          ``kv_seq_lengths[:bs] = prev_kv_seq_lengths[:bs] + 1`` and ``cu_kv`` is the
+          recomputed prefix sum.
+        * ``block_table`` is invariant except that a boundary-crossing request's last
+          entry points at its newly reserved block; both are captured by reading the
+          committed ``request_to_kv_block_ids`` (which ``update_requests`` already
+          advanced) -- exactly the source the from-scratch rebuild reads.
+
+        This is the mechanism the launch-before-commit prestage (C5) uses to build the
+        next step's metadata in the current forward's shadow. C4 lands and proves it
+        equals the from-scratch rebuild (see the unit battery) while the serial step
+        keeps using the rebuild as the authoritative source.
+
+        Args:
+            bs (int): the real (unpadded) decode request count.
+            prev_kv_seq_lengths (Tensor): the previous step's ``kv_seq_lengths[:bs]``.
+            committed_block_table (Tensor): the committed ``request_to_kv_block_ids`` rows
+                for the active slice (``[bs, max_kv_blocks]``).
+            out_* (Tensor): destination views (the CPU staging MHA fields). Padded rows are
+                left untouched (the caller pads them exactly as the rebuild does).
+        """
+        # query_lengths are unit for plain decode; cu_query = [0, 1, ..., bs].
+        out_query_lengths[:bs] = 1
+        out_cu_query[: bs + 1] = torch.arange(bs + 1, dtype=out_cu_query.dtype, device='cpu')
+
+        # kv_seq_lengths advance by the (unit) query length; cu_kv is the prefix sum.
+        out_kv_seq_lengths[:bs] = prev_kv_seq_lengths[:bs] + 1
+        out_cu_kv[0] = 0
+        if bs > 0:
+            out_cu_kv[1 : bs + 1] = torch.cumsum(out_kv_seq_lengths[:bs], dim=0)
+
+        # block_table tracks the committed physical KV block ids (advanced already by
+        # update_requests, including any boundary-crossing reallocation).
+        out_block_table[:bs] = committed_block_table[:bs]
+
     def reset_tensors(self) -> None:
         """Fill all bookkeeping tensors with sentinel values."""
+
+        # A full reset clears the CPU token ids; the GPU token region is no longer the
+        # authoritative source, so the next H2D must include it again (C4).
+        self._decode_token_ids_live_on_gpu = False
 
         # Reset request indexes.
         self.request_ids.fill_(-1)

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -49,6 +49,7 @@ from .base_context import BaseInferenceContext
 from .gpu_view import ContextGPUView
 from .kv_block_allocator import KVBlockAllocator
 from .mamba_slot_allocator import MambaSlotAllocator
+from .metadata_slot import DecodeMetadataSlot
 from .routing_metadata import RoutingMetadata
 
 try:
@@ -1222,6 +1223,27 @@ class DynamicInferenceContext(BaseInferenceContext):
             device=torch.cuda.current_device(),
             max_mamba_chunks=self._max_mamba_chunks,
         )
+
+        # Async scheduling (launch-before-commit): wrap the live gpu_view as
+        # slot_current and allocate a free slot_child to prestage the next step's
+        # metadata into. Built only when the opt-in flag is on; the serial path uses
+        # only the single live gpu_view above. The prestage that populates slot_child
+        # and the graph replay that consumes it land in later commits -- here the
+        # child slot is allocated, free, and at a distinct address.
+        self.slot_current: Optional[DecodeMetadataSlot] = None
+        self.slot_child: Optional[DecodeMetadataSlot] = None
+        if self.enable_async_scheduling:
+            self.slot_current = DecodeMetadataSlot(slot_id=0, gpu_view=self.gpu_view)
+            self.slot_child = DecodeMetadataSlot(
+                slot_id=1,
+                gpu_view=ContextGPUView(
+                    max_requests=self.max_requests,
+                    max_tokens=self.max_tokens,
+                    max_kv_blocks=self.max_kv_block_count,
+                    device=torch.cuda.current_device(),
+                    max_mamba_chunks=self._max_mamba_chunks,
+                ),
+            )
 
         # Cache of (input_ids_view, pos_ids_view) keyed by num_tokens. Instead of slicing and
         # unsqueezing on every new inference step (constructing new TensorImpls at 30-60 us),

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -49,7 +49,7 @@ from .base_context import BaseInferenceContext
 from .gpu_view import ContextGPUView
 from .kv_block_allocator import KVBlockAllocator
 from .mamba_slot_allocator import MambaSlotAllocator
-from .metadata_slot import DecodeMetadataSlot
+from .metadata_slot import DecodeMetadataBuffer, DepthTwoRing
 from .routing_metadata import RoutingMetadata
 
 try:
@@ -1224,25 +1224,32 @@ class DynamicInferenceContext(BaseInferenceContext):
             max_mamba_chunks=self._max_mamba_chunks,
         )
 
-        # Async scheduling (launch-before-commit): wrap the live gpu_view as
-        # slot_current and allocate a free slot_child to prestage the next step's
-        # metadata into. Built only when the opt-in flag is on; the serial path uses
-        # only the single live gpu_view above. The prestage that populates slot_child
-        # and the graph replay that consumes it land in later commits -- here the
-        # child slot is allocated, free, and at a distinct address.
-        self.slot_current: Optional[DecodeMetadataSlot] = None
-        self.slot_child: Optional[DecodeMetadataSlot] = None
+        # Async scheduling (launch-before-commit). The metadata GPU buffer is SINGLE and
+        # fixed-address: a captured decode graph reads it by absolute address, so it is
+        # never reallocated or swapped -- there is no second GPU buffer / no
+        # replay-against-child. `decode_metadata_buffer` wraps the live `gpu_view` above
+        # (carrying the two CUDA fences + the data_ptr()-invariance guard).
+        #
+        # The genuine double-buffer is CPU-side: the next step's bookkeeping is prestaged
+        # into a pinned CPU *staging* buffer (identical layout to `_cpu_bookkeeping_buf`)
+        # while the current forward's already-issued H2D still reads the live buffer, then
+        # the staging buffer is swapped in and one coalesced H2D copies it into the single
+        # GPU buffer. `cpu_staging_ring` is the depth-2 live<->staging ring. Built only
+        # when the opt-in flag is on; the serial path uses the single live gpu_view and
+        # `_cpu_bookkeeping_buf` directly and is unchanged. The prestage that writes the
+        # staging buffer and the graph replay that consumes the GPU buffer land in later
+        # commits.
+        self.decode_metadata_buffer: Optional[DecodeMetadataBuffer] = None
+        self.cpu_staging_ring: Optional[DepthTwoRing] = None
         if self.enable_async_scheduling:
-            self.slot_current = DecodeMetadataSlot(slot_id=0, gpu_view=self.gpu_view)
-            self.slot_child = DecodeMetadataSlot(
-                slot_id=1,
-                gpu_view=ContextGPUView(
-                    max_requests=self.max_requests,
-                    max_tokens=self.max_tokens,
-                    max_kv_blocks=self.max_kv_block_count,
-                    device=torch.cuda.current_device(),
-                    max_mamba_chunks=self._max_mamba_chunks,
-                ),
+            self.decode_metadata_buffer = DecodeMetadataBuffer(gpu_view=self.gpu_view)
+            # Pinned mirror (matches `_cpu_bookkeeping_buf`) so the staging->GPU H2D is a
+            # single cudaMemcpyAsync, exactly like the live buffer's transfer.
+            self._cpu_staging_buf = torch.empty_like(
+                self._cpu_bookkeeping_buf, pin_memory=True
+            )
+            self.cpu_staging_ring = DepthTwoRing.of(
+                self._cpu_bookkeeping_buf, self._cpu_staging_buf
             )
 
         # Cache of (input_ids_view, pos_ids_view) keyed by num_tokens. Instead of slicing and

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -259,6 +259,10 @@ class DynamicInferenceContext(BaseInferenceContext):
     def __init__(self, model_config: TransformerConfig, inference_config: InferenceConfig):
         super().__init__(inference_config=inference_config)
 
+        # Transactional async scheduling (launch-before-commit) opt-in. When False,
+        # the decode step is byte-for-byte identical to the legacy serial path.
+        self.enable_async_scheduling = inference_config.enable_async_scheduling
+
         # Prefix caching configuration
         self.enable_prefix_caching = inference_config.enable_prefix_caching
         self.prefix_caching_eviction_policy = inference_config.prefix_caching_eviction_policy

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2603,6 +2603,30 @@ class DynamicInferenceContext(BaseInferenceContext):
         threshold = self.block_size_tokens - 1 - self.num_speculative_tokens
         return torch.nonzero(num_tokens_in_last_block >= threshold, as_tuple=True)[0]
 
+    def _decode_crossers_within_window(self, lookahead_steps: int) -> int:
+        """Count active requests that would cross a KV block boundary within the next
+        ``lookahead_steps`` plain-decode steps.
+
+        Uses the SAME boundary condition as ``update_requests`` /
+        ``_boundary_crosser_local_indices`` (``num_tokens_in_last_block >= block_size_tokens
+        - 1 - num_speculative_tokens``), shifted by ``lookahead_steps - 1`` so a request
+        within ``lookahead_steps`` unit-query appends of its block boundary is counted.
+
+        This is the look-ahead the *speculative* launch-before-commit prestage needs: it
+        builds the forward AFTER the pending (not-yet-committed) decode step, so the predicted
+        block table is only invariant if NEITHER the pending commit NOR that forward crosses a
+        boundary. When any request would cross within the window the prestage is ineligible and
+        the engine takes a synchronous step (where the boundary block is allocated normally).
+        Pure read; mutates nothing.
+        """
+        active_request_count = self.total_request_count - self.paused_request_count
+        if active_request_count <= 0:
+            return 0
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        num_tokens_in_last_block = self.request_last_kv_block_offset[active_slice]
+        threshold = self.block_size_tokens - 1 - self.num_speculative_tokens - (lookahead_steps - 1)
+        return int((num_tokens_in_last_block >= threshold).sum().item())
+
     def build_launch_signals(
         self,
         *,
@@ -2653,11 +2677,25 @@ class DynamicInferenceContext(BaseInferenceContext):
         evict_pending: bool = False,
         forced_pause_overflow: bool = False,
         graph_recapture: bool = False,
+        speculate_pending_decode_commit: bool = False,
     ) -> "PrestagedDecodePlan":
         """Build the next decode step's launch plan into the CPU staging buffer.
 
         Speculating no finish this step, predict the next forward's plan from the *committed*
         layout and:
+
+        ``speculate_pending_decode_commit`` switches between the two plans the pipeline needs:
+
+        * ``False`` (default): build the metadata for the forward that runs against the *current*
+          committed layout -- the immediately-next forward (validated == ``initialize_attention_state``).
+        * ``True``: the launch-before-commit plan (design 1.1 step 2 -- "advance +1 token,
+          speculating no finish this step"). The current decode step's ``update_requests`` is
+          deferred, so the launched forward consumes the layout the pending commit *will* produce;
+          predict it by advancing each active request's kv length by its (unit) query length before
+          building the next forward's metadata. Only valid when no request crosses a KV block
+          boundary within the 2-step speculative window (the pending commit + the launched forward);
+          otherwise the predicted block table would change and the plan is ineligible
+          (``SPECULATIVE_BOUNDARY_WINDOW``) so the engine takes a synchronous step.
 
         * classify launch eligibility from committed state + KV headroom; if ineligible, return
           an empty plan carrying the static skip reason (no staging writes, no leases);
@@ -2676,6 +2714,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         that consumes the plan (a later commit).
         """
         from megatron.core.inference.engines.step_transaction import (
+            LaunchGateReason,
             PrestagedDecodePlan,
             classify_launch_eligibility,
         )
@@ -2697,6 +2736,17 @@ class DynamicInferenceContext(BaseInferenceContext):
                 step_id=self.step_count, eligible=False, skip_reason=decision.reason
             )
 
+        # Launch-before-commit (speculative): the launched forward consumes the layout the
+        # deferred current-step commit will produce, so the predicted block table is only
+        # invariant when no request crosses a boundary within the 2-step window. If one does,
+        # fall back to a synchronous step (where the boundary block is allocated normally).
+        if speculate_pending_decode_commit and self._decode_crossers_within_window(2) > 0:
+            return PrestagedDecodePlan(
+                step_id=self.step_count,
+                eligible=False,
+                skip_reason=LaunchGateReason.SPECULATIVE_BOUNDARY_WINDOW,
+            )
+
         bs = self.total_request_count - self.paused_request_count
         active_slice = slice(self.paused_request_count, self.total_request_count)
 
@@ -2704,12 +2754,22 @@ class DynamicInferenceContext(BaseInferenceContext):
         # later compaction of the live request_ids never perturbs the snapshot.
         snapshot_request_ids = self.request_ids[active_slice].detach().clone()
 
+        # Base kv lengths the next forward is built on. The non-speculative plan builds the
+        # immediately-next forward from the committed offsets (advance's +1 gives the unit query).
+        # The speculative plan predicts the deferred current-step commit first: each active
+        # request's kv length grows by its (unit) query length, so the launched forward sees
+        # request_kv_length_offsets + query_lengths as its base (advance's +1 then adds its own
+        # query). Boundary-gated above, so the block table is invariant either way.
+        prev_kv_seq_lengths = self.request_kv_length_offsets[active_slice]
+        if speculate_pending_decode_commit:
+            prev_kv_seq_lengths = prev_kv_seq_lengths + self.request_query_lengths[active_slice]
+
         # Build the next forward's MHA metadata into the STAGING views (never live / GPU). For
         # plain decode, query_lengths == 1, so request_kv_length_offsets + 1 == kv_offsets +
         # query_lengths -- exactly the rebuild's kv_seq_lengths.
         self.advance_decode_metadata_in_place(
             bs=bs,
-            prev_kv_seq_lengths=self.request_kv_length_offsets[active_slice],
+            prev_kv_seq_lengths=prev_kv_seq_lengths,
             committed_block_table=self.request_to_kv_block_ids[active_slice],
             out_query_lengths=self._staging_mha_query_lengths,
             out_cu_query=self._staging_mha_cu_query_seq_lengths,

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2678,6 +2678,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         forced_pause_overflow: bool = False,
         graph_recapture: bool = False,
         speculate_pending_decode_commit: bool = False,
+        snapshot_survival_mask: Optional[Tensor] = None,
     ) -> "PrestagedDecodePlan":
         """Build the next decode step's launch plan into the CPU staging buffer.
 
@@ -2753,6 +2754,19 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Snapshot the pre-compaction active request-id set (consume-by-request-id). Clone so a
         # later compaction of the live request_ids never perturbs the snapshot.
         snapshot_request_ids = self.request_ids[active_slice].detach().clone()
+
+        # C5: pre-exclude host-known max-length finishers from the launch snapshot. A request the
+        # host already knows will reach max_sequence_length at the pending commit is freed at its
+        # OWN commit (host-deterministic, no D2H) and must never ride the speculative forward, so
+        # it is dropped from the consume-by-request-id snapshot here. ``snapshot_survival_mask`` is
+        # the caller's ``_host_maxlen_finish_mask`` for the pending commit (1 = survives) over the
+        # active slice in row order. NOTE: the launch is also gated on the max-length half being
+        # clean (controller), so on any step that actually launches no request is excluded -- this
+        # narrowing is vacuous there (byte-identical to no exclusion) and is the seam that keeps
+        # max-length exactly gated under the C6 EOS ungate.
+        if snapshot_survival_mask is not None:
+            survive = snapshot_survival_mask[:bs].to(dtype=torch.bool, device=snapshot_request_ids.device)
+            snapshot_request_ids = snapshot_request_ids[survive]
 
         # Base kv lengths the next forward is built on. The non-speculative plan builds the
         # immediately-next forward from the committed offsets (advance's +1 gives the unit query).

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1267,6 +1267,47 @@ class DynamicInferenceContext(BaseInferenceContext):
             # buffer (the buffer's h2d_done_event). Allocated lazily on first transfer.
             self._h2d_done_event: Optional[Any] = None
 
+            # Staging-side MHA-metadata views (C5). The launch-before-commit prestage builds
+            # the *next* step's MHA metadata into these views -- slices of the CPU staging
+            # mirror at the SAME byte offsets as the live `_cpu_mha_*` views above -- while the
+            # current forward's already-issued H2D still reads the live buffer. publish then
+            # copies the staging MHA byte-region back into the live buffer and issues one
+            # coalesced token-excluded H2D. Offsets are recomputed from the stored max_* sizes
+            # to exactly mirror the live layout (see the coalesced-buffer offset walk above).
+            _tok_i64 = self.max_tokens * 8
+            _tok_i32 = self.max_tokens * 4
+            _req_4 = self.max_requests * 4
+            _mha_start = 3 * _tok_i64 + 3 * _tok_i32 + 7 * _req_4
+            _mha_ql = self.max_requests * 4
+            _mha_cuql = (self.max_requests + 1) * 4
+            _mha_kv = self.max_requests * 4
+            _mha_cukv = (self.max_requests + 1) * 4
+            _mha_bt = self.max_requests * self.max_kv_block_count * 4
+            self._mha_region_byte_start = _mha_start
+            self._mha_region_byte_end = _mha_start + _mha_ql + _mha_cuql + _mha_kv + _mha_cukv + _mha_bt
+            _o = _mha_start
+            self._staging_mha_query_lengths = self._cpu_staging_buf[_o : _o + _mha_ql].view(
+                torch.int32
+            )
+            _o += _mha_ql
+            self._staging_mha_cu_query_seq_lengths = self._cpu_staging_buf[_o : _o + _mha_cuql].view(
+                torch.int32
+            )
+            _o += _mha_cuql
+            self._staging_mha_kv_seq_lengths = self._cpu_staging_buf[_o : _o + _mha_kv].view(
+                torch.int32
+            )
+            _o += _mha_kv
+            self._staging_mha_cu_kv_seq_lengths = self._cpu_staging_buf[_o : _o + _mha_cukv].view(
+                torch.int32
+            )
+            _o += _mha_cukv
+            self._staging_mha_block_table = (
+                self._cpu_staging_buf[_o : _o + _mha_bt]
+                .view(torch.int32)
+                .view(self.max_requests, self.max_kv_block_count)
+            )
+
         # Cache of (input_ids_view, pos_ids_view) keyed by num_tokens. Instead of slicing and
         # unsqueezing on every new inference step (constructing new TensorImpls at 30-60 us),
         # we fix the underlying storage so views are reusable across steps. The number of entries
@@ -2544,6 +2585,189 @@ class DynamicInferenceContext(BaseInferenceContext):
         # block_table tracks the committed physical KV block ids (advanced already by
         # update_requests, including any boundary-crossing reallocation).
         out_block_table[:bs] = committed_block_table[:bs]
+
+    def _boundary_crosser_local_indices(self) -> Tensor:
+        """Active-row indices of requests whose last KV block would overflow next step.
+
+        Uses the SAME condition ``update_requests`` applies to decide a request needs a new
+        block (``num_tokens_in_last_block >= block_size_tokens - 1 - num_speculative_tokens``).
+        Each such request needs exactly one new KV block when the next forward runs. Returned
+        indices are relative to the active slice (``[paused_request_count, total_request_count)``).
+        Pure read; mutates nothing.
+        """
+        active_request_count = self.total_request_count - self.paused_request_count
+        if active_request_count <= 0:
+            return torch.empty(0, dtype=torch.long, device='cpu')
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        num_tokens_in_last_block = self.request_last_kv_block_offset[active_slice]
+        threshold = self.block_size_tokens - 1 - self.num_speculative_tokens
+        return torch.nonzero(num_tokens_in_last_block >= threshold, as_tuple=True)[0]
+
+    def build_launch_signals(
+        self,
+        *,
+        pending_admission: bool = False,
+        resume_pending: bool = False,
+        evict_pending: bool = False,
+        forced_pause_overflow: bool = False,
+        graph_recapture: bool = False,
+    ) -> "LaunchSignals":
+        """Build the static launch-eligibility signals from the *committed* context state.
+
+        Computes the facts ``classify_launch_eligibility`` (design 1.2 / 1.9) needs to decide
+        whether the next decode step may be launched speculatively before its commit. Only facts
+        derivable from committed state + KV headroom are computed here; engine-driven layout
+        signals (admission / resume / evict / forced-pause / graph recapture) are passed in by
+        the caller and default off.
+
+        A finish is *absorbable* (its row is discarded, never re-run), so it is deliberately NOT
+        a signal -- and the KV-headroom check counts only boundary crossers from the committed
+        active set, never a same-step finish's soon-to-free block. The check uses the free pool
+        only (``get_active_avail``), the conservative choice: when unsure, prefer a sync step.
+        """
+        from megatron.core.inference.engines.step_transaction import LaunchSignals
+
+        active_request_count = self.total_request_count - self.paused_request_count
+        chunked_prefill_active = self.get_index_of_chunked_prefill_request(safe=True) != -1
+        kv_blocks_needed = int(self._boundary_crosser_local_indices().numel())
+        kv_reservation_fits = self.kv_block_allocator.get_active_avail() >= kv_blocks_needed
+        return LaunchSignals(
+            decode_only=self.is_decode_only(),
+            active_request_count=active_request_count,
+            using_cuda_graph=self.using_cuda_graph_this_step(),
+            pending_admission=pending_admission,
+            resume_pending=resume_pending,
+            evict_pending=evict_pending,
+            forced_pause_overflow=forced_pause_overflow,
+            chunked_prefill_active=chunked_prefill_active,
+            graph_recapture=graph_recapture,
+            mtp_layout_change=self.num_speculative_tokens > 0,
+            kv_reservation_fits=kv_reservation_fits,
+        )
+
+    def prestage_next_decode_step_into_cpu_staging(
+        self,
+        *,
+        pending_admission: bool = False,
+        resume_pending: bool = False,
+        evict_pending: bool = False,
+        forced_pause_overflow: bool = False,
+        graph_recapture: bool = False,
+    ) -> "PrestagedDecodePlan":
+        """Build the next decode step's launch plan into the CPU staging buffer.
+
+        Speculating no finish this step, predict the next forward's plan from the *committed*
+        layout and:
+
+        * classify launch eligibility from committed state + KV headroom; if ineligible, return
+          an empty plan carrying the static skip reason (no staging writes, no leases);
+        * snapshot the pre-compaction active request ids the launched forward is consumed by
+          (consume-by-request-id, never by row);
+        * build the next forward's MHA metadata into the CPU *staging* MHA views via the C4
+          in-place advance -- ``prev_kv_seq_lengths = request_kv_length_offsets`` so the advance's
+          ``+1`` yields ``kv_offsets + query_lengths`` (the decode rebuild formula), robust to the
+          per-step attention-state reset;
+        * record the read-only lease manifest (current last-block KV ids, the boundary crossers
+          that would each need exactly one new block, mamba slots).
+
+        MUST NOT mutate any live CPU tensor, the KV/mamba allocators, or the single GPU buffer:
+        it writes only the staging buffer and clones the request-id snapshot. Actual allocation /
+        boundary-block adoption + the two-step retire are performed by the overlap launch path
+        that consumes the plan (a later commit).
+        """
+        from megatron.core.inference.engines.step_transaction import (
+            PrestagedDecodePlan,
+            classify_launch_eligibility,
+        )
+
+        assert (
+            self.enable_async_scheduling and self.decode_metadata_buffer is not None
+        ), "prestage requires async scheduling"
+
+        signals = self.build_launch_signals(
+            pending_admission=pending_admission,
+            resume_pending=resume_pending,
+            evict_pending=evict_pending,
+            forced_pause_overflow=forced_pause_overflow,
+            graph_recapture=graph_recapture,
+        )
+        decision = classify_launch_eligibility(signals)
+        if not decision.eligible:
+            return PrestagedDecodePlan(
+                step_id=self.step_count, eligible=False, skip_reason=decision.reason
+            )
+
+        bs = self.total_request_count - self.paused_request_count
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+
+        # Snapshot the pre-compaction active request-id set (consume-by-request-id). Clone so a
+        # later compaction of the live request_ids never perturbs the snapshot.
+        snapshot_request_ids = self.request_ids[active_slice].detach().clone()
+
+        # Build the next forward's MHA metadata into the STAGING views (never live / GPU). For
+        # plain decode, query_lengths == 1, so request_kv_length_offsets + 1 == kv_offsets +
+        # query_lengths -- exactly the rebuild's kv_seq_lengths.
+        self.advance_decode_metadata_in_place(
+            bs=bs,
+            prev_kv_seq_lengths=self.request_kv_length_offsets[active_slice],
+            committed_block_table=self.request_to_kv_block_ids[active_slice],
+            out_query_lengths=self._staging_mha_query_lengths,
+            out_cu_query=self._staging_mha_cu_query_seq_lengths,
+            out_kv_seq_lengths=self._staging_mha_kv_seq_lengths,
+            out_cu_kv=self._staging_mha_cu_kv_seq_lengths,
+            out_block_table=self._staging_mha_block_table,
+        )
+
+        # Read-only lease manifest: the KV blocks + mamba slots the forward would touch, and the
+        # boundary crossers that would each need exactly one new block (as (request_id, column)).
+        kv_block_leases = [
+            int(b) for b in self.request_last_kv_block_id[active_slice].tolist() if int(b) >= 0
+        ]
+        reserved_boundary_blocks = []
+        for li in self._boundary_crosser_local_indices().tolist():
+            row = self.paused_request_count + li
+            req_id = int(self.request_ids[row].item())
+            block_column = int(self.request_kv_block_counts[row].item())
+            reserved_boundary_blocks.append((req_id, block_column))
+        mamba_slot_leases = []
+        if self.is_hybrid_model and self.mamba_metadata is not None:
+            mamba_slot_leases = [
+                int(s)
+                for s in self.mamba_metadata.request_to_mamba_state_idx[active_slice].tolist()
+                if int(s) >= 0
+            ]
+
+        return PrestagedDecodePlan(
+            step_id=self.step_count,
+            eligible=True,
+            snapshot_request_ids=snapshot_request_ids,
+            active_request_count=bs,
+            kv_block_leases=kv_block_leases,
+            reserved_boundary_blocks=reserved_boundary_blocks,
+            mamba_slot_leases=mamba_slot_leases,
+            kv_blocks_needed=len(reserved_boundary_blocks),
+        )
+
+    def publish_prepared_decode_plan(self, plan: "PrestagedDecodePlan") -> None:
+        """Swap a prestaged plan's staging MHA metadata into the live buffer + token-excluded H2D.
+
+        The launch-before-commit "publish": copy the staging MHA byte-region into the live
+        coalesced buffer (so the live ``_cpu_mha_*`` views now hold the predicted next step),
+        then issue the single coalesced H2D with the token-id region EXCLUDED (the sampled ids
+        are scattered onto the single GPU buffer separately, C4). For an ineligible plan this is a
+        no-op.
+
+        This commit lands the publish *mechanic* and validates it produces the same live MHA
+        region as a from-scratch rebuild. Wiring publish into the live forward-launch ordering --
+        so it runs in the current forward's shadow before the next launch -- is the overlap
+        commit's job.
+        """
+        if not plan.eligible:
+            return
+        assert self.decode_metadata_buffer is not None, "publish requires async scheduling"
+        s, e = self._mha_region_byte_start, self._mha_region_byte_end
+        self._cpu_bookkeeping_buf[s:e].copy_(self._cpu_staging_buf[s:e])
+        self.transfer_bookkeeping_to_gpu(include_token_to_input_ids=False)
 
     def reset_tensors(self) -> None:
         """Fill all bookkeeping tensors with sentinel values."""

--- a/megatron/core/inference/contexts/metadata_slot.py
+++ b/megatron/core/inference/contexts/metadata_slot.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Decode metadata slots + depth-2 rings for async-scheduling (launch-before-commit).
+
+The launch-before-commit pipeline overlaps two decode forwards: while forward ``F(K)``
+runs against one GPU metadata buffer, the next step's metadata is *prestaged* into a
+**free** buffer so that, after sampling, only a token-scatter + launch separate
+``S(K)`` from ``F(K+1)``. That requires two GPU metadata buffers ("slots"):
+
+- ``slot_current`` -- the buffer the running/consumed forward observes.
+- ``slot_child``   -- the free buffer the next step is prestaged into.
+
+This module provides the slot/ring abstractions. The slots wrap
+:class:`~megatron.core.inference.contexts.gpu_view.ContextGPUView` buffers (whose
+addresses are fixed for CUDA-graph compatibility); a forward is bound to exactly one
+slot. A slot may not be re-staged until its H2D and forward fences have retired, so a
+still-in-flight forward never observes a buffer being overwritten.
+
+The serial (``enable_async_scheduling`` off) decode path uses a single live
+``gpu_view`` and never constructs slots, so its behavior is unchanged. The context
+constructs ``slot_current`` (wrapping the live ``gpu_view``) and a free ``slot_child``
+only when the flag is on; the prestage that builds metadata into ``slot_child`` and the
+graph replay that consumes it land in later commits.
+"""
+
+from typing import Any, Callable, List, Optional
+
+
+class DecodeMetadataSlot:
+    """A bindable GPU decode-metadata buffer plus its two CUDA fences and identity.
+
+    Wraps a ``ContextGPUView``. Slot reuse (re-staging the next step's metadata into it)
+    is gated by ``is_free()``: the slot must not be in use and both of its fences (the
+    coalesced-H2D fence and the forward fence) must have completed. This is the slot-level
+    expression of the design's "a slot can't be reused before its H2D/forward events
+    retire" rule.
+    """
+
+    def __init__(self, slot_id: int, gpu_view: Any):
+        self.slot_id = slot_id
+        self.gpu_view = gpu_view
+        # Signalled when the coalesced bookkeeping H2D into this slot completes.
+        self.h2d_done_event: Any = None
+        # Signalled when the forward bound to this slot completes.
+        self.forward_done_event: Any = None
+        self._in_use = False
+
+    @property
+    def base_ptr(self) -> int:
+        """Base address of the slot's backing metadata buffer (fixed for graph capture)."""
+        return self.gpu_view._buf.data_ptr()
+
+    def fences_retired(self) -> bool:
+        """True iff neither fence is pending (a pending fence means a forward may still read)."""
+        for event in (self.h2d_done_event, self.forward_done_event):
+            if event is not None and not event.query():
+                return False
+        return True
+
+    def is_free(self) -> bool:
+        """True iff the slot can be re-staged: not in use and both fences retired."""
+        return not self._in_use and self.fences_retired()
+
+    def acquire(self) -> None:
+        """Mark the slot in use for a new transaction. Must be free first."""
+        assert self.is_free(), (
+            f"slot {self.slot_id} acquired while busy "
+            f"(in_use={self._in_use}, fences_retired={self.fences_retired()})"
+        )
+        self._in_use = True
+
+    def release(self) -> None:
+        """Release the slot back to the free pool (its forward has been consumed)."""
+        self._in_use = False
+
+    def reset_fences(self) -> None:
+        """Clear both fences (e.g. on a barrier/drain that already synchronized them)."""
+        self.h2d_done_event = None
+        self.forward_done_event = None
+
+    def graph_slot_key(self) -> int:
+        """Slot identity for the CUDA-graph key.
+
+        When a captured graph references this slot's buffers, the key must encode the
+        slot's buffer address so a replay never targets the wrong slot's metadata. When
+        the key cannot carry slot identity, :func:`assert_slot_pointer_identity` guards
+        replay instead.
+        """
+        return self.base_ptr
+
+
+def assert_slot_pointer_identity(slot: DecodeMetadataSlot, captured_base_ptr: int) -> None:
+    """Assert ``slot``'s buffer still lives where a graph was captured against it.
+
+    Replaying a CUDA graph against a metadata buffer that moved would read stale
+    pointers; this guard turns that into a loud failure instead of silent corruption.
+    """
+    assert slot.base_ptr == captured_base_ptr, (
+        f"decode metadata slot {slot.slot_id} buffer moved: graph captured against "
+        f"{captured_base_ptr:#x} but slot is now at {slot.base_ptr:#x}; replaying would "
+        f"read stale metadata pointers"
+    )
+
+
+class DepthTwoRing:
+    """A depth-2 ring of per-step handles (H2D staging / logits / sample buffers).
+
+    Two forwards overlap in the launch-before-commit pipeline, so staging buffers and
+    output handles need depth 2: step ``K`` and step ``K+1`` must not share a buffer.
+    Index by step (or any monotonically increasing counter); the ring selects by parity.
+    """
+
+    def __init__(self, factory: Callable[[int], Any]):
+        # Materialize both entries up front so addresses are fixed (graph-friendly).
+        self._entries: List[Any] = [factory(0), factory(1)]
+
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, step: int) -> Any:
+        return self._entries[step % 2]
+
+    def current(self, step: int) -> Any:
+        """The entry bound to ``step``."""
+        return self._entries[step % 2]
+
+    def other(self, step: int) -> Any:
+        """The entry NOT bound to ``step`` (the one ``step+1`` will use)."""
+        return self._entries[(step + 1) % 2]
+
+
+def make_decode_metadata_slots(
+    gpu_view: Any, child_gpu_view_factory: Callable[[], Any]
+) -> "tuple[DecodeMetadataSlot, DecodeMetadataSlot]":
+    """Build ``(slot_current, slot_child)`` for async scheduling.
+
+    ``slot_current`` wraps the live ``gpu_view`` (the same buffer the serial path uses),
+    so binding the running forward to ``slot_current`` is identical to the serial path.
+    ``slot_child`` wraps a freshly-allocated metadata buffer that the prestage builds into.
+    """
+    slot_current = DecodeMetadataSlot(slot_id=0, gpu_view=gpu_view)
+    slot_child = DecodeMetadataSlot(slot_id=1, gpu_view=child_gpu_view_factory())
+    return slot_current, slot_child

--- a/megatron/core/inference/contexts/metadata_slot.py
+++ b/megatron/core/inference/contexts/metadata_slot.py
@@ -1,53 +1,74 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-"""Decode metadata slots + depth-2 rings for async-scheduling (launch-before-commit).
+"""Single fixed-address GPU decode-metadata buffer + CPU staging double-buffer.
 
 The launch-before-commit pipeline overlaps two decode forwards: while forward ``F(K)``
-runs against one GPU metadata buffer, the next step's metadata is *prestaged* into a
-**free** buffer so that, after sampling, only a token-scatter + launch separate
-``S(K)`` from ``F(K+1)``. That requires two GPU metadata buffers ("slots"):
+runs, the next step's metadata is *prestaged* so that, after sampling, only an in-place
+token-scatter + launch separate ``S(K)`` from ``F(K+1)``.
 
-- ``slot_current`` -- the buffer the running/consumed forward observes.
-- ``slot_child``   -- the free buffer the next step is prestaged into.
+A captured CUDA decode graph reads metadata by **ABSOLUTE ADDRESS**
+(``cuda_graphs.py:605-639``: only the embed-input / hidden-states surface is
+copy-on-replay; every *other* metadata field is read from the exact address captured), so
+the metadata GPU buffer cannot be a swappable child. There is therefore exactly **one**
+fixed-address GPU metadata buffer -- the live ``gpu_view`` -- which is **never reallocated
+or swapped**, only updated in place between steps and read by the captured graph at the
+addresses it captured.
 
-This module provides the slot/ring abstractions. The slots wrap
-:class:`~megatron.core.inference.contexts.gpu_view.ContextGPUView` buffers (whose
-addresses are fixed for CUDA-graph compatibility); a forward is bound to exactly one
-slot. A slot may not be re-staged until its H2D and forward fences have retired, so a
-still-in-flight forward never observes a buffer being overwritten.
+The genuine double-buffer is consequently **CPU-side**: the next step's bookkeeping is
+prestaged into a CPU *staging* buffer while the current forward's already-issued H2D still
+reads the *live* CPU buffer, then the staging buffer is swapped in and a single coalesced
+H2D copies it into the one GPU buffer. :class:`DepthTwoRing` provides that depth-2 CPU
+staging<->live double-buffer (and the per-step output handles two overlapping forwards
+must not share).
 
-The serial (``enable_async_scheduling`` off) decode path uses a single live
-``gpu_view`` and never constructs slots, so its behavior is unchanged. The context
-constructs ``slot_current`` (wrapping the live ``gpu_view``) and a free ``slot_child``
-only when the flag is on; the prestage that builds metadata into ``slot_child`` and the
-graph replay that consumes it land in later commits.
+Replay is only valid against the buffer the graph captured, so
+:class:`DecodeMetadataBuffer` records the GPU buffer's address (and the cached
+input/position view addresses) and :meth:`DecodeMetadataBuffer.assert_pointer_invariant`
+asserts they never move across decode steps -- turning an accidental reallocation (which
+would make a replay read freed/foreign memory) into a loud failure instead of silent
+corruption.
+
+The serial (``enable_async_scheduling`` off) decode path uses the single live ``gpu_view``
+directly and never constructs any of these helpers, so its behavior is unchanged. The
+prestage that builds the next step's metadata into the CPU staging buffer and the graph
+replay that consumes the GPU buffer land in later commits.
 """
 
 from typing import Any, Callable, List, Optional
 
 
-class DecodeMetadataSlot:
-    """A bindable GPU decode-metadata buffer plus its two CUDA fences and identity.
+class DecodeMetadataBuffer:
+    """The single fixed-address GPU decode-metadata buffer plus its two CUDA fences.
 
-    Wraps a ``ContextGPUView``. Slot reuse (re-staging the next step's metadata into it)
-    is gated by ``is_free()``: the slot must not be in use and both of its fences (the
-    coalesced-H2D fence and the forward fence) must have completed. This is the slot-level
-    expression of the design's "a slot can't be reused before its H2D/forward events
-    retire" rule.
+    Wraps the live ``ContextGPUView``. There is exactly one such buffer; it is never
+    reallocated or swapped (a captured decode graph reads its fields by absolute address),
+    only updated in place between steps. Reuse for the next step is gated by
+    :meth:`is_free`: both fences (the coalesced-H2D fence and the forward fence) must have
+    retired, so a still in-flight forward never observes the buffer being overwritten
+    mid-flight.
+
+    The buffer also records the address it (and its cached input/position views) was first
+    observed at; :meth:`assert_pointer_invariant` asserts those addresses never move,
+    because a captured CUDA graph may only be replayed against the exact buffer it
+    captured. This is the single-buffer replacement for the (discarded) two-GPU-buffer
+    "slot" model: there is no ``slot_child`` and no replay-against-child.
     """
 
-    def __init__(self, slot_id: int, gpu_view: Any):
-        self.slot_id = slot_id
+    def __init__(self, gpu_view: Any):
         self.gpu_view = gpu_view
-        # Signalled when the coalesced bookkeeping H2D into this slot completes.
+        # Signalled when the coalesced bookkeeping H2D into this buffer completes.
         self.h2d_done_event: Any = None
-        # Signalled when the forward bound to this slot completes.
+        # Signalled when the forward reading this buffer completes.
         self.forward_done_event: Any = None
-        self._in_use = False
+        # Invariant addresses, recorded lazily on first observation. A captured graph is
+        # only valid against these exact addresses.
+        self._captured_base_ptr: Optional[int] = None
+        self._captured_input_ids_ptr: Optional[int] = None
+        self._captured_pos_ids_ptr: Optional[int] = None
 
     @property
     def base_ptr(self) -> int:
-        """Base address of the slot's backing metadata buffer (fixed for graph capture)."""
+        """Base address of the single backing metadata buffer (fixed for graph capture)."""
         return self.gpu_view._buf.data_ptr()
 
     def fences_retired(self) -> bool:
@@ -58,61 +79,85 @@ class DecodeMetadataSlot:
         return True
 
     def is_free(self) -> bool:
-        """True iff the slot can be re-staged: not in use and both fences retired."""
-        return not self._in_use and self.fences_retired()
-
-    def acquire(self) -> None:
-        """Mark the slot in use for a new transaction. Must be free first."""
-        assert self.is_free(), (
-            f"slot {self.slot_id} acquired while busy "
-            f"(in_use={self._in_use}, fences_retired={self.fences_retired()})"
-        )
-        self._in_use = True
-
-    def release(self) -> None:
-        """Release the slot back to the free pool (its forward has been consumed)."""
-        self._in_use = False
+        """True iff the buffer can be updated in place for the next step (both fences retired)."""
+        return self.fences_retired()
 
     def reset_fences(self) -> None:
         """Clear both fences (e.g. on a barrier/drain that already synchronized them)."""
         self.h2d_done_event = None
         self.forward_done_event = None
 
-    def graph_slot_key(self) -> int:
-        """Slot identity for the CUDA-graph key.
+    def capture_pointers(
+        self, input_ids_ptr: Optional[int] = None, pos_ids_ptr: Optional[int] = None
+    ) -> None:
+        """Record the invariant addresses (call once, after the decode graph is captured).
 
-        When a captured graph references this slot's buffers, the key must encode the
-        slot's buffer address so a replay never targets the wrong slot's metadata. When
-        the key cannot carry slot identity, :func:`assert_slot_pointer_identity` guards
-        replay instead.
+        Records the GPU metadata buffer's base address and, when supplied, the cached
+        input/position view addresses. Idempotent for already-recorded slots.
         """
-        return self.base_ptr
+        self._captured_base_ptr = self.base_ptr
+        if input_ids_ptr is not None:
+            self._captured_input_ids_ptr = input_ids_ptr
+        if pos_ids_ptr is not None:
+            self._captured_pos_ids_ptr = pos_ids_ptr
 
+    def assert_pointer_invariant(
+        self, input_ids_ptr: Optional[int] = None, pos_ids_ptr: Optional[int] = None
+    ) -> None:
+        """Assert the single GPU buffer (and cached input/pos views) have not moved.
 
-def assert_slot_pointer_identity(slot: DecodeMetadataSlot, captured_base_ptr: int) -> None:
-    """Assert ``slot``'s buffer still lives where a graph was captured against it.
-
-    Replaying a CUDA graph against a metadata buffer that moved would read stale
-    pointers; this guard turns that into a loud failure instead of silent corruption.
-    """
-    assert slot.base_ptr == captured_base_ptr, (
-        f"decode metadata slot {slot.slot_id} buffer moved: graph captured against "
-        f"{captured_base_ptr:#x} but slot is now at {slot.base_ptr:#x}; replaying would "
-        f"read stale metadata pointers"
-    )
+        Replaying a captured decode graph against a metadata buffer that moved would read
+        stale/foreign memory; this guard turns that into a loud failure. The first call
+        records the baseline addresses; every subsequent call asserts invariance against
+        them. This is the single-buffer ``data_ptr()``-invariance guard that replaces the
+        two-slot pointer-identity check.
+        """
+        if self._captured_base_ptr is None:
+            self.capture_pointers(input_ids_ptr, pos_ids_ptr)
+            return
+        assert self.base_ptr == self._captured_base_ptr, (
+            f"decode metadata GPU buffer moved: graph captured against "
+            f"{self._captured_base_ptr:#x} but buffer is now at {self.base_ptr:#x}; "
+            f"replaying would read stale/foreign metadata. The single GPU metadata buffer "
+            f"must never be reallocated or swapped."
+        )
+        if input_ids_ptr is not None and self._captured_input_ids_ptr is not None:
+            assert input_ids_ptr == self._captured_input_ids_ptr, (
+                f"cached input_ids view moved: captured {self._captured_input_ids_ptr:#x} "
+                f"but now {input_ids_ptr:#x}"
+            )
+        if pos_ids_ptr is not None and self._captured_pos_ids_ptr is not None:
+            assert pos_ids_ptr == self._captured_pos_ids_ptr, (
+                f"cached pos_ids view moved: captured {self._captured_pos_ids_ptr:#x} "
+                f"but now {pos_ids_ptr:#x}"
+            )
 
 
 class DepthTwoRing:
-    """A depth-2 ring of per-step handles (H2D staging / logits / sample buffers).
+    """A depth-2 ring for the CPU staging<->live double-buffer (and per-step handles).
 
-    Two forwards overlap in the launch-before-commit pipeline, so staging buffers and
-    output handles need depth 2: step ``K`` and step ``K+1`` must not share a buffer.
-    Index by step (or any monotonically increasing counter); the ring selects by parity.
+    Two forwards overlap in the launch-before-commit pipeline, so the next step's metadata
+    must be prestaged into a CPU buffer that is *not* the one the current forward's
+    already-issued H2D is reading. Depth 2 is sufficient: step ``K`` and step ``K+1`` use
+    opposite entries, selected by parity. The same ring also backs per-step output handles
+    (logits / sample buffers) two overlapping forwards must not share.
+
+    Note: the ring's entries are **CPU-side** (staging vs live bookkeeping buffers / output
+    handles). The GPU metadata buffer is single and fixed-address (see
+    :class:`DecodeMetadataBuffer`) -- it is deliberately NOT ring-buffered, because a
+    captured decode graph reads it by absolute address.
     """
 
     def __init__(self, factory: Callable[[int], Any]):
         # Materialize both entries up front so addresses are fixed (graph-friendly).
         self._entries: List[Any] = [factory(0), factory(1)]
+
+    @classmethod
+    def of(cls, first: Any, second: Any) -> "DepthTwoRing":
+        """Build a ring from two already-constructed entries (e.g. live + staging buffers)."""
+        ring = cls.__new__(cls)
+        ring._entries = [first, second]
+        return ring
 
     def __len__(self) -> int:
         return 2
@@ -127,17 +172,3 @@ class DepthTwoRing:
     def other(self, step: int) -> Any:
         """The entry NOT bound to ``step`` (the one ``step+1`` will use)."""
         return self._entries[(step + 1) % 2]
-
-
-def make_decode_metadata_slots(
-    gpu_view: Any, child_gpu_view_factory: Callable[[], Any]
-) -> "tuple[DecodeMetadataSlot, DecodeMetadataSlot]":
-    """Build ``(slot_current, slot_child)`` for async scheduling.
-
-    ``slot_current`` wraps the live ``gpu_view`` (the same buffer the serial path uses),
-    so binding the running forward to ``slot_current`` is identical to the serial path.
-    ``slot_child`` wraps a freshly-allocated metadata buffer that the prestage builds into.
-    """
-    slot_current = DecodeMetadataSlot(slot_id=0, gpu_view=gpu_view)
-    slot_child = DecodeMetadataSlot(slot_id=1, gpu_view=child_gpu_view_factory())
-    return slot_current, slot_child

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -30,6 +30,7 @@ from megatron.core.inference.data_parallel_inference_coordinator import (
     DataParallelInferenceCoordinator,
 )
 from megatron.core.inference.engines.abstract_engine import AbstractEngine
+from megatron.core.inference.engines.step_transaction import StepTransactionManager
 from megatron.core.inference.headers import Headers, UnknownHeaderError
 from megatron.core.inference.inference_request import (
     DynamicInferenceEvent,
@@ -246,6 +247,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self.track_paused_request_events = inference_config.track_paused_request_events
         self.track_generated_token_events = inference_config.track_generated_token_events
         self.enable_chunked_prefill = inference_config.enable_chunked_prefill
+        self.enable_async_scheduling = inference_config.enable_async_scheduling
         self.metrics_writer = inference_config.metrics_writer
         self.logging_step_interval = inference_config.logging_step_interval
         self.unified_memory_level = inference_config.unified_memory_level
@@ -298,6 +300,14 @@ class DynamicInferenceEngine(AbstractEngine):
         """Reset by removing all requests and reset all state."""
 
         self.context.reset()
+
+        # Transactional async-scheduling manager (retire queue + diagnostics +
+        # per-step transaction lifecycle). Constructed only when the opt-in flag is
+        # on, so the disabled decode path carries no extra state or work.
+        self.step_txn_manager = (
+            StepTransactionManager(self.context) if self.enable_async_scheduling else None
+        )
+        self._current_txn = None
 
         # Request state.
         self.request_counter = Counter()
@@ -1771,6 +1781,17 @@ class DynamicInferenceEngine(AbstractEngine):
         # schedule requests
         self.schedule_waiting_requests()
 
+        # Transactional async-scheduling (opt-in): drain the retire queue, then wrap
+        # this step as an always-adopted serial transaction. This commit keeps the
+        # step fully serial -- no speculative child launch -- so generated tokens are
+        # identical to the disabled path; the wrapper only tracks lifecycle/diagnostics.
+        if self.enable_async_scheduling:
+            self.step_txn_manager.retire(self.context.step_count)
+            self._current_txn = self.step_txn_manager.begin_serial_txn(
+                step_id=self.context.step_count,
+                active_request_count=self.context.get_active_request_count(),
+            )
+
         # The print block (async_bookkeep) and metrics block both fire on this
         # condition after step_count is incremented. Predict it up-front so we
         # can skip the GPU-timing sync and the context_state dict builds that
@@ -2085,6 +2106,12 @@ class DynamicInferenceEngine(AbstractEngine):
             logging.info(output_str)
 
         nvtx_range_pop("console_logging")
+
+        # Transactional async-scheduling (opt-in): commit the wrapped serial
+        # transaction now that update_requests + bookkeeping for this step are done.
+        if self.enable_async_scheduling and self._current_txn is not None:
+            self.step_txn_manager.commit(self._current_txn)
+            self._current_txn = None
 
         return {
             "active_request_ids": active_request_ids,

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -308,6 +308,10 @@ class DynamicInferenceEngine(AbstractEngine):
             StepTransactionManager(self.context) if self.enable_async_scheduling else None
         )
         self._current_txn = None
+        # Drop any launch-before-commit forward left in flight by a prior generation: a reset
+        # rewinds the context, so a stale consume-by-request-id snapshot must not be consumed.
+        if self.enable_async_scheduling and getattr(self, "controller", None) is not None:
+            self.controller.async_drain_inflight_forward()
 
         # Request state.
         self.request_counter = Counter()

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -2130,6 +2130,20 @@ class DynamicInferenceEngine(AbstractEngine):
                     self._prefix_cache_hits,
                     self._prefix_cache_blocks_matched,
                 )
+            # C8 async-scheduling diagnostics (cumulative). launched ~= steady decode steps;
+            # adopted ~= launched; barrier_skips counts doomed-forward discards (data-dependent
+            # finish / adopt-guard); guard_failures should stay 0; retired counts fence-gated
+            # frees. retire_queue pending should return to 0 between waves (no leaks).
+            if self.enable_async_scheduling and self.step_txn_manager is not None:
+                d = self.step_txn_manager.diagnostics
+                output_str += (
+                    " ... async (cumul): launched=%d adopted=%d serial=%d sync=%d "
+                    "barrier=%d guard_fail=%d retired=%d pending=%d" % (
+                        d.launched, d.adopted, d.serial_steps, d.sync_steps,
+                        d.barrier_skips, d.guard_failures, d.retired,
+                        self.step_txn_manager.retire_queue.pending(),
+                    )
+                )
             if context_state["is_decode_only"]:
                 output_str = f"\033[94m{output_str}\033[0m"
             logging.info(output_str)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -308,10 +308,14 @@ class DynamicInferenceEngine(AbstractEngine):
             StepTransactionManager(self.context) if self.enable_async_scheduling else None
         )
         self._current_txn = None
-        # Drop any launch-before-commit forward left in flight by a prior generation: a reset
-        # rewinds the context, so a stale consume-by-request-id snapshot must not be consumed.
-        if self.enable_async_scheduling and getattr(self, "controller", None) is not None:
-            self.controller.async_drain_inflight_forward()
+        if getattr(self, "controller", None) is not None:
+            # Hand the controller the async-scheduling manager (None when the flag is off) so its
+            # launch-before-commit overlap can drive the InflightForward lifecycle. Also drop any
+            # forward left in flight by a prior generation: a reset rewinds the context, so a stale
+            # consume-by-request-id snapshot must not be consumed.
+            self.controller.attach_step_transaction_manager(self.step_txn_manager)
+            if self.enable_async_scheduling:
+                self.controller.async_drain_inflight_forward()
 
         # Request state.
         self.request_counter = Counter()
@@ -1791,10 +1795,18 @@ class DynamicInferenceEngine(AbstractEngine):
         # identical to the disabled path; the wrapper only tracks lifecycle/diagnostics.
         if self.enable_async_scheduling:
             self.step_txn_manager.retire(self.context.step_count)
-            self._current_txn = self.step_txn_manager.begin_serial_txn(
-                step_id=self.context.step_count,
-                active_request_count=self.context.get_active_request_count(),
-            )
+            # Only wrap the step as an always-adopted serial transaction when it will NOT take the
+            # launch-before-commit overlap path. The overlap path runs its own prestage/launch/
+            # adopt transaction lifecycle (InflightForward), so a serial wrap would double-count
+            # diagnostics and clobber current_txn. This is the "serial-only branch keeps
+            # begin_serial_txn" split; the check mirrors the controller's own path decision.
+            if self.controller._async_overlap_possible(self.context):
+                self._current_txn = None
+            else:
+                self._current_txn = self.step_txn_manager.begin_serial_txn(
+                    step_id=self.context.step_count,
+                    active_request_count=self.context.get_active_request_count(),
+                )
 
         # The print block (async_bookkeep) and metrics block both fire on this
         # condition after step_count is incremented. Predict it up-front so we

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1786,8 +1786,21 @@ class DynamicInferenceEngine(AbstractEngine):
         if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
             raise EngineSuspendedError(self.context.step_count)
 
-        # schedule requests
-        self.schedule_waiting_requests()
+        # schedule requests.
+        # C7 admission deferral: when a launch-before-commit forward is in flight, defer admitting
+        # new requests. A new prefill's allocate_memory_blocks must not run while a speculative
+        # forward built on the prior layout is in flight (it would allocate from the same pool a
+        # lazily-finished slot may return to, and would force an adopt-guard barrier). The
+        # controller is told to suppress the next launch (a sync prime step) so the FOLLOWING step
+        # has no forward in flight and admits safely. The non-async / no-inflight path is unchanged.
+        inflight_pending = (
+            self.enable_async_scheduling and getattr(self.controller, "_inflight", None) is not None
+        )
+        defer_admission = inflight_pending and len(self.waiting_request_ids) > 0
+        if self.enable_async_scheduling:
+            self.controller._async_defer_launch_for_admission = defer_admission
+        if not defer_admission:
+            self.schedule_waiting_requests()
 
         # Transactional async-scheduling (opt-in): drain the retire queue, then wrap
         # this step as an always-adopted serial transaction. This commit keeps the

--- a/megatron/core/inference/engines/inflight_forward.py
+++ b/megatron/core/inference/engines/inflight_forward.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""A typed handle for the single speculative forward F(K+1) launched before commit.
+
+The launch-before-commit decode pipeline launches *one* forward speculatively before the
+current step's ``update_requests`` runs. :class:`InflightForward` is the first-class handle for
+that forward, backed entirely by the already-built ``StepTxn`` / ``StepTransactionManager``
+lifecycle (``prestage_child`` -> ``launch_child`` -> ``adopt_child`` -> ``retire_txn_leases``).
+It carries:
+
+* the consume-by-request-id snapshot (``StepTxn.request_ids``),
+* the CUDA-graph bucket the forward replayed under (``StepTxn.bucket``),
+* the read-only resource lease manifest (KV blocks / reserved boundary blocks / mamba slots,
+  carried on the ``StepTxn``),
+* the two and only two CUDA fences (``h2d_done_event``, ``forward_done_event``),
+* the :class:`AsyncSampleRing` ticket whose D2H this forward's launch overlapped.
+
+It is a *thin facade*: it invents no new lifecycle or policy. ``resolve`` delegates to the
+pre-existing ``adopt_child`` consume-by-request-id guard (committed survivors must be a SUBSET
+of the snapshot AND the committed graph bucket must match). ``True`` => adopt; ``False`` => the
+caller takes the **barrier** recovery (drain the forward, consume its still-valid subset, take
+a sync prime step) -- never discard-and-rerun.
+
+It deliberately does NOT reimplement a three-way row-remap: the prestage is identity-+1-only
+and bails on any reshape (the ``SPECULATIVE_BOUNDARY_WINDOW`` gate), so a reused forward is
+always in identity row order -- the only outcomes are adopt-as-is or barrier.
+
+Extension points (do not implement here):
+
+* **mamba candidate-bank lease.** Hybrid models stay on the serial path (single mamba bank),
+  so no new field is added. ``StepTxn`` already carries ``mamba_slot_leases``; a future 2-bank
+  port would lease the candidate bank through the same handle without changing this facade.
+* **EP step-begin consensus.** The launch decision is a host-local boolean today; a future EP
+  port slots an all-reduce-max ``{has_real_work, launch_eligible, in_flight_present}`` consensus
+  in front of :meth:`launch` / :meth:`resolve` / :meth:`discard` without re-shaping this object.
+
+Pure addition this commit: no runtime call site uses it yet (the overlap wiring lands next).
+"""
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from megatron.core.inference.engines.step_transaction import (
+    _UNSET,
+    PrestagedDecodePlan,
+    StepTransactionManager,
+    StepTxn,
+)
+
+if TYPE_CHECKING:
+    from megatron.core.inference.text_generation_controllers.async_sample_ring import RingTicket
+
+
+class InflightForward:
+    """Typed handle for the in-flight speculative forward F(K+1), backed by a ``StepTxn``."""
+
+    def __init__(
+        self,
+        mgr: StepTransactionManager,
+        txn: StepTxn,
+        sample_ticket: Optional["RingTicket"] = None,
+    ):
+        self.mgr = mgr
+        self.txn = txn
+        self.sample_ticket = sample_ticket
+
+    @classmethod
+    def launch(
+        cls,
+        mgr: StepTransactionManager,
+        plan: PrestagedDecodePlan,
+        *,
+        bucket: Any = None,
+        forward_done_event: Any = None,
+        h2d_done_event: Any = None,
+        sample_ticket: Optional["RingTicket"] = None,
+    ) -> "InflightForward":
+        """Prestage + launch the speculative child and return its typed handle.
+
+        ``prestage_child`` seeds the PRESTAGED child from the (eligible) plan; ``launch_child``
+        attaches the two fences and transitions it to LAUNCHED. The plan must be eligible
+        (``prestage_child`` asserts this via ``StepTxn.from_prestaged_plan``).
+        """
+        child = mgr.prestage_child(plan, bucket=bucket)
+        assert child is not None, "InflightForward.launch requires an eligible prestaged plan"
+        txn = mgr.launch_child(forward_done_event=forward_done_event, h2d_done_event=h2d_done_event)
+        return cls(mgr, txn, sample_ticket=sample_ticket)
+
+    def resolve(self, committed_survivor_ids: Any, committed_bucket: Any = _UNSET) -> bool:
+        """Consume-by-request-id adopt guard: SUBSET(survivors, snapshot) AND bucket match.
+
+        Delegates to ``adopt_child`` -- the system's only adopt guard. ``True`` promotes the
+        child to the current transaction; ``False`` leaves it LAUNCHED for the caller's barrier
+        recovery (consume the valid subset, sync prime) and bumps ``guard_failures``.
+        """
+        return self.mgr.adopt_child(committed_survivor_ids, committed_bucket=committed_bucket)
+
+    def discard(self, *, current_step: int, release, event: Any = _UNSET, tag: str = "discard") -> None:
+        """Route the forward's leases through the fence-gated retire queue and drop the child.
+
+        Used on suspend / reset / shutdown / empty-batch boundary. The leases are freed only
+        after the in-flight forward's ``forward_done_event`` (the default fence) and the
+        two-step retire delay, so a still-running forward never has its KV/mamba pulled out from
+        under it. Clears ``mgr.child_txn`` so no stale snapshot is later consumed.
+        """
+        self.mgr.retire_txn_leases(
+            self.txn, current_step=current_step, release=release, event=event, tag=tag
+        )
+        if self.mgr.child_txn is self.txn:
+            self.mgr.child_txn = None
+
+    @property
+    def snapshot_request_ids(self) -> Any:
+        """The consume-by-request-id snapshot (== the launched ``StepTxn.request_ids``)."""
+        return self.txn.request_ids
+
+    @property
+    def cuda_graph_request_count(self) -> Any:
+        """The CUDA-graph bucket the forward replayed under (== ``StepTxn.bucket``)."""
+        return self.txn.bucket
+
+    @property
+    def forward_done_event(self) -> Any:
+        """The fence signalled when the in-flight forward completes."""
+        return self.txn.forward_done_event
+
+    @property
+    def h2d_done_event(self) -> Any:
+        """The fence signalled when the forward's coalesced metadata H2D completes."""
+        return self.txn.h2d_done_event

--- a/megatron/core/inference/engines/step_transaction.py
+++ b/megatron/core/inference/engines/step_transaction.py
@@ -141,6 +141,51 @@ def classify_launch_eligibility(signals: LaunchSignals) -> LaunchDecision:
     return LaunchDecision(LaunchEligibility.ELIGIBLE, LaunchGateReason.PURE_DECODE)
 
 
+@dataclass
+class PrestagedDecodePlan:
+    """A read-only plan for the next decode step's launch-before-commit transaction.
+
+    Built by ``DynamicInferenceContext.prestage_next_decode_step_into_cpu_staging`` from the
+    *committed* layout, speculating no finish this step (a finish is absorbable -- its row is
+    discarded, never re-run). It captures everything the launch needs EXCEPT the sampled token
+    values (those are scattered onto the single GPU buffer post-sample). Specifically:
+
+    * :attr:`eligible` / :attr:`skip_reason` -- the static launch decision (1.2 / 1.9), computed
+      from committed state + KV headroom (a same-step finish's soon-to-free block is intentionally
+      NOT counted as headroom).
+    * :attr:`snapshot_request_ids` -- the pre-compaction active request-id snapshot the launched
+      forward is consumed by (consume-by-request-id, never by row: compaction only permutes rows,
+      so physical KV-block / mamba-slot ids stay bonded to each surviving request).
+    * The resource lease manifest (:attr:`kv_block_leases`, :attr:`reserved_boundary_blocks`,
+      :attr:`mamba_slot_leases`, :attr:`kv_blocks_needed`) the forward would touch -- recorded
+      read-only. Actual allocation / boundary-block adoption + the two-step retire are performed by
+      the overlap launch path that consumes the plan (a later commit); the prestage itself MUST NOT
+      mutate live CPU tensors, the allocator, or the GPU buffer.
+
+    The predicted next-step MHA metadata is written into the CPU *staging* views (never the live
+    buffer, never the GPU buffer) so publish can swap it in with one coalesced token-excluded H2D.
+    """
+
+    step_id: int
+    eligible: bool
+    skip_reason: Optional["LaunchGateReason"] = None
+    snapshot_request_ids: Any = None  # torch.Tensor (clone) or None
+    active_request_count: int = 0
+    # Physical KV block ids the forward would read (current last block per active request).
+    kv_block_leases: List[int] = field(default_factory=list)
+    # Boundary crossers that would need a new block next step, as (request_id, block_column).
+    reserved_boundary_blocks: List[Tuple[int, int]] = field(default_factory=list)
+    # Mamba state slot ids the forward would advance in place (hybrid only).
+    mamba_slot_leases: List[int] = field(default_factory=list)
+    # Number of new KV blocks the predicted step needs (== len(reserved_boundary_blocks)).
+    kv_blocks_needed: int = 0
+
+    @property
+    def has_leases(self) -> bool:
+        """Whether the plan records any resource the forward would touch."""
+        return bool(self.kv_block_leases or self.reserved_boundary_blocks or self.mamba_slot_leases)
+
+
 class TxnPhase(str, Enum):
     """Lifecycle phase of a :class:`StepTxn`."""
 
@@ -405,6 +450,19 @@ class StepTransactionManager:
         """Publish ``txn``'s artifacts by request id. Filled in by the publication commit."""
         # Publication (logprobs / top-n / routing / coordinator replies) is keyed by
         # request id and happens after commit; wired up in a later commit.
+
+    def record_prestage(self, plan: "PrestagedDecodePlan") -> None:
+        """Record a prestage outcome in diagnostics.
+
+        An eligible plan counts as ``prepared`` (its metadata + lease manifest were built into
+        the CPU staging buffer this step); an ineligible plan records its static skip reason.
+        Cheap O(1) counter updates; nothing here mutates context state.
+        """
+        if plan.eligible:
+            self.diagnostics.prepared += 1
+        else:
+            reason = plan.skip_reason.value if plan.skip_reason is not None else "unknown"
+            self.diagnostics.skip_reasons[reason] += 1
 
     def note_sync_step(self, reason: str) -> None:
         """Record that this step ran synchronously (a layout-changing step)."""

--- a/megatron/core/inference/engines/step_transaction.py
+++ b/megatron/core/inference/engines/step_transaction.py
@@ -84,6 +84,7 @@ class LaunchGateReason(str, Enum):
     FORCED_PAUSE_OVERFLOW = "forced_pause_overflow"
     MTP_DEPENDENT_LAYOUT = "mtp_dependent_layout"  # MTP verify/rewind changes layout
     KV_RESERVATION_UNAVAILABLE = "kv_reservation_unavailable"  # boundary block can't be reserved
+    SPECULATIVE_BOUNDARY_WINDOW = "speculative_boundary_window"  # a crosser sits in the spec window
 
 
 @dataclass

--- a/megatron/core/inference/engines/step_transaction.py
+++ b/megatron/core/inference/engines/step_transaction.py
@@ -37,6 +37,110 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 
+class LaunchEligibility(str, Enum):
+    """Whether a step may launch a speculative child forward before committing."""
+
+    ELIGIBLE = "eligible"  # a speculative child forward may be launched before commit
+    SYNC = "sync"  # layout-changing / unsupported: must run as a synchronous step
+
+
+class LaunchGateReason(str, Enum):
+    """Why a step is (in)eligible for a speculative launch.
+
+    These are the *static* gates and the explicit barrier/sync reasons from the design
+    (sections 1.2 and 1.9). There are deliberately no per-step "disabled" vetoes beyond
+    these. Note that finish / stop-word / cancel are absent: a launched forward absorbs a
+    finish (it discards the finished row; compaction is a pure row permutation), so those
+    events do NOT force a sync step and are never a reason here.
+    """
+
+    PURE_DECODE = "pure_decode"  # eligible: pure decode for the committed members
+    NO_ACTIVE_REQUESTS = "no_active_requests"
+    NOT_DECODE_ONLY = "not_decode_only"  # prefill / mixed step
+    GRAPH_INELIGIBLE = "graph_ineligible"  # not running under a (block-scope) CUDA graph
+    GRAPH_RECAPTURE = "graph_recapture"  # a graph recapture barrier this step
+    CHUNKED_PREFILL = "chunked_prefill"
+    PENDING_ADMISSION = "pending_admission"  # a waiting request can be admitted
+    RESUME = "resume"
+    EVICT = "evict"
+    FORCED_PAUSE_OVERFLOW = "forced_pause_overflow"
+    MTP_DEPENDENT_LAYOUT = "mtp_dependent_layout"  # MTP verify/rewind changes layout
+    KV_RESERVATION_UNAVAILABLE = "kv_reservation_unavailable"  # boundary block can't be reserved
+
+
+@dataclass
+class LaunchSignals:
+    """The (static) facts needed to decide if a speculative child launch is eligible.
+
+    Absorbable events (finish / stop-word / cancel) are intentionally NOT inputs: a
+    launched forward discards a finished row without re-running, so they never block a
+    launch. Only changes a launched forward could not absorb appear here.
+    """
+
+    decode_only: bool  # this step is decode-only (no prefill/mixed)
+    active_request_count: int  # number of active (non-paused) requests
+    using_cuda_graph: bool  # the forward runs under a (block-scope) CUDA graph
+    pending_admission: bool = False  # a waiting request could be admitted
+    resume_pending: bool = False  # a paused request is being resumed
+    evict_pending: bool = False  # a request is being evicted
+    forced_pause_overflow: bool = False  # active requests force-paused on KV overflow
+    chunked_prefill_active: bool = False  # chunked prefill in progress
+    graph_recapture: bool = False  # a CUDA-graph recapture barrier this step
+    mtp_layout_change: bool = False  # MTP verify/rewind changes layout this step
+    kv_reservation_fits: bool = True  # the <=1 boundary block per crosser fits pre-launch
+
+
+@dataclass
+class LaunchDecision:
+    """The result of :func:`classify_launch_eligibility`."""
+
+    eligibility: LaunchEligibility
+    reason: LaunchGateReason
+
+    @property
+    def eligible(self) -> bool:
+        """True iff a speculative child forward may be launched this step."""
+        return self.eligibility is LaunchEligibility.ELIGIBLE
+
+
+def classify_launch_eligibility(signals: LaunchSignals) -> LaunchDecision:
+    """Statically classify whether a step may launch a speculative child forward.
+
+    A speculative launch is attempted ONLY when every static gate holds (feature on +
+    CUDA graph + decode-only + active>0) and no layout-changing / barrier condition is
+    present (admission, resume, evict, forced-pause, chunked prefill, graph recapture,
+    MTP-dependent layout, unfittable KV reservation). Otherwise the step runs
+    synchronously. This mirrors the design's launch gate (1.2) and static eligibility
+    gate (1.9): no per-step dynamic vetoes beyond these.
+
+    The order of checks is fixed so the reported reason is deterministic when several
+    conditions hold at once (the most fundamental gate wins).
+    """
+    if signals.active_request_count <= 0:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.NO_ACTIVE_REQUESTS)
+    if not signals.decode_only:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.NOT_DECODE_ONLY)
+    if not signals.using_cuda_graph:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.GRAPH_INELIGIBLE)
+    if signals.graph_recapture:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.GRAPH_RECAPTURE)
+    if signals.chunked_prefill_active:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.CHUNKED_PREFILL)
+    if signals.pending_admission:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.PENDING_ADMISSION)
+    if signals.resume_pending:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.RESUME)
+    if signals.evict_pending:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.EVICT)
+    if signals.forced_pause_overflow:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.FORCED_PAUSE_OVERFLOW)
+    if signals.mtp_layout_change:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.MTP_DEPENDENT_LAYOUT)
+    if not signals.kv_reservation_fits:
+        return LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.KV_RESERVATION_UNAVAILABLE)
+    return LaunchDecision(LaunchEligibility.ELIGIBLE, LaunchGateReason.PURE_DECODE)
+
+
 class TxnPhase(str, Enum):
     """Lifecycle phase of a :class:`StepTxn`."""
 

--- a/megatron/core/inference/engines/step_transaction.py
+++ b/megatron/core/inference/engines/step_transaction.py
@@ -1,0 +1,321 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Transactional primitives for async-scheduling (launch-before-commit) decode.
+
+These data structures make one decode step a *transaction* so the dynamic engine
+can launch the next forward before committing the current one
+(``enable_async_scheduling``), while keeping resource lifetimes provably safe:
+
+- :class:`StepTxn` -- one decode step's transaction. Holds the snapshot of the
+  request set the forward consumes, the resources it *leases* (KV blocks, reserved
+  boundary blocks, mamba slots), and its two CUDA fences (``h2d_done_event``,
+  ``forward_done_event``).
+- :class:`RetireQueue` -- a two-step deferred-free queue. A resource freed during
+  step K is returned to its allocator only after the forward that may still read
+  it has completed (its ``forward_done_event``) *and* two steps have elapsed.
+- :class:`StepTxnDiagnostics` -- cheap counters (prepared / launched / adopted /
+  sync-steps / barrier-skips / retired / guard-failures / per-reason skips).
+- :class:`StepTransactionManager` -- owns the retire queue + diagnostics and the
+  begin / commit / publish / retire / barrier lifecycle.
+
+Design invariants (enforced here and asserted by tests):
+
+* There are deliberately **no** global ``_async_reserved_*`` / ``_async_deferred_*``
+  arrays. Every resource a forward can touch is a lease field on its
+  :class:`StepTxn`; freeing goes through the :class:`RetireQueue`.
+* The structures are inert until ``enable_async_scheduling`` is set: the manager is
+  only constructed when the flag is on, so the disabled decode path is unchanged.
+
+The commit that introduces this module only wraps the existing *serial* step as an
+always-adopted transaction (no speculative child launch); :meth:`prestage` and
+:meth:`adopt` (the launch-before-commit machinery) arrive in later commits.
+"""
+
+from collections import Counter, deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+class TxnPhase(str, Enum):
+    """Lifecycle phase of a :class:`StepTxn`."""
+
+    PRESTAGED = "prestaged"  # metadata + H2D built into the free slot, not yet launched
+    LAUNCHED = "launched"  # forward enqueued speculatively, in flight
+    ADOPTED = "adopted"  # launched forward's outputs consumed this step
+    COMMITTED = "committed"  # update_requests applied for this step
+    RETIRED = "retired"  # resources released
+    SERIAL = "serial"  # always-adopted serial wrap (no speculative launch)
+
+
+@dataclass
+class StepTxn:
+    """A single decode step's transaction.
+
+    The launched forward is consumed by ``request_ids`` (the snapshotted
+    pre-compaction active request ids), never by row index -- compaction only
+    permutes rows, so physical KV-block ids and mamba-slot ids stay bonded to each
+    surviving request (see the design's consume-by-request-id rule).
+    """
+
+    step_id: int
+    phase: TxnPhase = TxnPhase.SERIAL
+
+    # Snapshot of the active request set the forward consumes (pre-compaction).
+    request_ids: Optional[Any] = None  # torch.Tensor or None
+    active_request_count: int = 0
+
+    # CUDA-graph bucket / padded batch dimensions this forward was built for.
+    bucket: Any = None
+
+    # Whether the forward was launched speculatively (False for the serial wrap).
+    speculative: bool = False
+
+    # --- Resource leases (no global arrays; the txn owns what its forward touches). ---
+    # Physical KV block ids leased for this step.
+    kv_block_leases: List[int] = field(default_factory=list)
+    # Boundary blocks reserved for crossers, keyed by (request_id, block_column).
+    reserved_boundary_blocks: Dict[Tuple[int, int], int] = field(default_factory=dict)
+    # Mamba state slot ids leased for this step.
+    mamba_slot_leases: List[int] = field(default_factory=list)
+
+    # --- The two (and only two) per-transaction CUDA fences. ---
+    # Signalled when the coalesced bookkeeping H2D into this txn's slot completes.
+    h2d_done_event: Any = None  # torch.cuda.Event or None
+    # Signalled when this txn's forward completes; gates retire-queue frees + barriers.
+    forward_done_event: Any = None  # torch.cuda.Event or None
+
+    # Output handles (logits / sample buffers) produced by the forward.
+    output_handles: Dict[str, Any] = field(default_factory=dict)
+
+    def lease_kv_block(self, block_id: int) -> None:
+        """Record that this transaction owns ``block_id`` for the duration of its forward."""
+        self.kv_block_leases.append(int(block_id))
+
+    def reserve_boundary_block(self, request_id: int, block_column: int, block_id: int) -> None:
+        """Reserve the (request_id, block_column) boundary block this forward may cross into."""
+        self.reserved_boundary_blocks[(int(request_id), int(block_column))] = int(block_id)
+
+    def lease_mamba_slot(self, slot_id: int) -> None:
+        """Record that this transaction owns mamba slot ``slot_id`` for its forward."""
+        self.mamba_slot_leases.append(int(slot_id))
+
+    def leased_kv_block_ids(self) -> List[int]:
+        """All KV block ids this transaction owns (direct leases + reserved boundary blocks)."""
+        return list(self.kv_block_leases) + list(self.reserved_boundary_blocks.values())
+
+    def has_leases(self) -> bool:
+        """Whether this transaction owns any resource."""
+        return bool(self.kv_block_leases or self.reserved_boundary_blocks or self.mamba_slot_leases)
+
+
+@dataclass
+class _RetireEntry:
+    """One deferred free: release ``payload`` once the fence clears and the delay elapses."""
+
+    enqueue_step: int
+    event: Any  # torch.cuda.Event-like (exposes .query()) or None
+    release: Callable[[], None]
+    tag: str = ""
+
+
+class RetireQueue:
+    """Two-step deferred-free queue gated by a CUDA fence.
+
+    A resource enqueued at step K is released only once **both** conditions hold:
+
+    1. at least :attr:`RETIRE_DELAY_STEPS` engine steps have elapsed
+       (``current_step - enqueue_step >= RETIRE_DELAY_STEPS``), and
+    2. its ``event`` has completed (``event.query()`` is True), or it has no event.
+
+    This guarantees a freed KV block / mamba slot is never handed back to its
+    allocator while a still-in-flight forward could read it.
+    """
+
+    RETIRE_DELAY_STEPS = 2
+
+    def __init__(self) -> None:
+        self._entries: "deque[_RetireEntry]" = deque()
+
+    def enqueue(
+        self,
+        *,
+        enqueue_step: int,
+        release: Callable[[], None],
+        event: Any = None,
+        tag: str = "",
+    ) -> None:
+        """Defer ``release`` until the fence clears and the two-step delay elapses."""
+        self._entries.append(
+            _RetireEntry(enqueue_step=enqueue_step, event=event, release=release, tag=tag)
+        )
+
+    @classmethod
+    def _ready(cls, entry: _RetireEntry, current_step: int) -> bool:
+        if current_step - entry.enqueue_step < cls.RETIRE_DELAY_STEPS:
+            return False
+        if entry.event is not None and not entry.event.query():
+            return False
+        return True
+
+    def drain(self, current_step: int) -> int:
+        """Release every ready entry; keep the rest in order. Returns count released.
+
+        Scans all entries (not just the front) so a ready entry is never blocked
+        behind a not-yet-ready one, regardless of fence-completion ordering.
+        """
+        if not self._entries:
+            return 0
+        remaining: "deque[_RetireEntry]" = deque()
+        released = 0
+        for entry in self._entries:
+            if self._ready(entry, current_step):
+                entry.release()
+                released += 1
+            else:
+                remaining.append(entry)
+        self._entries = remaining
+        return released
+
+    def drain_all_blocking(self) -> int:
+        """Synchronize every pending fence and release everything (shutdown / barrier)."""
+        released = 0
+        for entry in self._entries:
+            if entry.event is not None:
+                entry.event.synchronize()
+            entry.release()
+            released += 1
+        self._entries.clear()
+        return released
+
+    def pending(self) -> int:
+        """Number of not-yet-released entries."""
+        return len(self._entries)
+
+
+@dataclass
+class StepTxnDiagnostics:
+    """Cheap, always-on counters for the async-scheduling pipeline.
+
+    All increments are O(1) integer/Counter updates; nothing here is allocated or
+    touched when ``enable_async_scheduling`` is off (the manager is not constructed).
+    """
+
+    prepared: int = 0  # child metadata prestaged
+    launched: int = 0  # forwards launched speculatively (before commit)
+    adopted: int = 0  # launched children whose outputs were consumed
+    serial_steps: int = 0  # always-adopted serial wraps (no speculative launch)
+    sync_steps: int = 0  # layout-changing steps that ran synchronously
+    barrier_skips: int = 0  # steps where a barrier prevented a child launch
+    retired: int = 0  # resources released from the retire queue
+    guard_failures: int = 0  # adopt-guard assertion failures (expected to stay 0)
+    skip_reasons: Counter = field(default_factory=Counter)  # reason -> count
+
+    def as_dict(self) -> Dict[str, Any]:
+        """A plain-dict snapshot suitable for logging."""
+        return {
+            "prepared": self.prepared,
+            "launched": self.launched,
+            "adopted": self.adopted,
+            "serial_steps": self.serial_steps,
+            "sync_steps": self.sync_steps,
+            "barrier_skips": self.barrier_skips,
+            "retired": self.retired,
+            "guard_failures": self.guard_failures,
+            "skip_reasons": dict(self.skip_reasons),
+        }
+
+
+class StepTransactionManager:
+    """Owns the retire queue + diagnostics and the per-step transaction lifecycle.
+
+    Constructed by the engine only when ``enable_async_scheduling`` is on. In the
+    commit that introduces it, the manager wraps the existing serial step as an
+    always-adopted transaction via :meth:`begin_serial_txn`; the speculative
+    prestage / launch / adopt path is added in later commits.
+    """
+
+    def __init__(self, context: Any) -> None:
+        self.context = context
+        self.retire_queue = RetireQueue()
+        self.diagnostics = StepTxnDiagnostics()
+        # The currently-running (adopted) transaction and the in-flight child (later).
+        self.current_txn: Optional[StepTxn] = None
+        self.child_txn: Optional[StepTxn] = None
+
+    # --- Retire ---------------------------------------------------------------
+
+    def retire(self, current_step: int) -> int:
+        """Drain the retire queue for ``current_step``; returns the count released."""
+        released = self.retire_queue.drain(current_step)
+        self.diagnostics.retired += released
+        return released
+
+    def enqueue_retire(
+        self,
+        *,
+        enqueue_step: int,
+        release: Callable[[], None],
+        event: Any = None,
+        tag: str = "",
+    ) -> None:
+        """Defer ``release`` behind the two-step + fence gate (see :class:`RetireQueue`)."""
+        self.retire_queue.enqueue(
+            enqueue_step=enqueue_step, release=release, event=event, tag=tag
+        )
+
+    # --- Lifecycle ------------------------------------------------------------
+
+    def begin_serial_txn(
+        self,
+        *,
+        step_id: int,
+        active_request_count: int,
+        request_ids: Any = None,
+        bucket: Any = None,
+    ) -> StepTxn:
+        """Begin an always-adopted serial transaction (no speculative launch).
+
+        Used to route the legacy serial step through the transaction lifecycle
+        without changing what is computed.
+        """
+        txn = StepTxn(
+            step_id=step_id,
+            phase=TxnPhase.ADOPTED,
+            request_ids=request_ids,
+            active_request_count=active_request_count,
+            bucket=bucket,
+            speculative=False,
+        )
+        self.diagnostics.prepared += 1
+        self.diagnostics.adopted += 1
+        self.diagnostics.serial_steps += 1
+        self.current_txn = txn
+        return txn
+
+    def commit(self, txn: StepTxn) -> None:
+        """Mark ``txn`` committed (``update_requests`` has been applied for its step)."""
+        txn.phase = TxnPhase.COMMITTED
+
+    def publish(self, txn: StepTxn) -> None:
+        """Publish ``txn``'s artifacts by request id. Filled in by the publication commit."""
+        # Publication (logprobs / top-n / routing / coordinator replies) is keyed by
+        # request id and happens after commit; wired up in a later commit.
+
+    def note_sync_step(self, reason: str) -> None:
+        """Record that this step ran synchronously (a layout-changing step)."""
+        self.diagnostics.sync_steps += 1
+        self.diagnostics.skip_reasons[reason] += 1
+
+    def barrier(self, reason: str) -> None:
+        """Record a barrier that prevented a speculative child launch for one step."""
+        self.diagnostics.barrier_skips += 1
+        self.diagnostics.skip_reasons[reason] += 1
+
+    def note_skip(self, reason: str) -> None:
+        """Record that a speculative launch was skipped for ``reason`` (diagnostics only)."""
+        self.diagnostics.skip_reasons[reason] += 1
+
+    def note_guard_failure(self) -> None:
+        """Record an adopt-guard failure (expected to stay 0; recovery is a barrier)."""
+        self.diagnostics.guard_failures += 1

--- a/megatron/core/inference/engines/step_transaction.py
+++ b/megatron/core/inference/engines/step_transaction.py
@@ -34,7 +34,25 @@ always-adopted transaction (no speculative child launch); :meth:`prestage` and
 from collections import Counter, deque
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+# Sentinel for "argument not supplied" so that ``None`` remains a usable value
+# (e.g. a graph bucket of ``None`` must be distinguishable from "skip the check").
+_UNSET = object()
+
+
+def _request_id_set(request_ids: Any) -> Set[int]:
+    """Normalize a request-id container (tensor / list / None) to a ``set`` of ints.
+
+    Used by the consume-by-request-id adopt guard to compare the launched forward's
+    pre-compaction snapshot against the committed survivor set without depending on
+    container type or row order.
+    """
+    if request_ids is None:
+        return set()
+    if hasattr(request_ids, "tolist"):
+        request_ids = request_ids.tolist()
+    return {int(r) for r in request_ids}
 
 
 class LaunchEligibility(str, Enum):
@@ -225,6 +243,11 @@ class StepTxn:
     kv_block_leases: List[int] = field(default_factory=list)
     # Boundary blocks reserved for crossers, keyed by (request_id, block_column).
     reserved_boundary_blocks: Dict[Tuple[int, int], int] = field(default_factory=dict)
+    # Boundary crossers known at prestage time that still need a block allocated, as
+    # (request_id, block_column). The prestage MUST NOT allocate; the launch path
+    # allocates each one and records it via ``reserve_boundary_block`` (which moves it
+    # from "pending" to a concrete reserved block id).
+    pending_boundary_columns: List[Tuple[int, int]] = field(default_factory=list)
     # Mamba state slot ids leased for this step.
     mamba_slot_leases: List[int] = field(default_factory=list)
 
@@ -256,6 +279,31 @@ class StepTxn:
     def has_leases(self) -> bool:
         """Whether this transaction owns any resource."""
         return bool(self.kv_block_leases or self.reserved_boundary_blocks or self.mamba_slot_leases)
+
+    @classmethod
+    def from_prestaged_plan(cls, plan: "PrestagedDecodePlan", *, bucket: Any = None) -> "StepTxn":
+        """Seed a PRESTAGED speculative transaction from an (eligible) prestaged plan.
+
+        Carries the consume-by-request-id snapshot (``request_ids``) and the read-only
+        lease manifest the launch path will consume: the physical KV blocks the forward
+        reads, the mamba slots it advances in place, and the boundary crossers that each
+        still need a new block. The crossers are recorded as ``pending_boundary_columns``
+        -- the prestage does NOT allocate (see the design's 1.1 step 2), so their physical
+        block ids are assigned by the launch path, which then calls
+        :meth:`reserve_boundary_block`.
+        """
+        assert plan.eligible, "only an eligible prestaged plan can seed a speculative transaction"
+        return cls(
+            step_id=plan.step_id,
+            phase=TxnPhase.PRESTAGED,
+            request_ids=plan.snapshot_request_ids,
+            active_request_count=plan.active_request_count,
+            bucket=bucket,
+            speculative=True,
+            kv_block_leases=list(plan.kv_block_leases),
+            pending_boundary_columns=[(int(r), int(c)) for (r, c) in plan.reserved_boundary_blocks],
+            mamba_slot_leases=list(plan.mamba_slot_leases),
+        )
 
 
 @dataclass
@@ -463,6 +511,105 @@ class StepTransactionManager:
         else:
             reason = plan.skip_reason.value if plan.skip_reason is not None else "unknown"
             self.diagnostics.skip_reasons[reason] += 1
+
+    # --- Launch-before-commit handoff -----------------------------------------
+    #
+    # The prestage -> launch -> adopt -> commit -> retire-leases handoff the overlap
+    # engine wiring consumes. These are pure CPU bookkeeping over :class:`StepTxn`
+    # objects; they do not touch the GPU buffer or the allocators (the prestage builds
+    # CPU staging metadata; the launch path performs the GPU scatter / H2D / allocation
+    # and supplies the retire release callables). The runtime decode path does not call
+    # them yet -- they are landed + validated ahead of the overlap commit.
+
+    def prestage_child(
+        self, plan: "PrestagedDecodePlan", *, bucket: Any = None
+    ) -> Optional[StepTxn]:
+        """Stage the next forward's transaction from a prestaged plan.
+
+        Records prestage diagnostics either way (see :meth:`record_prestage`). For an
+        eligible plan, seeds the PRESTAGED speculative child (snapshot request ids +
+        read-only lease manifest) via :meth:`StepTxn.from_prestaged_plan` and stores it as
+        ``child_txn``. For an ineligible plan, the static skip reason is recorded and
+        ``child_txn`` is left unset (the step runs synchronously -- no speculative launch).
+
+        Returns the child transaction, or ``None`` for an ineligible plan.
+        """
+        self.record_prestage(plan)
+        if not plan.eligible:
+            self.child_txn = None
+            return None
+        child = StepTxn.from_prestaged_plan(plan, bucket=bucket)
+        self.child_txn = child
+        return child
+
+    def launch_child(
+        self, *, forward_done_event: Any = None, h2d_done_event: Any = None
+    ) -> StepTxn:
+        """Mark the prestaged child as launched (its forward enqueued before commit).
+
+        Attaches the two (and only two) per-transaction fences and transitions
+        PRESTAGED -> LAUNCHED. The launched forward is now in flight and will be consumed
+        (adopted) on the next step. Increments the ``launched`` diagnostic.
+        """
+        child = self.child_txn
+        assert (
+            child is not None and child.phase is TxnPhase.PRESTAGED
+        ), "launch_child requires a prestaged child transaction"
+        child.phase = TxnPhase.LAUNCHED
+        child.speculative = True
+        child.forward_done_event = forward_done_event
+        child.h2d_done_event = h2d_done_event
+        self.diagnostics.launched += 1
+        return child
+
+    def adopt_child(self, committed_survivor_ids: Any, *, committed_bucket: Any = _UNSET) -> bool:
+        """Adopt the in-flight launched forward via the consume-by-request-id guard.
+
+        The launched forward computed the snapshot rows; after commit the committed
+        survivors must be a SUBSET of that snapshot (a finish only removes a row --
+        absorbable, its row is discarded -- and nothing adds a row a launched forward did
+        not compute), and the graph bucket must match when supplied. This is the system's
+        only adopt guard, and it is an assert + diagnostic (design 1.2): on success the
+        child is promoted to the current (adopted) transaction; on failure the recovery is
+        a barrier (drain the in-flight forward, *consume* its valid outputs, take a sync
+        step) -- never discard-and-rerun. Returns ``True`` iff the child was adopted.
+        """
+        child = self.child_txn
+        assert (
+            child is not None and child.phase is TxnPhase.LAUNCHED
+        ), "adopt_child requires a launched child transaction"
+        snapshot = _request_id_set(child.request_ids)
+        survivors = _request_id_set(committed_survivor_ids)
+        bucket_ok = committed_bucket is _UNSET or committed_bucket == child.bucket
+        if not survivors.issubset(snapshot) or not bucket_ok:
+            self.note_guard_failure()
+            return False
+        child.phase = TxnPhase.ADOPTED
+        self.current_txn = child
+        self.child_txn = None
+        self.diagnostics.adopted += 1
+        return True
+
+    def retire_txn_leases(
+        self,
+        txn: StepTxn,
+        *,
+        current_step: int,
+        release: Callable[[], None],
+        event: Any = _UNSET,
+        tag: str = "lease",
+    ) -> None:
+        """Enqueue a transaction's freed resources for two-step fence-gated release.
+
+        A finished request's KV blocks / mamba slots are returned to their allocators only
+        after the forward that may still read them has completed (the transaction's
+        ``forward_done_event``) and the two-step delay has elapsed (see :class:`RetireQueue`).
+        The actual allocator release is the supplied ``release`` callable; this method only
+        schedules it behind the fence. ``event`` defaults to ``txn.forward_done_event``.
+        """
+        if event is _UNSET:
+            event = txn.forward_done_event
+        self.enqueue_retire(enqueue_step=current_step, release=release, event=event, tag=tag)
 
     def note_sync_step(self, reason: str) -> None:
         """Record that this step ran synchronously (a layout-changing step)."""

--- a/megatron/core/inference/sampling/base.py
+++ b/megatron/core/inference/sampling/base.py
@@ -41,6 +41,13 @@ class Sampling(ABC):
         """
         ...
 
+    def retire_requests(self, request_ids) -> None:
+        """Release any per-request sampling state for finished requests.
+
+        Default no-op. Backends that keep per-request RNG state (e.g. the torch backend's
+        per-request keyed generators) override this to drop finished requests' state.
+        """
+
     def sample_speculative(
         self,
         required_logits: Tensor,

--- a/megatron/core/inference/sampling/torch_sampling.py
+++ b/megatron/core/inference/sampling/torch_sampling.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 from collections import defaultdict
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import torch
 from torch import Tensor
@@ -9,15 +9,78 @@ from torch import Tensor
 from megatron.core.inference.sampling.base import Sampling
 
 
+def _modify_logits_for_top_k_filtering(logits: Tensor, top_k: int) -> None:
+    """Set the logits for non-top-k values to -inf (in place)."""
+    filter_ = logits < torch.topk(logits, top_k)[0][..., -1, None]
+    logits.masked_fill_(filter_, float("-Inf"))
+
+
+def _modify_logits_for_top_p_filtering(logits: Tensor, top_p: float) -> None:
+    """Set the logits for non-top-p values to -inf (in place)."""
+    sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+    cumulative_probs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)
+
+    filter_ = cumulative_probs > top_p
+    # Clone needed: filter_[:, 1:] and filter_[:, :-1] are overlapping views;
+    # without clone, each write would corrupt the next read during the shift.
+    filter_[:, 1:] = filter_[:, :-1].clone()
+    filter_[..., 0] = 0
+
+    filter_ = filter_.scatter(1, sorted_indices, filter_)
+    logits.masked_fill_(filter_, float("-Inf"))
+
+
 class TorchSampling(Sampling):
     """Sampling via bucketed `torch.multinomial`.
 
-    Groups requests into unique buckets by `(temperature, top_k, top_p)` for separate launches.
+    Groups requests into unique buckets by `(temperature, top_k, top_p)` for separate
+    launches. Within a bucket the (temperature / top-k / top-p) filtering is vectorized,
+    but the random draw is **per-request keyed**: each request draws from its own
+    `torch.Generator` seeded by `(seed + request_id)`. A request's draw therefore depends
+    only on `(request_id, its own draw count)` and is invariant to the batch composition
+    and row order. This is exactly the property the launch-before-commit async scheduler
+    needs (pre-commit sampling re-orders rows vs. the post-`update_requests` compacted
+    order), and it is what makes `async == serial` token-exact *by construction* for the
+    torch backend. Greedy rows (`top_k == 1`) short-circuit to `argmax` and draw no random
+    numbers, so greedy is unaffected by the keying.
     """
 
-    def __init__(self, rng: torch.Generator, vocab_size: int) -> None:
+    def __init__(
+        self, rng: torch.Generator, vocab_size: int, seed: Optional[int] = None
+    ) -> None:
+        # `rng` is retained for the static-batching path (`sample_from_logits`); dynamic
+        # decode / speculative sampling uses per-request keyed generators instead.
         self._rng = rng
         self._vocab_size = vocab_size
+        # Base seed for the per-request keyed generators. Defaults to the shared rng's
+        # seed so behavior is well-defined even if a caller omits it.
+        self._seed = int(seed if seed is not None else rng.initial_seed())
+        # request_id -> its dedicated generator (memoized; retired when a request finishes).
+        self._request_rngs: Dict[int, torch.Generator] = {}
+
+    def _generator_for_request(self, request_id: int) -> torch.Generator:
+        """Return ``request_id``'s dedicated generator, creating it on first use.
+
+        Seeded by ``(seed + request_id) % 2**63`` so a request's random stream depends only
+        on its id (and its own draw count), never on which other requests share the batch.
+        """
+        request_id = int(request_id)
+        gen = self._request_rngs.get(request_id)
+        if gen is None:
+            gen = torch.Generator(device=torch.cuda.current_device())
+            gen.manual_seed((self._seed + request_id) % (2**63))
+            self._request_rngs[request_id] = gen
+        return gen
+
+    def retire_requests(self, request_ids: Sequence[int]) -> None:
+        """Drop finished requests' generators (memory hygiene).
+
+        Per-request streams are independent, so retiring one never perturbs a survivor's
+        draws. A request id that is later reused gets a fresh, identically-seeded
+        generator, preserving determinism.
+        """
+        for request_id in request_ids:
+            self._request_rngs.pop(int(request_id), None)
 
     @staticmethod
     def sample_from_logits(
@@ -31,7 +94,9 @@ class TorchSampling(Sampling):
     ) -> Tensor:
         """Sample tokens from logits with temperature, top-k, and top-p filtering.
 
-        Shared between dynamic batching and static batching.
+        Used by the static-batching path (one shared generator for the whole batch).
+        Dynamic decode / speculative sampling goes through :meth:`sample_kernel`, which
+        draws per-request-keyed instead.
 
         Args:
             last_token_logits: Logits of shape `[batch_size, vocab_size]`.
@@ -50,25 +115,6 @@ class TorchSampling(Sampling):
         assert not (top_k > 0 and top_p > 0.0), "Cannot have top-p and top-k both greater than zero"
         assert top_p <= 1.0, "top-p should be in (0,1]"
 
-        def modify_logits_for_top_k_filtering(logits, top_k):
-            """Set the logits for none top-k values to -inf."""
-            filter_ = logits < torch.topk(logits, top_k)[0][..., -1, None]
-            logits.masked_fill_(filter_, float("-Inf"))
-
-        def modify_logits_for_top_p_filtering(logits, top_p):
-            """Set the logits for none top-p values to -inf."""
-            sorted_logits, sorted_indices = torch.sort(logits, descending=True)
-            cumulative_probs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)
-
-            filter_ = cumulative_probs > top_p
-            # Clone needed: filter_[:, 1:] and filter_[:, :-1] are overlapping views;
-            # without clone, each write would corrupt the next read during the shift.
-            filter_[:, 1:] = filter_[:, :-1].clone()
-            filter_[..., 0] = 0
-
-            filter_ = filter_.scatter(1, sorted_indices, filter_)
-            logits.masked_fill_(filter_, float("-Inf"))
-
         if top_k == 1:
             return torch.argmax(last_token_logits, dim=-1)
 
@@ -80,15 +126,64 @@ class TorchSampling(Sampling):
             assert top_k <= last_token_logits.size(1), "top-k is larger than logit size."
             if vocab_size:
                 assert top_k < vocab_size, "top-k is larger than vocab size."
-            modify_logits_for_top_k_filtering(last_token_logits, top_k)
+            _modify_logits_for_top_k_filtering(last_token_logits, top_k)
         elif top_p > 0.0:
-            modify_logits_for_top_p_filtering(last_token_logits, top_p)
+            _modify_logits_for_top_p_filtering(last_token_logits, top_p)
 
         probabilities = last_token_logits.softmax(dim=-1)
         sampled = torch.multinomial(probabilities, num_samples=1, generator=generator).view(-1)
 
         if vocab_size:
             sampled = torch.clamp(sampled, min=0, max=(vocab_size - 1))
+
+        return sampled
+
+    def _sample_bucket_per_request(
+        self,
+        bucket_logits: Tensor,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+        row_request_ids: Sequence[int],
+    ) -> Tensor:
+        """Sample one token per row of a single `(temperature, top_k, top_p)` bucket.
+
+        Greedy (`top_k == 1`) short-circuits to `argmax` with no generator -- a strict
+        no-op vs. the shared-rng path. Otherwise the bucket is filtered once (vectorized),
+        then each row is drawn from its own request's keyed generator, so the draw is
+        invariant to batch composition / row order.
+        """
+        assert isinstance(top_p, float)
+        assert isinstance(top_k, int)
+        assert not (top_k > 0 and top_p > 0.0), "Cannot have top-p and top-k both greater than zero"
+        assert top_p <= 1.0, "top-p should be in (0,1]"
+
+        if top_k == 1:
+            return torch.argmax(bucket_logits, dim=-1)
+
+        # Clone needed: .div_() and masked_fill_() below modify in-place.
+        logits = bucket_logits.clone()
+        if temperature != 1.0:
+            logits.div_(temperature)
+        if top_k > 1:
+            assert top_k <= logits.size(1), "top-k is larger than logit size."
+            if self._vocab_size:
+                assert top_k < self._vocab_size, "top-k is larger than vocab size."
+            _modify_logits_for_top_k_filtering(logits, top_k)
+        elif top_p > 0.0:
+            _modify_logits_for_top_p_filtering(logits, top_p)
+
+        probabilities = logits.softmax(dim=-1)
+        sampled = torch.empty(probabilities.shape[0], device=logits.device, dtype=torch.int64)
+        for row, request_id in enumerate(row_request_ids):
+            sampled[row : row + 1] = torch.multinomial(
+                probabilities[row : row + 1],
+                num_samples=1,
+                generator=self._generator_for_request(request_id),
+            ).view(-1)
+
+        if self._vocab_size:
+            sampled = torch.clamp(sampled, min=0, max=(self._vocab_size - 1))
 
         return sampled
 
@@ -126,6 +221,12 @@ class TorchSampling(Sampling):
         md = context.active_request_metadata
         device = torch.cuda.current_device()
 
+        # Active request ids in row order: active row i == request_ids[paused + i] (see
+        # build_active_slices). Used to key each row's generator. TorchSampling always runs
+        # eager (no captured sampling graph), so this host read is safe.
+        paused = context.paused_request_count
+        active_request_ids = context.request_ids[paused : paused + active_request_count].tolist()
+
         bucket_map: dict = defaultdict(list)
         temp = md["temperature"][:active_request_count].tolist()
         top_k = md["top_k"][:active_request_count].tolist()
@@ -144,19 +245,23 @@ class TorchSampling(Sampling):
         output = torch.empty(n, device=logits.device, dtype=torch.int64)
         token_list = []
         indices_list = []
-        for idx_tensor, (_, temp, top_k, top_p) in zip(bucket_index_tensors, buckets):
+        for idx_tensor, (request_indices, temp_val, top_k_val, top_p_val) in zip(
+            bucket_index_tensors, buckets
+        ):
             if token_to_request_index is None:
                 row_indices = idx_tensor
+                # Each row is one request; map its request index to its id.
+                row_request_ids = [active_request_ids[ri] for ri in request_indices]
             else:
                 row_indices = torch.where(torch.isin(token_to_request_index, idx_tensor))[0]
+                # Speculative: a request contributes 1+n_spec consecutive rows; map each
+                # selected token row (in ascending row order) to its request's id.
+                row_request_ids = [
+                    active_request_ids[ri] for ri in token_to_request_index[row_indices].tolist()
+                ]
             token_list.append(
-                TorchSampling.sample_from_logits(
-                    logits[row_indices, :],
-                    temp,
-                    top_k,
-                    top_p,
-                    generator=self._rng,
-                    vocab_size=self._vocab_size,
+                self._sample_bucket_per_request(
+                    logits[row_indices, :], temp_val, top_k_val, top_p_val, row_request_ids
                 )
             )
             indices_list.append(row_indices)

--- a/megatron/core/inference/text_generation_controllers/async_sample_ring.py
+++ b/megatron/core/inference/text_generation_controllers/async_sample_ring.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Asynchronous device->host read-back of sampled decode tokens.
+
+The launch-before-commit decode pipeline must enqueue the launch of the next forward
+``F(K+1)`` *before* the sampled tokens of ``F(K)`` are read to the host (that blocking D2H +
+host finish-check is the ~360us inter-forward bubble). :class:`AsyncSampleRing` owns that
+read-back so it no longer sits *between* ``sample(K)`` and the launch *enqueue*:
+
+* a small fixed ring (``depth=2``) of pinned CPU slots + one dedicated copy stream;
+* per slot a ``source_ready`` event (recorded on the compute stream after the sample
+  kernel) and a ``copy_done`` event (recorded on the copy stream after the D2H);
+* the D2H is enqueued behind ``source_ready`` and is **not** waited on at launch time;
+  the host syncs on ``copy_done`` only *after* the launch enqueue, off the launch path.
+
+``depth=2`` is a **double-buffer correctness margin**, not a deeper pipeline: the speculation
+depth stays 1. Step ``K+1``'s sampling rebinds/overwrites the GPU source while step ``K``'s
+slot may still be draining, so the reader must own a distinct pinned slot.
+
+**Critical ownership rule (anti-rebind).** Plain-decode ``_sampled_tokens_cuda`` is *rebound*
+each step to the sample kernel's output -- it is **not** a stable address. If nothing held a
+reference to slot ``K``'s exact source GPU tensor, the caching allocator could reuse that
+memory for step ``K+1``'s sample before the (still pending) copy stream drains it, so the
+async D2H would silently read step ``K+1``'s samples. The ring therefore retains a reference
+to the exact source tensor for slot ``K`` (``RingTicket.source_ref``) until ``copy_done(K)``
+clears, pinning that memory for the lifetime of the copy.
+
+This module is a pure data structure (mirrors how :mod:`metadata_slot` /
+:mod:`step_transaction` were landed before being wired). It is constructed lazily on the
+controller only when ``enable_async_scheduling`` is on; the serial path never touches it.
+
+Scope note: MTP (``num_speculative_tokens > 0``) is out of scope for the overlap path, so the
+ring carries only the base sampled tokens; the ``_sampled_mtp_tokens_cuda`` companion D2H
+stays on the synchronous serial path.
+"""
+
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+import torch
+
+
+@dataclass
+class RingTicket:
+    """A handle to one enqueued async read-back, consumed after the launch enqueue.
+
+    ``source_ref`` retains the exact GPU source tensor for this slot until ``copy_done``
+    clears (the anti-rebind rule above); it is dropped by :meth:`AsyncSampleRing.consume`
+    (or :meth:`AsyncSampleRing.drain`) once the copy is known complete.
+    """
+
+    slot: int
+    copy_done_event: torch.cuda.Event
+    snapshot_request_ids: Any  # the launched StepTxn.request_ids (consume-by-request-id tag)
+    n: int
+    source_ref: Optional[torch.Tensor]  # retained until copy_done clears (anti-rebind)
+
+
+class AsyncSampleRing:
+    """Depth-2 ring of pinned CPU slots draining sampled tokens off the launch critical path.
+
+    One dedicated copy stream serializes the per-step D2Hs; per-slot ``source_ready`` /
+    ``copy_done`` events order each copy after its sample kernel and let the host sync on
+    completion *after* the launch enqueue. The pinned slots are allocated lazily on the first
+    :meth:`enqueue_readback` to match the source dtype exactly, so the consumed tensor is
+    byte-identical to the legacy ``sampled_tokens_cuda[:n].cpu()`` it replaces.
+    """
+
+    def __init__(self, max_requests: int, device: Any, depth: int = 2):
+        assert depth >= 2, "depth must be >= 2 (double-buffer correctness margin)"
+        self.max_requests = max_requests
+        self.device = device
+        self.depth = depth
+        # One dedicated copy stream for all D2Hs (kept off the compute stream).
+        self.copy_stream = torch.cuda.Stream(device=device)
+        # Per-slot fences. source_ready: sample kernel done (compute stream). copy_done: D2H
+        # done (copy stream). Allocated up front; the pinned slots are allocated lazily.
+        self._source_ready: List[torch.cuda.Event] = [torch.cuda.Event() for _ in range(depth)]
+        self._copy_done: List[torch.cuda.Event] = [torch.cuda.Event() for _ in range(depth)]
+        # Pinned CPU slots (lazily allocated, see _ensure_slots) + per-slot retained source ref.
+        self._slots: Optional[List[torch.Tensor]] = None
+        self._slot_dtype: Optional[torch.dtype] = None
+        self._source_refs: List[Optional[torch.Tensor]] = [None] * depth
+        self.cursor = 0
+
+    def _ensure_slots(self, dtype: torch.dtype) -> None:
+        """Lazily allocate the pinned CPU slots matching the source dtype (once)."""
+        if self._slots is None:
+            self._slot_dtype = dtype
+            self._slots = [
+                torch.empty(self.max_requests, dtype=dtype, pin_memory=True)
+                for _ in range(self.depth)
+            ]
+        else:
+            assert dtype == self._slot_dtype, (
+                f"AsyncSampleRing source dtype changed: {self._slot_dtype} -> {dtype}"
+            )
+
+    def enqueue_readback(
+        self, sampled_tokens_cuda: torch.Tensor, *, n: int, snapshot_request_ids: Any
+    ) -> RingTicket:
+        """Enqueue an async D2H of ``sampled_tokens_cuda[:n]`` and return its ticket.
+
+        Records ``source_ready`` on the current (compute) stream, then on the copy stream
+        waits for it and issues the non-blocking pinned copy, recording ``copy_done``. Retains
+        the source tensor (anti-rebind) and advances the cursor. Does **not** synchronize, so
+        the caller can immediately enqueue the next forward's launch.
+        """
+        assert n <= self.max_requests, f"n={n} exceeds max_requests={self.max_requests}"
+        self._ensure_slots(sampled_tokens_cuda.dtype)
+        slot = self.cursor
+        source_ready = self._source_ready[slot]
+        copy_done = self._copy_done[slot]
+
+        # source_ready fires on the compute stream once the sample kernel has written
+        # sampled_tokens_cuda; the copy stream waits on it before reading.
+        source_ready.record(torch.cuda.current_stream())
+        with torch.cuda.stream(self.copy_stream):
+            self.copy_stream.wait_event(source_ready)
+            self._slots[slot][:n].copy_(sampled_tokens_cuda[:n], non_blocking=True)
+            copy_done.record(self.copy_stream)
+
+        # Retain the EXACT source tensor until copy_done clears (anti-rebind): keeps the
+        # caching allocator from reusing this memory for the next step's sample mid-copy.
+        self._source_refs[slot] = sampled_tokens_cuda
+        self.cursor = (self.cursor + 1) % self.depth
+
+        return RingTicket(
+            slot=slot,
+            copy_done_event=copy_done,
+            snapshot_request_ids=snapshot_request_ids,
+            n=n,
+            source_ref=sampled_tokens_cuda,
+        )
+
+    def consume(self, ticket: RingTicket) -> torch.Tensor:
+        """Block on the ticket's ``copy_done`` and return its pinned slot view ``[:n]``.
+
+        Called *after* the launch enqueue, so the D2H overlapped the launch. The caller must
+        CLONE the returned tensor before any in-place state mutation (the slot is reused after
+        ``depth`` further enqueues). Drops the retained source ref now that the copy is done.
+        """
+        ticket.copy_done_event.synchronize()
+        self._source_refs[ticket.slot] = None
+        ticket.source_ref = None
+        return self._slots[ticket.slot][: ticket.n]
+
+    def drain(self) -> None:
+        """Synchronize all in-flight copy events and drop every retained source ref.
+
+        Used on barrier / suspend / reset / shutdown so no pending D2H references a tensor the
+        teardown is about to free.
+        """
+        for event in self._copy_done:
+            event.synchronize()
+        self._source_refs = [None] * self.depth
+
+    def reset(self) -> None:
+        """Drain and rewind the cursor (e.g. an engine reset that rewinds the context)."""
+        self.drain()
+        self.cursor = 0

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -5,7 +5,7 @@ import concurrent
 import copy
 import functools
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, OrderedDict, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, OrderedDict, Tuple, Union
 
 import numpy as np
 import torch
@@ -60,12 +60,23 @@ except ImportError:
 
 from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensions
 from megatron.core.inference.sampling import FlashInferSampling, Sampling, TorchSampling
+from megatron.core.inference.text_generation_controllers.async_sample_ring import AsyncSampleRing
 from megatron.core.inference.text_generation_controllers.mtp_utils_pytorch import rewind_kv_cache
 from megatron.core.inference.text_generation_controllers.mtp_utils_triton import (
     mamba_state_selective_copy,
     prepare_next_forward_pass,
     verify_speculative_tokens,
 )
+
+if TYPE_CHECKING:
+    # Type-only imports. The runtime uses lazy imports inside the overlap methods because the
+    # ``engines`` package __init__ imports ``dynamic_engine`` (which imports this controller),
+    # so a module-top import of these symbols would be circular.
+    from megatron.core.inference.engines.inflight_forward import InflightForward
+    from megatron.core.inference.engines.step_transaction import (
+        PrestagedDecodePlan,
+        StepTransactionManager,
+    )
 
 
 # pylint: disable=line-too-long
@@ -200,11 +211,17 @@ class TextGenerationController:
         self._tp_size = get_pg_size(self.inference_wrapped_model.tp_group)
         self._sp_enabled = self.model_config.sequence_parallel and self._tp_size > 1
 
-        # Launch-before-commit overlap state (async scheduling). When a decode forward is
-        # launched speculatively before the current step's update_requests, its consume-by-
-        # request-id snapshot + graph bucket are stashed here; the next call samples + commits
-        # it instead of running a fresh forward. None means "no in-flight speculative forward".
-        self._async_overlap_inflight: Optional[Dict[str, Any]] = None
+        # Launch-before-commit overlap state (async scheduling). The single speculative forward
+        # F(K+1) launched before the current step's update_requests is held as a typed
+        # InflightForward (backed by a StepTxn): the next call adopts it (consume-by-request-id)
+        # + samples it instead of running a fresh forward. None means "no in-flight forward".
+        self._inflight: Optional["InflightForward"] = None
+        # The async-scheduling transaction manager (retire queue + diagnostics + prestage/launch/
+        # adopt lifecycle) and the async sampled-token read-back ring. Both belong to the engine's
+        # async setup: the engine attaches the manager on reset (only when the opt-in flag is on);
+        # the ring is lazily built on first overlap use. The serial path leaves both None.
+        self._step_txn_manager: Optional["StepTransactionManager"] = None
+        self._async_sample_ring: Optional["AsyncSampleRing"] = None
         # Diagnostic: number of forwards launched before the prior step's update_requests.
         self._async_launch_before_commit_count = 0
         # Diagnostic: set True whenever update_requests runs while a speculative forward that
@@ -1689,7 +1706,11 @@ class TextGenerationController:
                         mask[idx] = 0
         return mask
 
-    def _dynamic_step_prepare_commit(self) -> Dict[str, Any]:
+    def _dynamic_step_prepare_commit(
+        self,
+        sampled_tokens_cpu: Optional[Tensor] = None,
+        sampled_mtp_tokens_cpu: Optional[Tensor] = None,
+    ) -> Dict[str, Any]:
         """Compute the finish/survivor state for the just-sampled step (pre-update_requests).
 
         This is the first half of ``_dynamic_step_context_bookkeeping``: the GPU->CPU sample
@@ -1698,6 +1719,13 @@ class TextGenerationController:
         must be known *before* ``update_requests`` mutates the layout. Split out so the
         launch-before-commit overlap can decide whether the next forward is launchable (it is
         only when this step is finish-free) and launch it *before* the commit below.
+
+        Args:
+            sampled_tokens_cpu (Optional[Tensor]): the already-on-CPU sampled tokens. The serial
+                path leaves this ``None`` and does the legacy blocking ``.cpu()`` here. The overlap
+                path (C4) drains the sample through the :class:`AsyncSampleRing` and passes the
+                consumed (cloned) CPU tensor in, so the D2H flows through the ring + copy stream.
+            sampled_mtp_tokens_cpu (Optional[Tensor]): companion MTP samples (serial path only).
 
         Returns a dict carrying the prepared state for :meth:`_dynamic_step_apply_commit`.
         """
@@ -1710,11 +1738,13 @@ class TextGenerationController:
         # clean steady-state decode->decode transitions only.
         was_decode_only = context.is_decode_only()
 
-        # Batch GPU-to-CPU transfer of all sampled tokens.
+        # Batch GPU-to-CPU transfer of all sampled tokens (serial path). The overlap path
+        # supplies the CPU sample already drained through the AsyncSampleRing.
         range_push("transfer_samples_to_cpu")
-        sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
-            active_request_count
-        )
+        if sampled_tokens_cpu is None:
+            sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
+                active_request_count
+            )
         range_pop()
 
         range_push("active_request_mask")
@@ -1871,7 +1901,7 @@ class TextGenerationController:
             return False
         if self.num_speculative_tokens > 0 or context.is_hybrid_model:
             return False
-        if self._async_overlap_inflight is not None:
+        if self._inflight is not None:
             return True
         return context.is_decode_only() and context.using_cuda_graph_this_step()
 
@@ -1932,8 +1962,12 @@ class TextGenerationController:
         return plan
 
     def _async_commit_launch_next_decode_forward(
-        self, plan: Optional["PrestagedDecodePlan"], prepared: Dict[str, Any]
-    ) -> Optional[Dict]:
+        self,
+        plan: Optional["PrestagedDecodePlan"],
+        prepared: Dict[str, Any],
+        *,
+        sample_ticket: Any = None,
+    ) -> Optional["InflightForward"]:
         """Fire the speculative launch iff this step is finish-free (post-sample commit phase).
 
         Runs AFTER the sample D2H, so the finish-free / pause-free / decode-only state is known.
@@ -1947,14 +1981,22 @@ class TextGenerationController:
         finish (or no eligible prestage) suppresses the launch: the published metadata is then stale
         but never consumed -- the next step is a synchronous PRIME that rebuilds it from scratch.
 
-        Returns the in-flight record (consume-by-request-id snapshot + graph bucket) to stash, or
-        None when this step is not launchable (the engine then commits and primes again next step).
+        The fired GPU forward is wrapped in a typed :class:`InflightForward` (manager-backed
+        ``StepTxn``): ``InflightForward.launch`` records the consume-by-request-id snapshot, the
+        graph bucket, and the two CUDA fences via ``prestage_child`` / ``launch_child`` (pure CPU
+        bookkeeping -- no GPU work, no allocation). Returns the handle to stash, or ``None`` when
+        this step is not launchable (the engine then commits and primes again next step).
         """
+        from megatron.core.inference.engines.inflight_forward import InflightForward
+
         context = self.inference_wrapped_model.inference_context
         # No eligible shadow prestage => nothing to launch (sync step).
         if plan is None:
             return None
         # Absorbable-but-reshaping or unsupported conditions => no speculative launch this step.
+        # NOTE (C4): the launch stays gated on the FULL finished_count (max-length + EOS). C6
+        # relaxes only the EOS half (max-length stays host-gated); this commit is a structural
+        # swap with timing/behavior unchanged.
         if prepared["finished_count"] != 0:
             return None
         if not prepared["was_decode_only"]:
@@ -1977,13 +2019,26 @@ class TextGenerationController:
         range_push("forward_pass(launch-before-commit)")
         self._dynamic_step_forward_logits(input_ids, position_ids)
         context.kv_block_allocator.store_routing_per_block(self._router_record_bookkeeping())
+        # Record the forward-completion fence (gates the C6 fence-gated retire of finished
+        # leases). The H2D fence was recorded by the publish's token-excluded transfer.
+        forward_done_event = torch.cuda.Event()
+        forward_done_event.record()
+        h2d_done_event = (
+            context.decode_metadata_buffer.h2d_done_event
+            if context.decode_metadata_buffer is not None
+            else None
+        )
         range_pop()
 
         self._async_launch_before_commit_count += 1
-        return {
-            "snapshot": plan.snapshot_request_ids,
-            "cuda_graph_request_count": cuda_graph_request_count,
-        }
+        return InflightForward.launch(
+            self._step_txn_manager,
+            plan,
+            bucket=cuda_graph_request_count,
+            forward_done_event=forward_done_event,
+            h2d_done_event=h2d_done_event,
+            sample_ticket=sample_ticket,
+        )
 
     async def _async_overlap_step(self) -> Optional[Dict]:
         """Run one decode step on the launch-before-commit overlap path.
@@ -2004,7 +2059,7 @@ class TextGenerationController:
         for the step just committed, so engine accounting (step_count, post_process) is unchanged.
         """
         context = self.inference_wrapped_model.inference_context
-        inflight = self._async_overlap_inflight
+        inflight = self._inflight
 
         with torch.inference_mode():
             if inflight is None:
@@ -2025,9 +2080,20 @@ class TextGenerationController:
                 )
                 range_pop()
             else:
-                # PRIMED: the in-flight forward already ran; consume its logits.
-                current_cuda_graph_request_count = inflight["cuda_graph_request_count"]
-                self._async_overlap_inflight = None
+                # PRIMED: the in-flight forward already ran; adopt it (consume-by-request-id) and
+                # consume its logits. The launch was gated finish-free, so the committed active set
+                # equals the snapshot and the SUBSET adopt guard is trivially satisfied. (C4 skips
+                # the bucket check -- the survivor-bucket recompute arrives with the C6 ungate.)
+                current_cuda_graph_request_count = inflight.cuda_graph_request_count
+                committed_survivor_ids = context.request_ids[
+                    context.paused_request_count : context.total_request_count
+                ]
+                adopted = inflight.resolve(committed_survivor_ids)
+                assert adopted, (
+                    "C4 gated launch must always adopt: a finish-free launch snapshot equals the "
+                    "committed survivor set (the barrier-recovery path arrives with the C6 ungate)"
+                )
+                self._inflight = None
 
         await asyncio.sleep(0)
 
@@ -2056,17 +2122,36 @@ class TextGenerationController:
             # wall-clock-independent record that prestage(K+1) ran in F(K)'s shadow (the load-
             # bearing continuous-loop pipelining ordering). Counted in the prestage method.
 
-            # Prepare commit (finish detection): the GPU->CPU sample transfer reads F(K)'s logits,
-            # so this is where the host blocks on F(K). Must precede both the launch decision and
-            # update_requests so the launched forward only fires on a finish-free step.
-            prepared = self._dynamic_step_prepare_commit()
+            # Drain F(K)'s sampled tokens to the host through the AsyncSampleRing instead of a bare
+            # blocking .cpu(): enqueue the D2H on the ring's copy stream, then (C4) consume it
+            # IMMEDIATELY -- still same-iteration, so timing/behavior is unchanged vs the prior
+            # gated overlap. C6 moves this consume to AFTER the launch enqueue (the gap-closer).
+            range_push("transfer_samples_to_cpu(ring)")
+            active_request_count = context.total_request_count - context.paused_request_count
+            ring = self._ensure_async_sample_ring()
+            ticket = ring.enqueue_readback(
+                self._sampled_tokens_cuda,
+                n=active_request_count,
+                snapshot_request_ids=context.request_ids[
+                    context.paused_request_count : context.total_request_count
+                ],
+            )
+            # Clone so the returned "sample" is independent of the reused pinned slot (matches the
+            # legacy .cpu() semantics; update_requests mutates only the separate new_sample_copy).
+            sampled_tokens_cpu = ring.consume(ticket).clone()
+            range_pop()
+
+            # Prepare commit (finish detection) from the already-on-CPU sample. Must precede both
+            # the launch decision and update_requests so the launched forward only fires on a
+            # finish-free step (still gated this commit).
+            prepared = self._dynamic_step_prepare_commit(sampled_tokens_cpu=sampled_tokens_cpu)
 
             # Fire the speculative launch BEFORE committing this step (the overlap), now that the
             # finish-free state is known. Post-sample path = GPU token-scatter + launch enqueue.
-            self._async_overlap_inflight = self._async_commit_launch_next_decode_forward(
+            self._inflight = self._async_commit_launch_next_decode_forward(
                 prestaged_plan, prepared
             )
-            if self._async_overlap_inflight is not None:
+            if self._inflight is not None:
                 self._async_committed_with_inflight_forward = True
 
             # Commit this step. Runs on the CPU while the launched forward runs on the GPU.
@@ -2081,13 +2166,42 @@ class TextGenerationController:
             ret.update(request_bookkeeping)
             return ret
 
+    def attach_step_transaction_manager(self, manager: Optional["StepTransactionManager"]) -> None:
+        """Attach the engine's async-scheduling transaction manager (or ``None`` to detach).
+
+        Called by the engine on reset. The manager backs the :class:`InflightForward`
+        launch/adopt/retire lifecycle on the overlap path; the async sampled-token ring is rebuilt
+        lazily on first use. The serial path never carries a manager, so it never builds a ring.
+        """
+        self._step_txn_manager = manager
+        # A reset rewinds the context; drop any pending read-back so a stale source ref / event is
+        # not later consumed. The ring is rebuilt lazily (it sizes to the context's max_requests).
+        if self._async_sample_ring is not None:
+            self._async_sample_ring.reset()
+
+    def _ensure_async_sample_ring(self) -> "AsyncSampleRing":
+        """Lazily construct the depth-2 async sampled-token read-back ring (overlap path only)."""
+        if self._async_sample_ring is None:
+            context = self.inference_wrapped_model.inference_context
+            self._async_sample_ring = AsyncSampleRing(
+                max_requests=context.max_requests, device=torch.cuda.current_device()
+            )
+        return self._async_sample_ring
+
     def async_drain_inflight_forward(self) -> None:
         """Drop a stale in-flight speculative forward (suspend / reset / shutdown).
 
         The pipeline normally consumes its in-flight forward on the next step; this clears the
-        record when the engine tears down or rewinds, so no stale snapshot is consumed later.
+        record when the engine tears down or rewinds, so no stale snapshot is consumed later. The
+        forward's transaction leases are read-only (the prestage allocates nothing), so the
+        in-flight handle and the manager's child transaction are simply dropped, and the async
+        read-back ring is drained so no pending D2H references a soon-to-be-freed tensor.
         """
-        self._async_overlap_inflight = None
+        self._inflight = None
+        if self._step_txn_manager is not None:
+            self._step_txn_manager.child_txn = None
+        if self._async_sample_ring is not None:
+            self._async_sample_ring.drain()
 
     async def async_generate_output_tokens_dynamic_batch(
         self, skip_bookkeeping: Optional[bool] = False
@@ -2111,8 +2225,10 @@ class TextGenerationController:
 
         # No tokens and no active requests?
         if context.active_token_count == 0 and active_request_count == 0:
-            # Any in-flight speculative forward is moot with nothing active; drop it.
-            self._async_overlap_inflight = None
+            # Any in-flight speculative forward is moot with nothing active; drop it (and drain
+            # the read-back ring). C7 hardens this empty-batch boundary for the C6 lazy-retire
+            # pipeline (consume the pending ticket + commit_lagged before returning None).
+            self.async_drain_inflight_forward()
             return None
 
         # Launch-before-commit overlap (async scheduling, plain GPT decode under a graph).

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -222,6 +222,11 @@ class TextGenerationController:
         # the ring is lazily built on first overlap use. The serial path leaves both None.
         self._step_txn_manager: Optional["StepTransactionManager"] = None
         self._async_sample_ring: Optional["AsyncSampleRing"] = None
+        # C7 admission deferral: set by the engine when a waiting request is admittable but a
+        # forward is still in flight. While set, the prestage suppresses the launch so the NEXT
+        # step is clean (no forward in flight) and the engine can admit then -- a new prefill never
+        # allocates KV from the pool under an in-flight forward built on the prior layout.
+        self._async_defer_launch_for_admission = False
         # Diagnostic: number of forwards launched before the prior step's update_requests.
         self._async_launch_before_commit_count = 0
         # Diagnostic: set True whenever update_requests runs while a speculative forward that
@@ -1943,6 +1948,13 @@ class TextGenerationController:
         if not context.using_cuda_graph_this_step():
             return None
 
+        # C7: admission deferral. A waiting request is admittable but a forward is still in flight,
+        # so suppress this launch -- the next step then has no forward in flight and the engine
+        # admits there (the new prefill never allocates KV under an in-flight forward built on the
+        # prior layout). A sync prime step this step keeps async == serial.
+        if self._async_defer_launch_for_admission:
+            return None
+
         # C5: pre-exclude host-known max-length finishers from the launch snapshot. Predict which
         # active requests reach max_sequence_length at the pending commit using the C3 host-maxlen
         # survival mask -- exactly prepare_commit's max-length term for this step (no D2H, no GPU
@@ -2243,6 +2255,7 @@ class TextGenerationController:
         lazily on first use. The serial path never carries a manager, so it never builds a ring.
         """
         self._step_txn_manager = manager
+        self._async_defer_launch_for_admission = False
         # A reset rewinds the context; drop any pending read-back so a stale source ref / event is
         # not later consumed. The ring is rebuilt lazily (it sizes to the context's max_requests).
         if self._async_sample_ring is not None:
@@ -2263,10 +2276,15 @@ class TextGenerationController:
         The pipeline normally consumes its in-flight forward on the next step; this clears the
         record when the engine tears down or rewinds, so no stale snapshot is consumed later. The
         forward's transaction leases are read-only (the prestage allocates nothing), so the
-        in-flight handle and the manager's child transaction are simply dropped, and the async
-        read-back ring is drained so no pending D2H references a soon-to-be-freed tensor.
+        in-flight handle and the manager's child transaction are simply dropped. C7: the in-flight
+        forward's completion fence is drained first, so a still-running forward's KV/metadata reads
+        finish before a teardown frees the buffers it reads; the async read-back ring is then
+        drained so no pending D2H references a soon-to-be-freed tensor.
         """
+        if self._inflight is not None and self._inflight.forward_done_event is not None:
+            self._inflight.forward_done_event.synchronize()
         self._inflight = None
+        self._async_defer_launch_for_admission = False
         if self._step_txn_manager is not None:
             self._step_txn_manager.child_txn = None
         if self._async_sample_ring is not None:

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -200,6 +200,17 @@ class TextGenerationController:
         self._tp_size = get_pg_size(self.inference_wrapped_model.tp_group)
         self._sp_enabled = self.model_config.sequence_parallel and self._tp_size > 1
 
+        # Launch-before-commit overlap state (async scheduling). When a decode forward is
+        # launched speculatively before the current step's update_requests, its consume-by-
+        # request-id snapshot + graph bucket are stashed here; the next call samples + commits
+        # it instead of running a fresh forward. None means "no in-flight speculative forward".
+        self._async_overlap_inflight: Optional[Dict[str, Any]] = None
+        # Diagnostic: number of forwards launched before the prior step's update_requests.
+        self._async_launch_before_commit_count = 0
+        # Diagnostic: set True whenever update_requests runs while a speculative forward that
+        # was launched before it is in flight (the load-bearing ordering property).
+        self._async_committed_with_inflight_forward = False
+
         self._init_mtp_sampling_tensors()
 
     def _init_mtp_sampling_tensors(self):
@@ -1623,24 +1634,20 @@ class TextGenerationController:
             sampled_mtp_tokens_cpu = None
         return sampled_tokens_cpu, sampled_mtp_tokens_cpu
 
-    def _dynamic_step_context_bookkeeping(self) -> Dict[str, Tensor]:
-        """Update the dynamic inference context after sampling.
+    def _dynamic_step_prepare_commit(self) -> Dict[str, Any]:
+        """Compute the finish/survivor state for the just-sampled step (pre-update_requests).
 
-        Args:
-            new_sample (Tensor): The newly sampled tokens.
-            request_metadata (Optional[Dict[str, Tensor]]): An override for the tensors
-                that manage request metadata, such as sampling parameters. By default, this
-                metadata is retrieved from the context.
+        This is the first half of ``_dynamic_step_context_bookkeeping``: the GPU->CPU sample
+        transfer, the active/finished masks (termination id + length + stop words), the finished
+        per-request RNG retirement, and the saved finished-routing block ids -- everything that
+        must be known *before* ``update_requests`` mutates the layout. Split out so the
+        launch-before-commit overlap can decide whether the next forward is launchable (it is
+        only when this step is finish-free) and launch it *before* the commit below.
 
-        Return:
-            Dict [str, Tensor]: A dictionary containing:
-                active_request_ids (Tensor): Current active request IDs.
-                newly_paused_request_ids (Tensor): Newly paused request IDs.
-                finished_request_ids (Tensor): Finished request IDs.
+        Returns a dict carrying the prepared state for :meth:`_dynamic_step_apply_commit`.
         """
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
-        active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
         # C4: capture whether the step just run was decode-only BEFORE update_requests
         # (which flips every prefill request to decode, so is_decode_only() would read
@@ -1657,7 +1664,9 @@ class TextGenerationController:
 
         range_push("active_request_mask")
         # Everything below is 100% CPU.
-        active_request_ids = context.request_ids[active_request_slice].long()
+        active_request_ids = context.request_ids[
+            slice(context.paused_request_count, context.total_request_count)
+        ].long()
         active_sequence_lengths = context.get_active_sequence_lengths()
 
         # After the forward pass and KV-cache rewind, get_active_sequence_lengths()
@@ -1712,9 +1721,33 @@ class TextGenerationController:
         new_sample_copy = sampled_tokens_cpu.clone()
         range_pop()
 
+        return {
+            "active_request_ids": active_request_ids,
+            "finished_request_ids": finished_request_ids,
+            "finished_routing_block_ids": finished_routing_block_ids,
+            "sampled_tokens_cpu": sampled_tokens_cpu,
+            "sampled_mtp_tokens_cpu": sampled_mtp_tokens_cpu,
+            "new_sample_copy": new_sample_copy,
+            "active_request_mask": active_request_mask,
+            "finished_count": int(finished_idxs.numel()),
+            "was_decode_only": was_decode_only,
+        }
+
+    def _dynamic_step_apply_commit(self, prepared: Dict[str, Any]) -> Dict[str, Tensor]:
+        """Apply ``update_requests`` for a prepared step and return the engine bookkeeping dict.
+
+        Second half of ``_dynamic_step_context_bookkeeping``: commit the sampled tokens via
+        ``update_requests`` (KV offset advance, finish/compaction, boundary-block adoption), then
+        do the C4 in-place GPU token scatter for the clean steady-state decode transition. Takes
+        the dict produced by :meth:`_dynamic_step_prepare_commit`.
+        """
+        context = self.inference_wrapped_model.inference_context
+
         range_push("update_requests")
         update_result = context.update_requests(
-            active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
+            prepared["active_request_mask"],
+            prepared["new_sample_copy"],
+            prepared["sampled_mtp_tokens_cpu"],
         )
         range_pop()
 
@@ -1731,9 +1764,9 @@ class TextGenerationController:
         if (
             context.decode_metadata_buffer is not None
             and context.num_speculative_tokens == 0
-            and was_decode_only
+            and prepared["was_decode_only"]
             and context.paused_request_count == 0
-            and finished_idxs.numel() == 0
+            and prepared["finished_count"] == 0
             and context.active_token_count > 0
         ):
             context.scatter_decode_tokens_to_gpu(self._sampled_tokens_cuda)
@@ -1742,16 +1775,204 @@ class TextGenerationController:
             context._decode_token_ids_live_on_gpu = scattered
 
         return {
-            "active_request_ids": active_request_ids,
-            "finished_request_ids": finished_request_ids,
+            "active_request_ids": prepared["active_request_ids"],
+            "finished_request_ids": prepared["finished_request_ids"],
             # Already a CPU tensor (independent of _sampled_tokens_cuda via the
             # .cpu() in _transfer_samples_to_cpu; update_requests only mutates
             # the separate new_sample_copy). Returning the CPU copy avoids a
             # D2H sync when the engine later calls sample.tolist().
-            "sample": sampled_tokens_cpu,
-            "finished_routing_block_ids": finished_routing_block_ids,
+            "sample": prepared["sampled_tokens_cpu"],
+            "finished_routing_block_ids": prepared["finished_routing_block_ids"],
             **(update_result or {}),
         }
+
+    def _dynamic_step_context_bookkeeping(self) -> Dict[str, Tensor]:
+        """Update the dynamic inference context after sampling.
+
+        Return:
+            Dict [str, Tensor]: A dictionary containing:
+                active_request_ids (Tensor): Current active request IDs.
+                newly_paused_request_ids (Tensor): Newly paused request IDs.
+                finished_request_ids (Tensor): Finished request IDs.
+
+        This is the serial path: prepare (finish detection) and apply (update_requests) run
+        back-to-back, byte-identical to the original single method. The launch-before-commit
+        overlap calls the two halves separately so it can launch the next forward in between.
+        """
+        return self._dynamic_step_apply_commit(self._dynamic_step_prepare_commit())
+
+    def _async_overlap_possible(self, context) -> bool:
+        """Whether the launch-before-commit overlap path should handle this step.
+
+        The overlap is scoped (this branch) to plain (non-speculative) GPT decode under a CUDA
+        graph with async scheduling on. It engages when either a speculative forward is already
+        in flight (must be consumed) or this step is a graph-backed decode step that could prime
+        the pipeline. Every other case (eager, prefill/mixed, hybrid, MTP) takes the unchanged
+        serial path, so ``async == serial`` holds trivially there and ``async-off == main`` always.
+        """
+        if not context.enable_async_scheduling:
+            return False
+        if context.decode_metadata_buffer is None:
+            return False
+        if self.num_speculative_tokens > 0 or context.is_hybrid_model:
+            return False
+        if self._async_overlap_inflight is not None:
+            return True
+        return context.is_decode_only() and context.using_cuda_graph_this_step()
+
+    def _async_try_launch_next_decode_forward(self, prepared: Dict[str, Any]) -> Optional[Dict]:
+        """Launch the next decode forward BEFORE this step's update_requests (the overlap).
+
+        Only fires for a clean, finish-free, pause-free, boundary-safe plain decode step (so the
+        launched forward consumes the exact layout the deferred commit will produce -- no output
+        realignment is ever needed: KV blocks and mamba slots are request-bonded and unchanged).
+        Builds the speculative plan (predicting the pending commit), advances the per-token input
+        bookkeeping by one unit query, publishes the predicted metadata with a token-excluded H2D,
+        scatters this step's sampled tokens as the next forward's input ids, and replays the graph.
+
+        Returns the in-flight record (consume-by-request-id snapshot + graph bucket) to stash, or
+        None when this step is not launchable (the engine then commits and primes again next step).
+        """
+        context = self.inference_wrapped_model.inference_context
+        # Absorbable-but-reshaping or unsupported conditions => no speculative launch this step.
+        if prepared["finished_count"] != 0:
+            return None
+        if not prepared["was_decode_only"]:
+            return None
+        if context.paused_request_count != 0:
+            return None
+        if not context.using_cuda_graph_this_step():
+            return None
+
+        # Speculative plan for the forward that runs against the layout the pending commit will
+        # produce (design 1.1 step 2). Boundary-window gated inside; ineligible => sync step.
+        plan = context.prestage_next_decode_step_into_cpu_staging(
+            speculate_pending_decode_commit=True
+        )
+        if not plan.eligible:
+            return None
+
+        n = context.active_token_count
+        if n <= 0:
+            return None
+
+        # Advance the per-token input bookkeeping by one unit query (the pending commit's append),
+        # predicting the next forward's positions. update_requests rewrites these to the identical
+        # values when it commits below, so this early CPU advance is safe (boundary-gated: no
+        # block-id change and no local-position wrap). token_to_input_ids is supplied by the GPU
+        # scatter; token_to_request_idx / token_to_block_idx are invariant for finish-free decode.
+        context.token_to_pos_ids[:n] += 1
+        context.token_to_position_in_request[:n] += 1
+        context.token_to_local_position_within_kv_block[:n] += 1
+
+        # Publish the predicted metadata into the live buffer with one token-excluded H2D (carries
+        # the advanced per-token fields + the speculative MHA region to the single GPU buffer).
+        context.publish_prepared_decode_plan(plan)
+
+        # Scatter this step's sampled ids as the next forward's input ids (GPU, no D2H), then mark
+        # the token-id region GPU-authoritative so the next H2D keeps excluding it.
+        context.scatter_decode_tokens_to_gpu(self._sampled_tokens_cuda)
+        context._decode_token_ids_live_on_gpu = True
+
+        # Launch (replay) the next forward against the published metadata + scattered input ids.
+        cuda_graph_request_count = (
+            context.padded_active_request_count if context.using_cuda_graph_this_step() else None
+        )
+        input_ids, position_ids = context.current_input_and_position_ids()
+        range_push("forward_pass(launch-before-commit)")
+        self._dynamic_step_forward_logits(input_ids, position_ids)
+        context.kv_block_allocator.store_routing_per_block(self._router_record_bookkeeping())
+        range_pop()
+
+        self._async_launch_before_commit_count += 1
+        return {
+            "snapshot": plan.snapshot_request_ids,
+            "cuda_graph_request_count": cuda_graph_request_count,
+        }
+
+    async def _async_overlap_step(self) -> Optional[Dict]:
+        """Run one decode step on the launch-before-commit overlap path.
+
+        Two modes:
+        * PRIMED (a speculative forward is in flight from the previous call): skip the forward --
+          its logits are already in ``_all_logits_cuda`` -- and sample it.
+        * PRIME (no in-flight forward): run a normal forward for the current committed state (this
+          matches the serial head for plain GPT decode under a graph).
+
+        Then sample + log-probs, run the finish-detection prepare phase, launch the next forward
+        BEFORE update_requests (when launchable), and finally commit this step (update_requests +
+        scatter) -- which overlaps the launched forward on the GPU. The returned bookkeeping is
+        for the step just committed, so engine accounting (step_count, post_process) is unchanged.
+        """
+        context = self.inference_wrapped_model.inference_context
+        inflight = self._async_overlap_inflight
+
+        with torch.inference_mode():
+            if inflight is None:
+                # PRIME: forward for the current committed state (serial head, plain GPT decode).
+                input_ids, position_ids = self._dynamic_step_context_init()
+                current_cuda_graph_request_count = (
+                    context.padded_active_request_count
+                    if context.using_cuda_graph_this_step()
+                    else None
+                )
+                config = self.inference_wrapped_model.model.config
+                if config.moe_enable_routing_replay:
+                    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+                range_push("forward_pass")
+                self._dynamic_step_forward_logits(input_ids, position_ids)
+                context.kv_block_allocator.store_routing_per_block(
+                    self._router_record_bookkeeping()
+                )
+                range_pop()
+            else:
+                # PRIMED: the in-flight forward already ran; consume its logits.
+                current_cuda_graph_request_count = inflight["cuda_graph_request_count"]
+                self._async_overlap_inflight = None
+
+        await asyncio.sleep(0)
+
+        with torch.inference_mode():
+            range_push("sampling")
+            return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
+            self._dynamic_step_sample_logits()
+
+            log_probs = None
+            top_n_logprobs = None
+            if return_log_probs or return_top_n_logprobs:
+                log_probs, log_probs_tensor = self._dynamic_step_calculate_log_probs()
+                if return_top_n_logprobs:
+                    top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs(log_probs_tensor)
+            range_pop()
+
+            # Prepare commit (finish detection) -- must precede both the launch decision and
+            # update_requests so the launched forward only fires on a finish-free step.
+            prepared = self._dynamic_step_prepare_commit()
+
+            # Launch the next forward BEFORE committing this step (the overlap).
+            self._async_overlap_inflight = self._async_try_launch_next_decode_forward(prepared)
+            if self._async_overlap_inflight is not None:
+                self._async_committed_with_inflight_forward = True
+
+            # Commit this step. Runs on the CPU while the launched forward runs on the GPU.
+            request_bookkeeping = self._dynamic_step_apply_commit(prepared)
+
+            ret = {
+                "accepted_tokens": None,
+                "log_probs": log_probs,
+                "top_n_logprobs": top_n_logprobs,
+                "cuda_graph_request_count": current_cuda_graph_request_count,
+            }
+            ret.update(request_bookkeeping)
+            return ret
+
+    def async_drain_inflight_forward(self) -> None:
+        """Drop a stale in-flight speculative forward (suspend / reset / shutdown).
+
+        The pipeline normally consumes its in-flight forward on the next step; this clears the
+        record when the engine tears down or rewinds, so no stale snapshot is consumed later.
+        """
+        self._async_overlap_inflight = None
 
     async def async_generate_output_tokens_dynamic_batch(
         self, skip_bookkeeping: Optional[bool] = False
@@ -1775,7 +1996,13 @@ class TextGenerationController:
 
         # No tokens and no active requests?
         if context.active_token_count == 0 and active_request_count == 0:
+            # Any in-flight speculative forward is moot with nothing active; drop it.
+            self._async_overlap_inflight = None
             return None
+
+        # Launch-before-commit overlap (async scheduling, plain GPT decode under a graph).
+        if not skip_bookkeeping and self._async_overlap_possible(context):
+            return await self._async_overlap_step()
 
         with torch.inference_mode():
             input_ids, position_ids = self._dynamic_step_context_init()

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -210,6 +210,12 @@ class TextGenerationController:
         # Diagnostic: set True whenever update_requests runs while a speculative forward that
         # was launched before it is in flight (the load-bearing ordering property).
         self._async_committed_with_inflight_forward = False
+        # Diagnostic: number of steady steps whose next-forward metadata prestage + publish was
+        # issued in the current forward's GPU shadow (i.e. BEFORE that forward's logits were
+        # read to the host to sample). This is the structural proof of the continuous-loop
+        # pipelining: prestage(K+1) runs concurrently with F(K), so only the GPU token-scatter +
+        # the launch enqueue sit between sampling S(K) and F(K+1). Wall-clock-independent.
+        self._async_prestage_in_shadow_count = 0
 
         self._init_mtp_sampling_tensors()
 
@@ -1820,27 +1826,31 @@ class TextGenerationController:
             return True
         return context.is_decode_only() and context.using_cuda_graph_this_step()
 
-    def _async_try_launch_next_decode_forward(self, prepared: Dict[str, Any]) -> Optional[Dict]:
-        """Launch the next decode forward BEFORE this step's update_requests (the overlap).
+    def _async_prestage_next_decode_forward(self) -> Optional["PrestagedDecodePlan"]:
+        """Build + publish the next decode forward's metadata in the current forward's GPU shadow.
 
-        Only fires for a clean, finish-free, pause-free, boundary-safe plain decode step (so the
-        launched forward consumes the exact layout the deferred commit will produce -- no output
-        realignment is ever needed: KV blocks and mamba slots are request-bonded and unchanged).
-        Builds the speculative plan (predicting the pending commit), advances the per-token input
-        bookkeeping by one unit query, publishes the predicted metadata with a token-excluded H2D,
-        scatters this step's sampled tokens as the next forward's input ids, and replays the graph.
+        This is the *shadow* phase of the launch-before-commit overlap (design 1.1 / the
+        continuous-loop pipelining): it runs BEFORE the current forward F(K)'s logits are read to
+        the host. Everything here is derived purely from the *committed* layout (post the previous
+        step's commit) -- never from F(K)'s output -- so it overlaps F(K) on the GPU:
 
-        Returns the in-flight record (consume-by-request-id snapshot + graph bucket) to stash, or
-        None when this step is not launchable (the engine then commits and primes again next step).
+        * build the speculative plan for the forward that runs against the layout the pending
+          commit will produce (``speculate_pending_decode_commit=True``); boundary-window gated, so
+          an ineligible plan returns None and the engine falls back to a synchronous step;
+        * advance the per-token input bookkeeping by one unit query (the pending commit's append).
+          update_requests rewrites these to identical values on a finish-free commit; on a finish
+          the launch is suppressed and update_requests rebuilds the compacted layout, so the
+          speculative advance is always overwritten before it is read;
+        * publish the predicted metadata with one token-excluded H2D. The H2D is enqueued in F(K)'s
+          shadow but stream-ordered AFTER the sample kernel, so it overwrites the single GPU
+          metadata buffer only once F(K) (and the sample kernel reading its live params) is done.
+
+        All of the above is pure CPU work on pinned tensors plus one async H2D -- no host<->device
+        sync -- so it does not drain F(K). Returns the eligible plan to hand to
+        :meth:`_async_commit_launch_next_decode_forward`, or None when this step is not launch-
+        eligible from committed state.
         """
         context = self.inference_wrapped_model.inference_context
-        # Absorbable-but-reshaping or unsupported conditions => no speculative launch this step.
-        if prepared["finished_count"] != 0:
-            return None
-        if not prepared["was_decode_only"]:
-            return None
-        if context.paused_request_count != 0:
-            return None
         if not context.using_cuda_graph_this_step():
             return None
 
@@ -1858,9 +1868,9 @@ class TextGenerationController:
 
         # Advance the per-token input bookkeeping by one unit query (the pending commit's append),
         # predicting the next forward's positions. update_requests rewrites these to the identical
-        # values when it commits below, so this early CPU advance is safe (boundary-gated: no
-        # block-id change and no local-position wrap). token_to_input_ids is supplied by the GPU
-        # scatter; token_to_request_idx / token_to_block_idx are invariant for finish-free decode.
+        # values when it commits, so this early CPU advance is safe (boundary-gated: no block-id
+        # change and no local-position wrap). token_to_input_ids is supplied by the GPU scatter;
+        # token_to_request_idx / token_to_block_idx are invariant for finish-free decode.
         context.token_to_pos_ids[:n] += 1
         context.token_to_position_in_request[:n] += 1
         context.token_to_local_position_within_kv_block[:n] += 1
@@ -1868,6 +1878,42 @@ class TextGenerationController:
         # Publish the predicted metadata into the live buffer with one token-excluded H2D (carries
         # the advanced per-token fields + the speculative MHA region to the single GPU buffer).
         context.publish_prepared_decode_plan(plan)
+
+        self._async_prestage_in_shadow_count += 1
+        return plan
+
+    def _async_commit_launch_next_decode_forward(
+        self, plan: Optional["PrestagedDecodePlan"], prepared: Dict[str, Any]
+    ) -> Optional[Dict]:
+        """Fire the speculative launch iff this step is finish-free (post-sample commit phase).
+
+        Runs AFTER the sample D2H, so the finish-free / pause-free / decode-only state is known.
+        The metadata prestage + publish already ran in F(K)'s shadow
+        (:meth:`_async_prestage_next_decode_forward`); all that remains on the post-sample critical
+        path is the in-place GPU token-scatter of the sampled ids + the launch (graph replay).
+
+        Only fires for a clean, finish-free, pause-free, boundary-safe plain decode step (so the
+        launched forward consumes the exact layout the deferred commit will produce -- no output
+        realignment is ever needed: KV blocks and mamba slots are request-bonded and unchanged). A
+        finish (or no eligible prestage) suppresses the launch: the published metadata is then stale
+        but never consumed -- the next step is a synchronous PRIME that rebuilds it from scratch.
+
+        Returns the in-flight record (consume-by-request-id snapshot + graph bucket) to stash, or
+        None when this step is not launchable (the engine then commits and primes again next step).
+        """
+        context = self.inference_wrapped_model.inference_context
+        # No eligible shadow prestage => nothing to launch (sync step).
+        if plan is None:
+            return None
+        # Absorbable-but-reshaping or unsupported conditions => no speculative launch this step.
+        if prepared["finished_count"] != 0:
+            return None
+        if not prepared["was_decode_only"]:
+            return None
+        if context.paused_request_count != 0:
+            return None
+        if not context.using_cuda_graph_this_step():
+            return None
 
         # Scatter this step's sampled ids as the next forward's input ids (GPU, no D2H), then mark
         # the token-id region GPU-authoritative so the next H2D keeps excluding it.
@@ -1899,9 +1945,13 @@ class TextGenerationController:
         * PRIME (no in-flight forward): run a normal forward for the current committed state (this
           matches the serial head for plain GPT decode under a graph).
 
-        Then sample + log-probs, run the finish-detection prepare phase, launch the next forward
-        BEFORE update_requests (when launchable), and finally commit this step (update_requests +
-        scatter) -- which overlaps the launched forward on the GPU. The returned bookkeeping is
+        Then enqueue the sample kernel, prestage + publish the NEXT forward's metadata in F(K)'s
+        shadow (design 1.1: this needs only committed state, so it runs concurrently with F(K)
+        BEFORE its logits are read to the host), read the logits + run finish detection, fire the
+        speculative launch when finish-free, and finally commit this step (update_requests +
+        scatter) -- which overlaps the launched forward on the GPU. So the post-sample inter-
+        forward critical path is just the GPU token-scatter + the launch enqueue; the metadata
+        prestage and the previous step's commit run in F(K)'s shadow. The returned bookkeeping is
         for the step just committed, so engine accounting (step_count, post_process) is unchanged.
         """
         context = self.inference_wrapped_model.inference_context
@@ -1945,12 +1995,28 @@ class TextGenerationController:
                     top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs(log_probs_tensor)
             range_pop()
 
-            # Prepare commit (finish detection) -- must precede both the launch decision and
+            # SHADOW: build + publish the next forward's metadata while F(K) is still in flight,
+            # BEFORE reading F(K)'s logits to the host. Derived purely from committed state, so it
+            # overlaps F(K) on the GPU (and the publish H2D is stream-ordered after the sample
+            # kernel enqueued just above). The launch decision (finish-free) is deferred below.
+            range_push("prestage(shadow)")
+            prestaged_plan = self._async_prestage_next_decode_forward()
+            range_pop()
+
+            # The shadow prestage above was issued for THIS step before the logits read below: a
+            # wall-clock-independent record that prestage(K+1) ran in F(K)'s shadow (the load-
+            # bearing continuous-loop pipelining ordering). Counted in the prestage method.
+
+            # Prepare commit (finish detection): the GPU->CPU sample transfer reads F(K)'s logits,
+            # so this is where the host blocks on F(K). Must precede both the launch decision and
             # update_requests so the launched forward only fires on a finish-free step.
             prepared = self._dynamic_step_prepare_commit()
 
-            # Launch the next forward BEFORE committing this step (the overlap).
-            self._async_overlap_inflight = self._async_try_launch_next_decode_forward(prepared)
+            # Fire the speculative launch BEFORE committing this step (the overlap), now that the
+            # finish-free state is known. Post-sample path = GPU token-scatter + launch enqueue.
+            self._async_overlap_inflight = self._async_commit_launch_next_decode_forward(
+                prestaged_plan, prepared
+            )
             if self._async_overlap_inflight is not None:
                 self._async_committed_with_inflight_forward = True
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -186,7 +186,13 @@ class TextGenerationController:
                 enable_cuda_graph=self._enable_cuda_graph,
             )
         else:
-            self._sampling: Sampling = TorchSampling(self.sampling_rng, self.vocab_size)
+            # Per-request keyed RNG (torch backend): seeded by (inference_sampling_seed +
+            # request_id) so each request's draws are invariant to batch composition/order.
+            self._sampling: Sampling = TorchSampling(
+                self.sampling_rng,
+                self.vocab_size,
+                seed=self.model_config.inference_sampling_seed,
+            )
 
         # Cache values that are constant across inference steps.
         self._unwrapped_model = unwrap_model(self.inference_wrapped_model.model)
@@ -1660,6 +1666,12 @@ class TextGenerationController:
             torch.nonzero(active_request_mask == 0, as_tuple=True)[0] + context.paused_request_count
         )
         finished_request_ids = context.request_ids[finished_idxs]
+
+        # Retire finished requests' per-request sampling generators (memory hygiene;
+        # no-op for backends without per-request RNG state). Independent per-request
+        # streams mean this never perturbs a survivor's draws.
+        if finished_idxs.numel() > 0:
+            self._sampling.retire_requests(finished_request_ids.tolist())
 
         # Save block IDs for finished requests before update_requests releases them.
         # Needed for per-block routing reconstruction in the engine.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -615,11 +615,28 @@ class TextGenerationController:
         # If we are running a dummy forward step we want to use the token count agreed upon
         # by all EP ranks rather than the minimum number of tokens.
         if construct_graph_dimensions is not None and not is_dummy_forward:
-            return context.current_input_and_position_ids(
+            input_ids, position_ids = context.current_input_and_position_ids(
                 num_warmup_tokens=construct_graph_dimensions.token_count
             )
         else:
-            return context.current_input_and_position_ids()
+            input_ids, position_ids = context.current_input_and_position_ids()
+
+        # C4: assert the single GPU metadata buffer (and the cached input/position views
+        # the captured decode graph reads at absolute addresses) never moves across decode
+        # steps. A reallocation would make graph replay read freed/foreign memory; this
+        # turns that into a loud failure. Skipped during graph capture / dummy forwards.
+        if (
+            context.decode_metadata_buffer is not None
+            and context.is_decode_only()
+            and not context.is_creating_cuda_graphs
+            and construct_graph_dimensions is None
+            and not is_dummy_forward
+        ):
+            context.decode_metadata_buffer.assert_pointer_invariant(
+                input_ids.data_ptr(), position_ids.data_ptr()
+            )
+
+        return input_ids, position_ids
 
     def _dynamic_step_forward_logits(self, input_ids: Tensor, position_ids: Tensor):
         """Forward step the model to get logits for dynamic batching.
@@ -1625,6 +1642,12 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
+        # C4: capture whether the step just run was decode-only BEFORE update_requests
+        # (which flips every prefill request to decode, so is_decode_only() would read
+        # True afterwards regardless). Used to gate the in-place GPU token scatter to
+        # clean steady-state decode->decode transitions only.
+        was_decode_only = context.is_decode_only()
+
         # Batch GPU-to-CPU transfer of all sampled tokens.
         range_push("transfer_samples_to_cpu")
         sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
@@ -1694,6 +1717,29 @@ class TextGenerationController:
             active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
         )
         range_pop()
+
+        # C4: in-place GPU token scatter for clean steady-state plain decode. When the
+        # step just run was decode-only and nothing reshaped the active set (no finishes,
+        # no paused requests, plain decode), the next step's input ids are exactly this
+        # step's sampled tokens in identity order -- the same values update_requests just
+        # wrote into the CPU token_to_input_ids[:active_token_count]. Scatter them onto the
+        # single GPU buffer directly (no extra D2H) and mark the region GPU-authoritative
+        # so the next coalesced H2D excludes it. Any other transition (prefill, finish,
+        # pause, MTP) leaves the flag False and uses the legacy CPU write + full H2D path,
+        # so async stays byte-identical to serial. Off entirely when async is disabled.
+        scattered = False
+        if (
+            context.decode_metadata_buffer is not None
+            and context.num_speculative_tokens == 0
+            and was_decode_only
+            and context.paused_request_count == 0
+            and finished_idxs.numel() == 0
+            and context.active_token_count > 0
+        ):
+            context.scatter_decode_tokens_to_gpu(self._sampled_tokens_cuda)
+            scattered = True
+        if context.enable_async_scheduling:
+            context._decode_token_ids_live_on_gpu = scattered
 
         return {
             "active_request_ids": active_request_ids,
@@ -1837,6 +1883,10 @@ class TextGenerationController:
                 request_bookkeeping = {
                     "sample": self._sampled_tokens_cuda[:active_request_count].cpu()
                 }
+                # No update_requests / token scatter ran this step; the next H2D must
+                # include the token-id region again (C4).
+                if context.enable_async_scheduling:
+                    context._decode_token_ids_live_on_gpu = False
             else:
                 # request_bookkeeping supplies "sample" as the already-CPU
                 # tensor produced by _transfer_samples_to_cpu.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1640,6 +1640,55 @@ class TextGenerationController:
             sampled_mtp_tokens_cpu = None
         return sampled_tokens_cpu, sampled_mtp_tokens_cpu
 
+    def _host_maxlen_finish_mask(
+        self, active_sequence_lengths: Tensor, max_sequence_lengths: Tensor
+    ) -> Tensor:
+        """Host-deterministic max-length survival mask -- no D2H, never reads the GPU sample.
+
+        Returns a byte mask: 1 where the request's post-step sequence length is still strictly
+        below its ``max_sequence_length`` (it continues), 0 where it reaches max this step (a
+        host-known finish). ``request_output_lengths`` is fixed at ``add_request`` and KV
+        offsets advance +1 deterministically, so this term is exactly known on the host without
+        the sampled token.
+
+        Both operands are CPU tensors. This is the half C5 consults to pre-exclude host-known
+        max-length finishers from the launch snapshot (a max-length finisher is freed at its own
+        commit -- it never rides an extra forward), and it stays inline / exactly gated rather
+        than moving to the lagged RetirementLane.
+        """
+        return torch.less(active_sequence_lengths, max_sequence_lengths).byte()
+
+    def _data_dependent_finish_mask(
+        self, sampled_tokens_cpu: Tensor, active_request_ids: Tensor, active_request_count: int
+    ) -> Tensor:
+        """Data-dependent (EOS + stop-word) survival mask -- the lagged-capable half.
+
+        Returns a byte mask: 1 where the sampled token is not the request's termination id and
+        the request did not hit a stop word this step, 0 where it finished for one of those
+        data-dependent reasons. This is the only half that depends on the sampled token, so it
+        is the part the RetirementLane consumes after the launch enqueue (C6); max-length stays
+        host-inline.
+
+        Note: the stop-word callback (``_get_stop_word_finished_ids_callback``) advances the
+        two-phase stop-word state machine (it pops ids into ``stop_word_being_finished_ids``), so
+        this must be called exactly once per committed step with that step's active request ids.
+        """
+        context = self.inference_wrapped_model.inference_context
+        mask = (
+            sampled_tokens_cpu
+            != context.active_request_metadata["termination_id"][:active_request_count]
+        ).byte()
+        # Mark requests as finished if they hit stop words
+        # (detected in previous step's post_process_requests).
+        if self._get_stop_word_finished_ids_callback is not None:
+            request_ids_list = active_request_ids.tolist()
+            stop_word_finished_ids = self._get_stop_word_finished_ids_callback(request_ids_list)
+            if stop_word_finished_ids:
+                for idx, request_id in enumerate(request_ids_list):
+                    if request_id in stop_word_finished_ids:
+                        mask[idx] = 0
+        return mask
+
     def _dynamic_step_prepare_commit(self) -> Dict[str, Any]:
         """Compute the finish/survivor state for the just-sampled step (pre-update_requests).
 
@@ -1682,23 +1731,23 @@ class TextGenerationController:
         active_sequence_lengths += 1
         max_sequence_lengths = context.get_max_sequence_lengths()
 
-        # Request finished if termination_id or length >= max_sequence_length.
-        # Both operands are CPU: sampled_tokens_cpu was D2H'd above, and
-        # active_request_metadata is CPU-pinned.
-        active_request_mask = (
-            sampled_tokens_cpu
-            != context.active_request_metadata["termination_id"][:active_request_count]
-        ).byte() & torch.less(active_sequence_lengths, max_sequence_lengths).byte()
-
-        # Mark requests as finished if they hit stop words
-        # (detected in previous step's post_process_requests)
-        if self._get_stop_word_finished_ids_callback is not None:
-            request_ids_list = active_request_ids.tolist()
-            stop_word_finished_ids = self._get_stop_word_finished_ids_callback(request_ids_list)
-            if stop_word_finished_ids:
-                for idx, request_id in enumerate(request_ids_list):
-                    if request_id in stop_word_finished_ids:
-                        active_request_mask[idx] = 0
+        # Request finished if termination_id, stop word, or length >= max_sequence_length.
+        # The survival mask is built from two named halves (C3) so the launch-before-commit
+        # pipeline can treat them asymmetrically: the host-deterministic max-length half stays
+        # inline (no D2H), while the data-dependent EOS/stop-word half is the part the
+        # RetirementLane lags off the launch critical path. Here both halves are AND'd back-to-
+        # back, so the combined mask is byte-identical to the original single build:
+        #   original = (eos & maxlen), then stop-worded idxs zeroed
+        #   combined = maxlen & (eos, then stop-worded idxs zeroed)
+        # which are equal because AND is commutative and zeroing one operand zeroes the product
+        # (proved bit-for-bit in test_async_sched_txn's host&eos==original case).
+        host_maxlen_mask = self._host_maxlen_finish_mask(
+            active_sequence_lengths, max_sequence_lengths
+        )
+        data_dependent_mask = self._data_dependent_finish_mask(
+            sampled_tokens_cpu, active_request_ids, active_request_count
+        )
+        active_request_mask = data_dependent_mask & host_maxlen_mask
 
         finished_idxs = (
             torch.nonzero(active_request_mask == 0, as_tuple=True)[0] + context.paused_request_count

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1949,11 +1949,19 @@ class TextGenerationController:
         # sample): get_active_sequence_lengths() reads request_kv_length_offsets+query_lengths,
         # which the (not-yet-run) commit will read identically, and +1 is the new sampled token.
         # A predicted max-length finisher is dropped from the snapshot so it never rides the
-        # speculative forward (it is freed at its own commit). On a step that actually launches the
-        # launch is gated max-length-clean, so this mask survives every row -- vacuous there.
+        # speculative forward (it is freed at its own commit).
         host_maxlen_survival = self._host_maxlen_finish_mask(
             context.get_active_sequence_lengths() + 1, context.get_max_sequence_lengths()
         )
+
+        # C6: max-length stays EXACTLY gated -- host-deterministic, so the gate moves ahead of the
+        # (now-ungated) launch with zero D2H. If any active request reaches max_sequence_length at
+        # the pending commit, suppress the launch (return None => the engine takes a synchronous
+        # prime step), so a max-length finisher never rides an extra forward and never runs one
+        # token past its block table. Only the data-dependent EOS/stop-word half is ungated (it is
+        # detected after the launch and handled by discarding the doomed forward).
+        if not bool(host_maxlen_survival.all()):
+            return None
 
         # Speculative plan for the forward that runs against the layout the pending commit will
         # produce (design 1.1 step 2). Boundary-window gated inside; ineligible => sync step.
@@ -1987,49 +1995,41 @@ class TextGenerationController:
     def _async_commit_launch_next_decode_forward(
         self,
         plan: Optional["PrestagedDecodePlan"],
-        prepared: Dict[str, Any],
         *,
         sample_ticket: Any = None,
     ) -> Optional["InflightForward"]:
-        """Fire the speculative launch iff this step is finish-free (post-sample commit phase).
+        """Fire the speculative launch from HOST-KNOWN state, BEFORE the sample D2H (C6 ungate).
 
-        Runs AFTER the sample D2H, so the finish-free / pause-free / decode-only state is known.
-        The metadata prestage + publish already ran in F(K)'s shadow
-        (:meth:`_async_prestage_next_decode_forward`); all that remains on the post-sample critical
-        path is the in-place GPU token-scatter of the sampled ids + the launch (graph replay).
+        This is the single load-bearing relaxation. The launch now runs *before* the sampled
+        tokens of the current forward are read to the host, so the blocking D2H + finish-check no
+        longer gate it (that ordering defect was the ~360us inter-forward bubble). The decision is
+        therefore HOST-KNOWN only:
 
-        Only fires for a clean, finish-free, pause-free, boundary-safe plain decode step (so the
-        launched forward consumes the exact layout the deferred commit will produce -- no output
-        realignment is ever needed: KV blocks and mamba slots are request-bonded and unchanged). A
-        finish (or no eligible prestage) suppresses the launch: the published metadata is then stale
-        but never consumed -- the next step is a synchronous PRIME that rebuilds it from scratch.
+        * the eligible shadow prestage (``plan``) -- itself boundary-window gated AND max-length
+          gated (it returns None if any active request reaches max_sequence_length at the pending
+          commit, so a max-length finisher forces a sync prime step and never rides a forward); and
+        * the static decode-only / no-paused / under-a-graph checks.
+
+        The data-dependent EOS/stop-word finish is NOT consulted here (it needs the sample). It is
+        detected after this launch enqueue (off the inter-forward path), and if the step turns out
+        to finish for an EOS/stop-word reason the launched forward is doomed: the caller drains +
+        discards it and the next step re-primes synchronously (token-identical -- the finishing
+        step is simply re-run, like the gated path's finish step, never consumed).
 
         The fired GPU forward is wrapped in a typed :class:`InflightForward` (manager-backed
         ``StepTxn``): ``InflightForward.launch`` records the consume-by-request-id snapshot, the
-        graph bucket, and the two CUDA fences via ``prestage_child`` / ``launch_child`` (pure CPU
-        bookkeeping -- no GPU work, no allocation). Returns the handle to stash, or ``None`` when
-        this step is not launchable (the engine then commits and primes again next step).
+        graph bucket, and the two CUDA fences (the ``forward_done_event`` is the drain fence used
+        on discard so a still-in-flight forward never has its KV pulled out from under it). Returns
+        the handle to stash, or ``None`` when this step is not launchable.
         """
         from megatron.core.inference.engines.inflight_forward import InflightForward
 
         context = self.inference_wrapped_model.inference_context
-        # No eligible shadow prestage => nothing to launch (sync step).
+        # No eligible shadow prestage (boundary window / max-length gated) => nothing to launch.
         if plan is None:
             return None
-        # Absorbable-but-reshaping or unsupported conditions => no speculative launch this step.
-        # The finish gate is split into its two halves (C5):
-        #   * host-maxlen: host-deterministic (no D2H). A max-length finisher is freed at its own
-        #     commit and pre-excluded from the launch snapshot, so it never rides an extra forward.
-        #     This half stays gated through C6 (a max-length finish forces a sync prime step).
-        #   * data-dependent (EOS/stop-word): needs the sampled token. C6 DELETES this requirement
-        #     -- the single load-bearing ungate -- moving EOS finish-detection to the lagged
-        #     RetirementLane. This commit keeps BOTH required, so the gate == finished_count==0 and
-        #     the behavior is byte-identical to C4.
-        if prepared["host_maxlen_finished_count"] != 0:
-            return None
-        if prepared["data_dependent_finished_count"] != 0:
-            return None
-        if not prepared["was_decode_only"]:
+        # Static host-known gates (no D2H, no GPU sample): decode-only, no paused, under a graph.
+        if not context.is_decode_only():
             return None
         if context.paused_request_count != 0:
             return None
@@ -2049,8 +2049,9 @@ class TextGenerationController:
         range_push("forward_pass(launch-before-commit)")
         self._dynamic_step_forward_logits(input_ids, position_ids)
         context.kv_block_allocator.store_routing_per_block(self._router_record_bookkeeping())
-        # Record the forward-completion fence (gates the C6 fence-gated retire of finished
-        # leases). The H2D fence was recorded by the publish's token-excluded transfer.
+        # Record the forward-completion fence: the drain fence on discard, so the doomed forward's
+        # KV reads complete before its finisher rows' blocks are freed. The H2D fence was recorded
+        # by the publish's token-excluded transfer.
         forward_done_event = torch.cuda.Event()
         forward_done_event.record()
         h2d_done_event = (
@@ -2069,6 +2070,31 @@ class TextGenerationController:
             h2d_done_event=h2d_done_event,
             sample_ticket=sample_ticket,
         )
+
+    def _async_discard_inflight_forward(self, inflight: "InflightForward", *, reason: str) -> None:
+        """Drain + drop a launched forward whose outputs will NOT be consumed (C6 barrier/doomed).
+
+        Used when (a) the just-launched forward is doomed -- the step it predicted finish-free for
+        actually had a data-dependent (EOS/stop-word) finish, so its layout will reshape -- or
+        (b) the in-flight forward fails the consume-by-request-id adopt guard (a layout change
+        slipped in). In both cases the recovery is to consume-not-corrupt: drain the forward's
+        completion fence (so its KV reads finish before any finisher's blocks are freed at the
+        eager commit), drop the manager's child transaction (its leases are read-only -- the
+        prestage allocates nothing), and reset the GPU-authoritative token flag so the next PRIME's
+        H2D rebuilds the token region from scratch. The next step then re-primes synchronously and
+        is token-identical to serial. Diagnostics record the reason."""
+        context = self.inference_wrapped_model.inference_context
+        # Drain so the doomed forward's KV/metadata reads complete before the eager commit frees
+        # any finisher's blocks back to the allocator pool (no use-after-free under the forward).
+        if inflight.forward_done_event is not None:
+            inflight.forward_done_event.synchronize()
+        if self._step_txn_manager is not None:
+            if self._step_txn_manager.child_txn is inflight.txn:
+                self._step_txn_manager.child_txn = None
+            self._step_txn_manager.barrier(reason)
+        # The doomed forward scattered tokens + published next-step metadata; the next PRIME must
+        # rebuild from scratch with a full (token-inclusive) H2D.
+        context._decode_token_ids_live_on_gpu = False
 
     async def _async_overlap_step(self) -> Optional[Dict]:
         """Run one decode step on the launch-before-commit overlap path.
@@ -2092,6 +2118,24 @@ class TextGenerationController:
         inflight = self._inflight
 
         with torch.inference_mode():
+            if inflight is not None:
+                # PRIMED: the in-flight forward already ran; adopt it (consume-by-request-id) and
+                # consume its logits. We keep an in-flight forward only on a finish-free step (a
+                # data-dependent finish drains+discards it below), so the committed survivor set
+                # equals the snapshot and the SUBSET adopt guard holds exactly. If a layout change
+                # nonetheless slipped in (e.g. admission/eviction), resolve returns False and we
+                # barrier: drain+discard and re-prime synchronously (consume-not-corrupt).
+                committed_survivor_ids = context.request_ids[
+                    context.paused_request_count : context.total_request_count
+                ]
+                if inflight.resolve(committed_survivor_ids):
+                    current_cuda_graph_request_count = inflight.cuda_graph_request_count
+                    self._inflight = None
+                else:
+                    self._async_discard_inflight_forward(inflight, reason="adopt_guard_failure")
+                    self._inflight = None
+                    inflight = None
+
             if inflight is None:
                 # PRIME: forward for the current committed state (serial head, plain GPT decode).
                 input_ids, position_ids = self._dynamic_step_context_init()
@@ -2109,21 +2153,6 @@ class TextGenerationController:
                     self._router_record_bookkeeping()
                 )
                 range_pop()
-            else:
-                # PRIMED: the in-flight forward already ran; adopt it (consume-by-request-id) and
-                # consume its logits. The launch was gated finish-free, so the committed active set
-                # equals the snapshot and the SUBSET adopt guard is trivially satisfied. (C4 skips
-                # the bucket check -- the survivor-bucket recompute arrives with the C6 ungate.)
-                current_cuda_graph_request_count = inflight.cuda_graph_request_count
-                committed_survivor_ids = context.request_ids[
-                    context.paused_request_count : context.total_request_count
-                ]
-                adopted = inflight.resolve(committed_survivor_ids)
-                assert adopted, (
-                    "C4 gated launch must always adopt: a finish-free launch snapshot equals the "
-                    "committed survivor set (the barrier-recovery path arrives with the C6 ungate)"
-                )
-                self._inflight = None
 
         await asyncio.sleep(0)
 
@@ -2143,20 +2172,16 @@ class TextGenerationController:
             # SHADOW: build + publish the next forward's metadata while F(K) is still in flight,
             # BEFORE reading F(K)'s logits to the host. Derived purely from committed state, so it
             # overlaps F(K) on the GPU (and the publish H2D is stream-ordered after the sample
-            # kernel enqueued just above). The launch decision (finish-free) is deferred below.
+            # kernel enqueued just above). Returns None (=> no launch, sync prime) on a host-known
+            # max-length finish (max-length stays exactly gated) or an ineligible boundary step.
             range_push("prestage(shadow)")
             prestaged_plan = self._async_prestage_next_decode_forward()
             range_pop()
 
-            # The shadow prestage above was issued for THIS step before the logits read below: a
-            # wall-clock-independent record that prestage(K+1) ran in F(K)'s shadow (the load-
-            # bearing continuous-loop pipelining ordering). Counted in the prestage method.
-
-            # Drain F(K)'s sampled tokens to the host through the AsyncSampleRing instead of a bare
-            # blocking .cpu(): enqueue the D2H on the ring's copy stream, then (C4) consume it
-            # IMMEDIATELY -- still same-iteration, so timing/behavior is unchanged vs the prior
-            # gated overlap. C6 moves this consume to AFTER the launch enqueue (the gap-closer).
-            range_push("transfer_samples_to_cpu(ring)")
+            # Enqueue F(K)'s sampled tokens to the host on the ring's copy stream WITHOUT syncing,
+            # so the D2H overlaps the launch enqueue below (the gap-closer). The consume (sync on
+            # copy_done) happens AFTER the launch, off the inter-forward critical path.
+            range_push("enqueue_readback")
             active_request_count = context.total_request_count - context.paused_request_count
             ring = self._ensure_async_sample_ring()
             ticket = ring.enqueue_readback(
@@ -2166,25 +2191,39 @@ class TextGenerationController:
                     context.paused_request_count : context.total_request_count
                 ],
             )
-            # Clone so the returned "sample" is independent of the reused pinned slot (matches the
-            # legacy .cpu() semantics; update_requests mutates only the separate new_sample_copy).
+            range_pop()
+
+            # C6 UNGATE (the single load-bearing relaxation): fire the launch of the next forward
+            # from HOST-KNOWN state, BEFORE the sample D2H is read. The post-sample inter-forward
+            # critical path is now just the GPU token-scatter + the graph-replay enqueue -- no
+            # blocking .cpu()/.synchronize()/.item(). The blocking D2H + EOS finish-check that used
+            # to gate this launch (the ~360us bubble) move below, off the critical path.
+            self._inflight = self._async_commit_launch_next_decode_forward(
+                prestaged_plan, sample_ticket=ticket
+            )
+
+            # Consume F(K)'s sample AFTER the launch enqueue (its D2H overlapped the launch). Clone
+            # so the returned "sample" is independent of the reused pinned slot.
+            range_push("consume_readback")
             sampled_tokens_cpu = ring.consume(ticket).clone()
             range_pop()
 
-            # Prepare commit (finish detection) from the already-on-CPU sample. Must precede both
-            # the launch decision and update_requests so the launched forward only fires on a
-            # finish-free step (still gated this commit).
+            # Finish-detect step K from the already-on-CPU sample (lagged off the launch path).
             prepared = self._dynamic_step_prepare_commit(sampled_tokens_cpu=sampled_tokens_cpu)
 
-            # Fire the speculative launch BEFORE committing this step (the overlap), now that the
-            # finish-free state is known. Post-sample path = GPU token-scatter + launch enqueue.
-            self._inflight = self._async_commit_launch_next_decode_forward(
-                prestaged_plan, prepared
-            )
+            # The launch was fired on HOST-KNOWN state only (max-length gated, EOS ungated). If the
+            # step actually had a data-dependent (EOS/stop-word) finish, the launched forward
+            # predicted it away and is doomed: drain + discard it, and the next step re-primes
+            # synchronously. The commit below then frees the finisher's KV eagerly -- safe, because
+            # the discard drained the forward that read it. Token-identical: the finishing step is
+            # simply re-run, exactly as the gated path handled a finish (never consumed corrupt).
+            if self._inflight is not None and prepared["data_dependent_finished_count"] != 0:
+                self._async_discard_inflight_forward(self._inflight, reason="data_dependent_finish")
+                self._inflight = None
             if self._inflight is not None:
                 self._async_committed_with_inflight_forward = True
 
-            # Commit this step. Runs on the CPU while the launched forward runs on the GPU.
+            # Commit this step. On a finish-free step this overlaps the launched forward on the GPU.
             request_bookkeeping = self._dynamic_step_apply_commit(prepared)
 
             ret = {

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1901,14 +1901,25 @@ class TextGenerationController:
         """
         return self._dynamic_step_apply_commit(self._dynamic_step_prepare_commit())
 
-    def _async_overlap_possible(self, context) -> bool:
-        """Whether the launch-before-commit overlap path should handle this step.
+    def _async_overlap_scope_ok(self, context) -> bool:
+        """The STATIC scope gate for the launch-before-commit overlap (C8).
 
-        The overlap is scoped (this branch) to plain (non-speculative) GPT decode under a CUDA
-        graph with async scheduling on. It engages when either a speculative forward is already
-        in flight (must be consumed) or this step is a graph-backed decode step that could prime
-        the pipeline. Every other case (eager, prefill/mixed, hybrid, MTP) takes the unchanged
-        serial path, so ``async == serial`` holds trivially there and ``async-off == main`` always.
+        These conditions never change within a generation, so they are the hard scope boundary:
+        async scheduling on + a decode metadata buffer + NOT speculative (MTP) + NOT hybrid (mamba
+        single-bank) + EP == 1. The C6 ungate (launch before commit, lazy EOS finish-detect) is
+        sound ONLY for plain attention-only GPT decode at EP=1:
+
+        * MTP / spec decode: the post-verify rewind makes every step a data-dependent reshape
+          (unpredictable at launch); overlap would require the row-remap this design deletes.
+        * hybrid / mamba: SSM state advances in place and is not rewindable; a speculative forward
+          over a single bank would bake a post-finish advance into live state with no rollback.
+        * EP > 1: the step-begin decision (issue a real forward vs a dummy_forward on idle ranks)
+          is NOT rank-local, so a primed rank and an idle rank would enqueue a different number of
+          NCCL all-to-all collectives in the same wall-clock step and deadlock / mispair the MoE
+          all-to-all. EP needs an all-reduce-max step-begin consensus (a future commit).
+
+        The matching crash-loud assert lives at the launch site so a future widening cannot
+        silently launch a speculative forward outside this scope.
         """
         if not context.enable_async_scheduling:
             return False
@@ -1916,8 +1927,48 @@ class TextGenerationController:
             return False
         if self.num_speculative_tokens > 0 or context.is_hybrid_model:
             return False
+        ep_group = getattr(context, "expert_model_parallel_group", None)
+        if ep_group is not None and get_pg_size(ep_group) > 1:
+            return False
+        return True
+
+    def _active_requests_need_logprobs(self, context) -> bool:
+        """Whether any active request asks for log probs / top-n (host-only check, no D2H).
+
+        The overlap path is gated OFF the moment any active request needs logprobs: under the CUDA
+        graph the overlap requires, ``_all_logits_cuda`` is a fixed buffer the launched forward
+        overwrites in place, so a logprob computed against it after the launch would read the wrong
+        forward's logits. ``active_request_metadata`` is CPU-pinned, so ``.any()`` is a cheap host
+        read (no device sync). Such requests fall to the serial path, where logprobs are exact.
+        """
+        n = context.total_request_count - context.paused_request_count
+        if n <= 0:
+            return False
+        md = context.active_request_metadata
+        return bool(
+            md["return_log_probs"][:n].any() or (md["top_n_logprobs"][:n] > 0).any()
+        )
+
+    def _async_overlap_possible(self, context) -> bool:
+        """Whether the launch-before-commit overlap path should handle this step.
+
+        The overlap is scoped (C8) to plain (non-speculative, non-hybrid) GPT decode under a CUDA
+        graph, EP=1, with no logprob/top-n request active. It engages when either a speculative
+        forward is already in flight (must be consumed) or this step is a graph-backed decode step
+        with no logprobs that could prime the pipeline. Every other case (eager, prefill/mixed,
+        hybrid, MTP, EP>1, logprobs) takes the unchanged serial path, so ``async == serial`` holds
+        trivially there and ``async-off == main`` always.
+        """
+        if not self._async_overlap_scope_ok(context):
+            return False
+        # A forward already in flight must be consumed regardless of the per-step gates below
+        # (it ran under the prior, in-scope step). The launch site never fires under logprobs, and
+        # admission is deferred, so a logprob-bearing request never becomes active while a forward
+        # is in flight; this consume self-heals to the serial path on the next step.
         if self._inflight is not None:
             return True
+        if self._active_requests_need_logprobs(context):
+            return False
         return context.is_decode_only() and context.using_cuda_graph_this_step()
 
     def _async_prestage_next_decode_forward(self) -> Optional["PrestagedDecodePlan"]:
@@ -2040,12 +2091,27 @@ class TextGenerationController:
         # No eligible shadow prestage (boundary window / max-length gated) => nothing to launch.
         if plan is None:
             return None
-        # Static host-known gates (no D2H, no GPU sample): decode-only, no paused, under a graph.
-        if not context.is_decode_only():
-            return None
+
+        # C8 crash-loud scope asserts: a speculative forward must NEVER be launched outside the
+        # supported scope (the lazy-EOS-retire / launch-before-commit relaxation is unsound
+        # elsewhere). These mirror _async_overlap_scope_ok + the logprob gate exactly, so a future
+        # change that widens the overlap path trips here loudly instead of silently corrupting.
+        ep_group = getattr(context, "expert_model_parallel_group", None)
+        assert self.num_speculative_tokens == 0, "overlap launch forbidden for MTP/spec decode"
+        assert not context.is_hybrid_model, "overlap launch forbidden for hybrid (mamba single-bank)"
+        assert not (
+            ep_group is not None and get_pg_size(ep_group) > 1
+        ), "overlap launch forbidden for expert-parallel size > 1 (needs EP step-begin consensus)"
+        assert (
+            not self._active_requests_need_logprobs(context)
+        ), "overlap launch forbidden while a logprob/top-n request is active (single-buffered logits)"
+        assert context.is_decode_only(), "overlap launch forbidden on a non-decode (prefill/mixed) step"
+        assert (
+            context.using_cuda_graph_this_step()
+        ), "overlap launch forbidden on a non-graph step"
+
+        # Static host-known gates (no D2H, no GPU sample): no paused requests.
         if context.paused_request_count != 0:
-            return None
-        if not context.using_cuda_graph_this_step():
             return None
 
         # Scatter this step's sampled ids as the next forward's input ids (GPU, no D2H), then mark

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1779,6 +1779,14 @@ class TextGenerationController:
         )
         active_request_mask = data_dependent_mask & host_maxlen_mask
 
+        # C5: the per-half finisher counts, so the launch gate can treat them asymmetrically. The
+        # host-maxlen half is host-deterministic (no D2H, knowable before the launch); the
+        # data-dependent (EOS/stop-word) half needs the sampled token. This commit gates the
+        # launch on BOTH halves being clean (== finished_count==0, token-identical to C4); C6
+        # deletes only the data-dependent requirement (the ungate) while max-length stays gated.
+        host_maxlen_finished_count = int((host_maxlen_mask == 0).sum().item())
+        data_dependent_finished_count = int((data_dependent_mask == 0).sum().item())
+
         finished_idxs = (
             torch.nonzero(active_request_mask == 0, as_tuple=True)[0] + context.paused_request_count
         )
@@ -1815,6 +1823,8 @@ class TextGenerationController:
             "new_sample_copy": new_sample_copy,
             "active_request_mask": active_request_mask,
             "finished_count": int(finished_idxs.numel()),
+            "host_maxlen_finished_count": host_maxlen_finished_count,
+            "data_dependent_finished_count": data_dependent_finished_count,
             "was_decode_only": was_decode_only,
         }
 
@@ -1933,10 +1943,23 @@ class TextGenerationController:
         if not context.using_cuda_graph_this_step():
             return None
 
+        # C5: pre-exclude host-known max-length finishers from the launch snapshot. Predict which
+        # active requests reach max_sequence_length at the pending commit using the C3 host-maxlen
+        # survival mask -- exactly prepare_commit's max-length term for this step (no D2H, no GPU
+        # sample): get_active_sequence_lengths() reads request_kv_length_offsets+query_lengths,
+        # which the (not-yet-run) commit will read identically, and +1 is the new sampled token.
+        # A predicted max-length finisher is dropped from the snapshot so it never rides the
+        # speculative forward (it is freed at its own commit). On a step that actually launches the
+        # launch is gated max-length-clean, so this mask survives every row -- vacuous there.
+        host_maxlen_survival = self._host_maxlen_finish_mask(
+            context.get_active_sequence_lengths() + 1, context.get_max_sequence_lengths()
+        )
+
         # Speculative plan for the forward that runs against the layout the pending commit will
         # produce (design 1.1 step 2). Boundary-window gated inside; ineligible => sync step.
         plan = context.prestage_next_decode_step_into_cpu_staging(
-            speculate_pending_decode_commit=True
+            speculate_pending_decode_commit=True,
+            snapshot_survival_mask=host_maxlen_survival,
         )
         if not plan.eligible:
             return None
@@ -1994,10 +2017,17 @@ class TextGenerationController:
         if plan is None:
             return None
         # Absorbable-but-reshaping or unsupported conditions => no speculative launch this step.
-        # NOTE (C4): the launch stays gated on the FULL finished_count (max-length + EOS). C6
-        # relaxes only the EOS half (max-length stays host-gated); this commit is a structural
-        # swap with timing/behavior unchanged.
-        if prepared["finished_count"] != 0:
+        # The finish gate is split into its two halves (C5):
+        #   * host-maxlen: host-deterministic (no D2H). A max-length finisher is freed at its own
+        #     commit and pre-excluded from the launch snapshot, so it never rides an extra forward.
+        #     This half stays gated through C6 (a max-length finish forces a sync prime step).
+        #   * data-dependent (EOS/stop-word): needs the sampled token. C6 DELETES this requirement
+        #     -- the single load-bearing ungate -- moving EOS finish-detection to the lagged
+        #     RetirementLane. This commit keeps BOTH required, so the gate == finished_count==0 and
+        #     the behavior is byte-identical to C4.
+        if prepared["host_maxlen_finished_count"] != 0:
+            return None
+        if prepared["data_dependent_finished_count"] != 0:
             return None
         if not prepared["was_decode_only"]:
             return None

--- a/megatron/inference/utils.py
+++ b/megatron/inference/utils.py
@@ -371,6 +371,9 @@ def get_inference_config_from_model_and_args(model: MegatronModule, args):
         track_generated_token_events=args.inference_dynamic_batching_track_generated_token_events,
         track_paused_request_events=args.inference_dynamic_batching_track_paused_request_events,
         enable_chunked_prefill=args.enable_chunked_prefill,
+        enable_async_scheduling=getattr(
+            args, 'inference_dynamic_batching_async_scheduling', False
+        ),
         enable_prefix_caching=args.inference_dynamic_batching_enable_prefix_caching,
         prefix_caching_eviction_policy=PrefixCachingEvictionPolicy(args.inference_dynamic_batching_prefix_caching_eviction_policy),
         prefix_caching_coordinator_policy=PrefixCachingCoordinatorPolicy(args.inference_dynamic_batching_prefix_caching_coordinator_policy),

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1943,6 +1943,15 @@ def _add_inference_args(parser):
                        help='Enable/disable prefix caching for dynamic batching inference. '
                        'When disabled, KV cache blocks cannot be shared between '
                        'requests with identical prompt prefixes.')
+    group.add_argument('--inference-dynamic-batching-async-scheduling',
+                       dest='inference_dynamic_batching_async_scheduling',
+                       action=argparse.BooleanOptionalAction,
+                       default=False,
+                       help='Enable/disable transactional async scheduling for dynamic '
+                       'batching decode. When enabled, the engine overlaps CPU '
+                       'scheduling/bookkeeping with the GPU forward (launch-before-commit) '
+                       'so steady-state decode keeps the GPU busy. When disabled (default), '
+                       'the decode step is identical to the legacy serial path.')
     group.add_argument('--inference-dynamic-batching-prefix-caching-eviction-policy',
                        type=str, default='ref_zero',
                        choices=['ref_zero', 'lru'],

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -129,6 +129,7 @@ class DynamicEngineTestConfig:
     skip_prompt_log_probs: bool = False
     enable_chunked_prefill: bool = False
     enable_prefix_caching: bool = False
+    enable_async_scheduling: bool = False
     cuda_graph_modules: List[CudaGraphModule] = field(default_factory=list)
     inference_cuda_graph_scope: InferenceCudaGraphScope = InferenceCudaGraphScope.block
     cuda_graph_impl: Optional[str] = None
@@ -291,6 +292,7 @@ class DynamicInferenceEngineTestBase:
                 static_kv_memory_pointers=test_config.static_kv_memory_pointers,
                 enable_chunked_prefill=test_config.enable_chunked_prefill,
                 enable_prefix_caching=test_config.enable_prefix_caching,
+                enable_async_scheduling=test_config.enable_async_scheduling,
                 use_flashinfer_fused_rope=None,  # default to using flash-infer if available
                 # this is for compatibility with the LTS environment
                 unified_memory_level=0,  # unit tests currently broken with UVM

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -667,27 +667,31 @@ class TestDynamicInferenceEngine(DynamicInferenceEngineTestBase):
                 for layer in model.decoder.layers:
                     assert layer.cudagraph_manager.cudagraph_runners
 
-        # Validate generated tokens.
+        # Validate generated tokens. These torch-backend non-greedy goldens were
+        # re-baselined once when the sampler migrated to per-request keyed RNG (each
+        # request draws from a (seed + request_id)-keyed generator). The same per-request
+        # keying makes the tokens invariant across cuda-graph configs, so a single golden
+        # holds for every (num_cuda_graphs, scope) parametrization.
         gpt_expected_generated_tokens = [
             [69, 85, 55, 74, 56, 89, 64, 59, 55, 67, 15, 58, 6, 37, 54, 47],
-            [29, 54, 33, 72, 45, 76, 41, 56, 28, 25, 17, 2, 61, 6, 98, 76],
-            [35, 78, 54, 16, 79, 98, 22, 5, 60, 0, 1, 76, 77, 11, 25, 7],
-            [25, 75, 57, 85, 81, 37, 88, 17, 71, 15, 70, 64, 50, 0, 64, 45],
-            [32, 5, 85, 75, 30, 68, 23, 33, 20, 26, 89, 20, 49, 28, 38, 81],
-            [33, 69, 32, 49, 93, 24, 33, 6, 54, 89, 92, 97, 42, 80, 50, 53],
-            [82, 78, 78, 65, 26, 5, 69, 36, 37, 99],
-            [51, 70, 22, 1, 87, 42, 36, 26, 27, 56, 82, 32, 8, 80, 20, 43],
+            [33, 11, 16, 85, 17, 40, 11, 73, 92, 66, 64, 7, 2, 72, 5, 92],
+            [54, 77, 45, 69, 28, 61, 98, 89, 10, 89, 27, 96, 14, 8, 12, 18],
+            [6, 53, 50, 3, 27, 56, 5, 37, 11, 63, 83, 0, 48, 66, 99],
+            [58, 4, 88, 31, 8, 44, 34, 8, 24, 17, 35, 95, 8, 99],
+            [26, 90, 90, 77, 48, 64, 84, 55, 5, 21, 91, 31, 22, 21, 47, 14],
+            [47, 17, 28, 13, 77, 43, 22, 36, 80, 51, 84, 9, 47, 19, 6, 33],
+            [18, 73, 21, 1, 50, 21, 21, 67, 18, 47, 56, 58, 61, 22, 94, 22],
         ]
 
         mamba_expected_generated_tokens = [
             [69, 85, 55, 74, 85, 89, 64, 59, 55, 67, 15, 58, 6, 37, 34, 47],
-            [29, 16, 33, 30, 45, 76, 41, 46, 82, 17, 17, 2, 61, 6, 98, 76],
-            [35, 78, 54, 16, 79, 98, 22, 5, 37, 30, 1, 76, 5, 11, 25, 86],
-            [25, 75, 57, 85, 81, 59, 88, 38, 71, 15, 70, 64, 50, 0, 64, 45],
-            [32, 5, 85, 75, 30, 68, 23, 33, 20, 26, 35, 20, 49, 28, 34, 81],
-            [87, 69, 32, 49, 93, 24, 33, 6, 54, 89, 92, 97, 42, 80, 50, 53],
-            [82, 78, 78, 19, 70, 5, 97, 36, 37, 99],
-            [51, 70, 22, 1, 87, 42, 36, 26, 27, 56, 82, 32, 8, 20, 20, 43],
+            [67, 11, 16, 85, 17, 40, 11, 73, 81, 66, 64, 43, 2, 48, 5, 92],
+            [54, 67, 45, 69, 28, 61, 98, 89, 10, 89, 27, 96, 14, 8, 12, 18],
+            [6, 53, 25, 3, 18, 56, 5, 37, 11, 63, 83, 0, 48, 66, 99],
+            [58, 90, 88, 63, 8, 44, 24, 17, 24, 17, 35, 95, 8, 99],
+            [26, 90, 32, 77, 0, 64, 86, 55, 5, 21, 91, 31, 1, 21, 47, 14],
+            [47, 17, 28, 13, 72, 43, 83, 36, 80, 51, 84, 9, 47, 74, 6, 33],
+            [66, 73, 21, 1, 50, 21, 21, 67, 18, 47, 56, 98, 61, 22, 94, 22],
         ]
 
         if model_provider == "gpt":
@@ -2222,7 +2226,9 @@ class TestDynamicInferenceEngine(DynamicInferenceEngineTestBase):
                 f"num_requests ({len(env.requests)})."
             )
             assert context.max_requests == 4
-            assert step_count == 35
+            # step_count is downstream of the (non-greedy) token sequences: it shifted by
+            # one when the torch sampler migrated to per-request keyed RNG (C3 rebaseline).
+            assert step_count == 34
         assert context.kv_block_allocator.active_count == 655
 
     @pytest.mark.internal

--- a/tests/unit_tests/inference/engines/test_inflight_forward.py
+++ b/tests/unit_tests/inference/engines/test_inflight_forward.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""C2 unit tests for :class:`InflightForward` (the thin StepTxn-backed facade).
+
+All pure CPU bookkeeping over ``StepTxn`` objects -- no model, no allocators, no GPU buffer
+(mirrors the C5 handoff-lifecycle battery). The bar is the adopt truth table: ``resolve``
+is exactly ``adopt_child``'s pre-existing SUBSET + bucket guard (no new policy invented), and
+``discard`` routes the forward's leases through the fence-gated retire queue.
+"""
+
+import pytest
+
+from megatron.core.inference.engines.inflight_forward import InflightForward
+from megatron.core.inference.engines.step_transaction import (
+    LaunchGateReason,
+    PrestagedDecodePlan,
+    StepTransactionManager,
+    TxnPhase,
+)
+
+
+class _StubEvent:
+    """A CUDA-event stand-in with a controllable ``query()`` for deterministic tests."""
+
+    def __init__(self, ready: bool):
+        self.ready = ready
+        self.synchronized = False
+
+    def query(self) -> bool:
+        return self.ready
+
+    def synchronize(self) -> None:
+        self.synchronized = True
+        self.ready = True
+
+
+def _eligible_plan(step_id=3, request_ids=(10, 11, 12)):
+    return PrestagedDecodePlan(
+        step_id=step_id,
+        eligible=True,
+        snapshot_request_ids=list(request_ids),
+        active_request_count=len(request_ids),
+        kv_block_leases=[5, 6, 7],
+        reserved_boundary_blocks=[(11, 2)],
+        mamba_slot_leases=[1, 2, 3],
+        kv_blocks_needed=1,
+    )
+
+
+@pytest.mark.internal
+class TestInflightForward:
+    """The typed handle for the single speculative forward launched before commit."""
+
+    def test_launch_prestages_and_launches(self) -> None:
+        """launch() prestages + launches the child and carries its snapshot/bucket/ticket."""
+        mgr = StepTransactionManager(context=None)
+        fwd, h2d = _StubEvent(ready=False), _StubEvent(ready=True)
+        inflight = InflightForward.launch(
+            mgr,
+            _eligible_plan(),
+            bucket=("decode", 4),
+            forward_done_event=fwd,
+            h2d_done_event=h2d,
+            sample_ticket="ticket-K",
+        )
+        assert inflight.txn is mgr.child_txn
+        assert inflight.txn.phase is TxnPhase.LAUNCHED
+        assert inflight.snapshot_request_ids == [10, 11, 12]
+        assert inflight.cuda_graph_request_count == ("decode", 4)
+        assert inflight.forward_done_event is fwd
+        assert inflight.h2d_done_event is h2d
+        assert inflight.sample_ticket == "ticket-K"
+        assert mgr.diagnostics.prepared == 1 and mgr.diagnostics.launched == 1
+
+    def test_launch_requires_eligible_plan(self) -> None:
+        """An ineligible plan cannot back an in-flight forward."""
+        mgr = StepTransactionManager(context=None)
+        ineligible = PrestagedDecodePlan(
+            step_id=1, eligible=False, skip_reason=LaunchGateReason.RESUME
+        )
+        with pytest.raises(AssertionError):
+            InflightForward.launch(mgr, ineligible)
+
+    def test_resolve_true_exact_survivors(self) -> None:
+        """survivors == snapshot AND bucket match -> adopted; child promoted to current_txn."""
+        mgr = StepTransactionManager(context=None)
+        inflight = InflightForward.launch(mgr, _eligible_plan(), bucket=("decode", 4))
+        assert inflight.resolve([10, 11, 12], committed_bucket=("decode", 4)) is True
+        assert inflight.txn.phase is TxnPhase.ADOPTED
+        assert mgr.current_txn is inflight.txn and mgr.child_txn is None
+        assert mgr.diagnostics.adopted == 1 and mgr.diagnostics.guard_failures == 0
+
+    def test_resolve_true_subset_midbatch_finish(self) -> None:
+        """A finish removes a row (survivors strict subset) -> still adopted, no rerun."""
+        mgr = StepTransactionManager(context=None)
+        inflight = InflightForward.launch(mgr, _eligible_plan(request_ids=(10, 11, 12)))
+        assert inflight.resolve([10, 12]) is True  # request 11 finished mid-batch
+        assert mgr.diagnostics.adopted == 1 and mgr.diagnostics.guard_failures == 0
+
+    def test_resolve_false_superset_barrier(self) -> None:
+        """A survivor absent from the snapshot -> guard failure (no promotion, no rerun)."""
+        mgr = StepTransactionManager(context=None)
+        inflight = InflightForward.launch(mgr, _eligible_plan(request_ids=(1, 2)))
+        assert inflight.resolve([1, 2, 3]) is False  # request 3 never computed by the forward
+        assert mgr.diagnostics.guard_failures == 1 and mgr.diagnostics.adopted == 0
+        # Recovery is a barrier handled by the caller; the child stays LAUNCHED, not discarded.
+        assert mgr.current_txn is None
+        assert mgr.child_txn is inflight.txn and inflight.txn.phase is TxnPhase.LAUNCHED
+
+    def test_resolve_false_bucket_mismatch(self) -> None:
+        """A graph-bucket mismatch trips the guard even when survivors are a subset."""
+        mgr = StepTransactionManager(context=None)
+        inflight = InflightForward.launch(mgr, _eligible_plan(request_ids=(1, 2)), bucket=("decode", 4))
+        assert inflight.resolve([1, 2], committed_bucket=("decode", 8)) is False
+        assert mgr.diagnostics.guard_failures == 1 and mgr.diagnostics.adopted == 0
+
+    def test_resolve_default_bucket_skips_check(self) -> None:
+        """With no committed_bucket supplied, the bucket check is skipped (subset only)."""
+        mgr = StepTransactionManager(context=None)
+        inflight = InflightForward.launch(mgr, _eligible_plan(request_ids=(1, 2)), bucket=("decode", 4))
+        assert inflight.resolve([1, 2]) is True  # bucket not supplied -> not checked
+        assert mgr.diagnostics.adopted == 1
+
+    def test_discard_enqueues_leases_with_forward_fence(self) -> None:
+        """discard routes the leases through retire_txn_leases gated by the forward fence."""
+        mgr = StepTransactionManager(context=None)
+        fwd = _StubEvent(ready=False)
+        inflight = InflightForward.launch(
+            mgr, _eligible_plan(), forward_done_event=fwd, h2d_done_event=_StubEvent(ready=True)
+        )
+        freed = []
+        inflight.discard(current_step=5, release=lambda: freed.append("kv"))
+        # Child cleared so no stale snapshot is consumed later.
+        assert mgr.child_txn is None
+        # Held until BOTH the two-step delay and the forward fence are satisfied.
+        assert mgr.retire(5) == 0 and freed == []  # neither satisfied
+        assert mgr.retire(7) == 0 and freed == []  # delay ok, fence not ready
+        fwd.ready = True
+        assert mgr.retire(7) == 1 and freed == ["kv"]  # both satisfied
+        assert mgr.diagnostics.retired == 1
+
+    def test_discard_event_override(self) -> None:
+        """An explicit fence overrides the txn's forward fence (coalesced multi-resource free)."""
+        mgr = StepTransactionManager(context=None)
+        inflight = InflightForward.launch(
+            mgr, _eligible_plan(), forward_done_event=_StubEvent(ready=False)
+        )
+        override = _StubEvent(ready=True)
+        freed = []
+        inflight.discard(current_step=0, release=lambda: freed.append("slot"), event=override)
+        assert mgr.retire(2) == 1 and freed == ["slot"]
+
+    def test_facade_is_thin_no_extra_state(self) -> None:
+        """The facade holds only (mgr, txn, sample_ticket): properties read straight through."""
+        mgr = StepTransactionManager(context=None)
+        inflight = InflightForward.launch(mgr, _eligible_plan(), bucket=("decode", 2))
+        assert set(vars(inflight)) == {"mgr", "txn", "sample_ticket"}
+        assert inflight.snapshot_request_ids is inflight.txn.request_ids
+        assert inflight.cuda_graph_request_count is inflight.txn.bucket

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -1210,6 +1210,190 @@ class TestC5PrestagedPlanPrimitives:
         assert diag["skip_reasons"]["pending_admission"] == 1
 
 
+@pytest.mark.internal
+class TestC5HandoffLifecycle:
+    """C5 (CPU-only): the prestage -> launch -> adopt -> retire transaction handoff.
+
+    These exercise the manager-side launch-before-commit machinery the overlap engine
+    wiring consumes: seeding a speculative child from a prestaged plan, launching it with
+    its two fences, the consume-by-request-id adopt guard (design 1.2 / 1.3), and the
+    two-step fence-gated lease retire (design 1.7). All pure CPU bookkeeping over
+    ``StepTxn`` objects -- no model, no allocators, no GPU buffer.
+    """
+
+    @staticmethod
+    def _eligible_plan(step_id=3, request_ids=(10, 11, 12)):
+        return PrestagedDecodePlan(
+            step_id=step_id,
+            eligible=True,
+            snapshot_request_ids=list(request_ids),
+            active_request_count=len(request_ids),
+            kv_block_leases=[5, 6, 7],
+            reserved_boundary_blocks=[(11, 2)],
+            mamba_slot_leases=[1, 2, 3],
+            kv_blocks_needed=1,
+        )
+
+    def test_from_prestaged_plan_carries_snapshot_and_leases(self) -> None:
+        """A StepTxn seeded from an eligible plan carries its snapshot + lease manifest."""
+        plan = self._eligible_plan()
+        txn = StepTxn.from_prestaged_plan(plan, bucket=("decode", 4))
+        assert txn.phase is TxnPhase.PRESTAGED
+        assert txn.speculative is True
+        assert txn.step_id == 3 and txn.active_request_count == 3
+        assert txn.bucket == ("decode", 4)
+        assert txn.request_ids == [10, 11, 12]
+        # Physical leases the forward reads are carried; the lease lists are independent
+        # copies (mutating the txn must not perturb the plan).
+        assert txn.kv_block_leases == [5, 6, 7]
+        assert txn.mamba_slot_leases == [1, 2, 3]
+        txn.kv_block_leases.append(99)
+        assert plan.kv_block_leases == [5, 6, 7]
+        # Boundary crossers are recorded as PENDING (no block id) -- prestage never allocates.
+        assert txn.pending_boundary_columns == [(11, 2)]
+        assert txn.reserved_boundary_blocks == {}
+
+    def test_from_prestaged_plan_rejects_ineligible(self) -> None:
+        """An ineligible plan cannot seed a speculative transaction."""
+        ineligible = PrestagedDecodePlan(
+            step_id=1, eligible=False, skip_reason=LaunchGateReason.RESUME
+        )
+        with pytest.raises(AssertionError):
+            StepTxn.from_prestaged_plan(ineligible)
+
+    def test_prestage_child_eligible_builds_child(self) -> None:
+        """prestage_child seeds + stores the child and counts a prepared step."""
+        mgr = StepTransactionManager(context=None)
+        child = mgr.prestage_child(self._eligible_plan(), bucket=("decode", 4))
+        assert child is mgr.child_txn
+        assert child.phase is TxnPhase.PRESTAGED and child.request_ids == [10, 11, 12]
+        assert mgr.diagnostics.prepared == 1
+        assert mgr.diagnostics.skip_reasons == {}
+
+    def test_prestage_child_ineligible_records_skip_and_no_child(self) -> None:
+        """An ineligible plan leaves child_txn unset and records its static skip reason."""
+        mgr = StepTransactionManager(context=None)
+        # Seed a stale child to prove an ineligible prestage clears it (sync step).
+        mgr.child_txn = StepTxn(step_id=0, phase=TxnPhase.PRESTAGED)
+        out = mgr.prestage_child(
+            PrestagedDecodePlan(
+                step_id=2, eligible=False, skip_reason=LaunchGateReason.PENDING_ADMISSION
+            )
+        )
+        assert out is None and mgr.child_txn is None
+        assert mgr.diagnostics.prepared == 0
+        assert mgr.diagnostics.skip_reasons["pending_admission"] == 1
+
+    def test_launch_child_transitions_and_attaches_fences(self) -> None:
+        """launch_child moves PRESTAGED -> LAUNCHED, attaches both fences, counts launched."""
+        mgr = StepTransactionManager(context=None)
+        mgr.prestage_child(self._eligible_plan())
+        h2d, fwd = _StubEvent(ready=True), _StubEvent(ready=False)
+        child = mgr.launch_child(forward_done_event=fwd, h2d_done_event=h2d)
+        assert child.phase is TxnPhase.LAUNCHED
+        assert child.forward_done_event is fwd and child.h2d_done_event is h2d
+        assert mgr.diagnostics.launched == 1
+
+    def test_launch_child_requires_prestaged(self) -> None:
+        """launch_child asserts when there is no prestaged child (e.g. after a sync step)."""
+        mgr = StepTransactionManager(context=None)
+        with pytest.raises(AssertionError):
+            mgr.launch_child()
+
+    def test_adopt_child_exact_survivors_promotes(self) -> None:
+        """Survivors == snapshot -> adopted; child promoted to current_txn."""
+        mgr = StepTransactionManager(context=None)
+        child = mgr.prestage_child(self._eligible_plan())
+        mgr.launch_child()
+        assert mgr.adopt_child([10, 11, 12], committed_bucket=None) is True
+        assert child.phase is TxnPhase.ADOPTED
+        assert mgr.current_txn is child and mgr.child_txn is None
+        assert mgr.diagnostics.adopted == 1 and mgr.diagnostics.guard_failures == 0
+
+    def test_adopt_child_absorbs_mid_batch_finish(self) -> None:
+        """A finish removes a row (survivors subset of snapshot) -> still adopted, no rerun."""
+        mgr = StepTransactionManager(context=None)
+        mgr.prestage_child(self._eligible_plan(request_ids=(10, 11, 12)))
+        mgr.launch_child()
+        # Request 11 finished this step; survivors are a strict subset of the snapshot.
+        assert mgr.adopt_child([10, 12]) is True
+        assert mgr.diagnostics.adopted == 1 and mgr.diagnostics.guard_failures == 0
+
+    def test_adopt_guard_trips_on_foreign_survivor(self) -> None:
+        """A survivor absent from the snapshot trips the guard (no promotion, no rerun)."""
+        mgr = StepTransactionManager(context=None)
+        child = mgr.prestage_child(self._eligible_plan(request_ids=(1, 2)))
+        mgr.launch_child()
+        # Request 3 was never in the launched forward's snapshot -> guard failure.
+        assert mgr.adopt_child([1, 2, 3]) is False
+        assert mgr.diagnostics.guard_failures == 1 and mgr.diagnostics.adopted == 0
+        # Recovery is a barrier handled by the caller; the child stays LAUNCHED, not discarded.
+        assert mgr.current_txn is None
+        assert mgr.child_txn is child and child.phase is TxnPhase.LAUNCHED
+
+    def test_adopt_guard_trips_on_bucket_mismatch(self) -> None:
+        """A graph-bucket mismatch trips the guard even when survivors are a subset."""
+        mgr = StepTransactionManager(context=None)
+        mgr.prestage_child(self._eligible_plan(request_ids=(1, 2)), bucket=("decode", 4))
+        mgr.launch_child()
+        assert mgr.adopt_child([1, 2], committed_bucket=("decode", 8)) is False
+        assert mgr.diagnostics.guard_failures == 1 and mgr.diagnostics.adopted == 0
+
+    def test_adopt_child_requires_launched(self) -> None:
+        """adopt_child asserts unless a launched child is in flight."""
+        mgr = StepTransactionManager(context=None)
+        with pytest.raises(AssertionError):
+            mgr.adopt_child([1, 2])
+        mgr.prestage_child(self._eligible_plan())  # PRESTAGED, not yet LAUNCHED
+        with pytest.raises(AssertionError):
+            mgr.adopt_child([10, 11, 12])
+
+    def test_retire_txn_leases_gated_by_forward_event(self) -> None:
+        """A txn's freed leases release only after its forward fence + the two-step delay."""
+        mgr = StepTransactionManager(context=None)
+        fwd = _StubEvent(ready=False)
+        txn = StepTxn(step_id=5, forward_done_event=fwd)
+        freed = []
+        mgr.retire_txn_leases(
+            txn, current_step=5, release=lambda: freed.append("kv"), tag="kv_block"
+        )
+        assert mgr.retire(5) == 0 and freed == []  # neither delay nor fence satisfied
+        assert mgr.retire(7) == 0 and freed == []  # delay satisfied, fence not ready
+        fwd.ready = True
+        assert mgr.retire(7) == 1 and freed == ["kv"]  # both satisfied -> released
+        assert mgr.diagnostics.retired == 1
+
+    def test_retire_txn_leases_event_override(self) -> None:
+        """An explicit event overrides the txn fence (e.g. a coalesced multi-resource fence)."""
+        mgr = StepTransactionManager(context=None)
+        txn = StepTxn(step_id=0, forward_done_event=_StubEvent(ready=False))
+        override = _StubEvent(ready=True)
+        freed = []
+        mgr.retire_txn_leases(
+            txn, current_step=0, release=lambda: freed.append("slot"), event=override, tag="mamba"
+        )
+        assert mgr.retire(2) == 1 and freed == ["slot"]
+
+    def test_full_handoff_sequence_diagnostics(self) -> None:
+        """prestage -> launch -> adopt -> commit -> retire over two steps tallies cleanly."""
+        mgr = StepTransactionManager(context=None)
+        fwd = _StubEvent(ready=True)
+        # Step K: prestage + launch the child for K+1.
+        child = mgr.prestage_child(self._eligible_plan(step_id=1), bucket=("decode", 4))
+        mgr.launch_child(forward_done_event=fwd, h2d_done_event=_StubEvent(ready=True))
+        # Step K+1: adopt the launched forward, commit it, retire a finished request's block.
+        assert mgr.adopt_child([10, 12], committed_bucket=("decode", 4)) is True
+        mgr.commit(child)
+        assert child.phase is TxnPhase.COMMITTED
+        freed = []
+        mgr.retire_txn_leases(child, current_step=1, release=lambda: freed.append("blk"))
+        mgr.retire(3)  # two steps later, fence ready
+        assert freed == ["blk"]
+        snap = mgr.diagnostics.as_dict()
+        assert (snap["prepared"], snap["launched"], snap["adopted"]) == (1, 1, 1)
+        assert snap["guard_failures"] == 0 and snap["retired"] == 1
+
+
 @pytest.mark.skipif(
     not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
 )

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -2030,3 +2030,105 @@ class TestC5OverlapFlip(AsyncSchedTxnTestBase):
                 **self._greedy_cuda_graph_kwargs(num_requests=5, use_fixed_output_lengths=False)
             )
         assert async_env.engine.controller._async_launch_before_commit_count > 0
+
+
+@pytest.mark.skipif(
+    not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+)
+@pytest.mark.internal
+class TestC6Ungate(AsyncSchedTxnTestBase):
+    """C6: the launch is UNGATED -- fired before the sample D2H, from host-known state only.
+
+    The single load-bearing relaxation. The launch of the next forward no longer waits on the
+    blocking sample D2H + EOS finish-check (the ~360us bubble): it fires from host-known state
+    (max-length gated, EOS ungated) before the D2H, which is consumed after the launch enqueue.
+    Max-length stays exactly gated (a max-length finish forces a sync prime, no ride). A
+    data-dependent (EOS/stop-word) finish drains+discards the doomed forward and re-primes -- the
+    finishing step is re-run synchronously, so async stays token-exact vs serial across reshapes.
+
+    The bar (per the design) is token-exact ``async == serial`` across greedy AND per-request-RNG
+    sampling with staggered, mid-batch, and simultaneous finishes, plus evidence that the overlap
+    fired (the launch ran before the commit) and that max-length finishes never rode a forward.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        delete_cuda_graphs()
+        set_rounder(64)
+        Utils.destroy_model_parallel()
+
+    @staticmethod
+    def _cuda_graph_kwargs(**overrides):
+        cfg = dict(
+            model_provider="gpt",
+            num_requests=6,
+            num_gap_steps=0,
+            num_tokens_to_generate=20,
+            use_fixed_output_lengths=True,
+            num_cuda_graphs=4,
+            force_build_cuda_graphs=True,
+            inference_cuda_graph_scope=InferenceCudaGraphScope.block,
+            use_cuda_graphs_for_non_decode_steps=False,
+            context_max_requests=128,
+        )
+        cfg.update(overrides)
+        return cfg
+
+    @pytest.mark.internal
+    def test_ungated_nongreedy_staggered_midbatch_finishes(self) -> None:
+        """Per-request-RNG decode with staggered, mid-batch max-length finishes: token-exact
+        async==serial under the ungate. Each finish forces a sync prime (max-length stays gated);
+        survivors keep their own per-request keyed draws across the reshapes."""
+        from unittest import mock
+
+        base_build = AsyncSchedTxnTestBase._build_requests
+
+        def staggered_build(cls, test_config):
+            requests = base_build(test_config)
+            for i, request in enumerate(requests):
+                # Per-request RNG (no top_k=1). Staggered lengths => finishes land on different
+                # steps, including mid-batch (compaction reorders rows), exercising the re-prime.
+                request.sampling_params.num_tokens_to_generate = 10 + 2 * i
+            return requests
+
+        with mock.patch.object(type(self), "_build_requests", classmethod(staggered_build)):
+            serial_env, async_env = self.assert_async_equals_serial(
+                **self._cuda_graph_kwargs(num_requests=6, use_fixed_output_lengths=False)
+            )
+        # The overlap actually engaged (launched before commit), and the serial control did not.
+        assert async_env.engine.controller._async_launch_before_commit_count > 0
+        assert serial_env.engine.controller._async_launch_before_commit_count == 0
+        # Max-length finishes are host-gated: the launch is suppressed on a finishing step, so no
+        # doomed forward is ever drained/discarded (barrier_skips stays 0 -- no EOS in this mix).
+        assert async_env.engine.step_txn_manager.diagnostics.guard_failures == 0
+
+    @pytest.mark.internal
+    def test_ungated_greedy_equals_serial(self) -> None:
+        """Greedy (argmax, no RNG) fixed-length decode: token-exact async==serial, overlap fired,
+        and the consume-by-request-id adopt guard never failed (steady decode adopts every step)."""
+        from unittest import mock
+
+        base_build = AsyncSchedTxnTestBase._build_requests
+
+        def greedy_build(cls, test_config):
+            requests = base_build(test_config)
+            for request in requests:
+                request.sampling_params.top_k = 1
+            return requests
+
+        with mock.patch.object(type(self), "_build_requests", classmethod(greedy_build)):
+            serial_env, async_env = self.assert_async_equals_serial(**self._cuda_graph_kwargs())
+        diag = async_env.engine.step_txn_manager.diagnostics
+        assert async_env.engine.controller._async_launch_before_commit_count > 0
+        assert diag.launched > 0
+        assert diag.adopted > 0
+        assert diag.guard_failures == 0

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -24,6 +24,12 @@ import pytest
 import torch
 
 from megatron.core.inference.config import InferenceConfig
+from megatron.core.inference.contexts.metadata_slot import (
+    DecodeMetadataSlot,
+    DepthTwoRing,
+    assert_slot_pointer_identity,
+    make_decode_metadata_slots,
+)
 from megatron.core.inference.engines.step_transaction import (
     RetireQueue,
     StepTransactionManager,
@@ -402,3 +408,178 @@ class TestAsyncSchedTxnScaffold(AsyncSchedTxnTestBase):
         assert d.launched == 0
         assert d.guard_failures == 0
         assert d.retired == 0
+
+
+class _StubGpuView:
+    """A ContextGPUView stand-in exposing a ``_buf`` with a real ``data_ptr()``."""
+
+    def __init__(self, nbytes: int = 64):
+        self._buf = torch.zeros(nbytes, dtype=torch.uint8)
+
+
+@pytest.mark.internal
+class TestMetadataSlotPrimitives:
+    """C2 unit tests for the decode-metadata slot + depth-2 ring abstractions."""
+
+    def test_slot_reuse_gated_by_fences(self) -> None:
+        """A slot is free only when not in use and both fences have retired."""
+        slot = DecodeMetadataSlot(slot_id=1, gpu_view=_StubGpuView())
+        assert slot.is_free()  # fresh slot, no fences
+
+        slot.acquire()
+        assert not slot.is_free()  # in use
+        with pytest.raises(AssertionError):
+            slot.acquire()  # cannot double-acquire
+        slot.release()
+        assert slot.is_free()
+
+        # Pending fences keep the slot busy even after release.
+        slot.h2d_done_event = _StubEvent(ready=True)
+        slot.forward_done_event = _StubEvent(ready=False)
+        assert not slot.is_free()
+        with pytest.raises(AssertionError):
+            slot.acquire()
+
+        # Once the forward fence completes, the slot frees up.
+        slot.forward_done_event.ready = True
+        assert slot.is_free()
+        slot.acquire()  # now allowed
+        slot.release()
+        slot.reset_fences()
+        assert slot.h2d_done_event is None and slot.forward_done_event is None
+
+    def test_slot_identity_and_pointer_assertion(self) -> None:
+        """Distinct slots have distinct graph keys; the pointer guard catches moves."""
+        a = DecodeMetadataSlot(slot_id=0, gpu_view=_StubGpuView())
+        b = DecodeMetadataSlot(slot_id=1, gpu_view=_StubGpuView())
+        assert a.graph_slot_key() == a.base_ptr
+        assert a.graph_slot_key() != b.graph_slot_key()
+
+        # Captured-against-current-address: guard passes.
+        assert_slot_pointer_identity(a, a.base_ptr)
+        # Captured-against-the-other-slot's-address: guard fires.
+        with pytest.raises(AssertionError):
+            assert_slot_pointer_identity(a, b.base_ptr)
+
+    def test_depth_two_ring(self) -> None:
+        """The ring has two distinct entries selected by step parity."""
+        ring = DepthTwoRing(factory=lambda i: f"buf{i}")
+        assert len(ring) == 2
+        assert ring[0] == "buf0" and ring[1] == "buf1"
+        assert ring[2] == "buf0" and ring[3] == "buf1"  # parity
+        assert ring.current(0) == "buf0" and ring.other(0) == "buf1"
+        assert ring.current(1) == "buf1" and ring.other(1) == "buf0"
+
+    def test_make_decode_metadata_slots(self) -> None:
+        """slot_current wraps the live view; slot_child wraps a distinct fresh view."""
+        live = _StubGpuView()
+        current, child = make_decode_metadata_slots(
+            live, child_gpu_view_factory=lambda: _StubGpuView()
+        )
+        assert current.gpu_view is live
+        assert current.slot_id == 0 and child.slot_id == 1
+        assert current.base_ptr != child.base_ptr
+        assert current.is_free() and child.is_free()
+
+
+@pytest.mark.skipif(
+    not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+)
+class TestMetadataSlotsInContext(AsyncSchedTxnTestBase):
+    """C2: the context wires slot_current/slot_child only when async is enabled."""
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        delete_cuda_graphs()
+        set_rounder(64)
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.internal
+    def test_slots_present_only_when_enabled(self) -> None:
+        """Serial path: no slots. Async path: slot_current wraps the live gpu_view."""
+        set_rounder(4)
+        off = self._build_test_env(
+            DynamicEngineTestConfig(model_provider="gpt", enable_async_scheduling=False)
+        ).engine.context
+        assert off.slot_current is None and off.slot_child is None
+
+        ctx = self._build_test_env(
+            DynamicEngineTestConfig(model_provider="gpt", enable_async_scheduling=True)
+        ).engine.context
+        assert ctx.slot_current is not None and ctx.slot_child is not None
+        # slot_current is the live gpu_view; slot_child is a distinct free buffer.
+        assert ctx.slot_current.gpu_view is ctx.gpu_view
+        assert ctx.slot_child.gpu_view is not ctx.gpu_view
+        assert ctx.slot_current.base_ptr != ctx.slot_child.base_ptr
+        assert ctx.slot_child.is_free()
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_serial_metadata_copied_to_child_slot_matches(self) -> None:
+        """slot_child is a faithful, identically-laid-out, independent metadata buffer.
+
+        The prestage (a later commit) builds the next step's bookkeeping into the
+        child slot and copies it via a single coalesced H2D. This verifies the child
+        slot has the exact same byte layout as the live gpu_view (so the copy is
+        sound) and uses independent storage (so a running forward on slot_current is
+        never disturbed by writes to slot_child).
+        """
+        set_rounder(4)
+        ctx = self._build_test_env(
+            DynamicEngineTestConfig(
+                model_provider="gpt",
+                num_requests=2,
+                num_tokens_to_generate=4,
+                enable_async_scheduling=True,
+            )
+        ).engine.context
+        live = ctx.slot_current.gpu_view
+        child = ctx.slot_child.gpu_view
+
+        # Same backing-buffer size => identical field layout, distinct storage.
+        assert live._buf.shape == child._buf.shape
+        assert live._buf.data_ptr() != child._buf.data_ptr()
+
+        # Stamp the live buffer with a deterministic pattern, then copy into the
+        # child slot exactly as the prestage's coalesced H2D will.
+        live._buf.copy_(
+            (torch.arange(live._buf.numel(), device=live._buf.device) % 251).to(torch.uint8)
+        )
+        child._buf.copy_(live._buf)
+
+        for field in (
+            "token_to_input_ids",
+            "token_to_pos_ids",
+            "token_to_block_idx",
+            "request_query_lengths",
+            "request_kv_length_offsets",
+            "mha_cu_query_seq_lengths",
+            "mha_cu_kv_seq_lengths",
+        ):
+            assert torch.equal(getattr(live, field), getattr(child, field)), (
+                f"field {field} differs after copy"
+            )
+
+        # Independence: mutating the live buffer must not perturb the child slot.
+        before = child.token_to_input_ids.clone()
+        live.token_to_input_ids[:] += 7
+        assert torch.equal(child.token_to_input_ids, before)
+
+    @pytest.mark.internal
+    def test_async_equals_serial_with_slots(self) -> None:
+        """C2 regression: allocating slots (flag on) keeps decode token-exact vs serial."""
+        self.assert_async_equals_serial(
+            model_provider="gpt",
+            num_requests=4,
+            num_tokens_to_generate=8,
+            num_gap_steps=1,
+        )

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -19,6 +19,7 @@ Run (8 GPUs, in its own ``torch.distributed.run`` invocation)::
 """
 
 import argparse
+import types
 
 import pytest
 import torch
@@ -39,6 +40,9 @@ from megatron.core.inference.engines.step_transaction import (
     classify_launch_eligibility,
 )
 from megatron.core.inference.sampling import TorchSampling
+from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+    TextGenerationController,
+)
 from megatron.core.transformer.cuda_graphs import delete_cuda_graphs
 from megatron.core.transformer.enums import InferenceCudaGraphScope
 from megatron.core.utils import is_fa_min_version
@@ -2208,3 +2212,229 @@ class TestC7Hardening(AsyncSchedTxnTestBase):
         )
         assert async_env.engine.controller._async_launch_before_commit_count > 0
         assert async_env.engine.step_txn_manager.diagnostics.guard_failures == 0
+
+
+@pytest.mark.skipif(
+    not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+)
+@pytest.mark.internal
+class TestC8Parity(AsyncSchedTxnTestBase):
+    """C8: the async==serial parity harness across the full mandated prompt mix + scope gates.
+
+    This is the proof artifact for the build: the launch-before-commit overlap must reproduce the
+    serial oracle token-for-token across greedy AND per-request-RNG sampling, data-dependent
+    (EOS/stop-word) finishes (which drain+discard the doomed forward), simultaneous finishes,
+    batch-drain-to-zero, and (for logprob/top-n requests) the fall-to-serial scope gate. The
+    crash-loud launch-site asserts (mirrored here) keep the overlap from silently widening.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        delete_cuda_graphs()
+        set_rounder(64)
+        Utils.destroy_model_parallel()
+
+    @staticmethod
+    def _cuda_graph_kwargs(**overrides):
+        cfg = dict(
+            model_provider="gpt",
+            num_requests=4,
+            num_gap_steps=0,
+            num_tokens_to_generate=24,
+            use_fixed_output_lengths=True,
+            num_cuda_graphs=4,
+            force_build_cuda_graphs=True,
+            inference_cuda_graph_scope=InferenceCudaGraphScope.block,
+            use_cuda_graphs_for_non_decode_steps=False,
+            context_max_requests=128,
+        )
+        cfg.update(overrides)
+        return cfg
+
+    @staticmethod
+    def _force_data_dependent_finish(rows_at_step):
+        """Patch context: force a data-dependent (EOS-like) finish for given active rows at a step.
+
+        Returns a mock.patch context manager over the controller's data-dependent finish mask that
+        zeros the chosen active rows when the context reaches ``target_step`` -- deterministically,
+        in BOTH the serial and async runs (each env has its own context.step_count), so the
+        comparison is fair and the async path exercises the doomed-forward drain+discard + reprime.
+        """
+        from unittest import mock
+
+        orig = TextGenerationController._data_dependent_finish_mask
+        target_step, rows = rows_at_step
+
+        def forced(self, sampled_tokens_cpu, active_request_ids, active_request_count):
+            mask = orig(self, sampled_tokens_cpu, active_request_ids, active_request_count)
+            ctx = self.inference_wrapped_model.inference_context
+            if ctx.step_count == target_step and active_request_count > max(rows):
+                mask = mask.clone()
+                for r in rows:
+                    mask[r] = 0
+            return mask
+
+        return mock.patch.object(TextGenerationController, "_data_dependent_finish_mask", forced)
+
+    @pytest.mark.internal
+    def test_forced_eos_discard_midbatch_equals_serial(self) -> None:
+        """A single data-dependent (EOS-like) finish at a mid-batch row mid-decode: the launched
+        forward is doomed (it predicted finish-free), so it is drained+discarded and the step
+        re-primes. Token-exact async==serial across the reshape (the multi-finisher discard counter
+        is asserted in the two-EOS test); the overlap fired and the adopt guard never tripped."""
+        with self._force_data_dependent_finish((6, [0])):
+            serial_env, async_env = self.assert_async_equals_serial(
+                **self._cuda_graph_kwargs(num_requests=4)
+            )
+        diag = async_env.engine.step_txn_manager.diagnostics
+        assert async_env.engine.controller._async_launch_before_commit_count > 0
+        assert diag.guard_failures == 0
+
+    @pytest.mark.internal
+    def test_two_eos_same_step_equals_serial(self) -> None:
+        """Two simultaneous data-dependent finishers (rows 0 and 2) on the same step: both popped,
+        survivors stay aligned, the doomed forward drained+discarded. Token-exact async==serial."""
+        with self._force_data_dependent_finish((5, [0, 2])):
+            serial_env, async_env = self.assert_async_equals_serial(
+                **self._cuda_graph_kwargs(num_requests=5)
+            )
+        diag = async_env.engine.step_txn_manager.diagnostics
+        assert async_env.engine.controller._async_launch_before_commit_count > 0
+        assert diag.barrier_skips > 0
+        assert diag.guard_failures == 0
+
+    @pytest.mark.internal
+    def test_two_eos_same_step_nongreedy_equals_serial(self) -> None:
+        """Same, with per-request-RNG sampling: each survivor's keyed draw is its own across the
+        mid-batch compaction the discard+reprime produces."""
+        with self._force_data_dependent_finish((7, [1, 3])):
+            serial_env, async_env = self.assert_async_equals_serial(
+                **self._cuda_graph_kwargs(num_requests=5, use_fixed_output_lengths=False)
+            )
+        assert async_env.engine.controller._async_launch_before_commit_count > 0
+        assert async_env.engine.step_txn_manager.diagnostics.guard_failures == 0
+
+    @pytest.mark.internal
+    def test_two_finishers_same_step_maxlen_equals_serial(self) -> None:
+        """Two requests with the same fixed length finish (max-length) on the same step. Max-length
+        is host-gated, so the launch is suppressed that step (sync prime). Token-exact + drains to
+        zero at the end."""
+        serial_env, async_env = self.assert_async_equals_serial(
+            **self._cuda_graph_kwargs(num_requests=4, num_tokens_to_generate=18)
+        )
+        assert async_env.engine.controller._async_launch_before_commit_count > 0
+        assert async_env.engine.step_txn_manager.diagnostics.guard_failures == 0
+
+    @pytest.mark.internal
+    def test_logprobs_falls_to_serial_path(self) -> None:
+        """A request asking for log probs takes the SERIAL path (single-buffered logits cannot ride
+        the ungated overlap): the launch-before-commit overlap NEVER fires, and tokens are
+        identical to async-off."""
+        from unittest import mock
+
+        base_build = AsyncSchedTxnTestBase._build_requests
+
+        def logprob_build(cls, test_config):
+            requests = base_build(test_config)
+            for request in requests:
+                request.sampling_params.return_log_probs = True
+                # The tiny test model materializes only last-token logits; skip prompt logprobs so
+                # the generated-token logprobs (which force the serial path) are still requested.
+                request.sampling_params.skip_prompt_log_probs = True
+            return requests
+
+        with mock.patch.object(type(self), "_build_requests", classmethod(logprob_build)):
+            serial_env, async_env = self.assert_async_equals_serial(**self._cuda_graph_kwargs())
+        # Scope gate: logprob-bearing requests keep the overlap OFF entirely.
+        assert async_env.engine.controller._async_launch_before_commit_count == 0, (
+            "overlap must not fire while a logprob/top-n request is active (it falls to serial)"
+        )
+
+
+@pytest.mark.internal
+class TestC8ScopeAsserts:
+    """C8: the static scope predicate is crash-loud-tight (no silent widening).
+
+    Unit-level checks of ``_async_overlap_scope_ok`` / ``_active_requests_need_logprobs`` against a
+    tiny fake controller+context: the overlap is refused for MTP, hybrid, EP>1, and logprob/top-n,
+    matching the launch-site asserts exactly. (Multi-rank EP behavior is exercised by the EP gate
+    here without needing a multi-GPU job.)"""
+
+    def _fake(self, *, async_on=True, has_buffer=True, mtp=0, hybrid=False, ep_size=1):
+        class _PG:
+            pass
+
+        ep_group = _PG() if ep_size != 1 else None
+
+        ctx = types.SimpleNamespace(
+            enable_async_scheduling=async_on,
+            decode_metadata_buffer=object() if has_buffer else None,
+            is_hybrid_model=hybrid,
+            expert_model_parallel_group=ep_group,
+            total_request_count=2,
+            paused_request_count=0,
+            active_request_metadata={
+                "return_log_probs": torch.zeros(2, dtype=torch.int32),
+                "top_n_logprobs": torch.zeros(2, dtype=torch.int32),
+            },
+        )
+        iwm = types.SimpleNamespace(inference_context=ctx)
+        ctrl = types.SimpleNamespace(
+            inference_wrapped_model=iwm,
+            num_speculative_tokens=mtp,
+            _async_overlap_scope_ok=lambda c: TextGenerationController._async_overlap_scope_ok(
+                ctrl, c
+            ),
+            _active_requests_need_logprobs=(
+                lambda c: TextGenerationController._active_requests_need_logprobs(ctrl, c)
+            ),
+        )
+        return ctrl, ctx, ep_size
+
+    @pytest.mark.internal
+    def test_scope_ok_for_plain_gpt_ep1(self) -> None:
+        ctrl, ctx, _ = self._fake()
+        assert ctrl._async_overlap_scope_ok(ctx) is True
+
+    @pytest.mark.internal
+    def test_scope_refused_for_mtp_hybrid_ep_and_disabled(self) -> None:
+        import unittest.mock as mock
+
+        # MTP.
+        ctrl, ctx, _ = self._fake(mtp=2)
+        assert ctrl._async_overlap_scope_ok(ctx) is False
+        # Hybrid (mamba single bank).
+        ctrl, ctx, _ = self._fake(hybrid=True)
+        assert ctrl._async_overlap_scope_ok(ctx) is False
+        # Async off / no buffer.
+        ctrl, ctx, _ = self._fake(async_on=False)
+        assert ctrl._async_overlap_scope_ok(ctx) is False
+        ctrl, ctx, _ = self._fake(has_buffer=False)
+        assert ctrl._async_overlap_scope_ok(ctx) is False
+        # EP > 1 (the gate calls get_pg_size on the EP group; patch it to report size 4).
+        ctrl, ctx, _ = self._fake(ep_size=4)
+        with mock.patch(
+            "megatron.core.inference.text_generation_controllers."
+            "text_generation_controller.get_pg_size",
+            return_value=4,
+        ):
+            assert ctrl._async_overlap_scope_ok(ctx) is False
+
+    @pytest.mark.internal
+    def test_logprobs_predicate(self) -> None:
+        ctrl, ctx, _ = self._fake()
+        assert ctrl._active_requests_need_logprobs(ctx) is False
+        ctx.active_request_metadata["return_log_probs"][1] = 1
+        assert ctrl._active_requests_need_logprobs(ctx) is True
+        ctx.active_request_metadata["return_log_probs"][1] = 0
+        ctx.active_request_metadata["top_n_logprobs"][0] = 3
+        assert ctrl._active_requests_need_logprobs(ctx) is True

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Targeted battery for the transactional async-scheduling decode pipeline.
+
+The spine of this battery is :func:`assert_async_equals_serial`, which runs the
+same prompts/seed twice -- once with ``enable_async_scheduling=False`` (the serial
+ground truth) and once ``True`` -- and asserts identical generated token ids. The
+serial path is the oracle; the async path must reproduce it token-for-token.
+
+In the earliest commits the flag is a no-op, so the equivalence check passes
+trivially and exists to lock in the harness. As the async pipeline is built up
+(launch-before-commit, closed survivor set, hybrid single-bank, EP, MTP), the same
+check becomes the load-bearing correctness gate.
+
+Run (8 GPUs, in its own ``torch.distributed.run`` invocation)::
+
+    /opt/venv/bin/python -m torch.distributed.run --nproc-per-node 8 -m pytest -v \
+        tests/unit_tests/inference/test_async_sched_txn.py
+"""
+
+import argparse
+
+import pytest
+import torch
+
+from megatron.core.inference.config import InferenceConfig
+from megatron.core.transformer.cuda_graphs import delete_cuda_graphs
+from megatron.core.utils import is_fa_min_version
+from tests.unit_tests.inference.engines.test_dynamic_engine import (
+    DynamicEngineTestConfig,
+    DynamicInferenceEngineTestBase,
+    set_rounder,
+)
+from tests.unit_tests.test_utilities import Utils
+
+
+def _to_token_list(tokens):
+    """Normalize a generated-token container (list or tensor) to a list of ints."""
+    if tokens is None:
+        return []
+    if isinstance(tokens, torch.Tensor):
+        return tokens.detach().cpu().tolist()
+    return list(tokens)
+
+
+def _collect_outputs(env):
+    """Map request_id -> (status, generated token ids) after a completed run."""
+    outputs = {}
+    for request in env.requests:
+        outputs[request.request_id] = (
+            request.status,
+            _to_token_list(getattr(request, "output", None)),
+        )
+    return outputs
+
+
+class AsyncSchedTxnTestBase(DynamicInferenceEngineTestBase):
+    """Shared helpers for the async-scheduling battery.
+
+    Reuses the model/context/engine fixtures from the dynamic-engine test base so
+    the async path is exercised against the exact same tiny GPT / hybrid configs.
+    """
+
+    @classmethod
+    def assert_async_equals_serial(cls, **test_config_kwargs):
+        """Token-exact ``async == serial`` equivalence.
+
+        Builds and runs the engine twice from identical seeds/config -- once serial
+        (``enable_async_scheduling=False``) and once async (``True``) -- and asserts
+        every request produced the identical status and generated token ids.
+
+        Returns the (serial_env, async_env) pair for any further assertions.
+        """
+        # Disallow the caller overriding the toggle; this helper owns it.
+        test_config_kwargs.pop("enable_async_scheduling", None)
+
+        serial_env = cls._run_test(enable_async_scheduling=False, **test_config_kwargs)
+        serial_outputs = _collect_outputs(serial_env)
+
+        async_env = cls._run_test(enable_async_scheduling=True, **test_config_kwargs)
+        async_outputs = _collect_outputs(async_env)
+
+        assert set(serial_outputs.keys()) == set(async_outputs.keys()), (
+            f"request id sets differ: serial={sorted(serial_outputs)} "
+            f"async={sorted(async_outputs)}"
+        )
+
+        mismatches = []
+        for request_id, (serial_status, serial_tokens) in serial_outputs.items():
+            async_status, async_tokens = async_outputs[request_id]
+            if serial_status != async_status or serial_tokens != async_tokens:
+                mismatches.append(
+                    f"  request {request_id}: "
+                    f"serial=({serial_status}, {serial_tokens}) "
+                    f"async=({async_status}, {async_tokens})"
+                )
+        assert not mismatches, "async != serial for:\n" + "\n".join(mismatches)
+
+        return serial_env, async_env
+
+
+@pytest.mark.skipif(
+    not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+)
+class TestAsyncSchedTxnFlag(AsyncSchedTxnTestBase):
+    """C0: opt-in flag plumbing + the serial-equivalence spine (flag is a no-op here)."""
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        delete_cuda_graphs()
+        set_rounder(64)
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.internal
+    def test_arg_maps_to_config_dest(self) -> None:
+        """The Megatron arg parses to the documented dest, defaulting to False."""
+        from megatron.training.arguments import _add_inference_args
+
+        parser = argparse.ArgumentParser()
+        _add_inference_args(parser)
+
+        # Default is off.
+        default_args = parser.parse_args([])
+        assert default_args.inference_dynamic_batching_async_scheduling is False
+
+        # Enable flag.
+        on_args = parser.parse_args(["--inference-dynamic-batching-async-scheduling"])
+        assert on_args.inference_dynamic_batching_async_scheduling is True
+
+        # BooleanOptionalAction provides an explicit --no- variant.
+        off_args = parser.parse_args(["--no-inference-dynamic-batching-async-scheduling"])
+        assert off_args.inference_dynamic_batching_async_scheduling is False
+
+    @pytest.mark.internal
+    def test_config_field_defaults_false(self) -> None:
+        """The config field exists and defaults to False (disabled == legacy)."""
+        assert InferenceConfig().enable_async_scheduling is False
+        assert InferenceConfig(enable_async_scheduling=True).enable_async_scheduling is True
+
+    @pytest.mark.internal
+    def test_flag_plumbs_to_context(self) -> None:
+        """The flag reaches the live DynamicInferenceContext both off and on."""
+        set_rounder(4)
+        for enabled in (False, True):
+            env = self._build_test_env(
+                DynamicEngineTestConfig(model_provider="gpt", enable_async_scheduling=enabled)
+            )
+            assert env.engine.context.enable_async_scheduling is enabled
+
+    @pytest.mark.internal
+    def test_async_equals_serial_gpt_decode(self) -> None:
+        """Spine: tiny GPT greedy decode is identical with the flag off vs on.
+
+        In C0 the flag is a no-op, so this is a determinism + harness check; the
+        same assertion becomes the real correctness gate in later commits.
+        """
+        self.assert_async_equals_serial(
+            model_provider="gpt",
+            num_tokens_to_generate=8,
+            num_requests=4,
+            num_gap_steps=1,
+        )

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -44,6 +44,7 @@ from tests.unit_tests.inference.engines.test_dynamic_engine import (
     DynamicEngineTestConfig,
     DynamicInferenceEngineTestBase,
     set_rounder,
+    skip_if_mamba_sequence_packing_not_available,
 )
 from tests.unit_tests.test_utilities import Utils
 
@@ -903,3 +904,266 @@ class TestPerRequestKeyedRNG:
             eager=True,
         )
         assert torch.equal(batched, again)
+
+
+@pytest.mark.skipif(
+    not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+)
+class TestC4SingleBufferDecode(AsyncSchedTxnTestBase):
+    """C4: single in-place GPU metadata buffer + token-excluded H2D + GPU token scatter.
+
+    The async decode step now places the next step's input ids on the single GPU metadata
+    buffer with an in-place scatter (no D2H round trip) and excludes the token-id region
+    from the coalesced H2D. The in-place metadata advance is landed + proven equal to the
+    from-scratch rebuild. Everything is gated behind ``enable_async_scheduling``; the bar is
+    token-exact ``async == serial``.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        delete_cuda_graphs()
+        set_rounder(64)
+        Utils.destroy_model_parallel()
+
+    # --- (C) in-place metadata advance == from-scratch rebuild --------------------
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_inplace_advance_equals_rebuild(self) -> None:
+        """The in-place MHA advance reproduces the from-scratch rebuild, incl. a boundary.
+
+        Drives a real GPT decode with a small KV block size (so requests cross block
+        boundaries mid-generation) and, for every consecutive pair of same-batch decode
+        steps, checks that advancing the *previous* step's MHA metadata in place yields the
+        exact metadata ``initialize_attention_state`` rebuilt from scratch.
+        """
+        set_rounder(4)
+        # KV block size must be a multiple of 256 (flash-attn paged-KV constraint), so a
+        # boundary crossing is forced with a long prompt (250) + a short generation: the
+        # sequence crosses the first 256-token block boundary a few decode steps in.
+        env = self._build_test_env(
+            DynamicEngineTestConfig(
+                model_provider="gpt",
+                num_requests=1,
+                num_gap_steps=0,
+                min_prompt_length=250,
+                max_prompt_length=250,
+                num_tokens_to_generate=20,
+                enable_async_scheduling=True,
+            )
+        )
+        context = env.engine.context
+
+        snapshots: list = []
+        original_init = context.initialize_attention_state
+
+        def capturing_init(*args, **kwargs):
+            original_init(*args, **kwargs)
+            # Only capture real (non graph-capture) decode-only steps.
+            if context.is_creating_cuda_graphs or not context.is_decode_only():
+                snapshots.append(None)
+                return
+            bs = context.num_decode_requests
+            snapshots.append(
+                {
+                    "bs": bs,
+                    "query_lengths": context._cpu_mha_query_lengths[:bs].clone(),
+                    "cu_query": context._cpu_mha_cu_query_seq_lengths[: bs + 1].clone(),
+                    "kv_seq_lengths": context._cpu_mha_kv_seq_lengths[:bs].clone(),
+                    "cu_kv": context._cpu_mha_cu_kv_seq_lengths[: bs + 1].clone(),
+                    "block_table": context._cpu_mha_block_table[:bs].clone(),
+                }
+            )
+
+        context.initialize_attention_state = capturing_init
+        try:
+            env.engine._add_request(env.requests[0])
+            while env.engine.has_unfinished_requests():
+                self._run_step(env)
+        finally:
+            context.initialize_attention_state = original_init
+
+        max_req = context.max_requests
+        scratch = {
+            "query_lengths": torch.zeros(max_req, dtype=torch.int32),
+            "cu_query": torch.zeros(max_req + 1, dtype=torch.int32),
+            "kv_seq_lengths": torch.zeros(max_req, dtype=torch.int32),
+            "cu_kv": torch.zeros(max_req + 1, dtype=torch.int32),
+            "block_table": torch.full(
+                (max_req, context.max_kv_block_count), -1, dtype=torch.int32
+            ),
+        }
+
+        verified_pairs = 0
+        boundary_pairs = 0
+        for prev, cur in zip(snapshots, snapshots[1:]):
+            if prev is None or cur is None or prev["bs"] != cur["bs"] or cur["bs"] == 0:
+                continue
+            bs = cur["bs"]
+            context.advance_decode_metadata_in_place(
+                bs=bs,
+                prev_kv_seq_lengths=prev["kv_seq_lengths"],
+                committed_block_table=cur["block_table"],
+                out_query_lengths=scratch["query_lengths"],
+                out_cu_query=scratch["cu_query"],
+                out_kv_seq_lengths=scratch["kv_seq_lengths"],
+                out_cu_kv=scratch["cu_kv"],
+                out_block_table=scratch["block_table"],
+            )
+            assert torch.equal(scratch["query_lengths"][:bs], cur["query_lengths"])
+            assert torch.equal(scratch["cu_query"][: bs + 1], cur["cu_query"])
+            assert torch.equal(scratch["kv_seq_lengths"][:bs], cur["kv_seq_lengths"]), (
+                f"in-place kv_seq advance != rebuild: "
+                f"prev={prev['kv_seq_lengths']} -> got {scratch['kv_seq_lengths'][:bs]} "
+                f"expected {cur['kv_seq_lengths']}"
+            )
+            assert torch.equal(scratch["cu_kv"][: bs + 1], cur["cu_kv"])
+            assert torch.equal(scratch["block_table"][:bs], cur["block_table"])
+            verified_pairs += 1
+            if not torch.equal(prev["block_table"], cur["block_table"]):
+                boundary_pairs += 1
+
+        assert verified_pairs > 0, "no same-batch decode pairs were verified"
+        assert boundary_pairs > 0, "no block-boundary crossing exercised (tune block size)"
+
+    # --- (D) single GPU buffer never moves across decode steps --------------------
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_buffer_data_ptr_invariant_across_decode(self) -> None:
+        """The single GPU metadata buffer (and cached input/pos views) never move."""
+        set_rounder(4)
+        env = self._build_test_env(
+            DynamicEngineTestConfig(
+                model_provider="gpt",
+                num_requests=4,
+                num_gap_steps=1,
+                num_tokens_to_generate=8,
+                enable_async_scheduling=True,
+            )
+        )
+        context = env.engine.context
+        base_ptrs = set()
+        for request in env.requests:
+            env.engine._add_request(request)
+            for _ in range(env.config.num_gap_steps):
+                self._run_step(env)
+                base_ptrs.add(context.decode_metadata_buffer.base_ptr)
+        while env.engine.has_unfinished_requests():
+            self._run_step(env)
+            base_ptrs.add(context.decode_metadata_buffer.base_ptr)
+
+        assert len(base_ptrs) == 1, f"GPU metadata buffer moved across steps: {base_ptrs}"
+        # The live guard recorded the captured address; it equals the live buffer address.
+        buf = context.decode_metadata_buffer
+        assert buf.base_ptr == buf._captured_base_ptr == next(iter(base_ptrs))
+
+    # --- (A) token-excluded H2D leaves the GPU-scattered token region intact -------
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_h2d_excludes_scattered_token_region(self) -> None:
+        """``transfer_bookkeeping_to_gpu(include_token_to_input_ids=False)`` preserves the
+        GPU token-id region (scattered) while still transferring every other field."""
+        set_rounder(4)
+        env = self._build_test_env(
+            DynamicEngineTestConfig(
+                model_provider="gpt",
+                num_requests=2,
+                num_gap_steps=0,
+                num_tokens_to_generate=4,
+                enable_async_scheduling=True,
+            )
+        )
+        context = env.engine.context
+        # Step into a valid decode state.
+        env.engine._add_request(env.requests[0])
+        env.engine._add_request(env.requests[1])
+        self._run_step(env)
+
+        n = 6
+        device = context.gpu_view.token_to_input_ids.device
+        scattered = torch.arange(1000, 1000 + n, device=device, dtype=torch.long)
+        context.gpu_view.token_to_input_ids[:n].copy_(scattered)
+        # CPU token region holds DIFFERENT values; a token-excluded H2D must NOT apply them.
+        context.token_to_input_ids[:n] = torch.arange(2000, 2000 + n, dtype=torch.long)
+        # A non-token field (token_to_pos_ids) the H2D MUST transfer.
+        context.token_to_pos_ids[:n] = torch.arange(7, 7 + n, dtype=torch.long)
+
+        context.transfer_bookkeeping_to_gpu(include_token_to_input_ids=False)
+        torch.cuda.synchronize()
+
+        assert torch.equal(
+            context.gpu_view.token_to_input_ids[:n], scattered
+        ), "token-excluded H2D clobbered the GPU-scattered token ids"
+        assert torch.equal(
+            context.gpu_view.token_to_pos_ids[:n].cpu(),
+            torch.arange(7, 7 + n, dtype=torch.long),
+        ), "token-excluded H2D failed to transfer a non-token field"
+
+        # The H2D fence was recorded on the single buffer.
+        assert context.decode_metadata_buffer.h2d_done_event is not None
+
+        # A full H2D (include=True) DOES overwrite the token region from the CPU buffer.
+        context.transfer_bookkeeping_to_gpu(include_token_to_input_ids=True)
+        torch.cuda.synchronize()
+        assert torch.equal(
+            context.gpu_view.token_to_input_ids[:n].cpu(),
+            torch.arange(2000, 2000 + n, dtype=torch.long),
+        ), "full H2D should transfer the CPU token region"
+
+    # --- (B) end-to-end token-exact async == serial -------------------------------
+
+    @pytest.mark.internal
+    def test_async_equals_serial_torch_nongreedy_reshaping(self) -> None:
+        """Torch non-greedy decode, reshaping batches (staggered finishes)."""
+        self.assert_async_equals_serial(
+            model_provider="gpt",
+            num_requests=8,
+            num_gap_steps=1,
+            num_tokens_to_generate=24,
+            use_fixed_output_lengths=True,
+        )
+
+    @pytest.mark.internal
+    def test_async_equals_serial_greedy_reshaping(self) -> None:
+        """Greedy (argmax) decode, reshaping batches + boundaries -- token-exact."""
+        from unittest import mock
+
+        base_build = AsyncSchedTxnTestBase._build_requests
+
+        def greedy_build(cls, test_config):
+            requests = base_build(test_config)
+            for request in requests:
+                request.sampling_params.top_k = 1  # argmax => greedy, no RNG draws
+            return requests
+
+        with mock.patch.object(type(self), "_build_requests", classmethod(greedy_build)):
+            self.assert_async_equals_serial(
+                model_provider="gpt",
+                num_requests=8,
+                num_gap_steps=1,
+                num_tokens_to_generate=24,
+                use_fixed_output_lengths=True,
+            )
+
+    @pytest.mark.internal
+    def test_async_equals_serial_hybrid_decode(self) -> None:
+        """Hybrid (mamba) decode stays token-exact -- the scatter/exclusion path also fires
+        for hybrid steady-state decode (single coalesced H2D still carries mamba metadata)."""
+        skip_if_mamba_sequence_packing_not_available("hybrid")
+        self.assert_async_equals_serial(
+            model_provider="hybrid",
+            num_requests=4,
+            num_gap_steps=1,
+            num_tokens_to_generate=16,
+        )

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -30,6 +30,7 @@ from megatron.core.inference.engines.step_transaction import (
     LaunchEligibility,
     LaunchGateReason,
     LaunchSignals,
+    PrestagedDecodePlan,
     RetireQueue,
     StepTransactionManager,
     StepTxn,
@@ -1167,3 +1168,400 @@ class TestC4SingleBufferDecode(AsyncSchedTxnTestBase):
             num_gap_steps=1,
             num_tokens_to_generate=16,
         )
+
+
+class TestC5PrestagedPlanPrimitives:
+    """C5 (CPU-only): the prestaged-plan dataclass + manager diagnostics, no model."""
+
+    @pytest.mark.internal
+    def test_plan_dataclass_defaults(self) -> None:
+        empty = PrestagedDecodePlan(step_id=7, eligible=False, skip_reason=LaunchGateReason.RESUME)
+        assert empty.eligible is False
+        assert empty.skip_reason is LaunchGateReason.RESUME
+        assert empty.has_leases is False
+        assert empty.kv_blocks_needed == 0
+
+        leased = PrestagedDecodePlan(
+            step_id=8,
+            eligible=True,
+            kv_block_leases=[3, 4],
+            reserved_boundary_blocks=[(11, 2)],
+            mamba_slot_leases=[5],
+            kv_blocks_needed=1,
+        )
+        assert leased.eligible is True and leased.skip_reason is None
+        assert leased.has_leases is True
+        assert leased.kv_blocks_needed == 1
+
+    @pytest.mark.internal
+    def test_manager_record_prestage_diagnostics(self) -> None:
+        import types
+
+        manager = StepTransactionManager(types.SimpleNamespace())
+        manager.record_prestage(PrestagedDecodePlan(step_id=1, eligible=True))
+        manager.record_prestage(PrestagedDecodePlan(step_id=1, eligible=True))
+        manager.record_prestage(
+            PrestagedDecodePlan(
+                step_id=2, eligible=False, skip_reason=LaunchGateReason.PENDING_ADMISSION
+            )
+        )
+        diag = manager.diagnostics.as_dict()
+        assert diag["prepared"] == 2
+        assert diag["skip_reasons"]["pending_admission"] == 1
+
+
+@pytest.mark.skipif(
+    not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+)
+class TestC5Prestage(AsyncSchedTxnTestBase):
+    """C5: launch-before-commit prestage / publish builders + committed-state launch signals.
+
+    The prestage predicts the *next* decode forward's plan from the committed layout (speculating
+    no finish): it snapshots the consumed request-id set, builds the next forward's MHA metadata
+    into the CPU staging buffer (never live / never GPU), and records the read-only lease manifest
+    (KV blocks, <=1 reserved boundary block per crosser, mamba slots). publish swaps the staging
+    MHA into the live buffer + one token-excluded H2D. These are the building blocks the
+    cross-step shadow overlap consumes; this commit lands + validates them == the serial rebuild,
+    while the runtime decode path is unchanged (so ``async == serial`` / ``async-off == main``).
+
+    Launch eligibility requires a CUDA graph; the tiny test models run eager, so tests that need
+    an *eligible* plan force ``using_cuda_graph_this_step`` True (isolating the prestage logic from
+    the heavyweight graph-capture machinery, which the C4 battery already exercises).
+    """
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        delete_cuda_graphs()
+        set_rounder(64)
+        Utils.destroy_model_parallel()
+
+    def _decode_context(self, *, n_steps=4, **overrides):
+        """Build an async-enabled engine and step it into a committed decode-only state."""
+        set_rounder(4)
+        cfg = dict(
+            model_provider="gpt",
+            num_requests=2,
+            num_gap_steps=0,
+            num_tokens_to_generate=16,
+            enable_async_scheduling=True,
+        )
+        cfg.update(overrides)
+        env = self._build_test_env(DynamicEngineTestConfig(**cfg))
+        for request in env.requests:
+            env.engine._add_request(request)
+        for _ in range(n_steps):
+            if not env.engine.has_unfinished_requests():
+                break
+            self._run_step(env)
+        return env, env.engine.context
+
+    # --- committed-state launch signals -------------------------------------------
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_build_launch_signals_reads_committed_state(self) -> None:
+        """build_launch_signals reflects committed state; eager tiny model => graph-ineligible."""
+        env, ctx = self._decode_context()
+        assert ctx.is_decode_only()
+        sig = ctx.build_launch_signals()
+        assert sig.decode_only is True
+        assert sig.active_request_count == ctx.total_request_count - ctx.paused_request_count
+        assert sig.active_request_count > 0
+        assert sig.mtp_layout_change is False
+        assert sig.kv_reservation_fits is True  # tiny model, ample free blocks
+        assert sig.using_cuda_graph == ctx.using_cuda_graph_this_step()
+        decision = classify_launch_eligibility(sig)
+        if not sig.using_cuda_graph:
+            # No CUDA graph on the tiny eager model -> the launch gate vetoes (sync step).
+            assert not decision.eligible
+            assert decision.reason is LaunchGateReason.GRAPH_INELIGIBLE
+
+    # --- prestage: read-only on live; snapshot + MHA == committed rebuild formula ---
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_prestage_is_read_only_on_live_state(self) -> None:
+        """Prestage writes only the staging buffer; it mutates no live tensor or the allocator."""
+        env, ctx = self._decode_context()
+        ctx.using_cuda_graph_this_step = lambda: True
+        try:
+            buf_before = ctx._cpu_bookkeeping_buf.clone()
+            blocks_before = ctx.request_to_kv_block_ids.clone()
+            ids_before = ctx.request_ids.clone()
+            avail_before = ctx.kv_block_allocator.get_active_avail()
+            plan = ctx.prestage_next_decode_step_into_cpu_staging()
+            assert plan.eligible, plan.skip_reason
+            assert torch.equal(ctx._cpu_bookkeeping_buf, buf_before), "prestage mutated live buffer"
+            assert torch.equal(ctx.request_to_kv_block_ids, blocks_before)
+            assert torch.equal(ctx.request_ids, ids_before)
+            assert ctx.kv_block_allocator.get_active_avail() == avail_before
+            # The snapshot is an independent clone (consume-by-request-id stays stable under
+            # a later compaction of the live request_ids).
+            assert plan.snapshot_request_ids.data_ptr() != ctx.request_ids.data_ptr()
+        finally:
+            del ctx.using_cuda_graph_this_step
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_prestage_snapshot_and_mha_formula(self) -> None:
+        """Snapshot == active request ids; staging MHA == the decode rebuild formula."""
+        env, ctx = self._decode_context()
+        ctx.using_cuda_graph_this_step = lambda: True
+        try:
+            plan = ctx.prestage_next_decode_step_into_cpu_staging()
+            assert plan.eligible and plan.skip_reason is None
+            bs = plan.active_request_count
+            active = slice(ctx.paused_request_count, ctx.total_request_count)
+            assert torch.equal(plan.snapshot_request_ids, ctx.request_ids[active])
+            assert bs == ctx.total_request_count - ctx.paused_request_count
+
+            exp_kv = (
+                ctx.request_kv_length_offsets[active] + ctx.request_query_lengths[active]
+            ).int()
+            assert torch.equal(ctx._staging_mha_kv_seq_lengths[:bs], exp_kv[:bs])
+            assert torch.equal(
+                ctx._staging_mha_query_lengths[:bs], torch.ones(bs, dtype=torch.int32)
+            )
+            assert torch.equal(
+                ctx._staging_mha_cu_query_seq_lengths[: bs + 1],
+                torch.arange(bs + 1, dtype=torch.int32),
+            )
+            exp_cukv = torch.zeros(bs + 1, dtype=torch.int32)
+            exp_cukv[1:] = torch.cumsum(exp_kv[:bs], dim=0)
+            assert torch.equal(ctx._staging_mha_cu_kv_seq_lengths[: bs + 1], exp_cukv)
+            assert torch.equal(
+                ctx._staging_mha_block_table[:bs], ctx.request_to_kv_block_ids[active][:bs].int()
+            )
+        finally:
+            del ctx.using_cuda_graph_this_step
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_prestage_mha_equals_rebuild(self) -> None:
+        """Prestaged staging MHA == initialize_attention_state's live rebuild of the next forward.
+
+        Short prompts + the default (256-token) KV block size => no boundary crossing within a few
+        decode steps, so the full MHA (including the block table) is identical to the rebuild.
+        """
+        env, ctx = self._decode_context()
+        ctx.using_cuda_graph_this_step = lambda: True
+        try:
+            plan = ctx.prestage_next_decode_step_into_cpu_staging()
+        finally:
+            del ctx.using_cuda_graph_this_step
+        assert plan.eligible
+        assert plan.kv_blocks_needed == 0, "this test must not cross a block boundary"
+        bs = plan.active_request_count
+        staging = {
+            "ql": ctx._staging_mha_query_lengths[:bs].clone(),
+            "cuq": ctx._staging_mha_cu_query_seq_lengths[: bs + 1].clone(),
+            "kv": ctx._staging_mha_kv_seq_lengths[:bs].clone(),
+            "cukv": ctx._staging_mha_cu_kv_seq_lengths[: bs + 1].clone(),
+            "bt": ctx._staging_mha_block_table[:bs].clone(),
+        }
+
+        # Rebuild the real next forward's MHA into the live buffer and compare.
+        ctx.initialize_attention_state()
+        assert torch.equal(staging["ql"], ctx._cpu_mha_query_lengths[:bs])
+        assert torch.equal(staging["cuq"], ctx._cpu_mha_cu_query_seq_lengths[: bs + 1])
+        assert torch.equal(staging["kv"], ctx._cpu_mha_kv_seq_lengths[:bs]), (
+            f"prestaged kv_seq != rebuild: {staging['kv']} vs {ctx._cpu_mha_kv_seq_lengths[:bs]}"
+        )
+        assert torch.equal(staging["cukv"], ctx._cpu_mha_cu_kv_seq_lengths[: bs + 1])
+        assert torch.equal(staging["bt"], ctx._cpu_mha_block_table[:bs])
+
+    # --- boundary reservation manifest --------------------------------------------
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_prestage_boundary_reservation(self) -> None:
+        """A boundary crosser is recorded as exactly one reserved block (req_id, column)."""
+        set_rounder(4)
+        # Long prompt (250) + 256-token block => the sequence crosses the first block boundary a
+        # few decode steps in (mirrors the C4 boundary fixture).
+        env = self._build_test_env(
+            DynamicEngineTestConfig(
+                model_provider="gpt",
+                num_requests=1,
+                num_gap_steps=0,
+                min_prompt_length=250,
+                max_prompt_length=250,
+                num_tokens_to_generate=20,
+                enable_async_scheduling=True,
+            )
+        )
+        ctx = env.engine.context
+        env.engine._add_request(env.requests[0])
+
+        saw_boundary = False
+        while env.engine.has_unfinished_requests():
+            if ctx.is_decode_only() and (ctx.total_request_count - ctx.paused_request_count) > 0:
+                ctx.using_cuda_graph_this_step = lambda: True
+                try:
+                    plan = ctx.prestage_next_decode_step_into_cpu_staging()
+                finally:
+                    del ctx.using_cuda_graph_this_step
+                if plan.eligible:
+                    crossers = int(ctx._boundary_crosser_local_indices().numel())
+                    assert plan.kv_blocks_needed == len(plan.reserved_boundary_blocks)
+                    assert plan.kv_blocks_needed == crossers
+                    for req_id, column in plan.reserved_boundary_blocks:
+                        assert req_id >= 0 and column >= 0
+                    if plan.kv_blocks_needed > 0:
+                        saw_boundary = True
+            self._run_step(env)
+
+        assert saw_boundary, "no boundary crosser exercised (tune block size / prompt length)"
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_prestage_kv_unavailable_forces_sync(self) -> None:
+        """No free block for a boundary crosser => sync step (and a same-step finish is NOT
+        counted as headroom -- the gate never reads finishes)."""
+        env, ctx = self._decode_context()
+        ctx.using_cuda_graph_this_step = lambda: True
+        ctx._boundary_crosser_local_indices = lambda: torch.tensor([0], dtype=torch.long)
+        ctx.kv_block_allocator.get_active_avail = lambda: 0  # free pool exhausted
+        try:
+            sig = ctx.build_launch_signals()
+            assert sig.kv_reservation_fits is False
+            plan = ctx.prestage_next_decode_step_into_cpu_staging()
+            assert not plan.eligible
+            assert plan.skip_reason is LaunchGateReason.KV_RESERVATION_UNAVAILABLE
+            # A finish this step would free a block only AFTER commit's release; the prestage
+            # runs before finish-detection and must not count it -- still unavailable.
+            assert ctx.build_launch_signals().kv_reservation_fits is False
+        finally:
+            del ctx.using_cuda_graph_this_step
+            del ctx._boundary_crosser_local_indices
+            del ctx.kv_block_allocator.get_active_avail
+
+    # --- static skip reasons ------------------------------------------------------
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_prestage_skip_reasons(self) -> None:
+        """Each non-eligible condition surfaces its static skip reason (no staging writes)."""
+        env, ctx = self._decode_context()
+
+        # Eager (no CUDA graph) -> graph-ineligible.
+        assert (
+            ctx.prestage_next_decode_step_into_cpu_staging().skip_reason
+            is LaunchGateReason.GRAPH_INELIGIBLE
+        )
+
+        ctx.using_cuda_graph_this_step = lambda: True
+        try:
+            # Pending admission (engine-driven signal).
+            assert (
+                ctx.prestage_next_decode_step_into_cpu_staging(
+                    pending_admission=True
+                ).skip_reason
+                is LaunchGateReason.PENDING_ADMISSION
+            )
+
+            # Not decode-only (prefill / mixed).
+            ctx.is_decode_only = lambda: False
+            try:
+                assert (
+                    ctx.prestage_next_decode_step_into_cpu_staging().skip_reason
+                    is LaunchGateReason.NOT_DECODE_ONLY
+                )
+            finally:
+                del ctx.is_decode_only
+
+            # Chunked prefill in progress.
+            ctx.get_index_of_chunked_prefill_request = lambda safe=True: 0
+            try:
+                assert (
+                    ctx.prestage_next_decode_step_into_cpu_staging().skip_reason
+                    is LaunchGateReason.CHUNKED_PREFILL
+                )
+            finally:
+                del ctx.get_index_of_chunked_prefill_request
+
+            # MTP-dependent layout (speculative decoding).
+            saved_spec = ctx.num_speculative_tokens
+            ctx.num_speculative_tokens = 1
+            try:
+                assert (
+                    ctx.prestage_next_decode_step_into_cpu_staging().skip_reason
+                    is LaunchGateReason.MTP_DEPENDENT_LAYOUT
+                )
+            finally:
+                ctx.num_speculative_tokens = saved_spec
+        finally:
+            del ctx.using_cuda_graph_this_step
+
+    # --- publish: staging -> live + token-excluded H2D ----------------------------
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_publish_transfers_staging_to_live_and_gpu(self) -> None:
+        """publish copies the staging MHA into the live buffer and applies it on the GPU buffer."""
+        env, ctx = self._decode_context()
+        ctx.using_cuda_graph_this_step = lambda: True
+        try:
+            plan = ctx.prestage_next_decode_step_into_cpu_staging()
+            assert plan.eligible
+            bs = plan.active_request_count
+            staging_kv = ctx._staging_mha_kv_seq_lengths[:bs].clone()
+            staging_bt = ctx._staging_mha_block_table[:bs].clone()
+
+            ctx.publish_prepared_decode_plan(plan)
+            torch.cuda.synchronize()
+
+            # Staging MHA is now live.
+            assert torch.equal(ctx._cpu_mha_kv_seq_lengths[:bs], staging_kv)
+            assert torch.equal(ctx._cpu_mha_block_table[:bs], staging_bt)
+            # The GPU buffer's MHA byte-region reflects the live buffer (token-excluded H2D ran).
+            s, e = ctx._mha_region_byte_start, ctx._mha_region_byte_end
+            assert torch.equal(ctx.gpu_view._buf[s:e].cpu(), ctx._cpu_bookkeeping_buf[s:e])
+            assert ctx.decode_metadata_buffer.h2d_done_event is not None
+        finally:
+            del ctx.using_cuda_graph_this_step
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_publish_ineligible_plan_is_noop(self) -> None:
+        """Publishing an ineligible plan changes nothing."""
+        env, ctx = self._decode_context()
+        before = ctx._cpu_bookkeeping_buf.clone()
+        ctx.publish_prepared_decode_plan(
+            PrestagedDecodePlan(step_id=0, eligible=False, skip_reason=LaunchGateReason.RESUME)
+        )
+        assert torch.equal(ctx._cpu_bookkeeping_buf, before)
+
+    # --- regression: runtime decode unchanged (async == serial / async-off == main) ---
+
+    @pytest.mark.internal
+    def test_async_equals_serial_regression(self) -> None:
+        """The prestage/publish builders do not run on the decode path, so async stays
+        token-exact vs serial (greedy, reshaping batches)."""
+        from unittest import mock
+
+        base_build = AsyncSchedTxnTestBase._build_requests
+
+        def greedy_build(cls, test_config):
+            requests = base_build(test_config)
+            for request in requests:
+                request.sampling_params.top_k = 1
+            return requests
+
+        with mock.patch.object(type(self), "_build_requests", classmethod(greedy_build)):
+            self.assert_async_equals_serial(
+                model_provider="gpt",
+                num_requests=6,
+                num_gap_steps=1,
+                num_tokens_to_generate=20,
+                use_fixed_output_lengths=True,
+            )

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -1919,6 +1919,14 @@ class TestC5OverlapFlip(AsyncSchedTxnTestBase):
         assert serial_env.engine.controller._async_launch_before_commit_count == 0
 
     @pytest.mark.internal
+    def test_overlap_equals_serial_torch_nongreedy(self) -> None:
+        """Non-greedy torch decode under a CUDA graph: token-exact async==serial. The C3
+        per-request keyed RNG makes draws depend only on (request_id, draw count), which the
+        overlap preserves (each forward is still sampled once, in request order)."""
+        serial_env, async_env = self.assert_async_equals_serial(**self._greedy_cuda_graph_kwargs())
+        assert async_env.engine.controller._async_launch_before_commit_count > 0
+
+    @pytest.mark.internal
     def test_overlap_equals_serial_greedy_staggered_finishes(self) -> None:
         """Staggered finishes under the overlap: a finish forces a non-overlapped (sync) step and
         the pipeline re-primes, staying token-exact vs serial across the reshapes."""

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -2132,3 +2132,79 @@ class TestC6Ungate(AsyncSchedTxnTestBase):
         assert diag.launched > 0
         assert diag.adopted > 0
         assert diag.guard_failures == 0
+
+
+@pytest.mark.skipif(
+    not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+)
+@pytest.mark.internal
+class TestC7Hardening(AsyncSchedTxnTestBase):
+    """C7: boundary hardening -- admission deferral, barrier recovery, drain.
+
+    The ungated overlap launches a forward speculatively each step. A new request admitted while
+    that forward is in flight would allocate KV under a layout the forward did not compute, forcing
+    an adopt-guard barrier (or racing a deferred free). C7 DEFERS admission: while a forward is in
+    flight and a request is waiting, the next launch is suppressed (a sync prime step), so the
+    following step has no forward in flight and admits safely. The bar is token-exact async==serial
+    across staggered mid-decode admission, with the overlap still firing and the adopt guard never
+    failing (deferral prevents the barrier).
+    """
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        delete_cuda_graphs()
+        set_rounder(64)
+        Utils.destroy_model_parallel()
+
+    @staticmethod
+    def _cuda_graph_kwargs(**overrides):
+        cfg = dict(
+            model_provider="gpt",
+            num_requests=4,
+            num_tokens_to_generate=20,
+            use_fixed_output_lengths=True,
+            num_cuda_graphs=4,
+            force_build_cuda_graphs=True,
+            inference_cuda_graph_scope=InferenceCudaGraphScope.block,
+            use_cuda_graphs_for_non_decode_steps=False,
+            context_max_requests=128,
+        )
+        cfg.update(overrides)
+        return cfg
+
+    @pytest.mark.internal
+    def test_staggered_admission_deferred_equals_serial(self) -> None:
+        """Requests admitted mid-decode (num_gap_steps>0, so a new prefill lands while a forward is
+        in flight): token-exact async==serial, the overlap fired, and the consume-by-request-id
+        adopt guard never tripped -- the C7 admission deferral admits on a clean step, so a forward
+        in flight is never adopted against a layout that grew under it."""
+        serial_env, async_env = self.assert_async_equals_serial(
+            **self._cuda_graph_kwargs(num_requests=5, num_gap_steps=3)
+        )
+        diag = async_env.engine.step_txn_manager.diagnostics
+        assert async_env.engine.controller._async_launch_before_commit_count > 0
+        assert diag.guard_failures == 0, (
+            "admission deferral must prevent the adopt-guard barrier "
+            f"(guard_failures={diag.guard_failures})"
+        )
+
+    @pytest.mark.internal
+    def test_staggered_admission_nongreedy_equals_serial(self) -> None:
+        """Same, with per-request-RNG sampling: a survivor's keyed draws are unperturbed by a new
+        request admitted on a deferred (sync prime) step."""
+        serial_env, async_env = self.assert_async_equals_serial(
+            **self._cuda_graph_kwargs(
+                num_requests=6, num_gap_steps=2, use_fixed_output_lengths=False
+            )
+        )
+        assert async_env.engine.controller._async_launch_before_commit_count > 0
+        assert async_env.engine.step_txn_manager.diagnostics.guard_failures == 0

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -1919,6 +1919,54 @@ class TestC5OverlapFlip(AsyncSchedTxnTestBase):
         assert serial_env.engine.controller._async_launch_before_commit_count == 0
 
     @pytest.mark.internal
+    def test_prestage_issued_in_forward_shadow_before_logits_read(self) -> None:
+        """Deterministic (wall-clock-independent) proof of the continuous-loop pipelining: the
+        next forward's metadata prestage + publish is issued in the CURRENT forward's GPU shadow,
+        BEFORE that forward's logits are read to the host to sample.
+
+        ``_async_overlap_step`` calls ``_async_prestage_next_decode_forward`` (which increments
+        ``_async_prestage_in_shadow_count`` on each eligible prestage) strictly before
+        ``_dynamic_step_prepare_commit`` (the GPU->CPU sample transfer that reads the logits). So
+        every increment of the shadow counter provably happened before the logits read for that
+        step -- the load-bearing ordering, independent of any timing. We assert the shadow
+        prestage fired for at least as many steps as the launch (the launch can only fire when its
+        shadow prestage already published), that both are positive, and that the serial control
+        never prestages. Combined with token-exact ``async == serial`` (asserted here too) this
+        proves the prestage runs in F(K)'s shadow without perturbing the generated tokens.
+        """
+        from unittest import mock
+
+        base_build = AsyncSchedTxnTestBase._build_requests
+
+        def greedy_build(cls, test_config):
+            requests = base_build(test_config)
+            for request in requests:
+                request.sampling_params.top_k = 1  # argmax => greedy, no RNG draws
+            return requests
+
+        with mock.patch.object(type(self), "_build_requests", classmethod(greedy_build)):
+            serial_env, async_env = self.assert_async_equals_serial(
+                **self._greedy_cuda_graph_kwargs()
+            )
+
+        controller = async_env.engine.controller
+        shadow_prestages = controller._async_prestage_in_shadow_count
+        launches = controller._async_launch_before_commit_count
+        # The shadow prestage fired (each issued before its step's logits read, by code order).
+        assert shadow_prestages > 0, "prestage never ran in the forward's shadow"
+        # Every launch was preceded by a shadow prestage+publish for that step (the launch
+        # consumes the metadata the shadow prestage published). Prestage may additionally fire on
+        # a finishing step whose launch is then suppressed, so shadow >= launch > 0.
+        assert launches > 0
+        assert shadow_prestages >= launches, (
+            f"shadow prestages ({shadow_prestages}) must be >= launches ({launches}): "
+            "every launched forward is fed by a prestage published in the prior forward's shadow"
+        )
+        # The serial control issues no shadow prestage (the overlap path is async-only).
+        assert serial_env.engine.controller._async_prestage_in_shadow_count == 0
+        assert serial_env.engine.controller._async_launch_before_commit_count == 0
+
+    @pytest.mark.internal
     def test_overlap_equals_serial_torch_nongreedy(self) -> None:
         """Non-greedy torch decode under a CUDA graph: token-exact async==serial. The C3
         per-request keyed RNG makes draws depend only on (request_id, draw count), which the

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -24,12 +24,7 @@ import pytest
 import torch
 
 from megatron.core.inference.config import InferenceConfig
-from megatron.core.inference.contexts.metadata_slot import (
-    DecodeMetadataSlot,
-    DepthTwoRing,
-    assert_slot_pointer_identity,
-    make_decode_metadata_slots,
-)
+from megatron.core.inference.contexts.metadata_slot import DecodeMetadataBuffer, DepthTwoRing
 from megatron.core.inference.engines.step_transaction import (
     LaunchDecision,
     LaunchEligibility,
@@ -424,47 +419,60 @@ class _StubGpuView:
 
 @pytest.mark.internal
 class TestMetadataSlotPrimitives:
-    """C2 unit tests for the decode-metadata slot + depth-2 ring abstractions."""
+    """C2 (amended): single GPU metadata buffer + CPU staging double-buffer ring.
 
-    def test_slot_reuse_gated_by_fences(self) -> None:
-        """A slot is free only when not in use and both fences have retired."""
-        slot = DecodeMetadataSlot(slot_id=1, gpu_view=_StubGpuView())
-        assert slot.is_free()  # fresh slot, no fences
+    The two-GPU-buffer "slot" model was discarded: a captured decode graph reads metadata
+    by absolute address, so there is exactly ONE fixed-address GPU buffer
+    (:class:`DecodeMetadataBuffer`) updated in place, and the double-buffer is CPU-side
+    (:class:`DepthTwoRing`).
+    """
 
-        slot.acquire()
-        assert not slot.is_free()  # in use
-        with pytest.raises(AssertionError):
-            slot.acquire()  # cannot double-acquire
-        slot.release()
-        assert slot.is_free()
+    def test_buffer_reuse_gated_by_fences(self) -> None:
+        """The single GPU buffer can be re-staged only when both fences have retired."""
+        buf = DecodeMetadataBuffer(gpu_view=_StubGpuView())
+        assert buf.is_free()  # fresh buffer, no fences
 
-        # Pending fences keep the slot busy even after release.
-        slot.h2d_done_event = _StubEvent(ready=True)
-        slot.forward_done_event = _StubEvent(ready=False)
-        assert not slot.is_free()
-        with pytest.raises(AssertionError):
-            slot.acquire()
+        # Pending fences keep the buffer busy (a still in-flight forward may read it).
+        buf.h2d_done_event = _StubEvent(ready=True)
+        buf.forward_done_event = _StubEvent(ready=False)
+        assert not buf.is_free()
 
-        # Once the forward fence completes, the slot frees up.
-        slot.forward_done_event.ready = True
-        assert slot.is_free()
-        slot.acquire()  # now allowed
-        slot.release()
-        slot.reset_fences()
-        assert slot.h2d_done_event is None and slot.forward_done_event is None
+        # Once the forward fence completes, the buffer is reusable.
+        buf.forward_done_event.ready = True
+        assert buf.is_free()
 
-    def test_slot_identity_and_pointer_assertion(self) -> None:
-        """Distinct slots have distinct graph keys; the pointer guard catches moves."""
-        a = DecodeMetadataSlot(slot_id=0, gpu_view=_StubGpuView())
-        b = DecodeMetadataSlot(slot_id=1, gpu_view=_StubGpuView())
-        assert a.graph_slot_key() == a.base_ptr
-        assert a.graph_slot_key() != b.graph_slot_key()
+        buf.reset_fences()
+        assert buf.h2d_done_event is None and buf.forward_done_event is None
 
-        # Captured-against-current-address: guard passes.
-        assert_slot_pointer_identity(a, a.base_ptr)
-        # Captured-against-the-other-slot's-address: guard fires.
-        with pytest.raises(AssertionError):
-            assert_slot_pointer_identity(a, b.base_ptr)
+    def test_pointer_invariance_guard(self) -> None:
+        """The guard captures the buffer (and view) addresses, then asserts invariance.
+
+        This is the single-buffer ``data_ptr()``-invariance guard that replaces the
+        discarded two-slot pointer-identity check: replay is only valid against the buffer
+        the graph captured, so the address must never move.
+        """
+        buf = DecodeMetadataBuffer(gpu_view=_StubGpuView())
+        input_ptr, pos_ptr = 0x1000, 0x2000
+
+        # First call records the baseline addresses (lazy capture); it must not raise.
+        buf.assert_pointer_invariant(input_ids_ptr=input_ptr, pos_ids_ptr=pos_ptr)
+        assert buf._captured_base_ptr == buf.base_ptr
+
+        # Same addresses on every subsequent step: guard passes.
+        buf.assert_pointer_invariant(input_ids_ptr=input_ptr, pos_ids_ptr=pos_ptr)
+
+        # A moved GPU buffer (the bug the guard exists to catch) fires.
+        moved = DecodeMetadataBuffer(gpu_view=_StubGpuView())
+        moved.capture_pointers()
+        moved.gpu_view = _StubGpuView()  # simulate a reallocation to a new address
+        with pytest.raises(AssertionError, match="GPU buffer moved"):
+            moved.assert_pointer_invariant()
+
+        # A moved cached input/pos view also fires.
+        with pytest.raises(AssertionError, match="input_ids view moved"):
+            buf.assert_pointer_invariant(input_ids_ptr=0xBEEF, pos_ids_ptr=pos_ptr)
+        with pytest.raises(AssertionError, match="pos_ids view moved"):
+            buf.assert_pointer_invariant(input_ids_ptr=input_ptr, pos_ids_ptr=0xBEEF)
 
     def test_depth_two_ring(self) -> None:
         """The ring has two distinct entries selected by step parity."""
@@ -475,23 +483,21 @@ class TestMetadataSlotPrimitives:
         assert ring.current(0) == "buf0" and ring.other(0) == "buf1"
         assert ring.current(1) == "buf1" and ring.other(1) == "buf0"
 
-    def test_make_decode_metadata_slots(self) -> None:
-        """slot_current wraps the live view; slot_child wraps a distinct fresh view."""
-        live = _StubGpuView()
-        current, child = make_decode_metadata_slots(
-            live, child_gpu_view_factory=lambda: _StubGpuView()
-        )
-        assert current.gpu_view is live
-        assert current.slot_id == 0 and child.slot_id == 1
-        assert current.base_ptr != child.base_ptr
-        assert current.is_free() and child.is_free()
+    def test_depth_two_ring_of_prebuilt_entries(self) -> None:
+        """``DepthTwoRing.of`` rings two already-constructed entries (live + staging)."""
+        live, staging = ["live"], ["staging"]
+        ring = DepthTwoRing.of(live, staging)
+        assert len(ring) == 2
+        # Entry identity is preserved (the ring holds the live + staging buffers).
+        assert ring.current(0) is live and ring.other(0) is staging
+        assert ring.current(1) is staging and ring.other(1) is live
 
 
 @pytest.mark.skipif(
     not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
 )
 class TestMetadataSlotsInContext(AsyncSchedTxnTestBase):
-    """C2: the context wires slot_current/slot_child only when async is enabled."""
+    """C2 (amended): the context wires the single GPU buffer + CPU staging ring on async."""
 
     @classmethod
     def setup_class(cls):
@@ -509,34 +515,45 @@ class TestMetadataSlotsInContext(AsyncSchedTxnTestBase):
         Utils.destroy_model_parallel()
 
     @pytest.mark.internal
-    def test_slots_present_only_when_enabled(self) -> None:
-        """Serial path: no slots. Async path: slot_current wraps the live gpu_view."""
+    def test_buffer_and_ring_present_only_when_enabled(self) -> None:
+        """Serial path: nothing. Async path: ONE GPU buffer wrapping the live gpu_view."""
         set_rounder(4)
         off = self._build_test_env(
             DynamicEngineTestConfig(model_provider="gpt", enable_async_scheduling=False)
         ).engine.context
-        assert off.slot_current is None and off.slot_child is None
+        assert off.decode_metadata_buffer is None and off.cpu_staging_ring is None
 
         ctx = self._build_test_env(
             DynamicEngineTestConfig(model_provider="gpt", enable_async_scheduling=True)
         ).engine.context
-        assert ctx.slot_current is not None and ctx.slot_child is not None
-        # slot_current is the live gpu_view; slot_child is a distinct free buffer.
-        assert ctx.slot_current.gpu_view is ctx.gpu_view
-        assert ctx.slot_child.gpu_view is not ctx.gpu_view
-        assert ctx.slot_current.base_ptr != ctx.slot_child.base_ptr
-        assert ctx.slot_child.is_free()
+        # The single GPU metadata buffer wraps the live gpu_view -- there is no second
+        # GPU buffer / no replay-against-child.
+        assert ctx.decode_metadata_buffer is not None
+        assert ctx.decode_metadata_buffer.gpu_view is ctx.gpu_view
+        assert ctx.decode_metadata_buffer.base_ptr == ctx.gpu_view._buf.data_ptr()
+        assert ctx.decode_metadata_buffer.is_free()
+        # Exactly one GPU metadata buffer exists (no ContextGPUView other than gpu_view).
+        from megatron.core.inference.contexts.gpu_view import ContextGPUView
+
+        gpu_views = [v for v in vars(ctx).values() if isinstance(v, ContextGPUView)]
+        assert gpu_views == [ctx.gpu_view], "expected exactly one GPU metadata buffer"
+
+        # The genuine double-buffer is CPU-side: live <-> pinned staging mirror.
+        assert ctx.cpu_staging_ring is not None
+        assert ctx.cpu_staging_ring.current(0) is ctx._cpu_bookkeeping_buf
+        assert ctx.cpu_staging_ring.other(0) is ctx._cpu_staging_buf
 
     @pytest.mark.internal
     @torch.inference_mode()
-    def test_serial_metadata_copied_to_child_slot_matches(self) -> None:
-        """slot_child is a faithful, identically-laid-out, independent metadata buffer.
+    def test_cpu_staging_buffer_faithful_and_independent(self) -> None:
+        """The CPU staging mirror is identically laid out and independent from live.
 
-        The prestage (a later commit) builds the next step's bookkeeping into the
-        child slot and copies it via a single coalesced H2D. This verifies the child
-        slot has the exact same byte layout as the live gpu_view (so the copy is
-        sound) and uses independent storage (so a running forward on slot_current is
-        never disturbed by writes to slot_child).
+        The prestage (a later commit) builds the next step's bookkeeping into the CPU
+        staging buffer; one coalesced H2D then copies it into the single GPU buffer. This
+        verifies the staging buffer has the exact same byte layout as the live CPU
+        bookkeeping buffer (so the copy is sound) and uses independent, pinned storage (so
+        prestaging the next step never disturbs the live buffer the current forward's
+        already-issued H2D reads).
         """
         set_rounder(4)
         ctx = self._build_test_env(
@@ -547,41 +564,26 @@ class TestMetadataSlotsInContext(AsyncSchedTxnTestBase):
                 enable_async_scheduling=True,
             )
         ).engine.context
-        live = ctx.slot_current.gpu_view
-        child = ctx.slot_child.gpu_view
+        live = ctx._cpu_bookkeeping_buf
+        staging = ctx._cpu_staging_buf
 
-        # Same backing-buffer size => identical field layout, distinct storage.
-        assert live._buf.shape == child._buf.shape
-        assert live._buf.data_ptr() != child._buf.data_ptr()
+        # Same size/dtype => identical field layout; distinct, pinned storage.
+        assert live.shape == staging.shape and live.dtype == staging.dtype
+        assert live.data_ptr() != staging.data_ptr()
+        assert staging.is_pinned()
 
-        # Stamp the live buffer with a deterministic pattern, then copy into the
-        # child slot exactly as the prestage's coalesced H2D will.
-        live._buf.copy_(
-            (torch.arange(live._buf.numel(), device=live._buf.device) % 251).to(torch.uint8)
-        )
-        child._buf.copy_(live._buf)
-
-        for field in (
-            "token_to_input_ids",
-            "token_to_pos_ids",
-            "token_to_block_idx",
-            "request_query_lengths",
-            "request_kv_length_offsets",
-            "mha_cu_query_seq_lengths",
-            "mha_cu_kv_seq_lengths",
-        ):
-            assert torch.equal(getattr(live, field), getattr(child, field)), (
-                f"field {field} differs after copy"
-            )
-
-        # Independence: mutating the live buffer must not perturb the child slot.
-        before = child.token_to_input_ids.clone()
-        live.token_to_input_ids[:] += 7
-        assert torch.equal(child.token_to_input_ids, before)
+        # Stamp the staging buffer (as the prestage will), then copy into live exactly as
+        # the publish-step swap does -- the views must agree afterward.
+        staging.copy_((torch.arange(staging.numel()) % 251).to(torch.uint8))
+        before_live = live.clone()
+        # Independence: writing the staging buffer must not perturb the live buffer.
+        assert torch.equal(live, before_live)
+        live.copy_(staging)
+        assert torch.equal(live, staging)
 
     @pytest.mark.internal
-    def test_async_equals_serial_with_slots(self) -> None:
-        """C2 regression: allocating slots (flag on) keeps decode token-exact vs serial."""
+    def test_async_equals_serial_single_buffer(self) -> None:
+        """C2 (amended) regression: the single buffer + ring keep decode token-exact."""
         self.assert_async_equals_serial(
             model_provider="gpt",
             num_requests=4,

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -40,6 +40,7 @@ from megatron.core.inference.engines.step_transaction import (
 )
 from megatron.core.inference.sampling import TorchSampling
 from megatron.core.transformer.cuda_graphs import delete_cuda_graphs
+from megatron.core.transformer.enums import InferenceCudaGraphScope
 from megatron.core.utils import is_fa_min_version
 from tests.unit_tests.inference.engines.test_dynamic_engine import (
     DynamicEngineTestConfig,
@@ -1843,3 +1844,99 @@ class TestC5Prestage(AsyncSchedTxnTestBase):
                 num_tokens_to_generate=20,
                 use_fixed_output_lengths=True,
             )
+
+
+@pytest.mark.skipif(
+    not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+)
+class TestC5OverlapFlip(AsyncSchedTxnTestBase):
+    """C5 overlap flip: the runtime launches the next decode forward BEFORE update_requests.
+
+    The launch-before-commit overlap engages for plain GPT decode under a CUDA graph (the launch
+    gate requires a graph, design 1.9). It launches the next forward speculatively -- predicting
+    the pending commit, consume-by-request-id, finish-/boundary-gated so no output realignment is
+    ever needed -- so update_requests runs in the launched forward's GPU shadow. The bar is
+    token-exact ``async == serial`` AND evidence (the controller's ordering counter) that the
+    overlap actually fired. Eager / prefill / hybrid / MTP stay on the serial path.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        delete_cuda_graphs()
+        set_rounder(64)
+        Utils.destroy_model_parallel()
+
+    @staticmethod
+    def _greedy_cuda_graph_kwargs(**overrides):
+        cfg = dict(
+            model_provider="gpt",
+            num_requests=4,
+            num_gap_steps=0,
+            num_tokens_to_generate=24,
+            use_fixed_output_lengths=True,
+            num_cuda_graphs=4,
+            force_build_cuda_graphs=True,
+            inference_cuda_graph_scope=InferenceCudaGraphScope.block,
+            use_cuda_graphs_for_non_decode_steps=False,
+            context_max_requests=128,
+        )
+        cfg.update(overrides)
+        return cfg
+
+    @pytest.mark.internal
+    def test_overlap_fires_and_equals_serial_greedy(self) -> None:
+        """Greedy GPT decode under a CUDA graph: token-exact async==serial AND the overlap fired
+        (the next forward was launched before update_requests at least once)."""
+        from unittest import mock
+
+        base_build = AsyncSchedTxnTestBase._build_requests
+
+        def greedy_build(cls, test_config):
+            requests = base_build(test_config)
+            for request in requests:
+                request.sampling_params.top_k = 1  # argmax => greedy, no RNG draws
+            return requests
+
+        with mock.patch.object(type(self), "_build_requests", classmethod(greedy_build)):
+            serial_env, async_env = self.assert_async_equals_serial(
+                **self._greedy_cuda_graph_kwargs()
+            )
+
+        # The overlap actually engaged: at least one forward was launched before its commit.
+        launches = async_env.engine.controller._async_launch_before_commit_count
+        assert launches > 0, "launch-before-commit overlap never fired (no GPU shadow overlap)"
+        assert async_env.engine.controller._async_committed_with_inflight_forward
+        # The serial control did NOT overlap (the flag stays at its default).
+        assert serial_env.engine.controller._async_launch_before_commit_count == 0
+
+    @pytest.mark.internal
+    def test_overlap_equals_serial_greedy_staggered_finishes(self) -> None:
+        """Staggered finishes under the overlap: a finish forces a non-overlapped (sync) step and
+        the pipeline re-primes, staying token-exact vs serial across the reshapes."""
+        from unittest import mock
+
+        base_build = AsyncSchedTxnTestBase._build_requests
+
+        def greedy_build(cls, test_config):
+            requests = base_build(test_config)
+            for i, request in enumerate(requests):
+                request.sampling_params.top_k = 1
+                # Staggered output lengths => finishes land on different steps, exercising the
+                # finish-gated launch (no speculative launch on a finishing step) + re-prime.
+                request.sampling_params.num_tokens_to_generate = 12 + 3 * i
+            return requests
+
+        with mock.patch.object(type(self), "_build_requests", classmethod(greedy_build)):
+            serial_env, async_env = self.assert_async_equals_serial(
+                **self._greedy_cuda_graph_kwargs(num_requests=5, use_fixed_output_lengths=False)
+            )
+        assert async_env.engine.controller._async_launch_before_commit_count > 0

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -24,6 +24,13 @@ import pytest
 import torch
 
 from megatron.core.inference.config import InferenceConfig
+from megatron.core.inference.engines.step_transaction import (
+    RetireQueue,
+    StepTransactionManager,
+    StepTxn,
+    StepTxnDiagnostics,
+    TxnPhase,
+)
 from megatron.core.transformer.cuda_graphs import delete_cuda_graphs
 from megatron.core.utils import is_fa_min_version
 from tests.unit_tests.inference.engines.test_dynamic_engine import (
@@ -169,3 +176,229 @@ class TestAsyncSchedTxnFlag(AsyncSchedTxnTestBase):
             num_requests=4,
             num_gap_steps=1,
         )
+
+
+class _StubEvent:
+    """A CUDA-event stand-in with a controllable ``query()`` for deterministic tests."""
+
+    def __init__(self, ready: bool):
+        self.ready = ready
+        self.synchronized = False
+
+    def query(self) -> bool:
+        return self.ready
+
+    def synchronize(self) -> None:
+        self.synchronized = True
+        self.ready = True
+
+
+@pytest.mark.internal
+class TestStepTransactionPrimitives:
+    """C1 unit tests for the transaction data structures (no model parallel needed)."""
+
+    def test_lease_ownership_single_owner(self) -> None:
+        """Resources are owned by the transaction via lease fields -- no global arrays."""
+        txn = StepTxn(step_id=7, active_request_count=3)
+        assert txn.phase is TxnPhase.SERIAL
+        assert not txn.has_leases()
+
+        txn.lease_kv_block(11)
+        txn.lease_kv_block(12)
+        txn.reserve_boundary_block(request_id=5, block_column=2, block_id=99)
+        txn.lease_mamba_slot(4)
+
+        assert txn.kv_block_leases == [11, 12]
+        assert txn.reserved_boundary_blocks == {(5, 2): 99}
+        assert txn.mamba_slot_leases == [4]
+        # Reserved boundary blocks are included in the full KV-block ownership view.
+        assert sorted(txn.leased_kv_block_ids()) == [11, 12, 99]
+        assert txn.has_leases()
+
+    def test_retire_queue_two_step_delay_no_event(self) -> None:
+        """Without a fence, a resource is released only after the two-step delay."""
+        released = []
+        q = RetireQueue()
+        assert q.RETIRE_DELAY_STEPS == 2
+        q.enqueue(enqueue_step=0, release=lambda: released.append("blk"), tag="kv")
+
+        assert q.drain(0) == 0  # same step
+        assert q.drain(1) == 0  # one step later
+        assert released == []
+        assert q.pending() == 1
+        assert q.drain(2) == 1  # two steps later -> released
+        assert released == ["blk"]
+        assert q.pending() == 0
+
+    def test_retire_queue_fence_gate(self) -> None:
+        """Even past the delay, a resource is held until its fence completes."""
+        released = []
+        ev = _StubEvent(ready=False)
+        q = RetireQueue()
+        q.enqueue(enqueue_step=0, release=lambda: released.append("blk"), event=ev, tag="kv")
+
+        # Delay satisfied, but fence not yet complete -> still held.
+        assert q.drain(5) == 0
+        assert released == []
+        assert q.pending() == 1
+
+        # Fence completes -> released on next drain.
+        ev.ready = True
+        assert q.drain(5) == 1
+        assert released == ["blk"]
+
+    def test_retire_queue_real_cuda_event(self) -> None:
+        """Integration: a recorded+synchronized CUDA event gates the release."""
+        released = []
+        stream = torch.cuda.current_stream()
+        x = torch.ones(256, 256, device="cuda")
+        _ = x @ x  # enqueue real work
+        ev = torch.cuda.Event()
+        ev.record(stream)
+
+        q = RetireQueue()
+        q.enqueue(enqueue_step=0, release=lambda: released.append("blk"), event=ev)
+        ev.synchronize()  # guarantee completion
+        assert q.drain(2) == 1
+        assert released == ["blk"]
+
+    def test_retire_queue_drain_all_blocking(self) -> None:
+        """Shutdown drain synchronizes fences and releases everything."""
+        released = []
+        ev = _StubEvent(ready=False)
+        q = RetireQueue()
+        q.enqueue(enqueue_step=10, release=lambda: released.append("a"), event=ev)
+        q.enqueue(enqueue_step=10, release=lambda: released.append("b"))
+        assert q.drain_all_blocking() == 2
+        assert sorted(released) == ["a", "b"]
+        assert ev.synchronized is True
+        assert q.pending() == 0
+
+    def test_retire_queue_out_of_order_ready(self) -> None:
+        """A ready entry is not blocked behind an earlier not-ready one."""
+        released = []
+        not_ready = _StubEvent(ready=False)
+        ready = _StubEvent(ready=True)
+        q = RetireQueue()
+        q.enqueue(enqueue_step=0, release=lambda: released.append("first"), event=not_ready)
+        q.enqueue(enqueue_step=0, release=lambda: released.append("second"), event=ready)
+
+        assert q.drain(2) == 1  # only the ready one
+        assert released == ["second"]
+        assert q.pending() == 1
+
+    def test_manager_serial_txn_lifecycle_and_diagnostics(self) -> None:
+        """begin_serial_txn -> commit updates phase and the always-on counters."""
+        mgr = StepTransactionManager(context=None)
+        d = mgr.diagnostics
+        assert d.as_dict()["serial_steps"] == 0
+
+        txn = mgr.begin_serial_txn(step_id=0, active_request_count=2)
+        assert txn.phase is TxnPhase.ADOPTED
+        assert txn.speculative is False
+        assert (d.prepared, d.adopted, d.serial_steps, d.launched) == (1, 1, 1, 0)
+        assert mgr.current_txn is txn
+
+        mgr.commit(txn)
+        assert txn.phase is TxnPhase.COMMITTED
+
+        # Diagnostic hooks are O(1) and route to the right counters.
+        mgr.note_sync_step("admission")
+        mgr.barrier("graph_recapture")
+        mgr.note_skip("paused_request")
+        mgr.note_guard_failure()
+        snap = d.as_dict()
+        assert snap["sync_steps"] == 1
+        assert snap["barrier_skips"] == 1
+        assert snap["guard_failures"] == 1
+        assert snap["skip_reasons"] == {
+            "admission": 1,
+            "graph_recapture": 1,
+            "paused_request": 1,
+        }
+
+    def test_diagnostics_dict_keys(self) -> None:
+        """The diagnostics snapshot exposes the full documented counter set."""
+        keys = set(StepTxnDiagnostics().as_dict().keys())
+        assert keys == {
+            "prepared",
+            "launched",
+            "adopted",
+            "serial_steps",
+            "sync_steps",
+            "barrier_skips",
+            "retired",
+            "guard_failures",
+            "skip_reasons",
+        }
+
+
+@pytest.mark.skipif(
+    not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+)
+class TestAsyncSchedTxnScaffold(AsyncSchedTxnTestBase):
+    """C1: the serial step wrapped as an always-adopted transaction (still serial)."""
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        delete_cuda_graphs()
+        set_rounder(64)
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.internal
+    def test_manager_only_when_enabled(self) -> None:
+        """The manager (and its overhead) exists only when the flag is on."""
+        set_rounder(4)
+        off_env = self._build_test_env(
+            DynamicEngineTestConfig(model_provider="gpt", enable_async_scheduling=False)
+        )
+        assert off_env.engine.step_txn_manager is None
+
+        on_env = self._build_test_env(
+            DynamicEngineTestConfig(model_provider="gpt", enable_async_scheduling=True)
+        )
+        assert on_env.engine.step_txn_manager is not None
+        assert on_env.engine.step_txn_manager.diagnostics.as_dict() == StepTxnDiagnostics().as_dict()
+
+    @pytest.mark.internal
+    def test_no_global_async_resource_arrays(self) -> None:
+        """The context must not carry global _async_reserved_* / _async_deferred_* arrays."""
+        set_rounder(4)
+        env = self._build_test_env(
+            DynamicEngineTestConfig(model_provider="gpt", enable_async_scheduling=True)
+        )
+        ctx = env.engine.context
+        offenders = [
+            name
+            for name in vars(ctx)
+            if name.startswith("_async_reserved") or name.startswith("_async_deferred")
+        ]
+        assert offenders == [], f"global async resource arrays present: {offenders}"
+
+    @pytest.mark.internal
+    def test_serial_wrapped_txn_equals_serial_bs1(self) -> None:
+        """bs=1 tiny GPT decode is token-identical when wrapped as a serial txn."""
+        serial_env, async_env = self.assert_async_equals_serial(
+            model_provider="gpt",
+            num_requests=1,
+            num_tokens_to_generate=8,
+            num_gap_steps=1,
+        )
+        # The wrapped path ran as always-adopted serial transactions: every step was
+        # prepared+adopted, none launched speculatively, and no guard ever tripped.
+        d = async_env.engine.step_txn_manager.diagnostics
+        assert d.serial_steps > 0
+        assert d.prepared == d.serial_steps
+        assert d.adopted == d.serial_steps
+        assert d.launched == 0
+        assert d.guard_failures == 0
+        assert d.retired == 0

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -31,11 +31,16 @@ from megatron.core.inference.contexts.metadata_slot import (
     make_decode_metadata_slots,
 )
 from megatron.core.inference.engines.step_transaction import (
+    LaunchDecision,
+    LaunchEligibility,
+    LaunchGateReason,
+    LaunchSignals,
     RetireQueue,
     StepTransactionManager,
     StepTxn,
     StepTxnDiagnostics,
     TxnPhase,
+    classify_launch_eligibility,
 )
 from megatron.core.transformer.cuda_graphs import delete_cuda_graphs
 from megatron.core.utils import is_fa_min_version
@@ -583,3 +588,88 @@ class TestMetadataSlotsInContext(AsyncSchedTxnTestBase):
             num_tokens_to_generate=8,
             num_gap_steps=1,
         )
+
+
+@pytest.mark.internal
+class TestLaunchEligibilityGate:
+    """C5 (diagnostics-only) / section 1.9: the static launch-eligibility gate.
+
+    Pure classification logic for whether a step may launch a speculative child
+    forward before commit. No hot path / CUDA-graph surgery -- the prestage that
+    builds the child metadata and the launch that consumes it land in later commits.
+    """
+
+    @staticmethod
+    def _eligible_signals(**overrides) -> LaunchSignals:
+        """A baseline of signals for which a speculative launch IS eligible."""
+        base = dict(decode_only=True, active_request_count=4, using_cuda_graph=True)
+        base.update(overrides)
+        return LaunchSignals(**base)
+
+    def test_pure_decode_is_eligible(self) -> None:
+        decision = classify_launch_eligibility(self._eligible_signals())
+        assert decision.eligibility is LaunchEligibility.ELIGIBLE
+        assert decision.reason is LaunchGateReason.PURE_DECODE
+        assert decision.eligible is True
+
+    def test_each_ineligible_condition_maps_to_its_reason(self) -> None:
+        """Exhaustive: each non-absorbable condition forces a sync step with its reason."""
+        cases = [
+            (dict(active_request_count=0), LaunchGateReason.NO_ACTIVE_REQUESTS),
+            (dict(decode_only=False), LaunchGateReason.NOT_DECODE_ONLY),
+            (dict(using_cuda_graph=False), LaunchGateReason.GRAPH_INELIGIBLE),
+            (dict(graph_recapture=True), LaunchGateReason.GRAPH_RECAPTURE),
+            (dict(chunked_prefill_active=True), LaunchGateReason.CHUNKED_PREFILL),
+            (dict(pending_admission=True), LaunchGateReason.PENDING_ADMISSION),
+            (dict(resume_pending=True), LaunchGateReason.RESUME),
+            (dict(evict_pending=True), LaunchGateReason.EVICT),
+            (dict(forced_pause_overflow=True), LaunchGateReason.FORCED_PAUSE_OVERFLOW),
+            (dict(mtp_layout_change=True), LaunchGateReason.MTP_DEPENDENT_LAYOUT),
+            (dict(kv_reservation_fits=False), LaunchGateReason.KV_RESERVATION_UNAVAILABLE),
+        ]
+        # Every non-eligible reason is reachable, and no two cases collapse.
+        reasons_seen = set()
+        for overrides, expected_reason in cases:
+            decision = classify_launch_eligibility(self._eligible_signals(**overrides))
+            assert decision.eligibility is LaunchEligibility.SYNC, overrides
+            assert decision.reason is expected_reason, overrides
+            assert not decision.eligible
+            reasons_seen.add(expected_reason)
+        # The cases cover every LaunchGateReason except the eligible one.
+        assert reasons_seen == set(LaunchGateReason) - {LaunchGateReason.PURE_DECODE}
+
+    def test_reason_priority_is_deterministic(self) -> None:
+        """When several gates fail, the most fundamental one is reported."""
+        # not-decode-only outranks a pending admission.
+        d = classify_launch_eligibility(
+            self._eligible_signals(decode_only=False, pending_admission=True)
+        )
+        assert d.reason is LaunchGateReason.NOT_DECODE_ONLY
+        # no-active-requests outranks everything.
+        d = classify_launch_eligibility(
+            self._eligible_signals(active_request_count=0, decode_only=False)
+        )
+        assert d.reason is LaunchGateReason.NO_ACTIVE_REQUESTS
+        # graph recapture outranks downstream layout reasons.
+        d = classify_launch_eligibility(
+            self._eligible_signals(graph_recapture=True, evict_pending=True)
+        )
+        assert d.reason is LaunchGateReason.GRAPH_RECAPTURE
+
+    def test_absorbable_events_are_not_gate_inputs(self) -> None:
+        """Finish / stop-word / cancel must not appear as launch-gate signals.
+
+        They are absorbable (a launched forward discards the finished row), so they
+        never force a sync step -- encoded by their absence from LaunchSignals.
+        """
+        field_names = set(LaunchSignals.__dataclass_fields__.keys())
+        for forbidden in ("finish", "finished", "stop_word", "stopword", "cancel"):
+            assert not any(forbidden in name for name in field_names), (
+                f"absorbable signal '{forbidden}' must not gate launches"
+            )
+
+    def test_launch_decision_dataclass(self) -> None:
+        d = LaunchDecision(LaunchEligibility.ELIGIBLE, LaunchGateReason.PURE_DECODE)
+        assert d.eligible is True
+        d2 = LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.RESUME)
+        assert d2.eligible is False

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -1536,6 +1536,40 @@ class TestC5Prestage(AsyncSchedTxnTestBase):
 
     @pytest.mark.internal
     @torch.inference_mode()
+    def test_prestage_excludes_host_maxlen_finishers_from_snapshot(self) -> None:
+        """C5: a host-known max-length finisher is dropped from the launch snapshot.
+
+        The launch-before-commit prestage builds the consume-by-request-id snapshot from the
+        committed active set. When the caller supplies the host-maxlen survival mask (1 = survives,
+        0 = reaches max_sequence_length at the pending commit -- host-deterministic, no D2H), the
+        finisher row's request id must be absent from ``snapshot_request_ids`` (it is freed at its
+        own commit and must never ride the speculative forward). A None mask is byte-identical to
+        no exclusion (the serial-path default)."""
+        env, ctx = self._decode_context()
+        ctx.using_cuda_graph_this_step = lambda: True
+        try:
+            active = slice(ctx.paused_request_count, ctx.total_request_count)
+            bs = ctx.total_request_count - ctx.paused_request_count
+            assert bs >= 2, "need >=2 active requests to exercise a mid-batch exclusion"
+            full_ids = ctx.request_ids[active].clone()
+
+            # Baseline: no mask -> snapshot is the full active set (default serial behavior).
+            plan_full = ctx.prestage_next_decode_step_into_cpu_staging()
+            assert torch.equal(plan_full.snapshot_request_ids, full_ids)
+
+            # Mark the first active row a host-known max-length finisher; it must be excluded.
+            survival = torch.ones(bs, dtype=torch.uint8)
+            survival[0] = 0
+            plan = ctx.prestage_next_decode_step_into_cpu_staging(snapshot_survival_mask=survival)
+            finisher_id = int(full_ids[0].item())
+            snap = plan.snapshot_request_ids.tolist()
+            assert finisher_id not in snap, "host max-length finisher leaked into the snapshot"
+            assert snap == [int(x) for x in full_ids[1:].tolist()], "survivors must be kept in order"
+        finally:
+            del ctx.using_cuda_graph_this_step
+
+    @pytest.mark.internal
+    @torch.inference_mode()
     def test_prestage_mha_equals_rebuild(self) -> None:
         """Prestaged staging MHA == initialize_attention_state's live rebuild of the next forward.
 

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -640,8 +640,13 @@ class TestLaunchEligibilityGate:
             assert decision.reason is expected_reason, overrides
             assert not decision.eligible
             reasons_seen.add(expected_reason)
-        # The cases cover every LaunchGateReason except the eligible one.
-        assert reasons_seen == set(LaunchGateReason) - {LaunchGateReason.PURE_DECODE}
+        # The cases cover every reason produced by the static classifier. PURE_DECODE is the
+        # eligible reason, and SPECULATIVE_BOUNDARY_WINDOW is a prestage-only reason (set by the
+        # launch-before-commit boundary look-ahead, not derivable from the static LaunchSignals).
+        assert reasons_seen == set(LaunchGateReason) - {
+            LaunchGateReason.PURE_DECODE,
+            LaunchGateReason.SPECULATIVE_BOUNDARY_WINDOW,
+        }
 
     def test_reason_priority_is_deterministic(self) -> None:
         """When several gates fail, the most fundamental one is reported."""
@@ -1562,6 +1567,95 @@ class TestC5Prestage(AsyncSchedTxnTestBase):
         )
         assert torch.equal(staging["cukv"], ctx._cpu_mha_cu_kv_seq_lengths[: bs + 1])
         assert torch.equal(staging["bt"], ctx._cpu_mha_block_table[:bs])
+
+    # --- speculative (launch-before-commit) prestage ------------------------------
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_speculative_prestage_equals_commit_then_rebuild(self) -> None:
+        """The speculative plan == the metadata of the forward AFTER the pending commit.
+
+        Launch-before-commit defers the current decode step's ``update_requests`` and launches
+        the next forward against the layout that commit *will* produce (design 1.1 step 2). So
+        the speculative prestage taken at the committed layout must equal what
+        ``initialize_attention_state`` rebuilds after one more real decode step is committed.
+        """
+        env, ctx = self._decode_context()
+        ctx.using_cuda_graph_this_step = lambda: True
+        try:
+            plan = ctx.prestage_next_decode_step_into_cpu_staging(
+                speculate_pending_decode_commit=True
+            )
+        finally:
+            del ctx.using_cuda_graph_this_step
+        assert plan.eligible, plan.skip_reason
+        assert plan.kv_blocks_needed == 0, "fixture must not cross a boundary in the spec window"
+        bs = plan.active_request_count
+        spec = {
+            "ql": ctx._staging_mha_query_lengths[:bs].clone(),
+            "cuq": ctx._staging_mha_cu_query_seq_lengths[: bs + 1].clone(),
+            "kv": ctx._staging_mha_kv_seq_lengths[:bs].clone(),
+            "cukv": ctx._staging_mha_cu_kv_seq_lengths[: bs + 1].clone(),
+            "bt": ctx._staging_mha_block_table[:bs].clone(),
+        }
+        snapshot = plan.snapshot_request_ids.clone()
+
+        # Commit exactly one more real decode step, then rebuild the next forward's MHA.
+        self._run_step(env)
+        active = slice(ctx.paused_request_count, ctx.total_request_count)
+        # Finish-free, no-boundary step => the active set is unchanged, so the speculative
+        # snapshot (consume-by-request-id) matches the post-commit survivors exactly.
+        assert torch.equal(snapshot, ctx.request_ids[active])
+        ctx.initialize_attention_state()
+        assert torch.equal(spec["kv"], ctx._cpu_mha_kv_seq_lengths[:bs]), (
+            f"spec kv != post-commit rebuild: {spec['kv']} vs {ctx._cpu_mha_kv_seq_lengths[:bs]}"
+        )
+        assert torch.equal(spec["ql"], ctx._cpu_mha_query_lengths[:bs])
+        assert torch.equal(spec["cuq"], ctx._cpu_mha_cu_query_seq_lengths[: bs + 1])
+        assert torch.equal(spec["cukv"], ctx._cpu_mha_cu_kv_seq_lengths[: bs + 1])
+        assert torch.equal(spec["bt"], ctx._cpu_mha_block_table[:bs])
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_speculative_prestage_kv_is_one_ahead_of_nonspeculative(self) -> None:
+        """At one committed layout, the speculative kv lengths lead the non-speculative by one
+        unit query (the predicted pending-commit append)."""
+        env, ctx = self._decode_context()
+        ctx.using_cuda_graph_this_step = lambda: True
+        try:
+            non_spec = ctx.prestage_next_decode_step_into_cpu_staging()
+            bs = non_spec.active_request_count
+            non_spec_kv = ctx._staging_mha_kv_seq_lengths[:bs].clone()
+            spec = ctx.prestage_next_decode_step_into_cpu_staging(
+                speculate_pending_decode_commit=True
+            )
+            spec_kv = ctx._staging_mha_kv_seq_lengths[:bs].clone()
+        finally:
+            del ctx.using_cuda_graph_this_step
+        assert non_spec.eligible and spec.eligible
+        active = slice(ctx.paused_request_count, ctx.total_request_count)
+        assert torch.equal(spec_kv, non_spec_kv + ctx.request_query_lengths[active][:bs].int())
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_speculative_prestage_boundary_window_forces_sync(self) -> None:
+        """A crosser inside the 2-step speculative window makes the speculative plan ineligible
+        (SPECULATIVE_BOUNDARY_WINDOW) even though the non-speculative 1-step plan is eligible."""
+        env, ctx = self._decode_context()
+        ctx.using_cuda_graph_this_step = lambda: True
+        # Force "a request crosses within the spec window" while the 1-step gate still fits.
+        ctx._decode_crossers_within_window = lambda steps: 1 if steps >= 2 else 0
+        try:
+            non_spec = ctx.prestage_next_decode_step_into_cpu_staging()
+            assert non_spec.eligible, non_spec.skip_reason
+            spec = ctx.prestage_next_decode_step_into_cpu_staging(
+                speculate_pending_decode_commit=True
+            )
+            assert not spec.eligible
+            assert spec.skip_reason is LaunchGateReason.SPECULATIVE_BOUNDARY_WINDOW
+        finally:
+            del ctx.using_cuda_graph_this_step
+            del ctx._decode_crossers_within_window
 
     # --- boundary reservation manifest --------------------------------------------
 

--- a/tests/unit_tests/inference/test_async_sched_txn.py
+++ b/tests/unit_tests/inference/test_async_sched_txn.py
@@ -37,6 +37,7 @@ from megatron.core.inference.engines.step_transaction import (
     TxnPhase,
     classify_launch_eligibility,
 )
+from megatron.core.inference.sampling import TorchSampling
 from megatron.core.transformer.cuda_graphs import delete_cuda_graphs
 from megatron.core.utils import is_fa_min_version
 from tests.unit_tests.inference.engines.test_dynamic_engine import (
@@ -675,3 +676,230 @@ class TestLaunchEligibilityGate:
         assert d.eligible is True
         d2 = LaunchDecision(LaunchEligibility.SYNC, LaunchGateReason.RESUME)
         assert d2.eligible is False
+
+
+class _FakeSamplingContext:
+    """A minimal stand-in for DynamicInferenceContext, exposing only what the torch
+    sampler reads: the active request count, the (compacted) per-request sampling
+    metadata, and ``request_ids`` (active row i == request_ids[paused + i])."""
+
+    def __init__(self, request_ids, temperature, top_k, top_p, paused_request_count=0):
+        device = torch.cuda.current_device()
+        active = len(request_ids)
+        assert len(temperature) == len(top_k) == len(top_p) == active
+        self.paused_request_count = paused_request_count
+        self.total_request_count = paused_request_count + active
+        # request_ids: paused placeholders at the front, then the active ids.
+        rids = [-1] * paused_request_count + [int(r) for r in request_ids]
+        self.request_ids = torch.tensor(rids, dtype=torch.long, device=device)
+        # active_request_metadata is compacted (index 0 == first active request).
+        self.active_request_metadata = {
+            "temperature": torch.tensor(temperature, dtype=torch.float32, device=device),
+            "top_k": torch.tensor(top_k, dtype=torch.int32, device=device),
+            "top_p": torch.tensor(top_p, dtype=torch.float32, device=device),
+        }
+
+
+@pytest.mark.internal
+class TestPerRequestKeyedRNG:
+    """C3: the torch backend's per-request keyed RNG (serial behavior change).
+
+    The migrated sampler draws each request from its own ``(seed + request_id)``-keyed
+    generator, so a request's draw depends only on ``(request_id, its own draw count)`` --
+    invariant to batch composition and row order. That is exactly the property pre-commit
+    async sampling needs, and it makes ``async == serial`` token-exact by construction.
+    Greedy rows (``top_k == 1``) draw no random numbers and are a strict no-op.
+    """
+
+    VOCAB = 32
+
+    def _sampler(self, seed: int) -> TorchSampling:
+        # The shared rng is only used by the static path; per-request keying uses `seed`.
+        shared = torch.Generator(device=torch.cuda.current_device())
+        shared.manual_seed(seed)
+        return TorchSampling(shared, vocab_size=self.VOCAB, seed=seed)
+
+    def _uniform_logits(self, n: int) -> torch.Tensor:
+        # Uniform logits => the sampled token is fully determined by the RNG, which makes
+        # the determinism / invariance assertions sharp.
+        return torch.zeros(n, self.VOCAB, device=torch.cuda.current_device())
+
+    def _neutral(self, n: int):
+        # temperature=1.0, top_k=0, top_p=0.0 => no filtering, pure multinomial draw.
+        return [1.0] * n, [0] * n, [0.0] * n
+
+    def test_fixed_seed_reproducible(self) -> None:
+        """Same seed + same request ids => identical tokens (bs=1 and bs>1)."""
+        for request_ids in ([7], [3, 8, 5, 1]):
+            n = len(request_ids)
+            t, k, p = self._neutral(n)
+            logits = self._uniform_logits(n)
+            a = self._sampler(1234).sample_kernel(
+                logits.clone(), n, _FakeSamplingContext(request_ids, t, k, p)
+            )
+            b = self._sampler(1234).sample_kernel(
+                logits.clone(), n, _FakeSamplingContext(request_ids, t, k, p)
+            )
+            assert torch.equal(a, b), f"non-reproducible for {request_ids}: {a} vs {b}"
+
+    def test_invariant_to_batch_composition(self) -> None:
+        """A request's draw is identical alone vs. batched with other requests.
+
+        This is the load-bearing property: pre-commit async sampling re-orders / re-sizes
+        the batch, so a per-request draw must not depend on who else is present.
+        """
+        t1, k1, p1 = self._neutral(1)
+        alone = self._sampler(99).sample_kernel(
+            self._uniform_logits(1), 1, _FakeSamplingContext([42], t1, k1, p1)
+        )
+
+        # Request 42 is now row 2 in a 4-request batch; its logits row is identical.
+        request_ids = [10, 11, 42, 13]
+        n = len(request_ids)
+        t, k, p = self._neutral(n)
+        batched = self._sampler(99).sample_kernel(
+            self._uniform_logits(n), n, _FakeSamplingContext(request_ids, t, k, p)
+        )
+        assert batched[2].item() == alone[0].item(), (
+            f"request 42 drew {batched[2].item()} in a batch but {alone[0].item()} alone"
+        )
+
+    def test_invariant_to_row_order(self) -> None:
+        """Reordering the rows leaves each request's draw unchanged."""
+        t, k, p = self._neutral(2)
+        forward = self._sampler(7).sample_kernel(
+            self._uniform_logits(2), 2, _FakeSamplingContext([100, 200], t, k, p)
+        )
+        reversed_ = self._sampler(7).sample_kernel(
+            self._uniform_logits(2), 2, _FakeSamplingContext([200, 100], t, k, p)
+        )
+        # request 100 is row 0 forward / row 1 reversed; request 200 is the opposite.
+        assert forward[0].item() == reversed_[1].item()
+        assert forward[1].item() == reversed_[0].item()
+
+    def test_survivor_unperturbed_by_finish_and_retire(self) -> None:
+        """A request's stream is independent of others' presence; retiring is safe."""
+        t3, k3, p3 = self._neutral(3)
+        t1, k1, p1 = self._neutral(1)
+
+        # Survivor request 5 batched with two others, drawn over two steps.
+        big = self._sampler(55)
+        ctx_big = _FakeSamplingContext([5, 6, 7], t3, k3, p3)
+        big_step0 = big.sample_kernel(self._uniform_logits(3), 3, ctx_big)
+        # Retire a finished peer mid-run; survivors must not shift.
+        big.retire_requests([6])
+        big_step1 = big.sample_kernel(self._uniform_logits(3), 3, ctx_big)
+
+        # Request 5 alone over two steps must produce the same two tokens.
+        solo = self._sampler(55)
+        ctx_solo = _FakeSamplingContext([5], t1, k1, p1)
+        solo_step0 = solo.sample_kernel(self._uniform_logits(1), 1, ctx_solo)
+        solo_step1 = solo.sample_kernel(self._uniform_logits(1), 1, ctx_solo)
+
+        assert big_step0[0].item() == solo_step0[0].item()
+        assert big_step1[0].item() == solo_step1[0].item()
+
+        # Retiring then re-adding a request id gives a fresh, identically-seeded stream.
+        s = self._sampler(55)
+        first = s.sample_kernel(self._uniform_logits(1), 1, _FakeSamplingContext([9], t1, k1, p1))
+        s.retire_requests([9])
+        again = s.sample_kernel(self._uniform_logits(1), 1, _FakeSamplingContext([9], t1, k1, p1))
+        assert first[0].item() == again[0].item()
+
+    def test_deferred_admission_does_not_perturb_existing(self) -> None:
+        """Admitting a new request next step does not change existing requests' draws."""
+        t2, k2, p2 = self._neutral(2)
+        t3, k3, p3 = self._neutral(3)
+
+        # Two requests this step; a third admitted next step.
+        s = self._sampler(8)
+        before = s.sample_kernel(
+            self._uniform_logits(2), 2, _FakeSamplingContext([1, 2], t2, k2, p2)
+        )
+        after = s.sample_kernel(
+            self._uniform_logits(3), 3, _FakeSamplingContext([1, 2, 3], t3, k3, p3)
+        )
+
+        # A reference where request 3 was never admitted: requests 1 and 2 over two steps.
+        ref = self._sampler(8)
+        ref0 = ref.sample_kernel(
+            self._uniform_logits(2), 2, _FakeSamplingContext([1, 2], t2, k2, p2)
+        )
+        ref1 = ref.sample_kernel(
+            self._uniform_logits(2), 2, _FakeSamplingContext([1, 2], t2, k2, p2)
+        )
+        assert torch.equal(before, ref0)
+        # Requests 1 and 2's second-step draws are unchanged by admitting request 3.
+        assert after[0].item() == ref1[0].item()
+        assert after[1].item() == ref1[1].item()
+
+    def test_greedy_is_strict_no_op(self) -> None:
+        """top_k == 1 returns argmax and draws no random numbers (seed-independent)."""
+        n = 4
+        request_ids = [1, 2, 3, 4]
+        # Distinct logits so argmax is well-defined: row r peaks at token r.
+        logits = torch.full((n, self.VOCAB), -10.0, device=torch.cuda.current_device())
+        for r in range(n):
+            logits[r, r] = 10.0
+        greedy_t, greedy_k, greedy_p = [1.0] * n, [1] * n, [0.0] * n
+
+        # Two different seeds must give the identical (argmax) result.
+        out_a = self._sampler(1).sample_kernel(
+            logits.clone(), n, _FakeSamplingContext(request_ids, greedy_t, greedy_k, greedy_p)
+        )
+        out_b = self._sampler(987654).sample_kernel(
+            logits.clone(), n, _FakeSamplingContext(request_ids, greedy_t, greedy_k, greedy_p)
+        )
+        expected = torch.tensor([0, 1, 2, 3], device=out_a.device)
+        assert torch.equal(out_a, expected)
+        assert torch.equal(out_a, out_b)
+        # No generators were created for a purely greedy batch.
+        sampler = self._sampler(1)
+        sampler.sample_kernel(
+            logits.clone(), n, _FakeSamplingContext(request_ids, greedy_t, greedy_k, greedy_p)
+        )
+        assert sampler._request_rngs == {}
+
+    def test_speculative_path_routes_through_per_request_helper(self) -> None:
+        """sample_speculative keys per request: a decode request's 1+n_spec rows draw from
+        its own generator, invariant to batch composition."""
+        n_spec = 1
+        # Two decode requests, no prefill; each contributes (1 + n_spec) = 2 rows.
+        request_ids = [21, 22]
+        num_decode, num_prefill = 2, 0
+        n_tokens = num_decode * (1 + n_spec) + num_prefill
+        t, k, p = self._neutral(num_decode + num_prefill)
+
+        batched = self._sampler(321).sample_speculative(
+            self._uniform_logits(n_tokens),
+            num_decode,
+            num_prefill,
+            n_spec,
+            _FakeSamplingContext(request_ids, t, k, p),
+            eager=True,
+        )
+
+        # Request 21 alone: its two (base + spec) rows must match the batched draw.
+        t1, k1, p1 = self._neutral(1)
+        alone = self._sampler(321).sample_speculative(
+            self._uniform_logits(1 * (1 + n_spec)),
+            1,
+            0,
+            n_spec,
+            _FakeSamplingContext([21], t1, k1, p1),
+            eager=True,
+        )
+        # token_to_request_index = [0, 0, 1, 1] => request 21 owns rows 0,1.
+        assert batched[0].item() == alone[0].item()
+        assert batched[1].item() == alone[1].item()
+
+        # Determinism across same-seed samplers.
+        again = self._sampler(321).sample_speculative(
+            self._uniform_logits(n_tokens),
+            num_decode,
+            num_prefill,
+            n_spec,
+            _FakeSamplingContext(request_ids, t, k, p),
+            eager=True,
+        )
+        assert torch.equal(batched, again)

--- a/tests/unit_tests/inference/text_generation_controllers/test_async_sample_ring.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_async_sample_ring.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""C1 unit tests for :class:`AsyncSampleRing` (CUDA event ordering + source ownership).
+
+These reason about the ring in isolation -- no model, no engine -- exactly as the design's
+C1 lands it (data structure + tests, not yet wired). The load-bearing properties:
+
+* ``enqueue_readback`` does NOT host-synchronize (the launch must follow it immediately);
+* ``consume`` returns the bytes that were live at ``sample(K)`` time, after the launch enqueue;
+* the depth-2 double-buffer + retained source ref keep two in-flight read-backs from aliasing
+  even though the GPU source tensor is rebound every step;
+* ``drain`` / ``reset`` release every retained source ref.
+
+Run (single GPU is enough; no model parallel)::
+
+    /opt/venv/bin/python -m torch.distributed.run --nproc-per-node 1 -m pytest -v \
+        tests/unit_tests/inference/text_generation_controllers/test_async_sample_ring.py
+"""
+
+import pytest
+import torch
+
+from megatron.core.inference.text_generation_controllers.async_sample_ring import (
+    AsyncSampleRing,
+    RingTicket,
+)
+
+
+@pytest.mark.internal
+class TestAsyncSampleRing:
+    """The asynchronous sampled-token read-back ring."""
+
+    def _ring(self, max_requests: int = 8, depth: int = 2) -> AsyncSampleRing:
+        return AsyncSampleRing(
+            max_requests=max_requests, device=torch.cuda.current_device(), depth=depth
+        )
+
+    def test_enqueue_does_not_synchronize(self) -> None:
+        """enqueue_readback only enqueues: a copy gated behind a long GPU op is NOT yet done.
+
+        A deterministic GPU sleep busies the compute stream before the sample-ready event is
+        recorded; the copy stream waits on that event, so the copy cannot have completed by the
+        time enqueue returns. If enqueue had host-synchronized, ``copy_done`` would already be
+        ready. ``consume`` is what blocks.
+        """
+        ring = self._ring()
+        src = torch.arange(4, device=torch.cuda.current_device(), dtype=torch.int64)
+        # ~tens of ms of GPU-side spin on the compute stream (deterministic, not wall-clock racy).
+        torch.cuda._sleep(200_000_000)
+        ticket = ring.enqueue_readback(src, n=4, snapshot_request_ids=None)
+
+        # The copy is stream-ordered after the long sleep => cannot be done yet (no host sync).
+        assert not ticket.copy_done_event.query()
+
+        out = ring.consume(ticket)  # this blocks until the copy retires
+        assert out.tolist() == [0, 1, 2, 3]
+
+    def test_consume_returns_byte_identical_values(self) -> None:
+        """consume returns exactly the sampled values, with the source dtype preserved."""
+        ring = self._ring()
+        for dtype in (torch.int64, torch.int32):
+            r = self._ring()
+            src = torch.tensor([5, 9, 2, 7, 1], device=torch.cuda.current_device(), dtype=dtype)
+            ticket = r.enqueue_readback(src, n=5, snapshot_request_ids="tag")
+            out = r.consume(ticket)
+            assert out.dtype == dtype, f"dtype not preserved: {out.dtype} != {dtype}"
+            assert out.tolist() == [5, 9, 2, 7, 1]
+            assert ticket.snapshot_request_ids == "tag"
+
+    def test_depth2_interleaved_no_alias(self) -> None:
+        """Two read-backs in flight at once use distinct slots and never alias.
+
+        Mirrors the rebind hazard: step K's source tensor is one object, step K+1's sampling
+        produces a *different* tensor. With depth-2 distinct pinned slots + retained source
+        refs, consuming both returns each step's own values.
+        """
+        ring = self._ring()
+        dev = torch.cuda.current_device()
+        src0 = torch.full((4,), 7, device=dev, dtype=torch.int64)
+        t0 = ring.enqueue_readback(src0, n=4, snapshot_request_ids="k")
+        # Anti-rebind: the exact source tensor is retained until consume.
+        assert t0.source_ref is src0
+        assert ring._source_refs[t0.slot] is src0
+
+        src1 = torch.full((4,), 9, device=dev, dtype=torch.int64)  # rebound new tensor (step K+1)
+        t1 = ring.enqueue_readback(src1, n=4, snapshot_request_ids="k+1")
+        assert t1.slot != t0.slot, "depth-2 must hand out distinct slots for back-to-back reads"
+        assert t1.source_ref is src1
+
+        out0 = ring.consume(t0)
+        out1 = ring.consume(t1)
+        assert out0.tolist() == [7, 7, 7, 7], "slot 0 aliased slot 1"
+        assert out1.tolist() == [9, 9, 9, 9], "slot 1 aliased slot 0"
+        # Both retained refs dropped once their copies retired.
+        assert ring._source_refs == [None, None]
+        assert t0.source_ref is None and t1.source_ref is None
+
+    def test_slot_reuse_after_consume(self) -> None:
+        """A third read-back wraps back to slot 0 and reads its own (fresh) values."""
+        ring = self._ring()
+        dev = torch.cuda.current_device()
+        t0 = ring.enqueue_readback(torch.full((3,), 1, device=dev, dtype=torch.int64), n=3,
+                                   snapshot_request_ids=None)
+        t1 = ring.enqueue_readback(torch.full((3,), 2, device=dev, dtype=torch.int64), n=3,
+                                   snapshot_request_ids=None)
+        assert ring.consume(t0).tolist() == [1, 1, 1]
+        assert ring.consume(t1).tolist() == [2, 2, 2]
+        # Wraps to slot 0 again.
+        t2 = ring.enqueue_readback(torch.full((3,), 3, device=dev, dtype=torch.int64), n=3,
+                                   snapshot_request_ids=None)
+        assert t2.slot == t0.slot
+        assert ring.consume(t2).tolist() == [3, 3, 3]
+
+    def test_partial_n_only_reads_active_rows(self) -> None:
+        """Only the first ``n`` rows are read back (the active request count)."""
+        ring = self._ring(max_requests=8)
+        dev = torch.cuda.current_device()
+        src = torch.arange(8, device=dev, dtype=torch.int64)
+        ticket = ring.enqueue_readback(src, n=3, snapshot_request_ids=None)
+        out = ring.consume(ticket)
+        assert out.numel() == 3 and out.tolist() == [0, 1, 2]
+
+    def test_drain_releases_all_refs(self) -> None:
+        """drain synchronizes pending copies and drops every retained source ref."""
+        ring = self._ring()
+        dev = torch.cuda.current_device()
+        ring.enqueue_readback(torch.full((4,), 5, device=dev, dtype=torch.int64), n=4,
+                              snapshot_request_ids=None)
+        assert any(r is not None for r in ring._source_refs)
+        ring.drain()
+        assert all(r is None for r in ring._source_refs)
+
+    def test_reset_drains_and_rewinds_cursor(self) -> None:
+        """reset drains in-flight copies, drops refs, and rewinds the cursor to 0."""
+        ring = self._ring()
+        dev = torch.cuda.current_device()
+        ring.enqueue_readback(torch.full((2,), 1, device=dev, dtype=torch.int64), n=2,
+                              snapshot_request_ids=None)
+        assert ring.cursor == 1
+        ring.reset()
+        assert ring.cursor == 0
+        assert all(r is None for r in ring._source_refs)
+
+    def test_returns_ring_ticket_shape(self) -> None:
+        """The ticket carries the slot, the copy_done event, the snapshot tag, n, source_ref."""
+        ring = self._ring()
+        dev = torch.cuda.current_device()
+        snap = torch.tensor([10, 11], device=dev)
+        ticket = ring.enqueue_readback(
+            torch.tensor([3, 4], device=dev, dtype=torch.int64), n=2, snapshot_request_ids=snap
+        )
+        assert isinstance(ticket, RingTicket)
+        assert ticket.n == 2
+        assert isinstance(ticket.copy_done_event, torch.cuda.Event)
+        assert ticket.snapshot_request_ids is snap
+        ring.consume(ticket)
+
+    def test_dtype_change_is_rejected(self) -> None:
+        """The pinned slots are allocated once; a later source dtype mismatch is loud."""
+        ring = self._ring()
+        dev = torch.cuda.current_device()
+        t = ring.enqueue_readback(torch.tensor([1, 2], device=dev, dtype=torch.int64), n=2,
+                                  snapshot_request_ids=None)
+        ring.consume(t)
+        with pytest.raises(AssertionError, match="dtype changed"):
+            ring.enqueue_readback(torch.tensor([1, 2], device=dev, dtype=torch.int32), n=2,
+                                  snapshot_request_ids=None)
+
+    def test_depth_must_be_at_least_two(self) -> None:
+        """A depth-1 ring is rejected (no double-buffer margin)."""
+        with pytest.raises(AssertionError, match="depth must be >= 2"):
+            AsyncSampleRing(max_requests=4, device=torch.cuda.current_device(), depth=1)

--- a/tests/unit_tests/inference/text_generation_controllers/test_finish_mask_split.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_finish_mask_split.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""C3 unit tests: the finish-mask split is behavior-preserving (host & eos == original).
+
+The launch-before-commit pipeline splits the decode survival mask into a host-deterministic
+max-length half (inline, no D2H) and a data-dependent EOS/stop-word half (lagged-capable).
+This battery asserts -- on a synthetic batch with N>=2 simultaneous mid-batch EOS finishers, a
+max-length finisher, and a stop-word finisher -- that the AND of the two halves equals the
+original single combined build bit-for-bit, and that the max-length half never reads the
+sampled token.
+
+These call the two ``TextGenerationController`` helpers as unbound methods against a tiny fake
+``self`` (the methods only read ``inference_wrapped_model.inference_context.active_request_metadata``
+and ``_get_stop_word_finished_ids_callback``), so no model is needed.
+"""
+
+import types
+
+import pytest
+import torch
+
+from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+    TextGenerationController,
+)
+
+
+def _fake_controller(termination_id, stop_word_callback=None):
+    context = types.SimpleNamespace(
+        active_request_metadata={"termination_id": termination_id}
+    )
+    iwm = types.SimpleNamespace(inference_context=context)
+    return types.SimpleNamespace(
+        inference_wrapped_model=iwm,
+        _get_stop_word_finished_ids_callback=stop_word_callback,
+    )
+
+
+@pytest.mark.internal
+class TestFinishMaskSplit:
+    """The host-maxlen / data-dependent (EOS + stop-word) finish-mask split."""
+
+    def _original_combined_mask(
+        self, sampled, termination_id, active_seq_len, max_seq_len, active_ids, stop_ids
+    ):
+        """The pre-split single build (the oracle)."""
+        mask = (sampled != termination_id).byte() & torch.less(active_seq_len, max_seq_len).byte()
+        for idx, rid in enumerate(active_ids.tolist()):
+            if rid in stop_ids:
+                mask[idx] = 0
+        return mask
+
+    def test_host_and_eos_equals_original_multi_midbatch(self) -> None:
+        """N>=2 mid-batch EOS finishers + a max-length + a stop-word: split == original."""
+        n = 6
+        eos = 99
+        # Rows 1 and 3 hit EOS (two finishers, mid-batch positions).
+        sampled = torch.tensor([5, eos, 7, eos, 8, 9], dtype=torch.long)
+        termination_id = torch.full((n,), eos, dtype=torch.long)
+        # Row 4 hits max length (10 < 10 is False -> finishes).
+        active_seq_len = torch.tensor([3, 3, 3, 3, 10, 3], dtype=torch.int32)
+        max_seq_len = torch.full((n,), 10, dtype=torch.int32)
+        active_ids = torch.tensor([100, 101, 102, 103, 104, 105], dtype=torch.long)
+        stop_ids = {105}  # row 5 hit a stop word
+
+        oracle = self._original_combined_mask(
+            sampled, termination_id, active_seq_len, max_seq_len, active_ids, stop_ids
+        )
+        assert oracle.tolist() == [1, 0, 1, 0, 0, 0]  # only rows 0, 2 survive
+
+        fake = _fake_controller(termination_id, stop_word_callback=lambda ids: set(stop_ids))
+        host = TextGenerationController._host_maxlen_finish_mask(fake, active_seq_len, max_seq_len)
+        data = TextGenerationController._data_dependent_finish_mask(fake, sampled, active_ids, n)
+        combined = data & host
+
+        assert torch.equal(combined, oracle), f"split {combined.tolist()} != {oracle.tolist()}"
+        # The two halves partition the reasons: max-length only in host, EOS/stop-word only in data.
+        assert host.tolist() == [1, 1, 1, 1, 0, 1]  # only the max-length finisher
+        assert data.tolist() == [1, 0, 1, 0, 1, 0]  # EOS rows 1,3 + stop-word row 5
+
+    def test_host_mask_ignores_the_sample(self) -> None:
+        """The max-length half depends only on lengths -- changing the sample does not move it."""
+        n = 4
+        termination_id = torch.full((n,), 7, dtype=torch.long)
+        active_seq_len = torch.tensor([4, 9, 9, 4], dtype=torch.int32)
+        max_seq_len = torch.full((n,), 9, dtype=torch.int32)  # rows 1,2 at max
+        fake = _fake_controller(termination_id)
+        h1 = TextGenerationController._host_maxlen_finish_mask(fake, active_seq_len, max_seq_len)
+        # A completely different sample must not change the host mask.
+        h2 = TextGenerationController._host_maxlen_finish_mask(fake, active_seq_len, max_seq_len)
+        assert torch.equal(h1, h2)
+        assert h1.tolist() == [1, 0, 0, 1]
+
+    def test_no_finishers_all_survive(self) -> None:
+        """No EOS, no stop-word, none at max -> every request survives in both halves."""
+        n = 3
+        termination_id = torch.full((n,), 50, dtype=torch.long)
+        sampled = torch.tensor([1, 2, 3], dtype=torch.long)
+        active_seq_len = torch.tensor([2, 2, 2], dtype=torch.int32)
+        max_seq_len = torch.full((n,), 10, dtype=torch.int32)
+        active_ids = torch.tensor([1, 2, 3], dtype=torch.long)
+        fake = _fake_controller(termination_id, stop_word_callback=lambda ids: set())
+        host = TextGenerationController._host_maxlen_finish_mask(fake, active_seq_len, max_seq_len)
+        data = TextGenerationController._data_dependent_finish_mask(fake, sampled, active_ids, n)
+        assert (host & data).tolist() == [1, 1, 1]
+
+    def test_no_stop_word_callback(self) -> None:
+        """With no stop-word callback wired, the data half is pure EOS."""
+        n = 3
+        termination_id = torch.full((n,), 4, dtype=torch.long)
+        sampled = torch.tensor([4, 1, 4], dtype=torch.long)  # rows 0,2 EOS
+        active_ids = torch.tensor([1, 2, 3], dtype=torch.long)
+        fake = _fake_controller(termination_id, stop_word_callback=None)
+        data = TextGenerationController._data_dependent_finish_mask(fake, sampled, active_ids, n)
+        assert data.tolist() == [0, 1, 0]


### PR DESCRIPTION
> **Draft / work-in-progress.** This PR is being implemented commit-by-commit on a fresh branch off `main`; the description below states the **goal architecture**, not just what has landed so far. Each commit is gated on focused `async == serial` tests. Async scheduling is **opt-in** (`--inference-dynamic-batching-async-scheduling`); with it **off, behavior is byte-identical to `main`**.

## Goal

Make **steady-state dynamic decode keep the GPU ~100% busy** — alternating `forward → sampling → forward …` with no inter-forward idle — by overlapping **all** CPU work (`update_requests`, scheduling, bookkeeping, publication) behind the GPU forward, under a **single, small transactional contract** that makes the GPU/CPU race conditions structurally impossible rather than individually patched. Target: a few hundred LOC of net change (well under ~1k), gated behind one flag.

## The contract — "launch-before-commit, commit in the shadow"

One transaction per decode step. Using two GPU metadata slots (`slot_current`, `slot_child`):

```
GPU:  … F(K) ─ S(K) ─ F(K+1) ─ S(K+1) ─ F(K+2) …      (steady state: never idle)
```

- **While `F(K)` runs on the GPU, the CPU (in its shadow):** runs `commit(K-1)` = `update_requests` (advance KV offsets → step K-1's KV becomes visible; detect finishes; compact rows; adopt reserved boundary blocks), publishes step K-1's artifacts, retires resources, **and pre-stages `F(K+1)`'s metadata + coalesced H2D into the free slot** (everything except the token values).
- **Post-sampling critical path (`S(K) → F(K+1)`) is ONLY:** a GPU scatter of the sampled tokens into `slot_child`'s input, an already-signaled H2D-event wait, and the forward launch. **No CPU metadata build, allocator scan, MHA/mamba rebuild, or EP handshake sits between sampling and the next launch.**

### GPU-100%-busy guarantee
The steady-state critical path carries **zero CPU compute** — only GPU kernels (sample, scatter) + the host launch; the host enqueues `F(K) → S(K) → F(K+1)` back-to-back so the GPU never drains. The remaining condition (shadow CPU work fits within one forward+sample window) is validated by an nsys gate (no inter-forward GPU gap at bs=1 and large batch).

## Why it's race-free and compact — "no reject after launch"

We never reject a launched forward, because **we only launch speculatively when the forward is provably consumable.** The only thing speculated is *"no request finishes this step."* A finish is *absorbable* (discard its row — decode is per-request independent, and `update_requests` compaction is a pure row-permutation that preserves each surviving request's physical KV-block ids and mamba-slot values, so outputs are consumed **by request-id**, no row-map). Every change a launched forward could **not** absorb — resume, eviction, admission, KV-block exhaustion — is detected from committed state + KV headroom **before** the launch and converted to a synchronous step.

Consequences:
- **Single-bank, in-place mamba** for plain decode (no dual/candidate bank) — there is no discard-and-rerun, so in-place state is never double-applied.
- **No layout predictor, no row-map, no full-signature validation, no per-step EP consensus vote** — the launch gate removes the need for them.
- Resources are **leases on the transaction** + a two-step retire queue (no global async cleanup arrays); finished KV blocks / mamba slots are freed only after `forward_done_event`.

## Hybrid (Mamba), EP, and MTP

- **Hybrid/Mamba:** single-bank in-place decode (zero per-step CPU); finishes free slots after retire; verified `async == serial` incl. staggered-finish multi-turn.
- **EP/TP/PP:** every rank runs the identical deterministic "current layout +1" forward. Cross-rank determinism comes from a **cheap one-directional broadcast** (sampled tokens + stop-word finished-ids, and accepted-counts under MTP) from a canonical rank before finish-detection, plus a cached/overlapped graph-shape reduce — **not** a blocking consensus handshake. EP exchanges only tokens/action-booleans/graph-shape facts, never request ids/rows/blocks/slots.
- **MTP / spec-decode:** supported and **correct** via `forward → sample → verify → forward`, reusing `verify_speculative_tokens` + `rewind_kv_cache` + `mamba_state_selective_copy`. The verify/rewind stays on the critical path in this PR (an accepted, deferred-optimization bubble). **The GPU-vectorized MTP rewind — which would make MTP itself GPU-100%-busy — is intentionally a follow-up PR**, not in scope here.

## Scope

- **In:** GPT + hybrid/Mamba + EP + spec-decode/MTP (correct); the GPU-100%-busy steady state for non-MTP decode; opt-in flag; `async-off == main`.
- **Out (follow-up):** GPU-vectorized MTP rewind (MTP no-gap performance).

## Commit plan

`C0` opt-in flag/scaffold · `C1` `StepTxn` + transaction manager + retire queue · `C2` GPU metadata slots + depth-2 rings + graph-key slot identity · `C3` per-request RNG (+ serial migration) · `C4` in-place incremental metadata advance · `C5` prestage child metadata (no launch yet) + launch-gate predicate · `C6` launch-before-commit fast path (the GPU-busy milestone) · `C7` survivor set: finish/compaction + KV leases · `C8` request-id publication (logprobs/top-n/stop-words/routing) · `C9` hybrid single-bank · `C10` EP determinism (broadcast) · `C11` MTP correctness (unoptimized) · `C12` admission/chunked-prefill/barriers/prefix · `C13` cleanup + anti-regression + benchmark-arg gate.

## Testing

Per commit, a targeted battery (not the full suite): the spine is **token-exact `async == serial`** equivalence (serial is the oracle) across GPT/hybrid/MTP/EP over ≥ 2× block-size decode steps, plus 1–3 focused mechanism unit tests for that commit's invariant (retire-fence ordering, consume-by-request-id under a mid-batch finish, reserved-block adopt/release, EP broadcast determinism, RNG-migration equivalence). Tests run on 8 GPUs via `torch.distributed.run`, one suite per invocation. A commit is pushed only if its tests pass. Acceptance also includes an **nsys trace showing no inter-forward GPU gap** in steady-state decode at bs=1 and large batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
