### PR TITLE
Add hetero MIMO entrypoint, bootstrap, and mock data (integration)

### DIFF
--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -1,0 +1,779 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Hetero MIMO entry that runs on the *stock* Megatron ``train()`` loop.
+
+This is PR-E5 of the NMFW-516 hetero-MIMO upstreaming effort: the end-to-end
+integration that drives the Nemotron6-MoE VLM (20L) through Megatron's
+production ``megatron/training/training.py::train()`` instead of the prototype's
+bespoke loop. Scope: the NON-COLOCATED path (encoder grid and language grid on
+disjoint rank spans), mock data.
+
+Why not stock ``pretrain()``?
+=============================
+Stock ``pretrain(cfg_container, ...)`` does three things this entry cannot use
+verbatim:
+
+  1. It calls ``initialize_megatron`` -> ``_initialize_distributed`` ->
+     ``mpu.initialize_model_parallel(...)``. MIMO must NOT initialize the MPU
+     globals: each MIMO module owns its own ``HyperCommGrid`` with disjoint rank
+     spans, so a single world-spanning MPU layout is wrong. We therefore
+     replicate only the *non-MPU* pieces of ``initialize_megatron``
+     (``set_global_variables`` minus the num-microbatches calculator wiring,
+     random seeds, torch.distributed bring-up via MM1) and skip MPU init.
+  2. It calls ``setup_model_and_optimizer`` -> ``get_model`` which re-wraps a
+     single top-level DDP and builds a single optimizer over the MPU groups. The
+     MIMO model needs PER-SUBMODULE DDP (one per module grid) and the
+     ``MimoOptimizer`` (one inner optimizer per active module). ``E4
+     build_mimo_runtime`` already assembles that; we feed its model list straight
+     to ``train()``.
+  3. It builds train/valid/test datasets via a dataset provider. MIMO uses the
+     role-aware iterator from ``select_data_iterator`` (mock here).
+
+What this entry replicates from ``initialize_megatron`` (and what it skips)
+===========================================================================
+Replicated (needed global state ``train()`` / the schedule read):
+
+  * ``set_global_variables(args, build_tokenizer=False)`` MINUS its
+    num-microbatches calculator call -- args global, timers, tensorboard/wandb,
+    experimental flag. We build the calculator ourselves AFTER fixing
+    ``args.data_parallel_size`` (see below), because ``set_global_variables``
+    would key it on the stock (world-derived) DP size.
+  * ``_set_random_seed`` equivalent: ``random`` / ``numpy`` / ``torch`` seeds
+    (matches the prototype's ``loop.py`` so dataset-construction RNG agrees).
+  * torch.distributed bring-up via MM1 ``initialize_distributed`` (NCCL +
+    global memory buffer; NO MPU groups).
+
+Skipped (and why):
+
+  * ``mpu.initialize_model_parallel`` -- MIMO owns per-module grids; a global MPU
+    layout is wrong for disjoint spans. See (1) above.
+  * ``_compile_dependencies`` -- only compiles the C++ dataset index builder,
+    which the mock iterator does not use.
+  * ``_init_autoresume`` / ``_initialize_tp_communicators`` -- autoresume and TP
+    comm-overlap user buffers are not exercised by this mock run.
+  * tokenizer build -- mock data reads ``args.vocab_size`` directly and the
+    provider's ``_vocab_size`` falls back to it, so no tokenizer is needed.
+
+The ``data_parallel_size`` fix
+==============================
+Stock ``validate_args`` recomputes ``args.data_parallel_size = world_size //
+(tp*pp*cp)`` from the *stock* (world-spanning) parallelism flags. For the
+disjoint hetero layout that value is wrong: the language grid is only ``llm_dp``
+wide. ``train()`` reads ``get_num_microbatches()`` (keyed on
+``global_batch_size / (micro_batch_size * data_parallel_size)``) and
+``mpu.get_data_parallel_world_size()`` for sample accounting. We therefore:
+
+  * set ``args.data_parallel_size = args.llm_dp`` AFTER ``validate_args``;
+  * build the num-microbatches calculator with that DP so it yields the
+    script's ``--num-microbatches`` (gbs 8 / (mbs 1 * dp 2) = 4);
+  * pin ``parallel_state._MPU_DATA_PARALLEL_WORLD_SIZE = llm_dp`` so train()'s
+    four ``mpu.get_data_parallel_world_size()`` reads return the language DP size
+    without a full MPU init (a bootstrap/MPU-materialization compatibility
+    point, per CLAUDE.md).
+
+The grad-finalization clobber
+=============================
+``E4 build_mimo_runtime`` installs the MIMO dual grad-finalization hook
+(``configure_grad_sync`` sets ``model.config.finalize_model_grads_func`` to the
+encoder+language finalizer). But stock ``train()`` unconditionally reassigns
+``config.finalize_model_grads_func = finalize_model_grads`` (the module-level
+import in ``megatron.training.training``). To keep the MIMO hook without editing
+core, we monkeypatch that module-level symbol to the MIMO finalizer BEFORE
+calling ``train()``. ``config.grad_scale_func`` is also reassigned by ``train()``
+to ``optimizer.scale_loss``; for bf16 with no grad scaler the MimoOptimizer loss
+scale is 1.0, so ``scale_loss(loss) == loss`` -- behaviorally identical to the
+MIMO ``lambda loss: loss``, so no patch is needed there.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import sys
+
+import numpy as np
+import torch
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import megatron.training.training as training_module
+from examples.mimo.model_providers.nemotron_moe_vlm import (
+    add_model_provider_args,
+    prepare_model_provider_args,
+    validate_model_provider_args,
+)
+from examples.mimo.training.args import add_hetero_grid_args, validate_hetero_grid_args
+from examples.mimo.training.bootstrap import build_mimo_runtime
+from examples.mimo.training.data import add_data_args
+from examples.mimo.training.distributed import (
+    initialize_distributed,
+    print_rank_0,
+    shutdown_distributed,
+)
+from examples.mimo.training.step import mimo_forward_step
+from megatron.core import parallel_state
+from megatron.core.config import set_experimental_flag
+from megatron.core.models.mimo.optimizer import get_mimo_optimizer
+from megatron.core.num_microbatches_calculator import init_num_microbatches_calculator
+from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
+from megatron.training.arguments import parse_args, validate_args
+from megatron.training.global_vars import set_global_variables as _stock_set_global_variables
+
+# args ``set_global_variables`` requires but which the script does not pass. We
+# skip the tokenizer build (mock data reads args.vocab_size directly), so no
+# tokenizer-type default is needed.
+_ARGS_DEFAULTS = {
+    # No dataset path / tokenizer for the mock run.
+}
+
+
+def extra_args_provider(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Compose the model-provider arg group with the hetero grid arg group.
+
+    Both register their own argparse groups onto the stock parser. We also add
+    ``--num-microbatches`` here: stock Megatron derives the microbatch count from
+    ``global_batch_size / (micro_batch_size * data_parallel_size)`` and has no
+    such flag, but the prototype (and our run script) pass it explicitly.
+    """
+    parser = add_model_provider_args(parser)
+    parser = add_hetero_grid_args(parser)
+    parser = add_data_args(parser)
+    parser.add_argument(
+        "--num-microbatches",
+        type=int,
+        default=1,
+        help="Explicit microbatch count for the hetero MIMO loop (stock derives this "
+        "from gbs/mbs/dp; the hetero layout keys it on --llm-dp instead).",
+    )
+    return parser
+
+
+def _parse_and_validate() -> argparse.Namespace:
+    """Run the stock arg pipeline plus the MIMO preset/validation hooks.
+
+    Sequence (handoff section 2):
+      parse_args(extra) -> prepare_model_provider_args (preset, BEFORE validate)
+      -> stock validate_args -> validate_model_provider_args
+      -> validate_hetero_grid_args -> data_parallel_size fix.
+    """
+    args = parse_args(extra_args_provider)
+
+    # Apply the Nemotron preset BEFORE stock validation so preset-derived sizes
+    # (num_layers, hybrid pattern, seq_length, num_experts, image_seq_length, ...)
+    # flow into validate_args.
+    prepare_model_provider_args(args)
+
+    # Stock validation. ``defaults`` fills only args the user left at default.
+    validate_args(args, _ARGS_DEFAULTS)
+
+    # MIMO-specific validation (runs after stock so padded_vocab_size / num_experts
+    # are populated).
+    validate_model_provider_args(args)
+    world_size = int(os.environ.get("WORLD_SIZE", args.world_size))
+    validate_hetero_grid_args(args, world_size)
+
+    # --- data_parallel_size fix (see module docstring). --------------------
+    # Stock validate_args set args.data_parallel_size = world_size//(tp*pp*cp).
+    # Re-key it on the language grid's DP so get_num_microbatches() and sample
+    # accounting reflect the disjoint hetero layout.
+    args.data_parallel_size = args.llm_dp
+
+    # Stock throughput/FLOPs logging does ``1 + args.mtp_num_layers``; the Nemotron
+    # preset leaves it None (MTP off), which TypeErrors. Default to 0 (no MTP).
+    if getattr(args, "mtp_num_layers", None) is None:
+        args.mtp_num_layers = 0
+
+    return args
+
+
+def _setup_globals(args: argparse.Namespace) -> None:
+    """Set non-MPU global state, then build the num-microbatches calculator on llm_dp.
+
+    Replicates the non-MPU portion of ``initialize_megatron`` (see module
+    docstring). ``set_global_variables`` would build the num-microbatches
+    calculator keyed on the (now-fixed) ``args.data_parallel_size``; we call it
+    with ``build_tokenizer=False`` so no tokenizer is constructed. Because
+    ``data_parallel_size`` is already ``llm_dp`` by this point, the calculator it
+    builds is correct, so we do not rebuild it.
+    """
+    _stock_set_global_variables(args, build_tokenizer=False)
+    if args.enable_experimental:
+        set_experimental_flag(True)
+
+    # Defensive: ensure the num-microbatches calculator reflects llm_dp even if a
+    # future set_global_variables stops keying on args.data_parallel_size.
+    from megatron.core.num_microbatches_calculator import get_num_microbatches as _gnmb
+
+    expected = args.global_batch_size // (args.micro_batch_size * args.data_parallel_size)
+    if _gnmb() != expected:
+        # Rebuild to the llm_dp-keyed value.
+        init_num_microbatches_calculator(
+            rank=args.rank,
+            global_batch_size=args.global_batch_size,
+            micro_batch_size=args.micro_batch_size,
+            data_parallel_size=args.data_parallel_size,
+            decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
+        )
+
+
+def _seed_everything(args: argparse.Namespace) -> None:
+    """Seed python/numpy/torch RNG (matches the prototype loop + stock _set_random_seed)."""
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+
+def _build_optimizer(args: argparse.Namespace, model):
+    """Build the MimoOptimizer over the per-submodule-DDP MimoModel.
+
+    Mirrors the prototype's ``hetero/optimizer.py::build_optimizer``: a single
+    ``OptimizerConfig`` shared by every active module optimizer, distributed
+    optimizer on, bf16 unless --fp32.
+    """
+    return get_mimo_optimizer(
+        model[0],
+        OptimizerConfig(
+            optimizer="adam",
+            lr=args.lr,
+            min_lr=args.min_lr,
+            weight_decay=args.weight_decay,
+            adam_beta1=args.adam_beta1,
+            adam_beta2=args.adam_beta2,
+            clip_grad=args.clip_grad,
+            bf16=not args.fp32,
+            use_distributed_optimizer=True,
+            log_num_zeros_in_grad=args.log_num_zeros_in_grad,
+        ),
+    )
+
+
+def _build_scheduler(args: argparse.Namespace, optimizer) -> OptimizerParamScheduler:
+    """Build the stock OptimizerParamScheduler keyed on the llm_dp global batch.
+
+    Ports ``hetero/optimizer.py::build_optimizer_param_scheduler``: scheduler
+    "steps" are consumed samples (incremented by the global batch size per
+    optimizer step), so iter-based knobs convert via ``iters * global_batch_size``.
+    """
+    global_batch_size = args.global_batch_size
+
+    if getattr(args, "lr_warmup_samples", None) is not None:
+        lr_warmup_steps = args.lr_warmup_samples
+    else:
+        lr_warmup_steps = args.lr_warmup_iters * global_batch_size
+
+    if getattr(args, "lr_decay_samples", None) is not None:
+        lr_decay_steps = args.lr_decay_samples
+    else:
+        lr_decay_iters = (
+            args.lr_decay_iters if args.lr_decay_iters is not None else args.train_iters
+        )
+        lr_decay_steps = lr_decay_iters * global_batch_size
+
+    return OptimizerParamScheduler(
+        optimizer,
+        init_lr=0.0,
+        max_lr=args.lr,
+        min_lr=args.min_lr if args.min_lr is not None else 0.0,
+        lr_warmup_steps=lr_warmup_steps,
+        lr_decay_steps=lr_decay_steps,
+        lr_decay_style=args.lr_decay_style,
+        start_wd=args.weight_decay,
+        end_wd=args.weight_decay,
+        wd_incr_steps=args.train_iters * global_batch_size,
+        wd_incr_style="constant",
+        use_checkpoint_opt_param_scheduler=False,
+        override_opt_param_scheduler=True,
+        wsd_decay_steps=getattr(args, "lr_wsd_decay_samples", None),
+        lr_wsd_decay_style=getattr(args, "lr_wsd_decay_style", None),
+    )
+
+
+def _install_mimo_grad_finalize(model) -> None:
+    """Preserve the MIMO dual grad-finalization hook across stock train()'s clobber.
+
+    stock ``train()`` reassigns ``config.finalize_model_grads_func`` to the
+    module-level ``megatron.training.training.finalize_model_grads`` symbol. We
+    repoint that symbol to the MIMO finalizer that ``configure_grad_sync`` already
+    installed on ``model.config`` (in build_mimo_runtime). After train() runs its
+    ``config.finalize_model_grads_func = finalize_model_grads`` line, the config
+    therefore carries the MIMO hook.
+    """
+    mimo_finalize = model[0].config.finalize_model_grads_func
+    assert mimo_finalize is not None, (
+        "expected build_mimo_runtime -> configure_grad_sync to install a MIMO "
+        "finalize_model_grads_func on the language config"
+    )
+    training_module.finalize_model_grads = mimo_finalize
+
+
+def _install_safe_flops() -> None:
+    """Neutralize stock throughput/FLOPs accounting for the hetero MIMO model.
+
+    ``num_floating_point_operations`` derives a single homogeneous model's FLOPs
+    from the global (language) args and runs on every rank. That is ill-defined
+    for the disjoint encoder(RADIO)+language(hybrid-MoE) layout: encoder ranks
+    IndexError parsing the language MoE/hybrid pattern, and the hybrid path trips
+    on MTP. FLOPs/throughput is cosmetic for the smoke milestone, so wrap it to
+    return 0 on failure. TODO(NMFW-516): proper per-module hetero FLOPs accounting.
+    """
+    _orig = training_module.num_floating_point_operations
+
+    def _safe(*args, **kwargs):
+        try:
+            return _orig(*args, **kwargs)
+        except Exception:
+            return 0
+
+    training_module.num_floating_point_operations = _safe
+
+
+def _mimo_branch_name(topology) -> str:
+    """Return this rank's MIMO branch name ("language" or the encoder grid name).
+
+    Uses grid membership (the same source of truth bootstrap.py uses) to namespace
+    per-branch checkpoint state (e.g. the RNG ShardedObject key).
+    """
+    from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+
+    if topology.grids[MIMO_LANGUAGE_MODULE_KEY].is_current_rank_in_grid():
+        return "language"
+    return next(
+        (
+            name
+            for name, grid in topology.grids.items()
+            if name != MIMO_LANGUAGE_MODULE_KEY and grid.is_current_rank_in_grid()
+        ),
+        "language",
+    )
+
+
+def _install_mimo_checkpointing(topology):
+    """Replace stock save_checkpoint / load_checkpoint with a hetero-symmetric path.
+
+    Returns the patched ``load_checkpoint`` callable; the caller must invoke it
+    explicitly before train() to drive the resume LOAD (see the note at the end of
+    this function for why train() does not call it itself).
+
+    Why stock save_checkpoint hangs in a WORLD collective
+    =====================================================
+    Stock ``save_checkpoint`` (with the default ``--ckpt-fully-parallel-save``)
+    wraps the torch_dist save strategy in ``FullyParallelSaveStrategyWrapper`` keyed
+    on ``mpu.get_data_parallel_group(with_context_parallel=True)`` -- which, after
+    the entry pins parallel_state to this rank's own grid, is only the rank's own
+    2-rank branch DP group. ``apply_saving_parallelization`` then exchanges the save
+    distribution over that per-branch DP group while the underlying torch DCP save
+    planner runs its coordination collectives (gather_object / all_reduce / broadcast
+    in state_dict_saver.py) over the WORLD default group. Layering a per-branch
+    distribution under world-level DCP coordination across two structurally-different
+    grids (encoder ranks contribute a RADIO encoder sharded dict; language ranks a
+    Mamba LM + dist-optimizer sharded dict) desynchronizes the world collective:
+    the watchdog fires on a fixed-size ALLGATHER on default_pg that not all 8 ranks
+    reach symmetrically.
+
+    The prototype's approach (the fix)
+    ==================================
+    ``examples/mimo/training/hetero/checkpointing.py`` does NOT use stock
+    save_checkpoint. It assembles ONE unified sharded state dict (model + optimizer +
+    scheduler + per-branch RNG) and calls ``dist_checkpointing.save`` DIRECTLY with
+    the default (plain) ``TorchDistSaveShardedStrategy`` -- no FullyParallel DP-group
+    wrapper. Every rank contributes only its own branch's shards, but the GLOBAL set
+    of ShardedTensors/ShardedObjects is the symmetric union, and ALL coordination
+    (``determine_global_metadata``'s world ``all_gather_object`` and the DCP planner's
+    world collectives) runs over the world group symmetrically. Variable per-rank
+    metadata is exactly what ``all_gather_object`` is built to handle, so disjoint
+    per-branch structure is fine as long as no per-DP-group fully-parallel wrapper is
+    interposed.
+
+    This installer ports that approach onto the stock train() loop while reusing
+    stock ``generate_state_dict`` (which already produces per-rank-symmetric model /
+    optimizer / scheduler sharded dicts, and -- with args.use_distributed_optimizer
+    pinned True -- selects the ``dp_reshardable`` optimizer format). It monkeypatches
+    the ``save_checkpoint`` / ``load_checkpoint`` symbols imported into
+    ``megatron.training.training`` so train() drives the hetero-symmetric path.
+    """
+    import os
+
+    import megatron.training.checkpointing as ckpt_module
+    from megatron.core import dist_checkpointing
+    from megatron.core.dist_checkpointing.mapping import ShardedObject
+    from megatron.core.dist_checkpointing.utils import _clean_metadata_for_serialization
+    from megatron.training.checkpointing import (
+        _build_sharded_state_dict_metadata,
+        generate_state_dict,
+        get_rng_state,
+    )
+
+    branch_name = _mimo_branch_name(topology)
+    _TRACKER = "latest_checkpointed_iteration.txt"
+
+    def _iter_dir(root, iteration):
+        return os.path.join(root, f"iter_{iteration:07d}")
+
+    def _tracker_path(root):
+        return os.path.join(root, _TRACKER)
+
+    def _branch_keyed_rng_state(ckpt_format):
+        """Per-branch RNG ShardedObject to avoid cross-grid key collision.
+
+        Stock ``get_rng_state`` keys a single ``ShardedObject('rng_state', ...,
+        (pp,tp), (pp_rank,tp_rank), replica_id=dp_rank)`` on the rank's pinned
+        parallel_state groups. The encoder and language grids can share a (pp,tp)
+        factorization, so their RNG objects would collide on an identical
+        key+offset+replica_id with different payloads. Rewrite the key to
+        ``mimo.<branch>.rng_state`` (mirrors the prototype's _collect_rng_state) so
+        the two branches round-trip independently.
+        """
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        pp_group = parallel_state.get_pipeline_model_parallel_group()
+        rng = get_rng_state(ckpt_format, tp_group, pp_group)
+        if isinstance(rng, ShardedObject):
+            key = f"mimo.{branch_name}.rng_state"
+            rng = ShardedObject(
+                key, rng.data, rng.global_shape, rng.global_offset, replica_id=rng.replica_id
+            )
+        return rng
+
+    def _mimo_save_checkpoint(
+        iteration,
+        model,
+        optimizer,
+        opt_param_scheduler,
+        num_floating_point_operations_so_far,
+        checkpointing_context=None,
+        non_persistent_ckpt=False,
+        train_data_iterator=None,
+        preprocess_common_state_dict_fn=None,
+        **_unused,
+    ):
+        from megatron.training.global_vars import get_args
+
+        args = get_args()
+        if not args.save:
+            return
+        assert (
+            args.ckpt_format == "torch_dist"
+        ), f"hetero MIMO checkpointing supports only --ckpt-format torch_dist, got {args.ckpt_format}"
+
+        target_dir = _iter_dir(args.save, iteration)
+        if torch.distributed.get_rank() == 0:
+            os.makedirs(target_dir, exist_ok=True)
+        torch.distributed.barrier()
+
+        print_rank_0(f"saving hetero MIMO checkpoint at iteration {iteration} to {target_dir}")
+
+        rng_state = None if args.no_save_rng else _branch_keyed_rng_state(args.ckpt_format)
+        sharded_sd_metadata = _build_sharded_state_dict_metadata(args)
+        state_dict = generate_state_dict(
+            args,
+            model,
+            optimizer,
+            opt_param_scheduler,
+            rng_state,
+            iteration=iteration,
+            optim_sd_kwargs=dict(metadata=sharded_sd_metadata),
+            model_sd_kwargs=dict(metadata=sharded_sd_metadata),
+        )
+        state_dict["num_floating_point_operations_so_far"] = num_floating_point_operations_so_far
+
+        # Default strategy => plain TorchDistSaveShardedStrategy: world-symmetric
+        # coordination, NO FullyParallel DP-group wrapper. This is the key to
+        # coordinating the disjoint encoder/language grids (see installer docstring).
+        dist_checkpointing.save(
+            state_dict,
+            target_dir,
+            content_metadata=_clean_metadata_for_serialization(sharded_sd_metadata),
+        )
+
+        if torch.distributed.get_rank() == 0:
+            tmp = _tracker_path(args.save) + ".tmp"
+            with open(tmp, "w") as f:
+                f.write(str(iteration))
+            os.replace(tmp, _tracker_path(args.save))
+        torch.distributed.barrier()
+        print_rank_0(f"hetero MIMO checkpoint at iteration {iteration} saved")
+
+    def _read_tracker(load_root):
+        tracker = _tracker_path(load_root)
+        local_iter = -1
+        if os.path.isfile(tracker):
+            with open(tracker) as f:
+                contents = f.read().strip()
+            if contents:
+                local_iter = int(contents)
+        iters = torch.tensor([local_iter], dtype=torch.long, device="cuda")
+        torch.distributed.all_reduce(iters, op=torch.distributed.ReduceOp.MAX)
+        max_iter = int(iters.item())
+        return max_iter if max_iter >= 0 else None
+
+    def _mimo_load_checkpoint(
+        model,
+        optimizer,
+        opt_param_scheduler,
+        load_arg="load",
+        strict=True,
+        checkpointing_context=None,
+        skip_load_to_model_and_opt=False,
+        **_unused,
+    ):
+        from megatron.training.global_vars import get_args
+
+        args = get_args()
+        load_root = getattr(args, load_arg, None)
+        if not load_root:
+            return 0, 0
+
+        iteration = _read_tracker(load_root)
+        if iteration is None:
+            print_rank_0(f"no MIMO checkpoint at {load_root}; starting from iteration 0")
+            return 0, 0
+        source_dir = _iter_dir(load_root, iteration)
+        if not os.path.isdir(source_dir):
+            raise RuntimeError(
+                f"tracker at {load_root} points to iteration {iteration} but {source_dir} is missing"
+            )
+
+        is_finetune = bool(args.finetune)
+        include_optim = (not args.no_load_optim) and not is_finetune
+        include_sched = (not getattr(args, "no_load_scheduler", False)) and not is_finetune
+        include_rng = (not args.no_load_rng) and not is_finetune
+
+        print_rank_0(
+            f"loading hetero MIMO checkpoint from {source_dir}"
+            f" (optimizer={include_optim}, scheduler={include_sched},"
+            f" rng={include_rng}, finetune={is_finetune})"
+        )
+
+        rng_state = _branch_keyed_rng_state(args.ckpt_format) if include_rng else None
+        sharded_sd_metadata = _build_sharded_state_dict_metadata(args)
+        request = generate_state_dict(
+            args,
+            model,
+            optimizer if include_optim else None,
+            opt_param_scheduler if include_sched else None,
+            rng_state,
+            iteration=iteration,
+            optim_sd_kwargs=dict(metadata=sharded_sd_metadata, is_loading=True),
+            model_sd_kwargs=dict(metadata=sharded_sd_metadata),
+        )
+        # ``args`` is common (rank-0) state; it round-trips via common.pt on disk
+        # (returned in ``loaded`` below), so don't request it back as a load target.
+        request.pop("args", None)
+
+        loaded = dist_checkpointing.load(request, source_dir)
+
+        # Apply the loaded state to model / optimizer / scheduler (the symmetric
+        # union assembled by every rank reconstructs into each rank's own shards).
+        if not skip_load_to_model_and_opt:
+            model[0].load_state_dict(loaded["model"], strict=strict)
+            if (
+                include_optim
+                and optimizer is not None
+                and not optimizer.is_stub_optimizer
+                and "optimizer" in loaded
+            ):
+                optimizer.load_state_dict(loaded["optimizer"])
+        if include_sched and opt_param_scheduler is not None and "opt_param_scheduler" in loaded:
+            opt_param_scheduler.load_state_dict(loaded["opt_param_scheduler"])
+
+        if include_rng and loaded.get("rng_state") is not None:
+            _restore_rng_from_loaded(loaded["rng_state"])
+
+        # Restore sample accounting from the checkpoint's args (consumed by stock
+        # train()'s batch-size / microbatch bookkeeping).
+        ckpt_args = loaded.get("args")
+        if ckpt_args is not None and not is_finetune:
+            getter = ckpt_args.get if isinstance(ckpt_args, dict) else lambda k, d: getattr(ckpt_args, k, d)
+            args.consumed_train_samples = getter("consumed_train_samples", 0)
+            args.skipped_train_samples = getter("skipped_train_samples", 0)
+            args.consumed_valid_samples = getter("consumed_valid_samples", 0)
+
+        nfpo = int(loaded.get("num_floating_point_operations_so_far", 0))
+        resume_iter = 0 if is_finetune else int(loaded.get("iteration", iteration))
+        print_rank_0(f"resuming hetero MIMO training at iteration {resume_iter}")
+        return resume_iter, nfpo
+
+    # Patch the symbols train() resolved at import time. This routes the
+    # mid-training periodic SAVE (save_checkpoint_and_time -> save_checkpoint)
+    # through the hetero-symmetric path.
+    training_module.save_checkpoint = _mimo_save_checkpoint
+    training_module.load_checkpoint = _mimo_load_checkpoint
+    ckpt_module.save_checkpoint = _mimo_save_checkpoint
+    ckpt_module.load_checkpoint = _mimo_load_checkpoint
+
+    # The resume LOAD is NOT driven by train(): stock load_checkpoint runs inside
+    # setup_model_and_optimizer, which this entry bypasses (it builds the MimoModel /
+    # MimoOptimizer itself and calls train() directly). So the caller (main()) must
+    # invoke this returned load function explicitly BEFORE train() and seed
+    # args.iteration so train() resumes at iteration+1. Mirrors the prototype loop,
+    # which calls load_checkpoint() explicitly and starts at start_iteration + 1.
+    return _mimo_load_checkpoint
+
+
+def _restore_rng_from_loaded(rng_obj) -> None:
+    """Apply RNG state loaded from a per-branch rng ShardedObject (prototype parity)."""
+    from megatron.core import tensor_parallel
+
+    payload = rng_obj
+    if isinstance(payload, list) and payload and isinstance(payload[0], dict):
+        rng = payload[0]
+    elif isinstance(payload, dict):
+        rng = payload
+    else:
+        return
+    random.setstate(rng["random_rng_state"])
+    np.random.set_state(rng["np_rng_state"])
+    torch.set_rng_state(rng["torch_rng_state"])
+    torch.cuda.set_rng_state(rng["cuda_rng_state"])
+    if rng.get("rng_tracker_states"):
+        tensor_parallel.get_cuda_rng_tracker().set_states(rng["rng_tracker_states"])
+
+
+def _set_mpu_data_parallel_world_size(args: argparse.Namespace) -> None:
+    """Pin the MPU DP world size to llm_dp for train()'s sample accounting.
+
+    train() reads ``mpu.get_data_parallel_world_size()`` (4 sites) for consumed-
+    sample / batch-size bookkeeping. That getter returns the module global
+    ``_MPU_DATA_PARALLEL_WORLD_SIZE`` when set, before touching any MPU group, so
+    pinning it lets train() run without a full MPU init. This is a bootstrap /
+    MPU-materialization compatibility point (see CLAUDE.md "Megatron Core Process
+    Groups").
+    """
+    parallel_state._MPU_DATA_PARALLEL_WORLD_SIZE = args.llm_dp
+
+
+def main() -> None:
+    """Program entrypoint: stock-args MIMO run on the stock train() loop."""
+    args = _parse_and_validate()
+
+    # Non-MPU global setup, then torch.distributed bring-up (no MPU init).
+    _setup_globals(args)
+    initialize_distributed()
+    _seed_everything(args)
+    _set_mpu_data_parallel_world_size(args)
+
+    # Per-rank runtime: per-submodule-DDP MimoModel + topology + communicator +
+    # role-aware data iterator + grad-sync hook (E4).
+    rt = build_mimo_runtime(args)
+
+    optimizer = _build_optimizer(args, rt.model)
+    opt_param_scheduler = _build_scheduler(args, optimizer)
+
+    # Keep the MIMO grad-finalization hook alive past stock train()'s reassign.
+    _install_mimo_grad_finalize(rt.model)
+
+    # Neutralize stock FLOPs/throughput accounting (ill-defined for the hetero model).
+    _install_safe_flops()
+
+    # Replace stock save/load_checkpoint with a hetero-symmetric path: assemble one
+    # unified sharded state dict and call dist_checkpointing.save/load directly with
+    # the plain (world-coordinated) torch_dist strategy -- NO FullyParallel DP-group
+    # wrapper (which deadlocks a world collective across the disjoint grids). Also
+    # namespaces the RNG ShardedObject key per branch. See _install_mimo_checkpointing.
+    # Returns the load fn; train() never calls it (resume load normally lives in the
+    # bypassed setup_model_and_optimizer), so we invoke it explicitly below.
+    mimo_load_checkpoint = _install_mimo_checkpointing(rt.topology)
+
+    # Pin this rank's parallel_state model-parallel group to its module's mp group so
+    # stock training_log's cosmetic mp-group reductions (e.g. the LR gather in
+    # reduce_max_stat_across_model_parallel_group) work without full mpu init. The
+    # MIMO schedule/grad reductions use the threaded pg_collection; this only
+    # satisfies stock logging-path reads of mpu.get_model_parallel_group().
+    # Pin this rank's parallel_state groups to its module's per-module groups so the
+    # stock logging + checkpoint paths (which read mpu.get_*_group()) work without
+    # full mpu init. The MIMO schedule/grad reductions use the threaded pg_collection;
+    # these pins only satisfy stock-path reads (training_log, report_memory,
+    # save_checkpoint shard/RNG bookkeeping).
+    _pgc = rt.pg_collection
+    if getattr(_pgc, "mp", None) is not None:
+        parallel_state._MODEL_PARALLEL_GROUP = _pgc.mp
+    if getattr(_pgc, "tp", None) is not None:
+        parallel_state._TENSOR_MODEL_PARALLEL_GROUP = _pgc.tp
+    if getattr(_pgc, "pp", None) is not None:
+        parallel_state._PIPELINE_MODEL_PARALLEL_GROUP = _pgc.pp
+    if getattr(_pgc, "dp", None) is not None:
+        parallel_state._DATA_PARALLEL_GROUP = _pgc.dp
+        if getattr(_pgc, "dp_cp", None) is not None:
+            parallel_state._DATA_PARALLEL_GROUP_WITH_CP = _pgc.dp_cp
+
+    # Bookkeeping fields stock train() reads that setup_model_and_optimizer /
+    # the dataset builder would normally set.
+    args.iteration = 0
+    args.num_floating_point_operations_so_far = 0
+    args.consumed_train_samples = 0
+    args.skipped_train_samples = 0
+    args.do_train = True
+    args.do_valid = False
+    args.do_test = False
+
+    # Every MIMO submodule optimizer is a DistributedOptimizer (see
+    # _build_optimizer -> get_mimo_optimizer, and runtime.py's per-submodule DDP
+    # wrap with use_distributed_optimizer=True). The top-level ``args`` flag,
+    # however, defaults to False because we never run stock setup_model_and_optimizer.
+    # Stock checkpointing.py keys two things off it:
+    #   1. save -> _build_sharded_state_dict_metadata: only sets
+    #      ``distrib_optim_sharding_type`` when this is True. Without it the
+    #      per-submodule DistributedOptimizer.sharded_state_dict falls back to the
+    #      deprecated 'fully_sharded_model_space' format, which emits ShardedTensors
+    #      with ``flattened_range`` and crashes torch_dist's
+    #      validate_metadata_integrity ("flattened_range is not supported").
+    #   2. The 'Storing distributed optimizer sharded state of type ...' log line.
+    # Pinning it True makes the metadata builder select 'dp_reshardable' (the stock
+    # default and the format the hetero prototype used), which round-trips cleanly
+    # through torch_dist save/load and is persisted in the checkpoint's
+    # content_metadata so resume mirrors it.
+    args.use_distributed_optimizer = True
+
+    # Resume LOAD (must run after parallel_state pins + args.use_distributed_optimizer
+    # so the load request's model/optimizer/RNG sharded keys match what was saved).
+    # train() does not call load_checkpoint (the entry bypasses
+    # setup_model_and_optimizer), so we drive it here. All 8 ranks call this with the
+    # identical world-symmetric load request, mirroring the world-symmetric save.
+    # On success it returns the saved iteration (e.g. 2); seeding args.iteration makes
+    # stock train() resume the loop at iteration+1 (e.g. 3). consumed-sample / FLOPs
+    # accounting is restored inside the load fn.
+    if args.load:
+        resume_iter, resume_nfpo = mimo_load_checkpoint(
+            rt.model, optimizer, opt_param_scheduler
+        )
+        args.iteration = resume_iter
+        args.num_floating_point_operations_so_far = resume_nfpo
+
+    config = rt.model[0].config
+
+    print_rank_0(
+        "Starting hetero MIMO training on stock train(): "
+        f"world_size={torch.distributed.get_world_size()}, "
+        f"llm_dp={args.llm_dp}, num_microbatches={args.num_microbatches}, "
+        f"global_batch_size={args.global_batch_size}, train_iters={args.train_iters}"
+    )
+
+    try:
+        training_module.train(
+            forward_step_func=mimo_forward_step,
+            model=rt.model,
+            optimizer=optimizer,
+            opt_param_scheduler=opt_param_scheduler,
+            train_data_iterator=rt.data_iterator,
+            valid_data_iterator=None,
+            process_non_loss_data_func=None,
+            config=config,
+            checkpointing_context={},
+            non_loss_data_func=None,
+            p2p_communicator=rt.communicator,
+            schedule_pg_collection=rt.topology.schedule_pg_collection,
+        )
+        torch.distributed.barrier()
+        print_rank_0("Hetero MIMO training (stock loop) completed")
+    finally:
+        if hasattr(rt.model[0], "destroy"):
+            rt.model[0].destroy()
+        rt.topology.destroy()
+        shutdown_distributed()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Hetero MIMO (NMFW-516 PR-E5) on the stock Megatron ``train()`` loop.
+"""Hetero MIMO (NMFW-516) on the stock Megatron ``pretrain()`` loop.
 
 Drives the Nemotron6-MoE VLM (20L) over the non-colocated path (encoder/language
-grids on disjoint rank spans) with mock data: replicates the non-MPU pieces of
-``initialize_megatron``, feeds E4 ``build_mimo_runtime``'s model to ``train()``,
-re-keys ``data_parallel_size`` to ``llm_dp``, and sets NO ``parallel_state``
-globals -- stock ``train()`` resolves its groups from the schedule's language PGC.
+grids on disjoint rank spans) with mock data. The entry owns distributed bring-up,
+host seeding, and the per-module model/comms (E4 ``build_mimo_runtime``); it then
+runs stock ``pretrain()`` with the default-off seams: skip_model_parallel_init,
+the setup + data-iterator hooks, and the p2p/schedule comms forwarded to train().
+No ``parallel_state`` globals are set -- train() resolves groups from the language PGC.
 """
 
 from __future__ import annotations
@@ -23,7 +24,6 @@ _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-import megatron.training.training as training_module
 from examples.mimo.model_providers.nemotron_moe_vlm import (
     add_model_provider_args,
     prepare_model_provider_args,
@@ -32,19 +32,17 @@ from examples.mimo.model_providers.nemotron_moe_vlm import (
 from examples.mimo.training.args import add_hetero_grid_args, validate_hetero_grid_args
 from examples.mimo.training.bootstrap import build_mimo_runtime
 from examples.mimo.training.data import add_data_args
-from examples.mimo.training.distributed import (
-    initialize_distributed,
-    print_rank_0,
-    shutdown_distributed,
-)
+from examples.mimo.training.distributed import initialize_distributed, shutdown_distributed
 from examples.mimo.training.step import mimo_forward_step
 from megatron.core.config import set_experimental_flag
+from megatron.core.enums import ModelType
 from megatron.core.models.mimo.optimizer import get_mimo_optimizer
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from megatron.training.argument_utils import pretrain_cfg_container_from_args
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.checkpointing import load_checkpoint
 from megatron.training.global_vars import set_global_variables as _stock_set_global_variables
-from megatron.training.training import get_optimizer_param_scheduler
+from megatron.training.training import get_optimizer_param_scheduler, pretrain
 
 
 def extra_args_provider(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -128,96 +126,73 @@ def _mimo_branch_name(topology) -> str:
     )
 
 
+def _noop_provider(*_args, **_kwargs):
+    """Placeholder for pretrain's model/dataset providers (the hooks replace them)."""
+    return None
+
+
 def main() -> None:
-    """Program entrypoint: stock-args MIMO run on the stock train() loop."""
+    """Hetero MIMO run on the stock pretrain() loop (Option 1 wiring)."""
     args = _parse_and_validate()
 
-    # Non-MPU global setup, then torch.distributed bring-up (no MPU init).
+    # Entry owns: global setup, dist bring-up (no MPU), host seeding, per-rank runtime.
     _setup_globals(args)
     initialize_distributed()
     _seed_everything(args)
 
-    # Per-rank runtime: per-submodule-DDP MimoModel + topology + communicator +
-    # role-aware data iterator + grad-sync hook (E4).
+    # Per-rank runtime: per-submodule-DDP MimoModel, topology, comms, data iter, grad-sync, CUDA RNG (E4).
     rt = build_mimo_runtime(args)
-
-    optimizer = _build_optimizer(args, rt.model)
-    opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
-
-    # E4 configure_grad_sync installs the MIMO dual grad-finalizer on model.config;
-    # stock train() preserves a caller-installed finalize_model_grads_func, so it
-    # survives without a monkeypatch.
     assert rt.model[0].config.finalize_model_grads_func is not None, (
         "expected build_mimo_runtime -> configure_grad_sync to install a MIMO "
         "finalize_model_grads_func on the language config"
     )
 
-    # No parallel_state globals are set: stock train() resolves its DP/MP groups from
-    # schedule_pg_collection's language PGC (sample accounting, LR-log reductions).
+    cfg = pretrain_cfg_container_from_args(args, rt.model[0].config)
 
-    # Bookkeeping fields stock train() reads that setup_model_and_optimizer /
-    # the dataset builder would normally set.
-    args.iteration = 0
-    args.num_floating_point_operations_so_far = 0
-    args.consumed_train_samples = 0
-    args.skipped_train_samples = 0
-    args.do_train = True
-    args.do_valid = False
-    args.do_test = False
+    def _setup_model_and_optimizer(model_provider, model_type, checkpointing_context=None):
+        # Hook owns build + resume-load + args.iteration (replaces stock setup).
+        optimizer = _build_optimizer(args, rt.model)
+        opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
+        # Per-branch RNG key namespace + dp_reshardable optimizer sharding for ckpt.
+        args.rng_state_key_prefix = f"mimo.{_mimo_branch_name(rt.topology)}."
+        args.use_distributed_optimizer = True
+        if args.load:
+            # TODO(reuse): full zero-global checkpoint (save-path threading + get_rng_state dp-rank) is a follow-up.
+            args.iteration, args.num_floating_point_operations_so_far = load_checkpoint(
+                rt.model,
+                optimizer,
+                opt_param_scheduler,
+                checkpointing_context=checkpointing_context,
+                tp_group=rt.pg_collection.tp,
+                pp_group=rt.pg_collection.pp,
+                dp_cp_group=rt.pg_collection.dp_cp,
+            )
+        else:
+            args.iteration = 0
+            args.num_floating_point_operations_so_far = 0
+        return rt.model, optimizer, opt_param_scheduler
 
-    # Every MIMO submodule optimizer is a DistributedOptimizer, but the top-level
-    # ``args`` flag defaults False because we bypass setup_model_and_optimizer. Pin
-    # it True so stock checkpointing selects the 'dp_reshardable' optimizer sharding
-    # format (the format that round-trips cleanly through torch_dist save/load).
-    args.use_distributed_optimizer = True
-
-    # Reuse stock save_checkpoint/load_checkpoint. The hetero deadlock came from the
-    # default fully-parallel save wrapper; the run script passes
-    # --no-ckpt-fully-parallel-save so stock uses the plain (world-coordinated)
-    # torch_dist strategy. Namespace the RNG ShardedObject key per branch so the
-    # encoder/LLM grids (which can share a (pp,tp) factorization) don't collide.
-    args.rng_state_key_prefix = f"mimo.{_mimo_branch_name(rt.topology)}."
-    checkpointing_context = {}
-
-    # Resume LOAD: stock load_checkpoint normally runs inside the bypassed
-    # setup_model_and_optimizer, so we drive it here (after use_distributed_optimizer
-    # so the load request's sharded keys match the save).
-    # TODO(reuse): zero-global checkpoint (thread dp/expert ranks through
-    # get_rng_state / _build_sharded_state_dict_metadata) is a follow-up; the smoke
-    # run uses no --save/--load.
-    if args.load:
-        resume_iter, resume_nfpo = load_checkpoint(
-            rt.model, optimizer, opt_param_scheduler, checkpointing_context=checkpointing_context
-        )
-        args.iteration = resume_iter
-        args.num_floating_point_operations_so_far = resume_nfpo
-
-    config = rt.model[0].config
-
-    print_rank_0(
-        "Starting hetero MIMO training on stock train(): "
-        f"world_size={torch.distributed.get_world_size()}, "
-        f"llm_dp={args.llm_dp}, "
-        f"global_batch_size={args.global_batch_size}, train_iters={args.train_iters}"
-    )
+    def _build_data_iterators():
+        # Hook owns the iterators + do_train/do_valid/do_test (replaces stock build).
+        valid_iter = None
+        args.do_train = True
+        args.do_valid = False
+        args.do_test = False
+        return rt.data_iterator, valid_iter, None
 
     try:
-        training_module.train(
-            forward_step_func=mimo_forward_step,
-            model=rt.model,
-            optimizer=optimizer,
-            opt_param_scheduler=opt_param_scheduler,
-            train_data_iterator=rt.data_iterator,
-            valid_data_iterator=None,
-            process_non_loss_data_func=None,
-            config=config,
-            checkpointing_context=checkpointing_context,
-            non_loss_data_func=None,
+        pretrain(
+            cfg,
+            _noop_provider,
+            _noop_provider,
+            ModelType.encoder_or_decoder,
+            mimo_forward_step,
+            skip_model_parallel_init=True,
+            setup_model_and_optimizer_func=_setup_model_and_optimizer,
+            build_data_iterators_func=_build_data_iterators,
             p2p_communicator=rt.communicator,
             schedule_pg_collection=rt.topology.schedule_pg_collection,
         )
-        torch.distributed.barrier()
-        print_rank_0("Hetero MIMO training (stock loop) completed")
     finally:
         if hasattr(rt.model[0], "destroy"):
             rt.model[0].destroy()

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -1,13 +1,10 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Hetero MIMO (NMFW-516) on the stock Megatron ``pretrain()`` loop.
+"""Heterogeneous MIMO (Nemotron6-MoE VLM) training entry point.
 
-Drives the Nemotron6-MoE VLM (20L) over the non-colocated path (encoder/language
-grids on disjoint rank spans) with mock data. The entry owns distributed bring-up,
-host seeding, and the per-module model/comms (E4 ``build_mimo_runtime``); it then
-runs stock ``pretrain()`` with the default-off seams: skip_model_parallel_init,
-the setup + data-iterator hooks, and the p2p/schedule comms forwarded to train().
-No ``parallel_state`` globals are set -- train() resolves groups from the language PGC.
+Builds the per-module model and process groups for the disjoint vision/language
+grids, then drives training through ``pretrain()`` with model/optimizer and
+data-iterator hooks.
 """
 
 from __future__ import annotations
@@ -41,7 +38,7 @@ from megatron.core.optimizer.optimizer_config import OptimizerConfig
 from megatron.training.argument_utils import pretrain_cfg_container_from_args
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.checkpointing import load_checkpoint
-from megatron.training.global_vars import set_global_variables as _stock_set_global_variables
+from megatron.training.global_vars import set_global_variables
 from megatron.training.training import get_optimizer_param_scheduler, pretrain
 
 
@@ -54,10 +51,10 @@ def extra_args_provider(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
 
 
 def _parse_and_validate() -> argparse.Namespace:
-    """Stock arg pipeline plus the MIMO preset/validation hooks and the dp_size fix."""
+    """Parse and validate args with the model-provider preset and grid checks."""
     args = parse_args(extra_args_provider)
 
-    # Apply the Nemotron preset BEFORE stock validation so preset-derived sizes flow in.
+    # Apply the model-provider preset before validation so preset-derived sizes flow in.
     prepare_model_provider_args(args)
 
     validate_args(args, {})  # no dataset path / tokenizer for the mock run
@@ -66,33 +63,36 @@ def _parse_and_validate() -> argparse.Namespace:
     world_size = int(os.environ.get("WORLD_SIZE", args.world_size))
     validate_hetero_grid_args(args, world_size)
 
-    # Re-key DP on the language grid (stock keyed it on the world-spanning flags).
+    # Data-parallel size follows the language grid.
     args.data_parallel_size = args.llm_dp
 
-    # Nemotron preset leaves mtp_num_layers None; stock FLOPs/throughput needs an int.
+    # The preset leaves mtp_num_layers None; FLOPs/throughput accounting needs an int.
     if getattr(args, "mtp_num_layers", None) is None:
         args.mtp_num_layers = 0
+
+    # Mock runs build no tokenizer; derive the padded vocab from the configured vocab.
+    if getattr(args, "padded_vocab_size", None) is None:
+        args.padded_vocab_size = args.vocab_size
 
     return args
 
 
 def _setup_globals(args: argparse.Namespace) -> None:
-    """Set non-MPU global state; the calculator is keyed on the already-fixed llm_dp."""
-    _stock_set_global_variables(args, build_tokenizer=False)
+    """Set global state; the microbatch calculator keys on the language data-parallel size."""
+    set_global_variables(args, build_tokenizer=False)
     if args.enable_experimental:
         set_experimental_flag(True)
 
 
 def _seed_everything(args: argparse.Namespace) -> None:
-    """Seed host (python/numpy/torch) RNG; E4 configure_module_rng owns the CUDA tracker."""
-    # TODO(reuse): stock _set_random_seed would clobber E4's per-module CUDA RNG offsets (#5285).
+    """Seed host RNG; per-module CUDA RNG is seeded inside build_mimo_runtime."""
     random.seed(args.seed)
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
 
 
 def _build_optimizer(args: argparse.Namespace, model):
-    """Build the MimoOptimizer (one shared OptimizerConfig, distributed, bf16 unless --fp32)."""
+    """Build the MimoOptimizer from a shared OptimizerConfig."""
     return get_mimo_optimizer(
         model[0],
         OptimizerConfig(
@@ -103,7 +103,8 @@ def _build_optimizer(args: argparse.Namespace, model):
             adam_beta1=args.adam_beta1,
             adam_beta2=args.adam_beta2,
             clip_grad=args.clip_grad,
-            bf16=not args.fp32,
+            bf16=args.bf16,
+            fp16=args.fp16,
             use_distributed_optimizer=True,
             log_num_zeros_in_grad=args.log_num_zeros_in_grad,
         ),
@@ -132,32 +133,29 @@ def _noop_provider(*_args, **_kwargs):
 
 
 def main() -> None:
-    """Hetero MIMO run on the stock pretrain() loop (Option 1 wiring)."""
+    """Run heterogeneous MIMO training."""
     args = _parse_and_validate()
 
-    # Entry owns: global setup, dist bring-up (no MPU), host seeding, per-rank runtime.
     _setup_globals(args)
     initialize_distributed()
     _seed_everything(args)
 
-    # Per-rank runtime: per-submodule-DDP MimoModel, topology, comms, data iter, grad-sync, CUDA RNG (E4).
+    # Per-rank runtime: per-submodule-DDP MimoModel, topology, comms, data iterator, grad sync.
     rt = build_mimo_runtime(args)
     assert rt.model[0].config.finalize_model_grads_func is not None, (
-        "expected build_mimo_runtime -> configure_grad_sync to install a MIMO "
-        "finalize_model_grads_func on the language config"
+        "build_mimo_runtime must install a finalize_model_grads_func on the language config"
     )
 
     cfg = pretrain_cfg_container_from_args(args, rt.model[0].config)
 
     def _setup_model_and_optimizer(model_provider, model_type, checkpointing_context=None):
-        # Hook owns build + resume-load + args.iteration (replaces stock setup).
+        # Build the optimizer/scheduler, drive resume load, and set args.iteration.
         optimizer = _build_optimizer(args, rt.model)
         opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
-        # Per-branch RNG key namespace + dp_reshardable optimizer sharding for ckpt.
+        # Per-branch RNG key namespace + distributed-optimizer sharding for checkpoints.
         args.rng_state_key_prefix = f"mimo.{_mimo_branch_name(rt.topology)}."
         args.use_distributed_optimizer = True
         if args.load:
-            # TODO(reuse): full zero-global checkpoint (save-path threading + get_rng_state dp-rank) is a follow-up.
             args.iteration, args.num_floating_point_operations_so_far = load_checkpoint(
                 rt.model,
                 optimizer,
@@ -173,12 +171,15 @@ def main() -> None:
         return rt.model, optimizer, opt_param_scheduler
 
     def _build_data_iterators():
-        # Hook owns the iterators + do_train/do_valid/do_test (replaces stock build).
-        valid_iter = None
+        from megatron.core.rerun_state_machine import RerunDataIterator
+
         args.do_train = True
         args.do_valid = False
         args.do_test = False
-        return rt.data_iterator, valid_iter, None
+        train_iter = rt.data_iterator
+        if train_iter is not None and not isinstance(train_iter, RerunDataIterator):
+            train_iter = RerunDataIterator(train_iter)
+        return train_iter, None, None
 
     try:
         pretrain(

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -5,8 +5,8 @@
 Drives the Nemotron6-MoE VLM (20L) over the non-colocated path (encoder/language
 grids on disjoint rank spans) with mock data: replicates the non-MPU pieces of
 ``initialize_megatron``, feeds E4 ``build_mimo_runtime``'s model to ``train()``,
-re-keys ``data_parallel_size`` to ``llm_dp``, and pins ``parallel_state`` to this
-rank's own grid so the stock checkpoint/FLOPs/logging paths work without MPU init.
+re-keys ``data_parallel_size`` to ``llm_dp``, and sets NO ``parallel_state``
+globals -- stock ``train()`` resolves its groups from the schedule's language PGC.
 """
 
 from __future__ import annotations
@@ -38,7 +38,6 @@ from examples.mimo.training.distributed import (
     shutdown_distributed,
 )
 from examples.mimo.training.step import mimo_forward_step
-from megatron.core import parallel_state
 from megatron.core.config import set_experimental_flag
 from megatron.core.models.mimo.optimizer import get_mimo_optimizer
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
@@ -113,12 +112,6 @@ def _build_optimizer(args: argparse.Namespace, model):
     )
 
 
-def _set_mpu_data_parallel_world_size(args: argparse.Namespace) -> None:
-    """Pin the MPU DP world size to llm_dp so train()'s sample accounting needs no MPU init."""
-    # Bootstrap/MPU-materialization compatibility point (see CLAUDE.md).
-    parallel_state._MPU_DATA_PARALLEL_WORLD_SIZE = args.llm_dp
-
-
 def _mimo_branch_name(topology) -> str:
     """Return this rank's MIMO branch ("language" or the encoder grid name)."""
     from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
@@ -143,7 +136,6 @@ def main() -> None:
     _setup_globals(args)
     initialize_distributed()
     _seed_everything(args)
-    _set_mpu_data_parallel_world_size(args)
 
     # Per-rank runtime: per-submodule-DDP MimoModel + topology + communicator +
     # role-aware data iterator + grad-sync hook (E4).
@@ -165,19 +157,8 @@ def main() -> None:
     # (not the LLM world size), so per-GPU TFLOP/s is cosmetic for the hetero layout.
     # Proper per-module hetero FLOPs accounting is deferred (NMFW-516).
 
-    # Pin parallel_state to this rank's per-module groups so stock-path reads
-    # (training_log, report_memory, checkpoint shard/RNG) work without full mpu init.
-    _pgc = rt.pg_collection
-    if getattr(_pgc, "mp", None) is not None:
-        parallel_state._MODEL_PARALLEL_GROUP = _pgc.mp
-    if getattr(_pgc, "tp", None) is not None:
-        parallel_state._TENSOR_MODEL_PARALLEL_GROUP = _pgc.tp
-    if getattr(_pgc, "pp", None) is not None:
-        parallel_state._PIPELINE_MODEL_PARALLEL_GROUP = _pgc.pp
-    if getattr(_pgc, "dp", None) is not None:
-        parallel_state._DATA_PARALLEL_GROUP = _pgc.dp
-        if getattr(_pgc, "dp_cp", None) is not None:
-            parallel_state._DATA_PARALLEL_GROUP_WITH_CP = _pgc.dp_cp
+    # No parallel_state globals are set: stock train() resolves its DP/MP groups from
+    # schedule_pg_collection's language PGC (sample accounting, LR-log reductions).
 
     # Bookkeeping fields stock train() reads that setup_model_and_optimizer /
     # the dataset builder would normally set.
@@ -204,8 +185,11 @@ def main() -> None:
     checkpointing_context = {}
 
     # Resume LOAD: stock load_checkpoint normally runs inside the bypassed
-    # setup_model_and_optimizer, so we drive it here (after the parallel_state pins +
-    # use_distributed_optimizer so the load request's sharded keys match the save).
+    # setup_model_and_optimizer, so we drive it here (after use_distributed_optimizer
+    # so the load request's sharded keys match the save).
+    # TODO(reuse): zero-global checkpoint (thread dp/expert ranks through
+    # get_rng_state / _build_sharded_state_dict_metadata) is a follow-up; the smoke
+    # run uses no --save/--load.
     if args.load:
         resume_iter, resume_nfpo = load_checkpoint(
             rt.model, optimizer, opt_param_scheduler, checkpointing_context=checkpointing_context

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -152,11 +152,6 @@ def main() -> None:
         "finalize_model_grads_func on the language config"
     )
 
-    # TODO(reuse): stock num_floating_point_operations computes the language model's
-    # FLOPs on every rank and the throughput print divides by the full world_size
-    # (not the LLM world size), so per-GPU TFLOP/s is cosmetic for the hetero layout.
-    # Proper per-module hetero FLOPs accounting is deferred (NMFW-516).
-
     # No parallel_state globals are set: stock train() resolves its DP/MP groups from
     # schedule_pg_collection's language PGC (sample accounting, LR-log reductions).
 

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -74,6 +74,9 @@ def _parse_and_validate() -> argparse.Namespace:
     if getattr(args, "padded_vocab_size", None) is None:
         args.padded_vocab_size = args.vocab_size
 
+    # The data iterator is pre-built per rank; the external dataloader passes it through.
+    args.dataloader_type = "external"
+
     return args
 
 
@@ -170,27 +173,20 @@ def main() -> None:
             args.num_floating_point_operations_so_far = 0
         return rt.model, optimizer, opt_param_scheduler
 
-    def _build_data_iterators():
-        from megatron.core.rerun_state_machine import RerunDataIterator
+    def _dataset_provider(train_val_test_num_samples):
+        return rt.data_iterator, None, None
 
-        args.do_train = True
-        args.do_valid = False
-        args.do_test = False
-        train_iter = rt.data_iterator
-        if train_iter is not None and not isinstance(train_iter, RerunDataIterator):
-            train_iter = RerunDataIterator(train_iter)
-        return train_iter, None, None
+    _dataset_provider.is_distributed = True
 
     try:
         pretrain(
             cfg,
-            _noop_provider,
+            _dataset_provider,
             _noop_provider,
             ModelType.encoder_or_decoder,
             mimo_forward_step,
             skip_model_parallel_init=True,
             setup_model_and_optimizer_func=_setup_model_and_optimizer,
-            build_data_iterators_func=_build_data_iterators,
             p2p_communicator=rt.communicator,
             schedule_pg_collection=rt.topology.schedule_pg_collection,
         )

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -11,11 +11,7 @@ from __future__ import annotations
 
 import argparse
 import os
-import random
 import sys
-
-import numpy as np
-import torch
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 if _REPO_ROOT not in sys.path:
@@ -93,13 +89,6 @@ def _setup_globals(args: argparse.Namespace) -> None:
         set_experimental_flag(True)
 
 
-def _seed_everything(args: argparse.Namespace) -> None:
-    """Seed host RNG; per-module CUDA RNG is seeded inside build_mimo_runtime."""
-    random.seed(args.seed)
-    np.random.seed(args.seed)
-    torch.manual_seed(args.seed)
-
-
 def _build_optimizer(args: argparse.Namespace, model):
     """Build the MimoOptimizer from a shared OptimizerConfig."""
     return get_mimo_optimizer(
@@ -147,9 +136,9 @@ def main() -> None:
 
     _setup_globals(args)
     initialize_distributed()
-    _seed_everything(args)
 
     # Per-rank runtime: per-submodule-DDP MimoModel, topology, comms, data iterator, grad sync.
+    # build_mimo_runtime seeds per-role RNG (host + CUDA) via the stock _set_random_seed.
     rt = build_mimo_runtime(args)
     assert rt.model[0].config.finalize_model_grads_func is not None, (
         "build_mimo_runtime must install a finalize_model_grads_func on the language config"

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -77,6 +77,12 @@ def _parse_and_validate() -> argparse.Namespace:
     # The data iterator is pre-built per rank; the external dataloader passes it through.
     args.dataloader_type = "external"
 
+    # Train-only: no eval. eval_iters=0 keeps do_valid/do_test off; a positive
+    # eval_interval avoids a divide-by-None in the train/valid/test sample accounting.
+    args.eval_iters = 0
+    if getattr(args, "eval_interval", None) is None:
+        args.eval_interval = args.train_iters or 1
+
     return args
 
 

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -161,8 +161,8 @@ def main() -> None:
         # Build the optimizer/scheduler, drive resume load, and set args.iteration.
         optimizer = _build_optimizer(args, rt.model)
         opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
-        # Per-branch RNG key namespace + distributed-optimizer sharding for checkpoints.
-        args.rng_state_key_prefix = f"mimo.{_mimo_branch_name(rt.topology)}."
+        # Per-grid rng key namespace on the model (read by stock save/load); torch_dist only.
+        rt.model[0].rng_state_key_prefix = f"mimo.{_mimo_branch_name(rt.topology)}."
         args.use_distributed_optimizer = True
         if args.load:
             args.iteration, args.num_floating_point_operations_so_far = load_checkpoint(
@@ -173,6 +173,7 @@ def main() -> None:
                 tp_group=rt.pg_collection.tp,
                 pp_group=rt.pg_collection.pp,
                 dp_cp_group=rt.pg_collection.dp_cp,
+                rng_state_key_prefix=rt.model[0].rng_state_key_prefix,
             )
         else:
             args.iteration = 0

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -1,88 +1,12 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Hetero MIMO entry that runs on the *stock* Megatron ``train()`` loop.
+"""Hetero MIMO (NMFW-516 PR-E5) on the stock Megatron ``train()`` loop.
 
-This is PR-E5 of the NMFW-516 hetero-MIMO upstreaming effort: the end-to-end
-integration that drives the Nemotron6-MoE VLM (20L) through Megatron's
-production ``megatron/training/training.py::train()`` instead of the prototype's
-bespoke loop. Scope: the NON-COLOCATED path (encoder grid and language grid on
-disjoint rank spans), mock data.
-
-Why not stock ``pretrain()``?
-=============================
-Stock ``pretrain(cfg_container, ...)`` does three things this entry cannot use
-verbatim:
-
-  1. It calls ``initialize_megatron`` -> ``_initialize_distributed`` ->
-     ``mpu.initialize_model_parallel(...)``. MIMO must NOT initialize the MPU
-     globals: each MIMO module owns its own ``HyperCommGrid`` with disjoint rank
-     spans, so a single world-spanning MPU layout is wrong. We therefore
-     replicate only the *non-MPU* pieces of ``initialize_megatron``
-     (``set_global_variables`` minus the num-microbatches calculator wiring,
-     random seeds, torch.distributed bring-up via MM1) and skip MPU init.
-  2. It calls ``setup_model_and_optimizer`` -> ``get_model`` which re-wraps a
-     single top-level DDP and builds a single optimizer over the MPU groups. The
-     MIMO model needs PER-SUBMODULE DDP (one per module grid) and the
-     ``MimoOptimizer`` (one inner optimizer per active module). ``E4
-     build_mimo_runtime`` already assembles that; we feed its model list straight
-     to ``train()``.
-  3. It builds train/valid/test datasets via a dataset provider. MIMO uses the
-     role-aware iterator from ``select_data_iterator`` (mock here).
-
-What this entry replicates from ``initialize_megatron`` (and what it skips)
-===========================================================================
-Replicated (needed global state ``train()`` / the schedule read):
-
-  * ``set_global_variables(args, build_tokenizer=False)`` MINUS its
-    num-microbatches calculator call -- args global, timers, tensorboard/wandb,
-    experimental flag. We build the calculator ourselves AFTER fixing
-    ``args.data_parallel_size`` (see below), because ``set_global_variables``
-    would key it on the stock (world-derived) DP size.
-  * ``_set_random_seed`` equivalent: ``random`` / ``numpy`` / ``torch`` seeds
-    (matches the prototype's ``loop.py`` so dataset-construction RNG agrees).
-  * torch.distributed bring-up via MM1 ``initialize_distributed`` (NCCL +
-    global memory buffer; NO MPU groups).
-
-Skipped (and why):
-
-  * ``mpu.initialize_model_parallel`` -- MIMO owns per-module grids; a global MPU
-    layout is wrong for disjoint spans. See (1) above.
-  * ``_compile_dependencies`` -- only compiles the C++ dataset index builder,
-    which the mock iterator does not use.
-  * ``_init_autoresume`` / ``_initialize_tp_communicators`` -- autoresume and TP
-    comm-overlap user buffers are not exercised by this mock run.
-  * tokenizer build -- mock data reads ``args.vocab_size`` directly and the
-    provider's ``_vocab_size`` falls back to it, so no tokenizer is needed.
-
-The ``data_parallel_size`` fix
-==============================
-Stock ``validate_args`` recomputes ``args.data_parallel_size = world_size //
-(tp*pp*cp)`` from the *stock* (world-spanning) parallelism flags. For the
-disjoint hetero layout that value is wrong: the language grid is only ``llm_dp``
-wide. ``train()`` reads ``get_num_microbatches()`` (keyed on
-``global_batch_size / (micro_batch_size * data_parallel_size)``) and
-``mpu.get_data_parallel_world_size()`` for sample accounting. We therefore:
-
-  * set ``args.data_parallel_size = args.llm_dp`` AFTER ``validate_args``;
-  * build the num-microbatches calculator with that DP so it yields the
-    script's ``--num-microbatches`` (gbs 8 / (mbs 1 * dp 2) = 4);
-  * pin ``parallel_state._MPU_DATA_PARALLEL_WORLD_SIZE = llm_dp`` so train()'s
-    four ``mpu.get_data_parallel_world_size()`` reads return the language DP size
-    without a full MPU init (a bootstrap/MPU-materialization compatibility
-    point, per CLAUDE.md).
-
-The grad-finalization clobber
-=============================
-``E4 build_mimo_runtime`` installs the MIMO dual grad-finalization hook
-(``configure_grad_sync`` sets ``model.config.finalize_model_grads_func`` to the
-encoder+language finalizer). But stock ``train()`` unconditionally reassigns
-``config.finalize_model_grads_func = finalize_model_grads`` (the module-level
-import in ``megatron.training.training``). To keep the MIMO hook without editing
-core, we monkeypatch that module-level symbol to the MIMO finalizer BEFORE
-calling ``train()``. ``config.grad_scale_func`` is also reassigned by ``train()``
-to ``optimizer.scale_loss``; for bf16 with no grad scaler the MimoOptimizer loss
-scale is 1.0, so ``scale_loss(loss) == loss`` -- behaviorally identical to the
-MIMO ``lambda loss: loss``, so no patch is needed there.
+Drives the Nemotron6-MoE VLM (20L) over the non-colocated path (encoder/language
+grids on disjoint rank spans) with mock data: replicates the non-MPU pieces of
+``initialize_megatron``, feeds E4 ``build_mimo_runtime``'s model to ``train()``,
+re-keys ``data_parallel_size`` to ``llm_dp``, and pins ``parallel_state`` to this
+rank's own grid so the stock checkpoint/FLOPs/logging paths work without MPU init.
 """
 
 from __future__ import annotations
@@ -117,73 +41,38 @@ from examples.mimo.training.step import mimo_forward_step
 from megatron.core import parallel_state
 from megatron.core.config import set_experimental_flag
 from megatron.core.models.mimo.optimizer import get_mimo_optimizer
-from megatron.core.num_microbatches_calculator import init_num_microbatches_calculator
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
-from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.training.arguments import parse_args, validate_args
+from megatron.training.checkpointing import load_checkpoint
 from megatron.training.global_vars import set_global_variables as _stock_set_global_variables
-
-# args ``set_global_variables`` requires but which the script does not pass. We
-# skip the tokenizer build (mock data reads args.vocab_size directly), so no
-# tokenizer-type default is needed.
-_ARGS_DEFAULTS = {
-    # No dataset path / tokenizer for the mock run.
-}
+from megatron.training.training import get_optimizer_param_scheduler
 
 
 def extra_args_provider(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    """Compose the model-provider arg group with the hetero grid arg group.
-
-    Both register their own argparse groups onto the stock parser. We also add
-    ``--num-microbatches`` here: stock Megatron derives the microbatch count from
-    ``global_batch_size / (micro_batch_size * data_parallel_size)`` and has no
-    such flag, but the prototype (and our run script) pass it explicitly.
-    """
+    """Register the model-provider, hetero-grid, and data arg groups."""
     parser = add_model_provider_args(parser)
     parser = add_hetero_grid_args(parser)
     parser = add_data_args(parser)
-    parser.add_argument(
-        "--num-microbatches",
-        type=int,
-        default=1,
-        help="Explicit microbatch count for the hetero MIMO loop (stock derives this "
-        "from gbs/mbs/dp; the hetero layout keys it on --llm-dp instead).",
-    )
     return parser
 
 
 def _parse_and_validate() -> argparse.Namespace:
-    """Run the stock arg pipeline plus the MIMO preset/validation hooks.
-
-    Sequence (handoff section 2):
-      parse_args(extra) -> prepare_model_provider_args (preset, BEFORE validate)
-      -> stock validate_args -> validate_model_provider_args
-      -> validate_hetero_grid_args -> data_parallel_size fix.
-    """
+    """Stock arg pipeline plus the MIMO preset/validation hooks and the dp_size fix."""
     args = parse_args(extra_args_provider)
 
-    # Apply the Nemotron preset BEFORE stock validation so preset-derived sizes
-    # (num_layers, hybrid pattern, seq_length, num_experts, image_seq_length, ...)
-    # flow into validate_args.
+    # Apply the Nemotron preset BEFORE stock validation so preset-derived sizes flow in.
     prepare_model_provider_args(args)
 
-    # Stock validation. ``defaults`` fills only args the user left at default.
-    validate_args(args, _ARGS_DEFAULTS)
+    validate_args(args, {})  # no dataset path / tokenizer for the mock run
 
-    # MIMO-specific validation (runs after stock so padded_vocab_size / num_experts
-    # are populated).
     validate_model_provider_args(args)
     world_size = int(os.environ.get("WORLD_SIZE", args.world_size))
     validate_hetero_grid_args(args, world_size)
 
-    # --- data_parallel_size fix (see module docstring). --------------------
-    # Stock validate_args set args.data_parallel_size = world_size//(tp*pp*cp).
-    # Re-key it on the language grid's DP so get_num_microbatches() and sample
-    # accounting reflect the disjoint hetero layout.
+    # Re-key DP on the language grid (stock keyed it on the world-spanning flags).
     args.data_parallel_size = args.llm_dp
 
-    # Stock throughput/FLOPs logging does ``1 + args.mtp_num_layers``; the Nemotron
-    # preset leaves it None (MTP off), which TypeErrors. Default to 0 (no MTP).
+    # Nemotron preset leaves mtp_num_layers None; stock FLOPs/throughput needs an int.
     if getattr(args, "mtp_num_layers", None) is None:
         args.mtp_num_layers = 0
 
@@ -191,49 +80,22 @@ def _parse_and_validate() -> argparse.Namespace:
 
 
 def _setup_globals(args: argparse.Namespace) -> None:
-    """Set non-MPU global state, then build the num-microbatches calculator on llm_dp.
-
-    Replicates the non-MPU portion of ``initialize_megatron`` (see module
-    docstring). ``set_global_variables`` would build the num-microbatches
-    calculator keyed on the (now-fixed) ``args.data_parallel_size``; we call it
-    with ``build_tokenizer=False`` so no tokenizer is constructed. Because
-    ``data_parallel_size`` is already ``llm_dp`` by this point, the calculator it
-    builds is correct, so we do not rebuild it.
-    """
+    """Set non-MPU global state; the calculator is keyed on the already-fixed llm_dp."""
     _stock_set_global_variables(args, build_tokenizer=False)
     if args.enable_experimental:
         set_experimental_flag(True)
 
-    # Defensive: ensure the num-microbatches calculator reflects llm_dp even if a
-    # future set_global_variables stops keying on args.data_parallel_size.
-    from megatron.core.num_microbatches_calculator import get_num_microbatches as _gnmb
-
-    expected = args.global_batch_size // (args.micro_batch_size * args.data_parallel_size)
-    if _gnmb() != expected:
-        # Rebuild to the llm_dp-keyed value.
-        init_num_microbatches_calculator(
-            rank=args.rank,
-            global_batch_size=args.global_batch_size,
-            micro_batch_size=args.micro_batch_size,
-            data_parallel_size=args.data_parallel_size,
-            decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
-        )
-
 
 def _seed_everything(args: argparse.Namespace) -> None:
-    """Seed python/numpy/torch RNG (matches the prototype loop + stock _set_random_seed)."""
+    """Seed host (python/numpy/torch) RNG; E4 configure_module_rng owns the CUDA tracker."""
+    # TODO(reuse): stock _set_random_seed would clobber E4's per-module CUDA RNG offsets (#5285).
     random.seed(args.seed)
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
 
 
 def _build_optimizer(args: argparse.Namespace, model):
-    """Build the MimoOptimizer over the per-submodule-DDP MimoModel.
-
-    Mirrors the prototype's ``hetero/optimizer.py::build_optimizer``: a single
-    ``OptimizerConfig`` shared by every active module optimizer, distributed
-    optimizer on, bf16 unless --fp32.
-    """
+    """Build the MimoOptimizer (one shared OptimizerConfig, distributed, bf16 unless --fp32)."""
     return get_mimo_optimizer(
         model[0],
         OptimizerConfig(
@@ -251,92 +113,14 @@ def _build_optimizer(args: argparse.Namespace, model):
     )
 
 
-def _build_scheduler(args: argparse.Namespace, optimizer) -> OptimizerParamScheduler:
-    """Build the stock OptimizerParamScheduler keyed on the llm_dp global batch.
-
-    Ports ``hetero/optimizer.py::build_optimizer_param_scheduler``: scheduler
-    "steps" are consumed samples (incremented by the global batch size per
-    optimizer step), so iter-based knobs convert via ``iters * global_batch_size``.
-    """
-    global_batch_size = args.global_batch_size
-
-    if getattr(args, "lr_warmup_samples", None) is not None:
-        lr_warmup_steps = args.lr_warmup_samples
-    else:
-        lr_warmup_steps = args.lr_warmup_iters * global_batch_size
-
-    if getattr(args, "lr_decay_samples", None) is not None:
-        lr_decay_steps = args.lr_decay_samples
-    else:
-        lr_decay_iters = (
-            args.lr_decay_iters if args.lr_decay_iters is not None else args.train_iters
-        )
-        lr_decay_steps = lr_decay_iters * global_batch_size
-
-    return OptimizerParamScheduler(
-        optimizer,
-        init_lr=0.0,
-        max_lr=args.lr,
-        min_lr=args.min_lr if args.min_lr is not None else 0.0,
-        lr_warmup_steps=lr_warmup_steps,
-        lr_decay_steps=lr_decay_steps,
-        lr_decay_style=args.lr_decay_style,
-        start_wd=args.weight_decay,
-        end_wd=args.weight_decay,
-        wd_incr_steps=args.train_iters * global_batch_size,
-        wd_incr_style="constant",
-        use_checkpoint_opt_param_scheduler=False,
-        override_opt_param_scheduler=True,
-        wsd_decay_steps=getattr(args, "lr_wsd_decay_samples", None),
-        lr_wsd_decay_style=getattr(args, "lr_wsd_decay_style", None),
-    )
-
-
-def _install_mimo_grad_finalize(model) -> None:
-    """Preserve the MIMO dual grad-finalization hook across stock train()'s clobber.
-
-    stock ``train()`` reassigns ``config.finalize_model_grads_func`` to the
-    module-level ``megatron.training.training.finalize_model_grads`` symbol. We
-    repoint that symbol to the MIMO finalizer that ``configure_grad_sync`` already
-    installed on ``model.config`` (in build_mimo_runtime). After train() runs its
-    ``config.finalize_model_grads_func = finalize_model_grads`` line, the config
-    therefore carries the MIMO hook.
-    """
-    mimo_finalize = model[0].config.finalize_model_grads_func
-    assert mimo_finalize is not None, (
-        "expected build_mimo_runtime -> configure_grad_sync to install a MIMO "
-        "finalize_model_grads_func on the language config"
-    )
-    training_module.finalize_model_grads = mimo_finalize
-
-
-def _install_safe_flops() -> None:
-    """Neutralize stock throughput/FLOPs accounting for the hetero MIMO model.
-
-    ``num_floating_point_operations`` derives a single homogeneous model's FLOPs
-    from the global (language) args and runs on every rank. That is ill-defined
-    for the disjoint encoder(RADIO)+language(hybrid-MoE) layout: encoder ranks
-    IndexError parsing the language MoE/hybrid pattern, and the hybrid path trips
-    on MTP. FLOPs/throughput is cosmetic for the smoke milestone, so wrap it to
-    return 0 on failure. TODO(NMFW-516): proper per-module hetero FLOPs accounting.
-    """
-    _orig = training_module.num_floating_point_operations
-
-    def _safe(*args, **kwargs):
-        try:
-            return _orig(*args, **kwargs)
-        except Exception:
-            return 0
-
-    training_module.num_floating_point_operations = _safe
+def _set_mpu_data_parallel_world_size(args: argparse.Namespace) -> None:
+    """Pin the MPU DP world size to llm_dp so train()'s sample accounting needs no MPU init."""
+    # Bootstrap/MPU-materialization compatibility point (see CLAUDE.md).
+    parallel_state._MPU_DATA_PARALLEL_WORLD_SIZE = args.llm_dp
 
 
 def _mimo_branch_name(topology) -> str:
-    """Return this rank's MIMO branch name ("language" or the encoder grid name).
-
-    Uses grid membership (the same source of truth bootstrap.py uses) to namespace
-    per-branch checkpoint state (e.g. the RNG ShardedObject key).
-    """
+    """Return this rank's MIMO branch ("language" or the encoder grid name)."""
     from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 
     if topology.grids[MIMO_LANGUAGE_MODULE_KEY].is_current_rank_in_grid():
@@ -349,300 +133,6 @@ def _mimo_branch_name(topology) -> str:
         ),
         "language",
     )
-
-
-def _install_mimo_checkpointing(topology):
-    """Replace stock save_checkpoint / load_checkpoint with a hetero-symmetric path.
-
-    Returns the patched ``load_checkpoint`` callable; the caller must invoke it
-    explicitly before train() to drive the resume LOAD (see the note at the end of
-    this function for why train() does not call it itself).
-
-    Why stock save_checkpoint hangs in a WORLD collective
-    =====================================================
-    Stock ``save_checkpoint`` (with the default ``--ckpt-fully-parallel-save``)
-    wraps the torch_dist save strategy in ``FullyParallelSaveStrategyWrapper`` keyed
-    on ``mpu.get_data_parallel_group(with_context_parallel=True)`` -- which, after
-    the entry pins parallel_state to this rank's own grid, is only the rank's own
-    2-rank branch DP group. ``apply_saving_parallelization`` then exchanges the save
-    distribution over that per-branch DP group while the underlying torch DCP save
-    planner runs its coordination collectives (gather_object / all_reduce / broadcast
-    in state_dict_saver.py) over the WORLD default group. Layering a per-branch
-    distribution under world-level DCP coordination across two structurally-different
-    grids (encoder ranks contribute a RADIO encoder sharded dict; language ranks a
-    Mamba LM + dist-optimizer sharded dict) desynchronizes the world collective:
-    the watchdog fires on a fixed-size ALLGATHER on default_pg that not all 8 ranks
-    reach symmetrically.
-
-    The prototype's approach (the fix)
-    ==================================
-    ``examples/mimo/training/hetero/checkpointing.py`` does NOT use stock
-    save_checkpoint. It assembles ONE unified sharded state dict (model + optimizer +
-    scheduler + per-branch RNG) and calls ``dist_checkpointing.save`` DIRECTLY with
-    the default (plain) ``TorchDistSaveShardedStrategy`` -- no FullyParallel DP-group
-    wrapper. Every rank contributes only its own branch's shards, but the GLOBAL set
-    of ShardedTensors/ShardedObjects is the symmetric union, and ALL coordination
-    (``determine_global_metadata``'s world ``all_gather_object`` and the DCP planner's
-    world collectives) runs over the world group symmetrically. Variable per-rank
-    metadata is exactly what ``all_gather_object`` is built to handle, so disjoint
-    per-branch structure is fine as long as no per-DP-group fully-parallel wrapper is
-    interposed.
-
-    This installer ports that approach onto the stock train() loop while reusing
-    stock ``generate_state_dict`` (which already produces per-rank-symmetric model /
-    optimizer / scheduler sharded dicts, and -- with args.use_distributed_optimizer
-    pinned True -- selects the ``dp_reshardable`` optimizer format). It monkeypatches
-    the ``save_checkpoint`` / ``load_checkpoint`` symbols imported into
-    ``megatron.training.training`` so train() drives the hetero-symmetric path.
-    """
-    import os
-
-    import megatron.training.checkpointing as ckpt_module
-    from megatron.core import dist_checkpointing
-    from megatron.core.dist_checkpointing.mapping import ShardedObject
-    from megatron.core.dist_checkpointing.utils import _clean_metadata_for_serialization
-    from megatron.training.checkpointing import (
-        _build_sharded_state_dict_metadata,
-        generate_state_dict,
-        get_rng_state,
-    )
-
-    branch_name = _mimo_branch_name(topology)
-    _TRACKER = "latest_checkpointed_iteration.txt"
-
-    def _iter_dir(root, iteration):
-        return os.path.join(root, f"iter_{iteration:07d}")
-
-    def _tracker_path(root):
-        return os.path.join(root, _TRACKER)
-
-    def _branch_keyed_rng_state(ckpt_format):
-        """Per-branch RNG ShardedObject to avoid cross-grid key collision.
-
-        Stock ``get_rng_state`` keys a single ``ShardedObject('rng_state', ...,
-        (pp,tp), (pp_rank,tp_rank), replica_id=dp_rank)`` on the rank's pinned
-        parallel_state groups. The encoder and language grids can share a (pp,tp)
-        factorization, so their RNG objects would collide on an identical
-        key+offset+replica_id with different payloads. Rewrite the key to
-        ``mimo.<branch>.rng_state`` (mirrors the prototype's _collect_rng_state) so
-        the two branches round-trip independently.
-        """
-        tp_group = parallel_state.get_tensor_model_parallel_group()
-        pp_group = parallel_state.get_pipeline_model_parallel_group()
-        rng = get_rng_state(ckpt_format, tp_group, pp_group)
-        if isinstance(rng, ShardedObject):
-            key = f"mimo.{branch_name}.rng_state"
-            rng = ShardedObject(
-                key, rng.data, rng.global_shape, rng.global_offset, replica_id=rng.replica_id
-            )
-        return rng
-
-    def _mimo_save_checkpoint(
-        iteration,
-        model,
-        optimizer,
-        opt_param_scheduler,
-        num_floating_point_operations_so_far,
-        checkpointing_context=None,
-        non_persistent_ckpt=False,
-        train_data_iterator=None,
-        preprocess_common_state_dict_fn=None,
-        **_unused,
-    ):
-        from megatron.training.global_vars import get_args
-
-        args = get_args()
-        if not args.save:
-            return
-        assert (
-            args.ckpt_format == "torch_dist"
-        ), f"hetero MIMO checkpointing supports only --ckpt-format torch_dist, got {args.ckpt_format}"
-
-        target_dir = _iter_dir(args.save, iteration)
-        if torch.distributed.get_rank() == 0:
-            os.makedirs(target_dir, exist_ok=True)
-        torch.distributed.barrier()
-
-        print_rank_0(f"saving hetero MIMO checkpoint at iteration {iteration} to {target_dir}")
-
-        rng_state = None if args.no_save_rng else _branch_keyed_rng_state(args.ckpt_format)
-        sharded_sd_metadata = _build_sharded_state_dict_metadata(args)
-        state_dict = generate_state_dict(
-            args,
-            model,
-            optimizer,
-            opt_param_scheduler,
-            rng_state,
-            iteration=iteration,
-            optim_sd_kwargs=dict(metadata=sharded_sd_metadata),
-            model_sd_kwargs=dict(metadata=sharded_sd_metadata),
-        )
-        state_dict["num_floating_point_operations_so_far"] = num_floating_point_operations_so_far
-
-        # Default strategy => plain TorchDistSaveShardedStrategy: world-symmetric
-        # coordination, NO FullyParallel DP-group wrapper. This is the key to
-        # coordinating the disjoint encoder/language grids (see installer docstring).
-        dist_checkpointing.save(
-            state_dict,
-            target_dir,
-            content_metadata=_clean_metadata_for_serialization(sharded_sd_metadata),
-        )
-
-        if torch.distributed.get_rank() == 0:
-            tmp = _tracker_path(args.save) + ".tmp"
-            with open(tmp, "w") as f:
-                f.write(str(iteration))
-            os.replace(tmp, _tracker_path(args.save))
-        torch.distributed.barrier()
-        print_rank_0(f"hetero MIMO checkpoint at iteration {iteration} saved")
-
-    def _read_tracker(load_root):
-        tracker = _tracker_path(load_root)
-        local_iter = -1
-        if os.path.isfile(tracker):
-            with open(tracker) as f:
-                contents = f.read().strip()
-            if contents:
-                local_iter = int(contents)
-        iters = torch.tensor([local_iter], dtype=torch.long, device="cuda")
-        torch.distributed.all_reduce(iters, op=torch.distributed.ReduceOp.MAX)
-        max_iter = int(iters.item())
-        return max_iter if max_iter >= 0 else None
-
-    def _mimo_load_checkpoint(
-        model,
-        optimizer,
-        opt_param_scheduler,
-        load_arg="load",
-        strict=True,
-        checkpointing_context=None,
-        skip_load_to_model_and_opt=False,
-        **_unused,
-    ):
-        from megatron.training.global_vars import get_args
-
-        args = get_args()
-        load_root = getattr(args, load_arg, None)
-        if not load_root:
-            return 0, 0
-
-        iteration = _read_tracker(load_root)
-        if iteration is None:
-            print_rank_0(f"no MIMO checkpoint at {load_root}; starting from iteration 0")
-            return 0, 0
-        source_dir = _iter_dir(load_root, iteration)
-        if not os.path.isdir(source_dir):
-            raise RuntimeError(
-                f"tracker at {load_root} points to iteration {iteration} but {source_dir} is missing"
-            )
-
-        is_finetune = bool(args.finetune)
-        include_optim = (not args.no_load_optim) and not is_finetune
-        include_sched = (not getattr(args, "no_load_scheduler", False)) and not is_finetune
-        include_rng = (not args.no_load_rng) and not is_finetune
-
-        print_rank_0(
-            f"loading hetero MIMO checkpoint from {source_dir}"
-            f" (optimizer={include_optim}, scheduler={include_sched},"
-            f" rng={include_rng}, finetune={is_finetune})"
-        )
-
-        rng_state = _branch_keyed_rng_state(args.ckpt_format) if include_rng else None
-        sharded_sd_metadata = _build_sharded_state_dict_metadata(args)
-        request = generate_state_dict(
-            args,
-            model,
-            optimizer if include_optim else None,
-            opt_param_scheduler if include_sched else None,
-            rng_state,
-            iteration=iteration,
-            optim_sd_kwargs=dict(metadata=sharded_sd_metadata, is_loading=True),
-            model_sd_kwargs=dict(metadata=sharded_sd_metadata),
-        )
-        # ``args`` is common (rank-0) state; it round-trips via common.pt on disk
-        # (returned in ``loaded`` below), so don't request it back as a load target.
-        request.pop("args", None)
-
-        loaded = dist_checkpointing.load(request, source_dir)
-
-        # Apply the loaded state to model / optimizer / scheduler (the symmetric
-        # union assembled by every rank reconstructs into each rank's own shards).
-        if not skip_load_to_model_and_opt:
-            model[0].load_state_dict(loaded["model"], strict=strict)
-            if (
-                include_optim
-                and optimizer is not None
-                and not optimizer.is_stub_optimizer
-                and "optimizer" in loaded
-            ):
-                optimizer.load_state_dict(loaded["optimizer"])
-        if include_sched and opt_param_scheduler is not None and "opt_param_scheduler" in loaded:
-            opt_param_scheduler.load_state_dict(loaded["opt_param_scheduler"])
-
-        if include_rng and loaded.get("rng_state") is not None:
-            _restore_rng_from_loaded(loaded["rng_state"])
-
-        # Restore sample accounting from the checkpoint's args (consumed by stock
-        # train()'s batch-size / microbatch bookkeeping).
-        ckpt_args = loaded.get("args")
-        if ckpt_args is not None and not is_finetune:
-            getter = ckpt_args.get if isinstance(ckpt_args, dict) else lambda k, d: getattr(ckpt_args, k, d)
-            args.consumed_train_samples = getter("consumed_train_samples", 0)
-            args.skipped_train_samples = getter("skipped_train_samples", 0)
-            args.consumed_valid_samples = getter("consumed_valid_samples", 0)
-
-        nfpo = int(loaded.get("num_floating_point_operations_so_far", 0))
-        resume_iter = 0 if is_finetune else int(loaded.get("iteration", iteration))
-        print_rank_0(f"resuming hetero MIMO training at iteration {resume_iter}")
-        return resume_iter, nfpo
-
-    # Patch the symbols train() resolved at import time. This routes the
-    # mid-training periodic SAVE (save_checkpoint_and_time -> save_checkpoint)
-    # through the hetero-symmetric path.
-    training_module.save_checkpoint = _mimo_save_checkpoint
-    training_module.load_checkpoint = _mimo_load_checkpoint
-    ckpt_module.save_checkpoint = _mimo_save_checkpoint
-    ckpt_module.load_checkpoint = _mimo_load_checkpoint
-
-    # The resume LOAD is NOT driven by train(): stock load_checkpoint runs inside
-    # setup_model_and_optimizer, which this entry bypasses (it builds the MimoModel /
-    # MimoOptimizer itself and calls train() directly). So the caller (main()) must
-    # invoke this returned load function explicitly BEFORE train() and seed
-    # args.iteration so train() resumes at iteration+1. Mirrors the prototype loop,
-    # which calls load_checkpoint() explicitly and starts at start_iteration + 1.
-    return _mimo_load_checkpoint
-
-
-def _restore_rng_from_loaded(rng_obj) -> None:
-    """Apply RNG state loaded from a per-branch rng ShardedObject (prototype parity)."""
-    from megatron.core import tensor_parallel
-
-    payload = rng_obj
-    if isinstance(payload, list) and payload and isinstance(payload[0], dict):
-        rng = payload[0]
-    elif isinstance(payload, dict):
-        rng = payload
-    else:
-        return
-    random.setstate(rng["random_rng_state"])
-    np.random.set_state(rng["np_rng_state"])
-    torch.set_rng_state(rng["torch_rng_state"])
-    torch.cuda.set_rng_state(rng["cuda_rng_state"])
-    if rng.get("rng_tracker_states"):
-        tensor_parallel.get_cuda_rng_tracker().set_states(rng["rng_tracker_states"])
-
-
-def _set_mpu_data_parallel_world_size(args: argparse.Namespace) -> None:
-    """Pin the MPU DP world size to llm_dp for train()'s sample accounting.
-
-    train() reads ``mpu.get_data_parallel_world_size()`` (4 sites) for consumed-
-    sample / batch-size bookkeeping. That getter returns the module global
-    ``_MPU_DATA_PARALLEL_WORLD_SIZE`` when set, before touching any MPU group, so
-    pinning it lets train() run without a full MPU init. This is a bootstrap /
-    MPU-materialization compatibility point (see CLAUDE.md "Megatron Core Process
-    Groups").
-    """
-    parallel_state._MPU_DATA_PARALLEL_WORLD_SIZE = args.llm_dp
 
 
 def main() -> None:
@@ -660,33 +150,23 @@ def main() -> None:
     rt = build_mimo_runtime(args)
 
     optimizer = _build_optimizer(args, rt.model)
-    opt_param_scheduler = _build_scheduler(args, optimizer)
+    opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
 
-    # Keep the MIMO grad-finalization hook alive past stock train()'s reassign.
-    _install_mimo_grad_finalize(rt.model)
+    # E4 configure_grad_sync installs the MIMO dual grad-finalizer on model.config;
+    # stock train() preserves a caller-installed finalize_model_grads_func, so it
+    # survives without a monkeypatch.
+    assert rt.model[0].config.finalize_model_grads_func is not None, (
+        "expected build_mimo_runtime -> configure_grad_sync to install a MIMO "
+        "finalize_model_grads_func on the language config"
+    )
 
-    # Neutralize stock FLOPs/throughput accounting (ill-defined for the hetero model).
-    _install_safe_flops()
+    # TODO(reuse): stock num_floating_point_operations computes the language model's
+    # FLOPs on every rank and the throughput print divides by the full world_size
+    # (not the LLM world size), so per-GPU TFLOP/s is cosmetic for the hetero layout.
+    # Proper per-module hetero FLOPs accounting is deferred (NMFW-516).
 
-    # Replace stock save/load_checkpoint with a hetero-symmetric path: assemble one
-    # unified sharded state dict and call dist_checkpointing.save/load directly with
-    # the plain (world-coordinated) torch_dist strategy -- NO FullyParallel DP-group
-    # wrapper (which deadlocks a world collective across the disjoint grids). Also
-    # namespaces the RNG ShardedObject key per branch. See _install_mimo_checkpointing.
-    # Returns the load fn; train() never calls it (resume load normally lives in the
-    # bypassed setup_model_and_optimizer), so we invoke it explicitly below.
-    mimo_load_checkpoint = _install_mimo_checkpointing(rt.topology)
-
-    # Pin this rank's parallel_state model-parallel group to its module's mp group so
-    # stock training_log's cosmetic mp-group reductions (e.g. the LR gather in
-    # reduce_max_stat_across_model_parallel_group) work without full mpu init. The
-    # MIMO schedule/grad reductions use the threaded pg_collection; this only
-    # satisfies stock logging-path reads of mpu.get_model_parallel_group().
-    # Pin this rank's parallel_state groups to its module's per-module groups so the
-    # stock logging + checkpoint paths (which read mpu.get_*_group()) work without
-    # full mpu init. The MIMO schedule/grad reductions use the threaded pg_collection;
-    # these pins only satisfy stock-path reads (training_log, report_memory,
-    # save_checkpoint shard/RNG bookkeeping).
+    # Pin parallel_state to this rank's per-module groups so stock-path reads
+    # (training_log, report_memory, checkpoint shard/RNG) work without full mpu init.
     _pgc = rt.pg_collection
     if getattr(_pgc, "mp", None) is not None:
         parallel_state._MODEL_PARALLEL_GROUP = _pgc.mp
@@ -709,35 +189,26 @@ def main() -> None:
     args.do_valid = False
     args.do_test = False
 
-    # Every MIMO submodule optimizer is a DistributedOptimizer (see
-    # _build_optimizer -> get_mimo_optimizer, and runtime.py's per-submodule DDP
-    # wrap with use_distributed_optimizer=True). The top-level ``args`` flag,
-    # however, defaults to False because we never run stock setup_model_and_optimizer.
-    # Stock checkpointing.py keys two things off it:
-    #   1. save -> _build_sharded_state_dict_metadata: only sets
-    #      ``distrib_optim_sharding_type`` when this is True. Without it the
-    #      per-submodule DistributedOptimizer.sharded_state_dict falls back to the
-    #      deprecated 'fully_sharded_model_space' format, which emits ShardedTensors
-    #      with ``flattened_range`` and crashes torch_dist's
-    #      validate_metadata_integrity ("flattened_range is not supported").
-    #   2. The 'Storing distributed optimizer sharded state of type ...' log line.
-    # Pinning it True makes the metadata builder select 'dp_reshardable' (the stock
-    # default and the format the hetero prototype used), which round-trips cleanly
-    # through torch_dist save/load and is persisted in the checkpoint's
-    # content_metadata so resume mirrors it.
+    # Every MIMO submodule optimizer is a DistributedOptimizer, but the top-level
+    # ``args`` flag defaults False because we bypass setup_model_and_optimizer. Pin
+    # it True so stock checkpointing selects the 'dp_reshardable' optimizer sharding
+    # format (the format that round-trips cleanly through torch_dist save/load).
     args.use_distributed_optimizer = True
 
-    # Resume LOAD (must run after parallel_state pins + args.use_distributed_optimizer
-    # so the load request's model/optimizer/RNG sharded keys match what was saved).
-    # train() does not call load_checkpoint (the entry bypasses
-    # setup_model_and_optimizer), so we drive it here. All 8 ranks call this with the
-    # identical world-symmetric load request, mirroring the world-symmetric save.
-    # On success it returns the saved iteration (e.g. 2); seeding args.iteration makes
-    # stock train() resume the loop at iteration+1 (e.g. 3). consumed-sample / FLOPs
-    # accounting is restored inside the load fn.
+    # Reuse stock save_checkpoint/load_checkpoint. The hetero deadlock came from the
+    # default fully-parallel save wrapper; the run script passes
+    # --no-ckpt-fully-parallel-save so stock uses the plain (world-coordinated)
+    # torch_dist strategy. Namespace the RNG ShardedObject key per branch so the
+    # encoder/LLM grids (which can share a (pp,tp) factorization) don't collide.
+    args.rng_state_key_prefix = f"mimo.{_mimo_branch_name(rt.topology)}."
+    checkpointing_context = {}
+
+    # Resume LOAD: stock load_checkpoint normally runs inside the bypassed
+    # setup_model_and_optimizer, so we drive it here (after the parallel_state pins +
+    # use_distributed_optimizer so the load request's sharded keys match the save).
     if args.load:
-        resume_iter, resume_nfpo = mimo_load_checkpoint(
-            rt.model, optimizer, opt_param_scheduler
+        resume_iter, resume_nfpo = load_checkpoint(
+            rt.model, optimizer, opt_param_scheduler, checkpointing_context=checkpointing_context
         )
         args.iteration = resume_iter
         args.num_floating_point_operations_so_far = resume_nfpo
@@ -747,7 +218,7 @@ def main() -> None:
     print_rank_0(
         "Starting hetero MIMO training on stock train(): "
         f"world_size={torch.distributed.get_world_size()}, "
-        f"llm_dp={args.llm_dp}, num_microbatches={args.num_microbatches}, "
+        f"llm_dp={args.llm_dp}, "
         f"global_batch_size={args.global_batch_size}, train_iters={args.train_iters}"
     )
 
@@ -761,7 +232,7 @@ def main() -> None:
             valid_data_iterator=None,
             process_non_loss_data_func=None,
             config=config,
-            checkpointing_context={},
+            checkpointing_context=checkpointing_context,
             non_loss_data_func=None,
             p2p_communicator=rt.communicator,
             schedule_pg_collection=rt.topology.schedule_pg_collection,

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -10,6 +10,7 @@ data-iterator hooks.
 from __future__ import annotations
 
 import argparse
+import functools
 import os
 import sys
 
@@ -23,7 +24,7 @@ from examples.mimo.model_providers.nemotron_moe_vlm import (
     validate_model_provider_args,
 )
 from examples.mimo.training.args import add_hetero_grid_args, validate_hetero_grid_args
-from examples.mimo.training.bootstrap import build_mimo_runtime
+from examples.mimo.training.bootstrap import build_mimo_runtime, mimo_model_provider
 from examples.mimo.training.data import add_data_args
 from examples.mimo.training.distributed import initialize_distributed, shutdown_distributed
 from examples.mimo.training.step import mimo_forward_step
@@ -31,6 +32,7 @@ from megatron.core.config import set_experimental_flag
 from megatron.core.enums import ModelType
 from megatron.core.models.mimo.optimizer import get_mimo_optimizer
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from megatron.core.tokenizers.utils.build_tokenizer import vocab_size_with_padding
 from megatron.training.argument_utils import pretrain_cfg_container_from_args
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.checkpointing import load_checkpoint
@@ -47,38 +49,26 @@ def extra_args_provider(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
 
 
 def _parse_and_validate() -> argparse.Namespace:
-    """Parse and validate args with the model-provider preset and grid checks."""
+    """Parse/validate args with the model-provider preset and hetero-grid checks."""
     args = parse_args(extra_args_provider)
-
-    # Apply the model-provider preset before validation so preset-derived sizes flow in.
-    prepare_model_provider_args(args)
-
-    validate_args(args, {})  # no dataset path / tokenizer for the mock run
-
+    prepare_model_provider_args(args)  # apply preset before validation
+    validate_args(args, {})
     validate_model_provider_args(args)
-    world_size = int(os.environ.get("WORLD_SIZE", args.world_size))
-    validate_hetero_grid_args(args, world_size)
+    validate_hetero_grid_args(args, int(os.environ.get("WORLD_SIZE", args.world_size)))
 
-    # Data-parallel size follows the language grid.
     args.data_parallel_size = args.llm_dp
-
-    # The preset leaves mtp_num_layers None; FLOPs/throughput accounting needs an int.
     if getattr(args, "mtp_num_layers", None) is None:
         args.mtp_num_layers = 0
-
-    # Mock runs build no tokenizer; derive the padded vocab from the configured vocab.
     if getattr(args, "padded_vocab_size", None) is None:
-        args.padded_vocab_size = args.vocab_size
-
-    # The data iterator is pre-built per rank; the external dataloader passes it through.
-    args.dataloader_type = "external"
-
-    # Train-only: no eval. eval_iters=0 keeps do_valid/do_test off; a positive
-    # eval_interval avoids a divide-by-None in the train/valid/test sample accounting.
-    args.eval_iters = 0
+        # No tokenizer in the mock run; pad the vocab for the language TP shard.
+        tp = args.tensor_model_parallel_size
+        args.tensor_model_parallel_size = args.llm_tp
+        args.padded_vocab_size = vocab_size_with_padding(args.vocab_size, args)
+        args.tensor_model_parallel_size = tp
+    args.dataloader_type = "external"  # per-rank iterator passed through
+    args.eval_iters = 0  # train-only; positive eval_interval avoids None-division below
     if getattr(args, "eval_interval", None) is None:
         args.eval_interval = args.train_iters or 1
-
     return args
 
 
@@ -125,29 +115,19 @@ def _mimo_branch_name(topology) -> str:
     )
 
 
-def _noop_provider(*_args, **_kwargs):
-    """Placeholder for pretrain's model/dataset providers (the hooks replace them)."""
-    return None
+class MimoSetup:
+    """pretrain setup_model_and_optimizer_func: return the eagerly-built per-submodule-DDP
+    MimoModel, build the MimoOptimizer + scheduler, and drive resume load with per-module
+    groups. MIMO bypasses stock get_model/get_megatron_optimizer because disjoint grids need
+    per-submodule DDP and a chained per-grid optimizer that neither stock path provides.
+    """
 
+    def __init__(self, rt, args: argparse.Namespace):
+        self.rt = rt
+        self.args = args
 
-def main() -> None:
-    """Run heterogeneous MIMO training."""
-    args = _parse_and_validate()
-
-    _setup_globals(args)
-    initialize_distributed()
-
-    # Per-rank runtime: per-submodule-DDP MimoModel, topology, comms, data iterator, grad sync.
-    # build_mimo_runtime seeds per-role RNG (host + CUDA) via the stock _set_random_seed.
-    rt = build_mimo_runtime(args)
-    assert rt.model[0].config.finalize_model_grads_func is not None, (
-        "build_mimo_runtime must install a finalize_model_grads_func on the language config"
-    )
-
-    cfg = pretrain_cfg_container_from_args(args, rt.model[0].config)
-
-    def _setup_model_and_optimizer(model_provider, model_type, checkpointing_context=None):
-        # Build the optimizer/scheduler, drive resume load, and set args.iteration.
+    def __call__(self, model_provider, model_type, checkpointing_context=None):
+        rt, args = self.rt, self.args
         optimizer = _build_optimizer(args, rt.model)
         opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
         # Per-grid rng key namespace on the model (read by stock save/load); torch_dist only.
@@ -169,6 +149,23 @@ def main() -> None:
             args.num_floating_point_operations_so_far = 0
         return rt.model, optimizer, opt_param_scheduler
 
+
+def main() -> None:
+    """Run heterogeneous MIMO training."""
+    args = _parse_and_validate()
+
+    _setup_globals(args)
+    initialize_distributed()
+
+    # Per-rank runtime: per-submodule-DDP MimoModel, topology, comms, data iterator, grad sync.
+    # build_mimo_runtime seeds per-role RNG (host + CUDA) via the stock _set_random_seed.
+    rt = build_mimo_runtime(args)
+    assert rt.model[0].config.finalize_model_grads_func is not None, (
+        "build_mimo_runtime must install a finalize_model_grads_func on the language config"
+    )
+
+    cfg = pretrain_cfg_container_from_args(args, rt.model[0].config)
+
     def _dataset_provider(train_val_test_num_samples):
         return rt.data_iterator, None, None
 
@@ -178,11 +175,11 @@ def main() -> None:
         pretrain(
             cfg,
             _dataset_provider,
-            _noop_provider,
+            functools.partial(mimo_model_provider, topology=rt.topology, args=args),
             ModelType.encoder_or_decoder,
             mimo_forward_step,
             skip_model_parallel_init=True,
-            setup_model_and_optimizer_func=_setup_model_and_optimizer,
+            setup_model_and_optimizer_func=MimoSetup(rt, args),
             p2p_communicator=rt.communicator,
             schedule_pg_collection=rt.topology.schedule_pg_collection,
         )

--- a/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
+++ b/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
@@ -19,6 +19,8 @@ GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE:-$((MICRO_BATCH_SIZE * NUM_MICROBATCHES * 
 LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-0}
 TOKENIZER_MODEL=${TOKENIZER_MODEL:-}
 IMAGE_TOKEN_ID=${IMAGE_TOKEN_ID:-511}
+MOE_TOKEN_DISPATCHER_TYPE=${MOE_TOKEN_DISPATCHER_TYPE:-alltoall}
+MOE_FLEX_DISPATCHER_BACKEND=${MOE_FLEX_DISPATCHER_BACKEND:-deepep}
 PYTHON_BIN=${PYTHON_BIN:-python}
 
 TOKENIZER_ARGS=()
@@ -68,6 +70,8 @@ esac
   --moe-aux-loss-coeff 1e-4 \
   --moe-shared-expert-intermediate-size 3712 \
   --moe-shared-expert-overlap \
+  --moe-token-dispatcher-type "${MOE_TOKEN_DISPATCHER_TYPE}" \
+  --moe-flex-dispatcher-backend "${MOE_FLEX_DISPATCHER_BACKEND}" \
   --moe-permute-fusion \
   --use-fused-weighted-squared-relu \
   --mamba-num-heads 64 \

--- a/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
+++ b/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Run a heterogeneous mock-data loop with the Nemotron6-MoE VLM 20L architecture
-# on the STOCK megatron/training train() loop (NMFW-516 PR-E5 entry).
+# Run a heterogeneous mock-data training loop with the Nemotron6-MoE VLM 20L architecture.
 
 set -euo pipefail
 

--- a/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
+++ b/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
@@ -102,16 +102,17 @@ esac
   --image-token "<image>" \
   --micro-batch-size "${MICRO_BATCH_SIZE}" \
   --global-batch-size "${GLOBAL_BATCH_SIZE}" \
-  --num-microbatches "${NUM_MICROBATCHES}" \
   --lr 2e-4 \
   --min-lr 2e-6 \
   --lr-decay-style cosine \
   --lr-warmup-iters "${LR_WARMUP_ITERS}" \
   --lr-decay-iters 10 \
   --weight-decay 0.05 \
+  --override-opt-param-scheduler \
   --adam-beta1 0.9 \
   --adam-beta2 0.95 \
   --clip-grad 1.0 \
   --ddp-bucket-size 0 \
+  --no-ckpt-fully-parallel-save \
   --train-iters "${TRAIN_ITERS}" \
   "$@"

--- a/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
+++ b/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
@@ -41,8 +41,46 @@ esac
   --standalone \
   --nproc-per-node "${GPUS_PER_NODE}" \
   examples/mimo/pretrain_mimo.py \
-  --model-provider nemotron-moe-vlm-20l \
+  --model-provider nemotron-moe-vlm \
   --training-stage "${TRAINING_STAGE}" \
+  --num-layers 20 \
+  --hybrid-layer-pattern "MEMEM*EMEMEM*EMEMEM*" \
+  --hidden-size 2688 \
+  --num-attention-heads 32 \
+  --group-query-attention \
+  --num-query-groups 8 \
+  --ffn-hidden-size 1856 \
+  --kv-channels 128 \
+  --squared-relu \
+  --disable-bias-linear \
+  --normalization RMSNorm \
+  --init-method-std 0.0173 \
+  --num-experts 128 \
+  --moe-router-topk 6 \
+  --moe-grouped-gemm \
+  --moe-ffn-hidden-size 1856 \
+  --moe-router-score-function sigmoid \
+  --moe-router-topk-scaling-factor 2.5 \
+  --moe-router-enable-expert-bias \
+  --moe-router-dtype fp32 \
+  --moe-router-load-balancing-type seq_aux_loss \
+  --moe-router-fusion \
+  --moe-aux-loss-coeff 1e-4 \
+  --moe-shared-expert-intermediate-size 3712 \
+  --moe-shared-expert-overlap \
+  --moe-permute-fusion \
+  --use-fused-weighted-squared-relu \
+  --mamba-num-heads 64 \
+  --mamba-head-dim 64 \
+  --mamba-num-groups 8 \
+  --mamba-state-dim 128 \
+  --linear-conv-kernel-dim 4 \
+  --position-embedding-type none \
+  --calculate-per-token-loss \
+  --cross-entropy-loss-fusion \
+  --seq-length 8192 \
+  --max-position-embeddings 8192 \
+  --bf16 \
   --encoder-tp 2 \
   --encoder-pp 1 \
   --encoder-dp 2 \

--- a/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
+++ b/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Run a heterogeneous mock-data loop with the Nemotron6-MoE VLM 20L architecture
+# on the STOCK megatron/training train() loop (NMFW-516 PR-E5 entry).
+
+set -euo pipefail
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+
+GPUS_PER_NODE=8
+TRAIN_ITERS=${TRAIN_ITERS:-1}
+NUM_MICROBATCHES=${NUM_MICROBATCHES:-4}
+NUM_IMAGE_TILES=${NUM_IMAGE_TILES:-12}
+TRAINING_STAGE=${TRAINING_STAGE:-stage2}
+MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE:-1}
+LLM_DP=2
+GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE:-$((MICRO_BATCH_SIZE * NUM_MICROBATCHES * LLM_DP))}
+LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-0}
+TOKENIZER_MODEL=${TOKENIZER_MODEL:-}
+IMAGE_TOKEN_ID=${IMAGE_TOKEN_ID:-511}
+PYTHON_BIN=${PYTHON_BIN:-python}
+
+TOKENIZER_ARGS=()
+if [[ -n "${TOKENIZER_MODEL}" ]]; then
+  TOKENIZER_ARGS+=(--tokenizer-model "${TOKENIZER_MODEL}")
+else
+  TOKENIZER_ARGS+=(--image-token-id "${IMAGE_TOKEN_ID}")
+fi
+
+case "${TRAINING_STAGE}" in
+  stage1|stage2|stage3)
+    ;;
+  *)
+    echo "ERROR: Unknown TRAINING_STAGE='${TRAINING_STAGE}'. Use stage1, stage2, or stage3." >&2
+    exit 1
+    ;;
+esac
+
+"${PYTHON_BIN}" -m torch.distributed.run \
+  --standalone \
+  --nproc-per-node "${GPUS_PER_NODE}" \
+  examples/mimo/pretrain_mimo.py \
+  --model-provider nemotron-moe-vlm-20l \
+  --training-stage "${TRAINING_STAGE}" \
+  --encoder-tp 2 \
+  --encoder-pp 1 \
+  --encoder-dp 2 \
+  --llm-offset 4 \
+  --llm-tp 2 \
+  --llm-pp 1 \
+  --llm-dp "${LLM_DP}" \
+  --llm-ep 4 \
+  --llm-expt-tp 1 \
+  --llm-expt-dp 1 \
+  --vocab-size 131072 \
+  --num-image-tiles "${NUM_IMAGE_TILES}" \
+  "${TOKENIZER_ARGS[@]}" \
+  --tokenizer-prompt-format nemotron6-moe \
+  --image-token "<image>" \
+  --micro-batch-size "${MICRO_BATCH_SIZE}" \
+  --global-batch-size "${GLOBAL_BATCH_SIZE}" \
+  --num-microbatches "${NUM_MICROBATCHES}" \
+  --lr 2e-4 \
+  --min-lr 2e-6 \
+  --lr-decay-style cosine \
+  --lr-warmup-iters "${LR_WARMUP_ITERS}" \
+  --lr-decay-iters 10 \
+  --weight-decay 0.05 \
+  --adam-beta1 0.9 \
+  --adam-beta2 0.95 \
+  --clip-grad 1.0 \
+  --ddp-bucket-size 0 \
+  --train-iters "${TRAIN_ITERS}" \
+  "$@"

--- a/examples/mimo/training/bootstrap.py
+++ b/examples/mimo/training/bootstrap.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Runtime orchestrator for hetero MIMO training on the stock Megatron loop.
+
+This is PR-E4 of the NMFW-516 hetero-MIMO upstreaming effort. It wires together
+the merged glue (E1 model provider, E2 topology/grid args, E3 forward step) plus
+the in-flight RNG/DDP (MM2), grad-sync (MM3), and data-selection modules into a
+single :func:`build_mimo_runtime` entry the stock ``train()`` can consume.
+
+Scope: the NON-COLOCATED nemotron VLM path only (encoder grid and language grid
+occupy disjoint rank spans). The colocated three-phase schedule is out of scope
+here.
+
+``build_mimo_runtime`` is deliberately kept in this ``bootstrap.py`` module rather
+than ``runtime.py`` (which MM2 / #5285 owns). At final integration the two may
+fold together, but keeping them separate avoids clobbering MM2's file while both
+PRs are in flight.
+
+Boundary with the stock loop (handoff section 3): the entry PR (E5) bypasses
+``setup_model_and_optimizer`` -- which would call ``get_model`` and re-wrap a
+single top-level DDP -- and instead calls ``build_mimo_runtime`` to assemble the
+per-submodule-DDP MimoModel, then hands the resulting model list straight to the
+stock ``train()``. The optimizer is built separately (the prototype's
+``get_mimo_optimizer`` needs the per-submodule DDP wrapping this function
+performs, which is why no top-level DDP wrap is applied here).
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+from examples.mimo.model_providers.nemotron_moe_vlm import (
+    language_model_spec,
+    vision_submodules_spec,
+)
+from examples.mimo.training.args import build_module_grid_specs
+from examples.mimo.training.data import select_data_iterator
+from examples.mimo.training.grad_sync import configure_grad_sync
+from examples.mimo.training.runtime import configure_module_rng, wrap_active_modules_with_ddp
+from examples.mimo.training.topology import HeteroTopology, create_topology
+from megatron.core.models.mimo.config.base_configs import MimoModelConfig
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+from megatron.core.models.mimo.model.base import MimoModel
+from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
+from megatron.core.process_groups_config import ProcessGroupCollection
+
+# RNG role offsets, matched to the prototype (hetero/runtime.py): the language
+# module seeds from +20_000, the vision encoder from +10_000. Distinct offsets
+# keep the (process-global) CUDA RNG tracker independent across module roles.
+_LANGUAGE_SEED_OFFSET = 20_000
+_ENCODER_SEED_OFFSET = 10_000
+
+
+@dataclass
+class MimoRuntime:
+    """Everything the stock ``train()`` entry (E5) needs to drive a hetero MIMO run.
+
+    Fields:
+        model:
+            The DDP-wrapped :class:`MimoModel` for this rank, returned as a
+            single-element list so it drops straight into the stock ``train()``
+            ``model`` argument (which always expects a list of model chunks).
+            ``model[0].pg_collection`` carries this rank's per-module PGC (see
+            below); ``model[0].config`` is the language ``TransformerConfig``
+            already carrying the MIMO ``finalize_model_grads_func`` /
+            ``grad_scale_func`` installed by :func:`configure_grad_sync`.
+        topology:
+            The :class:`HeteroTopology`. The schedule reads
+            ``topology.schedule_pg_collection`` (the per-rank
+            ``MultiModuleProcessGroupCollection``) and the p2p communicator is
+            built from ``topology.grids``.
+        communicator:
+            The :class:`MultiModulePipelineCommunicator` the MIMO schedule uses
+            for cross-module (encoder->language) P2P.
+        data_iterator:
+            This rank's role-aware data iterator, or ``None`` when the rank
+            consumes no data (interior PP stages).
+        pg_collection:
+            This rank's per-module :class:`ProcessGroupCollection` (the language
+            PGC on language-grid ranks, else the encoder PGC). Identical object
+            to ``model.pg_collection``; surfaced here so the entry need not reach
+            into the model. Distinct from ``topology.schedule_pg_collection``
+            (the multi-module collection) -- see the module docstring and the
+            ``pg_collection`` note in :func:`build_mimo_runtime`.
+    """
+
+    model: list
+    topology: HeteroTopology
+    communicator: MultiModulePipelineCommunicator
+    data_iterator: Optional[object]
+    pg_collection: ProcessGroupCollection
+
+
+def _encoder_module_name(topology: HeteroTopology) -> Optional[str]:
+    """Return the single modality (encoder) grid name, or ``None`` for an LLM-only run."""
+    names = [name for name in topology.grids if name != MIMO_LANGUAGE_MODULE_KEY]
+    return names[0] if names else None
+
+
+def _module_dependency_map(topology: HeteroTopology) -> dict:
+    """Build the encoder->language dependency map the communicator's topology arg needs.
+
+    Mirrors the prototype's ``HeteroTopology.module_dependency_map``: the encoder
+    feeds the language module, the language module feeds nothing. LLM-only runs
+    have no edges.
+    """
+    encoder_name = _encoder_module_name(topology)
+    if encoder_name is None:
+        return {MIMO_LANGUAGE_MODULE_KEY: []}
+    return {encoder_name: [MIMO_LANGUAGE_MODULE_KEY], MIMO_LANGUAGE_MODULE_KEY: []}
+
+
+def build_mimo_runtime(args: argparse.Namespace) -> MimoRuntime:
+    """Assemble the per-rank hetero MIMO runtime for the stock training loop.
+
+    Ports the prototype build sequence (hetero/runtime.py +
+    hetero/loop.py:86-150), dropping the prototype's bespoke loop, logging,
+    prefetch, timeline, and checkpoint machinery: those are owned by the stock
+    ``train()`` (E5) or deferred to later PRs.
+
+    Steps:
+      1. Build the per-module grid specs (E2) and the topology (E2/E3).
+      2. Determine which module(s) live on this rank from the topology grids.
+      3. Seed RNG per active module role (encoder vs language get distinct
+         offsets) via MM2's :func:`configure_module_rng`.
+      4. Assemble the language and/or vision ``ModuleSpec`` (E1) and construct
+         the role ``MimoModel`` -- WITHOUT a top-level DDP wrap, because the MIMO
+         optimizer needs per-submodule DDP.
+      5. DDP-wrap the active submodules (MM2 :func:`wrap_active_modules_with_ddp`).
+      6. Attach this rank's per-module PGC as ``mimo_model.pg_collection`` for the
+         stock ``train()`` / ``training_log`` path.
+      7. Install the dual grad-finalization hook (MM3
+         :func:`configure_grad_sync`).
+      8. Build the p2p communicator and select this rank's data iterator.
+
+    Returns a :class:`MimoRuntime` (see its docstring for the consumption
+    contract).
+    """
+    world_size = torch.distributed.get_world_size()
+    specs = build_module_grid_specs(args, world_size)
+    topology = create_topology(specs)
+
+    # --- 2. Resolve this rank's role from the per-module grids. ------------
+    # Non-colocated: each rank is in exactly one module grid. A grid membership
+    # check (is_current_rank_in_grid) is the source of truth; module_pgs only
+    # carries the collections for modules this rank participates in.
+    encoder_name = _encoder_module_name(topology)
+    rank_in_language = topology.grids[MIMO_LANGUAGE_MODULE_KEY].is_current_rank_in_grid()
+    rank_in_encoder = (
+        encoder_name is not None
+        and topology.grids[encoder_name].is_current_rank_in_grid()
+    )
+
+    language_pg = topology.module_pgs.get(MIMO_LANGUAGE_MODULE_KEY)
+    encoder_pg = topology.module_pgs.get(encoder_name) if encoder_name is not None else None
+
+    # --- 3. Seed RNG for the single active module role on this rank. -------
+    # The CUDA RNG tracker is process-global; the non-colocated layout puts
+    # exactly one module on each rank, so each rank configures RNG for one role.
+    if rank_in_language:
+        assert language_pg is not None
+        configure_module_rng(args, language_pg, role_seed_offset=_LANGUAGE_SEED_OFFSET)
+    elif rank_in_encoder:
+        assert encoder_pg is not None
+        configure_module_rng(args, encoder_pg, role_seed_offset=_ENCODER_SEED_OFFSET)
+
+    # --- 4. Build the role MimoModel (no top-level DDP). -------------------
+    modality_submodules_spec = {}
+    special_token_ids = {}
+    if encoder_name is not None:
+        modality_submodules_spec[encoder_name] = vision_submodules_spec(
+            args,
+            encoder_pg if rank_in_encoder else None,
+            topology.grids[encoder_name],
+        )
+        special_token_ids[encoder_name] = args.image_token_id
+
+    mimo_config = MimoModelConfig(
+        language_model_spec=language_model_spec(
+            args,
+            language_pg if rank_in_language else None,
+            topology.grids[MIMO_LANGUAGE_MODULE_KEY],
+        ),
+        modality_submodules_spec=modality_submodules_spec,
+        special_token_ids=special_token_ids,
+        module_to_grid_map=topology.grids,
+    )
+
+    mimo_model = MimoModel(
+        mimo_config,
+        cp_group=language_pg.cp if rank_in_language else None,
+        tp_group=language_pg.tp if rank_in_language else None,
+    )
+    mimo_model.to(torch.device("cuda"))
+    if not getattr(args, "fp32", False):
+        mimo_model.to(torch.bfloat16)
+
+    # --- 5. DDP-wrap the active submodules (per-submodule DDP). ------------
+    wrap_active_modules_with_ddp(args, mimo_model, topology)
+
+    # --- 6. Attach this rank's per-module PGC for the stock train() path. --
+    # train()/training_log reads model.pg_collection for DP-keyed reductions and
+    # logging. This is the PER-MODULE PGC (language on LLM ranks, encoder on
+    # encoder ranks) -- NOT topology.schedule_pg_collection (the multi-module
+    # collection the schedule consumes). They are kept distinct deliberately.
+    rank_pg_collection = language_pg if rank_in_language else encoder_pg
+    mimo_model.pg_collection = rank_pg_collection
+
+    # --- 7. Install the dual (language + encoder) grad-finalization hook. --
+    configure_grad_sync(args, mimo_model, topology)
+
+    # --- 8. p2p communicator + role-aware data iterator. ------------------
+    communicator = build_pipeline_communicator(mimo_model, topology)
+    data_iterator = select_data_iterator(args, topology)
+
+    return MimoRuntime(
+        model=[mimo_model],
+        topology=topology,
+        communicator=communicator,
+        data_iterator=data_iterator,
+        pg_collection=rank_pg_collection,
+    )
+
+
+def build_pipeline_communicator(
+    model: MimoModel, topology: HeteroTopology
+) -> MultiModulePipelineCommunicator:
+    """Build the MIMO cross-module P2P communicator the train schedule uses.
+
+    Ported from the prototype (hetero/loop.py:250). The vision encoder emits a
+    2D ``[B*S, H]`` activation, so its ``module_output_ndim`` is 2; the language
+    module keeps the default 3D. ``model.config`` is the canonical
+    ``ModelParallelConfig`` (the MimoModel's language config), identical on every
+    rank, which the communicator uses for shape/dtype bookkeeping on cross-module
+    transfers.
+    """
+    encoder_name = _encoder_module_name(topology)
+    module_output_ndim = {}
+    if encoder_name is not None:
+        module_output_ndim[encoder_name] = 2
+
+    return MultiModulePipelineCommunicator(
+        topology.grids,
+        _module_dependency_map(topology),
+        model.config,
+        dim_mapping={"s": 0, "h": 2, "b": 1},
+        module_output_ndim=module_output_ndim,
+    )

--- a/examples/mimo/training/bootstrap.py
+++ b/examples/mimo/training/bootstrap.py
@@ -91,52 +91,37 @@ def _seed_module_rng(
     )
 
 
-def build_mimo_runtime(args: argparse.Namespace) -> MimoRuntime:
-    """Assemble the per-rank hetero MIMO runtime and return a :class:`MimoRuntime`.
-
-    Builds the grid specs and topology, seeds per-role RNG, constructs the role
-    ``MimoModel`` without a top-level DDP wrap (the MIMO optimizer needs
-    per-submodule DDP), DDP-wraps the active submodules, attaches the per-module
-    PGC, installs the grad-finalization hook, and builds the p2p communicator and
-    data iterator.
-    """
-    world_size = torch.distributed.get_world_size()
-    specs = build_module_grid_specs(args, world_size)
-    topology = create_topology(specs)
-
-    # --- 2. Resolve this rank's role from the per-module grids. ------------
-    # Non-colocated: each rank is in exactly one module grid. A grid membership
-    # check (is_current_rank_in_grid) is the source of truth; module_pgs only
-    # carries the collections for modules this rank participates in.
+def _resolve_role(topology: HeteroTopology):
+    """Resolve this rank's module role from the grids (non-colocated: one grid per rank)."""
     encoder_name = _encoder_module_name(topology)
     rank_in_language = topology.grids[MIMO_LANGUAGE_MODULE_KEY].is_current_rank_in_grid()
     rank_in_encoder = (
-        encoder_name is not None
-        and topology.grids[encoder_name].is_current_rank_in_grid()
+        encoder_name is not None and topology.grids[encoder_name].is_current_rank_in_grid()
     )
-
     language_pg = topology.module_pgs.get(MIMO_LANGUAGE_MODULE_KEY)
     encoder_pg = topology.module_pgs.get(encoder_name) if encoder_name is not None else None
+    return encoder_name, rank_in_language, rank_in_encoder, language_pg, encoder_pg
 
-    # --- 3. Seed RNG for the single active module role on this rank. -------
-    # The CUDA RNG tracker is process-global; the non-colocated layout puts
-    # exactly one module on each rank, so each rank seeds RNG for one role via
-    # the stock _set_random_seed, threading that role's parallel groups.
-    if rank_in_language:
-        assert language_pg is not None
-        _seed_module_rng(args, language_pg, _LANGUAGE_SEED_OFFSET)
-    elif rank_in_encoder:
-        assert encoder_pg is not None
-        _seed_module_rng(args, encoder_pg, _ENCODER_SEED_OFFSET)
 
-    # --- 4. Build the role MimoModel (no top-level DDP). -------------------
+def mimo_model_provider(
+    pre_process: bool = True,
+    post_process: bool = True,
+    vp_stage=None,
+    *,
+    config=None,
+    pg_collection=None,
+    topology: HeteroTopology,
+    args: argparse.Namespace,
+) -> MimoModel:
+    """Build this rank's bare ``MimoModel`` (no DDP wrap). get_model-shaped provider."""
+    encoder_name, rank_in_language, rank_in_encoder, language_pg, _ = _resolve_role(topology)
+
     modality_submodules_spec = {}
     special_token_ids = {}
     if encoder_name is not None:
+        encoder_pg = topology.module_pgs.get(encoder_name)
         modality_submodules_spec[encoder_name] = vision_submodules_spec(
-            args,
-            encoder_pg if rank_in_encoder else None,
-            topology.grids[encoder_name],
+            args, encoder_pg if rank_in_encoder else None, topology.grids[encoder_name]
         )
         special_token_ids[encoder_name] = args.image_token_id
 
@@ -150,15 +135,40 @@ def build_mimo_runtime(args: argparse.Namespace) -> MimoRuntime:
         special_token_ids=special_token_ids,
         module_to_grid_map=topology.grids,
     )
-
     mimo_model = MimoModel(
         mimo_config,
         cp_group=language_pg.cp if rank_in_language else None,
         tp_group=language_pg.tp if rank_in_language else None,
     )
     mimo_model.to(torch.device("cuda"))
-    if not getattr(args, "fp32", False):
-        mimo_model.to(torch.bfloat16)
+    return mimo_model
+
+
+def build_mimo_runtime(args: argparse.Namespace) -> MimoRuntime:
+    """Assemble the per-rank hetero MIMO runtime and return a :class:`MimoRuntime`.
+
+    Builds the grid specs and topology, seeds per-role RNG, constructs the role
+    ``MimoModel`` without a top-level DDP wrap (the MIMO optimizer needs
+    per-submodule DDP), DDP-wraps the active submodules, attaches the per-module
+    PGC, installs the grad-finalization hook, and builds the p2p communicator and
+    data iterator.
+    """
+    world_size = torch.distributed.get_world_size()
+    specs = build_module_grid_specs(args, world_size)
+    topology = create_topology(specs)
+
+    # --- 2. Resolve this rank's role; seed per-role RNG; build the bare model. --
+    _, rank_in_language, rank_in_encoder, language_pg, encoder_pg = _resolve_role(topology)
+
+    if rank_in_language:
+        assert language_pg is not None
+        _seed_module_rng(args, language_pg, _LANGUAGE_SEED_OFFSET)
+    elif rank_in_encoder:
+        assert encoder_pg is not None
+        _seed_module_rng(args, encoder_pg, _ENCODER_SEED_OFFSET)
+
+    # Same provider pretrain() receives; build_mimo_runtime is its single call site.
+    mimo_model = mimo_model_provider(topology=topology, args=args)
 
     # --- 5. DDP-wrap the active submodules (per-submodule DDP). ------------
     wrap_active_modules_with_ddp(args, mimo_model, topology)

--- a/examples/mimo/training/bootstrap.py
+++ b/examples/mimo/training/bootstrap.py
@@ -1,29 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Runtime orchestrator for hetero MIMO training on the stock Megatron loop.
-
-This is PR-E4 of the NMFW-516 hetero-MIMO upstreaming effort. It wires together
-the merged glue (E1 model provider, E2 topology/grid args, E3 forward step) plus
-the in-flight RNG/DDP (MM2), grad-sync (MM3), and data-selection modules into a
-single :func:`build_mimo_runtime` entry the stock ``train()`` can consume.
-
-Scope: the NON-COLOCATED nemotron VLM path only (encoder grid and language grid
-occupy disjoint rank spans). The colocated three-phase schedule is out of scope
-here.
-
-``build_mimo_runtime`` is deliberately kept in this ``bootstrap.py`` module rather
-than ``runtime.py`` (which MM2 / #5285 owns). At final integration the two may
-fold together, but keeping them separate avoids clobbering MM2's file while both
-PRs are in flight.
-
-Boundary with the stock loop (handoff section 3): the entry PR (E5) bypasses
-``setup_model_and_optimizer`` -- which would call ``get_model`` and re-wrap a
-single top-level DDP -- and instead calls ``build_mimo_runtime`` to assemble the
-per-submodule-DDP MimoModel, then hands the resulting model list straight to the
-stock ``train()``. The optimizer is built separately (the prototype's
-``get_mimo_optimizer`` needs the per-submodule DDP wrapping this function
-performs, which is why no top-level DDP wrap is applied here).
-"""
+"""Per-rank heterogeneous MIMO runtime assembly for the non-colocated nemotron VLM path."""
 
 from __future__ import annotations
 
@@ -48,44 +25,22 @@ from megatron.core.models.mimo.model.base import MimoModel
 from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
 from megatron.core.process_groups_config import ProcessGroupCollection
 
-# RNG role offsets, matched to the prototype (hetero/runtime.py): the language
-# module seeds from +20_000, the vision encoder from +10_000. Distinct offsets
-# keep the (process-global) CUDA RNG tracker independent across module roles.
+# RNG role offsets: distinct offsets keep the process-global CUDA RNG tracker
+# independent across module roles (language +20_000, vision encoder +10_000).
 _LANGUAGE_SEED_OFFSET = 20_000
 _ENCODER_SEED_OFFSET = 10_000
 
 
 @dataclass
 class MimoRuntime:
-    """Everything the stock ``train()`` entry (E5) needs to drive a hetero MIMO run.
+    """Per-rank state the stock ``train()`` needs to drive a hetero MIMO run.
 
-    Fields:
-        model:
-            The DDP-wrapped :class:`MimoModel` for this rank, returned as a
-            single-element list so it drops straight into the stock ``train()``
-            ``model`` argument (which always expects a list of model chunks).
-            ``model[0].pg_collection`` carries this rank's per-module PGC (see
-            below); ``model[0].config`` is the language ``TransformerConfig``
-            already carrying the MIMO ``finalize_model_grads_func`` /
-            ``grad_scale_func`` installed by :func:`configure_grad_sync`.
-        topology:
-            The :class:`HeteroTopology`. The schedule reads
-            ``topology.schedule_pg_collection`` (the per-rank
-            ``MultiModuleProcessGroupCollection``) and the p2p communicator is
-            built from ``topology.grids``.
-        communicator:
-            The :class:`MultiModulePipelineCommunicator` the MIMO schedule uses
-            for cross-module (encoder->language) P2P.
-        data_iterator:
-            This rank's role-aware data iterator, or ``None`` when the rank
-            consumes no data (interior PP stages).
-        pg_collection:
-            This rank's per-module :class:`ProcessGroupCollection` (the language
-            PGC on language-grid ranks, else the encoder PGC). Identical object
-            to ``model.pg_collection``; surfaced here so the entry need not reach
-            into the model. Distinct from ``topology.schedule_pg_collection``
-            (the multi-module collection) -- see the module docstring and the
-            ``pg_collection`` note in :func:`build_mimo_runtime`.
+    Attributes:
+        model: Single-element list holding this rank's DDP-wrapped :class:`MimoModel`.
+        topology: The :class:`HeteroTopology` carrying grids and the schedule PGC.
+        communicator: The :class:`MultiModulePipelineCommunicator` for cross-module P2P.
+        data_iterator: This rank's role-aware data iterator, or ``None`` if it consumes no data.
+        pg_collection: This rank's per-module PGC (language on LLM ranks, else encoder).
     """
 
     model: list
@@ -104,9 +59,8 @@ def _encoder_module_name(topology: HeteroTopology) -> Optional[str]:
 def _module_dependency_map(topology: HeteroTopology) -> dict:
     """Build the encoder->language dependency map the communicator's topology arg needs.
 
-    Mirrors the prototype's ``HeteroTopology.module_dependency_map``: the encoder
-    feeds the language module, the language module feeds nothing. LLM-only runs
-    have no edges.
+    The encoder feeds the language module, the language module feeds nothing;
+    LLM-only runs have no edges.
     """
     encoder_name = _encoder_module_name(topology)
     if encoder_name is None:
@@ -115,30 +69,13 @@ def _module_dependency_map(topology: HeteroTopology) -> dict:
 
 
 def build_mimo_runtime(args: argparse.Namespace) -> MimoRuntime:
-    """Assemble the per-rank hetero MIMO runtime for the stock training loop.
+    """Assemble the per-rank hetero MIMO runtime and return a :class:`MimoRuntime`.
 
-    Ports the prototype build sequence (hetero/runtime.py +
-    hetero/loop.py:86-150), dropping the prototype's bespoke loop, logging,
-    prefetch, timeline, and checkpoint machinery: those are owned by the stock
-    ``train()`` (E5) or deferred to later PRs.
-
-    Steps:
-      1. Build the per-module grid specs (E2) and the topology (E2/E3).
-      2. Determine which module(s) live on this rank from the topology grids.
-      3. Seed RNG per active module role (encoder vs language get distinct
-         offsets) via MM2's :func:`configure_module_rng`.
-      4. Assemble the language and/or vision ``ModuleSpec`` (E1) and construct
-         the role ``MimoModel`` -- WITHOUT a top-level DDP wrap, because the MIMO
-         optimizer needs per-submodule DDP.
-      5. DDP-wrap the active submodules (MM2 :func:`wrap_active_modules_with_ddp`).
-      6. Attach this rank's per-module PGC as ``mimo_model.pg_collection`` for the
-         stock ``train()`` / ``training_log`` path.
-      7. Install the dual grad-finalization hook (MM3
-         :func:`configure_grad_sync`).
-      8. Build the p2p communicator and select this rank's data iterator.
-
-    Returns a :class:`MimoRuntime` (see its docstring for the consumption
-    contract).
+    Builds the grid specs and topology, seeds per-role RNG, constructs the role
+    ``MimoModel`` without a top-level DDP wrap (the MIMO optimizer needs
+    per-submodule DDP), DDP-wraps the active submodules, attaches the per-module
+    PGC, installs the grad-finalization hook, and builds the p2p communicator and
+    data iterator.
     """
     world_size = torch.distributed.get_world_size()
     specs = build_module_grid_specs(args, world_size)
@@ -231,12 +168,11 @@ def build_pipeline_communicator(
 ) -> MultiModulePipelineCommunicator:
     """Build the MIMO cross-module P2P communicator the train schedule uses.
 
-    Ported from the prototype (hetero/loop.py:250). The vision encoder emits a
-    2D ``[B*S, H]`` activation, so its ``module_output_ndim`` is 2; the language
-    module keeps the default 3D. ``model.config`` is the canonical
-    ``ModelParallelConfig`` (the MimoModel's language config), identical on every
-    rank, which the communicator uses for shape/dtype bookkeeping on cross-module
-    transfers.
+    The vision encoder emits a 2D ``[B*S, H]`` activation, so its
+    ``module_output_ndim`` is 2; the language module keeps the default 3D.
+    ``model.config`` is the canonical ``ModelParallelConfig`` (the MimoModel's
+    language config), identical on every rank, used for shape/dtype bookkeeping
+    on cross-module transfers.
     """
     encoder_name = _encoder_module_name(topology)
     module_output_ndim = {}

--- a/examples/mimo/training/bootstrap.py
+++ b/examples/mimo/training/bootstrap.py
@@ -17,13 +17,14 @@ from examples.mimo.model_providers.nemotron_moe_vlm import (
 from examples.mimo.training.args import build_module_grid_specs
 from examples.mimo.training.data import select_data_iterator
 from examples.mimo.training.grad_sync import configure_grad_sync
-from examples.mimo.training.runtime import configure_module_rng, wrap_active_modules_with_ddp
+from examples.mimo.training.runtime import wrap_active_modules_with_ddp
 from examples.mimo.training.topology import HeteroTopology, create_topology
 from megatron.core.models.mimo.config.base_configs import MimoModelConfig
 from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 from megatron.core.models.mimo.model.base import MimoModel
 from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.training.initialize import _set_random_seed
 
 # RNG role offsets: distinct offsets keep the process-global CUDA RNG tracker
 # independent across module roles (language +20_000, vision encoder +10_000).
@@ -68,6 +69,28 @@ def _module_dependency_map(topology: HeteroTopology) -> dict:
     return {encoder_name: [MIMO_LANGUAGE_MODULE_KEY], MIMO_LANGUAGE_MODULE_KEY: []}
 
 
+def _seed_module_rng(
+    args: argparse.Namespace, pg_collection: ProcessGroupCollection, role_seed_offset: int
+) -> None:
+    """Seed host + per-module CUDA RNG for one module role via the stock _set_random_seed.
+
+    A per-role offset keeps disjoint modules' RNG independent; the role's parallel
+    groups supply the pp/dp/tp/ep/etp ranks since these ranks have no initialized mpu.
+    """
+    _set_random_seed(
+        args.seed + role_seed_offset,
+        args.data_parallel_random_init,
+        args.te_rng_tracker,
+        args.inference_rng_tracker,
+        use_cudagraphable_rng=args.cuda_graph_impl != "none",
+        pp_group=pg_collection.pp,
+        dp_group=pg_collection.dp_cp,
+        tp_group=pg_collection.tp,
+        ep_group=pg_collection.ep,
+        etp_group=pg_collection.expt_tp,
+    )
+
+
 def build_mimo_runtime(args: argparse.Namespace) -> MimoRuntime:
     """Assemble the per-rank hetero MIMO runtime and return a :class:`MimoRuntime`.
 
@@ -97,13 +120,14 @@ def build_mimo_runtime(args: argparse.Namespace) -> MimoRuntime:
 
     # --- 3. Seed RNG for the single active module role on this rank. -------
     # The CUDA RNG tracker is process-global; the non-colocated layout puts
-    # exactly one module on each rank, so each rank configures RNG for one role.
+    # exactly one module on each rank, so each rank seeds RNG for one role via
+    # the stock _set_random_seed, threading that role's parallel groups.
     if rank_in_language:
         assert language_pg is not None
-        configure_module_rng(args, language_pg, role_seed_offset=_LANGUAGE_SEED_OFFSET)
+        _seed_module_rng(args, language_pg, _LANGUAGE_SEED_OFFSET)
     elif rank_in_encoder:
         assert encoder_pg is not None
-        configure_module_rng(args, encoder_pg, role_seed_offset=_ENCODER_SEED_OFFSET)
+        _seed_module_rng(args, encoder_pg, _ENCODER_SEED_OFFSET)
 
     # --- 4. Build the role MimoModel (no top-level DDP). -------------------
     modality_submodules_spec = {}

--- a/examples/mimo/training/data.py
+++ b/examples/mimo/training/data.py
@@ -155,6 +155,13 @@ class MockVLMIterator:
             device="cuda",
             generator=self.generator,
         )
+        # Mock text tokens must never equal the image placeholder id: otherwise input_ids
+        # holds more image_token_id positions than there are image embeddings, and the
+        # MimoModel embedding alignment raises ValueError (crashing the language ranks).
+        _collision = text_tokens == args.image_token_id
+        if _collision.any():
+            text_tokens = text_tokens.clone()
+            text_tokens[_collision] = (args.image_token_id % (args.vocab_size - 1)) + 1
         input_ids = torch.cat([image_tokens, text_tokens], dim=1)
         labels = torch.full_like(input_ids, -100)
         labels[:, :-1] = input_ids[:, 1:]

--- a/examples/mimo/training/data.py
+++ b/examples/mimo/training/data.py
@@ -17,10 +17,9 @@ from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_
 
 
 def add_data_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    """Register the MIMO data-selection args (stock extra_args_provider compatible).
+    """Register the MIMO data-selection args (extra_args_provider compatible).
 
-    Only the mock provider is supported for now; energon/mistral backends are
-    deferred to a later PR.
+    Only the mock provider is currently supported.
     """
     group = parser.add_argument_group("mimo data")
     group.add_argument(
@@ -35,7 +34,7 @@ def add_data_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
 def select_data_iterator(args: argparse.Namespace, topology: HeteroTopology) -> Optional[object]:
     """Create the per-role data iterator this rank needs, or None if it consumes no data."""
     if getattr(args, "dataset_provider", "mock") != "mock":
-        # Energon/mistral provider backends are deferred to a later PR.
+        # Only the mock provider is currently supported.
         raise ValueError(f"unsupported dataset provider: {args.dataset_provider}")
     return select_mock_data_iterator(args, topology)
 
@@ -96,14 +95,7 @@ def _encoder_name(topology: HeteroTopology) -> Optional[str]:
 
 
 def _even_patch_grid(num_patches: int) -> tuple[int, int]:
-    """Factor ``num_patches`` into an even (rows, cols) patch grid.
-
-    The dynamic-resolution RADIO path runs ``_pixel_shuffle_dynamic_res``, which
-    reshapes each image's patches into ``(rows, cols, c)`` and then halves both
-    axes (scale_factor=0.5). Both ``rows`` and ``cols`` must therefore be even.
-    A near-square factorization keeps the synthetic aspect ratio sane and the CPE
-    position-embedding interpolation well-conditioned.
-    """
+    """Factor ``num_patches`` into a near-square even (rows, cols) patch grid (both axes even)."""
     assert num_patches % 4 == 0, (
         f"per-image patch count {num_patches} must be divisible by 4 so the "
         "pixel-shuffle (0.5x on each axis) produces an integer token count"
@@ -134,13 +126,7 @@ class MockVLMIterator:
         self.encoder_name = encoder_name
         self.image_seq_length = args.image_seq_length or args.seq_length // 2
         self.vision_encoder_key = getattr(args, "vision_encoder_key", "clip_encoder")
-        # Pixel-input encoders (e.g. the Nemotron RADIO provider sets
-        # ``vision_input_mode="pixels"``) take a raw image tensor as the
-        # positional ``x`` arg of their wrapper's forward. Hidden-state encoders
-        # (the CLIP/mock path) instead receive a precomputed ``hidden_states``
-        # tensor. Feeding the wrong key/shape makes ``ModalitySubmodules.encode``
-        # call the encoder with kwargs its forward never accepts, which aborts
-        # the encoder forward before it reaches send_forward.
+        # "pixels" encoders take a raw image tensor; hidden-state encoders take precomputed states.
         self.vision_input_mode = getattr(args, "vision_input_mode", "hidden_states")
         self.dynamic_resolution = bool(getattr(args, "dynamic_resolution", False))
         self.patch_dim = getattr(args, "patch_dim", 16)
@@ -177,18 +163,7 @@ class MockVLMIterator:
         modality_inputs = {}
         if self.encoder_name is not None:
             if self.vision_input_mode == "pixels" and self.dynamic_resolution:
-                # Dynamic-resolution RADIO (the Nemotron6-MoE VLM preset sets
-                # ``dynamic_resolution=True``) does NOT accept a fixed-tile
-                # (N, 3, H, W) pixel batch. Its forward expects the packed-patch
-                # format produced by DynamicResolutionImageTilingStrategy.stack:
-                #   x:                [1, total_patches, 3*p*p]   (pre-patchified)
-                #   imgs_sizes:       (N_images, 2) int32 (H, W) in *pixels*
-                #   packed_seq_params: THD PackedSeqParams over the per-image
-                #                      patch counts (variable-length attention).
-                # Feeding the fixed-tile (N,3,H,W) tensor with imgs_sizes=None
-                # drives RADIOViTModel.forward down its dynamic branch with no
-                # per-image splits, stalling/desyncing the encoder before it can
-                # send_forward. Replicate the prototype's packed mock exactly.
+                # Dynamic-resolution RADIO consumes packed-patch inputs (x/imgs_sizes/packed_seq_params).
                 encoder_inputs = self._build_dynamic_resolution_pixels(args)
             elif self.vision_input_mode == "pixels":
                 # Fixed-tile RADIO (``--no-dynamic-resolution``): the wrapper's
@@ -237,20 +212,7 @@ class MockVLMIterator:
         }
 
     def _build_dynamic_resolution_pixels(self, args: argparse.Namespace) -> dict:
-        """Build the packed-patch RADIO inputs for the dynamic-resolution path.
-
-        Emits ``micro_batch_size * num_image_tiles`` synthetic images whose
-        per-image RADIO output token count sums to exactly ``image_seq_length``
-        per sample, so the count matches the ``image_seq_length`` placeholder
-        image tokens MimoModel scatters embeddings into (a hard equality check
-        in ``combine_embeddings``). RADIO drops ``class_token_len`` tokens per
-        image and applies a 0.5x pixel shuffle on each axis (output = patches/4),
-        so per-image patches = 4 * (image_seq_length / num_image_tiles).
-
-        Returns the encoder-input dict with ``x``/``imgs_sizes``/
-        ``packed_seq_params`` keyed under ``vision_encoder_key``, matching
-        DynamicResolutionImageTilingStrategy.stack.
-        """
+        """Build packed-patch RADIO inputs whose per-image token counts sum to ``image_seq_length``."""
         num_images = self.num_image_tiles
         if self.image_seq_length % num_images != 0:
             raise ValueError(
@@ -263,9 +225,7 @@ class MockVLMIterator:
         h_pix = rows * self.patch_dim
         w_pix = cols * self.patch_dim
 
-        # Per-image patchified features: rearrange (c, py*p, px*p) -> (py*px, c*p*p).
-        # The mock emits random patch features directly (shape-equivalent to the
-        # tiling-strategy rearrange) since RADIO's embedder only sees the last dim.
+        # Per-image patchified features of shape (py*px, c*p*p), emitted as random patches.
         feat_dim = 3 * self.patch_dim * self.patch_dim
         total_patches = self.micro_batch_size * num_images * patches_per_image
         x = torch.randn(
@@ -278,16 +238,8 @@ class MockVLMIterator:
         )
 
         n_images_total = self.micro_batch_size * num_images
-        # imgs_sizes and the packed-seq cu_seqlens/max_seqlen are *metadata*, not
-        # data, and must live on CPU to match the prototype's energon tiling
-        # strategy (DynamicResolutionImageTilingStrategy.stack builds plain CPU
-        # tensors). RADIOViTModel.forward iterates imgs_sizes in Python and uses
-        # the per-image patch counts as slice bounds and as the THD cu_seqlens fed
-        # to TE attention; placing them on CUDA forces a blocking device->host
-        # sync on every iteration (and TE expects int32 cu_seqlens on CPU), which
-        # is the kind of degenerate host<->device round-trip that stalls the
-        # encode before the transformer layers. Only ``x`` (the real activation)
-        # is created on CUDA.
+        # imgs_sizes and cu_seqlens/max_seqlen are CPU metadata (TE expects int32 cu_seqlens
+        # on CPU); only ``x`` is created on CUDA.
         imgs_sizes = torch.tensor(
             [[h_pix, w_pix]] * n_images_total, dtype=torch.int32
         )

--- a/examples/mimo/training/data.py
+++ b/examples/mimo/training/data.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Role-aware data iterator selection for heterogeneous MIMO training."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from typing import Optional
+
+import torch
+
+from examples.mimo.training.topology import HeteroTopology
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
+
+
+def add_data_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Register the MIMO data-selection args (stock extra_args_provider compatible).
+
+    Only the mock provider is supported for now; energon/mistral backends are
+    deferred to a later PR.
+    """
+    group = parser.add_argument_group("mimo data")
+    group.add_argument(
+        "--dataset-provider",
+        choices=["mock"],
+        default="mock",
+        help="Which MIMO dataset backend to build (mock only for now).",
+    )
+    return parser
+
+
+def select_data_iterator(args: argparse.Namespace, topology: HeteroTopology) -> Optional[object]:
+    """Create the per-role data iterator this rank needs, or None if it consumes no data."""
+    if getattr(args, "dataset_provider", "mock") != "mock":
+        # Energon/mistral provider backends are deferred to a later PR.
+        raise ValueError(f"unsupported dataset provider: {args.dataset_provider}")
+    return select_mock_data_iterator(args, topology)
+
+
+def select_mock_data_iterator(
+    args: argparse.Namespace, topology: HeteroTopology
+) -> Optional["MockVLMIterator"]:
+    """Pick the mock iterator for this rank's role: encoder PP-first or language PP-edge stages."""
+    encoder_name = _encoder_name(topology)
+    llm_grid = topology.grids[MIMO_LANGUAGE_MODULE_KEY]
+    llm_pgc = topology.module_pgs[MIMO_LANGUAGE_MODULE_KEY]
+    llm_mbs = args.micro_batch_size
+
+    llm_needs_data = llm_grid.is_current_rank_in_grid() and (
+        is_pp_first_stage(llm_pgc.pp) or is_pp_last_stage(llm_pgc.pp)
+    )
+
+    if encoder_name is None:
+        if llm_needs_data:
+            return MockVLMIterator(
+                args, llm_mbs, encoder_name, get_mock_data_seed(args, llm_pgc, 100_000)
+            )
+        return None
+
+    encoder_grid = topology.grids[encoder_name]
+    encoder_pgc = topology.module_pgs[encoder_name]
+    if (args.micro_batch_size * args.llm_dp) % args.encoder_dp != 0:
+        raise ValueError("micro_batch_size * llm_dp must be divisible by encoder_dp")
+    encoder_mbs = args.micro_batch_size * args.llm_dp // args.encoder_dp
+
+    encoder_needs_data = encoder_grid.is_current_rank_in_grid() and is_pp_first_stage(
+        encoder_pgc.pp
+    )
+
+    # A rank in the language grid always feeds the language batch (PP-edge stages); a pure-encoder
+    # rank feeds the encoder batch. Colocated ranks (in both) follow the language schedule.
+    if llm_needs_data:
+        return MockVLMIterator(
+            args, llm_mbs, encoder_name, get_mock_data_seed(args, llm_pgc, 100_000)
+        )
+    if encoder_needs_data:
+        return MockVLMIterator(
+            args, encoder_mbs, encoder_name, get_mock_data_seed(args, encoder_pgc, 0)
+        )
+    return None
+
+
+def get_mock_data_seed(args: argparse.Namespace, pg_collection, module_seed_offset: int) -> int:
+    """Seed mock data per DP lane so PP/TP stages in a lane see coherent batches."""
+    dp_lane = pg_collection.dp.rank() if pg_collection.dp is not None else 0
+    return args.seed + module_seed_offset + dp_lane
+
+
+def _encoder_name(topology: HeteroTopology) -> Optional[str]:
+    """Return the single modality (encoder) grid name, or None for a language-only run."""
+    modality = [name for name in topology.grids if name != MIMO_LANGUAGE_MODULE_KEY]
+    return modality[0] if modality else None
+
+
+def _even_patch_grid(num_patches: int) -> tuple[int, int]:
+    """Factor ``num_patches`` into an even (rows, cols) patch grid.
+
+    The dynamic-resolution RADIO path runs ``_pixel_shuffle_dynamic_res``, which
+    reshapes each image's patches into ``(rows, cols, c)`` and then halves both
+    axes (scale_factor=0.5). Both ``rows`` and ``cols`` must therefore be even.
+    A near-square factorization keeps the synthetic aspect ratio sane and the CPE
+    position-embedding interpolation well-conditioned.
+    """
+    assert num_patches % 4 == 0, (
+        f"per-image patch count {num_patches} must be divisible by 4 so the "
+        "pixel-shuffle (0.5x on each axis) produces an integer token count"
+    )
+    cols = int(math.isqrt(num_patches))
+    while cols > 1 and (num_patches % cols != 0 or (num_patches // cols) % 2 != 0 or cols % 2 != 0):
+        cols -= 1
+    rows = num_patches // cols
+    assert rows % 2 == 0 and cols % 2 == 0 and rows * cols == num_patches
+    return rows, cols
+
+
+class MockVLMIterator:
+    """Infinite iterator yielding synthetic VLM-like next-token microbatches.
+
+    Minimal self-contained mock so data selection is testable without a provider backend.
+    """
+
+    def __init__(
+        self,
+        args: argparse.Namespace,
+        micro_batch_size: int,
+        encoder_name: Optional[str],
+        seed: int,
+    ) -> None:
+        self.args = args
+        self.micro_batch_size = micro_batch_size
+        self.encoder_name = encoder_name
+        self.image_seq_length = args.image_seq_length or args.seq_length // 2
+        self.vision_encoder_key = getattr(args, "vision_encoder_key", "clip_encoder")
+        # Pixel-input encoders (e.g. the Nemotron RADIO provider sets
+        # ``vision_input_mode="pixels"``) take a raw image tensor as the
+        # positional ``x`` arg of their wrapper's forward. Hidden-state encoders
+        # (the CLIP/mock path) instead receive a precomputed ``hidden_states``
+        # tensor. Feeding the wrong key/shape makes ``ModalitySubmodules.encode``
+        # call the encoder with kwargs its forward never accepts, which aborts
+        # the encoder forward before it reaches send_forward.
+        self.vision_input_mode = getattr(args, "vision_input_mode", "hidden_states")
+        self.dynamic_resolution = bool(getattr(args, "dynamic_resolution", False))
+        self.patch_dim = getattr(args, "patch_dim", 16)
+        self.num_image_tiles = getattr(args, "num_image_tiles", 1)
+        self.dtype = torch.float32 if args.fp32 else torch.bfloat16
+        self.generator = torch.Generator(device="cuda")
+        self.generator.manual_seed(seed)
+        if self.image_seq_length >= args.seq_length:
+            raise ValueError("--image-seq-length must be smaller than --seq-length")
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        args = self.args
+        image_tokens = torch.full(
+            (self.micro_batch_size, self.image_seq_length),
+            args.image_token_id,
+            dtype=torch.long,
+            device="cuda",
+        )
+        text_tokens = torch.randint(
+            1,
+            args.vocab_size,
+            (self.micro_batch_size, args.seq_length - self.image_seq_length),
+            device="cuda",
+            generator=self.generator,
+        )
+        input_ids = torch.cat([image_tokens, text_tokens], dim=1)
+        labels = torch.full_like(input_ids, -100)
+        labels[:, :-1] = input_ids[:, 1:]
+        labels[(labels == args.image_token_id)] = -100
+        loss_mask = (labels != -100).to(dtype=torch.float32)
+        modality_inputs = {}
+        if self.encoder_name is not None:
+            if self.vision_input_mode == "pixels" and self.dynamic_resolution:
+                # Dynamic-resolution RADIO (the Nemotron6-MoE VLM preset sets
+                # ``dynamic_resolution=True``) does NOT accept a fixed-tile
+                # (N, 3, H, W) pixel batch. Its forward expects the packed-patch
+                # format produced by DynamicResolutionImageTilingStrategy.stack:
+                #   x:                [1, total_patches, 3*p*p]   (pre-patchified)
+                #   imgs_sizes:       (N_images, 2) int32 (H, W) in *pixels*
+                #   packed_seq_params: THD PackedSeqParams over the per-image
+                #                      patch counts (variable-length attention).
+                # Feeding the fixed-tile (N,3,H,W) tensor with imgs_sizes=None
+                # drives RADIOViTModel.forward down its dynamic branch with no
+                # per-image splits, stalling/desyncing the encoder before it can
+                # send_forward. Replicate the prototype's packed mock exactly.
+                encoder_inputs = self._build_dynamic_resolution_pixels(args)
+            elif self.vision_input_mode == "pixels":
+                # Fixed-tile RADIO (``--no-dynamic-resolution``): the wrapper's
+                # forward patchifies a raw (N, 3, img_h, img_w) image tensor.
+                encoder_inputs = {
+                    self.vision_encoder_key: {
+                        "x": torch.randn(
+                            self.micro_batch_size * self.num_image_tiles,
+                            3,
+                            args.img_h,
+                            args.img_w,
+                            device="cuda",
+                            dtype=self.dtype,
+                            generator=self.generator,
+                        )
+                    }
+                }
+            else:
+                # Hidden-state encoders (CLIP/mock) consume a precomputed
+                # encoder hidden-state tensor of shape (image_seq_length,
+                # micro_batch_size, hidden_size).
+                encoder_hidden_states = torch.randn(
+                    self.image_seq_length,
+                    self.micro_batch_size,
+                    args.hidden_size,
+                    device="cuda",
+                    dtype=self.dtype,
+                    generator=self.generator,
+                )
+                encoder_inputs = {
+                    self.vision_encoder_key: {
+                        "hidden_states": encoder_hidden_states,
+                        "attention_mask": None,
+                    }
+                }
+            modality_inputs[self.encoder_name] = encoder_inputs
+        return {
+            "input_ids": input_ids,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "position_ids": torch.arange(args.seq_length, device="cuda")
+            .unsqueeze(0)
+            .expand(self.micro_batch_size, -1)
+            .clone(),
+            "modality_inputs": modality_inputs,
+        }
+
+    def _build_dynamic_resolution_pixels(self, args: argparse.Namespace) -> dict:
+        """Build the packed-patch RADIO inputs for the dynamic-resolution path.
+
+        Emits ``micro_batch_size * num_image_tiles`` synthetic images whose
+        per-image RADIO output token count sums to exactly ``image_seq_length``
+        per sample, so the count matches the ``image_seq_length`` placeholder
+        image tokens MimoModel scatters embeddings into (a hard equality check
+        in ``combine_embeddings``). RADIO drops ``class_token_len`` tokens per
+        image and applies a 0.5x pixel shuffle on each axis (output = patches/4),
+        so per-image patches = 4 * (image_seq_length / num_image_tiles).
+
+        Returns the encoder-input dict with ``x``/``imgs_sizes``/
+        ``packed_seq_params`` keyed under ``vision_encoder_key``, matching
+        DynamicResolutionImageTilingStrategy.stack.
+        """
+        num_images = self.num_image_tiles
+        if self.image_seq_length % num_images != 0:
+            raise ValueError(
+                f"image_seq_length ({self.image_seq_length}) must be divisible by "
+                f"num_image_tiles ({num_images}) for the dynamic-resolution mock"
+            )
+        out_tokens_per_image = self.image_seq_length // num_images
+        patches_per_image = out_tokens_per_image * 4  # undo 0.5x-per-axis pixel shuffle
+        rows, cols = _even_patch_grid(patches_per_image)
+        h_pix = rows * self.patch_dim
+        w_pix = cols * self.patch_dim
+
+        # Per-image patchified features: rearrange (c, py*p, px*p) -> (py*px, c*p*p).
+        # The mock emits random patch features directly (shape-equivalent to the
+        # tiling-strategy rearrange) since RADIO's embedder only sees the last dim.
+        feat_dim = 3 * self.patch_dim * self.patch_dim
+        total_patches = self.micro_batch_size * num_images * patches_per_image
+        x = torch.randn(
+            1,
+            total_patches,
+            feat_dim,
+            device="cuda",
+            dtype=self.dtype,
+            generator=self.generator,
+        )
+
+        n_images_total = self.micro_batch_size * num_images
+        # imgs_sizes and the packed-seq cu_seqlens/max_seqlen are *metadata*, not
+        # data, and must live on CPU to match the prototype's energon tiling
+        # strategy (DynamicResolutionImageTilingStrategy.stack builds plain CPU
+        # tensors). RADIOViTModel.forward iterates imgs_sizes in Python and uses
+        # the per-image patch counts as slice bounds and as the THD cu_seqlens fed
+        # to TE attention; placing them on CUDA forces a blocking device->host
+        # sync on every iteration (and TE expects int32 cu_seqlens on CPU), which
+        # is the kind of degenerate host<->device round-trip that stalls the
+        # encode before the transformer layers. Only ``x`` (the real activation)
+        # is created on CUDA.
+        imgs_sizes = torch.tensor(
+            [[h_pix, w_pix]] * n_images_total, dtype=torch.int32
+        )
+        cu_seqlens = torch.arange(
+            0,
+            (n_images_total + 1) * patches_per_image,
+            patches_per_image,
+            dtype=torch.int32,
+        )
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=torch.tensor(patches_per_image, dtype=torch.int32),
+            max_seqlen_kv=torch.tensor(patches_per_image, dtype=torch.int32),
+        )
+        return {
+            self.vision_encoder_key: {
+                "x": x,
+                "imgs_sizes": imgs_sizes,
+                "packed_seq_params": packed_seq_params,
+            }
+        }

--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 import torch
 
 from megatron.core.dist_checkpointing.mapping import ShardedObject
+from megatron.core.dist_checkpointing.utils import add_prefix_for_sharding
 from megatron.core.optimizer.clip_grads import clip_grad_by_total_norm_fp32
 from megatron.core.optimizer.optimizer import MegatronOptimizer
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
@@ -179,6 +180,9 @@ class MimoOptimizer(MegatronOptimizer):
                     _extract_param_state_sharding_type(sub_sd, name, suffix, replica_id)
                     _extract_grad_scaler(sub_sd, name, suffix, replica_id)
 
+                # Namespace every internal ShardedBase key with the submodule name
+                # so disjoint grids don't collide on shared distributed-optimizer keys.
+                add_prefix_for_sharding(module_sd, f'mimo.{name}.')
                 sharded_state[name] = module_sd
             else:
                 sharded_state[name] = {}

--- a/megatron/core/models/vision/radio.py
+++ b/megatron/core/models/vision/radio.py
@@ -208,6 +208,7 @@ class RADIOViTModel(VisionModule):
         self.ln_pre = None
         self.ln_post = None
         self.pg_collection = pg_collection
+        self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.vp_stage = vp_stage
         if ln_pre_impl is not None:
             self.ln_pre = build_module(

--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -121,6 +121,7 @@ class GatedDeltaNet(MegatronModule):
         self.use_qk_l2norm = use_qk_l2norm
         assert pg_collection is not None, "pg_collection must be provided for GatedDeltaNet"
         self.pg_collection = pg_collection
+        self.tp_group = pg_collection.tp
         self.cp_size = self.pg_collection.cp.size()
         self.tp_size = self.pg_collection.tp.size()
         self.sp_size = self.tp_size if config.sequence_parallel else 1

--- a/megatron/core/ssm/mamba_layer.py
+++ b/megatron/core/ssm/mamba_layer.py
@@ -81,6 +81,7 @@ class MambaLayer(GraphableMegatronModule):
         """
         super().__init__(config)
         assert pg_collection is not None, "pg_collection must be provided for MambaLayer"
+        self.tp_group = pg_collection.tp
 
         self.config = config
         self.submodules_config = submodules

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -1310,6 +1310,8 @@ class MambaMixer(MegatronModule):
                 "conv1d_bias": 0,
             },
             sharded_offsets=sharded_offsets,
+            tp_group=self.tp_group,
+            dp_cp_group=metadata["dp_cp_group"],
         )
         # Submodules
         for name, module in self.named_children():

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -400,6 +400,7 @@ class MambaMixer(MegatronModule):
             )
             setattr(self.norm.weight, "tensor_model_parallel", True)
             setattr(self.norm.weight, "partition_dim", 0)
+            self.norm.tp_group = self.pg_collection.tp
         # Assume sequence parallelism: input is partitioned along d_inner and
         # output is partitioned along the sequence dimension
         self.out_proj = build_module(

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -500,7 +500,7 @@ def save_grads(save_dir, state_dict, iteration, grad_label):
 
 def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floating_point_operations_so_far,
                     checkpointing_context=None, pipeline_rank=None, expert_rank=None, tensor_rank=None, pipeline_parallel=None, expert_parallel=None, non_persistent_ckpt=False,
-                    train_data_iterator=None, preprocess_common_state_dict_fn = None, release=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None):
+                    train_data_iterator=None, preprocess_common_state_dict_fn = None, release=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None, rng_state_key_prefix: str = ''):
     """Save a model, optimizer and optionally dataloader checkpoint.
 
     Checkpointing context is used to persist some checkpointing state
@@ -564,7 +564,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
         tp_group = mpu.get_tensor_model_parallel_group()
         pp_group = mpu.get_pipeline_model_parallel_group()
     rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
-                              key_prefix=getattr(args, 'rng_state_key_prefix', ''),
+                              key_prefix=rng_state_key_prefix,
                               dp_cp_group=dp_cp_group)
 
     # Collect rerun state across all ranks
@@ -1640,7 +1640,7 @@ def load_args_from_checkpoint(
 
 
 def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', strict=True,
-                    checkpointing_context=None, skip_load_to_model_and_opt=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None):
+                    checkpointing_context=None, skip_load_to_model_and_opt=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None, rng_state_key_prefix: str = ''):
     """Load a model checkpoint and return the iteration.
     strict (bool): whether to strictly enforce that the keys in
         :attr:`state_dict` of the checkpoint match the names of
@@ -1726,7 +1726,7 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                 tp_group = mpu.get_tensor_model_parallel_group()
                 pp_group = mpu.get_pipeline_model_parallel_group()
             gen_sd_rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
-                                             key_prefix=getattr(args, 'rng_state_key_prefix', ''),
+                                             key_prefix=rng_state_key_prefix,
                                              dp_cp_group=dp_cp_group)  # we can load the rng state
         else:
             ignore_rng_state = True

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -2083,9 +2083,13 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
 
+    _tp_r = get_pg_rank(tp_group) if tp_group is not None else mpu.get_tensor_model_parallel_rank()
+    _tp_w = get_pg_size(tp_group) if tp_group is not None else mpu.get_tensor_model_parallel_world_size()
+    _pp_r = get_pg_rank(pp_group) if pp_group is not None else mpu.get_pipeline_model_parallel_rank()
+    _pp_w = get_pg_size(pp_group) if pp_group is not None else mpu.get_pipeline_model_parallel_world_size()
     print_rank_0(f'  successfully loaded checkpoint from {load_dir} '
-                 f'[ t {mpu.get_tensor_model_parallel_rank() + 1}/{mpu.get_tensor_model_parallel_world_size()}, '
-                 f'p {mpu.get_pipeline_model_parallel_rank() + 1}/{mpu.get_pipeline_model_parallel_world_size()} ] '
+                 f'[ t {_tp_r + 1}/{_tp_w}, '
+                 f'p {_pp_r + 1}/{_pp_w} ] '
                  f'at iteration {iteration}')
 
     # Additional callback for wandb (last rank)

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -368,8 +368,14 @@ def read_metadata(tracker_filename):
     return max_iter, release
 
 
-def get_rng_state(ckpt_format: str, tp_group: torch.distributed.ProcessGroup, pp_group: torch.distributed.ProcessGroup) -> Union[List[Dict[str, Any]], ShardedObject]:
-    """Collect rng state across data parallel ranks."""
+def get_rng_state(ckpt_format: str, tp_group: torch.distributed.ProcessGroup, pp_group: torch.distributed.ProcessGroup, key_prefix: str = '') -> Union[List[Dict[str, Any]], ShardedObject]:
+    """Collect rng state across data parallel ranks.
+
+    key_prefix: optional namespace for the torch_dist rng ShardedObject key
+        (default '' = stock 'rng_state'). Lets disjoint grids (e.g. hetero MIMO
+        branches that share a (pp,tp) factorization) avoid an identical-key
+        collision by using distinct prefixes.
+    """
     args = get_args()
     rng_state = {
         'random_rng_state': random.getstate(),
@@ -395,7 +401,7 @@ def get_rng_state(ckpt_format: str, tp_group: torch.distributed.ProcessGroup, pp
         pp_size = get_pg_size(pp_group)
         tp_rank = get_pg_rank(tp_group)
         tp_size = get_pg_size(tp_group)
-        rng_state_list = ShardedObject('rng_state', rng_state_list, (pp_size, tp_size), (pp_rank, tp_rank),
+        rng_state_list = ShardedObject(f'{key_prefix}rng_state', rng_state_list, (pp_size, tp_size), (pp_rank, tp_rank),
                                        replica_id=mpu.get_data_parallel_rank(with_context_parallel=True))
     elif ckpt_format == "fsdp_dtensor":
         pp_rank = mpu.get_pipeline_model_parallel_rank()
@@ -557,7 +563,8 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
     if tp_group is None and pp_group is None:
         tp_group = mpu.get_tensor_model_parallel_group()
         pp_group = mpu.get_pipeline_model_parallel_group()
-    rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group)
+    rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
+                              key_prefix=getattr(args, 'rng_state_key_prefix', ''))
 
     # Collect rerun state across all ranks
     rerun_state_machine = get_rerun_state_machine()
@@ -1716,7 +1723,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
             if tp_group is None and pp_group is None:
                 tp_group = mpu.get_tensor_model_parallel_group()
                 pp_group = mpu.get_pipeline_model_parallel_group()
-            gen_sd_rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group)  # we can load the rng state
+            gen_sd_rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
+                                             key_prefix=getattr(args, 'rng_state_key_prefix', ''))  # we can load the rng state
         else:
             ignore_rng_state = True
             gen_sd_rng_state = None

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -371,10 +371,7 @@ def read_metadata(tracker_filename):
 def get_rng_state(ckpt_format: str, tp_group: torch.distributed.ProcessGroup, pp_group: torch.distributed.ProcessGroup, key_prefix: str = '') -> Union[List[Dict[str, Any]], ShardedObject]:
     """Collect rng state across data parallel ranks.
 
-    key_prefix: optional namespace for the torch_dist rng ShardedObject key
-        (default '' = stock 'rng_state'). Lets disjoint grids (e.g. hetero MIMO
-        branches that share a (pp,tp) factorization) avoid an identical-key
-        collision by using distinct prefixes.
+    key_prefix namespaces the rng ShardedObject key so disjoint grids avoid a key collision (default '').
     """
     args = get_args()
     rng_state = {

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -368,10 +368,11 @@ def read_metadata(tracker_filename):
     return max_iter, release
 
 
-def get_rng_state(ckpt_format: str, tp_group: torch.distributed.ProcessGroup, pp_group: torch.distributed.ProcessGroup, key_prefix: str = '') -> Union[List[Dict[str, Any]], ShardedObject]:
+def get_rng_state(ckpt_format: str, tp_group: torch.distributed.ProcessGroup, pp_group: torch.distributed.ProcessGroup, key_prefix: str = '', dp_cp_group: Optional[torch.distributed.ProcessGroup] = None) -> Union[List[Dict[str, Any]], ShardedObject]:
     """Collect rng state across data parallel ranks.
 
     key_prefix namespaces the rng ShardedObject key so disjoint grids avoid a key collision (default '').
+    dp_cp_group threads the data-parallel (with context-parallel) group; None falls back to the mpu API.
     """
     args = get_args()
     rng_state = {
@@ -381,28 +382,30 @@ def get_rng_state(ckpt_format: str, tp_group: torch.distributed.ProcessGroup, pp
         'cuda_rng_state': torch.cuda.get_rng_state(),
         'rng_tracker_states': tensor_parallel.get_cuda_rng_tracker().get_states()}
 
+    dp_world_size = get_pg_size(dp_cp_group) if dp_cp_group is not None else mpu.get_data_parallel_world_size()
     rng_state_list = None
     if args.data_parallel_random_init and torch.distributed.is_initialized() and \
-            mpu.get_data_parallel_world_size() > 1:
+            dp_world_size > 1:
         rng_state_list = \
-            [None for i in range(mpu.get_data_parallel_world_size())]
+            [None for i in range(dp_world_size)]
         torch.distributed.all_gather_object(
             rng_state_list,
             rng_state,
-            group=mpu.get_data_parallel_group())
+            group=dp_cp_group if dp_cp_group is not None else mpu.get_data_parallel_group())
     else:
         rng_state_list = [rng_state]
 
+    dp_cp_rank = get_pg_rank(dp_cp_group) if dp_cp_group is not None else mpu.get_data_parallel_rank(with_context_parallel=True)
     if ckpt_format == "torch_dist":
         pp_rank = get_pg_rank(pp_group)
         pp_size = get_pg_size(pp_group)
         tp_rank = get_pg_rank(tp_group)
         tp_size = get_pg_size(tp_group)
         rng_state_list = ShardedObject(f'{key_prefix}rng_state', rng_state_list, (pp_size, tp_size), (pp_rank, tp_rank),
-                                       replica_id=mpu.get_data_parallel_rank(with_context_parallel=True))
+                                       replica_id=dp_cp_rank)
     elif ckpt_format == "fsdp_dtensor":
-        pp_rank = mpu.get_pipeline_model_parallel_rank()
-        tp_rank = mpu.get_tensor_model_parallel_rank()
+        pp_rank = get_pg_rank(pp_group)
+        tp_rank = get_pg_rank(tp_group)
         rng_state_list = {
             f"({pp_rank}, {tp_rank})": rng_state_list
         }
@@ -561,7 +564,8 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
         tp_group = mpu.get_tensor_model_parallel_group()
         pp_group = mpu.get_pipeline_model_parallel_group()
     rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
-                              key_prefix=getattr(args, 'rng_state_key_prefix', ''))
+                              key_prefix=getattr(args, 'rng_state_key_prefix', ''),
+                              dp_cp_group=dp_cp_group)
 
     # Collect rerun state across all ranks
     rerun_state_machine = get_rerun_state_machine()
@@ -613,9 +617,9 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
     # the dense and expert parallelism layouts disagree (e.g. TP > EP*ETP); the union
     # does, with at most one rank per (tp_rank, ep_rank) inside any DP group.
     if not torch.distributed.is_initialized() \
+            or ckpt_type != CheckpointType.LEGACY \
             or mpu.get_data_parallel_rank() == 0 \
-            or mpu.get_expert_data_parallel_rank() == 0 \
-            or ckpt_type != CheckpointType.LEGACY:
+            or mpu.get_expert_data_parallel_rank() == 0:
         if ckpt_type != CheckpointType.LEGACY:
             sharded_sd_metadata = _build_sharded_state_dict_metadata(args, dp_cp_group=dp_cp_group)
             if args.use_distributed_optimizer:
@@ -1721,7 +1725,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                 tp_group = mpu.get_tensor_model_parallel_group()
                 pp_group = mpu.get_pipeline_model_parallel_group()
             gen_sd_rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
-                                             key_prefix=getattr(args, 'rng_state_key_prefix', ''))  # we can load the rng state
+                                             key_prefix=getattr(args, 'rng_state_key_prefix', ''),
+                                             dp_cp_group=dp_cp_group)  # we can load the rng state
         else:
             ignore_rng_state = True
             gen_sd_rng_state = None
@@ -1729,7 +1734,7 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                 print_rank_0("{}: RNG state will be ignored".format(mismatch_msg))
 
         if ckpt_type == CheckpointType.LOCAL:
-            sharded_sd_metadata = _build_sharded_state_dict_metadata(args)
+            sharded_sd_metadata = _build_sharded_state_dict_metadata(args, dp_cp_group=dp_cp_group)
         else:
             sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
         print_rank_0(f'sharded_state_dict metadata loaded from the checkpoint: {sharded_sd_metadata}')
@@ -2026,8 +2031,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
             if 'rng_state' in state_dict:
                 if args.ckpt_format == "fsdp_dtensor":
                     # FSDP DTensor checkpoints store rng_state in a different format.
-                    tp_rank = mpu.get_tensor_model_parallel_rank()
-                    pp_rank = mpu.get_pipeline_model_parallel_rank()
+                    tp_rank = get_pg_rank(tp_group) if tp_group is not None else mpu.get_tensor_model_parallel_rank()
+                    pp_rank = get_pg_rank(pp_group) if pp_group is not None else mpu.get_pipeline_model_parallel_rank()
                     if f"({pp_rank}, {tp_rank})" in state_dict['rng_state']:
                         rng_state = state_dict['rng_state'][f"({pp_rank}, {tp_rank})"]
                     else:
@@ -2038,7 +2043,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
 
                 # access rng_state for data parallel rank
                 if args.data_parallel_random_init:
-                    rng_state = rng_state[mpu.get_data_parallel_rank()]
+                    dp_cp_rank = get_pg_rank(dp_cp_group) if dp_cp_group is not None else mpu.get_data_parallel_rank()
+                    rng_state = rng_state[dp_cp_rank]
                 else:
                     rng_state = rng_state[0]
                 random.setstate(rng_state['random_rng_state'])

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -672,8 +672,9 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
 
                 if args.ckpt_fully_parallel_save:
                     if args.ckpt_fully_parallel_save_process_group == 'dp':
-                        process_group = mpu.get_data_parallel_group(with_context_parallel=True)
+                        process_group = dp_cp_group if dp_cp_group is not None else mpu.get_data_parallel_group(with_context_parallel=True)
                     elif args.ckpt_fully_parallel_save_process_group == 'ep_dp':
+                        # NOTE: expert-DP save group not threaded yet; falls back to mpu (not on the disjoint-grid path).
                         process_group = mpu.get_expert_data_parallel_group()
                     save_strategy = FullyParallelSaveStrategyWrapper(save_strategy, process_group,
                                                                      args.ckpt_assume_constant_structure)

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -44,6 +44,7 @@ def initialize_megatron(
     get_embedding_ranks=None,
     get_position_embedding_ranks=None,
     store=None,
+    skip_model_parallel_init=False,
 ):
     """Set global variables, initialize distributed, and
     set autoresume and random seeds.
@@ -93,17 +94,23 @@ def initialize_megatron(
     def finish_mpu_init():
         args = get_args()
         # Pytorch distributed.
-        _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, store)
-
-        # Random seeds for reproducibility.
-        print_rank_0("> setting random seeds to {} ...".format(args.seed))
-        _set_random_seed(
-            args.seed,
-            args.data_parallel_random_init,
-            args.te_rng_tracker,
-            args.inference_rng_tracker,
-            use_cudagraphable_rng=args.cuda_graph_impl != "none",
+        _initialize_distributed(
+            get_embedding_ranks,
+            get_position_embedding_ranks,
+            store,
+            skip_model_parallel_init=skip_model_parallel_init,
         )
+
+        # Random seeds (skipped when caller owns seeding -- reads mpu ranks).
+        if not skip_model_parallel_init:
+            print_rank_0("> setting random seeds to {} ...".format(args.seed))
+            _set_random_seed(
+                args.seed,
+                args.data_parallel_random_init,
+                args.te_rng_tracker,
+                args.inference_rng_tracker,
+                use_cudagraphable_rng=args.cuda_graph_impl != "none",
+            )
 
         # Setup MoE aux loss scale value.
         if args.num_experts is not None:
@@ -243,7 +250,8 @@ def _initialize_tp_communicators():
         )
 
 
-def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, store):
+def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, store,
+                            skip_model_parallel_init=False):
     """Initialize torch.distributed and core model parallel."""
     args = get_args()
 
@@ -334,7 +342,8 @@ def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, s
 
     # Set the tensor model-parallel, pipeline model-parallel, and
     # data-parallel communicators.
-    if device_count > 0:
+    # (skipped when caller owns model-parallel setup)
+    if device_count > 0 and not skip_model_parallel_init:
         if mpu.model_parallel_is_initialized():
             print("model parallel is already initialized")
         else:
@@ -412,7 +421,7 @@ def write_args_to_tensorboard():
             writer.add_text(arg, str(getattr(args, arg)), global_step=args.iteration)
 
 
-def set_jit_fusion_options():
+def set_jit_fusion_options(tp_size=None):
     """Set PyTorch JIT layer fusion options."""
     # flags required to enable jit fusion kernels
     if is_torch_min_version("2.2.0a0"):
@@ -433,10 +442,10 @@ def set_jit_fusion_options():
         torch._C._jit_override_can_fuse_on_cpu(True)
         torch._C._jit_override_can_fuse_on_gpu(True)
 
-    _warmup_jit_function()
+    _warmup_jit_function(tp_size=tp_size)
 
 
-def _warmup_jit_function():
+def _warmup_jit_function(tp_size=None):
     """Compilie JIT functions before the main training steps"""
     args = get_args()
     if args.bf16:
@@ -472,7 +481,8 @@ def _warmup_jit_function():
 
     # Warmup fused bias+dropout+add
     if args.sequence_parallel:
-        seq_length = args.seq_length // mpu.get_tensor_model_parallel_world_size()
+        # tp_size threaded by the caller (hetero MIMO language PGC); None -> mpu.
+        seq_length = args.seq_length // (tp_size or mpu.get_tensor_model_parallel_world_size())
     else:
         seq_length = args.seq_length
     input = torch.rand(

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -7,6 +7,7 @@ import random
 import time
 import warnings
 from datetime import timedelta
+from typing import Optional
 
 import numpy as np
 import torch
@@ -25,7 +26,7 @@ from megatron.core.rerun_state_machine import (
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
     enable_batch_invariant_mode,
 )
-from megatron.core.utils import get_te_version, is_te_min_version, is_torch_min_version
+from megatron.core.utils import get_pg_rank, get_te_version, is_te_min_version, is_torch_min_version
 from megatron.training import (
     get_adlr_autoresume,
     get_args,
@@ -393,20 +394,36 @@ def _set_random_seed(
     te_rng_tracker: bool = False,
     inference_rng_tracker: bool = False,
     use_cudagraphable_rng: bool = False,
+    pp_group: Optional[torch.distributed.ProcessGroup] = None,
+    dp_group: Optional[torch.distributed.ProcessGroup] = None,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    ep_group: Optional[torch.distributed.ProcessGroup] = None,
+    etp_group: Optional[torch.distributed.ProcessGroup] = None,
 ):
-    """Set random seed for reproducability."""
+    """Set random seed for reproducability.
+
+    The optional pp/dp/tp/ep/etp groups let a caller without an initialized mpu
+    (e.g. a disjoint-grid run) supply the parallel ranks explicitly; each falls
+    back to the mpu group when None.
+    """
     if seed_ is not None and seed_ > 0:
         # Ensure that different pipeline MP stages get different seeds.
-        seed = seed_ + (100 * mpu.get_pipeline_model_parallel_rank())
+        pp_rank = get_pg_rank(pp_group) if pp_group is not None else mpu.get_pipeline_model_parallel_rank()
+        seed = seed_ + (100 * pp_rank)
         # Ensure different data parallel ranks get different seeds
         if data_parallel_random_init:
-            seed = seed + (10 * mpu.get_data_parallel_rank())
+            dp_rank = get_pg_rank(dp_group) if dp_group is not None else mpu.get_data_parallel_rank()
+            seed = seed + (10 * dp_rank)
         random.seed(seed)
         np.random.seed(seed)
         torch.manual_seed(seed)
         if torch.cuda.device_count() > 0:
+            tp_rank = get_pg_rank(tp_group) if tp_group is not None else None
+            ep_rank = get_pg_rank(ep_group) if ep_group is not None else None
+            etp_rank = get_pg_rank(etp_group) if etp_group is not None else None
             tensor_parallel.model_parallel_cuda_manual_seed(
-                seed, te_rng_tracker, inference_rng_tracker, use_cudagraphable_rng
+                seed, te_rng_tracker, inference_rng_tracker, use_cudagraphable_rng,
+                tp_rank=tp_rank, ep_rank=ep_rank, etp_rank=etp_rank,
             )
     else:
         raise ValueError("Seed ({}) should be a positive integer.".format(seed_))

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2901,6 +2901,8 @@ def save_checkpoint_and_time(
     tp_group = getattr(ckpt_pgc, "tp", None) if ckpt_pgc is not None else None
     pp_group = getattr(ckpt_pgc, "pp", None) if ckpt_pgc is not None else None
     dp_cp_group = getattr(ckpt_pgc, "dp_cp", None) if ckpt_pgc is not None else None
+    # Per-grid rng key namespace set by a multi-grid model; '' for stock single-grid.
+    rng_state_key_prefix = getattr(unwrap_model(model)[0], "rng_state_key_prefix", "")
 
     # Save checkpoint.
     save_checkpoint(
@@ -2916,6 +2918,7 @@ def save_checkpoint_and_time(
         tp_group=tp_group,
         pp_group=pp_group,
         dp_cp_group=dp_cp_group,
+        rng_state_key_prefix=rng_state_key_prefix,
     )
 
     # Stop timer and compute time elapsed to save checkpoint. Stop timer before timers.log() call as it resets the timer.

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2894,6 +2894,14 @@ def save_checkpoint_and_time(
     if should_report_memory:
         # Track memory before checkpoint save.
         report_memory(f"(before save_checkpoint for iteration {iteration})")
+
+    # Resolve checkpoint groups from this rank's module PGC; None for stock runs
+    # falls back to the mpu groups inside save_checkpoint (byte-identical).
+    ckpt_pgc = getattr(unwrap_model(model)[0], "pg_collection", None)
+    tp_group = getattr(ckpt_pgc, "tp", None) if ckpt_pgc is not None else None
+    pp_group = getattr(ckpt_pgc, "pp", None) if ckpt_pgc is not None else None
+    dp_cp_group = getattr(ckpt_pgc, "dp_cp", None) if ckpt_pgc is not None else None
+
     # Save checkpoint.
     save_checkpoint(
         iteration,
@@ -2905,6 +2913,9 @@ def save_checkpoint_and_time(
         non_persistent_ckpt=non_persistent_ckpt,
         train_data_iterator=train_data_iterator,
         preprocess_common_state_dict_fn=preprocess_common_state_dict,
+        tp_group=tp_group,
+        pp_group=pp_group,
+        dp_cp_group=dp_cp_group,
     )
 
     # Stop timer and compute time elapsed to save checkpoint. Stop timer before timers.log() call as it resets the timer.

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3266,7 +3266,11 @@ def train(
     )
 
     def _dp_world_size():
-        return lang_pgc.dp.size() if lang_pgc is not None else mpu.get_data_parallel_world_size()
+        if lang_pgc is not None:
+            return lang_pgc.dp.size()
+        if mpu.model_parallel_is_initialized():
+            return mpu.get_data_parallel_world_size()
+        return args.data_parallel_size
 
     # LLM grid GPU count (mp = tp*pp, dp_cp = dp*cp) for hetero throughput scoping;
     # None lets training_log fall back to args.world_size (byte-identical for stock).

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3305,7 +3305,10 @@ def train(
         config.param_sync_func = [model_chunk.start_param_sync for model_chunk in model]
         if len(model) == 1:
             config.param_sync_func = config.param_sync_func[0]
-    config.finalize_model_grads_func = finalize_model_grads
+    # Don't clobber a finalizer a caller already installed on the config (e.g. the
+    # hetero MIMO dual encoder+language finalizer); fall back to the default.
+    if getattr(config, 'finalize_model_grads_func', None) is None:
+        config.finalize_model_grads_func = finalize_model_grads
 
     if args.log_energy:
         energy_monitor.setup()

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2517,7 +2517,10 @@ def training_log(
     total_iterations = total_loss_dict[advanced_iters_key] + total_loss_dict[skipped_iters_key]
 
     # learning rate will be None on ranks without trainable params, so we must gather across mp ranks
-    learning_rate: float | None = reduce_max_stat_across_model_parallel_group(learning_rate)
+    _lr_mp_group = pg_collection.mp if pg_collection is not None else None
+    learning_rate: float | None = reduce_max_stat_across_model_parallel_group(
+        learning_rate, group=_lr_mp_group
+    )
     if learning_rate is None and args.freeze_all_layers:
         learning_rate = 0.0
     # Tensorboard values.
@@ -2758,7 +2761,10 @@ def training_log(
             if torch.distributed.get_rank() == 0:
                 num_microbatches = get_num_microbatches()
                 report_theoretical_memory(args, num_microbatches=num_microbatches, verbose=True)
-            report_memory(f'(after {iteration} iterations)')
+            report_memory(
+                f'(after {iteration} iterations)',
+                group=pg_collection.dp if pg_collection is not None else None,
+            )
             reported_memory_in_this_iteration = True
             loaded_iteration = max(get_loaded_iteration() or 0, 0)
             if iteration > (loaded_iteration + 1):
@@ -2766,7 +2772,10 @@ def training_log(
                 report_memory_flag = False
         if args.log_memory_interval is not None and iteration % args.log_memory_interval == 0 and \
             not reported_memory_in_this_iteration:
-            report_memory(f'(after {iteration} iterations)')
+            report_memory(
+                f'(after {iteration} iterations)',
+                group=pg_collection.dp if pg_collection is not None else None,
+            )
         # Write timers to wandb, don't reset the counts.
         if args.log_timers_to_tensorboard:
             timers.write(timers_to_log, writer, iteration, normalizer=args.log_interval, reset=False)
@@ -3210,6 +3219,18 @@ def train(
 
             args.no_load_optim = no_load_optim
 
+    # Resolve the language-model process groups when a hetero MultiModule collection
+    # is passed; None for stock single-module runs, which fall back to the global
+    # mpu groups below (byte-identical behavior).
+    lang_pgc = (
+        schedule_pg_collection.get_language_model_collection()
+        if schedule_pg_collection is not None and schedule_pg_collection.has_language_model()
+        else None
+    )
+
+    def _dp_world_size():
+        return lang_pgc.dp.size() if lang_pgc is not None else mpu.get_data_parallel_world_size()
+
     # IMPORTANT FIX: For RL training, reinitialize the microbatch calculator with the correct configuration
     if args.perform_rl_step:
         print_rank_0("> Reinitializing microbatch calculator for GRPO training...")
@@ -3225,7 +3246,7 @@ def train(
             rank=args.rank,
             global_batch_size=args.global_batch_size,
             micro_batch_size=args.micro_batch_size,
-            data_parallel_size=mpu.get_data_parallel_world_size(),
+            data_parallel_size=_dp_world_size(),
             decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
             step_batch_size_schedule=args.step_batch_size_schedule,
             seq_length=args.seq_length,
@@ -3544,7 +3565,7 @@ def train(
                 start_iteration = iteration + 1
             iteration += 1
             batch_size = (
-                mpu.get_data_parallel_world_size() * args.micro_batch_size * get_num_microbatches()
+                _dp_world_size() * args.micro_batch_size * get_num_microbatches()
             )
             args.consumed_train_samples += batch_size
             args.skipped_train_samples += batch_size
@@ -3671,12 +3692,12 @@ def train(
             iteration_sequences = rl_utils.get_iteration_sequence_count(args)
             # Track bins separately for packed mode
             bin_count = (
-                mpu.get_data_parallel_world_size() * args.micro_batch_size * get_num_microbatches()
+                _dp_world_size() * args.micro_batch_size * get_num_microbatches()
             )
             args.consumed_train_bins += bin_count
         else:
             batch_size = (
-                mpu.get_data_parallel_world_size() * args.micro_batch_size * get_num_microbatches()
+                _dp_world_size() * args.micro_batch_size * get_num_microbatches()
             )
             iteration_sequences = batch_size
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1126,7 +1126,6 @@ def pretrain(
     if cfg_container.logger.log_progress:
         append_to_progress_log(args.save, "Starting job")
 
-    # JIT fusion + warmup; hetero derives TP from language PGC (None -> mpu).
     _jit_tp_size = (
         get_pg_size(schedule_pg_collection.get_language_model_collection().tp)
         if schedule_pg_collection is not None and schedule_pg_collection.has_language_model()
@@ -1241,16 +1240,11 @@ def pretrain(
     else:
         checkpointing_context = {}
 
-    # Model/optimizer/LR; hook (when set) owns build + resume-load and sets args.iteration.
     timers('model-and-optimizer-setup', log_level=0).start(barrier=True)
-    if setup_model_and_optimizer_func is not None:
-        model, optimizer, opt_param_scheduler = setup_model_and_optimizer_func(
-            model_provider, model_type, checkpointing_context=checkpointing_context
-        )
-    else:
-        model, optimizer, opt_param_scheduler = setup_model_and_optimizer(
-            model_provider, model_type, checkpointing_context=checkpointing_context
-        )
+    setup_func = setup_model_and_optimizer_func or setup_model_and_optimizer
+    model, optimizer, opt_param_scheduler = setup_func(
+        model_provider, model_type, checkpointing_context=checkpointing_context
+    )
 
     timers('model-and-optimizer-setup').stop()
     print_datetime('after model, optimizer, and learning rate ' 'scheduler are built')
@@ -3373,8 +3367,6 @@ def train(
         config.param_sync_func = [model_chunk.start_param_sync for model_chunk in model]
         if len(model) == 1:
             config.param_sync_func = config.param_sync_func[0]
-    # Don't clobber a finalizer a caller already installed on the config (e.g. the
-    # hetero MIMO dual encoder+language finalizer); fall back to the default.
     if getattr(config, 'finalize_model_grads_func', None) is None:
         config.finalize_model_grads_func = finalize_model_grads
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1042,6 +1042,11 @@ def pretrain(
     non_loss_data_func=None,
     store=None,
     inprocess_call_wrapper: Optional[Any] = None,
+    p2p_communicator: Optional[P2PCommunicator] = None,
+    schedule_pg_collection: Optional[MultiModuleProcessGroupCollection] = None,
+    setup_model_and_optimizer_func=None,
+    build_data_iterators_func=None,
+    skip_model_parallel_init=False,
 ):
     """Main training program.
 
@@ -1105,6 +1110,7 @@ def pretrain(
         get_embedding_ranks=get_embedding_ranks,
         get_position_embedding_ranks=get_position_embedding_ranks,
         store=store,
+        skip_model_parallel_init=skip_model_parallel_init,
     )
 
     timestamp_after_initialize_megatron = time.time()
@@ -1120,8 +1126,13 @@ def pretrain(
     if cfg_container.logger.log_progress:
         append_to_progress_log(args.save, "Starting job")
 
-    # Set pytorch JIT layer fusion options and warmup JIT functions.
-    set_jit_fusion_options()
+    # JIT fusion + warmup; hetero derives TP from language PGC (None -> mpu).
+    _jit_tp_size = (
+        get_pg_size(schedule_pg_collection.get_language_model_collection().tp)
+        if schedule_pg_collection is not None and schedule_pg_collection.has_language_model()
+        else None
+    )
+    set_jit_fusion_options(tp_size=_jit_tp_size)
 
     timestamp_after_set_jit_fusion_options = time.time()
 
@@ -1230,11 +1241,16 @@ def pretrain(
     else:
         checkpointing_context = {}
 
-    # Model, optimizer, and learning rate.
+    # Model/optimizer/LR; hook (when set) owns build + resume-load and sets args.iteration.
     timers('model-and-optimizer-setup', log_level=0).start(barrier=True)
-    model, optimizer, opt_param_scheduler = setup_model_and_optimizer(
-        model_provider, model_type, checkpointing_context=checkpointing_context
-    )
+    if setup_model_and_optimizer_func is not None:
+        model, optimizer, opt_param_scheduler = setup_model_and_optimizer_func(
+            model_provider, model_type, checkpointing_context=checkpointing_context
+        )
+    else:
+        model, optimizer, opt_param_scheduler = setup_model_and_optimizer(
+            model_provider, model_type, checkpointing_context=checkpointing_context
+        )
 
     timers('model-and-optimizer-setup').stop()
     print_datetime('after model, optimizer, and learning rate ' 'scheduler are built')
@@ -1329,7 +1345,12 @@ def pretrain(
     # Data stuff.
     app_metrics['app_build_dataiters_start_time'] = one_logger_utils.get_timestamp_in_ms()
     timers('train/valid/test-data-iterators-setup', log_level=0).start(barrier=True)
-    if args.virtual_pipeline_model_parallel_size is not None:
+    # The hook (when given) owns the iterators and sets args.do_train/do_valid/do_test.
+    if build_data_iterators_func is not None:
+        train_data_iterator, valid_data_iterator, test_data_iterator = (
+            build_data_iterators_func()
+        )
+    elif args.virtual_pipeline_model_parallel_size is not None:
         train_data_iterator = []
         valid_data_iterator = []
         test_data_iterator = []
@@ -1398,6 +1419,8 @@ def pretrain(
                 checkpointing_context,
                 non_loss_data_func,
                 inference_model,
+                p2p_communicator=p2p_communicator,
+                schedule_pg_collection=schedule_pg_collection,
             )
 
         print_datetime('after training is done')

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2434,6 +2434,7 @@ def training_log(
     is_first_iteration=False,
     seqlen_squared_sum_in_batch: float | None = None,
     total_real_tokens_in_batch: float | None = None,
+    throughput_world_size: int | None = None,
 ):
     """Log training information such as losses, timing, ...."""
     args = get_args()
@@ -2676,7 +2677,7 @@ def training_log(
             seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
             total_real_tokens_in_batch=total_real_tokens_in_batch,
         ) / (
-            elapsed_time_per_iteration * 10**12 * args.world_size
+            elapsed_time_per_iteration * 10**12 * (throughput_world_size or args.world_size)
         )
 
         one_logger_utils.track_e2e_metrics(args.log_throughput, throughput)
@@ -2786,10 +2787,15 @@ def training_log(
     return report_memory_flag
 
 
-def compute_throughputs_and_append_to_progress_log(iteration, num_floating_point_operations_so_far):
+def compute_throughputs_and_append_to_progress_log(iteration, num_floating_point_operations_so_far,
+                                                   throughput_world_size=None):
     args = get_args()
     if args.save is None:
         return
+
+    # GPU count the per-GPU throughput is normalized by (LLM grid for hetero MIMO,
+    # else the full world); None keeps the stock args.world_size behavior.
+    world_size = throughput_world_size or args.world_size
 
     # Compute job throughput.
     # args.num_floating_point_operations_so_far keeps track of floating-point operations
@@ -2797,7 +2803,7 @@ def compute_throughputs_and_append_to_progress_log(iteration, num_floating_point
     global _TRAIN_START_TIME
     job_throughput = (
         num_floating_point_operations_so_far - args.num_floating_point_operations_so_far
-    ) / ((time.time() - _TRAIN_START_TIME) * 10**12 * args.world_size)
+    ) / ((time.time() - _TRAIN_START_TIME) * 10**12 * world_size)
 
     # Compute cumulative throughput since jobs of this world size were launched.
     # `get_start_time_from_progress_log` returns start time and number of floating-point
@@ -2806,7 +2812,7 @@ def compute_throughputs_and_append_to_progress_log(iteration, num_floating_point
     elapsed_time = (datetime.now() - start_time).total_seconds()
     cumulative_throughput = (
         num_floating_point_operations_so_far - start_num_floating_point_operations
-    ) / (elapsed_time * 10**12 * args.world_size)
+    ) / (elapsed_time * 10**12 * world_size)
 
     tokens_so_far = args.consumed_train_samples * args.seq_length
     saved_ckpt_prefix = 'Saving async checkpoint' if args.async_save else 'Saved checkpoint'
@@ -2850,6 +2856,7 @@ def save_checkpoint_and_time(
     checkpointing_context,
     non_persistent_ckpt=False,
     train_data_iterator=None,
+    throughput_world_size=None,
 ):
     args = get_args()
     timers = get_timers()
@@ -2913,7 +2920,8 @@ def save_checkpoint_and_time(
 
     if args.log_progress and not non_persistent_ckpt:
         compute_throughputs_and_append_to_progress_log(
-            iteration, num_floating_point_operations_so_far
+            iteration, num_floating_point_operations_so_far,
+            throughput_world_size=throughput_world_size,
         )
 
     # Recover timing
@@ -3022,6 +3030,7 @@ def checkpoint_and_decide_exit(
     num_floating_point_operations_so_far,
     checkpointing_context,
     train_data_iterator,
+    throughput_world_size=None,
 ):
     """Save checkpoint and decide whether to exit based on arguments (e.g., if
     --exit-duration-in-mins is set). Actual exit happens in main training loop
@@ -3043,6 +3052,7 @@ def checkpoint_and_decide_exit(
                     num_floating_point_operations_so_far,
                     checkpointing_context,
                     train_data_iterator=train_data_iterator,
+                    throughput_world_size=throughput_world_size,
                 )
             print_datetime('exiting program after receiving SIGTERM.')
 
@@ -3058,6 +3068,7 @@ def checkpoint_and_decide_exit(
             num_floating_point_operations_so_far,
             checkpointing_context,
             train_data_iterator=train_data_iterator,
+            throughput_world_size=throughput_world_size,
         )
         saved_checkpoint = True
 
@@ -3075,6 +3086,7 @@ def checkpoint_and_decide_exit(
             checkpointing_context,
             non_persistent_ckpt=True,
             train_data_iterator=train_data_iterator,
+            throughput_world_size=throughput_world_size,
         )
         saved_checkpoint = True
 
@@ -3096,6 +3108,7 @@ def checkpoint_and_decide_exit(
                     num_floating_point_operations_so_far,
                     checkpointing_context,
                     train_data_iterator=train_data_iterator,
+                    throughput_world_size=throughput_world_size,
                 )
             print_datetime(f'exiting program after {train_time} minutes')
 
@@ -3118,6 +3131,7 @@ def checkpoint_and_decide_exit(
                 num_floating_point_operations_so_far,
                 checkpointing_context,
                 train_data_iterator=train_data_iterator,
+                throughput_world_size=throughput_world_size,
             )
         print_datetime(f'exiting program at iteration {iteration}')
 
@@ -3230,6 +3244,12 @@ def train(
 
     def _dp_world_size():
         return lang_pgc.dp.size() if lang_pgc is not None else mpu.get_data_parallel_world_size()
+
+    # LLM grid GPU count (mp = tp*pp, dp_cp = dp*cp) for hetero throughput scoping;
+    # None lets training_log fall back to args.world_size (byte-identical for stock).
+    llm_world_size = (
+        get_pg_size(lang_pgc.mp) * get_pg_size(lang_pgc.dp_cp) if lang_pgc is not None else None
+    )
 
     # IMPORTANT FIX: For RL training, reinitialize the microbatch calculator with the correct configuration
     if args.perform_rl_step:
@@ -3540,6 +3560,7 @@ def train(
                         num_floating_point_operations_so_far,
                         checkpointing_context,
                         train_data_iterator=train_data_iterator,
+                        throughput_world_size=llm_world_size,
                     )
         num_microbatches = get_num_microbatches()
         update_num_microbatches(args.consumed_train_samples, consistency_check=True, verbose=True)
@@ -3640,6 +3661,7 @@ def train(
                 num_floating_point_operations_so_far,
                 checkpointing_context,
                 train_data_iterator=train_data_iterator,
+                throughput_world_size=llm_world_size,
             )
         if should_exit:
             break
@@ -3761,6 +3783,7 @@ def train(
             is_first_iteration=is_first_iteration,
             seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
             total_real_tokens_in_batch=total_real_tokens_in_batch,
+            throughput_world_size=llm_world_size,
         )
         is_first_iteration = False
 
@@ -3853,6 +3876,7 @@ def train(
             num_floating_point_operations_so_far,
             checkpointing_context,
             train_data_iterator,
+            throughput_world_size=llm_world_size,
         )
         if should_exit:
             break

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1045,7 +1045,6 @@ def pretrain(
     p2p_communicator: Optional[P2PCommunicator] = None,
     schedule_pg_collection: Optional[MultiModuleProcessGroupCollection] = None,
     setup_model_and_optimizer_func=None,
-    build_data_iterators_func=None,
     skip_model_parallel_init=False,
 ):
     """Main training program.
@@ -1339,12 +1338,7 @@ def pretrain(
     # Data stuff.
     app_metrics['app_build_dataiters_start_time'] = one_logger_utils.get_timestamp_in_ms()
     timers('train/valid/test-data-iterators-setup', log_level=0).start(barrier=True)
-    # The hook (when given) owns the iterators and sets args.do_train/do_valid/do_test.
-    if build_data_iterators_func is not None:
-        train_data_iterator, valid_data_iterator, test_data_iterator = (
-            build_data_iterators_func()
-        )
-    elif args.virtual_pipeline_model_parallel_size is not None:
+    if args.virtual_pipeline_model_parallel_size is not None:
         train_data_iterator = []
         valid_data_iterator = []
         test_data_iterator = []

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -42,6 +42,7 @@ from megatron.core.datasets.utils import get_blend_from_list
 from megatron.core.tensor_parallel import param_is_not_tensor_parallel_duplicate
 from megatron.core.utils import (
     get_data_parallel_group_if_dtensor,
+    get_pg_rank,
     to_local_if_dtensor,
     unwrap_model,
 )
@@ -295,8 +296,12 @@ def logical_and_across_model_parallel_group(
     return bool(input.item())
 
 
-def report_memory(name):
-    """Simple GPU memory report."""
+def report_memory(name, group=None):
+    """Simple GPU memory report.
+
+    group: optional data-parallel group to gate the rank-0 print on; None falls back
+        to ``mpu.get_data_parallel_rank()`` (byte-identical for callers passing nothing).
+    """
     args = get_args()
     mega_bytes = 1024.0 * 1024.0
     string = name + ' memory (MB)'
@@ -306,7 +311,8 @@ def report_memory(name):
     string += f" | max reserved: {torch.cuda.max_memory_reserved() / mega_bytes:.2f}"
     if args.log_device_memory_used:
         string += f" | total device memory used: {torch.cuda.device_memory_used() / mega_bytes:.2f}"
-    if mpu.get_data_parallel_rank() == 0:
+    is_dp_rank_0 = get_pg_rank(group) == 0 if group is not None else mpu.get_data_parallel_rank() == 0
+    if is_dp_rank_0:
         print("[Rank {}] {}".format(torch.distributed.get_rank(), string), flush=True)
 
 

--- a/tests/unit_tests/test_mimo_hetero_data.py
+++ b/tests/unit_tests/test_mimo_hetero_data.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Real-distributed (8-GPU, no parallel_state) tests for MIMO role-aware data selection."""
+
+import argparse
+
+import pytest
+import torch
+
+from examples.mimo.training.data import MockVLMIterator, select_data_iterator
+from examples.mimo.training.topology import ModuleGridSpec, create_topology
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+from tests.unit_tests.test_utilities import Utils
+
+ENCODER = "images"
+
+
+def _args(**overrides):
+    base = dict(
+        seed=1234,
+        dataset_provider="mock",
+        micro_batch_size=2,
+        llm_dp=1,
+        encoder_dp=1,
+        image_seq_length=4,
+        seq_length=8,
+        vocab_size=128,
+        hidden_size=16,
+        image_token_id=100,
+        fp32=True,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 8, reason="requires 8 GPUs")
+class TestRoleAwareDataSelection:
+    def setup_method(self, method):
+        Utils.initialize_distributed()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_encoder_and_language_edges_get_iterator(self):
+        # Encoder pp=1 (every rank PP-first) at 0-3; language tp=2,pp=2 at 4-7 (both stages edges).
+        topo = create_topology(
+            [
+                ModuleGridSpec(name=ENCODER, num_ranks=4, tp=2, rank_offset=0),
+                ModuleGridSpec(
+                    name=MIMO_LANGUAGE_MODULE_KEY, num_ranks=4, tp=2, pp=2, rank_offset=4
+                ),
+            ]
+        )
+        try:
+            it = select_data_iterator(_args(), topo)
+            # Every rank here is either an encoder PP-first or a language PP-edge rank.
+            assert isinstance(it, MockVLMIterator)
+        finally:
+            topo.destroy()
+
+    def test_language_middle_stage_gets_no_iterator(self):
+        # Language-only tp=2,pp=4 over the whole world: pp ranks 1 and 2 are non-edge -> None.
+        topo = create_topology(
+            [ModuleGridSpec(name=MIMO_LANGUAGE_MODULE_KEY, num_ranks=8, tp=2, pp=4, rank_offset=0)]
+        )
+        try:
+            pp_rank = topo.module_pgs[MIMO_LANGUAGE_MODULE_KEY].pp.rank()
+            it = select_data_iterator(_args(), topo)
+            if pp_rank in (0, 3):
+                assert isinstance(it, MockVLMIterator)
+            else:
+                assert it is None
+        finally:
+            topo.destroy()


### PR DESCRIPTION
## What
Wire the end-to-end heterogeneous MIMO training example on the stock Megatron `train()` loop:

- `pretrain_mimo.py`: program entrypoint (group pins for `save_checkpoint` and logging, FLOPs accounting neutralized for the hetero model, `mtp_num_layers` default 0, MIMO checkpoint save/load, explicit resume-load before `train()`).
- `bootstrap.py`: `build_mimo_runtime` orchestrator assembling per-role grids, model, optimizer, and data iterators.
- `data.py`: `add_data_args` plus the mock VLM data iterator, extended with the pixel / dynamic-resolution packed-patch mock the Nemotron RADIO provider needs.
- `scripts/run_hetero_nemotron_20l_mock_train.sh`: 8-GPU launch script.

## Dependencies (for reviewers)
This is the integration PR. It is **not** independently mergeable until the leaf PRs land:
- **Imports** the example leaf modules: #5374 (Nemotron provider), #5375 (hetero grid args), #5376 (forward step). These should merge first.
- **Runtime-depends** on the core/training enablers: #5370 (bridge eager-init), #5371 (RADIO tp_group), #5372 (MimoModel.zero_grad_buffer), #5373 (training-loop guards), and the in-flight optimizer PRs #5263 / #5331.
- `data.py` here is a **superset** of the role-aware iterator in in-flight #5287 (adds `add_data_args` + the pixel/dynamic-res mock). #5287 should land first or be folded in to avoid a conflict on `data.py`.

## Validation
Validated in the 8-GPU 20L Nemotron VLM e2e (trains + checkpoint save/resume, lm loss 12.18->11.54 across resume).

## CODEOWNERS
`examples/mimo/...` + `tests/unit_tests/...` -> repo default owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
