### PR TITLE
Route bridge communicator cross-grid P2P through a dedicated process group

### DIFF
--- a/megatron/core/pipeline_parallel/bridge_communicator.py
+++ b/megatron/core/pipeline_parallel/bridge_communicator.py
@@ -48,6 +48,8 @@ class BridgeCommunicator:
 
     # Cache broadcast PGs to avoid creating duplicate NCCL communicators for identical rank sets.
     _broadcast_pg_cache: Dict[str, "torch.distributed.ProcessGroup"] = {}
+    # Cache bridge PGs (cross-grid leader<->leader P2P) keyed by sorted leader ranks.
+    _bridge_pg_cache: Dict[str, "torch.distributed.ProcessGroup"] = {}
 
     @classmethod
     def destroy_broadcast_pgs(cls):
@@ -56,6 +58,14 @@ class BridgeCommunicator:
             if pg is not None:
                 dist.destroy_process_group(pg)
         cls._broadcast_pg_cache.clear()
+
+    @classmethod
+    def destroy_bridge_pgs(cls):
+        """Destroy all cached bridge process groups."""
+        for pg in cls._bridge_pg_cache.values():
+            if pg is not None:
+                dist.destroy_process_group(pg)
+        cls._bridge_pg_cache.clear()
 
     def __init__(
         self,
@@ -154,6 +164,9 @@ class BridgeCommunicator:
             self.dest_grid, is_src=False
         )
 
+        bridge_ranks = sorted(set(self.src_tp_leaders) | set(self.dest_tp_leaders))
+        self.bridge_pg = self._get_or_create_bridge_pg(bridge_ranks)
+
         log_msg = (
             f"[Rank {self.current_rank}] "
             f"srcLeader={self.src_local_leader_rank} "
@@ -186,6 +199,15 @@ class BridgeCommunicator:
             pg, _ = dist.new_subgroups_by_enumeration(ranks_list, backend='nccl')
             cls._broadcast_pg_cache[cache_key] = pg
         return cls._broadcast_pg_cache[cache_key]
+
+    @classmethod
+    def _get_or_create_bridge_pg(cls, ranks: List[int]):
+        """Get or create a bridge PG, caching to avoid duplicate NCCL communicators."""
+        ranks = sorted(ranks)
+        cache_key = str(ranks)
+        if cache_key not in cls._bridge_pg_cache:
+            cls._bridge_pg_cache[cache_key] = dist.new_group(ranks, backend='nccl')
+        return cls._bridge_pg_cache[cache_key]
 
     def get_leader_rank(self, grid: HyperCommGrid, is_src: bool) -> List[int]:
         """Get the leader rank for a given grid and direction.
@@ -356,7 +378,7 @@ class BridgeCommunicator:
                         f"[Bridge Comunicator] [send_forward] Rank {self.current_rank} "
                         f"send to rank {dest_rank}"
                     )
-                    dist.send(tensor_split, dst=dest_rank)
+                    dist.send(tensor_split, dst=dest_rank, group=self.bridge_pg)
 
     def recv_forward(self) -> torch.Tensor:
         """Receive forward activation tensor.
@@ -399,7 +421,7 @@ class BridgeCommunicator:
                     dtype=self.comm_dtype,
                     requires_grad=True,
                 )
-                dist.recv(tensor_to_recv, src=src_rank)
+                dist.recv(tensor_to_recv, src=src_rank, group=self.bridge_pg)
                 logging.debug(
                     f"[Bridge Communicator] [receive_forward] Rank {self.current_rank} "
                     f"received tensor from src rank {src_rank} "
@@ -489,7 +511,7 @@ class BridgeCommunicator:
                         f"sending gradient to src rank {src_rank} "
                         f"shape {tensor_split.shape} sum {tensor_split.sum()}"
                     )
-                    dist.send(tensor_split, dst=src_rank)
+                    dist.send(tensor_split, dst=src_rank, group=self.bridge_pg)
 
     def recv_backward(self) -> torch.Tensor:
         """Receive backward gradient tensor.
@@ -528,7 +550,7 @@ class BridgeCommunicator:
                 grad_tensor = torch.empty(
                     grad_shape, device=torch.cuda.current_device(), dtype=self.comm_dtype
                 )
-                dist.recv(grad_tensor, src=dest_rank)
+                dist.recv(grad_tensor, src=dest_rank, group=self.bridge_pg)
                 logging.debug(
                     f"[Bridge Communicator] [receive_backward] Rank {self.current_rank} "
                     f"received gradient from dest rank {dest_rank} "
@@ -643,12 +665,14 @@ class BridgeCommunicator:
                     # Send activation
                     ops.append(
                         torch.distributed.P2POp(
-                            torch.distributed.isend, activation_split, dest_rank
+                            torch.distributed.isend, activation_split, dest_rank, self.bridge_pg
                         )
                     )
                     # Receive gradient
                     ops.append(
-                        torch.distributed.P2POp(torch.distributed.irecv, grad_tensor, dest_rank)
+                        torch.distributed.P2POp(
+                            torch.distributed.irecv, grad_tensor, dest_rank, self.bridge_pg
+                        )
                     )
 
                 logging.debug(
@@ -764,13 +788,15 @@ class BridgeCommunicator:
                 ):
                     # Send gradient
                     ops.append(
-                        torch.distributed.P2POp(torch.distributed.isend, gradient_split, src_rank)
+                        torch.distributed.P2POp(
+                            torch.distributed.isend, gradient_split, src_rank, self.bridge_pg
+                        )
                     )
 
                     # Receive activation
                     ops.append(
                         torch.distributed.P2POp(
-                            torch.distributed.irecv, activation_tensor, src_rank
+                            torch.distributed.irecv, activation_tensor, src_rank, self.bridge_pg
                         )
                     )
 
@@ -888,7 +914,7 @@ class BridgeCommunicator:
                     )
                     ops.append(
                         torch.distributed.P2POp(
-                            torch.distributed.isend, send_shape_tensor, dest_rank
+                            torch.distributed.isend, send_shape_tensor, dest_rank, self.bridge_pg
                         )
                     )
 
@@ -901,7 +927,7 @@ class BridgeCommunicator:
                     recv_grad_shape_tensors.append(grad_shape_tensor)
                     ops.append(
                         torch.distributed.P2POp(
-                            torch.distributed.irecv, grad_shape_tensor, dest_rank
+                            torch.distributed.irecv, grad_shape_tensor, dest_rank, self.bridge_pg
                         )
                     )
 
@@ -915,7 +941,7 @@ class BridgeCommunicator:
                     recv_forward_shape_tensors.append(forward_shape_tensor)
                     ops.append(
                         torch.distributed.P2POp(
-                            torch.distributed.irecv, forward_shape_tensor, src_rank
+                            torch.distributed.irecv, forward_shape_tensor, src_rank, self.bridge_pg
                         )
                     )
 
@@ -932,7 +958,7 @@ class BridgeCommunicator:
                     )
                     ops.append(
                         torch.distributed.P2POp(
-                            torch.distributed.isend, grad_shape_tensor, src_rank
+                            torch.distributed.isend, grad_shape_tensor, src_rank, self.bridge_pg
                         )
                     )
 

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -112,6 +112,7 @@ def destroy_all_grids():
     _active_grids.clear()
     _embedding_pg_cache.clear()
     BridgeCommunicator.destroy_broadcast_pgs()
+    BridgeCommunicator.destroy_bridge_pgs()
 
 
 def get_pg_collection(grid):

--- a/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
+++ b/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
@@ -17,7 +17,7 @@ from megatron.core.parallel_state import (
     get_expert_model_parallel_rank,
     get_tensor_model_parallel_rank,
 )
-from megatron.core.pipeline_parallel.bridge_communicator import BridgeCommunicator
+from megatron.core.pipeline_parallel.bridge_communicator import BridgeCommunicator, CommRole
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -142,6 +142,7 @@ def destroy_all_grids():
         grid.destroy()
     _active_grids.clear()
     BridgeCommunicator.destroy_broadcast_pgs()
+    BridgeCommunicator.destroy_bridge_pgs()
 
 
 def _get_pg_collection_from_grid(grid):
@@ -301,6 +302,29 @@ class TestBridgeCommunicator:
         assert bridge_communicator.dest_grid is grid2
         assert bridge_communicator.current_rank == dist.get_rank()
         assert bridge_communicator.comm_map is not None
+
+    @pytest.mark.parametrize(
+        "grid1_tp, grid1_dp, grid2_tp, grid2_dp",
+        [
+            (2, 2, 4, 1),  # fan-in: 2 src leaders -> 1 dest leader
+            (4, 1, 2, 2),  # fan-out: 1 src leader -> 2 dest leaders
+            (2, 1, 2, 1),  # equal leaders
+        ],
+    )
+    def test_bridge_pg_membership(self, grid1_tp, grid1_dp, grid2_tp, grid2_dp):
+        grid1 = create_hypercomm_grid(offset=0, tp=grid1_tp, cp=1, pp=1, dp=grid1_dp)
+        grid2 = create_hypercomm_grid(offset=4, tp=grid2_tp, cp=1, pp=1, dp=grid2_dp)
+        bridge = BridgeCommunicator(grid1, grid2)
+
+        assert bridge.bridge_pg is not None
+        expected = sorted(set(bridge.src_tp_leaders) | set(bridge.dest_tp_leaders))
+        assert dist.get_process_group_ranks(bridge.bridge_pg) == expected
+
+        # MEMBER (broadcast-only) ranks must not be in the bridge group.
+        member_ranks = [
+            rank for rank, info in bridge.comm_map.items() if info.role == CommRole.MEMBER
+        ]
+        assert all(rank not in expected for rank in member_ranks)
 
     def test_send_forward_recv_forward(self):
         """Test send_forward and recv_forward operations."""

--- a/tests/unit_tests/pipeline_parallel/test_multimodule_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_multimodule_schedules.py
@@ -61,6 +61,7 @@ def destroy_all_grids():
         grid.destroy()
     _active_grids.clear()
     BridgeCommunicator.destroy_broadcast_pgs()
+    BridgeCommunicator.destroy_bridge_pgs()
 
 
 def get_pg_collection(grid):


### PR DESCRIPTION
## What
`BridgeCommunicator`'s cross-grid leader↔leader P2P (`send`/`recv`, `batch_isend_irecv`, and the `_communicate_shapes` handshake) ran with no `group=` argument, i.e. on the implicit default (world) process group. This creates a dedicated NCCL group per bridge and routes all cross-grid P2P through it.

## How
- Each `BridgeCommunicator` builds a group whose members are exactly its communicating leader ranks — `sorted(set(src_tp_leaders) | set(dest_tp_leaders))`. Broadcast-only (`MEMBER`) ranks are excluded; they keep using the existing within-grid broadcast PGs, which are unchanged.
- Mirrors the existing broadcast-PG machinery: a cache (`_bridge_pg_cache`), `_get_or_create_bridge_pg`, and `destroy_bridge_pgs`. Global peer ranks are unchanged — on torch ≥2.6 `send`/`recv`/`P2POp` canonicalize a global peer to group-local when a group is passed.
- No public API or caller changes.

## Testing
8×H100: `50 passed, 4 skipped` across `test_bridge_communicator`, `test_multimodule_communicator`, `test_multimodule_schedules`, `test_mimo_1f1b_schedule`. New tests assert group membership equals the leader union (`MEMBER` ranks excluded) and that every P2P routes through the dedicated PG rather than `WORLD`.
