### PR TITLE
Support the MIMO cross-grid path in training loop

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -45,7 +45,11 @@ from .hybrid_cp_schedule import hybrid_context_parallel_forward_backward
 Shape = Union[List[int], torch.Size]
 
 
-def get_forward_backward_func(pp_size: Optional[int] = None, vp_size: Optional[int] = None):
+def get_forward_backward_func(
+    pp_size: Optional[int] = None,
+    vp_size: Optional[int] = None,
+    schedule_pg_collection: Optional[MultiModuleProcessGroupCollection] = None,
+):
     """Retrieves the appropriate forward_backward function given the
     configuration of parallel_state.
 
@@ -138,8 +142,13 @@ def get_forward_backward_func(pp_size: Optional[int] = None, vp_size: Optional[i
         vp_size (Optional[int]): Virtual pipeline model parallel size to use.
             If both pp_size and vp_size are None, both values fall back to parallel_state.
             Otherwise, provided values are used as-is and None is treated as an explicit input.
+        schedule_pg_collection (Optional[MultiModuleProcessGroupCollection]): When a
+            multi-module (cross-grid) collection is passed, select the bridge schedule.
 
     """
+    if isinstance(schedule_pg_collection, MultiModuleProcessGroupCollection):
+        return forward_backward_pipelining_without_interleaving
+
     if pp_size is None and vp_size is None:
         pp_size = parallel_state.get_pipeline_model_parallel_world_size()
         vp_size = parallel_state.get_virtual_pipeline_model_parallel_world_size()

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3354,8 +3354,6 @@ def train(
     eval_iterations = 0
     # Wrap forward_backward_func for Full iteration CUDA graph
     if p2p_communicator is not None:
-        # MIMO cross-grid bridge: pick the schedule by p2p_communicator presence, not
-        # parallel_state pp size (unset without mpu). without-interleaving supports both.
         from megatron.core.pipeline_parallel.schedules import (
             forward_backward_pipelining_without_interleaving,
         )

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3353,14 +3353,9 @@ def train(
     eval_duration = 0.0
     eval_iterations = 0
     # Wrap forward_backward_func for Full iteration CUDA graph
-    if p2p_communicator is not None:
-        from megatron.core.pipeline_parallel.schedules import (
-            forward_backward_pipelining_without_interleaving,
-        )
-
-        forward_backward_func = forward_backward_pipelining_without_interleaving
-    else:
-        forward_backward_func = get_forward_backward_func()
+    forward_backward_func = get_forward_backward_func(
+        schedule_pg_collection=schedule_pg_collection
+    )
     if args.cuda_graph_impl == "full_iteration":
         forward_backward_func = FullCudaGraphWrapper(
             forward_backward_func,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2236,9 +2236,7 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
 
         if has_nvidia_modelopt and p2p_communicator is None:
             # [ModelOpt]: Pipeline-parallel Distillation stacks student and teacher tensors.
-            # Skipped on the MIMO cross-grid path (p2p_communicator present): MIMO does not
-            # use distillation, and this helper reads parallel_state pp groups that are not
-            # initialized without mpu. The MIMO bridge schedule handles its own tensor shapes.
+            # Skipped on the MIMO path: it reads uninitialized parallel_state pp groups.
             adjust_tensor_shapes_fn = get_tensor_shapes_adjust_fn_for_distillation(
                 model,
                 seq_length=args.seq_length,
@@ -2393,9 +2391,7 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
 
     if is_last_stage and losses_reduced:
         # Average loss across microbatches. ``losses_reduced`` is empty on ranks
-        # that produce no loss (e.g. MIMO encoder-grid ranks, which are their own
-        # module's last PP stage but never compute the language loss), so guard the
-        # ``losses_reduced[0]`` access.
+        # that produce no loss (e.g. MIMO encoder-grid ranks), so guard the access.
         loss_reduced = {}
         for key in losses_reduced[0].keys():
             val = [x[key].view(-1) for x in losses_reduced]
@@ -3359,10 +3355,8 @@ def train(
     eval_iterations = 0
     # Wrap forward_backward_func for Full iteration CUDA graph
     if p2p_communicator is not None:
-        # MIMO cross-grid bridge: select the schedule by the presence of a
-        # cross-module P2P communicator, not by parallel_state pp size (which is
-        # unset when mpu is not initialized). The without-interleaving schedule
-        # accepts both p2p_communicator and the MultiModuleProcessGroupCollection.
+        # MIMO cross-grid bridge: pick the schedule by p2p_communicator presence, not
+        # parallel_state pp size (unset without mpu). without-interleaving supports both.
         from megatron.core.pipeline_parallel.schedules import (
             forward_backward_pipelining_without_interleaving,
         )

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2234,8 +2234,11 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
             model_chunk.force_all_reduce = save_wgrads_in_this_iteration
         optimizer.zero_grad()
 
-        if has_nvidia_modelopt:
-            # [ModelOpt]: Pipeline-parallel Distillation stacks student and teacher tensors
+        if has_nvidia_modelopt and p2p_communicator is None:
+            # [ModelOpt]: Pipeline-parallel Distillation stacks student and teacher tensors.
+            # Skipped on the MIMO cross-grid path (p2p_communicator present): MIMO does not
+            # use distillation, and this helper reads parallel_state pp groups that are not
+            # initialized without mpu. The MIMO bridge schedule handles its own tensor shapes.
             adjust_tensor_shapes_fn = get_tensor_shapes_adjust_fn_for_distillation(
                 model,
                 seq_length=args.seq_length,
@@ -2388,8 +2391,11 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     if args.empty_unused_memory_level >= 2:
         torch.cuda.empty_cache()
 
-    if is_last_stage:
-        # Average loss across microbatches.
+    if is_last_stage and losses_reduced:
+        # Average loss across microbatches. ``losses_reduced`` is empty on ranks
+        # that produce no loss (e.g. MIMO encoder-grid ranks, which are their own
+        # module's last PP stage but never compute the language loss), so guard the
+        # ``losses_reduced[0]`` access.
         loss_reduced = {}
         for key in losses_reduced[0].keys():
             val = [x[key].view(-1) for x in losses_reduced]
@@ -3352,7 +3358,18 @@ def train(
     eval_duration = 0.0
     eval_iterations = 0
     # Wrap forward_backward_func for Full iteration CUDA graph
-    forward_backward_func = get_forward_backward_func()
+    if p2p_communicator is not None:
+        # MIMO cross-grid bridge: select the schedule by the presence of a
+        # cross-module P2P communicator, not by parallel_state pp size (which is
+        # unset when mpu is not initialized). The without-interleaving schedule
+        # accepts both p2p_communicator and the MultiModuleProcessGroupCollection.
+        from megatron.core.pipeline_parallel.schedules import (
+            forward_backward_pipelining_without_interleaving,
+        )
+
+        forward_backward_func = forward_backward_pipelining_without_interleaving
+    else:
+        forward_backward_func = get_forward_backward_func()
     if args.cuda_graph_impl == "full_iteration":
         forward_backward_func = FullCudaGraphWrapper(
             forward_backward_func,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2234,9 +2234,8 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
             model_chunk.force_all_reduce = save_wgrads_in_this_iteration
         optimizer.zero_grad()
 
-        if has_nvidia_modelopt and p2p_communicator is None:
-            # [ModelOpt]: Pipeline-parallel Distillation stacks student and teacher tensors.
-            # Skipped on the MIMO path: it reads uninitialized parallel_state pp groups.
+        if has_nvidia_modelopt and getattr(args, "modelopt_enabled", False):
+            # Distillation shape-adjust reads parallel_state; only for modelopt-enabled runs.
             adjust_tensor_shapes_fn = get_tensor_shapes_adjust_fn_for_distillation(
                 model,
                 seq_length=args.seq_length,
@@ -2390,8 +2389,8 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
         torch.cuda.empty_cache()
 
     if is_last_stage and losses_reduced:
-        # Average loss across microbatches. ``losses_reduced`` is empty on ranks
-        # that produce no loss (e.g. MIMO encoder-grid ranks), so guard the access.
+        # Average loss across microbatches.
+        # Last stage may have no loss (e.g. MIMO encoder-grid ranks).
         loss_reduced = {}
         for key in losses_reduced[0].keys():
             val = [x[key].view(-1) for x in losses_reduced]


### PR DESCRIPTION
## What
Three adjustments so the stock training loop supports the MIMO cross-grid path, all no-ops for non-MIMO runs:

- `get_forward_backward_func` selects `forward_backward_pipelining_without_interleaving` when passed a `MultiModuleProcessGroupCollection` (the cross-grid bridge); `train()` calls the selector unconditionally instead of branching on `p2p_communicator`.
- Guard the `losses_reduced[0]` access: MIMO encoder-grid ranks are their module's last PP stage but compute no language loss, so the list is empty there.
- Skip the ModelOpt distillation shape hook unless `modelopt_enabled`; it reads `parallel_state`, which is uninitialized on the MIMO path.

## Validation
8-GPU 20L Nemotron VLM e2e: trains + checkpoint save/resume (lm loss 12.18 → 11.54 across resume).
