### PR TITLE
[split 5/5] Wire hybrid DSA spec to absorbed MLA

### DIFF
--- a/megatron/core/models/hybrid/hybrid_layer_specs.py
+++ b/megatron/core/models/hybrid/hybrid_layer_specs.py
@@ -26,6 +26,10 @@ from megatron.core.tensor_parallel import (
 )
 from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
 from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
+    AbsorbedMLASelfAttention,
+    AbsorbedMLASelfAttentionSubmodules,
+)
 from megatron.core.transformer.experimental_attention_variant.dsa import (
     DSAIndexer,
     DSAIndexerSubmodules,
@@ -135,9 +139,9 @@ hybrid_stack_spec = ModuleSpec(
             submodules=TransformerLayerSubmodules(
                 input_layernorm=TENorm,
                 self_attention=ModuleSpec(
-                    module=MLASelfAttention,
+                    module=AbsorbedMLASelfAttention,
                     params={"attn_mask_type": AttnMaskType.causal},
-                    submodules=MLASelfAttentionSubmodules(
+                    submodules=AbsorbedMLASelfAttentionSubmodules(
                         linear_q_proj=TEColumnParallelLinear,
                         linear_q_down_proj=TELinear,
                         linear_q_up_proj=TEColumnParallelLinear,


### PR DESCRIPTION
Split out from #3674 to reduce review scope.

Original changes by @HollowMan6 in #3674.

## Scope
- Update the hybrid DSA layer spec to use `AbsorbedMLASelfAttention` and absorbed MLA submodules.

## Dependencies
- Depends on #5245 for the absorbed MLA submodule interface.
- Depends on #5246 for the DSA CP/THD core behavior this spec enables.

## Validation
- `git diff --check upstream/main..split-3674-hybrid-dsa-spec`