### PR TITLE
Remove O(DP-world-size) overhead from distributed optimizer init and dp_zero checkpoint paths

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -191,10 +191,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         Build mapping between params and their grad buffers.
 
         This method does the initial setup for the method above. This setup
-        includes determining the shard ranges into the param_and_grad_buffer
-        for each data-parallel (DP) rank. Each DP rank keeps range info for
-        all other DP ranks, for the purpose of creating args for
-        reduce-scatter and all-gather.
+        includes determining the shard range into the param_and_grad_buffer
+        owned by the local data-parallel (DP) rank; rank r owns the r'th
+        contiguous 1/world_size shard of each bucket.
         """
 
         data_parallel_rank = param_and_grad_buffer.data_parallel_group.rank()
@@ -207,20 +206,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         ), f"Each bucket's buffer size should be divisible by {data_parallel_world_size}"
         max_gbuf_range_size = gbuf_size // data_parallel_world_size
 
-        # All world ranges (i.e., across all data parallel ranks).
-        gbuf_world_all_ranges = []
-        for r in range(data_parallel_world_size):
-            # Compute start of chunk in this bucket.
-            gbuf_world_start = r * max_gbuf_range_size
-            gbuf_world_end = min(gbuf_size, gbuf_world_start + max_gbuf_range_size)
-            # Add bucket's offset in grad buffer.
-            gbuf_world_range = Range(
-                gbuf_world_start + bucket.offset, gbuf_world_end + bucket.offset
-            )
-            gbuf_world_all_ranges.append(gbuf_world_range)
-
-        # Local DP's ranges.
-        gbuf_world_range = gbuf_world_all_ranges[data_parallel_rank]
+        # Local DP rank's range. Computed directly (rather than materializing
+        # ranges for all DP ranks) to keep init cost O(1) in DP world size.
+        gbuf_world_start = data_parallel_rank * max_gbuf_range_size
+        gbuf_world_end = min(gbuf_size, gbuf_world_start + max_gbuf_range_size)
+        # Add bucket's offset in grad buffer.
+        gbuf_world_range = Range(gbuf_world_start + bucket.offset, gbuf_world_end + bucket.offset)
 
         # Get each param's ranges.
         param_range_map = cls._build_model_gbuf_param_range_map(
@@ -1301,16 +1292,19 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         # Gather contiguous shards on DP rank 0.
                         for key, send_tensor in local_shards.items():
 
-                            # Gather tensor list.
+                            # Gather list of views into one contiguous receive
+                            # buffer, instead of data_parallel_world_size separate
+                            # tensors that would later need a torch.cat: this keeps
+                            # the number of allocations O(1) in DP world size and
+                            # avoids a full extra copy of the gathered state.
                             if data_parallel_rank == 0 or return_on_all_ranks:
                                 device = "cpu" if use_gloo_comm else torch.cuda.current_device()
-                                recv_tensors = [
-                                    torch.zeros(
-                                        (gbuf_local_numel,), dtype=torch.float32, device=device
-                                    )
-                                    for _ in range(data_parallel_world_size)
-                                ]
+                                recv_buffer = torch.empty(
+                                    (gbuf_world_numel,), dtype=torch.float32, device=device
+                                )
+                                recv_tensors = list(recv_buffer.chunk(data_parallel_world_size))
                             else:
+                                recv_buffer = None
                                 recv_tensors = None
 
                             # Gather.
@@ -1330,19 +1324,16 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                             send_tensor = None  # allow mem deallocation
 
-                            # Concatenate.
                             if data_parallel_rank == 0 or return_on_all_ranks:
-                                if not use_gloo_comm:
-                                    recv_tensors = [t.cpu() for t in recv_tensors]
-                                recv_tensors_concatenated = torch.cat(recv_tensors)
-                                # Copy this bucket's collected all-gather tensors into the right
-                                # place in the tensor for the buffer. The tensor for the buffer
-                                # gets rid of the padding between buckets.
+                                # Copy this bucket's gathered tensor into the right
+                                # place in the tensor for the buffer. The tensor for
+                                # the buffer gets rid of the padding between buckets.
                                 start = offset_in_world_tensors
                                 end = offset_in_world_tensors + gbuf_world_numel_unpadded
                                 world_tensors[key][start:end].copy_(
-                                    recv_tensors_concatenated[:gbuf_world_numel_unpadded]
+                                    recv_buffer[:gbuf_world_numel_unpadded]
                                 )
+                                recv_buffer = None  # allow mem deallocation
 
                         offset_in_world_tensors += gbuf_world_numel_unpadded
 
@@ -2159,10 +2150,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                                 world_tensor, (0, gbuf_world_numel - gbuf_world_numel_unpadded)
                             )
                             assert world_tensor.numel() == gbuf_world_numel
-                            gbuf_start_idxs = list(range(0, gbuf_world_numel, gbuf_local_numel))
-                            send_tensors = [
-                                world_tensor[i : (i + gbuf_local_numel)] for i in gbuf_start_idxs
-                            ]
+                            send_tensors = list(world_tensor.chunk(data_parallel_world_size))
                         else:
                             send_tensors = None
 
@@ -2271,10 +2259,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                                 world_tensor, (0, gbuf_world_numel - gbuf_world_numel_unpadded)
                             )
                             assert world_tensor.numel() == gbuf_world_numel
-                            gbuf_start_idxs = list(range(0, gbuf_world_numel, gbuf_local_numel))
-                            send_tensors = [
-                                world_tensor[i : (i + gbuf_local_numel)] for i in gbuf_start_idxs
-                            ]
+                            send_tensors = list(world_tensor.chunk(data_parallel_world_size))
                         else:
                             send_tensors = None
 

--- a/tests/unit_tests/optimizer/test_distrib_optimizer_ranges.py
+++ b/tests/unit_tests/optimizer/test_distrib_optimizer_ranges.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Tests for the DP-rank shard range computation in DistributedOptimizer.
+
+These tests guard the O(1)-in-DP-world-size computation of the local rank's
+grad-buffer shard range against the straightforward reference implementation
+that materializes ranges for every DP rank. They run on CPU with mock buffers
+so very large world sizes (e.g. 16k ranks) can be checked directly.
+"""
+
+import pytest
+import torch
+
+from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer, Range
+
+
+class _MockProcessGroup:
+    def __init__(self, rank, world_size):
+        self._rank = rank
+        self._world_size = world_size
+
+    def rank(self):
+        return self._rank
+
+    def size(self):
+        return self._world_size
+
+
+class _MockGradData:
+    def __init__(self, numel):
+        self._numel = numel
+
+    def numel(self):
+        return self._numel
+
+
+class _MockBucket:
+    def __init__(self, numel, offset):
+        self.grad_data = _MockGradData(numel)
+        self.offset = offset
+
+
+class _MockParamAndGradBuffer:
+    def __init__(self, rank, world_size, bucket_numels, param_index_map):
+        self.data_parallel_group = _MockProcessGroup(rank, world_size)
+        self.buckets = []
+        offset = 0
+        for numel in bucket_numels:
+            self.buckets.append(_MockBucket(numel, offset))
+            offset += numel
+        self.param_index_map = param_index_map
+
+
+def _reference_local_world_range(rank, world_size, gbuf_size, bucket_offset):
+    """Reference implementation: build all DP ranks' ranges, select the local one."""
+    max_gbuf_range_size = gbuf_size // world_size
+    all_ranges = []
+    for r in range(world_size):
+        start = r * max_gbuf_range_size
+        end = min(gbuf_size, start + max_gbuf_range_size)
+        all_ranges.append(Range(start + bucket_offset, end + bucket_offset))
+    return all_ranges[rank]
+
+
+def _make_params(world_size, bucket_numel):
+    """A few params tiled across the bucket so every rank owns at least a shard."""
+    params = {}
+    boundaries = [0, bucket_numel // 3 + 1, (2 * bucket_numel) // 3 - 1, bucket_numel]
+    for i in range(len(boundaries) - 1):
+        param = torch.nn.Parameter(torch.empty(1), requires_grad=True)
+        params[param] = (boundaries[i], boundaries[i + 1], 0)
+    return params
+
+
+@pytest.mark.parametrize("world_size", [1, 2, 8, 64, 512, 4096, 16384])
+def test_local_gbuf_range_matches_reference(world_size):
+    bucket_numel = world_size * 24
+    param_index_map = _make_params(world_size, bucket_numel)
+    # Check first, last, and a middle rank.
+    for rank in sorted({0, world_size // 2, world_size - 1}):
+        buffer = _MockParamAndGradBuffer(rank, world_size, [bucket_numel], param_index_map)
+        expected_world_range = _reference_local_world_range(rank, world_size, bucket_numel, 0)
+        expected = DistributedOptimizer._build_model_gbuf_param_range_map(
+            param_index_map, expected_world_range, 0
+        )
+        actual = DistributedOptimizer._build_model_gbuf_range(buffer, 0)["param_map"]
+        assert actual.keys() == expected.keys()
+        for param in expected:
+            for key in ("gbuf_world", "gbuf_world_in_bucket", "gbuf_local", "param"):
+                assert actual[param][key].start == expected[param][key].start, (rank, key)
+                assert actual[param][key].end == expected[param][key].end, (rank, key)
+
+
+def test_local_gbuf_range_with_multiple_buckets():
+    world_size = 1024
+    bucket_numels = [world_size * 8, world_size * 4, world_size * 16]
+    rank = world_size - 1
+    param_index_map = {}
+    offset = 0
+    for bucket_index, numel in enumerate(bucket_numels):
+        param = torch.nn.Parameter(torch.empty(1), requires_grad=True)
+        param_index_map[param] = (offset, offset + numel, bucket_index)
+        offset += numel
+    buffer = _MockParamAndGradBuffer(rank, world_size, bucket_numels, param_index_map)
+
+    bucket_offset = 0
+    for bucket_index, numel in enumerate(bucket_numels):
+        expected_world_range = _reference_local_world_range(rank, world_size, numel, bucket_offset)
+        expected = DistributedOptimizer._build_model_gbuf_param_range_map(
+            param_index_map, expected_world_range, bucket_offset
+        )
+        actual = DistributedOptimizer._build_model_gbuf_range(buffer, bucket_index)["param_map"]
+        assert actual.keys() == expected.keys()
+        for param in expected:
+            for key in ("gbuf_world", "gbuf_world_in_bucket", "gbuf_local", "param"):
+                assert actual[param][key].start == expected[param][key].start
+                assert actual[param][key].end == expected[param][key].end
+        bucket_offset += numel


### PR DESCRIPTION
# Remove O(DP-world-size) overhead from distributed optimizer init and dp_zero checkpoint paths

## What does this PR do?

At very large data-parallel sizes (multi-thousand-rank DP groups, e.g. 10k+ GPU jobs), the distributed optimizer performs CPU work and allocations on every rank that scale linearly with the DP world size, even though only the local rank's data is needed. This PR removes three such spots without changing behavior:

1. **`_build_model_gbuf_range()` (init path, runs on every rank for every bucket).** Previously materialized a `Range` object for every DP rank in every bucket and then kept exactly one. With thousands of DP ranks and many buckets this is millions of pointless allocations at startup, on every rank. Now computes the local rank's range directly: O(DP × num_buckets) → O(num_buckets).

2. **`get_parameter_state_dp_zero()` (checkpoint save / `--ckpt-format torch` path).** Previously allocated `dp_world_size` separate receive tensors per state key per bucket on rank 0 (or all ranks with `return_on_all_ranks=True`), gathered into them, then `torch.cat`'d the list. Now gathers into chunk views of a single contiguous buffer:
   - removes the O(DP) per-key-per-bucket tensor allocations,
   - removes the full extra copy from the concat (~2x lower peak rank-0 memory for the gather staging),
   - on the NCCL (`use_gloo_comm=False`) path, replaces `dp_world_size` separate device-to-host copies with one.

3. **Both `load_parameter_state_from_dp_zero*` scatter paths.** Replaced the O(DP) Python loop building slice lists with a single `tensor.chunk(dp_world_size)` call producing identical views.

## Why it's behavior-preserving

- The local range computed in (1) is the identical formula evaluated for `r == data_parallel_rank` only; verified against the old loop-based reference for world sizes 1 → 16384 (new unit test `tests/unit_tests/optimizer/test_distrib_optimizer_ranges.py`).
- `gather`/`all_gather`/`scatter` participants, ordering, and resulting tensor contents are unchanged: collectives write into / read from the provided per-rank tensors, and contiguous chunk views of one buffer are element-wise identical to separate tensors followed by `torch.cat`. Verified with a 4-process gloo equivalence script comparing old and new paths bit-for-bit.

## Contribution process

- [x] Unit test added (`tests/unit_tests/optimizer/test_distrib_optimizer_ranges.py`, CPU-only, exercises simulated DP world sizes up to 16k)
- [x] `black` / `isort` / `ruff` / `pylint` clean (pylint 10.00/10 on changed file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
