### PR TITLE
feat(moe): discard-output recompute for shared experts

### DIFF
--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -635,6 +635,12 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             # as a gradient hook of expert_output
             layer.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(expert_output)
 
+        # Register the shared-expert recompute on expert_output, after the pre_mlp_norm recompute so
+        # it runs once the layernorm input is restored (the output is freed in the combine step).
+        shared_experts_checkpoint = getattr(layer.mlp, "shared_experts_checkpoint", None)
+        if shared_experts_checkpoint is not None:
+            shared_experts_checkpoint.register_recompute_hook(expert_output)
+
         return expert_output
 
     def submodule_combine_forward(node: ScheduleNode, output: torch.Tensor):
@@ -684,6 +690,12 @@ def build_transformer_layer_callables(layer: TransformerLayer):
         if not node.is_mtp and final_layernorm and node.is_last_layer:
             output = final_layernorm(output)
             output = make_viewless_tensor(inp=output, requires_grad=True, keep_graph=True)
+
+        # postprocess() consumed the shared-expert output; free it now (hook already registered).
+        shared_experts_checkpoint = getattr(layer.mlp, "shared_experts_checkpoint", None)
+        if shared_experts_checkpoint is not None:
+            shared_experts_checkpoint.discard_output()
+            layer.mlp.shared_experts_checkpoint = None
         return output
 
     @copy_signature(layer._forward_mlp, handle_first_dst_param='preserve')

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -921,30 +921,31 @@ class CheckpointWithoutOutput(object):
         self.outputs = None
         self.ctx = None
 
-    def discard_output_and_register_recompute(self, hook_tensor):
-        """
-        Release the output tensor storages and register the recompute function as a grad hook of
-        the hook_tensor.
+    def discard_output(self):
+        """Free the output storages, keeping tensor metadata for backward.
 
-        Note: the caller should make sure that the output tensors are no longer used
-        in the forward pass and the gradient of the hook_tensor is computed before the recomputed
-        tensors are used.
+        Pair with :meth:`register_recompute_hook` when discard and hook happen in different places.
         """
-        # When ckpt_manager is set, this is a no-op.
-        # Manager handles all discarding and hook registration uniformly.
         from megatron.core.transformer.cuda_graphs import is_graph_warmup
 
         if self.ckpt_manager is not None or is_graph_warmup():
             return
-
-        # use resize to release the output tensor memory and still keep the metadata in the tensors.
-        # the metadata is still needed for backward
+        # resize keeps tensor metadata (needed for backward) while releasing the memory.
         for output in self.outputs:
             output.untyped_storage().resize_(0)
 
-        # register the recomputation as a backward hook, when the the gradient of the hook_tensor
-        # is computed, the recomputation will be triggered. The hook_tensor should be selected
-        # carefully to ensure that the tensors are recomputed before it is used by other backward
-        # computations.
+    def register_recompute_hook(self, hook_tensor):
+        """Recompute from ``hook_tensor``'s grad hook (its grad must run before the discarded
+        outputs are needed in backward).
+        """
+        from megatron.core.transformer.cuda_graphs import is_graph_warmup
+
+        if self.ckpt_manager is not None or is_graph_warmup():
+            return
         if hook_tensor.requires_grad:
             hook_tensor.register_hook(self._recompute)
+
+    def discard_output_and_register_recompute(self, hook_tensor):
+        """Free the output storages and register the recompute as a grad hook on ``hook_tensor``."""
+        self.discard_output()
+        self.register_recompute_hook(hook_tensor)

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -255,6 +255,14 @@ class MoELayer(BaseMoELayer):
             config.recompute_granularity == 'selective'
             and "shared_experts" in config.recompute_modules
         )
+        # Recompute the shared-expert output in backward instead of keeping it; the caller frees it
+        # and registers the recompute hook in the correct order. Off under MoE cudagraph partial
+        # capture, where the output is a graph output that must keep its storage.
+        self.shared_experts_recompute_discard_output = self.shared_experts_recompute and not bool(
+            getattr(config, "cuda_graph_modules", None)
+        )
+        # Active CheckpointWithoutOutput handed to the caller for discard + hook (None otherwise).
+        self.shared_experts_checkpoint = None
 
         self.tp_group = pg_collection.tp
         self.tp_ep_group = pg_collection.tp_ep
@@ -534,7 +542,17 @@ class MoELayer(BaseMoELayer):
         shared_expert_output = None
         if self.use_shared_expert and not self.shared_expert_overlap:
             # Compute the shared expert separately when not overlapped with communication.
-            if self.shared_experts_recompute:
+            if self.shared_experts_recompute_discard_output and self.training:
+                # Discard-output recompute: the output is freed later and regenerated from a grad
+                # hook (CheckpointWithoutOutput handles fp8/fp4 via its fp8 flag).
+                self.shared_experts_checkpoint = tensor_parallel.CheckpointWithoutOutput(
+                    fp8=(self.config.fp8 or self.config.fp4)
+                )
+                shared_expert_output = self.shared_experts_checkpoint.checkpoint(
+                    apply_module(self.shared_experts), hidden_states
+                )
+            elif self.shared_experts_recompute:
+                # Standard checkpoint fallback: keep the output, recompute only the intermediates.
                 if self.config.fp8 or self.config.fp4:
                     shared_expert_output = te_checkpoint(
                         apply_module(self.shared_experts),

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -957,6 +957,17 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 mlp_output_with_bias[0]
             )
 
+        # Non-overlap path: free the shared-expert output (consumed by the MoE postprocess add) and
+        # recompute it from mlp_output_with_bias[0], after the pre_mlp_norm recompute above so the
+        # layernorm input is restored first. (A2A overlap uses the fine-grained callables instead.)
+        if self.is_moe_layer:
+            shared_experts_checkpoint = getattr(self.mlp, "shared_experts_checkpoint", None)
+            if shared_experts_checkpoint is not None:
+                shared_experts_checkpoint.discard_output_and_register_recompute(
+                    mlp_output_with_bias[0]
+                )
+                self.mlp.shared_experts_checkpoint = None
+
         # TODO: could we move `bias_dropout_add_exec_handler` itself
         # inside the module provided in the `bias_dropout_add_spec` module?
         nvtx_range_push(suffix="mlp_bda")

--- a/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
+++ b/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
@@ -74,9 +74,12 @@ class TestFSDP1F1BOverlap:
         [[], ["attn_norm", "core_attn", "attn_proj", "mlp_norm", "expert_fc1", "moe_act"]],
     )
     def test_fsdp_1f1b_memory_opt(self, recompute_modules, offload_modules):
+        # Configure shared experts so recompute_modules=[..., "shared_experts"] actually
+        # exercises the shared-experts discard-output recompute (a no-op without them).
         self._run_test_helper(
             dispatcher_type="alltoall",
             sharding_strategy="optim_grads_params",
+            shared_expert_intermediate_size=512,
             recompute_modules=recompute_modules,
             offload_modules=offload_modules,
         )


### PR DESCRIPTION
Adds output-discarding **selective recompute for the MoE shared-expert path**, for both the A2A-overlap and non-overlap schedules.

Wires the recompute through `fine_grained_callables`, `moe_layer`, `transformer_layer`, and the RNG-state handling in `tensor_parallel/random.py`, and configures shared experts in `test_fsdp_1f1b_memory_opt`.

Rebased as a single commit on current `dev`. Draft pending CI / GPU test sign-off.
