### PR TITLE
fix(ci): stabilize failing functional test recipes

### DIFF
--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp1_pp4_vp2/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp1_pp4_vp2/model_config.yaml
@@ -42,4 +42,9 @@ MODEL_ARGS:
   --bf16: true
   --ckpt-format: torch
   --attention-backend: unfused
+  # Interleaved/VPP schedule defaults to overlap_p2p_comm=True, which forces
+  # batch_p2p_comm=False and uses unbatched per-pair P2P that lazily creates
+  # 2-rank NCCL communicators -> intermittent lazy-comm-init deadlock (RECV hang).
+  # Use batched P2P here (pp=4 > 2 satisfies the interleaved+no-overlap assert).
+  --no-overlap-p2p-communication: true
 TEST_TYPE: regular

--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp1_pp4_vp2/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp1_pp4_vp2/model_config.yaml
@@ -42,9 +42,9 @@ MODEL_ARGS:
   --bf16: true
   --ckpt-format: torch
   --attention-backend: unfused
-  # Interleaved/VPP schedule defaults to overlap_p2p_comm=True, which forces
-  # batch_p2p_comm=False and uses unbatched per-pair P2P that lazily creates
-  # 2-rank NCCL communicators -> intermittent lazy-comm-init deadlock (RECV hang).
-  # Use batched P2P here (pp=4 > 2 satisfies the interleaved+no-overlap assert).
+  # Use batched P2P for the interleaved/VPP schedule. The CI failure can also
+  # park a rank in DataLoader queue.get, so use in-process loading to remove
+  # the worker/pin-memory queue hang surface.
   --no-overlap-p2p-communication: true
+  --num-workers: 0
 TEST_TYPE: regular

--- a/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput/model_config.yaml
@@ -13,6 +13,10 @@ MODEL_ARGS:
   --inference-dynamic-batching-unified-memory-level: 1
   --inference-dynamic-batching-buffer-size-gb: 20
   --ckpt-format: torch_dist
+  # Pin the pre-#3509 (linear) CUDA-graph sizing distribution. #3509 switched the
+  # default to exponential + a mixed-prefill grid, which raised peak memory and
+  # tripped this test's mem-allocated-bytes guardrail (~69GB vs ~61GB golden, +13.6%).
+  --inference-dynamic-batching-cuda-graph-sizing-distribution: linear
   --seq-length: 1024
   --inference-max-seq-length: 1024
   --load: ${CHECKPOINT_LOAD_PATH}/model/qwen3-8b-dist

--- a/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_throughput/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_throughput/model_config.yaml
@@ -13,6 +13,10 @@ MODEL_ARGS:
   --inference-dynamic-batching-unified-memory-level: 1
   --inference-dynamic-batching-buffer-size-gb: 20
   --ckpt-format: torch_dist
+  # Pin the pre-#3509 (linear) CUDA-graph sizing distribution. #3509 switched the
+  # default to exponential + a mixed-prefill grid, which raised peak memory and
+  # tripped this test's mem-allocated-bytes guardrail (~69GB vs ~61GB golden, +13.6%).
+  --inference-dynamic-batching-cuda-graph-sizing-distribution: linear
   --seq-length: 1024
   --inference-max-seq-length: 1024
   --load: ${CHECKPOINT_LOAD_PATH}/model/qwen3-8b-dist

--- a/tests/functional_tests/test_cases/t5/t5_mcore_te_tp1_pp1_vp1_resume_torch/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_te_tp1_pp1_vp1_resume_torch/model_config.yaml
@@ -53,4 +53,10 @@ MODEL_ARGS:
   --ckpt-format: torch
   --attention-backend: unfused
   --log-memory-to-tensorboard: true
+  # Synchronous data loading: the default 2 persistent dataloader workers
+  # (pin_memory, no DataLoader timeout) can stall on the CI data mount, leaving
+  # the rank blocked in get_batch -> queue.get forever -> the other ranks time
+  # out in the grad all-reduce (600s NCCL watchdog). In-process loading removes
+  # the worker-queue hang surface; test data is tiny so perf impact is nil.
+  --num-workers: 0
 TEST_TYPE: ckpt-resume

--- a/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1/model_config.yaml
@@ -51,4 +51,10 @@ MODEL_ARGS:
   --deterministic-mode: true
   --ckpt-format: torch
   --log-memory-to-tensorboard: true
+  # Synchronous data loading: the default 2 persistent dataloader workers
+  # (pin_memory, no DataLoader timeout) can stall on the CI data mount, leaving
+  # the rank blocked in get_batch -> queue.get forever -> the other ranks time
+  # out in the grad all-reduce (600s NCCL watchdog). In-process loading removes
+  # the worker-queue hang surface; test data is tiny so perf impact is nil.
+  --num-workers: 0
 TEST_TYPE: regular

--- a/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1_resume_torch/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1_resume_torch/model_config.yaml
@@ -51,4 +51,10 @@ MODEL_ARGS:
   --deterministic-mode: true
   --ckpt-format: torch
   --log-memory-to-tensorboard: true
+  # Synchronous data loading: the default 2 persistent dataloader workers
+  # (pin_memory, no DataLoader timeout) can stall on the CI data mount, leaving
+  # the rank blocked in get_batch -> queue.get forever -> the other ranks time
+  # out in the grad all-reduce (600s NCCL watchdog). In-process loading removes
+  # the worker-queue hang surface; test data is tiny so perf impact is nil.
+  --num-workers: 0
 TEST_TYPE: ckpt-resume


### PR DESCRIPTION
## What
Combine the CI recipe mitigations from:
- #5240: use batched pipeline P2P for `bert_mcore_tp1_pp4_vp2`
- #5241: use synchronous data loading for hanging T5 functional tests
- #5242: pin linear CUDA-graph sizing distribution for GRPO 8B throughput tests

Follow-up from the latest GitLab/JET BERT logs: `bert_mcore_tp1_pp4_vp2` still hung after the batched-P2P change, with one rank blocked in DataLoader `queue.get` while another timed out in batched pipeline P2P. This PR now also sets `--num-workers: 0` for that BERT recipe.

The fixes are kept as separate commits so each mitigation remains easy to inspect or revert independently.

## Why
These are all test-config-only fixes for functional tests that are currently failing or flaky in CI.

### BERT pp4/vp2 hang
`bert_mcore_tp1_pp4_vp2` originally failed as an intermittent pipeline-parallel P2P hang. Disabling P2P overlap routes the interleaved pp4/vp2 recipe to batched P2P (`batch_isend_irecv`) instead of the unbatched per-pair P2P path that can lazily create 2-rank NCCL communicators in inconsistent order.

The follow-up GitLab/JET failure shows the recipe update was applied (`overlap_p2p_comm=False`) and the hang moved to a batched `COALESCED` NCCL operation after iteration 15, while another rank was parked in `get_batch` / DataLoader `queue.get`. Setting `--num-workers: 0` removes the worker subprocess and pin-memory queue from this small functional test.

### T5 dataloader hang
The affected T5 recipes can surface as `finalize_model_grads` all-reduce timeouts, but fault-handler dumps show the stuck rank parked in `get_batch` / DataLoader `queue.get`. Setting `--num-workers: 0` removes the worker subprocess queue from these small functional tests.

### GRPO CUDA-graph memory guardrail
The GRPO throughput recipes fail their memory guardrail after the CUDA graph sizing default changed to `exponential` plus mixed-prefill grid. Pinning `--inference-dynamic-batching-cuda-graph-sizing-distribution: linear` restores the pre-change sizing behavior for these tests. This still needs CI confirmation because mixed-prefill count may also contribute to peak memory.

## Validation
- Parsed the updated BERT YAML locally with `python3` / PyYAML.
- Inspected the failing GitLab/JET BERT logs and confirmed the recipe was using `--no-overlap-p2p-communication`, `overlap_p2p_comm=False`, and still timing out in batched P2P while another rank was blocked in DataLoader `queue.get`.

Needs `Run functional tests` to validate the CI-dependent failure modes.

Supersedes #5240, #5241, and #5242.
