### PR TITLE
Normalize unsupported HybridEP dispatch API options

### DIFF
--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -282,9 +282,7 @@ _hybrid_ep_warned_unsupported_fused_dispatch = False
 
 
 def _normalize_hybrid_ep_dispatch_options(
-    fused: bool,
-    num_blocks_permute: Optional[int],
-    num_blocks_unpermute: Optional[int],
+    fused: bool, num_blocks_permute: Optional[int], num_blocks_unpermute: Optional[int]
 ):
     """Drop unsupported HybridEP fused-dispatch options after checking the API once."""
     global _hybrid_ep_supports_fused_dispatch

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2025 DeepSeek
 # Licensed under the MIT License - https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE
 
+import inspect
+import warnings
 from typing import Optional
 
 from megatron.core.utils import internal_api
@@ -275,6 +277,40 @@ except ImportError:
     HAVE_HYBRIDEP = False
 
 _hybrid_ep_buffer = None
+_hybrid_ep_supports_fused_dispatch = None
+_hybrid_ep_warned_unsupported_fused_dispatch = False
+
+
+def _normalize_hybrid_ep_dispatch_options(
+    fused: bool,
+    num_blocks_permute: Optional[int],
+    num_blocks_unpermute: Optional[int],
+):
+    """Drop unsupported HybridEP fused-dispatch options after checking the API once."""
+    global _hybrid_ep_supports_fused_dispatch
+    global _hybrid_ep_warned_unsupported_fused_dispatch
+
+    if not fused and num_blocks_permute is None and num_blocks_unpermute is None:
+        return fused, num_blocks_permute, num_blocks_unpermute
+
+    if _hybrid_ep_supports_fused_dispatch is None:
+        sig = inspect.signature(HybridEPBuffer.dispatch_with_permute)
+        _hybrid_ep_supports_fused_dispatch = 'fuse_permute_dispatch' in sig.parameters
+
+    if _hybrid_ep_supports_fused_dispatch:
+        return fused, num_blocks_permute, num_blocks_unpermute
+
+    if not _hybrid_ep_warned_unsupported_fused_dispatch:
+        warnings.warn(
+            "Current DeepEP version does not support fused permute dispatch or "
+            "num_blocks_permute/num_blocks_unpermute. Falling back to unfused "
+            "HybridEP dispatch.",
+            UserWarning,
+            stacklevel=3,
+        )
+        _hybrid_ep_warned_unsupported_fused_dispatch = True
+
+    return False, None, None
 
 
 def init_hybrid_ep_buffer(
@@ -375,22 +411,9 @@ class HybridEPDispatch(torch.autograd.Function):
         '''
         Forward pass of fused dispatch of the HybridEP backend
         '''
-        if fused or num_blocks_permute is not None or num_blocks_unpermute is not None:
-            import inspect
-            import warnings
-
-            sig = inspect.signature(HybridEPBuffer.dispatch_with_permute)
-            if 'fuse_permute_dispatch' not in sig.parameters:
-                warnings.warn(
-                    "Current DeepEP version does not support fused permute dispatch or "
-                    "num_blocks_permute/num_blocks_unpermute. Falling back to unfused "
-                    "HybridEP dispatch.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                fused = False
-                num_blocks_permute = None
-                num_blocks_unpermute = None
+        fused, num_blocks_permute, num_blocks_unpermute = _normalize_hybrid_ep_dispatch_options(
+            fused, num_blocks_permute, num_blocks_unpermute
+        )
 
         if _hybrid_ep_buffer is None:
             num_tokens, hidden_dim = x.shape[-2:]

--- a/tests/unit_tests/transformer/moe/test_hybridep_api_normalization.py
+++ b/tests/unit_tests/transformer/moe/test_hybridep_api_normalization.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import warnings
+
+from megatron.core.transformer.moe import fused_a2a
+
+
+class _HybridEPBufferWithoutFusedArgs:
+    def dispatch_with_permute(self, hidden):
+        return hidden
+
+
+class _HybridEPBufferWithFusedArgs:
+    def dispatch_with_permute(self, hidden, fuse_permute_dispatch=False):
+        return hidden, fuse_permute_dispatch
+
+
+def _reset_cache():
+    fused_a2a._hybrid_ep_supports_fused_dispatch = None
+    fused_a2a._hybrid_ep_warned_unsupported_fused_dispatch = False
+
+
+def test_hybridep_dispatch_options_drop_unsupported_kwargs(monkeypatch):
+    _reset_cache()
+    monkeypatch.setattr(fused_a2a, "HybridEPBuffer", _HybridEPBufferWithoutFusedArgs)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        normalized = fused_a2a._normalize_hybrid_ep_dispatch_options(True, 128, 256)
+        normalized_again = fused_a2a._normalize_hybrid_ep_dispatch_options(True, 128, 256)
+
+    assert normalized == (False, None, None)
+    assert normalized_again == (False, None, None)
+    assert len(caught) == 1
+    assert "does not support fused permute dispatch" in str(caught[0].message)
+
+
+def test_hybridep_dispatch_options_keep_supported_kwargs(monkeypatch):
+    _reset_cache()
+    monkeypatch.setattr(fused_a2a, "HybridEPBuffer", _HybridEPBufferWithFusedArgs)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        normalized = fused_a2a._normalize_hybrid_ep_dispatch_options(True, 128, 256)
+
+    assert normalized == (True, 128, 256)
+    assert caught == []


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

This PR caches and normalizes optional HybridEP dispatch API options when the installed DeepEP HybridEP package does not support them.

## Issue tracking

Linked issue: N/A. This is a small compatibility fix for environments with older DeepEP HybridEP API support.

## Changes

- Check `HybridEPBuffer.dispatch_with_permute` once for fused dispatch support.
- Drop unsupported fused/block-count options before calling HybridEP.
- Emit only one warning for the unsupported API shape.
- Add focused unit tests for supported and unsupported signatures.

## Validation

- `python3 -m compileall -q megatron/core/transformer/moe/fused_a2a.py tests/unit_tests/transformer/moe/test_hybridep_api_normalization.py`
- OCI-HSG unit/e2e validation job `3210607` on the behavior commit `e6cf08b677c578ec091fe8cb064fa384fc70afbf`:
  - targeted HybridEP API normalization unit tests passed
  - 1-node / 4-GPU mock-data MoE + HybridEP e2e training with HybridEP chunk-128 environment reached iter `3/3`
  - skipped iterations: `0`; NaN iterations: `0`; Slurm exit: `0:0`
- OCI-HSG style validation job `3210917` on final branch head `e0cc54ea8a500bc6db2517d704723a830cce19a2`:
  - `CHECK_ONLY=true tools/autoformat.sh` passed for this PR branch

Important caveat: the current OCI DeepEP stack warns that fused permute dispatch and `num_blocks_permute/num_blocks_unpermute` are unsupported and falls back to unfused HybridEP. That is expected for this validation and matches the compatibility surface this PR protects; this smoke should not be read as proof that fused block-count knobs are active in that OCI image.

Note: OCI validation did not use nsys/profile.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR