### PR TITLE
[codex] Avoid redundant MTP hidden state concatenation

### DIFF
--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -657,6 +657,7 @@ class GPTModel(LanguageModule):
                 sequence_len_offset=sequence_len_offset,
                 padding_mask=padding_mask,
                 embedding=self.embedding,
+                return_hidden_state_list=self.post_process,
                 **(extra_block_kwargs or {}),
             )
 

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -758,7 +758,7 @@ class MTPLossAutoScaler(torch.autograd.Function):
 
 
 def process_mtp_loss(
-    hidden_states: Tensor,
+    hidden_states: Union[Tensor, List[Tensor], tuple],
     labels: Tensor,
     loss_mask: Optional[Tensor],
     output_layer: Callable,
@@ -776,10 +776,12 @@ def process_mtp_loss(
     """Process Multi-Token Prediction (MTP) loss computation.
 
     This is a standalone function that handles MTP loss computation. It's used on the
-    post_process rank to split concatenated hidden states and compute MTP losses.
+    post_process rank to split concatenated hidden states and compute MTP losses. It also
+    accepts pre-split hidden states to avoid a redundant cat-then-chunk sequence.
 
     Args:
-        hidden_states (Tensor): Hidden states tensor (concatenated with MTP outputs).
+        hidden_states (Tensor or list[Tensor]): Hidden states tensor (concatenated with MTP
+            outputs), or already split ``[decoder, mtp_1, ...]`` tensors.
         labels (Tensor): Ground truth labels.
         loss_mask (Optional[Tensor]): Mask for loss computation. If None, uses all ones.
         output_layer (Callable): Output layer method to compute logits.
@@ -801,7 +803,16 @@ def process_mtp_loss(
     Returns:
         Tensor: Updated hidden states after MTP loss processing (first chunk only).
     """
-    hidden_states_list = torch.chunk(hidden_states, 1 + config.mtp_num_layers, dim=0)
+    if isinstance(hidden_states, (list, tuple)):
+        hidden_states_list = hidden_states
+        expected_chunks = 1 + config.mtp_num_layers
+        if len(hidden_states_list) != expected_chunks:
+            raise ValueError(
+                f"MTP hidden state list must contain {expected_chunks} tensors, "
+                f"got {len(hidden_states_list)}."
+            )
+    else:
+        hidden_states_list = torch.chunk(hidden_states, 1 + config.mtp_num_layers, dim=0)
     hidden_states = hidden_states_list[0]
 
     # When labels are not provided (e.g. RL training), derive them from input_ids by
@@ -1772,7 +1783,8 @@ class MultiTokenPredictionBlock(MegatronModule):
         sequence_len_offset: Optional[Tensor] = None,
         extra_block_kwargs: Optional[dict] = None,
         embedding=None,
-    ) -> Tensor:
+        return_hidden_state_list: bool = False,
+    ) -> Union[Tensor, List[Tensor]]:
         """
         Perform the forward pass through all of the MTP modules.
 
@@ -1810,6 +1822,9 @@ class MultiTokenPredictionBlock(MegatronModule):
             # append the output hidden states of the current mtp layer
             # to the hidden_states_list
             hidden_states_list.append(hidden_states)
+
+        if return_hidden_state_list:
+            return hidden_states_list
 
         # concat the hidden states of all mtp layers
         hidden_states = torch.cat(hidden_states_list, dim=0)

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -740,6 +740,68 @@ class TestMultiTokenPrediction:
         assert not called['value']
         assert torch.equal(out, torch.chunk(hidden_states, 2, dim=0)[0])
 
+    def test_process_mtp_loss_accepts_presplit_hidden_states(self, monkeypatch):
+        config = TransformerConfig(
+            hidden_size=8, num_layers=2, num_attention_heads=2, mtp_num_layers=1
+        )
+        decoder_hidden = torch.ones(1, 1, 4)
+        mtp_hidden = torch.full((1, 1, 4), 2.0)
+        labels = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        seen = {'hidden': None}
+
+        def forbidden_chunk(*_args, **_kwargs):
+            raise AssertionError("pre-split MTP hidden states should not be chunked")
+
+        def output_layer(hidden, weight=None, runtime_gather_output=None):
+            seen['hidden'] = hidden
+            return torch.ones_like(hidden), None
+
+        def compute_language_model_loss(mtp_labels, mtp_logits):
+            return torch.ones_like(mtp_labels, dtype=mtp_logits.dtype)
+
+        monkeypatch.setattr(torch, "chunk", forbidden_chunk)
+
+        out = process_mtp_loss(
+            hidden_states=[decoder_hidden, mtp_hidden],
+            labels=labels,
+            loss_mask=None,
+            output_layer=output_layer,
+            output_weight=None,
+            runtime_gather_output=None,
+            is_training=False,
+            compute_language_model_loss=compute_language_model_loss,
+            config=config,
+            cp_group=None,
+            packed_seq_params=None,
+        )
+
+        assert seen['hidden'] is mtp_hidden
+        assert torch.equal(out, decoder_hidden)
+
+    def test_process_mtp_loss_validates_presplit_hidden_state_count(self):
+        config = TransformerConfig(
+            hidden_size=8, num_layers=2, num_attention_heads=2, mtp_num_layers=1
+        )
+
+        with pytest.raises(ValueError, match="must contain 2 tensors"):
+            process_mtp_loss(
+                hidden_states=[torch.ones(1, 1, 4)],
+                labels=None,
+                loss_mask=None,
+                output_layer=lambda hidden, weight=None, runtime_gather_output=None: (
+                    hidden,
+                    None,
+                ),
+                output_weight=None,
+                runtime_gather_output=None,
+                is_training=False,
+                compute_language_model_loss=lambda labels, logits: torch.ones_like(logits),
+                config=config,
+                cp_group=None,
+                packed_seq_params=None,
+                input_ids=None,
+            )
+
     def test_process_mtp_loss_derives_labels_from_input_ids(self):
         """When labels is None (RL), labels are derived from input_ids by rolling left.
 


### PR DESCRIPTION
## Summary

This PR lets the MTP path return and consume a pre-split hidden-state list on the post-process rank, avoiding a redundant concatenate-then-chunk sequence.

Changes:
- allow `process_mtp_loss` to accept either a concatenated tensor or a pre-split hidden-state list
- add `return_hidden_state_list` to `MultiTokenPredictionBlock.forward`
- request the hidden-state list from `GPTModel` when post-processing
- add focused unit coverage for list input and validation behavior

## Why

The existing MTP path concatenates decoder and MTP hidden states, then immediately chunks them again for loss processing. Keeping the list form removes that avoidable tensor plumbing while preserving the tensor input path for compatibility.

## Validation

- `python3 -m compileall -q megatron/core/transformer/multi_token_prediction.py megatron/core/models/gpt/gpt_model.py tests/unit_tests/transformer/test_multi_token_prediction.py`
- Full pytest was not run locally because the desktop Python environment is missing `pytest`, `torch`, and Transformer Engine.