### PR TITLE
[1/N] Add Megatron Lite skeleton contracts

### DIFF
--- a/experimental/lite/README.md
+++ b/experimental/lite/README.md
@@ -1,0 +1,51 @@
+# Megatron Lite
+
+Megatron Lite is an experimental package for building Megatron-native model
+implementations behind a small, explicit contract. It is intentionally staged:
+this first slice adds the public shape of the package, the runtime/model
+registries, primitive interface contracts, validation scaffolding, and a tiny
+pure PyTorch model that proves the contracts are importable and executable on a
+single CPU process.
+
+## Motivation
+
+Megatron model work often mixes several concerns at once: model composition,
+parallel runtime setup, primitive selection, checkpointing, and downstream
+training-framework integration. Megatron Lite separates those concerns so that a
+model implementation can declare what it needs, a runtime can consume the
+declaration through a stable API, and primitive work can be reviewed in small
+increments.
+
+This package is meant to make early model bring-up easier to review. Each later
+PR can add one capability at a time while keeping the import path and contracts
+stable.
+
+## Current Contents
+
+- `megatron.lite.runtime`: runtime creation, backend registration, and runtime
+  interface definitions.
+- `megatron.lite.model.registry`: model and implementation registry.
+- `megatron.lite.primitive`: protocol, config, and bundle dataclasses used by
+  model implementations.
+- `megatron.lite.model.toy_dense`: a two-layer dense model used only to validate
+  the contract.
+- `tests/run_primitive_validation.sh`: a local CPU validation entrypoint.
+- `skills/`: short operating notes for keeping future Lite changes scoped.
+
+## Non-Goals For This Slice
+
+This PR does not add production model support, Qwen support, distributed
+parallelism, FSDP2, LoRA, checkpointing, VERL integration, custom kernels, or
+real primitive implementations. Those pieces should land in follow-up slices
+after this package boundary is reviewed.
+
+## Local Validation
+
+Run from the repository root:
+
+```bash
+experimental/lite/tests/run_primitive_validation.sh
+```
+
+The script exports `experimental/lite` on `PYTHONPATH` and runs the local CPU
+tests. No GPU is required.

--- a/experimental/lite/docs/architecture.md
+++ b/experimental/lite/docs/architecture.md
@@ -1,0 +1,31 @@
+# Megatron Lite Architecture
+
+Megatron Lite is organized around three narrow contracts:
+
+1. Runtime backends own execution.
+2. Model implementations own model construction.
+3. Primitive packages expose reusable building blocks through explicit
+   dataclasses and protocols.
+
+The first PR keeps those layers intentionally small. The only executable backend
+is the local `mlite` backend, and the only model is `toy_dense`.
+
+## Package Layers
+
+`megatron.lite.runtime` provides `RuntimeConfig`, `create_runtime`, and
+`register_runtime`. A backend implements the `Runtime` abstract base class and
+returns `ModelHandle` objects from `build_model`.
+
+`megatron.lite.model.registry` maps a public model name and implementation name
+to a protocol module. Runtime backends use the registry instead of importing
+model packages directly.
+
+`megatron.lite.primitive` contains only interface-level objects in this slice:
+`ModelBundle`, primitive config dataclasses, and protocol type definitions.
+Concrete distributed primitives are deliberately out of scope.
+
+## Review Boundary
+
+The package lives under `experimental/lite` and is imported by adding that
+directory to `PYTHONPATH`. This keeps the experimental API isolated from the
+main Megatron package until the interface is stable enough to promote.

--- a/experimental/lite/docs/models.md
+++ b/experimental/lite/docs/models.md
@@ -1,0 +1,32 @@
+# Models
+
+Megatron Lite model packages register themselves through
+`megatron.lite.model.registry.register_model`.
+
+Each registered implementation points at a protocol module. A protocol module is
+expected to expose:
+
+- `ImplConfig`: a dataclass for implementation-specific options.
+- `build_model_config(hf_path)`: returns a model config object.
+- `build_model(model_cfg, impl_cfg)`: returns a `ModelBundle`.
+
+## Toy Dense
+
+`toy_dense` is the only model included in this slice. It is a two-layer PyTorch
+MLP used to validate the package boundary:
+
+```python
+from megatron.lite.runtime import RuntimeConfig, create_runtime
+from megatron.lite.runtime.backends.mlite import MegatronLiteConfig
+
+runtime = create_runtime(
+    RuntimeConfig(
+        backend="mlite",
+        backend_cfg=MegatronLiteConfig(model_name="toy_dense", impl="torch"),
+    )
+)
+handle = runtime.build_model()
+```
+
+Toy Dense is not intended as a benchmark, reference transformer, or production
+training example.

--- a/experimental/lite/docs/porting.md
+++ b/experimental/lite/docs/porting.md
@@ -1,0 +1,16 @@
+# Porting Guidance
+
+Use this package as a staging area for small Megatron-native model ports.
+
+Recommended order:
+
+1. Register the model and a single implementation in `model.registry`.
+2. Define a protocol module that returns a `ModelBundle`.
+3. Add only the primitive contracts needed by that model.
+4. Add CPU import and toy-level contract checks before GPU validation.
+5. Move distributed, checkpoint, and downstream framework integration into
+   separate PRs.
+
+Avoid mixing model bring-up with unrelated runtime features. The main review
+question for a model PR should be whether the model implementation follows the
+contract and whether its validation evidence covers the behavior it adds.

--- a/experimental/lite/docs/runtime.md
+++ b/experimental/lite/docs/runtime.md
@@ -1,0 +1,24 @@
+# Runtime
+
+Runtime backends provide the execution surface for Megatron Lite. A runtime is
+created from `RuntimeConfig`:
+
+```python
+from megatron.lite.runtime import RuntimeConfig, create_runtime
+
+runtime = create_runtime(RuntimeConfig(backend="mlite"))
+```
+
+The minimal runtime interface is:
+
+- `build_model()`
+- `train_mode(handle)`
+- `eval_mode(handle)`
+- `forward_backward(handle, data, loss_fn=None, ...)`
+- `zero_grad(handle)`
+- `optimizer_step(handle)`
+- `lr_scheduler_step(handle)`
+
+Checkpointing, offload, distributed execution, and external training framework
+bridges are non-goals for this slice. They should extend the interface in later
+PRs only when the behavior is implemented and validated.

--- a/experimental/lite/megatron/lite/__init__.py
+++ b/experimental/lite/megatron/lite/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Experimental Megatron Lite package."""
+
+from megatron.lite.runtime import RuntimeConfig, create_runtime, register_runtime
+
+__all__ = ["RuntimeConfig", "create_runtime", "register_runtime"]

--- a/experimental/lite/megatron/lite/model/__init__.py
+++ b/experimental/lite/megatron/lite/model/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Model registration helpers for Megatron Lite."""
+
+from megatron.lite.model.registry import (
+    get_model_package,
+    get_train_runtime_module,
+    list_models,
+    register_model,
+    resolve_model_type_from_hf,
+    resolve_runtime_model_name,
+)
+
+__all__ = [
+    "get_model_package",
+    "get_train_runtime_module",
+    "list_models",
+    "register_model",
+    "resolve_model_type_from_hf",
+    "resolve_runtime_model_name",
+]

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Model and implementation registry."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ModelRegistration:
+    """Registry entry for one public model family."""
+
+    package: str
+    hf_model_types: list[str] = field(default_factory=list)
+    impls: dict[str, str] = field(default_factory=dict)
+
+
+MODEL_REGISTRY: dict[str, ModelRegistration] = {}
+HF_MODEL_TYPE_MAP: dict[str, str] = {}
+TRAIN_RUNTIME_MODULES: dict[str, str] = {}
+IMPL_TO_RUNTIME_MODEL: dict[tuple[str, str], str] = {}
+
+
+def register_model(
+    model_name: str,
+    *,
+    package: str,
+    hf_model_types: list[str] | None = None,
+    impls: dict[str, str] | None = None,
+) -> None:
+    """Register a model family and its runtime protocol modules."""
+
+    if not model_name:
+        raise ValueError("Model name must be non-empty.")
+    if not package:
+        raise ValueError("Model package must be non-empty.")
+
+    entry = ModelRegistration(
+        package=package,
+        hf_model_types=list(hf_model_types or []),
+        impls=dict(impls or {}),
+    )
+    MODEL_REGISTRY[model_name] = entry
+
+    for hf_model_type in entry.hf_model_types:
+        HF_MODEL_TYPE_MAP[hf_model_type] = model_name
+
+    for index, (impl_name, module_path) in enumerate(entry.impls.items()):
+        runtime_key = model_name if index == 0 else f"{model_name}_{impl_name}"
+        IMPL_TO_RUNTIME_MODEL[(model_name, impl_name)] = runtime_key
+        TRAIN_RUNTIME_MODULES[runtime_key] = module_path
+
+
+def list_models() -> list[str]:
+    """Return registered model names."""
+
+    return sorted(MODEL_REGISTRY)
+
+
+def get_model_package(model_name: str):
+    """Import the package registered for ``model_name``."""
+
+    try:
+        package = MODEL_REGISTRY[model_name].package
+    except KeyError as exc:
+        raise ValueError(f"Unknown model {model_name!r}. Known: {list_models()}") from exc
+    return importlib.import_module(package)
+
+
+def get_train_runtime_module(runtime_model_name: str):
+    """Import the protocol module registered for a runtime model key."""
+
+    try:
+        module_path = TRAIN_RUNTIME_MODULES[runtime_model_name]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown runtime model {runtime_model_name!r}. "
+            f"Known: {sorted(TRAIN_RUNTIME_MODULES)}"
+        ) from exc
+    return importlib.import_module(module_path)
+
+
+def resolve_runtime_model_name(model_name: str, impl: str) -> str:
+    """Resolve ``(model_name, impl)`` to the runtime registry key."""
+
+    try:
+        return IMPL_TO_RUNTIME_MODEL[(model_name, impl)]
+    except KeyError as exc:
+        known = sorted(f"{model}:{implementation}" for model, implementation in IMPL_TO_RUNTIME_MODEL)
+        raise ValueError(f"No runtime registered for ({model_name!r}, {impl!r}). Known: {known}") from exc
+
+
+def resolve_model_type_from_hf(source: str | Path | dict[str, Any] | Any) -> str:
+    """Resolve a Lite model name from a HuggingFace-style config source."""
+
+    if isinstance(source, dict):
+        hf_config = source
+    elif hasattr(source, "model_type"):
+        hf_config = {"model_type": source.model_type}
+    else:
+        path = Path(source)
+        config_path = path if path.is_file() else path / "config.json"
+        with open(config_path, encoding="utf-8") as handle:
+            hf_config = json.load(handle)
+
+    hf_model_type = hf_config.get("model_type", "")
+    try:
+        return HF_MODEL_TYPE_MAP[hf_model_type]
+    except KeyError as exc:
+        raise ValueError(
+            f"Cannot resolve HF model_type {hf_model_type!r}. "
+            f"Known: {sorted(HF_MODEL_TYPE_MAP)}"
+        ) from exc
+
+
+register_model(
+    "toy_dense",
+    package="megatron.lite.model.toy_dense",
+    hf_model_types=["mlite_toy_dense"],
+    impls={"torch": "megatron.lite.model.toy_dense"},
+)
+
+
+__all__ = [
+    "HF_MODEL_TYPE_MAP",
+    "IMPL_TO_RUNTIME_MODEL",
+    "MODEL_REGISTRY",
+    "TRAIN_RUNTIME_MODULES",
+    "get_model_package",
+    "get_train_runtime_module",
+    "list_models",
+    "register_model",
+    "resolve_model_type_from_hf",
+    "resolve_runtime_model_name",
+]

--- a/experimental/lite/megatron/lite/model/toy_dense.py
+++ b/experimental/lite/megatron/lite/model/toy_dense.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Tiny two-layer dense model used for contract validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.primitive.bundle import ModelBundle
+
+
+@dataclass
+class ToyDenseConfig:
+    """Shape config for the toy dense model."""
+
+    input_dim: int = 4
+    hidden_dim: int = 8
+    output_dim: int = 2
+
+
+@dataclass
+class ImplConfig:
+    """Implementation options for the pure PyTorch toy model."""
+
+    input_dim: int = 4
+    hidden_dim: int = 8
+    output_dim: int = 2
+
+
+class ToyDenseModel(nn.Module):
+    """Two linear layers with one ReLU activation."""
+
+    def __init__(self, config: ToyDenseConfig):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(config.input_dim, config.hidden_dim),
+            nn.ReLU(),
+            nn.Linear(config.hidden_dim, config.output_dim),
+        )
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return self.layers(inputs)
+
+
+def build_model_config(hf_path: str = "") -> ToyDenseConfig:
+    """Return the default toy model config.
+
+    ``hf_path`` is accepted to match the model protocol. The toy model does not
+    read external config files.
+    """
+
+    _ = hf_path
+    return ToyDenseConfig()
+
+
+def build_model(model_cfg: ToyDenseConfig, impl_cfg: ImplConfig | None = None) -> ModelBundle:
+    """Build the toy model and return a contract bundle."""
+
+    if impl_cfg is not None:
+        model_cfg = ToyDenseConfig(
+            input_dim=impl_cfg.input_dim,
+            hidden_dim=impl_cfg.hidden_dim,
+            output_dim=impl_cfg.output_dim,
+        )
+
+    return ModelBundle(chunks=[ToyDenseModel(model_cfg)])
+
+
+__all__ = ["ImplConfig", "ToyDenseConfig", "ToyDenseModel", "build_model", "build_model_config"]

--- a/experimental/lite/megatron/lite/primitive/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Primitive interface contracts for Megatron Lite."""
+
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.config import PrecisionConfig, PrimitiveConfig
+from megatron.lite.primitive.protocols import ModelBuildProtocol
+
+__all__ = ["ModelBuildProtocol", "ModelBundle", "PrecisionConfig", "PrimitiveConfig"]

--- a/experimental/lite/megatron/lite/primitive/bundle.py
+++ b/experimental/lite/megatron/lite/primitive/bundle.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Model bundle returned by Lite model protocol modules."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch.nn as nn
+
+
+@dataclass
+class ModelBundle:
+    """Everything a runtime needs after model construction."""
+
+    chunks: list[nn.Module]
+    optimizer: Any | None = None
+    finalize_grads: Callable[[], None] | None = None
+    forward_step: Callable[[nn.Module, dict[str, Any]], Any] | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = ["ModelBundle"]

--- a/experimental/lite/megatron/lite/primitive/config.py
+++ b/experimental/lite/megatron/lite/primitive/config.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Shared primitive configuration dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PrecisionConfig:
+    """Precision requested by a primitive implementation."""
+
+    dtype: str = "float32"
+    params_dtype: str | None = None
+    reduce_dtype: str | None = None
+
+
+@dataclass(frozen=True)
+class PrimitiveConfig:
+    """Generic primitive descriptor used before concrete primitives exist."""
+
+    name: str
+    enabled: bool = True
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = ["PrecisionConfig", "PrimitiveConfig"]

--- a/experimental/lite/megatron/lite/primitive/protocols.py
+++ b/experimental/lite/megatron/lite/primitive/protocols.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Protocol definitions for Lite model and primitive integration."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from megatron.lite.primitive.bundle import ModelBundle
+
+
+class ModelBuildProtocol(Protocol):
+    """Protocol implemented by registered model implementation modules."""
+
+    def build_model_config(self, hf_path: str = "") -> Any:
+        """Build or load a model config object."""
+
+    def build_model(self, model_cfg: Any, impl_cfg: Any | None = None) -> ModelBundle:
+        """Build model chunks and return a runtime-consumable bundle."""
+
+
+__all__ = ["ModelBuildProtocol"]

--- a/experimental/lite/megatron/lite/runtime/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/__init__.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Runtime entrypoints for Megatron Lite."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+from megatron.lite.runtime.contracts.config import RuntimeConfig
+
+if TYPE_CHECKING:
+    from megatron.lite.runtime.backends import Runtime
+
+
+def _runtime_registry() -> dict[str, str]:
+    from megatron.lite.runtime.backends import RUNTIME_REGISTRY
+
+    return RUNTIME_REGISTRY
+
+
+def register_runtime(name: str, module_path: str) -> None:
+    """Register a runtime backend module.
+
+    The module must provide a ``create(hf_path, cfg)`` function returning a
+    ``Runtime`` instance.
+    """
+
+    if not name:
+        raise ValueError("Runtime name must be non-empty.")
+    _runtime_registry()[name] = module_path
+
+
+def create_runtime(cfg: RuntimeConfig) -> Runtime:
+    """Create a runtime from a public runtime config."""
+
+    registry = _runtime_registry()
+    if cfg.backend not in registry:
+        raise ValueError(f"Unknown runtime backend {cfg.backend!r}. Known: {sorted(registry)}")
+    mod = importlib.import_module(registry[cfg.backend])
+    return mod.create(cfg.hf_path, cfg.backend_cfg)
+
+
+def __getattr__(name: str):
+    lazy = {
+        "ForwardResult": "megatron.lite.runtime.contracts.data",
+        "ModelHandle": "megatron.lite.runtime.contracts.handle",
+        "Runtime": "megatron.lite.runtime.backends",
+        "TrainBatch": "megatron.lite.runtime.contracts.data",
+    }
+    if name in lazy:
+        mod = importlib.import_module(lazy[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "ForwardResult",
+    "ModelHandle",
+    "Runtime",
+    "RuntimeConfig",
+    "TrainBatch",
+    "create_runtime",
+    "register_runtime",
+]

--- a/experimental/lite/megatron/lite/runtime/backends/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/__init__.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Runtime interface and backend registry."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any
+
+from megatron.lite.runtime.contracts.data import ForwardResult
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+class Runtime(ABC):
+    """Base class implemented by Megatron Lite runtime backends."""
+
+    @abstractmethod
+    def build_model(self, hf_path: str | None = None, cfg: Any = None, **kwargs) -> ModelHandle:
+        """Build runtime-owned model state and return an opaque handle."""
+
+    @abstractmethod
+    def train_mode(self, handle: ModelHandle) -> Any:
+        """Put the handled model in training mode."""
+
+    @abstractmethod
+    def eval_mode(self, handle: ModelHandle) -> Any:
+        """Put the handled model in evaluation mode."""
+
+    @abstractmethod
+    def forward_backward(
+        self,
+        handle: ModelHandle,
+        data: Any,
+        loss_fn: Callable[[Any, Any], tuple[Any, dict[str, Any]]] | None = None,
+        *,
+        num_microbatches: int = 1,
+        forward_only: bool = False,
+    ) -> ForwardResult:
+        """Run a local forward/backward atom for one logical step."""
+
+    @abstractmethod
+    def zero_grad(self, handle: ModelHandle) -> None:
+        """Clear gradients for the handled optimizer/model."""
+
+    @abstractmethod
+    def optimizer_step(self, handle: ModelHandle) -> tuple[bool, float, int | None]:
+        """Run the optimizer step and return ``(ok, grad_norm, zero_grad_count)``."""
+
+    @abstractmethod
+    def lr_scheduler_step(self, handle: ModelHandle) -> float | list[float]:
+        """Advance or query the runtime learning-rate scheduler."""
+
+
+RUNTIME_REGISTRY: dict[str, str] = {
+    "mlite": "megatron.lite.runtime.backends.mlite",
+}
+
+
+__all__ = ["RUNTIME_REGISTRY", "Runtime"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Default local Megatron Lite backend."""
+
+from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime, create
+
+__all__ = ["MegatronLiteConfig", "MegatronLiteRuntime", "create"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Configuration for the local Megatron Lite backend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any
+
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+
+
+def _pick_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
+    names = {field.name for field in fields(cls)}
+    return {name: value for name, value in values.items() if name in names}
+
+
+@dataclass
+class MegatronLiteConfig:
+    """Backend config used by the local ``mlite`` runtime."""
+
+    model_name: str = "toy_dense"
+    impl: str = "torch"
+    device: str = "cpu"
+    hf_path: str = ""
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: OptimizerConfig = field(default_factory=OptimizerConfig)
+    impl_cfg: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, hf_path: str, values: dict[str, Any]) -> "MegatronLiteConfig":
+        values = dict(values)
+        if "parallel" in values and isinstance(values["parallel"], dict):
+            values["parallel"] = ParallelConfig(**_pick_fields(ParallelConfig, values["parallel"]))
+        if "optimizer" in values and isinstance(values["optimizer"], dict):
+            values["optimizer"] = OptimizerConfig(**_pick_fields(OptimizerConfig, values["optimizer"]))
+        values.setdefault("hf_path", hf_path)
+        return cls(**_pick_fields(cls, values))
+
+
+__all__ = ["MegatronLiteConfig"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Single-process PyTorch runtime used to validate the Lite contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import fields as dataclass_fields
+from typing import Any
+
+import torch
+
+from megatron.lite.model.registry import get_train_runtime_module, resolve_runtime_model_name
+from megatron.lite.runtime.backends import Runtime
+from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
+from megatron.lite.runtime.contracts.data import ForwardResult, TrainBatch
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+def _as_backend_config(hf_path: str, cfg: MegatronLiteConfig | dict[str, Any] | None) -> MegatronLiteConfig:
+    if cfg is None:
+        return MegatronLiteConfig(hf_path=hf_path)
+    if isinstance(cfg, MegatronLiteConfig):
+        return cfg
+    return MegatronLiteConfig.from_dict(hf_path, cfg)
+
+
+def _dataclass_kwargs(cls, values: dict[str, Any]) -> dict[str, Any]:
+    names = {field.name for field in dataclass_fields(cls)}
+    return {name: value for name, value in values.items() if name in names}
+
+
+def _batch_to_mapping(data: Any) -> dict[str, Any]:
+    if isinstance(data, TrainBatch):
+        return {"inputs": data.inputs, "targets": data.targets, **data.metadata}
+    if isinstance(data, dict):
+        return data
+    return {"inputs": data, "targets": None}
+
+
+class MegatronLiteRuntime(Runtime):
+    """A minimal local runtime for contract validation."""
+
+    def __init__(self, hf_path: str = "", cfg: MegatronLiteConfig | dict[str, Any] | None = None):
+        self._hf_path = hf_path
+        self._cfg = _as_backend_config(hf_path, cfg)
+
+    def build_model(
+        self,
+        hf_path: str | None = None,
+        cfg: MegatronLiteConfig | dict[str, Any] | None = None,
+        **kwargs,
+    ) -> ModelHandle:
+        rt_cfg = _as_backend_config(hf_path or self._hf_path, cfg) if cfg is not None else self._cfg
+        if kwargs:
+            rt_cfg.impl_cfg.update(kwargs)
+
+        runtime_key = resolve_runtime_model_name(rt_cfg.model_name, rt_cfg.impl)
+        protocol = get_train_runtime_module(runtime_key)
+        model_cfg = protocol.build_model_config(rt_cfg.hf_path)
+
+        impl_cfg = None
+        if hasattr(protocol, "ImplConfig"):
+            impl_cfg = protocol.ImplConfig(**_dataclass_kwargs(protocol.ImplConfig, rt_cfg.impl_cfg))
+
+        bundle = protocol.build_model(model_cfg, impl_cfg=impl_cfg)
+        if not bundle.chunks:
+            raise ValueError("Model protocol returned an empty ModelBundle.")
+
+        model = bundle.chunks[0].to(rt_cfg.device)
+        optimizer = bundle.optimizer
+        if optimizer is None:
+            optimizer = torch.optim.SGD(model.parameters(), lr=rt_cfg.optimizer.lr)
+
+        return ModelHandle(
+            model=model,
+            optimizer=optimizer,
+            lr_scheduler=None,
+            config=rt_cfg,
+            extras={
+                "forward_step": bundle.forward_step,
+                "model_cfg": model_cfg,
+                "protocol": protocol,
+                **bundle.extras,
+            },
+        )
+
+    def train_mode(self, handle: ModelHandle) -> Any:
+        return handle.model.train()
+
+    def eval_mode(self, handle: ModelHandle) -> Any:
+        return handle.model.eval()
+
+    def forward_backward(
+        self,
+        handle: ModelHandle,
+        data: Any,
+        loss_fn: Callable[[Any, Any], tuple[torch.Tensor, dict[str, Any]]] | None = None,
+        *,
+        num_microbatches: int = 1,
+        forward_only: bool = False,
+    ) -> ForwardResult:
+        if num_microbatches != 1:
+            raise ValueError("The PR1 local runtime supports exactly one microbatch.")
+
+        batch = _batch_to_mapping(data)
+        model = handle.model
+        forward_step = handle.extras.get("forward_step")
+        outputs = forward_step(model, batch) if forward_step is not None else model(batch["inputs"])
+
+        if loss_fn is None:
+            targets = batch.get("targets")
+            if targets is None:
+                loss = outputs.mean()
+                metrics: dict[str, Any] = {"loss": float(loss.detach())}
+            else:
+                loss = torch.nn.functional.mse_loss(outputs, targets.to(outputs.device))
+                metrics = {"loss": float(loss.detach())}
+        else:
+            loss, metrics = loss_fn(outputs, batch)
+
+        if not forward_only:
+            loss.backward()
+
+        return ForwardResult(loss=loss, metrics=metrics, outputs=outputs)
+
+    def zero_grad(self, handle: ModelHandle) -> None:
+        handle.optimizer.zero_grad(set_to_none=True)
+
+    def optimizer_step(self, handle: ModelHandle) -> tuple[bool, float, int | None]:
+        grad_norm_sq = 0.0
+        zero_grad_count = 0
+        for parameter in handle.model.parameters():
+            if parameter.grad is None:
+                continue
+            grad = parameter.grad.detach()
+            grad_norm_sq += float(grad.pow(2).sum())
+            zero_grad_count += int(torch.count_nonzero(grad == 0).item())
+        handle.optimizer.step()
+        return True, grad_norm_sq**0.5, zero_grad_count
+
+    def lr_scheduler_step(self, handle: ModelHandle) -> float | list[float]:
+        scheduler = handle.lr_scheduler
+        if scheduler is not None:
+            scheduler.step()
+        lrs = [float(group["lr"]) for group in handle.optimizer.param_groups]
+        return lrs[0] if len(lrs) == 1 else lrs
+
+
+def create(hf_path: str = "", cfg: MegatronLiteConfig | dict[str, Any] | None = None) -> MegatronLiteRuntime:
+    """Factory used by ``megatron.lite.runtime.create_runtime``."""
+
+    return MegatronLiteRuntime(hf_path, cfg)
+
+
+__all__ = ["MegatronLiteRuntime", "create"]

--- a/experimental/lite/megatron/lite/runtime/contracts/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Public runtime contract objects."""
+
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+from megatron.lite.runtime.contracts.data import ForwardResult, TrainBatch
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+__all__ = [
+    "ForwardResult",
+    "ModelHandle",
+    "OptimizerConfig",
+    "ParallelConfig",
+    "RuntimeConfig",
+    "TrainBatch",
+]

--- a/experimental/lite/megatron/lite/runtime/contracts/config.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/config.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Shared runtime configuration contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ParallelConfig:
+    """Parallel dimensions requested by a model/runtime pair."""
+
+    tp: int = 1
+    pp: int = 1
+    cp: int = 1
+    ep: int = 1
+
+
+@dataclass
+class OptimizerConfig:
+    """Optimizer options shared by lightweight runtime backends."""
+
+    optimizer: str = "sgd"
+    lr: float = 1e-2
+    weight_decay: float = 0.0
+    clip_grad: float | None = None
+
+
+@dataclass
+class RuntimeConfig:
+    """Top-level runtime creation config."""
+
+    backend: str = "mlite"
+    hf_path: str = ""
+    backend_cfg: Any = field(default_factory=dict)
+
+
+__all__ = ["OptimizerConfig", "ParallelConfig", "RuntimeConfig"]

--- a/experimental/lite/megatron/lite/runtime/contracts/data.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/data.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Data contracts for runtime calls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+
+@dataclass
+class TrainBatch:
+    """Minimal tensor batch used by local contract checks."""
+
+    inputs: torch.Tensor
+    targets: torch.Tensor | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ForwardResult:
+    """Result returned by ``Runtime.forward_backward``."""
+
+    loss: torch.Tensor
+    metrics: dict[str, Any] = field(default_factory=dict)
+    outputs: Any = None
+
+
+__all__ = ["ForwardResult", "TrainBatch"]

--- a/experimental/lite/megatron/lite/runtime/contracts/handle.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/handle.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Opaque model handle returned by runtime backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ModelHandle:
+    """Runtime-owned model state with a small public surface."""
+
+    model: Any
+    optimizer: Any = None
+    lr_scheduler: Any = None
+    config: Any = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def dp_rank(self) -> int:
+        return 0
+
+    @property
+    def dp_size(self) -> int:
+        return 1
+
+    @property
+    def dp_group(self) -> None:
+        return None
+
+
+__all__ = ["ModelHandle"]

--- a/experimental/lite/skills/README.md
+++ b/experimental/lite/skills/README.md
@@ -1,0 +1,10 @@
+# Megatron Lite Skills
+
+These notes capture review habits for future Megatron Lite work. They are
+deliberately short and local to the experimental package.
+
+## Core Paths
+
+- `basic/`: general operating rules for Lite changes.
+- `primitive/`: primitive design and validation rules.
+- `insight/`: scope-control guidance for staged model support.

--- a/experimental/lite/skills/basic/constitution.md
+++ b/experimental/lite/skills/basic/constitution.md
@@ -1,0 +1,9 @@
+# Lite Constitution
+
+Megatron Lite changes should keep three boundaries explicit:
+
+- Runtime code executes models but does not own model architecture.
+- Model code declares what it needs through protocol modules and bundles.
+- Primitive code exposes reusable capabilities behind typed contracts.
+
+Prefer small PRs that add one behavior and one validation story.

--- a/experimental/lite/skills/basic/find-reference.md
+++ b/experimental/lite/skills/basic/find-reference.md
@@ -1,0 +1,12 @@
+# Find Reference
+
+Before porting a model or primitive, identify the source implementation and the
+minimal behavior needed for the current PR.
+
+Record:
+
+- The upstream source file or paper section.
+- The expected tensor shapes.
+- The smallest local check that can catch a regression.
+
+Do not copy large model stacks into Lite when a smaller contract check is enough.

--- a/experimental/lite/skills/basic/review-threshold.md
+++ b/experimental/lite/skills/basic/review-threshold.md
@@ -1,0 +1,11 @@
+# Review Threshold
+
+A Lite PR is ready for review when it has:
+
+- A narrow stated scope.
+- Local import coverage.
+- A validation command that reviewers can run.
+- Clear non-goals for behavior deferred to later slices.
+
+If a change needs GPU evidence, collect it separately and include job IDs in the
+PR evidence. Do not treat skipped tests as passing evidence.

--- a/experimental/lite/skills/insight/progressive-model-support.md
+++ b/experimental/lite/skills/insight/progressive-model-support.md
@@ -1,0 +1,11 @@
+# Progressive Model Support
+
+Add new model support in layers:
+
+1. Register the model and a minimal protocol.
+2. Build an importable config path.
+3. Add a tiny forward path.
+4. Add weight loading.
+5. Add distributed execution and checkpointing.
+
+Do not combine all layers in the first PR for a model family.

--- a/experimental/lite/skills/insight/progressive-primitive-design.md
+++ b/experimental/lite/skills/insight/progressive-primitive-design.md
@@ -1,0 +1,9 @@
+# Progressive Primitive Design
+
+A primitive should move from contract to reference to optimized implementation.
+
+The contract defines behavior. The reference proves correctness. The optimized
+implementation proves performance without changing the contract.
+
+When these steps are split, reviewers can evaluate correctness before performance
+complexity enters the diff.

--- a/experimental/lite/skills/insight/scope-control.md
+++ b/experimental/lite/skills/insight/scope-control.md
@@ -1,0 +1,7 @@
+# Scope Control
+
+Megatron Lite is easier to review when each PR has a crisp exclusion list.
+
+Use non-goals to keep the current slice honest. If a change needs Qwen support,
+checkpointing, VERL, FSDP2, or custom kernels, it should usually be a follow-up
+unless the PR is specifically about that feature.

--- a/experimental/lite/skills/primitive/contract.md
+++ b/experimental/lite/skills/primitive/contract.md
@@ -1,0 +1,14 @@
+# Primitive Contract
+
+Primitive work should start with a typed contract before adding optimized code.
+
+For each primitive, document:
+
+- Inputs and outputs.
+- Shape and dtype expectations.
+- Distributed assumptions.
+- Fallback behavior.
+- Validation against a simple PyTorch reference.
+
+This PR includes only the shared contract layer; concrete primitives are
+follow-up work.

--- a/experimental/lite/skills/primitive/design.md
+++ b/experimental/lite/skills/primitive/design.md
@@ -1,0 +1,14 @@
+# Primitive Design
+
+Primitive implementations should be independent units that can be tested without
+bringing up a full model.
+
+Design rules:
+
+- Keep primitive configuration explicit.
+- Prefer pure PyTorch references for first validation.
+- Add optimized kernels only after the reference behavior is covered.
+- Avoid hidden dependencies on global distributed state.
+
+If a primitive needs process groups, pass them through config or bundle metadata
+instead of importing runtime internals.

--- a/experimental/lite/skills/primitive/validate.md
+++ b/experimental/lite/skills/primitive/validate.md
@@ -1,0 +1,11 @@
+# Primitive Validation
+
+Validation should scale with the primitive risk:
+
+- Interface-only changes need import and registry tests.
+- Pure PyTorch primitives need numerical parity tests.
+- Distributed primitives need CPU-safe unit coverage plus real Slurm evidence
+  for GPU paths.
+
+Keep the validation command stable so follow-up PRs can add tests without
+changing reviewer workflow.

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -1,0 +1,7 @@
+# Megatron Lite Tests
+
+The PR1 validation suite is intentionally local and CPU-only. It verifies that
+the package imports, the registries resolve the toy model, and the local runtime
+can run one dense-model training step.
+
+Future primitive parity tests should be added here as real primitives land.

--- a/experimental/lite/tests/conftest.py
+++ b/experimental/lite/tests/conftest.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Pytest configuration for Megatron Lite tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+LITE_ROOT = Path(__file__).resolve().parents[1]
+if str(LITE_ROOT) not in sys.path:
+    sys.path.insert(0, str(LITE_ROOT))

--- a/experimental/lite/tests/run_primitive_validation.sh
+++ b/experimental/lite/tests/run_primitive_validation.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+LITE_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd -- "${LITE_ROOT}/../.." && pwd)"
+
+export PYTHONPATH="${LITE_ROOT}:${PYTHONPATH:-}"
+
+cd "${REPO_ROOT}"
+python -m pytest -q "${LITE_ROOT}/tests/unit" "$@"

--- a/experimental/lite/tests/unit/test_toy_runtime.py
+++ b/experimental/lite/tests/unit/test_toy_runtime.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU contract checks for the PR1 Megatron Lite skeleton."""
+
+from __future__ import annotations
+
+import torch
+
+from megatron.lite.model.registry import list_models, resolve_runtime_model_name
+from megatron.lite.runtime import RuntimeConfig, create_runtime
+from megatron.lite.runtime.backends.mlite import MegatronLiteConfig
+from megatron.lite.runtime.contracts import OptimizerConfig, TrainBatch
+
+
+def test_toy_dense_registry_contract():
+    assert "toy_dense" in list_models()
+    assert resolve_runtime_model_name("toy_dense", "torch") == "toy_dense"
+
+
+def test_toy_dense_runtime_one_cpu_step():
+    torch.manual_seed(1234)
+
+    runtime = create_runtime(
+        RuntimeConfig(
+            backend="mlite",
+            backend_cfg=MegatronLiteConfig(
+                model_name="toy_dense",
+                impl="torch",
+                device="cpu",
+                optimizer=OptimizerConfig(lr=0.05),
+                impl_cfg={"input_dim": 4, "hidden_dim": 8, "output_dim": 2},
+            ),
+        )
+    )
+    handle = runtime.build_model()
+    runtime.train_mode(handle)
+
+    batch = TrainBatch(
+        inputs=torch.randn(3, 4),
+        targets=torch.randn(3, 2),
+    )
+
+    runtime.zero_grad(handle)
+    result = runtime.forward_backward(handle, batch)
+    ok, grad_norm, zero_grad_count = runtime.optimizer_step(handle)
+    lr = runtime.lr_scheduler_step(handle)
+
+    assert ok is True
+    assert result.loss.ndim == 0
+    assert torch.isfinite(result.loss)
+    assert grad_norm > 0.0
+    assert zero_grad_count is not None
+    assert lr == 0.05


### PR DESCRIPTION

  ## Summary

  This is PR 1/N in the Megatron Lite stacked series. It establishes the minimal skeleton that follow-up PRs will build on.

  This PR adds the first Megatron Lite skeleton under `experimental/lite`.

  It includes:
  - public runtime contracts and the `mlite` local backend registry
  - model registration and implementation registry APIs
  - primitive protocol/config/bundle dataclasses
  - core Lite review/porting skills
  - local validation scaffolding
  - a tiny two-layer PyTorch `toy_dense` model that validates the contract on CPU

  ## Non-goals

  This PR intentionally does not add:
  - Qwen model support
  - real primitive implementations
  - distributed runtime support
  - FSDP2
  - LoRA
  - checkpointing
  - VERL integration
  - custom kernels

  Those pieces should land in follow-up PRs after the skeleton API boundary is reviewed.

  ## Validation

  ```bash
  python -m compileall -q experimental/lite/megatron/lite experimental/lite/tests
  experimental/lite/tests/run_primitive_validation.sh
  PYTHONPATH=experimental/lite python -c "from megatron.lite.runtime import RuntimeConfig, create_runtime; print(RuntimeConfig().backend, type(create_runtime(RuntimeConfig())).__name__)"

  Results:

  - run_primitive_validation.sh: 2 passed
  - direct import/runtime smoke: mlite MegatronLiteRuntime