### PR TITLE
[TE] Restore original CP group after dynamic CP forward in TEDotProductAttention

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1652,9 +1652,11 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
             core_attn_out = super().forward(query, key, value, attention_mask, **_fa_kwargs)
 
         # Restore TE's CP group after dynamic CP forward.
-        if packed_seq_params is not None \
-           and packed_seq_params.local_cp_size is not None \
-           and self.config.context_parallel_size > 1:
+        if (
+            packed_seq_params is not None
+            and packed_seq_params.local_cp_size is not None
+            and self.config.context_parallel_size > 1
+        ):
             super().set_context_parallel_group(
                 _te_orig_cp_group,
                 _te_orig_cp_global_ranks,

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1557,6 +1557,10 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
         num_splits: Optional[int] = None,
     ) -> torch.Tensor:
         """Forward."""
+        # Save TE's current CP group before potential DCP switch (for restore at end).
+        _te_orig_cp_group = self.cp_group
+        _te_orig_cp_global_ranks = self.cp_global_ranks
+
         if packed_seq_params is not None:
             # If Dynamic CP group is provided, update TE DPA CP group
             if packed_seq_params.local_cp_size is not None:
@@ -1646,6 +1650,17 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
             if num_splits is not None:
                 _fa_kwargs["num_splits"] = num_splits
             core_attn_out = super().forward(query, key, value, attention_mask, **_fa_kwargs)
+
+        # Restore TE's CP group after dynamic CP forward.
+        if packed_seq_params is not None \
+           and packed_seq_params.local_cp_size is not None \
+           and self.config.context_parallel_size > 1:
+            super().set_context_parallel_group(
+                _te_orig_cp_group,
+                _te_orig_cp_global_ranks,
+                TEDotProductAttention.cp_stream,
+                self.cp_comm_type,
+            )
 
         return core_attn_out
 


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Fix TE DotProductAttention not restoring its original context-parallel group after a dynamic CP (DCP) forward pass, which causes incorrect CP group state in subsequent GRPO rollout.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
