### PR TITLE
Fix wgrad race condition when using double buffers.

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -340,15 +340,8 @@ class MegatronFSDP(torch.nn.Module):
         self._init_fsdp_param_and_grad_buffer()
         self._register_fsdp_hooks(self.module)
         self.microbatch_count = 0
-
-        # Add a reference from the distributed parameters to self for API
-        # accessibility, e.g. when attaching MegatronFSDP scheduled ops
-        # to the distributed optimizer.step() and optimizer.zero_grad().
         self.is_param_fsdp_distributed = False
         self._replace_param_with_distributed_if_needed()
-        for param in self.module.parameters():
-            # Attach MegatronFSDP reference to the parameter.
-            setattr(param, "_megatron_fsdp_model", self)
 
     def _check_module_parameter_types(self):
         """
@@ -604,12 +597,7 @@ class MegatronFSDP(torch.nn.Module):
                 # If TransformerEngine gradient accumulation is fused, then param.get_main_grad()
                 # already holds the wgrad and param.grad_added_to_main_grad=True.
                 if not param.grad_added_to_main_grad:
-                    # Get `main_grad` will allocate bucket, check that the currently
-                    # used main_grad buffer does not exceed the scope of two FSDP Unit
-                    # Modules, i.e., the buffer limit imposed by double-buffer allocator.
-                    if self.ddp_config.fsdp_double_buffer:
-                        self.grad_reduce_pipeline._enforce_double_buffer_limit([group_id])
-
+                    # Allocate a unsharded gradient buffer.
                     param.main_grad = param.get_main_grad()
                     if param.grad is not None:
                         if self.report_nan_in_param_grad:
@@ -1359,6 +1347,8 @@ class MegatronFSDP(torch.nn.Module):
             # DTensor parameter is managed by Megatron FSDP.
             if not hasattr(dist_param, "__fsdp_param__"):
                 dist_param.__fsdp_param__ = True
+            if not hasattr(dist_param, "_megatron_fsdp_model"):
+                dist_param._megatron_fsdp_model = self
             _replace_module_parameter(self.module, name, dist_param)
 
         # Handle shared weights
@@ -1371,6 +1361,8 @@ class MegatronFSDP(torch.nn.Module):
 
         for name, _ in self.module.named_parameters():
             assert name in self.raw_param, f"Raw parameter {name} not found in module."
+            if not hasattr(self.raw_param[name], "_megatron_fsdp_model"):
+                self.raw_param[name]._megatron_fsdp_model = self
             _replace_module_parameter(self.module, name, self.raw_param[name])
 
         # Handle shared weights

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -2685,18 +2685,23 @@ class ParamAndGradBuffer:
                 p._item_id = item_id
 
                 def main_grad_getter(p):
+                    # Get gradient buffer and item ID.
+                    gbuf = p._gbuf
+                    item_id = p._item_id
+                    # Need to free a bucket for the incoming bucket if double-buffering.
+                    p._megatron_fsdp_model.grad_reduce_pipeline._enforce_double_buffer_limit(
+                        [gbuf.bucket_id]
+                    )
                     # Make sure main_grad memory is allocated when initially accessed.
                     # When gradients are sharded, we can pre-allocate a communication
                     # bucket to avoid casting to a communication data-type. Otherwise,
                     # return the item backed by the main gradient buffer required to
                     # support un-sharded gradient accumulation at high precision.
-                    bucket = p._gbuf.fetch_bucket(
+                    bucket = gbuf.fetch_bucket(
                         dtype=(
                             self.mp_policy.grad_comm_dtype if p._gbuf.is_data_distributed else None
                         )
                     )
-                    gbuf = p._gbuf
-                    item_id = p._item_id
                     # View it as p.shape so you can insert the param.grad into
                     # the bucket seamlessly.
                     return gbuf.get_item_from_bucket(bucket, item_id).view(
@@ -2909,6 +2914,7 @@ class ParamAndGradBuffer:
                             "is_embedding_or_output_parameter",
                             "is_embedding_parameter",
                             "_tensor_parallel_mode",
+                            "_megatron_fsdp_model",
                         ]:
                             if hasattr(orig_param, attr_name):
                                 setattr(param, attr_name, getattr(orig_param, attr_name))
@@ -3558,7 +3564,7 @@ class GradReducePipeline:
         for _, _, bucket_id in reversed(self.grad_reduce_queue):
             fsdp_unit_id = param_groups[bucket_id].fsdp_unit_id
             double_buf_units.add(fsdp_unit_id)
-            if len(double_buf_units) > 1:
+            if len(double_buf_units) > 2:
                 keep_n -= 1
 
         with torch.cuda.stream(self.rs_stream):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -906,7 +906,7 @@ class DataParallelBuffer:
             # Build the data parallel buffer index, which contains information
             # on where each parameter / gradient tensor will be stored in this
             # distributed buffer.
-            (self.item_index_map, self.bucket_index, self.shard_bucket_index) = (
+            self.item_index_map, self.bucket_index, self.shard_bucket_index = (
                 build_data_parallel_buffer_index(
                     [to_local_if_dtensor(p).shape for p in self.params],
                     self.dp_rank,
@@ -1767,7 +1767,7 @@ class ParamAndGradBuffer:
                         )
 
         # Get the parameter groups.
-        (self.parameter_groups, self.param_to_param_group, self.bucket_to_bucket_group) = (
+        self.parameter_groups, self.param_to_param_group, self.bucket_to_bucket_group = (
             _get_parameter_groups(module, bucketing_policy, meta_device_init_fp8_params)
         )
         self._init_each_parameter_group_buffers(meta_device_init_fp8_params)
@@ -3946,7 +3946,7 @@ class AllGatherPipeline:
                 UserWarning,
             )
             while len(self.param_gather_event_map) > 0:
-                (bucket_id, bwd) = next(iter(self.param_gather_event_map))
+                bucket_id, bwd = next(iter(self.param_gather_event_map))
                 self.wait_bucket_ready(bucket_id, bwd)
 
         for bucket_id in range(self.num_buckets):


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

- https://github.com/NVIDIA/Megatron-LM/pull/4054 introduced a `wgrad` race condition when using double buffering, because we always `wait` on reduce-scatter until we have a single unsharded gradient buffer in-use to make room for fused `wgrad` accumulation in TE. When this shared buffer is assigned to adjacent layers (which is common!), the subsequent `wgrad` will partially-overwrite the previous `wgrad` input to the reduce-scatter, slightly corrupting our reduced gradient in a very difficult-to-see way.
  - Instead of always reducing the number of used buffers to 1, just dynamically check how many FSDP units are allocated during the `get_main_grad` call, and if there are already 2 units allocated for reduce-scatter with a new FSDP unit incoming for the allocation, we need to wait on one of them to make room for the `get_main_grad` allocation. Will block computation, but is required to be `wgrad`-safe.
  
```
if len(double_buf_units) > 1:  # Should be 2, this is WAR for fused WGRAD accumulation!
    keep_n -= 1
```

# Testing

- No major difference in performance or memory, and loss parity is achieved with non-double-buffer runs. Tested here: https://github.com/cspades/Megatron-LM/tree/cye/nemotron_fsdp_partcg_dev
- Not sure how to write the unit test for the race condition, since the earliest way to spot the problem is the output of the reduce-scatter, after the input has been corrupted.

```
USE_UV=0 ./examples/megatron_fsdp/train_llama3_8b_fsdp_h100_fp8.sh

# Loss parity with NCCL UBR on (double buffered) and off (dynamic allocation):
[2026-06-08 19:23:01.024494] iteration       21/15258789 | consumed samples:         2688 | elapsed time per iteration (ms): 7494.9 | throughput per GPU (TFLOP/s/GPU): 1800.3 | learning rate: 1.032192E-07 | global batch size:   128 | lm loss: 1.205886E+01 | loss scale: 1.0 | grad norm: 28.231
```

# Details

- Gradients are now being double buffered by FixedPoolAllocator and MaxPoolAllocator.
```
INFO:megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer:[MaxPool][fsdp_grads] Assigned Bucket 26 to MaxPool Buffer 0.
INFO:megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer:[MaxPool][fsdp_grads] Assigned Bucket 27 to MaxPool Buffer 0.
INFO:megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer:[MaxPool][fsdp_grads] Assigned Bucket 25 to MaxPool Buffer 0.
INFO:megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer:[MaxPool][fsdp_grads] Assigned Bucket 23 to MaxPool Buffer 1.
INFO:megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer:[MaxPool][fsdp_grads] Assigned Bucket 24 to MaxPool Buffer 1.
```
- Parity tests look great on https://github.com/cspades/Megatron-LM/tree/cye/nemotron_fsdp_partcg_dev.
```
# Vanilla FSDP (No CG / Double Buffer)

[Rank 0] (after 2 iterations) memory (MB) | allocated: 42608.04 | max allocated: 68321.44 | reserved: 72574.00 | max reserved: 72574.00 | total device memory used: 81271.19
[2026-06-08 16:47:52.882585] iteration        5/   10000 | consumed samples:           20 | elapsed time per iteration (ms): 404.7 | throughput per GPU (TFLOP/s/GPU): 843.2 | learning rate: 8.000000E-06 | global batch size:     4 | lm loss: 9.250051E+00 | load_balancing_loss: 0.000000E+00 | seq_load_balancing_loss: 8.571738E-01 | mtp_1 loss: 1.157496E+01 | loss scale: 1.0 | grad norm: 14.665 | num zeros: 1043195904.0 | params norm: 895.768

# Vanilla FSDP + WGRAD Fusion

[Rank 0] (after 2 iterations) memory (MB) | allocated: 46012.04 | max allocated: 71853.31 | reserved: 75894.00 | max reserved: 75894.00 | total device memory used: 84591.19
[2026-06-08 16:43:28.188433] iteration        5/   10000 | consumed samples:           20 | elapsed time per iteration (ms): 405.7 | throughput per GPU (TFLOP/s/GPU): 841.1 | learning rate: 8.000000E-06 | global batch size:     4 | lm loss: 9.280489E+00 | load_balancing_loss: 0.000000E+00 | seq_load_balancing_loss: 8.571738E-01 | mtp_1 loss: 1.155565E+01 | loss scale: 1.0 | grad norm: 14.580 | num zeros: 1043110144.0 | params norm: 895.769

# Partial CG + MaxPool

[Rank 0] (after 2 iterations) memory (MB) | allocated: 48011.08 | max allocated: 65345.02 | reserved: 85176.00 | max reserved: 85176.00 | total device memory used: 93873.19
[2026-06-08 16:38:29.573345] iteration        5/   10000 | consumed samples:           20 | elapsed time per iteration (ms): 415.1 | throughput per GPU (TFLOP/s/GPU): 822.1 | learning rate: 8.000000E-06 | global batch size:     4 | lm loss: 9.251588E+00 | load_balancing_loss: 0.000000E+00 | seq_load_balancing_loss: 8.571738E-01 | mtp_1 loss: 1.157490E+01 | loss scale: 1.0 | grad norm: 14.665 | num zeros: 1043199616.0 | params norm: 895.768

# Partial CG + MaxPool + WGRAD Fusion

[Rank 0] (after 2 iterations) memory (MB) | allocated: 51415.08 | max allocated: 68780.89 | reserved: 88516.00 | max reserved: 88516.00 | total device memory used: 97213.19
[2026-06-08 16:40:32.402599] iteration        5/   10000 | consumed samples:           20 | elapsed time per iteration (ms): 395.9 | throughput per GPU (TFLOP/s/GPU): 862.0 | learning rate: 8.000000E-06 | global batch size:     4 | lm loss: 9.280520E+00 | load_balancing_loss: 0.000000E+00 | seq_load_balancing_loss: 8.571738E-01 | mtp_1 loss: 1.155480E+01 | loss scale: 1.0 | grad norm: 14.579 | num zeros: 1043111744.0 | params norm: 895.769

# Full-Iter CG

[Rank 0] (after 2 iterations) memory (MB) | allocated: 49425.98 | max allocated: 69725.55 | reserved: 73260.00 | max reserved: 73260.00 | total device memory used: 81953.19
[2026-06-08 16:33:56.536509] iteration        5/   10000 | consumed samples:           20 | elapsed time per iteration (ms): 391.3 | throughput per GPU (TFLOP/s/GPU): 872.0 | learning rate: 8.000000E-06 | global batch size:     4 | lm loss: 9.249974E+00 | load_balancing_loss: 0.000000E+00 | seq_load_balancing_loss: 8.571738E-01 | mtp_1 loss: 1.163277E+01 | loss scale: 1.0 | grad norm: 14.666 | num zeros: 1043200320.0 | params norm: 895.768

# Full-Iter CG + WGRAD Fusion

[Rank 0] (after 2 iterations) memory (MB) | allocated: 52829.98 | max allocated: 73257.42 | reserved: 76500.00 | max reserved: 76500.00 | total device memory used: 85193.19
[2026-06-08 16:31:02.795828] iteration        5/   10000 | consumed samples:           20 | elapsed time per iteration (ms): 403.1 | throughput per GPU (TFLOP/s/GPU): 846.5 | learning rate: 8.000000E-06 | global batch size:     4 | lm loss: 9.279935E+00 | load_balancing_loss: 0.000000E+00 | seq_load_balancing_loss: 8.571738E-01 | mtp_1 loss: 1.161233E+01 | loss scale: 1.0 | grad norm: 14.580 | num zeros: 1043113920.0 | params norm: 895.769
```

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
