### PR TITLE
fix(ci): pin linear CUDA-graph sizing distribution for gpt_grpo_*_8b_throughput

### DIFF
--- a/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput/model_config.yaml
@@ -13,6 +13,10 @@ MODEL_ARGS:
   --inference-dynamic-batching-unified-memory-level: 1
   --inference-dynamic-batching-buffer-size-gb: 20
   --ckpt-format: torch_dist
+  # Pin the pre-#3509 (linear) CUDA-graph sizing distribution. #3509 switched the
+  # default to exponential + a mixed-prefill grid, which raised peak memory and
+  # tripped this test's mem-allocated-bytes guardrail (~69GB vs ~61GB golden, +13.6%).
+  --inference-dynamic-batching-cuda-graph-sizing-distribution: linear
   --seq-length: 1024
   --inference-max-seq-length: 1024
   --load: ${CHECKPOINT_LOAD_PATH}/model/qwen3-8b-dist

--- a/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_throughput/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_throughput/model_config.yaml
@@ -13,6 +13,10 @@ MODEL_ARGS:
   --inference-dynamic-batching-unified-memory-level: 1
   --inference-dynamic-batching-buffer-size-gb: 20
   --ckpt-format: torch_dist
+  # Pin the pre-#3509 (linear) CUDA-graph sizing distribution. #3509 switched the
+  # default to exponential + a mixed-prefill grid, which raised peak memory and
+  # tripped this test's mem-allocated-bytes guardrail (~69GB vs ~61GB golden, +13.6%).
+  --inference-dynamic-batching-cuda-graph-sizing-distribution: linear
   --seq-length: 1024
   --inference-max-seq-length: 1024
   --load: ${CHECKPOINT_LOAD_PATH}/model/qwen3-8b-dist


### PR DESCRIPTION
## What
Pin the **linear** CUDA-graph sizing distribution for the GRPO throughput tests:
- `gpt_grpo_tp4_pp1_dp2_8b_throughput`
- `gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput`

via `--inference-dynamic-batching-cuda-graph-sizing-distribution: linear`.

## Why
Both fail their **`mem-allocated-bytes`** guardrail in CI: peak **~69.2 GB vs ~60.9 GB golden (+13.6%, tol 10%)**. `lm-loss` passes — training is numerically correct; only peak memory grew.

Bisected (scanned every GRPO run May 18→Jun 5) to a **single commit** — last-pass `bdcaf267` → first-fail `16b71941`, the only commit between:
> **PR #3509** — "Change the cudagraph distribution from linearly to exponentially-decreasing + grid for mixed prefill"

It made `exponential` the default sizing distribution and added a mixed-prefill grid. This pins the pre-#3509 (`linear`) behavior for these tests.

## Caveat (validate on CI)
These recipes use `--inference-dynamic-batching-num-cuda-graphs 1`, so the sizing distribution mainly selects the single captured graph size; #3509 *also* added the mixed-prefill grid (`--inference-dynamic-batching-cuda-graph-mixed-prefill-count`, default 16), which may be a separate memory driver. If `linear` alone doesn't bring peak memory under the 10 % bound, the follow-up lever is reducing `mixed-prefill-count` — or the inference team confirms exponential+grid is the intended default and the golden is rebaselined. (Couldn't reproduce locally — GRPO needs the Qwen3-8B ckpt + RL rollout harness.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)