### PR TITLE
Support non-colocated/heterogeneous grids in the MIMO optimizer

### DIFF
--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 import torch
 
 from megatron.core.dist_checkpointing.mapping import ShardedObject
+from megatron.core.dist_checkpointing.utils import add_prefix_for_sharding
 from megatron.core.optimizer.clip_grads import clip_grad_by_total_norm_fp32
 from megatron.core.optimizer.optimizer import MegatronOptimizer
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
@@ -119,7 +120,26 @@ class MimoOptimizer(MegatronOptimizer):
         return torch.tensor([1.0], dtype=torch.float32, device="cuda")
 
     def count_zeros(self) -> int:
-        return sum(opt.count_zeros() for opt in self._active_optimizers)
+        """Count zero gradients globally across all modules via all_reduce MAX.
+
+        Mirrors ``get_grad_norm``: each module optimizer's ``count_zeros`` already
+        SUM-reduces over its own grad-stats group, so the count is identical across
+        all ranks that own the module but is ``0`` on ranks where the module is
+        inactive. A plain local ``sum`` over ``self._active_optimizers`` therefore
+        returns a *different* value on encoder ranks vs. language-model ranks in
+        non-colocated mode. Indexing each module into its own slot and taking a
+        cross-rank MAX recovers every module's true count on every rank, so the
+        summed total is consistent everywhere.
+        """
+        num_modules = len(self.module_infos)
+        zeros_by_module = torch.zeros(num_modules, device="cuda", dtype=torch.float32)
+
+        for i, (name, info) in enumerate(sorted(self.module_infos.items())):
+            if info.is_active and info.optimizer:
+                zeros_by_module[i] = float(info.optimizer.count_zeros())
+
+        torch.distributed.all_reduce(zeros_by_module, op=torch.distributed.ReduceOp.MAX)
+        return int(zeros_by_module.sum().item())
 
     @property
     def param_groups(self) -> List[dict]:
@@ -178,6 +198,21 @@ class MimoOptimizer(MegatronOptimizer):
                     _extract_param_groups(sub_sd, name, suffix, replica_id)
                     _extract_param_state_sharding_type(sub_sd, name, suffix, replica_id)
                     _extract_grad_scaler(sub_sd, name, suffix, replica_id)
+
+                # Namespace every internal ShardedBase key with the submodule name.
+                # DistributedOptimizer.sharded_state_dict emits regular optimizer
+                # state (param_groups, step, ...) as ShardedObjects keyed by
+                # `optimizer.distributed.dp_group_idx_{model_parallel_rank}.*`. In
+                # non-colocated mode each module has its own model-parallel group, so
+                # both the encoder and the language model produce model_parallel_rank 0
+                # and therefore identical keys for different data on disjoint ranks --
+                # a global key collision. Prefixing with the module name disambiguates
+                # them. The prefix renames the `.key` of every ShardedBase in the module
+                # sub-dict (the param-state tensors and the extracted param_groups/
+                # grad_scaler objects alike); it is applied symmetrically on save and
+                # load, and the `_restore_*` helpers match on dict key (not `.key`), so
+                # restore is unaffected.
+                add_prefix_for_sharding(module_sd, f'mimo.{name}.')
 
                 sharded_state[name] = module_sd
             else:
@@ -314,53 +349,126 @@ def _get_replica_id(pg_collection: Optional[ProcessGroupCollection]) -> tuple:
     return (pg_collection.tp.rank(), pg_collection.pp.rank(), pg_collection.dp.rank())
 
 
+def _module_has_trainable_parameters(module) -> bool:
+    """Return whether this rank owns any trainable parameters for a module."""
+    return module is not None and any(param.requires_grad for param in module.parameters())
+
+
+def _module_has_any_trainable_parameters(module, pg_collection: ProcessGroupCollection) -> bool:
+    """Return whether any rank in the module optimizer group has trainable parameters.
+
+    Without this cross-rank check, `get_mimo_optimizer` would call
+    `get_megatron_optimizer` on a module whose params are all frozen on every
+    rank (e.g. the language model under stage1 = ``--freeze-vit --freeze-lm``),
+    producing a placeholder optimizer that breaks downstream setup. Pattern
+    from NVIDIA/Megatron-LM#4790.
+    """
+    local_has_params = torch.tensor(
+        [int(_module_has_trainable_parameters(module))],
+        device=torch.cuda.current_device(),
+        dtype=torch.int,
+    )
+    torch.distributed.all_reduce(
+        local_has_params, op=torch.distributed.ReduceOp.MAX, group=pg_collection.intra_dist_opt
+    )
+    return bool(local_has_params.item())
+
+
+#: Name of the optional grid rank-view that holds the expert (MoE) factorization.
+EXPERT_VIEW = "expert"
+
+
 def _get_pg_collection_for_optimizer(grid) -> ProcessGroupCollection:
     """Create ProcessGroupCollection from HyperCommGrid for optimizer use.
 
-    Only fetches process groups required by the optimizer. Assumes all groups
-    are pre-created in the grid via grid.create_pg() - does not create any new groups.
+    Only fetches process groups required by the optimizer. Assumes all groups are
+    pre-created in the grid via ``grid.create_pg()`` - this function does not create
+    any new groups.
 
-    The following groups must be pre-created in the grid before calling this function:
+    Dense vs. expert factorization
+    ------------------------------
+    The optimizer needs two different partitions of the same ranks:
+
+    - The *dense* (attention/MLP) parameters are partitioned by the base grid's
+      ``tp``/``cp``/``pp``/``dp`` dimensions and replicated over any expert axis.
+    - The *expert* (MoE) parameters use a separate factorization
+      (``expt_tp``/``ep``/``expt_dp``/``pp``) over the *same* ranks. For a true
+      heterogeneous grid this is a distinct rank-view registered with
+      ``grid.register_view("expert", ...)``, so the expert groups must be read from
+      that view (``grid.get_pg(..., view="expert")``) rather than from the base
+      grid's (degenerate) ``ep`` dim. ``pp`` is declared a *shared* dim of that view,
+      so the expert ``[expt_tp, ep, pp]`` group reuses the base ``pp`` ranks and the
+      optimizer's ``pg.pp`` (base) group stays consistent with the expert view.
+
+    The caller is responsible for registering and creating the ``"expert"`` view
+    groups (out of scope here). When no ``"expert"`` view is registered (e.g. a
+    colocated single-view grid), the expert groups fall back to the base view.
+
+    .. note::
+       ``intra_dist_opt`` is narrowed to the dense ``["tp","cp","dp","pp"]`` axes so
+       dense gradient statistics are not SUM-counted ``ep`` times. This is correct for
+       MIMO submodules whose parameters are all dense (the only configuration today).
+       MoE submodule parameters would need their grad-stats group to span the expert
+       (``ep``) axis instead; that case is not yet handled here.
+
+    Pre-created groups (base view):
         grid.create_pg(["dp"])
         grid.create_pg(["dp", "cp"])
         grid.create_pg(["tp"])
         grid.create_pg(["pp"])
         grid.create_pg(["tp", "pp"])
-        grid.create_pg(["tp", "ep", "pp"])
-        grid.create_pg(["dp", "ep"])
-        grid.create_pg(["tp", "cp", "ep", "pp", "dp"])
+        grid.create_pg(["tp", "cp", "dp", "pp"])
+    Pre-created groups (expert view, when registered):
+        grid.register_view("expert", ..., shared_dims=["pp"])
+        grid.create_pg(["expt_tp", "ep", "pp"], view="expert")
+        grid.create_pg(["expt_dp"], view="expert")
 
     Args:
         grid: HyperCommGrid with pre-created process groups.
 
     Returns:
         ProcessGroupCollection containing optimizer-required groups:
-        - dp: Data parallel group
-        - dp_cp: Data parallel with context parallel
+        - dp / dp_cp / intra_dp_cp: (intra) data-parallel groups
         - tp: Tensor parallel group
-        - mp: Model parallel group (tp × pp)
-        - tp_ep_pp: Expert tensor-model-pipeline group
-        - expt_dp: Expert data parallel group
+        - pp: Pipeline parallel group
+        - mp: Model parallel group (tp x pp)
+        - tp_ep_pp / expt_dp / intra_expt_dp: expert model- and data-parallel groups
+        - intra_dist_opt: distributed-optimizer grad-stats group (dense dims only)
     """
     pg = ProcessGroupCollection()
 
-    # Core groups needed by optimizer and checkpointing
+    # Dense groups (base view).
     pg.dp = grid.get_pg("dp")
     pg.dp_cp = grid.get_pg(["dp", "cp"])
+    # With a single distributed-optimizer instance the intra/full DP groups coincide.
+    pg.intra_dp_cp = pg.dp_cp
     pg.tp = grid.get_pg("tp")
     pg.pp = grid.get_pg("pp")
     pg.mp = grid.get_pg(["tp", "pp"])
 
-    # Expert groups
-    pg.tp_ep_pp = grid.get_pg(["tp", "ep", "pp"])
-    pg.expt_dp = grid.get_pg(["dp", "ep"])
+    # Expert groups. Read them from the registered "expert" view when present so a
+    # genuine MoE factorization (expt_tp/ep/expt_dp/pp) is honored; otherwise fall back
+    # to the base view for colocated single-view grids. ``get_pg(..., view="expert")``
+    # raises ``KeyError`` when the view is absent, so catch that to drive the fallback.
+    try:
+        # ``pp`` is a shared dim of the expert view, so this [expt_tp, ep, pp] group
+        # reuses the base ``pp`` ranks; ``pg.pp`` above (base) stays consistent.
+        pg.tp_ep_pp = grid.get_pg(["expt_tp", "ep", "pp"], view=EXPERT_VIEW)
+        pg.expt_dp = grid.get_pg(["expt_dp"], view=EXPERT_VIEW)
+    except KeyError:
+        pg.tp_ep_pp = grid.get_pg(["tp", "ep", "pp"])
+        pg.expt_dp = grid.get_pg(["dp", "ep"])
+    pg.intra_expt_dp = pg.expt_dp
 
-    # Distributed optimizer grad stats group: must span all dimensions so grad norm
-    # and found-inf all-reduces see every unique gradient shard. TP/PP/EP ranks hold
-    # different parameters, DP ranks hold different optimizer shards after reduce-scatter.
-    # This mirrors standard Megatron's intra_distributed_optimizer_instance_group which
-    # spans the full world when num_distributed_optimizer_instances == 1.
-    pg.intra_dist_opt = grid.get_pg(["tp", "cp", "ep", "pp", "dp"])
+    # Distributed-optimizer grad-stats group. ``get_grad_norm_fp32`` /
+    # ``count_zeros_fp32`` SUM-reduce over this group, so it must contain exactly the
+    # ranks that hold *unique* dense gradient shards: tp/cp/pp partition the
+    # parameters and dp holds distinct optimizer shards after reduce-scatter. It must
+    # NOT include the expert ``ep`` axis: dense parameters are replicated across ``ep``
+    # in a heterogeneous grid (where ``ep`` is an independent dimension rather than a
+    # sub-partition of ``dp``), so including it would SUM each dense contribution
+    # ``ep_size`` times and inflate the grad norm / zero count.
+    pg.intra_dist_opt = grid.get_pg(["tp", "cp", "dp", "pp"])
 
     return pg
 
@@ -388,7 +496,16 @@ def get_mimo_optimizer(mimo_model: "MimoModel", config: OptimizerConfig) -> Mimo
             else:
                 module = mimo_model.modality_submodules[module_name]
 
-            if module is not None:
+            # Skip the optimizer build when no rank in this module's
+            # intra-dist-opt group has any trainable parameters (e.g. the
+            # language model under stage1 = `--freeze-vit --freeze-lm`).
+            # Leaving `optimizer = None` lets `MimoOptimizer.is_stub_optimizer`
+            # handle the branch correctly, instead of constructing a
+            # placeholder DistributedOptimizer that breaks downstream setup.
+            module_has_trainable_params = _module_has_any_trainable_parameters(
+                module, pg_collection
+            )
+            if module is not None and module_has_trainable_params:
                 assert (
                     not hasattr(module, 'ddp_config')
                     or module.ddp_config is None

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -16,6 +16,7 @@ import torch.distributed as dist
 from packaging import version
 
 import megatron.core.pipeline_parallel.schedules as schedule
+from megatron.core import parallel_state, tensor_parallel
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
 from megatron.core.distributed.finalize_model_grads import finalize_model_grads
 from megatron.core.hyper_comm_grid import HyperCommGrid
@@ -38,6 +39,7 @@ from megatron.core.process_groups_config import (
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.utils import unwrap_model
 from tests.unit_tests.test_utilities import Utils
 
 try:
@@ -81,8 +83,29 @@ def build_no_sync_func(mimo_model):
     return no_sync_func
 
 
-def create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=1):
-    """Create a HyperCommGrid with specified parallelism."""
+def create_hypercomm_grid(
+    offset=0, tp=1, cp=1, pp=1, dp=1, expert_tp=None, expert_ep=1, expert_dp=1
+):
+    """Create a HyperCommGrid with specified parallelism.
+
+    When ``expert_ep > 1`` or ``expert_tp`` differs from the dense ``tp`` an
+    ``"expert"`` MoE factorization is registered as a *separate* grid rank-view via
+    the ``register_view(...)`` API (rather than via the degenerate base
+    ``ep``/``expt_dp`` dims). The expert view re-partitions the SAME ranks as the
+    dense base view into ``expt_tp x ep x expt_dp x pp``.
+
+    ``pp`` is declared a shared dim of the expert view. ``register_view`` enforces
+    that a shared dim enumerate to the SAME ranks under both factorizations, so the
+    expert ``dim_names`` are ordered ``[expt_tp, pp, expt_dp, ep]`` -- this makes the
+    expert ``pp`` groups identical to the base ``pp`` groups (the base order is
+    ``[tp, cp, pp, dp, ...]``; with ``cp == 1`` the base ``pp`` stride matches the
+    expert ``pp`` stride). The expert ``[expt_tp, ep, pp]`` group then reuses the
+    base ``pp`` ranks.
+
+    The optimizer (``_get_pg_collection_for_optimizer``) reads the expert groups
+    from this registered view via ``grid.get_pg(..., view="expert")`` rather than
+    the base-dim KeyError fallback.
+    """
     grid = HyperCommGrid(
         shape=[tp, cp, pp, dp, 1, 1],  # [tp, cp, pp, dp, ep, expt_dp]
         dim_names=["tp", "cp", "pp", "dp", "ep", "expt_dp"],
@@ -94,13 +117,41 @@ def create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=1):
     grid.create_pg(["pp"])
     grid.create_pg(["dp"])
     grid.create_pg(["dp", "cp"])
+    grid.create_pg(["tp", "cp"])  # tp_cp: consumed by the MoE router (and TP+CP collectives)
+    grid.create_pg(["tp", "cp", "dp"])  # tp_dp_cp: consumed by the MoE router
     grid.create_pg(["ep"])
     grid.create_pg(["expt_dp"])
     # Required by _get_pg_collection_for_optimizer
     grid.create_pg(["tp", "pp"])
     grid.create_pg(["tp", "ep", "pp"])
     grid.create_pg(["dp", "ep"])
-    grid.create_pg(["tp", "cp", "ep", "pp", "dp"])
+    # Dense distributed-optimizer grad-stats group (excludes the expert ep axis).
+    grid.create_pg(["tp", "cp", "dp", "pp"])
+
+    if expert_tp is None:
+        expert_tp = tp
+    register_expert = expert_ep > 1 or expert_dp > 1 or expert_tp != tp
+    if register_expert:
+        assert expert_tp * expert_ep * expert_dp * pp == grid.size, (
+            f"expert factorization expt_tp={expert_tp} * ep={expert_ep} * "
+            f"expt_dp={expert_dp} * pp={pp} must equal grid size {grid.size}"
+        )
+        # dim order chosen so that the shared 'pp' dim enumerates to the same ranks
+        # as the base view's 'pp' (see docstring).
+        grid.register_view(
+            "expert",
+            shape=[expert_tp, pp, expert_dp, expert_ep],
+            dim_names=["expt_tp", "pp", "expt_dp", "ep"],
+            shared_dims=["pp"],
+        )
+        # Groups consumed by the optimizer (expert path).
+        grid.create_pg(["expt_tp", "ep", "pp"], view="expert")
+        grid.create_pg(["expt_dp"], view="expert")
+        # Groups consumed by the MoE model (router / token dispatcher / experts).
+        grid.create_pg(["ep"], view="expert")
+        grid.create_pg(["expt_tp"], view="expert")
+        grid.create_pg(["expt_tp", "ep"], view="expert")
+
     _active_grids.append(grid)
     return grid
 
@@ -116,15 +167,33 @@ def destroy_all_grids():
 
 
 def get_pg_collection(grid):
-    """Get ProcessGroupCollection from grid."""
+    """Get ProcessGroupCollection from grid.
+
+    When the grid has a registered ``"expert"`` rank-view (MoE), the expert-parallel
+    groups consumed by the MoE router / token dispatcher / experts
+    (``ep``/``expt_tp``/``tp_ep``/``expt_dp``) are read from that view via
+    ``grid.get_pg(..., view="expert")`` rather than from the degenerate base dims, so
+    the model and the optimizer agree on the same expert factorization. The dense
+    ``tp`` group always comes from the base view (attention/dense MLP).
+    """
     pg_collection = ProcessGroupCollection()
     pg_collection.tp = grid.get_pg("tp")
     pg_collection.cp = grid.get_pg("cp")
     pg_collection.pp = grid.get_pg("pp")
-    pg_collection.ep = grid.get_pg("ep")
     pg_collection.dp = grid.get_pg("dp")
     pg_collection.dp_cp = grid.get_pg(["dp", "cp"])
-    pg_collection.expt_dp = grid.get_pg("expt_dp")
+    pg_collection.tp_cp = grid.get_pg(["tp", "cp"])  # consumed by the MoE router
+    pg_collection.tp_dp_cp = grid.get_pg(["tp", "cp", "dp"])  # consumed by the MoE router
+
+    try:
+        pg_collection.ep = grid.get_pg("ep", view="expert")
+    except KeyError:
+        pg_collection.ep = grid.get_pg("ep")
+        pg_collection.expt_dp = grid.get_pg("expt_dp")
+    else:
+        pg_collection.expt_tp = grid.get_pg("expt_tp", view="expert")
+        pg_collection.tp_ep = grid.get_pg(["expt_tp", "ep"], view="expert")
+        pg_collection.expt_dp = grid.get_pg("expt_dp", view="expert")
     return pg_collection
 
 
@@ -215,6 +284,9 @@ def get_language_model_spec(
     bias=True,
     dropout=True,
     per_token_loss=False,
+    num_moe_experts=None,
+    moe_router_topk=2,
+    moe_grouped_gemm=False,
 ):
     """Get the language model spec.
 
@@ -226,6 +298,12 @@ def get_language_model_spec(
     TransformerConfig, which pins DDP's gradient_scaling_factor to 1.0
     (pure SUM reduction). Callers that flip this must supply a 3-tuple
     loss_func and drive the external divide in their finalize hook.
+
+    ``num_moe_experts`` builds an MoE language model. The expert-model-parallel
+    and expert-tensor-parallel sizes are taken from ``pg_collection.ep`` /
+    ``pg_collection.expt_tp`` (which the caller sources from the grid's registered
+    ``"expert"`` view), and the layer spec is built with MoE submodules so tokens
+    actually route through experts.
     """
     pp_rank = dist.get_rank(pg_collection.pp)
     pp_size = dist.get_world_size(pg_collection.pp)
@@ -238,6 +316,24 @@ def get_language_model_spec(
     if not dropout:
         extra_kwargs['attention_dropout'] = 0.0
         extra_kwargs['hidden_dropout'] = 0.0
+
+    if num_moe_experts is not None:
+        ep_size = pg_collection.ep.size() if pg_collection.ep is not None else 1
+        expt_tp_size = (
+            pg_collection.expt_tp.size() if pg_collection.expt_tp is not None else tp_size
+        )
+        extra_kwargs.update(
+            num_moe_experts=num_moe_experts,
+            moe_router_topk=moe_router_topk,
+            moe_grouped_gemm=moe_grouped_gemm,
+            expert_model_parallel_size=ep_size,
+            expert_tensor_parallel_size=expt_tp_size,
+            # Bias in MoE is only supported with ETP==1; disable for the ETP>1 toy.
+            add_bias_linear=False,
+            # The MoE layer raises during training when attention tensor parallelism
+            # (tp_size > 1) is enabled without sequence parallelism, so turn it on.
+            sequence_parallel=tp_size > 1,
+        )
 
     lm_config = TransformerConfig(
         num_layers=num_layers,
@@ -255,16 +351,23 @@ def get_language_model_spec(
         calculate_per_token_loss=per_token_loss,
         **extra_kwargs,
     )
+    transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
+        num_experts=num_moe_experts, moe_grouped_gemm=moe_grouped_gemm
+    )
     return ModuleSpec(
         module=GPTModel,
         params={
             "config": lm_config,
-            "transformer_layer_spec": get_gpt_layer_with_transformer_engine_spec(),
+            "transformer_layer_spec": transformer_layer_spec,
             "vocab_size": vocab_size,
             "max_sequence_length": seq_len,
             "pre_process": (pp_rank == 0),
             "post_process": (pp_rank == pp_size - 1),
             "pg_collection": pg_collection,
+            # Under sequence parallelism the MIMO partition adapter owns the
+            # sequence-dim scatter, so the GPT embedding must NOT also scatter to the
+            # SP region; MimoModel raises otherwise.
+            "scatter_embedding_sequence_parallel": not lm_config.sequence_parallel,
         },
     )
 
@@ -381,6 +484,9 @@ def get_mimo_model(
     bias=True,
     dropout=True,
     per_token_loss=False,
+    num_moe_experts=None,
+    moe_router_topk=2,
+    moe_grouped_gemm=False,
 ):
     """Create MIMO model with TransformerBlock encoder and GPTModel LLM.
 
@@ -415,6 +521,9 @@ def get_mimo_model(
         bias=bias,
         dropout=dropout,
         per_token_loss=per_token_loss,
+        num_moe_experts=num_moe_experts,
+        moe_router_topk=moe_router_topk,
+        moe_grouped_gemm=moe_grouped_gemm,
     )
     vision_submodule_spec = get_vision_submodules_spec(
         num_layers=num_layers,
@@ -438,7 +547,11 @@ def get_mimo_model(
         module_to_grid_map=module_to_grid_map,
     )
 
-    mimo_model = MimoModel(mimo_config)
+    # Thread the LLM's tp/cp groups so the partition adapter (engaged when the LLM
+    # uses sequence parallelism or context parallelism, e.g. the MoE+ETP test) reads
+    # them from the grid instead of falling back to the uninitialized global
+    # parallel_state tensor-model-parallel group.
+    mimo_model = MimoModel(mimo_config, cp_group=language_pg.cp, tp_group=language_pg.tp)
     mimo_model.to(torch.device("cuda"))
     if bf16:
         mimo_model.to(torch.bfloat16)
@@ -567,10 +680,24 @@ def run_mimo_1f1b_test(
     seq_length=64,
     micro_batch_size=2,
     num_microbatches=4,
+    llm_expert_tp=None,
+    llm_expert_ep=1,
+    llm_expert_dp=1,
+    num_moe_experts=None,
+    moe_router_topk=2,
+    moe_grouped_gemm=False,
 ):
-    """Run MIMO model through 1F1B schedule and verify."""
+    """Run MIMO model through 1F1B schedule and verify.
+
+    When ``num_moe_experts`` is set, the language model is an MoE GPT model with
+    expert parallelism. The LLM grid registers an ``"expert"`` rank-view whose
+    factorization is ``expt_tp=llm_expert_tp x ep=llm_expert_ep x
+    expt_dp=llm_expert_dp x pp=llm_pp`` (see ``create_hypercomm_grid``); the
+    optimizer consumes it via the ``grid.get_pg(..., view="expert")`` path.
+    """
     # Clear NVTE env vars that the conftest set_env fixture sets to '0'.
     # GPTModel (LanguageModule) asserts these are unset or match the attention backend.
+    import math
     import os
 
     os.environ.pop('NVTE_FLASH_ATTN', None)
@@ -582,7 +709,16 @@ def run_mimo_1f1b_test(
     encoder_grid = create_hypercomm_grid(
         offset=encoder_offset, tp=encoder_tp, cp=1, pp=encoder_pp, dp=encoder_dp
     )
-    llm_grid = create_hypercomm_grid(offset=llm_offset, tp=llm_tp, cp=1, pp=llm_pp, dp=llm_dp)
+    llm_grid = create_hypercomm_grid(
+        offset=llm_offset,
+        tp=llm_tp,
+        cp=1,
+        pp=llm_pp,
+        dp=llm_dp,
+        expert_tp=llm_expert_tp,
+        expert_ep=llm_expert_ep,
+        expert_dp=llm_expert_dp,
+    )
 
     # Create all embedding PGs upfront — dist.new_group is a collective that
     # requires ALL ranks to participate, so we must create them before any
@@ -590,6 +726,34 @@ def run_mimo_1f1b_test(
     create_all_embedding_groups([encoder_grid, llm_grid])
 
     torch.manual_seed(12345)
+    # Register the 'model-parallel-rng' / expert-parallel RNG states in the TP RNG
+    # tracker. Under sequence parallelism the language embedding forks the
+    # 'model-parallel-rng' region (for SP dropout) and the MoE experts fork the
+    # expert-parallel region. These HyperCommGrid-based tests never initialize the
+    # global parallel_state, so derive the tp/ep/etp ranks from the rank's own grid
+    # and pass them explicitly instead of letting the helper read uninitialized globals.
+    if is_rank_in_grid(llm_grid):
+        seed_tp_rank = dist.get_rank(llm_grid.get_pg("tp"))
+        try:
+            seed_ep_rank = dist.get_rank(llm_grid.get_pg("ep", view="expert"))
+            seed_etp_rank = dist.get_rank(llm_grid.get_pg("expt_tp", view="expert"))
+        except KeyError:
+            seed_ep_rank = 0
+            seed_etp_rank = 0
+    else:
+        seed_tp_rank = dist.get_rank(encoder_grid.get_pg("tp"))
+        seed_ep_rank = 0
+        seed_etp_rank = 0
+    tensor_parallel.model_parallel_cuda_manual_seed(
+        12345, tp_rank=seed_tp_rank, ep_rank=seed_ep_rank, etp_rank=seed_etp_rank
+    )
+
+    # The sequence-parallel output-layer all-gather pulls a scratch buffer from
+    # parallel_state's global memory buffer, which full parallel_state init would
+    # normally create. These HyperCommGrid tests don't init parallel_state, so set it
+    # up directly (idempotently) before the forward pass.
+    if parallel_state._GLOBAL_MEMORY_BUFFER is None:
+        parallel_state._set_global_memory_buffer()
 
     mimo_model, module_to_grid_map, topology, language_pg, vision_pg = get_mimo_model(
         encoder_name=encoder_name,
@@ -599,6 +763,9 @@ def run_mimo_1f1b_test(
         num_layers=num_layers,
         vocab_size=vocab_size,
         seq_len=seq_length,
+        num_moe_experts=num_moe_experts,
+        moe_router_topk=moe_router_topk,
+        moe_grouped_gemm=moe_grouped_gemm,
     )
 
     no_sync_func = build_no_sync_func(mimo_model)
@@ -700,6 +867,25 @@ def run_mimo_1f1b_test(
         output_tensor, loss_mask = model(**batch)
         return output_tensor, partial(loss_func, loss_mask)
 
+    # When MoE is enabled, verify the optimizer takes the expert-view path
+    # (grid.get_pg(..., view="expert")) rather than the base-dim KeyError fallback: the
+    # LLM optimizer's expert groups must be the registered view's groups.
+    if num_moe_experts is not None and is_rank_in_grid(llm_grid):
+        from megatron.core.models.mimo.optimizer import EXPERT_VIEW
+
+        llm_info = optimizer.module_infos[MIMO_LANGUAGE_MODULE_KEY]
+        assert llm_info.pg_collection.tp_ep_pp is llm_grid.get_pg(
+            ["expt_tp", "ep", "pp"], view=EXPERT_VIEW
+        ), "MIMO optimizer did not source tp_ep_pp from the registered 'expert' view"
+        assert llm_info.pg_collection.expt_dp is llm_grid.get_pg(
+            ["expt_dp"], view=EXPERT_VIEW
+        ), "MIMO optimizer did not source expt_dp from the registered 'expert' view"
+        # The expert tp_ep_pp partition must differ from the dense mp ([tp,pp]) one,
+        # confirming a genuine EP/ETP factorization is honored (not aliased onto dense).
+        assert sorted(dist.get_process_group_ranks(llm_info.pg_collection.tp_ep_pp)) != sorted(
+            dist.get_process_group_ranks(llm_info.pg_collection.mp)
+        ), "expert tp_ep_pp aliased onto dense mp; EP/ETP not actually exercised"
+
     optimizer.zero_grad()
 
     try:
@@ -715,18 +901,42 @@ def run_mimo_1f1b_test(
             pg_collection=pg_collection,
         )
 
+        # Cheap MoE sanity: at least one expert parameter received a finite gradient
+        # on LLM ranks. Checked after the schedule's finalize hook has run (which
+        # reduces grads into main_grad) but before the optimizer consumes them.
+        if num_moe_experts is not None and is_rank_in_grid(llm_grid):
+            lm = unwrap_model(mimo_model.language_model)
+            expert_grads = [
+                p.main_grad
+                for name, p in lm.named_parameters()
+                if 'experts' in name and getattr(p, 'main_grad', None) is not None
+            ]
+            assert expert_grads, "No expert parameters with a main_grad found on LLM rank"
+            assert any(
+                g.abs().sum().item() > 0 for g in expert_grads
+            ), "All expert-parameter gradients are zero; tokens did not route through experts"
+            assert all(
+                torch.isfinite(g).all() for g in expert_grads
+            ), "Expert-parameter gradient is not finite"
+
         # Optimizer step with global gradient clipping
         success, grad_norm, num_zeros = optimizer.step()
         assert success, "Optimizer step failed"
         assert (
             grad_norm is not None and grad_norm > 0
         ), f"Expected positive grad norm, got {grad_norm}"
+        if num_moe_experts is not None:
+            assert math.isfinite(grad_norm), f"grad_norm is not finite: {grad_norm}"
 
         # Verify results on last LLM stage
         if is_rank_in_grid(llm_grid) and is_pp_last_stage(llm_grid.get_pg("pp")):
             assert len(losses) > 0, "Expected losses on last LLM stage"
             for loss_dict in losses:
                 assert 'loss_reduced' in loss_dict
+                if num_moe_experts is not None:
+                    loss_val = loss_dict['loss_reduced']
+                    loss_val = loss_val.item() if torch.is_tensor(loss_val) else float(loss_val)
+                    assert math.isfinite(loss_val), f"Loss is not finite: {loss_val}"
 
         return losses
     finally:
@@ -920,5 +1130,52 @@ class TestMimo1F1BSchedule:
             vocab_size=1000,
             seq_length=64,
             micro_batch_size=2,
+            num_microbatches=4,
+        )
+
+    def test_moe_llm_ep2_etp2_8gpu(self):
+        """MoE LLM with EP=2 and ETP=2 trains e2e on 8 GPUs (expert rank-view).
+
+        Heterogeneous 8-rank split:
+          - Encoder (dense vision): ranks 0-3, TP=1 PP=1 DP=4.
+          - MoE LLM: ranks 4-7, dense attention TP=2 PP=1 DP=2; the SAME 4 ranks
+            are re-partitioned by a registered ``"expert"`` rank-view into
+            ``expt_tp=2 x ep=2 x expt_dp=1 x pp=1`` (8 = 4 encoder + 4 LLM).
+
+        This exercises expert parallelism (EP>1) AND expert-tensor parallelism
+        (ETP>1) via ``register_view("expert", ...)``: the MoE model's expert process
+        groups and the optimizer's expert groups both come from
+        ``grid.get_pg(..., view="expert")`` (NOT the degenerate base-dim fallback).
+        The run asserts the schedule completes, ``optimizer.step()`` returns a finite
+        positive ``grad_norm``, the loss is finite, and at least one expert parameter
+        received a finite non-zero gradient (tokens actually routed through experts).
+        ``add_bias_linear`` is disabled because bias in MoE is only supported with
+        ETP==1.
+
+        Gated identically to the other ``_8gpu`` tests: RUNS on the 8-GPU lane.
+        """
+        if self.world_size != 8:
+            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
+
+        run_mimo_1f1b_test(
+            encoder_tp=1,
+            encoder_pp=1,
+            encoder_dp=4,
+            encoder_offset=0,
+            llm_tp=2,
+            llm_pp=1,
+            llm_dp=2,
+            llm_offset=4,
+            llm_expert_tp=2,
+            llm_expert_ep=2,
+            llm_expert_dp=1,
+            num_moe_experts=4,
+            moe_router_topk=2,
+            moe_grouped_gemm=False,
+            hidden_size=256,
+            num_layers=2,
+            vocab_size=1000,
+            seq_length=64,
+            micro_batch_size=4,
             num_microbatches=4,
         )

--- a/tests/unit_tests/models/mimo/test_mimo_optimizer.py
+++ b/tests/unit_tests/models/mimo/test_mimo_optimizer.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the MIMO optimizer's process-group resolution and cross-rank
+gradient statistics, focused on the non-colocated / heterogeneous grid case.
+
+The ``item1`` (process-group resolution) and ``item2`` (cross-rank ``count_zeros``)
+tests are REAL distributed tests: they initialize the process group, build a real
+``HyperCommGrid`` spanning all 8 ranks, register the expert factorization via the
+``register_view(...)`` rank-view API, create the base + expert-view process groups,
+and assert actual group membership / actual collective results. They run on the
+standard 1-node x 8-GPU unit-test lane and skip on any other world size, matching
+the skip-gating convention used by the rest of the MIMO test suite.
+
+Run with 8 GPUs:
+    uv run python -m torch.distributed.run --nproc-per-node=8 \
+        -m pytest tests/unit_tests/models/mimo/test_mimo_optimizer.py -v -s
+"""
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from megatron.core.dist_checkpointing.mapping import ShardedObject
+from megatron.core.dist_checkpointing.utils import add_prefix_for_sharding
+from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.models.mimo.optimizer import (
+    EXPERT_VIEW,
+    MimoOptimizer,
+    ModuleOptimizerInfo,
+    _get_pg_collection_for_optimizer,
+)
+from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+def _ranks(pg):
+    return sorted(dist.get_process_group_ranks(pg))
+
+
+def _build_dense_grid(tp=1, cp=1, pp=1, dp=1, ep=1, expt_dp=1, register_expert=False):
+    """Build a HyperCommGrid spanning the whole world with optimizer groups.
+
+    The base view carries the dense ``tp/cp/pp/dp`` factorization (plus degenerate
+    ``ep``/``expt_dp`` placeholders for backward compatibility). When ``register_expert``
+    is set, a separate ``"expert"`` rank-view (``expt_tp/ep/expt_dp/pp``) is registered
+    via ``register_view`` with ``pp`` declared a shared dim, and its groups are created
+    through the ``view="expert"`` kwarg, exercising the heterogeneous path.
+    """
+    grid = HyperCommGrid(
+        shape=[tp, cp, pp, dp, 1, 1],
+        dim_names=["tp", "cp", "pp", "dp", "ep", "expt_dp"],
+        rank_offset=0,
+        backend="nccl",
+    )
+    grid.create_pg(["tp"])
+    grid.create_pg(["pp"])
+    grid.create_pg(["dp"])
+    grid.create_pg(["dp", "cp"])
+    grid.create_pg(["tp", "pp"])
+    grid.create_pg(["tp", "cp", "dp", "pp"])
+    if register_expert:
+        # expt_tp * ep * expt_dp * pp must equal the grid size. ``pp`` is shared with the
+        # base view: ``register_view`` enforces that a shared dim enumerate to the SAME
+        # ranks under both factorizations, so the expert dim ordering is chosen
+        # (``[expt_tp, pp, expt_dp, ep]``) such that its ``pp`` groups match the base grid's
+        # ``pp`` groups exactly. The expert ``[expt_tp, ep, pp]`` group then reuses the
+        # base pp ranks for its pp component.
+        grid.register_view(
+            EXPERT_VIEW,
+            shape=[tp, pp, expt_dp, ep],
+            dim_names=["expt_tp", "pp", "expt_dp", "ep"],
+            shared_dims=["pp"],
+        )
+        grid.create_pg(["expt_tp", "ep", "pp"], view=EXPERT_VIEW)
+        grid.create_pg(["expt_dp"], view=EXPERT_VIEW)
+    else:
+        grid.create_pg(["ep"])
+        grid.create_pg(["tp", "ep", "pp"])
+        grid.create_pg(["dp", "ep"])
+    return grid
+
+
+@pytest.fixture
+def dist_env():
+    Utils.initialize_distributed()
+    yield dist.get_world_size()
+    # Process groups created per-test are torn down inside each test.
+
+
+class TestGetPgCollectionForOptimizer:
+    """item1: expert-view group resolution + narrowed intra_dist_opt.
+
+    REAL 8-GPU distributed test: builds real process groups and asserts on actual
+    rank membership. Runs unconditionally on the 8-GPU unit-test lane.
+    """
+
+    def test_expert_view_groups_and_dense_intra_dist_opt(self, dist_env):
+        world_size = dist_env
+        if world_size != 8:
+            pytest.skip(f"This real distributed test requires 8 GPUs, got {world_size}")
+
+        # Dense: tp=2, dp=2, pp=2. Expert: expt_tp=2, ep=2, expt_dp=1, pp=2 (same 8 ranks,
+        # different factorization). ep is an INDEPENDENT axis carved from the dense dp here.
+        grid = _build_dense_grid(tp=2, pp=2, dp=2, ep=2, expt_dp=1, register_expert=True)
+        try:
+            pg = _get_pg_collection_for_optimizer(grid)
+
+            # Dense groups come from the base view.
+            assert pg.tp is grid.get_pg("tp")
+            assert pg.mp is grid.get_pg(["tp", "pp"])
+            assert pg.pp is grid.get_pg("pp")
+
+            # intra_dist_opt is the DENSE grad-stats group: tp x cp x dp x pp, NOT ep.
+            # It must equal the [tp,cp,dp,pp] base group.
+            assert pg.intra_dist_opt is grid.get_pg(["tp", "cp", "dp", "pp"])
+            # For this config [tp,cp,dp,pp] spans all 8 ranks (cp=1), so the dense
+            # grad-stats group is the full world.
+            assert _ranks(pg.intra_dist_opt) == list(range(8))
+
+            # Expert groups come from the registered "expert" view, NOT the base dims.
+            assert pg.tp_ep_pp is grid.get_pg(["expt_tp", "ep", "pp"], view=EXPERT_VIEW)
+            assert pg.expt_dp is grid.get_pg(["expt_dp"], view=EXPERT_VIEW)
+            assert pg.intra_expt_dp is pg.expt_dp
+
+            # pp is a SHARED dim of the expert view: the expert [expt_tp, ep, pp]
+            # group's pp membership must agree with the base pp group, and the view
+            # reuses the base pp group object for a pure-pp request.
+            assert grid.get_pg(["pp"], view=EXPERT_VIEW) is grid.get_pg("pp")
+
+            # The expert tp_ep_pp partition differs from the base [tp,pp] (mp) partition:
+            # it additionally folds in the ep axis, so a heterogeneous expert view is
+            # genuinely honored rather than silently aliased onto the dense groups.
+            assert _ranks(pg.tp_ep_pp) != _ranks(pg.mp)
+        finally:
+            grid.destroy()
+
+    def test_falls_back_to_base_view_without_expert_view(self, dist_env):
+        world_size = dist_env
+        if world_size != 8:
+            pytest.skip(f"This real distributed test requires 8 GPUs, got {world_size}")
+
+        grid = _build_dense_grid(tp=2, pp=2, dp=2, register_expert=False)
+        try:
+            pg = _get_pg_collection_for_optimizer(grid)
+            # No expert view -> expert groups resolve against the base view.
+            assert pg.tp_ep_pp is grid.get_pg(["tp", "ep", "pp"])
+            assert pg.expt_dp is grid.get_pg(["dp", "ep"])
+            # intra_dist_opt is still the dense [tp,cp,dp,pp] group.
+            assert pg.intra_dist_opt is grid.get_pg(["tp", "cp", "dp", "pp"])
+        finally:
+            grid.destroy()
+
+
+class _FakeModuleOptimizer:
+    """Minimal stand-in for a per-module MegatronOptimizer.
+
+    ``count_zeros`` returns a fixed per-module value to emulate the real optimizer,
+    whose own SUM reduce over its grad-stats group makes the value identical across
+    all ranks that own the module.
+    """
+
+    def __init__(self, zeros):
+        self._zeros = zeros
+        self.is_stub_optimizer = False
+
+    def count_zeros(self):
+        return self._zeros
+
+
+class TestCountZeros:
+    """item2: count_zeros must be consistent across ranks in non-colocated mode.
+
+    REAL 8-GPU distributed test: builds a real ``MimoOptimizer`` over two modules
+    with disjoint rank ownership and verifies the cross-rank all_reduce(MAX) makes
+    ``count_zeros`` agree on every rank via a real ``all_gather_object`` collective.
+    Runs unconditionally on the 8-GPU unit-test lane.
+    """
+
+    def test_count_zeros_consistent_across_ranks(self, dist_env):
+        world_size = dist_env
+        if world_size != 8:
+            pytest.skip(f"This real distributed test requires 8 GPUs, got {world_size}")
+
+        rank = dist.get_rank()
+        # Two modules with disjoint rank ownership: "images" on ranks 0-3, "language"
+        # on ranks 4-7 (the canonical non-colocated split).
+        images_active = rank < 4
+        language_active = rank >= 4
+
+        IMAGES_ZEROS = 7
+        LANGUAGE_ZEROS = 11
+
+        module_infos = {
+            "images": ModuleOptimizerInfo(
+                optimizer=_FakeModuleOptimizer(IMAGES_ZEROS) if images_active else None,
+                grid=None,
+                pg_collection=None,
+                is_active=images_active,
+            ),
+            "language": ModuleOptimizerInfo(
+                optimizer=_FakeModuleOptimizer(LANGUAGE_ZEROS) if language_active else None,
+                grid=None,
+                pg_collection=None,
+                is_active=language_active,
+            ),
+        }
+        config = OptimizerConfig(optimizer="adam", lr=1e-3)
+        mimo_opt = MimoOptimizer(module_infos, config)
+
+        total = mimo_opt.count_zeros()
+
+        # The cross-rank MAX recovers every module's count on every rank, so the
+        # global total is the SAME on all ranks and equals the sum of both modules.
+        assert total == IMAGES_ZEROS + LANGUAGE_ZEROS
+
+        # Sanity: a naive local sum would have returned 7 on ranks 0-3 and 11 on
+        # ranks 4-7 -- inconsistent. Confirm every rank agrees on the global value
+        # via a real collective.
+        gathered = [None] * world_size
+        dist.all_gather_object(gathered, total)
+        assert len(set(gathered)) == 1, f"count_zeros disagrees across ranks: {gathered}"
+
+
+class TestShardedKeyCollision:
+    """item3: add_prefix_for_sharding disambiguates colliding inner optimizer keys.
+
+    DistributedOptimizer.sharded_state_dict keys its regular optimizer state as
+    ``optimizer.distributed.dp_group_idx_{model_parallel_rank}.*``. In non-colocated
+    mode each module has its own model-parallel group, so two modules both produce
+    model_parallel_rank 0 and therefore identical keys for different data on disjoint
+    ranks -- a global key collision. Prefixing with ``mimo.{module_name}.`` fixes it.
+
+    This is a real collision repro: it constructs real ShardedObjects and checks key
+    disjointness; it does not fake torch.distributed.
+    """
+
+    @staticmethod
+    def _module_sharded_state_dict():
+        # Emulate the colliding ShardedObjects DistributedOptimizer emits when both
+        # modules land on model_parallel_rank 0 (data_parallel_group_idx == 0).
+        return {
+            "step": ShardedObject(
+                "optimizer.distributed.dp_group_idx_0.step", torch.tensor(0), (1,), (0,)
+            ),
+            "param_groups": ShardedObject(
+                "optimizer.distributed.dp_group_idx_0.param_groups", [], (1,), (0,)
+            ),
+        }
+
+    def test_keys_collide_without_prefix(self):
+        images = self._module_sharded_state_dict()
+        language = self._module_sharded_state_dict()
+        images_keys = {v.key for v in images.values()}
+        language_keys = {v.key for v in language.values()}
+        # Demonstrate the collision: the two modules share identical inner keys.
+        assert images_keys & language_keys == images_keys
+        assert "optimizer.distributed.dp_group_idx_0.step" in images_keys & language_keys
+
+    def test_prefix_disambiguates_keys(self):
+        images = self._module_sharded_state_dict()
+        language = self._module_sharded_state_dict()
+
+        add_prefix_for_sharding(images, "mimo.images.")
+        add_prefix_for_sharding(language, "mimo.language.")
+
+        images_keys = {v.key for v in images.values()}
+        language_keys = {v.key for v in language.values()}
+
+        # After prefixing the two modules no longer collide on any key.
+        assert images_keys.isdisjoint(language_keys)
+        assert "mimo.images.optimizer.distributed.dp_group_idx_0.step" in images_keys
+        assert "mimo.language.optimizer.distributed.dp_group_idx_0.step" in language_keys


### PR DESCRIPTION
## What

Make the MIMO per-module optimizer work when a MIMO model's submodules live on **disjoint rank grids** (e.g. a vision encoder and a (MoE) language model on separate grids stitched by the 1F1B bridge schedule), rather than only the colocated case.

## Changes (`megatron/core/models/mimo/optimizer.py`)

1. **Expert-parallel groups from the grid's registered `"expert"` rank view.** `_get_pg_collection_for_optimizer` sources `tp_ep_pp` / `expt_dp` via `grid.get_pg([...], view="expert")`, falling back to base dims (`["tp","ep","pp"]` / `["dp","ep"]`) when the view is absent (`KeyError`). The dense `intra_dist_opt = grid.get_pg(["tp","cp","dp","pp"])` deliberately **excludes** the expert dim so dense grad statistics are not inflated by `ep_size`.
2. **`count_zeros` via per-module cross-rank `all_reduce(MAX)`** (was a local sum), so the reported count is consistent across each module's grid — mirroring the existing `get_grad_norm` pattern.
3. **`sharded_state_dict` prefixes each submodule with `mimo.{name}.`** via `add_prefix_for_sharding`, so distributed-optimizer checkpoint keys don't collide between submodules sharing an mp-rank-0 slot. Save/load are symmetric; the existing dist-checkpoint machinery is preserved.
4. **Skip building an optimizer for fully frozen submodules**, gated by a cross-rank trainable-parameter check (`all_reduce(MAX)` over the module's own `intra_dist_opt` group, so hetero subsets don't deadlock).

## Tests

- `tests/unit_tests/models/mimo/test_mimo_optimizer.py` (new): expert-view resolution + base-dim fallback, `count_zeros` cross-rank consistency, and sharded-key collision/disambiguation. Real distributed tests on the 1-node x 8-GPU lane.
- `tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py`: adds `test_moe_llm_ep2_etp2_8gpu`, an 8-GPU MoE e2e exercising the optimizer through the hetero 1F1B bridge schedule (encoder PP1/DP4 -> MoE LLM TP2/PP1/DP2, EP2/ETP2). Asserts finite positive `grad_norm`, finite loss, non-zero expert-param grads, and that expert (`tp_ep_pp`) ranks differ from dense (`mp`) ranks.

Both suites pass on 8 GPUs.

## Scope

Touches only `megatron/core/models/mimo/optimizer.py` and its tests (single CODEOWNERS group). No changes to `megatron/core/optimizer/__init__.py`.