### PR TITLE
Implement minimal async decode scheduling

### DIFF
--- a/megatron/core/inference/async_scheduling.py
+++ b/megatron/core/inference/async_scheduling.py
@@ -180,6 +180,47 @@ class AsyncDecodeTransaction:
     row_map: Optional[AsyncRowMap] = None
     drop_reason: Optional[str] = None
 
+    @classmethod
+    def from_plan(
+        cls,
+        *,
+        transaction_id: int,
+        prepared_layout: Any,
+        tokens_per_request: int = 1,
+        uses_mamba_candidate_bank: bool = False,
+        cuda_graph_request_count: Optional[int] = None,
+    ) -> "AsyncDecodeTransaction":
+        """Build a transaction and derive all resource leases from the prepared plan."""
+
+        request_ids = prepared_layout.request_ids.clone()
+        transaction = cls(
+            transaction_id=transaction_id,
+            prepared_layout=prepared_layout,
+            graph_shape=AsyncGraphShape.from_plan(
+                prepared_layout, tokens_per_request=tokens_per_request
+            ),
+            kv_lease=AsyncKVBlockLease(
+                reserved_request_ids=prepared_layout.reserved_request_ids.clone(),
+                reserved_block_ids=prepared_layout.reserved_block_ids.clone(),
+                reserved_block_columns=prepared_layout.reserved_block_columns.clone(),
+            ),
+            mamba_lease=AsyncMambaLease(
+                candidate_request_ids=(
+                    request_ids
+                    if uses_mamba_candidate_bank
+                    else torch.empty(0, dtype=request_ids.dtype, device=request_ids.device)
+                ),
+                uses_candidate_bank=uses_mamba_candidate_bank,
+            ),
+            mtp_state=(
+                AsyncMTPState(tokens_per_request=tokens_per_request)
+                if tokens_per_request > 1
+                else None
+            ),
+        )
+        transaction.launch(cuda_graph_request_count=cuda_graph_request_count)
+        return transaction
+
     @property
     def request_ids(self) -> Tensor:
         """Request IDs in the pending forward row order."""

--- a/megatron/core/inference/async_scheduling.py
+++ b/megatron/core/inference/async_scheduling.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Transaction objects for async decode scheduling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+import torch
+from torch import Tensor
+
+
+class AsyncTransactionState(str, Enum):
+    """Lifecycle states for one launched async decode transaction."""
+
+    PREPARED = "prepared"
+    IN_FLIGHT = "in_flight"
+    READY = "ready"
+    CONSUMED = "consumed"
+    DROPPED = "dropped"
+
+
+@dataclass(frozen=True)
+class AsyncGraphShape:
+    """CUDA graph and logical token shape for a pending async decode forward."""
+
+    active_request_count: int
+    active_token_count: int
+    padded_active_request_count: int
+    tokens_per_request: int = 1
+
+    @classmethod
+    def from_plan(cls, plan: Any, *, tokens_per_request: int = 1) -> "AsyncGraphShape":
+        """Build a graph shape from a context async decode plan."""
+
+        return cls(
+            active_request_count=int(plan.active_request_count),
+            active_token_count=int(plan.active_token_count),
+            padded_active_request_count=int(plan.padded_active_request_count),
+            tokens_per_request=int(tokens_per_request),
+        )
+
+    def compatible_with(self, other: "AsyncGraphShape") -> bool:
+        """Return whether two shapes expose logits with the same captured layout."""
+
+        return (
+            self.padded_active_request_count == other.padded_active_request_count
+            and self.tokens_per_request == other.tokens_per_request
+            and self.active_token_count >= other.active_token_count
+            and self.active_request_count >= other.active_request_count
+        )
+
+
+@dataclass(frozen=True)
+class AsyncRowMap:
+    """Map current live request rows onto rows produced by a pending forward."""
+
+    pending_request_ids: Tensor
+    current_request_ids: Tensor
+    pending_rows_cpu: Tensor
+    pending_rows: Optional[Tensor] = None
+
+    @classmethod
+    def for_current(
+        cls,
+        *,
+        pending_request_ids: Tensor,
+        current_request_ids: Tensor,
+        device: Optional[torch.device | int | str] = None,
+    ) -> Optional["AsyncRowMap"]:
+        """Resolve current request rows against pending rows, or return None."""
+
+        pending_cpu = pending_request_ids.to(dtype=torch.long, device="cpu")
+        current_cpu = current_request_ids.to(dtype=torch.long, device="cpu")
+        if current_cpu.numel() > pending_cpu.numel():
+            return None
+        if pending_cpu.unique().numel() != pending_cpu.numel():
+            return None
+        if current_cpu.unique().numel() != current_cpu.numel():
+            return None
+
+        row_by_request_id = {int(request_id): row for row, request_id in enumerate(pending_cpu)}
+        mapped_rows = []
+        for request_id in current_cpu.tolist():
+            row = row_by_request_id.get(int(request_id))
+            if row is None:
+                return None
+            mapped_rows.append(row)
+
+        pending_rows_cpu = torch.tensor(mapped_rows, dtype=torch.long, device="cpu")
+        if device is None:
+            pending_rows = None
+        else:
+            pending_rows = pending_rows_cpu.to(device=device)
+
+        return cls(
+            pending_request_ids=pending_cpu.clone(),
+            current_request_ids=current_cpu.clone(),
+            pending_rows_cpu=pending_rows_cpu,
+            pending_rows=pending_rows,
+        )
+
+    @property
+    def row_mapped(self) -> bool:
+        """Whether current rows differ from the pending forward row prefix."""
+
+        identity = torch.arange(
+            self.current_request_ids.numel(), dtype=self.pending_rows_cpu.dtype, device="cpu"
+        )
+        return not bool(torch.equal(self.pending_rows_cpu, identity))
+
+    def rows_for_device(self, device: torch.device | int | str) -> Tensor:
+        """Return pending rows on the requested device."""
+
+        rows = self.pending_rows_cpu.to(device=device)
+        if self.pending_rows is not None and self.pending_rows.device == rows.device:
+            return self.pending_rows
+        return rows
+
+
+@dataclass(frozen=True)
+class AsyncKVBlockLease:
+    """KV blocks reserved or deferred by one async transaction."""
+
+    reserved_request_ids: Tensor = field(default_factory=lambda: torch.empty(0, dtype=torch.long))
+    reserved_block_ids: Tensor = field(default_factory=lambda: torch.empty(0, dtype=torch.int32))
+    reserved_block_columns: Tensor = field(default_factory=lambda: torch.empty(0, dtype=torch.int32))
+    deferred_block_ids: Tensor = field(default_factory=lambda: torch.empty(0, dtype=torch.int32))
+
+    @property
+    def has_reservations(self) -> bool:
+        """Whether this transaction owns reserved KV blocks."""
+
+        return self.reserved_block_ids.numel() > 0
+
+
+@dataclass(frozen=True)
+class AsyncMambaLease:
+    """Mamba state ownership for candidate/live state under async decode."""
+
+    candidate_request_ids: Tensor = field(default_factory=lambda: torch.empty(0, dtype=torch.long))
+    deferred_slot_ids: Tensor = field(default_factory=lambda: torch.empty(0, dtype=torch.int32))
+    uses_candidate_bank: bool = False
+
+
+@dataclass
+class AsyncSampleTransfer:
+    """Sample buffer and D2H transfer state owned by a transaction."""
+
+    active_request_count: int = 0
+    started: bool = False
+    finished: bool = False
+
+
+@dataclass
+class AsyncMTPState:
+    """Speculative token rows and acceptance metadata owned by a transaction."""
+
+    tokens_per_request: int
+    accepted_counts: Optional[Tensor] = None
+    accepted_tokens: Optional[Tensor] = None
+    rewind_metadata: Optional[Any] = None
+
+
+@dataclass
+class AsyncDecodeTransaction:
+    """Own one pending async decode forward from layout preparation to retirement."""
+
+    transaction_id: int
+    prepared_layout: Any
+    graph_shape: AsyncGraphShape
+    kv_lease: AsyncKVBlockLease = field(default_factory=AsyncKVBlockLease)
+    mamba_lease: AsyncMambaLease = field(default_factory=AsyncMambaLease)
+    sample_transfer: AsyncSampleTransfer = field(default_factory=AsyncSampleTransfer)
+    mtp_state: Optional[AsyncMTPState] = None
+    state: AsyncTransactionState = AsyncTransactionState.PREPARED
+    cuda_graph_request_count: Optional[int] = None
+    row_map: Optional[AsyncRowMap] = None
+    drop_reason: Optional[str] = None
+
+    @property
+    def request_ids(self) -> Tensor:
+        """Request IDs in the pending forward row order."""
+
+        return self.prepared_layout.request_ids
+
+    @property
+    def is_pending(self) -> bool:
+        """Whether the transaction still owns an unconsumed forward."""
+
+        return self.state in {
+            AsyncTransactionState.PREPARED,
+            AsyncTransactionState.IN_FLIGHT,
+            AsyncTransactionState.READY,
+        }
+
+    def launch(self, *, cuda_graph_request_count: Optional[int]) -> None:
+        """Mark the prepared transaction as launched."""
+
+        self._require_state(AsyncTransactionState.PREPARED)
+        self.cuda_graph_request_count = cuda_graph_request_count
+        self.state = AsyncTransactionState.IN_FLIGHT
+
+    def resolve_for_current(
+        self,
+        *,
+        current_request_ids: Tensor,
+        current_graph_shape: AsyncGraphShape,
+        device: Optional[torch.device | int | str] = None,
+    ) -> Optional[AsyncRowMap]:
+        """Return the row map if current rows can consume this transaction."""
+
+        if self.state != AsyncTransactionState.IN_FLIGHT:
+            return None
+        if not self.graph_shape.compatible_with(current_graph_shape):
+            return None
+        return AsyncRowMap.for_current(
+            pending_request_ids=self.request_ids,
+            current_request_ids=current_request_ids,
+            device=device,
+        )
+
+    def mark_ready(self, row_map: AsyncRowMap) -> None:
+        """Mark the pending forward ready for sampling."""
+
+        self._require_state(AsyncTransactionState.IN_FLIGHT)
+        self.row_map = row_map
+        self.state = AsyncTransactionState.READY
+
+    def consume(self) -> None:
+        """Mark logits and owned resources as consumed."""
+
+        self._require_state(AsyncTransactionState.READY)
+        self.state = AsyncTransactionState.CONSUMED
+
+    def drop(self, reason: str) -> None:
+        """Drop the transaction and quarantine/release its owned resources."""
+
+        if self.state in {AsyncTransactionState.CONSUMED, AsyncTransactionState.DROPPED}:
+            raise RuntimeError(f"cannot drop async transaction in state {self.state.value}")
+        self.drop_reason = reason
+        self.state = AsyncTransactionState.DROPPED
+
+    def _require_state(self, expected: AsyncTransactionState) -> None:
+        if self.state != expected:
+            raise RuntimeError(
+                f"async transaction expected state {expected.value}, got {self.state.value}"
+            )

--- a/megatron/core/inference/async_scheduling.py
+++ b/megatron/core/inference/async_scheduling.py
@@ -90,7 +90,10 @@ class AsyncRowMap:
             mapped_rows.append(row)
 
         pending_rows_cpu = torch.tensor(mapped_rows, dtype=torch.long, device="cpu")
-        if device is None:
+        identity = torch.arange(
+            current_cpu.numel(), dtype=pending_rows_cpu.dtype, device="cpu"
+        )
+        if device is None or torch.equal(pending_rows_cpu, identity):
             pending_rows = None
         else:
             pending_rows = pending_rows_cpu.to(device=device)

--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -144,6 +144,7 @@ class InferenceBatchDimensions:
         local_batch_dims,
         ep_group: Optional[torch.distributed.ProcessGroup] = None,
         ep_zmq_communicator=None,
+        ep_async_protocol=None,
     ) -> Optional["InferenceBatchDimensions"]:
         """Adjust CUDA graph batch dimensions for expert parallelism.
 
@@ -162,6 +163,8 @@ class InferenceBatchDimensions:
                       (no GPU kernel, no H2D/D2H), avoiding a per-step NCCL AllReduce
                       on the compute stream. When absent, falls back to
                       torch.distributed.all_reduce on a GPU tensor.
+            ep_async_protocol: Optional EPAsyncStepProtocol used to tag the graph-shape
+                      reduction inside a coordinator-driven async EP work step.
 
         Returns:
             InferenceBatchDimensions with max token count, or None for eager mode.
@@ -172,7 +175,14 @@ class InferenceBatchDimensions:
 
         is_non_decode = local_batch_dims.prefill_req_count > 0
 
-        if ep_zmq_communicator is not None:
+        if ep_async_protocol is not None and ep_async_protocol.enabled:
+            from megatron.core.inference.ep_async_protocol import EPAsyncPhase
+
+            # CPU-only tagged sync via the EP async protocol.
+            (max_token_count, max_is_non_decode) = ep_async_protocol.sync_all_reduce_max(
+                EPAsyncPhase.GRAPH_SHAPE, local_batch_dims.token_count, int(is_non_decode)
+            )
+        elif ep_zmq_communicator is not None:
             # CPU-only sync via ZMQ: avoids a NCCL AllReduce kernel on the
             # compute stream plus the H2D/D2H pair that sandwiches it.
             (max_token_count, max_is_non_decode) = ep_zmq_communicator.sync_all_reduce_max(
@@ -625,6 +635,7 @@ class CUDAGraphBatchDimensionBuilder:
         strict: bool = False,
         ep_group: Optional[torch.distributed.ProcessGroup] = None,
         ep_zmq_communicator=None,
+        ep_async_protocol=None,
         match_ep_token_counts: bool = True,
     ) -> Optional[InferenceBatchDimensions]:
         """
@@ -645,6 +656,7 @@ class CUDAGraphBatchDimensionBuilder:
                       provided, batch-dimension MAX reduction uses a CPU-only ZMQ sync
                       instead of a GPU NCCL AllReduce. Forwarded to
                       adjust_batch_dims_for_expert_parallelism.
+            ep_async_protocol: Optional EPAsyncStepProtocol used to tag graph-shape sync.
             match_ep_token_counts: If True (default), token counts are synced across EP ranks via
                 all-reduce-max so all ranks select the same CUDA graph. Set to False when the
                 dispatcher handles per-rank token variation internally (e.g. AGV/RSV in the NVLS
@@ -661,7 +673,10 @@ class CUDAGraphBatchDimensionBuilder:
             # NCCL dispatcher: all EP ranks must select the same CUDA graph. Sync batch dims
             # across the EP group so graph selection is consistent.
             adjusted_batch_dim = InferenceBatchDimensions.adjust_batch_dims_for_expert_parallelism(
-                real_batch_dim, ep_group=ep_group, ep_zmq_communicator=ep_zmq_communicator
+                real_batch_dim,
+                ep_group=ep_group,
+                ep_zmq_communicator=ep_zmq_communicator,
+                ep_async_protocol=ep_async_protocol,
             )
 
             if adjusted_batch_dim is None:

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -278,6 +278,9 @@ class InferenceConfig:
     num_speculative_tokens: int = 0
     """The number of speculative tokens to generate for decode steps."""
 
+    enable_async_scheduling: bool = False
+    """Whether to enable async scheduling for eligible decode-only steps."""
+
     enable_prefix_caching: bool = False
     """Whether to enable prefix caching for KV cache block sharing."""
 

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -14,7 +14,12 @@ class MambaMetadata:
     """Manages the metadata tensors required for Mamba layers during inference."""
 
     def __init__(
-        self, max_requests: int, max_tokens: int, mamba_chunk_size: int = 128, d_conv: int = 0
+        self,
+        max_requests: int,
+        max_tokens: int,
+        mamba_chunk_size: int = 128,
+        d_conv: int = 0,
+        state_bank_count: int = 1,
     ):
         """
         Initializes the Mamba slot allocator.
@@ -30,6 +35,7 @@ class MambaMetadata:
         self.max_tokens = max_tokens
         self.mamba_chunk_size = mamba_chunk_size
         self.d_conv = d_conv
+        self.state_bank_count = state_bank_count
         self.device = torch.cuda.current_device()
 
         # Maximum possible chunks across all batch configurations
@@ -39,10 +45,16 @@ class MambaMetadata:
         self.request_to_mamba_state_idx = torch.full(
             (self.max_requests,), -1, dtype=torch.int32, device='cpu'
         )
+        self.request_to_mamba_state_bank = torch.zeros(
+            (self.max_requests,), dtype=torch.int32, device='cpu'
+        )
 
         # Map from requests to slots in the static Mamba state buffer for active decode requests.
         # int64 so selective_state_update can index directly without a per-layer upcast kernel;
         self._batch_indices_decode_buffer = torch.full(
+            (self.max_requests,), -1, dtype=torch.int64, device=self.device
+        )
+        self._batch_indices_decode_write_buffer = torch.full(
             (self.max_requests,), -1, dtype=torch.int64, device=self.device
         )
 
@@ -138,6 +150,7 @@ class MambaMetadata:
         Resets all Mamba states and frees all allocated slots.
         """
         self.request_to_mamba_state_idx.fill_(-1)
+        self.request_to_mamba_state_bank.zero_()
 
         self.reset_varlen_metadata()
 
@@ -150,6 +163,7 @@ class MambaMetadata:
     def reset_varlen_metadata(self) -> None:
         """Resets varlen metadata."""
         self.batch_indices_decode = None
+        self.batch_indices_decode_write = None
         self.batch_indices_prefill = None
         self.cu_seqlens = None
         self.seq_idx = None
@@ -182,6 +196,7 @@ class MambaMetadata:
         enable_chunked_prefill: bool,
         intermediate_offsets_gpu: Optional[torch.Tensor] = None,
         intermediate_counts_gpu: Optional[torch.Tensor] = None,
+        active_mamba_write_indices: Optional[torch.Tensor] = None,
     ) -> None:
         """
         Updates the dedicated CUDA graph mapping tensor with the indices
@@ -198,6 +213,7 @@ class MambaMetadata:
                 per-request intermediate token offsets, or None.
             intermediate_counts_gpu (Tensor): [prefill_count] int32 GPU tensor of
                 per-request intermediate offset counts, or None.
+            active_mamba_write_indices (Tensor): Optional decode-state destination slots.
         """
         real_decode_count = batch_dimensions.decode_req_count
         real_prefill_count = batch_dimensions.prefill_req_count
@@ -211,9 +227,20 @@ class MambaMetadata:
             self._batch_indices_decode_buffer[:real_decode_count].copy_(
                 active_mamba_indices[:real_decode_count]
             )
+            if active_mamba_write_indices is None:
+                active_mamba_write_indices = active_mamba_indices
+            self._batch_indices_decode_write_buffer[:real_decode_count].copy_(
+                active_mamba_write_indices[:real_decode_count]
+            )
             if padded_decode_count > real_decode_count:
                 self._batch_indices_decode_buffer[real_decode_count:padded_decode_count] = -1
+                self._batch_indices_decode_write_buffer[
+                    real_decode_count:padded_decode_count
+                ] = -1
             self.batch_indices_decode = self._batch_indices_decode_buffer[:padded_decode_count]
+            self.batch_indices_decode_write = self._batch_indices_decode_write_buffer[
+                :padded_decode_count
+            ]
 
         if padded_prefill_count > 0:
             # Update prefill indices (all prefill requests go through varlen)
@@ -482,6 +509,7 @@ class MambaMetadata:
         enable_chunked_prefill: bool,
         intermediate_offsets_gpu: Optional[torch.Tensor] = None,
         intermediate_counts_gpu: Optional[torch.Tensor] = None,
+        active_mamba_write_indices: Optional[torch.Tensor] = None,
     ) -> dict:
         """Compute all Mamba metadata on CPU, writing directly into the bound
         pinned CPU views.
@@ -500,6 +528,7 @@ class MambaMetadata:
             enable_chunked_prefill: Whether chunked prefill is enabled.
             intermediate_offsets_gpu: GPU tensor of per-request intermediate offsets, or None.
             intermediate_counts_gpu: GPU tensor of per-request intermediate counts, or None.
+            active_mamba_write_indices: Optional CPU tensor of decode-state destination slots.
         """
         assert self._cpu_bufs is not None, "bind_cpu_buffers() must be called first"
         bufs = self._cpu_bufs
@@ -524,8 +553,16 @@ class MambaMetadata:
             bufs['batch_indices_decode'][:real_decode_count] = active_mamba_indices[
                 :real_decode_count
             ]
+            if active_mamba_write_indices is None:
+                active_mamba_write_indices = active_mamba_indices
+            bufs['batch_indices_decode_write'][:real_decode_count] = (
+                active_mamba_write_indices[:real_decode_count]
+            )
             if padded_decode_count > real_decode_count:
                 bufs['batch_indices_decode'][real_decode_count:padded_decode_count] = -1
+                bufs['batch_indices_decode_write'][
+                    real_decode_count:padded_decode_count
+                ] = -1
 
         # Prefill batch indices, seq_idx, cu_seqlens, chunk/conv metadata.
         if padded_prefill_count > 0:
@@ -660,6 +697,9 @@ class MambaMetadata:
 
         if padded_decode_count > 0:
             self.batch_indices_decode = v.mamba_batch_indices_decode[:padded_decode_count]
+            self.batch_indices_decode_write = v.mamba_batch_indices_decode_write[
+                :padded_decode_count
+            ]
 
         if padded_prefill_count > 0:
             self.batch_indices_prefill = v.mamba_batch_indices_prefill[:padded_prefill_count]
@@ -726,6 +766,18 @@ class MambaMetadata:
 
         return mamba_idx
 
+    def free_slot_ids(self, mamba_indices_to_free: torch.Tensor) -> None:
+        """Return concrete Mamba state slots to the free pool."""
+
+        mamba_indices_to_free = mamba_indices_to_free[mamba_indices_to_free != -1]
+        num_to_free = len(mamba_indices_to_free)
+
+        if num_to_free > 0:
+            start_idx = self.mamba_state_free_slot_count
+            end_idx = start_idx + num_to_free
+            self.mamba_state_free_slots[start_idx:end_idx] = mamba_indices_to_free
+            self.mamba_state_free_slot_count = end_idx
+
     def free_slots(self, request_indices: torch.Tensor) -> None:
         """
         Frees the Mamba state slots associated with the given request indices.
@@ -735,17 +787,8 @@ class MambaMetadata:
         """
         # Get the Mamba state indices for finished requests
         mamba_indices_to_free = self.request_to_mamba_state_idx[request_indices]
-
-        # Filter out any invalid indices (e.g., -1)
-        mamba_indices_to_free = mamba_indices_to_free[mamba_indices_to_free != -1]
-        num_to_free = len(mamba_indices_to_free)
-
-        if num_to_free > 0:
-            # Add the freed indices back to the free slot pool
-            start_idx = self.mamba_state_free_slot_count
-            end_idx = start_idx + num_to_free
-            self.mamba_state_free_slots[start_idx:end_idx] = mamba_indices_to_free
-            self.mamba_state_free_slot_count = end_idx
+        self.free_slot_ids(mamba_indices_to_free)
 
         # Invalidate the Mamba state index for the finished requests
         self.request_to_mamba_state_idx[request_indices] = -1
+        self.request_to_mamba_state_bank[request_indices] = 0

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1874,7 +1874,16 @@ class DynamicInferenceContext(BaseInferenceContext):
 
     def reset_mamba_state(self) -> None:
         """Reset state used within Mamba layers."""
+
         if self.is_hybrid_model:
+            if self._async_forward_in_flight:
+                self._append_deferred_async_mamba_slots(
+                    self.mamba_metadata.request_to_mamba_state_idx
+                )
+                self.mamba_metadata.request_to_mamba_state_idx.fill_(-1)
+                self.mamba_metadata.request_to_mamba_state_bank.zero_()
+                self.mamba_metadata.reset_varlen_metadata()
+                return
             self.mamba_metadata.reset()
 
     def add_dummy_requests_parallel(
@@ -2414,6 +2423,29 @@ class DynamicInferenceContext(BaseInferenceContext):
         """Forget a prepared async decode plan after launch or fallback."""
 
         self._async_prepared_decode_plan = None
+
+    def discard_async_prepared_decode_plan(self) -> None:
+        """Drop an unlaunched async decode plan and release its reserved resources."""
+
+        plan = self._async_prepared_decode_plan
+        if plan is not None and plan.reserved_block_ids.numel() > 0:
+            self.kv_block_allocator.release_memory_blocks(plan.reserved_block_ids)
+            self.record_async_scheduling_counter(
+                "kv_lease_dropped", int(plan.reserved_block_ids.numel())
+            )
+        elif self._async_reserved_kv_block_count > 0:
+            reserved_blocks = self._async_reserved_kv_block_ids[
+                : self._async_reserved_kv_block_count
+            ]
+            reserved_blocks = reserved_blocks[reserved_blocks != -1]
+            if reserved_blocks.numel() > 0:
+                self.kv_block_allocator.release_memory_blocks(reserved_blocks)
+                self.record_async_scheduling_counter(
+                    "kv_lease_dropped", int(reserved_blocks.numel())
+                )
+
+        self._clear_async_reserved_kv_blocks()
+        self.clear_async_prepared_decode_plan()
 
     def _clear_async_reserved_kv_blocks(self) -> None:
         """Clear the request-to-reserved-block map after CPU reconciliation."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2487,7 +2487,27 @@ class DynamicInferenceContext(BaseInferenceContext):
             return False
         return torch.equal(self.request_kv_length_offsets[active_slice], plan.kv_length_offsets)
 
-    def async_decode_next_step_skip_reason(self) -> Optional[str]:
+    def active_request_metadata_needs_logprob_results(
+        self, active_request_count: Optional[int] = None
+    ) -> bool:
+        """Return whether current active requests need generated logprob results."""
+
+        active_request_count = (
+            self.total_request_count - self.paused_request_count
+            if active_request_count is None
+            else active_request_count
+        )
+        if active_request_count <= 0:
+            return False
+        active_slice = slice(0, active_request_count)
+        return bool(
+            self.active_request_metadata["return_log_probs"][active_slice].any().item()
+            or (self.active_request_metadata["top_n_logprobs"][active_slice] > 0).any().item()
+        )
+
+    def async_decode_next_step_skip_reason(
+        self, *, skip_bookkeeping: bool = False, active_stop_words: bool = False
+    ) -> Optional[str]:
         """Return why a no-reject async decode child cannot launch locally."""
 
         if not self.enable_async_scheduling:
@@ -2496,6 +2516,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             return "skip_reserved_kv_pending"
         if self.num_speculative_tokens != 0:
             return "skip_mtp"
+        if skip_bookkeeping:
+            return "skip_bookkeeping"
         if not self.is_decode_only():
             return "skip_not_decode"
         if self.paused_request_count != 0:
@@ -2506,6 +2528,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         active_request_count = self.total_request_count - self.paused_request_count
         if active_request_count <= 0:
             return "skip_no_active"
+        if self.active_request_metadata_needs_logprob_results(active_request_count):
+            return "skip_logprob_results"
+        if active_stop_words:
+            return "skip_stop_words"
 
         active_slice = slice(self.paused_request_count, self.total_request_count)
         current_offsets = self.request_kv_length_offsets[active_slice]
@@ -2591,13 +2617,17 @@ class DynamicInferenceContext(BaseInferenceContext):
             max_seqlen_k=max_seqlen_k,
         )
 
-    def prepare_async_decode_next_step(self) -> bool:
+    def prepare_async_decode_next_step(
+        self, *, skip_bookkeeping: bool = False, active_stop_words: bool = False
+    ) -> bool:
         """Prepare next-step decode metadata without mutating request rows."""
 
         self.clear_async_prepared_decode_plan()
         self.record_async_scheduling_counter("prepare_attempt")
 
-        skip_reason = self.async_decode_next_step_skip_reason()
+        skip_reason = self.async_decode_next_step_skip_reason(
+            skip_bookkeeping=skip_bookkeeping, active_stop_words=active_stop_words
+        )
         if skip_reason is not None:
             self.record_async_scheduling_counter(skip_reason)
             return False

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -5,6 +5,7 @@ import math
 import operator
 import warnings
 from contextlib import nullcontext
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Tuple
 
 import torch  # type: ignore
@@ -212,6 +213,18 @@ class ContextErrorFactory:
         return error
 
 
+@dataclass
+class AsyncDecodePlan:
+    """Prepared next-step decode layout for a no-reject async forward."""
+
+    request_ids: Tensor
+    kv_length_offsets: Tensor
+    reserved_block_ids: Tensor
+    active_request_count: int
+    active_token_count: int
+    padded_active_request_count: int
+
+
 def get_mem_size_str(n_bytes: int) -> str:
     """Convert number of bytes to human-readable string."""
     if n_bytes == 0:
@@ -308,6 +321,10 @@ class DynamicInferenceContext(BaseInferenceContext):
             f"num_speculative_tokens ({self.num_speculative_tokens}) must be < "
             f"block_size_tokens ({inference_config.block_size_tokens})"
         )
+        self.enable_async_scheduling = inference_config.enable_async_scheduling
+        self._async_prepared_decode_plan: Optional[AsyncDecodePlan] = None
+        self._async_forward_in_flight = False
+        self.async_scheduling_counters: Dict[str, int] = {}
 
         # Cache the PP group we should use for PP collectives inside the context.
         # If the model provides a pg_collection with a pp group, prefer it.
@@ -359,6 +376,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.num_attention_layers = len(attention_layer_map) + len(dsa_layer_map)
             self.num_mamba_layers = len(mamba_layer_map)
             self.layer_map = attention_layer_map | dsa_layer_map | mamba_layer_map
+            self.mamba_state_bank_count = 2 if inference_config.enable_async_scheduling else 1
         else:
             # The layer map is the identity function for pure Transformer models.
             # Use the same per-PP-rank layer count as TransformerBlock (handles
@@ -383,6 +401,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.num_mamba_layers = 0
             (self.mamba_conv_states_shape, self.mamba_ssm_states_shape) = (None, None)
             self.layer_map = {i: i for i in range(self.num_attention_layers)}
+            self.mamba_state_bank_count = 1
 
         if self.num_attention_layers == 0:
             raise NotImplementedError(
@@ -421,6 +440,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                 math.prod(self.mamba_ssm_states_shape) * self.mamba_ssm_states_dtype.itemsize
             )
             mamba_states_memory_per_request *= self.num_mamba_layers
+            mamba_states_memory_per_request *= self.mamba_state_bank_count
             if self.num_speculative_tokens > 0:
                 # Add memory for intermediate conv and SSM states
                 intermediate_memory_per_request = (
@@ -813,6 +833,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                 max_tokens=self.max_tokens,
                 mamba_chunk_size=self.mamba_chunk_size,
                 d_conv=self.mamba_conv_states_shape[-1],
+                state_bank_count=self.mamba_state_bank_count,
             )
             # Bind the unified CPU/GPU buffers so the per-step Mamba metadata
             # fields ride along with the single coalesced H2D in
@@ -820,6 +841,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata.bind_cpu_buffers(
                 {
                     "batch_indices_decode": self._cpu_mamba_batch_indices_decode,
+                    "batch_indices_decode_write": self._cpu_mamba_batch_indices_decode_write,
                     "batch_indices_prefill": self._cpu_mamba_batch_indices_prefill,
                     "seq_idx": self._cpu_mamba_seq_idx,
                     "cu_seqlens": self._cpu_mamba_cu_seqlens,
@@ -832,12 +854,14 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
             self.mamba_metadata.bind_gpu_buffers(self.gpu_view)
             self.mamba_conv_states = torch.empty(
-                (self.num_mamba_layers, self.max_requests) + self.mamba_conv_states_shape,
+                (self.num_mamba_layers, self.max_requests * self.mamba_state_bank_count)
+                + self.mamba_conv_states_shape,
                 dtype=self.mamba_conv_states_dtype,
                 device=torch.cuda.current_device(),
             )
             self.mamba_ssm_states = torch.empty(
-                (self.num_mamba_layers, self.max_requests) + self.mamba_ssm_states_shape,
+                (self.num_mamba_layers, self.max_requests * self.mamba_state_bank_count)
+                + self.mamba_ssm_states_shape,
                 dtype=self.mamba_ssm_states_dtype,
                 device=torch.cuda.current_device(),
             )
@@ -943,6 +967,22 @@ class DynamicInferenceContext(BaseInferenceContext):
             device='cpu',
             pin_memory=True,
         )
+        self._async_deferred_kv_blocks_to_release = torch.empty(
+            (0,), dtype=torch.int32, device='cpu'
+        )
+        self._async_reserved_kv_block_request_ids = torch.full(
+            (self.max_requests,), -1, dtype=torch.int32, device='cpu'
+        )
+        self._async_reserved_kv_block_ids = torch.full(
+            (self.max_requests,), -1, dtype=torch.int32, device='cpu'
+        )
+        self._async_reserved_kv_block_columns = torch.full(
+            (self.max_requests,), -1, dtype=torch.int32, device='cpu'
+        )
+        self._async_reserved_kv_block_count = 0
+        self._async_deferred_mamba_slots_to_free = torch.empty(
+            (0,), dtype=torch.int32, device='cpu'
+        )
 
         # Track request metadata. Backed by pinned CPU memory: bookkeeping is
         # CPU-resident; GPU consumers read from the active-slice mirror in
@@ -1009,12 +1049,13 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
         # Mamba section (hybrid models only). Must match the MambaMetadata
         # shapes (mirrors the layout documented in ContextGPUView).
-        # batch_indices_decode is int64; all other fields are int32.
+        # batch_indices_decode and batch_indices_decode_write are int64; all other fields are int32.
         if self.is_hybrid_model:
             # mamba_batch_indices_decode is int64; pad to 8-byte alignment.
             _mamba_align_pad = (8 - _pre_mamba_bytes % 8) % 8
             self._max_mamba_chunks = self.max_tokens // self.mamba_chunk_size + self.max_requests
             _mamba_batch_indices_decode_bytes = self.max_requests * 8
+            _mamba_batch_indices_decode_write_bytes = self.max_requests * 8
             _mamba_batch_indices_prefill_bytes = self.max_requests * 4
             _mamba_seq_idx_bytes = self.max_tokens * 4
             _mamba_cu_seqlens_bytes = (self.max_requests + 1) * 4
@@ -1027,6 +1068,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             _mamba_align_pad = 0
             self._max_mamba_chunks = 0
             _mamba_batch_indices_decode_bytes = 0
+            _mamba_batch_indices_decode_write_bytes = 0
             _mamba_batch_indices_prefill_bytes = 0
             _mamba_seq_idx_bytes = 0
             _mamba_cu_seqlens_bytes = 0
@@ -1039,6 +1081,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             _pre_mamba_bytes
             + _mamba_align_pad
             + _mamba_batch_indices_decode_bytes
+            + _mamba_batch_indices_decode_write_bytes
             + _mamba_batch_indices_prefill_bytes
             + _mamba_seq_idx_bytes
             + _mamba_cu_seqlens_bytes
@@ -1172,6 +1215,10 @@ class DynamicInferenceContext(BaseInferenceContext):
                 _off : _off + _mamba_batch_indices_decode_bytes
             ].view(torch.int64)
             _off += _mamba_batch_indices_decode_bytes
+            self._cpu_mamba_batch_indices_decode_write = self._cpu_bookkeeping_buf[
+                _off : _off + _mamba_batch_indices_decode_write_bytes
+            ].view(torch.int64)
+            _off += _mamba_batch_indices_decode_write_bytes
             self._cpu_mamba_batch_indices_prefill = self._cpu_bookkeeping_buf[
                 _off : _off + _mamba_batch_indices_prefill_bytes
             ].view(torch.int32)
@@ -1218,6 +1265,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             device=torch.cuda.current_device(),
             max_mamba_chunks=self._max_mamba_chunks,
         )
+        self._bookkeeping_h2d_done_event = torch.cuda.Event()
 
         # Cache of (input_ids_view, pos_ids_view) keyed by num_tokens. Instead of slicing and
         # unsqueezing on every new inference step (constructing new TensorImpls at 30-60 us),
@@ -1576,6 +1624,61 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         return (conv_state, ssm_state)
 
+    def _mamba_flat_indices(
+        self, request_slice: slice, *, use_candidate_bank: bool = False
+    ) -> Tensor:
+        """Return flattened Mamba state rows for selected request rows."""
+
+        assert self.is_hybrid_model, "Only hybrid models have Mamba state tensors"
+        base_indices = self.mamba_metadata.request_to_mamba_state_idx[request_slice].to(
+            dtype=torch.int64
+        )
+        bank_indices = self.mamba_metadata.request_to_mamba_state_bank[request_slice].to(
+            dtype=torch.int64
+        )
+        if use_candidate_bank and self.mamba_state_bank_count > 1:
+            bank_indices = 1 - bank_indices
+        return base_indices * self.mamba_state_bank_count + bank_indices
+
+    def _mamba_flat_indices_from_request_idxs(
+        self, request_idxs: Tensor, *, use_candidate_bank: bool = False
+    ) -> Tensor:
+        """Return flattened Mamba state rows for explicit request rows."""
+
+        assert self.is_hybrid_model, "Only hybrid models have Mamba state tensors"
+        base_indices = self.mamba_metadata.request_to_mamba_state_idx[request_idxs].to(
+            dtype=torch.int64
+        )
+        bank_indices = self.mamba_metadata.request_to_mamba_state_bank[request_idxs].to(
+            dtype=torch.int64
+        )
+        if use_candidate_bank and self.mamba_state_bank_count > 1:
+            bank_indices = 1 - bank_indices
+        return base_indices * self.mamba_state_bank_count + bank_indices
+
+    def _mamba_base_indices(self, request_slice: slice) -> Tensor:
+        """Return unbanked Mamba request slots for intermediate-state buffers."""
+
+        assert self.is_hybrid_model, "Only hybrid models have Mamba state tensors"
+        return self.mamba_metadata.request_to_mamba_state_idx[request_slice].to(dtype=torch.int64)
+
+    def accept_async_mamba_state(self, request_ids: Tensor) -> None:
+        """Commit candidate Mamba banks for accepted async-forward requests."""
+
+        if not self.is_hybrid_model or self.mamba_state_bank_count == 1 or request_ids.numel() == 0:
+            return
+
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        active_request_ids = self.request_ids[active_slice]
+        for request_id in request_ids.tolist():
+            matches = torch.nonzero(active_request_ids == int(request_id), as_tuple=True)[0]
+            if matches.numel() == 0:
+                continue
+            request_idx = self.paused_request_count + int(matches[0].item())
+            self.mamba_metadata.request_to_mamba_state_bank[request_idx] = (
+                1 - self.mamba_metadata.request_to_mamba_state_bank[request_idx]
+            )
+
     # =========================================================================
     # Mamba prefix cache infrastructure
     # =========================================================================
@@ -1901,6 +2004,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                     )
                 self._pending_mamba_zeros.append(mamba_idx)
                 self.mamba_metadata.request_to_mamba_state_idx[request_idx] = mamba_idx
+                self.mamba_metadata.request_to_mamba_state_bank[request_idx] = 0
 
         self.active_token_count = token_end
         self.total_request_count = end_request_idx
@@ -2039,6 +2143,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata.request_to_mamba_state_idx[0:N] = (
                 self.mamba_metadata.batch_allocate_slots(N)
             )
+            self.mamba_metadata.request_to_mamba_state_bank[0:N] = 0
 
     def initialize_attention_state(
         self,
@@ -2264,7 +2369,8 @@ class DynamicInferenceContext(BaseInferenceContext):
                     self.mamba_slot_allocator.get_intermediate_cpu_data()
                 )
             self._pending_mamba_transfer = self.mamba_metadata.compute_cpu_metadata(
-                active_mamba_indices=self.mamba_metadata.request_to_mamba_state_idx[active_slice],
+                active_mamba_indices=self._mamba_flat_indices(active_slice),
+                active_mamba_write_indices=self._mamba_flat_indices(active_slice),
                 token_to_request_idx=self.token_to_request_idx[: self.active_token_count],
                 cpu_cu_query=self._cpu_mha_cu_query_seq_lengths,
                 batch_dimensions=attn_dimensions,
@@ -2299,6 +2405,441 @@ class DynamicInferenceContext(BaseInferenceContext):
         # explicitly; that second call is a cheap idempotent re-copy.
         self.transfer_bookkeeping_to_gpu()
 
+    def clear_async_prepared_decode_plan(self) -> None:
+        """Forget a prepared async decode plan after launch or fallback."""
+
+        self._async_prepared_decode_plan = None
+
+    def _clear_async_reserved_kv_blocks(self) -> None:
+        """Clear the request-to-reserved-block map after CPU reconciliation."""
+
+        count = self._async_reserved_kv_block_count
+        if count > 0:
+            self._async_reserved_kv_block_request_ids[:count] = -1
+            self._async_reserved_kv_block_ids[:count] = -1
+            self._async_reserved_kv_block_columns[:count] = -1
+        self._async_reserved_kv_block_count = 0
+
+    def async_prepared_decode_plan(self) -> Optional[AsyncDecodePlan]:
+        """Return the currently prepared decode plan, if any."""
+
+        return self._async_prepared_decode_plan
+
+    def record_async_scheduling_counter(self, name: str) -> None:
+        """Increment a cumulative async scheduling diagnostic counter."""
+
+        self.async_scheduling_counters[name] = self.async_scheduling_counters.get(name, 0) + 1
+
+    def async_scheduling_counters_summary(self) -> str:
+        """Return compact cumulative async scheduling diagnostics."""
+
+        return ", ".join(
+            f"{name}={value}" for name, value in sorted(self.async_scheduling_counters.items())
+        )
+
+    def prepared_async_request_ids_match_live(self, plan: AsyncDecodePlan) -> bool:
+        """Return whether live CPU bookkeeping still matches a launched child plan."""
+
+        active_count = self.total_request_count - self.paused_request_count
+        if active_count != plan.active_request_count:
+            return False
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        if not torch.equal(self.request_ids[active_slice], plan.request_ids):
+            return False
+        return torch.equal(self.request_kv_length_offsets[active_slice], plan.kv_length_offsets)
+
+    def async_decode_next_step_skip_reason(self) -> Optional[str]:
+        """Return why a no-reject async decode child cannot launch locally."""
+
+        if not self.enable_async_scheduling:
+            return "skip_disabled"
+        if self._async_reserved_kv_block_count != 0:
+            return "skip_reserved_kv_pending"
+        if self.num_speculative_tokens != 0:
+            return "skip_mtp"
+        if not self.is_decode_only():
+            return "skip_not_decode"
+        if self.paused_request_count != 0:
+            return "skip_paused"
+        if self.get_index_of_chunked_prefill_request(safe=True) != -1:
+            return "skip_chunked_prefill"
+
+        active_request_count = self.total_request_count - self.paused_request_count
+        if active_request_count <= 0:
+            return "skip_no_active"
+
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        current_offsets = self.request_kv_length_offsets[active_slice]
+        current_query_lengths = self.request_query_lengths[active_slice]
+        next_offsets = current_offsets + current_query_lengths
+
+        termination_ids = self.request_metadata["termination_id"][active_slice]
+        if (termination_ids >= 0).any().item():
+            return "skip_token_termination"
+
+        if (next_offsets + 1 >= self.request_output_lengths[active_slice]).any():
+            return "skip_max_length"
+
+        boundary_mask = self.request_last_kv_block_offset[active_slice] >= (
+            self.block_size_tokens - 1
+        )
+        boundary_count = int(boundary_mask.sum().item())
+        if boundary_count not in (0, active_request_count):
+            return "skip_mixed_block_boundary"
+        if boundary_count > 0 and boundary_count > self.kv_block_allocator.total_avail:
+            return "skip_kv_block_unavailable"
+
+        return None
+
+    def _prepare_decode_mha_metadata(
+        self,
+        *,
+        batch_dimensions: InferenceBatchDimensions,
+        query_lengths: Tensor,
+        kv_length_offsets: Tensor,
+        request_to_kv_block_ids: Tensor,
+    ) -> None:
+        """Prepare MHA metadata from already planned decode CPU tensors."""
+
+        real_bs = batch_dimensions.req_count
+        padded_bs = self.padded_batch_dimensions.req_count
+        mha = self.active_attn_metadata["mha_metadata"]
+
+        self._cpu_mha_query_lengths[:real_bs] = query_lengths[:real_bs]
+        if real_bs < padded_bs:
+            self._cpu_mha_query_lengths[real_bs:padded_bs] = 0
+
+        self._cpu_mha_cu_query_seq_lengths[0] = 0
+        if real_bs > 0:
+            self._cpu_mha_cu_query_seq_lengths[1 : real_bs + 1] = torch.cumsum(
+                query_lengths[:real_bs], dim=0
+            )
+        if real_bs < padded_bs:
+            self._cpu_mha_cu_query_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                self._cpu_mha_cu_query_seq_lengths[real_bs]
+            )
+
+        self._cpu_mha_kv_seq_lengths[:real_bs] = (
+            kv_length_offsets[:real_bs] + query_lengths[:real_bs]
+        )
+        if real_bs < padded_bs:
+            self._cpu_mha_kv_seq_lengths[real_bs:padded_bs] = 0
+
+        self._cpu_mha_cu_kv_seq_lengths[0] = 0
+        if real_bs > 0:
+            self._cpu_mha_cu_kv_seq_lengths[1 : real_bs + 1] = torch.cumsum(
+                self._cpu_mha_kv_seq_lengths[:real_bs], dim=0
+            )
+        if real_bs < padded_bs:
+            self._cpu_mha_cu_kv_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                self._cpu_mha_cu_kv_seq_lengths[real_bs]
+            )
+
+        self._cpu_mha_block_table[:real_bs] = request_to_kv_block_ids[:real_bs]
+        if real_bs < padded_bs:
+            self._cpu_mha_block_table[real_bs:padded_bs] = -1
+
+        if not self.using_cuda_graph_this_step() and real_bs > 0:
+            max_seqlen_q = self._cpu_mha_query_lengths[:real_bs].max().item()
+            max_seqlen_k = self._cpu_mha_kv_seq_lengths[:real_bs].max().item()
+        else:
+            max_seqlen_q = self.num_speculative_tokens + 1
+            max_seqlen_k = mha.max_seqlen
+
+        mha.set_state_data(
+            padded_active_request_count=padded_bs,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+        )
+
+    def prepare_async_decode_next_step(self) -> bool:
+        """Prepare next-step decode metadata without mutating request rows."""
+
+        self.clear_async_prepared_decode_plan()
+        self.record_async_scheduling_counter("prepare_attempt")
+
+        skip_reason = self.async_decode_next_step_skip_reason()
+        if skip_reason is not None:
+            self.record_async_scheduling_counter(skip_reason)
+            return False
+
+        active_request_count = self.total_request_count - self.paused_request_count
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        current_offsets = self.request_kv_length_offsets[active_slice]
+        current_query_lengths = self.request_query_lengths[active_slice]
+        next_offsets = current_offsets + current_query_lengths
+
+        batch_dimensions = InferenceBatchDimensions(
+            token_count=active_request_count,
+            prefill_req_count=0,
+            decode_req_count=active_request_count,
+        )
+        best_graph = CUDAGraphBatchDimensionBuilder.match_graph_config(
+            batch_dimensions,
+            self.cuda_graph_batch_dimensions_list,
+            strict=self.is_hybrid_model,
+            ep_group=self.expert_model_parallel_group,
+            match_ep_token_counts=self._nccl_ep_dispatcher or self._training_ep_dispatcher,
+            ep_zmq_communicator=self._ep_zmq_communicator,
+        )
+        if best_graph is None:
+            self.record_async_scheduling_counter("skip_no_graph")
+            return False
+
+        self.batch_dimensions = batch_dimensions
+        self._using_cuda_graph_this_step = True
+        self.padded_batch_dimensions = best_graph
+        self.padded_active_token_count = best_graph.token_count
+        self.padded_active_request_count = best_graph.req_count
+        self.padding_slice = slice(active_request_count, self.padded_active_token_count)
+
+        self.build_active_slices(
+            min(self.padded_active_request_count, self.max_requests - self.paused_request_count)
+        )
+        self.pad_active_slices()
+
+        self.active_attn_metadata = self.graph_attn_metadata
+        request_rows = torch.arange(
+            self.paused_request_count,
+            self.total_request_count,
+            dtype=torch.int32,
+            device='cpu',
+        )
+        boundary_mask = self.request_last_kv_block_offset[active_slice] >= (
+            self.block_size_tokens - 1
+        )
+        boundary_count = int(boundary_mask.sum().item())
+        request_to_kv_block_ids_view = self.request_to_kv_block_ids[active_slice]
+        planned_block_ids = self.request_last_kv_block_id[active_slice].clone()
+        reserved_block_ids = torch.empty((0,), dtype=torch.int32, device='cpu')
+        if boundary_count > 0:
+            reserved_block_ids = self.kv_block_allocator.allocate_memory_blocks(boundary_count)
+            if reserved_block_ids is None or int(reserved_block_ids.numel()) != boundary_count:
+                self.record_async_scheduling_counter("skip_kv_block_unavailable")
+                return False
+
+            request_to_kv_block_ids_view = request_to_kv_block_ids_view.clone()
+            boundary_rows = torch.nonzero(boundary_mask, as_tuple=True)[0]
+            block_columns = self.request_kv_block_counts[active_slice][boundary_rows].to(
+                dtype=torch.long
+            )
+            request_to_kv_block_ids_view[boundary_rows, block_columns] = reserved_block_ids
+            planned_block_ids[boundary_rows] = reserved_block_ids
+
+            self._async_reserved_kv_block_count = boundary_count
+            self._async_reserved_kv_block_request_ids[:boundary_count] = self.request_ids[
+                active_slice
+            ][boundary_rows].to(dtype=torch.int32)
+            self._async_reserved_kv_block_ids[:boundary_count] = reserved_block_ids.to(
+                dtype=torch.int32
+            )
+            self._async_reserved_kv_block_columns[:boundary_count] = block_columns.to(
+                dtype=torch.int32
+            )
+
+        self.token_to_pos_ids[:active_request_count] = next_offsets.to(dtype=torch.int64)
+        self.token_to_request_idx[:active_request_count] = request_rows
+        self.token_to_position_in_request[:active_request_count] = next_offsets
+        self.token_to_local_position_within_kv_block[:active_request_count] = (
+            next_offsets % self.block_size_tokens
+        )
+        self.token_to_block_idx[:active_request_count] = planned_block_ids
+
+        if active_request_count < self.padded_active_token_count:
+            pad_slice = slice(active_request_count, self.padded_active_token_count)
+            self.token_to_pos_ids[pad_slice] = 0
+            self.token_to_request_idx[pad_slice] = -1
+            self.token_to_position_in_request[pad_slice] = 0
+            self.token_to_local_position_within_kv_block[pad_slice] = 0
+            self.token_to_block_idx[pad_slice] = self.kv_block_allocator.dummy_block_idx
+
+        padded_active = max(active_request_count, self.padded_active_request_count)
+        self._staging_request_in_prefill_status[:active_request_count] = 0
+        self._staging_request_query_lengths[:active_request_count] = 1
+        self._staging_request_kv_length_offsets[:active_request_count] = next_offsets
+        self._staging_temperature[:padded_active] = self.active_request_metadata["temperature"][
+            :padded_active
+        ]
+        self._staging_top_k[:padded_active] = self.active_request_metadata["top_k"][
+            :padded_active
+        ]
+        self._staging_top_p[:padded_active] = self.active_request_metadata["top_p"][
+            :padded_active
+        ]
+        if active_request_count < padded_active:
+            self._staging_request_in_prefill_status[active_request_count:padded_active] = 0
+            self._staging_request_query_lengths[active_request_count:padded_active] = 0
+            self._staging_request_kv_length_offsets[active_request_count:padded_active] = 0
+
+        query_lengths = torch.ones(
+            active_request_count, dtype=self.request_query_lengths.dtype, device='cpu'
+        )
+        self._prepare_decode_mha_metadata(
+            batch_dimensions=batch_dimensions,
+            query_lengths=query_lengths,
+            kv_length_offsets=next_offsets,
+            request_to_kv_block_ids=request_to_kv_block_ids_view,
+        )
+
+        if self.is_hybrid_model:
+            intermediate_offsets_gpu = None
+            intermediate_counts_gpu = None
+            if self.mamba_slot_allocator is not None:
+                intermediate_offsets_gpu, intermediate_counts_gpu = (
+                    self.mamba_slot_allocator.get_intermediate_cpu_data()
+                )
+            self._pending_mamba_transfer = self.mamba_metadata.compute_cpu_metadata(
+                active_mamba_indices=self._mamba_flat_indices(active_slice),
+                active_mamba_write_indices=self._mamba_flat_indices(
+                    active_slice, use_candidate_bank=True
+                ),
+                token_to_request_idx=self.token_to_request_idx[:active_request_count],
+                cpu_cu_query=self._cpu_mha_cu_query_seq_lengths,
+                batch_dimensions=batch_dimensions,
+                padded_batch_dimensions=self.padded_batch_dimensions,
+                enable_chunked_prefill=False,
+                intermediate_offsets_gpu=intermediate_offsets_gpu,
+                intermediate_counts_gpu=intermediate_counts_gpu,
+            )
+
+        if self.moe_enable_routing_replay:
+            self.moe_routing_metadata.enable_static_buffer_recording()
+        if self._nccl_ep_dispatcher:
+            NCCLAllGatherDispatcher._use_allgather_v = False
+
+        self._async_prepared_decode_plan = AsyncDecodePlan(
+            request_ids=self.request_ids[active_slice].clone(),
+            kv_length_offsets=next_offsets.clone(),
+            reserved_block_ids=reserved_block_ids.clone(),
+            active_request_count=active_request_count,
+            active_token_count=active_request_count,
+            padded_active_request_count=self.padded_active_request_count,
+        )
+        self.record_async_scheduling_counter("prepare_success")
+        return True
+
+    def copy_async_prepared_decode_input_ids_from_samples(self, sampled_tokens_cuda: Tensor) -> bool:
+        """Write sampled tokens into the prepared child input buffer."""
+
+        plan = self._async_prepared_decode_plan
+        if plan is None:
+            return False
+        self.gpu_view.token_to_input_ids[: plan.active_request_count].copy_(
+            sampled_tokens_cuda[: plan.active_request_count]
+        )
+        return True
+
+    def mark_async_forward_in_flight(self) -> None:
+        """Mark that an async child forward may still be using request-owned state."""
+
+        self._async_forward_in_flight = True
+
+    def release_deferred_async_resources(self) -> None:
+        """Release resources quarantined while an async child forward was in flight."""
+
+        self._async_forward_in_flight = False
+        if self._async_deferred_kv_blocks_to_release.numel() > 0:
+            kv_blocks = self._async_deferred_kv_blocks_to_release
+            self.kv_block_allocator.release_memory_blocks(kv_blocks)
+            self._async_deferred_kv_blocks_to_release = torch.empty(
+                (0,), dtype=torch.int32, device='cpu'
+            )
+        self._release_deferred_async_mamba_slots()
+
+    def _append_deferred_async_kv_blocks(self, blocks: Tensor) -> None:
+        """Quarantine KV blocks until the in-flight async child is retired."""
+
+        if blocks.numel() == 0:
+            return
+        blocks = blocks.to(dtype=torch.int32, device='cpu')
+        self._async_deferred_kv_blocks_to_release = torch.cat(
+            (self._async_deferred_kv_blocks_to_release, blocks)
+        )
+
+    def _consume_async_reserved_kv_blocks(
+        self, request_ids: Tensor, block_columns: Tensor
+    ) -> Tensor:
+        """Return reserved blocks for resumed requests, or -1 where none is reserved."""
+
+        reserved_block_ids = torch.full(
+            (request_ids.numel(),), -1, dtype=torch.int32, device='cpu'
+        )
+        count = self._async_reserved_kv_block_count
+        if count == 0 or request_ids.numel() == 0:
+            return reserved_block_ids
+
+        for request_idx, (request_id_tensor, block_column_tensor) in enumerate(
+            zip(request_ids.tolist(), block_columns.tolist())
+        ):
+            request_id = int(request_id_tensor)
+            block_column = int(block_column_tensor)
+            for slot in range(count):
+                if int(self._async_reserved_kv_block_request_ids[slot]) != request_id:
+                    continue
+                if int(self._async_reserved_kv_block_columns[slot]) != block_column:
+                    continue
+                reserved_block_ids[request_idx] = self._async_reserved_kv_block_ids[slot]
+                self._async_reserved_kv_block_request_ids[slot] = -1
+                self._async_reserved_kv_block_ids[slot] = -1
+                self._async_reserved_kv_block_columns[slot] = -1
+                break
+        return reserved_block_ids
+
+    def _defer_remaining_async_reserved_kv_blocks(self) -> None:
+        """Quarantine reserved blocks that actual CPU bookkeeping did not consume."""
+
+        count = self._async_reserved_kv_block_count
+        if count == 0:
+            return
+        remaining_blocks = self._async_reserved_kv_block_ids[:count]
+        remaining_blocks = remaining_blocks[remaining_blocks != -1]
+        if remaining_blocks.numel() > 0:
+            self._append_deferred_async_kv_blocks(remaining_blocks)
+        self._clear_async_reserved_kv_blocks()
+
+    def _append_deferred_async_mamba_slots(self, slots: Tensor) -> None:
+        """Quarantine Mamba slots until the in-flight async child is retired."""
+
+        if slots.numel() == 0:
+            return
+        slots = slots[slots != -1].to(dtype=torch.int32, device='cpu')
+        if slots.numel() == 0:
+            return
+        self._async_deferred_mamba_slots_to_free = torch.cat(
+            (self._async_deferred_mamba_slots_to_free, slots)
+        )
+
+    def _release_deferred_async_mamba_slots(self) -> None:
+        """Return deferred Mamba slots to the free pool after child retirement."""
+
+        if (
+            not self.is_hybrid_model
+            or self._async_deferred_mamba_slots_to_free.numel() == 0
+        ):
+            return
+        slots = self._async_deferred_mamba_slots_to_free
+        self.mamba_metadata.free_slot_ids(
+            slots.to(device=self.mamba_metadata.mamba_state_free_slots.device)
+        )
+        self._async_deferred_mamba_slots_to_free = torch.empty(
+            (0,), dtype=torch.int32, device='cpu'
+        )
+
+    def _free_mamba_slots_for_request_indexes(self, request_indexes: Tensor) -> None:
+        """Free request-owned Mamba slots now, or defer them past an async child."""
+
+        if not self.is_hybrid_model:
+            return
+        if self._async_forward_in_flight:
+            mamba_indices_to_free = self.mamba_metadata.request_to_mamba_state_idx[
+                request_indexes
+            ]
+            self._append_deferred_async_mamba_slots(mamba_indices_to_free)
+            self.mamba_metadata.request_to_mamba_state_idx[request_indexes] = -1
+            self.mamba_metadata.request_to_mamba_state_bank[request_indexes] = 0
+            return
+        self.mamba_metadata.free_slots(request_indexes)
+
     def _execute_pending_mamba_ops(self) -> None:
         """Execute Mamba GPU operations deferred from add_request() / update_requests().
 
@@ -2318,12 +2859,25 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Batch-zero newly allocated Mamba slots.
         if self._pending_mamba_zeros:
             device = self.mamba_conv_states.device
-            indices = torch.tensor(self._pending_mamba_zeros, dtype=torch.long, device=device)
+            base_indices = torch.tensor(self._pending_mamba_zeros, dtype=torch.long, device=device)
+            if self.mamba_state_bank_count > 1:
+                banks = torch.arange(self.mamba_state_bank_count, dtype=torch.long, device=device)
+                indices = (base_indices[:, None] * self.mamba_state_bank_count + banks).flatten()
+            else:
+                indices = base_indices
             self.mamba_conv_states[:, indices] = 0.0
             self.mamba_ssm_states[:, indices] = 0.0
             self._pending_mamba_zeros.clear()
 
-    def transfer_bookkeeping_to_gpu(self) -> None:
+    def transfer_bookkeeping_to_gpu(
+        self,
+        *,
+        include_token_to_input_ids: bool = True,
+        refresh_request_staging: bool = True,
+        record_done_event: bool = False,
+        done_event: Optional[torch.cuda.Event] = None,
+        target_stream: Optional[torch.cuda.Stream] = None,
+    ) -> Optional[torch.cuda.Event]:
         """Batch transfer CPU bookkeeping state to GPU staging buffers.
 
         Called after initialize_attention_state() and before the forward pass.
@@ -2340,39 +2894,56 @@ class DynamicInferenceContext(BaseInferenceContext):
         active_slice = slice(self.paused_request_count, self.total_request_count)
         padded_active = max(n_active, self.padded_active_request_count)
 
-        # Refresh request-level staging slots from the persistent CPU source.
-        # CPU-to-CPU slice assignment on pinned memory (~15 KB total for 6
-        # 4-byte fields at max_requests=624). Negligible vs. the launch overhead
-        # we save by merging the H2D memcpys into 1.
-        self._staging_request_in_prefill_status[:n_active] = self.request_in_prefill_status_tensor[
-            active_slice
-        ]
-        self._staging_request_query_lengths[:n_active] = self.request_query_lengths[active_slice]
-        self._staging_request_kv_length_offsets[:n_active] = self.request_kv_length_offsets[
-            active_slice
-        ]
-        # Sampling-parameter staging slots: read from `active_request_metadata`,
-        # which `build_active_slices` + `pad_active_slices` already populated for
-        # `[:padded_active]` (active values + neutral padding defaults).
-        self._staging_temperature[:padded_active] = self.active_request_metadata["temperature"][
-            :padded_active
-        ]
-        self._staging_top_k[:padded_active] = self.active_request_metadata["top_k"][:padded_active]
-        self._staging_top_p[:padded_active] = self.active_request_metadata["top_p"][:padded_active]
+        if refresh_request_staging:
+            # Refresh request-level staging slots from the persistent CPU source.
+            # CPU-to-CPU slice assignment on pinned memory (~15 KB total for 6
+            # 4-byte fields at max_requests=624). Negligible vs. the launch overhead
+            # we save by merging the H2D memcpys into 1.
+            self._staging_request_in_prefill_status[
+                :n_active
+            ] = self.request_in_prefill_status_tensor[active_slice]
+            self._staging_request_query_lengths[:n_active] = self.request_query_lengths[
+                active_slice
+            ]
+            self._staging_request_kv_length_offsets[:n_active] = self.request_kv_length_offsets[
+                active_slice
+            ]
+            # Sampling-parameter staging slots: read from `active_request_metadata`,
+            # which `build_active_slices` + `pad_active_slices` already populated for
+            # `[:padded_active]` (active values + neutral padding defaults).
+            self._staging_temperature[:padded_active] = self.active_request_metadata[
+                "temperature"
+            ][:padded_active]
+            self._staging_top_k[:padded_active] = self.active_request_metadata["top_k"][
+                :padded_active
+            ]
+            self._staging_top_p[:padded_active] = self.active_request_metadata["top_p"][
+                :padded_active
+            ]
 
-        # Full-iteration CUDA graphs may have captured GPU consumers with the
-        # padded graph request count. Keep those padded staging rows bounded so
-        # graph replay never builds indices from stale request lengths.
-        if n_active < padded_active:
-            self._staging_request_in_prefill_status[n_active:padded_active] = 0
-            self._staging_request_query_lengths[n_active:padded_active] = 0
-            self._staging_request_kv_length_offsets[n_active:padded_active] = 0
+            # Full-iteration CUDA graphs may have captured GPU consumers with the
+            # padded graph request count. Keep those padded staging rows bounded so
+            # graph replay never builds indices from stale request lengths.
+            if n_active < padded_active:
+                self._staging_request_in_prefill_status[n_active:padded_active] = 0
+                self._staging_request_query_lengths[n_active:padded_active] = 0
+                self._staging_request_kv_length_offsets[n_active:padded_active] = 0
 
         # Coalesced H2D: one cudaMemcpyAsync for the entire bookkeeping buffer.
         # Copying the whole (max_tokens + max_requests)-sized buffer including
         # unused slots is cheap (~71 KB total, ~3-5 us on PCIe Gen4) and saves
         # 8 redundant launch overheads vs. the prior per-field copies.
-        self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+        stream_context = (
+            torch.cuda.stream(target_stream) if target_stream is not None else nullcontext()
+        )
+        with stream_context:
+            if include_token_to_input_ids:
+                self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+            else:
+                input_ids_nbytes = self.max_tokens * self.token_to_input_ids.element_size()
+                self.gpu_view._buf[input_ids_nbytes:].copy_(
+                    self._cpu_bookkeeping_buf[input_ids_nbytes:], non_blocking=True
+                )
 
         # MHA metadata GPU views were already bound to state_data in
         # initialize_attention_state(); the H2D above populates the underlying
@@ -2382,6 +2953,15 @@ class DynamicInferenceContext(BaseInferenceContext):
         if hasattr(self, '_pending_mamba_transfer') and self._pending_mamba_transfer is not None:
             self.mamba_metadata.load_from_cpu(self._pending_mamba_transfer)
             self._pending_mamba_transfer = None
+
+        if record_done_event:
+            done_event = done_event or self._bookkeeping_h2d_done_event
+            with stream_context:
+                done_event.record(torch.cuda.current_stream())
+        else:
+            done_event = None
+
+        return done_event
 
     def reset_tensors(self) -> None:
         """Fill all bookkeeping tensors with sentinel values."""
@@ -2396,6 +2976,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_last_kv_block_offset.fill_(0)
         self.request_to_kv_block_ids.fill_(-1)
         self.request_in_prefill_status_tensor.fill_(-1)
+        self._async_deferred_kv_blocks_to_release = torch.empty(
+            (0,), dtype=torch.int32, device='cpu'
+        )
+        self._clear_async_reserved_kv_blocks()
 
         # Reset request metadata.
         for metadata_tensor in self.request_metadata.values():
@@ -2890,6 +3474,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             if mamba_idx is None:
                 raise ContextOverflowError(req.request_id, "No Mamba slots available")
             self.mamba_metadata.request_to_mamba_state_idx[self.total_request_count] = mamba_idx
+            self.mamba_metadata.request_to_mamba_state_bank[self.total_request_count] = 0
 
             # Restore Mamba state from the block corresponding to prefix_skip_tokens
             restore_block_count = prefix_skip_tokens // self.block_size_tokens
@@ -2949,6 +3534,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata.request_to_mamba_state_idx[dst_idxs] = (
                 self.mamba_metadata.request_to_mamba_state_idx[src_idxs]
             )
+            self.mamba_metadata.request_to_mamba_state_bank[dst_idxs] = (
+                self.mamba_metadata.request_to_mamba_state_bank[src_idxs]
+            )
 
     def _swap_book_keeping_tensors(
         self, src_idxs, dst_idxs, next_tokens=None, new_speculative_tokens=None
@@ -2979,6 +3567,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         if self.is_hybrid_model:
             tensor_swap(self.mamba_metadata.request_to_mamba_state_idx, src_idxs, dst_idxs)
+            tensor_swap(self.mamba_metadata.request_to_mamba_state_bank, src_idxs, dst_idxs)
 
     def get_index_of_chunked_prefill_request(self, safe: bool = True) -> int:
         """
@@ -3015,7 +3604,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         kv_blocks_assigned = self.request_to_kv_block_ids[request_indexes]
         non_zero_values_in_kv_memory = kv_blocks_assigned[kv_blocks_assigned != -1]
-        self.kv_block_allocator.release_memory_blocks(non_zero_values_in_kv_memory)
+        if self._async_forward_in_flight:
+            self._append_deferred_async_kv_blocks(non_zero_values_in_kv_memory)
+        else:
+            self.kv_block_allocator.release_memory_blocks(non_zero_values_in_kv_memory)
 
         # Reset the KV blocks for finished requests.
         # Note: do not use fill_() (or add_() and similar inplace ops) here.
@@ -3025,8 +3617,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_to_kv_block_ids[request_indexes] = -1
 
         # Free Mamba slots.
-        if self.is_hybrid_model:
-            self.mamba_metadata.free_slots(request_indexes)
+        self._free_mamba_slots_for_request_indexes(request_indexes)
 
         # Clear intermediate offset entries for released requests (CPU writes).
         if self.mamba_slot_allocator is not None:
@@ -3098,13 +3689,20 @@ class DynamicInferenceContext(BaseInferenceContext):
             num_new_blocks = needs_new_block.sum().item()
 
             if num_new_blocks > 0:
-                assert num_new_blocks <= self.kv_block_allocator.total_avail
-                block_ids = self.kv_block_allocator.allocate_memory_blocks(num_new_blocks)
-
                 # Apply updates only to the requests that required a new block
                 relative_row_idx = torch.nonzero(needs_new_block).squeeze(1)
                 row_idx = resume_start + relative_row_idx
                 col_idx = self.request_kv_block_counts[row_idx]
+                request_ids = self.request_ids[row_idx]
+                block_ids = self._consume_async_reserved_kv_blocks(request_ids, col_idx)
+                missing_reserved_mask = block_ids == -1
+                missing_reserved_count = int(missing_reserved_mask.sum().item())
+                if missing_reserved_count > 0:
+                    assert missing_reserved_count <= self.kv_block_allocator.total_avail
+                    allocated_block_ids = self.kv_block_allocator.allocate_memory_blocks(
+                        missing_reserved_count
+                    )
+                    block_ids[missing_reserved_mask] = allocated_block_ids
 
                 self.request_to_kv_block_ids[row_idx, col_idx] = block_ids
                 self.request_kv_block_counts[row_idx] += 1
@@ -3230,6 +3828,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_to_kv_block_ids[evict_slice] = -1
         if self.is_hybrid_model:
             self.mamba_metadata.request_to_mamba_state_idx[evict_slice] = -1
+            self.mamba_metadata.request_to_mamba_state_bank[evict_slice] = 0
 
         return evict_request_ids
 
@@ -3385,6 +3984,7 @@ class DynamicInferenceContext(BaseInferenceContext):
                 self.request_to_kv_block_ids[active_idxs_on_right] = -1
                 if self.is_hybrid_model:
                     self.mamba_metadata.request_to_mamba_state_idx[active_idxs_on_right] = -1
+                    self.mamba_metadata.request_to_mamba_state_bank[active_idxs_on_right] = 0
 
         # 5. We identify requests that require a new block and add them to the paused requests (i.e move them left) :-
         #       a) Put requests that have filled their current block and  require a new one in a pause state temporarily
@@ -3684,6 +4284,8 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             # Convert back to 1d tensor
             self.token_to_block_idx[: self.active_token_count] = block_idx.flatten()
+
+        self._defer_remaining_async_reserved_kv_blocks()
 
         return {
             "newly_paused_request_ids": newly_paused_request_ids,

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -219,7 +219,9 @@ class AsyncDecodePlan:
 
     request_ids: Tensor
     kv_length_offsets: Tensor
+    reserved_request_ids: Tensor
     reserved_block_ids: Tensor
+    reserved_block_columns: Tensor
     active_request_count: int
     active_token_count: int
     padded_active_request_count: int
@@ -983,6 +985,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         self._async_deferred_mamba_slots_to_free = torch.empty(
             (0,), dtype=torch.int32, device='cpu'
         )
+        self._async_reserved_kv_block_adoption_count = 0
+        self._async_deferred_kv_block_release_count = 0
+        self._async_deferred_mamba_slot_release_count = 0
 
         # Track request metadata. Backed by pinned CPU memory: bookkeeping is
         # CPU-resident; GPU consumers read from the active-slice mirror in
@@ -2425,10 +2430,12 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         return self._async_prepared_decode_plan
 
-    def record_async_scheduling_counter(self, name: str) -> None:
+    def record_async_scheduling_counter(self, name: str, amount: int = 1) -> None:
         """Increment a cumulative async scheduling diagnostic counter."""
 
-        self.async_scheduling_counters[name] = self.async_scheduling_counters.get(name, 0) + 1
+        self.async_scheduling_counters[name] = (
+            self.async_scheduling_counters.get(name, 0) + amount
+        )
 
     def async_scheduling_counters_summary(self) -> str:
         """Return compact cumulative async scheduling diagnostics."""
@@ -2611,7 +2618,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         boundary_count = int(boundary_mask.sum().item())
         request_to_kv_block_ids_view = self.request_to_kv_block_ids[active_slice]
         planned_block_ids = self.request_last_kv_block_id[active_slice].clone()
+        reserved_request_ids = torch.empty((0,), dtype=torch.int32, device='cpu')
         reserved_block_ids = torch.empty((0,), dtype=torch.int32, device='cpu')
+        reserved_block_columns = torch.empty((0,), dtype=torch.int32, device='cpu')
         if boundary_count > 0:
             reserved_block_ids = self.kv_block_allocator.allocate_memory_blocks(boundary_count)
             if reserved_block_ids is None or int(reserved_block_ids.numel()) != boundary_count:
@@ -2626,16 +2635,17 @@ class DynamicInferenceContext(BaseInferenceContext):
             request_to_kv_block_ids_view[boundary_rows, block_columns] = reserved_block_ids
             planned_block_ids[boundary_rows] = reserved_block_ids
 
+            reserved_request_ids = self.request_ids[active_slice][boundary_rows].to(
+                dtype=torch.int32
+            )
+            reserved_block_columns = block_columns.to(dtype=torch.int32)
             self._async_reserved_kv_block_count = boundary_count
-            self._async_reserved_kv_block_request_ids[:boundary_count] = self.request_ids[
-                active_slice
-            ][boundary_rows].to(dtype=torch.int32)
+            self._async_reserved_kv_block_request_ids[:boundary_count] = reserved_request_ids
             self._async_reserved_kv_block_ids[:boundary_count] = reserved_block_ids.to(
                 dtype=torch.int32
             )
-            self._async_reserved_kv_block_columns[:boundary_count] = block_columns.to(
-                dtype=torch.int32
-            )
+            self._async_reserved_kv_block_columns[:boundary_count] = reserved_block_columns
+            self.record_async_scheduling_counter("kv_lease_reserved", boundary_count)
 
         self.token_to_pos_ids[:active_request_count] = next_offsets.to(dtype=torch.int64)
         self.token_to_request_idx[:active_request_count] = request_rows
@@ -2710,7 +2720,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         self._async_prepared_decode_plan = AsyncDecodePlan(
             request_ids=self.request_ids[active_slice].clone(),
             kv_length_offsets=next_offsets.clone(),
+            reserved_request_ids=reserved_request_ids.clone(),
             reserved_block_ids=reserved_block_ids.clone(),
+            reserved_block_columns=reserved_block_columns.clone(),
             active_request_count=active_request_count,
             active_token_count=active_request_count,
             padded_active_request_count=self.padded_active_request_count,
@@ -2741,6 +2753,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self._async_deferred_kv_blocks_to_release.numel() > 0:
             kv_blocks = self._async_deferred_kv_blocks_to_release
             self.kv_block_allocator.release_memory_blocks(kv_blocks)
+            self._async_deferred_kv_block_release_count += int(kv_blocks.numel())
+            self.record_async_scheduling_counter("kv_lease_released", int(kv_blocks.numel()))
             self._async_deferred_kv_blocks_to_release = torch.empty(
                 (0,), dtype=torch.int32, device='cpu'
             )
@@ -2752,6 +2766,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         if blocks.numel() == 0:
             return
         blocks = blocks.to(dtype=torch.int32, device='cpu')
+        self.record_async_scheduling_counter("kv_lease_deferred", int(blocks.numel()))
         self._async_deferred_kv_blocks_to_release = torch.cat(
             (self._async_deferred_kv_blocks_to_release, blocks)
         )
@@ -2782,6 +2797,8 @@ class DynamicInferenceContext(BaseInferenceContext):
                 self._async_reserved_kv_block_request_ids[slot] = -1
                 self._async_reserved_kv_block_ids[slot] = -1
                 self._async_reserved_kv_block_columns[slot] = -1
+                self._async_reserved_kv_block_adoption_count += 1
+                self.record_async_scheduling_counter("kv_lease_adopted")
                 break
         return reserved_block_ids
 
@@ -2805,6 +2822,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         slots = slots[slots != -1].to(dtype=torch.int32, device='cpu')
         if slots.numel() == 0:
             return
+        self.record_async_scheduling_counter("mamba_lease_deferred", int(slots.numel()))
         self._async_deferred_mamba_slots_to_free = torch.cat(
             (self._async_deferred_mamba_slots_to_free, slots)
         )
@@ -2818,6 +2836,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         ):
             return
         slots = self._async_deferred_mamba_slots_to_free
+        self._async_deferred_mamba_slot_release_count += int(slots.numel())
+        self.record_async_scheduling_counter("mamba_lease_released", int(slots.numel()))
         self.mamba_metadata.free_slot_ids(
             slots.to(device=self.mamba_metadata.mamba_state_free_slots.device)
         )
@@ -2980,6 +3000,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             (0,), dtype=torch.int32, device='cpu'
         )
         self._clear_async_reserved_kv_blocks()
+        self._async_reserved_kv_block_adoption_count = 0
+        self._async_deferred_kv_block_release_count = 0
+        self._async_deferred_mamba_slot_release_count = 0
 
         # Reset request metadata.
         for metadata_tensor in self.request_metadata.values():

--- a/megatron/core/inference/contexts/gpu_view.py
+++ b/megatron/core/inference/contexts/gpu_view.py
@@ -60,8 +60,9 @@ class ContextGPUView:
         mha_block_table_bytes = max_bs * max_kv_blocks * 4
 
         # Mamba section, only present for hybrid models.
-        #   mamba_batch_indices_decode    int64 (max_bs,)
-        #   mamba_batch_indices_prefill   int32 (max_bs,)
+        #   mamba_batch_indices_decode       int64 (max_bs,)
+        #   mamba_batch_indices_decode_write int64 (max_bs,)
+        #   mamba_batch_indices_prefill      int32 (max_bs,)
         #   mamba_seq_idx                 int32 (1, max_tokens)
         #   mamba_cu_seqlens              int32 (max_bs + 1,)
         #   mamba_cu_chunk_seqlens        int32 (max_mamba_chunks + 1,)
@@ -85,6 +86,7 @@ class ContextGPUView:
             # mamba_batch_indices_decode is int64; pad to 8-byte alignment.
             mamba_align_pad = (8 - pre_mamba_bytes % 8) % 8
             mamba_batch_indices_decode_bytes = max_bs * 8
+            mamba_batch_indices_decode_write_bytes = max_bs * 8
             mamba_batch_indices_prefill_bytes = max_bs * 4
             mamba_seq_idx_bytes = max_tokens * 4
             mamba_cu_seqlens_bytes = (max_bs + 1) * 4
@@ -96,6 +98,7 @@ class ContextGPUView:
         else:
             mamba_align_pad = 0
             mamba_batch_indices_decode_bytes = 0
+            mamba_batch_indices_decode_write_bytes = 0
             mamba_batch_indices_prefill_bytes = 0
             mamba_seq_idx_bytes = 0
             mamba_cu_seqlens_bytes = 0
@@ -109,6 +112,7 @@ class ContextGPUView:
             pre_mamba_bytes
             + mamba_align_pad
             + mamba_batch_indices_decode_bytes
+            + mamba_batch_indices_decode_write_bytes
             + mamba_batch_indices_prefill_bytes
             + mamba_seq_idx_bytes
             + mamba_cu_seqlens_bytes
@@ -194,6 +198,10 @@ class ContextGPUView:
                 off : off + mamba_batch_indices_decode_bytes
             ].view(torch.int64)
             off += mamba_batch_indices_decode_bytes
+            self.mamba_batch_indices_decode_write = self._buf[
+                off : off + mamba_batch_indices_decode_write_bytes
+            ].view(torch.int64)
+            off += mamba_batch_indices_decode_write_bytes
             self.mamba_batch_indices_prefill = self._buf[
                 off : off + mamba_batch_indices_prefill_bytes
             ].view(torch.int32)
@@ -226,6 +234,7 @@ class ContextGPUView:
             off += mamba_conv_seq_start_bytes
         else:
             self.mamba_batch_indices_decode = None
+            self.mamba_batch_indices_decode_write = None
             self.mamba_batch_indices_prefill = None
             self.mamba_seq_idx = None
             self.mamba_cu_seqlens = None

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -320,6 +320,17 @@ class MambaSlotAllocator:
         self.ssm_states[layer_idx, slot].copy_(ssm_state)
         self.conv_states[layer_idx, slot].copy_(conv_state)
 
+    def _live_mamba_indices(self, request_indices: list, device: torch.device) -> Tensor:
+        """Return flattened accepted Mamba-state rows for context request indices."""
+
+        req_tensor_cpu = torch.tensor(request_indices, dtype=torch.int64)
+        base_indices = self.context.mamba_metadata.request_to_mamba_state_idx[req_tensor_cpu]
+        state_bank_count = getattr(self.context, "mamba_state_bank_count", 1)
+        if state_bank_count > 1:
+            bank_indices = self.context.mamba_metadata.request_to_mamba_state_bank[req_tensor_cpu]
+            base_indices = base_indices * state_bank_count + bank_indices
+        return base_indices.to(device=device, dtype=torch.int64)
+
     def store_from_live_batch(self, slots: list, request_indices: list) -> None:
         """Copy all layers from live per-request buffers to cache slots.
 
@@ -331,12 +342,7 @@ class MambaSlotAllocator:
             return
         device = self.conv_states.device
         slot_tensor = torch.tensor(slots, dtype=torch.int64, device=device)
-        # Lookup mamba indices from CPU bookkeeping, then move to GPU for state copy.
-        req_tensor_cpu = torch.tensor(request_indices, dtype=torch.int64)
-        mamba_indices = self.context.mamba_metadata.request_to_mamba_state_idx[
-            req_tensor_cpu
-        ].tolist()
-        mamba_idx_tensor = torch.tensor(mamba_indices, dtype=torch.int64, device=device)
+        mamba_idx_tensor = self._live_mamba_indices(request_indices, device)
         # Fancy-indexed copy (2 kernel launches instead of 2E)
         self.conv_states[:, slot_tensor] = self.context.mamba_conv_states[:, mamba_idx_tensor]
         self.ssm_states[:, slot_tensor] = self.context.mamba_ssm_states[:, mamba_idx_tensor]
@@ -354,7 +360,7 @@ class MambaSlotAllocator:
         slot = self.block_to_slot[block_id].item()
         if slot < 0:
             return False
-        mamba_idx = self.context.mamba_metadata.request_to_mamba_state_idx[request_idx].item()
+        mamba_idx = self._live_mamba_indices([request_idx], self.conv_states.device)[0].item()
         self.context.mamba_conv_states[:, mamba_idx].copy_(self.conv_states[:, slot])
         self.context.mamba_ssm_states[:, mamba_idx].copy_(self.ssm_states[:, slot])
         return True

--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -17,6 +17,15 @@ except ImportError:
     HAVE_ZMQ = False
 
 
+_SETUP_MAGIC = b"AZQS"
+_DATA_MAGIC = b"AZQD"
+_ERROR_MAGIC = b"AZQE"
+
+
+class ZMQCollectiveError(RuntimeError):
+    """Raised when a tagged ZMQ collective observes a protocol mismatch."""
+
+
 class AsyncZMQCommunicator:
     """
     An asyncio-friendly communicator abstraction using ZMQ.
@@ -46,6 +55,9 @@ class AsyncZMQCommunicator:
         self.is_leader = self.rank == 0
         # Get the global rank of the leader (first rank in the process group)
         src_rank = dist.get_process_group_ranks(process_group)[0]
+        self._async_collective_step = 0
+        self._sync_collective_step = 0
+        self.protocol_mismatch_count = 0
 
         if self.is_leader:
             local_ip = hostname or socket.gethostname()
@@ -53,33 +65,150 @@ class AsyncZMQCommunicator:
             self.gather_sock.bind_to_random_port(f"tcp://{local_ip}")
             gather_socket_addr = self.gather_sock.getsockopt_string(zmq.LAST_ENDPOINT)
 
-            self.bcast_sock = zmq_context.socket(zmq.PUB)
-            self.bcast_sock.bind_to_random_port(f"tcp://{local_ip}")
-            bcast_socket_addr = self.bcast_sock.getsockopt_string(zmq.LAST_ENDPOINT)
+            # Share the socket address with all peers.
+            dist.broadcast_object_list([gather_socket_addr], src=src_rank, group=process_group)
 
-            # Share the socket addresses with all peers
-            dist.broadcast_object_list(
-                [gather_socket_addr, bcast_socket_addr], src=src_rank, group=process_group
-            )
+            self.result_push_socks = {}
+            while len(self.result_push_socks) < self.world_size - 1:
+                peer_rank, result_socket_addr = self._unpack_setup_message(self.gather_sock.recv())
+                result_push_sock = zmq_context.socket(zmq.PUSH)
+                result_push_sock.connect(result_socket_addr)
+                self.result_push_socks[peer_rank] = result_push_sock
 
         else:
-            bcast_output = [None, None]
+            bcast_output = [None]
             dist.broadcast_object_list(bcast_output, src=src_rank, group=process_group)
-            gather_socket_addr, bcast_socket_addr = bcast_output
+            [gather_socket_addr] = bcast_output
             self.gather_sock = zmq_context.socket(zmq.PUSH)
             self.gather_sock.connect(gather_socket_addr)
-            self.bcast_sock = zmq_context.socket(zmq.SUB)
-            self.bcast_sock.connect(bcast_socket_addr)
-            self.bcast_sock.setsockopt_string(zmq.SUBSCRIBE, "")
+            local_ip = hostname or socket.gethostname()
+            self.result_recv_sock = zmq_context.socket(zmq.PULL)
+            self.result_recv_sock.bind_to_random_port(f"tcp://{local_ip}")
+            result_socket_addr = self.result_recv_sock.getsockopt_string(zmq.LAST_ENDPOINT)
+            self.gather_sock.send(self._pack_setup_message(self.rank, result_socket_addr))
 
-    async def all_reduce_max(self, *local_vals: int, async_op=True) -> int | tuple[int, ...]:
-        """Element-wise all-reduce max of one or more integers.
+        # Prevent a fast peer from sending the first collective before the leader has collected
+        # all per-rank result sockets. ZMQ preserves per-peer ordering, not global ordering.
+        dist.barrier(group=process_group)
 
-        Packs all values into a single message so the communication cost
-        is independent of the number of values.
+    @staticmethod
+    def _pack_setup_message(rank: int, socket_addr: str) -> bytes:
+        addr = socket_addr.encode("utf-8")
+        return struct.pack(f"!4siH{len(addr)}s", _SETUP_MAGIC, rank, len(addr), addr)
 
-        Returns a single int when called with one argument, otherwise a tuple.
-        """
+    @staticmethod
+    def _unpack_setup_message(msg: bytes) -> tuple[int, str]:
+        magic, rank, addr_len = struct.unpack("!4siH", msg[:10])
+        if magic != _SETUP_MAGIC:
+            raise ZMQCollectiveError("Unexpected ZMQ communicator setup message")
+        addr = struct.unpack(f"!{addr_len}s", msg[10 : 10 + addr_len])[0].decode("utf-8")
+        return rank, addr
+
+    @staticmethod
+    def _pack_values_message(phase: str, step_id: int, values: tuple[int, ...]) -> bytes:
+        phase_bytes = phase.encode("utf-8")
+        n = len(values)
+        return struct.pack(
+            f"!4sHqH{len(phase_bytes)}s{n}i",
+            _DATA_MAGIC,
+            len(phase_bytes),
+            step_id,
+            n,
+            phase_bytes,
+            *values,
+        )
+
+    @staticmethod
+    def _unpack_values_message(
+        msg: bytes, *, expected_phase: str, expected_step_id: int, expected_count: int
+    ) -> tuple[int, ...]:
+        if len(msg) < 16:
+            raise ZMQCollectiveError("Malformed ZMQ collective message")
+
+        magic = msg[:4]
+        if magic == _ERROR_MAGIC:
+            raise ZMQCollectiveError(AsyncZMQCommunicator._unpack_error_message(msg))
+        if magic != _DATA_MAGIC:
+            raise ZMQCollectiveError("Unexpected ZMQ collective message type")
+
+        _, phase_len, step_id, value_count = struct.unpack("!4sHqH", msg[:16])
+        phase_start = 16
+        phase_end = phase_start + phase_len
+        phase = struct.unpack(f"!{phase_len}s", msg[phase_start:phase_end])[0].decode("utf-8")
+        if phase != expected_phase:
+            raise ZMQCollectiveError(
+                f"ZMQ collective phase mismatch: expected {expected_phase}, got {phase}"
+            )
+        if step_id != expected_step_id:
+            raise ZMQCollectiveError(
+                f"ZMQ collective step mismatch for {phase}: "
+                f"expected {expected_step_id}, got {step_id}"
+            )
+        if value_count != expected_count:
+            raise ZMQCollectiveError(
+                f"ZMQ collective value_count mismatch for {phase} step {step_id}: "
+                f"expected {expected_count}, got {value_count}"
+            )
+
+        values_start = phase_end
+        values_end = values_start + (4 * value_count)
+        if len(msg) != values_end:
+            raise ZMQCollectiveError(
+                f"Malformed ZMQ collective payload for {phase} step {step_id}: "
+                f"expected {values_end} bytes, got {len(msg)}"
+            )
+        return struct.unpack(f"!{value_count}i", msg[values_start:values_end])
+
+    def _unpack_collective_values_message(
+        self, msg: bytes, *, expected_phase: str, expected_step_id: int, expected_count: int
+    ) -> tuple[int, ...]:
+        try:
+            return self._unpack_values_message(
+                msg,
+                expected_phase=expected_phase,
+                expected_step_id=expected_step_id,
+                expected_count=expected_count,
+            )
+        except ZMQCollectiveError:
+            self.protocol_mismatch_count += 1
+            raise
+
+    @staticmethod
+    def _pack_error_message(message: str) -> bytes:
+        encoded = message.encode("utf-8")
+        return struct.pack(f"!4sI{len(encoded)}s", _ERROR_MAGIC, len(encoded), encoded)
+
+    @staticmethod
+    def _unpack_error_message(msg: bytes) -> str:
+        _, message_len = struct.unpack("!4sI", msg[:8])
+        return struct.unpack(f"!{message_len}s", msg[8 : 8 + message_len])[0].decode("utf-8")
+
+    def _next_collective_tag(
+        self, *, phase: str | None, step_id: int | None, sync: bool
+    ) -> tuple[str, int]:
+        if phase is None:
+            phase = "sync_all_reduce_max" if sync else "all_reduce_max"
+        if step_id is None:
+            if sync:
+                step_id = self._sync_collective_step
+                self._sync_collective_step += 1
+            else:
+                step_id = self._async_collective_step
+                self._async_collective_step += 1
+        return phase, step_id
+
+    def _send_result_to_peers(self, msg: bytes) -> None:
+        for peer_rank in sorted(self.result_push_socks):
+            self.result_push_socks[peer_rank].send(msg)
+
+    def _send_error_to_peers(self, error: Exception) -> None:
+        self._send_result_to_peers(self._pack_error_message(str(error)))
+
+    async def all_reduce_max(
+        self, *local_vals: int, async_op=True, phase: str | None = None, step_id: int | None = None
+    ) -> int | tuple[int, ...]:
+        """Element-wise all-reduce max of one or more integers."""
+
         n = len(local_vals)
         if n == 0:
             raise ValueError("all_reduce_max requires at least one value")
@@ -87,8 +216,8 @@ class AsyncZMQCommunicator:
         if self.world_size <= 1:
             return local_vals[0] if n == 1 else local_vals
 
-        fmt = f'!{n}i'
-        payload = struct.pack(fmt, *local_vals)
+        phase, step_id = self._next_collective_tag(phase=phase, step_id=step_id, sync=False)
+        payload = self._pack_values_message(phase, step_id, local_vals)
 
         if self.is_leader:
             rows = [local_vals]
@@ -99,53 +228,45 @@ class AsyncZMQCommunicator:
                         msg = self.gather_sock.recv(flags=zmq.NOBLOCK)
                     else:
                         msg = self.gather_sock.recv()
-                    rows.append(struct.unpack(fmt, msg))
+                    rows.append(
+                        self._unpack_collective_values_message(
+                            msg, expected_phase=phase, expected_step_id=step_id, expected_count=n
+                        )
+                    )
                 except zmq.Again:
                     await asyncio.sleep(0.001)
+                except Exception as error:
+                    self._send_error_to_peers(error)
+                    raise
 
             maxes = tuple(max(row[i] for row in rows) for i in range(n))
-            self.bcast_sock.send(struct.pack(fmt, *maxes))
+            self._send_result_to_peers(self._pack_values_message(phase, step_id, maxes))
             if not async_op:
-                await asyncio.sleep(
-                    0
-                )  # Yield control once to ensure that other coroutines can run.
-                # This might be needed for colocated RL.
+                await asyncio.sleep(0)
             return maxes[0] if n == 1 else maxes
 
-        else:
-            self.gather_sock.send(payload)
+        self.gather_sock.send(payload)
 
-            while True:
-                try:
-                    if async_op:
-                        msg = self.bcast_sock.recv(flags=zmq.NOBLOCK)
-                    else:
-                        msg = self.bcast_sock.recv()
-                    result = struct.unpack(fmt, msg)
-                    if not async_op:
-                        await asyncio.sleep(
-                            0
-                        )  # Yield control once to ensure that other coroutines can run.
-                        # This might be needed for colocated RL.
-                    return result[0] if n == 1 else result
-                except zmq.Again:
-                    await asyncio.sleep(0.001)
+        while True:
+            try:
+                if async_op:
+                    msg = self.result_recv_sock.recv(flags=zmq.NOBLOCK)
+                else:
+                    msg = self.result_recv_sock.recv()
+                result = self._unpack_collective_values_message(
+                    msg, expected_phase=phase, expected_step_id=step_id, expected_count=n
+                )
+                if not async_op:
+                    await asyncio.sleep(0)
+                return result[0] if n == 1 else result
+            except zmq.Again:
+                await asyncio.sleep(0.001)
 
-    def sync_all_reduce_max(self, *local_vals: int) -> int | tuple[int, ...]:
-        """Synchronous (non-asyncio) variant of all_reduce_max.
+    def sync_all_reduce_max(
+        self, *local_vals: int, phase: str | None = None, step_id: int | None = None
+    ) -> int | tuple[int, ...]:
+        """Synchronous variant of all_reduce_max for tiny CPU payloads."""
 
-        Uses blocking ZMQ sends/recvs so it can be called from synchronous
-        call sites that need a CPU-only MAX reduction across the process
-        group. Intended for tiny payloads (e.g. a few integers) that would
-        otherwise force a NCCL AllReduce kernel on the compute stream.
-
-        Note: when called from inside a running asyncio event loop, the
-        blocking recv will pause other coroutines on this rank until all
-        peers respond. This is acceptable here because every rank reaches
-        the call simultaneously and the message size is trivial.
-
-        Returns a single int when called with one argument, otherwise a tuple.
-        """
         n = len(local_vals)
         if n == 0:
             raise ValueError("sync_all_reduce_max requires at least one value")
@@ -153,28 +274,39 @@ class AsyncZMQCommunicator:
         if self.world_size <= 1:
             return local_vals[0] if n == 1 else local_vals
 
-        fmt = f'!{n}i'
-        payload = struct.pack(fmt, *local_vals)
+        phase, step_id = self._next_collective_tag(phase=phase, step_id=step_id, sync=True)
+        payload = self._pack_values_message(phase, step_id, local_vals)
 
         if self.is_leader:
             rows = [local_vals]
-            while len(rows) < self.world_size:
-                msg = self.gather_sock.recv()
-                rows.append(struct.unpack(fmt, msg))
+            try:
+                while len(rows) < self.world_size:
+                    msg = self.gather_sock.recv()
+                    rows.append(
+                        self._unpack_collective_values_message(
+                            msg, expected_phase=phase, expected_step_id=step_id, expected_count=n
+                        )
+                    )
+            except Exception as error:
+                self._send_error_to_peers(error)
+                raise
             maxes = tuple(max(row[i] for row in rows) for i in range(n))
-            self.bcast_sock.send(struct.pack(fmt, *maxes))
+            self._send_result_to_peers(self._pack_values_message(phase, step_id, maxes))
             return maxes[0] if n == 1 else maxes
-        else:
-            self.gather_sock.send(payload)
-            msg = self.bcast_sock.recv()
-            result = struct.unpack(fmt, msg)
-            return result[0] if n == 1 else result
+
+        self.gather_sock.send(payload)
+        msg = self.result_recv_sock.recv()
+        result = self._unpack_collective_values_message(
+            msg, expected_phase=phase, expected_step_id=step_id, expected_count=n
+        )
+        return result[0] if n == 1 else result
 
     def close(self):
-        """
-        Close the ZMQ sockets.
-        """
-        # linger=0: discard unsent messages immediately on close rather than blocking until sent.
-        # The ZMQ default is to not allow `close` until all messages have been successfully sent.
+        """Close the ZMQ sockets."""
+
         self.gather_sock.close(linger=0)
-        self.bcast_sock.close(linger=0)
+        if self.is_leader:
+            for sock in self.result_push_socks.values():
+                sock.close(linger=0)
+        else:
+            self.result_recv_sock.close(linger=0)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -30,6 +30,7 @@ from megatron.core.inference.data_parallel_inference_coordinator import (
     DataParallelInferenceCoordinator,
 )
 from megatron.core.inference.engines.abstract_engine import AbstractEngine
+from megatron.core.inference.ep_async_protocol import EPAsyncStepProtocol
 from megatron.core.inference.headers import Headers, UnknownHeaderError
 from megatron.core.inference.inference_request import (
     DynamicInferenceEvent,
@@ -262,6 +263,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self.controller.set_stop_word_finished_ids_callback(
             self._get_and_clear_stop_word_finished_ids
         )
+        self.controller.set_has_active_stop_words_callback(self._has_active_stop_words)
 
         # Configure wandb to use separate step counter for inference metrics (only once)
         if self.logging_step_interval > 0 and self.metrics_writer is not None:
@@ -683,16 +685,20 @@ class DynamicInferenceEngine(AbstractEngine):
         # initialize zmq-based EP communicator
         self.ep_rank = get_pg_rank(self.pg_collection.ep)
         self.ep_world_size = get_pg_size(self.pg_collection.ep)
+        self.ep_async_step_protocol = EPAsyncStepProtocol()
         self._ep_consensus_loop_counter = 0
         self._last_ep_consensus: tuple[int, bool] = (0, False)
         if self.ep_world_size > 1:
             self.expert_parallel_zmq_communicator = AsyncZMQCommunicator(
                 self.zmq_context, process_group=self.pg_collection.ep, hostname=hostname
             )
+            self.ep_async_step_protocol = EPAsyncStepProtocol(self.expert_parallel_zmq_communicator)
             # Give the context a CPU-side MAX-reduction primitive so
             # match_graph_config() can avoid a per-step NCCL AllReduce kernel.
             if hasattr(self.context, "set_ep_zmq_communicator"):
                 self.context.set_ep_zmq_communicator(self.expert_parallel_zmq_communicator)
+            if hasattr(self.controller, "set_ep_async_protocol"):
+                self.controller.set_ep_async_protocol(self.ep_async_step_protocol)
 
         # initialize zmq-based world communicator for consensus barriers
         total_world_size = torch.distributed.get_world_size()
@@ -1007,6 +1013,8 @@ class DynamicInferenceEngine(AbstractEngine):
                 "Set materialize_only_last_token_logits to False in DynamicInferenceContext "
                 "or skip_prompt_log_probs to True in SamplingParams."
             )
+
+        self.controller.note_request_sampling_params(request.sampling_params)
 
         if request.sampling_params.num_tokens_total is not None:
             request.sampling_params.num_tokens_to_generate = (
@@ -1480,6 +1488,17 @@ class DynamicInferenceEngine(AbstractEngine):
         self.stop_word_finished_request_ids -= result
         return result
 
+    def _has_active_stop_words(self, active_request_ids: list[int]) -> bool:
+        """Return whether any active request depends on stop-word handling."""
+
+        for request_id in active_request_ids:
+            if request_id in self.stop_word_finished_request_ids:
+                return True
+            request_entry = self.requests.get(request_id)
+            if request_entry is not None and request_entry.record[-1].stop_word_ids:
+                return True
+        return False
+
     def _check_stop_words_for_request_post_append(
         self, request: DynamicInferenceRequest
     ) -> Tuple[bool, int]:
@@ -1842,8 +1861,56 @@ class DynamicInferenceEngine(AbstractEngine):
 
         return result, context_state, step_time
 
+    def _send_finished_records_to_coordinator(
+        self, finished_request_records: list[DynamicInferenceRequestRecord]
+    ) -> None:
+        """Queue completed request records for the data-parallel coordinator."""
+
+        if not self.use_coordinator or not self.is_mp_coordinator:
+            return
+
+        # Failed request replies were already sent in _handle_failed_request,
+        # so only send completed records here.
+        records_to_send = [
+            r for r in finished_request_records if r.requests[-1].status != Status.FAILED
+        ]
+        if not records_to_send:
+            return
+
+        payload = self._pack_finished_records_for_coordinator(records_to_send)
+        self._send_coordinator_reply_payload(payload)
+
+    @staticmethod
+    def _pack_finished_records_for_coordinator(
+        records_to_send: list[DynamicInferenceRequestRecord],
+    ) -> bytes:
+        """Serialize finished request records for a coordinator reply."""
+
+        nvtx_range_push("coordinator_reply_pack")
+        try:
+            return msgpack.packb(
+                [Headers.ENGINE_REPLY.value, [r.merge().serialize() for r in records_to_send]],
+                use_bin_type=True,
+            )
+        finally:
+            nvtx_range_pop("coordinator_reply_pack")
+
+    def _send_coordinator_reply_payload(self, payload: bytes) -> None:
+        """Send an already-packed coordinator reply payload."""
+
+        nvtx_range_push("coordinator_reply_send")
+        try:
+            self.socket_for_receiving_requests.send(payload)
+        finally:
+            nvtx_range_pop("coordinator_reply_send")
+
     async def async_bookkeep(
-        self, step_result: Optional[Dict], context_state: Dict, step_time: float
+        self,
+        step_result: Optional[Dict],
+        context_state: Dict,
+        step_time: float,
+        *,
+        send_coordinator_replies: bool = True,
     ):
         """Uses `asyncio` for continuous bookkeeping.
 
@@ -1931,21 +1998,8 @@ class DynamicInferenceEngine(AbstractEngine):
                     )
             nvtx_range_pop("detokenization")
 
-        # Handle necessary ZMQ DP coordinator communication.
-        # Failed request replies were already sent in _handle_failed_request,
-        # so only send completed records here.
-        if self.use_coordinator and self.is_mp_coordinator:
-            records_to_send = [
-                r for r in finished_request_records if r.requests[-1].status != Status.FAILED
-            ]
-            if records_to_send:
-                nvtx_range_push("coordinator_communication")
-                payload = msgpack.packb(
-                    [Headers.ENGINE_REPLY.value, [r.merge().serialize() for r in records_to_send]],
-                    use_bin_type=True,
-                )
-                self.socket_for_receiving_requests.send(payload)
-                nvtx_range_pop("coordinator_communication")
+        if send_coordinator_replies:
+            self._send_finished_records_to_coordinator(finished_request_records)
 
         # Drain prefix cache hit counters from context into engine accumulators.
         if self.context.enable_prefix_caching:
@@ -2080,6 +2134,9 @@ class DynamicInferenceEngine(AbstractEngine):
                     self._prefix_cache_hits,
                     self._prefix_cache_blocks_matched,
                 )
+            async_summary = self.context.async_scheduling_counters_summary()
+            if async_summary:
+                output_str += f" ... async (cumul): {async_summary}"
             if context_state["is_decode_only"]:
                 output_str = f"\033[94m{output_str}\033[0m"
             logging.info(output_str)
@@ -2094,7 +2151,7 @@ class DynamicInferenceEngine(AbstractEngine):
         }
 
     async def async_step(
-        self,
+        self, *, send_coordinator_replies: bool = True
     ) -> Tuple[List[DynamicInferenceRequest], List[DynamicInferenceRequest], float]:
         """
         Wrapper for controller.generate_output_tokens_dynamic_batch(), to
@@ -2108,7 +2165,9 @@ class DynamicInferenceEngine(AbstractEngine):
                 3. The step time in seconds.
         """
         last_step_data = await self.async_forward()
-        ret = await self.async_bookkeep(*last_step_data)
+        ret = await self.async_bookkeep(
+            *last_step_data, send_coordinator_replies=send_coordinator_replies
+        )
         # Keep for compatibility with current test suite.
         return ret
 
@@ -2380,8 +2439,6 @@ class DynamicInferenceEngine(AbstractEngine):
         """
         nvtx_range_push("_ep_establish_consensus")
 
-        consensus_val = -1 if signal_consensus else 0
-
         # Signals can be received asynchronously on EP ranks.
         # We do not want a rank to pause prematurely if its peers have yet to receive the signal.
         # So this is an *attempt* to process the signal. This rank has received the signal
@@ -2390,21 +2447,45 @@ class DynamicInferenceEngine(AbstractEngine):
         # will be zero and we will defer processing the signal.
         # When all ranks receive the signal, global consensus will be -1 and we can process.
 
-        if self.ep_world_size > 1:
-            # Note that it is important to use a non-blocking asyncio-friendly all-reduce here.
-            # The user may have other tasks running in the event loop that need to be serviced.
-            # Do not using a torch.distributed blocking all-reduce here using nccl/gloo.
-            # We have tried that and it blocks the event loop in megatron-rl.
-            global_work, global_consensus = (
-                await self.expert_parallel_zmq_communicator.all_reduce_max(
-                    local_work, consensus_val, async_op=(not self.use_synchronous_zmq_collectives)
-                )
-            )
-        else:
-            global_work, global_consensus = local_work, consensus_val
+        # Note that it is important to use a non-blocking asyncio-friendly all-reduce here.
+        # The user may have other tasks running in the event loop that need to be serviced.
+        # Do not use a torch.distributed blocking all-reduce here using nccl/gloo.
+        # We have tried that and it blocks the event loop in megatron-rl.
+        consensus = await self.ep_async_step_protocol.establish_work_consensus(
+            local_work, signal_consensus, async_op=(not self.use_synchronous_zmq_collectives)
+        )
 
         nvtx_range_pop("_ep_establish_consensus")
-        return global_work, global_consensus == -1
+        return consensus.global_work, consensus.all_pausing
+
+    async def _ep_complete_work_step(self) -> None:
+        """Keep real and dummy EP ranks aligned before the next work consensus."""
+
+        if self.ep_world_size > 1:
+            nvtx_range_push("_ep_complete_work_step")
+            await self.ep_async_step_protocol.complete_work_step(
+                async_op=(not self.use_synchronous_zmq_collectives)
+            )
+            nvtx_range_pop("_ep_complete_work_step")
+        else:
+            self.ep_async_step_protocol.complete_idle_step()
+
+    async def _run_ep_work_step(self, local_pending: int) -> None:
+        """Run one coordinator-driven EP work step and close it before external replies."""
+
+        finished_request_records = None
+        if local_pending > 0:
+            step_result = await self.async_step(send_coordinator_replies=False)
+            finished_request_records = step_result["finished_request_records"]
+        else:
+            self.controller.dummy_forward()
+            self.context.step_count += 1
+            self.context.prefix_cache_lru_clock += 1
+
+        await self._ep_complete_work_step()
+
+        if finished_request_records is not None:
+            self._send_finished_records_to_coordinator(finished_request_records)
 
     async def _world_barrier(self):
         """World-wide ZMQ all-reduce barrier for global rank consensus.
@@ -2493,25 +2574,16 @@ class DynamicInferenceEngine(AbstractEngine):
 
                     if all_pausing:
                         # All EP peers are PAUSING: pause immediately.
+                        self.ep_async_step_protocol.complete_idle_step()
                         await self._world_barrier()
                         self.state = EngineState.PAUSED
                         self._state_events[EngineState.PAUSED].set()
                     elif global_work > 0:
                         # At least one EP peer has work: all must participate.
-                        if local_pending > 0:
-                            await self.async_step()
-                        else:
-                            # Dummy forward to participate in the EP collective.
-                            self.step_start_event.record()
-                            nvtx_range_push("EP-dummy-forward")
-                            self.controller.dummy_forward()
-                            self.step_end_event.record()
-                            self.step_end_event.synchronize()
-                            nvtx_range_pop("EP-dummy-forward")
-                            self.context.step_count += 1
-                            self.context.prefix_cache_lru_clock += 1
+                        await self._run_ep_work_step(local_pending)
                     else:
                         # No work, but not all pausing: idle.
+                        self.ep_async_step_protocol.complete_idle_step()
                         await asyncio.sleep(0.02)
 
                 elif self.state == EngineState.PAUSED:

--- a/megatron/core/inference/ep_async_protocol.py
+++ b/megatron/core/inference/ep_async_protocol.py
@@ -1,0 +1,265 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class EPAsyncPhase(str, Enum):
+    """Tagged collective phases owned by the EP async protocol."""
+
+    WORK_CONSENSUS = "ep_work_consensus"
+    WORK_CONSENSUS_ACK = "ep_work_consensus_ack"
+    STEP_COMPLETE = "ep_step_complete"
+    STEP_COMPLETE_ACK = "ep_step_complete_ack"
+    STEP_BEGIN = "ep_step_begin"
+    STEP_BEGIN_ACK = "ep_step_begin_ack"
+    ASYNC_HANDOFF = "ep_async_handoff"
+    ASYNC_HANDOFF_ACK = "ep_async_handoff_ack"
+
+
+@dataclass(frozen=True)
+class EPWorkConsensus:
+    """EP-wide work and state-transition consensus for one engine-loop iteration."""
+
+    step_id: int
+    global_work: int
+    all_pausing: bool
+
+
+@dataclass(frozen=True)
+class EPStepBeginDecision:
+    """EP-wide decision for state carried into the next decode step."""
+
+    step_id: int
+    has_real_work: bool
+    reuse_pending_forward: bool
+    discard_pending_forward: bool
+
+
+@dataclass(frozen=True)
+class EPAsyncHandoffDecision:
+    """EP-wide decision for launching or skipping an async forward handoff."""
+
+    step_id: int
+    has_real_work: bool
+    launch_async_forward: bool
+    skip_async_forward: bool
+    any_launch_request: bool
+    any_skip_request: bool
+
+
+class EPAsyncStepProtocol:
+    """Own tagged EP async collectives and per-work-step ordering."""
+
+    def __init__(self, communicator=None):
+        self.communicator = communicator
+        self._phase_step_ids: dict[EPAsyncPhase, int] = {phase: 0 for phase in EPAsyncPhase}
+        self._next_ep_step_id = 0
+        self._active_ep_step_id: int | None = None
+        self._work_consensus_count = 0
+        self._work_completion_count = 0
+        self._idle_completion_count = 0
+        self._step_begin_reuse_count = 0
+        self._step_begin_discard_count = 0
+        self._async_handoff_launch_count = 0
+        self._async_handoff_skip_count = 0
+        self._collective_error_count = 0
+
+    @property
+    def enabled(self) -> bool:
+        """Whether this rank participates in multi-rank EP protocol collectives."""
+
+        return self.communicator is not None and self.communicator.world_size > 1
+
+    def diagnostics(self) -> dict[str, int | bool | None]:
+        """Return protocol counters for tests and benchmark logs."""
+
+        return {
+            "enabled": self.enabled,
+            "active_step_id": self._active_ep_step_id,
+            "next_step_id": self._next_ep_step_id,
+            "work_consensus": self._work_consensus_count,
+            "work_completions": self._work_completion_count,
+            "idle_completions": self._idle_completion_count,
+            "step_begin_reuses": self._step_begin_reuse_count,
+            "step_begin_discards": self._step_begin_discard_count,
+            "handoff_launches": self._async_handoff_launch_count,
+            "handoff_skips": self._async_handoff_skip_count,
+            "collective_errors": self._collective_error_count,
+            "phase_mismatches": getattr(self.communicator, "protocol_mismatch_count", 0),
+        }
+
+    def _next_step_id(self, phase: EPAsyncPhase) -> int:
+        step_id = self._phase_step_ids[phase]
+        self._phase_step_ids[phase] = step_id + 1
+        return step_id
+
+    def _begin_ep_step(self) -> int:
+        if self._active_ep_step_id is not None:
+            raise RuntimeError(f"EP protocol step {self._active_ep_step_id} is still active")
+        step_id = self._next_ep_step_id
+        self._next_ep_step_id += 1
+        self._active_ep_step_id = step_id
+        return step_id
+
+    def _finish_ep_step(self) -> None:
+        self._active_ep_step_id = None
+
+    def _step_id_for_phase(self, phase: EPAsyncPhase) -> int:
+        if self._active_ep_step_id is not None:
+            return self._active_ep_step_id
+        return self._next_step_id(phase)
+
+    async def _all_reduce_max_at_step(
+        self, phase: EPAsyncPhase, step_id: int, *local_vals: int, async_op: bool = True
+    ) -> int | tuple[int, ...]:
+        if not self.enabled:
+            return local_vals[0] if len(local_vals) == 1 else local_vals
+        try:
+            return await self.communicator.all_reduce_max(
+                *local_vals, async_op=async_op, phase=phase.value, step_id=step_id
+            )
+        except Exception:
+            self._collective_error_count += 1
+            raise
+
+    async def _ack_at_step(
+        self, phase: EPAsyncPhase, step_id: int, *, async_op: bool = True
+    ) -> None:
+        await self._all_reduce_max_at_step(phase, step_id, 1, async_op=async_op)
+
+    def _sync_all_reduce_max_at_step(
+        self, phase: EPAsyncPhase, step_id: int, *local_vals: int
+    ) -> int | tuple[int, ...]:
+        if not self.enabled:
+            return local_vals[0] if len(local_vals) == 1 else local_vals
+        try:
+            return self.communicator.sync_all_reduce_max(
+                *local_vals, phase=phase.value, step_id=step_id
+            )
+        except Exception:
+            self._collective_error_count += 1
+            raise
+
+    def _sync_ack_at_step(self, phase: EPAsyncPhase, step_id: int) -> None:
+        self._sync_all_reduce_max_at_step(phase, step_id, 1)
+
+    async def establish_work_consensus(
+        self, local_work: int, signal_consensus: bool, *, async_op: bool = True
+    ) -> EPWorkConsensus:
+        """Share pending work and pause intent across EP ranks."""
+
+        consensus_val = -1 if signal_consensus else 0
+        step_id = self._begin_ep_step()
+        global_work, global_consensus = await self._all_reduce_max_at_step(
+            EPAsyncPhase.WORK_CONSENSUS, step_id, local_work, consensus_val, async_op=async_op
+        )
+        await self._ack_at_step(EPAsyncPhase.WORK_CONSENSUS_ACK, step_id, async_op=async_op)
+        self._work_consensus_count += 1
+
+        return EPWorkConsensus(
+            step_id=step_id, global_work=global_work, all_pausing=(global_consensus == -1)
+        )
+
+    async def complete_work_step(self, *, async_op: bool = True) -> None:
+        """Close the active EP work step after real and dummy ranks finish it."""
+
+        if self._active_ep_step_id is None:
+            return
+        step_id = self._active_ep_step_id
+        try:
+            await self._all_reduce_max_at_step(
+                EPAsyncPhase.STEP_COMPLETE, step_id, 1, async_op=async_op
+            )
+            await self._ack_at_step(EPAsyncPhase.STEP_COMPLETE_ACK, step_id, async_op=async_op)
+            self._work_completion_count += 1
+        finally:
+            self._finish_ep_step()
+
+    def complete_idle_step(self) -> None:
+        """Close an EP step that ended at consensus without model work."""
+
+        if self._active_ep_step_id is not None:
+            self._idle_completion_count += 1
+        self._finish_ep_step()
+
+    def decide_step_begin(
+        self,
+        *,
+        has_real_work: bool,
+        has_pending_forward: bool,
+        pending_forward_reusable: bool,
+    ) -> EPStepBeginDecision:
+        """Synchronize pending async state at the start of an EP work step."""
+
+        step_id = self._step_id_for_phase(EPAsyncPhase.STEP_BEGIN)
+        local_real = int(has_real_work)
+        local_pending_forward = int(has_pending_forward)
+        local_reusable = int(has_pending_forward and pending_forward_reusable)
+        local_discard = int(has_pending_forward and not pending_forward_reusable)
+        local_real_missing_forward = int(has_real_work and not has_pending_forward)
+
+        (
+            any_real,
+            any_pending_forward,
+            any_reusable,
+            any_discard,
+            any_real_missing_forward,
+        ) = self._sync_all_reduce_max_at_step(
+            EPAsyncPhase.STEP_BEGIN,
+            step_id,
+            local_real,
+            local_pending_forward,
+            local_reusable,
+            local_discard,
+            local_real_missing_forward,
+        )
+        self._sync_ack_at_step(EPAsyncPhase.STEP_BEGIN_ACK, step_id)
+
+        reuse_pending_forward = bool(
+            any_pending_forward
+            and any_reusable
+            and not any_discard
+            and not any_real_missing_forward
+        )
+        discard_pending_forward = bool(any_pending_forward and not reuse_pending_forward)
+        if reuse_pending_forward:
+            self._step_begin_reuse_count += 1
+        if discard_pending_forward:
+            self._step_begin_discard_count += 1
+
+        return EPStepBeginDecision(
+            step_id=step_id,
+            has_real_work=bool(any_real),
+            reuse_pending_forward=reuse_pending_forward,
+            discard_pending_forward=discard_pending_forward,
+        )
+
+    def decide_async_handoff(
+        self, *, has_real_work: bool, can_launch_async_handoff: bool
+    ) -> EPAsyncHandoffDecision:
+        """Synchronize whether the current EP work step launches an async forward."""
+
+        step_id = self._step_id_for_phase(EPAsyncPhase.ASYNC_HANDOFF)
+        local_real = int(has_real_work)
+        local_launch = int(has_real_work and can_launch_async_handoff)
+        local_real_skip = int(has_real_work and not can_launch_async_handoff)
+
+        any_real, any_launch, any_real_skip = self._sync_all_reduce_max_at_step(
+            EPAsyncPhase.ASYNC_HANDOFF, step_id, local_real, local_launch, local_real_skip
+        )
+        self._sync_ack_at_step(EPAsyncPhase.ASYNC_HANDOFF_ACK, step_id)
+        launch_async_forward = bool(any_launch and not any_real_skip)
+        if launch_async_forward:
+            self._async_handoff_launch_count += 1
+        else:
+            self._async_handoff_skip_count += 1
+
+        return EPAsyncHandoffDecision(
+            step_id=step_id,
+            has_real_work=bool(any_real),
+            launch_async_forward=launch_async_forward,
+            skip_async_forward=not launch_async_forward,
+            any_launch_request=bool(any_launch),
+            any_skip_request=bool(any_real_skip),
+        )

--- a/megatron/core/inference/ep_async_protocol.py
+++ b/megatron/core/inference/ep_async_protocol.py
@@ -11,6 +11,7 @@ class EPAsyncPhase(str, Enum):
     WORK_CONSENSUS_ACK = "ep_work_consensus_ack"
     STEP_COMPLETE = "ep_step_complete"
     STEP_COMPLETE_ACK = "ep_step_complete_ack"
+    GRAPH_SHAPE = "ep_graph_shape"
     STEP_BEGIN = "ep_step_begin"
     STEP_BEGIN_ACK = "ep_step_begin_ack"
     ASYNC_HANDOFF = "ep_async_handoff"
@@ -34,6 +35,7 @@ class EPStepBeginDecision:
     has_real_work: bool
     reuse_pending_forward: bool
     discard_pending_forward: bool
+    row_mapped_forward: bool
 
 
 @dataclass(frozen=True)
@@ -144,6 +146,24 @@ class EPAsyncStepProtocol:
     def _sync_ack_at_step(self, phase: EPAsyncPhase, step_id: int) -> None:
         self._sync_all_reduce_max_at_step(phase, step_id, 1)
 
+    async def all_reduce_max(
+        self, phase: EPAsyncPhase, *local_vals: int, async_op: bool = True
+    ) -> int | tuple[int, ...]:
+        """Run a tagged EP MAX collective for an async call site."""
+
+        if len(local_vals) == 0:
+            raise ValueError("EP async protocol all_reduce_max requires at least one value")
+        step_id = self._step_id_for_phase(phase)
+        return await self._all_reduce_max_at_step(phase, step_id, *local_vals, async_op=async_op)
+
+    def sync_all_reduce_max(self, phase: EPAsyncPhase, *local_vals: int) -> int | tuple[int, ...]:
+        """Run a tagged EP MAX collective for a synchronous call site."""
+
+        if len(local_vals) == 0:
+            raise ValueError("EP async protocol sync_all_reduce_max requires at least one value")
+        step_id = self._step_id_for_phase(phase)
+        return self._sync_all_reduce_max_at_step(phase, step_id, *local_vals)
+
     async def establish_work_consensus(
         self, local_work: int, signal_consensus: bool, *, async_op: bool = True
     ) -> EPWorkConsensus:
@@ -189,6 +209,7 @@ class EPAsyncStepProtocol:
         has_real_work: bool,
         has_pending_forward: bool,
         pending_forward_reusable: bool,
+        pending_forward_row_mapped: bool = False,
     ) -> EPStepBeginDecision:
         """Synchronize pending async state at the start of an EP work step."""
 
@@ -196,6 +217,7 @@ class EPAsyncStepProtocol:
         local_real = int(has_real_work)
         local_pending_forward = int(has_pending_forward)
         local_reusable = int(has_pending_forward and pending_forward_reusable)
+        local_row_mapped = int(has_pending_forward and pending_forward_row_mapped)
         local_discard = int(has_pending_forward and not pending_forward_reusable)
         local_real_missing_forward = int(has_real_work and not has_pending_forward)
 
@@ -203,6 +225,7 @@ class EPAsyncStepProtocol:
             any_real,
             any_pending_forward,
             any_reusable,
+            any_row_mapped,
             any_discard,
             any_real_missing_forward,
         ) = self._sync_all_reduce_max_at_step(
@@ -211,6 +234,7 @@ class EPAsyncStepProtocol:
             local_real,
             local_pending_forward,
             local_reusable,
+            local_row_mapped,
             local_discard,
             local_real_missing_forward,
         )
@@ -233,6 +257,7 @@ class EPAsyncStepProtocol:
             has_real_work=bool(any_real),
             reuse_pending_forward=reuse_pending_forward,
             discard_pending_forward=discard_pending_forward,
+            row_mapped_forward=bool(any_row_mapped and reuse_pending_forward),
         )
 
     def decide_async_handoff(

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -2234,7 +2234,11 @@ class TextGenerationController:
                     if pending_transaction is not None
                     else None
                 )
-                pending_forward_row_indices = pending_forward_row_map.pending_rows
+                pending_forward_row_indices = (
+                    pending_forward_row_map.pending_rows
+                    if pending_forward_row_map.row_mapped
+                    else None
+                )
                 self._async_pending_transaction = None
             else:
                 input_ids, position_ids = self._dynamic_step_context_init()

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -20,6 +20,10 @@ from megatron.core.inference.communication_utils import (
     is_pipeline_last_stage,
 )
 from megatron.core.inference.contexts.dynamic_context import MaxSequenceLengthOverflowError
+from megatron.core.inference.ep_async_protocol import (
+    EPAsyncHandoffDecision,
+    EPStepBeginDecision,
+)
 from megatron.core.inference.contexts.static_context import StaticInferenceContext
 from megatron.core.inference.inference_request import InferenceRequest, Status
 from megatron.core.inference.model_inference_wrappers.abstract_model_inference_wrapper import (
@@ -143,6 +147,21 @@ class TextGenerationController:
         """
         self._get_stop_word_finished_ids_callback = callback
 
+    def set_has_active_stop_words_callback(self, callback):
+        """Set a callback to test whether active requests depend on stop-word handling."""
+
+        self._has_active_stop_words_callback = callback
+
+    def note_request_sampling_params(self, sampling_params: SamplingParams) -> None:
+        """Record request features that affect async scheduling hot-path checks."""
+
+        if sampling_params.return_log_probs or sampling_params.top_n_logprobs > 0:
+            self._async_logprob_requests_seen = True
+        if sampling_params.top_k != 1 or sampling_params.top_p != 0.0:
+            self._async_non_greedy_requests_seen = True
+        if sampling_params.stop_words:
+            self._async_stop_word_requests_seen = True
+
     def _init_dynamic_sampling_tensors(self):
         """Initialize tensors needed for dynamic sampling."""
         context = self.inference_wrapped_model.inference_context
@@ -155,6 +174,7 @@ class TextGenerationController:
 
         # Callback to get request IDs that should be marked as finished due to stop words
         self._get_stop_word_finished_ids_callback = None
+        self._has_active_stop_words_callback = None
 
         device = torch.cuda.current_device()
         logits_dtype = self.inference_wrapped_model.config.params_dtype
@@ -176,6 +196,12 @@ class TextGenerationController:
         #     - `self._sampled_tokens_cuda` is rebound to the output of `sample_kernel`,
         #     which uses CudaGraphManager syntactic sugar to keep it as a static tensor.
         self._sampled_tokens_cuda = None
+        self._greedy_sample_values_cuda = torch.empty(
+            max_requests, dtype=logits_dtype, device=device
+        )
+        self._greedy_sampled_tokens_cuda = torch.empty(
+            max_requests, dtype=torch.int64, device=device
+        )
 
         # Sampling backend: provides the sampling kernel.
         if self._sampling_backend == "flashinfer":
@@ -187,6 +213,24 @@ class TextGenerationController:
             )
         else:
             self._sampling: Sampling = TorchSampling(self.sampling_rng, self.vocab_size)
+
+        self._async_pending_forward_plan = None
+        self._async_pending_cuda_graph_request_count = None
+        self._async_copy_stream = torch.cuda.Stream(device=device)
+        self._async_sample_ready_event = torch.cuda.Event()
+        self._async_sample_transfer_done_event = torch.cuda.Event()
+        self._async_child_h2d_done_event = torch.cuda.Event()
+        self._async_sampled_tokens_cpu = torch.empty(
+            max_requests, dtype=torch.int64, device='cpu', pin_memory=True
+        )
+        self._ep_forward_phase_open = False
+        self._dummy_context_h2d_done_event = None
+        self._ep_async_protocol = None
+        self._ep_async_handoff_decided_this_step = False
+        self._ep_async_handoff_decision_this_step: Optional[EPAsyncHandoffDecision] = None
+        self._async_logprob_requests_seen = False
+        self._async_non_greedy_requests_seen = False
+        self._async_stop_word_requests_seen = False
 
         # Cache values that are constant across inference steps.
         self._unwrapped_model = unwrap_model(self.inference_wrapped_model.model)
@@ -559,7 +603,9 @@ class TextGenerationController:
 
         # Single batch CPU-to-GPU transfer of bookkeeping state.
         range_push("transfer_bookkeeping_to_gpu")
-        context.transfer_bookkeeping_to_gpu()
+        h2d_done_event = context.transfer_bookkeeping_to_gpu(record_done_event=is_dummy_forward)
+        if is_dummy_forward:
+            self._dummy_context_h2d_done_event = h2d_done_event
         range_pop()
 
         set_moe_metadata_sync(unwrapped_model)
@@ -1035,6 +1081,78 @@ class TextGenerationController:
         # Expose the active slice so downstream code sees the right length.
         self._last_accepted_seq_indices = self._last_accepted_seq_indices_buf[:active_request_count]
 
+    def _active_requests_use_greedy_sampling(
+        self, active_request_count: Optional[int] = None
+    ) -> bool:
+        """Return whether active requests are deterministic greedy requests."""
+
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+            if active_request_count is None
+            else active_request_count
+        )
+        if active_request_count <= 0:
+            return True
+        if not self._async_non_greedy_requests_seen:
+            return True
+
+        active_metadata = context.active_request_metadata
+        active_slice = slice(0, active_request_count)
+        return bool(
+            (active_metadata["top_k"][active_slice] == 1).all()
+            and (active_metadata["top_p"][active_slice] == 0.0).all()
+        )
+
+    def _active_requests_have_stop_words(self) -> bool:
+        """Return whether active requests can finish through CPU stop-word handling."""
+
+        if self._has_active_stop_words_callback is None:
+            return False
+        if not self._async_stop_word_requests_seen:
+            return False
+        context = self.inference_wrapped_model.inference_context
+        active_slice = slice(context.paused_request_count, context.total_request_count)
+        active_request_ids = context.request_ids[active_slice].tolist()
+        return bool(self._has_active_stop_words_callback(active_request_ids))
+
+    def _dynamic_step_required_token_logits(self) -> Tensor:
+        """Return the per-active-request logits consumed by normal decode sampling."""
+
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = context.total_request_count - context.paused_request_count
+        if context.config.materialize_only_last_token_logits:
+            return self._all_logits_cuda.squeeze(0)[:active_request_count, :]
+        return context.last_token_logits(
+            self._all_logits_cuda[:, : context.padded_active_token_count, :]
+        )
+
+    def _dynamic_step_sample_logits_greedy(self) -> None:
+        """Greedy-sample logits into the stable sampled-token buffer."""
+
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = context.total_request_count - context.paused_request_count
+        if active_request_count <= 0:
+            self._sampled_tokens_cuda = self._greedy_sampled_tokens_cuda
+            return
+        required_token_logits = self._dynamic_step_required_token_logits()
+        torch.max(
+            required_token_logits[:active_request_count],
+            dim=-1,
+            out=(
+                self._greedy_sample_values_cuda[:active_request_count],
+                self._greedy_sampled_tokens_cuda[:active_request_count],
+            ),
+        )
+        self._sampled_tokens_cuda = self._greedy_sampled_tokens_cuda
+
+    def _dynamic_step_sample_logits_to_next_input_ids(self) -> None:
+        """Sample logits and write sampled ids into prepared next-step GPU inputs."""
+
+        context = self.inference_wrapped_model.inference_context
+        self._dynamic_step_sample_logits()
+        context.copy_async_prepared_decode_input_ids_from_samples(self._sampled_tokens_cuda)
+
     def _dynamic_step_sample_logits(self):
         """Sample tokens from logits for dynamic batching."""
         # TODO(ksanthanam): Evaluate whether it makes more sense to sample on 1 rank
@@ -1042,6 +1160,10 @@ class TextGenerationController:
 
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
+        if self._active_requests_use_greedy_sampling(active_request_count):
+            self._dynamic_step_sample_logits_greedy()
+            return
+
         use_graph = (
             self._sampling_backend == "flashinfer"
             and self._enable_cuda_graph
@@ -1079,6 +1201,24 @@ class TextGenerationController:
             (context.active_request_metadata["return_log_probs"][:active_request_count]).any(),
             (context.active_request_metadata["top_n_logprobs"][:active_request_count] > 0).any(),
         )
+
+    def _active_requests_need_logprob_results(self) -> bool:
+        """Return whether active requests need generated-token logprob work."""
+
+        if not self._async_logprob_requests_seen:
+            return False
+
+        return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
+        return bool(return_log_probs or return_top_n_logprobs)
+
+    def _should_collect_dynamic_logprob_bookkeeping(
+        self, *, async_next_prepared: bool, pending_forward_reused: bool
+    ) -> bool:
+        """Return whether this step must inspect logprob request metadata."""
+
+        if not (async_next_prepared or pending_forward_reused):
+            return True
+        return self._active_requests_need_logprob_results()
 
     def _router_record_bookkeeping(self) -> Optional[np.ndarray]:
         """Collect flat routing indices for MoE router recording.
@@ -1469,16 +1609,149 @@ class TextGenerationController:
 
         return top_n_results if top_n_results else None
 
+    def set_ep_async_protocol(self, protocol) -> None:
+        """Attach the EP async protocol used by coordinator-driven EP decoding."""
+
+        self._ep_async_protocol = protocol
+
+    def _pending_async_forward_reusable(self) -> bool:
+        """Return whether this rank's pending async forward still matches live CPU state."""
+
+        plan = self._async_pending_forward_plan
+        if plan is None:
+            return True
+        context = self.inference_wrapped_model.inference_context
+        return context.prepared_async_request_ids_match_live(plan)
+
+    def _discard_pending_async_forward(self) -> None:
+        """Drop a pending async forward and release resources reserved for it."""
+
+        context = self.inference_wrapped_model.inference_context
+        if self._async_pending_forward_plan is not None:
+            self._async_pending_forward_plan = None
+            self._async_pending_cuda_graph_request_count = None
+            context.clear_async_prepared_decode_plan()
+            context.release_deferred_async_resources()
+            context.record_async_scheduling_counter("discard")
+
+    def _decide_ep_step_begin(self, *, has_real_work: bool) -> EPStepBeginDecision:
+        """Synchronize pending async state at the beginning of an EP work step."""
+
+        self._ep_async_handoff_decided_this_step = False
+        self._ep_async_handoff_decision_this_step = None
+        has_pending_forward = self._async_pending_forward_plan is not None
+        pending_forward_reusable = self._pending_async_forward_reusable()
+
+        if self._ep_async_protocol is not None and self._ep_async_protocol.enabled:
+            return self._ep_async_protocol.decide_step_begin(
+                has_real_work=has_real_work,
+                has_pending_forward=has_pending_forward,
+                pending_forward_reusable=pending_forward_reusable,
+            )
+
+        return EPStepBeginDecision(
+            step_id=-1,
+            has_real_work=has_real_work,
+            reuse_pending_forward=bool(has_pending_forward and pending_forward_reusable),
+            discard_pending_forward=bool(has_pending_forward and not pending_forward_reusable),
+        )
+
+    def _decide_ep_async_handoff(
+        self, *, has_real_work: bool, can_launch_async_handoff: bool
+    ) -> EPAsyncHandoffDecision:
+        """Synchronize whether this EP work step launches an async forward handoff."""
+
+        if self._ep_async_handoff_decision_this_step is not None:
+            return self._ep_async_handoff_decision_this_step
+
+        self._ep_async_handoff_decided_this_step = True
+        if self._ep_async_protocol is not None and self._ep_async_protocol.enabled:
+            decision = self._ep_async_protocol.decide_async_handoff(
+                has_real_work=has_real_work, can_launch_async_handoff=can_launch_async_handoff
+            )
+            self._ep_async_handoff_decision_this_step = decision
+            return decision
+
+        decision = EPAsyncHandoffDecision(
+            step_id=-1,
+            has_real_work=has_real_work,
+            launch_async_forward=can_launch_async_handoff,
+            skip_async_forward=not can_launch_async_handoff,
+            any_launch_request=can_launch_async_handoff,
+            any_skip_request=not can_launch_async_handoff,
+        )
+        self._ep_async_handoff_decision_this_step = decision
+        return decision
+
+    def _ensure_ep_async_handoff_decided(self, *, has_real_work: bool) -> None:
+        """Publish an explicit EP async handoff skip when this step did not attempt one."""
+
+        if self._ep_async_handoff_decided_this_step:
+            return
+        self._decide_ep_async_handoff(has_real_work=has_real_work, can_launch_async_handoff=False)
+
+    def _wait_for_dummy_context_h2d(self) -> None:
+        """Wait for dummy metadata H2D before reusing its pinned CPU source buffer."""
+
+        h2d_done_event = self._dummy_context_h2d_done_event
+        if h2d_done_event is None:
+            return
+        h2d_done_event.synchronize()
+        self._dummy_context_h2d_done_event = None
+
+    def _dummy_async_handoff_disabled_reason(self) -> Optional[str]:
+        """Return why a dummy EP rank cannot mirror an async handoff, or None."""
+
+        context = self.inference_wrapped_model.inference_context
+        if not context.config.enable_async_scheduling:
+            return "skip_disabled"
+        if self.num_speculative_tokens != 0:
+            return "skip_mtp"
+        if self.model_is_pipeline_parallel:
+            return "skip_pipeline_parallel"
+        if not self._enable_cuda_graph:
+            return "skip_no_cuda_graph"
+        return None
+
+    def _try_launch_dummy_async_handoff(self) -> bool:
+        """Mirror the real-rank async forward handoff on an EP dummy rank."""
+
+        context = self.inference_wrapped_model.inference_context
+        disabled_reason = self._dummy_async_handoff_disabled_reason()
+        handoff_decision = self._decide_ep_async_handoff(
+            has_real_work=False, can_launch_async_handoff=(disabled_reason is None)
+        )
+        if disabled_reason is not None:
+            context.record_async_scheduling_counter(disabled_reason)
+            return False
+        if not handoff_decision.launch_async_forward:
+            context.record_async_scheduling_counter("ep_async_handoff_skipped")
+            return False
+
+        self._wait_for_dummy_context_h2d()
+        context.reset()
+        range_push("ep_dummy_async_handoff")
+        try:
+            input_ids, position_ids = self._dynamic_step_context_init(is_dummy_forward=True)
+            self._dynamic_step_forward_logits(input_ids, position_ids)
+            context.record_async_scheduling_counter("dummy_launch")
+        finally:
+            range_pop()
+        return True
+
     @torch.inference_mode()
     def dummy_forward(self):
         """Perform a dummy forward pass. This is used in expert model parallelism
         on ranks that do not have any real requests. It may run in eager mode."""
 
         context = self.inference_wrapped_model.inference_context
+        step_begin_decision = self._decide_ep_step_begin(has_real_work=False)
 
-        # attempt to use cuda-graph if possible
-        input_ids, position_ids = self._dynamic_step_context_init(is_dummy_forward=True)
-        self._dynamic_step_forward_logits(input_ids, position_ids)
+        # If real ranks are reusing a pending async forward, the matching dummy
+        # forward already ran in the previous step's async handoff.
+        if not step_begin_decision.reuse_pending_forward:
+            input_ids, position_ids = self._dynamic_step_context_init(is_dummy_forward=True)
+            self._dynamic_step_forward_logits(input_ids, position_ids)
 
         # Disable MoE padding for MTP computation, unless CUDA graphs
         # are active (the graphs were captured with padding enabled).
@@ -1493,6 +1766,9 @@ class TextGenerationController:
         # all-to-all collectives. The dummy rank must participate in these
         # collectives to avoid a hang.
         self._dummy_serial_mtp_forward()
+
+        self._try_launch_dummy_async_handoff()
+        self._wait_for_dummy_context_h2d()
 
         # clear the context of any temporary state from the dummy forward
         context.reset()
@@ -1600,7 +1876,30 @@ class TextGenerationController:
             sampled_mtp_tokens_cpu = None
         return sampled_tokens_cpu, sampled_mtp_tokens_cpu
 
-    def _dynamic_step_context_bookkeeping(self) -> Dict[str, Tensor]:
+    def _start_async_sample_transfer(self, active_request_count: int) -> None:
+        """Copy sampled tokens to pinned CPU memory on a side stream."""
+
+        self._async_sample_ready_event.record(torch.cuda.current_stream())
+        with torch.cuda.stream(self._async_copy_stream):
+            self._async_copy_stream.wait_event(self._async_sample_ready_event)
+            self._async_sampled_tokens_cpu[:active_request_count].copy_(
+                self._sampled_tokens_cuda[:active_request_count], non_blocking=True
+            )
+            self._async_sample_transfer_done_event.record(self._async_copy_stream)
+
+    def _finish_async_sample_transfer(self, active_request_count: int) -> Tensor:
+        """Return sampled tokens after the side-stream D2H copy is complete."""
+
+        self._async_sample_transfer_done_event.synchronize()
+        return self._async_sampled_tokens_cpu[:active_request_count]
+
+    def _dynamic_step_context_bookkeeping(
+        self,
+        *,
+        sampled_tokens_cpu: Optional[Tensor] = None,
+        sampled_mtp_tokens_cpu: Optional[Tensor] = None,
+        h2d_done_event: Optional[torch.cuda.Event] = None,
+    ) -> Dict[str, Tensor]:
         """Update the dynamic inference context after sampling.
 
         Args:
@@ -1619,12 +1918,13 @@ class TextGenerationController:
         active_request_count = context.total_request_count - context.paused_request_count
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
-        # Batch GPU-to-CPU transfer of all sampled tokens.
-        range_push("transfer_samples_to_cpu")
-        sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
-            active_request_count
-        )
-        range_pop()
+        if sampled_tokens_cpu is None:
+            # Batch GPU-to-CPU transfer of all sampled tokens.
+            range_push("transfer_samples_to_cpu")
+            sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
+                active_request_count
+            )
+            range_pop()
 
         range_push("active_request_mask")
         # Everything below is 100% CPU.
@@ -1673,9 +1973,13 @@ class TextGenerationController:
                     finished_routing_block_ids[req_id] = valid
 
         # Clone needed: update_requests mutates next_tokens in-place via tensor_swap,
-        # which would corrupt the reused buffer.
-        new_sample_copy = sampled_tokens_cpu.clone()
+        # and async D2H uses a pinned buffer that is reused on the next step.
+        sample_for_return = sampled_tokens_cpu.clone()
+        new_sample_copy = sample_for_return.clone()
         range_pop()
+
+        if h2d_done_event is not None:
+            h2d_done_event.synchronize()
 
         range_push("update_requests")
         update_result = context.update_requests(
@@ -1690,10 +1994,104 @@ class TextGenerationController:
             # .cpu() in _transfer_samples_to_cpu; update_requests only mutates
             # the separate new_sample_copy). Returning the CPU copy avoids a
             # D2H sync when the engine later calls sample.tolist().
-            "sample": sampled_tokens_cpu,
+            "sample": sample_for_return,
             "finished_routing_block_ids": finished_routing_block_ids,
             **(update_result or {}),
         }
+
+    def _retire_dynamic_forward_side_effects(self) -> None:
+        """Commit side effects produced by the most recent dynamic forward pass."""
+
+        context = self.inference_wrapped_model.inference_context
+
+        if context.is_hybrid_model and context.mamba_slot_allocator is not None:
+            context.mamba_slot_allocator.commit_intermediate_states()
+
+        context.kv_block_allocator.store_routing_per_block(self._router_record_bookkeeping())
+
+    def _try_use_async_pending_forward(self) -> bool:
+        """Use logits from a launched async child if the no-reject invariant holds."""
+
+        plan = self._async_pending_forward_plan
+        if plan is None:
+            return False
+
+        context = self.inference_wrapped_model.inference_context
+        if not context.prepared_async_request_ids_match_live(plan):
+            self._async_pending_forward_plan = None
+            self._async_pending_cuda_graph_request_count = None
+            context.clear_async_prepared_decode_plan()
+            context.release_deferred_async_resources()
+            context.record_async_scheduling_counter("invariant_failure")
+            raise RuntimeError("async decode child invariant failed before reuse")
+
+        context.record_async_scheduling_counter("reuse")
+        if context.is_hybrid_model:
+            context.accept_async_mamba_state(plan.request_ids)
+        self._retire_dynamic_forward_side_effects()
+        context.release_deferred_async_resources()
+        context.clear_async_prepared_decode_plan()
+        return True
+
+    def _try_prepare_async_decode_next_step(
+        self, *, skip_bookkeeping: bool
+    ) -> bool:
+        """Prepare next-step metadata when the child layout is deterministic."""
+
+        context = self.inference_wrapped_model.inference_context
+        if (
+            not context.config.enable_async_scheduling
+            or self.num_speculative_tokens != 0
+            or self._active_requests_need_logprob_results()
+            or skip_bookkeeping
+            or self._active_requests_have_stop_words()
+        ):
+            return False
+
+        return context.prepare_async_decode_next_step()
+
+    def _launch_async_prepared_decode_forward(
+        self, active_request_count: int
+    ) -> Optional[torch.cuda.Event]:
+        """Launch the already-prepared child decode forward after sampling."""
+
+        context = self.inference_wrapped_model.inference_context
+        plan = context.async_prepared_decode_plan()
+        if plan is None:
+            context.record_async_scheduling_counter("launch_missing_plan")
+            return None
+        handoff_decision = self._decide_ep_async_handoff(
+            has_real_work=True, can_launch_async_handoff=True
+        )
+        if not handoff_decision.launch_async_forward:
+            context.clear_async_prepared_decode_plan()
+            context.record_async_scheduling_counter("ep_async_handoff_skipped")
+            return None
+
+        range_push("async_transfer_bookkeeping_to_gpu")
+        h2d_done_event = context.transfer_bookkeeping_to_gpu(
+            include_token_to_input_ids=False,
+            refresh_request_staging=False,
+            record_done_event=True,
+            done_event=self._async_child_h2d_done_event,
+        )
+        range_pop()
+
+        next_input_ids, next_position_ids = context.current_input_and_position_ids()
+        config = self.inference_wrapped_model.model.config
+        if config.moe_enable_routing_replay:
+            RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+        range_push("async_decode_child_forward")
+        self._dynamic_step_forward_logits(next_input_ids, next_position_ids)
+        range_pop()
+
+        self._async_pending_forward_plan = plan
+        self._async_pending_cuda_graph_request_count = (
+            context.padded_active_request_count if context.using_cuda_graph_this_step() else None
+        )
+        context.mark_async_forward_in_flight()
+        context.record_async_scheduling_counter("launch")
+        return h2d_done_event
 
     async def async_generate_output_tokens_dynamic_batch(
         self, skip_bookkeeping: Optional[bool] = False
@@ -1719,37 +2117,48 @@ class TextGenerationController:
         if context.active_token_count == 0 and active_request_count == 0:
             return None
 
+        pending_forward_reused = False
+        async_next_prepared = False
+        async_sample_transfer_started = False
+        async_h2d_done_event = None
+        ep_step_begin_decision = self._decide_ep_step_begin(has_real_work=True)
+        if ep_step_begin_decision.discard_pending_forward:
+            self._discard_pending_async_forward()
+
         with torch.inference_mode():
-            input_ids, position_ids = self._dynamic_step_context_init()
-
-            cuda_graph_request_count = (
-                context.padded_active_request_count
-                if context.using_cuda_graph_this_step()
-                else None
+            input_ids = None
+            pending_forward_reused = (
+                ep_step_begin_decision.reuse_pending_forward
+                and self._try_use_async_pending_forward()
             )
+            if pending_forward_reused:
+                cuda_graph_request_count = self._async_pending_cuda_graph_request_count
+                self._async_pending_forward_plan = None
+                self._async_pending_cuda_graph_request_count = None
+            else:
+                input_ids, position_ids = self._dynamic_step_context_init()
 
-            # Enable routing recording before forward pass if routing replay is enabled
-            config = self.inference_wrapped_model.model.config
-            if config.moe_enable_routing_replay:
-                RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+                cuda_graph_request_count = (
+                    context.padded_active_request_count
+                    if context.using_cuda_graph_this_step()
+                    else None
+                )
 
-            # Forward pass produces only base logits. When speculative decoding is
-            # active, MTP logits are computed serially after verification.
-            range_push("forward_pass")
-            self._dynamic_step_forward_logits(input_ids, position_ids)
+                # Enable routing recording before forward pass if routing replay is enabled
+                config = self.inference_wrapped_model.model.config
+                if config.moe_enable_routing_replay:
+                    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
 
-            # Commit Mamba intermediate states before update_requests, which
-            # may swap request indices. The Python lists tracking EOS block IDs
-            # and intermediate offsets are not swapped along with tensors, so
-            # commit must run while indices are still valid.
-            if context.is_hybrid_model and context.mamba_slot_allocator is not None:
-                context.mamba_slot_allocator.commit_intermediate_states()
+                # Forward pass produces only base logits. When speculative decoding is
+                # active, MTP logits are computed serially after verification.
+                range_push("forward_pass")
+                self._dynamic_step_forward_logits(input_ids, position_ids)
+                self._retire_dynamic_forward_side_effects()
+                range_pop()
 
-            # Collect flat routing indices and scatter them into per-block storage.
-            # Must be done before update_requests while token-to-block mappings are valid.
-            # Reconstruction happens from blocks at request completion.
-            context.kv_block_allocator.store_routing_per_block(self._router_record_bookkeeping())
-            range_pop()
+            async_next_prepared = self._try_prepare_async_decode_next_step(
+                skip_bookkeeping=bool(skip_bookkeeping),
+            )
 
         # This is the best place to yield control back to event loop.
         # At this point we have enqueued FW pass GPU kernels asynchronously.
@@ -1758,15 +2167,16 @@ class TextGenerationController:
         # asynchronous.
         # Todo [Siddharth]: Can we condition the sleep on a cuda event?
         # NOTE [TDE]: This will be moved once CPU and GPU methods are separated.
-        await asyncio.sleep(0)
+        if not async_next_prepared and not pending_forward_reused:
+            await asyncio.sleep(0)
 
         with torch.inference_mode():
             range_push("sampling")
-            return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
 
             if self.num_speculative_tokens > 0:
                 # Phase 1: Verify speculative tokens using base logits only.
                 nvtx_range_push("mtp-spec-decoding/verify")
+                assert input_ids is not None
                 self._dynamic_step_sample_logits_and_verify_tokens(input_ids)
                 nvtx_range_pop("mtp-spec-decoding/verify")
                 # Phase 2: Rewind KV cache for rejected tokens.
@@ -1789,10 +2199,31 @@ class TextGenerationController:
                 # data-dependent boolean-mask sync overlaps with MTP GPU work.
                 context.kv_block_allocator.release_memory_blocks(blocks_to_release[remove_mask])
             else:
-                self._dynamic_step_sample_logits()
+                if async_next_prepared:
+                    self._dynamic_step_sample_logits_to_next_input_ids()
+                    self._start_async_sample_transfer(active_request_count)
+                    async_sample_transfer_started = True
+                    async_h2d_done_event = self._launch_async_prepared_decode_forward(
+                        active_request_count
+                    )
+                    if async_h2d_done_event is None:
+                        context.clear_async_prepared_decode_plan()
+                        async_next_prepared = False
+                else:
+                    self._dynamic_step_sample_logits()
+
+            self._ensure_ep_async_handoff_decided(has_real_work=True)
 
             log_probs = None
             top_n_logprobs = None
+            if self._should_collect_dynamic_logprob_bookkeeping(
+                async_next_prepared=async_next_prepared,
+                pending_forward_reused=pending_forward_reused,
+            ):
+                return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
+            else:
+                return_log_probs = False
+                return_top_n_logprobs = False
             if return_log_probs or return_top_n_logprobs:
                 if self.num_speculative_tokens > 0:
                     log_probs, log_probs_tensor = (
@@ -1825,6 +2256,12 @@ class TextGenerationController:
                 request_bookkeeping = {
                     "sample": self._sampled_tokens_cuda[:active_request_count].cpu()
                 }
+            elif async_sample_transfer_started:
+                sampled_tokens_cpu = self._finish_async_sample_transfer(active_request_count)
+                request_bookkeeping = self._dynamic_step_context_bookkeeping(
+                    sampled_tokens_cpu=sampled_tokens_cpu,
+                    h2d_done_event=async_h2d_done_event,
+                )
             else:
                 # request_bookkeeping supplies "sample" as the already-CPU
                 # tensor produced by _transfer_samples_to_cpu.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -14,17 +14,20 @@ from torch import Tensor
 from torch.cuda.nvtx import range_pop, range_push
 
 from megatron.core import parallel_state
+from megatron.core.inference.async_scheduling import (
+    AsyncDecodeTransaction,
+    AsyncGraphShape,
+    AsyncKVBlockLease,
+    AsyncRowMap,
+)
 from megatron.core.inference.async_stream import AsyncStream
 from megatron.core.inference.communication_utils import (
     broadcast_from_last_pipeline_stage,
     is_pipeline_last_stage,
 )
 from megatron.core.inference.contexts.dynamic_context import MaxSequenceLengthOverflowError
-from megatron.core.inference.ep_async_protocol import (
-    EPAsyncHandoffDecision,
-    EPStepBeginDecision,
-)
 from megatron.core.inference.contexts.static_context import StaticInferenceContext
+from megatron.core.inference.ep_async_protocol import EPAsyncHandoffDecision, EPStepBeginDecision
 from megatron.core.inference.inference_request import InferenceRequest, Status
 from megatron.core.inference.model_inference_wrappers.abstract_model_inference_wrapper import (
     AbstractModelInferenceWrapper,
@@ -214,8 +217,8 @@ class TextGenerationController:
         else:
             self._sampling: Sampling = TorchSampling(self.sampling_rng, self.vocab_size)
 
-        self._async_pending_forward_plan = None
-        self._async_pending_cuda_graph_request_count = None
+        self._async_pending_transaction: Optional[AsyncDecodeTransaction] = None
+        self._async_transaction_counter = 0
         self._async_copy_stream = torch.cuda.Stream(device=device)
         self._async_sample_ready_event = torch.cuda.Event()
         self._async_sample_transfer_done_event = torch.cuda.Event()
@@ -1116,52 +1119,73 @@ class TextGenerationController:
         active_request_ids = context.request_ids[active_slice].tolist()
         return bool(self._has_active_stop_words_callback(active_request_ids))
 
-    def _dynamic_step_required_token_logits(self) -> Tensor:
+    def _dynamic_step_required_token_logits(self, row_indices: Optional[Tensor] = None) -> Tensor:
         """Return the per-active-request logits consumed by normal decode sampling."""
 
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
+        if not context.config.materialize_only_last_token_logits and context.is_decode_only():
+            required_token_logits = self._all_logits_cuda.squeeze(0)
+            if row_indices is None:
+                return required_token_logits[:active_request_count, :]
+            return required_token_logits.index_select(0, row_indices)
         if context.config.materialize_only_last_token_logits:
-            return self._all_logits_cuda.squeeze(0)[:active_request_count, :]
-        return context.last_token_logits(
+            required_token_logits = self._all_logits_cuda.squeeze(0)
+            if row_indices is None:
+                return required_token_logits[:active_request_count, :]
+            return required_token_logits.index_select(0, row_indices)
+        required_token_logits = context.last_token_logits(
             self._all_logits_cuda[:, : context.padded_active_token_count, :]
         )
+        if row_indices is not None:
+            required_token_logits = required_token_logits.index_select(0, row_indices)
+        return required_token_logits
 
-    def _dynamic_step_sample_logits_greedy(self) -> None:
+    def _dynamic_step_sample_logits_greedy(
+        self, sample_count: Optional[int] = None, row_indices: Optional[Tensor] = None
+    ) -> None:
         """Greedy-sample logits into the stable sampled-token buffer."""
 
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
-        if active_request_count <= 0:
+        sample_count = active_request_count if sample_count is None else sample_count
+        if sample_count <= 0:
             self._sampled_tokens_cuda = self._greedy_sampled_tokens_cuda
             return
-        required_token_logits = self._dynamic_step_required_token_logits()
+        required_token_logits = self._dynamic_step_required_token_logits(row_indices=row_indices)
         torch.max(
-            required_token_logits[:active_request_count],
+            required_token_logits[:sample_count],
             dim=-1,
             out=(
-                self._greedy_sample_values_cuda[:active_request_count],
-                self._greedy_sampled_tokens_cuda[:active_request_count],
+                self._greedy_sample_values_cuda[:sample_count],
+                self._greedy_sampled_tokens_cuda[:sample_count],
             ),
         )
         self._sampled_tokens_cuda = self._greedy_sampled_tokens_cuda
 
-    def _dynamic_step_sample_logits_to_next_input_ids(self) -> None:
+    def _dynamic_step_sample_logits_to_next_input_ids(
+        self, row_indices: Optional[Tensor] = None
+    ) -> None:
         """Sample logits and write sampled ids into prepared next-step GPU inputs."""
 
         context = self.inference_wrapped_model.inference_context
-        self._dynamic_step_sample_logits()
+        self._dynamic_step_sample_logits(row_indices=row_indices)
         context.copy_async_prepared_decode_input_ids_from_samples(self._sampled_tokens_cuda)
 
-    def _dynamic_step_sample_logits(self):
+    def _dynamic_step_sample_logits(
+        self, sample_count: Optional[int] = None, row_indices: Optional[Tensor] = None
+    ):
         """Sample tokens from logits for dynamic batching."""
         # TODO(ksanthanam): Evaluate whether it makes more sense to sample on 1 rank
         # and then broadcast the sampled tokens rather than broadcasting the raw logits.
 
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
+        sample_count = active_request_count if sample_count is None else sample_count
         if self._active_requests_use_greedy_sampling(active_request_count):
-            self._dynamic_step_sample_logits_greedy()
+            self._dynamic_step_sample_logits_greedy(
+                sample_count=sample_count, row_indices=row_indices
+            )
             return
 
         use_graph = (
@@ -1170,15 +1194,22 @@ class TextGenerationController:
             and context.using_cuda_graph_this_step()
         )
         # Padded count when running a captured graph (cache key buckets); actual otherwise.
-        n = context.padded_active_request_count if use_graph else active_request_count
+        n = context.padded_active_request_count if use_graph else sample_count
         # When `materialize_only_last_token_logits` is true the forward pass already
         # selected the right rows. Otherwise we point the kernel at the per-request
         # last-token positions via `gather_indices`; padded slots safely fan in to row 0.
-        gather_indices = (
-            None
-            if context.config.materialize_only_last_token_logits
-            else context.gpu_view.active_request_last_token_idxs
-        )
+        if context.config.materialize_only_last_token_logits or (
+            not context.config.materialize_only_last_token_logits and context.is_decode_only()
+        ):
+            gather_indices = row_indices
+        else:
+            gather_indices = context.gpu_view.active_request_last_token_idxs
+            if row_indices is not None:
+                gather_indices = gather_indices.index_select(0, row_indices)
+        if gather_indices is not None and gather_indices.numel() < n:
+            padded_gather_indices = torch.zeros(n, dtype=gather_indices.dtype, device=gather_indices.device)
+            padded_gather_indices[: gather_indices.numel()] = gather_indices
+            gather_indices = padded_gather_indices
         self._sampled_tokens_cuda = self._sampling.sample_kernel(
             self._all_logits_cuda.squeeze(0),
             n,
@@ -1279,12 +1310,22 @@ class TextGenerationController:
         _ri_dtype = np.int16 if (config.num_moe_experts or 0) <= 32768 else np.int32
         return stacked_routing[:active_token_count].cpu().numpy().astype(_ri_dtype)
 
-    def _dynamic_step_calculate_log_probs(self) -> Optional[Tensor]:
+    def _dynamic_step_calculate_log_probs(
+        self, row_indices: Optional[Tensor] = None
+    ) -> Optional[Tensor]:
         """Calculate log probs from logits."""
         context = self.inference_wrapped_model.inference_context
         active_request_count = context.total_request_count - context.paused_request_count
         # This code cannot be reached when we are using speculative decode.
         assert self.num_speculative_tokens == 0
+        if row_indices is not None:
+            logits = self._all_logits_cuda.index_select(1, row_indices)
+            return context.calculate_log_probs(
+                logits,
+                self._sampled_tokens_cuda[:active_request_count],
+                only_last_token_logits=True,
+            )
+
         logits_seq_len = (
             active_request_count
             if context.config.materialize_only_last_token_logits
@@ -1529,7 +1570,7 @@ class TextGenerationController:
         return top_n_results if top_n_results else None
 
     def _dynamic_step_calculate_top_n_logprobs(
-        self, log_probs_tensor: Optional[Tensor] = None
+        self, log_probs_tensor: Optional[Tensor] = None, row_indices: Optional[Tensor] = None
     ) -> Optional[Dict[int, List[Tuple[Tensor, Tensor]]]]:
         """Calculate top-n log probs from logits for dynamic batching.
 
@@ -1552,7 +1593,11 @@ class TextGenerationController:
         active_request_slice = slice(context.paused_request_count, context.total_request_count)
 
         # Handle decode-only mode (only last token)
-        if context.config.materialize_only_last_token_logits or context.is_decode_only():
+        if (
+            row_indices is not None
+            or context.config.materialize_only_last_token_logits
+            or context.is_decode_only()
+        ):
             # In decode mode or when only last token logits are materialized,
             # logits already represent only the last tokens
             log_probs = log_probs_tensor[:active_request_count]
@@ -1614,22 +1659,61 @@ class TextGenerationController:
 
         self._ep_async_protocol = protocol
 
-    def _pending_async_forward_reusable(self) -> bool:
-        """Return whether this rank's pending async forward still matches live CPU state."""
+    def _current_async_request_ids(self) -> Tensor:
+        """Return current active request IDs in row order."""
 
-        plan = self._async_pending_forward_plan
-        if plan is None:
-            return True
         context = self.inference_wrapped_model.inference_context
-        return context.prepared_async_request_ids_match_live(plan)
+        active_slice = slice(context.paused_request_count, context.total_request_count)
+        return context.request_ids[active_slice].clone()
+
+    def _current_async_graph_shape(self) -> AsyncGraphShape:
+        """Return the graph shape current consumers expect for decode logits."""
+
+        context = self.inference_wrapped_model.inference_context
+        active_request_count = context.total_request_count - context.paused_request_count
+        transaction = self._async_pending_transaction
+        if context.using_cuda_graph_this_step():
+            padded_request_count = context.padded_active_request_count
+        elif transaction is not None:
+            padded_request_count = transaction.graph_shape.padded_active_request_count
+        else:
+            padded_request_count = active_request_count
+        return AsyncGraphShape(
+            active_request_count=active_request_count,
+            active_token_count=context.active_token_count,
+            padded_active_request_count=padded_request_count,
+            tokens_per_request=self.num_speculative_tokens + 1,
+        )
+
+    def _resolve_pending_async_row_map(self) -> Optional[AsyncRowMap]:
+        """Resolve the pending transaction against current live rows."""
+
+        transaction = self._async_pending_transaction
+        if transaction is None:
+            return None
+        return transaction.resolve_for_current(
+            current_request_ids=self._current_async_request_ids(),
+            current_graph_shape=self._current_async_graph_shape(),
+            device=torch.cuda.current_device(),
+        )
+
+    def _pending_async_forward_row_status(self) -> tuple[bool, bool]:
+        """Return whether the pending forward is reusable and whether it is row-mapped."""
+
+        if self._async_pending_transaction is None:
+            return True, False
+        row_map = self._resolve_pending_async_row_map()
+        if row_map is None:
+            return False, False
+        return True, row_map.row_mapped
 
     def _discard_pending_async_forward(self) -> None:
         """Drop a pending async forward and release resources reserved for it."""
 
         context = self.inference_wrapped_model.inference_context
-        if self._async_pending_forward_plan is not None:
-            self._async_pending_forward_plan = None
-            self._async_pending_cuda_graph_request_count = None
+        if self._async_pending_transaction is not None:
+            self._async_pending_transaction.drop("discard")
+            self._async_pending_transaction = None
             context.clear_async_prepared_decode_plan()
             context.release_deferred_async_resources()
             context.record_async_scheduling_counter("discard")
@@ -1639,14 +1723,17 @@ class TextGenerationController:
 
         self._ep_async_handoff_decided_this_step = False
         self._ep_async_handoff_decision_this_step = None
-        has_pending_forward = self._async_pending_forward_plan is not None
-        pending_forward_reusable = self._pending_async_forward_reusable()
+        has_pending_forward = self._async_pending_transaction is not None
+        pending_forward_reusable, pending_forward_row_mapped = (
+            self._pending_async_forward_row_status()
+        )
 
         if self._ep_async_protocol is not None and self._ep_async_protocol.enabled:
             return self._ep_async_protocol.decide_step_begin(
                 has_real_work=has_real_work,
                 has_pending_forward=has_pending_forward,
                 pending_forward_reusable=pending_forward_reusable,
+                pending_forward_row_mapped=pending_forward_row_mapped,
             )
 
         return EPStepBeginDecision(
@@ -1654,6 +1741,7 @@ class TextGenerationController:
             has_real_work=has_real_work,
             reuse_pending_forward=bool(has_pending_forward and pending_forward_reusable),
             discard_pending_forward=bool(has_pending_forward and not pending_forward_reusable),
+            row_mapped_forward=bool(has_pending_forward and pending_forward_row_mapped),
         )
 
     def _decide_ep_async_handoff(
@@ -2009,29 +2097,33 @@ class TextGenerationController:
 
         context.kv_block_allocator.store_routing_per_block(self._router_record_bookkeeping())
 
-    def _try_use_async_pending_forward(self) -> bool:
-        """Use logits from a launched async child if the no-reject invariant holds."""
+    def _try_use_async_pending_forward(self) -> Optional[AsyncRowMap]:
+        """Use logits from a launched async child if the transaction still matches."""
 
-        plan = self._async_pending_forward_plan
-        if plan is None:
-            return False
-
+        transaction = self._async_pending_transaction
+        if transaction is None:
+            return None
         context = self.inference_wrapped_model.inference_context
-        if not context.prepared_async_request_ids_match_live(plan):
-            self._async_pending_forward_plan = None
-            self._async_pending_cuda_graph_request_count = None
+        row_map = self._resolve_pending_async_row_map()
+        if row_map is None:
+            transaction.drop("invariant_failure")
+            self._async_pending_transaction = None
             context.clear_async_prepared_decode_plan()
             context.release_deferred_async_resources()
             context.record_async_scheduling_counter("invariant_failure")
             raise RuntimeError("async decode child invariant failed before reuse")
 
+        transaction.mark_ready(row_map)
         context.record_async_scheduling_counter("reuse")
+        if row_map.row_mapped:
+            context.record_async_scheduling_counter("row_mapped_reuse")
         if context.is_hybrid_model:
-            context.accept_async_mamba_state(plan.request_ids)
+            context.accept_async_mamba_state(row_map.current_request_ids)
         self._retire_dynamic_forward_side_effects()
         context.release_deferred_async_resources()
         context.clear_async_prepared_decode_plan()
-        return True
+        transaction.consume()
+        return row_map
 
     def _try_prepare_async_decode_next_step(
         self, *, skip_bookkeeping: bool
@@ -2085,10 +2177,20 @@ class TextGenerationController:
         self._dynamic_step_forward_logits(next_input_ids, next_position_ids)
         range_pop()
 
-        self._async_pending_forward_plan = plan
-        self._async_pending_cuda_graph_request_count = (
+        cuda_graph_request_count = (
             context.padded_active_request_count if context.using_cuda_graph_this_step() else None
         )
+        self._async_transaction_counter += 1
+        transaction = AsyncDecodeTransaction(
+            transaction_id=self._async_transaction_counter,
+            prepared_layout=plan,
+            graph_shape=AsyncGraphShape.from_plan(
+                plan, tokens_per_request=self.num_speculative_tokens + 1
+            ),
+            kv_lease=AsyncKVBlockLease(reserved_block_ids=plan.reserved_block_ids.clone()),
+        )
+        transaction.launch(cuda_graph_request_count=cuda_graph_request_count)
+        self._async_pending_transaction = transaction
         context.mark_async_forward_in_flight()
         context.record_async_scheduling_counter("launch")
         return h2d_done_event
@@ -2115,9 +2217,13 @@ class TextGenerationController:
 
         # No tokens and no active requests?
         if context.active_token_count == 0 and active_request_count == 0:
+            if self._async_pending_transaction is not None:
+                self._discard_pending_async_forward()
             return None
 
         pending_forward_reused = False
+        pending_forward_row_map = None
+        pending_forward_row_indices = None
         async_next_prepared = False
         async_sample_transfer_started = False
         async_h2d_done_event = None
@@ -2127,14 +2233,18 @@ class TextGenerationController:
 
         with torch.inference_mode():
             input_ids = None
-            pending_forward_reused = (
-                ep_step_begin_decision.reuse_pending_forward
-                and self._try_use_async_pending_forward()
-            )
+            pending_transaction = self._async_pending_transaction
+            if ep_step_begin_decision.reuse_pending_forward:
+                pending_forward_row_map = self._try_use_async_pending_forward()
+                pending_forward_reused = pending_forward_row_map is not None
             if pending_forward_reused:
-                cuda_graph_request_count = self._async_pending_cuda_graph_request_count
-                self._async_pending_forward_plan = None
-                self._async_pending_cuda_graph_request_count = None
+                cuda_graph_request_count = (
+                    pending_transaction.cuda_graph_request_count
+                    if pending_transaction is not None
+                    else None
+                )
+                pending_forward_row_indices = pending_forward_row_map.pending_rows
+                self._async_pending_transaction = None
             else:
                 input_ids, position_ids = self._dynamic_step_context_init()
 
@@ -2200,7 +2310,9 @@ class TextGenerationController:
                 context.kv_block_allocator.release_memory_blocks(blocks_to_release[remove_mask])
             else:
                 if async_next_prepared:
-                    self._dynamic_step_sample_logits_to_next_input_ids()
+                    self._dynamic_step_sample_logits_to_next_input_ids(
+                        row_indices=pending_forward_row_indices
+                    )
                     self._start_async_sample_transfer(active_request_count)
                     async_sample_transfer_started = True
                     async_h2d_done_event = self._launch_async_prepared_decode_forward(
@@ -2210,7 +2322,7 @@ class TextGenerationController:
                         context.clear_async_prepared_decode_plan()
                         async_next_prepared = False
                 else:
-                    self._dynamic_step_sample_logits()
+                    self._dynamic_step_sample_logits(row_indices=pending_forward_row_indices)
 
             self._ensure_ep_async_handoff_decided(has_real_work=True)
 
@@ -2234,10 +2346,12 @@ class TextGenerationController:
                             log_probs_tensor
                         )
                 else:
-                    log_probs, log_probs_tensor = self._dynamic_step_calculate_log_probs()
+                    log_probs, log_probs_tensor = self._dynamic_step_calculate_log_probs(
+                        row_indices=pending_forward_row_indices
+                    )
                     if return_top_n_logprobs:
                         top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs(
-                            log_probs_tensor
+                            log_probs_tensor, row_indices=pending_forward_row_indices
                         )
             range_pop()
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1237,9 +1237,8 @@ class TextGenerationController:
 
         if not self._async_logprob_requests_seen:
             return False
-
-        return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
-        return bool(return_log_probs or return_top_n_logprobs)
+        context = self.inference_wrapped_model.inference_context
+        return context.active_request_metadata_needs_logprob_results()
 
     def _should_collect_dynamic_logprob_bookkeeping(
         self, *, async_next_prepared: bool, pending_forward_reused: bool
@@ -2130,16 +2129,11 @@ class TextGenerationController:
         """Prepare next-step metadata when the child layout is deterministic."""
 
         context = self.inference_wrapped_model.inference_context
-        if (
-            not context.config.enable_async_scheduling
-            or self.num_speculative_tokens != 0
-            or self._active_requests_need_logprob_results()
-            or skip_bookkeeping
-            or self._active_requests_have_stop_words()
-        ):
-            return False
 
-        return context.prepare_async_decode_next_step()
+        return context.prepare_async_decode_next_step(
+            skip_bookkeeping=skip_bookkeeping,
+            active_stop_words=self._active_requests_have_stop_words(),
+        )
 
     def _launch_async_prepared_decode_forward(
         self, active_request_count: int

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -17,7 +17,6 @@ from megatron.core import parallel_state
 from megatron.core.inference.async_scheduling import (
     AsyncDecodeTransaction,
     AsyncGraphShape,
-    AsyncKVBlockLease,
     AsyncRowMap,
 )
 from megatron.core.inference.async_stream import AsyncStream
@@ -2156,7 +2155,7 @@ class TextGenerationController:
             has_real_work=True, can_launch_async_handoff=True
         )
         if not handoff_decision.launch_async_forward:
-            context.clear_async_prepared_decode_plan()
+            context.discard_async_prepared_decode_plan()
             context.record_async_scheduling_counter("ep_async_handoff_skipped")
             return None
 
@@ -2181,19 +2180,13 @@ class TextGenerationController:
             context.padded_active_request_count if context.using_cuda_graph_this_step() else None
         )
         self._async_transaction_counter += 1
-        transaction = AsyncDecodeTransaction(
+        transaction = AsyncDecodeTransaction.from_plan(
             transaction_id=self._async_transaction_counter,
             prepared_layout=plan,
-            graph_shape=AsyncGraphShape.from_plan(
-                plan, tokens_per_request=self.num_speculative_tokens + 1
-            ),
-            kv_lease=AsyncKVBlockLease(
-                reserved_request_ids=plan.reserved_request_ids.clone(),
-                reserved_block_ids=plan.reserved_block_ids.clone(),
-                reserved_block_columns=plan.reserved_block_columns.clone(),
-            ),
+            tokens_per_request=self.num_speculative_tokens + 1,
+            uses_mamba_candidate_bank=context.is_hybrid_model and context.mamba_state_bank_count > 1,
+            cuda_graph_request_count=cuda_graph_request_count,
         )
-        transaction.launch(cuda_graph_request_count=cuda_graph_request_count)
         self._async_pending_transaction = transaction
         context.mark_async_forward_in_flight()
         context.record_async_scheduling_counter("launch")
@@ -2323,7 +2316,7 @@ class TextGenerationController:
                         active_request_count
                     )
                     if async_h2d_done_event is None:
-                        context.clear_async_prepared_decode_plan()
+                        context.discard_async_prepared_decode_plan()
                         async_next_prepared = False
                 else:
                     self._dynamic_step_sample_logits(row_indices=pending_forward_row_indices)

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -2187,7 +2187,11 @@ class TextGenerationController:
             graph_shape=AsyncGraphShape.from_plan(
                 plan, tokens_per_request=self.num_speculative_tokens + 1
             ),
-            kv_lease=AsyncKVBlockLease(reserved_block_ids=plan.reserved_block_ids.clone()),
+            kv_lease=AsyncKVBlockLease(
+                reserved_request_ids=plan.reserved_request_ids.clone(),
+                reserved_block_ids=plan.reserved_block_ids.clone(),
+                reserved_block_columns=plan.reserved_block_columns.clone(),
+            ),
         )
         transaction.launch(cuda_graph_request_count=cuda_graph_request_count)
         self._async_pending_transaction = transaction

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -538,8 +538,10 @@ class MambaMixer(MegatronModule):
                 conv_state,
                 ssm_state,
                 batch_indices=context.mamba_metadata.batch_indices_decode,
+                write_batch_indices=context.mamba_metadata.batch_indices_decode_write,
                 intermediate_conv_state=int_conv_state,
                 intermediate_ssm_state=int_ssm_state,
+                state_bank_count=context.mamba_metadata.state_bank_count,
             )
 
             # Flatten back to [N*S, 1, d] to match merge logic
@@ -1081,8 +1083,10 @@ class MambaMixer(MegatronModule):
         conv_state: torch.Tensor,
         ssm_state: torch.Tensor,
         batch_indices: Optional[torch.Tensor] = None,
+        write_batch_indices: Optional[torch.Tensor] = None,
         intermediate_conv_state: Optional[torch.Tensor] = None,
         intermediate_ssm_state: Optional[torch.Tensor] = None,
+        state_bank_count: int = 1,
     ) -> torch.Tensor:
         """
         Performs SSM computation for inference decode step.
@@ -1139,7 +1143,9 @@ class MambaMixer(MegatronModule):
                 self.conv1d_bias.to(conv_state.dtype),
                 self.activation,
                 conv_state_indices=batch_indices,
+                conv_state_write_indices=write_batch_indices,
                 intermediate_conv_states=intermediate_conv_state,
+                state_bank_count=state_bank_count,
             ).to(xBC_dtype)
 
         x, B, C = torch.split(
@@ -1236,7 +1242,9 @@ class MambaMixer(MegatronModule):
                 dt_bias=dt_bias,
                 dt_softplus=True,
                 state_batch_indices=batch_indices,
+                state_batch_write_indices=write_batch_indices,
                 intermediate_ssm_states=intermediate_ssm_state,  # SSM only
+                state_bank_count=state_bank_count,
             )
             y = rearrange(y, "b s h p -> b s (h p)")
 

--- a/megatron/core/ssm/ops/causal_conv1d_triton.py
+++ b/megatron/core/ssm/ops/causal_conv1d_triton.py
@@ -47,6 +47,7 @@ def causal_conv1d_update_kernel(
     out_s_stride,
     out_c_stride,
     conv_state_indices_ptr,
+    conv_state_write_indices_ptr,
     batch,
     seq_len,
     dim,
@@ -55,7 +56,9 @@ def causal_conv1d_update_kernel(
     BLOCK_DIM: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     HAS_STATE_INDICES: tl.constexpr,
+    HAS_WRITE_STATE_INDICES: tl.constexpr,
     HAS_INT_STATE: tl.constexpr,
+    STATE_BANK_COUNT: tl.constexpr,
     SILU_ACTIVATION: tl.constexpr,
 ):
     """Triton implementation of causal_conv1d_update (kernel)."""
@@ -70,6 +73,10 @@ def causal_conv1d_update_kernel(
         state_batch_coord = tl.load(conv_state_indices_ptr + batch_id)
     else:
         state_batch_coord = batch_id
+    if HAS_WRITE_STATE_INDICES:
+        write_state_batch_coord = tl.load(conv_state_write_indices_ptr + batch_id)
+    else:
+        write_state_batch_coord = state_batch_coord
 
     # Base Pointers
     conv_state_ptrs = (
@@ -77,10 +84,15 @@ def causal_conv1d_update_kernel(
         + state_batch_coord * conv_state_b_stride
         + channel_offsets * conv_state_c_stride
     )
+    conv_state_write_ptrs = (
+        conv_state_ptr
+        + write_state_batch_coord * conv_state_b_stride
+        + channel_offsets * conv_state_c_stride
+    )
     weight_ptrs = weight_ptr + channel_offsets * weight_c_stride
 
     # Skip padding tokens (block-level uniform condition)
-    if state_batch_coord < 0:
+    if state_batch_coord < 0 or write_state_batch_coord < 0:
         for s in range(seq_len):
             out_ptrs = (
                 out_ptr
@@ -227,6 +239,7 @@ def causal_conv1d_update_kernel(
             out_val = out_val * tl.sigmoid(out_val)
 
         tl.store(out_ptrs, out_val.to(out_ptrs.dtype.element_ty), mask=mask)
+        conv_state_ptrs = conv_state_write_ptrs
 
 
 def causal_conv1d_update(
@@ -236,7 +249,9 @@ def causal_conv1d_update(
     bias: torch.Tensor | None,
     silu_activation: bool,
     conv_state_indices: torch.Tensor | None,
+    conv_state_write_indices: torch.Tensor | None = None,
     intermediate_conv_states: torch.Tensor | None = None,
+    state_bank_count: int = 1,
 ) -> torch.Tensor:
     """Triton implementation of causal_conv1d_update (entrypoint)."""
 
@@ -263,6 +278,11 @@ def causal_conv1d_update(
     else:
         conv_state_indices = x  # Dummy pointer
         has_state_indices = False
+    if conv_state_write_indices is not None:
+        has_write_state_indices = True
+    else:
+        conv_state_write_indices = x  # Dummy pointer
+        has_write_state_indices = False
 
     # Extract intermediate state strides if provided
     if intermediate_conv_states is not None:
@@ -307,6 +327,7 @@ def causal_conv1d_update(
         out.stride(1),
         out.stride(2),
         conv_state_indices,
+        conv_state_write_indices,
         batch,
         seq_len,
         dim,
@@ -315,7 +336,9 @@ def causal_conv1d_update(
         BLOCK_DIM=BLOCK_DIM,
         HAS_BIAS=has_bias,
         HAS_STATE_INDICES=has_state_indices,
+        HAS_WRITE_STATE_INDICES=has_write_state_indices,
         HAS_INT_STATE=has_int_state,
+        STATE_BANK_COUNT=state_bank_count,
         SILU_ACTIVATION=silu_activation == "silu",
     )
 

--- a/megatron/core/ssm/ops/mamba_ssm.py
+++ b/megatron/core/ssm/ops/mamba_ssm.py
@@ -74,6 +74,7 @@ def _selective_scan_update_kernel(
     z_ptr,
     out_ptr,
     state_batch_indices_ptr,
+    state_batch_write_indices_ptr,
     int_state_ptr,
     # Matrix dimensions
     batch,
@@ -131,7 +132,9 @@ def _selective_scan_update_kernel(
     HAS_D: tl.constexpr,
     HAS_Z: tl.constexpr,
     HAS_STATE_BATCH_INDICES: tl.constexpr,
+    HAS_STATE_BATCH_WRITE_INDICES: tl.constexpr,
     HAS_INT_STATE: tl.constexpr,
+    STATE_BANK_COUNT: tl.constexpr,
     BLOCK_SIZE_DSTATE: tl.constexpr,
 ):
     pid_m = tl.program_id(axis=0)
@@ -148,17 +151,26 @@ def _selective_scan_update_kernel(
     if HAS_STATE_BATCH_INDICES:
         state_batch_indices_ptr += pid_b
         state_batch_idx = tl.load(state_batch_indices_ptr)
+        if HAS_STATE_BATCH_WRITE_INDICES:
+            state_batch_write_indices_ptr += pid_b
+            state_batch_write_idx = tl.load(state_batch_write_indices_ptr)
+        else:
+            state_batch_write_idx = state_batch_idx
         # Skip padding tokens (e.g. from graph capture or inactive slots)
-        if state_batch_idx < 0:
+        if state_batch_idx < 0 or state_batch_write_idx < 0:
             for s in range(seq_len):
                 out_s_ptrs = out_ptrs + s * stride_out_seq
                 tl.store(out_s_ptrs, 0.0, mask=offs_m < dim)
             return
         state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
+        state_write_ptr = state_ptr + (state_batch_write_idx - state_batch_idx) * stride_state_batch
         if HAS_INT_STATE:
-            int_state_ptr += state_batch_idx * stride_int_batch + pid_h * stride_int_head
+            int_state_ptr += (
+                state_batch_idx // STATE_BANK_COUNT
+            ) * stride_int_batch + pid_h * stride_int_head
     else:
         state_ptr += pid_b * stride_state_batch + pid_h * stride_state_head
+        state_write_ptr = state_ptr
         if HAS_INT_STATE:
             int_state_ptr += pid_b * stride_int_batch + pid_h * stride_int_head
 
@@ -176,6 +188,9 @@ def _selective_scan_update_kernel(
 
     # Constant offsets (A, D, and bias do not have a sequence dimension)
     state_ptrs = state_ptr + (
+        offs_m[:, None] * stride_state_dim + offs_n[None, :] * stride_state_dstate
+    )
+    state_write_ptrs = state_write_ptr + (
         offs_m[:, None] * stride_state_dim + offs_n[None, :] * stride_state_dstate
     )
     if HAS_INT_STATE:
@@ -279,7 +294,7 @@ def _selective_scan_update_kernel(
         tl.store(out_s_ptrs, out, mask=offs_m < dim)
 
     # After processing all sequence steps, persist the final state back to HBM
-    tl.store(state_ptrs, state, mask=(offs_m[:, None] < dim) & (offs_n[None, :] < dstate))
+    tl.store(state_write_ptrs, state, mask=(offs_m[:, None] < dim) & (offs_n[None, :] < dstate))
 
 
 def selective_state_update(
@@ -294,7 +309,9 @@ def selective_state_update(
     dt_bias=None,
     dt_softplus=False,
     state_batch_indices=None,
+    state_batch_write_indices=None,
     intermediate_ssm_states=None,
+    state_bank_count: int = 1,
 ):
     """
     Argument:
@@ -308,8 +325,11 @@ def selective_state_update(
         D: (dim,) or (nheads, dim)
         z: Matches x
         dt_bias: (dim,) or (nheads, dim)
+        state_batch_indices: Optional read-state slot index for each batch row.
+        state_batch_write_indices: Optional write-state slot index for each batch row.
         intermediate_ssm_states: Optional buffer of shape (batch, seqlen, nheads, dim, dstate)
                                  or (batch, seqlen, dim, dstate)
+        state_bank_count: Number of flattened state banks per logical request slot.
     Return:
         out: shape matches x
     """
@@ -378,6 +398,9 @@ def selective_state_update(
     z_strides = (
         (z.stride(0), z.stride(1), z.stride(2), z.stride(3)) if z is not None else (0, 0, 0, 0)
     )
+    has_state_batch_write_indices = state_batch_write_indices is not None
+    if state_batch_write_indices is None:
+        state_batch_write_indices = state_batch_indices
 
     is_blackwell = torch.cuda.get_device_capability(x.device)[0] >= 10
 
@@ -417,6 +440,7 @@ def selective_state_update(
             z,
             out,
             state_batch_indices,
+            state_batch_write_indices,
             intermediate_ssm_states,
             batch,
             seq_len,
@@ -461,6 +485,8 @@ def selective_state_update(
             dt_softplus,
             tie_hdim,
             BLOCK_SIZE_M,
+            HAS_STATE_BATCH_WRITE_INDICES=has_state_batch_write_indices,
+            STATE_BANK_COUNT=state_bank_count,
             num_warps=num_warps,
         )
 

--- a/megatron/inference/utils.py
+++ b/megatron/inference/utils.py
@@ -371,6 +371,7 @@ def get_inference_config_from_model_and_args(model: MegatronModule, args):
         track_generated_token_events=args.inference_dynamic_batching_track_generated_token_events,
         track_paused_request_events=args.inference_dynamic_batching_track_paused_request_events,
         enable_chunked_prefill=args.enable_chunked_prefill,
+        enable_async_scheduling=args.inference_dynamic_batching_enable_async_scheduling,
         enable_prefix_caching=args.inference_dynamic_batching_enable_prefix_caching,
         prefix_caching_eviction_policy=PrefixCachingEvictionPolicy(args.inference_dynamic_batching_prefix_caching_eviction_policy),
         prefix_caching_coordinator_policy=PrefixCachingCoordinatorPolicy(args.inference_dynamic_batching_prefix_caching_coordinator_policy),

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1936,6 +1936,11 @@ def _add_inference_args(parser):
                        help="Enable chunked prefill (disabled by default)")
     group.add_argument('--num-speculative-tokens', type=int, default=0,
                        help='Number of speculative tokens generated during decode')
+    group.add_argument('--inference-dynamic-batching-async-scheduling',
+                       '--enable-async-scheduling',
+                       dest='inference_dynamic_batching_enable_async_scheduling',
+                       action='store_true', default=False,
+                       help='Enable async scheduling for eligible dynamic batching decode steps.')
     group.add_argument('--inference-dynamic-batching-prefix-caching',
                        dest='inference_dynamic_batching_enable_prefix_caching',
                        action=argparse.BooleanOptionalAction,

--- a/tests/unit_tests/inference/test_async_scheduling_transaction.py
+++ b/tests/unit_tests/inference/test_async_scheduling_transaction.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
 import pytest
 import torch
@@ -13,6 +13,7 @@ from megatron.core.inference.async_scheduling import (
     AsyncTransactionState,
 )
 from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensions
+from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
 from megatron.core.inference.ep_async_protocol import EPAsyncPhase, EPAsyncStepProtocol
 from megatron.core.inference.text_generation_controllers.text_generation_controller import (
     TextGenerationController,
@@ -153,6 +154,76 @@ def test_kv_lease_records_reserved_blocks():
     assert lease.reserved_block_ids.tolist() == [100, 101]
 
 
+@pytest.mark.internal
+@pytest.mark.parametrize("uses_mamba_candidate_bank", [False, True])
+def test_transaction_from_plan_records_resource_leases(uses_mamba_candidate_bank):
+    plan = SimpleNamespace(
+        request_ids=torch.tensor([10, 11], dtype=torch.int32),
+        reserved_request_ids=torch.tensor([11], dtype=torch.int32),
+        reserved_block_ids=torch.tensor([101], dtype=torch.int32),
+        reserved_block_columns=torch.tensor([2], dtype=torch.int32),
+        active_request_count=2,
+        active_token_count=6,
+        padded_active_request_count=4,
+    )
+
+    txn = AsyncDecodeTransaction.from_plan(
+        transaction_id=9,
+        prepared_layout=plan,
+        tokens_per_request=3,
+        uses_mamba_candidate_bank=uses_mamba_candidate_bank,
+        cuda_graph_request_count=4,
+    )
+
+    assert txn.state == AsyncTransactionState.IN_FLIGHT
+    assert txn.graph_shape == AsyncGraphShape(
+        active_request_count=2,
+        active_token_count=6,
+        padded_active_request_count=4,
+        tokens_per_request=3,
+    )
+    assert txn.kv_lease.reserved_request_ids.tolist() == [11]
+    assert txn.kv_lease.reserved_block_ids.tolist() == [101]
+    assert txn.mamba_lease.uses_candidate_bank is uses_mamba_candidate_bank
+    assert txn.mamba_lease.candidate_request_ids.tolist() == (
+        [10, 11] if uses_mamba_candidate_bank else []
+    )
+    assert txn.mtp_state is not None
+    assert txn.mtp_state.tokens_per_request == 3
+    assert txn.cuda_graph_request_count == 4
+
+
+@pytest.mark.internal
+def test_transaction_rejects_tokens_per_request_mismatch():
+    plan = SimpleNamespace(
+        request_ids=torch.tensor([1, 2], dtype=torch.int32),
+        reserved_request_ids=torch.empty(0, dtype=torch.int32),
+        reserved_block_ids=torch.empty(0, dtype=torch.int32),
+        reserved_block_columns=torch.empty(0, dtype=torch.int32),
+        active_request_count=2,
+        active_token_count=6,
+        padded_active_request_count=4,
+    )
+    txn = AsyncDecodeTransaction.from_plan(
+        transaction_id=3,
+        prepared_layout=plan,
+        tokens_per_request=3,
+    )
+
+    assert (
+        txn.resolve_for_current(
+            current_request_ids=torch.tensor([1, 2], dtype=torch.int32),
+            current_graph_shape=AsyncGraphShape(
+                active_request_count=2,
+                active_token_count=2,
+                padded_active_request_count=4,
+                tokens_per_request=1,
+            ),
+        )
+        is None
+    )
+
+
 class _RecordingEPCommunicator:
     def __init__(self, *, sync_results=(), world_size=2):
         self.sync_results = list(sync_results)
@@ -204,6 +275,31 @@ def test_ep_step_begin_agrees_on_row_mapped_reuse(global_state, expected):
 
 
 @pytest.mark.internal
+def test_ep_handoff_diagnostics_count_launch_and_skip():
+    communicator = _RecordingEPCommunicator(sync_results=[(1, 1, 0), 1, (1, 1, 1), 1])
+    protocol = EPAsyncStepProtocol(communicator)
+
+    launch = protocol.decide_async_handoff(
+        has_real_work=True, can_launch_async_handoff=True
+    )
+    skip = protocol.decide_async_handoff(
+        has_real_work=True, can_launch_async_handoff=True
+    )
+
+    assert launch.launch_async_forward
+    assert skip.skip_async_forward
+    diagnostics = protocol.diagnostics()
+    assert diagnostics["handoff_launches"] == 1
+    assert diagnostics["handoff_skips"] == 1
+    assert communicator.calls == [
+        (EPAsyncPhase.ASYNC_HANDOFF, 0, (1, 1, 0)),
+        (EPAsyncPhase.ASYNC_HANDOFF_ACK, 0, (1,)),
+        (EPAsyncPhase.ASYNC_HANDOFF, 1, (1, 1, 0)),
+        (EPAsyncPhase.ASYNC_HANDOFF_ACK, 1, (1,)),
+    ]
+
+
+@pytest.mark.internal
 def test_ep_graph_shape_sync_uses_protocol_tag(monkeypatch):
     communicator = _RecordingEPCommunicator(sync_results=[(16, 0)])
     protocol = EPAsyncStepProtocol(communicator)
@@ -242,3 +338,170 @@ def test_controller_required_logits_uses_pending_row_indices(materialize_only_la
     )
 
     assert torch.equal(selected, logits.squeeze(0).index_select(0, torch.tensor([1, 3])))
+
+
+@pytest.mark.internal
+def test_controller_generated_logprobs_use_pending_row_indices():
+    logits = torch.arange(1 * 4 * 5, dtype=torch.float32).view(1, 4, 5)
+    sampled = torch.tensor([3, 1], dtype=torch.long)
+    recorded = {}
+
+    def _calculate_log_probs(logits_arg, new_tokens, only_last_token_logits=False):
+        recorded["logits"] = logits_arg.clone()
+        recorded["new_tokens"] = new_tokens.clone()
+        recorded["only_last"] = only_last_token_logits
+        return [[0.0], [0.0]], torch.log_softmax(logits_arg.squeeze(0), dim=-1)
+
+    context = SimpleNamespace(
+        total_request_count=2,
+        paused_request_count=0,
+        config=SimpleNamespace(materialize_only_last_token_logits=False),
+        is_decode_only=lambda: True,
+        calculate_log_probs=_calculate_log_probs,
+    )
+    controller = SimpleNamespace(
+        num_speculative_tokens=0,
+        inference_wrapped_model=SimpleNamespace(inference_context=context),
+        _all_logits_cuda=logits,
+        _sampled_tokens_cuda=sampled,
+    )
+
+    log_probs, _ = TextGenerationController._dynamic_step_calculate_log_probs(
+        controller, row_indices=torch.tensor([3, 1])
+    )
+
+    assert log_probs == [[0.0], [0.0]]
+    assert recorded["only_last"]
+    assert torch.equal(recorded["new_tokens"], sampled)
+    assert torch.equal(recorded["logits"], logits.index_select(1, torch.tensor([3, 1])))
+
+
+@pytest.mark.internal
+def test_controller_top_n_logprobs_use_selected_row_tensor():
+    context = SimpleNamespace(
+        total_request_count=2,
+        paused_request_count=0,
+        active_request_metadata={
+            "top_n_logprobs": torch.tensor([1, 2], dtype=torch.int32),
+        },
+        config=SimpleNamespace(materialize_only_last_token_logits=False),
+        is_decode_only=lambda: True,
+    )
+    controller = SimpleNamespace(
+        inference_wrapped_model=SimpleNamespace(inference_context=context),
+    )
+    selected_log_probs = torch.tensor(
+        [
+            [0.0, 10.0, 2.0, 3.0],
+            [9.0, 7.0, 11.0, 1.0],
+        ],
+        dtype=torch.float32,
+    )
+
+    top_n = TextGenerationController._dynamic_step_calculate_top_n_logprobs(
+        controller,
+        selected_log_probs,
+        row_indices=torch.tensor([3, 1]),
+    )
+
+    assert top_n is not None
+    assert top_n[0][0][1].tolist() == [1]
+    assert top_n[1][0][1].tolist() == [2, 0]
+
+
+class _ReleaseRecordingAllocator:
+    def __init__(self):
+        self.released = []
+
+    def release_memory_blocks(self, blocks):
+        self.released.append(blocks.clone())
+
+
+@pytest.mark.internal
+def test_discard_prepared_plan_releases_unlaunched_kv_reservations():
+    allocator = _ReleaseRecordingAllocator()
+    context = SimpleNamespace(
+        _async_prepared_decode_plan=SimpleNamespace(
+            reserved_block_ids=torch.tensor([30, 31], dtype=torch.int32)
+        ),
+        _async_reserved_kv_block_count=2,
+        _async_reserved_kv_block_request_ids=torch.tensor([10, 11], dtype=torch.int32),
+        _async_reserved_kv_block_ids=torch.tensor([30, 31], dtype=torch.int32),
+        _async_reserved_kv_block_columns=torch.tensor([1, 1], dtype=torch.int32),
+        kv_block_allocator=allocator,
+        async_scheduling_counters={},
+    )
+    context.record_async_scheduling_counter = MethodType(
+        DynamicInferenceContext.record_async_scheduling_counter, context
+    )
+    context._clear_async_reserved_kv_blocks = MethodType(
+        DynamicInferenceContext._clear_async_reserved_kv_blocks, context
+    )
+    context.clear_async_prepared_decode_plan = MethodType(
+        DynamicInferenceContext.clear_async_prepared_decode_plan, context
+    )
+
+    DynamicInferenceContext.discard_async_prepared_decode_plan(context)
+
+    assert [blocks.tolist() for blocks in allocator.released] == [[30, 31]]
+    assert context._async_prepared_decode_plan is None
+    assert context._async_reserved_kv_block_count == 0
+    assert context._async_reserved_kv_block_ids.tolist() == [-1, -1]
+    assert context.async_scheduling_counters["kv_lease_dropped"] == 2
+
+
+class _MambaMetadataWithFreeRecording:
+    def __init__(self):
+        self.request_to_mamba_state_idx = torch.tensor([2, -1, 4], dtype=torch.int32)
+        self.request_to_mamba_state_bank = torch.tensor([1, 0, 1], dtype=torch.int32)
+        self.mamba_state_free_slots = torch.empty(0, dtype=torch.int32)
+        self.freed_slots = []
+        self.reset_called = False
+        self.reset_varlen_count = 0
+
+    def free_slot_ids(self, slots):
+        self.freed_slots.append(slots.clone().cpu())
+
+    def reset(self):
+        self.reset_called = True
+
+    def reset_varlen_metadata(self):
+        self.reset_varlen_count += 1
+
+
+@pytest.mark.internal
+def test_async_mamba_reset_defers_allocated_slots_while_forward_is_in_flight():
+    metadata = _MambaMetadataWithFreeRecording()
+    context = SimpleNamespace(
+        is_hybrid_model=True,
+        _async_forward_in_flight=True,
+        _async_deferred_kv_blocks_to_release=torch.empty(0, dtype=torch.int32),
+        _async_deferred_mamba_slots_to_free=torch.empty(0, dtype=torch.int32),
+        _async_deferred_kv_block_release_count=0,
+        _async_deferred_mamba_slot_release_count=0,
+        mamba_metadata=metadata,
+        async_scheduling_counters={},
+    )
+    context.record_async_scheduling_counter = MethodType(
+        DynamicInferenceContext.record_async_scheduling_counter, context
+    )
+    context._append_deferred_async_mamba_slots = MethodType(
+        DynamicInferenceContext._append_deferred_async_mamba_slots, context
+    )
+    context._release_deferred_async_mamba_slots = MethodType(
+        DynamicInferenceContext._release_deferred_async_mamba_slots, context
+    )
+
+    DynamicInferenceContext.reset_mamba_state(context)
+
+    assert not metadata.reset_called
+    assert metadata.reset_varlen_count == 1
+    assert metadata.request_to_mamba_state_idx.tolist() == [-1, -1, -1]
+    assert metadata.request_to_mamba_state_bank.tolist() == [0, 0, 0]
+    assert context._async_deferred_mamba_slots_to_free.tolist() == [2, 4]
+
+    DynamicInferenceContext._release_deferred_async_mamba_slots(context)
+
+    assert [slots.tolist() for slots in metadata.freed_slots] == [[2, 4]]
+    assert context._async_deferred_mamba_slots_to_free.numel() == 0
+    assert context._async_deferred_mamba_slot_release_count == 2

--- a/tests/unit_tests/inference/test_async_scheduling_transaction.py
+++ b/tests/unit_tests/inference/test_async_scheduling_transaction.py
@@ -12,6 +12,11 @@ from megatron.core.inference.async_scheduling import (
     AsyncRowMap,
     AsyncTransactionState,
 )
+from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensions
+from megatron.core.inference.ep_async_protocol import EPAsyncPhase, EPAsyncStepProtocol
+from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+    TextGenerationController,
+)
 
 
 def _plan(request_ids):
@@ -146,3 +151,94 @@ def test_kv_lease_records_reserved_blocks():
 
     assert lease.has_reservations
     assert lease.reserved_block_ids.tolist() == [100, 101]
+
+
+class _RecordingEPCommunicator:
+    def __init__(self, *, sync_results=(), world_size=2):
+        self.sync_results = list(sync_results)
+        self.world_size = world_size
+        self.protocol_mismatch_count = 0
+        self.calls = []
+
+    def sync_all_reduce_max(self, *values, phase=None, step_id=None):
+        self.calls.append((EPAsyncPhase(phase), step_id, tuple(values)))
+        if self.sync_results:
+            return self.sync_results.pop(0)
+        return values[0] if len(values) == 1 else tuple(values)
+
+
+@pytest.mark.internal
+@pytest.mark.parametrize(
+    ("global_state", "expected"),
+    [
+        ((1, 1, 1, 0, 0, 0), (True, False, False)),
+        ((1, 1, 1, 1, 0, 0), (True, False, True)),
+        ((1, 1, 0, 0, 1, 0), (False, True, False)),
+        ((1, 1, 1, 0, 0, 1), (False, True, False)),
+    ],
+)
+def test_ep_step_begin_agrees_on_row_mapped_reuse(global_state, expected):
+    communicator = _RecordingEPCommunicator(sync_results=[global_state, 1])
+    protocol = EPAsyncStepProtocol(communicator)
+
+    decision = protocol.decide_step_begin(
+        has_real_work=True,
+        has_pending_forward=True,
+        pending_forward_reusable=True,
+        pending_forward_row_mapped=bool(global_state[3]),
+    )
+
+    assert (
+        decision.reuse_pending_forward,
+        decision.discard_pending_forward,
+        decision.row_mapped_forward,
+    ) == expected
+    assert communicator.calls == [
+        (
+            EPAsyncPhase.STEP_BEGIN,
+            0,
+            (1, 1, 1, int(bool(global_state[3])), 0, 0),
+        ),
+        (EPAsyncPhase.STEP_BEGIN_ACK, 0, (1,)),
+    ]
+
+
+@pytest.mark.internal
+def test_ep_graph_shape_sync_uses_protocol_tag(monkeypatch):
+    communicator = _RecordingEPCommunicator(sync_results=[(16, 0)])
+    protocol = EPAsyncStepProtocol(communicator)
+    monkeypatch.setattr("megatron.core.inference.batch_dimensions_utils.get_pg_size", lambda _: 2)
+
+    adjusted = InferenceBatchDimensions.adjust_batch_dims_for_expert_parallelism(
+        InferenceBatchDimensions(8, 0, 4),
+        ep_group=object(),
+        ep_async_protocol=protocol,
+    )
+
+    assert adjusted == InferenceBatchDimensions(16, 0, 4)
+    assert communicator.calls == [(EPAsyncPhase.GRAPH_SHAPE, 0, (8, 0))]
+
+
+@pytest.mark.internal
+@pytest.mark.parametrize("materialize_only_last_token_logits", [False, True])
+def test_controller_required_logits_uses_pending_row_indices(materialize_only_last_token_logits):
+    logits = torch.arange(1 * 4 * 3, dtype=torch.float32).view(1, 4, 3)
+    context = SimpleNamespace(
+        total_request_count=2,
+        paused_request_count=0,
+        padded_active_token_count=4,
+        config=SimpleNamespace(
+            materialize_only_last_token_logits=materialize_only_last_token_logits
+        ),
+        is_decode_only=lambda: True,
+    )
+    controller = SimpleNamespace(
+        inference_wrapped_model=SimpleNamespace(inference_context=context),
+        _all_logits_cuda=logits,
+    )
+
+    selected = TextGenerationController._dynamic_step_required_token_logits(
+        controller, row_indices=torch.tensor([1, 3])
+    )
+
+    assert torch.equal(selected, logits.squeeze(0).index_select(0, torch.tensor([1, 3])))

--- a/tests/unit_tests/inference/test_async_scheduling_transaction.py
+++ b/tests/unit_tests/inference/test_async_scheduling_transaction.py
@@ -320,6 +320,17 @@ def _eligible_async_context(**overrides):
             "top_n_logprobs": torch.tensor(top_n_logprobs, dtype=torch.int32),
         },
     )
+    context.active_request_metadata_needs_logprob_results = lambda active_count=None: bool(
+        context.active_request_metadata["return_log_probs"][
+            : active_request_count if active_count is None else active_count
+        ].any()
+        or (
+            context.active_request_metadata["top_n_logprobs"][
+                : active_request_count if active_count is None else active_count
+            ]
+            > 0
+        ).any()
+    )
     for name, value in overrides.items():
         setattr(context, name, value)
     return context

--- a/tests/unit_tests/inference/test_async_scheduling_transaction.py
+++ b/tests/unit_tests/inference/test_async_scheduling_transaction.py
@@ -124,6 +124,33 @@ def test_row_map_rejects_incompatible_rows(pending, current):
 
 
 @pytest.mark.internal
+def test_identity_row_map_does_not_materialize_device_gather_rows():
+    row_map = AsyncRowMap.for_current(
+        pending_request_ids=torch.tensor([10, 11, 12]),
+        current_request_ids=torch.tensor([10, 11]),
+        device="cpu",
+    )
+
+    assert row_map is not None
+    assert not row_map.row_mapped
+    assert row_map.pending_rows is None
+
+
+@pytest.mark.internal
+def test_row_mapped_forward_materializes_device_gather_rows():
+    row_map = AsyncRowMap.for_current(
+        pending_request_ids=torch.tensor([10, 11, 12]),
+        current_request_ids=torch.tensor([11, 12]),
+        device="cpu",
+    )
+
+    assert row_map is not None
+    assert row_map.row_mapped
+    assert row_map.pending_rows is not None
+    assert row_map.pending_rows.tolist() == [1, 2]
+
+
+@pytest.mark.internal
 def test_transaction_rejects_graph_shape_mismatch():
     plan = _plan([1, 2])
     txn = AsyncDecodeTransaction(

--- a/tests/unit_tests/inference/test_async_scheduling_transaction.py
+++ b/tests/unit_tests/inference/test_async_scheduling_transaction.py
@@ -14,7 +14,11 @@ from megatron.core.inference.async_scheduling import (
 )
 from megatron.core.inference.batch_dimensions_utils import InferenceBatchDimensions
 from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
+from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
 from megatron.core.inference.ep_async_protocol import EPAsyncPhase, EPAsyncStepProtocol
+from megatron.core.inference.text_generation_controllers import (
+    text_generation_controller as tgc_module,
+)
 from megatron.core.inference.text_generation_controllers.text_generation_controller import (
     TextGenerationController,
 )
@@ -224,6 +228,136 @@ def test_transaction_rejects_tokens_per_request_mismatch():
     )
 
 
+@pytest.mark.internal
+def test_transaction_resolves_row_mapped_mtp_stride_subset():
+    plan = SimpleNamespace(
+        request_ids=torch.tensor([10, 11], dtype=torch.int32),
+        reserved_request_ids=torch.empty(0, dtype=torch.int32),
+        reserved_block_ids=torch.empty(0, dtype=torch.int32),
+        reserved_block_columns=torch.empty(0, dtype=torch.int32),
+        active_request_count=2,
+        active_token_count=6,
+        padded_active_request_count=4,
+    )
+    txn = AsyncDecodeTransaction.from_plan(
+        transaction_id=5,
+        prepared_layout=plan,
+        tokens_per_request=3,
+    )
+
+    row_map = txn.resolve_for_current(
+        current_request_ids=torch.tensor([11], dtype=torch.int32),
+        current_graph_shape=AsyncGraphShape(
+            active_request_count=1,
+            active_token_count=3,
+            padded_active_request_count=4,
+            tokens_per_request=3,
+        ),
+    )
+
+    assert row_map is not None
+    assert row_map.row_mapped
+    assert row_map.pending_rows_cpu.tolist() == [1]
+
+
+def _eligible_async_context(**overrides):
+    active_request_count = overrides.pop("active_request_count", 2)
+    block_size_tokens = overrides.pop("block_size_tokens", 8)
+    top_k = overrides.pop("top_k", [1] * active_request_count)
+    top_p = overrides.pop("top_p", [0.0] * active_request_count)
+    return_log_probs = overrides.pop("return_log_probs", [False] * active_request_count)
+    top_n_logprobs = overrides.pop("top_n_logprobs", [0] * active_request_count)
+    last_offsets = overrides.pop("last_offsets", [2] * active_request_count)
+    context = SimpleNamespace(
+        enable_async_scheduling=True,
+        _async_reserved_kv_block_count=0,
+        num_speculative_tokens=0,
+        is_decode_only=lambda: True,
+        paused_request_count=0,
+        total_request_count=active_request_count,
+        get_index_of_chunked_prefill_request=lambda safe=True: -1,
+        request_kv_length_offsets=torch.arange(active_request_count, dtype=torch.int64) + 10,
+        request_query_lengths=torch.ones(active_request_count, dtype=torch.int64),
+        request_metadata={
+            "termination_id": torch.full((active_request_count,), -1, dtype=torch.int64)
+        },
+        request_output_lengths=torch.full((active_request_count,), 100, dtype=torch.int64),
+        request_last_kv_block_offset=torch.tensor(last_offsets, dtype=torch.int64),
+        block_size_tokens=block_size_tokens,
+        kv_block_allocator=SimpleNamespace(total_avail=active_request_count),
+        active_request_metadata={
+            "temperature": torch.ones(active_request_count, dtype=torch.float32),
+            "top_k": torch.tensor(top_k, dtype=torch.int32),
+            "top_p": torch.tensor(top_p, dtype=torch.float32),
+            "return_log_probs": torch.tensor(return_log_probs, dtype=torch.bool),
+            "top_n_logprobs": torch.tensor(top_n_logprobs, dtype=torch.int32),
+        },
+    )
+    for name, value in overrides.items():
+        setattr(context, name, value)
+    return context
+
+
+@pytest.mark.internal
+@pytest.mark.parametrize(
+    ("overrides", "kwargs", "expected"),
+    [
+        ({"num_speculative_tokens": 2}, {}, "skip_mtp"),
+        ({}, {"skip_bookkeeping": True}, "skip_bookkeeping"),
+        ({"return_log_probs": [True, False]}, {}, "skip_logprob_results"),
+        ({"top_n_logprobs": [0, 3]}, {}, "skip_logprob_results"),
+        ({}, {"active_stop_words": True}, "skip_stop_words"),
+        ({"last_offsets": [7, 2]}, {}, "skip_mixed_block_boundary"),
+        (
+            {"last_offsets": [7, 7], "kv_block_allocator": SimpleNamespace(total_avail=1)},
+            {},
+            "skip_kv_block_unavailable",
+        ),
+        ({"top_k": [4, 1]}, {}, None),
+        ({"top_p": [0.7, 0.0]}, {}, None),
+    ],
+)
+def test_async_decode_planner_skip_reason_matrix(overrides, kwargs, expected):
+    context = _eligible_async_context(**overrides)
+
+    reason = DynamicInferenceContext.async_decode_next_step_skip_reason(context, **kwargs)
+
+    assert reason == expected
+
+
+@pytest.mark.internal
+def test_prompt_logprob_history_does_not_disable_async_after_active_metadata_clears():
+    context = _eligible_async_context(return_log_probs=[True, False], top_n_logprobs=[0, 0])
+
+    assert (
+        DynamicInferenceContext.async_decode_next_step_skip_reason(context)
+        == "skip_logprob_results"
+    )
+
+    context.active_request_metadata["return_log_probs"].zero_()
+    assert DynamicInferenceContext.async_decode_next_step_skip_reason(context) is None
+
+
+@pytest.mark.internal
+def test_controller_delegates_async_prepare_eligibility_to_context_planner():
+    events = []
+    context = SimpleNamespace(
+        paused_request_count=0,
+        total_request_count=2,
+        request_ids=torch.tensor([10, 11], dtype=torch.int64),
+        prepare_async_decode_next_step=lambda **kwargs: events.append(kwargs) or True,
+    )
+    controller = object.__new__(TextGenerationController)
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
+    controller._async_stop_word_requests_seen = True
+    controller._has_active_stop_words_callback = lambda request_ids: {11}.intersection(
+        request_ids
+    )
+
+    assert controller._try_prepare_async_decode_next_step(skip_bookkeeping=True)
+    assert events == [{"skip_bookkeeping": True, "active_stop_words": True}]
+
+
 class _RecordingEPCommunicator:
     def __init__(self, *, sync_results=(), world_size=2):
         self.sync_results = list(sync_results)
@@ -296,6 +430,67 @@ def test_ep_handoff_diagnostics_count_launch_and_skip():
         (EPAsyncPhase.ASYNC_HANDOFF_ACK, 0, (1,)),
         (EPAsyncPhase.ASYNC_HANDOFF, 1, (1, 1, 0)),
         (EPAsyncPhase.ASYNC_HANDOFF_ACK, 1, (1,)),
+    ]
+
+
+@pytest.mark.internal
+def test_dummy_async_handoff_fences_h2d_before_context_reset(monkeypatch):
+    monkeypatch.setattr(tgc_module, "range_push", lambda _msg: None)
+    monkeypatch.setattr(tgc_module, "range_pop", lambda: None)
+    events = []
+    context = SimpleNamespace(
+        reset=lambda: events.append("reset"),
+        record_async_scheduling_counter=lambda name: events.append(("counter", name)),
+    )
+    controller = object.__new__(TextGenerationController)
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
+    controller._dummy_async_handoff_disabled_reason = lambda: None
+    controller._decide_ep_async_handoff = lambda **_kwargs: SimpleNamespace(
+        launch_async_forward=True
+    )
+    controller._wait_for_dummy_context_h2d = lambda: events.append("wait_h2d")
+    controller._dynamic_step_context_init = lambda is_dummy_forward=False: events.append(
+        ("context_init", is_dummy_forward)
+    ) or (None, None)
+    controller._dynamic_step_forward_logits = lambda _input_ids, _position_ids: events.append(
+        "forward"
+    )
+
+    assert controller._try_launch_dummy_async_handoff()
+    assert events == [
+        "wait_h2d",
+        "reset",
+        ("context_init", True),
+        "forward",
+        ("counter", "dummy_launch"),
+    ]
+
+
+@pytest.mark.internal
+@pytest.mark.asyncio
+async def test_ep_work_step_sends_coordinator_replies_after_step_completion():
+    events = []
+    engine = object.__new__(DynamicInferenceEngine)
+
+    async def _async_step(*, send_coordinator_replies=True):
+        events.append(("step", send_coordinator_replies))
+        return {"finished_request_records": ["finished"]}
+
+    async def _ep_complete_work_step():
+        events.append("ep_complete")
+
+    engine.async_step = _async_step
+    engine._ep_complete_work_step = _ep_complete_work_step
+    engine._send_finished_records_to_coordinator = lambda records: events.append(
+        ("coordinator_reply", records)
+    )
+
+    await engine._run_ep_work_step(local_pending=1)
+
+    assert events == [
+        ("step", False),
+        "ep_complete",
+        ("coordinator_reply", ["finished"]),
     ]
 
 
@@ -409,6 +604,45 @@ def test_controller_top_n_logprobs_use_selected_row_tensor():
     assert top_n[1][0][1].tolist() == [2, 0]
 
 
+@pytest.mark.internal
+def test_row_mapped_sampled_token_transfer_uses_current_request_order():
+    logits = torch.zeros(1, 4, 5, dtype=torch.float32)
+    logits[0, 2, 4] = 10.0
+    logits[0, 0, 1] = 9.0
+    copied = {}
+
+    def _copy_async_prepared_decode_input_ids_from_samples(sampled_tokens):
+        copied["sampled_tokens"] = sampled_tokens[:2].clone()
+        return True
+
+    context = SimpleNamespace(
+        total_request_count=2,
+        paused_request_count=0,
+        config=SimpleNamespace(materialize_only_last_token_logits=True),
+        is_decode_only=lambda: True,
+        active_request_metadata={
+            "top_k": torch.tensor([1, 1], dtype=torch.int32),
+            "top_p": torch.tensor([0.0, 0.0], dtype=torch.float32),
+        },
+        copy_async_prepared_decode_input_ids_from_samples=(
+            _copy_async_prepared_decode_input_ids_from_samples
+        ),
+    )
+    controller = object.__new__(TextGenerationController)
+    controller._async_non_greedy_requests_seen = False
+    controller._all_logits_cuda = logits
+    controller._greedy_sample_values_cuda = torch.empty(2, dtype=torch.float32)
+    controller._greedy_sampled_tokens_cuda = torch.empty(2, dtype=torch.int64)
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
+
+    TextGenerationController._dynamic_step_sample_logits_to_next_input_ids(
+        controller,
+        row_indices=torch.tensor([2, 0], dtype=torch.long),
+    )
+
+    assert copied["sampled_tokens"].tolist() == [4, 1]
+
+
 class _ReleaseRecordingAllocator:
     def __init__(self):
         self.released = []
@@ -448,6 +682,45 @@ def test_discard_prepared_plan_releases_unlaunched_kv_reservations():
     assert context._async_reserved_kv_block_count == 0
     assert context._async_reserved_kv_block_ids.tolist() == [-1, -1]
     assert context.async_scheduling_counters["kv_lease_dropped"] == 2
+
+
+@pytest.mark.internal
+def test_async_reserved_kv_blocks_are_adopted_or_deferred_then_released():
+    context = object.__new__(DynamicInferenceContext)
+    context._async_reserved_kv_block_count = 3
+    context._async_reserved_kv_block_request_ids = torch.tensor([10, 11, 99], dtype=torch.int32)
+    context._async_reserved_kv_block_ids = torch.tensor([100, 101, 102], dtype=torch.int32)
+    context._async_reserved_kv_block_columns = torch.tensor([1, 1, 1], dtype=torch.int32)
+    context._async_deferred_kv_blocks_to_release = torch.empty(0, dtype=torch.int32)
+    context._async_deferred_mamba_slots_to_free = torch.empty(0, dtype=torch.int32)
+    context._async_reserved_kv_block_adoption_count = 0
+    context._async_deferred_kv_block_release_count = 0
+    context._async_deferred_mamba_slot_release_count = 0
+    context.is_hybrid_model = False
+    context.async_scheduling_counters = {}
+    context.kv_block_allocator = _ReleaseRecordingAllocator()
+
+    consumed = context._consume_async_reserved_kv_blocks(
+        torch.tensor([10], dtype=torch.int32), torch.tensor([1], dtype=torch.int32)
+    )
+
+    assert consumed.tolist() == [100]
+    assert context._async_reserved_kv_block_ids.tolist() == [-1, 101, 102]
+    assert context._async_reserved_kv_block_adoption_count == 1
+    assert context.async_scheduling_counters["kv_lease_adopted"] == 1
+
+    context._defer_remaining_async_reserved_kv_blocks()
+
+    assert context._async_reserved_kv_block_count == 0
+    assert context._async_reserved_kv_block_request_ids.tolist() == [-1, -1, -1]
+    assert context._async_deferred_kv_blocks_to_release.tolist() == [101, 102]
+
+    context.release_deferred_async_resources()
+
+    assert [blocks.tolist() for blocks in context.kv_block_allocator.released] == [[101, 102]]
+    assert context._async_deferred_kv_blocks_to_release.numel() == 0
+    assert context._async_deferred_kv_block_release_count == 2
+    assert context.async_scheduling_counters["kv_lease_released"] == 2
 
 
 class _MambaMetadataWithFreeRecording:

--- a/tests/unit_tests/inference/test_async_scheduling_transaction.py
+++ b/tests/unit_tests/inference/test_async_scheduling_transaction.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.inference.async_scheduling import (
+    AsyncDecodeTransaction,
+    AsyncGraphShape,
+    AsyncKVBlockLease,
+    AsyncRowMap,
+    AsyncTransactionState,
+)
+
+
+def _plan(request_ids):
+    request_ids_tensor = torch.tensor(request_ids, dtype=torch.long, device="cpu")
+    return SimpleNamespace(
+        request_ids=request_ids_tensor,
+        active_request_count=request_ids_tensor.numel(),
+        active_token_count=request_ids_tensor.numel(),
+        padded_active_request_count=4,
+    )
+
+
+@pytest.mark.internal
+def test_transaction_state_transitions():
+    plan = _plan([10, 11])
+    txn = AsyncDecodeTransaction(
+        transaction_id=7,
+        prepared_layout=plan,
+        graph_shape=AsyncGraphShape.from_plan(plan),
+    )
+
+    assert txn.state == AsyncTransactionState.PREPARED
+    txn.launch(cuda_graph_request_count=4)
+    assert txn.state == AsyncTransactionState.IN_FLIGHT
+    assert txn.cuda_graph_request_count == 4
+
+    row_map = txn.resolve_for_current(
+        current_request_ids=torch.tensor([10, 11]),
+        current_graph_shape=AsyncGraphShape(2, 2, 4),
+    )
+    assert row_map is not None
+    assert not row_map.row_mapped
+
+    txn.mark_ready(row_map)
+    assert txn.state == AsyncTransactionState.READY
+    txn.consume()
+    assert txn.state == AsyncTransactionState.CONSUMED
+
+
+@pytest.mark.internal
+def test_transaction_rejects_illegal_transitions():
+    plan = _plan([1])
+    txn = AsyncDecodeTransaction(
+        transaction_id=1,
+        prepared_layout=plan,
+        graph_shape=AsyncGraphShape.from_plan(plan),
+    )
+
+    with pytest.raises(RuntimeError, match="expected state ready"):
+        txn.consume()
+
+    txn.launch(cuda_graph_request_count=None)
+    txn.drop("test")
+    assert txn.state == AsyncTransactionState.DROPPED
+    assert txn.drop_reason == "test"
+
+    with pytest.raises(RuntimeError, match="cannot drop"):
+        txn.drop("again")
+
+
+@pytest.mark.internal
+@pytest.mark.parametrize(
+    ("pending", "current", "expected_rows", "row_mapped"),
+    [
+        ([10, 11, 12], [10, 11, 12], [0, 1, 2], False),
+        ([10, 11, 12], [11, 12], [1, 2], True),
+        ([10, 11, 12], [10, 12], [0, 2], True),
+        ([10, 11, 12], [10, 11], [0, 1], False),
+    ],
+)
+def test_row_map_resolves_finished_rows(pending, current, expected_rows, row_mapped):
+    row_map = AsyncRowMap.for_current(
+        pending_request_ids=torch.tensor(pending),
+        current_request_ids=torch.tensor(current),
+    )
+
+    assert row_map is not None
+    assert row_map.pending_rows_cpu.tolist() == expected_rows
+    assert row_map.row_mapped is row_mapped
+
+
+@pytest.mark.internal
+@pytest.mark.parametrize(
+    ("pending", "current"),
+    [
+        ([10, 11], [12]),
+        ([10, 10], [10]),
+        ([10, 11], [11, 11]),
+        ([10], [10, 11]),
+    ],
+)
+def test_row_map_rejects_incompatible_rows(pending, current):
+    assert (
+        AsyncRowMap.for_current(
+            pending_request_ids=torch.tensor(pending),
+            current_request_ids=torch.tensor(current),
+        )
+        is None
+    )
+
+
+@pytest.mark.internal
+def test_transaction_rejects_graph_shape_mismatch():
+    plan = _plan([1, 2])
+    txn = AsyncDecodeTransaction(
+        transaction_id=1,
+        prepared_layout=plan,
+        graph_shape=AsyncGraphShape.from_plan(plan),
+    )
+    txn.launch(cuda_graph_request_count=4)
+
+    assert (
+        txn.resolve_for_current(
+            current_request_ids=torch.tensor([1, 2]),
+            current_graph_shape=AsyncGraphShape(
+                active_request_count=2,
+                active_token_count=2,
+                padded_active_request_count=8,
+            ),
+        )
+        is None
+    )
+
+
+@pytest.mark.internal
+def test_kv_lease_records_reserved_blocks():
+    lease = AsyncKVBlockLease(
+        reserved_request_ids=torch.tensor([7, 8]),
+        reserved_block_ids=torch.tensor([100, 101], dtype=torch.int32),
+        reserved_block_columns=torch.tensor([1, 1], dtype=torch.int32),
+    )
+
+    assert lease.has_reservations
+    assert lease.reserved_block_ids.tolist() == [100, 101]


### PR DESCRIPTION
Implements a compact async decode scheduling path based on a no-reject steady-state handoff.

Key points:
- Adds EP-aware async step/handoff protocol for real/dummy rank alignment.
- Prepares and launches reusable decode child forwards when the next layout is deterministic.
- Keeps Mamba state safe with candidate/live state handling.
- Keeps coordinator replies ordered after EP work-step completion.
- Adds hot-path guards to avoid repeated metadata scans for workloads without logprobs, non-greedy sampling, or stop words.

Validation on HSG clean/minimal checkout:
- mcore nano, OSL=32768, BATCH_SIZES="1 1", async enabled: 4.10 and 4.13 ms/output token.
- Server logs showed async reuse active essentially every decode step.
- Direct coordinator HSG 4-GPU forced-rank0 BFCL first-8 workflow: async off/on comparison wrote 23 turn records each, compare_diffs.json length 0, log reported diffs=0.

Benchmark experiment:
/lustre/fs1/portfolios/llmservice/projects/llmservice_fm_text/users/lmcafee/inference/megatrons/async-sched-txn-codex-minimal-bench-6204/inference-bench/experiments/20260606_203918_mcore_minimal_stopflags_osl32768_b1x2

Direct coordinator output:
/lustre/fs1/portfolios/llmservice/projects/llmservice_fm_text/users/lmcafee/inference/megatrons/async-sched-txn-codex-minimal-bench-6204/lawrence/ns-eval/output/direct_coordinator/codex_minimal_hsg4_direct_20260606_204942_on