### PR TITLE
Add support for local SquashFS images in JET workloads

### DIFF
--- a/.gitlab/stages/04.functional-tests.yml
+++ b/.gitlab/stages/04.functional-tests.yml
@@ -66,6 +66,11 @@ functional:configure:
         RELEASE_ARGS=()
       fi
     - |
+      WORKLOAD_IMAGE_ARGS=()
+      if [[ -n "${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH:-}" ]]; then
+        WORKLOAD_IMAGE_ARGS+=("--workload-local-image-path ${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH}")
+      fi
+    - |
       # NOTE: $FUNCTIONAL_TEST_SCOPE is supplied by external scheduled-pipeline
       # configurations and uses the GitLab-side legacy values: `mr`, `mr-slim`,
       # `nightly`, `weekly`, `unit-tests`, `release`.
@@ -88,6 +93,7 @@ functional:configure:
         "--slurm-account ${CI_SLURM_ACCOUNT}"
         "--no-enable-warmup"
       )
+      ARGS+=("${WORKLOAD_IMAGE_ARGS[@]}")
     - |
       SMOKE_ARGS=(
         "--scope L0-smoke"
@@ -102,6 +108,7 @@ functional:configure:
         "--slurm-account ${CI_SLURM_ACCOUNT}"
         "--no-enable-warmup"
       )
+      SMOKE_ARGS+=("${WORKLOAD_IMAGE_ARGS[@]}")
     - |
       export PYTHONPATH=$(pwd)
       python tests/test_utils/python_scripts/generate_jet_trigger_job.py \

--- a/.gitlab/stages/04.functional-tests.yml
+++ b/.gitlab/stages/04.functional-tests.yml
@@ -66,10 +66,11 @@ functional:configure:
         RELEASE_ARGS=()
       fi
     - |
-      WORKLOAD_IMAGE_ARGS=()
-      if [[ -n "${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH:-}" ]]; then
-        WORKLOAD_IMAGE_ARGS+=("--workload-local-image-path ${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH}")
-      fi
+      WORKLOAD_LOCAL_IMAGE_PATH="${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH:-/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_mcore/mcore_ci/{build}-{platforms}-{container_tag}.sqsh}"
+      LOCAL_WORKLOAD_IMAGE_ARGS=(
+        "--workload-local-image-path ${WORKLOAD_LOCAL_IMAGE_PATH}"
+        "--skip-local-image-prepare"
+      )
     - |
       # NOTE: $FUNCTIONAL_TEST_SCOPE is supplied by external scheduled-pipeline
       # configurations and uses the GitLab-side legacy values: `mr`, `mr-slim`,
@@ -93,7 +94,6 @@ functional:configure:
         "--slurm-account ${CI_SLURM_ACCOUNT}"
         "--no-enable-warmup"
       )
-      ARGS+=("${WORKLOAD_IMAGE_ARGS[@]}")
     - |
       SMOKE_ARGS=(
         "--scope L0-smoke"
@@ -108,11 +108,11 @@ functional:configure:
         "--slurm-account ${CI_SLURM_ACCOUNT}"
         "--no-enable-warmup"
       )
-      SMOKE_ARGS+=("${WORKLOAD_IMAGE_ARGS[@]}")
     - |
       export PYTHONPATH=$(pwd)
       python tests/test_utils/python_scripts/generate_jet_trigger_job.py \
         ${SMOKE_ARGS[@]} \
+        ${LOCAL_WORKLOAD_IMAGE_ARGS[@]} \
         --environment dev \
         --platform dgx_h100 \
         --cluster $H100_CLUSTER \
@@ -121,6 +121,7 @@ functional:configure:
       export PYTHONPATH=$(pwd)
       python tests/test_utils/python_scripts/generate_jet_trigger_job.py \
         ${SMOKE_ARGS[@]} \
+        ${LOCAL_WORKLOAD_IMAGE_ARGS[@]} \
         --environment dev \
         --platform dgx_gb200 \
         --cluster $GB200_CLUSTER \
@@ -129,6 +130,7 @@ functional:configure:
       export PYTHONPATH=$(pwd)
       python tests/test_utils/python_scripts/generate_jet_trigger_job.py \
         ${ARGS[@]} \
+        ${LOCAL_WORKLOAD_IMAGE_ARGS[@]} \
         --environment dev \
         --platform dgx_a100 \
         --cluster $A100_CLUSTER \
@@ -138,6 +140,7 @@ functional:configure:
       export PYTHONPATH=$(pwd)
       python tests/test_utils/python_scripts/generate_jet_trigger_job.py \
         ${ARGS[@]} \
+        ${LOCAL_WORKLOAD_IMAGE_ARGS[@]} \
         --environment dev \
         --platform dgx_h100 \
         --cluster $H100_CLUSTER \
@@ -147,6 +150,7 @@ functional:configure:
       export PYTHONPATH=$(pwd)
       python tests/test_utils/python_scripts/generate_jet_trigger_job.py \
         ${ARGS[@]} \
+        ${LOCAL_WORKLOAD_IMAGE_ARGS[@]} \
         --environment lts \
         --platform dgx_a100 \
         --cluster $A100_CLUSTER \
@@ -156,6 +160,7 @@ functional:configure:
       export PYTHONPATH=$(pwd)
       python tests/test_utils/python_scripts/generate_jet_trigger_job.py \
         ${ARGS[@]} \
+        ${LOCAL_WORKLOAD_IMAGE_ARGS[@]} \
         --environment lts \
         --platform dgx_h100 \
         --cluster $H100_CLUSTER \
@@ -165,6 +170,7 @@ functional:configure:
       export PYTHONPATH=$(pwd)
       python tests/test_utils/python_scripts/generate_jet_trigger_job.py \
         ${ARGS[@]} \
+        ${LOCAL_WORKLOAD_IMAGE_ARGS[@]} \
         --environment dev \
         --platform dgx_gb200 \
         --cluster $GB200_CLUSTER \
@@ -174,6 +180,7 @@ functional:configure:
       export PYTHONPATH=$(pwd)
       python tests/test_utils/python_scripts/generate_jet_trigger_job.py \
         ${ARGS[@]} \
+        ${LOCAL_WORKLOAD_IMAGE_ARGS[@]} \
         --environment lts \
         --platform dgx_gb200 \
         --cluster $GB200_CLUSTER \
@@ -230,6 +237,10 @@ functional:configure:
 # so its rules win over `.functional_run`'s inherited `.functional_tests_rules`.
 functional:smoke-h100:
   extends: [.functional_run, .functional_smoke_rules]
+  needs:
+    - functional:configure
+    - test:build_image
+    - functional:prepare_sqsh_image_h100
   trigger:
     include:
       - artifact: functional-smoke-h100-job.yaml
@@ -242,6 +253,10 @@ functional:smoke-h100:
 # generated for the dgx_gb200 platform, gating the GB200 functional runs.
 functional:smoke-gb200:
   extends: [.functional_run, .functional_smoke_rules]
+  needs:
+    - functional:configure
+    - test:build_image
+    - functional:prepare_sqsh_image_gb200
   trigger:
     include:
       - artifact: functional-smoke-gb200-job.yaml
@@ -249,6 +264,86 @@ functional:smoke-gb200:
     strategy: depend
   variables:
     CLUSTER: GB200
+
+.functional_prepare_sqsh:
+  needs:
+    - job: functional:configure
+      artifacts: true
+    - test:build_image
+  extends: [.functional_tests_rules]
+  image: ${UTILITY_IMAGE}:${CI_PIPELINE_ID}
+  tags:
+    - arch/amd64
+    - env/prod
+    - origin/jet-fleet
+    - owner/jet-core
+    - purpose/utility
+    - team/megatron
+  timeout: 7 days
+  variables:
+    RO_API_TOKEN: $PAT
+  script:
+    - set -x
+    - |
+      WORKLOAD_LOCAL_IMAGE_PATH="${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH:-/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_mcore/mcore_ci/{build}-{platforms}-{container_tag}.sqsh}"
+      case "$SQSH_PLATFORM" in
+        dgx_a100)
+          SQSH_CLUSTER=$([[ "$CLUSTER_A100" != "" ]] && echo "$CLUSTER_A100" || echo "$DEFAULT_A100_CLUSTER")
+          SQSH_DEV_SCOPE="${FUNCTIONAL_TEST_SCOPE}"
+          SQSH_DEV_TEST_CASES="${FUNCTIONAL_TEST_CASES}"
+          ;;
+        dgx_h100)
+          SQSH_CLUSTER=$([[ "$CLUSTER_H100" != "" ]] && echo "$CLUSTER_H100" || echo "$DEFAULT_H100_CLUSTER")
+          SQSH_DEV_SCOPE="L0-smoke"
+          SQSH_DEV_TEST_CASES="all"
+          ;;
+        dgx_gb200)
+          SQSH_CLUSTER=$([[ "$CLUSTER_GB200" != "" ]] && echo "$CLUSTER_GB200" || echo "$DEFAULT_GB200_CLUSTER")
+          SQSH_DEV_SCOPE="L0-smoke"
+          SQSH_DEV_TEST_CASES="all"
+          ;;
+        *)
+          echo "Unknown SQSH_PLATFORM: $SQSH_PLATFORM"
+          exit 1
+          ;;
+      esac
+      echo "Preparing local SquashFS image(s) on ${SQSH_CLUSTER} for ${SQSH_PLATFORM}"
+    - export PYTHONPATH=$(pwd)
+    - |
+      python tests/test_utils/python_scripts/prepare_jet_sqsh_image.py \
+        --scope ${SQSH_DEV_SCOPE} \
+        --environment dev \
+        --test-cases "${SQSH_DEV_TEST_CASES}" \
+        --platform ${SQSH_PLATFORM} \
+        --cluster ${SQSH_CLUSTER} \
+        --container-tag ${CI_PIPELINE_ID} \
+        --workload-local-image-path "${WORKLOAD_LOCAL_IMAGE_PATH}" \
+        --account ${CI_SLURM_ACCOUNT}
+    - |
+      python tests/test_utils/python_scripts/prepare_jet_sqsh_image.py \
+        --scope ${FUNCTIONAL_TEST_SCOPE} \
+        --environment lts \
+        --test-cases "${FUNCTIONAL_TEST_CASES}" \
+        --platform ${SQSH_PLATFORM} \
+        --cluster ${SQSH_CLUSTER} \
+        --container-tag ${CI_PIPELINE_ID} \
+        --workload-local-image-path "${WORKLOAD_LOCAL_IMAGE_PATH}" \
+        --account ${CI_SLURM_ACCOUNT}
+
+functional:prepare_sqsh_image_a100:
+  extends: [.functional_prepare_sqsh]
+  variables:
+    SQSH_PLATFORM: dgx_a100
+
+functional:prepare_sqsh_image_h100:
+  extends: [.functional_prepare_sqsh]
+  variables:
+    SQSH_PLATFORM: dgx_h100
+
+functional:prepare_sqsh_image_gb200:
+  extends: [.functional_prepare_sqsh]
+  variables:
+    SQSH_PLATFORM: dgx_gb200
 
 # Prune artifacts older than 14 days from the JET assets/artifacts roots on
 # each cluster. Gated on release/weekly scope so it does not run on every MR
@@ -339,6 +434,7 @@ functional:run_lts_dgx_a100:
   needs:
     - functional:configure
     - test:build_image
+    - functional:prepare_sqsh_image_a100
     - job: functional:smoke-h100
       optional: true
     - job: functional:cleanup_dgx_a100
@@ -353,6 +449,7 @@ functional:run_lts_dgx_h100:
   needs:
     - functional:configure
     - test:build_image
+    - functional:prepare_sqsh_image_h100
     - job: functional:smoke-h100
       optional: true
     - job: functional:cleanup_dgx_h100
@@ -367,6 +464,7 @@ functional:run_lts_dgx_gb200:
   needs:
     - functional:configure
     - test:build_image
+    - functional:prepare_sqsh_image_gb200
     - job: functional:smoke-gb200
       optional: true
     - job: functional:cleanup_dgx_gb200
@@ -380,6 +478,7 @@ functional:run_dev_dgx_a100:
   needs:
     - functional:configure
     - test:build_image
+    - functional:prepare_sqsh_image_a100
     - job: functional:smoke-h100
       optional: true
     - job: functional:cleanup_dgx_a100
@@ -393,6 +492,7 @@ functional:run_dev_dgx_h100:
   needs:
     - functional:configure
     - test:build_image
+    - functional:prepare_sqsh_image_h100
     - job: functional:smoke-h100
       optional: true
     - job: functional:cleanup_dgx_h100
@@ -406,6 +506,7 @@ functional:run_dev_dgx_gb200:
   needs:
     - functional:configure
     - test:build_image
+    - functional:prepare_sqsh_image_gb200
     - job: functional:smoke-gb200
       optional: true
     - job: functional:cleanup_dgx_gb200

--- a/.gitlab/stages/04.functional-tests.yml
+++ b/.gitlab/stages/04.functional-tests.yml
@@ -66,7 +66,12 @@ functional:configure:
         RELEASE_ARGS=()
       fi
     - |
-      WORKLOAD_LOCAL_IMAGE_PATH="${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH:-/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_mcore/mcore_ci/{build}-{platforms}-{container_tag}.sqsh}"
+      DEFAULT_WORKLOAD_LOCAL_IMAGE_PATH='/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_mcore/mcore_ci/{build}-{platforms}-{container_tag}.sqsh'
+      if [[ -n "${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH:-}" ]]; then
+        WORKLOAD_LOCAL_IMAGE_PATH="${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH}"
+      else
+        WORKLOAD_LOCAL_IMAGE_PATH="${DEFAULT_WORKLOAD_LOCAL_IMAGE_PATH}"
+      fi
       LOCAL_WORKLOAD_IMAGE_ARGS=(
         "--workload-local-image-path ${WORKLOAD_LOCAL_IMAGE_PATH}"
         "--skip-local-image-prepare"
@@ -285,7 +290,12 @@ functional:smoke-gb200:
   script:
     - set -x
     - |
-      WORKLOAD_LOCAL_IMAGE_PATH="${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH:-/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_mcore/mcore_ci/{build}-{platforms}-{container_tag}.sqsh}"
+      DEFAULT_WORKLOAD_LOCAL_IMAGE_PATH='/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_mcore/mcore_ci/{build}-{platforms}-{container_tag}.sqsh'
+      if [[ -n "${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH:-}" ]]; then
+        WORKLOAD_LOCAL_IMAGE_PATH="${FUNCTIONAL_TEST_WORKLOAD_LOCAL_IMAGE_PATH}"
+      else
+        WORKLOAD_LOCAL_IMAGE_PATH="${DEFAULT_WORKLOAD_LOCAL_IMAGE_PATH}"
+      fi
       case "$SQSH_PLATFORM" in
         dgx_a100)
           SQSH_CLUSTER=$([[ "$CLUSTER_A100" != "" ]] && echo "$CLUSTER_A100" || echo "$DEFAULT_A100_CLUSTER")

--- a/tests/test_utils/python_scripts/generate_jet_trigger_job.py
+++ b/tests/test_utils/python_scripts/generate_jet_trigger_job.py
@@ -70,6 +70,15 @@ BASE_PATH = pathlib.Path(__file__).parent.resolve()
     help="Run one job as dependency to others as to warm up cache",
 )
 @click.option(
+    "--skip-local-image-prepare",
+    is_flag=True,
+    show_default=True,
+    required=False,
+    type=bool,
+    default=False,
+    help="Use workload-local-image-path without generating a child-pipeline prepare_sqsh_image job.",
+)
+@click.option(
     "--cadence",
     required=False,
     type=str,
@@ -100,6 +109,7 @@ def main(
     wandb_experiment: Optional[str] = None,
     enable_lightweight_mode: bool = False,
     enable_warmup: Optional[bool] = None,
+    skip_local_image_prepare: bool = False,
     cadence: Optional[str] = None,
 ):
     # Treat empty string as "no cadence filter" so callers can wire shell
@@ -161,7 +171,11 @@ def main(
 
     else:
         list_of_test_cases = sorted(list_of_test_cases, key=lambda x: x["spec"]["model"])
-        prepare_job_name = "prepare_sqsh_image" if workload_local_image_path is not None else None
+        prepare_job_name = (
+            "prepare_sqsh_image"
+            if workload_local_image_path is not None and not skip_local_image_prepare
+            else None
+        )
         model_stages = sorted(
             list(set([test_case["spec"]["model"] for test_case in list_of_test_cases]))
         )

--- a/tests/test_utils/python_scripts/generate_jet_trigger_job.py
+++ b/tests/test_utils/python_scripts/generate_jet_trigger_job.py
@@ -26,6 +26,15 @@ BASE_PATH = pathlib.Path(__file__).parent.resolve()
 @click.option("--container-image", required=True, type=str, help="LTS Container image to use")
 @click.option("--container-tag", required=True, type=str, help="Container tag to use")
 @click.option(
+    "--workload-local-image-path",
+    required=False,
+    type=str,
+    help=(
+        "Local SquashFS image path/template to use for JET basic workloads via "
+        "spec.image_source.local_path. Skips the JET build workload."
+    ),
+)
+@click.option(
     "--dependent-job",
     required=True,
     type=str,
@@ -82,6 +91,7 @@ def main(
     output_path: str,
     container_image: str,
     container_tag: str,
+    workload_local_image_path: Optional[str],
     dependent_job: str,
     record_checkpoints: str,
     slurm_account: str,
@@ -101,6 +111,7 @@ def main(
         for test_case in recipe_parser.load_workloads(
             scope=scope,
             container_tag=container_tag,
+            workload_local_image_path=workload_local_image_path,
             environment=environment,
             test_cases=test_cases,
             platform=platform,
@@ -150,11 +161,16 @@ def main(
 
     else:
         list_of_test_cases = sorted(list_of_test_cases, key=lambda x: x["spec"]["model"])
+        prepare_job_name = "prepare_sqsh_image" if workload_local_image_path is not None else None
+        model_stages = sorted(
+            list(set([test_case["spec"]["model"] for test_case in list_of_test_cases]))
+        )
+        stages = model_stages
+        if prepare_job_name is not None:
+            stages = ["prepare_sqsh"] + stages
 
         gitlab_pipeline = {
-            "stages": sorted(
-                list(set([test_case["spec"]["model"] for test_case in list_of_test_cases]))
-            ),
+            "stages": stages,
             "workflow": {
                 "rules": [
                     {
@@ -171,6 +187,51 @@ def main(
                 "retry": {"max": 2, "when": "runner_system_failure"},
             },
         }
+
+        if prepare_job_name is not None:
+            prepare_cluster = recipe_parser.resolve_local_image_prepare_cluster(cluster)
+            prepare_tags = list(tags)
+            prepare_tags.append(f"cluster/{recipe_parser.resolve_cluster_config(prepare_cluster)}")
+            prepare_script = [
+                "export PYTHONPATH=$(pwd); "
+                "python tests/test_utils/python_scripts/prepare_jet_sqsh_image.py",
+                f"--scope {scope}",
+                f"--environment {environment}",
+                f"--test-cases '{test_cases}'",
+                f"--platform {platform}",
+                f"--cluster {cluster}",
+                f"--container-tag {container_tag}",
+                f"--workload-local-image-path '{workload_local_image_path}'",
+                f"--account {slurm_account}",
+                "--time-limit 1800",
+            ]
+
+            if tag is not None:
+                prepare_script.append(f"--tag {tag}")
+
+            if partition is not None and prepare_cluster == cluster:
+                prepare_script.append(f"--partition {partition}")
+
+            if cadence_arg is not None:
+                prepare_script.append(f"--cadence {cadence_arg}")
+
+            gitlab_pipeline[prepare_job_name] = {
+                "stage": "prepare_sqsh",
+                "image": f"{container_image}:{container_tag}",
+                "tags": prepare_tags,
+                "timeout": "7 days",
+                "needs": [{"pipeline": '$PARENT_PIPELINE_ID', "job": dependent_job}],
+                "script": [" ".join(prepare_script)],
+                "artifacts": {"paths": ["results/"], "when": "always"},
+                "retry": {
+                    "max": 2,
+                    "when": [
+                        "unknown_failure",
+                        "stuck_or_timeout_failure",
+                        "runner_system_failure",
+                    ],
+                },
+            }
 
         warmup_job = ""
 
@@ -194,6 +255,9 @@ def main(
                 f"--account {slurm_account}",
             ]
 
+            if workload_local_image_path is not None:
+                script.append(f"--workload-local-image-path '{workload_local_image_path}'")
+
             if partition is not None:
                 script.append(f"--partition {partition}")
 
@@ -210,6 +274,9 @@ def main(
                 )
 
             needs = [{"pipeline": '$PARENT_PIPELINE_ID', "job": dependent_job}]
+
+            if prepare_job_name is not None:
+                needs.append({"job": prepare_job_name})
 
             if enable_warmup:
                 if test_idx == 0:

--- a/tests/test_utils/python_scripts/launch_jet_workload.py
+++ b/tests/test_utils/python_scripts/launch_jet_workload.py
@@ -652,10 +652,11 @@ def main(
                 )
                 sys.exit(int(not success))  # invert for exit 0
 
-            if parse_failed_job(logs=mainrank_log):
+            if not success or parse_failed_job(logs=mainrank_log):
+                logger.error("Release pipeline finished with status %s, retrying.", status.name)
                 send_slack_alert(
                     test_case=test_case,
-                    context="pipeline failed, retrying",
+                    context=f"pipeline finished with status {status.name}, retrying",
                     n_iteration=n_iteration,
                     n_attempts=n_attempts,
                 )

--- a/tests/test_utils/python_scripts/launch_jet_workload.py
+++ b/tests/test_utils/python_scripts/launch_jet_workload.py
@@ -172,6 +172,7 @@ def launch_and_wait_for_completion(
     run_name: Optional[str],
     wandb_experiment: Optional[str],
     enable_lightweight_mode: bool,
+    workload_local_image_path: Optional[str],
 ) -> jetclient.JETPipeline:
     cluster_config = {"account": account}
     if partition is not None:
@@ -193,6 +194,7 @@ def launch_and_wait_for_completion(
                         scope=scope,
                         container_image=container_image,
                         container_tag=container_tag,
+                        workload_local_image_path=workload_local_image_path,
                         platform=platform,
                         environment=environment,
                         record_checkpoints=record_checkpoints,
@@ -227,6 +229,9 @@ def launch_and_wait_for_completion(
                                         "CLUSTER": cluster,
                                         "RUN_ID": str(uuid.uuid4()),
                                         "CLEANUP_PATHS": os.getenv("CLEANUP_PATHS") or "",
+                                        "MCORE_WORKLOAD_LOCAL_IMAGE_PATH": (
+                                            workload_local_image_path or ""
+                                        ),
                                     }
                                 }
                             }
@@ -438,6 +443,16 @@ def is_flaky_failure(concat_allranks_logs: str) -> bool:
 @click.option("--platform", required=True, type=str, help="Platform to select")
 @click.option("--container-tag", required=True, type=str, help="Base image of Mcore image")
 @click.option("--container-image", required=False, type=str, help="Base image of Mcore image")
+@click.option(
+    "--workload-local-image-path",
+    required=False,
+    type=str,
+    help=(
+        "Local SquashFS image path/template to use via JET spec.image_source.local_path. "
+        "Skips the JET build workload. Template fields can reference workload spec fields "
+        "and {container_tag}."
+    ),
+)
 @click.option("--tag", required=False, type=str, help="Tag (only relevant for unit tests)")
 @click.option("--record-checkpoints", required=False, type=str, help="Values are 'true' or 'false'")
 @click.option(
@@ -473,6 +488,7 @@ def main(
     record_checkpoints: str,
     tag: Optional[str] = None,
     container_image: Optional[str] = None,
+    workload_local_image_path: Optional[str] = None,
     run_name: Optional[str] = None,
     wandb_experiment: Optional[str] = None,
     enable_lightweight_mode: bool = False,
@@ -529,6 +545,7 @@ def main(
             wandb_experiment=wandb_experiment,
             record_checkpoints=record_checkpoints,
             enable_lightweight_mode=enable_lightweight_mode,
+            workload_local_image_path=workload_local_image_path,
         )
 
         n_download_attempt = 0

--- a/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
+++ b/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
@@ -23,14 +23,18 @@ def _local_image_workload_name(source_image: str, local_path: str) -> str:
     return f"prepare-sqsh-{digest}"
 
 
-def build_prepare_workload(source_image: str, local_path: str, time_limit: int) -> Dict:
+def build_prepare_workload(
+    build: str, source_image: str, local_path: str, time_limit: int
+) -> Dict:
+    workload_name = _local_image_workload_name(source_image=source_image, local_path=local_path)
     return {
         "type": "basic",
         "format_version": 1,
         "maintainers": ["mcore"],
         "loggers": ["stdout"],
         "spec": {
-            "name": _local_image_workload_name(source_image=source_image, local_path=local_path),
+            "name": workload_name,
+            "build": build,
             "image_source": {"image_tag": source_image},
             "nodes": 1,
             "gpus": 0,
@@ -47,6 +51,7 @@ def build_prepare_workload(source_image: str, local_path: str, time_limit: int) 
 
 
 def submit_prepare_workload(
+    build: str,
     source_image: str,
     local_path: str,
     cluster: str,
@@ -67,7 +72,10 @@ def submit_prepare_workload(
                 workloads=[
                     jetclient.JETWorkloadManifest(
                         **build_prepare_workload(
-                            source_image=source_image, local_path=local_path, time_limit=time_limit
+                            build=build,
+                            source_image=source_image,
+                            local_path=local_path,
+                            time_limit=time_limit,
                         )
                     )
                 ],
@@ -111,6 +119,7 @@ def submit_prepare_workload(
 
 
 def prepare_local_image(
+    build: str,
     source_image: str,
     local_path: str,
     cluster: str,
@@ -120,6 +129,7 @@ def prepare_local_image(
 ) -> bool:
     logger.info("Preparing %s from %s on %s", local_path, source_image, cluster)
     pipeline = submit_prepare_workload(
+        build=build,
         source_image=source_image,
         local_path=local_path,
         cluster=cluster,
@@ -225,6 +235,7 @@ def main(
     )
     for image_source in local_image_sources:
         success = prepare_local_image(
+            build=image_source.build,
             source_image=image_source.source_image,
             local_path=image_source.local_path,
             cluster=prepare_cluster,

--- a/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
+++ b/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
@@ -24,9 +24,7 @@ def _local_image_workload_name(source_image: str, local_path: str) -> str:
     return f"prepare-sqsh-{digest}"
 
 
-def build_prepare_workload(
-    build: str, source_image: str, local_path: str, time_limit: int
-) -> Dict:
+def build_prepare_workload(source_image: str, local_path: str, time_limit: int) -> Dict:
     workload_name = _local_image_workload_name(source_image=source_image, local_path=local_path)
     return {
         "type": "basic",
@@ -35,7 +33,6 @@ def build_prepare_workload(
         "loggers": ["stdout"],
         "spec": {
             "name": workload_name,
-            "build": build,
             "image_source": {"image_tag": source_image},
             "nodes": 1,
             "gpus": 0,
@@ -52,7 +49,6 @@ def build_prepare_workload(
 
 
 def submit_prepare_workload(
-    build: str,
     source_image: str,
     local_path: str,
     cluster: str,
@@ -74,13 +70,10 @@ def submit_prepare_workload(
                 customer="mcore", gitlab_ci_token=os.getenv("RO_API_TOKEN"), env="prod"
             ).workloads.submit(
                 workloads=[
-                    jetclient.JETWorkloadManifest(
-                        **build_prepare_workload(
-                            build=build,
-                            source_image=source_image,
-                            local_path=local_path,
-                            time_limit=time_limit,
-                        )
+                    build_prepare_workload(
+                        source_image=source_image,
+                        local_path=local_path,
+                        time_limit=time_limit,
                     )
                 ],
                 config_id=f"mcore/{recipe_parser.resolve_cluster_config(cluster)}",
@@ -145,7 +138,6 @@ def prepare_local_image(
 
     logger.info("Preparing %s for %s from %s on %s", local_path, build, source_image, cluster)
     pipeline = submit_prepare_workload(
-        build=build,
         source_image=source_image,
         local_path=local_path,
         cluster=cluster,

--- a/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
+++ b/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
@@ -5,13 +5,14 @@ import logging
 import os
 import sys
 import time
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import click
-import jetclient
-from jetclient.services.dtos.pipeline import PipelineStatus
 
-from tests.test_utils.python_scripts import launch_jet_workload, recipe_parser
+try:
+    from tests.test_utils.python_scripts import recipe_parser
+except ModuleNotFoundError:
+    import recipe_parser
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -23,9 +24,7 @@ def _local_image_workload_name(source_image: str, local_path: str) -> str:
     return f"prepare-sqsh-{digest}"
 
 
-def build_prepare_workload(
-    build: str, source_image: str, local_path: str, time_limit: int
-) -> Dict:
+def build_prepare_workload(source_image: str, local_path: str, time_limit: int) -> Dict:
     workload_name = _local_image_workload_name(source_image=source_image, local_path=local_path)
     return {
         "type": "basic",
@@ -34,7 +33,6 @@ def build_prepare_workload(
         "loggers": ["stdout"],
         "spec": {
             "name": workload_name,
-            "build": build,
             "image_source": {"image_tag": source_image},
             "nodes": 1,
             "gpus": 0,
@@ -51,14 +49,16 @@ def build_prepare_workload(
 
 
 def submit_prepare_workload(
-    build: str,
     source_image: str,
     local_path: str,
     cluster: str,
     account: str,
     partition: Optional[str],
     time_limit: int,
-) -> jetclient.JETPipeline:
+) -> Any:
+    import jetclient
+    from jetclient.services.dtos.pipeline import PipelineStatus
+
     cluster_config = {"account": account, "srun_additional_flags": {"container_save": local_path}}
     if partition is not None:
         cluster_config["partition"] = partition
@@ -72,7 +72,6 @@ def submit_prepare_workload(
                 workloads=[
                     jetclient.JETWorkloadManifest(
                         **build_prepare_workload(
-                            build=build,
                             source_image=source_image,
                             local_path=local_path,
                             time_limit=time_limit,
@@ -109,7 +108,11 @@ def submit_prepare_workload(
 
         if pipeline.get_status() == PipelineStatus.SUBMISSION_FAILED:
             n_submission_attempts += 1
-            logger.info("Submission failed, attempt again (%s/3)", str(n_submission_attempts))
+            logger.info(
+                "Submission failed for pipeline %s, attempt again (%s/3)",
+                pipeline.jet_id,
+                str(n_submission_attempts),
+            )
             continue
 
         return pipeline
@@ -127,9 +130,16 @@ def prepare_local_image(
     partition: Optional[str],
     time_limit: int,
 ) -> bool:
-    logger.info("Preparing %s from %s on %s", local_path, source_image, cluster)
+    import jetclient
+    from jetclient.services.dtos.pipeline import PipelineStatus
+
+    try:
+        from tests.test_utils.python_scripts import launch_jet_workload
+    except ModuleNotFoundError:
+        import launch_jet_workload
+
+    logger.info("Preparing %s for %s from %s on %s", local_path, build, source_image, cluster)
     pipeline = submit_prepare_workload(
-        build=build,
         source_image=source_image,
         local_path=local_path,
         cluster=cluster,

--- a/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
+++ b/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
@@ -54,10 +54,7 @@ def submit_prepare_workload(
     partition: Optional[str],
     time_limit: int,
 ) -> jetclient.JETPipeline:
-    cluster_config = {
-        "account": account,
-        "srun_additional_flags": {"container_save": local_path},
-    }
+    cluster_config = {"account": account, "srun_additional_flags": {"container_save": local_path}}
     if partition is not None:
         cluster_config["partition"] = partition
 
@@ -70,9 +67,7 @@ def submit_prepare_workload(
                 workloads=[
                     jetclient.JETWorkloadManifest(
                         **build_prepare_workload(
-                            source_image=source_image,
-                            local_path=local_path,
-                            time_limit=time_limit,
+                            source_image=source_image, local_path=local_path, time_limit=time_limit
                         )
                     )
                 ],

--- a/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
+++ b/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
@@ -24,7 +24,9 @@ def _local_image_workload_name(source_image: str, local_path: str) -> str:
     return f"prepare-sqsh-{digest}"
 
 
-def build_prepare_workload(source_image: str, local_path: str, time_limit: int) -> Dict:
+def build_prepare_workload(
+    build: str, source_image: str, local_path: str, time_limit: int
+) -> Dict:
     workload_name = _local_image_workload_name(source_image=source_image, local_path=local_path)
     return {
         "type": "basic",
@@ -33,6 +35,7 @@ def build_prepare_workload(source_image: str, local_path: str, time_limit: int) 
         "loggers": ["stdout"],
         "spec": {
             "name": workload_name,
+            "build": build,
             "image_source": {"image_tag": source_image},
             "nodes": 1,
             "gpus": 0,
@@ -49,6 +52,7 @@ def build_prepare_workload(source_image: str, local_path: str, time_limit: int) 
 
 
 def submit_prepare_workload(
+    build: str,
     source_image: str,
     local_path: str,
     cluster: str,
@@ -72,6 +76,7 @@ def submit_prepare_workload(
                 workloads=[
                     jetclient.JETWorkloadManifest(
                         **build_prepare_workload(
+                            build=build,
                             source_image=source_image,
                             local_path=local_path,
                             time_limit=time_limit,
@@ -140,6 +145,7 @@ def prepare_local_image(
 
     logger.info("Preparing %s for %s from %s on %s", local_path, build, source_image, cluster)
     pipeline = submit_prepare_workload(
+        build=build,
         source_image=source_image,
         local_path=local_path,
         cluster=cluster,

--- a/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
+++ b/tests/test_utils/python_scripts/prepare_jet_sqsh_image.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import hashlib
+import logging
+import os
+import sys
+import time
+from typing import Dict, List, Optional
+
+import click
+import jetclient
+from jetclient.services.dtos.pipeline import PipelineStatus
+
+from tests.test_utils.python_scripts import launch_jet_workload, recipe_parser
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def _local_image_workload_name(source_image: str, local_path: str) -> str:
+    digest = hashlib.sha1(f"{source_image}\n{local_path}".encode()).hexdigest()[:12]
+    return f"prepare-sqsh-{digest}"
+
+
+def build_prepare_workload(source_image: str, local_path: str, time_limit: int) -> Dict:
+    return {
+        "type": "basic",
+        "format_version": 1,
+        "maintainers": ["mcore"],
+        "loggers": ["stdout"],
+        "spec": {
+            "name": _local_image_workload_name(source_image=source_image, local_path=local_path),
+            "image_source": {"image_tag": source_image},
+            "nodes": 1,
+            "gpus": 0,
+            "time_limit": time_limit,
+            "script": "\n".join(
+                [
+                    "set -euo pipefail",
+                    "echo 'Creating a local SquashFS image with Pyxis --container-save'",
+                    "true",
+                ]
+            ),
+        },
+    }
+
+
+def submit_prepare_workload(
+    source_image: str,
+    local_path: str,
+    cluster: str,
+    account: str,
+    partition: Optional[str],
+    time_limit: int,
+) -> jetclient.JETPipeline:
+    cluster_config = {
+        "account": account,
+        "srun_additional_flags": {"container_save": local_path},
+    }
+    if partition is not None:
+        cluster_config["partition"] = partition
+
+    n_submission_attempts = 0
+    while n_submission_attempts < 3:
+        try:
+            pipeline = jetclient.JETClient(
+                customer="mcore", gitlab_ci_token=os.getenv("RO_API_TOKEN"), env="prod"
+            ).workloads.submit(
+                workloads=[
+                    jetclient.JETWorkloadManifest(
+                        **build_prepare_workload(
+                            source_image=source_image,
+                            local_path=local_path,
+                            time_limit=time_limit,
+                        )
+                    )
+                ],
+                config_id=f"mcore/{recipe_parser.resolve_cluster_config(cluster)}",
+                custom_config={
+                    "launchers": {cluster: cluster_config},
+                    "executors": {
+                        "jet-ci": {
+                            "environments": {
+                                cluster: {
+                                    "variables": {
+                                        "PYTHONUNBUFFERED": "1",
+                                        "RO_API_TOKEN": os.getenv("RO_API_TOKEN") or "",
+                                    }
+                                }
+                            }
+                        }
+                    },
+                },
+                wait_for_validation=True,
+                max_wait_time=60 * 60,
+            )
+        except (
+            jetclient.clients.gitlab.GitlabAPIError,
+            jetclient.facades.objects.util.WaitTimeExceeded,
+        ) as e:
+            logger.error("Faced %s. Waiting and retrying...", str(e))
+            n_submission_attempts += 1
+            time.sleep(2**n_submission_attempts * 5)
+            continue
+
+        if pipeline.get_status() == PipelineStatus.SUBMISSION_FAILED:
+            n_submission_attempts += 1
+            logger.info("Submission failed, attempt again (%s/3)", str(n_submission_attempts))
+            continue
+
+        return pipeline
+
+    logger.error("Failed to submit local SquashFS image prepare workload after 3 attempts")
+    sys.exit(1)
+
+
+def prepare_local_image(
+    source_image: str,
+    local_path: str,
+    cluster: str,
+    account: str,
+    partition: Optional[str],
+    time_limit: int,
+) -> bool:
+    logger.info("Preparing %s from %s on %s", local_path, source_image, cluster)
+    pipeline = submit_prepare_workload(
+        source_image=source_image,
+        local_path=local_path,
+        cluster=cluster,
+        account=account,
+        partition=partition,
+        time_limit=time_limit,
+    )
+
+    launch_jet_workload.register_pipeline_terminator(pipeline=pipeline)
+    logger.info(
+        "Pipeline triggered; inspect it here: https://gitlab-master.nvidia.com/dl/jet/ci/-/pipelines/%s",
+        pipeline.jet_id,
+    )
+
+    try:
+        status = launch_jet_workload.wait_for_pipeline_completion(
+            pipeline=pipeline, max_wait_time=time_limit + 60 * 30, interval=30
+        )
+    except jetclient.facades.objects.util.WaitTimeExceeded:
+        logger.error("Pipeline %s exceeded the wall-clock budget; cancelling.", pipeline.jet_id)
+        try:
+            pipeline.cancel()
+        except jetclient.clients.gitlab.GitlabAPIError:
+            logger.exception("Failed to cancel pipeline %s", pipeline.jet_id)
+        return False
+
+    logger.info("Pipeline terminated; status: %s", status)
+    return status == PipelineStatus.SUCCESS
+
+
+@click.command()
+@click.option("--scope", required=True, type=str, help="Test scope")
+@click.option("--environment", required=True, type=str, help="LTS or dev features")
+@click.option(
+    "--test-cases", required=True, type=str, help="Comma-separated list of test_cases, or 'all'"
+)
+@click.option("--platform", required=True, type=str, help="Platform to select")
+@click.option("--cluster", required=True, type=str, help="Cluster to run on")
+@click.option("--container-tag", required=True, type=str, help="Container tag to use")
+@click.option(
+    "--workload-local-image-path",
+    required=True,
+    type=str,
+    help="Local SquashFS image path/template to create for JET basic workloads.",
+)
+@click.option(
+    "--account",
+    required=False,
+    type=str,
+    help="Slurm account to use",
+    default="coreai_dlalgo_mcore",
+)
+@click.option("--partition", required=False, type=str, help="Slurm partition to use", default=None)
+@click.option("--tag", required=False, type=str, help="Tag (only relevant for unit tests)")
+@click.option(
+    "--cadence",
+    required=False,
+    type=str,
+    default=None,
+    help="Trigger cadence to filter tests by (pr|nightly|mergegroup).",
+)
+@click.option(
+    "--time-limit",
+    required=False,
+    default=1800,
+    type=int,
+    help="Slurm time limit in seconds for the image prepare workload.",
+)
+def main(
+    scope: str,
+    environment: str,
+    test_cases: str,
+    platform: str,
+    cluster: str,
+    container_tag: str,
+    workload_local_image_path: str,
+    account: str,
+    partition: Optional[str],
+    tag: Optional[str] = None,
+    cadence: Optional[str] = None,
+    time_limit: int = 1800,
+):
+    prepare_cluster = recipe_parser.resolve_local_image_prepare_cluster(cluster)
+    local_image_sources: List[recipe_parser.dotdict] = (
+        recipe_parser.resolve_workload_local_image_sources(
+            container_tag=container_tag,
+            tag=tag,
+            environment=environment,
+            platform=platform,
+            test_cases=test_cases,
+            scope=scope,
+            workload_local_image_path=workload_local_image_path,
+            cadence=cadence or None,
+        )
+    )
+
+    if not local_image_sources:
+        logger.info("No local SquashFS images to prepare.")
+        return
+
+    logger.info(
+        "Preparing %s local SquashFS image(s) on %s", len(local_image_sources), prepare_cluster
+    )
+    for image_source in local_image_sources:
+        success = prepare_local_image(
+            source_image=image_source.source_image,
+            local_path=image_source.local_path,
+            cluster=prepare_cluster,
+            account=account,
+            partition=partition,
+            time_limit=time_limit,
+        )
+        if not success:
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_utils/python_scripts/recipe_parser.py
+++ b/tests/test_utils/python_scripts/recipe_parser.py
@@ -391,7 +391,6 @@ def _apply_local_image_source(
         return
 
     local_path = _format_image_source_value(workload_local_image_path, workload, container_tag)
-    workload.spec.pop("build", None)
     workload.spec["image_source"] = {"local_path": local_path}
 
 

--- a/tests/test_utils/python_scripts/recipe_parser.py
+++ b/tests/test_utils/python_scripts/recipe_parser.py
@@ -116,6 +116,17 @@ def resolve_cluster_config(cluster: str) -> str:
     raise ValueError(f"Unknown cluster {cluster} provided.")
 
 
+def resolve_local_image_prepare_cluster(cluster: str) -> str:
+    """Pick a same-site CPU cluster to create a local SquashFS image when possible."""
+    prepare_clusters = {
+        "dgxh100_eos": "cpu_eos",
+        "dgxh100_coreweave": "cpu_coreweave",
+        "dgxa100_dracooci": "cpu_dracooci",
+        "dgxgb200_oci-hsg": "cpu_oci-hsg",
+    }
+    return prepare_clusters.get(cluster, cluster)
+
+
 def flatten_products(workload_manifest: dotdict) -> dotdict:
     """Flattens a nested dict of products"""
     flattened_products = []
@@ -360,6 +371,89 @@ def filter_by_test_cases(workload_manifests: List[dotdict], test_cases: str) -> 
     return workload_manifests
 
 
+def _format_image_source_value(template: str, workload: dotdict, container_tag: str) -> str:
+    format_values = dict(workload.spec)
+    format_values["container_tag"] = container_tag
+    try:
+        return template.format(**format_values)
+    except KeyError as exc:
+        missing_key = exc.args[0]
+        raise ValueError(
+            f"Unknown image source template field {missing_key!r} in {template!r}. "
+            f"Available fields: {sorted(format_values)}"
+        ) from exc
+
+
+def _apply_local_image_source(
+    workload: dotdict, container_tag: str, workload_local_image_path: Optional[str]
+) -> None:
+    if workload_local_image_path is None:
+        return
+
+    local_path = _format_image_source_value(workload_local_image_path, workload, container_tag)
+    workload.spec.pop("build", None)
+    workload.spec["image_source"] = {"local_path": local_path}
+
+
+def resolve_workload_local_image_sources(
+    container_tag: str,
+    workload_local_image_path: str,
+    tag: Optional[str] = None,
+    environment: Optional[str] = None,
+    platform: Optional[str] = None,
+    test_cases: str = "all",
+    scope: Optional[str] = None,
+    model: Optional[str] = None,
+    test_case: Optional[str] = None,
+    container_image: Optional[str] = None,
+    cadence: Optional[str] = None,
+) -> List[dotdict]:
+    """Resolve source Docker images and destination SquashFS paths for selected workloads."""
+    workloads = load_workloads(
+        container_tag=container_tag,
+        tag=tag,
+        environment=environment,
+        platform=platform,
+        test_cases=test_cases,
+        scope=scope,
+        model=model,
+        test_case=test_case,
+        container_image=container_image,
+        cadence=cadence,
+    )
+    build_workloads = {
+        workload.spec["name"]: workload for workload in workloads if workload.type == "build"
+    }
+
+    local_image_sources: List[dotdict] = []
+    seen = set()
+    for workload in workloads:
+        if workload.type == "build":
+            continue
+
+        build_name = workload.spec["build"]
+        if build_name not in build_workloads:
+            raise ValueError(f"Build workload {build_name!r} was not loaded for {workload.spec}")
+
+        local_path = _format_image_source_value(workload_local_image_path, workload, container_tag)
+        source_image = build_workloads[build_name].spec["source"]["image"]
+        source_key = (source_image, local_path)
+        if source_key in seen:
+            continue
+
+        seen.add(source_key)
+        local_image_sources.append(
+            dotdict(
+                build=build_name,
+                source_image=source_image,
+                local_path=local_path,
+                workload=workload.spec["name"],
+            )
+        )
+
+    return local_image_sources
+
+
 def load_workloads(
     container_tag: str,
     n_repeat: int = 1,
@@ -372,6 +466,7 @@ def load_workloads(
     model: Optional[str] = None,
     test_case: Optional[str] = None,
     container_image: Optional[str] = None,
+    workload_local_image_path: Optional[str] = None,
     record_checkpoints: Optional[str] = None,
     cadence: Optional[str] = None,
 ) -> List[dotdict]:
@@ -415,13 +510,20 @@ def load_workloads(
         return []
 
     for workload in list(workloads):
-        for build_workload in build_workloads:
-            if (
-                workload.spec["build"] == build_workload.spec["name"]
-            ) and build_workload not in workloads:
-                container_image = container_image or build_workload.spec["source"]["image"]
-                build_workload.spec["source"]["image"] = f"{container_image}:{container_tag}"
-                workloads.append(build_workload)
+        if workload_local_image_path is not None:
+            _apply_local_image_source(
+                workload=workload,
+                container_tag=container_tag,
+                workload_local_image_path=workload_local_image_path,
+            )
+        else:
+            for build_workload in build_workloads:
+                if (
+                    workload.spec["build"] == build_workload.spec["name"]
+                ) and build_workload not in workloads:
+                    container_image = container_image or build_workload.spec["source"]["image"]
+                    build_workload.spec["source"]["image"] = f"{container_image}:{container_tag}"
+                    workloads.append(build_workload)
 
         workload.spec["n_repeat"] = n_repeat
         workload.spec["time_limit"] = time_limit

--- a/tests/test_utils/python_scripts/recipe_parser.py
+++ b/tests/test_utils/python_scripts/recipe_parser.py
@@ -392,6 +392,7 @@ def _apply_local_image_source(
 
     local_path = _format_image_source_value(workload_local_image_path, workload, container_tag)
     workload.spec["image_source"] = {"local_path": local_path}
+    workload.spec.pop("build", None)
 
 
 def resolve_workload_local_image_sources(

--- a/tests/test_utils/python_scripts/test_recipe_parser.py
+++ b/tests/test_utils/python_scripts/test_recipe_parser.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import prepare_jet_sqsh_image
 import recipe_parser
 
 SMOKE_TEST_CASE = "gpt3_mcore_te_tp1_pp1_te_4experts_groupedGEMM_op_fuser"
@@ -64,3 +65,17 @@ def test_resolve_local_image_prepare_cluster_uses_same_site_cpu_cluster():
     assert recipe_parser.resolve_local_image_prepare_cluster("dgxh100_coreweave") == "cpu_coreweave"
     assert recipe_parser.resolve_local_image_prepare_cluster("dgxgb200_oci-hsg") == "cpu_oci-hsg"
     assert recipe_parser.resolve_local_image_prepare_cluster("cpu_coreweave") == "cpu_coreweave"
+
+
+def test_prepare_workload_uses_image_source_without_build():
+    workload = prepare_jet_sqsh_image.build_prepare_workload(
+        source_image="gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345",
+        local_path="/lustre/enroot/mcore-pyt-dev-dgx_h100-12345.sqsh",
+        time_limit=1800,
+    )
+
+    spec = workload["spec"]
+    assert "build" not in spec
+    assert spec["image_source"] == {
+        "image_tag": "gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345"
+    }

--- a/tests/test_utils/python_scripts/test_recipe_parser.py
+++ b/tests/test_utils/python_scripts/test_recipe_parser.py
@@ -41,7 +41,7 @@ def test_load_workloads_uses_local_image_source_without_build_workload():
 
     assert len(basic_workloads) == 1
     assert all(workload.type != "build" for workload in workloads)
-    assert basic_workloads[0].spec["build"] == "mcore-pyt-dev"
+    assert "build" not in basic_workloads[0].spec
     assert basic_workloads[0].spec["image_source"] == {
         "local_path": "/lustre/enroot/mcore-pyt-dev-dgx_h100-12345.sqsh"
     }

--- a/tests/test_utils/python_scripts/test_recipe_parser.py
+++ b/tests/test_utils/python_scripts/test_recipe_parser.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import recipe_parser
+
+SMOKE_TEST_CASE = "gpt3_mcore_te_tp1_pp1_te_4experts_groupedGEMM_op_fuser"
+
+
+def _load_smoke_workloads(**kwargs):
+    return recipe_parser.load_workloads(
+        container_tag="12345",
+        environment="dev",
+        platform="dgx_h100",
+        scope="L0-smoke",
+        test_case=SMOKE_TEST_CASE,
+        **kwargs,
+    )
+
+
+def test_load_workloads_keeps_build_dependency_by_default():
+    workloads = _load_smoke_workloads()
+
+    basic_workloads = [workload for workload in workloads if workload.type == "basic"]
+    build_workloads = [workload for workload in workloads if workload.type == "build"]
+
+    assert len(basic_workloads) == 1
+    assert len(build_workloads) == 1
+    assert basic_workloads[0].spec["build"] == "mcore-pyt-dev"
+    assert build_workloads[0].spec["source"]["image"].endswith(":12345")
+
+
+def test_load_workloads_uses_local_image_source_without_build_dependency():
+    workloads = _load_smoke_workloads(
+        workload_local_image_path="/lustre/enroot/{build}-{platforms}-{container_tag}.sqsh"
+    )
+
+    basic_workloads = [workload for workload in workloads if workload.type == "basic"]
+
+    assert len(basic_workloads) == 1
+    assert all(workload.type != "build" for workload in workloads)
+    assert "build" not in basic_workloads[0].spec
+    assert basic_workloads[0].spec["image_source"] == {
+        "local_path": "/lustre/enroot/mcore-pyt-dev-dgx_h100-12345.sqsh"
+    }
+
+
+def test_resolve_workload_local_image_sources_uses_build_source_image():
+    sources = recipe_parser.resolve_workload_local_image_sources(
+        container_tag="12345",
+        environment="dev",
+        platform="dgx_h100",
+        scope="L0-smoke",
+        test_case=SMOKE_TEST_CASE,
+        workload_local_image_path="/lustre/enroot/{build}-{platforms}-{container_tag}.sqsh",
+    )
+
+    assert len(sources) == 1
+    assert sources[0].build == "mcore-pyt-dev"
+    assert (
+        sources[0].source_image
+        == "gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345"
+    )
+    assert sources[0].local_path == "/lustre/enroot/mcore-pyt-dev-dgx_h100-12345.sqsh"
+
+
+def test_resolve_local_image_prepare_cluster_uses_same_site_cpu_cluster():
+    assert recipe_parser.resolve_local_image_prepare_cluster("dgxh100_coreweave") == "cpu_coreweave"
+    assert recipe_parser.resolve_local_image_prepare_cluster("cpu_coreweave") == "cpu_coreweave"

--- a/tests/test_utils/python_scripts/test_recipe_parser.py
+++ b/tests/test_utils/python_scripts/test_recipe_parser.py
@@ -55,10 +55,7 @@ def test_resolve_workload_local_image_sources_uses_build_source_image():
 
     assert len(sources) == 1
     assert sources[0].build == "mcore-pyt-dev"
-    assert (
-        sources[0].source_image
-        == "gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345"
-    )
+    assert sources[0].source_image == "gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345"
     assert sources[0].local_path == "/lustre/enroot/mcore-pyt-dev-dgx_h100-12345.sqsh"
 
 

--- a/tests/test_utils/python_scripts/test_recipe_parser.py
+++ b/tests/test_utils/python_scripts/test_recipe_parser.py
@@ -67,15 +67,16 @@ def test_resolve_local_image_prepare_cluster_uses_same_site_cpu_cluster():
     assert recipe_parser.resolve_local_image_prepare_cluster("cpu_coreweave") == "cpu_coreweave"
 
 
-def test_prepare_workload_uses_image_source_without_build():
+def test_prepare_workload_uses_build_and_image_source():
     workload = prepare_jet_sqsh_image.build_prepare_workload(
+        build="mcore-pyt-dev",
         source_image="gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345",
         local_path="/lustre/enroot/mcore-pyt-dev-dgx_h100-12345.sqsh",
         time_limit=1800,
     )
 
     spec = workload["spec"]
-    assert "build" not in spec
+    assert spec["build"] == "mcore-pyt-dev"
     assert spec["image_source"] == {
         "image_tag": "gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345"
     }

--- a/tests/test_utils/python_scripts/test_recipe_parser.py
+++ b/tests/test_utils/python_scripts/test_recipe_parser.py
@@ -28,7 +28,7 @@ def test_load_workloads_keeps_build_dependency_by_default():
     assert build_workloads[0].spec["source"]["image"].endswith(":12345")
 
 
-def test_load_workloads_uses_local_image_source_without_build_dependency():
+def test_load_workloads_uses_local_image_source_without_build_workload():
     workloads = _load_smoke_workloads(
         workload_local_image_path="/lustre/enroot/{build}-{platforms}-{container_tag}.sqsh"
     )
@@ -37,7 +37,7 @@ def test_load_workloads_uses_local_image_source_without_build_dependency():
 
     assert len(basic_workloads) == 1
     assert all(workload.type != "build" for workload in workloads)
-    assert "build" not in basic_workloads[0].spec
+    assert basic_workloads[0].spec["build"] == "mcore-pyt-dev"
     assert basic_workloads[0].spec["image_source"] == {
         "local_path": "/lustre/enroot/mcore-pyt-dev-dgx_h100-12345.sqsh"
     }

--- a/tests/test_utils/python_scripts/test_recipe_parser.py
+++ b/tests/test_utils/python_scripts/test_recipe_parser.py
@@ -60,5 +60,7 @@ def test_resolve_workload_local_image_sources_uses_build_source_image():
 
 
 def test_resolve_local_image_prepare_cluster_uses_same_site_cpu_cluster():
+    assert recipe_parser.resolve_local_image_prepare_cluster("dgxa100_dracooci") == "cpu_dracooci"
     assert recipe_parser.resolve_local_image_prepare_cluster("dgxh100_coreweave") == "cpu_coreweave"
+    assert recipe_parser.resolve_local_image_prepare_cluster("dgxgb200_oci-hsg") == "cpu_oci-hsg"
     assert recipe_parser.resolve_local_image_prepare_cluster("cpu_coreweave") == "cpu_coreweave"

--- a/tests/test_utils/python_scripts/test_recipe_parser.py
+++ b/tests/test_utils/python_scripts/test_recipe_parser.py
@@ -1,5 +1,8 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import sys
+import types
+
 import prepare_jet_sqsh_image
 import recipe_parser
 
@@ -67,16 +70,63 @@ def test_resolve_local_image_prepare_cluster_uses_same_site_cpu_cluster():
     assert recipe_parser.resolve_local_image_prepare_cluster("cpu_coreweave") == "cpu_coreweave"
 
 
-def test_prepare_workload_uses_build_and_image_source():
+def test_prepare_workload_uses_image_source_without_build():
     workload = prepare_jet_sqsh_image.build_prepare_workload(
-        build="mcore-pyt-dev",
         source_image="gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345",
         local_path="/lustre/enroot/mcore-pyt-dev-dgx_h100-12345.sqsh",
         time_limit=1800,
     )
 
     spec = workload["spec"]
-    assert spec["build"] == "mcore-pyt-dev"
+    assert "build" not in spec
     assert spec["image_source"] == {
+        "image_tag": "gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345"
+    }
+
+
+def test_submit_prepare_workload_passes_raw_image_source_workload(monkeypatch):
+    captured = {}
+
+    class FakePipeline:
+        jet_id = 123
+
+        def get_status(self):
+            return "success"
+
+    class FakeWorkloads:
+        def submit(self, **kwargs):
+            captured.update(kwargs)
+            return FakePipeline()
+
+    class FakeJETClient:
+        def __init__(self, **kwargs):
+            self.workloads = FakeWorkloads()
+
+    fake_pipeline_module = types.SimpleNamespace(PipelineStatus=types.SimpleNamespace(SUBMISSION_FAILED="failed"))
+    fake_jetclient = types.SimpleNamespace(
+        JETClient=FakeJETClient,
+        clients=types.SimpleNamespace(gitlab=types.SimpleNamespace(GitlabAPIError=Exception)),
+        facades=types.SimpleNamespace(
+            objects=types.SimpleNamespace(util=types.SimpleNamespace(WaitTimeExceeded=Exception))
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "jetclient", fake_jetclient)
+    monkeypatch.setitem(sys.modules, "jetclient.services", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "jetclient.services.dtos", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "jetclient.services.dtos.pipeline", fake_pipeline_module)
+
+    pipeline = prepare_jet_sqsh_image.submit_prepare_workload(
+        source_image="gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345",
+        local_path="/lustre/enroot/mcore-pyt-dev-dgx_h100-12345.sqsh",
+        cluster="cpu_coreweave",
+        account="coreai_dlalgo_ci",
+        partition=None,
+        time_limit=1800,
+    )
+
+    assert pipeline.jet_id == 123
+    workload = captured["workloads"][0]
+    assert "build" not in workload["spec"]
+    assert workload["spec"]["image_source"] == {
         "image_tag": "gitlab-master.nvidia.com/adlr/megatron-lm/mcore_ci_dev:12345"
     }


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Add support for local SquashFS images in JET workloads
- Introduced a new option `--workload-local-image-path` in various scripts to specify local image paths for JET basic workloads.
- Updated `generate_jet_trigger_job.py` to handle local image paths and prepare workloads accordingly.
- Enhanced `launch_jet_workload.py` to accept local image paths and include them in the pipeline configuration.
- Added a new script `prepare_jet_sqsh_image.py` to manage the preparation of local SquashFS images.
- Modified `recipe_parser.py` to resolve local image sources and apply them to workloads.

This change improves the flexibility of workload management by allowing the use of pre-built local images, streamlining the testing process.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
