### PR TITLE
[2/N] Add Megatron Lite execution path primitives

### DIFF
--- a/experimental/lite/README.md
+++ b/experimental/lite/README.md
@@ -1,0 +1,51 @@
+# Megatron Lite
+
+Megatron Lite is an experimental package for building Megatron-native model
+implementations behind a small, explicit contract. It is intentionally staged:
+this first slice adds the public shape of the package, the runtime/model
+registries, primitive interface contracts, validation scaffolding, and a tiny
+pure PyTorch model that proves the contracts are importable and executable on a
+single CPU process.
+
+## Motivation
+
+Megatron model work often mixes several concerns at once: model composition,
+parallel runtime setup, primitive selection, checkpointing, and downstream
+training-framework integration. Megatron Lite separates those concerns so that a
+model implementation can declare what it needs, a runtime can consume the
+declaration through a stable API, and primitive work can be reviewed in small
+increments.
+
+This package is meant to make early model bring-up easier to review. Each later
+PR can add one capability at a time while keeping the import path and contracts
+stable.
+
+## Current Contents
+
+- `megatron.lite.runtime`: runtime creation, backend registration, and runtime
+  interface definitions.
+- `megatron.lite.model.registry`: model and implementation registry.
+- `megatron.lite.primitive`: protocol, config, and bundle dataclasses used by
+  model implementations.
+- `megatron.lite.model.toy_dense`: a two-layer dense model used only to validate
+  the contract.
+- `tests/run_primitive_validation.sh`: a local CPU validation entrypoint.
+- `skills/`: short operating notes for keeping future Lite changes scoped.
+
+## Non-Goals For This Slice
+
+This PR does not add production model support, Qwen support, distributed
+parallelism, FSDP2, LoRA, checkpointing, VERL integration, custom kernels, or
+real primitive implementations. Those pieces should land in follow-up slices
+after this package boundary is reviewed.
+
+## Local Validation
+
+Run from the repository root:
+
+```bash
+experimental/lite/tests/run_primitive_validation.sh
+```
+
+The script exports `experimental/lite` on `PYTHONPATH` and runs the local CPU
+tests. No GPU is required.

--- a/experimental/lite/docs/architecture.md
+++ b/experimental/lite/docs/architecture.md
@@ -1,0 +1,31 @@
+# Megatron Lite Architecture
+
+Megatron Lite is organized around three narrow contracts:
+
+1. Runtime backends own execution.
+2. Model implementations own model construction.
+3. Primitive packages expose reusable building blocks through explicit
+   dataclasses and protocols.
+
+The first PR keeps those layers intentionally small. The only executable backend
+is the local `mlite` backend, and the only model is `toy_dense`.
+
+## Package Layers
+
+`megatron.lite.runtime` provides `RuntimeConfig`, `create_runtime`, and
+`register_runtime`. A backend implements the `Runtime` abstract base class and
+returns `ModelHandle` objects from `build_model`.
+
+`megatron.lite.model.registry` maps a public model name and implementation name
+to a protocol module. Runtime backends use the registry instead of importing
+model packages directly.
+
+`megatron.lite.primitive` contains only interface-level objects in this slice:
+`ModelBundle`, primitive config dataclasses, and protocol type definitions.
+Concrete distributed primitives are deliberately out of scope.
+
+## Review Boundary
+
+The package lives under `experimental/lite` and is imported by adding that
+directory to `PYTHONPATH`. This keeps the experimental API isolated from the
+main Megatron package until the interface is stable enough to promote.

--- a/experimental/lite/docs/models.md
+++ b/experimental/lite/docs/models.md
@@ -1,0 +1,32 @@
+# Models
+
+Megatron Lite model packages register themselves through
+`megatron.lite.model.registry.register_model`.
+
+Each registered implementation points at a protocol module. A protocol module is
+expected to expose:
+
+- `ImplConfig`: a dataclass for implementation-specific options.
+- `build_model_config(hf_path)`: returns a model config object.
+- `build_model(model_cfg, impl_cfg)`: returns a `ModelBundle`.
+
+## Toy Dense
+
+`toy_dense` is the only model included in this slice. It is a two-layer PyTorch
+MLP used to validate the package boundary:
+
+```python
+from megatron.lite.runtime import RuntimeConfig, create_runtime
+from megatron.lite.runtime.backends.mlite import MegatronLiteConfig
+
+runtime = create_runtime(
+    RuntimeConfig(
+        backend="mlite",
+        backend_cfg=MegatronLiteConfig(model_name="toy_dense", impl="torch"),
+    )
+)
+handle = runtime.build_model()
+```
+
+Toy Dense is not intended as a benchmark, reference transformer, or production
+training example.

--- a/experimental/lite/docs/porting.md
+++ b/experimental/lite/docs/porting.md
@@ -1,0 +1,16 @@
+# Porting Guidance
+
+Use this package as a staging area for small Megatron-native model ports.
+
+Recommended order:
+
+1. Register the model and a single implementation in `model.registry`.
+2. Define a protocol module that returns a `ModelBundle`.
+3. Add only the primitive contracts needed by that model.
+4. Add CPU import and toy-level contract checks before GPU validation.
+5. Move distributed, checkpoint, and downstream framework integration into
+   separate PRs.
+
+Avoid mixing model bring-up with unrelated runtime features. The main review
+question for a model PR should be whether the model implementation follows the
+contract and whether its validation evidence covers the behavior it adds.

--- a/experimental/lite/docs/runtime.md
+++ b/experimental/lite/docs/runtime.md
@@ -1,0 +1,24 @@
+# Runtime
+
+Runtime backends provide the execution surface for Megatron Lite. A runtime is
+created from `RuntimeConfig`:
+
+```python
+from megatron.lite.runtime import RuntimeConfig, create_runtime
+
+runtime = create_runtime(RuntimeConfig(backend="mlite"))
+```
+
+The minimal runtime interface is:
+
+- `build_model()`
+- `train_mode(handle)`
+- `eval_mode(handle)`
+- `forward_backward(handle, data, loss_fn=None, ...)`
+- `zero_grad(handle)`
+- `optimizer_step(handle)`
+- `lr_scheduler_step(handle)`
+
+Checkpointing, offload, distributed execution, and external training framework
+bridges are non-goals for this slice. They should extend the interface in later
+PRs only when the behavior is implemented and validated.

--- a/experimental/lite/megatron/lite/__init__.py
+++ b/experimental/lite/megatron/lite/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Experimental Megatron Lite package."""
+
+from megatron.lite.runtime import RuntimeConfig, create_runtime, register_runtime
+
+__all__ = ["RuntimeConfig", "create_runtime", "register_runtime"]

--- a/experimental/lite/megatron/lite/model/__init__.py
+++ b/experimental/lite/megatron/lite/model/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Model registration helpers for Megatron Lite."""
+
+from megatron.lite.model.registry import (
+    get_model_package,
+    get_train_runtime_module,
+    list_models,
+    register_model,
+    resolve_model_type_from_hf,
+    resolve_runtime_model_name,
+)
+
+__all__ = [
+    "get_model_package",
+    "get_train_runtime_module",
+    "list_models",
+    "register_model",
+    "resolve_model_type_from_hf",
+    "resolve_runtime_model_name",
+]

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Model and implementation registry."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ModelRegistration:
+    """Registry entry for one public model family."""
+
+    package: str
+    hf_model_types: list[str] = field(default_factory=list)
+    impls: dict[str, str] = field(default_factory=dict)
+
+
+MODEL_REGISTRY: dict[str, ModelRegistration] = {}
+HF_MODEL_TYPE_MAP: dict[str, str] = {}
+TRAIN_RUNTIME_MODULES: dict[str, str] = {}
+IMPL_TO_RUNTIME_MODEL: dict[tuple[str, str], str] = {}
+
+
+def register_model(
+    model_name: str,
+    *,
+    package: str,
+    hf_model_types: list[str] | None = None,
+    impls: dict[str, str] | None = None,
+) -> None:
+    """Register a model family and its runtime protocol modules."""
+
+    if not model_name:
+        raise ValueError("Model name must be non-empty.")
+    if not package:
+        raise ValueError("Model package must be non-empty.")
+
+    entry = ModelRegistration(
+        package=package,
+        hf_model_types=list(hf_model_types or []),
+        impls=dict(impls or {}),
+    )
+    MODEL_REGISTRY[model_name] = entry
+
+    for hf_model_type in entry.hf_model_types:
+        HF_MODEL_TYPE_MAP[hf_model_type] = model_name
+
+    for index, (impl_name, module_path) in enumerate(entry.impls.items()):
+        runtime_key = model_name if index == 0 else f"{model_name}_{impl_name}"
+        IMPL_TO_RUNTIME_MODEL[(model_name, impl_name)] = runtime_key
+        TRAIN_RUNTIME_MODULES[runtime_key] = module_path
+
+
+def list_models() -> list[str]:
+    """Return registered model names."""
+
+    return sorted(MODEL_REGISTRY)
+
+
+def get_model_package(model_name: str):
+    """Import the package registered for ``model_name``."""
+
+    try:
+        package = MODEL_REGISTRY[model_name].package
+    except KeyError as exc:
+        raise ValueError(f"Unknown model {model_name!r}. Known: {list_models()}") from exc
+    return importlib.import_module(package)
+
+
+def get_train_runtime_module(runtime_model_name: str):
+    """Import the protocol module registered for a runtime model key."""
+
+    try:
+        module_path = TRAIN_RUNTIME_MODULES[runtime_model_name]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown runtime model {runtime_model_name!r}. "
+            f"Known: {sorted(TRAIN_RUNTIME_MODULES)}"
+        ) from exc
+    return importlib.import_module(module_path)
+
+
+def resolve_runtime_model_name(model_name: str, impl: str) -> str:
+    """Resolve ``(model_name, impl)`` to the runtime registry key."""
+
+    try:
+        return IMPL_TO_RUNTIME_MODEL[(model_name, impl)]
+    except KeyError as exc:
+        known = sorted(f"{model}:{implementation}" for model, implementation in IMPL_TO_RUNTIME_MODEL)
+        raise ValueError(f"No runtime registered for ({model_name!r}, {impl!r}). Known: {known}") from exc
+
+
+def resolve_model_type_from_hf(source: str | Path | dict[str, Any] | Any) -> str:
+    """Resolve a Lite model name from a HuggingFace-style config source."""
+
+    if isinstance(source, dict):
+        hf_config = source
+    elif hasattr(source, "model_type"):
+        hf_config = {"model_type": source.model_type}
+    else:
+        path = Path(source)
+        config_path = path if path.is_file() else path / "config.json"
+        with open(config_path, encoding="utf-8") as handle:
+            hf_config = json.load(handle)
+
+    hf_model_type = hf_config.get("model_type", "")
+    try:
+        return HF_MODEL_TYPE_MAP[hf_model_type]
+    except KeyError as exc:
+        raise ValueError(
+            f"Cannot resolve HF model_type {hf_model_type!r}. "
+            f"Known: {sorted(HF_MODEL_TYPE_MAP)}"
+        ) from exc
+
+
+register_model(
+    "toy_dense",
+    package="megatron.lite.model.toy_dense",
+    hf_model_types=["mlite_toy_dense"],
+    impls={"torch": "megatron.lite.model.toy_dense"},
+)
+
+
+__all__ = [
+    "HF_MODEL_TYPE_MAP",
+    "IMPL_TO_RUNTIME_MODEL",
+    "MODEL_REGISTRY",
+    "TRAIN_RUNTIME_MODULES",
+    "get_model_package",
+    "get_train_runtime_module",
+    "list_models",
+    "register_model",
+    "resolve_model_type_from_hf",
+    "resolve_runtime_model_name",
+]

--- a/experimental/lite/megatron/lite/model/toy_dense.py
+++ b/experimental/lite/megatron/lite/model/toy_dense.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Tiny two-layer dense model used for contract validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.primitive.bundle import ModelBundle
+
+
+@dataclass
+class ToyDenseConfig:
+    """Shape config for the toy dense model."""
+
+    input_dim: int = 4
+    hidden_dim: int = 8
+    output_dim: int = 2
+
+
+@dataclass
+class ImplConfig:
+    """Implementation options for the pure PyTorch toy model."""
+
+    input_dim: int = 4
+    hidden_dim: int = 8
+    output_dim: int = 2
+
+
+class ToyDenseModel(nn.Module):
+    """Two linear layers with one ReLU activation."""
+
+    def __init__(self, config: ToyDenseConfig):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(config.input_dim, config.hidden_dim),
+            nn.ReLU(),
+            nn.Linear(config.hidden_dim, config.output_dim),
+        )
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return self.layers(inputs)
+
+
+def build_model_config(hf_path: str = "") -> ToyDenseConfig:
+    """Return the default toy model config.
+
+    ``hf_path`` is accepted to match the model protocol. The toy model does not
+    read external config files.
+    """
+
+    _ = hf_path
+    return ToyDenseConfig()
+
+
+def build_model(model_cfg: ToyDenseConfig, impl_cfg: ImplConfig | None = None) -> ModelBundle:
+    """Build the toy model and return a contract bundle."""
+
+    if impl_cfg is not None:
+        model_cfg = ToyDenseConfig(
+            input_dim=impl_cfg.input_dim,
+            hidden_dim=impl_cfg.hidden_dim,
+            output_dim=impl_cfg.output_dim,
+        )
+
+    return ModelBundle(chunks=[ToyDenseModel(model_cfg)])
+
+
+__all__ = ["ImplConfig", "ToyDenseConfig", "ToyDenseModel", "build_model", "build_model_config"]

--- a/experimental/lite/megatron/lite/primitive/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Primitive interface contracts for Megatron Lite."""
+
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.config import PrecisionConfig, PrimitiveConfig
+from megatron.lite.primitive.protocols import ModelBuildProtocol
+
+__all__ = ["ModelBuildProtocol", "ModelBundle", "PrecisionConfig", "PrimitiveConfig"]

--- a/experimental/lite/megatron/lite/primitive/bundle.py
+++ b/experimental/lite/megatron/lite/primitive/bundle.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Model bundle returned by Lite model protocol modules."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch.nn as nn
+
+
+@dataclass
+class ModelBundle:
+    """Everything a runtime needs after model construction."""
+
+    chunks: list[nn.Module]
+    optimizer: Any | None = None
+    finalize_grads: Callable[[], None] | None = None
+    forward_step: Callable[[nn.Module, dict[str, Any]], Any] | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = ["ModelBundle"]

--- a/experimental/lite/megatron/lite/primitive/config.py
+++ b/experimental/lite/megatron/lite/primitive/config.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Shared primitive configuration dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PrecisionConfig:
+    """Precision requested by a primitive implementation."""
+
+    dtype: str = "float32"
+    params_dtype: str | None = None
+    reduce_dtype: str | None = None
+
+
+@dataclass(frozen=True)
+class PrimitiveConfig:
+    """Generic primitive descriptor used before concrete primitives exist."""
+
+    name: str
+    enabled: bool = True
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = ["PrecisionConfig", "PrimitiveConfig"]

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Megatron Lite-owned parallel runtime exports."""
+
+from __future__ import annotations
+
+from megatron.lite.primitive.parallel.cp import (
+    split_packed_for_cp,
+    zigzag_position_ids_for_cp,
+    zigzag_reconstruct_from_cp_parts,
+    zigzag_slice_for_cp,
+    zigzag_split_for_cp,
+)
+from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+from megatron.lite.primitive.parallel.pp import PipelineChunkLayout, build_pipeline_chunk_layout
+from megatron.lite.primitive.parallel.sp import (
+    gather_for_non_sp_head,
+    gather_from_sequence_parallel,
+    scatter_to_sequence_parallel,
+)
+from megatron.lite.primitive.parallel.state import ParallelState, init_parallel
+from megatron.lite.primitive.parallel.thd import (
+    PackedSeqParams,
+    PackedTHDBatch,
+    pack_nested_thd,
+    reconstruct_packed_from_cp_parts,
+    roll_packed_thd_left,
+    split_packed_to_cp_local,
+    unpack_packed_thd_to_nested,
+)
+
+_LAZY_LINEAR_EXPORTS = {
+    "ColumnParallelLinear",
+    "RowParallelLinear",
+    "VanillaColumnParallelLinear",
+    "VocabParallelEmbedding",
+    "VocabParallelOutput",
+    "pad_vocab_for_tp",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_LINEAR_EXPORTS:
+        from megatron.lite.primitive.parallel import linear as _linear
+
+        return getattr(_linear, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "ColumnParallelLinear",
+    "PackedSeqParams",
+    "PackedTHDBatch",
+    "PipelineChunkLayout",
+    "ParallelState",
+    "RowParallelLinear",
+    "VanillaColumnParallelLinear",
+    "VocabParallelEmbedding",
+    "VocabParallelOutput",
+    "build_pipeline_chunk_layout",
+    "forward_backward_pipelining",
+    "gather_for_non_sp_head",
+    "gather_from_sequence_parallel",
+    "init_parallel",
+    "pad_vocab_for_tp",
+    "pack_nested_thd",
+    "reconstruct_packed_from_cp_parts",
+    "roll_packed_thd_left",
+    "scatter_to_sequence_parallel",
+    "split_packed_to_cp_local",
+    "split_packed_for_cp",
+    "unpack_packed_thd_to_nested",
+    "zigzag_position_ids_for_cp",
+    "zigzag_reconstruct_from_cp_parts",
+    "zigzag_slice_for_cp",
+    "zigzag_split_for_cp",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Context parallel zigzag sequence splitting helpers."""
+
+from __future__ import annotations
+
+import torch
+
+
+def zigzag_split_for_cp(
+    tensor: torch.Tensor, cp_rank: int, cp_size: int, seq_dim: int = 1
+) -> torch.Tensor:
+    """Split tensor along sequence dim using zigzag (striped) pattern for CP.
+
+    Splits into 2*cp_size chunks; GPU i gets chunk[i] + chunk[2*cp_size-1-i].
+    This balances causal-mask workload across CP ranks.
+
+    Example (CP=2, seq=8): chunks [0,1,2,3] ->
+        GPU0: chunk[0]+chunk[3] = tokens [0,1,6,7]
+        GPU1: chunk[1]+chunk[2] = tokens [2,3,4,5]
+    """
+    if cp_size <= 1:
+        return tensor
+    seq_len = tensor.shape[seq_dim]
+    assert (
+        seq_len % (2 * cp_size) == 0
+    ), f"seq_len={seq_len} must be divisible by 2*cp_size={2 * cp_size}"
+    shape = list(tensor.shape)
+    shape[seq_dim : seq_dim + 1] = [2 * cp_size, seq_len // (2 * cp_size)]
+    tensor = tensor.view(*shape)
+    idx = torch.tensor([cp_rank, 2 * cp_size - cp_rank - 1], dtype=torch.long, device=tensor.device)
+    tensor = tensor.index_select(seq_dim, idx)
+    shape[seq_dim : seq_dim + 2] = [seq_len // cp_size]
+    return tensor.reshape(*shape)
+
+
+def zigzag_reconstruct_from_cp_parts(
+    parts: list[torch.Tensor] | tuple[torch.Tensor, ...], seq_dim: int = 1
+) -> torch.Tensor:
+    """Reconstruct a full sequence from per-rank zigzag CP shards."""
+    cp_size = len(parts)
+    if cp_size <= 1:
+        return parts[0]
+    local_len = parts[0].shape[seq_dim]
+    assert (
+        local_len % 2 == 0
+    ), f"local seq_len={local_len} must be divisible by 2 for zigzag CP reconstruction"
+    for idx, part in enumerate(parts):
+        assert (
+            part.shape == parts[0].shape
+        ), f"CP part {idx} shape {tuple(part.shape)} != {tuple(parts[0].shape)}"
+
+    chunk = local_len // 2
+    full_len = local_len * cp_size
+    out_shape = list(parts[0].shape)
+    out_shape[seq_dim] = full_len
+    full = torch.zeros(out_shape, dtype=parts[0].dtype, device=parts[0].device)
+    for rank, part in enumerate(parts):
+        first = part.narrow(seq_dim, 0, chunk)
+        second = part.narrow(seq_dim, chunk, chunk)
+        full.narrow(seq_dim, rank * chunk, chunk).copy_(first)
+        full.narrow(seq_dim, full_len - (rank + 1) * chunk, chunk).copy_(second)
+    return full
+
+
+def zigzag_slice_for_cp(
+    tensor: torch.Tensor, cp_rank: int, cp_size: int, seq_dim: int = 1
+) -> torch.Tensor:
+    """Return one rank's zigzag CP shard from a full sequence tensor."""
+    if cp_size <= 1:
+        return tensor
+    seq_len = tensor.shape[seq_dim]
+    assert (
+        seq_len % (2 * cp_size) == 0
+    ), f"seq_len={seq_len} must be divisible by 2*cp_size={2 * cp_size}"
+    chunk = seq_len // (2 * cp_size)
+    first = tensor.narrow(seq_dim, cp_rank * chunk, chunk)
+    second_start = seq_len - (cp_rank + 1) * chunk
+    second = tensor.narrow(seq_dim, second_start, chunk)
+    return torch.cat((first, second), dim=seq_dim).contiguous()
+
+
+def zigzag_position_ids_for_cp(
+    seq_len: int, cp_rank: int, cp_size: int, device: torch.device
+) -> torch.Tensor:
+    """Return global position IDs for this CP rank under zigzag splitting.
+
+    Returns shape [1, seq_len // cp_size] matching batch dim convention.
+    """
+    if cp_size <= 1:
+        return torch.arange(seq_len, device=device).unsqueeze(0)
+    chunk = seq_len // (2 * cp_size)
+    first = torch.arange(cp_rank * chunk, (cp_rank + 1) * chunk, device=device)
+    second_start = (2 * cp_size - cp_rank - 1) * chunk
+    second = torch.arange(second_start, second_start + chunk, device=device)
+    return torch.cat([first, second]).unsqueeze(0)
+
+
+def split_packed_for_cp(
+    input_ids: torch.Tensor,
+    position_ids: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    max_seqlen: int,
+    cp_rank: int,
+    cp_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Zigzag-split a packed sequence batch for context parallelism.
+
+    Each sample defined by *cu_seqlens* is split with the same zigzag
+    (striped) pattern as :func:`zigzag_split_for_cp`: tokens are divided
+    into ``2 * cp_size`` chunks, and this rank keeps
+    ``chunk[cp_rank] + chunk[2*cp_size - 1 - cp_rank]``.
+
+    Returns:
+        ``(input_ids, position_ids, cu_seqlens, max_seqlen)`` for this CP rank.
+    """
+    if cp_size <= 1:
+        return input_ids, position_ids, cu_seqlens, max_seqlen
+
+    num_seqs = cu_seqlens.size(0) - 1
+    ids_parts: list[torch.Tensor] = []
+    pos_parts: list[torch.Tensor] = []
+    new_lengths: list[int] = []
+
+    for i in range(num_seqs):
+        start = int(cu_seqlens[i].item())
+        end = int(cu_seqlens[i + 1].item())
+        seq_len = end - start
+        assert (
+            seq_len % (2 * cp_size) == 0
+        ), f"Sample {i} length {seq_len} not divisible by 2*cp_size={2 * cp_size}"
+        chunk = seq_len // (2 * cp_size)
+        c1 = start + cp_rank * chunk
+        c2 = start + (2 * cp_size - cp_rank - 1) * chunk
+        ids_parts.append(input_ids[c1 : c1 + chunk])
+        ids_parts.append(input_ids[c2 : c2 + chunk])
+        pos_parts.append(position_ids[c1 : c1 + chunk])
+        pos_parts.append(position_ids[c2 : c2 + chunk])
+        new_lengths.append(2 * chunk)
+
+    new_ids = torch.cat(ids_parts)
+    new_pos = torch.cat(pos_parts)
+    lens = torch.tensor(new_lengths, dtype=torch.int32, device=cu_seqlens.device)
+    new_cu = torch.zeros(num_seqs + 1, dtype=torch.int32, device=cu_seqlens.device)
+    torch.cumsum(lens, dim=0, out=new_cu[1:])
+    return new_ids, new_pos, new_cu, max(new_lengths)
+
+
+__all__ = [
+    "split_packed_for_cp",
+    "zigzag_reconstruct_from_cp_parts",
+    "zigzag_position_ids_for_cp",
+    "zigzag_slice_for_cp",
+    "zigzag_split_for_cp",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/linear.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/linear.py
@@ -1,0 +1,429 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""TP-parallel linear layers and vocab-parallel embedding/output."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+try:
+    import transformer_engine.pytorch as te  # pyright: ignore[reportMissingImports]
+except (ImportError, OSError):
+    te = None
+
+if TYPE_CHECKING:
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+
+def _ensure_divisible(numerator: int, denominator: int, msg: str = "") -> int:
+    if numerator % denominator != 0:
+        detail = f" ({msg})" if msg else ""
+        raise ValueError(f"{numerator} is not divisible by {denominator}{detail}")
+    return numerator // denominator
+
+
+def _require_transformer_engine():
+    if te is None:
+        raise RuntimeError("Transformer Engine is required to instantiate TE-backed lite layers.")
+    return te
+
+
+# ---------------------------------------------------------------------------
+# Vanilla column-parallel linear (torch.matmul kernel, NOT TE).
+#
+# Matches Megatron-Core `tensor_parallel.ColumnParallelLinear` bit-for-bit
+# in bf16: same `torch.matmul(input, weight.t())` forward, same
+# all-reduce-on-backward-grad_input pattern. Use this for heads like the
+# vocab LM projection where MC's GPT model uses vanilla torch matmul
+# (hardcoded in `LinearCrossEntropyModule(tensor_parallel.ColumnParallelLinear)`)
+# — TE's `te.Linear` uses a different cuBLAS algo selection that introduces
+# ~3e-4 loss-level drift under bf16 vs torch.matmul.
+#
+# For QKV / MoE experts we still prefer the TE path (fused LN+linear, FP8
+# readiness) — this vanilla path is a drop-in substitute only when kernel
+# parity with the reference backend is required.
+# ---------------------------------------------------------------------------
+
+
+class _VanillaColParallelMatmul(torch.autograd.Function):
+    """forward: output = matmul(input, weight.t()) — replicated input, sharded output.
+    backward: grad_input = grad_output @ weight (+ all-reduce across TP);
+              grad_weight = grad_output.T @ input.
+    Mirrors MC `LinearWithGradAccumulationAndAsyncCommunication`.
+    """
+
+    @staticmethod
+    def forward(ctx, input_, weight, tp_group):
+        ctx.save_for_backward(input_, weight)
+        ctx.tp_group = tp_group
+        return torch.matmul(input_, weight.t())
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input_, weight = ctx.saved_tensors
+        grad_input = grad_output.matmul(weight)
+        if ctx.tp_group is not None and dist.get_world_size(ctx.tp_group) > 1:
+            dist.all_reduce(grad_input, group=ctx.tp_group)
+        # grad_weight = grad_output^T @ input (sum over leading dims).
+        gi = grad_output.reshape(-1, grad_output.shape[-1])
+        xi = input_.reshape(-1, input_.shape[-1])
+        grad_weight = gi.t().matmul(xi)
+        return grad_input, grad_weight, None
+
+
+class _VanillaColParallelMatmulSP(torch.autograd.Function):
+    """SP-aware column-parallel matmul matching MC's
+    `ColumnParallelLinear(sequence_parallel=True)` kernel bit-for-bit.
+
+    forward:
+      - all-gather input along dim-0 from [S/tp, B, H] → [S, B, H]
+      - matmul(gathered, weight.t()) → [S, B, V/tp]
+    backward:
+      - grad_input_full = grad_output @ weight  → [S, B, H]
+      - reduce-scatter dim-0 → [S/tp, B, H]
+      - grad_weight = grad_output^T @ gathered_input
+    """
+
+    @staticmethod
+    def forward(ctx, input_, weight, tp_group):
+        ws = dist.get_world_size(tp_group) if tp_group is not None else 1
+        if ws > 1:
+            s_local = input_.shape[0]
+            total_shape = (s_local * ws, *input_.shape[1:])
+            total_input = torch.empty(total_shape, dtype=input_.dtype, device=input_.device)
+            dist.all_gather_into_tensor(total_input, input_.contiguous(), group=tp_group)
+        else:
+            total_input = input_
+        ctx.save_for_backward(total_input, weight)
+        ctx.tp_group = tp_group
+        ctx.tp_size = ws
+        ctx.local_s = input_.shape[0]
+        return torch.matmul(total_input, weight.t())
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        total_input, weight = ctx.saved_tensors
+        grad_input_full = grad_output.matmul(weight)
+        if ctx.tp_size > 1:
+            out_shape = (ctx.local_s, *grad_input_full.shape[1:])
+            grad_input = torch.empty(
+                out_shape, dtype=grad_input_full.dtype, device=grad_input_full.device
+            )
+            dist.reduce_scatter_tensor(grad_input, grad_input_full.contiguous(), group=ctx.tp_group)
+        else:
+            grad_input = grad_input_full
+        gi = grad_output.reshape(-1, grad_output.shape[-1])
+        xi = total_input.reshape(-1, total_input.shape[-1])
+        grad_weight = gi.t().matmul(xi)
+        return grad_input, grad_weight, None
+
+
+class _VanillaColLinear(nn.Module):
+    """Drop-in for `te.Linear(parallel_mode='column')` using torch.matmul.
+
+    Shape: `self.weight` is (out_features_per_tp, in_features). Exposes
+    `.weight` at the same attribute path as TE Linear for state-dict compatibility.
+
+    When `sp=True`, input is assumed SP-sharded on dim-0; forward gathers
+    before matmul and backward reduce-scatters grad_input — matching MC's
+    `ColumnParallelLinear(sequence_parallel=True)` bit-for-bit. When
+    `sp=False`, input is assumed replicated and grad_input is all-reduced.
+    """
+
+    def __init__(self, in_features: int, out_features: int, ps: ParallelState, *, sp: bool = False):
+        super().__init__()
+        self.tp_group = ps.tp_group
+        self.tp_size = ps.tp_size
+        self.sp = sp
+        local_out = _ensure_divisible(out_features, ps.tp_size)
+        self.weight = nn.Parameter(torch.empty(local_out, in_features, dtype=torch.bfloat16))
+        nn.init.xavier_uniform_(self.weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.sp:
+            return _VanillaColParallelMatmulSP.apply(x, self.weight, self.tp_group)
+        return _VanillaColParallelMatmul.apply(x, self.weight, self.tp_group)
+
+
+class VanillaColumnParallelLinear(nn.Module):
+    """Public vanilla column-parallel linear matching MCore torch matmul."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        ps: ParallelState,
+        *,
+        sp: bool = False,
+        gather_output: bool = False,
+    ):
+        super().__init__()
+        self.linear = _VanillaColLinear(in_features, out_features, ps, sp=sp)
+        self.tp_size = ps.tp_size
+        self.tp_group = ps.tp_group
+        self.gather_output = gather_output
+
+    @property
+    def weight(self) -> torch.nn.Parameter:
+        return self.linear.weight
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.linear(x)
+        if self.gather_output and self.tp_size > 1:
+            out = _AllGatherLastDim.apply(out, self.tp_size, self.tp_group)
+        return out
+
+
+class ColumnParallelLinear(nn.Module):
+    """TE-based column-parallel linear. Splits output dim across TP."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        ps: ParallelState,
+        bias: bool = False,
+        gather_output: bool = False,
+        normalization: str | None = None,
+        eps: float = 1e-6,
+        zero_centered_gamma: bool = False,
+        sequence_parallel: bool | None = None,
+    ):
+        super().__init__()
+        self.tp_size = ps.tp_size
+        self.tp_rank = ps.tp_rank
+        self.tp_group = ps.tp_group
+        self.local_out = _ensure_divisible(out_features, ps.tp_size)
+        self.use_sp = (
+            ps.tp_size > 1 and not gather_output if sequence_parallel is None else sequence_parallel
+        )
+        te_mod = _require_transformer_engine()
+        if normalization is not None:
+            self.linear = te_mod.LayerNormLinear(
+                in_features,
+                out_features,
+                bias=bias,
+                normalization=normalization,
+                eps=eps,
+                zero_centered_gamma=zero_centered_gamma,
+                params_dtype=torch.bfloat16,
+                parallel_mode="column",
+                sequence_parallel=self.use_sp,
+                tp_group=ps.tp_group,
+                tp_size=ps.tp_size,
+            )
+        else:
+            self.linear = te_mod.Linear(
+                in_features,
+                out_features,
+                bias=bias,
+                params_dtype=torch.bfloat16,
+                parallel_mode="column",
+                sequence_parallel=self.use_sp,
+                tp_group=ps.tp_group,
+                tp_size=ps.tp_size,
+            )
+        self.gather_output = gather_output
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.linear(x)
+        if self.gather_output and self.tp_size > 1:
+            out = _AllGatherLastDim.apply(out, self.tp_size, self.tp_group)
+        return out
+
+
+class RowParallelLinear(nn.Module):
+    """TE-based row-parallel linear. Splits input dim across TP."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        ps: ParallelState,
+        bias: bool = False,
+        input_is_parallel: bool = True,
+    ):
+        super().__init__()
+        self.tp_size = ps.tp_size
+        self.tp_rank = ps.tp_rank
+        self.tp_group = ps.tp_group
+        self.use_sp = ps.tp_size > 1
+        self.local_in = _ensure_divisible(in_features, ps.tp_size)
+        te_mod = _require_transformer_engine()
+        self.linear = te_mod.Linear(
+            in_features,
+            out_features,
+            bias=bias,
+            params_dtype=torch.bfloat16,
+            parallel_mode="row",
+            sequence_parallel=self.use_sp,
+            tp_group=ps.tp_group,
+            tp_size=ps.tp_size,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+def pad_vocab_for_tp(vocab_size: int, tp_size: int) -> int:
+    """Round vocab up to be divisible by `lcm(128, tp_size)`.
+
+    Matches MC's `_vocab_size_with_padding(..., make_vocab_size_divisible_by=128)`:
+    pad to 128-multiple for GEMM alignment, and also require tp-divisibility.
+    For typical `tp_size ∈ {1,2,4,...,128}`, `lcm = 128` so a vocab already
+    divisible by 128 (e.g. Qwen3-MoE's 151936) stays unchanged — which is
+    what MC's `output_layer` sees. Using `128 * tp_size` instead would
+    over-pad (e.g. 151936 -> 152064
+    at tp=2), introducing 128 extra logits into the vocab-parallel cross-
+    entropy log-sum-exp and driving a ~3e-4 loss drift.
+    """
+    import math
+
+    divisor = math.lcm(128, tp_size)
+    return ((vocab_size + divisor - 1) // divisor) * divisor
+
+
+class VocabParallelEmbedding(nn.Module):
+    """Embedding table split across TP on the vocab dimension."""
+
+    def __init__(
+        self, vocab_size: int, hidden_size: int, ps: ParallelState, *, deterministic: bool = False
+    ):
+        super().__init__()
+        self.tp_size = ps.tp_size
+        self.tp_rank = ps.tp_rank
+        self.deterministic = bool(deterministic)
+        padded_vocab = pad_vocab_for_tp(vocab_size, ps.tp_size)
+        self.local_vocab = _ensure_divisible(padded_vocab, ps.tp_size)
+        self.vocab_start = self.tp_rank * self.local_vocab
+        self.vocab_end = self.vocab_start + self.local_vocab
+        self.embedding = nn.Embedding(self.local_vocab, hidden_size)
+        self.tp_group = ps.tp_group
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        # input_ids: [B, S] → out: [S, B, H]
+        mask = (input_ids >= self.vocab_start) & (input_ids < self.vocab_end)
+        local_ids = (input_ids - self.vocab_start).clamp(min=0, max=self.local_vocab - 1)
+        if self.deterministic:
+            out = self.embedding.weight[local_ids]
+        else:
+            out = self.embedding(local_ids)
+        out = out * mask.unsqueeze(-1)
+        if self.tp_size > 1:
+            out = _ReduceFromTP.apply(out, self.tp_group)
+        return out.transpose(0, 1).contiguous()
+
+
+class _ColForLMHead(nn.Module):
+    """Thin wrapper exposing `.linear` (with `.weight`) for state-dict
+    compatibility, switchable between TE and vanilla torch.matmul kernel.
+
+    `sp=True` threads to the underlying linear: vanilla uses the SP-aware
+    matmul (gather-in / reduce-scatter-on-bwd); TE uses `sequence_parallel=True`
+    on `te.Linear`. Both match MC's `output_layer(sequence_parallel=True)`
+    semantics so the upstream final_layernorm can run on SP-sharded input.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        ps: ParallelState,
+        *,
+        backend: str = "vanilla",
+        sp: bool = False,
+    ):
+        super().__init__()
+        if backend == "vanilla":
+            # Matches MC's LinearCrossEntropyModule → tensor_parallel.ColumnParallelLinear
+            # kernel bit-for-bit in bf16. Preferred for LM head parity with the reference backend.
+            self.linear = _VanillaColLinear(in_features, out_features, ps, sp=sp)
+        elif backend == "te":
+            # TE-backed path — cuBLAS algo may differ from MC's torch.matmul
+            # under bf16, producing ~3e-4 loss-level drift. Keep for future
+            # FP8 / fused-norm paths.
+            _wrapper = ColumnParallelLinear(
+                in_features, out_features, ps, bias=False, gather_output=not sp
+            )
+            self.linear = _wrapper.linear
+        else:
+            raise ValueError(f"Unknown LM-head backend: {backend!r}")
+
+
+class VocabParallelOutput(nn.Module):
+    """Output projection split across TP on the vocab dimension (column parallel).
+
+    Default backend is `"vanilla"` (torch.matmul) to match the reference backend's
+    `tensor_parallel.ColumnParallelLinear` bit-for-bit. Pass `backend="te"`
+    to use TE's `te.Linear` kernel (e.g. for FP8 inference paths).
+    """
+
+    def __init__(
+        self, vocab_size: int, hidden_size: int, ps: ParallelState, *, backend: str = "vanilla"
+    ):
+        super().__init__()
+        padded_vocab = pad_vocab_for_tp(vocab_size, ps.tp_size)
+        # SP-aware head: when tp>1 we run on SP-sharded input (matches MC
+        # GPTModel where final_layernorm runs on SP-sharded hiddens and
+        # output_layer gathers internally + reduce-scatters on backward).
+        self.col = _ColForLMHead(hidden_size, padded_vocab, ps, backend=backend, sp=ps.tp_size > 1)
+        self.padded_vocab = padded_vocab
+        self.local_vocab = padded_vocab // ps.tp_size
+        self.vocab_size = vocab_size
+        self.ps = ps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.col.linear(x)
+
+    def gather(self, logits: torch.Tensor) -> torch.Tensor:
+        """All-gather TP-sharded logits and trim to actual vocab_size."""
+        if self.ps.tp_size > 1:
+            chunks = [torch.empty_like(logits) for _ in range(self.ps.tp_size)]
+            dist.all_gather(chunks, logits, group=self.ps.tp_group)
+            logits = torch.cat(chunks, dim=-1)
+        return logits[..., : self.vocab_size]
+
+
+class _AllGatherLastDim(torch.autograd.Function):
+    """all-gather along last dim; backward = take local shard."""
+
+    @staticmethod
+    def forward(ctx, x, tp_size, group):
+        ctx.tp_size = tp_size
+        ctx.group = group
+        ctx.local_dim = x.shape[-1]
+        ctx.rank = dist.get_rank(group)
+        chunks = [torch.empty_like(x) for _ in range(tp_size)]
+        dist.all_gather(chunks, x.contiguous(), group=group)
+        return torch.cat(chunks, dim=-1)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        start = ctx.rank * ctx.local_dim
+        return grad_output[..., start : start + ctx.local_dim].contiguous(), None, None
+
+
+class _ReduceFromTP(torch.autograd.Function):
+    """all-reduce forward; identity backward."""
+
+    @staticmethod
+    def forward(ctx, x, group):
+        out = x.clone()
+        dist.all_reduce(out, group=group)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return grad_output, None
+
+
+__all__ = [
+    "ColumnParallelLinear",
+    "RowParallelLinear",
+    "VanillaColumnParallelLinear",
+    "VocabParallelEmbedding",
+    "VocabParallelOutput",
+    "pad_vocab_for_tp",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -1,0 +1,795 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Pipeline parallel: 1F1B schedule with correct backward handling."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+if TYPE_CHECKING:
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+
+def _ensure_divisible(numerator: int, denominator: int, msg: str = "") -> int:
+    if numerator % denominator != 0:
+        detail = f" ({msg})" if msg else ""
+        raise ValueError(f"{numerator} is not divisible by {denominator}{detail}")
+    return numerator // denominator
+
+
+def forward_backward_pipelining(
+    forward_step_fn: Callable,
+    model_chunks: list,
+    data_iter,
+    config,
+    ps: ParallelState,
+    tensor_shape: tuple[int, ...] | None = None,
+    grad_sync_fn: Callable[[], None] | None = None,
+    pre_forward_hook: Callable[[torch.Tensor], None] | None = None,
+    loss_fn: Callable | None = None,
+    forward_only: bool = False,
+) -> list[dict]:
+    """
+    Run forward and backward passes with pipeline parallelism.
+
+    Args:
+        forward_step_fn: Callable(model, batch) -> output_dict with "loss" and "hidden_states"
+        model_chunks: local model chunks. ``len>1`` enables interleaved VPP.
+        data_iter: iterator yielding micro-batches
+        config: training config
+        ps: parallel state
+        tensor_shape: shape of hidden states passed between stages [B, S, H]
+        grad_sync_fn: called before the last micro-batch's backward to enable
+                       async gradient ReduceScatter in DistributedOptimizer.
+
+    Returns:
+        List of output dicts from forward passes.
+    """
+    if ps.pp_size <= 1:
+        if forward_only:
+            return _forward_only_no_pipeline(
+                forward_step_fn,
+                model_chunks[0],
+                data_iter,
+                config,
+                ps,
+                pre_forward_hook=pre_forward_hook,
+                loss_fn=loss_fn,
+            )
+        return _no_pipeline(
+            forward_step_fn,
+            model_chunks[0],
+            data_iter,
+            config,
+            ps,
+            grad_sync_fn=grad_sync_fn,
+            pre_forward_hook=pre_forward_hook,
+            loss_fn=loss_fn,
+        )
+
+    if tensor_shape is None:
+        raise ValueError("tensor_shape is required when PP > 1")
+
+    num_microbatches = _num_microbatches_from_config(config, ps)
+
+    if forward_only:
+        return _forward_only_pipeline_schedule(
+            forward_step_fn,
+            model_chunks,
+            data_iter,
+            num_microbatches,
+            ps,
+            tensor_shape,
+            pre_forward_hook=pre_forward_hook,
+            loss_fn=loss_fn,
+        )
+
+    if len(model_chunks) > 1:
+        return _interleaved_1f1b_schedule(
+            forward_step_fn,
+            model_chunks,
+            data_iter,
+            num_microbatches,
+            config,
+            ps,
+            tensor_shape,
+            grad_sync_fn=grad_sync_fn,
+            pre_forward_hook=pre_forward_hook,
+            loss_fn=loss_fn,
+        )
+
+    return _1f1b_schedule(
+        forward_step_fn,
+        model_chunks[0],
+        data_iter,
+        num_microbatches,
+        config,
+        ps,
+        tensor_shape,
+        grad_sync_fn=grad_sync_fn,
+        pre_forward_hook=pre_forward_hook,
+        loss_fn=loss_fn,
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# No pipeline (PP=1)
+# ══════════════════════════════════════════════════════════════════════
+def _num_microbatches_from_config(config, ps: ParallelState) -> int:
+    explicit = getattr(config, "num_microbatches", None)
+    if explicit is not None:
+        return int(explicit)
+    return _ensure_divisible(config.gbs, config.mbs * ps.dp_size)
+
+
+def _set_aux_loss_scale(pre_forward_hook, num_microbatches: int) -> None:
+    if pre_forward_hook is not None:
+        scale = torch.tensor(1.0 / num_microbatches, device="cuda")
+        pre_forward_hook(scale)
+
+
+def _batch_get(batch, key: str):
+    if isinstance(batch, dict):
+        return batch.get(key)
+    return getattr(batch, key, None)
+
+
+def _batch_input_ids(batch):
+    input_ids = _batch_get(batch, "input_ids")
+    if input_ids is not None and input_ids.dim() == 1:
+        input_ids = input_ids.unsqueeze(0)
+    return input_ids
+
+
+def _apply_external_loss(
+    out: dict, batch, loss_fn
+) -> tuple[torch.Tensor, dict] | tuple[None, None]:
+    if loss_fn is None:
+        return None, None
+    loss, metrics = loss_fn(out, batch)
+    out["loss"] = loss
+    out["_loss_fn_metrics"] = metrics
+    return loss, metrics
+
+
+def _compact_pipeline_output(out: dict | None) -> dict:
+    if not out:
+        return {}
+    compact: dict = {}
+    if "loss" in out and out["loss"] is not None:
+        loss = out["loss"]
+        compact["loss"] = loss.detach().item() if isinstance(loss, torch.Tensor) else float(loss)
+    if "_loss_fn_metrics" in out:
+        compact["metrics"] = out["_loss_fn_metrics"]
+    return compact
+
+
+def _no_pipeline(
+    forward_step_fn,
+    model,
+    data_iter,
+    config,
+    ps,
+    *,
+    grad_sync_fn=None,
+    pre_forward_hook=None,
+    loss_fn=None,
+):
+    num_microbatches = _num_microbatches_from_config(config, ps)
+    outputs = []
+    for i in range(num_microbatches):
+        if grad_sync_fn and i == num_microbatches - 1:
+            grad_sync_fn()
+        batch = next(data_iter)
+        _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+        output = forward_step_fn(model, batch)
+        if loss_fn is not None:
+            loss, _metrics = _apply_external_loss(output, batch, loss_fn)
+            assert loss is not None
+        else:
+            loss = output["loss"]
+        loss = loss / num_microbatches
+        loss.backward()
+        outputs.append(_compact_pipeline_output(output))
+    return outputs
+
+
+def _forward_only_no_pipeline(
+    forward_step_fn, model, data_iter, config, ps, *, pre_forward_hook=None, loss_fn=None
+):
+    num_microbatches = _num_microbatches_from_config(config, ps)
+    del ps
+    outputs = []
+    for _ in range(num_microbatches):
+        batch = next(data_iter)
+        _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+        output = forward_step_fn(model, batch)
+        _apply_external_loss(output, batch, loss_fn)
+        outputs.append(_compact_pipeline_output(output))
+    return outputs
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 1F1B Schedule
+# ══════════════════════════════════════════════════════════════════════
+def _1f1b_schedule(
+    forward_step_fn,
+    model,
+    data_iter,
+    num_microbatches: int,
+    config,
+    ps: ParallelState,
+    tensor_shape: tuple[int, ...],
+    *,
+    grad_sync_fn=None,
+    pre_forward_hook=None,
+    loss_fn=None,
+):
+    """
+    1-Forward-1-Backward pipeline schedule using batch_isend_irecv.
+
+    Communication is always done via combined send+recv to avoid deadlocks.
+    """
+    num_warmup = min(ps.pp_size - ps.pp_rank - 1, num_microbatches)
+    num_steady = num_microbatches - num_warmup
+
+    batches = [next(data_iter) for _ in range(num_microbatches)]
+    mb_idx = 0
+
+    input_tensors: list[torch.Tensor | None] = []
+    output_hiddens: list[torch.Tensor | None] = []
+    losses: list[torch.Tensor | None] = []
+    outputs: list[dict] = []
+
+    # Fix 3: Pre-allocate recv buffers to avoid torch.empty per P2P call.
+    _fwd_recv_buf = (
+        torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
+        if not ps.pp_is_first
+        else None
+    )
+    _bwd_recv_buf = (
+        torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
+        if not ps.pp_is_last
+        else None
+    )
+
+    def _run_forward(input_tensor, batch):
+        _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+        position_ids = _batch_get(batch, "position_ids")
+        packed_seq_params = _batch_get(batch, "packed_seq_params")
+        if ps.pp_is_first:
+            return forward_step_fn(model, batch)
+        if ps.pp_is_last:
+            out = model(
+                input_ids=_batch_input_ids(batch),
+                hidden_states=input_tensor,
+                position_ids=position_ids,
+                packed_seq_params=packed_seq_params,
+                labels=_batch_get(batch, "labels"),
+                loss_mask=_batch_get(batch, "loss_mask"),
+                temperature=_batch_get(batch, "temperature") or 1.0,
+                use_fused_kernels=bool(_batch_get(batch, "use_fused_kernels") or False),
+                calculate_entropy=bool(_batch_get(batch, "calculate_entropy") or False),
+            )
+            _apply_external_loss(out, batch, loss_fn)
+            return out
+        return model(
+            hidden_states=input_tensor,
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+        )
+
+    def _run_backward(inp_t, hid_t, loss_t, grad_t):
+        if ps.pp_is_last:
+            if loss_t is not None:
+                loss_t.backward()
+        else:
+            if hid_t is not None and hid_t.requires_grad:
+                torch.autograd.backward(hid_t, grad_t)
+        return inp_t.grad if inp_t is not None else None
+
+    def _p2p(send_fwd=None, send_bwd=None, recv_fwd=False, recv_bwd=False):
+        return _send_recv_pipeline(
+            send_fwd,
+            send_bwd,
+            recv_fwd,
+            recv_bwd,
+            ps,
+            tensor_shape,
+            fwd_recv_buf=_fwd_recv_buf,
+            bwd_recv_buf=_bwd_recv_buf,
+        )
+
+    # ── Warmup: pure forward passes ──
+    fwd_input: torch.Tensor | None = None
+    for k in range(num_warmup):
+        if not ps.pp_is_first and k == 0:
+            fwd_input, _ = _p2p(recv_fwd=True)
+
+        batch = batches[mb_idx]
+        mb_idx += 1
+        current_input = fwd_input
+        out = _run_forward(fwd_input, batch)
+        hidden = out.get("hidden_states")
+        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+
+        need_recv_next = not ps.pp_is_first and k < num_warmup - 1
+        if not ps.pp_is_last:
+            fwd_input, _ = _p2p(send_fwd=hidden, recv_fwd=need_recv_next)
+        elif need_recv_next:
+            fwd_input, _ = _p2p(recv_fwd=True)
+
+        input_tensors.append(current_input if not ps.pp_is_first else None)
+        output_hiddens.append(hidden)
+        losses.append(loss_s)
+        # Fix 4: only keep loss from output, drop logits/hidden references
+        outputs.append(_compact_pipeline_output(out))
+
+    # ── Steady: interleaved forward + backward ──
+    for k in range(num_steady):
+        if grad_sync_fn and num_warmup == 0 and k == num_steady - 1:
+            grad_sync_fn()
+
+        if not ps.pp_is_first and k == 0 and num_warmup == 0:
+            fwd_input, _ = _p2p(recv_fwd=True)
+
+        batch = batches[mb_idx]
+        mb_idx += 1
+        out = _run_forward(fwd_input, batch)
+        hidden = out.get("hidden_states")
+        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+
+        input_tensors.append(fwd_input if not ps.pp_is_first else None)
+        output_hiddens.append(hidden)
+        losses.append(loss_s)
+        outputs.append(_compact_pipeline_output(out))
+
+        send_fwd = hidden if not ps.pp_is_last else None
+        need_bwd = not ps.pp_is_last
+        _, bwd_grad = _p2p(send_fwd=send_fwd, recv_bwd=need_bwd)
+
+        old_inp = input_tensors.pop(0)
+        old_hid = output_hiddens.pop(0)
+        old_loss = losses.pop(0)
+        in_grad = _run_backward(old_inp, old_hid, old_loss, bwd_grad)
+
+        send_bwd = in_grad if not ps.pp_is_first else None
+        need_fwd = not ps.pp_is_first and k < num_steady - 1
+        fwd_input, _ = _p2p(send_bwd=send_bwd, recv_fwd=need_fwd)
+
+    # ── Cooldown: drain remaining backwards ──
+    for k in range(num_warmup):
+        if grad_sync_fn and k == num_warmup - 1:
+            grad_sync_fn()
+
+        need_bwd = not ps.pp_is_last
+        _, bwd_grad = _p2p(recv_bwd=need_bwd)
+
+        old_inp = input_tensors.pop(0)
+        old_hid = output_hiddens.pop(0)
+        old_loss = losses.pop(0)
+        in_grad = _run_backward(old_inp, old_hid, old_loss, bwd_grad)
+
+        send_bwd = in_grad if not ps.pp_is_first else None
+        if send_bwd is not None:
+            _p2p(send_bwd=send_bwd)
+
+    return outputs
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Pipeline communication helpers
+# ══════════════════════════════════════════════════════════════════════
+_PIPELINE_TENSOR_DTYPE = torch.bfloat16
+
+
+def _deallocate_output_tensor(tensor: torch.Tensor | None) -> None:
+    """Free a large output tensor after it has been sent to the next stage."""
+    if tensor is not None:
+        tensor.data = torch.empty(1, device=tensor.device, dtype=tensor.dtype)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Interleaved 1F1B (VPP) Schedule
+# ══════════════════════════════════════════════════════════════════════
+def _build_schedule_table(
+    num_microbatches: int, num_chunks: int, group_size: int
+) -> list[tuple[int, int]]:
+    """Build (microbatch_id, model_chunk_id) table for VPP scheduling."""
+    table: list[tuple[int, int]] = []
+    for start in range(0, num_microbatches, group_size):
+        end = min(start + group_size, num_microbatches)
+        for chunk in range(num_chunks):
+            for mb in range(start, end):
+                table.append((mb, chunk))
+    return table
+
+
+def _send_recv_pipeline(
+    send_fwd: torch.Tensor | None,
+    send_bwd: torch.Tensor | None,
+    recv_fwd: bool,
+    recv_bwd: bool,
+    ps: ParallelState,
+    tensor_shape: tuple[int, ...],
+    *,
+    fwd_recv_buf: torch.Tensor | None = None,
+    bwd_recv_buf: torch.Tensor | None = None,
+    batch_p2p: bool = True,
+    clone_recv: bool = False,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """P2P communication between pipeline stages."""
+    _dbg = int(os.environ.get("MEGATRON_LITE_PP_DEBUG", "0"))
+    rank = dist.get_rank()
+
+    ops: list[dist.P2POp] = []
+    fwd_buf: torch.Tensor | None = None
+    bwd_buf: torch.Tensor | None = None
+
+    p2p_group = ps.pp_group
+
+    if send_fwd is not None:
+        t = send_fwd.to(_PIPELINE_TENSOR_DTYPE)
+        ops.append(dist.P2POp(dist.isend, t, ps.pp_next_rank, p2p_group))
+    if recv_fwd:
+        fwd_buf = (
+            fwd_recv_buf
+            if fwd_recv_buf is not None
+            else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
+        )
+        ops.append(dist.P2POp(dist.irecv, fwd_buf, ps.pp_prev_rank, p2p_group))
+    if send_bwd is not None:
+        t = send_bwd.to(_PIPELINE_TENSOR_DTYPE)
+        ops.append(dist.P2POp(dist.isend, t, ps.pp_prev_rank, p2p_group))
+    if recv_bwd:
+        bwd_buf = (
+            bwd_recv_buf
+            if bwd_recv_buf is not None
+            else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
+        )
+        ops.append(dist.P2POp(dist.irecv, bwd_buf, ps.pp_next_rank, p2p_group))
+
+    if ops:
+        if _dbg:
+            desc = []
+            if send_fwd is not None:
+                desc.append(f"send_fwd→{ps.pp_next_rank}({list(send_fwd.shape)})")
+            if recv_fwd:
+                desc.append(f"recv_fwd←{ps.pp_prev_rank}")
+            if send_bwd is not None:
+                desc.append(f"send_bwd→{ps.pp_prev_rank}")
+            if recv_bwd:
+                desc.append(f"recv_bwd←{ps.pp_next_rank}")
+            op_name = "batch_isend_irecv" if batch_p2p else "isend_irecv"
+            print(f"[P2P r{rank}] {op_name}: {' '.join(desc)}", flush=True)
+        if batch_p2p:
+            reqs = dist.batch_isend_irecv(ops)
+        else:
+            direct_tensors = []
+            reqs = []
+            if send_fwd is not None:
+                t = send_fwd.to(_PIPELINE_TENSOR_DTYPE)
+                direct_tensors.append(t)
+                reqs.append(dist.isend(t, ps.pp_next_rank, group=p2p_group))
+            if recv_fwd:
+                reqs.append(dist.irecv(fwd_buf, ps.pp_prev_rank, group=p2p_group))
+            if send_bwd is not None:
+                t = send_bwd.to(_PIPELINE_TENSOR_DTYPE)
+                direct_tensors.append(t)
+                reqs.append(dist.isend(t, ps.pp_prev_rank, group=p2p_group))
+            if recv_bwd:
+                reqs.append(dist.irecv(bwd_buf, ps.pp_next_rank, group=p2p_group))
+        for req in reqs:
+            req.wait()
+        if _dbg:
+            print(f"[P2P r{rank}] batch done", flush=True)
+
+    if fwd_buf is not None:
+        if clone_recv:
+            fwd_buf = fwd_buf.clone()
+        fwd_buf.grad = None
+        fwd_buf.requires_grad_()
+    if bwd_buf is not None and clone_recv:
+        bwd_buf = bwd_buf.clone()
+    return fwd_buf, bwd_buf
+
+
+def _pipeline_stage_barrier(ps: ParallelState) -> None:
+    if ps.pp_cpu_group is not None and ps.pp_size > 1:
+        dist.barrier(group=ps.pp_cpu_group)
+
+
+def _set_virtual_pipeline_rank(chunk_id: int | None, num_chunks: int) -> None:
+    if chunk_id is None or num_chunks <= 1:
+        return
+    try:
+        from megatron.core import parallel_state as mpu  # pyright: ignore[reportMissingImports]
+    except Exception:
+        return
+    if not mpu.is_initialized():
+        return
+    vpp_size = mpu.get_virtual_pipeline_model_parallel_world_size()
+    if vpp_size is not None and vpp_size > 1:
+        mpu.set_virtual_pipeline_model_parallel_rank(chunk_id)
+
+
+def _run_pipeline_chunk_forward(
+    forward_step_fn,
+    model,
+    batch,
+    input_tensor: torch.Tensor | None,
+    *,
+    is_first_stage: bool,
+    is_last_stage: bool,
+    num_microbatches: int,
+    pre_forward_hook=None,
+    loss_fn=None,
+) -> dict:
+    _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+    position_ids = _batch_get(batch, "position_ids")
+    packed_seq_params = _batch_get(batch, "packed_seq_params")
+    if is_first_stage:
+        return forward_step_fn(model, batch)
+    if is_last_stage:
+        out = model(
+            input_ids=_batch_input_ids(batch),
+            hidden_states=input_tensor,
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+            labels=_batch_get(batch, "labels"),
+            loss_mask=_batch_get(batch, "loss_mask"),
+            temperature=_batch_get(batch, "temperature") or 1.0,
+            use_fused_kernels=bool(_batch_get(batch, "use_fused_kernels") or False),
+            calculate_entropy=bool(_batch_get(batch, "calculate_entropy") or False),
+        )
+        _apply_external_loss(out, batch, loss_fn)
+        return out
+    return model(
+        hidden_states=input_tensor, position_ids=position_ids, packed_seq_params=packed_seq_params
+    )
+
+
+def _forward_only_pipeline_schedule(
+    forward_step_fn,
+    model_chunks: list,
+    data_iter,
+    num_microbatches: int,
+    ps: ParallelState,
+    tensor_shape: tuple[int, ...],
+    *,
+    pre_forward_hook=None,
+    loss_fn=None,
+):
+    """Simple PP/VPP forward-only schedule used for log-prob inference."""
+    num_chunks = len(model_chunks)
+    total_stages = ps.pp_size * num_chunks
+    outputs: list[dict] = []
+
+    for _mb in range(num_microbatches):
+        batch = next(data_iter)
+        _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+        pending_activation: torch.Tensor | None = None
+        last_output: dict | None = None
+        for stage_id in range(total_stages):
+            stage_pp_rank = stage_id % ps.pp_size
+            is_local_stage = stage_pp_rank == ps.pp_rank
+            hidden: torch.Tensor | None = None
+            if is_local_stage:
+                chunk_id = stage_id // ps.pp_size
+                _set_virtual_pipeline_rank(chunk_id, num_chunks)
+                model = model_chunks[chunk_id]
+                is_first_stage = stage_id == 0
+                is_last_stage = stage_id == total_stages - 1
+                activation = None if is_first_stage else pending_activation
+                pending_activation = None
+                out = _run_pipeline_chunk_forward(
+                    forward_step_fn,
+                    model,
+                    batch,
+                    activation,
+                    is_first_stage=is_first_stage,
+                    is_last_stage=is_last_stage,
+                    num_microbatches=num_microbatches,
+                    pre_forward_hook=None,
+                    loss_fn=loss_fn,
+                )
+                if is_last_stage:
+                    last_output = out
+                else:
+                    hidden = out.get("hidden_states")
+
+            if stage_id < total_stages - 1:
+                recv_next = (stage_id + 1) % ps.pp_size == ps.pp_rank
+                _pipeline_stage_barrier(ps)
+                fwd_buf, _ = _send_recv_pipeline(
+                    hidden if is_local_stage else None,
+                    None,
+                    recv_next,
+                    False,
+                    ps,
+                    tensor_shape,
+                    batch_p2p=False,
+                    clone_recv=True,
+                )
+                if recv_next:
+                    pending_activation = fwd_buf
+
+        outputs.append(_compact_pipeline_output(last_output) if last_output is not None else {})
+
+    return outputs
+
+
+def _interleaved_1f1b_schedule(
+    forward_step_fn,
+    model_chunks: list,
+    data_iter,
+    num_microbatches: int,
+    config,
+    ps: ParallelState,
+    tensor_shape: tuple[int, ...],
+    *,
+    grad_sync_fn=None,
+    pre_forward_hook=None,
+    loss_fn=None,
+):
+    """
+    Correct serial schedule for Virtual Pipeline Parallelism (VPP).
+
+    Local chunks are laid out in global layer order as
+    ``chunk_id * pp_size + pp_rank``.  The previous interleaved 1F1B bringup
+    schedule could ask the first physical PP stage to receive the next virtual
+    chunk before the last physical stage had produced it.  This schedule keeps
+    the same VPP semantics but runs one micro-batch at a time in global stage
+    order, which is slower but deterministic and easy to validate against
+    Megatron.
+    """
+    num_chunks = len(model_chunks)
+    total_stages = ps.pp_size * num_chunks
+    rank = dist.get_rank()
+    outputs: list[dict] = []
+
+    _dbg = int(os.environ.get("MEGATRON_LITE_PP_DEBUG", "0"))
+    if _dbg:
+        print(
+            f"[VPP r{rank}] entered simple schedule pp_rank={ps.pp_rank} "
+            f"microbatches={num_microbatches} chunks={num_chunks} total_stages={total_stages}",
+            flush=True,
+        )
+
+    for mb_id in range(num_microbatches):
+        batch = next(data_iter)
+        _set_aux_loss_scale(pre_forward_hook, num_microbatches)
+        saved: dict[
+            int, tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, dict]
+        ] = {}
+        pending_activation: torch.Tensor | None = None
+
+        # Forward in true virtual-stage order:
+        # chunk0/rank0 -> chunk0/rank1 -> ... -> chunkN/rankP.
+        for stage_id in range(total_stages):
+            stage_pp_rank = stage_id % ps.pp_size
+            is_local_stage = stage_pp_rank == ps.pp_rank
+            hidden: torch.Tensor | None = None
+            if is_local_stage:
+                chunk_id = stage_id // ps.pp_size
+                _set_virtual_pipeline_rank(chunk_id, num_chunks)
+                model = model_chunks[chunk_id]
+                is_first_stage = stage_id == 0
+                is_last_stage = stage_id == total_stages - 1
+                activation = None if is_first_stage else pending_activation
+                pending_activation = None
+                if _dbg:
+                    activation_shape = None if activation is None else tuple(activation.shape)
+                    print(
+                        f"[VPP r{rank}] mb={mb_id} fwd stage={stage_id} "
+                        f"chunk={chunk_id} activation_shape={activation_shape}",
+                        flush=True,
+                    )
+                out = _run_pipeline_chunk_forward(
+                    forward_step_fn,
+                    model,
+                    batch,
+                    activation,
+                    is_first_stage=is_first_stage,
+                    is_last_stage=is_last_stage,
+                    num_microbatches=num_microbatches,
+                    pre_forward_hook=None,
+                    loss_fn=loss_fn,
+                )
+
+                hidden = out.get("hidden_states")
+                if _dbg:
+                    hidden_shape = None if hidden is None else tuple(hidden.shape)
+                    print(
+                        f"[VPP r{rank}] mb={mb_id} fwd stage={stage_id} "
+                        f"chunk={chunk_id} hidden_shape={hidden_shape}",
+                        flush=True,
+                    )
+                loss = out["loss"] / num_microbatches if is_last_stage and "loss" in out else None
+                saved[stage_id] = (activation, hidden, loss, out)
+
+                if is_last_stage:
+                    outputs.append(_compact_pipeline_output(out))
+
+            if stage_id < total_stages - 1:
+                recv_next = (stage_id + 1) % ps.pp_size == ps.pp_rank
+                if _dbg and (is_local_stage or recv_next):
+                    print(
+                        f"[VPP r{rank}] mb={mb_id} fwd boundary={stage_id} "
+                        f"send={is_local_stage and hidden is not None} recv_next={recv_next}",
+                        flush=True,
+                    )
+                _pipeline_stage_barrier(ps)
+                fwd_buf, _ = _send_recv_pipeline(
+                    hidden if is_local_stage else None,
+                    None,
+                    recv_next,
+                    False,
+                    ps,
+                    tensor_shape,
+                    batch_p2p=False,
+                    clone_recv=True,
+                )
+                if recv_next:
+                    pending_activation = fwd_buf
+
+        if grad_sync_fn and mb_id == num_microbatches - 1:
+            grad_sync_fn()
+
+        # Backward in the reverse virtual-stage order.
+        pending_grad: torch.Tensor | None = None
+        for stage_id in range(total_stages - 1, -1, -1):
+            stage_pp_rank = stage_id % ps.pp_size
+            is_local_stage = stage_pp_rank == ps.pp_rank
+            inp_grad: torch.Tensor | None = None
+            if is_local_stage:
+                chunk_id = stage_id // ps.pp_size
+                _set_virtual_pipeline_rank(chunk_id, num_chunks)
+                is_first_stage = stage_id == 0
+                is_last_stage = stage_id == total_stages - 1
+                inp, out_t, loss, _out = saved[stage_id]
+                grad = None if is_last_stage else pending_grad
+                pending_grad = None
+                if _dbg:
+                    print(f"[VPP r{rank}] mb={mb_id} bwd stage={stage_id}", flush=True)
+                if is_last_stage:
+                    if loss is not None:
+                        loss.backward()
+                elif out_t is not None and out_t.requires_grad:
+                    torch.autograd.backward(out_t, grad)
+                if not is_first_stage:
+                    inp_grad = inp.grad if inp is not None else None
+
+            if stage_id > 0:
+                recv_prev = (stage_id - 1) % ps.pp_size == ps.pp_rank
+                if _dbg and (is_local_stage or recv_prev):
+                    print(
+                        f"[VPP r{rank}] mb={mb_id} bwd boundary={stage_id} "
+                        f"send={is_local_stage and inp_grad is not None} recv_prev={recv_prev}",
+                        flush=True,
+                    )
+                _pipeline_stage_barrier(ps)
+                _, bwd_buf = _send_recv_pipeline(
+                    None,
+                    inp_grad if is_local_stage else None,
+                    False,
+                    recv_prev,
+                    ps,
+                    tensor_shape,
+                    batch_p2p=False,
+                    clone_recv=True,
+                )
+                if recv_prev:
+                    pending_grad = bwd_buf
+
+        if _dbg:
+            print(f"[VPP r{rank}] mb={mb_id} complete", flush=True)
+
+    return outputs
+
+
+__all__ = ["forward_backward_pipelining"]

--- a/experimental/lite/megatron/lite/primitive/parallel/pp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pp.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Context/pipeline parallel sequence splitting utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+
+def _ensure_divisible(numerator: int, denominator: int, msg: str = "") -> int:
+    if numerator % denominator != 0:
+        detail = f" ({msg})" if msg else ""
+        raise ValueError(f"{numerator} is not divisible by {denominator}{detail}")
+    return numerator // denominator
+
+
+@dataclass
+class PipelineChunkLayout:
+    layer_indices: list[int] = field(default_factory=list)
+    has_embed: bool = False
+    has_head: bool = False
+
+
+def build_pipeline_chunk_layout(
+    num_hidden_layers: int,
+    ps: ParallelState,
+    vpp: int | None = None,
+    vpp_chunk_id: int | None = None,
+) -> PipelineChunkLayout:
+    """Compute layer_indices, has_embed, has_head for this PP rank / VPP chunk."""
+    if vpp_chunk_id is not None:
+        assert vpp is not None
+        layers_per_chunk = _ensure_divisible(num_hidden_layers, ps.pp_size * vpp)
+        start = ps.pp_rank * layers_per_chunk + vpp_chunk_id * (ps.pp_size * layers_per_chunk)
+        layer_indices = list(range(start, start + layers_per_chunk))
+        has_embed = ps.pp_is_first and vpp_chunk_id == 0
+        has_head = ps.pp_is_last and vpp_chunk_id == vpp - 1
+    elif vpp is not None:
+        layers_per_chunk = _ensure_divisible(num_hidden_layers, ps.pp_size * vpp)
+        layer_indices = []
+        for chunk in range(vpp):
+            start = ps.pp_rank * layers_per_chunk + chunk * (ps.pp_size * layers_per_chunk)
+            layer_indices.extend(range(start, start + layers_per_chunk))
+        has_embed = ps.pp_is_first
+        has_head = ps.pp_is_last
+    else:
+        layers_per_stage = _ensure_divisible(num_hidden_layers, ps.pp_size)
+        start = ps.pp_rank * layers_per_stage
+        layer_indices = list(range(start, start + layers_per_stage))
+        has_embed = ps.pp_is_first
+        has_head = ps.pp_is_last
+    return PipelineChunkLayout(layer_indices=layer_indices, has_embed=has_embed, has_head=has_head)
+
+
+__all__ = ["PipelineChunkLayout", "build_pipeline_chunk_layout"]

--- a/experimental/lite/megatron/lite/primitive/parallel/sp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/sp.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Sequence parallel scatter/gather helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+if TYPE_CHECKING:
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+
+def _ag_dim0(x: torch.Tensor, tp_size: int, group: dist.ProcessGroup) -> torch.Tensor:
+    out = torch.empty(tp_size * x.shape[0], x.shape[1], x.shape[2], dtype=x.dtype, device=x.device)
+    dist.all_gather_into_tensor(out, x.contiguous(), group=group)
+    return out
+
+
+def _rs_dim0(x: torch.Tensor, local_seq: int, group: dist.ProcessGroup) -> torch.Tensor:
+    out = torch.empty(local_seq, x.shape[1], x.shape[2], dtype=x.dtype, device=x.device)
+    dist.reduce_scatter_tensor(out, x.contiguous(), group=group)
+    return out
+
+
+class _AllGatherDim0(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, tp_size, tp_rank, group):
+        del tp_rank
+        ctx.group = group
+        ctx.local_seq = x.shape[0]
+        return _ag_dim0(x, tp_size, group)
+
+    @staticmethod
+    def backward(ctx, grad):
+        out = _rs_dim0(grad, ctx.local_seq, ctx.group)
+        return out, None, None, None
+
+
+class _AllGatherDim0ForNonSPConsumer(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, tp_size, tp_rank, group):
+        ctx.tp_rank = tp_rank
+        ctx.local_seq = x.shape[0]
+        return _ag_dim0(x, tp_size, group)
+
+    @staticmethod
+    def backward(ctx, grad):
+        start = ctx.tp_rank * ctx.local_seq
+        return grad[start : start + ctx.local_seq].contiguous(), None, None, None
+
+
+class _ScatterToSP(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, tp_size, tp_rank, group):
+        ctx.tp_size = tp_size
+        ctx.group = group
+        local_seq = x.shape[0] // tp_size
+        start = tp_rank * local_seq
+        return x[start : start + local_seq, :, :].contiguous()
+
+    @staticmethod
+    def backward(ctx, grad):
+        return _ag_dim0(grad, ctx.tp_size, ctx.group), None, None, None
+
+
+def scatter_to_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+    """Scatter [S, B, H] → [S/tp, B, H] for sequence parallel. No-op when tp=1."""
+    if ps.tp_size == 1:
+        return x
+    return _ScatterToSP.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
+
+
+def gather_from_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+    """Gather [S/tp, B, H] → [S, B, H] from sequence parallel. No-op when tp=1."""
+    if ps.tp_size == 1:
+        return x
+    return _AllGatherDim0.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
+
+
+def gather_for_non_sp_head(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+    """AllGather for non-SP consumer (e.g. vocab parallel head)."""
+    if ps.tp_size == 1:
+        return x
+    return _AllGatherDim0ForNonSPConsumer.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
+
+
+__all__ = [
+    "gather_for_non_sp_head",
+    "gather_from_sequence_parallel",
+    "scatter_to_sequence_parallel",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/state.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/state.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""ParallelState and process group initialization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+
+@dataclass
+class ParallelState:
+    tp_group: dist.ProcessGroup | None = None
+    ep_group: dist.ProcessGroup | None = None
+    etp_group: dist.ProcessGroup | None = None
+    cp_group: dist.ProcessGroup | None = None
+    pp_group: dist.ProcessGroup | None = None
+    pp_cpu_group: dist.ProcessGroup | None = None
+    dp_group: dist.ProcessGroup | None = None
+    dp_cp_group: dist.ProcessGroup | None = None
+    tp_ep_group: dist.ProcessGroup | None = None
+    ep_dp_group: dist.ProcessGroup | None = None
+    cp_global_ranks: list[int] | None = None
+    pp_global_ranks: list[int] | None = None
+
+    tp_size: int = 1
+    ep_size: int = 1
+    etp_size: int = 1
+    cp_size: int = 1
+    pp_size: int = 1
+    dp_size: int = 1
+    dp_cp_size: int = 1
+    expert_dp_size: int = 1
+
+    tp_rank: int = 0
+    ep_rank: int = 0
+    etp_rank: int = 0
+    cp_rank: int = 0
+    pp_rank: int = 0
+    dp_rank: int = 0
+    dp_cp_rank: int = 0
+    expert_dp_rank: int = 0
+
+    pp_is_first: bool = True
+    pp_is_last: bool = True
+    pp_next_rank: int = -1
+    pp_prev_rank: int = -1
+
+
+def _ensure_divisible(numerator: int, denominator: int, msg: str = "") -> int:
+    if numerator % denominator != 0:
+        detail = f" ({msg})" if msg else ""
+        raise ValueError(f"{numerator} is not divisible by {denominator}{detail}")
+    return numerator // denominator
+
+
+def init_parallel(config) -> ParallelState:
+    """
+    Initialize all process groups using dual rank decomposition.
+
+    Dense layers: world = TP × CP × PP × DP
+    Expert layers: world = ETP × EP × PP × expert_DP
+    """
+    assert dist.is_initialized(), "Call torch.distributed.init_process_group first"
+
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    tp, ep, etp, cp, pp = config.tp, config.ep, config.etp, config.cp, config.pp
+
+    dense_dp = _ensure_divisible(world, tp * cp * pp)
+    expert_dp = _ensure_divisible(world, etp * ep * pp)
+
+    ps = ParallelState()
+    ps.tp_size, ps.ep_size, ps.etp_size = tp, ep, etp
+    ps.cp_size, ps.pp_size, ps.dp_size = cp, pp, dense_dp
+    ps.expert_dp_size = expert_dp
+    ps.dp_cp_size = dense_dp * cp
+
+    def _d(tp_i, cp_i, dp_i, pp_i):
+        return ((pp_i * dense_dp + dp_i) * cp + cp_i) * tp + tp_i
+
+    def _e(etp_i, ep_i, edp_i, pp_i):
+        return ((pp_i * expert_dp + edp_i) * ep + ep_i) * etp + etp_i
+
+    t = rank
+    my_tp = t % tp
+    t //= tp
+    my_cp = t % cp
+    t //= cp
+    my_ddp = t % dense_dp
+    t //= dense_dp
+    my_pp = t
+
+    t = rank
+    my_etp = t % etp
+    t //= etp
+    my_ep = t % ep
+    t //= ep
+    my_edp = t % expert_dp
+    t //= expert_dp
+    assert t == my_pp, "PP rank must agree between dense and expert decompositions"
+
+    ps.tp_rank, ps.cp_rank, ps.dp_rank, ps.pp_rank = my_tp, my_cp, my_ddp, my_pp
+    ps.dp_cp_rank = my_ddp * cp + my_cp
+    ps.ep_rank, ps.etp_rank, ps.expert_dp_rank = my_ep, my_etp, my_edp
+    ps.pp_is_first = my_pp == 0
+    ps.pp_is_last = my_pp == pp - 1
+
+    for d in range(dense_dp):
+        for p in range(pp):
+            for c in range(cp):
+                ranks = [_d(t, c, d, p) for t in range(tp)]
+                g = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.tp_group = g
+
+    for d in range(dense_dp):
+        for p in range(pp):
+            for t in range(tp):
+                ranks = [_d(t, c, d, p) for c in range(cp)]
+                g = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.cp_group = g
+                    ps.cp_global_ranks = ranks
+
+    for d in range(dense_dp):
+        for c in range(cp):
+            for t in range(tp):
+                ranks = [_d(t, c, d, p) for p in range(pp)]
+                g = dist.new_group(ranks)
+                try:
+                    cpu_g = dist.new_group(ranks, backend="gloo")
+                except (RuntimeError, ValueError):
+                    cpu_g = None
+                if rank in ranks:
+                    ps.pp_group = g
+                    ps.pp_cpu_group = cpu_g
+                    ps.pp_global_ranks = ranks
+
+    for p in range(pp):
+        for c in range(cp):
+            for t in range(tp):
+                ranks = [_d(t, c, d, p) for d in range(dense_dp)]
+                g = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.dp_group = g
+
+    for p in range(pp):
+        for t in range(tp):
+            ranks = [_d(t, c, d, p) for d in range(dense_dp) for c in range(cp)]
+            g = dist.new_group(ranks)
+            if rank in ranks:
+                ps.dp_cp_group = g
+
+    for d in range(expert_dp):
+        for p in range(pp):
+            for t in range(etp):
+                ranks = [_e(t, e, d, p) for e in range(ep)]
+                g = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.ep_group = g
+
+    if etp > 1:
+        for d in range(expert_dp):
+            for p in range(pp):
+                for e in range(ep):
+                    ranks = [_e(t, e, d, p) for t in range(etp)]
+                    g = dist.new_group(ranks)
+                    if rank in ranks:
+                        ps.etp_group = g
+
+    for d in range(expert_dp):
+        for p in range(pp):
+            ranks = [_e(t, e, d, p) for e in range(ep) for t in range(etp)]
+            g = dist.new_group(ranks)
+            if rank in ranks:
+                ps.tp_ep_group = g
+
+    for p in range(pp):
+        for e in range(ep):
+            for t in range(etp):
+                ranks = [_e(t, e, d, p) for d in range(expert_dp)]
+                g = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.ep_dp_group = g
+
+    pp_ranks = ps.pp_global_ranks
+    if pp_ranks is None:
+        raise RuntimeError("Pipeline ranks were not initialized.")
+    ps.pp_next_rank = pp_ranks[(my_pp + 1) % pp] if pp > 1 else rank
+    ps.pp_prev_rank = pp_ranks[(my_pp - 1) % pp] if pp > 1 else rank
+
+    return ps
+
+
+__all__ = ["ParallelState", "init_parallel"]

--- a/experimental/lite/megatron/lite/primitive/parallel/thd.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/thd.py
@@ -1,0 +1,457 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Packed sequence helpers for variable-length (THD) attention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+
+@dataclass
+class PackedSeqParams:
+    """Parameters for THD-format packed-sequence attention.
+
+    Mirrors the fields consumed by TE's ``DotProductAttention.forward()``
+    when ``qkv_format="thd"`` is used (total-tokens x heads x dim).
+
+    Typical construction::
+
+        params = PackedSeqParams.from_cu_seqlens(batch.cu_seqlens, batch.max_seqlen)
+    """
+
+    qkv_format: str = "thd"
+    cu_seqlens_q: torch.Tensor | None = None
+    cu_seqlens_kv: torch.Tensor | None = None
+    max_seqlen_q: int | None = None
+    max_seqlen_kv: int | None = None
+    cu_seqlens_q_padded: torch.Tensor | None = None
+    cu_seqlens_kv_padded: torch.Tensor | None = None
+    local_cp_size: int | None = None
+    cp_group: Any | None = None
+    cp_rank: int | None = None
+
+    @staticmethod
+    def from_cu_seqlens(cu_seqlens: torch.Tensor, max_seqlen: int) -> PackedSeqParams:
+        """Build from shared Q/KV cu_seqlens (self-attention)."""
+        return PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+        )
+
+
+@dataclass(frozen=True)
+class PackedTHDBatch:
+    """Dense packed representation of a jagged no-padding batch."""
+
+    input_ids: torch.Tensor
+    labels: torch.Tensor | None
+    loss_mask: torch.Tensor | None
+    position_ids: torch.Tensor
+    packed_seq_params: Any
+    cu_seqlens_padded: torch.Tensor
+    lengths: torch.Tensor
+    padded_lengths: torch.Tensor
+    cp_size: int = 1
+    cp_rank: int = 0
+    cp_group: Any | None = None
+
+
+def _make_packed_seq_params(
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    max_seqlen: int,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+    cp_group: Any | None = None,
+):
+    extra_args = {}
+    if cp_size > 1:
+        extra_args["local_cp_size"] = cp_size
+        if cp_group is not None:
+            extra_args["cp_group"] = cp_group
+    try:
+        from megatron.core.packed_seq_params import PackedSeqParams as MCorePackedSeqParams
+
+        params = MCorePackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens_padded,
+            cu_seqlens_kv=cu_seqlens_padded,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            cu_seqlens_q_padded=cu_seqlens_padded,
+            cu_seqlens_kv_padded=cu_seqlens_padded,
+            **extra_args,
+        )
+        # MCore's PackedSeqParams does not carry rank, but local rolling needs it.
+        params.cp_rank = cp_rank
+        return params
+    except Exception:
+        return PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens_padded,
+            cu_seqlens_kv=cu_seqlens_padded,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            cu_seqlens_q_padded=cu_seqlens_padded,
+            cu_seqlens_kv_padded=cu_seqlens_padded,
+            cp_rank=cp_rank,
+            **extra_args,
+        )
+
+
+def _slice_along_dim(tensor: torch.Tensor, dim: int, start: int, end: int) -> torch.Tensor:
+    index = [slice(None)] * tensor.dim()
+    index[dim] = slice(start, end)
+    return tensor[tuple(index)]
+
+
+def _assign_along_dim(dst: torch.Tensor, dim: int, start: int, src: torch.Tensor) -> None:
+    index = [slice(None)] * dst.dim()
+    index[dim] = slice(start, start + src.size(dim))
+    dst[tuple(index)] = src
+
+
+def _split_full_to_cp_local(
+    tensor: torch.Tensor, *, cu_seqlens_padded: torch.Tensor, cp_size: int, cp_rank: int, dim: int
+) -> torch.Tensor:
+    if cp_size <= 1:
+        return tensor
+
+    total_local = int(cu_seqlens_padded[-1].item()) // cp_size
+    out_shape = list(tensor.shape)
+    out_shape[dim] = total_local
+    local = torch.zeros(out_shape, dtype=tensor.dtype, device=tensor.device)
+
+    for idx in range(int(cu_seqlens_padded.numel()) - 1):
+        full_start = int(cu_seqlens_padded[idx].item())
+        full_end = int(cu_seqlens_padded[idx + 1].item())
+        padded_len = full_end - full_start
+        if padded_len <= 0:
+            continue
+        chunk = padded_len // (2 * cp_size)
+        local_start = full_start // cp_size
+
+        first = _slice_along_dim(
+            tensor, dim, full_start + cp_rank * chunk, full_start + (cp_rank + 1) * chunk
+        )
+        second = _slice_along_dim(
+            tensor, dim, full_end - (cp_rank + 1) * chunk, full_end - cp_rank * chunk
+        )
+        _assign_along_dim(local, dim, local_start, first)
+        _assign_along_dim(local, dim, local_start + chunk, second)
+
+    return local
+
+
+def _reconstruct_full_from_cp_parts(
+    parts: list[torch.Tensor], *, cu_seqlens_padded: torch.Tensor, cp_size: int, dim: int
+) -> torch.Tensor:
+    if cp_size <= 1:
+        return parts[0]
+
+    total_full = int(cu_seqlens_padded[-1].item())
+    out_shape = list(parts[0].shape)
+    out_shape[dim] = total_full
+    full = torch.zeros(out_shape, dtype=parts[0].dtype, device=parts[0].device)
+
+    for idx in range(int(cu_seqlens_padded.numel()) - 1):
+        full_start = int(cu_seqlens_padded[idx].item())
+        full_end = int(cu_seqlens_padded[idx + 1].item())
+        padded_len = full_end - full_start
+        if padded_len <= 0:
+            continue
+        chunk = padded_len // (2 * cp_size)
+        local_start = full_start // cp_size
+
+        for rank, part in enumerate(parts):
+            first = _slice_along_dim(part, dim, local_start, local_start + chunk)
+            second = _slice_along_dim(part, dim, local_start + chunk, local_start + 2 * chunk)
+            _assign_along_dim(full, dim, full_start + rank * chunk, first)
+            _assign_along_dim(full, dim, full_end - (rank + 1) * chunk, second)
+
+    return full
+
+
+def reconstruct_packed_from_cp_parts(
+    parts: list[torch.Tensor], *, cu_seqlens_padded: torch.Tensor, cp_size: int, dim: int
+) -> torch.Tensor:
+    """Reconstruct a full packed THD tensor from CP-local zigzag parts."""
+    return _reconstruct_full_from_cp_parts(
+        parts, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, dim=dim
+    )
+
+
+def split_packed_to_cp_local(
+    tensor: torch.Tensor, *, cu_seqlens_padded: torch.Tensor, cp_size: int, cp_rank: int, dim: int
+) -> torch.Tensor:
+    """Slice a full packed THD tensor back to one CP rank's zigzag shard."""
+    return _split_full_to_cp_local(
+        tensor, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, cp_rank=cp_rank, dim=dim
+    )
+
+
+def _all_gather_cp_tensor(
+    tensor: torch.Tensor, *, cp_size: int, cp_group: Any
+) -> list[torch.Tensor]:
+    if cp_size <= 1:
+        return [tensor]
+    if cp_group is None:
+        raise ValueError("CP THD gather requires cp_group.")
+    try:
+        from torch.distributed.nn.functional import all_gather
+
+        return list(all_gather(tensor, group=cp_group))
+    except Exception:
+        parts = [torch.empty_like(tensor) for _ in range(cp_size)]
+        dist.all_gather(parts, tensor, group=cp_group)
+        return parts
+
+
+def _roll_packed_thd_left_local(
+    tensor: torch.Tensor, *, cu_seqlens_padded: torch.Tensor, dims: int = -1
+) -> tuple[torch.Tensor, torch.Tensor]:
+    dim = dims if dims >= 0 else tensor.dim() + dims
+    if dim < 0 or dim >= tensor.dim():
+        raise ValueError(f"Invalid roll dim {dims} for tensor with {tensor.dim()} dims.")
+
+    rolled = tensor.clone()
+    for idx in range(int(cu_seqlens_padded.numel()) - 1):
+        start = int(cu_seqlens_padded[idx].item())
+        end = int(cu_seqlens_padded[idx + 1].item())
+        if end <= start:
+            continue
+
+        index = [slice(None)] * tensor.dim()
+        index[dim] = slice(start, end)
+        seq = torch.roll(tensor[tuple(index)], shifts=-1, dims=dim)
+
+        zero_index = [slice(None)] * seq.dim()
+        zero_index[dim] = slice(-1, None)
+        seq[tuple(zero_index)] = 0
+        rolled[tuple(index)] = seq
+
+    return rolled, rolled.sum()
+
+
+def roll_packed_thd_left(
+    tensor: torch.Tensor,
+    *,
+    cu_seqlens_padded: torch.Tensor | None = None,
+    packed_seq_params: Any | None = None,
+    dims: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Roll a THD packed tensor left without crossing sequence boundaries."""
+
+    cp_size = 1
+    cp_rank = 0
+    cp_group = None
+    if packed_seq_params is not None:
+        cu_seqlens_padded = getattr(packed_seq_params, "cu_seqlens_q", None)
+        cp_size = int(getattr(packed_seq_params, "local_cp_size", None) or 1)
+        cp_rank = int(getattr(packed_seq_params, "cp_rank", 0) or 0)
+        cp_group = getattr(packed_seq_params, "cp_group", None)
+    if cu_seqlens_padded is None:
+        raise ValueError("THD packed roll requires cu_seqlens.")
+
+    dim = dims if dims >= 0 else tensor.dim() + dims
+    if cp_size <= 1:
+        return _roll_packed_thd_left_local(tensor, cu_seqlens_padded=cu_seqlens_padded, dims=dim)
+
+    parts = _all_gather_cp_tensor(tensor, cp_size=cp_size, cp_group=cp_group)
+    full = _reconstruct_full_from_cp_parts(
+        parts, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, dim=dim
+    )
+    rolled_full, token_sum = _roll_packed_thd_left_local(
+        full, cu_seqlens_padded=cu_seqlens_padded, dims=dim
+    )
+    local = _split_full_to_cp_local(
+        rolled_full, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, cp_rank=cp_rank, dim=dim
+    )
+    return local, token_sum
+
+
+def pack_nested_thd(
+    input_ids: torch.Tensor,
+    *,
+    tp_size: int = 1,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+    cp_group: Any | None = None,
+    labels: torch.Tensor | None = None,
+    roll_labels: bool = False,
+    loss_mask: torch.Tensor | None = None,
+    roll_loss_mask: bool = False,
+) -> PackedTHDBatch:
+    """Pack a jagged no-padding batch into Megatron Lite's THD model input.
+
+    Mirrors VERL/Megatron's THD engine convention: each sequence is
+    padded to the tensor-parallel alignment, concatenated, then represented as
+    a single ``[1, local_padded_tokens]`` token row plus ``PackedSeqParams``.
+    For CP>1 the local row uses Megatron/TE zigzag chunking.
+    """
+
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be >= 1, got {cp_size}")
+    if cp_rank < 0 or cp_rank >= cp_size:
+        raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}")
+    if not getattr(input_ids, "is_nested", False):
+        raise TypeError("pack_nested_thd expects a jagged NestedTensor input_ids.")
+    if labels is not None and not getattr(labels, "is_nested", False):
+        raise TypeError(
+            "pack_nested_thd expects jagged NestedTensor labels when labels are provided."
+        )
+    if loss_mask is not None and not getattr(loss_mask, "is_nested", False):
+        raise TypeError(
+            "pack_nested_thd expects jagged NestedTensor loss_mask when loss_mask is provided."
+        )
+
+    align_size = max(int(tp_size), 1) * (2 * cp_size if cp_size > 1 else 1)
+    device = input_ids.device
+    offsets = input_ids.offsets().to(device=device)
+    lengths = offsets.diff().to(dtype=torch.int32)
+    pad_size = (align_size - lengths % align_size) % align_size
+    padded_lengths = lengths + pad_size
+
+    cu_seqlens_padded = torch.zeros(lengths.numel() + 1, dtype=torch.int32, device=device)
+    cu_seqlens_padded[1:] = torch.cumsum(padded_lengths, dim=0)
+    total_padded = int(cu_seqlens_padded[-1].item())
+    total_local = total_padded // cp_size
+    max_seqlen = int(padded_lengths.max().item()) if padded_lengths.numel() else 0
+
+    packed_input = torch.zeros(total_local, dtype=input_ids.dtype, device=device)
+    packed_labels = (
+        torch.zeros(total_local, dtype=labels.dtype, device=device) if labels is not None else None
+    )
+    packed_loss_mask = (
+        torch.zeros(total_local, dtype=loss_mask.dtype, device=device)
+        if loss_mask is not None
+        else None
+    )
+    # Megatron's rotary embedding slices position embeddings on the CP rank.
+    # Keep packed position ids full-length while CP-slicing tokens/labels/masks.
+    position_ids = torch.zeros(total_padded, dtype=torch.long, device=device)
+
+    for idx, length_t in enumerate(lengths):
+        length = int(length_t.item())
+        padded_length = int(padded_lengths[idx].item())
+        full_start = int(cu_seqlens_padded[idx].item())
+        local_start = full_start // cp_size
+
+        seq_input = torch.zeros(padded_length, dtype=input_ids.dtype, device=device)
+        seq_input[:length] = input_ids[idx]
+        seq_labels = None
+        if labels is not None:
+            assert packed_labels is not None
+            seq_labels = torch.zeros(padded_length, dtype=labels.dtype, device=device)
+            seq_labels[:length] = labels[idx]
+            if roll_labels and length > 0:
+                seq_labels[:length] = torch.roll(seq_labels[:length], shifts=-1, dims=0)
+                seq_labels[length - 1] = 0
+        seq_loss_mask = None
+        if loss_mask is not None:
+            assert packed_loss_mask is not None
+            seq_loss_mask = torch.zeros(padded_length, dtype=loss_mask.dtype, device=device)
+            seq_loss_mask[:length] = loss_mask[idx]
+            if roll_loss_mask and length > 0:
+                seq_loss_mask[:length] = torch.roll(seq_loss_mask[:length], shifts=-1, dims=0)
+                seq_loss_mask[length - 1] = 0
+        seq_positions = torch.zeros(padded_length, dtype=torch.long, device=device)
+        seq_positions[:length] = torch.arange(length, dtype=torch.long, device=device)
+
+        local_input = _split_full_to_cp_local(
+            seq_input,
+            cu_seqlens_padded=torch.tensor([0, padded_length], dtype=torch.int32, device=device),
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            dim=0,
+        )
+        packed_input[local_start : local_start + local_input.numel()] = local_input
+        if seq_labels is not None:
+            local_labels = _split_full_to_cp_local(
+                seq_labels,
+                cu_seqlens_padded=torch.tensor(
+                    [0, padded_length], dtype=torch.int32, device=device
+                ),
+                cp_size=cp_size,
+                cp_rank=cp_rank,
+                dim=0,
+            )
+            assert packed_labels is not None
+            packed_labels[local_start : local_start + local_labels.numel()] = local_labels
+        if seq_loss_mask is not None:
+            local_loss_mask = _split_full_to_cp_local(
+                seq_loss_mask,
+                cu_seqlens_padded=torch.tensor(
+                    [0, padded_length], dtype=torch.int32, device=device
+                ),
+                cp_size=cp_size,
+                cp_rank=cp_rank,
+                dim=0,
+            )
+            assert packed_loss_mask is not None
+            packed_loss_mask[local_start : local_start + local_loss_mask.numel()] = local_loss_mask
+        position_ids[full_start : full_start + padded_length] = seq_positions
+
+    return PackedTHDBatch(
+        input_ids=packed_input.unsqueeze(0),
+        labels=packed_labels.unsqueeze(0) if packed_labels is not None else None,
+        loss_mask=packed_loss_mask.unsqueeze(0) if packed_loss_mask is not None else None,
+        position_ids=position_ids.unsqueeze(0),
+        packed_seq_params=_make_packed_seq_params(
+            cu_seqlens_padded=cu_seqlens_padded,
+            max_seqlen=max_seqlen,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            cp_group=cp_group,
+        ),
+        cu_seqlens_padded=cu_seqlens_padded,
+        lengths=lengths,
+        padded_lengths=padded_lengths,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        cp_group=cp_group,
+    )
+
+
+def unpack_packed_thd_to_nested(output: torch.Tensor, batch: PackedTHDBatch) -> torch.Tensor:
+    """Unpack ``[1, total_padded, ...]`` THD model output back to jagged form."""
+
+    if output.dim() >= 2 and output.shape[0] == 1:
+        flat = output[0]
+    elif output.dim() >= 2 and output.shape[1] == 1:
+        flat = output[:, 0]
+    else:
+        flat = output
+
+    if batch.cp_size > 1:
+        dim = 0
+        parts = _all_gather_cp_tensor(flat, cp_size=batch.cp_size, cp_group=batch.cp_group)
+        flat = _reconstruct_full_from_cp_parts(
+            parts, cu_seqlens_padded=batch.cu_seqlens_padded, cp_size=batch.cp_size, dim=dim
+        )
+
+    pieces = []
+    for idx, length_t in enumerate(batch.lengths):
+        length = int(length_t.item())
+        start = int(batch.cu_seqlens_padded[idx].item())
+        pieces.append(flat[start : start + length])
+    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+
+
+__all__ = [
+    "PackedSeqParams",
+    "PackedTHDBatch",
+    "pack_nested_thd",
+    "reconstruct_packed_from_cp_parts",
+    "roll_packed_thd_left",
+    "split_packed_to_cp_local",
+    "unpack_packed_thd_to_nested",
+]

--- a/experimental/lite/megatron/lite/primitive/protocols.py
+++ b/experimental/lite/megatron/lite/primitive/protocols.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Protocol definitions for Lite model and primitive integration."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from megatron.lite.primitive.bundle import ModelBundle
+
+
+class ModelBuildProtocol(Protocol):
+    """Protocol implemented by registered model implementation modules."""
+
+    def build_model_config(self, hf_path: str = "") -> Any:
+        """Build or load a model config object."""
+
+    def build_model(self, model_cfg: Any, impl_cfg: Any | None = None) -> ModelBundle:
+        """Build model chunks and return a runtime-consumable bundle."""
+
+
+__all__ = ["ModelBuildProtocol"]

--- a/experimental/lite/megatron/lite/primitive/train_step.py
+++ b/experimental/lite/megatron/lite/primitive/train_step.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Reusable train-step primitives owned by Megatron Lite."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import torch
+import torch.distributed as dist
+
+from megatron.lite.primitive.parallel import ParallelState
+
+ExpertClassifierFn = Callable[[str], bool]
+
+
+def default_expert_classifier(name: str) -> bool:
+    """Default: params with 'experts' but not router/shared are expert params."""
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+def _first_tensor_device(*values) -> torch.device:
+    for value in values:
+        if isinstance(value, torch.Tensor):
+            return value.device
+        if isinstance(value, dict):
+            device = _first_tensor_device(*value.values())
+            if device is not None:
+                return device
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def run_microbatch_loop(
+    model,
+    data_iter,
+    num_microbatches: int,
+    forward_fn,
+    optimizer=None,
+    dist_opt: bool = False,
+    pre_forward_hook: Callable[[torch.Tensor], None] | None = None,
+    loss_fn: Callable | None = None,
+):
+    """Run forward-backward over microbatches with loss accumulation.
+
+    Args:
+        forward_fn: ``forward_fn(model, batch) -> dict`` with at least ``"loss"`` key
+            (when ``loss_fn`` is None) or model outputs (when ``loss_fn`` is provided).
+        pre_forward_hook: Optional callable ``hook(scale: torch.Tensor) -> None``
+            invoked once per microbatch, right before ``forward_fn``. ``scale`` is
+            ``1.0 / num_microbatches`` (matches MC's ``schedules.forward_step``,
+            see `pipeline_parallel/schedules.py`). Used e.g. by MoE aux-loss
+            scale-setting; runtime stays model-agnostic by passing the hook
+            through from the model bundle's extras.
+            # TODO: once CP is supported, align with MC's
+            # `schedules:297`-style scale of `cp_group_size / num_microbatches`
+            # (currently assumes ``cp_group_size == 1``).
+        loss_fn: Optional external loss function.
+            ``loss_fn(model_output: dict, batch) -> (loss: Tensor, metrics: dict)``.
+            When provided, ``forward_fn`` output is passed to ``loss_fn`` instead of
+            reading ``out["loss"]`` directly. This enables RLHF policy/value losses.
+    """
+    last_out = None
+    all_metrics: list[dict] = []
+    for mb in range(num_microbatches):
+        batch = next(data_iter)
+        if pre_forward_hook is not None:
+            scale = torch.tensor(1.0 / num_microbatches, device=_first_tensor_device(batch))
+            pre_forward_hook(scale)
+        out = forward_fn(model, batch)
+        if dist_opt and optimizer is not None and mb == num_microbatches - 1:
+            optimizer.grad_sync_enabled = True
+        if loss_fn is not None:
+            loss, metrics = loss_fn(out, batch)
+            (loss / num_microbatches).backward()
+            out["loss"] = loss.detach()
+            all_metrics.append(metrics)
+        else:
+            (out["loss"] / num_microbatches).backward()
+        last_out = out
+    if last_out is not None and all_metrics:
+        last_out["_loss_fn_metrics"] = all_metrics
+    return last_out
+
+
+def compute_and_clip_grad_norm(
+    model,
+    optimizer,
+    max_norm: float,
+    use_dist_opt: bool,
+    sp_params=None,
+    sp_group=None,
+    *,
+    report_global_norm: bool = False,
+    ps: ParallelState | None = None,
+    is_expert_param: ExpertClassifierFn = default_expert_classifier,
+):
+    """SP AllReduce + finish grad sync + clip grad norm. Returns grad_norm."""
+    if sp_params:
+        sp_grads = [p.grad for p in sp_params if p.grad is not None]
+        if sp_grads:
+            flat = torch.cat([g.view(-1) for g in sp_grads])
+            dist.all_reduce(flat, op=dist.ReduceOp.SUM, group=sp_group)
+            offset = 0
+            for g in sp_grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+    report_norm = None
+    if report_global_norm:
+        if ps is None:
+            raise ValueError("`ps` is required when `report_global_norm=True`.")
+        report_norm = compute_global_grad_norm(model, ps, is_expert_param=is_expert_param)
+    if use_dist_opt:
+        optimizer.finish_grad_sync()
+        return optimizer.clip_grad_norm()
+    local_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
+    return report_norm if report_norm is not None else local_norm
+
+
+def compute_global_grad_norm(
+    model, ps: ParallelState, *, is_expert_param: ExpertClassifierFn = default_expert_classifier
+) -> torch.Tensor:
+    """Compute benchmark global grad norm with dist-opt-aligned reduction order."""
+    dense_sq = _bucketed_grad_sq_sum(
+        model,
+        include_param=lambda name: not is_expert_param(name),
+        replica_group=ps.dp_cp_group,
+        replica_size=ps.dp_cp_size,
+    )
+    expert_sq = _bucketed_grad_sq_sum(
+        model,
+        include_param=is_expert_param,
+        replica_group=ps.ep_dp_group,
+        replica_size=ps.expert_dp_size,
+    )
+
+    if ps.tp_size > 1 and ps.tp_group is not None:
+        dist.all_reduce(dense_sq, group=ps.tp_group)
+
+    if ps.ep_size > 1 and ps.ep_group is not None:
+        dist.all_reduce(expert_sq, group=ps.ep_group)
+    if ps.etp_size > 1 and ps.etp_group is not None:
+        dist.all_reduce(expert_sq, group=ps.etp_group)
+
+    total_sq = dense_sq + expert_sq
+    if ps.pp_size > 1 and ps.pp_group is not None:
+        dist.all_reduce(total_sq, group=ps.pp_group)
+    return total_sq.sqrt()
+
+
+def _bucketed_grad_sq_sum(
+    model,
+    *,
+    include_param: Callable[[str], bool],
+    replica_group,
+    replica_size: int,
+    max_bucket_bytes: int = 80 * 1024 * 1024,
+) -> torch.Tensor:
+    """Accumulate squared norm after averaging replica grads within each bucket."""
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    for _name, param in model.named_parameters():
+        if param.grad is not None:
+            device = param.grad.device
+            break
+    total_sq = torch.zeros(1, device=device)
+    bucket: list[torch.Tensor] = []
+    bucket_bytes = 0
+
+    def flush_bucket() -> None:
+        nonlocal bucket_bytes, bucket, total_sq
+        if not bucket:
+            return
+        flat = torch.cat(bucket)
+        if replica_size > 1 and replica_group is not None:
+            dist.all_reduce(flat, group=replica_group)
+            flat.div_(replica_size)
+        total_sq += flat.float().norm().pow(2)
+        bucket = []
+        bucket_bytes = 0
+
+    for name, param in model.named_parameters():
+        if param.grad is None or not include_param(name):
+            continue
+        grad = param.grad.view(-1)
+        grad_bytes = grad.numel() * grad.element_size()
+        if bucket and bucket_bytes + grad_bytes > max_bucket_bytes:
+            flush_bucket()
+        bucket.append(grad)
+        bucket_bytes += grad_bytes
+
+    flush_bucket()
+    return total_sq
+
+
+def optimizer_step(optimizer) -> None:
+    """Execute optimizer step."""
+    optimizer.step()
+
+
+__all__ = [
+    "compute_and_clip_grad_norm",
+    "compute_global_grad_norm",
+    "optimizer_step",
+    "run_microbatch_loop",
+]

--- a/experimental/lite/megatron/lite/runtime/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/__init__.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Runtime entrypoints for Megatron Lite."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+from megatron.lite.runtime.contracts.config import RuntimeConfig
+
+if TYPE_CHECKING:
+    from megatron.lite.runtime.backends import Runtime
+
+
+def _runtime_registry() -> dict[str, str]:
+    from megatron.lite.runtime.backends import RUNTIME_REGISTRY
+
+    return RUNTIME_REGISTRY
+
+
+def register_runtime(name: str, module_path: str) -> None:
+    """Register a runtime backend module.
+
+    The module must provide a ``create(hf_path, cfg)`` function returning a
+    ``Runtime`` instance.
+    """
+
+    if not name:
+        raise ValueError("Runtime name must be non-empty.")
+    _runtime_registry()[name] = module_path
+
+
+def create_runtime(cfg: RuntimeConfig) -> Runtime:
+    """Create a runtime from a public runtime config."""
+
+    registry = _runtime_registry()
+    if cfg.backend not in registry:
+        raise ValueError(f"Unknown runtime backend {cfg.backend!r}. Known: {sorted(registry)}")
+    mod = importlib.import_module(registry[cfg.backend])
+    return mod.create(cfg.hf_path, cfg.backend_cfg)
+
+
+def __getattr__(name: str):
+    lazy = {
+        "ForwardResult": "megatron.lite.runtime.contracts.data",
+        "ModelHandle": "megatron.lite.runtime.contracts.handle",
+        "Runtime": "megatron.lite.runtime.backends",
+        "TrainBatch": "megatron.lite.runtime.contracts.data",
+    }
+    if name in lazy:
+        mod = importlib.import_module(lazy[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "ForwardResult",
+    "ModelHandle",
+    "Runtime",
+    "RuntimeConfig",
+    "TrainBatch",
+    "create_runtime",
+    "register_runtime",
+]

--- a/experimental/lite/megatron/lite/runtime/backends/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/__init__.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Runtime interface and backend registry."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any
+
+from megatron.lite.runtime.contracts.data import ForwardResult
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+class Runtime(ABC):
+    """Base class implemented by Megatron Lite runtime backends."""
+
+    @abstractmethod
+    def build_model(self, hf_path: str | None = None, cfg: Any = None, **kwargs) -> ModelHandle:
+        """Build runtime-owned model state and return an opaque handle."""
+
+    @abstractmethod
+    def train_mode(self, handle: ModelHandle) -> Any:
+        """Put the handled model in training mode."""
+
+    @abstractmethod
+    def eval_mode(self, handle: ModelHandle) -> Any:
+        """Put the handled model in evaluation mode."""
+
+    @abstractmethod
+    def forward_backward(
+        self,
+        handle: ModelHandle,
+        data: Any,
+        loss_fn: Callable[[Any, Any], tuple[Any, dict[str, Any]]] | None = None,
+        *,
+        num_microbatches: int = 1,
+        forward_only: bool = False,
+    ) -> ForwardResult:
+        """Run a local forward/backward atom for one logical step."""
+
+    @abstractmethod
+    def zero_grad(self, handle: ModelHandle) -> None:
+        """Clear gradients for the handled optimizer/model."""
+
+    @abstractmethod
+    def optimizer_step(self, handle: ModelHandle) -> tuple[bool, float, int | None]:
+        """Run the optimizer step and return ``(ok, grad_norm, zero_grad_count)``."""
+
+    @abstractmethod
+    def lr_scheduler_step(self, handle: ModelHandle) -> float | list[float]:
+        """Advance or query the runtime learning-rate scheduler."""
+
+
+RUNTIME_REGISTRY: dict[str, str] = {
+    "mlite": "megatron.lite.runtime.backends.mlite",
+}
+
+
+__all__ = ["RUNTIME_REGISTRY", "Runtime"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Default local Megatron Lite backend."""
+
+from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime, create
+
+__all__ = ["MegatronLiteConfig", "MegatronLiteRuntime", "create"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Configuration for the local Megatron Lite backend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any
+
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+
+
+def _pick_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
+    names = {field.name for field in fields(cls)}
+    return {name: value for name, value in values.items() if name in names}
+
+
+@dataclass
+class MegatronLiteConfig:
+    """Backend config used by the local ``mlite`` runtime."""
+
+    model_name: str = "toy_dense"
+    impl: str = "torch"
+    device: str = "cpu"
+    hf_path: str = ""
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: OptimizerConfig = field(default_factory=OptimizerConfig)
+    impl_cfg: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, hf_path: str, values: dict[str, Any]) -> "MegatronLiteConfig":
+        values = dict(values)
+        if "parallel" in values and isinstance(values["parallel"], dict):
+            values["parallel"] = ParallelConfig(**_pick_fields(ParallelConfig, values["parallel"]))
+        if "optimizer" in values and isinstance(values["optimizer"], dict):
+            values["optimizer"] = OptimizerConfig(**_pick_fields(OptimizerConfig, values["optimizer"]))
+        values.setdefault("hf_path", hf_path)
+        return cls(**_pick_fields(cls, values))
+
+
+__all__ = ["MegatronLiteConfig"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Single-process PyTorch runtime used to validate the Lite contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import fields as dataclass_fields
+from typing import Any
+
+import torch
+
+from megatron.lite.model.registry import get_train_runtime_module, resolve_runtime_model_name
+from megatron.lite.runtime.backends import Runtime
+from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
+from megatron.lite.runtime.contracts.data import ForwardResult, TrainBatch
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+def _as_backend_config(hf_path: str, cfg: MegatronLiteConfig | dict[str, Any] | None) -> MegatronLiteConfig:
+    if cfg is None:
+        return MegatronLiteConfig(hf_path=hf_path)
+    if isinstance(cfg, MegatronLiteConfig):
+        return cfg
+    return MegatronLiteConfig.from_dict(hf_path, cfg)
+
+
+def _dataclass_kwargs(cls, values: dict[str, Any]) -> dict[str, Any]:
+    names = {field.name for field in dataclass_fields(cls)}
+    return {name: value for name, value in values.items() if name in names}
+
+
+def _batch_to_mapping(data: Any) -> dict[str, Any]:
+    if isinstance(data, TrainBatch):
+        return {"inputs": data.inputs, "targets": data.targets, **data.metadata}
+    if isinstance(data, dict):
+        return data
+    return {"inputs": data, "targets": None}
+
+
+class MegatronLiteRuntime(Runtime):
+    """A minimal local runtime for contract validation."""
+
+    def __init__(self, hf_path: str = "", cfg: MegatronLiteConfig | dict[str, Any] | None = None):
+        self._hf_path = hf_path
+        self._cfg = _as_backend_config(hf_path, cfg)
+
+    def build_model(
+        self,
+        hf_path: str | None = None,
+        cfg: MegatronLiteConfig | dict[str, Any] | None = None,
+        **kwargs,
+    ) -> ModelHandle:
+        rt_cfg = _as_backend_config(hf_path or self._hf_path, cfg) if cfg is not None else self._cfg
+        if kwargs:
+            rt_cfg.impl_cfg.update(kwargs)
+
+        runtime_key = resolve_runtime_model_name(rt_cfg.model_name, rt_cfg.impl)
+        protocol = get_train_runtime_module(runtime_key)
+        model_cfg = protocol.build_model_config(rt_cfg.hf_path)
+
+        impl_cfg = None
+        if hasattr(protocol, "ImplConfig"):
+            impl_cfg = protocol.ImplConfig(**_dataclass_kwargs(protocol.ImplConfig, rt_cfg.impl_cfg))
+
+        bundle = protocol.build_model(model_cfg, impl_cfg=impl_cfg)
+        if not bundle.chunks:
+            raise ValueError("Model protocol returned an empty ModelBundle.")
+
+        model = bundle.chunks[0].to(rt_cfg.device)
+        optimizer = bundle.optimizer
+        if optimizer is None:
+            optimizer = torch.optim.SGD(model.parameters(), lr=rt_cfg.optimizer.lr)
+
+        return ModelHandle(
+            model=model,
+            optimizer=optimizer,
+            lr_scheduler=None,
+            config=rt_cfg,
+            extras={
+                "forward_step": bundle.forward_step,
+                "model_cfg": model_cfg,
+                "protocol": protocol,
+                **bundle.extras,
+            },
+        )
+
+    def train_mode(self, handle: ModelHandle) -> Any:
+        return handle.model.train()
+
+    def eval_mode(self, handle: ModelHandle) -> Any:
+        return handle.model.eval()
+
+    def forward_backward(
+        self,
+        handle: ModelHandle,
+        data: Any,
+        loss_fn: Callable[[Any, Any], tuple[torch.Tensor, dict[str, Any]]] | None = None,
+        *,
+        num_microbatches: int = 1,
+        forward_only: bool = False,
+    ) -> ForwardResult:
+        if num_microbatches != 1:
+            raise ValueError("The PR1 local runtime supports exactly one microbatch.")
+
+        batch = _batch_to_mapping(data)
+        model = handle.model
+        forward_step = handle.extras.get("forward_step")
+        outputs = forward_step(model, batch) if forward_step is not None else model(batch["inputs"])
+
+        if loss_fn is None:
+            targets = batch.get("targets")
+            if targets is None:
+                loss = outputs.mean()
+                metrics: dict[str, Any] = {"loss": float(loss.detach())}
+            else:
+                loss = torch.nn.functional.mse_loss(outputs, targets.to(outputs.device))
+                metrics = {"loss": float(loss.detach())}
+        else:
+            loss, metrics = loss_fn(outputs, batch)
+
+        if not forward_only:
+            loss.backward()
+
+        return ForwardResult(loss=loss, metrics=metrics, outputs=outputs)
+
+    def zero_grad(self, handle: ModelHandle) -> None:
+        handle.optimizer.zero_grad(set_to_none=True)
+
+    def optimizer_step(self, handle: ModelHandle) -> tuple[bool, float, int | None]:
+        grad_norm_sq = 0.0
+        zero_grad_count = 0
+        for parameter in handle.model.parameters():
+            if parameter.grad is None:
+                continue
+            grad = parameter.grad.detach()
+            grad_norm_sq += float(grad.pow(2).sum())
+            zero_grad_count += int(torch.count_nonzero(grad == 0).item())
+        handle.optimizer.step()
+        return True, grad_norm_sq**0.5, zero_grad_count
+
+    def lr_scheduler_step(self, handle: ModelHandle) -> float | list[float]:
+        scheduler = handle.lr_scheduler
+        if scheduler is not None:
+            scheduler.step()
+        lrs = [float(group["lr"]) for group in handle.optimizer.param_groups]
+        return lrs[0] if len(lrs) == 1 else lrs
+
+
+def create(hf_path: str = "", cfg: MegatronLiteConfig | dict[str, Any] | None = None) -> MegatronLiteRuntime:
+    """Factory used by ``megatron.lite.runtime.create_runtime``."""
+
+    return MegatronLiteRuntime(hf_path, cfg)
+
+
+__all__ = ["MegatronLiteRuntime", "create"]

--- a/experimental/lite/megatron/lite/runtime/contracts/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Public runtime contract objects."""
+
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+from megatron.lite.runtime.contracts.data import ForwardResult, TrainBatch
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+__all__ = [
+    "ForwardResult",
+    "ModelHandle",
+    "OptimizerConfig",
+    "ParallelConfig",
+    "RuntimeConfig",
+    "TrainBatch",
+]

--- a/experimental/lite/megatron/lite/runtime/contracts/config.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/config.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Shared runtime configuration contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ParallelConfig:
+    """Parallel dimensions requested by a model/runtime pair."""
+
+    tp: int = 1
+    pp: int = 1
+    cp: int = 1
+    ep: int = 1
+
+
+@dataclass
+class OptimizerConfig:
+    """Optimizer options shared by lightweight runtime backends."""
+
+    optimizer: str = "sgd"
+    lr: float = 1e-2
+    weight_decay: float = 0.0
+    clip_grad: float | None = None
+
+
+@dataclass
+class RuntimeConfig:
+    """Top-level runtime creation config."""
+
+    backend: str = "mlite"
+    hf_path: str = ""
+    backend_cfg: Any = field(default_factory=dict)
+
+
+__all__ = ["OptimizerConfig", "ParallelConfig", "RuntimeConfig"]

--- a/experimental/lite/megatron/lite/runtime/contracts/data.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/data.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Data contracts for runtime calls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+
+@dataclass
+class TrainBatch:
+    """Minimal tensor batch used by local contract checks."""
+
+    inputs: torch.Tensor
+    targets: torch.Tensor | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ForwardResult:
+    """Result returned by ``Runtime.forward_backward``."""
+
+    loss: torch.Tensor
+    metrics: dict[str, Any] = field(default_factory=dict)
+    outputs: Any = None
+
+
+__all__ = ["ForwardResult", "TrainBatch"]

--- a/experimental/lite/megatron/lite/runtime/contracts/handle.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/handle.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Opaque model handle returned by runtime backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ModelHandle:
+    """Runtime-owned model state with a small public surface."""
+
+    model: Any
+    optimizer: Any = None
+    lr_scheduler: Any = None
+    config: Any = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def dp_rank(self) -> int:
+        return 0
+
+    @property
+    def dp_size(self) -> int:
+        return 1
+
+    @property
+    def dp_group(self) -> None:
+        return None
+
+
+__all__ = ["ModelHandle"]

--- a/experimental/lite/skills/README.md
+++ b/experimental/lite/skills/README.md
@@ -1,0 +1,10 @@
+# Megatron Lite Skills
+
+These notes capture review habits for future Megatron Lite work. They are
+deliberately short and local to the experimental package.
+
+## Core Paths
+
+- `basic/`: general operating rules for Lite changes.
+- `primitive/`: primitive design and validation rules.
+- `insight/`: scope-control guidance for staged model support.

--- a/experimental/lite/skills/basic/constitution.md
+++ b/experimental/lite/skills/basic/constitution.md
@@ -1,0 +1,9 @@
+# Lite Constitution
+
+Megatron Lite changes should keep three boundaries explicit:
+
+- Runtime code executes models but does not own model architecture.
+- Model code declares what it needs through protocol modules and bundles.
+- Primitive code exposes reusable capabilities behind typed contracts.
+
+Prefer small PRs that add one behavior and one validation story.

--- a/experimental/lite/skills/basic/find-reference.md
+++ b/experimental/lite/skills/basic/find-reference.md
@@ -1,0 +1,12 @@
+# Find Reference
+
+Before porting a model or primitive, identify the source implementation and the
+minimal behavior needed for the current PR.
+
+Record:
+
+- The upstream source file or paper section.
+- The expected tensor shapes.
+- The smallest local check that can catch a regression.
+
+Do not copy large model stacks into Lite when a smaller contract check is enough.

--- a/experimental/lite/skills/basic/review-threshold.md
+++ b/experimental/lite/skills/basic/review-threshold.md
@@ -1,0 +1,11 @@
+# Review Threshold
+
+A Lite PR is ready for review when it has:
+
+- A narrow stated scope.
+- Local import coverage.
+- A validation command that reviewers can run.
+- Clear non-goals for behavior deferred to later slices.
+
+If a change needs GPU evidence, collect it separately and include job IDs in the
+PR evidence. Do not treat skipped tests as passing evidence.

--- a/experimental/lite/skills/insight/progressive-model-support.md
+++ b/experimental/lite/skills/insight/progressive-model-support.md
@@ -1,0 +1,11 @@
+# Progressive Model Support
+
+Add new model support in layers:
+
+1. Register the model and a minimal protocol.
+2. Build an importable config path.
+3. Add a tiny forward path.
+4. Add weight loading.
+5. Add distributed execution and checkpointing.
+
+Do not combine all layers in the first PR for a model family.

--- a/experimental/lite/skills/insight/progressive-primitive-design.md
+++ b/experimental/lite/skills/insight/progressive-primitive-design.md
@@ -1,0 +1,9 @@
+# Progressive Primitive Design
+
+A primitive should move from contract to reference to optimized implementation.
+
+The contract defines behavior. The reference proves correctness. The optimized
+implementation proves performance without changing the contract.
+
+When these steps are split, reviewers can evaluate correctness before performance
+complexity enters the diff.

--- a/experimental/lite/skills/insight/scope-control.md
+++ b/experimental/lite/skills/insight/scope-control.md
@@ -1,0 +1,7 @@
+# Scope Control
+
+Megatron Lite is easier to review when each PR has a crisp exclusion list.
+
+Use non-goals to keep the current slice honest. If a change needs Qwen support,
+checkpointing, VERL, FSDP2, or custom kernels, it should usually be a follow-up
+unless the PR is specifically about that feature.

--- a/experimental/lite/skills/primitive/contract.md
+++ b/experimental/lite/skills/primitive/contract.md
@@ -1,0 +1,14 @@
+# Primitive Contract
+
+Primitive work should start with a typed contract before adding optimized code.
+
+For each primitive, document:
+
+- Inputs and outputs.
+- Shape and dtype expectations.
+- Distributed assumptions.
+- Fallback behavior.
+- Validation against a simple PyTorch reference.
+
+This PR includes only the shared contract layer; concrete primitives are
+follow-up work.

--- a/experimental/lite/skills/primitive/design.md
+++ b/experimental/lite/skills/primitive/design.md
@@ -1,0 +1,14 @@
+# Primitive Design
+
+Primitive implementations should be independent units that can be tested without
+bringing up a full model.
+
+Design rules:
+
+- Keep primitive configuration explicit.
+- Prefer pure PyTorch references for first validation.
+- Add optimized kernels only after the reference behavior is covered.
+- Avoid hidden dependencies on global distributed state.
+
+If a primitive needs process groups, pass them through config or bundle metadata
+instead of importing runtime internals.

--- a/experimental/lite/skills/primitive/validate.md
+++ b/experimental/lite/skills/primitive/validate.md
@@ -1,0 +1,11 @@
+# Primitive Validation
+
+Validation should scale with the primitive risk:
+
+- Interface-only changes need import and registry tests.
+- Pure PyTorch primitives need numerical parity tests.
+- Distributed primitives need CPU-safe unit coverage plus real Slurm evidence
+  for GPU paths.
+
+Keep the validation command stable so follow-up PRs can add tests without
+changing reviewer workflow.

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -1,0 +1,7 @@
+# Megatron Lite Tests
+
+The PR1 validation suite is intentionally local and CPU-only. It verifies that
+the package imports, the registries resolve the toy model, and the local runtime
+can run one dense-model training step.
+
+Future primitive parity tests should be added here as real primitives land.

--- a/experimental/lite/tests/conftest.py
+++ b/experimental/lite/tests/conftest.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Pytest configuration for Megatron Lite tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+LITE_ROOT = Path(__file__).resolve().parents[1]
+if str(LITE_ROOT) not in sys.path:
+    sys.path.insert(0, str(LITE_ROOT))

--- a/experimental/lite/tests/run_primitive_validation.sh
+++ b/experimental/lite/tests/run_primitive_validation.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+LITE_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd -- "${LITE_ROOT}/../.." && pwd)"
+
+export PYTHONPATH="${LITE_ROOT}:${PYTHONPATH:-}"
+
+cd "${REPO_ROOT}"
+python -m pytest -q "${LITE_ROOT}/tests/unit" "$@"

--- a/experimental/lite/tests/unit/primitive/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_unit.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import torch
+
+from megatron.lite.primitive.parallel import (
+    ParallelState,
+    build_pipeline_chunk_layout,
+    reconstruct_packed_from_cp_parts,
+    roll_packed_thd_left,
+    split_packed_to_cp_local,
+    zigzag_position_ids_for_cp,
+    zigzag_reconstruct_from_cp_parts,
+    zigzag_slice_for_cp,
+    zigzag_split_for_cp,
+)
+
+
+def test_cp_zigzag_split_slice_and_reconstruct_match():
+    tensor = torch.arange(16).reshape(1, 8, 2)
+    parts = [zigzag_split_for_cp(tensor, rank, cp_size=2, seq_dim=1) for rank in range(2)]
+
+    assert torch.equal(parts[0], tensor[:, [0, 1, 6, 7], :])
+    assert torch.equal(parts[1], tensor[:, [2, 3, 4, 5], :])
+    assert torch.equal(zigzag_slice_for_cp(tensor, 0, cp_size=2, seq_dim=1), parts[0])
+    assert torch.equal(zigzag_slice_for_cp(tensor, 1, cp_size=2, seq_dim=1), parts[1])
+    assert torch.equal(zigzag_reconstruct_from_cp_parts(parts, seq_dim=1), tensor)
+
+
+def test_cp_position_ids_follow_zigzag_order():
+    assert torch.equal(
+        zigzag_position_ids_for_cp(8, cp_rank=0, cp_size=2, device=torch.device("cpu")),
+        torch.tensor([[0, 1, 6, 7]]),
+    )
+    assert torch.equal(
+        zigzag_position_ids_for_cp(8, cp_rank=1, cp_size=2, device=torch.device("cpu")),
+        torch.tensor([[2, 3, 4, 5]]),
+    )
+
+
+def test_pp_layout_marks_stage_boundaries_and_vpp_chunks():
+    rank0 = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
+    rank1 = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
+
+    assert build_pipeline_chunk_layout(8, rank0).layer_indices == [0, 1, 2, 3]
+    assert build_pipeline_chunk_layout(8, rank0).has_embed is True
+    assert build_pipeline_chunk_layout(8, rank0).has_head is False
+    assert build_pipeline_chunk_layout(8, rank1).layer_indices == [4, 5, 6, 7]
+    assert build_pipeline_chunk_layout(8, rank1).has_embed is False
+    assert build_pipeline_chunk_layout(8, rank1).has_head is True
+
+    vpp_rank0_chunk1 = build_pipeline_chunk_layout(8, rank0, vpp=2, vpp_chunk_id=1)
+    vpp_rank1_chunk1 = build_pipeline_chunk_layout(8, rank1, vpp=2, vpp_chunk_id=1)
+    assert vpp_rank0_chunk1.layer_indices == [4, 5]
+    assert vpp_rank0_chunk1.has_head is False
+    assert vpp_rank1_chunk1.layer_indices == [6, 7]
+    assert vpp_rank1_chunk1.has_head is True
+
+
+def test_thd_roll_keeps_sequence_boundaries():
+    cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
+    rolled, token_sum = roll_packed_thd_left(torch.arange(8), cu_seqlens_padded=cu_seqlens, dims=0)
+
+    assert torch.equal(rolled, torch.tensor([1, 2, 3, 0, 5, 6, 7, 0]))
+    assert token_sum.item() == 24
+
+
+def test_thd_cp_split_and_reconstruct_roundtrip():
+    cu_seqlens = torch.tensor([0, 8], dtype=torch.int32)
+    tensor = torch.arange(8)
+    parts = [
+        split_packed_to_cp_local(
+            tensor, cu_seqlens_padded=cu_seqlens, cp_size=2, cp_rank=rank, dim=0
+        )
+        for rank in range(2)
+    ]
+
+    assert torch.equal(parts[0], torch.tensor([0, 1, 6, 7]))
+    assert torch.equal(parts[1], torch.tensor([2, 3, 4, 5]))
+    assert torch.equal(
+        reconstruct_packed_from_cp_parts(parts, cu_seqlens_padded=cu_seqlens, cp_size=2, dim=0),
+        tensor,
+    )

--- a/experimental/lite/tests/unit/primitive/test_train_step_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_train_step_unit.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from megatron.lite.primitive.train_step import compute_and_clip_grad_norm, run_microbatch_loop
+
+
+def test_train_step_microbatch_loop_and_grad_clip_cpu_contract():
+    model = nn.Linear(2, 1, bias=False)
+    with torch.no_grad():
+        model.weight.fill_(0.5)
+    data = iter(
+        [
+            {"x": torch.tensor([[1.0, 2.0]]), "y": torch.tensor([[1.0]])},
+            {"x": torch.tensor([[3.0, 4.0]]), "y": torch.tensor([[2.0]])},
+        ]
+    )
+
+    def forward_fn(module, batch):
+        return {"loss": F.mse_loss(module(batch["x"]), batch["y"])}
+
+    output = run_microbatch_loop(model, data, 2, forward_fn)
+
+    assert output is not None
+    assert output["loss"].ndim == 0
+    assert model.weight.grad is not None
+    assert torch.isfinite(model.weight.grad).all()
+
+    grad_norm = compute_and_clip_grad_norm(model, optimizer=None, max_norm=0.25, use_dist_opt=False)
+
+    assert torch.isfinite(grad_norm)
+    assert model.weight.grad.norm() <= 0.25 + 1.0e-6

--- a/experimental/lite/tests/unit/test_toy_runtime.py
+++ b/experimental/lite/tests/unit/test_toy_runtime.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU contract checks for the PR1 Megatron Lite skeleton."""
+
+from __future__ import annotations
+
+import torch
+
+from megatron.lite.model.registry import list_models, resolve_runtime_model_name
+from megatron.lite.runtime import RuntimeConfig, create_runtime
+from megatron.lite.runtime.backends.mlite import MegatronLiteConfig
+from megatron.lite.runtime.contracts import OptimizerConfig, TrainBatch
+
+
+def test_toy_dense_registry_contract():
+    assert "toy_dense" in list_models()
+    assert resolve_runtime_model_name("toy_dense", "torch") == "toy_dense"
+
+
+def test_toy_dense_runtime_one_cpu_step():
+    torch.manual_seed(1234)
+
+    runtime = create_runtime(
+        RuntimeConfig(
+            backend="mlite",
+            backend_cfg=MegatronLiteConfig(
+                model_name="toy_dense",
+                impl="torch",
+                device="cpu",
+                optimizer=OptimizerConfig(lr=0.05),
+                impl_cfg={"input_dim": 4, "hidden_dim": 8, "output_dim": 2},
+            ),
+        )
+    )
+    handle = runtime.build_model()
+    runtime.train_mode(handle)
+
+    batch = TrainBatch(
+        inputs=torch.randn(3, 4),
+        targets=torch.randn(3, 2),
+    )
+
+    runtime.zero_grad(handle)
+    result = runtime.forward_backward(handle, batch)
+    ok, grad_norm, zero_grad_count = runtime.optimizer_step(handle)
+    lr = runtime.lr_scheduler_step(handle)
+
+    assert ok is True
+    assert result.loss.ndim == 0
+    assert torch.isfinite(result.loss)
+    assert grad_norm > 0.0
+    assert zero_grad_count is not None
+    assert lr == 0.05


### PR DESCRIPTION
## Summary

Second PR in the Megatron Lite staged series. Adds the **execution-path primitives** on top of the skeleton contracts (PR1).

Stacked on `mlite-main-pr1-skeleton`.

## Contents

- `primitive/parallel/{state,linear,pp,cp,sp,pipeline,thd}` — parallelism primitives covering TP / EP / PP / CP / SP
- `primitive/train_step` — microbatch loop + grad-norm
- Unit tests: `tests/unit/primitive/test_parallel_unit.py`, `test_train_step_unit.py`

## Validation

- `ruff` clean on touched paths
- `compileall` clean
- `PYTHONPATH=experimental/lite` import check for `parallel`, `parallel.linear`, `train_step`