### PR TITLE
fix: restore checkpoint-time GPU cache reclaim before async save

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2860,6 +2860,13 @@ def save_checkpoint_and_time(
 
     # Log E2E metrics before save-checkpoint
     one_logger_utils.track_e2e_metrics()
+    # Free overlap param-gather buffers and release cached GPU memory so
+    # that the async checkpoint worker process has enough GPU headroom for
+    # D2H tensor transfers.
+    for model_chunk in model:
+        if hasattr(model_chunk, 'free_overlap_buffers'):
+            model_chunk.free_overlap_buffers()
+    torch.cuda.empty_cache()
 
     global num_checkpoints_memory_reported, MAX_NUM_CHECKPOINTS_MEMORY_REPORTED
     should_report_memory = num_checkpoints_memory_reported < MAX_NUM_CHECKPOINTS_MEMORY_REPORTED


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation
- The `nemotron3_super_release_gb200_sm` **weekly** release test OOM'd on rank 0 during its first checkpoint save (iteration 100) on 16× GB200.
- Root cause: #5170 ("Remove checkpoint-time GPU cache reclaim workaround") deleted the block in `save_checkpoint_and_time()` that freed overlap param-gather buffers and released the caching allocator before an async checkpoint save.
- That config runs with `--overlap-param-gather`, `--async-save`, `--use-persistent-ckpt-worker` and sits at **~177 GB reserved on a 186 GB GB200**. With the reclaim gone, the save-plan `gather_object` collective couldn't `cudaMalloc` NCCL buffers → `NCCL WARN Cuda failure 2 'out of memory'` → rank 0 died → TCPStore broken-pipe cascade → gang timeout.

## What changed
- Revert of commit `3a183e235c` (#5170): restore the GPU cache reclaim before async checkpoint save.

## Details
- `megatron/training/training.py`, `save_checkpoint_and_time()` — re-adds:
  ```python
  # Free overlap param-gather buffers and release cached GPU memory so
  # that the async checkpoint worker process has enough GPU headroom for
  # D2H tensor transfers.
  for model_chunk in model:
      if hasattr(model_chunk, 'free_overlap_buffers'):
          model_chunk.free_overlap_buffers()
  torch.cuda.empty_cache()
  ```
- Guarded by `hasattr(..., 'free_overlap_buffers')`, so it is a no-op for model chunks that do not expose it.

## Tested
- Internal weekly CI triggered on this branch, scoped to the single failing case with a 4 h limit:
  - `FUNCTIONAL_TEST_SCOPE=weekly`, `FUNCTIONAL_TEST_CASES=nemotron3_super_release_gb200_sm`, `FUNCTIONAL_TEST_TIME_LIMIT=14400`, `CLUSTER_GB200=dgxgb200_oci-hsg` (isolated run-name).
  - `ADLR/megatron-lm` pipeline **54912395** — in progress; will update with the checkpoint-save result.

</details>
