### PR TITLE
Add optional group= to common_utils model/data-parallel reduction helpers

### DIFF
--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -8,6 +8,7 @@ import warnings
 from contextlib import contextmanager
 from datetime import datetime
 from collections import defaultdict
+from typing import Optional
 
 import torch
 
@@ -234,29 +235,40 @@ def calc_dtensor_params_l2_norm(params):
     return total_norm_2.item() ** 0.5
 
 
-def average_losses_across_data_parallel_group(losses):
-    """Reduce a tensor of losses across all GPUs."""
+def average_losses_across_data_parallel_group(
+    losses, group: Optional[torch.distributed.ProcessGroup] = None
+):
+    """Reduce a tensor of losses across all GPUs.
+
+    group: data-parallel process group; defaults to mpu.get_data_parallel_group().
+    """
+    if group is None:
+        group = mpu.get_data_parallel_group()
     averaged_losses = torch.cat([loss.clone().detach().view(1) for loss in losses])
-    torch.distributed.all_reduce(averaged_losses, group=mpu.get_data_parallel_group())
-    averaged_losses = averaged_losses / mpu.get_data_parallel_group().size()
+    torch.distributed.all_reduce(averaged_losses, group=group)
+    averaged_losses = averaged_losses / group.size()
 
     return averaged_losses
 
 
-def reduce_max_stat_across_model_parallel_group(stat: float) -> float | None:
+def reduce_max_stat_across_model_parallel_group(
+    stat: float, group: Optional[torch.distributed.ProcessGroup] = None
+) -> float | None:
     """
     Ranks without an optimizer will have no grad_norm or num_zeros_in_grad stats.
     We need to ensure the logging and writer rank has those values.
     This function reduces a stat tensor across the model parallel group.
 
     We use an all_reduce max since the values have already been summed across optimizer ranks where possible
+
+    group: model-parallel process group; defaults to mpu.get_model_parallel_group().
     """
+    if group is None:
+        group = mpu.get_model_parallel_group()
     if stat is None:
         stat = -1.0
     stat = torch.tensor([stat], dtype=torch.float32, device=torch.cuda.current_device())
-    torch.distributed.all_reduce(
-        stat, op=torch.distributed.ReduceOp.MAX, group=mpu.get_model_parallel_group()
-    )
+    torch.distributed.all_reduce(stat, op=torch.distributed.ReduceOp.MAX, group=group)
     if stat.item() == -1.0:
         # No rank has a valid stat, so return None to indicate that it is None across all ranks.
         return None
@@ -264,18 +276,22 @@ def reduce_max_stat_across_model_parallel_group(stat: float) -> float | None:
         return stat.item()
 
 
-def logical_and_across_model_parallel_group(input: bool) -> bool:
+def logical_and_across_model_parallel_group(
+    input: bool, group: Optional[torch.distributed.ProcessGroup] = None
+) -> bool:
     """
     This function gathers a bool value across the model parallel group
+
+    group: model-parallel process group; defaults to mpu.get_model_parallel_group().
     """
+    if group is None:
+        group = mpu.get_model_parallel_group()
     if input is True:
         input = 1
     else:
         input = 0
     input = torch.tensor([input], dtype=torch.int, device=torch.cuda.current_device())
-    torch.distributed.all_reduce(
-        input, op=torch.distributed.ReduceOp.MIN, group=mpu.get_model_parallel_group()
-    )
+    torch.distributed.all_reduce(input, op=torch.distributed.ReduceOp.MIN, group=group)
     return bool(input.item())
 
 

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -543,3 +543,64 @@ class TestGetLocalRankPreinit:
     def test_defaults_to_zero_with_warning(self):
         with pytest.warns(UserWarning, match="Could not determine local rank"):
             assert get_local_rank_preinit() == 0
+
+
+class TestSingleGroupReductionHelpers:
+    """The optional ``group=`` on the reduction helpers, exercised with a HyperCommGrid-derived
+    process group (no ``parallel_state`` init — the MIMO use case) plus a default→mpu fallback."""
+
+    @staticmethod
+    def _ranks(group):
+        return torch.distributed.get_process_group_ranks(group)
+
+    def test_explicit_grid_group(self):
+        """Helpers reduce correctly over a group built from a HyperCommGrid, no parallel_state."""
+        from megatron.core.hyper_comm_grid import HyperCommGrid
+        from megatron.training.utils.common_utils import (
+            average_losses_across_data_parallel_group,
+            logical_and_across_model_parallel_group,
+            reduce_max_stat_across_model_parallel_group,
+        )
+
+        Utils.initialize_distributed()  # torch.distributed only; NOT initialize_model_parallel
+        world = torch.distributed.get_world_size()
+        rank = torch.distributed.get_rank()
+        # tp=2 over the world: "tp" groups stand in for a model-parallel group, "dp" for data.
+        grid = HyperCommGrid([2, world // 2], ["tp", "dp"], backend="nccl")
+        grid.create_pg(["tp"])
+        grid.create_pg(["dp"])
+        mp_group, dp_group = grid.get_pg("tp"), grid.get_pg("dp")
+        mp_ranks, dp_ranks = self._ranks(mp_group), self._ranks(dp_group)
+        try:
+            # reduce_max: MAX over the grid mp group.
+            assert reduce_max_stat_across_model_parallel_group(
+                float(rank), group=mp_group
+            ) == float(max(mp_ranks))
+
+            # logical_and: True iff every member is True (only the lowest mp rank passes True).
+            flag = rank == min(mp_ranks)
+            expected_and = all(r == min(mp_ranks) for r in mp_ranks)
+            assert logical_and_across_model_parallel_group(flag, group=mp_group) is expected_and
+
+            # average: SUM-then-divide over the grid dp group -> mean of member ranks.
+            loss = torch.tensor(float(rank), device=torch.cuda.current_device())
+            out = average_losses_across_data_parallel_group([loss], group=dp_group)
+            torch.testing.assert_close(
+                out.cpu(), torch.tensor([sum(dp_ranks) / len(dp_ranks)], dtype=torch.float32)
+            )
+        finally:
+            grid.destroy()
+
+    def test_default_falls_back_to_mpu(self):
+        """With no ``group=``, helpers read the mpu global (back-compat for non-MIMO callers)."""
+        from megatron.core import parallel_state as mpu
+        from megatron.training.utils.common_utils import reduce_max_stat_across_model_parallel_group
+
+        Utils.initialize_model_parallel(tensor_model_parallel_size=2)
+        rank = torch.distributed.get_rank()
+        explicit = reduce_max_stat_across_model_parallel_group(
+            float(rank), group=mpu.get_model_parallel_group()
+        )
+        default = reduce_max_stat_across_model_parallel_group(float(rank))
+        assert default == explicit
+        Utils.destroy_model_parallel()


### PR DESCRIPTION
Adds an optional `group=` parameter (default `None`) to the three single-group reduction helpers in `common_utils`: `average_losses_across_data_parallel_group`, `reduce_max_stat_across_model_parallel_group`, and `logical_and_across_model_parallel_group`. When `group` is `None`, each helper falls back to the same `mpu` getter as before.

Why: enables hetero-MIMO to reuse the stock training loop by threading an explicit ProcessGroupCollection; default `None` preserves current behavior for homogeneous runs.

Testing: unit test added covering explicit-group routing and default-None fall-through (including divisor correctness). Homogeneous goldens / cog 8-GPU validation is the next gate and has NOT yet been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)