### PR TITLE
fix(ci): synchronous data loading for hanging t5 functional tests

### DIFF
--- a/tests/functional_tests/test_cases/t5/t5_mcore_te_tp1_pp1_vp1_resume_torch/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_te_tp1_pp1_vp1_resume_torch/model_config.yaml
@@ -53,4 +53,10 @@ MODEL_ARGS:
   --ckpt-format: torch
   --attention-backend: unfused
   --log-memory-to-tensorboard: true
+  # Synchronous data loading: the default 2 persistent dataloader workers
+  # (pin_memory, no DataLoader timeout) can stall on the CI data mount, leaving
+  # the rank blocked in get_batch -> queue.get forever -> the other ranks time
+  # out in the grad all-reduce (600s NCCL watchdog). In-process loading removes
+  # the worker-queue hang surface; test data is tiny so perf impact is nil.
+  --num-workers: 0
 TEST_TYPE: ckpt-resume

--- a/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1/model_config.yaml
@@ -51,4 +51,10 @@ MODEL_ARGS:
   --deterministic-mode: true
   --ckpt-format: torch
   --log-memory-to-tensorboard: true
+  # Synchronous data loading: the default 2 persistent dataloader workers
+  # (pin_memory, no DataLoader timeout) can stall on the CI data mount, leaving
+  # the rank blocked in get_batch -> queue.get forever -> the other ranks time
+  # out in the grad all-reduce (600s NCCL watchdog). In-process loading removes
+  # the worker-queue hang surface; test data is tiny so perf impact is nil.
+  --num-workers: 0
 TEST_TYPE: regular

--- a/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1_resume_torch/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1_resume_torch/model_config.yaml
@@ -51,4 +51,10 @@ MODEL_ARGS:
   --deterministic-mode: true
   --ckpt-format: torch
   --log-memory-to-tensorboard: true
+  # Synchronous data loading: the default 2 persistent dataloader workers
+  # (pin_memory, no DataLoader timeout) can stall on the CI data mount, leaving
+  # the rank blocked in get_batch -> queue.get forever -> the other ranks time
+  # out in the grad all-reduce (600s NCCL watchdog). In-process loading removes
+  # the worker-queue hang surface; test data is tiny so perf impact is nil.
+  --num-workers: 0
 TEST_TYPE: ckpt-resume


### PR DESCRIPTION
## What
Set `--num-workers: 0` (synchronous, in-process data loading) for the t5 functional tests that intermittently hang in CI:
- `t5_mcore_tp1_pp1_vp1`
- `t5_mcore_tp1_pp1_vp1_resume_torch`
- `t5_mcore_te_tp1_pp1_vp1_resume_torch`

## Why
These hang in CI with a `finalize_model_grads` all-reduce timeout — but the fault-handler dump shows the stuck rank's **main thread parked in the input pipeline**, not a collective:
```
pretrain_t5.py:148 get_batch -> rerun_state_machine.py __next__
 -> torch/utils/data/dataloader.py _try_get_data -> multiprocessing/queues.py:113 get  (blocked)
```
A dataloader worker stops delivering batches → that rank never enters the step's grad all-reduce → the ranks that did get data time out (600 s NCCL watchdog). Loss is healthy up to the hang (no NaN), so it's the **data pipeline**, not the model/comms.

`build_pretraining_data_loader` uses `num_workers=2` + `pin_memory=True` + `persistent_workers=True` and sets **no `DataLoader(timeout=)`**, so a stalled worker blocks forever. The same recipe runs clean on fast local storage → the trigger is the CI data mount / worker subprocess pipeline. `--num-workers 0` removes that surface (no worker subprocesses, no pin-memory queue); test data is tiny so perf impact is nil.

## Validation
Candidate fix — **needs a CI run** (`Run functional tests`); the stall doesn't reproduce on fast local storage. If it still hangs with `num_workers=0` (now in the inline read), the trigger is raw mount I/O and the follow-up is a `DataLoader(timeout=)` in `build_pretraining_data_loader` + local data staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)