### PR TITLE
Thread tensor-parallel group into the RADIO patch embedder

### DIFF
--- a/megatron/core/models/vision/radio.py
+++ b/megatron/core/models/vision/radio.py
@@ -173,6 +173,7 @@ class RADIOViTModel(VisionModule):
                 gather_output=True,
                 disable_grad_reduce=True,
                 init_method=lambda tensor: torch.nn.init.normal_(tensor, mean=0.0, std=1.0),
+                tp_group=pg_collection.tp if pg_collection is not None else None,
             )
             self.video_embedder = ColumnParallelLinear(
                 input_size=3 * self.temporal_patch_dim * self.patch_dim * self.patch_dim,
@@ -182,6 +183,7 @@ class RADIOViTModel(VisionModule):
                 gather_output=True,
                 disable_grad_reduce=True,
                 init_method=lambda tensor: torch.nn.init.normal_(tensor, mean=0.0, std=1.0),
+                tp_group=pg_collection.tp if pg_collection is not None else None,
             )
         else:
             self.embedder = ColumnParallelLinear(
@@ -192,6 +194,7 @@ class RADIOViTModel(VisionModule):
                 gather_output=True,
                 disable_grad_reduce=True,
                 init_method=lambda tensor: torch.nn.init.normal_(tensor, mean=0.0, std=1.0),
+                tp_group=pg_collection.tp if pg_collection is not None else None,
             )
         transformer_config.sequence_parallel = orig_sequence_parallel
 


### PR DESCRIPTION
## What
Thread the encoder's tensor-parallel group from a provided `ProcessGroupCollection` into the RADIO patch embedder (and the separate video embedder) `ColumnParallelLinear`'s `tp_group`. The argument defaults to `None` when no `pg_collection` is supplied, preserving stock behavior for existing callers.

## Why
The RADIO ViT patch embedder built its `ColumnParallelLinear` without an explicit tensor-parallel group, so it fell back to the global TP group. Under a heterogeneous MIMO grid the encoder lives on its own grid whose TP group is not the global one, producing a wrong/empty TP group for the embedder.

Purely additive / default-None; no change to stock behavior.

## Validation
Validated in the 8-GPU 20L Nemotron VLM e2e (trains + checkpoint save/resume, lm loss 12.18->11.54 across resume).

## CODEOWNERS
`megatron/core/` -> @NVIDIA/core-adlr @NVIDIA/core-nemo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
