### PR TITLE
Fix variable-seq-length P2P shape swap at pipeline-parallel size 2

### DIFF
--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -232,31 +232,28 @@ class P2PCommunicator:
                 group=self.pp_group,
             )
         else:
-            ops = []
-            if send_prev_shape_tensor is not None:
-                send_prev_op = torch.distributed.P2POp(
-                    torch.distributed.isend, send_prev_shape_tensor, self.prev_rank, self.pp_group
-                )
-                ops.append(send_prev_op)
-            if recv_prev_shape_tensor is not None:
-                recv_prev_op = torch.distributed.P2POp(
-                    torch.distributed.irecv, recv_prev_shape_tensor, self.prev_rank, self.pp_group
-                )
-                ops.append(recv_prev_op)
-            if send_next_shape_tensor is not None:
-                send_next_op = torch.distributed.P2POp(
-                    torch.distributed.isend, send_next_shape_tensor, self.next_rank, self.pp_group
-                )
-                ops.append(send_next_op)
-            if recv_next_shape_tensor is not None:
-                recv_next_op = torch.distributed.P2POp(
-                    torch.distributed.irecv, recv_next_shape_tensor, self.next_rank, self.pp_group
-                )
-                ops.append(recv_next_op)
-            if len(ops) > 0:
-                reqs = torch.distributed.batch_isend_irecv(ops)
-                for req in reqs:
-                    req.wait()
+            # The shape exchange must use _p2p_ops (point-to-point isend/irecv)
+            # rather than batch_isend_irecv. batch_isend_irecv issues a single
+            # tagless NCCL group; when the pipeline-parallel group has size 2,
+            # prev_rank == next_rank (a single physical peer), so the two sends and
+            # two recvs all target the same peer and pair FIFO by enqueue order.
+            # Both ranks build ops in the same fixed order but hold opposite
+            # prev/next roles, so recv_prev_shape and recv_next_shape get silently
+            # crossed. _p2p_ops handles size 2 by routing the two directions over
+            # separate communicators (the group.WORLD trick) plus even/odd ordering,
+            # and is correct for size >= 4 (prev != next). The shape tensors are
+            # tiny (3,), so not batching them costs nothing.
+            reqs = _p2p_ops(
+                tensor_send_prev=send_prev_shape_tensor,
+                tensor_recv_prev=recv_prev_shape_tensor,
+                tensor_send_next=send_next_shape_tensor,
+                tensor_recv_next=recv_next_shape_tensor,
+                group=self.pp_group,
+                prev_pipeline_rank=self.prev_rank,
+                next_pipeline_rank=self.next_rank,
+            )
+            for req in reqs.values():
+                req.wait()
 
             # To protect against race condition when using batch_isend_irecv().
             # should take this out once the bug with batch_isend_irecv is resolved.
@@ -371,19 +368,26 @@ class P2PCommunicator:
                 return []
 
             p2p_func = _ring_exchange_wrapper
-        elif config.batch_p2p_comm:
+        elif config.batch_p2p_comm and self.pp_group.size() > 2:
             assert wait_on_reqs
             p2p_func = _batched_p2p_ops
         else:
+            # At pipeline-parallel group size 2, prev_rank == next_rank, so a
+            # bidirectional exchange posts two sends + two recvs to the same peer.
+            # Only _p2p_ops pairs these correctly (separate communicators); the
+            # batched path would FIFO-cross them, mismatching the (now-correct)
+            # shape exchange. Force _p2p_ops at size 2.
             p2p_func = _p2p_ops
 
         pp_group = self.pp_group
         next_rank = self.next_rank
         prev_rank = self.prev_rank
 
-        if config.use_ring_exchange_p2p or config.batch_p2p_comm:
+        if config.use_ring_exchange_p2p or (config.batch_p2p_comm and self.pp_group.size() > 2):
             reqs = []
         else:
+            # At size 2 the batched path is bypassed in favor of _p2p_ops (see
+            # the p2p_func dispatch above), which returns a dict of requests.
             reqs = {}
 
         tensor_recv_prev = None

--- a/tests/unit_tests/pipeline_parallel/test_p2p_variable_seq_shapes.py
+++ b/tests/unit_tests/pipeline_parallel/test_p2p_variable_seq_shapes.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+
+"""Regression tests for the variable-sequence-length P2P shape exchange.
+
+These tests target the silent shape-swap bug (MCORE-382 / PR#1451 lineage) in
+``P2PCommunicator._communicate_shapes``. When the pipeline-parallel group has
+size 2, ``next_rank == prev_rank`` (a single physical peer). The shape exchange
+always enqueues ops in the fixed order ``[send_prev, recv_prev, send_next,
+recv_next]`` into one tagless ``batch_isend_irecv`` collective and never
+consults ``config.batch_p2p_comm``. Because NCCL P2P is tagless, same-peer ops
+pair FIFO by enqueue order, so the ``recv_prev`` and ``recv_next`` shape
+tensors get crossed when both a send-next and a send-prev target the same peer.
+The data transfer (when it goes through the batched ``batch_isend_irecv`` path)
+uses the identical fixed order, so the byte sizes still match and the swap is
+silent at the comm layer -- the returned tensors simply carry the wrong
+(swapped) shapes.
+
+Test design notes (why the structure is what it is):
+
+  * ``test_variable_seq_shape_swap_pp2`` exercises the full end-to-end
+    ``send_forward_backward_recv_forward_backward`` path with
+    ``batch_p2p_comm=True``. Both the shape exchange AND the data transfer use
+    ``batch_isend_irecv``, so the FIFO byte sizes match the (swapped) recv
+    buffers and the call completes silently -- producing a clean shape
+    assertion failure on buggy main rather than an NCCL count-mismatch.
+
+  * ``test_communicate_shapes_swap_pp2`` is parametrized over
+    ``batch_p2p_comm`` and calls ``_communicate_shapes`` DIRECTLY. This proves
+    Claim C: the shape exchange ignores ``batch_p2p_comm`` entirely (it only
+    branches on ``use_ring_exchange_p2p``), so the swap occurs for BOTH flag
+    values. Calling the shape helper directly is deliberate: the non-batched
+    (``batch_p2p_comm=False``) DATA path uses point-to-point ``isend``/``irecv``
+    matched by explicit src/dst, and after a swapped shape exchange the recv
+    buffers would be sized wrong, risking an NCCL count mismatch / hang rather
+    than a clean assertion. The shape exchange itself is symmetric and balanced
+    (2 sends + 2 recvs per rank, all to the single peer), so it cannot hang.
+"""
+
+import pytest
+import torch
+from packaging import version
+
+from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.model_parallel_config import ModelParallelConfig
+from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
+from tests.unit_tests.test_utilities import Utils
+
+# Distinct sequence lengths so a swap is observable. The activation (sent to
+# the next stage) and the gradient (sent to the previous stage) must differ.
+HIDDEN_SIZE = 16
+ACT_SEQ_LEN = 10  # output_tensor / activation -> sent to next stage
+GRAD_SEQ_LEN = 20  # input_tensor_grad / gradient -> sent to prev stage
+
+
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse('2.3.0'),
+    reason="HyperCommGrid device mesh feature requires PyTorch 2.3 or later",
+)
+@pytest.mark.internal
+def test_variable_seq_shape_swap_pp2():
+    """Bidirectional shape exchange at PP-group size 2 crosses the shapes (end-to-end).
+
+    Reproduces Claim A through the full
+    ``send_forward_backward_recv_forward_backward`` entry point with
+    ``batch_p2p_comm=True`` (the default). Both the shape exchange and the data
+    transfer go through ``batch_isend_irecv``, so the swapped recv-buffer byte
+    sizes still match the FIFO pairing and the call completes silently --
+    yielding a clean shape assertion failure on buggy main (not an NCCL error).
+
+    2-rank ring reasoning (PP group indices {0, 1}):
+      * For rank ``r``: ``next = (r+1) % 2``, ``prev = (r-1) % 2``; with size 2
+        this gives ``next == prev`` (one physical peer).
+      * Every rank sends its activation (seq=ACT_SEQ_LEN) to ``next`` and its
+        gradient (seq=GRAD_SEQ_LEN) to ``prev``.
+      * The activation a rank RECEIVES comes from its ``prev`` stage; the peer
+        that has this rank as its ``next`` sends its activation here. So the
+        received ``input_tensor`` (activation from prev) must carry the
+        activation seq len -> shape[0] == ACT_SEQ_LEN (10).
+      * The gradient a rank RECEIVES comes from its ``next`` stage; that peer
+        sends its gradient to its ``prev`` (this rank). So the received
+        ``output_tensor_grad`` (grad from next) must carry the gradient seq
+        len -> shape[0] == GRAD_SEQ_LEN (20).
+
+    On current main the fixed-order same-peer exchange swaps the two shape
+    tensors, so ``input_tensor.shape[0] == 20`` and
+    ``output_tensor_grad.shape[0] == 10`` -- the assertions below fail.
+    """
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=2)
+
+    # 8 GPUs: PP=2 (the size-2 group that triggers the same-peer collision),
+    # DP=4. The pp group therefore has exactly two ranks.
+    grid = HyperCommGrid([1, 1, 2, 4], ["tp", "cp", "pp", "dp"])
+    pp_group = grid.create_pg("pp")
+    assert pp_group.size() == 2, "This test requires a size-2 pipeline-parallel group."
+
+    config = ModelParallelConfig(
+        pipeline_model_parallel_size=2, pipeline_dtype=torch.float, variable_seq_lengths=True
+    )
+    config.hidden_size = HIDDEN_SIZE
+    # batch_p2p_comm=True (the default): the data transfer uses batch_isend_irecv,
+    # so swapped recv buffers still byte-match the FIFO pairing and the call
+    # completes silently instead of raising an NCCL count mismatch.
+    config.batch_p2p_comm = True
+
+    comm = P2PCommunicator(pp_group=pp_group, config=config)
+
+    # Deterministic, identical construction on every rank: the activation has a
+    # distinct seq length from the gradient so a swap is observable.
+    output_tensor = torch.ones(
+        (ACT_SEQ_LEN, 1, HIDDEN_SIZE), device=torch.cuda.current_device(), dtype=torch.float
+    )
+    input_tensor_grad = torch.ones(
+        (GRAD_SEQ_LEN, 1, HIDDEN_SIZE), device=torch.cuda.current_device(), dtype=torch.float
+    )
+
+    # tensor_shape is ignored when variable_seq_lengths=True, but must be valid.
+    input_tensor, output_tensor_grad = comm.send_forward_backward_recv_forward_backward(
+        output_tensor=output_tensor,
+        input_tensor_grad=input_tensor_grad,
+        recv_prev=True,
+        recv_next=True,
+        tensor_shape=(ACT_SEQ_LEN, 1, HIDDEN_SIZE),
+    )
+
+    assert input_tensor is not None and output_tensor_grad is not None
+
+    assert input_tensor.shape[0] == ACT_SEQ_LEN, (
+        f"SHAPE SWAP DETECTED: input_tensor is the activation received from the "
+        f"previous stage and must have seq len {ACT_SEQ_LEN}, but got "
+        f"{input_tensor.shape[0]}. A value of {GRAD_SEQ_LEN} means the "
+        f"recv_prev/recv_next shape tensors were crossed in _communicate_shapes "
+        f"(same-peer FIFO pairing at PP-group size 2)."
+    )
+    assert output_tensor_grad.shape[0] == GRAD_SEQ_LEN, (
+        f"SHAPE SWAP DETECTED: output_tensor_grad is the gradient received from the "
+        f"next stage and must have seq len {GRAD_SEQ_LEN}, but got "
+        f"{output_tensor_grad.shape[0]}. A value of {ACT_SEQ_LEN} means the "
+        f"recv_prev/recv_next shape tensors were crossed in _communicate_shapes "
+        f"(same-peer FIFO pairing at PP-group size 2)."
+    )
+
+    Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse('2.3.0'),
+    reason="HyperCommGrid device mesh feature requires PyTorch 2.3 or later",
+)
+@pytest.mark.internal
+@pytest.mark.parametrize("batch_p2p_comm", [True, False])
+def test_communicate_shapes_swap_pp2(batch_p2p_comm):
+    """``_communicate_shapes`` crosses the shapes at PP size 2 for BOTH flag values.
+
+    Reproduces Claim A and Claim C directly at the shape-exchange layer. We call
+    ``_communicate_shapes`` itself (not the full ``_communicate`` data path) for
+    two reasons:
+
+      1. Claim C: ``_communicate_shapes`` only branches on
+         ``use_ring_exchange_p2p`` and never reads ``config.batch_p2p_comm``, so
+         the documented "set batch_p2p_comm=False" workaround cannot reach it.
+         Parametrizing the flag and asserting the swap happens for BOTH values
+         proves the flag is irrelevant to the shape exchange.
+
+      2. Safety on the cluster: the shape exchange is symmetric and balanced
+         (each rank posts 2 sends + 2 recvs, all to the single peer), so it
+         completes regardless of the flag and cannot hang. The non-batched DATA
+         path, by contrast, would mis-size its recv buffers after a swapped
+         shape exchange and risk an NCCL count mismatch -- which is why the
+         end-to-end test above stays on the batched path.
+
+    Each rank passes ``tensor_send_next`` = activation (seq=ACT_SEQ_LEN) and
+    ``tensor_send_prev`` = gradient (seq=GRAD_SEQ_LEN), with recv_prev=recv_next=True.
+
+    Correct semantics (independently of the bug):
+      * ``recv_prev_shape`` is the shape received from ``prev``; the prev peer
+        has this rank as its ``next`` and sends its activation -> seq=ACT_SEQ_LEN.
+      * ``recv_next_shape`` is the shape received from ``next``; the next peer
+        sends its gradient backward to its ``prev`` (this rank) -> seq=GRAD_SEQ_LEN.
+
+    On buggy main both ranks enqueue [send_prev(grad), recv_prev, send_next(act),
+    recv_next] to the single peer; FIFO pairing crosses them, giving
+    recv_prev_shape[0] == GRAD_SEQ_LEN and recv_next_shape[0] == ACT_SEQ_LEN.
+    """
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=2)
+
+    grid = HyperCommGrid([1, 1, 2, 4], ["tp", "cp", "pp", "dp"])
+    pp_group = grid.create_pg("pp")
+    assert pp_group.size() == 2, "This test requires a size-2 pipeline-parallel group."
+
+    config = ModelParallelConfig(
+        pipeline_model_parallel_size=2, pipeline_dtype=torch.float, variable_seq_lengths=True
+    )
+    config.hidden_size = HIDDEN_SIZE
+    # Parametrized: this flag MUST NOT change the outcome, because
+    # _communicate_shapes never reads it (Claim C). The swap happens regardless.
+    config.batch_p2p_comm = batch_p2p_comm
+
+    comm = P2PCommunicator(pp_group=pp_group, config=config)
+
+    output_tensor = torch.ones(
+        (ACT_SEQ_LEN, 1, HIDDEN_SIZE), device=torch.cuda.current_device(), dtype=torch.float
+    )
+    input_tensor_grad = torch.ones(
+        (GRAD_SEQ_LEN, 1, HIDDEN_SIZE), device=torch.cuda.current_device(), dtype=torch.float
+    )
+
+    recv_prev_shape, recv_next_shape = comm._communicate_shapes(
+        tensor_send_next=output_tensor,
+        tensor_send_prev=input_tensor_grad,
+        recv_prev=True,
+        recv_next=True,
+    )
+
+    assert recv_prev_shape[0] == ACT_SEQ_LEN, (
+        f"SHAPE SWAP DETECTED (batch_p2p_comm={batch_p2p_comm}): recv_prev_shape is the "
+        f"activation shape received from the previous stage and must have seq len "
+        f"{ACT_SEQ_LEN}, but got {recv_prev_shape[0]}. A value of {GRAD_SEQ_LEN} means "
+        f"the recv_prev/recv_next shape tensors were crossed by the same-peer FIFO "
+        f"pairing at PP-group size 2 -- and the batch_p2p_comm flag did not prevent it "
+        f"(Claim C: _communicate_shapes ignores that flag)."
+    )
+    assert recv_next_shape[0] == GRAD_SEQ_LEN, (
+        f"SHAPE SWAP DETECTED (batch_p2p_comm={batch_p2p_comm}): recv_next_shape is the "
+        f"gradient shape received from the next stage and must have seq len "
+        f"{GRAD_SEQ_LEN}, but got {recv_next_shape[0]}. A value of {ACT_SEQ_LEN} means "
+        f"the recv_prev/recv_next shape tensors were crossed by the same-peer FIFO "
+        f"pairing at PP-group size 2 -- and the batch_p2p_comm flag did not prevent it "
+        f"(Claim C: _communicate_shapes ignores that flag)."
+    )
+
+    Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse('2.3.0'),
+    reason="HyperCommGrid device mesh feature requires PyTorch 2.3 or later",
+)
+@pytest.mark.internal
+def test_variable_seq_shape_ring_pp4_control():
+    """Positive control: ring shape exchange at PP-group size 4 is correct (no swap).
+
+    At PP-group size >= 4, ``prev_rank != next_rank``. ``send_forward_recv_forward``
+    posts ``send_next`` and ``recv_prev`` to DIFFERENT peers, so there is no
+    same-peer FIFO collision and no shape swap. This must PASS on current main,
+    proving the harness is sound and the bug is specific to the size-2
+    bidirectional same-peer case.
+
+    IMPORTANT (why a ring and not send_forward_recv_backward): every rank issues
+    the SAME call simultaneously. ``send_forward_recv_forward`` = ``send_next`` +
+    ``recv_prev``, which forms a balanced ring rotation (rank r sends to r+1 and
+    receives from r-1), so every send has a matching recv and the collective
+    cannot hang. By contrast a ring of ``send_forward_recv_backward``
+    (``send_next`` + ``recv_next``) is NOT balanced -- rank r's send to r+1 has
+    no matching recv on r+1 -- and would deadlock.
+
+    Reasoning (ring of 4, every rank sends the same fixed activation seq len):
+      * ``input_tensor`` is received from ``prev``; the prev stage sends its
+        activation (seq=ACT_SEQ_LEN) forward to its ``next`` (this rank), so
+        ``input_tensor.shape[0] == ACT_SEQ_LEN``.
+    """
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=4)
+
+    # 8 GPUs: PP=4 (prev != next, no same-peer collision), DP=2.
+    grid = HyperCommGrid([1, 1, 4, 2], ["tp", "cp", "pp", "dp"])
+    pp_group = grid.create_pg("pp")
+    assert pp_group.size() == 4, "This control requires a size-4 pipeline-parallel group."
+
+    config = ModelParallelConfig(
+        pipeline_model_parallel_size=4, pipeline_dtype=torch.float, variable_seq_lengths=True
+    )
+    config.hidden_size = HIDDEN_SIZE
+
+    comm = P2PCommunicator(pp_group=pp_group, config=config)
+
+    output_tensor = torch.ones(
+        (ACT_SEQ_LEN, 1, HIDDEN_SIZE), device=torch.cuda.current_device(), dtype=torch.float
+    )
+
+    # Balanced ring: send activation to next, recv activation from prev.
+    # (send_next + recv_prev) -- exercises _communicate_shapes at size 4 with the
+    # send and recv targeting DIFFERENT peers, so there is no swap and no hang.
+    input_tensor = comm.send_forward_recv_forward(
+        output_tensor=output_tensor, recv_prev=True, tensor_shape=(ACT_SEQ_LEN, 1, HIDDEN_SIZE)
+    )
+
+    assert input_tensor is not None
+    assert input_tensor.shape[0] == ACT_SEQ_LEN, (
+        f"input_tensor (activation from prev stage) must have seq len {ACT_SEQ_LEN}, "
+        f"got {input_tensor.shape[0]}. At PP size 4 there is no same-peer collision, "
+        f"so the shape exchange must be correct."
+    )
+
+    Utils.destroy_model_parallel()


### PR DESCRIPTION
## Problem

With `variable_seq_lengths=True` and a **pipeline-parallel group of size 2**, training silently corrupts pipeline tensors and later crashes in `torch.autograd.backward` with a `grad_output` vs `output` shape mismatch (reported as MCORE-382 / #5100; same family as the unmerged #1451 / #1485).

**Root cause.** At PP-group size 2, `next_rank == prev_rank` (one physical peer). A bidirectional exchange — `send_forward_backward_recv_forward_backward`, used by the interleaved/VPP schedule — posts **two sends + two recvs to the same peer**. `_communicate_shapes` enqueues them in a fixed order `[send_prev, recv_prev, send_next, recv_next]` into a single tagless `batch_isend_irecv`. NCCL point-to-point is tagless, so same-peer ops pair **FIFO by enqueue order**; because both ranks build the same order but hold opposite prev/next roles, `recv_prev_shape` and `recv_next_shape` get **silently crossed**. The data transfer uses the identical order, so byte sizes still match and nothing errors at the comm layer — the tensors just carry the wrong (swapped) shapes.

`_communicate_shapes` also never consulted `config.batch_p2p_comm`, so the often-suggested `batch_p2p_comm=False` workaround never reached the shape exchange.

> Note: the original report attributes a "PP>=4 deadlock" to op ordering. At size >= 4, `prev_rank != next_rank`, no two ops target the same peer, and `batch_isend_irecv` coalesces into one NCCL group where ordering cannot deadlock — so this fix is scoped to the real, size-2 defect.

## Fix

Route both the **shape exchange** (`_communicate_shapes`) and the **size-2 data path** (`_communicate` dispatch) through `_p2p_ops`, which already pairs same-peer bidirectional ops correctly by issuing the two directions over separate communicators (the `group.WORLD` trick) with even/odd ordering. Size >= 4 is unchanged: `prev_rank != next_rank`, so the batched path is retained.

## Repro / validation (unit tests, 8 GPUs)

New `tests/unit_tests/pipeline_parallel/test_p2p_variable_seq_shapes.py`:

- `test_variable_seq_shape_swap_pp2` — end-to-end `send_forward_backward_recv_forward_backward` at PP=2 with distinct activation (seq=10) vs gradient (seq=20) shapes; asserts the received shapes are not crossed.
- `test_communicate_shapes_swap_pp2[True|False]` — calls `_communicate_shapes` directly; the `False` case demonstrates the flag never reached the shape path.
- `test_variable_seq_shape_ring_pp4_control` — size-4 positive control (balanced ring); confirms the bug is specific to the size-2 same-peer case.

Results on 8×H100:

| | before fix | after fix |
|---|---|---|
| new test file (4 cases) | `3 failed, 1 passed` (size-2 cases fail with the shape-swap assertion; size-4 control passes) | `4 passed` |
| `test_schedules.py` + `test_multimodule_schedules.py` | — | `67 passed, 2 skipped` (skips pre-existing, GPU-count gated) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)