### PR TITLE
[feat] Add MTP HSM, logits KD, and backbone freeze

### DIFF
--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
 
 import logging
+from contextlib import nullcontext
 from typing import Literal, Optional
 
+import torch
 from torch import Tensor
 
 from megatron.core import tensor_parallel
@@ -501,15 +503,20 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         #   be None, so this assert will succeed.
         # assert attention_mask is None, "The attention mask is ignored and should be set to None"
 
-        # Run decoder.
-        hidden_states = self.decoder(
-            hidden_states=decoder_input,
-            attention_mask=attention_mask,
-            inference_context=inference_context,
-            rotary_pos_emb=rotary_pos_emb,
-            packed_seq_params=packed_seq_params,
-            padding_mask=padding_mask,
+        freeze_ctx = (
+            torch.no_grad()
+            if getattr(self.config, 'freeze_base_model_for_mtp', False) and self.training
+            else nullcontext()
         )
+        with freeze_ctx:
+            hidden_states = self.decoder(
+                hidden_states=decoder_input,
+                attention_mask=attention_mask,
+                inference_context=inference_context,
+                rotary_pos_emb=rotary_pos_emb,
+                packed_seq_params=packed_seq_params,
+                padding_mask=padding_mask,
+            )
 
         output_weight = None
         if self.share_embeddings_and_output_weights:

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import torch
+import torch.nn.functional as F
 from torch import Tensor
 
 from megatron.core import InferenceParams, parallel_state, tensor_parallel
@@ -55,6 +56,29 @@ SUPPORTED_ATTN_MASK = [
     AttnMaskType.no_mask,
     AttnMaskType.padding_causal,
 ]
+
+
+def _hsm_mix(hidden_states_list: List[Tensor]) -> Tensor:
+    """Sample uniformly from accumulated hidden states for Hidden State Mixing (HSM)."""
+    num_states = len(hidden_states_list)
+    seq_len, batch_size, _ = hidden_states_list[0].shape
+    indices = torch.randint(
+        0, num_states, (seq_len, batch_size, 1), device=hidden_states_list[0].device
+    )
+    stacked = torch.stack(hidden_states_list, dim=0)
+    one_hot = (
+        torch.arange(num_states, device=indices.device).view(num_states, 1, 1, 1)
+        == indices.unsqueeze(0)
+    ).to(dtype=stacked.dtype)
+    return (stacked * one_hot).sum(dim=0)
+
+
+def _scale_mtp_loss_for_token_count(
+    loss: Tensor, loss_scale: float, original_num_tokens: Tensor, num_tokens: Tensor
+) -> Tensor:
+    """Scale per-token MTP loss so final gradient division uses rolled-token normalization."""
+    return loss_scale * loss * (original_num_tokens / num_tokens.clamp(min=1))
+
 
 if HAVE_TE:
     from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
@@ -384,6 +408,25 @@ class MTPLossLoggingHelper:
         tracker["avg_group"] = avg_group
 
     @staticmethod
+    def save_kd_loss_to_tracker(
+        kd_logit_loss: Optional[torch.Tensor],
+        layer_number: int,
+        num_layers: int,
+        avg_group: Optional[torch.distributed.ProcessGroup] = None,
+    ):
+        """Save the MTP KD logit loss for logging."""
+        if layer_number is None or kd_logit_loss is None:
+            return
+
+        tracker = MTPLossLoggingHelper.tracker
+        if "kd_logit_loss_values" not in tracker:
+            tracker["kd_logit_loss_values"] = torch.zeros(
+                num_layers, device=torch.cuda.current_device()
+            )
+        tracker["kd_logit_loss_values"][layer_number] += kd_logit_loss.detach()
+        tracker["avg_group"] = avg_group
+
+    @staticmethod
     def clean_metrics_in_tracker():
         """Clear the mtp metrics."""
         tracker = MTPLossLoggingHelper.tracker
@@ -393,6 +436,8 @@ class MTPLossLoggingHelper:
             tracker["correct_values"].zero_()
         if "total_values" in tracker:
             tracker["total_values"].zero_()
+        if "kd_logit_loss_values" in tracker:
+            tracker["kd_logit_loss_values"].zero_()
         tracker["reduce_group"] = None
         tracker["avg_group"] = None
 
@@ -400,16 +445,19 @@ class MTPLossLoggingHelper:
     def reduce_metrics_in_tracker():
         """Collect and reduce the mtp metrics across ranks."""
         tracker = MTPLossLoggingHelper.tracker
-        if "loss_values" not in tracker:
+        if "loss_values" not in tracker and "kd_logit_loss_values" not in tracker:
             return
 
-        loss_values = tracker["loss_values"]
-        if tracker.get('reduce_group') is not None:
-            torch.distributed.all_reduce(loss_values, group=tracker.get('reduce_group'))
-        if tracker.get('avg_group') is not None:
-            torch.distributed.all_reduce(
-                loss_values, group=tracker['avg_group'], op=torch.distributed.ReduceOp.AVG
-            )
+        for key in ["loss_values", "kd_logit_loss_values"]:
+            if key not in tracker:
+                continue
+            values = tracker[key]
+            if tracker.get('reduce_group') is not None:
+                torch.distributed.all_reduce(values, group=tracker.get('reduce_group'))
+            if tracker.get('avg_group') is not None:
+                torch.distributed.all_reduce(
+                    values, group=tracker['avg_group'], op=torch.distributed.ReduceOp.AVG
+                )
 
         for key in ["correct_values", "total_values"]:
             if key not in tracker:
@@ -427,56 +475,68 @@ class MTPLossLoggingHelper:
         """Track the Multi-Token Prediction (MTP) metrics for logging."""
         MTPLossLoggingHelper.reduce_metrics_in_tracker()
         tracker = MTPLossLoggingHelper.tracker
-        if "loss_values" not in tracker:
+        if "loss_values" not in tracker and "kd_logit_loss_values" not in tracker:
             return
 
-        mtp_losses = tracker["loss_values"] * loss_scale
-        mtp_corrects = tracker.get("correct_values", torch.zeros_like(mtp_losses))
-        mtp_totals = tracker.get("total_values", torch.ones_like(mtp_losses))
+        if "loss_values" in tracker:
+            mtp_losses = tracker["loss_values"] * loss_scale
+            mtp_corrects = tracker.get("correct_values", torch.zeros_like(mtp_losses))
+            mtp_totals = tracker.get("total_values", torch.ones_like(mtp_losses))
 
-        # Process-local logging state; cumulative rates intentionally reset after restart/resume.
-        if (
-            "cumulative_correct_values" not in tracker
-            or tracker["cumulative_correct_values"].shape != mtp_corrects.shape
-        ):
-            tracker["cumulative_correct_values"] = torch.zeros_like(mtp_corrects)
-        if (
-            "cumulative_total_values" not in tracker
-            or tracker["cumulative_total_values"].shape != mtp_totals.shape
-        ):
-            tracker["cumulative_total_values"] = torch.zeros_like(mtp_totals)
+            # Process-local logging state; cumulative rates intentionally reset after restart.
+            if (
+                "cumulative_correct_values" not in tracker
+                or tracker["cumulative_correct_values"].shape != mtp_corrects.shape
+            ):
+                tracker["cumulative_correct_values"] = torch.zeros_like(mtp_corrects)
+            if (
+                "cumulative_total_values" not in tracker
+                or tracker["cumulative_total_values"].shape != mtp_totals.shape
+            ):
+                tracker["cumulative_total_values"] = torch.zeros_like(mtp_totals)
 
-        tracker["cumulative_correct_values"] += mtp_corrects
-        tracker["cumulative_total_values"] += mtp_totals
-        mtp_cumulative_corrects = tracker["cumulative_correct_values"]
-        mtp_cumulative_totals = tracker["cumulative_total_values"]
+            tracker["cumulative_correct_values"] += mtp_corrects
+            tracker["cumulative_total_values"] += mtp_totals
+            mtp_cumulative_corrects = tracker["cumulative_correct_values"]
+            mtp_cumulative_totals = tracker["cumulative_total_values"]
 
-        mtp_num_layers = mtp_losses.shape[0]
-        for i in range(mtp_num_layers):
-            loss_name = f"mtp_{i+1} loss"
-            step_acc_name = f"mtp_{i+1}_acceptance_rate"
-            cum_acc_name = f"mtp_{i+1}_cumulative_acceptance_rate"
+            for i in range(mtp_losses.shape[0]):
+                loss_name = f"mtp_{i+1} loss"
+                step_acc_name = f"mtp_{i+1}_acceptance_rate"
+                cum_acc_name = f"mtp_{i+1}_cumulative_acceptance_rate"
 
-            loss = mtp_losses[i]
-            # Empty masks can leave no valid MTP positions, so clamp denominators to avoid NaNs.
-            step_rate = (mtp_corrects[i] / torch.clamp(mtp_totals[i], min=1)) * 100.0
-            cum_rate = (
-                mtp_cumulative_corrects[i] / torch.clamp(mtp_cumulative_totals[i], min=1)
-            ) * 100.0
+                loss = mtp_losses[i]
+                # Empty masks can leave no valid MTP positions, so clamp denominators to avoid NaNs.
+                step_rate = (mtp_corrects[i] / torch.clamp(mtp_totals[i], min=1)) * 100.0
+                cum_rate = (
+                    mtp_cumulative_corrects[i] / torch.clamp(mtp_cumulative_totals[i], min=1)
+                ) * 100.0
 
-            if total_loss_dict is not None:
-                total_loss_dict[loss_name] = (
-                    total_loss_dict.get(loss_name, torch.zeros_like(loss)) + loss
-                )
+                if total_loss_dict is not None:
+                    total_loss_dict[loss_name] = (
+                        total_loss_dict.get(loss_name, torch.zeros_like(loss)) + loss
+                    )
 
-            if writer is not None:
-                writer.add_scalar(loss_name, loss, iteration)
-                writer.add_scalar(step_acc_name, step_rate, iteration)
-                writer.add_scalar(cum_acc_name, cum_rate, iteration)
-            if wandb_writer is not None:
-                wandb_writer.log({f"{loss_name}": loss}, iteration)
-                wandb_writer.log({f"{step_acc_name}": step_rate}, iteration)
-                wandb_writer.log({f"{cum_acc_name}": cum_rate}, iteration)
+                if writer is not None:
+                    writer.add_scalar(loss_name, loss, iteration)
+                    writer.add_scalar(step_acc_name, step_rate, iteration)
+                    writer.add_scalar(cum_acc_name, cum_rate, iteration)
+                if wandb_writer is not None:
+                    wandb_writer.log({f"{loss_name}": loss}, iteration)
+                    wandb_writer.log({f"{step_acc_name}": step_rate}, iteration)
+                    wandb_writer.log({f"{cum_acc_name}": cum_rate}, iteration)
+
+        if "kd_logit_loss_values" in tracker:
+            kd_values = tracker["kd_logit_loss_values"] * loss_scale
+            for i in range(kd_values.shape[0]):
+                name = f"mtp_{i+1}_kd_logit_loss"
+                val = kd_values[i]
+                if total_loss_dict is not None:
+                    total_loss_dict[name] = total_loss_dict.get(name, torch.zeros_like(val)) + val
+                if writer is not None:
+                    writer.add_scalar(name, val, iteration)
+                if wandb_writer is not None:
+                    wandb_writer.log({name: val}, iteration)
 
         MTPLossLoggingHelper.clean_metrics_in_tracker()
 
@@ -837,6 +897,11 @@ def process_mtp_loss(
     # correctly scaled relative to the main loss gradients in finalize_model_grads.
     original_num_tokens = loss_mask.sum()
 
+    logit_kd_enabled = getattr(config, 'mtp_kd_logit_enabled', False) and is_training
+    mtp_disable_ce_loss = getattr(config, 'mtp_disable_ce_loss', False)
+    if logit_kd_enabled:
+        base_hidden_for_kd = hidden_states_list[0].detach()
+
     for mtp_layer_number in range(config.mtp_num_layers):
         mtp_logits, _ = output_layer(
             hidden_states_list[mtp_layer_number + 1],
@@ -856,6 +921,16 @@ def process_mtp_loss(
 
         mtp_loss = loss_mask * mtp_loss
 
+        if logit_kd_enabled:
+            base_hidden_for_kd, _ = roll_tensor(
+                base_hidden_for_kd.permute(1, 2, 0),
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+            )
+            base_hidden_for_kd = base_hidden_for_kd.permute(2, 0, 1)
+
         if is_training:
             mtp_loss_for_log = (
                 torch.sum(mtp_loss) * (num_tokens > 0).to(mtp_loss.dtype)
@@ -872,23 +947,75 @@ def process_mtp_loss(
                 config.mtp_num_layers,
                 avg_group=parallel_state.get_data_parallel_group(with_context_parallel=True),
             )
+
         mtp_loss_scale = config.mtp_loss_scaling_factor / config.mtp_num_layers
-        if config.calculate_per_token_loss:
-            # When calculate_per_token_loss is enabled, finalize_model_grads will
-            # divide all gradients by total_num_tokens (from main loss).
-            # However, MTP has fewer valid tokens due to rolling. To ensure correct
-            # per-token gradient weighting, we normalize by the rolled token count
-            # and re-scale by the original token count.
-            # Avoid division by zero
-            num_tokens_safe = torch.clamp(num_tokens, min=1)
-            mtp_loss_normalized = (
-                mtp_loss_scale * mtp_loss * (original_num_tokens / num_tokens_safe)
+        safe_num_tokens = num_tokens.clamp(min=1)
+
+        if not mtp_disable_ce_loss:
+            if config.calculate_per_token_loss:
+                # When calculate_per_token_loss is enabled, finalize_model_grads will
+                # divide all gradients by total_num_tokens (from main loss).
+                # However, MTP has fewer valid tokens due to rolling. To ensure correct
+                # per-token gradient weighting, we normalize by the rolled token count
+                # and re-scale by the original token count.
+                mtp_loss_normalized = _scale_mtp_loss_for_token_count(
+                    mtp_loss, mtp_loss_scale, original_num_tokens, num_tokens
+                )
+                hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_normalized)
+            else:
+                hidden_states = MTPLossAutoScaler.apply(
+                    hidden_states, mtp_loss_scale * mtp_loss / safe_num_tokens
+                )
+
+        kd_logit_loss_scalar = None
+        if logit_kd_enabled:
+            with torch.no_grad():
+                base_logits_kd, _ = output_layer(
+                    base_hidden_for_kd, weight=output_weight, runtime_gather_output=True
+                )
+                if scale_logits_fn is not None:
+                    base_logits_kd = scale_logits_fn(base_logits_kd)
+            if runtime_gather_output:
+                mtp_logits_kd = mtp_logits
+            else:
+                mtp_logits_kd, _ = output_layer(
+                    hidden_states_list[mtp_layer_number + 1],
+                    weight=output_weight,
+                    runtime_gather_output=True,
+                )
+                if scale_logits_fn is not None:
+                    mtp_logits_kd = scale_logits_fn(mtp_logits_kd)
+
+            kd_loss_mask = loss_mask
+            kd_safe_num_tokens = safe_num_tokens
+
+            temperature = config.mtp_kd_logit_temperature
+            student_log = F.log_softmax(mtp_logits_kd / temperature, dim=-1)
+            teacher_probs = F.softmax(base_logits_kd / temperature, dim=-1)
+            kd_logit_per_token = F.kl_div(student_log, teacher_probs, reduction='none').sum(-1)
+            kd_logit_loss = kd_logit_per_token.transpose(0, 1) * (temperature**2) * kd_loss_mask
+            kd_logit_scale = (
+                config.mtp_kd_logit_loss_weight
+                * config.mtp_loss_scaling_factor
+                / config.mtp_num_layers
             )
-            hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_normalized)
-        else:
-            safe_num_tokens = num_tokens.clamp(min=1)
-            hidden_states = MTPLossAutoScaler.apply(
-                hidden_states, mtp_loss_scale * mtp_loss / safe_num_tokens
+            if config.calculate_per_token_loss:
+                kd_logit_loss_normalized = _scale_mtp_loss_for_token_count(
+                    kd_logit_loss, kd_logit_scale, original_num_tokens, kd_safe_num_tokens
+                )
+                hidden_states = MTPLossAutoScaler.apply(hidden_states, kd_logit_loss_normalized)
+            else:
+                hidden_states = MTPLossAutoScaler.apply(
+                    hidden_states, kd_logit_scale * kd_logit_loss / kd_safe_num_tokens
+                )
+            kd_logit_loss_scalar = torch.sum(kd_logit_loss) / kd_safe_num_tokens
+
+        if logit_kd_enabled:
+            MTPLossLoggingHelper.save_kd_loss_to_tracker(
+                kd_logit_loss_scalar,
+                mtp_layer_number,
+                config.mtp_num_layers,
+                avg_group=parallel_state.get_data_parallel_group(with_context_parallel=True),
             )
 
     return hidden_states
@@ -1814,12 +1941,45 @@ class MultiTokenPredictionBlock(MegatronModule):
         if self.config.mtp_detach_heads:
             hidden_states = hidden_states.detach()
 
+        hsm_mode = getattr(self.config, 'mtp_hsm_mode', None) if self.training else None
+        if hsm_mode is not None:
+            hsm_hidden_history = [hidden_states]
+
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
+
+            # Diagonal-align accumulated HSM states before mixing. Older entries
+            # roll once per depth while the newest entry remains at its current
+            # position, so every state at position i targets the same token.
+            if hsm_mode is not None and len(hsm_hidden_history) > 1:
+                entries_to_roll = hsm_hidden_history[:-1]
+                last_entry = hsm_hidden_history[-1]
+                num_entries = len(entries_to_roll)
+                seq_len, batch_size, hidden_size = entries_to_roll[0].shape
+                stacked = torch.stack(entries_to_roll, dim=0)
+                flat = stacked.permute(0, 2, 3, 1).reshape(
+                    num_entries * batch_size, hidden_size, seq_len
+                )
+                rolled, _ = roll_tensor(
+                    flat,
+                    shifts=-1,
+                    dims=-1,
+                    cp_group=self.cp_group,
+                    packed_seq_params=packed_seq_params,
+                )
+                hsm_hidden_history = list(
+                    rolled.reshape(num_entries, batch_size, hidden_size, seq_len)
+                    .permute(0, 3, 1, 2)
+                    .unbind(0)
+                ) + [last_entry]
+                mtp_hidden_states = _hsm_mix(hsm_hidden_history)
+            else:
+                mtp_hidden_states = hidden_states
+
             (hidden_states, input_ids, position_ids, padding_mask) = self.layers[layer_idx](
                 input_ids=input_ids,
                 position_ids=position_ids,
-                hidden_states=hidden_states,
+                hidden_states=mtp_hidden_states,
                 attention_mask=attention_mask,
                 padding_mask=padding_mask,
                 inference_params=inference_params,
@@ -1831,6 +1991,9 @@ class MultiTokenPredictionBlock(MegatronModule):
                 embedding=embedding,
                 **(extra_block_kwargs or {}),
             )
+
+            if hsm_mode is not None:
+                hsm_hidden_history.append(hidden_states)
 
             # append the output hidden states of the current mtp layer
             # to the hidden_states_list

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -86,6 +86,27 @@ class TransformerConfig(ModelParallelConfig):
     This prevents MTP loss gradients from flowing back to the main model,
     only training the MTP heads themselves."""
 
+    freeze_base_model_for_mtp: bool = False
+    """Freeze all base model parameters and run the decoder under torch.no_grad()
+    to avoid storing activations for the backward pass through the frozen layers."""
+
+    mtp_disable_ce_loss: bool = False
+    """Disable the standard cross-entropy MTP loss, keeping only KD losses."""
+
+    mtp_kd_logit_enabled: bool = False
+    """Enable logit-level KD from shifted base-model logits to MTP logits."""
+
+    mtp_kd_logit_temperature: float = 1.0
+    """Softmax temperature for MTP logit KD. Higher values produce softer distributions."""
+
+    mtp_kd_logit_loss_weight: float = 1.0
+    """Weight for MTP logit KD loss, before applying mtp_loss_scaling_factor."""
+
+    mtp_hsm_mode: Optional[str] = field(
+        default=None, metadata={"argparse_meta": {"choices": ["uniform_layer_sample"]}}
+    )
+    """Hidden State Mixing mode for MTP. Only 'uniform_layer_sample' is supported."""
+
     mtp_hybrid_override_pattern: Optional[str] = None
     """DEPRECATED: Use unified hybrid_layer_pattern instead.
     Legacy argument for loading old checkpoints.

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -884,6 +884,27 @@ def validate_args(args, defaults={}):
                 args.rank
             )
 
+    if getattr(args, 'mtp_hsm_mode', None) is not None:
+        assert args.mtp_num_layers and args.mtp_num_layers >= 2, (
+            "--mtp-hsm-mode requires --mtp-num-layers to be at least 2."
+        )
+
+    if getattr(args, 'freeze_base_model_for_mtp', False):
+        assert args.mtp_num_layers, (
+            "--freeze-base-model-for-mtp requires --mtp-num-layers to be set."
+        )
+
+    if getattr(args, 'mtp_kd_logit_enabled', False):
+        assert args.mtp_num_layers, (
+            "MTP Knowledge Distillation (--mtp-kd-logit-enabled) "
+            "requires --mtp-num-layers to be set."
+        )
+
+    if getattr(args, 'mtp_disable_ce_loss', False):
+        assert getattr(args, 'mtp_kd_logit_enabled', False), (
+            "--mtp-disable-ce-loss requires --mtp-kd-logit-enabled."
+        )
+
     # Infer use of MLA from unified pattern
     if args.hybrid_layer_pattern and Symbols.DS_ATTENTION in args.hybrid_layer_pattern:
         args.multi_latent_attention = True

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1766,6 +1766,28 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
     # After TE2.x: Below function is an empty function and does nothing.
     correct_amax_history_if_needed(model)
 
+    # Freeze base model parameters if requested, training only the MTP layers.
+    # This must happen after Float16Module wrapping but before DDP wrapping, which
+    # builds gradient buffers only for trainable parameters.
+    if getattr(args, 'freeze_base_model_for_mtp', False):
+        frozen_params = 0
+        trainable_params = 0
+        for model_module in model:
+            for name, param in model_module.named_parameters():
+                if 'mtp.' in name:
+                    trainable_params += param.numel()
+                else:
+                    param.requires_grad_(False)
+                    frozen_params += param.numel()
+            for name, module in model_module.named_modules():
+                if hasattr(module, 'frozen_expert_bias') and 'mtp.' not in name:
+                    module.frozen_expert_bias = True
+        print_rank_0(
+            f'[freeze-base-model-for-mtp] Frozen {frozen_params:,} parameters '
+            f'and base-model expert_bias buffers. '
+            f'Trainable MTP parameters: {trainable_params:,}.'
+        )
+
     if wrap_with_ddp:
         if args.use_torch_fsdp2:
             assert HAVE_FSDP2, "Torch FSDP2 requires torch>=2.4.0"

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -7,6 +7,7 @@ import types
 import pytest
 import torch
 
+import megatron.core.transformer.multi_token_prediction as mtp_module
 from megatron.core.enums import ModelType
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.models.gpt.gpt_layer_specs import (
@@ -26,6 +27,7 @@ from megatron.core.transformer.multi_token_prediction import (
     MTPLossLoggingHelper,
     MultiTokenPredictionBlock,
     _mtp_logits_are_vocab_sharded,
+    _scale_mtp_loss_for_token_count,
     process_mtp_loss,
     roll_tensor,
 )
@@ -87,6 +89,31 @@ class TestMultiTokenPredictionLayer:
             num_layers=4, hidden_size=64, num_attention_heads=8, use_cpu_initialization=True
         )
         assert config.mtp_detach_heads is False
+
+    def test_hsm_and_kd_config_defaults(self):
+        """Test that MTP HSM and KD options default to disabled."""
+        config = TransformerConfig(
+            num_layers=4, hidden_size=64, num_attention_heads=8, use_cpu_initialization=True
+        )
+        assert config.mtp_disable_ce_loss is False
+        assert config.mtp_kd_logit_enabled is False
+        assert config.mtp_kd_logit_temperature == 1.0
+        assert config.mtp_kd_logit_loss_weight == 1.0
+        assert config.mtp_hsm_mode is None
+        assert config.freeze_base_model_for_mtp is False
+
+    def test_mtp_per_token_loss_scaling_uses_rolled_token_count(self):
+        """MTP per-token losses should normalize by rolled valid tokens after final grad scaling."""
+        loss = torch.ones(2, 4)
+        loss_scale = 0.3
+        original_num_tokens = torch.tensor(8.0)
+        rolled_num_tokens = torch.tensor(6.0)
+
+        scaled_loss = _scale_mtp_loss_for_token_count(
+            loss, loss_scale, original_num_tokens, rolled_num_tokens
+        )
+
+        torch.testing.assert_close(scaled_loss, loss * loss_scale * (8.0 / 6.0))
 
     def test_constructor_with_detach_heads(self):
         """Test construction of MTP module with mtp_detach_heads=True."""
@@ -363,6 +390,57 @@ class TestMultiTokenPredictionLayer:
         else:
             assert hidden_states.grad is not None
             assert emb_weight.grad is not None
+
+    def test_hsm_rolls_older_states_before_mixing(self, monkeypatch):
+        """HSM diagonal-aligns older states and leaves the newest state unrolled."""
+        torch.manual_seed(_SEED)
+        config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
+        config.mtp_hsm_mode = "uniform_layer_sample"
+        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+
+        class _FakeMTPLayer(torch.nn.Module):
+            def __init__(self, delta):
+                super().__init__()
+                self.delta = delta
+
+            def forward(self, hidden_states, input_ids, position_ids, padding_mask=None, **kwargs):
+                return hidden_states + self.delta, input_ids, position_ids, padding_mask
+
+        mtp.layers = torch.nn.ModuleList([_FakeMTPLayer(100.0), _FakeMTPLayer(200.0)])
+        captured_history = []
+
+        def fake_hsm_mix(hidden_states_list):
+            captured_history.append([state.clone() for state in hidden_states_list])
+            return hidden_states_list[-1]
+
+        monkeypatch.setattr(mtp_module, "_hsm_mix", fake_hsm_mix)
+        mtp.train()
+
+        seq_len = 4
+        batch_size = 1
+        hidden_states = (
+            torch.arange(seq_len, dtype=torch.float32)
+            .view(seq_len, batch_size, 1)
+            .expand(seq_len, batch_size, config.hidden_size)
+            .clone()
+        )
+        input_ids = torch.arange(seq_len, dtype=torch.int64).view(batch_size, seq_len)
+        position_ids = input_ids.clone()
+
+        mtp.forward(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attention_mask=None,
+            embedding=lambda input_ids, position_ids: torch.zeros_like(hidden_states),
+        )
+
+        expected_rolled, _ = roll_tensor(hidden_states.permute(1, 2, 0), shifts=-1, dims=-1)
+        expected_rolled = expected_rolled.permute(2, 0, 1)
+
+        assert len(captured_history) == 1
+        torch.testing.assert_close(captured_history[0][0], expected_rolled)
+        torch.testing.assert_close(captured_history[0][1], hidden_states + 100.0)
 
     @pytest.mark.parametrize("detach_heads", [False, True])
     def test_process_mtp_loss_detaches_output_weight(self, detach_heads):
@@ -1095,6 +1173,22 @@ class TestMTPLossLoggingHelper:
         assert tracker["reduce_group"] is None
         assert tracker["avg_group"] is None
 
+    def test_save_kd_loss_to_tracker(self):
+        """Test saving KD loss to tracker."""
+        kd_loss = torch.tensor(0.7)
+        layer_number = 1
+        num_layers = self.num_layers
+
+        MTPLossLoggingHelper.save_kd_loss_to_tracker(
+            kd_logit_loss=kd_loss, layer_number=layer_number, num_layers=num_layers
+        )
+
+        tracker = MTPLossLoggingHelper.tracker
+        assert "kd_logit_loss_values" in tracker
+        assert tracker["kd_logit_loss_values"].shape == (num_layers,)
+        assert tracker["kd_logit_loss_values"][layer_number] == kd_loss
+        assert tracker["avg_group"] is None
+
     def test_mtp_logits_are_vocab_sharded(self):
         """Test detection for vocab-sharded versus gathered MTP logits."""
 
@@ -1111,12 +1205,16 @@ class TestMTPLossLoggingHelper:
         """Test tracking MTP metrics including acceptance rate."""
         num_layers = self.num_layers
         loss = torch.tensor(2.3)
+        kd_loss = torch.tensor(0.4)
         correct = torch.tensor(7.0)
         total = torch.tensor(10.0)
 
         for i in range(num_layers):
             MTPLossLoggingHelper.save_metrics_to_tracker(
                 loss=loss, correct=correct, total=total, layer_number=i, num_layers=num_layers
+            )
+            MTPLossLoggingHelper.save_kd_loss_to_tracker(
+                kd_logit_loss=kd_loss, layer_number=i, num_layers=num_layers
             )
 
         class DummyWriter:
@@ -1150,6 +1248,11 @@ class TestMTPLossLoggingHelper:
             assert f"mtp_{i+1} loss" in writer.scalars
             assert torch.isclose(torch.as_tensor(writer.scalars[f"mtp_{i+1} loss"]), expected_loss)
             assert torch.isclose(total_loss_dict[f"mtp_{i+1} loss"], expected_loss)
+            expected_kd_loss = kd_loss * loss_scale
+            assert torch.isclose(
+                torch.as_tensor(writer.scalars[f"mtp_{i+1}_kd_logit_loss"]), expected_kd_loss
+            )
+            assert torch.isclose(total_loss_dict[f"mtp_{i+1}_kd_logit_loss"], expected_kd_loss)
 
         # Verify acceptance rate is computed as (correct / total) * 100
         expected_rate = (correct / total) * 100.0
@@ -1200,6 +1303,7 @@ class TestMTPLossLoggingHelper:
 
         # Verify tracker is cleaned
         assert torch.all(MTPLossLoggingHelper.tracker["loss_values"] == 0)
+        assert torch.all(MTPLossLoggingHelper.tracker["kd_logit_loss_values"] == 0)
         assert MTPLossLoggingHelper.tracker["reduce_group"] is None
         assert MTPLossLoggingHelper.tracker["avg_group"] is None
 


### PR DESCRIPTION
## Summary

This PR adds MTP training support for hidden-state mixing, logit-level KD, and optional backbone freezing.
This code was used for the MTP boosting of Nemotron 3 Ultra

Changes:
- Adds MTP hidden-state mixing using uniform layer/state sampling.
- Adds logit-level KD from shifted base-model logits to MTP logits.
- Adds optional backbone freezing for MTP-only training while keeping MTP parameters trainable.
- Preserves rolling of MTP hidden states, labels, and masks across MTP depths.
- Adds unit coverage for HSM rolling, KD metric logging, and config defaults.

## Testing

- `git diff --check upstream/main..HEAD`
- `python -m py_compile` on changed Python files
- `PATH=.venv/bin:$PATH BASE_REF=main bash tools/autoformat.sh`
- Confirmed HSM, logits KD, and frozen-backbone training run without breaking on the ported main branch.