### PR TITLE
Enable BF16 token-major paged-stash capture

### DIFF
--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -605,6 +605,7 @@ class TEGroupedMLP(MegatronModule):
                 max_num_tokens=max_num_tokens,
                 num_tokens_tensor=tokens_per_expert.sum(),
                 avg_num_tokens=avg_num_tokens,
+                allow_untagged_token_major_tensors=not (self.config.fp8 or self.config.fp4),
             )
         else:
             stash_context = nullcontext()

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -223,10 +223,14 @@ class PagedTensor:
             "scale_inv_offsets": metadata["scale_inv_offsets"],
             "columnwise_scale_inv_offsets": metadata["columnwise_scale_inv_offsets"],
             "with_gemm_swizzled_scales": metadata["with_gemm_swizzled_scales"],
-            "row_scaled_nvfp4": metadata["row_scaled_nvfp4"],
         }
         optional_kwargs = {}
-        for optional_name in ("requires_grad", "nvfp4_use_4over6", "nvfp4_e4m3_max"):
+        for optional_name in (
+            "requires_grad",
+            "nvfp4_use_4over6",
+            "nvfp4_e4m3_max",
+            "row_scaled_nvfp4",
+        ):
             if optional_name in metadata:
                 optional_kwargs[optional_name] = metadata[optional_name]
 

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import inspect
 import logging
 from contextlib import nullcontext
 from typing import Any
@@ -145,6 +146,8 @@ class PagedTensor:
         max_num_tokens=None,
         hidden_size=None,
         page_size=64,
+        tensor_attrs=None,
+        grouped_tensor_metadata=None,
     ):
         """
         Args:
@@ -171,6 +174,8 @@ class PagedTensor:
         self.max_num_tokens = max_num_tokens
         self.hidden_size = hidden_size
         self.page_size = page_size
+        self.tensor_attrs = tensor_attrs or {}
+        self.grouped_tensor_metadata = grouped_tensor_metadata
 
         # Original tensor information
         self.original_shape = list(tensor.shape) if original_shape is None else original_shape
@@ -184,6 +189,62 @@ class PagedTensor:
         # Page record / spill flag: allocated here; zeroed in offload_to_stash (pack stream).
         self.page_record = torch.empty(self.max_num_pages, dtype=torch.int64, device=self.device)
         self.spilled_to_host = torch.empty(1, dtype=torch.int64, device=self.device)
+
+    def restore_tensor_metadata(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Restore lightweight Python metadata expected by TE tensor wrappers."""
+        for name, value in self.tensor_attrs.items():
+            setattr(tensor, name, value)
+        return tensor
+
+    def restore_grouped_tensor(self) -> torch.Tensor:
+        """Recreate a TE GroupedTensor wrapper over the reloaded rowwise backing data."""
+        assert self._tensor is not None
+        metadata = self.grouped_tensor_metadata
+        assert metadata is not None
+
+        grouped_cls = metadata["cls"]
+        kwargs = {
+            "shape": metadata["shape"],
+            "dtype": metadata["dtype"],
+            "num_tensors": metadata["num_tensors"],
+            "shapes": metadata["shapes"],
+            "quantizer": metadata["quantizer"],
+            "data": self._tensor.view(-1),
+            "columnwise_data": metadata["columnwise_data"],
+            "scale_inv": metadata["scale_inv"],
+            "columnwise_scale_inv": metadata["columnwise_scale_inv"],
+            "amax": metadata["amax"],
+            "columnwise_amax": metadata["columnwise_amax"],
+            "scale": metadata["scale"],
+            "first_dims": metadata["first_dims"],
+            "last_dims": metadata["last_dims"],
+            "tensor_offsets": metadata["tensor_offsets"],
+            "offsets": metadata["offsets"],
+            "scale_inv_offsets": metadata["scale_inv_offsets"],
+            "columnwise_scale_inv_offsets": metadata["columnwise_scale_inv_offsets"],
+            "with_gemm_swizzled_scales": metadata["with_gemm_swizzled_scales"],
+            "row_scaled_nvfp4": metadata["row_scaled_nvfp4"],
+        }
+        optional_kwargs = {}
+        for optional_name in (
+            "requires_grad",
+            "nvfp4_use_4over6",
+            "nvfp4_e4m3_max",
+        ):
+            if optional_name in metadata:
+                optional_kwargs[optional_name] = metadata[optional_name]
+
+        try:
+            signature = inspect.signature(grouped_cls)
+            for name, value in optional_kwargs.items():
+                if name in signature.parameters:
+                    kwargs[name] = value
+        except (TypeError, ValueError):
+            # Some TE builds expose tensor wrappers without Python signatures.
+            pass
+
+        grouped_tensor = grouped_cls(**kwargs)
+        return self.restore_tensor_metadata(grouped_tensor)
 
     @property
     def schedule_layer(self):
@@ -429,6 +490,10 @@ class PagedStashManager:
         self.max_num_tokens = None
         # Optional hint: expected/average number of tokens (e.g., pre-padding estimate)
         self.avg_num_tokens = None
+        # Pure BF16 TE op-fuser activations do not carry the MXFP8 grouped-tensor scale marker.
+        # Keep this opt-in and scoped to the GroupedMLP paged-stash context so generic saved
+        # tensors such as weights, counters, and internal metadata are not captured accidentally.
+        self.allow_untagged_token_major_tensors = False
         self.stash_buffers = None
         self.overflow = None
         self.host_spill = None
@@ -436,6 +501,45 @@ class PagedStashManager:
 
         # Page size for paged memory (default; overwritten from config in paged_stash_reset)
         self.page_size = 64
+
+    def _get_grouped_tensor_metadata(self, tensor: torch.Tensor):
+        """Capture TE GroupedTensor metadata needed to recreate the wrapper on reload."""
+        rowwise_data = getattr(tensor, 'rowwise_data', None)
+        if (
+            rowwise_data is None
+            or not hasattr(tensor, 'num_tensors')
+            or not hasattr(tensor, 'logical_shape')
+        ):
+            return None
+
+        get_dtype = getattr(tensor, 'get_dtype', None)
+        return {
+            "cls": type(tensor),
+            "shape": tuple(tensor.shape),
+            "logical_shape": tuple(tensor.logical_shape),
+            "dtype": get_dtype() if get_dtype is not None else tensor.dtype,
+            "num_tensors": tensor.num_tensors,
+            "shapes": getattr(tensor, 'tensor_shapes', None),
+            "quantizer": getattr(tensor, 'quantizer', None),
+            "columnwise_data": getattr(tensor, 'columnwise_data', None),
+            "scale_inv": getattr(tensor, 'scale_inv', None),
+            "columnwise_scale_inv": getattr(tensor, 'columnwise_scale_inv', None),
+            "amax": getattr(tensor, 'amax', None),
+            "columnwise_amax": getattr(tensor, 'columnwise_amax', None),
+            "scale": getattr(tensor, 'scale', None),
+            "first_dims": getattr(tensor, 'first_dims', None),
+            "last_dims": getattr(tensor, 'last_dims', None),
+            "tensor_offsets": getattr(tensor, 'tensor_offsets', None),
+            "offsets": getattr(tensor, 'offsets', None),
+            "scale_inv_offsets": getattr(tensor, 'scale_inv_offsets', None),
+            "columnwise_scale_inv_offsets": getattr(tensor, 'columnwise_scale_inv_offsets', None),
+            "with_gemm_swizzled_scales": getattr(tensor, '_with_gemm_swizzled_scales', False),
+            "row_scaled_nvfp4": getattr(tensor, 'row_scaled_nvfp4', False),
+            "requires_grad": tensor.requires_grad,
+            "stride": tuple(tensor.stride()),
+            "nvfp4_use_4over6": getattr(tensor, 'nvfp4_use_4over6', False),
+            "nvfp4_e4m3_max": getattr(tensor, 'nvfp4_e4m3_max', 448),
+        }
 
     @property
     def pack_stream(self):
@@ -681,19 +785,38 @@ class PagedStashManager:
         Hook called when autograd saves a tensor for backward pass.
         Returns a tag to identify the tensor later.
         """
-        # Handle 0-dim tensors (torch.Size([])) - they have no size(0)
-        if (
-            self.max_num_tokens is None
-            or tensor.dim() == 0
-            or not hasattr(tensor, 'grouped_tensor_scale_inv')
-        ):
+        if not isinstance(tensor, torch.Tensor):
             return tensor
 
-        assert isinstance(tensor, torch.Tensor), f"tensor is not a torch.Tensor {type(tensor)}"
+        # Handle 0-dim tensors (torch.Size([])) - they have no size(0).
+        if self.max_num_tokens is None or tensor.dim() == 0:
+            return tensor
 
-        original_shape = tensor.shape
-        columnwise_scale_inv = tensor.grouped_tensor_scale_inv
-        tensor = tensor.flatten()
+        has_grouped_tensor_marker = hasattr(tensor, 'grouped_tensor_scale_inv')
+        if has_grouped_tensor_marker:
+            columnwise_scale_inv = tensor.grouped_tensor_scale_inv
+        elif (
+            self.allow_untagged_token_major_tensors
+            and tensor.is_floating_point()
+            and tensor.dim() == 2
+            and tensor.shape[0] == self.max_num_tokens
+            and tensor.numel() % self.max_num_tokens == 0
+        ):
+            columnwise_scale_inv = False
+        else:
+            return tensor
+
+        tensor_attrs = {"grouped_tensor_scale_inv": columnwise_scale_inv}
+        grouped_tensor_metadata = (
+            None if has_grouped_tensor_marker else self._get_grouped_tensor_metadata(tensor)
+        )
+        if grouped_tensor_metadata is not None:
+            tensor = tensor.rowwise_data
+            original_shape = tensor.shape
+        else:
+            original_shape = tensor.shape
+            tensor = tensor.flatten()
+
         dtype = tensor.dtype
         hidden_size = tensor.numel() // (
             self.max_num_tokens
@@ -766,6 +889,8 @@ class PagedStashManager:
             max_num_tokens=self.max_num_tokens,
             hidden_size=hidden_size,
             page_size=self.page_size,
+            tensor_attrs=tensor_attrs,
+            grouped_tensor_metadata=grouped_tensor_metadata,
         )
 
         if self.status == 'captured':
@@ -818,7 +943,11 @@ class PagedStashManager:
                 saved_state._tensor is not None
             ), f"saved_state._tensor is None {saved_state._tensor}"
 
-            return saved_state._tensor.view(saved_state.original_shape)
+            if saved_state.grouped_tensor_metadata is not None:
+                return saved_state.restore_grouped_tensor()
+            return saved_state.restore_tensor_metadata(
+                saved_state._tensor.view(saved_state.original_shape)
+            )
 
         return saved_state
 
@@ -853,7 +982,11 @@ def paged_stash_group_start(tensor):
 
 
 def get_paged_stash_context(
-    name=None, max_num_tokens=None, num_tokens_tensor=None, avg_num_tokens=None
+    name=None,
+    max_num_tokens=None,
+    num_tokens_tensor=None,
+    avg_num_tokens=None,
+    allow_untagged_token_major_tensors=False,
 ):
     """Get the paged stash context"""
     stash_manager = PagedStashManager.get_instance()
@@ -861,6 +994,7 @@ def get_paged_stash_context(
         return nullcontext()
     stash_manager.max_num_tokens = max_num_tokens
     stash_manager.avg_num_tokens = avg_num_tokens
+    stash_manager.allow_untagged_token_major_tensors = allow_untagged_token_major_tensors
     assert num_tokens_tensor is not None and isinstance(num_tokens_tensor, torch.Tensor)
     # One clone per context; PagedTensor reuses this tensor (no per-instance clone).
     stash_manager.num_tokens_tensor = num_tokens_tensor.clone()

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -226,11 +226,7 @@ class PagedTensor:
             "row_scaled_nvfp4": metadata["row_scaled_nvfp4"],
         }
         optional_kwargs = {}
-        for optional_name in (
-            "requires_grad",
-            "nvfp4_use_4over6",
-            "nvfp4_e4m3_max",
-        ):
+        for optional_name in ("requires_grad", "nvfp4_use_4over6", "nvfp4_e4m3_max"):
             if optional_name in metadata:
                 optional_kwargs[optional_name] = metadata[optional_name]
 

--- a/tests/unit_tests/transformer/moe/test_paged_stashing.py
+++ b/tests/unit_tests/transformer/moe/test_paged_stashing.py
@@ -12,6 +12,7 @@ from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.moe.moe_utils import get_align_size_for_quantization
 from megatron.core.transformer.moe.paged_stash import (
     PagedStashManager,
+    PagedTensor,
     check_paged_stash_overflow,
     paged_stash_init_chunk_handler,
     paged_stash_reset,
@@ -209,6 +210,174 @@ def _is_mxfp8_supported() -> bool:
 _MXFP8_SKIP_REASON = (
     "MXFP8 (tests configure fp8_recipe='mxfp8') requires compute capability >= 10.0 (Blackwell)"
 )
+
+
+class _LegacyGroupedTensor:
+    """Fake TE 2.14/2.15-style GroupedTensor constructor."""
+
+    def __init__(
+        self,
+        shape,
+        dtype,
+        *,
+        num_tensors,
+        shapes=None,
+        quantizer=None,
+        data=None,
+        columnwise_data=None,
+        scale_inv=None,
+        columnwise_scale_inv=None,
+        amax=None,
+        columnwise_amax=None,
+        scale=None,
+        first_dims=None,
+        last_dims=None,
+        tensor_offsets=None,
+        offsets=None,
+        scale_inv_offsets=None,
+        columnwise_scale_inv_offsets=None,
+        requires_grad=False,
+        with_gemm_swizzled_scales=False,
+    ):
+        self.kwargs = {
+            "shape": shape,
+            "dtype": dtype,
+            "num_tensors": num_tensors,
+            "shapes": shapes,
+            "quantizer": quantizer,
+            "data": data,
+            "columnwise_data": columnwise_data,
+            "scale_inv": scale_inv,
+            "columnwise_scale_inv": columnwise_scale_inv,
+            "amax": amax,
+            "columnwise_amax": columnwise_amax,
+            "scale": scale,
+            "first_dims": first_dims,
+            "last_dims": last_dims,
+            "tensor_offsets": tensor_offsets,
+            "offsets": offsets,
+            "scale_inv_offsets": scale_inv_offsets,
+            "columnwise_scale_inv_offsets": columnwise_scale_inv_offsets,
+            "requires_grad": requires_grad,
+            "with_gemm_swizzled_scales": with_gemm_swizzled_scales,
+        }
+
+
+class _RowScaledGroupedTensor(_LegacyGroupedTensor):
+    """Fake newer GroupedTensor constructor with row-scaled NVFP4 support."""
+
+    def __init__(
+        self,
+        shape,
+        dtype,
+        *,
+        num_tensors,
+        shapes=None,
+        quantizer=None,
+        data=None,
+        columnwise_data=None,
+        scale_inv=None,
+        columnwise_scale_inv=None,
+        amax=None,
+        columnwise_amax=None,
+        scale=None,
+        first_dims=None,
+        last_dims=None,
+        tensor_offsets=None,
+        offsets=None,
+        scale_inv_offsets=None,
+        columnwise_scale_inv_offsets=None,
+        requires_grad=False,
+        with_gemm_swizzled_scales=False,
+        row_scaled_nvfp4=False,
+    ):
+        super().__init__(
+            shape,
+            dtype,
+            num_tensors=num_tensors,
+            shapes=shapes,
+            quantizer=quantizer,
+            data=data,
+            columnwise_data=columnwise_data,
+            scale_inv=scale_inv,
+            columnwise_scale_inv=columnwise_scale_inv,
+            amax=amax,
+            columnwise_amax=columnwise_amax,
+            scale=scale,
+            first_dims=first_dims,
+            last_dims=last_dims,
+            tensor_offsets=tensor_offsets,
+            offsets=offsets,
+            scale_inv_offsets=scale_inv_offsets,
+            columnwise_scale_inv_offsets=columnwise_scale_inv_offsets,
+            requires_grad=requires_grad,
+            with_gemm_swizzled_scales=with_gemm_swizzled_scales,
+        )
+        self.kwargs["row_scaled_nvfp4"] = row_scaled_nvfp4
+
+
+def _grouped_tensor_metadata(grouped_cls):
+    return {
+        "cls": grouped_cls,
+        "shape": (2, 3),
+        "logical_shape": (2, 3),
+        "dtype": torch.float32,
+        "num_tensors": 2,
+        "shapes": [(1, 3), (1, 3)],
+        "quantizer": None,
+        "columnwise_data": None,
+        "scale_inv": None,
+        "columnwise_scale_inv": None,
+        "amax": None,
+        "columnwise_amax": None,
+        "scale": None,
+        "first_dims": None,
+        "last_dims": None,
+        "tensor_offsets": None,
+        "offsets": None,
+        "scale_inv_offsets": None,
+        "columnwise_scale_inv_offsets": None,
+        "with_gemm_swizzled_scales": False,
+        "row_scaled_nvfp4": True,
+        "requires_grad": True,
+        "nvfp4_use_4over6": True,
+        "nvfp4_e4m3_max": 448,
+    }
+
+
+def _restore_fake_grouped_tensor(grouped_cls):
+    rowwise_data = torch.arange(6, dtype=torch.float32).view(2, 3)
+    paged_tensor = PagedTensor(
+        rowwise_data,
+        num_tokens_tensor=torch.tensor([2], dtype=torch.int64),
+        max_num_tokens=2,
+        hidden_size=3,
+        tensor_attrs={"grouped_tensor_scale_inv": False},
+        grouped_tensor_metadata=_grouped_tensor_metadata(grouped_cls),
+    )
+    return paged_tensor.restore_grouped_tensor()
+
+
+def test_grouped_tensor_restore_skips_row_scaled_nvfp4_for_legacy_signature():
+    """Older TE GroupedTensor constructors should not receive newer NVFP4 kwargs."""
+    restored = _restore_fake_grouped_tensor(_LegacyGroupedTensor)
+
+    assert restored.kwargs["requires_grad"] is True
+    assert "row_scaled_nvfp4" not in restored.kwargs
+    assert "nvfp4_use_4over6" not in restored.kwargs
+    assert "nvfp4_e4m3_max" not in restored.kwargs
+    assert restored.grouped_tensor_scale_inv is False
+
+
+def test_grouped_tensor_restore_passes_row_scaled_nvfp4_when_signature_supports_it():
+    """Newer TE GroupedTensor constructors should keep row-scaled NVFP4 metadata."""
+    restored = _restore_fake_grouped_tensor(_RowScaledGroupedTensor)
+
+    assert restored.kwargs["requires_grad"] is True
+    assert restored.kwargs["row_scaled_nvfp4"] is True
+    assert "nvfp4_use_4over6" not in restored.kwargs
+    assert "nvfp4_e4m3_max" not in restored.kwargs
+    assert restored.grouped_tensor_scale_inv is False
 
 
 @pytest.mark.skipif(not _is_mxfp8_supported(), reason=_MXFP8_SKIP_REASON)

--- a/tests/unit_tests/transformer/moe/test_paged_stashing.py
+++ b/tests/unit_tests/transformer/moe/test_paged_stashing.py
@@ -11,6 +11,7 @@ from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transfor
 from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.moe.moe_utils import get_align_size_for_quantization
 from megatron.core.transformer.moe.paged_stash import (
+    PagedStashManager,
     check_paged_stash_overflow,
     paged_stash_init_chunk_handler,
     paged_stash_reset,
@@ -83,15 +84,17 @@ class MoEModelTestContainer:
             expert_tensor_parallel_size=moe_tp_size,
         )
         _set_random_seed(seed_=123, data_parallel_random_init=data_parallel_random_init)
+        fp8 = kwargs.get("fp8", 'e4m3')
+        fp8_recipe = kwargs.get("fp8_recipe", 'mxfp8')
         self.config = TransformerConfig(
             tensor_model_parallel_size=tp_size,
             expert_model_parallel_size=ep_size,
             pipeline_model_parallel_size=pp_size,
             context_parallel_size=cp_size,
             expert_tensor_parallel_size=moe_tp_size,
-            fp8='e4m3',
-            fp8_recipe='mxfp8',
-            fp8_wgrad=True,
+            fp8=fp8,
+            fp8_recipe=fp8_recipe,
+            fp8_wgrad=kwargs.get("fp8_wgrad", fp8 is not None),
             fp8_amax_compute_algo='most_recent',
             fp8_amax_history_len=1,
             fp8_interval=1,
@@ -115,7 +118,7 @@ class MoEModelTestContainer:
             moe_grouped_gemm=kwargs.get("moe_grouped_gemm", False),
             moe_paged_stash=kwargs.get("moe_paged_stash", False),
             moe_expert_rank_capacity_factor=kwargs.get("moe_expert_rank_capacity_factor", None),
-            moe_router_padding_for_fp8=kwargs.get("moe_router_padding_for_fp8", True),
+            moe_router_padding_for_fp8=kwargs.get("moe_router_padding_for_fp8", fp8 is not None),
             use_transformer_engine_op_fuser=kwargs.get("use_transformer_engine_op_fuser", False),
             moe_mlp_glu_interleave_size=kwargs.get("moe_mlp_glu_interleave_size", None),
             moe_router_padding_for_quantization=kwargs.get(
@@ -216,9 +219,10 @@ _MXFP8_SKIP_REASON = (
 @pytest.mark.skipif(not is_hybrid_ep_available(), reason="Hybrid EP are not available")
 class TestPagedStashing:
     def setup_method(self, method):
-        pass
+        PagedStashManager.STASH_MGR = None
 
     def teardown_method(self, method):
+        PagedStashManager.STASH_MGR = None
         Utils.destroy_model_parallel()
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -298,6 +302,87 @@ class TestPagedStashing:
             ), f"tokens_per_expert != ref: max diff = {(tpe_f - ref_f).abs().max().item()}"
 
 
+@pytest.mark.skipif(
+    not _te_grouped_mlp_op_fuser_environment_supported(),
+    reason=_TE_GROUPED_MLP_OP_FUSER_SKIP_REASON,
+)
+@pytest.mark.skipif(not is_hybrid_ep_available(), reason="Hybrid EP are not available")
+class TestPagedStashingPureBF16:
+    def setup_method(self, method):
+        PagedStashManager.STASH_MGR = None
+
+    def teardown_method(self, method):
+        PagedStashManager.STASH_MGR = None
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.internal
+    def test_forward_backward_4_layers_pure_bf16(self):
+        """Pure BF16 paged stashing captures token-major fused expert activations."""
+        if not is_hybrid_ep_available():
+            pytest.skip("Hybrid EP is not available")
+
+        config.ENABLE_EXPERIMENTAL = True
+
+        container = MoEModelTestContainer(
+            tp_size=1,
+            ep_size=4,
+            pp_size=1,
+            num_moe_experts=8,
+            num_layers=4,
+            moe_router_topk=2,
+            moe_router_load_balancing_type="aux_loss",
+            moe_token_dispatcher_type="flex",
+            moe_permute_fusion=True,
+            hidden_size=1024,
+            moe_flex_dispatcher_backend="hybridep",
+            test_dtype=torch.bfloat16,
+            fp8=None,
+            fp8_recipe=None,
+            fp8_wgrad=False,
+            moe_router_padding_for_fp8=False,
+            moe_router_padding_for_quantization=False,
+            moe_grouped_gemm=True,
+            moe_use_legacy_grouped_gemm=False,
+            moe_paged_stash=True,
+            moe_expert_rank_capacity_factor=1.5,
+            use_transformer_engine_op_fuser=True,
+            moe_mlp_glu_interleave_size=32,
+            gated_linear_unit=True,
+            activation_func=F.silu,
+        )
+
+        seq_length = 1024
+        batch_size = 1
+        hidden_size = container.config.hidden_size
+        hidden_states = torch.randn((seq_length, batch_size, hidden_size), dtype=torch.bfloat16)
+
+        paged_stash_reset(True, config=container.config)
+        paged_stash_init_chunk_handler(1, 0)
+        output_ref, hidden_states_grad_ref, _, _ = _forward_backward_all_layers(
+            container, hidden_states
+        )
+
+        container.zero_grad()
+
+        paged_stash_reset(True, config=container.config)
+        stash_manager = PagedStashManager.get_instance()
+        assert stash_manager.stash_buffers is not None
+        assert torch.bfloat16 in stash_manager.stash_buffers
+        paged_stash_init_chunk_handler(1, 0)
+        output, hidden_states_grad, _, _ = _forward_backward_all_layers(container, hidden_states)
+
+        overflow = check_paged_stash_overflow()
+        assert overflow.any().item() == 0
+        assert torch.allclose(
+            output, output_ref, atol=1e-4, rtol=1e-4
+        ), f"output != output_ref: max diff = {(output - output_ref).abs().max().item()}"
+        assert torch.allclose(hidden_states_grad, hidden_states_grad_ref, atol=1e-4, rtol=1e-4), (
+            f"hidden_states_grad != ref: max diff = "
+            f"{(hidden_states_grad - hidden_states_grad_ref).abs().max().item()}"
+        )
+
+
 @pytest.mark.skipif(not _is_mxfp8_supported(), reason=_MXFP8_SKIP_REASON)
 @pytest.mark.skipif(
     not _te_grouped_mlp_op_fuser_environment_supported(),
@@ -306,9 +391,10 @@ class TestPagedStashing:
 @pytest.mark.skipif(not is_hybrid_ep_available(), reason="Hybrid EP are not available")
 class TestPagedStashingOverBudget:
     def setup_method(self, method):
-        pass
+        PagedStashManager.STASH_MGR = None
 
     def teardown_method(self, method):
+        PagedStashManager.STASH_MGR = None
         Utils.destroy_model_parallel()
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

This PR enables the existing MoE paged-stash path to capture pure BF16 token-major activations produced by the TE grouped MLP op-fuser path.

## Issue tracking

Linked issue: N/A. This is a scoped correctness/compatibility fix for an existing paged-stash feature path.

## Changes

- Add an opt-in `allow_untagged_token_major_tensors` flag for paged-stash contexts.
- Enable that flag only for non-FP8/non-FP4 `TEGroupedMLP` paged-stash contexts.
- Restore lightweight saved tensor metadata on reload.
- Capture and restore TE GroupedTensor wrapper metadata when the saved object is backed by rowwise tensor storage.
- Add a pure-BF16 paged-stash test outside the MXFP8/Blackwell skip gate.
- Reset the paged-stash singleton between paged-stash tests.

## Validation

- `python3 -m compileall -q megatron/core/transformer/moe/experts.py megatron/core/transformer/moe/paged_stash.py tests/unit_tests/transformer/moe/test_paged_stashing.py`
- On a GB200 node:
  - distributed pure-BF16 paged-stash unit test passed
  - 1-node / 4-GPU mock-data MoE + HybridEP + TE op-fuser + rank-capacity + paged-stash e2e training reached iter 3/3
  - skipped iterations: 0; NaN iterations: 0; Slurm exit: 0:0
  - actual BF16 paged-stash allocation was observed via `allocate_stash_buffers cuda:` in both unit and e2e runs
- `CHECK_ONLY=true tools/autoformat.sh` passed for this PR branch


## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR