### PR TITLE
[Main] Generalized fix for mxfp8 param gather

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -2801,9 +2801,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         """Stage FP32 master shards into DDP param buffers before explicit param sync."""
         if self.is_stub_optimizer:
             return
-        if not (
-            self.config.reuse_grad_buf_for_mxfp8_param_ag and self.config.overlap_param_gather
-        ):
+        if not (self.config.reuse_grad_buf_for_mxfp8_param_ag and self.config.overlap_param_gather):
             return
 
         for model_chunk in self.model_chunks:

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -2796,6 +2796,20 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         copy_group_params(self.shard_fp32_from_float16_groups, self.model_float16_groups)
         copy_group_params(self.shard_fp32_groups, self.model_fp32_groups)
 
+    @torch.no_grad()
+    def prepare_model_params_for_param_sync(self) -> None:
+        """Stage FP32 master shards into DDP param buffers before explicit param sync."""
+        if self.is_stub_optimizer:
+            return
+        if not (
+            self.config.reuse_grad_buf_for_mxfp8_param_ag and self.config.overlap_param_gather
+        ):
+            return
+
+        for model_chunk in self.model_chunks:
+            model_chunk.zero_grad_buffer()
+        self._copy_main_params_to_param_buffer()
+
     def _copy_main_params_to_param_buffer(self):
         """
         This function is only used for MXFP8 params.

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -170,6 +170,10 @@ class MegatronOptimizer(ABC):
                     params.append(param)
         return params
 
+    def prepare_model_params_for_param_sync(self) -> None:
+        """Stage optimizer-owned model params before an explicit DDP param sync."""
+        return
+
     def _filter_grads_for_norm(
         self,
         params: List[torch.nn.Parameter],
@@ -1391,6 +1395,43 @@ class ChainedOptimizer(MegatronOptimizer):
         for optimizer, state in zip(self.chained_optimizers, state_dict):
             optimizer.load_state_dict(state)
         self._synchronize_steps()
+
+    @override
+    @torch.no_grad()
+    def prepare_model_params_for_param_sync(self) -> None:
+        """Stage params once per DDP model chunk before explicit param sync."""
+        use_reused_grad_buffer = (
+            self.config.reuse_grad_buf_for_mxfp8_param_ag and self.config.overlap_param_gather
+        )
+        if not use_reused_grad_buffer:
+            for optimizer in self.chained_optimizers:
+                optimizer.prepare_model_params_for_param_sync()
+            return
+
+        from .distrib_optimizer import DistributedOptimizer
+
+        model_chunks = []
+        model_chunk_ids = set()
+        dist_optimizers = []
+
+        for optimizer in self.chained_optimizers:
+            if isinstance(optimizer, DistributedOptimizer):
+                dist_optimizers.append(optimizer)
+                if getattr(optimizer, 'is_stub_optimizer', False):
+                    continue
+                for model_chunk in optimizer.model_chunks:
+                    model_chunk_id = id(model_chunk)
+                    if model_chunk_id not in model_chunk_ids:
+                        model_chunk_ids.add(model_chunk_id)
+                        model_chunks.append(model_chunk)
+            else:
+                optimizer.prepare_model_params_for_param_sync()
+
+        for model_chunk in model_chunks:
+            model_chunk.zero_grad_buffer()
+        for optimizer in dist_optimizers:
+            if not getattr(optimizer, 'is_stub_optimizer', False):
+                optimizer._copy_main_params_to_param_buffer()
 
     @torch.no_grad()
     def prepare_grads(self) -> bool:

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -421,6 +421,12 @@ class OptimizerConfig:
                     "recommended for mxfp8 training."
                 )
 
+        if self.reuse_grad_buf_for_mxfp8_param_ag and self.overlap_param_gather_with_optimizer_step:
+            raise ValueError(
+                "overlap_param_gather_with_optimizer_step is not supported with "
+                "reuse_grad_buf_for_mxfp8_param_ag."
+            )
+
         if self.use_precision_aware_optimizer:
             assert (
                 self.optimizer == 'adam'

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2820,13 +2820,17 @@ def enable_forward_pre_hook(model_chunks):
         model_chunk.enable_forward_pre_hook()
 
 
-def disable_forward_pre_hook(model_chunks, param_sync=True):
+def disable_forward_pre_hook(model_chunks, optimizer=None, param_sync=True):
+    if param_sync and optimizer is not None:
+        optimizer.prepare_model_params_for_param_sync()
     for model_chunk in model_chunks:
         assert isinstance(model_chunk, DDP)
         model_chunk.disable_forward_pre_hook(param_sync=param_sync)
 
 
-def force_param_sync(model_chunks: list[DDP]) -> None:
+def force_param_sync(model_chunks: list[DDP], optimizer=None) -> None:
+    if optimizer is not None:
+        optimizer.prepare_model_params_for_param_sync()
     for model_chunk in model_chunks:
         assert isinstance(model_chunk, DDP)
         model_chunk.start_param_sync(force_sync=True)
@@ -2851,7 +2855,7 @@ def save_checkpoint_and_time(
 
     # Synchronize forward pre-hook state before checkpoint save to avoid race conditions
     if should_disable_forward_pre_hook(args):
-        force_param_sync(model)
+        force_param_sync(model, optimizer=optimizer)
 
     # Stop timer to get accurate train interval time and exclude checkpointing duration
     timers('interval-time').stop()
@@ -2966,7 +2970,7 @@ def post_training_step_callbacks(
         and iteration % args.check_weight_hash_across_dp_replicas_interval == 0
     ):
         if should_disable_forward_pre_hook(args):
-            disable_forward_pre_hook(model)
+            disable_forward_pre_hook(model, optimizer=optimizer)
         assert check_param_hashes_across_dp_replicas(
             model, cross_check=True
         ), "Parameter hashes not matching across DP replicas"
@@ -3756,16 +3760,8 @@ def train(
             if args.log_energy:
                 energy_monitor.pause()
             timers('interval-time').stop()
-            if args.reuse_grad_buf_for_mxfp8_param_ag and args.overlap_param_gather:
-                # disable_forward_pre_hook(param_sync=True) below force-syncs params for eval.
-                # Copy the main params to param buffer before the forced AllGather.
-                for model_chunk in model:
-                    model_chunk.zero_grad_buffer()
-                for optim_instance in optimizer.chained_optimizers:
-                    if isinstance(optim_instance, DistributedOptimizer):
-                        optim_instance._copy_main_params_to_param_buffer()
             if should_disable_forward_pre_hook(args):
-                disable_forward_pre_hook(model)
+                disable_forward_pre_hook(model, optimizer=optimizer)
                 pre_hook_enabled = False
             if args.manual_gc and args.manual_gc_eval:
                 # Collect all objects.
@@ -3860,7 +3856,7 @@ def train(
 
     # Close out pre-hooks if using distributed optimizer and overlapped param gather.
     if pre_hook_enabled:
-        disable_forward_pre_hook(model)
+        disable_forward_pre_hook(model, optimizer=optimizer)
 
     ft_integration.on_checkpointing_start()
     # This will finalize all unfinalized async request and terminate


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

Dev: https://github.com/NVIDIA/Megatron-LM/pull/4994

Mbridge needs to be updated as well after main is merged: https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3980

E2E test from @WanZzzzzz  is done for dev: https://github.com/NVIDIA/Megatron-LM/pull/4994#issuecomment-4617164126

# What does this PR do ?
This PR fixes a general correctness issue in the interaction between:

--fp8-param-gather
--reuse-grad-buf-for-mxfp8-param-ag
--overlap-param-gather

With MXFP8 grad-buffer reuse, DDP param_data is not a persistent parameter buffer. It is a temporary high-precision all-gather staging buffer shared with the gradient buffer. After param all-gather completes, the gathered values are copied/quantized into TE MXFP8 parameter storage, and the shared buffer is zeroed so the next backward pass can safely accumulate gradients into it.

That means any explicit/forced param sync must first ask the optimizer to restage the updated FP32 master-weight shards into the DDP param buffer. Otherwise DDP may all-gather stale data or zeroes and overwrite model parameters.

Previously checkpoint path did roughly:

  if should_disable_forward_pre_hook(args):
      force_param_sync(model)

  save_checkpoint(...)
Then force_param_sync(model) called:

  model_chunk.start_param_sync(force_sync=True)
DDP does not all-gather from optimizer master weights. It all-gathers from the local shard view of bucket.param_data

So if nobody first did _copy_main_params_to_param_buffer(), then the checkpoint forced AG reads whatever is currently in the shared DDP staging buffer.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
