### PR TITLE
Add code owners for optimizer-related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,19 @@ megatron/core/transformer/fsdp_dtensor_checkpoint.py @NVIDIA/core-adlr @NVIDIA/c
 megatron/core/dist_checkpointing/ @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/dist-checkpointing
 
 megatron/core/optimizer/distrib_optimizer.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/dist-optimizer
+megatron/core/optimizer/layer_wise_optimizer.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/dist-optimizer
+megatron/core/optimizer/param_layout.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/dist-optimizer
+
+megatron/core/optimizer/__init__.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
+megatron/core/optimizer/clip_grads.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
+megatron/core/optimizer/grad_scaler.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
+megatron/core/optimizer/optimizer_config.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
+megatron/core/optimizer/optimizer_cuda_graph.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
+megatron/core/optimizer/optimizer.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
+
+megatron/core/optimizer/emerging_optimizers.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-emerging-optimizers
+megatron/core/optimizer/muon.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-emerging-optimizers
+megatron/core/optimizer/qk_clip.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-emerging-optimizers @NVIDIA/transformer
 
 megatron/core/inference/modelopt_support @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/post-training
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,16 +22,11 @@ megatron/core/transformer/fsdp_dtensor_checkpoint.py @NVIDIA/core-adlr @NVIDIA/c
 
 megatron/core/dist_checkpointing/ @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/dist-checkpointing
 
+megatron/core/optimizer/ @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
+
 megatron/core/optimizer/distrib_optimizer.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/dist-optimizer
 megatron/core/optimizer/layer_wise_optimizer.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/dist-optimizer
 megatron/core/optimizer/param_layout.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/dist-optimizer
-
-megatron/core/optimizer/__init__.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
-megatron/core/optimizer/clip_grads.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
-megatron/core/optimizer/grad_scaler.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
-megatron/core/optimizer/optimizer_config.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
-megatron/core/optimizer/optimizer_cuda_graph.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
-megatron/core/optimizer/optimizer.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-optimizer
 
 megatron/core/optimizer/emerging_optimizers.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-emerging-optimizers
 megatron/core/optimizer/muon.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/mcore-emerging-optimizers


### PR DESCRIPTION
- [X] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Previously, most files in `megatron/core/optimizers` didn't have code owners. This adds expert review teams for most of them, with only `megatron/core/optimizers/cpu_offloading` not being assigned for now.

This is a summary:

* Default behavior (`NVIDIA/mcore-optimizer`)
* Emerging Optimizers-related (`NVIDIA/mcore-emerging-optimizers`)
    * `emerging_optimizers.py`
    * `muon.py`
    * `qk_clip.py` (also owned by `NVIDIA/transformer` due to the interplay)
* `NVIDIA/dist-optimizer`
    * `distrib_optimizer.py`
    * `layer_wise_optimizer.py`
    * `param_layout.py`