### PR TITLE
Two fixes for post_training/modelopt examples used by downstream QAT/QAD CI

### DIFF
--- a/examples/post_training/modelopt/quantize.py
+++ b/examples/post_training/modelopt/quantize.py
@@ -236,6 +236,14 @@ def get_modelopt_torch_quantization_config():
     # Weight Only Quantization
     if args.weight_only:
         mtq_config["quant_cfg"].append({"quantizer_name": "*input_quantizer", "enable": False})
+
+    if os.environ.get("MODELOPT_SYNC_EXPERT_WEIGHT_AMAX", "0") == "1":
+        algorithm = mtq_config.get("algorithm", "max")
+        if isinstance(algorithm, str):
+            mtq_config["algorithm"] = {"method": algorithm, "sync_expert_weight_amax": True}
+        elif isinstance(algorithm, dict):
+            mtq_config["algorithm"]["sync_expert_weight_amax"] = True
+
     return mtq_config
 
 

--- a/examples/post_training/modelopt/train.sh
+++ b/examples/post_training/modelopt/train.sh
@@ -6,8 +6,9 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "${SCRIPT_DIR}/conf/arguments.sh"
 
 
-# Set up cache dir for HF to avoid out of space error
-export HF_DATASETS_CACHE="/tmp/hf_datasets_cache"
+# Set up cache dir for HF to avoid out of space error (overridable from caller).
+: "${HF_DATASETS_CACHE:=/tmp/hf_datasets_cache}"
+export HF_DATASETS_CACHE
 
 # Extra arguments of this script
 MLM_DEFAULT_ARGS=" \


### PR DESCRIPTION
## Summary

Two small, independent fixes to the `examples/post_training/modelopt/`
example scripts that downstream QAT/QAD CI pipelines (NeMo Megatron
ModelOpt Sandbox, etc.) need in order to (a) get cache hits on a
pre-warmed HF datasets cache and (b) opt into MoE expert amax
synchronization during PTQ calibration without script edits.

Both commits are atomic and independently revertable.

## Commits

### 1. `Don't override HF_DATASETS_CACHE when the caller sets it`

`train.sh` hard-exports `HF_DATASETS_CACHE=/tmp/hf_datasets_cache`,
which clobbers any value the caller's pipeline has already exported.
Downstream test harnesses that pre-warm a persistent lustre-mounted
cache (so the ~735GB SFT blend doesn't re-index every QAT run) see
zero benefit because of this override — HF rebuilds Arrow shards into
ephemeral container `/tmp` each time, ~40 min/run.

Switch to a soft default (`: "${HF_DATASETS_CACHE:=/tmp/hf_datasets_cache}"`)
so the `/tmp` path remains the fallback when nothing is set, and the
caller's env wins otherwise.

### 2. `Add MODELOPT_SYNC_EXPERT_WEIGHT_AMAX env var to enable MoE expert amax sync`

ModelOpt's algorithm config supports `sync_expert_weight_amax: True`
to synchronize amax across architecturally-identical experts during
calibration, which reduces unnecessary per-expert quantization-scale
variance for MoE models. The example script had no way to toggle this
short of editing the file.

Plumb a `MODELOPT_SYNC_EXPERT_WEIGHT_AMAX=1` env var through to the
mtq algorithm config. Off by default; opt-in.

## Test plan

- [x] `train.sh` change: manually verified locally that
      `HF_DATASETS_CACHE=/some/path ./train.sh ...` propagates instead
      of being overridden, and `./train.sh ...` (no caller env) still
      defaults to `/tmp/hf_datasets_cache` exactly as before.
- [x] `quantize.py` change: confirmed that with
      `MODELOPT_SYNC_EXPERT_WEIGHT_AMAX=1`, the resulting `mtq_config`
      carries `algorithm = {"method": <str>, "sync_expert_weight_amax": True}`,
      and that with the env unset the config is byte-identical to
      before this change.
- [ ] No automated test added — these are config-plumbing changes;
      happy to add focused unit tests if requested.