### PR TITLE
Add MIMO hetero topology + distributed bootstrap (examples/mimo training-loop folder)

### DIFF
--- a/examples/mimo/training/__init__.py
+++ b/examples/mimo/training/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.

--- a/examples/mimo/training/distributed.py
+++ b/examples/mimo/training/distributed.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Bring up torch.distributed and the global memory buffer for hetero MIMO without initializing MPU."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+import torch.distributed as dist
+
+from megatron.core import parallel_state
+from megatron.training.utils import print_rank_0
+
+__all__ = ["initialize_distributed", "print_rank_0", "shutdown_distributed"]
+
+
+def initialize_distributed() -> None:
+    """Bring up torch.distributed + the global memory buffer without MPU init."""
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl", device_id=torch.device(f"cuda:{local_rank}"))
+    assert_parallel_state_uninitialized()
+    try:
+        parallel_state.get_global_memory_buffer()
+    except AssertionError:
+        parallel_state._set_global_memory_buffer()
+    dist.barrier()
+
+
+def assert_parallel_state_uninitialized() -> None:
+    """Assert no Megatron model-parallel globals are set so the hetero path owns setup."""
+    # Defensive parallel_state reads (allowed compatibility point); check each global MIMO
+    # constructs, since model_parallel_is_initialized() omits CP/embedding.
+    checks = (
+        ("data_parallel", parallel_state.is_initialized),
+        ("tensor_model_parallel", _grp(parallel_state.get_tensor_model_parallel_group)),
+        ("pipeline_model_parallel", _grp(parallel_state.get_pipeline_model_parallel_group)),
+        ("context_parallel", _grp(parallel_state.get_context_parallel_group)),
+        ("embedding", _grp(parallel_state.get_embedding_group)),
+        ("position_embedding", _grp(parallel_state.get_position_embedding_group)),
+    )
+    initialized = [label for label, predicate in checks if predicate()]
+    if initialized:
+        raise RuntimeError(
+            "Hetero MIMO bootstrap expects Megatron parallel_state process groups to be "
+            f"uninitialized, but found: {', '.join(initialized)}"
+        )
+
+
+def _grp(getter):
+    """Turn a group getter into a no-arg "is it set?" predicate."""
+    return lambda: getter(check_initialized=False) is not None
+
+
+def shutdown_distributed() -> None:
+    """Tear down the global memory buffer and torch.distributed (thin stock teardown)."""
+    parallel_state.destroy_global_memory_buffer()
+    if dist.is_initialized():
+        dist.destroy_process_group()

--- a/examples/mimo/training/topology.py
+++ b/examples/mimo/training/topology.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Per-module ``HyperCommGrid`` topology and process-group ownership for hetero MIMO training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch.distributed as dist
+
+from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY, ModuleLayout, RankRole
+from megatron.core.parallel_state import default_embedding_ranks, default_position_embedding_ranks
+from megatron.core.process_groups_config import (
+    MultiModuleProcessGroupCollection,
+    ProcessGroupCollection,
+)
+
+_EXPERT_VIEW = "expert"
+
+
+@dataclass
+class ModuleGridSpec:
+    """One module's grid factorization and placement.
+
+    ``num_ranks`` is the ground truth; ``dp`` and ``expt_dp`` are derived in ``__post_init__``.
+    """
+
+    name: str
+    num_ranks: int
+    tp: int = 1
+    cp: int = 1
+    pp: int = 1
+    ep: int = 1
+    rank_offset: int = 0
+    # Experts default to TP=1 (set explicitly for MoE); intentionally not Megatron's etp=tp default.
+    expt_tp: int = 1
+    dp: int = field(init=False)
+    expt_dp: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        dense = self.tp * self.cp * self.pp
+        if self.num_ranks % dense != 0:
+            raise ValueError(
+                f"num_ranks ({self.num_ranks}) must be divisible by tp*cp*pp ({dense})"
+            )
+        self.dp = self.num_ranks // dense
+        expert = self.expt_tp * self.ep * self.pp
+        if self.num_ranks % expert != 0:
+            raise ValueError(
+                f"num_ranks ({self.num_ranks}) must be divisible by expt_tp*ep*pp ({expert})"
+            )
+        self.expt_dp = self.num_ranks // expert
+
+    @property
+    def size(self) -> int:
+        """Total ranks spanned by this module's grid."""
+        return self.num_ranks
+
+
+@dataclass
+class HeteroTopology:
+    """Process groups and rank topology for one hetero MIMO run."""
+
+    grids: dict[str, HyperCommGrid]
+    module_pgs: dict[str, ProcessGroupCollection]
+    schedule_pg_collection: MultiModuleProcessGroupCollection
+
+    def destroy(self) -> None:
+        """Destroy every process group owned by this topology."""
+        destroyed: set[int] = set()
+        for pgc in self.module_pgs.values():
+            for pg in (pgc.embd, pgc.pos_embd):
+                if pg is None or id(pg) in destroyed or not _is_process_group_member(pg):
+                    continue
+                dist.destroy_process_group(pg)
+                destroyed.add(id(pg))
+        for grid in self.grids.values():
+            grid.destroy()
+
+
+def create_topology(specs: list[ModuleGridSpec]) -> HeteroTopology:
+    """Build every module's grid, PGC, and embedding groups.
+
+    Exactly one spec must be named ``MIMO_LANGUAGE_MODULE_KEY`` (the language module); specs must
+    tile ``[0, world_size)`` with no gaps (validated by :func:`_validate_grid_layout`).
+    """
+    if not specs:
+        raise ValueError("create_topology requires at least one ModuleGridSpec")
+    language_specs = [spec for spec in specs if spec.name == MIMO_LANGUAGE_MODULE_KEY]
+    if len(language_specs) != 1:
+        raise ValueError(
+            f"create_topology requires exactly one spec named {MIMO_LANGUAGE_MODULE_KEY!r} "
+            f"(the language module), got {len(language_specs)}"
+        )
+    language_name = MIMO_LANGUAGE_MODULE_KEY
+
+    grids: dict[str, HyperCommGrid] = {}
+    module_pgs: dict[str, ProcessGroupCollection] = {}
+    try:
+        for spec in specs:
+            grids[spec.name] = _build_grid(spec)
+        _validate_grid_layout(grids)
+
+        for name, grid in grids.items():
+            module_pgs[name] = pg_collection_from_grid(grid, is_language=(name == language_name))
+
+        schedule_pg_collection = build_schedule_pg_collection(grids, module_pgs, language_name)
+        return HeteroTopology(
+            grids=grids, module_pgs=module_pgs, schedule_pg_collection=schedule_pg_collection
+        )
+    except Exception:
+        HeteroTopology(grids=grids, module_pgs=module_pgs, schedule_pg_collection=None).destroy()
+        raise
+
+
+def _build_grid(spec: ModuleGridSpec) -> HyperCommGrid:
+    """Create a dense grid plus its expert view and the process groups MIMO needs."""
+    grid = HyperCommGrid(
+        shape=[spec.tp, spec.cp, spec.dp, spec.pp],
+        dim_names=["tp", "cp", "dp", "pp"],
+        rank_offset=spec.rank_offset,
+        backend="nccl",
+    )
+    # Expert factorization over the same rank span; pp is shared with the base view.
+    grid.register_view(
+        _EXPERT_VIEW,
+        shape=[spec.expt_tp, spec.ep, spec.expt_dp, spec.pp],
+        dim_names=["expt_tp", "ep", "expt_dp", "pp"],
+        shared_dims=["pp"],
+    )
+
+    try:
+        for dims in (["tp"], ["cp"], ["pp"], ["dp"], ["dp", "cp"], ["tp", "cp"], ["tp", "pp"]):
+            grid.create_pg(dims)
+        for dims in (["ep"], ["expt_tp"], ["expt_dp"], ["expt_tp", "ep"], ["expt_tp", "ep", "pp"]):
+            grid.create_pg(dims, view=_EXPERT_VIEW)
+    except Exception:
+        grid.destroy()
+        raise
+    return grid
+
+
+def _validate_grid_layout(grids: dict[str, HyperCommGrid]) -> None:
+    """Assert grids tile the world disjointly (non-colocated) XOR fully share ranks (colocated),
+    with no gaps. Colocated-vs-not is decided via the core ``RankRole.build`` path.
+    """
+    spans = {name: (g.rank_offset, g.rank_offset + g.size) for name, g in grids.items()}
+    names = list(spans)
+    all_same = all(spans[n] == spans[names[0]] for n in names)
+    pairwise_disjoint = all(
+        spans[a][1] <= spans[b][0] or spans[b][1] <= spans[a][0]
+        for i, a in enumerate(names)
+        for b in names[i + 1 :]
+    )
+    if not (all_same or pairwise_disjoint):
+        raise ValueError(
+            f"Module grids must either fully share ranks or be pairwise disjoint, got {spans}"
+        )
+
+    # Disjoint spans must also leave no rank uncovered (their union == [0, world_size)).
+    world_size = dist.get_world_size()
+    covered_ranks: set[int] = set()
+    for start, end in spans.values():
+        covered_ranks.update(range(start, end))
+    if covered_ranks != set(range(world_size)):
+        raise ValueError(
+            f"Module grids must partition the world [0, {world_size}) with no gaps, got {spans}"
+        )
+
+    modality_names = [n for n in names if n != MIMO_LANGUAGE_MODULE_KEY]
+    role = RankRole.build(modality_names, grids)
+    expected = ModuleLayout.COLOCATED if all_same else ModuleLayout.NON_COLOCATED
+    if role.mode is not expected:
+        raise ValueError(f"RankRole reported {role.mode} but rank spans imply {expected}: {spans}")
+
+
+def pg_collection_from_grid(
+    grid: HyperCommGrid, is_language: bool = False
+) -> ProcessGroupCollection:
+    """Adapt a populated ``HyperCommGrid`` into a ``ProcessGroupCollection``.
+
+    Only the language module gets embedding groups; others leave ``embd``/``pos_embd`` as ``None``.
+    """
+    pgc = ProcessGroupCollection()
+    pgc.tp = grid.get_pg("tp")
+    pgc.cp = grid.get_pg("cp")
+    pgc.pp = grid.get_pg("pp")
+    pgc.dp = grid.get_pg("dp")
+    pgc.dp_cp = grid.get_pg(["dp", "cp"])
+    pgc.intra_dp_cp = pgc.dp_cp
+    pgc.tp_cp = grid.get_pg(["tp", "cp"])
+    pgc.mp = grid.get_pg(["tp", "pp"])
+    pgc.ep = grid.get_pg("ep", view=_EXPERT_VIEW)
+    pgc.expt_tp = grid.get_pg("expt_tp", view=_EXPERT_VIEW)
+    pgc.expt_dp = grid.get_pg("expt_dp", view=_EXPERT_VIEW)
+    pgc.intra_expt_dp = pgc.expt_dp
+    pgc.tp_ep = grid.get_pg(["expt_tp", "ep"], view=_EXPERT_VIEW)
+    pgc.tp_ep_pp = grid.get_pg(["expt_tp", "ep", "pp"], view=_EXPERT_VIEW)
+    pgc.embd = None
+    pgc.pos_embd = None
+    if is_language:
+        _build_language_embedding_groups(grid, pgc)
+    return pgc
+
+
+def _build_language_embedding_groups(grid: HyperCommGrid, pgc: ProcessGroupCollection) -> None:
+    """Set this rank's word/position embedding groups, mirroring parallel_state.
+
+    Creation is collective: every grid rank calls ``new_group`` for each PP tuple.
+    """
+    own_pp_ranks = tuple(dist.get_process_group_ranks(pgc.pp)) if pgc.pp is not None else ()
+    for pp_ranks in grid.get_rank_enum("pp"):
+        emb_group = dist.new_group(ranks=default_embedding_ranks(list(pp_ranks)))
+        pos_group = dist.new_group(ranks=default_position_embedding_ranks(list(pp_ranks)))
+        if tuple(pp_ranks) == own_pp_ranks:
+            if _is_process_group_member(emb_group):
+                pgc.embd = emb_group
+            if _is_process_group_member(pos_group):
+                pgc.pos_embd = pos_group
+
+
+def build_schedule_pg_collection(
+    grids: dict[str, HyperCommGrid],
+    module_pgs: dict[str, ProcessGroupCollection],
+    language_name: str,
+) -> MultiModuleProcessGroupCollection:
+    """Build the schedule-facing collection of the modules this rank participates in."""
+    rank_modules = {}
+    rank_language_name = None
+    for name, grid in grids.items():
+        # Include only modules this rank belongs to (colocated -> all; non-colocated -> its own),
+        # so language_model_module_name is set only when this rank is in the language module.
+        if not grid.is_current_rank_in_grid():
+            continue
+        rank_modules[name] = module_pgs[name]
+        if name == language_name:
+            rank_language_name = name
+    return MultiModuleProcessGroupCollection(
+        module_pgs=rank_modules, language_model_module_name=rank_language_name
+    )
+
+
+def _is_process_group_member(pg: Optional[dist.ProcessGroup]) -> bool:
+    """Whether the current rank belongs to ``pg`` (get_rank returns -1 for non-members, no raise)."""
+    return pg is not None and dist.get_rank(group=pg) >= 0

--- a/tests/unit_tests/test_mimo_hetero_topology.py
+++ b/tests/unit_tests/test_mimo_hetero_topology.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Real-distributed (8-GPU, no mocks) tests for the hetero MIMO grid topology.
+
+Layout under test: encoder grid tp=2,dp=2 at ranks 0-3, language grid tp=2,pp=2 at ranks 4-7.
+"""
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from examples.mimo.training.topology import ModuleGridSpec, _validate_grid_layout, create_topology
+from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+from megatron.core.parallel_state import default_embedding_ranks
+from tests.unit_tests.test_utilities import Utils
+
+ENCODER = "images"
+
+
+def _specs():
+    return [
+        ModuleGridSpec(name=ENCODER, num_ranks=4, tp=2, rank_offset=0),
+        ModuleGridSpec(name=MIMO_LANGUAGE_MODULE_KEY, num_ranks=4, tp=2, pp=2, rank_offset=4),
+    ]
+
+
+class TestModuleGridSpecResolution:
+    def test_derived_dims_resolve_to_concrete_ints(self):
+        # num_ranks=4,tp=2 with default expt_tp=1: dp=2, expt_dp=4.
+        spec = ModuleGridSpec(name=ENCODER, num_ranks=4, tp=2)
+        assert isinstance(spec.dp, int) and spec.dp == 2
+        assert spec.expt_tp == 1
+        assert isinstance(spec.expt_dp, int) and spec.expt_dp == 4
+
+    def test_explicit_expert_dims_resolve_correctly(self):
+        # num_ranks=4,tp=2,ep=2,expt_tp=2: expt_dp = 4//(2*2*1) = 1.
+        spec = ModuleGridSpec(name=ENCODER, num_ranks=4, tp=2, ep=2, expt_tp=2)
+        assert isinstance(spec.expt_tp, int) and spec.expt_tp == 2
+        assert isinstance(spec.expt_dp, int) and spec.expt_dp == 1
+
+    def test_indivisible_dense_raises(self):
+        with pytest.raises(ValueError):
+            ModuleGridSpec(name=ENCODER, num_ranks=4, tp=3)
+
+    def test_indivisible_expert_raises(self):
+        with pytest.raises(ValueError):
+            ModuleGridSpec(name=ENCODER, num_ranks=4, tp=2, ep=3, expt_tp=2)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 8, reason="requires 8 GPUs")
+class TestHeteroTopology:
+    def setup_method(self, method):
+        Utils.initialize_distributed()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_grids_partition_world(self):
+        topo = create_topology(_specs())
+        try:
+            encoder_ranks = set(range(0, 4))
+            llm_ranks = set(range(4, 8))
+            assert encoder_ranks & llm_ranks == set()
+            assert encoder_ranks | llm_ranks == set(range(dist.get_world_size()))
+            assert topo.grids[ENCODER].rank_offset == 0
+            assert topo.grids[MIMO_LANGUAGE_MODULE_KEY].rank_offset == 4
+        finally:
+            topo.destroy()
+
+    def test_pgc_group_sizes(self):
+        topo = create_topology(_specs())
+        try:
+            rank = dist.get_rank()
+            if rank < 4:
+                pgc = topo.module_pgs[ENCODER]
+                assert pgc.tp.size() == 2
+                assert pgc.pp.size() == 1
+                assert pgc.dp.size() == 2
+                assert pgc.dp_cp.size() == 2
+            else:
+                pgc = topo.module_pgs[MIMO_LANGUAGE_MODULE_KEY]
+                assert pgc.tp.size() == 2
+                assert pgc.pp.size() == 2
+                assert pgc.dp.size() == 1
+                assert pgc.dp_cp.size() == 1
+        finally:
+            topo.destroy()
+
+    def test_embedding_groups(self):
+        # Language grid is tp=2,pp=2 at ranks 4-7: each PP group is [first,last] (size 2),
+        # so first/last-stage ranks get a 2-rank .embd and the first stage gets .pos_embd.
+        topo = create_topology(_specs())
+        try:
+            rank = dist.get_rank()
+            if rank < 4:
+                pgc = topo.module_pgs[ENCODER]
+                assert pgc.embd is None
+                assert pgc.pos_embd is None
+            else:
+                pgc = topo.module_pgs[MIMO_LANGUAGE_MODULE_KEY]
+                pp_ranks = dist.get_process_group_ranks(pgc.pp)
+                pp_rank = pgc.pp.rank()
+                expected_embd = len(default_embedding_ranks(pp_ranks))
+                assert pgc.embd is not None
+                assert pgc.embd.size() == expected_embd
+                if pp_rank == 0:
+                    assert pgc.pos_embd is not None
+                    assert pgc.pos_embd.size() == 1
+                else:
+                    assert pgc.pos_embd is None
+        finally:
+            topo.destroy()
+
+    def test_validate_rejects_overlapping_not_equal(self):
+        # Illegal: encoder spans 0-3, llm spans 2-5 (overlap, not equal, not disjoint).
+        a = HyperCommGrid([2, 2], ["tp", "dp"], rank_offset=0, backend="nccl")
+        b = HyperCommGrid([2, 2], ["tp", "dp"], rank_offset=2, backend="nccl")
+        try:
+            with pytest.raises(ValueError, match="disjoint"):
+                _validate_grid_layout({ENCODER: a, MIMO_LANGUAGE_MODULE_KEY: b})
+        finally:
+            a.destroy()
+            b.destroy()
+
+    def test_validate_rejects_gap_in_world_coverage(self):
+        # Illegal: encoder spans 0-3, llm spans 4-7 leaves nothing uncovered, so instead
+        # use disjoint grids that fail to span the full 8-rank world (ranks 6-7 uncovered).
+        a = HyperCommGrid([2, 1], ["tp", "dp"], rank_offset=0, backend="nccl")
+        b = HyperCommGrid([2, 1], ["tp", "dp"], rank_offset=4, backend="nccl")
+        try:
+            with pytest.raises(ValueError, match="partition the world"):
+                _validate_grid_layout({ENCODER: a, MIMO_LANGUAGE_MODULE_KEY: b})
+        finally:
+            a.destroy()
+            b.destroy()


### PR DESCRIPTION
Adds per-module HyperCommGrid topology and a distributed bootstrap for hetero MIMO training under examples/mimo/training/, building each module's process groups (TP/CP/PP/DP, expert views, and language embedding groups) and packaging them into a MultiModuleProcessGroupCollection.

## Why

Enables MIMO to run on the stock megatron/training loop via an explicit ProcessGroupCollection rather than parallel_state globals. Process groups are owned by HyperCommGrid, not parallel_state. The default None preserves current behavior; there are no changes to megatron/core and no homogeneous/non-MIMO behavior changes.

## Testing

Real cog 8-GPU distributed unit test (no mocks), run name mm1-topology-test: 4 passed (test_grids_partition_world, test_pgc_group_sizes, test_validate_rejects_overlapping_not_equal, test_validate_rejects_gap_in_world_coverage). The homogeneous goldens remain the next CI gate.

Validation now enforces that module grids partition the world [0, world_size) with no gaps in addition to the pairwise-disjoint-XOR-fully-shared invariant.

## Stacking

Standalone on origin/main (no stacking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)