### PR TITLE
Enable no-TE HybridEP bounded workspace

### DIFF
--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -477,7 +477,15 @@ class HybridEPCombine(torch.autograd.Function):
     '''
 
     @staticmethod
-    def forward(ctx, x, handle, num_permuted_tokens=None, pad_multiple=None, fused=False):
+    def forward(
+        ctx,
+        x,
+        handle,
+        num_permuted_tokens=None,
+        pad_multiple=None,
+        fused=False,
+        num_actual_permuted_tokens=None,
+    ):
         '''
         Forward pass of fused combine of the HybridEP backend
         '''
@@ -490,6 +498,7 @@ class HybridEPCombine(torch.autograd.Function):
         ctx.handle = handle
         ctx.pad_multiple = pad_multiple
         ctx.num_permuted_tokens = num_permuted_tokens
+        ctx.num_actual_permuted_tokens = num_actual_permuted_tokens
         ctx.fused = fused
         return combined_hidden
 
@@ -507,7 +516,9 @@ class HybridEPCombine(torch.autograd.Function):
             num_permuted_tokens=ctx.num_permuted_tokens,
             **({"fuse_permute_dispatch": ctx.fused} if ctx.fused else {}),
         )
-        return dispatched_hidden, None, None, None, None
+        if ctx.num_actual_permuted_tokens is not None:
+            dispatched_hidden = dispatched_hidden[: ctx.num_actual_permuted_tokens]
+        return dispatched_hidden, None, None, None, None, None
 
 
 if HAVE_HYBRIDEP:
@@ -578,7 +589,14 @@ if HAVE_HYBRIDEP:
         )
 
     @internal_api
-    def hybrid_ep_combine(x, handle, num_permuted_tokens, pad_multiple, fused=False):
+    def hybrid_ep_combine(
+        x,
+        handle,
+        num_permuted_tokens,
+        pad_multiple,
+        fused=False,
+        num_actual_permuted_tokens=None,
+    ):
         '''
         Perform fused combine operation for unpermute + combine a2a + unpermute
         using the HybridEP backend
@@ -595,7 +613,14 @@ if HAVE_HYBRIDEP:
                 The alignment multiple required for FP8 GEMM. If not provided, no padding
                 is performed.
         '''
-        return HybridEPCombine.apply(x, handle, num_permuted_tokens, pad_multiple, fused)
+        return HybridEPCombine.apply(
+            x,
+            handle,
+            num_permuted_tokens,
+            pad_multiple,
+            fused,
+            num_actual_permuted_tokens,
+        )
 
 else:
     hybrid_ep_dispatch = None

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -9,6 +9,7 @@ import torch
 from megatron.core._rank_utils import log_single_rank
 from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
 from megatron.core.transformer.moe.ops.paged_stash import (
     GLOBAL_BLOCK_SIZE,
     paged_stash_copy_kernel,
@@ -966,7 +967,7 @@ def check_paged_stash_host_spill():
 
 
 class PagedStashRunner:
-    """Runner for paged stash"""
+    """Runner for bounded MoE workspace overflow and optional paged stash fallback."""
 
     def __init__(self, config, copy_main_params, model, optimizer, forward_backward_func):
         self.stash_manager = PagedStashManager.get_instance()
@@ -1089,8 +1090,8 @@ class PagedStashRunner:
         log_single_rank(
             logger,
             logging.INFO,
-            "Paged stash: rerunning forward-backward without "
-            "moe_expert_rank_capacity_factor padding and with moe_paged_stash disabled.",
+            "MoE bounded workspace: rerunning forward-backward without "
+            "moe_expert_rank_capacity_factor and with moe_paged_stash disabled.",
         )
         # check for token dispatcher overflow
         for mlp in self.moe_layers:
@@ -1104,6 +1105,10 @@ class PagedStashRunner:
         if self.stash_manager.host_spill is not None:
             self.stash_manager.host_spill.zero_()
         self._set_moe_paged_stash_all(False)
+        get_moe_metrics_tracker().clear()
+        from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
+
+        MTPLossLoggingHelper.clean_metrics_in_tracker()
 
         # Set grad to zero.
         for model_chunk in self.model:
@@ -1147,14 +1152,13 @@ class PagedStashRunner:
             self.stash_manager.release_stash_buffers()
 
     def __call__(self, *args, **kwargs):
-        """Training-step wrapper with fallback when static-buffer paths overflow.
+        """Training-step wrapper with fallback when bounded-buffer paths overflow.
 
-        The first attempt runs forward/backward with a static HybridEP receive budget
-        (moe_expert_rank_capacity_factor) and paged stashing enabled. If either the
-        HybridEP permute buffer is over budget (tokens dropped) or the paged stash
-        buffer overflows, this wrapper retries once in synced dropless mode: no static
-        limit on HybridEP (capacity factor cleared, dynamic permuted size via CPU sync)
-        and no paged stash (moe_paged_stash disabled).
+        The first attempt runs forward/backward with a bounded HybridEP permuted-token
+        workspace (moe_expert_rank_capacity_factor) and optional paged stashing. If either the
+        HybridEP workspace is over budget or the paged stash buffer overflows, this wrapper
+        retries once in synced dropless mode: no static limit on HybridEP (capacity factor
+        cleared, dynamic permuted size via CPU sync) and no paged stash (moe_paged_stash disabled).
 
         At most two attempts. Each attempt prefetches microbatches, runs the schedule,
         then all-reduces stash overflow, HybridEP over-budget, and host spill across ranks.
@@ -1205,7 +1209,7 @@ class PagedStashRunner:
                         "potentially better performance.",
                     )
                 # Restore moe_expert_rank_capacity_factor on every HybridEP MoE layer so the
-                # next step uses the static dispatch budget again (cleared by prepare_for_rerun
+                # next step uses the bounded dispatch workspace again (cleared by prepare_for_rerun
                 # on a failed retry).
                 for mlp in self.moe_layers:
                     if hasattr(mlp, 'token_dispatcher') and hasattr(
@@ -1222,15 +1226,15 @@ class PagedStashRunner:
                 log_single_rank(
                     logger,
                     logging.INFO,
-                    "Paged stash: token drop during MoE token dispatch (over budget) "
+                    "MoE bounded workspace: HybridEP dispatch exceeded rank capacity "
                     f"on {overbudget_ranks} rank(s). "
-                    "Consider increasing moe_expert_rank_capacity_factor.",
+                    "Rerunning dropless; consider increasing moe_expert_rank_capacity_factor.",
                 )
             if stash_overflow_ranks > 0:
                 log_single_rank(
                     logger,
                     logging.INFO,
-                    "Paged stash: stashing buffer overflow "
+                    "MoE bounded workspace: paged-stash buffer overflow "
                     f"on {stash_overflow_ranks} rank(s). "
                     "Consider increasing moe_paged_stash_buffer_size_factor_cuda or "
                     "moe_paged_stash_buffer_size_factor_cpu.",

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -186,6 +186,14 @@ class SharedExpertMLP(MLP):
                 self.__class__.stream = torch.cuda.Stream()
             self.stream = self.__class__.stream
 
+    def reset_parameters(self):
+        """Reset direct shared-expert parameters for meta-device initialization."""
+        if self.use_shared_expert_gate and self.gate_weight is not None:
+            if self.config.perform_initialization:
+                self.config.init_method(self.gate_weight)
+            self.gate_weight.data = self.gate_weight.data.to(dtype=self.config.params_dtype)
+            setattr(self.gate_weight, 'sequence_parallel', self.config.sequence_parallel)
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Forward function"""
         output, _ = super().forward(hidden_states)

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -1016,6 +1016,8 @@ class _HybridEPManager(_DispatchManager):
         # Actually the the up-bound for the number of tokens
         # after permute op, None means no up-bound, will cause a CPU sync
         self.num_permuted_tokens = None
+        # Exact number of dispatched tokens when a bounded workspace contains an inactive tail.
+        self.num_actual_permuted_tokens = None
 
         # Metadata
         self.token_probs: Optional[torch.Tensor] = None
@@ -1040,16 +1042,19 @@ class _HybridEPManager(_DispatchManager):
 
         if self.moe_expert_rank_capacity_factor is not None:
             pad_multiple = get_align_size_for_quantization(self.config)
-            # Static upper bound on permuted tokens passed to HybridEP (dropless EP rank
-            # budget). Tokens above this budget are dropped inside HybridEP; dispatch then
-            # sets overflow_flag on the handle (accumulated in over_budget in dispatch()).
+            # Upper bound on permuted tokens passed to HybridEP. This enables nonblocking
+            # dispatch and avoids the dynamic-size host sync. If the real dynamic routing result
+            # is over budget, HybridEP reports it through the handle; the training/eval wrapper
+            # must discard the attempt and rerun without this bound.
             budget = int(
                 routing_map.shape[0]
                 * self.config.moe_router_topk
                 * self.moe_expert_rank_capacity_factor
             )
-            # Round budget up to pad_multiple (FP8/FP4/CUTLASS alignment for permute buffers).
-            budget += -budget % pad_multiple
+            # Round budget up when the dispatcher/expert path needs aligned permute buffers
+            # (FP8/FP4/CUTLASS). BF16 without the TE op-fuser has no alignment requirement.
+            if pad_multiple > 0:
+                budget += -budget % pad_multiple
             self.num_permuted_tokens = budget
         # else: num_permuted_tokens stays None; HybridEP sizes buffers dynamically (CPU sync
         # in dispatch) and does not drop tokens or report overflow.
@@ -1102,8 +1107,8 @@ class _HybridEPManager(_DispatchManager):
             )
         )
         if self.moe_expert_rank_capacity_factor is not None:
-            # Static-budget path only: handle[-1] is HybridEP overflow_flag when tokens were
-            # dropped because permuted count exceeded num_permuted_tokens from setup_metadata.
+            # Bounded-workspace path only: handle[-1] is HybridEP overflow_flag when the real
+            # permuted count exceeded num_permuted_tokens from setup_metadata.
             over_budget = self.handle[-1] != 0
             self.over_budget |= over_budget
         # When capacity factor is None, skip overflow tracking (no token drops). Actual
@@ -1115,6 +1120,15 @@ class _HybridEPManager(_DispatchManager):
             self.num_permuted_tokens = self.tokens_per_expert.sum()
         if self.moe_expert_rank_capacity_factor is not None:
             self.tokens_per_expert = tokens_per_expert.to(torch.int64)
+            if not self.config.use_transformer_engine_op_fuser:
+                # Non-fuser grouped GEMM consumes exact split metadata via tokens_per_expert.
+                # Trim the inactive workspace tail before experts; combine receives exact tokens,
+                # while backward uses the bounded workspace and trims gradients back to this count.
+                # Routing probabilities must be trimmed with hidden states because non-fuser expert
+                # activations apply them elementwise.
+                self.num_actual_permuted_tokens = int(self.tokens_per_expert.sum().item())
+                dispatched_hidden = dispatched_hidden[: self.num_actual_permuted_tokens]
+                self.dispatched_probs = self.dispatched_probs[: self.num_actual_permuted_tokens]
         return dispatched_hidden
 
     def combine(
@@ -1123,17 +1137,34 @@ class _HybridEPManager(_DispatchManager):
         async_finish: bool = True,
         allocate_on_comm_stream: bool = True,
     ) -> torch.Tensor:
+        if (
+            self.moe_expert_rank_capacity_factor is not None
+            and not self.config.use_transformer_engine_op_fuser
+            and self.num_actual_permuted_tokens is not None
+        ):
+            if hidden_states.shape[0] > self.num_permuted_tokens:
+                raise RuntimeError(
+                    "HybridEP bounded workspace expert output exceeds num_permuted_tokens: "
+                    f"{hidden_states.shape[0]} > {self.num_permuted_tokens}"
+                )
+            if hidden_states.shape[0] != self.num_actual_permuted_tokens:
+                raise RuntimeError(
+                    "HybridEP bounded workspace expert output must preserve exact token count: "
+                    f"{hidden_states.shape[0]} != {self.num_actual_permuted_tokens}"
+                )
         hidden_states = hybrid_ep_combine(
             x=hidden_states,
             handle=self.handle,
             num_permuted_tokens=self.num_permuted_tokens,
             pad_multiple=self.pad_multiple,
             fused=self.config.moe_permute_fusion_into_hybridep,
+            num_actual_permuted_tokens=self.num_actual_permuted_tokens,
         )
         # Release the used handle/num_permuted_tokens which could change in each iteration.
         # For drop_and_pad mode, we don't need to reset the num_permuted_tokens and
         # num_dispatched_tokens, because their values never change.
         self.handle = None
+        self.num_actual_permuted_tokens = None
         if not self.drop_and_pad:
             self.num_permuted_tokens = None
         return hidden_states

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -874,9 +874,11 @@ class TransformerConfig(ModelParallelConfig):
     advanced fused kernels."""
 
     moe_expert_rank_capacity_factor: Optional[float] = None
-    """moe_expert_rank_capacity_factor (float): The capacity factor for each expert rank. Tokens 
-    exceeding this budget will be dropped. None means no token will be dropped. 
-    The default is None."""
+    """moe_expert_rank_capacity_factor (float): The capacity factor for each expert rank.
+    When set for HybridEP, this provides a bounded permuted-token workspace to avoid dispatch
+    shape synchronization. If the dynamic routing result exceeds the budget, overflow is detected
+    and the training/eval wrapper reruns the step without the bound. None means unbounded
+    dropless dispatch. The default is None."""
 
     ##################
     # Context Parallel
@@ -1513,11 +1515,6 @@ class TransformerConfig(ModelParallelConfig):
                 )
 
         if self.moe_expert_rank_capacity_factor is not None:
-            if not self.use_transformer_engine_op_fuser:
-                raise ValueError(
-                    "moe_expert_rank_capacity_factor requires use_transformer_engine_op_fuser to "
-                    "be enabled."
-                )
             if self.moe_flex_dispatcher_backend != "hybridep":
                 raise ValueError(
                     "moe_expert_rank_capacity_factor requires moe_flex_dispatcher_backend to be "

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3296,7 +3296,7 @@ def train(
             cuda_graph_warmup_steps=args.cuda_graph_warmup_steps,
             use_single_mempool=config.cuda_graph_use_single_mempool,
         )
-    # Wrap forward_backward_func for overflow handling with moe_expert_rank_capacity_factor
+    # Wrap forward_backward_func for bounded MoE workspace overflow handling.
     if args.moe_expert_rank_capacity_factor is not None:
         copy_main_params = args.reuse_grad_buf_for_mxfp8_param_ag and args.overlap_param_gather
         forward_backward_func = PagedStashRunner(
@@ -3861,7 +3861,7 @@ def evaluate(
             cuda_graph_warmup_steps=args.cuda_graph_warmup_steps,
             use_single_mempool=config.cuda_graph_use_single_mempool,
         )
-    # Wrap forward_backward_func for overflow handling with moe_expert_rank_capacity_factor
+    # Wrap forward_backward_func for bounded MoE workspace overflow handling.
     if args.moe_expert_rank_capacity_factor is not None:
         copy_main_params = args.reuse_grad_buf_for_mxfp8_param_ag and args.overlap_param_gather
         forward_backward_func = PagedStashRunner(

--- a/tests/unit_tests/transformer/moe/test_hybridep_rank_capacity_config.py
+++ b/tests/unit_tests/transformer/moe/test_hybridep_rank_capacity_config.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+import torch
+
+import megatron.core.transformer.moe.fused_a2a as fused_a2a
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def test_hybridep_rank_capacity_does_not_require_te_op_fuser():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_moe_experts=8,
+        moe_router_topk=2,
+        moe_token_dispatcher_type="flex",
+        moe_flex_dispatcher_backend="hybridep",
+        moe_expert_rank_capacity_factor=1.10,
+        use_transformer_engine_op_fuser=False,
+    )
+
+    assert config.moe_expert_rank_capacity_factor == 1.10
+    assert not config.use_transformer_engine_op_fuser
+
+
+def test_rank_capacity_still_requires_hybridep_backend():
+    with pytest.raises(ValueError, match="moe_flex_dispatcher_backend"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            num_moe_experts=8,
+            moe_router_topk=2,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="deepep",
+            moe_expert_rank_capacity_factor=1.10,
+            use_transformer_engine_op_fuser=False,
+        )
+
+
+def test_hybridep_combine_backward_trims_bounded_workspace_gradient(monkeypatch):
+    class FakeHybridEPBuffer:
+        def combine_with_unpermute(self, *, hidden, handle, pad_multiple, **kwargs):
+            return hidden * 2, None
+
+        def dispatch_with_permute(self, *, hidden, handle, num_permuted_tokens, **kwargs):
+            assert num_permuted_tokens == 5
+            grad = hidden.new_ones((num_permuted_tokens, hidden.shape[1]))
+            return grad, None, None, None, None
+
+    monkeypatch.setattr(fused_a2a, "_hybrid_ep_buffer", FakeHybridEPBuffer())
+
+    x = torch.randn(3, 4, requires_grad=True)
+    y = fused_a2a.HybridEPCombine.apply(x, (), 5, None, False, 3)
+
+    y.sum().backward()
+
+    assert x.grad.shape == x.shape
+    torch.testing.assert_close(x.grad, torch.ones_like(x))

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import dataclasses
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -9,9 +10,31 @@ from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodu
 from megatron.core.parallel_state import get_tensor_model_parallel_world_size
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
+from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
+
+
+def test_shared_expert_reset_parameters_initializes_direct_gate_weight():
+    module = SharedExpertMLP.__new__(SharedExpertMLP)
+    torch.nn.Module.__init__(module)
+    module.use_shared_expert_gate = True
+    module.gate_weight = torch.nn.Parameter(torch.empty((1, 4), dtype=torch.float32))
+    module.config = SimpleNamespace(
+        perform_initialization=True,
+        init_method=lambda weight: torch.nn.init.constant_(weight, 0.25),
+        params_dtype=torch.bfloat16,
+        sequence_parallel=True,
+    )
+
+    module.reset_parameters()
+
+    assert module.gate_weight.dtype == torch.bfloat16
+    assert module.gate_weight.sequence_parallel is True
+    torch.testing.assert_close(
+        module.gate_weight, torch.full((1, 4), 0.25, dtype=torch.bfloat16)
+    )
 
 
 class TestSharedExperts:


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

Enable HybridEP rank capacity as a no-TE-op-fuser bounded workspace path.

- Allow `moe_expert_rank_capacity_factor` with the HybridEP flex dispatcher without requiring `use_transformer_engine_op_fuser`.
- Treat rank capacity as a bounded `num_permuted_tokens` workspace for HybridEP nonblocking dispatch, while preserving exact expert split metadata.
- Trim inactive bounded-workspace tail rows before non-fuser expert compute.
- Pass exact expert output into HybridEP combine and trim bounded-workspace gradients back to the exact active token count in backward.
- Rename bounded workspace fallback logs/comments away from token-drop-only wording.
- Clear MoE metrics and MTP loss trackers before dropless rerun after an over-budget bounded attempt.
- Initialize direct shared-expert gate weights during meta-device reset.
- Add unit coverage for no-TE HybridEP rank capacity config validation, combine backward gradient trimming, and shared-expert gate reset.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
