### PR TITLE
Synchronize shared expert FSDP grad processing

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import logging
 from contextlib import contextmanager
 from enum import Enum, auto
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -101,6 +101,54 @@ def setup_delayed_wgrad_acc_hook(module, grad_acc_func):
     for param in module.parameters():
         if getattr(param, 'skip_backward_post_hook', False):
             param.post_wgrad_grad_acc_hook = partial(grad_acc_func, [param])
+
+
+def _get_shared_expert_stream():
+    if not torch.cuda.is_available():
+        return None
+    try:
+        from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
+
+        return SharedExpertMLP.stream
+    except Exception:
+        return None
+
+
+def _is_shared_expert_param(param_to_name: Dict[torch.nn.Parameter, str], param):
+    param_name = param_to_name.get(param, "")
+    return ".shared_experts." in f".{param_name}."
+
+
+def _run_shared_expert_grad_processing_on_default_stream(
+    param_to_name: Dict[torch.nn.Parameter, str],
+    param_list: List[torch.nn.Parameter],
+    process_fn: Callable[[], None],
+) -> Optional[Tuple[torch.cuda.Stream, torch.cuda.Stream]]:
+    """Run shared expert FSDP grad handling on the default stream when needed.
+
+    Shared expert backward can complete on the shared expert stream. Grad accumulation and
+    reduce-scatter readiness are consumed by the FSDP default-stream path, so bridge from the
+    producing stream to the default stream before processing these parameters.
+    """
+    if not torch.cuda.is_available():
+        return None
+
+    if _get_shared_expert_stream() is None:
+        return None
+
+    if not any(_is_shared_expert_param(param_to_name, param) for param in param_list):
+        return None
+
+    current_stream = torch.cuda.current_stream()
+    default_stream = torch.cuda.default_stream(current_stream.device)
+    if current_stream.cuda_stream == default_stream.cuda_stream:
+        return None
+
+    default_stream.wait_stream(current_stream)
+    with torch.cuda.stream(default_stream):
+        process_fn()
+    current_stream.wait_stream(default_stream)
+    return current_stream, default_stream
 
 
 class MegatronFSDP(torch.nn.Module):
@@ -698,32 +746,43 @@ class MegatronFSDP(torch.nn.Module):
             if not param_list:
                 return
 
-            for param in param_list:
-                _grad_acc(param)
+            def _process_post_backward_gradients_impl():
+                for param in param_list:
+                    _grad_acc(param)
 
-            grad_reduce_every_bprop = self.data_parallel_sharding_strategy in [
-                "optim_grads",
-                "optim_grads_params",
-            ]
-            is_last_microbatch = getattr(self, "is_last_microbatch", False)
+                grad_reduce_every_bprop = self.data_parallel_sharding_strategy in [
+                    "optim_grads",
+                    "optim_grads_params",
+                ]
+                is_last_microbatch = getattr(self, "is_last_microbatch", False)
 
-            if grad_reduce_every_bprop or is_last_microbatch or self.model_auto_sync:
-                # Launch asynchronous reduce-scatter of gradients before the optimizer
-                # step. This requires a later call to finish_grad_sync() to wait for
-                # completion.
-                self.grad_reduce_pipeline.reduce_gradients(
-                    param_list,
-                    suggested_queue_capacity=self.suggested_RS_queue_capacity,
-                    outer_fsdp_group_grad_reduce=(
-                        # HSDP all-reduce or HFSDP reduce-scatter on the DP-Outer PG.
-                        self.dist_index.use_hybrid_fsdp
-                        and (is_last_microbatch or self.model_auto_sync)
-                    ),
+                if grad_reduce_every_bprop or is_last_microbatch or self.model_auto_sync:
+                    # Launch asynchronous reduce-scatter of gradients before the optimizer
+                    # step. This requires a later call to finish_grad_sync() to wait for
+                    # completion.
+                    self.grad_reduce_pipeline.reduce_gradients(
+                        param_list,
+                        suggested_queue_capacity=self.suggested_RS_queue_capacity,
+                        outer_fsdp_group_grad_reduce=(
+                            # HSDP all-reduce or HFSDP reduce-scatter on the DP-Outer PG.
+                            self.dist_index.use_hybrid_fsdp
+                            and (is_last_microbatch or self.model_auto_sync)
+                        ),
+                    )
+
+                # Mark parameters as processed.
+                for param in param_list:
+                    self._params_require_handle_grad.discard(param)
+
+            if (
+                _run_shared_expert_grad_processing_on_default_stream(
+                    self.param_to_name, param_list, _process_post_backward_gradients_impl
                 )
+                is not None
+            ):
+                return
 
-            # Mark parameters as processed.
-            for param in param_list:
-                self._params_require_handle_grad.discard(param)
+            _process_post_backward_gradients_impl()
 
         @torch.compiler.disable
         def _pre_forward_param_unshard(module: nn.Module, *unused):

--- a/tests/unit_tests/distributed/megatron_fsdp/test_shared_expert_grad_stream.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_shared_expert_grad_stream.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import torch
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp import megatron_fsdp
+
+
+class _FakeStream:
+    def __init__(self, name, cuda_stream, events, device="cuda:0"):
+        self.name = name
+        self.cuda_stream = cuda_stream
+        self.device = device
+        self._events = events
+
+    def wait_stream(self, stream):
+        self._events.append((self.name, "wait_stream", stream.name))
+
+
+class _FakeStreamContext:
+    def __init__(self, stream, events, active_streams):
+        self.stream = stream
+        self.events = events
+        self.active_streams = active_streams
+
+    def __enter__(self):
+        self.events.append(("enter", self.stream.name))
+        self.active_streams.append(self.stream)
+        return self.stream
+
+    def __exit__(self, exc_type, exc, tb):
+        self.events.append(("exit", self.stream.name))
+        self.active_streams.pop()
+        return False
+
+
+def test_shared_expert_grad_processing_bridges_to_default_stream(monkeypatch):
+    """Regression guard for the FSDP shared-expert backward stream ordering bug.
+
+    Before the fix, shared expert post-backward grad handling ran directly on the
+    producing shared-expert stream. The fixed path must wait from default stream,
+    process on default stream, then make the producing stream wait for default.
+    """
+    events = []
+    active_streams = []
+    shared_stream = _FakeStream("shared", 7, events)
+    default_stream = _FakeStream("default", 0, events)
+
+    monkeypatch.setattr(megatron_fsdp.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(megatron_fsdp, "_get_shared_expert_stream", lambda: shared_stream)
+    monkeypatch.setattr(megatron_fsdp.torch.cuda, "current_stream", lambda: shared_stream)
+    monkeypatch.setattr(
+        megatron_fsdp.torch.cuda, "default_stream", lambda device=None: default_stream
+    )
+    monkeypatch.setattr(
+        megatron_fsdp.torch.cuda,
+        "stream",
+        lambda stream: _FakeStreamContext(stream, events, active_streams),
+    )
+
+    shared_param = torch.nn.Parameter(torch.empty(1))
+    other_param = torch.nn.Parameter(torch.empty(1))
+    param_to_name = {
+        shared_param: "layers.0.mlp.shared_experts.linear_fc1.weight",
+        other_param: "layers.0.mlp.experts.local_experts.weight",
+    }
+
+    def process_grads():
+        assert active_streams == [default_stream]
+        events.append(("process", active_streams[-1].name))
+
+    routed_streams = megatron_fsdp._run_shared_expert_grad_processing_on_default_stream(
+        param_to_name, [shared_param, other_param], process_grads
+    )
+
+    assert routed_streams == (shared_stream, default_stream)
+    assert events == [
+        ("default", "wait_stream", "shared"),
+        ("enter", "default"),
+        ("process", "default"),
+        ("exit", "default"),
+        ("shared", "wait_stream", "default"),
+    ]
+
+
+def test_shared_expert_grad_processing_leaves_non_shared_params_on_caller_stream(monkeypatch):
+    events = []
+    active_streams = []
+    source_stream = _FakeStream("source", 7, events)
+    default_stream = _FakeStream("default", 0, events)
+
+    monkeypatch.setattr(megatron_fsdp.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(megatron_fsdp, "_get_shared_expert_stream", lambda: source_stream)
+    monkeypatch.setattr(megatron_fsdp.torch.cuda, "current_stream", lambda: source_stream)
+    monkeypatch.setattr(
+        megatron_fsdp.torch.cuda, "default_stream", lambda device=None: default_stream
+    )
+    monkeypatch.setattr(
+        megatron_fsdp.torch.cuda,
+        "stream",
+        lambda stream: _FakeStreamContext(stream, events, active_streams),
+    )
+
+    param = torch.nn.Parameter(torch.empty(1))
+
+    def process_grads():
+        events.append(("process", "unexpected"))
+
+    routed_streams = megatron_fsdp._run_shared_expert_grad_processing_on_default_stream(
+        {param: "layers.0.mlp.experts.local_experts.weight"}, [param], process_grads
+    )
+
+    assert routed_streams is None
+    assert events == []


### PR DESCRIPTION
## Summary
- Run shared-expert FSDP post-backward grad processing on the default CUDA stream when the grad is produced on the shared expert stream.
- Preserve the existing FSDP grad accumulation/reduce-scatter path for non-shared-expert params and default-stream callers.
- Add a regression unit test for the stream wait/default-stream/process/source-stream wait ordering.

## Test plan
- `python3 -m py_compile megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py tests/unit_tests/distributed/megatron_fsdp/test_shared_expert_grad_stream.py`
- `CHECK_ONLY=true BASE_REF=main uv run --project /project/agentic-mcore-dev --extra mcore-lint -- bash tools/autoformat.sh` (black/isort/pylint/ruff pass; mypy reports local missing torch imports/stubs in this environment)
- `uv run --project /project/agentic-mcore-dev --extra mcore-lint -- python tools/check_copyright.py <changed files>`
- Previously verified on cluster with the reproducer: overlap=true NaN before fix, overlap=false stable; post-fix overlap=true and overlap=false both stable to 250 iterations.
- Previously verified the added Megatron-FSDP shared expert stream unit test on SLURM job 3241152: 4 ranks, 2 passed.

🤖 Generated with Codex.