### PR TITLE
fix(ci): batched P2P for bert_mcore_tp1_pp4_vp2 to avoid interleaved-PP NCCL deadlock

### DIFF
--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp1_pp4_vp2/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp1_pp4_vp2/model_config.yaml
@@ -42,4 +42,9 @@ MODEL_ARGS:
   --bf16: true
   --ckpt-format: torch
   --attention-backend: unfused
+  # Interleaved/VPP schedule defaults to overlap_p2p_comm=True, which forces
+  # batch_p2p_comm=False and uses unbatched per-pair P2P that lazily creates
+  # 2-rank NCCL communicators -> intermittent lazy-comm-init deadlock (RECV hang).
+  # Use batched P2P here (pp=4 > 2 satisfies the interleaved+no-overlap assert).
+  --no-overlap-p2p-communication: true
 TEST_TYPE: regular


### PR DESCRIPTION
## What
Use **batched** pipeline P2P for `bert_mcore_tp1_pp4_vp2` by disabling P2P/compute overlap (`--no-overlap-p2p-communication`).

## Why
This test intermittently hangs in CI with a `ProcessGroupNCCL` **RECV timeout** on `PIPELINE_MODEL_PARALLEL_GROUP`. Analysis of the full job log (9/9 retries hung):
- Hang is always a P2P `RECV`, at **rotating ranks (0/1/3/4/6)**, varying SeqNums/iterations, with **no numerical error** (healthy loss).
- The interleaved/VPP schedule defaults to `overlap_p2p_comm=True`, which forces `batch_p2p_comm=False` and takes the **unbatched `_p2p_ops`** path. Unbatched send/recv on the >2-rank PP group **lazily creates a new 2-rank NCCL communicator per pair** (the log warns: *"unbatched P2P op … new 2-rank NCCL communicator"*); under pp4+vp2 these lazy inits can be entered in inconsistent order across ranks and **deadlock**.
- `p2p_communication.py` is unchanged since 2026-03 (path dates to 2024) → latent hazard, not a recent regression.

Disabling overlap routes to `_batched_p2p_ops` (single `batch_isend_irecv` on the existing group, no per-pair lazy comms). `pp=4 > 2` satisfies the interleaved+no-overlap assertion in `arguments.py`.

## Validation
Candidate fix — **needs a CI run** (`Run functional tests`); the deadlock is NCCL/timing-dependent and doesn't reliably reproduce on fast local storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)