### PR TITLE
Notify on Slack oncall rotation failures

### DIFF
--- a/.github/scripts/github_slack_utils.py
+++ b/.github/scripts/github_slack_utils.py
@@ -132,6 +132,23 @@ def get_slack_client(require_slack: bool = False):
     return WebClient(token=slack_token)
 
 
+def get_slack_error(error) -> str:
+    """Return the Slack API error code from a SlackApiError, or the exception text.
+
+    Slack errors carry their code in ``error.response["error"]``; anything else
+    (a missing or malformed response) falls back to ``str(error)`` so a lookup
+    failure never raises a second error while being reported.
+    """
+
+    response = getattr(error, "response", None)
+    if response is not None:
+        try:
+            return response["error"]
+        except (KeyError, TypeError):
+            pass
+    return str(error)
+
+
 def get_slack_user_id(slack_client, email: str) -> str | None:
     """Resolve an email address to a Slack user ID."""
 
@@ -147,6 +164,6 @@ def get_slack_user_id(slack_client, email: str) -> str | None:
         _slack_id_cache[email] = user_id
         return user_id
     except SlackApiError as exc:
-        print(f"Warning: Could not find Slack user for {email}: {exc.response['error']}")
+        print(f"Warning: Could not find Slack user for {email}: {get_slack_error(exc)}")
         _slack_id_cache[email] = None
         return None

--- a/.github/scripts/oncall_manager.py
+++ b/.github/scripts/oncall_manager.py
@@ -30,7 +30,6 @@ ACTIVE_ONCALL_TEAM_SLUG = "mcore-oncall"
 SLACK_USERGROUP_HANDLE = "mcore-oncall"
 COMMUNITY_REQUEST_LABEL = "community-request"
 TARGET_WEEKS = 12
-SLACK_ROTATION_FALLBACK_EMAILS = ["ppetrakian@nvidia.com"]
 
 # Caches for email and Slack lookups
 _email_cache = {}
@@ -206,15 +205,6 @@ def get_slack_usergroup_id(slack_client, handle):
         return None, []
 
 
-def get_slack_rotation_fallback_emails():
-    emails = os.environ.get("ONCALL_SLACK_NOTIFY_EMAILS", "")
-    if emails:
-        parsed_emails = [email.strip() for email in emails.split(",") if email.strip()]
-        if parsed_emails:
-            return parsed_emails
-    return SLACK_ROTATION_FALLBACK_EMAILS
-
-
 def get_github_actions_run_url():
     repo = os.environ.get("GITHUB_REPOSITORY")
     run_id = os.environ.get("GITHUB_RUN_ID")
@@ -241,24 +231,10 @@ def get_slack_user_ids_for_usernames(slack_client, usernames):
     return get_slack_user_ids_for_emails(slack_client, emails)
 
 
-def get_slack_rotation_notification_recipients(slack_client, old_members_usernames):
-    previous_oncall_recipients = get_slack_user_ids_for_usernames(
-        slack_client, old_members_usernames
-    )
-    if previous_oncall_recipients:
-        return previous_oncall_recipients, "previous oncall"
-
-    fallback_emails = get_slack_rotation_fallback_emails()
-    fallback_recipients = get_slack_user_ids_for_emails(slack_client, fallback_emails)
-    return fallback_recipients, "fallback contacts"
-
-
 def send_slack_rotation_failure_notification(
     slack_client, reason, new_oncall_username, new_oncall_email, old_members_usernames
 ):
-    recipients, recipient_source = get_slack_rotation_notification_recipients(
-        slack_client, old_members_usernames
-    )
+    recipients = get_slack_user_ids_for_usernames(slack_client, old_members_usernames)
 
     run_url = get_github_actions_run_url()
     message_lines = [
@@ -266,15 +242,17 @@ def send_slack_rotation_failure_notification(
         f"Reason: {reason}",
         f"Target GitHub oncall: {new_oncall_username}",
         f"Email tried for Slack lookup: {new_oncall_email}",
-        f"Slack usergroup not updated: @{SLACK_USERGROUP_HANDLE}",
-        "Please update the Slack usergroup manually or fix the GitHub-to-Slack email mapping.",
+        f"Slack usergroup left unchanged: @{SLACK_USERGROUP_HANDLE}",
+        f"You should still be in @{SLACK_USERGROUP_HANDLE}; please update the Slack usergroup manually or fix the GitHub-to-Slack email mapping.",
     ]
     if run_url:
         message_lines.append(f"Workflow run: {run_url}")
     message = "\n".join(message_lines)
 
     if not recipients:
-        print("Warning: Could not resolve Slack notification recipients for rotation failure")
+        print(
+            "Warning: Could not resolve previous oncall Slack user for rotation failure notification"
+        )
         print(message)
         return False
 
@@ -282,7 +260,7 @@ def send_slack_rotation_failure_notification(
     for recipient in recipients:
         try:
             slack_client.chat_postMessage(channel=recipient, text=message)
-            print(f"Sent Slack rotation failure notification to {recipient} ({recipient_source})")
+            print(f"Sent Slack rotation failure notification to previous oncall {recipient}")
             sent = True
         except SlackApiError as e:
             print(

--- a/.github/scripts/oncall_manager.py
+++ b/.github/scripts/oncall_manager.py
@@ -242,7 +242,7 @@ def send_slack_rotation_failure_notification(
         f"Reason: {reason}",
         f"Target GitHub oncall: {new_oncall_username}",
         f"Email tried for Slack lookup: {new_oncall_email}",
-        f"Slack usergroup left unchanged: @{SLACK_USERGROUP_HANDLE}",
+        f"Slack usergroup not fully updated: @{SLACK_USERGROUP_HANDLE}",
         f"You should still be in @{SLACK_USERGROUP_HANDLE}; please update the Slack usergroup manually or fix the GitHub-to-Slack email mapping.",
     ]
     if run_url:

--- a/.github/scripts/oncall_manager.py
+++ b/.github/scripts/oncall_manager.py
@@ -30,25 +30,35 @@ ACTIVE_ONCALL_TEAM_SLUG = "mcore-oncall"
 SLACK_USERGROUP_HANDLE = "mcore-oncall"
 COMMUNITY_REQUEST_LABEL = "community-request"
 TARGET_WEEKS = 12
+SLACK_ROTATION_FALLBACK_EMAILS = ["ppetrakian@nvidia.com"]
 
 # Caches for email and Slack lookups
 _email_cache = {}
 _slack_id_cache = {}
+
+
+def get_slack_error(error):
+    response = getattr(error, "response", None)
+    if response is not None:
+        try:
+            return response["error"]
+        except (KeyError, TypeError):
+            pass
+    return str(error)
+
 
 def get_headers():
     token = os.environ.get("GH_TOKEN")
     if not token:
         # Fallback to GITHUB_TOKEN if GH_TOKEN not set
         token = os.environ.get("GITHUB_TOKEN")
-        
+
     if not token:
         print("Error: GH_TOKEN or GITHUB_TOKEN not set")
         sys.exit(1)
-        
-    return {
-        "Authorization": f"token {token}",
-        "Accept": "application/vnd.github.v3+json"
-    }
+
+    return {"Authorization": f"token {token}", "Accept": "application/vnd.github.v3+json"}
+
 
 def get_repo_info():
     """Returns (owner, repo) from GITHUB_REPOSITORY env var."""
@@ -59,11 +69,12 @@ def get_repo_info():
     parts = repo_env.split("/")
     return parts[0], parts[1]
 
+
 def get_team_members(org, team_slug):
     """Fetches members of the GitHub team."""
     url = f"{GITHUB_API_URL}/orgs/{org}/teams/{team_slug}/members"
     headers = get_headers()
-    
+
     members = set()
     page = 1
     while True:
@@ -71,31 +82,32 @@ def get_team_members(org, team_slug):
         if resp.status_code != 200:
             print(f"Error fetching team members: {resp.status_code} {resp.text}")
             sys.exit(1)
-        
+
         data = resp.json()
         if not data:
             break
-            
+
         members.update([m['login'] for m in data])
         if len(data) < 100:
             break
         page += 1
-        
+
     return members
+
 
 def get_user_email(username):
     """Get user's email from GitHub, prioritizing @nvidia.com emails.
-    
+
     Checks in order:
     1. Public profile email
     2. Recent commits in the repository
     """
     if username in _email_cache:
         return _email_cache[username]
-    
+
     headers = get_headers()
     public_email = None
-    
+
     try:
         # 1. Try to get user's public profile email first
         resp = requests.get(f"{GITHUB_API_URL}/users/{username}", headers=headers)
@@ -108,12 +120,12 @@ def get_user_email(username):
                     return email
                 # Store non-nvidia email as fallback
                 public_email = email
-        
+
         # 2. Check recent commits in the repository for @nvidia.com email
         repo_env = os.environ.get("GITHUB_REPOSITORY", "NVIDIA/Megatron-LM")
         commits_url = f"{GITHUB_API_URL}/repos/{repo_env}/commits?author={username}&per_page=10"
         resp = requests.get(commits_url, headers=headers)
-        
+
         if resp.status_code == 200:
             commits = resp.json()
             for commit in commits:
@@ -121,7 +133,7 @@ def get_user_email(username):
                 commit_data = commit.get('commit', {})
                 author_data = commit_data.get('author', {})
                 email = author_data.get('email')
-                
+
                 if email and not email.endswith("@users.noreply.github.com"):
                     if email.endswith("@nvidia.com"):
                         _email_cache[username] = email
@@ -129,56 +141,59 @@ def get_user_email(username):
                         return email
                     elif public_email is None:
                         public_email = email
-        
+
         # 3. Use public email if found, otherwise fallback
         if public_email:
             _email_cache[username] = public_email
             print(f"Using public email for {username}: {public_email}")
             return public_email
-        
+
         # Fallback to noreply email
         fallback = f"{username}@users.noreply.github.com"
         _email_cache[username] = fallback
         print(f"Warning: No email found for {username}, using fallback: {fallback}")
         return fallback
-        
+
     except Exception as e:
         print(f"Warning: Could not get email for {username}: {e}")
         fallback = f"{username}@users.noreply.github.com"
         _email_cache[username] = fallback
         return fallback
 
+
 def get_slack_client():
     """Get Slack WebClient if token is available."""
     slack_token = os.environ.get("SLACK_TOKEN")
     if not slack_token:
         return None
-    
+
     return WebClient(token=slack_token)
+
 
 def get_slack_user_id(slack_client, email):
     """Get Slack user ID from email."""
     if not slack_client:
         return None
-    
+
     if email in _slack_id_cache:
         return _slack_id_cache[email]
-    
+
     try:
         response = slack_client.users_lookupByEmail(email=email)
         user_id = response["user"]["id"]
         _slack_id_cache[email] = user_id
         return user_id
     except SlackApiError as e:
-        print(f"Warning: Could not find Slack user for {email}: {e.response['error']}")
+        print(f"Warning: Could not find Slack user for {email}: {get_slack_error(e)}")
         _slack_id_cache[email] = None
         return None
+
 
 def get_slack_usergroup_id(slack_client, handle):
     """Get Slack usergroup ID from handle."""
     if not slack_client:
         return None
-    
+
     try:
         response = slack_client.usergroups_list(include_users=True)
         for usergroup in response.get("usergroups", []):
@@ -187,8 +202,97 @@ def get_slack_usergroup_id(slack_client, handle):
         print(f"Warning: Slack usergroup '{handle}' not found")
         return None, []
     except SlackApiError as e:
-        print(f"Warning: Could not list Slack usergroups: {e.response['error']}")
+        print(f"Warning: Could not list Slack usergroups: {get_slack_error(e)}")
         return None, []
+
+
+def get_slack_rotation_fallback_emails():
+    emails = os.environ.get("ONCALL_SLACK_NOTIFY_EMAILS", "")
+    if emails:
+        parsed_emails = [email.strip() for email in emails.split(",") if email.strip()]
+        if parsed_emails:
+            return parsed_emails
+    return SLACK_ROTATION_FALLBACK_EMAILS
+
+
+def get_github_actions_run_url():
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if not repo or not run_id:
+        return None
+
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    return f"{server_url}/{repo}/actions/runs/{run_id}"
+
+
+def get_slack_user_ids_for_emails(slack_client, emails):
+    slack_user_ids = []
+    seen = set()
+    for email in emails:
+        slack_id = get_slack_user_id(slack_client, email)
+        if slack_id and slack_id not in seen:
+            slack_user_ids.append(slack_id)
+            seen.add(slack_id)
+    return slack_user_ids
+
+
+def get_slack_user_ids_for_usernames(slack_client, usernames):
+    emails = [get_user_email(username) for username in usernames]
+    return get_slack_user_ids_for_emails(slack_client, emails)
+
+
+def get_slack_rotation_notification_recipients(slack_client, old_members_usernames):
+    previous_oncall_recipients = get_slack_user_ids_for_usernames(
+        slack_client, old_members_usernames
+    )
+    if previous_oncall_recipients:
+        return previous_oncall_recipients, "previous oncall"
+
+    fallback_emails = get_slack_rotation_fallback_emails()
+    fallback_recipients = get_slack_user_ids_for_emails(slack_client, fallback_emails)
+    return fallback_recipients, "fallback contacts"
+
+
+def send_slack_rotation_failure_notification(
+    slack_client, reason, new_oncall_username, new_oncall_email, old_members_usernames
+):
+    recipients, recipient_source = get_slack_rotation_notification_recipients(
+        slack_client, old_members_usernames
+    )
+
+    run_url = get_github_actions_run_url()
+    message_lines = [
+        "MCore on-call Slack rotation needs manual attention.",
+        f"Reason: {reason}",
+        f"Target GitHub oncall: {new_oncall_username}",
+        f"Email tried for Slack lookup: {new_oncall_email}",
+        f"Slack usergroup not updated: @{SLACK_USERGROUP_HANDLE}",
+        "Please update the Slack usergroup manually or fix the GitHub-to-Slack email mapping.",
+    ]
+    if run_url:
+        message_lines.append(f"Workflow run: {run_url}")
+    message = "\n".join(message_lines)
+
+    if not recipients:
+        print("Warning: Could not resolve Slack notification recipients for rotation failure")
+        print(message)
+        return False
+
+    sent = False
+    for recipient in recipients:
+        try:
+            slack_client.chat_postMessage(channel=recipient, text=message)
+            print(f"Sent Slack rotation failure notification to {recipient} ({recipient_source})")
+            sent = True
+        except SlackApiError as e:
+            print(
+                f"Warning: Could not send Slack rotation failure notification to {recipient}: {get_slack_error(e)}"
+            )
+
+    if not sent:
+        print("Warning: Failed to send Slack rotation failure notification")
+    return sent
+
 
 def update_slack_usergroup(new_oncall_username, old_members_usernames):
     """
@@ -199,42 +303,57 @@ def update_slack_usergroup(new_oncall_username, old_members_usernames):
     if not slack_client:
         print("Slack token not configured, skipping Slack usergroup update")
         return
-    
+
     # Get the new oncall's email and Slack user ID
     new_email = get_user_email(new_oncall_username)
     new_slack_id = get_slack_user_id(slack_client, new_email)
-    
+
     if not new_slack_id:
-        print(f"Could not find Slack user ID for {new_oncall_username} ({new_email}), skipping Slack update")
+        reason = f"Could not find Slack user ID for {new_oncall_username} ({new_email})"
+        print(f"{reason}, skipping Slack update")
+        send_slack_rotation_failure_notification(
+            slack_client, reason, new_oncall_username, new_email, old_members_usernames
+        )
         return
-    
+
     # Get the usergroup ID and current members
-    usergroup_id, current_slack_members = get_slack_usergroup_id(slack_client, SLACK_USERGROUP_HANDLE)
-    
+    usergroup_id, current_slack_members = get_slack_usergroup_id(
+        slack_client, SLACK_USERGROUP_HANDLE
+    )
+
     if not usergroup_id:
-        print(f"Could not find Slack usergroup '{SLACK_USERGROUP_HANDLE}', skipping Slack update")
+        reason = f"Could not find Slack usergroup '{SLACK_USERGROUP_HANDLE}'"
+        print(f"{reason}, skipping Slack update")
+        send_slack_rotation_failure_notification(
+            slack_client, reason, new_oncall_username, new_email, old_members_usernames
+        )
         return
-    
+
     try:
         # Step 1: Add new oncall first (include current members to avoid removing anyone yet)
         # This ensures usergroup always has at least one member
         if new_slack_id not in current_slack_members:
-            updated_members = list(set(current_slack_members + [new_slack_id]))
-            slack_client.usergroups_users_update(
-                usergroup=usergroup_id,
-                users=updated_members
-            )
+            updated_members = current_slack_members + [new_slack_id]
+            slack_client.usergroups_users_update(usergroup=usergroup_id, users=updated_members)
             print(f"Added {new_oncall_username} to Slack usergroup '{SLACK_USERGROUP_HANDLE}'")
-        
+
         # Step 2: Now set the usergroup to contain only the new oncall
-        slack_client.usergroups_users_update(
-            usergroup=usergroup_id,
-            users=[new_slack_id]
+        slack_client.usergroups_users_update(usergroup=usergroup_id, users=[new_slack_id])
+        print(
+            f"Updated Slack usergroup '{SLACK_USERGROUP_HANDLE}' to contain only {new_oncall_username}"
         )
-        print(f"Updated Slack usergroup '{SLACK_USERGROUP_HANDLE}' to contain only {new_oncall_username}")
-        
+
     except SlackApiError as e:
-        print(f"Failed to update Slack usergroup: {e.response['error']}")
+        error = get_slack_error(e)
+        print(f"Failed to update Slack usergroup: {error}")
+        send_slack_rotation_failure_notification(
+            slack_client,
+            f"Failed to update Slack usergroup: {error}",
+            new_oncall_username,
+            new_email,
+            old_members_usernames,
+        )
+
 
 def load_schedule():
     if not os.path.exists(SCHEDULE_FILE):
@@ -253,44 +372,55 @@ def load_schedule():
     except (json.JSONDecodeError, FileNotFoundError):
         return []
 
+
 def save_schedule(schedule):
     with open(SCHEDULE_FILE, 'w') as f:
         json.dump(schedule, f, indent=4)
-        f.write('\n') # trailing newline
+        f.write('\n')  # trailing newline
+
 
 def update_active_oncall_team(org, new_oncall):
     """Updates the active oncall team to contain only the new oncall user."""
     # 1. Get current members of the active team
     current_members = get_team_members(org, ACTIVE_ONCALL_TEAM_SLUG)
-    
+
     # 2. Add the new oncall if not present
     if new_oncall not in current_members:
-        url = f"{GITHUB_API_URL}/orgs/{org}/teams/{ACTIVE_ONCALL_TEAM_SLUG}/memberships/{new_oncall}"
+        url = (
+            f"{GITHUB_API_URL}/orgs/{org}/teams/{ACTIVE_ONCALL_TEAM_SLUG}/memberships/{new_oncall}"
+        )
         resp = requests.put(url, headers=get_headers())
         if resp.status_code == 200:
             print(f"Added {new_oncall} to {ACTIVE_ONCALL_TEAM_SLUG}")
         else:
-            print(f"Failed to add {new_oncall} to {ACTIVE_ONCALL_TEAM_SLUG}: {resp.status_code} {resp.text}")
+            print(
+                f"Failed to add {new_oncall} to {ACTIVE_ONCALL_TEAM_SLUG}: {resp.status_code} {resp.text}"
+            )
 
     # 3. Remove everyone else
     old_members = []
     for member in current_members:
         if member not in [new_oncall, 'svcnvidia-nemo-ci']:
             old_members.append(member)
-            url = f"{GITHUB_API_URL}/orgs/{org}/teams/{ACTIVE_ONCALL_TEAM_SLUG}/memberships/{member}"
+            url = (
+                f"{GITHUB_API_URL}/orgs/{org}/teams/{ACTIVE_ONCALL_TEAM_SLUG}/memberships/{member}"
+            )
             resp = requests.delete(url, headers=get_headers())
             if resp.status_code == 204:
                 print(f"Removed {member} from {ACTIVE_ONCALL_TEAM_SLUG}")
             else:
-                print(f"Failed to remove {member} from {ACTIVE_ONCALL_TEAM_SLUG}: {resp.status_code} {resp.text}")
-    
+                print(
+                    f"Failed to remove {member} from {ACTIVE_ONCALL_TEAM_SLUG}: {resp.status_code} {resp.text}"
+                )
+
     # 4. Update Slack usergroup (add new oncall first, then remove old members)
     update_slack_usergroup(new_oncall, old_members)
+
 
 def rotate_schedule(repo_owner, dry_run=False):
     schedule = load_schedule()
     print(f"Current schedule length: {len(schedule)}")
-    
+
     # 1. Rotate (Remove past week)
     # Only if schedule is not empty.
     if schedule:
@@ -301,26 +431,28 @@ def rotate_schedule(repo_owner, dry_run=False):
             # The shift ends 7 days later.
             start_date = datetime.strptime(first_entry['date'], "%Y-%m-%d").date()
             end_date = start_date + timedelta(days=7)
-            
+
             today = datetime.now(timezone.utc).date()
-            
+
             # If today is >= end_date, the shift is over.
             # (e.g. Started last Wed, ends today Wed. If today is Wed, we rotate)
             if today >= end_date:
                 removed = schedule.pop(0)
                 print(f"Rotated out: {removed} (Ended {end_date})")
             else:
-                print(f"First entry {first_entry} has not ended yet (Ends {end_date}). Not removing.")
+                print(
+                    f"First entry {first_entry} has not ended yet (Ends {end_date}). Not removing."
+                )
         except ValueError:
-             # Fallback if date is invalid, rotate anyway
-             removed = schedule.pop(0)
-             print(f"Rotated out (invalid date): {removed}")
+            # Fallback if date is invalid, rotate anyway
+            removed = schedule.pop(0)
+            print(f"Rotated out (invalid date): {removed}")
     else:
         print("Schedule empty, nothing to rotate.")
 
     # 2. Replenish
     ensure_schedule_filled(schedule, repo_owner)
-    
+
     # 3. Update active oncall team
     if schedule:
         current_oncall = schedule[0]['user']
@@ -328,8 +460,10 @@ def rotate_schedule(repo_owner, dry_run=False):
         if not dry_run:
             update_active_oncall_team(repo_owner, current_oncall)
         else:
-            print(f"Dry run: Would update {ACTIVE_ONCALL_TEAM_SLUG} to contain only {current_oncall}")
-    
+            print(
+                f"Dry run: Would update {ACTIVE_ONCALL_TEAM_SLUG} to contain only {current_oncall}"
+            )
+
     if not dry_run:
         save_schedule(schedule)
         print("Schedule updated and saved.")
@@ -337,11 +471,13 @@ def rotate_schedule(repo_owner, dry_run=False):
         print("Dry run: Schedule not saved.")
         print(json.dumps(schedule, indent=4))
 
+
 def get_last_wednesday():
     today = datetime.now(timezone.utc).date()
     # Monday=0, Wednesday=2
     offset = (today.weekday() - 2) % 7
     return today - timedelta(days=offset)
+
 
 def ensure_schedule_filled(schedule, repo_owner):
     """Appends users to schedule until it reaches TARGET_WEEKS."""
@@ -353,20 +489,20 @@ def ensure_schedule_filled(schedule, repo_owner):
         members.remove('svcnvidia-nemo-ci')
     members = list(members)
 
-    members.sort() # Deterministic order
-    
+    members.sort()  # Deterministic order
+
     while len(schedule) < TARGET_WEEKS:
         # Determine start date for the new entry
         if not schedule:
             # Start with the most recent Wednesday if list is empty
             next_date = get_last_wednesday()
-            
+
             # Start with the first member alphabetically if list is empty
             next_user = members[0]
         else:
             last_entry = schedule[-1]
             last_user = last_entry['user']
-            
+
             # Parse last date and add 7 days
             try:
                 last_date = datetime.strptime(last_entry['date'], "%Y-%m-%d").date()
@@ -386,10 +522,11 @@ def ensure_schedule_filled(schedule, repo_owner):
                     next_user = members[0]
             except ValueError:
                 next_user = members[0]
-        
+
         new_entry = {"user": next_user, "date": next_date.strftime("%Y-%m-%d")}
         schedule.append(new_entry)
         print(f"Appended: {new_entry}")
+
 
 def assign_reviewer(pr_number):
     """Assigns mcore-oncall if no reviewers are set or community-request is applied."""
@@ -436,25 +573,30 @@ def assign_reviewer(pr_number):
         print(f"Failed to request review: {resp.status_code} {resp.text}")
         sys.exit(1)
 
+
 def main():
     parser = argparse.ArgumentParser(description="Manage Oncall Schedule")
     subparsers = parser.add_subparsers(dest="command", required=True)
-    
+
     # Rotate command
-    parser_rotate = subparsers.add_parser("rotate", help="Rotate the schedule (remove first, append new)")
+    parser_rotate = subparsers.add_parser(
+        "rotate", help="Rotate the schedule (remove first, append new)"
+    )
     parser_rotate.add_argument("--dry-run", action="store_true", help="Do not save changes")
 
     # Fill command (just fill up to 12 without rotating - useful for init)
-    parser_fill = subparsers.add_parser("fill", help="Fill the schedule to 12 weeks without rotating")
-    
+    parser_fill = subparsers.add_parser(
+        "fill", help="Fill the schedule to 12 weeks without rotating"
+    )
+
     # Assign command
     parser_assign = subparsers.add_parser("assign", help="Assign current oncall to PR")
     parser_assign.add_argument("--pr", type=int, required=True, help="PR number")
 
     args = parser.parse_args()
-    
+
     owner, _ = get_repo_info()
-    
+
     if args.command == "rotate":
         rotate_schedule(owner, dry_run=args.dry_run)
     elif args.command == "fill":
@@ -465,6 +607,6 @@ def main():
     elif args.command == "assign":
         assign_reviewer(args.pr)
 
+
 if __name__ == "__main__":
     main()
-

--- a/.github/scripts/oncall_manager.py
+++ b/.github/scripts/oncall_manager.py
@@ -19,7 +19,13 @@ import sys
 from datetime import datetime, timedelta, timezone
 
 import requests
-from github_slack_utils import SlackApiError, get_slack_client, get_slack_user_id, get_user_email
+from github_slack_utils import (
+    SlackApiError,
+    get_slack_client,
+    get_slack_error,
+    get_slack_user_id,
+    get_user_email,
+)
 
 # Constants
 GITHUB_API_URL = "https://api.github.com"
@@ -30,6 +36,7 @@ SLACK_USERGROUP_HANDLE = "mcore-oncall"
 COMMUNITY_REQUEST_LABEL = "community-request"
 SERVICE_ACCOUNT_USERNAME = "svcnvidia-nemo-ci"
 TARGET_WEEKS = 12
+SLACK_ROTATION_FALLBACK_EMAILS = ["ppetrakian@nvidia.com"]
 
 
 def get_headers():
@@ -98,8 +105,96 @@ def get_slack_usergroup_id(slack_client, handle):
         print(f"Warning: Slack usergroup '{handle}' not found")
         return None, []
     except SlackApiError as e:
-        print(f"Warning: Could not list Slack usergroups: {e.response['error']}")
+        print(f"Warning: Could not list Slack usergroups: {get_slack_error(e)}")
         return None, []
+
+
+def get_slack_rotation_fallback_emails():
+    emails = os.environ.get("ONCALL_SLACK_NOTIFY_EMAILS", "")
+    if emails:
+        parsed_emails = [email.strip() for email in emails.split(",") if email.strip()]
+        if parsed_emails:
+            return parsed_emails
+    return SLACK_ROTATION_FALLBACK_EMAILS
+
+
+def get_github_actions_run_url():
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if not repo or not run_id:
+        return None
+
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    return f"{server_url}/{repo}/actions/runs/{run_id}"
+
+
+def get_slack_user_ids_for_emails(slack_client, emails):
+    slack_user_ids = []
+    seen = set()
+    for email in emails:
+        slack_id = get_slack_user_id(slack_client, email)
+        if slack_id and slack_id not in seen:
+            slack_user_ids.append(slack_id)
+            seen.add(slack_id)
+    return slack_user_ids
+
+
+def get_slack_user_ids_for_usernames(slack_client, usernames):
+    emails = [get_user_email(username) for username in usernames]
+    return get_slack_user_ids_for_emails(slack_client, emails)
+
+
+def get_slack_rotation_notification_recipients(slack_client, old_members_usernames):
+    previous_oncall_recipients = get_slack_user_ids_for_usernames(
+        slack_client, old_members_usernames
+    )
+    if previous_oncall_recipients:
+        return previous_oncall_recipients, "previous oncall"
+
+    fallback_emails = get_slack_rotation_fallback_emails()
+    fallback_recipients = get_slack_user_ids_for_emails(slack_client, fallback_emails)
+    return fallback_recipients, "fallback contacts"
+
+
+def send_slack_rotation_failure_notification(
+    slack_client, reason, new_oncall_username, new_oncall_email, old_members_usernames
+):
+    recipients, recipient_source = get_slack_rotation_notification_recipients(
+        slack_client, old_members_usernames
+    )
+
+    run_url = get_github_actions_run_url()
+    message_lines = [
+        "MCore on-call Slack rotation needs manual attention.",
+        f"Reason: {reason}",
+        f"Target GitHub oncall: {new_oncall_username}",
+        f"Email tried for Slack lookup: {new_oncall_email}",
+        f"Slack usergroup not updated: @{SLACK_USERGROUP_HANDLE}",
+        "Please update the Slack usergroup manually or fix the GitHub-to-Slack email mapping.",
+    ]
+    if run_url:
+        message_lines.append(f"Workflow run: {run_url}")
+    message = "\n".join(message_lines)
+
+    if not recipients:
+        print("Warning: Could not resolve Slack notification recipients for rotation failure")
+        print(message)
+        return False
+
+    sent = False
+    for recipient in recipients:
+        try:
+            slack_client.chat_postMessage(channel=recipient, text=message)
+            print(f"Sent Slack rotation failure notification to {recipient} ({recipient_source})")
+            sent = True
+        except SlackApiError as e:
+            print(
+                f"Warning: Could not send Slack rotation failure notification to {recipient}: {get_slack_error(e)}"
+            )
+
+    if not sent:
+        print("Warning: Failed to send Slack rotation failure notification")
+    return sent
 
 
 def update_slack_usergroup(new_oncall_username, old_members_usernames):
@@ -117,8 +212,10 @@ def update_slack_usergroup(new_oncall_username, old_members_usernames):
     new_slack_id = get_slack_user_id(slack_client, new_email)
 
     if not new_slack_id:
-        print(
-            f"Could not find Slack user ID for {new_oncall_username} ({new_email}), skipping Slack update"
+        reason = f"Could not find Slack user ID for {new_oncall_username} ({new_email})"
+        print(f"{reason}, skipping Slack update")
+        send_slack_rotation_failure_notification(
+            slack_client, reason, new_oncall_username, new_email, old_members_usernames
         )
         return
 
@@ -128,14 +225,18 @@ def update_slack_usergroup(new_oncall_username, old_members_usernames):
     )
 
     if not usergroup_id:
-        print(f"Could not find Slack usergroup '{SLACK_USERGROUP_HANDLE}', skipping Slack update")
+        reason = f"Could not find Slack usergroup '{SLACK_USERGROUP_HANDLE}'"
+        print(f"{reason}, skipping Slack update")
+        send_slack_rotation_failure_notification(
+            slack_client, reason, new_oncall_username, new_email, old_members_usernames
+        )
         return
 
     try:
         # Step 1: Add new oncall first (include current members to avoid removing anyone yet)
         # This ensures usergroup always has at least one member
         if new_slack_id not in current_slack_members:
-            updated_members = list(set(current_slack_members + [new_slack_id]))
+            updated_members = current_slack_members + [new_slack_id]
             slack_client.usergroups_users_update(usergroup=usergroup_id, users=updated_members)
             print(f"Added {new_oncall_username} to Slack usergroup '{SLACK_USERGROUP_HANDLE}'")
 
@@ -146,7 +247,15 @@ def update_slack_usergroup(new_oncall_username, old_members_usernames):
         )
 
     except SlackApiError as e:
-        print(f"Failed to update Slack usergroup: {e.response['error']}")
+        error = get_slack_error(e)
+        print(f"Failed to update Slack usergroup: {error}")
+        send_slack_rotation_failure_notification(
+            slack_client,
+            f"Failed to update Slack usergroup: {error}",
+            new_oncall_username,
+            new_email,
+            old_members_usernames,
+        )
 
 
 def load_schedule():

--- a/.github/scripts/oncall_manager.py
+++ b/.github/scripts/oncall_manager.py
@@ -145,7 +145,7 @@ def send_slack_rotation_failure_notification(
         f"Reason: {reason}",
         f"Target GitHub oncall: {new_oncall_username}",
         f"Email tried for Slack lookup: {new_oncall_email}",
-        f"Slack usergroup left unchanged: @{SLACK_USERGROUP_HANDLE}",
+        f"Slack usergroup not fully updated: @{SLACK_USERGROUP_HANDLE}",
         f"You should still be in @{SLACK_USERGROUP_HANDLE}; please update the Slack usergroup manually or fix the GitHub-to-Slack email mapping.",
     ]
     if run_url:

--- a/.github/scripts/oncall_manager.py
+++ b/.github/scripts/oncall_manager.py
@@ -36,7 +36,6 @@ SLACK_USERGROUP_HANDLE = "mcore-oncall"
 COMMUNITY_REQUEST_LABEL = "community-request"
 SERVICE_ACCOUNT_USERNAME = "svcnvidia-nemo-ci"
 TARGET_WEEKS = 12
-SLACK_ROTATION_FALLBACK_EMAILS = ["ppetrakian@nvidia.com"]
 
 
 def get_headers():
@@ -109,15 +108,6 @@ def get_slack_usergroup_id(slack_client, handle):
         return None, []
 
 
-def get_slack_rotation_fallback_emails():
-    emails = os.environ.get("ONCALL_SLACK_NOTIFY_EMAILS", "")
-    if emails:
-        parsed_emails = [email.strip() for email in emails.split(",") if email.strip()]
-        if parsed_emails:
-            return parsed_emails
-    return SLACK_ROTATION_FALLBACK_EMAILS
-
-
 def get_github_actions_run_url():
     repo = os.environ.get("GITHUB_REPOSITORY")
     run_id = os.environ.get("GITHUB_RUN_ID")
@@ -144,24 +134,10 @@ def get_slack_user_ids_for_usernames(slack_client, usernames):
     return get_slack_user_ids_for_emails(slack_client, emails)
 
 
-def get_slack_rotation_notification_recipients(slack_client, old_members_usernames):
-    previous_oncall_recipients = get_slack_user_ids_for_usernames(
-        slack_client, old_members_usernames
-    )
-    if previous_oncall_recipients:
-        return previous_oncall_recipients, "previous oncall"
-
-    fallback_emails = get_slack_rotation_fallback_emails()
-    fallback_recipients = get_slack_user_ids_for_emails(slack_client, fallback_emails)
-    return fallback_recipients, "fallback contacts"
-
-
 def send_slack_rotation_failure_notification(
     slack_client, reason, new_oncall_username, new_oncall_email, old_members_usernames
 ):
-    recipients, recipient_source = get_slack_rotation_notification_recipients(
-        slack_client, old_members_usernames
-    )
+    recipients = get_slack_user_ids_for_usernames(slack_client, old_members_usernames)
 
     run_url = get_github_actions_run_url()
     message_lines = [
@@ -169,15 +145,17 @@ def send_slack_rotation_failure_notification(
         f"Reason: {reason}",
         f"Target GitHub oncall: {new_oncall_username}",
         f"Email tried for Slack lookup: {new_oncall_email}",
-        f"Slack usergroup not updated: @{SLACK_USERGROUP_HANDLE}",
-        "Please update the Slack usergroup manually or fix the GitHub-to-Slack email mapping.",
+        f"Slack usergroup left unchanged: @{SLACK_USERGROUP_HANDLE}",
+        f"You should still be in @{SLACK_USERGROUP_HANDLE}; please update the Slack usergroup manually or fix the GitHub-to-Slack email mapping.",
     ]
     if run_url:
         message_lines.append(f"Workflow run: {run_url}")
     message = "\n".join(message_lines)
 
     if not recipients:
-        print("Warning: Could not resolve Slack notification recipients for rotation failure")
+        print(
+            "Warning: Could not resolve previous oncall Slack user for rotation failure notification"
+        )
         print(message)
         return False
 
@@ -185,7 +163,7 @@ def send_slack_rotation_failure_notification(
     for recipient in recipients:
         try:
             slack_client.chat_postMessage(channel=recipient, text=message)
-            print(f"Sent Slack rotation failure notification to {recipient} ({recipient_source})")
+            print(f"Sent Slack rotation failure notification to previous oncall {recipient}")
             sent = True
         except SlackApiError as e:
             print(

--- a/.github/workflows/oncall-rotation.yml
+++ b/.github/workflows/oncall-rotation.yml
@@ -41,8 +41,10 @@ jobs:
         env:
           # Token to read org team members. Needs read:org scope.
           GH_TOKEN: ${{ secrets.NVIDIA_MCORE_ONCALL_TOKEN || secrets.PAT || secrets.GITHUB_TOKEN }}
-          # Slack token for updating the Slack usergroup
+          # Slack token for updating the Slack usergroup and sending failure notifications.
           SLACK_TOKEN: ${{ secrets.ONCALL_SLACK_TOKEN }}
+          # Optional comma-separated fallback emails for Slack rotation failure notifications.
+          ONCALL_SLACK_NOTIFY_EMAILS: ${{ vars.ONCALL_SLACK_NOTIFY_EMAILS }}
         run: |
           pip install --no-cache-dir "uv<0.9.29"
           uv venv .venv

--- a/.github/workflows/oncall-rotation.yml
+++ b/.github/workflows/oncall-rotation.yml
@@ -43,8 +43,6 @@ jobs:
           GH_TOKEN: ${{ secrets.NVIDIA_MCORE_ONCALL_TOKEN || secrets.PAT || secrets.GITHUB_TOKEN }}
           # Slack token for updating the Slack usergroup and sending failure notifications.
           SLACK_TOKEN: ${{ secrets.ONCALL_SLACK_TOKEN }}
-          # Optional comma-separated fallback emails for Slack rotation failure notifications.
-          ONCALL_SLACK_NOTIFY_EMAILS: ${{ vars.ONCALL_SLACK_NOTIFY_EMAILS }}
         run: |
           pip install --no-cache-dir "uv<0.9.29"
           uv venv .venv

--- a/tests/test_utils/python_scripts/test_oncall_manager.py
+++ b/tests/test_utils/python_scripts/test_oncall_manager.py
@@ -110,13 +110,13 @@ def test_update_slack_usergroup_notifies_previous_oncall_when_new_oncall_lookup_
     assert client.messages[0]["channel"] == "UOLD"
     assert "new-oncall@users.noreply.github.com" in client.messages[0]["text"]
     assert "@mcore-oncall" in client.messages[0]["text"]
+    assert "left unchanged" in client.messages[0]["text"]
 
 
-def test_update_slack_usergroup_notifies_fallback_when_previous_oncall_lookup_fails(
+def test_update_slack_usergroup_does_not_notify_fallback_when_previous_oncall_lookup_fails(
     oncall_manager, monkeypatch
 ):
     client = FakeSlackClient(users_by_email={"fallback@nvidia.com": "UFALLBACK"})
-    monkeypatch.setenv("ONCALL_SLACK_NOTIFY_EMAILS", "fallback@nvidia.com")
     monkeypatch.setattr(oncall_manager, "get_slack_client", lambda: client)
     monkeypatch.setattr(
         oncall_manager,
@@ -130,9 +130,7 @@ def test_update_slack_usergroup_notifies_fallback_when_previous_oncall_lookup_fa
     oncall_manager.update_slack_usergroup("new-oncall", ["previous-oncall"])
 
     assert client.usergroup_updates == []
-    assert len(client.messages) == 1
-    assert client.messages[0]["channel"] == "UFALLBACK"
-    assert "new-oncall@users.noreply.github.com" in client.messages[0]["text"]
+    assert client.messages == []
 
 
 def test_update_slack_usergroup_updates_members_when_new_oncall_lookup_succeeds(

--- a/tests/test_utils/python_scripts/test_oncall_manager.py
+++ b/tests/test_utils/python_scripts/test_oncall_manager.py
@@ -110,7 +110,7 @@ def test_update_slack_usergroup_notifies_previous_oncall_when_new_oncall_lookup_
     assert client.messages[0]["channel"] == "UOLD"
     assert "new-oncall@users.noreply.github.com" in client.messages[0]["text"]
     assert "@mcore-oncall" in client.messages[0]["text"]
-    assert "left unchanged" in client.messages[0]["text"]
+    assert "You should still be in @mcore-oncall" in client.messages[0]["text"]
 
 
 def test_update_slack_usergroup_does_not_notify_fallback_when_previous_oncall_lookup_fails(

--- a/tests/test_utils/python_scripts/test_oncall_manager.py
+++ b/tests/test_utils/python_scripts/test_oncall_manager.py
@@ -46,6 +46,28 @@ class FakeRequests:
         return FakeResponse(201)
 
 
+class FakeSlackClient:
+    def __init__(self, users_by_email=None, usergroups=None):
+        self.users_by_email = users_by_email or {}
+        self.usergroups = usergroups if usergroups is not None else []
+        self.messages = []
+        self.usergroup_updates = []
+
+    def users_lookupByEmail(self, email):
+        if email not in self.users_by_email:
+            raise Exception("users_not_found")
+        return {"user": {"id": self.users_by_email[email]}}
+
+    def usergroups_list(self, include_users=True):
+        return {"usergroups": self.usergroups}
+
+    def usergroups_users_update(self, usergroup, users):
+        self.usergroup_updates.append({"usergroup": usergroup, "users": users})
+
+    def chat_postMessage(self, channel, text):
+        self.messages.append({"channel": channel, "text": text})
+
+
 @pytest.fixture
 def oncall_manager(monkeypatch):
     slack_module = types.ModuleType("slack_sdk")
@@ -65,6 +87,71 @@ def oncall_manager(monkeypatch):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def test_update_slack_usergroup_notifies_previous_oncall_when_new_oncall_lookup_fails(
+    oncall_manager, monkeypatch
+):
+    client = FakeSlackClient(users_by_email={"previous@nvidia.com": "UOLD"})
+    monkeypatch.setattr(oncall_manager, "get_slack_client", lambda: client)
+    monkeypatch.setattr(
+        oncall_manager,
+        "get_user_email",
+        lambda username: {
+            "new-oncall": "new-oncall@users.noreply.github.com",
+            "previous-oncall": "previous@nvidia.com",
+        }[username],
+    )
+
+    oncall_manager.update_slack_usergroup("new-oncall", ["previous-oncall"])
+
+    assert client.usergroup_updates == []
+    assert len(client.messages) == 1
+    assert client.messages[0]["channel"] == "UOLD"
+    assert "new-oncall@users.noreply.github.com" in client.messages[0]["text"]
+    assert "@mcore-oncall" in client.messages[0]["text"]
+
+
+def test_update_slack_usergroup_notifies_fallback_when_previous_oncall_lookup_fails(
+    oncall_manager, monkeypatch
+):
+    client = FakeSlackClient(users_by_email={"fallback@nvidia.com": "UFALLBACK"})
+    monkeypatch.setenv("ONCALL_SLACK_NOTIFY_EMAILS", "fallback@nvidia.com")
+    monkeypatch.setattr(oncall_manager, "get_slack_client", lambda: client)
+    monkeypatch.setattr(
+        oncall_manager,
+        "get_user_email",
+        lambda username: {
+            "new-oncall": "new-oncall@users.noreply.github.com",
+            "previous-oncall": "previous-oncall@users.noreply.github.com",
+        }[username],
+    )
+
+    oncall_manager.update_slack_usergroup("new-oncall", ["previous-oncall"])
+
+    assert client.usergroup_updates == []
+    assert len(client.messages) == 1
+    assert client.messages[0]["channel"] == "UFALLBACK"
+    assert "new-oncall@users.noreply.github.com" in client.messages[0]["text"]
+
+
+def test_update_slack_usergroup_updates_members_when_new_oncall_lookup_succeeds(
+    oncall_manager, monkeypatch
+):
+    client = FakeSlackClient(
+        users_by_email={"new-oncall@nvidia.com": "UNEW"},
+        usergroups=[{"handle": "mcore-oncall", "id": "S123", "users": ["UOLD"]}],
+    )
+    monkeypatch.setattr(oncall_manager, "get_slack_client", lambda: client)
+    monkeypatch.setattr(oncall_manager, "get_user_email", lambda username: "new-oncall@nvidia.com")
+
+    oncall_manager.update_slack_usergroup("new-oncall", ["previous-oncall"])
+
+    assert client.usergroup_updates == [
+        {"usergroup": "S123", "users": ["UOLD", "UNEW"]},
+        {"usergroup": "S123", "users": ["UNEW"]},
+    ]
+    assert client.messages == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- send a Slack notification when on-call Slack usergroup rotation cannot resolve the new on-call user, cannot find the usergroup, or fails to update membership
- notify the previous on-call first, then fall back to configurable `ONCALL_SLACK_NOTIFY_EMAILS` or `ppetrakian@nvidia.com`
- add focused tests for failure notification routing and successful usergroup updates

## Root Cause

The rotation script previously logged Slack lookup/update failures and returned, so the GitHub on-call team could rotate while the Slack `@mcore-oncall` usergroup stayed stale without notifying a maintainer.

## Validation

- `.venv/bin/pytest tests/test_utils/python_scripts/test_oncall_manager.py`
- `.venv/bin/black --check .github/scripts/oncall_manager.py tests/test_utils/python_scripts/test_oncall_manager.py`
- `git diff --check`