### PR TITLE
fix(tensor_parallel): _reduce returns unreduced tensor for non-contig…

### DIFF
--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -28,7 +28,11 @@ def _reduce(input_, group):
         return input_
 
     # All-reduce.
-    torch.distributed.all_reduce(input_.contiguous(), group=group)
+    # Note: If input_ is contiguous, it is mutated in-place.  
+    # If not, a new contiguous tensor is created and returned;  
+    # callers must use the returned value to ensure the reduced result is captured.
+    input_ = input_.contiguous()
+    torch.distributed.all_reduce(input_, group=group)
 
     return input_
 

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -28,8 +28,8 @@ def _reduce(input_, group):
         return input_
 
     # All-reduce.
-    # Note: If input_ is contiguous, it is mutated in-place.  
-    # If not, a new contiguous tensor is created and returned;  
+    # Note: If input_ is contiguous, it is mutated in-place.
+    # If not, a new contiguous tensor is created and returned;
     # callers must use the returned value to ensure the reduced result is captured.
     input_ = input_.contiguous()
     torch.distributed.all_reduce(input_, group=group)


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Fix silent correctness issue in `_reduce` where non-contiguous input causes all-reduce result to be discarded.

## Issue tracking
Fixes #5337 

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR