### PR TITLE
Fix RoPE fallback for Hybrid CP local_cp_size=1

### DIFF
--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -182,6 +182,7 @@ class RotaryEmbedding(nn.Module):
         offset: int = 0,
         packed_seq: bool = False,
         cp_group: Optional[torch.distributed.ProcessGroup] = None,
+        use_default_cp_group: bool = True,
     ) -> Tensor:
         """Forward pass of RoPE embedding.
 
@@ -191,12 +192,14 @@ class RotaryEmbedding(nn.Module):
             packed_seq (bool, optional): Whether to use packed sequence. Defaults to False.
             cp_group (torch.distributed.ProcessGroup, optional): Context parallel group.
                 Defaults to None.
+            use_default_cp_group (bool, optional): Whether to fall back to the static context
+                parallel group when cp_group is None. Defaults to True.
 
         Returns:
             Tensor: Embeddings after applying RoPE.
         """
         emb = self.get_emb(max_seq_len, offset)
-        if cp_group is None:
+        if cp_group is None and use_default_cp_group:
             cp_group = self.cp_group
         if cp_group is not None and cp_group.size() > 1 and not packed_seq:
             # slice rotary_pos_emb along sequence dimension
@@ -317,6 +320,7 @@ class MultimodalRotaryEmbedding(nn.Module):
         position_ids: torch.Tensor,
         mrope_section: List[int],
         cp_group: Optional[torch.distributed.ProcessGroup] = None,
+        use_default_cp_group: bool = True,
     ) -> Tensor:
         """Forward pass of multimodal RoPE embedding.
 
@@ -326,6 +330,8 @@ class MultimodalRotaryEmbedding(nn.Module):
                 height and width in rope calculation.
             cp_group (torch.distributed.ProcessGroup, optional): Context parallel group.
                 Defaults to None.
+            use_default_cp_group (bool, optional): Whether to fall back to the static context
+                parallel group when cp_group is None. Defaults to True.
 
         Returns:
             Tensor: Embeddings after applying RoPE.
@@ -358,7 +364,7 @@ class MultimodalRotaryEmbedding(nn.Module):
 
         # shape (seq_length, bs, 1, 2 * dim)
         emb = emb[..., None, :].transpose(0, 1).contiguous()
-        if cp_group is None:
+        if cp_group is None and use_default_cp_group:
             cp_group = self.cp_group
         if cp_group is not None and cp_group.size() > 1:
             # slice rotary_pos_emb along sequence dimension and select the parition of the current

--- a/megatron/core/models/common/embeddings/yarn_rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/yarn_rotary_pos_embedding.py
@@ -164,6 +164,7 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         offset: int = 0,
         packed_seq: bool = False,
         cp_group: Optional[torch.distributed.ProcessGroup] = None,
+        use_default_cp_group: bool = True,
     ) -> Tensor:
         """Forward pass of Yarn Rotary Embedding.
 
@@ -173,12 +174,14 @@ class YarnRotaryEmbedding(RotaryEmbedding):
             packed_seq (bool, optional): Whether to use packed sequence. Defaults to False.
             cp_group (torch.distributed.ProcessGroup, optional): Context parallel group.
                 Defaults to None.
+            use_default_cp_group (bool, optional): Whether to fall back to the static context
+                parallel group when cp_group is None. Defaults to True.
 
         Returns:
             Tensor: Embeddings after applying Yarn RoPE.
         """
         emb, _mscale = self.get_emb(max_seq_len, offset)
-        if cp_group is None:
+        if cp_group is None and use_default_cp_group:
             cp_group = self.cp_group
         if cp_group is not None and cp_group.size() > 1 and not packed_seq:
             # slice rotary_pos_emb along sequence dimension

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -351,6 +351,9 @@ class GPTModel(LanguageModule):
         rotary_pos_sin = None
         # this is used to store combined cos/sin embeddings, exclusively for flash infer rope
         rotary_pos_cos_sin = None
+        use_default_cp_group = not (
+            packed_seq_params is not None and packed_seq_params.local_cp_size == 1
+        )
 
         if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
             use_flash_infer_fused_rope = (
@@ -391,6 +394,7 @@ class GPTModel(LanguageModule):
                     packed_seq=packed_seq_params is not None
                     and packed_seq_params.qkv_format == 'thd',
                     cp_group=packed_seq_params.cp_group if packed_seq_params is not None else None,
+                    use_default_cp_group=use_default_cp_group,
                 )
         elif self.position_embedding_type == 'yarn':
             if not InferenceMode.is_active() or not self.config.flash_decode:
@@ -402,6 +406,7 @@ class GPTModel(LanguageModule):
                     packed_seq=packed_seq_params is not None
                     and packed_seq_params.qkv_format == 'thd',
                     cp_group=packed_seq_params.cp_group if packed_seq_params is not None else None,
+                    use_default_cp_group=use_default_cp_group,
                 )
             else:
                 raise NotImplementedError(
@@ -414,6 +419,7 @@ class GPTModel(LanguageModule):
                     position_ids,
                     self.mrope_section,
                     cp_group=packed_seq_params.cp_group if packed_seq_params is not None else None,
+                    use_default_cp_group=use_default_cp_group,
                 )
             else:
                 # Flash decoding uses precomputed cos and sin for RoPE

--- a/tests/unit_tests/models/test_gpt_model.py
+++ b/tests/unit_tests/models/test_gpt_model.py
@@ -24,12 +24,32 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_mlp_module_spec,
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.module import Float16Module
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_fa_min_version, is_te_min_version
 from tests.unit_tests.test_utilities import Utils
+
+
+class FakeRotaryEmbedding:
+    def __init__(self):
+        self.use_default_cp_group = None
+
+    def get_rotary_seq_len(self, *args, **kwargs):
+        return 4
+
+    def __call__(
+        self,
+        max_seq_len,
+        offset=0,
+        packed_seq=False,
+        cp_group=None,
+        use_default_cp_group=True,
+    ):
+        self.use_default_cp_group = use_default_cp_group
+        return torch.empty(max_seq_len, 1, 1, 4, device="cuda")
 
 
 class TestGPTModel:
@@ -228,6 +248,31 @@ class TestGPTModel:
         assert seen["context"] is context
         assert seen["labels"] is labels
         assert seen["output_layer"] is self.gpt_model.output_layer
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_hybrid_cp_local_size_one_disables_rope_default_cp_group(self):
+        self.gpt_model.cuda()
+        self.gpt_model.position_embedding_type = 'rope'
+        self.gpt_model.rotary_pos_emb = FakeRotaryEmbedding()
+
+        sequence_length = self.gpt_model.max_sequence_length
+        input_ids = torch.arange(sequence_length, dtype=torch.int64, device="cuda").repeat((1, 1))
+        position_ids = input_ids.clone()
+        packed_seq_params = PackedSeqParams(
+            qkv_format="sbhd",
+            max_seqlen_q=sequence_length,
+            max_seqlen_kv=sequence_length,
+            local_cp_size=1,
+            cp_group=None,
+        )
+
+        self.gpt_model._preprocess(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+        )
+
+        assert self.gpt_model.rotary_pos_emb.use_default_cp_group is False
 
 
 def test_get_mlp_module_spec_interface():

--- a/tests/unit_tests/transformer/test_rope.py
+++ b/tests/unit_tests/transformer/test_rope.py
@@ -21,6 +21,18 @@ except ImportError:
 from tests.unit_tests.test_utilities import Utils
 
 
+class FakeCPGroup:
+    def __init__(self, size, rank):
+        self._size = size
+        self._rank = rank
+
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
+
+
 class TestMultimodalRotaryEmbedding:
     def setup_method(self):
         Utils.initialize_model_parallel(1, 1)
@@ -93,6 +105,17 @@ class TestRotaryEmbedding:
         assert output.shape[3] == self.kv_channels
         assert output.dtype == torch.float32
         assert output.device.type == 'cuda'
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_can_disable_default_cp_group(self):
+        self.rope_gpu_init.cp_group = FakeCPGroup(size=2, rank=0)
+
+        output = self.rope_gpu_init(64, use_default_cp_group=False)
+
+        assert output.shape[0] == 64
+        assert output.shape[1] == 1
+        assert output.shape[2] == 1
+        assert output.shape[3] == self.kv_channels
 
 
 class TestQKVRotaryEmbedding:


### PR DESCRIPTION
  - [x] I, the PR author, have personally reviewed every line of this PR.

  # What does this PR do ?

  Fix RoPE/Yarn/MRoPE CP-group fallback so Hybrid CP packed samples with `local_cp_size=1` do not use the static CP group for rotary embedding slicing.

  :warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

  ## Issue tracking

  For PRs from open-source community contributors:

  - **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
  - **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

  Linked issue: Fixes #5352

  ## Contribution process

  ### Pre-checks

  - [x] I have added relevant unit tests
  - [ ] I have added relevant functional tests
  - [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
  - [ ] I have added relevant documentation
  - [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

  ### Code review

  Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

  All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

  #### Step 1: Mark PR as "Ready for Review"

  1. When your PR is ready, click **Ready for Review**.
  2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
     - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

  :warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
  Final Review might get declined if these requirements are not fulfilled.

  #### Step 2: Final Review

  For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

  ## Summary

  - Add an explicit `use_default_cp_group` flag to RoPE, Yarn RoPE, and MRoPE.
  - In GPT preprocessing, disable static CP group fallback when `packed_seq_params.local_cp_size == 1`.
  - Add regression coverage for disabling default CP fallback and for the GPT Hybrid CP `local_cp_size=1` path.

  ## Testing

  - `PYENV_VERSION=3.10.13 python -m py_compile ...` passed.
  - Targeted pytest was not run because pytest is not installed in the local pyenv environment.
