### PR TITLE
Respond to issue triage workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,16 +12,38 @@ assignees: ''
 A clear and concise description of what the bug is. Tag @NVIDIA/mcore-oncall
 to get oncall's attention to this issue.
 
+**Scenario / affected area**
+
+Tell us what workflow is affected, for example: model family, training vs.
+inference, dataset/checkpoint assumptions, precision, and parallelism setup
+(TP/PP/DP/CP/EP/FSDP).
+
 **Steps/Code to reproduce bug**
 
-Please list *minimal* steps or code snippet for us to be able to reproduce the bug.
+Please list *minimal* steps or a code snippet for us to reproduce the bug.
+Include the exact command, script, config, and any required input assumptions.
+Please also say whether this reproduces on the latest `main` branch.
 
-A helpful guide on on how to craft a minimal bug report http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports.
+A helpful guide on how to craft a minimal bug report http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports.
 
 
 **Expected behavior**
 
 A clear and concise description of what you expected to happen.
+
+
+**Actual behavior / logs**
+
+Add the full stack trace, error message, or relevant log excerpt.
+
+
+**Environment (please complete the following information):**
+ - Megatron-LM commit ID or release
+ - Container image or OS
+ - PyTorch version
+ - CUDA version
+ - NCCL version
+ - GPU type and number of GPUs/nodes
 
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -26,7 +26,7 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Affected area / possible owners**
 If you know the relevant files, modules, or maintainers, list them here. This
-helps oncall route the request to the right owner.
+helps maintainers route the request to the right owner.
 
 **Contribution**
 Are you interested in contributing this change or helping validate a proposed

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,8 +16,21 @@ to get oncall's attention to this issue.
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
+**Scenario / users**
+Describe the user scenario this would enable, including the model family,
+training vs. inference path, distributed setup, or deployment context if
+relevant.
+
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
+
+**Affected area / possible owners**
+If you know the relevant files, modules, or maintainers, list them here. This
+helps oncall route the request to the right owner.
+
+**Contribution**
+Are you interested in contributing this change or helping validate a proposed
+implementation?
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -19,4 +19,4 @@ inference path, command/config if relevant, and parallelism setup
 
 **What have you tried?**
 Share links to docs, examples, configs, or related issues you have already
-checked. This helps oncall route the question to the right owner.
+checked. This helps maintainers route the question to the right owner.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -11,3 +11,12 @@ assignees: ''
 **Your question**
 Ask a clear and concise question about Megatron-LM. Tag @NVIDIA/mcore-oncall
 to get oncall's attention to this issue.
+
+**Scenario / context**
+Tell us what you are trying to do, including the model family, training vs.
+inference path, command/config if relevant, and parallelism setup
+(TP/PP/DP/CP/EP/FSDP).
+
+**What have you tried?**
+Share links to docs, examples, configs, or related issues you have already
+checked. This helps oncall route the question to the right owner.

--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -11,14 +11,24 @@ assignees: ''
 A clear and concise description of what the regression is. Tag @NVIDIA/mcore-oncall
 to get oncall's attention to this issue.
 
+**Scenario / affected area**
+Tell us what workflow is affected, for example: model family, training vs.
+inference, dataset/checkpoint assumptions, precision, and parallelism setup
+(TP/PP/DP/CP/EP/FSDP).
+
 **To Reproduce**
-Steps to reproduce the behavior. The easier it is to reproduce the faster it will get maintainer attention.
+Steps to reproduce the behavior. Include the exact command, script, config, and
+any required input assumptions. Please also say whether this reproduces on the
+latest `main` branch. The easier it is to reproduce the faster it will get
+maintainer attention.
 
 **Previous performance**
-What speed or accuracy did you previously see.
+What speed, memory use, or accuracy did you previously see. Include run-to-run
+variance if known.
 
 **New performance**
-What speed or accuracy do you see after the update.
+What speed, memory use, or accuracy do you see after the update. Include
+run-to-run variance if known.
 
 **Stack trace/logs**
 If applicable, add the stack trace or logs related to the regression.
@@ -26,12 +36,14 @@ If applicable, add the stack trace or logs related to the regression.
 **Environment (please complete the following information):**
  - Previous Megatron-LM commit ID
  - New Megatron-LM commit ID
+ - Container image or OS
  - Previous PyTorch version
  - New PyTorch version
  - Previous CUDA version
  - New CUDA version
  - Previous NCCL version
  - New NCCL version
+ - GPU type and number of GPUs/nodes
 
 **Proposed fix**
 If you have a proposal for how to fix the issue state it here or link to a PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,14 @@
 
 :warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.
 
+## Scenario and routing
+
+User scenario this PR fixes or enables: <!-- training/inference path, model family, parallelism setup, performance/accuracy issue, etc. -->
+
+Affected area / likely owners: <!-- e.g. megatron/core/transformer/moe, @NVIDIA/<team>, or "not sure" -->
+
+Risk notes: <!-- backward compatibility, checkpoint format, config defaults, numerics, performance, distributed behavior, or "none known" -->
+
 ## Issue tracking
 
 For PRs from open-source community contributors:
@@ -23,6 +31,12 @@ Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->
 - [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
 - [ ] I have added relevant documentation
 - [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
+
+### Validation
+
+Reproduction or before/after signal: <!-- issue repro, benchmark, accuracy/perf numbers, or "not applicable" -->
+
+Test commands and results: <!-- exact commands run, CI links, or "not run" with reason -->
 
 ### Code review
 

--- a/skills/respond-to-issue/SKILL.md
+++ b/skills/respond-to-issue/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: respond-to-issue
-description: On-call triage and response for GitHub issues and PRs in NVIDIA/Megatron-LM. Use when asked to reply to, classify, route, assign, scan open or out-of-SLA issues, batch-draft maintainer responses, ask for reproducibility/scenario details, or identify owners from CODEOWNERS, changed files, history, and similar reports.
-when_to_use: User shares a GitHub issue or PR URL/number, asks on-call to triage, route, assign, respond, draft a reply, scan issues needing response, find out-of-SLA community issues, ask for more information, or design automation for GitHub community intake.
+description: Maintainer triage and response for GitHub issues and PRs in NVIDIA/Megatron-LM. Use when asked to reply to, classify, route, assign, scan open or out-of-SLA issues, batch-draft responses, ask for reproducibility/scenario details, or identify owners from CODEOWNERS, changed files, history, and similar reports.
+when_to_use: User shares a GitHub issue or PR URL/number, asks a maintainer or on-call to triage, route, assign, respond, draft a reply, scan issues needing response, find out-of-SLA community issues, ask for more information, or design automation for GitHub community intake.
 user_invocable: true
 argument: "<github-issue-or-pr-url-or-number>"
 ---
 
-# On-call GitHub Triage
+# GitHub Issue and PR Triage
 
-Help the on-call maintainer respond quickly, route to the right owner, and ask for the minimum information needed to make progress on GitHub issues and PRs.
+Help maintainers and on-call responders reply quickly, route to the right owner, and ask for the minimum information needed to make progress on GitHub issues and PRs.
 
-Default posture: helpful coordinator first, technical diagnoser second. The on-call reply should either unblock the reporter, route the item to a likely owner, or ask for the exact missing data needed to reproduce and diagnose.
+Default posture: helpful coordinator first, technical diagnoser second. The reply should either unblock the reporter, route the item to a likely owner, or ask for the exact missing data needed to reproduce and diagnose.
 
 ## Workflow
 
@@ -84,9 +84,9 @@ Use evidence in this order:
 2. `.github/CODEOWNERS` for path/team ownership.
 3. Recent file history: `git log --oneline -20 -- <path>` and, when useful, `git log -S "<symbol>" -- <path>`.
 4. Similar issues/PRs and maintainers who already handled the same area.
-5. Current on-call when the report lacks enough information to route.
+5. Current on-call or maintainer coordinator when the report lacks enough information to route.
 
-Prefer routing to teams from CODEOWNERS when possible. Assign or request an individual only when they are clearly the code-change writer, active owner, or already engaged. If ownership is uncertain, keep on-call as coordinator and ask for the missing scenario/repro details.
+Prefer routing to teams from CODEOWNERS when possible. Assign or request an individual only when they are clearly the code-change writer, active owner, or already engaged. If ownership is uncertain, keep a maintainer/on-call responder as coordinator and ask for the missing scenario/repro details.
 
 Common owner evidence:
 
@@ -104,12 +104,12 @@ If the response will make a technical claim, verify it against code or CI first.
 - If claiming code is unused or missing, use `rg` and, if needed, `git log -S`.
 - If a fix already exists, link the issue/PR and state the relationship precisely.
 
-### 6. Draft the on-call reply
+### 6. Draft the maintainer reply
 
 Every reply should contain:
 
 1. Acknowledge the report or PR.
-2. Summarize the on-call understanding in one sentence.
+2. Summarize the maintainer understanding in one sentence.
 3. State the route or next action.
 4. Ask for exactly the missing information, or point to the likely owner/workaround/guide.
 
@@ -127,7 +127,7 @@ Thanks for the report. To route this to the right maintainer and reproduce it, c
 - Environment: container/OS, PyTorch, CUDA, NCCL, GPU type/count, node count
 - Scenario: model family, training/inference path, precision, and parallelism setup (TP/PP/DP/CP/EP/FSDP)
 
-Once we have that, on-call can route it to the right area owner.
+Once we have that, a maintainer can route it to the right area owner.
 ```
 
 Owner routing template:
@@ -141,13 +141,13 @@ If you can also add <one missing item>, that will make it easier for the owner t
 Question template:
 
 ```markdown
-Thanks for the question. My understanding is that you are trying to <scenario>. The relevant path appears to be <feature/config/doc>. Could you share the command/config and the parallelism/model setup you are using? With that, on-call can either answer directly or route to the owner of that path.
+Thanks for the question. My understanding is that you are trying to <scenario>. The relevant path appears to be <feature/config/doc>. Could you share the command/config and the parallelism/model setup you are using? With that, a maintainer can either answer directly or route to the owner of that path.
 ```
 
 PR routing template:
 
 ```markdown
-Thanks for the PR. To accelerate review, could you link the issue or describe the user scenario this fixes, list the validation commands/results, and note the affected area/owners if known? Based on the changed files, this likely needs review from @NVIDIA/<team>. On-call will keep this routed once the PR is ready for review and CI is passing.
+Thanks for the PR. To accelerate review, could you link the issue or describe the user scenario this fixes, list the validation commands/results, and note the affected area/owners if known? Based on the changed files, this likely needs review from @NVIDIA/<team>. Maintainers will keep this routed once the PR is ready for review and CI is passing.
 ```
 
 ### 7. Automation guidance
@@ -166,11 +166,11 @@ Recommended event model:
 
 - Issues: `opened`, `reopened`, `edited`, and `labeled` with `community-request`.
 - PRs: `opened`, `ready_for_review`, `reopened`, and `synchronize` only for routing/checklist refreshes.
-- Outputs: labels, team review requests, a concise public ask-for-info comment, and an on-call summary with owner evidence.
+- Outputs: labels, team review requests, a concise public ask-for-info comment, and a maintainer-facing summary with owner evidence.
 
 ### 8. Batch SLA scan
 
-When asked to scan issues needing on-call response, produce drafts first; never post during the scan.
+When asked to scan issues needing maintainer response, produce drafts first; never post during the scan.
 
 If the user gives an SLA, use it. If not, use age buckets instead of claiming an issue is out-of-SLA: `new` (<1 day), `watch` (1-2 days), `at-risk` (2-5 days), `stale` (>5 days), based on the latest reporter/community update that still needs maintainer action.
 
@@ -195,7 +195,7 @@ Classify as **needs reply** when:
 - the latest substantive comment is from the reporter/community and asks a new question or adds requested data;
 - the issue has `community-request`, `needs-info`, `needs-repro`, or no clear owner/label and is aging;
 - the issue was routed but no owner has engaged after the requested SLA;
-- a prior on-call reply asked for information and the reporter has now provided it.
+- a prior maintainer/on-call reply asked for information and the reporter has now provided it.
 
 Do **not** draft a new reply when:
 

--- a/skills/respond-to-issue/SKILL.md
+++ b/skills/respond-to-issue/SKILL.md
@@ -1,65 +1,243 @@
 ---
 name: respond-to-issue
-description: Research and draft a response to a GitHub issue or question from an external contributor.
-when_to_use: User shares a GitHub issue URL or asks to respond to a community question; 'respond to this issue', 'draft a reply', 'answer this GitHub question'.
+description: On-call triage and response for GitHub issues and PRs in NVIDIA/Megatron-LM. Use when asked to reply to, classify, route, assign, scan open or out-of-SLA issues, batch-draft maintainer responses, ask for reproducibility/scenario details, or identify owners from CODEOWNERS, changed files, history, and similar reports.
+when_to_use: User shares a GitHub issue or PR URL/number, asks on-call to triage, route, assign, respond, draft a reply, scan issues needing response, find out-of-SLA community issues, ask for more information, or design automation for GitHub community intake.
 user_invocable: true
-argument: "<github-issue-url-or-number>"
+argument: "<github-issue-or-pr-url-or-number>"
 ---
 
-# Respond to GitHub Issue
+# On-call GitHub Triage
 
-Help a maintainer draft a high-quality response to a GitHub issue from an external contributor.
+Help the on-call maintainer respond quickly, route to the right owner, and ask for the minimum information needed to make progress on GitHub issues and PRs.
+
+Default posture: helpful coordinator first, technical diagnoser second. The on-call reply should either unblock the reporter, route the item to a likely owner, or ask for the exact missing data needed to reproduce and diagnose.
 
 ## Workflow
 
-### 1. Understand the issue
+### 1. Read the artifact first
 
-- Fetch the issue using `gh issue view <number> --repo NVIDIA/Megatron-LM --json title,body,comments,labels,state`.
-- Read the title, body, and all existing comments to understand the full context.
-- Identify the type: bug report, feature request, question, or discussion.
+Do not infer or draft before reading the live issue/PR and comments.
 
-### 2. Research the codebase
+For issues:
 
-- Based on what the issue is asking, search the Megatron-LM codebase for the relevant code.
-- Read the relevant source files to understand the current behavior.
-- If the issue references specific files or functions, read those directly.
-- Check `git log --oneline -20 -- <relevant-files>` to see if there have been recent changes that address or relate to the issue.
-- Use `git log -S "<symbol>" --oneline` to trace when code was added or removed — this is especially useful for questions about unused/deprecated code or missing features.
-- If the issue is about a bug, try to confirm whether the reported behavior matches the code.
-- Check whether an existing PR already addresses the issue: `gh pr list --repo NVIDIA/Megatron-LM --search "<keywords>" --limit 5`.
+```bash
+gh issue view <number> --repo NVIDIA/Megatron-LM --json title,body,comments,labels,state,author,createdAt,updatedAt,url
+```
 
-### 3. Verify before citing
+For PRs:
 
-Before including specific details in the response, verify them:
-- If citing a commit hash, confirm the commit message and diff match what you're claiming (`git show <hash> --stat`).
-- If citing a file path and line number, re-read the file to confirm the line content is correct.
-- If claiming code is unused or missing, do a thorough grep to make sure you haven't missed a reference.
+```bash
+gh pr view <number> --repo NVIDIA/Megatron-LM --json title,body,comments,labels,state,isDraft,author,files,reviewRequests,reviews,statusCheckRollup,baseRefName,headRefName,headRefOid,url,mergeable
+gh pr diff <number> --repo NVIDIA/Megatron-LM
+```
 
-### 4. Draft the response
+Also search for prior art before routing:
 
-Write a response that:
-- Is technically accurate and grounded in the actual code (cite file paths and line numbers where helpful).
-- Is respectful and welcoming to external contributors.
-- Directly addresses the question or concern raised.
-- If the contributor identified a real gap or bug, acknowledge it clearly.
-- If there's a workaround, mention it.
-- If work is planned or a fix would be welcome, say so and suggest next steps (e.g., "a PR to address this would be welcome").
-- Keeps the tone professional but friendly.
-- Is concise -- contributors appreciate direct answers, not walls of text.
+```bash
+gh issue list --repo NVIDIA/Megatron-LM --search "<keywords>" --limit 10
+gh pr list --repo NVIDIA/Megatron-LM --search "<keywords>" --limit 10
+```
 
-### 5. Suggest follow-up actions
+### 2. Classify the intake
 
-If the issue identifies something cleanly actionable (dead code to remove, a small bug fix, a missing feature), tell the maintainer and offer to create a branch and PR to address it — don't just draft a comment.
+Choose one primary queue:
 
-### 6. Present to the maintainer
+- **Bug**: something fails or produces wrong behavior.
+- **Regression**: behavior, speed, memory, or accuracy got worse between two commits/releases.
+- **Question**: usage, expected behavior, configuration, or design clarification.
+- **Feature request**: new capability or changed behavior.
+- **PR review/routing**: contributor opened a PR and needs owner review, scope guidance, CI help, or missing context.
+- **CI/release/infrastructure**: GitHub Actions, GitLab, containers, wheels, release, docs publishing.
+- **Security/private data**: do not request public repro details; route to the appropriate private security/reporting channel.
 
-Show the drafted response to the user (the maintainer) for review. Do NOT post it to GitHub automatically. The maintainer will decide whether to post it, edit it, or ask for changes.
+Apply or suggest labels if available: `bug`, `enhancement`, `community-request`, `needs-info`, `needs-repro`, `regression`, and area labels. If labels do not exist, mention the intended label rather than inventing it silently.
 
-Format the draft as a quoted markdown block so it's easy to copy.
+### 3. Check reproducibility and scenario completeness
+
+For bugs and regressions, verify whether the report contains enough to reproduce. Ask only for missing items.
+
+Minimum useful repro packet:
+
+- Megatron-LM commit or release, and whether it reproduces on latest `main`.
+- Exact command, script, config, or minimal code snippet.
+- Expected behavior and actual behavior.
+- Full stack trace or relevant log excerpt.
+- Environment: container/OS, PyTorch, CUDA, NCCL, GPU type/count, node count.
+- Scenario: model family, training vs inference, dataset/checkpoint assumptions, precision, and parallelism topology (TP/PP/DP/CP/EP/FSDP).
+- For regressions: known-good commit, first-bad or current-bad commit, old/new metric values, run-to-run variance if known.
+
+For questions, ask for the user scenario instead of a full bug repro: what they are trying to do, the config/command, and what behavior is unclear.
+
+For PRs, check for:
+
+- Linked issue or clear problem statement.
+- Affected area and likely owner/team.
+- Tests, docs, and validation commands.
+- Backward compatibility risk: API/config defaults, checkpoint format, training numerics, performance, distributed behavior.
+- CI status and whether failures are related to the PR.
+
+### 4. Route to an owner
+
+Use evidence in this order:
+
+1. Referenced files, changed files, stack traces, commands, and labels.
+2. `.github/CODEOWNERS` for path/team ownership.
+3. Recent file history: `git log --oneline -20 -- <path>` and, when useful, `git log -S "<symbol>" -- <path>`.
+4. Similar issues/PRs and maintainers who already handled the same area.
+5. Current on-call when the report lacks enough information to route.
+
+Prefer routing to teams from CODEOWNERS when possible. Assign or request an individual only when they are clearly the code-change writer, active owner, or already engaged. If ownership is uncertain, keep on-call as coordinator and ask for the missing scenario/repro details.
+
+Common owner evidence:
+
+- `megatron/core/transformer/moe/` -> MoE teams from CODEOWNERS.
+- `megatron/core/distributed/`, FSDP, optimizer, checkpointing, pipeline, datasets, tokenizers, inference, RL, CI, docs, and training paths -> use the matching CODEOWNERS entry.
+- PRs touching multiple areas -> identify primary area plus secondary reviewers; ask author to split only if review ownership or blast radius is too broad.
+
+### 5. Research before technical claims
+
+If the response will make a technical claim, verify it against code or CI first.
+
+- Read relevant source files and surrounding context.
+- Re-read exact file/line references before citing them.
+- Confirm commit hashes with `git show <hash> --stat`.
+- If claiming code is unused or missing, use `rg` and, if needed, `git log -S`.
+- If a fix already exists, link the issue/PR and state the relationship precisely.
+
+### 6. Draft the on-call reply
+
+Every reply should contain:
+
+1. Acknowledge the report or PR.
+2. Summarize the on-call understanding in one sentence.
+3. State the route or next action.
+4. Ask for exactly the missing information, or point to the likely owner/workaround/guide.
+
+Keep the tone respectful and concise. Do not promise a fix, timeline, or owner action unless already confirmed.
+
+Missing repro template:
+
+```markdown
+Thanks for the report. To route this to the right maintainer and reproduce it, could you add the missing details below?
+
+- Megatron-LM commit or release, and whether this reproduces on latest `main`
+- Exact command/config or a minimal script
+- Expected behavior vs actual behavior
+- Full stack trace or relevant logs
+- Environment: container/OS, PyTorch, CUDA, NCCL, GPU type/count, node count
+- Scenario: model family, training/inference path, precision, and parallelism setup (TP/PP/DP/CP/EP/FSDP)
+
+Once we have that, on-call can route it to the right area owner.
+```
+
+Owner routing template:
+
+```markdown
+Thanks for the details. This looks related to `<path-or-feature>`, so routing to @NVIDIA/<team> for area-owner input. My understanding is: <one-sentence summary>. The current repro/validation signal is: <brief evidence>.
+
+If you can also add <one missing item>, that will make it easier for the owner to reproduce quickly.
+```
+
+Question template:
+
+```markdown
+Thanks for the question. My understanding is that you are trying to <scenario>. The relevant path appears to be <feature/config/doc>. Could you share the command/config and the parallelism/model setup you are using? With that, on-call can either answer directly or route to the owner of that path.
+```
+
+PR routing template:
+
+```markdown
+Thanks for the PR. To accelerate review, could you link the issue or describe the user scenario this fixes, list the validation commands/results, and note the affected area/owners if known? Based on the changed files, this likely needs review from @NVIDIA/<team>. On-call will keep this routed once the PR is ready for review and CI is passing.
+```
+
+### 7. Automation guidance
+
+An automated GitHub agent is useful, but keep it constrained:
+
+- Start with triage/draft mode: classify, label, identify likely owners, and produce a proposed comment in a job summary or Slack/on-call notification.
+- Allow auto-comments only for low-risk cases: missing repro/template fields, obvious PR checklist gaps, or deterministic CODEOWNERS routing.
+- Require human approval for closing issues, declaring duplicates, making unverified technical diagnoses, assigning specific individuals, or promising fixes/timelines.
+- Add an `agent-triaged` marker/label or hidden comment marker so the bot does not repeat itself on every edit.
+- Skip automation if a maintainer has already replied after the latest reporter update.
+- Use least-privilege permissions. For `pull_request_target`, do not checkout or execute untrusted PR code; inspect metadata/diff via GitHub APIs or checkout only the trusted base repo.
+- Keep a dry-run/manual trigger such as `/oncall triage` for sensitive issues or early rollout.
+
+Recommended event model:
+
+- Issues: `opened`, `reopened`, `edited`, and `labeled` with `community-request`.
+- PRs: `opened`, `ready_for_review`, `reopened`, and `synchronize` only for routing/checklist refreshes.
+- Outputs: labels, team review requests, a concise public ask-for-info comment, and an on-call summary with owner evidence.
+
+### 8. Batch SLA scan
+
+When asked to scan issues needing on-call response, produce drafts first; never post during the scan.
+
+If the user gives an SLA, use it. If not, use age buckets instead of claiming an issue is out-of-SLA: `new` (<1 day), `watch` (1-2 days), `at-risk` (2-5 days), `stale` (>5 days), based on the latest reporter/community update that still needs maintainer action.
+
+Candidate search:
+
+```bash
+gh issue list --repo NVIDIA/Megatron-LM --state open --limit 100 \
+  --json number,title,labels,assignees,author,createdAt,updatedAt,url
+gh issue list --repo NVIDIA/Megatron-LM --state open --search "label:community-request" --limit 100 \
+  --json number,title,labels,assignees,author,createdAt,updatedAt,url
+```
+
+For each candidate, fetch full context:
+
+```bash
+gh issue view <number> --repo NVIDIA/Megatron-LM --json title,body,comments,labels,state,author,createdAt,updatedAt,url
+```
+
+Classify as **needs reply** when:
+
+- no maintainer has replied yet;
+- the latest substantive comment is from the reporter/community and asks a new question or adds requested data;
+- the issue has `community-request`, `needs-info`, `needs-repro`, or no clear owner/label and is aging;
+- the issue was routed but no owner has engaged after the requested SLA;
+- a prior on-call reply asked for information and the reporter has now provided it.
+
+Do **not** draft a new reply when:
+
+- a maintainer already replied after the latest reporter update;
+- the issue is clearly waiting on reporter info and the reporter has not responded;
+- the latest activity is bot-only, label-only, or project-board churn;
+- the issue is security/private-data sensitive.
+
+For each issue that needs response, apply this skill's single-issue workflow and output a review packet:
+
+```markdown
+## #<issue-number> <title>
+
+- URL:
+- SLA state:
+- Intake type:
+- Latest action needed:
+- Likely owner/team:
+- Owner evidence:
+- Suggested labels:
+- Suggested assignee:
+- Risk/uncertainty:
+
+Draft reply:
+> <editable public reply>
+
+Approval:
+- [ ] Post reply
+- [ ] Apply labels
+- [ ] Assign owner
+```
+
+After presenting the batch, wait for explicit approval. Accept maintainer edits in chat or in a checked/generated draft file. Post only approved items, and post exactly the edited text. Use `gh issue comment <number> --repo NVIDIA/Megatron-LM --body-file <file>` for comments and `gh issue edit <number> --repo NVIDIA/Megatron-LM --add-label <label>` for labels.
+
+### 9. Present to the maintainer
+
+Unless the user explicitly asks you to post or the repository automation is intentionally running in auto-comment mode, show the draft response and recommended labels/owners to the maintainer first. Format the draft as a quoted Markdown block so it is easy to review.
 
 ## Important guidelines
 
-- Never post comments to GitHub without explicit approval from the user.
-- If you're unsure about the answer, say so clearly in your draft and flag the uncertainty for the maintainer.
-- If the issue is outside the scope of what you can determine from the code, tell the maintainer what you found and what remains unclear.
-- Check whether similar issues exist that might be relevant: `gh issue list --repo NVIDIA/Megatron-LM --search "<keywords>" --limit 5`.
+- Never post comments to GitHub without explicit approval from the user, except inside a deliberately configured automation path with clear guardrails.
+- Ask for the smallest useful missing information, not a generic wall of questions.
+- Do not route publicly to a person/team based only on a guess; state the evidence.
+- If the issue is outside what can be determined from code, say what remains unclear.
+- If the issue identifies a cleanly actionable bug or missing feature, tell the maintainer and offer to create a branch/PR after triage.


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Document the on-call GitHub issue/PR triage workflow and update issue/PR templates so reports include the context needed for reproducibility, routing, and owner assignment.

## Scenario and routing

User scenario this PR fixes or enables: Enables mcore on-call to scan issues needing response, draft replies, route to owners, ask for missing repro/scenario details, and post only after maintainer approval.

Affected area / likely owners: `skills/respond-to-issue/SKILL.md`, `.github/ISSUE_TEMPLATE/*`, `.github/pull_request_template.md`; likely repo process/on-call owners.

Risk notes: Documentation/template-only change. It changes the information requested from issue and PR authors, but does not change runtime code or CI behavior.

## Issue tracking

Linked issue: N/A

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Validation

Reproduction or before/after signal: N/A, docs/template-only change.

Test commands and results:

```bash
git diff --check
```

Passed.