### PR TITLE
[split 2/4] Scale DSA indexer loss in pipeline schedules

### DIFF
--- a/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
+++ b/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
@@ -545,9 +545,15 @@ def hybrid_context_parallel_forward_backward(
             )
             sample["local_cp_size"] = torch.tensor(partner_cp_size, dtype=torch.int32)
             new_data_iterator = RerunDataIterator(iter([sample]))
-            return new_data_iterator
         else:
-            return None
+            partner_cp_size = 0
+            new_data_iterator = None
+
+        partner_cp_size_tensor = torch.tensor(
+            [partner_cp_size], dtype=torch.int32, device=torch.cuda.current_device()
+        )
+        _broadcast(partner_cp_size_tensor)
+        return new_data_iterator, int(partner_cp_size_tensor.item())
 
     # We get data once per global batch and schedule the sub-samples.
     # TODO(pmannan): Should we wrap the data_iterator here instead of the training.py file?
@@ -579,7 +585,7 @@ def hybrid_context_parallel_forward_backward(
             sample_ids_this_group = sample_id_groups[j][hdp_rank] if is_first_tp_rank else None
             for i in range(num_samples_this_group[j]):
                 # Call forward step for each sub-sample
-                new_data_iterator = _get_new_data_iterator(i, j)
+                new_data_iterator, cp_group_size = _get_new_data_iterator(i, j)
                 # TODO: Find the usage of current_microbatch and is_first_microbatch and
                 # how that may affect my usage.
                 output_tensor, num_tokens = forward_step(
@@ -590,7 +596,8 @@ def hybrid_context_parallel_forward_backward(
                     input_tensor,
                     forward_data_store,
                     config,
-                    collect_non_loss_data,
+                    cp_group_size=cp_group_size,
+                    collect_non_loss_data=collect_non_loss_data,
                     is_first_microbatch=check_first_val_step(
                         first_val_step, forward_only, current_microbatch == 0
                     ),
@@ -599,9 +606,7 @@ def hybrid_context_parallel_forward_backward(
                 current_microbatch += 1
                 total_num_tokens += num_tokens.item()
                 if not forward_only:
-                    backward_step(
-                        input_tensor, output_tensor, output_tensor_grad, model_type, config
-                    )
+                    backward_step(input_tensor, output_tensor, output_tensor_grad, config)
 
             # Create a barrier at end of each group.
             # This barrier ensures that all ranks are prepared to change assigned CP group sizes and
@@ -614,7 +619,7 @@ def hybrid_context_parallel_forward_backward(
     with no_sync_func():
         sample_ids_this_group = sample_id_groups[-1][hdp_rank] if is_first_tp_rank else None
         for i in range(num_samples_this_group[-1] - 1):
-            new_data_iterator = _get_new_data_iterator(i, -1)
+            new_data_iterator, cp_group_size = _get_new_data_iterator(i, -1)
             # Call forward step for each sub-sample
             output_tensor, num_tokens = forward_step(
                 forward_step_func,
@@ -624,7 +629,8 @@ def hybrid_context_parallel_forward_backward(
                 input_tensor,
                 forward_data_store,
                 config,
-                collect_non_loss_data,
+                cp_group_size=cp_group_size,
+                collect_non_loss_data=collect_non_loss_data,
                 is_first_microbatch=check_first_val_step(
                     first_val_step, forward_only, current_microbatch == 0
                 ),
@@ -633,11 +639,11 @@ def hybrid_context_parallel_forward_backward(
             current_microbatch += 1
             total_num_tokens += num_tokens.item()
             if not forward_only:
-                backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, config)
+                backward_step(input_tensor, output_tensor, output_tensor_grad, config)
 
     # The last sub-sample of the last group of the last microbatch is
     # run out of the context handler.
-    new_data_iterator = _get_new_data_iterator(-1, -1)
+    new_data_iterator, cp_group_size = _get_new_data_iterator(-1, -1)
     # Call forward step for each sub-sample
     output_tensor, num_tokens = forward_step(
         forward_step_func,
@@ -647,7 +653,8 @@ def hybrid_context_parallel_forward_backward(
         input_tensor,
         forward_data_store,
         config,
-        collect_non_loss_data,
+        cp_group_size=cp_group_size,
+        collect_non_loss_data=collect_non_loss_data,
         is_first_microbatch=check_first_val_step(
             first_val_step, forward_only, current_microbatch == 0
         ),
@@ -655,6 +662,6 @@ def hybrid_context_parallel_forward_backward(
     )
     total_num_tokens += num_tokens.item()
     if not forward_only:
-        backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, config)
+        backward_step(input_tensor, output_tensor, output_tensor_grad, config)
 
     return forward_data_store, total_num_tokens

--- a/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
+++ b/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
@@ -549,6 +549,8 @@ def hybrid_context_parallel_forward_backward(
             partner_cp_size = 0
             new_data_iterator = None
 
+        # Keep this int32 to match the hybrid-CP batch metadata dtype
+        # (`local_cp_size`) used by get_batch_on_this_cp_rank.
         partner_cp_size_tensor = torch.tensor(
             [partner_cp_size], dtype=torch.int32, device=torch.cuda.current_device()
         )

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -373,6 +373,10 @@ def forward_step_calc_loss(
         if config.calculate_per_token_loss:
             experimental_attention_variant_loss_scale_func(loss_scale)
         else:
+            # TODO: This path assumes static CP across outstanding pipeline microbatches.
+            # Hybrid/dynamic CP currently requires per-token loss and no PP; if that
+            # changes, carry the scale per autograd context instead of via a
+            # process-wide scaler hook.
             cp_size_for_scaling = cp_group_size if cp_group_size is not None else 1
             experimental_attention_variant_loss_scale_func(
                 loss_scale * cp_size_for_scaling / num_microbatches

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -226,26 +226,56 @@ def get_tensor_device(tensor: Union[torch.Tensor, Dict[str, torch.Tensor]]):
     return tensor.device
 
 
-def _get_mtp_loss_scale(config, device: torch.device) -> torch.Tensor:
-    """Get the MTP loss scale on the output tensor device."""
+def _normalize_loss_scale(loss_scale, device: torch.device, scale_func_name: str) -> torch.Tensor:
+    """Normalize loss scale outputs to a size-1 tensor on the output tensor device."""
+    loss_scale = torch.as_tensor(loss_scale, device=device)
+    if loss_scale.numel() != 1:
+        raise ValueError(
+            f"{scale_func_name} must return a scalar or size-1 tensor for loss scaling, "
+            f"but returned a tensor with {loss_scale.numel()} elements."
+        )
+    return loss_scale
 
-    def _normalize_loss_scale(loss_scale, scale_func_name: str) -> torch.Tensor:
-        loss_scale = torch.as_tensor(loss_scale, device=device)
-        if loss_scale.numel() != 1:
-            raise ValueError(
-                f"{scale_func_name} must return a scalar or size-1 tensor for MTP loss scaling, "
-                f"but returned a tensor with {loss_scale.numel()} elements."
-            )
-        return loss_scale
 
-    mtp_grad_scale_func = getattr(config, 'mtp_grad_scale_func', None)
-    if mtp_grad_scale_func is not None:
-        return _normalize_loss_scale(mtp_grad_scale_func(), "mtp_grad_scale_func")
+def _compute_loss_scale(config, device: torch.device) -> torch.Tensor:
+    """Calculate the loss scale from grad_scale_func or default to 1."""
     if config.grad_scale_func is not None:
         return _normalize_loss_scale(
-            config.grad_scale_func(torch.ones(1, device=device)), "grad_scale_func"
+            config.grad_scale_func(torch.ones(1, device=device)), device, "grad_scale_func"
         )
     return torch.ones(1, device=device)
+
+
+def _get_moe_loss_scale(config, device: torch.device) -> torch.Tensor:
+    """Get the MoE loss scale on the output tensor device."""
+    moe_grad_scale_func = getattr(config, 'moe_grad_scale_func', None)
+    if moe_grad_scale_func is not None:
+        return _normalize_loss_scale(moe_grad_scale_func(), device, "moe_grad_scale_func")
+    return _compute_loss_scale(config, device)
+
+
+def _get_mtp_loss_scale(config, device: torch.device) -> torch.Tensor:
+    """Get the MTP loss scale on the output tensor device."""
+    mtp_grad_scale_func = getattr(config, 'mtp_grad_scale_func', None)
+    if mtp_grad_scale_func is not None:
+        return _normalize_loss_scale(mtp_grad_scale_func(), device, "mtp_grad_scale_func")
+    return _compute_loss_scale(config, device)
+
+
+def _get_experimental_attention_variant_loss_scale_func(config):
+    """Get the loss scale hook for experimental attention variants."""
+    loss_scale_func = getattr(config, 'experimental_attention_variant_loss_scale_func', None)
+    if loss_scale_func is not None:
+        return loss_scale_func
+
+    if getattr(config, 'experimental_attention_variant', None) == 'dsa':
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            DSAIndexerLossAutoScaler,
+        )
+
+        return DSAIndexerLossAutoScaler.set_loss_scale
+
+    return None
 
 
 def forward_step_calc_loss(
@@ -262,9 +292,6 @@ def forward_step_calc_loss(
 ):
     """Calculate the loss and number of tokens for forward_step()"""
 
-    from megatron.core.transformer.experimental_attention_variant.dsa import (
-        DSAIndexerLossAutoScaler,
-    )
     from megatron.core.transformer.multi_token_prediction import MTPLossAutoScaler
 
     model_vp_stage = getattr(model, "vp_stage", None)
@@ -315,16 +342,8 @@ def forward_step_calc_loss(
     # Since we use a trick to do backward on the auxiliary loss, we need to set the scale
     # explicitly.
     if hasattr(config, 'num_moe_experts') and config.num_moe_experts is not None:
-        # Calculate the loss scale based on moe_grad_scale_func (preferred),
-        # grad_scale_func (fallback), or default to 1.
         device = get_tensor_device(output_tensor)
-        moe_grad_scale_func = getattr(config, 'moe_grad_scale_func', None)
-        if moe_grad_scale_func is not None:
-            loss_scale = moe_grad_scale_func()
-        elif config.grad_scale_func is not None:
-            loss_scale = config.grad_scale_func(torch.ones(1, device=device))
-        else:
-            loss_scale = torch.ones(1, device=device)
+        loss_scale = _get_moe_loss_scale(config, device)
         # Set the loss scale
         if config.calculate_per_token_loss:
             MoEAuxLossAutoScaler.set_loss_scale(loss_scale)
@@ -344,17 +363,20 @@ def forward_step_calc_loss(
         else:
             MTPLossAutoScaler.set_loss_scale(loss_scale / num_microbatches)
 
-    # Set the loss scale for DSA (Dynamic Sparse Attention) indexer loss.
-    if getattr(config, 'experimental_attention_variant', None) == 'dsa':
-        loss_scale = (
-            config.grad_scale_func(torch.ones(1, device=output_tensor.device))
-            if config.grad_scale_func is not None
-            else torch.ones(1, device=output_tensor.device)
-        )
+    # Set the loss scale for any experimental attention-variant auxiliary loss.
+    experimental_attention_variant_loss_scale_func = (
+        _get_experimental_attention_variant_loss_scale_func(config)
+    )
+    if experimental_attention_variant_loss_scale_func is not None:
+        device = get_tensor_device(output_tensor)
+        loss_scale = _compute_loss_scale(config, device)
         if config.calculate_per_token_loss:
-            DSAIndexerLossAutoScaler.set_loss_scale(loss_scale)
+            experimental_attention_variant_loss_scale_func(loss_scale)
         else:
-            DSAIndexerLossAutoScaler.set_loss_scale(loss_scale / num_microbatches)
+            cp_size_for_scaling = cp_group_size if cp_group_size is not None else 1
+            experimental_attention_variant_loss_scale_func(
+                loss_scale * cp_size_for_scaling / num_microbatches
+            )
 
     return output_tensor, num_tokens
 

--- a/tests/unit_tests/pipeline_parallel/test_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedules.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
 
 import os
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -76,6 +77,120 @@ def test_deallocate_output_tensor():
     out = torch.tensor([[1, 2, 3], [4, 5, 6]])
     schedule.deallocate_output_tensor(out)
     assert out.nelement() == 6
+
+
+@pytest.mark.parametrize("calculate_per_token_loss,expected_scale", [(False, 6.0), (True, 3.0)])
+def test_dsa_indexer_loss_scale_matches_schedule_cp_scaling(
+    calculate_per_token_loss, expected_scale
+):
+    from megatron.core.transformer.experimental_attention_variant.dsa import (
+        DSAIndexerLossAutoScaler,
+    )
+
+    config = SimpleNamespace(
+        calculate_per_token_loss=calculate_per_token_loss,
+        experimental_attention_variant_loss_scale_func=DSAIndexerLossAutoScaler.set_loss_scale,
+        experimental_attention_variant='dsa',
+        grad_scale_func=lambda tensor: tensor * 3.0,
+        num_moe_experts=None,
+        mtp_num_layers=None,
+        timers=None,
+    )
+    forward_data_store = []
+
+    def loss_func(output_tensor):
+        return output_tensor.clone(), torch.tensor(4), {'loss_reduced': output_tensor.detach()}
+
+    DSAIndexerLossAutoScaler.main_loss_backward_scale = None
+    schedule.forward_step_calc_loss(
+        model=None,
+        output_tensor=torch.tensor(8.0),
+        loss_func=loss_func,
+        config=config,
+        vp_stage=None,
+        collect_non_loss_data=False,
+        num_microbatches=2,
+        forward_data_store=forward_data_store,
+        cp_group_size=4,
+        is_last_stage=True,
+    )
+
+    torch.testing.assert_close(
+        DSAIndexerLossAutoScaler.main_loss_backward_scale, torch.tensor([expected_scale])
+    )
+
+
+def test_dsa_indexer_loss_scale_accepts_dict_output_tensor():
+    from megatron.core.transformer.experimental_attention_variant.dsa import (
+        DSAIndexerLossAutoScaler,
+    )
+
+    config = SimpleNamespace(
+        calculate_per_token_loss=True,
+        experimental_attention_variant_loss_scale_func=DSAIndexerLossAutoScaler.set_loss_scale,
+        experimental_attention_variant='dsa',
+        grad_scale_func=lambda tensor: tensor * 5.0,
+        num_moe_experts=None,
+        mtp_num_layers=None,
+        timers=None,
+    )
+
+    forward_data_store = []
+
+    DSAIndexerLossAutoScaler.main_loss_backward_scale = None
+    schedule.forward_step_calc_loss(
+        model=None,
+        output_tensor={'loss': torch.tensor(8.0)},
+        loss_func=None,
+        config=config,
+        vp_stage=None,
+        collect_non_loss_data=False,
+        num_microbatches=2,
+        forward_data_store=forward_data_store,
+        cp_group_size=4,
+        is_last_stage=True,
+    )
+
+    assert len(forward_data_store) == 1
+    torch.testing.assert_close(forward_data_store[0]['loss'], torch.tensor(8.0))
+    torch.testing.assert_close(
+        DSAIndexerLossAutoScaler.main_loss_backward_scale, torch.tensor([5.0])
+    )
+
+
+def test_dsa_indexer_loss_scale_defaults_from_variant_without_mutating_config():
+    from megatron.core.transformer.experimental_attention_variant.dsa import (
+        DSAIndexerLossAutoScaler,
+    )
+
+    config = SimpleNamespace(
+        calculate_per_token_loss=True,
+        experimental_attention_variant_loss_scale_func=None,
+        experimental_attention_variant='dsa',
+        grad_scale_func=lambda tensor: tensor * 7.0,
+        num_moe_experts=None,
+        mtp_num_layers=None,
+        timers=None,
+    )
+
+    DSAIndexerLossAutoScaler.main_loss_backward_scale = None
+    schedule.forward_step_calc_loss(
+        model=None,
+        output_tensor=torch.tensor(8.0),
+        loss_func=None,
+        config=config,
+        vp_stage=None,
+        collect_non_loss_data=False,
+        num_microbatches=2,
+        forward_data_store=[],
+        cp_group_size=4,
+        is_last_stage=True,
+    )
+
+    assert config.experimental_attention_variant_loss_scale_func is None
+    torch.testing.assert_close(
+        DSAIndexerLossAutoScaler.main_loss_backward_scale, torch.tensor([7.0])
+    )
 
 
 @pytest.mark.internal

--- a/tests/unit_tests/pipeline_parallel/test_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedules.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
 
 import os
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
@@ -9,6 +10,7 @@ import torch.distributed as dist
 from packaging import version
 from pytest_mock import mocker
 
+import megatron.core.pipeline_parallel.hybrid_cp_schedule as hybrid_cp_schedule
 import megatron.core.pipeline_parallel.schedules as schedule
 from megatron.core import ModelParallelConfig
 from megatron.core.distributed.finalize_model_grads import finalize_model_grads
@@ -16,6 +18,7 @@ from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.rerun_state_machine import RerunDataIterator
 from megatron.core.transformer.cuda_graphs import (
     convert_schedule_table_to_order,
     get_overlap_moe_expert_parallel_comm_order,
@@ -77,6 +80,222 @@ def test_deallocate_output_tensor():
     out = torch.tensor([[1, 2, 3], [4, 5, 6]])
     schedule.deallocate_output_tensor(out)
     assert out.nelement() == 6
+
+
+@contextmanager
+def _no_sync():
+    yield
+
+
+def _patch_hybrid_cp_parallel_state(monkeypatch, *, is_first_tp_rank):
+    monkeypatch.setattr(
+        hybrid_cp_schedule.parallel_state,
+        "get_data_parallel_rank",
+        lambda with_context_parallel=False: 0,
+    )
+    monkeypatch.setattr(
+        hybrid_cp_schedule.parallel_state,
+        "get_tensor_model_parallel_rank",
+        lambda: 0 if is_first_tp_rank else 1,
+    )
+    monkeypatch.setattr(
+        hybrid_cp_schedule.parallel_state, "get_tensor_model_parallel_src_rank", lambda: 0
+    )
+    monkeypatch.setattr(
+        hybrid_cp_schedule.parallel_state, "get_tensor_model_parallel_group", lambda: "tp_group"
+    )
+    monkeypatch.setattr(
+        hybrid_cp_schedule.parallel_state,
+        "get_data_parallel_group",
+        lambda with_context_parallel=False: "dp_cp_group",
+    )
+
+
+def _patch_hybrid_cp_cpu_tensors(monkeypatch):
+    original_tensor = torch.tensor
+
+    def cpu_tensor(*args, **kwargs):
+        if kwargs.get("device") == "cuda":
+            kwargs["device"] = "cpu"
+        return original_tensor(*args, **kwargs)
+
+    monkeypatch.setattr(hybrid_cp_schedule.torch, "tensor", cpu_tensor)
+    monkeypatch.setattr(
+        hybrid_cp_schedule.torch.cuda, "current_device", lambda: torch.device("cpu")
+    )
+
+
+def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypatch):
+    _patch_hybrid_cp_cpu_tensors(monkeypatch)
+    _patch_hybrid_cp_parallel_state(monkeypatch, is_first_tp_rank=True)
+
+    monkeypatch.setattr(
+        hybrid_cp_schedule.torch.distributed, "broadcast", lambda *args, **kwargs: None
+    )
+    barrier_groups = []
+    monkeypatch.setattr(
+        hybrid_cp_schedule.torch.distributed,
+        "barrier",
+        lambda group=None: barrier_groups.append(group),
+    )
+
+    batch = [{"id": 0}, {"id": 1}, {"id": 2}]
+    sample_id_groups = [[[0], [0], []], [[1, 2], [1], [1, 2]]]
+    forward_calls = []
+
+    def fake_forward_step(
+        forward_step_func,
+        data_iterator,
+        model,
+        num_microbatches,
+        input_tensor,
+        forward_data_store,
+        config,
+        cp_group_size,
+        **kwargs,
+    ):
+        assert isinstance(data_iterator, RerunDataIterator)
+        sample = next(data_iterator)
+        forward_calls.append(
+            {
+                "sample_id": sample["id"],
+                "local_cp_size": int(sample["local_cp_size"].item()),
+                "local_cp_size_dtype": sample["local_cp_size"].dtype,
+                "cp_group_size": cp_group_size,
+                "current_microbatch": kwargs["current_microbatch"],
+                "is_first_microbatch": kwargs["is_first_microbatch"],
+            }
+        )
+        return torch.tensor(float(kwargs["current_microbatch"])), torch.tensor(10)
+
+    backward_calls = []
+
+    def fake_backward_step(input_tensor, output_tensor, output_tensor_grad, config):
+        backward_calls.append((input_tensor, output_tensor.item(), output_tensor_grad, config))
+
+    monkeypatch.setattr(schedule, "forward_step", fake_forward_step)
+    monkeypatch.setattr(schedule, "backward_step", fake_backward_step)
+
+    config = SimpleNamespace()
+    forward_data_store, total_num_tokens = (
+        hybrid_cp_schedule.hybrid_context_parallel_forward_backward(
+            forward_step_func=None,
+            data_iterator=iter([(batch, sample_id_groups)]),
+            model="model",
+            num_microbatches=3,
+            input_tensor="input",
+            output_tensor_grad="grad",
+            forward_data_store=[],
+            config=config,
+            collect_non_loss_data=False,
+            first_val_step=True,
+            forward_only=False,
+            no_sync_func=_no_sync,
+            total_num_tokens=0,
+            check_first_val_step=lambda first_val_step, forward_only, is_first: is_first,
+            model_type="unused",
+        )
+    )
+
+    assert forward_data_store == []
+    assert total_num_tokens == 30
+    assert forward_calls == [
+        {
+            "sample_id": 0,
+            "local_cp_size": 2,
+            "local_cp_size_dtype": torch.int32,
+            "cp_group_size": 2,
+            "current_microbatch": 0,
+            "is_first_microbatch": True,
+        },
+        {
+            "sample_id": 1,
+            "local_cp_size": 3,
+            "local_cp_size_dtype": torch.int32,
+            "cp_group_size": 3,
+            "current_microbatch": 1,
+            "is_first_microbatch": False,
+        },
+        {
+            "sample_id": 2,
+            "local_cp_size": 2,
+            "local_cp_size_dtype": torch.int32,
+            "cp_group_size": 2,
+            "current_microbatch": 2,
+            "is_first_microbatch": False,
+        },
+    ]
+    assert [(call[0], call[1], call[2]) for call in backward_calls] == [
+        ("input", 0.0, "grad"),
+        ("input", 1.0, "grad"),
+        ("input", 2.0, "grad"),
+    ]
+    assert all(call[3] is config for call in backward_calls)
+    assert "dp_cp_group" in barrier_groups
+
+
+def test_hybrid_context_parallel_non_first_tp_rank_uses_broadcast_cp_size(monkeypatch):
+    _patch_hybrid_cp_parallel_state(monkeypatch, is_first_tp_rank=False)
+    monkeypatch.setattr(
+        hybrid_cp_schedule.torch.cuda, "current_device", lambda: torch.device("cpu")
+    )
+    monkeypatch.setattr(hybrid_cp_schedule.torch.distributed, "barrier", lambda group=None: None)
+
+    broadcast_values = [
+        torch.tensor([1], dtype=torch.int64),
+        torch.tensor([1], dtype=torch.int32),
+        torch.tensor([7], dtype=torch.int32),
+    ]
+
+    def fake_broadcast(item, src, group=None):
+        item.copy_(broadcast_values.pop(0))
+
+    monkeypatch.setattr(hybrid_cp_schedule.torch.distributed, "broadcast", fake_broadcast)
+
+    forward_calls = []
+
+    def fake_forward_step(
+        forward_step_func,
+        data_iterator,
+        model,
+        num_microbatches,
+        input_tensor,
+        forward_data_store,
+        config,
+        cp_group_size,
+        **kwargs,
+    ):
+        forward_calls.append((data_iterator, cp_group_size, kwargs["current_microbatch"]))
+        return torch.tensor(0.0), torch.tensor(4)
+
+    monkeypatch.setattr(schedule, "forward_step", fake_forward_step)
+    monkeypatch.setattr(
+        schedule,
+        "backward_step",
+        lambda input_tensor, output_tensor, output_tensor_grad, config: None,
+    )
+
+    _, total_num_tokens = hybrid_cp_schedule.hybrid_context_parallel_forward_backward(
+        forward_step_func=None,
+        data_iterator=None,
+        model="model",
+        num_microbatches=1,
+        input_tensor="input",
+        output_tensor_grad="grad",
+        forward_data_store=[],
+        config=SimpleNamespace(),
+        collect_non_loss_data=False,
+        first_val_step=True,
+        forward_only=True,
+        no_sync_func=_no_sync,
+        total_num_tokens=0,
+        check_first_val_step=lambda first_val_step, forward_only, is_first: is_first,
+        model_type="unused",
+    )
+
+    assert forward_calls == [(None, 7, 0)]
+    assert total_num_tokens == 4
+    assert broadcast_values == []
 
 
 @pytest.mark.parametrize("calculate_per_token_loss,expected_scale", [(False, 6.0), (True, 3.0)])


### PR DESCRIPTION
Split out from #3674 to reduce review scope.

Original changes by @HollowMan6 in #3674.

## Scope
- Generalize auxiliary loss-scale handling in pipeline schedules.
- Wire DSA indexer loss scaling through the experimental attention variant hook.
- Update hybrid CP schedule calls after the `backward_step` signature change.
- Add unit coverage for CP scaling, dict outputs, and non-mutating default DSA hook behavior.

## Dependencies
None.

## Validation
- `git diff --check upstream/main..split-3674-dsa-loss-scale`