### PR TITLE
Enable dbias_dprob triton kernel in TE GroupedLinear

### DIFF
--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -508,6 +508,7 @@ class TEGroupedMLP(MegatronModule):
             single_grouped_weight=fc2_single_grouped_weight,
             single_grouped_bias=fc2_single_grouped_bias,
             delay_wgrad_compute=fc2_delay_wgrad_compute,
+            scale_bias=self.linear_fc2.use_bias,
         )
 
         # Copy the weights from GroupedLinear module to GroupedLinear op.
@@ -616,13 +617,19 @@ class TEGroupedMLP(MegatronModule):
             forced_released_tensors = (
                 [permuted_local_hidden_states] if fine_grained_activation_offloading else []
             )
+            # Pass permuted_probs to FC2 to use fused dprop, dbias
+            extra_inputs_fc2 = (
+                (tokens_per_expert, permuted_probs)
+                if self.linear_fc2.use_bias
+                else (tokens_per_expert,)
+            )
             with stash_context:
                 # Call fused impl
                 output = ops(
                     permuted_local_hidden_states,
                     tokens_per_expert,  # FC1
                     permuted_probs,  # Scaled activation
-                    tokens_per_expert,  # FC2
+                    *extra_inputs_fc2,  # FC2
                 )
         if fine_grained_activation_offloading:
             output = off_interface.group_commit(


### PR DESCRIPTION
- [ x ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

This PR enables fused dbias_dprob kernel in TransformerEngine GroupedLinear code path.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
