### PR TITLE
Add experimental FSDP microbatch context helper

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/dbuffer.py
@@ -1,0 +1,497 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Distributed flat buffers for Megatron-FSDP."""
+
+import dataclasses
+import math
+from typing import Sequence
+
+import torch
+import torch.distributed as dist
+import torch.distributed.tensor as dist_tensor
+from torch.distributed import DeviceMesh
+from torch.distributed.tensor import DTensor
+
+MeshAxis = int | str
+
+
+class Placement:
+    """Base class for DBuffer placements."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Replicate(Placement):
+    """Replicated local buffer placement."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Partial(Placement):
+    """Unreduced replicated local buffer placement."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Flat(Placement):
+    """Flat per-unit dim-0 sharded local buffer placement."""
+
+
+@dataclasses.dataclass(frozen=True)
+class GlobalLayout:
+    """Global flat-buffer layout in element coordinates."""
+
+    tensor_shapes: tuple[torch.Size, ...]
+    tensor_to_offset: tuple[int, ...]
+    size: int
+
+    def get_local_range(self, mesh: DeviceMesh, placements: Sequence[Placement]) -> tuple[int, int]:
+        """Return this rank's local element offset and length for ``placements``."""
+        offset = 0
+        numel = self.size
+        for axis, placement in reversed(tuple(enumerate(placements))):
+            if not isinstance(placement, Flat):
+                continue
+            axis_size = mesh.size(axis)
+            if numel % axis_size != 0:
+                raise ValueError(
+                    f"Local range size {numel} is not divisible by Flat axis size {axis_size}."
+                )
+            shard_size = numel // axis_size
+            offset += mesh.get_local_rank(axis) * shard_size
+            numel = shard_size
+        return offset, numel
+
+
+def _non_leading_numel(shape: torch.Size) -> int:
+    return shape[1:].numel() if len(shape) > 1 else 1
+
+
+def _pad_to_multiple(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
+    if isinstance(axis, int):
+        if axis < 0:
+            axis += mesh.ndim
+        if axis < 0 or axis >= mesh.ndim:
+            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
+        return axis
+
+    dim_names = mesh.mesh_dim_names
+    if dim_names is None or axis not in dim_names:
+        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
+    return dim_names.index(axis)
+
+
+def _validate_placement(placement: Placement) -> None:
+    if not isinstance(placement, (Replicate, Partial, Flat)):
+        raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
+
+
+def _validate_placements(placements: Sequence[Placement]) -> None:
+    seen_flat = False
+    for placement in placements:
+        _validate_placement(placement)
+        if isinstance(placement, Flat):
+            seen_flat = True
+        elif seen_flat:
+            raise ValueError(
+                "Flat placements must be a suffix of the placement list so each "
+                "local buffer is a contiguous global-buffer range."
+            )
+
+
+def _compute_layout(shapes: Sequence[torch.Size], dp_size: int) -> GlobalLayout:
+    """Compute flat-buffer element offsets and globally padded size.
+
+    Args:
+        shapes: Logical tensor shapes in tensor-id order.
+        dp_size: Data-parallel shard count for this flat buffer layout.
+
+    Returns:
+        Global layout with element offsets and size padded to a multiple of
+        ``LCM(shape[1:].numel()) * dp_size``.
+    """
+    if dp_size <= 0:
+        raise ValueError(f"DP size must be positive, got {dp_size}.")
+
+    shapes = tuple(torch.Size(shape) for shape in shapes)
+    chunk_size = 1
+    for shape in shapes:
+        non_leading_numel = _non_leading_numel(shape)
+        if non_leading_numel <= 0:
+            raise ValueError(f"Cannot compute a layout for zero-sized non-leading dims: {shape}.")
+        chunk_size = math.lcm(chunk_size, non_leading_numel)
+
+    tensor_to_offset: list[int | None] = [None] * len(shapes)
+    fragment_items = []
+    regular_items = []
+    for tensor_id, shape in enumerate(shapes):
+        if shape.numel() < chunk_size:
+            fragment_items.append((tensor_id, shape))
+        else:
+            regular_items.append((tensor_id, shape))
+
+    fragment_items.sort(key=lambda id_shape: -id_shape[1].numel())
+
+    data_index = 0
+    while regular_items:
+        tensor_id, shape = regular_items.pop(0)
+        tensor_numel = shape.numel()
+        tensor_to_offset[tensor_id] = data_index
+
+        if tensor_numel % chunk_size == 0:
+            data_index += tensor_numel
+            continue
+
+        gap_offset = data_index + tensor_numel
+        data_index += _pad_to_multiple(tensor_numel, chunk_size)
+        fragment_gap_end = data_index
+        remain = tensor_numel % chunk_size
+
+        found_rhs = None
+        for rhs in regular_items[:]:
+            _, rhs_shape = rhs
+            rhs_numel = rhs_shape.numel()
+            rhs_remain = rhs_numel % chunk_size
+            if rhs_remain == 0:
+                continue
+            if remain + rhs_remain <= chunk_size:
+                found_rhs = rhs
+                regular_items.remove(rhs)
+                break
+
+        if found_rhs is not None:
+            rhs_id, rhs_shape = found_rhs
+            rhs_numel = rhs_shape.numel()
+            rhs_remain = rhs_numel % chunk_size
+            rhs_offset = data_index - rhs_remain
+            tensor_to_offset[rhs_id] = rhs_offset
+            fragment_gap_end = rhs_offset
+            data_index += (rhs_numel // chunk_size) * chunk_size
+
+        for fragment in fragment_items[:]:
+            frag_id, frag_shape = fragment
+            frag_numel = frag_shape.numel()
+            aligned_gap_offset = _pad_to_multiple(gap_offset, _non_leading_numel(frag_shape))
+            if aligned_gap_offset + frag_numel > fragment_gap_end:
+                continue
+            tensor_to_offset[frag_id] = aligned_gap_offset
+            gap_offset = aligned_gap_offset + frag_numel
+            fragment_items.remove(fragment)
+
+    for frag_id, frag_shape in fragment_items:
+        data_index = _pad_to_multiple(data_index, _non_leading_numel(frag_shape))
+        tensor_to_offset[frag_id] = data_index
+        data_index += frag_shape.numel()
+
+    if any(offset is None for offset in tensor_to_offset):
+        raise AssertionError(f"Incomplete DBuffer layout for shapes {shapes}.")
+
+    resolved_tensor_to_offset = tuple(offset for offset in tensor_to_offset if offset is not None)
+    for shape, offset in zip(shapes, resolved_tensor_to_offset, strict=True):
+        row_size = _non_leading_numel(shape)
+        if offset % row_size != 0:
+            raise AssertionError(f"Tensor offset {offset} is not aligned to row size {row_size}.")
+    size = _pad_to_multiple(data_index, chunk_size * dp_size)
+    return GlobalLayout(tensor_shapes=shapes, tensor_to_offset=resolved_tensor_to_offset, size=size)
+
+
+class DBuffer:
+    """A flat distributed buffer holding a group of logical tensors.
+
+    DBuffer stores one flat local tensor and enough metadata to return per-tensor
+    views, redistribute the buffer across mesh axes, and materialize per-tensor
+    DTensors for optimizer state or distributed checkpointing.
+    """
+
+    mesh: DeviceMesh
+    placements: tuple[Placement, ...]
+    layout: GlobalLayout
+    offset: int
+    local_buffer: torch.Tensor
+
+    def __init__(
+        self,
+        mesh: DeviceMesh,
+        placements: Sequence[Placement],
+        tensor_shapes: Sequence[torch.Size],
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> None:
+        """Create a DBuffer and allocate its local flat buffer.
+
+        Args:
+            mesh: Device mesh whose dimensions correspond to ``placements``.
+            placements: Per-mesh-axis DBuffer placements.
+            tensor_shapes: Global shapes for each logical tensor in this buffer.
+            dtype: Dtype for the local flat buffer.
+            device: Device for the local flat buffer.
+        """
+        placements = tuple(placements)
+        if len(placements) != mesh.ndim:
+            raise ValueError(
+                f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
+            )
+        _validate_placements(placements)
+
+        self.mesh = mesh
+        self.placements = placements
+
+        tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
+        self.layout = _compute_layout(tensor_shapes, dp_size=self.mesh.size())
+
+        self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
+        self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
+
+    @classmethod
+    def distribute_tensors(
+        cls, tensors: Sequence[torch.Tensor], mesh: DeviceMesh, placements: Sequence[Placement]
+    ) -> "DBuffer":
+        """Distribute full local tensor values into a DBuffer.
+
+        Args:
+            tensors: Full tensor values available on this rank.
+            mesh: Device mesh whose dimensions correspond to ``placements``.
+            placements: Per-mesh-axis DBuffer placements.
+
+        Returns:
+            A DBuffer whose local storage matches ``placements``.
+        """
+        if not tensors:
+            raise ValueError("DBuffer.distribute_tensors() requires at least one tensor.")
+
+        tensors = tuple(
+            (
+                tensor.to(mesh.device_type)
+                if tensor.device.type != mesh.device_type and not tensor.is_meta
+                else tensor
+            )
+            for tensor in tensors
+        )
+        dtype = tensors[0].dtype
+        device = tensors[0].device
+        for tensor in tensors:
+            if tensor.dtype != dtype or tensor.device != device:
+                raise ValueError("All tensors in a DBuffer must have the same dtype and device.")
+            if not tensor.is_contiguous():
+                raise ValueError("DBuffer.distribute_tensors() expects contiguous tensors.")
+
+        tensor_shapes = tuple(tensor.shape for tensor in tensors)
+        buffer = cls(
+            mesh=mesh,
+            placements=placements,
+            tensor_shapes=tensor_shapes,
+            dtype=dtype,
+            device=device,
+        )
+        full_buffer = torch.zeros(buffer.layout.size, dtype=dtype, device=device)
+        for tensor, offset in zip(tensors, buffer.layout.tensor_to_offset, strict=True):
+            full_buffer.narrow(0, offset, tensor.numel()).copy_(tensor.view(-1))
+
+        local_buffer = full_buffer.narrow(0, buffer.offset, buffer.local_buffer.numel())
+        buffer.local_buffer.copy_(local_buffer)
+        return buffer
+
+    def redistribute(self, new_placements: Sequence[Placement]) -> "DBuffer":
+        """Redistribute this buffer to ``new_placements``.
+
+        This dispatcher composes the supported one-axis transitions:
+        Flat -> Replicate, Partial -> Replicate, Partial -> Flat, and
+        Replicate -> Flat. Other placement changes are intentionally unsupported.
+        """
+        new_placements = tuple(new_placements)
+        if len(new_placements) != self.mesh.ndim:
+            raise ValueError(
+                f"Expected {self.mesh.ndim} placements for device mesh, got "
+                f"{len(new_placements)}."
+            )
+        _validate_placements(new_placements)
+
+        buffer = self
+        for axis, new_placement in enumerate(new_placements):
+            old_placement = buffer.placements[axis]
+            if old_placement == new_placement:
+                continue
+            if isinstance(old_placement, Flat) and isinstance(new_placement, Replicate):
+                buffer = buffer.allgather(axis)
+            elif isinstance(old_placement, Partial) and isinstance(new_placement, Replicate):
+                buffer = buffer.allreduce(axis)
+            elif isinstance(old_placement, Partial) and isinstance(new_placement, Flat):
+                buffer = buffer.reduce_scatter(axis, new_placement)
+            elif isinstance(old_placement, Replicate) and isinstance(new_placement, Flat):
+                buffer = buffer.scatter(axis, new_placement)
+            else:
+                raise NotImplementedError(
+                    "Unsupported DBuffer placement transition on axis "
+                    f"{axis}: {old_placement!r} -> {new_placement!r}."
+                )
+
+        if buffer.placements != new_placements:
+            raise AssertionError(
+                f"Redistribute produced placements {buffer.placements}, expected {new_placements}."
+            )
+        return buffer
+
+    def allgather(self, mesh_axis: MeshAxis) -> "DBuffer":
+        """All-gather a Flat axis into Replicate placement."""
+        axis = _axis_index(self.mesh, mesh_axis)
+        if not isinstance(self.placements[axis], Flat):
+            raise ValueError(f"allgather() requires Flat placement on axis {mesh_axis!r}.")
+
+        placements = list(self.placements)
+        placements[axis] = Replicate()
+        _validate_placements(placements)
+        buffer = DBuffer(
+            mesh=self.mesh,
+            placements=placements,
+            tensor_shapes=self.layout.tensor_shapes,
+            dtype=self.local_buffer.dtype,
+            device=self.local_buffer.device,
+        )
+        dist.all_gather_into_tensor(
+            output_tensor=buffer.local_buffer,
+            input_tensor=self.local_buffer,
+            group=self.mesh.get_group(axis),
+        )
+        return buffer
+
+    def allreduce(self, mesh_axis: MeshAxis) -> "DBuffer":
+        """All-reduce a Partial axis into Replicate placement."""
+        axis = _axis_index(self.mesh, mesh_axis)
+        if not isinstance(self.placements[axis], Partial):
+            raise ValueError(f"allreduce() requires Partial placement on axis {mesh_axis!r}.")
+
+        placements = list(self.placements)
+        placements[axis] = Replicate()
+        buffer = DBuffer(
+            mesh=self.mesh,
+            placements=placements,
+            tensor_shapes=self.layout.tensor_shapes,
+            dtype=self.local_buffer.dtype,
+            device=self.local_buffer.device,
+        )
+        buffer.local_buffer.copy_(self.local_buffer)
+        dist.all_reduce(buffer.local_buffer, op=dist.ReduceOp.SUM, group=self.mesh.get_group(axis))
+        return buffer
+
+    def reduce_scatter(self, mesh_axis: MeshAxis, new_placement: Placement) -> "DBuffer":
+        """Reduce-scatter a Partial axis into ``new_placement``."""
+        axis = _axis_index(self.mesh, mesh_axis)
+        if not isinstance(new_placement, Flat):
+            raise NotImplementedError("DBuffer currently supports reduce_scatter() to Flat only.")
+        if not isinstance(self.placements[axis], Partial):
+            raise ValueError(f"reduce_scatter() requires Partial placement on axis {mesh_axis!r}.")
+
+        placements = list(self.placements)
+        placements[axis] = new_placement
+        _validate_placements(placements)
+        buffer = DBuffer(
+            mesh=self.mesh,
+            placements=placements,
+            tensor_shapes=self.layout.tensor_shapes,
+            dtype=self.local_buffer.dtype,
+            device=self.local_buffer.device,
+        )
+        dist.reduce_scatter_tensor(
+            output=buffer.local_buffer,
+            input=self.local_buffer,
+            op=dist.ReduceOp.SUM,
+            group=self.mesh.get_group(axis),
+        )
+        return buffer
+
+    def scatter(self, mesh_axis: MeshAxis, new_placement: Placement) -> "DBuffer":
+        """Locally chunk a Replicate axis into ``new_placement``."""
+        axis = _axis_index(self.mesh, mesh_axis)
+        if not isinstance(new_placement, Flat):
+            raise NotImplementedError("DBuffer currently supports scatter() to Flat only.")
+        if not isinstance(self.placements[axis], Replicate):
+            raise ValueError(f"scatter() requires Replicate placement on axis {mesh_axis!r}.")
+
+        placements = list(self.placements)
+        placements[axis] = new_placement
+        _validate_placements(placements)
+        buffer = DBuffer(
+            mesh=self.mesh,
+            placements=placements,
+            tensor_shapes=self.layout.tensor_shapes,
+            dtype=self.local_buffer.dtype,
+            device=self.local_buffer.device,
+        )
+        local_buffer_offset = buffer.offset - self.offset
+        if (
+            local_buffer_offset < 0
+            or local_buffer_offset + buffer.local_buffer.numel() > self.local_buffer.numel()
+        ):
+            raise RuntimeError("scatter() destination is not contained in the source local buffer.")
+        buffer.local_buffer.copy_(
+            self.local_buffer.narrow(0, local_buffer_offset, buffer.local_buffer.numel())
+        )
+        return buffer
+
+    def get_tensor(self, index: int) -> torch.Tensor:
+        """Return this rank's local view for logical tensor ``index``.
+
+        Flat placements shard dim 0, so the returned view preserves all
+        non-leading dimensions and only changes the leading dimension.
+        """
+        shape = self.layout.tensor_shapes[index]
+        offset = self.layout.tensor_to_offset[index]
+        numel = shape.numel()
+
+        tensor_start = offset
+        tensor_end = offset + numel
+        overlap_start = max(tensor_start, self.offset)
+        overlap_end = min(tensor_end, self.offset + self.local_buffer.numel())
+
+        row_size = _non_leading_numel(shape)
+        if overlap_end <= overlap_start:
+            empty_shape = torch.Size((0, *shape[1:]))
+            return torch.empty(
+                empty_shape, dtype=self.local_buffer.dtype, device=self.local_buffer.device
+            )
+
+        local_numel = overlap_end - overlap_start
+        local_buffer_offset = overlap_start - self.offset
+        if (overlap_start - tensor_start) % row_size != 0 or local_numel % row_size != 0:
+            raise RuntimeError(
+                f"Local tensor shard for tensor {index} does not preserve dim-0 boundaries."
+            )
+        local_shape = torch.Size((local_numel // row_size, *shape[1:]))
+        return self.local_buffer.narrow(0, local_buffer_offset, local_numel).view(local_shape)
+
+    def get_dtensor(self, index: int) -> DTensor:
+        """Return logical tensor ``index`` as a DTensor."""
+        torch_placements = []
+        for placement in self.placements:
+            if isinstance(placement, Replicate):
+                torch_placements.append(dist_tensor.Replicate())
+            elif isinstance(placement, Flat):
+                torch_placements.append(dist_tensor.Shard(0))
+            elif isinstance(placement, Partial):
+                raise ValueError("Partial DBuffer placements cannot be represented as DTensor.")
+            else:
+                raise TypeError(f"Unsupported placement for DTensor conversion: {placement!r}.")
+
+        local_tensor = self.get_tensor(index)
+        tensor_shape = self.layout.tensor_shapes[index]
+        return DTensor.from_local(
+            local_tensor=local_tensor,
+            device_mesh=self.mesh,
+            placements=tuple(torch_placements),
+            run_check=False,
+            shape=tensor_shape,
+            stride=local_tensor.stride(),
+        )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -15,7 +15,8 @@
 """Experimental Megatron-FSDP implementation."""
 
 from .dbuffer import DBuffer
-from .fully_shard import FsdpModule, fully_shard
+from .fsdp_module import FsdpModule
+from .fully_shard import fully_shard
 from .parameter_group import ParameterGroup
 from .placement import Flat, Partial, Placement, Placements, Replicate
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -16,11 +16,4 @@
 
 from .dbuffer import DBuffer, Flat, MeshAxis, Partial, Placement, Replicate
 
-__all__ = [
-    "DBuffer",
-    "Flat",
-    "MeshAxis",
-    "Partial",
-    "Placement",
-    "Replicate",
-]
+__all__ = ["DBuffer", "Flat", "MeshAxis", "Partial", "Placement", "Replicate"]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -14,6 +14,7 @@
 
 """Experimental Megatron-FSDP implementation."""
 
-from .dbuffer import DBuffer, Flat, MeshAxis, Partial, Placement, Replicate
+from .dbuffer import DBuffer, MeshAxis
+from .placement import Flat, Partial, Placement, Replicate
 
 __all__ = ["DBuffer", "Flat", "MeshAxis", "Partial", "Placement", "Replicate"]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -15,6 +15,17 @@
 """Experimental Megatron-FSDP implementation."""
 
 from .dbuffer import DBuffer
+from .fully_shard import FsdpModule, ParameterGroup, Placements, fully_shard
 from .placement import Flat, Partial, Placement, Replicate
 
-__all__ = ["DBuffer", "Flat", "Partial", "Placement", "Replicate"]
+__all__ = [
+    "DBuffer",
+    "Flat",
+    "FsdpModule",
+    "ParameterGroup",
+    "Partial",
+    "Placement",
+    "Placements",
+    "Replicate",
+    "fully_shard",
+]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -15,14 +15,15 @@
 """Experimental Megatron-FSDP implementation."""
 
 from .dbuffer import DBuffer
-from .fsdp_module import FsdpModule
-from .fully_shard import fully_shard
+from .fsdp_module import FsdpContext, FsdpModule
+from .fully_shard import fully_shard, microbatch
 from .parameter_group import ParameterGroup
 from .placement import Flat, Partial, Placement, Placements, Replicate
 
 __all__ = [
     "DBuffer",
     "Flat",
+    "FsdpContext",
     "FsdpModule",
     "ParameterGroup",
     "Partial",
@@ -30,4 +31,5 @@ __all__ = [
     "Placements",
     "Replicate",
     "fully_shard",
+    "microbatch",
 ]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -15,8 +15,9 @@
 """Experimental Megatron-FSDP implementation."""
 
 from .dbuffer import DBuffer
-from .fully_shard import FsdpModule, ParameterGroup, Placements, fully_shard
-from .placement import Flat, Partial, Placement, Replicate
+from .fully_shard import FsdpModule, fully_shard
+from .parameter_group import ParameterGroup
+from .placement import Flat, Partial, Placement, Placements, Replicate
 
 __all__ = [
     "DBuffer",

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Experimental Megatron-FSDP implementation."""
+
+from .dbuffer import DBuffer, Flat, MeshAxis, Partial, Placement, Replicate
+
+__all__ = [
+    "DBuffer",
+    "Flat",
+    "MeshAxis",
+    "Partial",
+    "Placement",
+    "Replicate",
+]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -14,7 +14,7 @@
 
 """Experimental Megatron-FSDP implementation."""
 
-from .dbuffer import DBuffer, MeshAxis
+from .dbuffer import DBuffer
 from .placement import Flat, Partial, Placement, Replicate
 
-__all__ = ["DBuffer", "Flat", "MeshAxis", "Partial", "Placement", "Replicate"]
+__all__ = ["DBuffer", "Flat", "Partial", "Placement", "Replicate"]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -243,6 +243,11 @@ class DBuffer:
         """Dtype of the local buffer."""
         return self.local_buffer.dtype
 
+    @property
+    def device(self) -> torch.device:
+        """Device of the local buffer."""
+        return self.local_buffer.device
+
     @classmethod
     def from_local(
         cls,
@@ -302,24 +307,14 @@ class DBuffer:
         Returns:
             A DBuffer whose local storage matches ``placements``.
         """
-        tensors = tuple(
-            (
-                tensor.to(mesh.device_type)
-                if tensor.device.type != mesh.device_type and not tensor.is_meta
-                else tensor
-            )
-            .detach()
-            .contiguous()
-            for tensor in tensors
-        )
+        tensors = tuple(tensor.detach().contiguous() for tensor in tensors)
         if not tensors:
             raise ValueError("DBuffer.distribute_tensors() requires at least one tensor.")
 
         dtype = tensors[0].dtype
-        device = tensors[0].device
         for tensor in tensors:
-            if tensor.dtype != dtype or tensor.device != device:
-                raise ValueError("All tensors in a DBuffer must have the same dtype and device.")
+            if tensor.dtype != dtype:
+                raise ValueError("All tensors in a DBuffer must have the same dtype.")
 
         tensor_shapes = tuple(tensor.shape for tensor in tensors)
         buffer = cls(
@@ -327,7 +322,7 @@ class DBuffer:
             placements=placements,
             tensor_shapes=tensor_shapes,
             dtype=dtype,
-            device=device,
+            device=mesh.device_type,
         )
         local_start = buffer.offset
         local_end = local_start + buffer.local_buffer.numel()
@@ -343,8 +338,9 @@ class DBuffer:
             overlap_numel = overlap_end - overlap_start
             source_offset = overlap_start - tensor_start
             destination_offset = overlap_start - local_start
+            source_slice = tensor.view(-1).narrow(0, source_offset, overlap_numel)
             buffer.local_buffer.narrow(0, destination_offset, overlap_numel).copy_(
-                tensor.view(-1).narrow(0, source_offset, overlap_numel)
+                source_slice.to(buffer.device)
             )
         return buffer
 
@@ -358,7 +354,7 @@ class DBuffer:
                 placements=placements,
                 tensor_shapes=self.layout.tensor_shapes,
                 dtype=self.dtype,
-                device=self.local_buffer.device,
+                device=self.device,
             )
 
         if out.mesh != self.mesh:
@@ -369,10 +365,8 @@ class DBuffer:
             raise ValueError(f"Expected out layout {self.layout!r}, got {out.layout!r}.")
         if out.dtype != self.dtype:
             raise ValueError(f"Expected out dtype {self.dtype}, got {out.dtype}.")
-        if out.local_buffer.device != self.local_buffer.device:
-            raise ValueError(
-                f"Expected out device {self.local_buffer.device}, got {out.local_buffer.device}."
-            )
+        if out.device != self.device:
+            raise ValueError(f"Expected out device {self.device}, got {out.device}.")
         return out
 
     def redistribute(
@@ -542,7 +536,7 @@ class DBuffer:
         row_size = _non_leading_numel(shape)
         if overlap_end <= overlap_start:
             empty_shape = torch.Size((0, *shape[1:]))
-            return torch.empty(empty_shape, dtype=self.dtype, device=self.local_buffer.device)
+            return torch.empty(empty_shape, dtype=self.dtype, device=self.device)
 
         local_numel = overlap_end - overlap_start
         local_buffer_offset = overlap_start - self.offset

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -367,15 +367,17 @@ class DBuffer:
             )
 
         if out.mesh != self.mesh:
-            raise ValueError("out must use the same mesh.")
+            raise ValueError(f"Expected out mesh {self.mesh!r}, got {out.mesh!r}.")
         if out.placements != placements:
-            raise ValueError(f"Expected out placements {placements}, got {out.placements}.")
+            raise ValueError(f"Expected out placements {placements!r}, got {out.placements!r}.")
         if out.layout != self.layout:
-            raise ValueError("out layout must match the source layout.")
+            raise ValueError(f"Expected out layout {self.layout!r}, got {out.layout!r}.")
         if out.dtype != self.dtype:
-            raise ValueError("out dtype must match the source dtype.")
+            raise ValueError(f"Expected out dtype {self.dtype}, got {out.dtype}.")
         if out.local_buffer.device != self.local_buffer.device:
-            raise ValueError("out device must match the source device.")
+            raise ValueError(
+                f"Expected out device {self.local_buffer.device}, got {out.local_buffer.device}."
+            )
         return out
 
     def redistribute(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -24,7 +24,7 @@ from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
 from .layout import GlobalLayout, Shape, non_leading_numel
-from .placement import Flat, Partial, Placement, Replicate, validate_placements
+from .placement import Flat, Partial, Placement, Replicate
 
 
 @dataclasses.dataclass(frozen=True)
@@ -39,6 +39,20 @@ def _validate_mesh_axis(mesh: DeviceMesh, axis: int) -> None:
         raise TypeError(f"Mesh axis must be an int, got {type(axis).__name__}.")
     if axis < 0 or axis >= mesh.ndim:
         raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
+
+
+def _validate_placements(placements: Iterable[Placement]) -> None:
+    seen_flat = False
+    for placement in placements:
+        if not isinstance(placement, (Replicate, Partial, Flat)):
+            raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
+        if isinstance(placement, Flat):
+            seen_flat = True
+        elif seen_flat:
+            raise ValueError(
+                "Flat placements must be a suffix of the placement list so each "
+                "local buffer is a contiguous global-buffer range."
+            )
 
 
 class DBuffer:
@@ -81,7 +95,7 @@ class DBuffer:
             raise ValueError(
                 f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
             )
-        validate_placements(placements)
+        _validate_placements(placements)
 
         self.mesh = mesh
         self.placements = placements
@@ -146,7 +160,7 @@ class DBuffer:
             raise ValueError(
                 f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
             )
-        validate_placements(placements)
+        _validate_placements(placements)
         if local_buffer.dim() != 1:
             raise ValueError("local_buffer must be a flat 1D tensor.")
         if not local_buffer.is_contiguous():
@@ -255,7 +269,7 @@ class DBuffer:
                 f"Expected {self.mesh.ndim} placements for device mesh, got "
                 f"{len(new_placements)}."
             )
-        validate_placements(new_placements)
+        _validate_placements(new_placements)
 
         changed_axis: int | None = None
         for axis, (old_placement, new_placement) in enumerate(
@@ -303,7 +317,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[mesh_axis] = Replicate()
-        validate_placements(placements)
+        _validate_placements(placements)
         out = self._create_or_validate_out(placements, out)
         dist.all_gather_into_tensor(
             output_tensor=out.local_buffer,
@@ -343,7 +357,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = new_placement
-        validate_placements(placements)
+        _validate_placements(placements)
         out = self._create_or_validate_out(placements, out)
         dist.reduce_scatter_tensor(
             output=out.local_buffer,
@@ -366,7 +380,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = new_placement
-        validate_placements(placements)
+        _validate_placements(placements)
 
         if out is None:
             destination_offset, destination_numel = self.layout.get_local_range(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -116,6 +116,20 @@ class DBuffer:
         """Device of the local buffer."""
         return self.local_buffer.device
 
+    def reallocate_storage(self) -> None:
+        """Restore the local buffer's backing storage to its logical size."""
+        self._resize_storage(self.local_buffer.numel())
+
+    def release_storage(self) -> None:
+        """Release local buffer storage without replacing the Storage object."""
+        # Autograd may save views that share this Storage object. Resizing the
+        # existing Storage releases the allocation while preserving those aliases
+        # for a later reallocate_storage().
+        self._resize_storage(0)
+
+    def _resize_storage(self, numel: int) -> None:
+        self.local_buffer.untyped_storage().resize_(numel * self.local_buffer.element_size())
+
     def _get_owned_range(self, tensor_index: int) -> _OwnedRange | None:
         """Return this buffer's owned range for logical tensor ``tensor_index``."""
         tensor_start = self.layout.tensor_to_offset[tensor_index]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -423,20 +423,21 @@ class DBuffer:
         )
 
     def allgather(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
-        """All-gather a Flat axis into Replicate placement."""
+        """All-gather a sharded axis into Replicate placement."""
         _validate_mesh_axis(self.mesh, mesh_axis)
-        axis = mesh_axis
-        if not isinstance(self.placements[axis], Flat):
-            raise ValueError(f"allgather() requires Flat placement on axis {mesh_axis!r}.")
+        if not isinstance(self.placements[mesh_axis], Flat):
+            raise ValueError(
+                f"allgather() currently requires Flat placement on axis {mesh_axis!r}."
+            )
 
         placements = list(self.placements)
-        placements[axis] = Replicate()
+        placements[mesh_axis] = Replicate()
         validate_placements(placements)
         out = self._create_or_validate_out(placements, out)
         dist.all_gather_into_tensor(
             output_tensor=out.local_buffer,
             input_tensor=self.local_buffer,
-            group=self.mesh.get_group(axis),
+            group=self.mesh.get_group(mesh_axis),
         )
         return out
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -24,29 +24,10 @@ import torch.distributed.tensor as dist_tensor
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
+from .placement import Flat, Partial, Placement, Replicate, validate_placements
+
 MeshAxis = int | str
 Shape = torch.Size | Iterable[int]
-
-
-class Placement:
-    """Base class for DBuffer placements."""
-
-
-@dataclasses.dataclass(frozen=True)
-class Replicate(Placement):
-    """Replicated local buffer placement."""
-
-
-@dataclasses.dataclass(frozen=True)
-class Partial(Placement):
-    """Unreduced replicated local buffer placement."""
-
-    reduce_op: dist.ReduceOp.RedOpType = dist.ReduceOp.SUM
-
-
-@dataclasses.dataclass(frozen=True)
-class Flat(Placement):
-    """Flat per-unit dim-0 sharded local buffer placement."""
 
 
 @dataclasses.dataclass(frozen=True)
@@ -95,24 +76,6 @@ def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
     if dim_names is None or axis not in dim_names:
         raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
     return dim_names.index(axis)
-
-
-def _validate_placement(placement: Placement) -> None:
-    if not isinstance(placement, (Replicate, Partial, Flat)):
-        raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
-
-
-def _validate_placements(placements: Iterable[Placement]) -> None:
-    seen_flat = False
-    for placement in placements:
-        _validate_placement(placement)
-        if isinstance(placement, Flat):
-            seen_flat = True
-        elif seen_flat:
-            raise ValueError(
-                "Flat placements must be a suffix of the placement list so each "
-                "local buffer is a contiguous global-buffer range."
-            )
 
 
 def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
@@ -254,7 +217,7 @@ class DBuffer:
             raise ValueError(
                 f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
             )
-        _validate_placements(placements)
+        validate_placements(placements)
 
         self.mesh = mesh
         self.placements = placements
@@ -294,7 +257,7 @@ class DBuffer:
             raise ValueError(
                 f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
             )
-        _validate_placements(placements)
+        validate_placements(placements)
         if local_buffer.dim() != 1:
             raise ValueError("local_buffer must be a flat 1D tensor.")
 
@@ -415,7 +378,7 @@ class DBuffer:
                 f"Expected {self.mesh.ndim} placements for device mesh, got "
                 f"{len(new_placements)}."
             )
-        _validate_placements(new_placements)
+        validate_placements(new_placements)
 
         changed_axis: int | None = None
         for axis, (old_placement, new_placement) in enumerate(
@@ -461,7 +424,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = Replicate()
-        _validate_placements(placements)
+        validate_placements(placements)
         destination = self._create_or_validate_out(placements, out)
         dist.all_gather_into_tensor(
             output_tensor=destination.local_buffer,
@@ -501,7 +464,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = new_placement
-        _validate_placements(placements)
+        validate_placements(placements)
         destination = self._create_or_validate_out(placements, out)
         dist.reduce_scatter_tensor(
             output=destination.local_buffer,
@@ -523,7 +486,7 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = new_placement
-        _validate_placements(placements)
+        validate_placements(placements)
 
         if out is None:
             destination_offset, destination_numel = self.layout.get_local_range(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -327,7 +327,7 @@ class DBuffer:
         local_start = buffer.offset
         local_end = local_start + buffer.local_buffer.numel()
         # Only logical tensor ranges are initialized. Padding and layout gaps are not
-        # observable through get_tensor() and can remain unspecified.
+        # observable through get_local_tensor() and can remain unspecified.
         for tensor, tensor_start in zip(tensors, buffer.layout.tensor_to_offset, strict=True):
             tensor_end = tensor_start + tensor.numel()
             overlap_start = max(local_start, tensor_start)
@@ -518,7 +518,7 @@ class DBuffer:
         out.local_buffer.copy_(local_slice)
         return out
 
-    def get_tensor(self, index: int) -> torch.Tensor:
+    def get_local_tensor(self, index: int) -> torch.Tensor:
         """Return this rank's local view for logical tensor ``index``.
 
         Flat placements shard dim 0, so the returned view preserves all
@@ -560,7 +560,7 @@ class DBuffer:
             else:
                 raise TypeError(f"Unsupported placement for DTensor conversion: {placement!r}.")
 
-        local_tensor = self.get_tensor(index)
+        local_tensor = self.get_local_tensor(index)
         tensor_shape = self.layout.tensor_shapes[index]
         return DTensor.from_local(
             local_tensor=local_tensor,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -16,7 +16,7 @@
 
 import dataclasses
 import math
-from typing import Sequence
+from collections.abc import Iterable, Sequence
 
 import torch
 import torch.distributed as dist
@@ -39,6 +39,8 @@ class Replicate(Placement):
 @dataclasses.dataclass(frozen=True)
 class Partial(Placement):
     """Unreduced replicated local buffer placement."""
+
+    reduce_op: dist.ReduceOp.RedOpType = dist.ReduceOp.SUM
 
 
 @dataclasses.dataclass(frozen=True)
@@ -257,7 +259,7 @@ class DBuffer:
 
     @classmethod
     def distribute_tensors(
-        cls, tensors: Sequence[torch.Tensor], mesh: DeviceMesh, placements: Sequence[Placement]
+        cls, tensors: Iterable[torch.Tensor], mesh: DeviceMesh, placements: Sequence[Placement]
     ) -> "DBuffer":
         """Distribute full local tensor values into a DBuffer.
 
@@ -269,24 +271,24 @@ class DBuffer:
         Returns:
             A DBuffer whose local storage matches ``placements``.
         """
-        if not tensors:
-            raise ValueError("DBuffer.distribute_tensors() requires at least one tensor.")
-
         tensors = tuple(
             (
                 tensor.to(mesh.device_type)
                 if tensor.device.type != mesh.device_type and not tensor.is_meta
                 else tensor
             )
+            .detach()
+            .contiguous()
             for tensor in tensors
         )
+        if not tensors:
+            raise ValueError("DBuffer.distribute_tensors() requires at least one tensor.")
+
         dtype = tensors[0].dtype
         device = tensors[0].device
         for tensor in tensors:
             if tensor.dtype != dtype or tensor.device != device:
                 raise ValueError("All tensors in a DBuffer must have the same dtype and device.")
-            if not tensor.is_contiguous():
-                raise ValueError("DBuffer.distribute_tensors() expects contiguous tensors.")
 
         tensor_shapes = tuple(tensor.shape for tensor in tensors)
         buffer = cls(
@@ -296,12 +298,23 @@ class DBuffer:
             dtype=dtype,
             device=device,
         )
-        full_buffer = torch.zeros(buffer.layout.size, dtype=dtype, device=device)
-        for tensor, offset in zip(tensors, buffer.layout.tensor_to_offset, strict=True):
-            full_buffer.narrow(0, offset, tensor.numel()).copy_(tensor.view(-1))
+        local_start = buffer.offset
+        local_end = local_start + buffer.local_buffer.numel()
+        # Only logical tensor ranges are initialized. Padding and layout gaps are not
+        # observable through get_tensor() and can remain unspecified.
+        for tensor, tensor_start in zip(tensors, buffer.layout.tensor_to_offset, strict=True):
+            tensor_end = tensor_start + tensor.numel()
+            overlap_start = max(local_start, tensor_start)
+            overlap_end = min(local_end, tensor_end)
+            if overlap_start >= overlap_end:
+                continue
 
-        local_buffer = full_buffer.narrow(0, buffer.offset, buffer.local_buffer.numel())
-        buffer.local_buffer.copy_(local_buffer)
+            overlap_numel = overlap_end - overlap_start
+            source_offset = overlap_start - tensor_start
+            destination_offset = overlap_start - local_start
+            buffer.local_buffer.narrow(0, destination_offset, overlap_numel).copy_(
+                tensor.view(-1).narrow(0, source_offset, overlap_numel)
+            )
         return buffer
 
     def redistribute(self, new_placements: Sequence[Placement]) -> "DBuffer":
@@ -370,7 +383,8 @@ class DBuffer:
     def allreduce(self, mesh_axis: MeshAxis) -> "DBuffer":
         """All-reduce a Partial axis into Replicate placement."""
         axis = _axis_index(self.mesh, mesh_axis)
-        if not isinstance(self.placements[axis], Partial):
+        partial_placement = self.placements[axis]
+        if not isinstance(partial_placement, Partial):
             raise ValueError(f"allreduce() requires Partial placement on axis {mesh_axis!r}.")
 
         placements = list(self.placements)
@@ -383,7 +397,11 @@ class DBuffer:
             device=self.local_buffer.device,
         )
         buffer.local_buffer.copy_(self.local_buffer)
-        dist.all_reduce(buffer.local_buffer, op=dist.ReduceOp.SUM, group=self.mesh.get_group(axis))
+        dist.all_reduce(
+            buffer.local_buffer,
+            op=partial_placement.reduce_op,
+            group=self.mesh.get_group(axis),
+        )
         return buffer
 
     def reduce_scatter(self, mesh_axis: MeshAxis, new_placement: Placement) -> "DBuffer":
@@ -391,7 +409,8 @@ class DBuffer:
         axis = _axis_index(self.mesh, mesh_axis)
         if not isinstance(new_placement, Flat):
             raise NotImplementedError("DBuffer currently supports reduce_scatter() to Flat only.")
-        if not isinstance(self.placements[axis], Partial):
+        partial_placement = self.placements[axis]
+        if not isinstance(partial_placement, Partial):
             raise ValueError(f"reduce_scatter() requires Partial placement on axis {mesh_axis!r}.")
 
         placements = list(self.placements)
@@ -407,7 +426,7 @@ class DBuffer:
         dist.reduce_scatter_tensor(
             output=buffer.local_buffer,
             input=self.local_buffer,
-            op=dist.ReduceOp.SUM,
+            op=partial_placement.reduce_op,
             group=self.mesh.get_group(axis),
         )
         return buffer

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -112,21 +112,21 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         else:
             regular_items.append((tensor_id, shape))
 
-    fragment_items.sort(key=lambda id_shape: -id_shape[1].numel())
+    fragment_items.sort(key=lambda id_shape: id_shape[1].numel(), reverse=True)
 
-    data_index = 0
+    next_offset = 0
     while regular_items:
         tensor_id, shape = regular_items.pop(0)
         tensor_numel = shape.numel()
-        tensor_to_offset[tensor_id] = data_index
+        tensor_to_offset[tensor_id] = next_offset
 
         if tensor_numel % chunk_size == 0:
-            data_index += tensor_numel
+            next_offset += tensor_numel
             continue
 
-        gap_offset = data_index + tensor_numel
-        data_index += _pad_to_multiple(tensor_numel, chunk_size)
-        fragment_gap_end = data_index
+        gap_offset = next_offset + tensor_numel
+        next_offset += _pad_to_multiple(tensor_numel, chunk_size)
+        fragment_gap_end = next_offset
         remain = tensor_numel % chunk_size
 
         found_rhs = None
@@ -145,10 +145,10 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             rhs_id, rhs_shape = found_rhs
             rhs_numel = rhs_shape.numel()
             rhs_remain = rhs_numel % chunk_size
-            rhs_offset = data_index - rhs_remain
+            rhs_offset = next_offset - rhs_remain
             tensor_to_offset[rhs_id] = rhs_offset
             fragment_gap_end = rhs_offset
-            data_index += (rhs_numel // chunk_size) * chunk_size
+            next_offset += (rhs_numel // chunk_size) * chunk_size
 
         for fragment in fragment_items[:]:
             frag_id, frag_shape = fragment
@@ -161,9 +161,9 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             fragment_items.remove(fragment)
 
     for frag_id, frag_shape in fragment_items:
-        data_index = _pad_to_multiple(data_index, _non_leading_numel(frag_shape))
-        tensor_to_offset[frag_id] = data_index
-        data_index += frag_shape.numel()
+        next_offset = _pad_to_multiple(next_offset, _non_leading_numel(frag_shape))
+        tensor_to_offset[frag_id] = next_offset
+        next_offset += frag_shape.numel()
 
     if any(offset is None for offset in tensor_to_offset):
         raise AssertionError(f"Incomplete DBuffer layout for shapes {shapes}.")
@@ -173,7 +173,7 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         row_size = _non_leading_numel(shape)
         if offset % row_size != 0:
             raise AssertionError(f"Tensor offset {offset} is not aligned to row size {row_size}.")
-    size = _pad_to_multiple(data_index, chunk_size * dp_size)
+    size = _pad_to_multiple(next_offset, chunk_size * dp_size)
     return GlobalLayout(tensor_shapes=shapes, tensor_to_offset=resolved_tensor_to_offset, size=size)
 
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -81,6 +81,11 @@ def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
 def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
     """Compute global tensor element offsets and padded size.
 
+    This is a DBuffer-specific reimplementation of
+    ``param_and_grad_buffer.build_data_parallel_buffer_index``. It keeps only
+    the global offset construction and final DP-LCM padding; DBuffer derives
+    rank-local slices later through DTensor placements.
+
     The computed layout is compatible with Flat, TensorAtomic, and BlockAtomic,
     even though the latter two are not implemented.
 
@@ -103,6 +108,8 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             raise ValueError(f"Cannot compute a layout for zero-sized non-leading dims: {shape}.")
         chunk_size = math.lcm(chunk_size, non_leading_numel)
 
+    # The LCM part is the packing grid. Since every row size divides this grid,
+    # DP shard boundaries that are multiples of the grid avoid splitting dim-0 rows.
     tensor_to_offset: list[int | None] = [None] * len(shapes)
     fragment_items = []
     regular_items = []
@@ -112,6 +119,8 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         else:
             regular_items.append((tensor_id, shape))
 
+    # Regular tensors anchor the layout. Fragments are held back to fill padding
+    # gaps left by regular tensors whose sizes are not exact multiples of the grid.
     fragment_items.sort(key=lambda id_shape: id_shape[1].numel(), reverse=True)
 
     next_offset = 0
@@ -127,29 +136,34 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         gap_offset = next_offset + tensor_numel
         next_offset += _pad_to_multiple(tensor_numel, chunk_size)
         fragment_gap_end = next_offset
-        remain = tensor_numel % chunk_size
+        remainder = tensor_numel % chunk_size
 
-        found_rhs = None
-        for rhs in regular_items[:]:
-            _, rhs_shape = rhs
-            rhs_numel = rhs_shape.numel()
-            rhs_remain = rhs_numel % chunk_size
-            if rhs_remain == 0:
+        # Try to pair this non-divisible regular tensor with a conjugate regular
+        # tensor whose remainder fits in the same LCM part. The conjugate starts
+        # in the gap and then continues with full LCM parts after this one.
+        conjugate_item = None
+        for candidate_item in regular_items[:]:
+            _, candidate_shape = candidate_item
+            candidate_numel = candidate_shape.numel()
+            candidate_remainder = candidate_numel % chunk_size
+            if candidate_remainder == 0:
                 continue
-            if remain + rhs_remain <= chunk_size:
-                found_rhs = rhs
-                regular_items.remove(rhs)
+            if remainder + candidate_remainder <= chunk_size:
+                conjugate_item = candidate_item
+                regular_items.remove(candidate_item)
                 break
 
-        if found_rhs is not None:
-            rhs_id, rhs_shape = found_rhs
-            rhs_numel = rhs_shape.numel()
-            rhs_remain = rhs_numel % chunk_size
-            rhs_offset = next_offset - rhs_remain
-            tensor_to_offset[rhs_id] = rhs_offset
-            fragment_gap_end = rhs_offset
-            next_offset += (rhs_numel // chunk_size) * chunk_size
+        if conjugate_item is not None:
+            conjugate_id, conjugate_shape = conjugate_item
+            conjugate_numel = conjugate_shape.numel()
+            conjugate_remainder = conjugate_numel % chunk_size
+            conjugate_offset = next_offset - conjugate_remainder
+            tensor_to_offset[conjugate_id] = conjugate_offset
+            fragment_gap_end = conjugate_offset
+            next_offset += (conjugate_numel // chunk_size) * chunk_size
 
+        # Fill any remaining gap with fragments, keeping each fragment aligned to
+        # its own row size so dim-0 rows remain contiguous within DP shards.
         for fragment in fragment_items[:]:
             frag_id, frag_shape = fragment
             frag_numel = frag_shape.numel()
@@ -160,6 +174,7 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             gap_offset = aligned_gap_offset + frag_numel
             fragment_items.remove(fragment)
 
+    # Fragments that did not fit into regular-tensor gaps are appended at the tail.
     for frag_id, frag_shape in fragment_items:
         next_offset = _pad_to_multiple(next_offset, _non_leading_numel(frag_shape))
         tensor_to_offset[frag_id] = next_offset

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -259,7 +259,9 @@ class DBuffer:
         """Create a DBuffer from an existing local buffer.
 
         Args:
-            local_buffer: Local tensor storage for this rank.
+            local_buffer: Contiguous local tensor storage for this rank. DBuffer
+                uses it directly in collectives such as all-gather and
+                reduce-scatter, which are efficient with contiguous tensors.
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
             tensor_shapes: Global shapes for each logical tensor in this buffer.
@@ -275,6 +277,8 @@ class DBuffer:
         validate_placements(placements)
         if local_buffer.dim() != 1:
             raise ValueError("local_buffer must be a flat 1D tensor.")
+        if not local_buffer.is_contiguous():
+            raise ValueError("local_buffer must be contiguous for collective operations.")
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
         layout = _compute_layout(tensor_shapes, dp_size=mesh.size())
@@ -563,6 +567,8 @@ class DBuffer:
 
         local_tensor = self.get_local_tensor(index)
         tensor_shape = self.layout.tensor_shapes[index]
+        # DBuffer uses contiguous flat storage, and Flat only shards dim 0, so
+        # the local view's stride matches the logical global tensor stride.
         return DTensor.from_local(
             local_tensor=local_tensor,
             device_mesh=self.mesh,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -15,9 +15,7 @@
 """Distributed tensor buffers for Megatron-FSDP."""
 
 import dataclasses
-import math
 from collections.abc import Iterable
-from typing import TypeAlias
 
 import torch
 import torch.distributed as dist
@@ -25,9 +23,8 @@ import torch.distributed.tensor as dist_tensor
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
+from .layout import GlobalLayout, Shape, non_leading_numel
 from .placement import Flat, Partial, Placement, Replicate, validate_placements
-
-Shape: TypeAlias = torch.Size | Iterable[int]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -37,228 +34,11 @@ class _OwnedRange:
     buffer_relative_offset: int
 
 
-@dataclasses.dataclass(frozen=True)
-class GlobalLayout:
-    """Global tensor layout in element coordinates."""
-
-    tensor_shapes: tuple[torch.Size, ...]
-    tensor_to_offset: tuple[int, ...]
-    size: int
-
-    def __post_init__(self) -> None:
-        """Validate tensor offsets are row-aligned, in bounds, and non-overlapping."""
-
-        @dataclasses.dataclass(frozen=True)
-        class TensorRange:
-            start: int
-            end: int
-            tensor_id: int
-
-        if self.size < 0:
-            raise AssertionError(f"Global layout size {self.size} is negative.")
-        if len(self.tensor_shapes) != len(self.tensor_to_offset):
-            raise AssertionError(
-                "Global layout has mismatched tensor shapes and offsets: "
-                f"{len(self.tensor_shapes)} shapes and {len(self.tensor_to_offset)} offsets."
-            )
-
-        tensor_ranges: list[TensorRange] = []
-        for tensor_id, (shape, start) in enumerate(
-            zip(self.tensor_shapes, self.tensor_to_offset, strict=True)
-        ):
-            if start < 0:
-                raise AssertionError(f"Tensor {tensor_id} offset {start} is negative.")
-
-            row_size = _non_leading_numel(shape)
-            if row_size <= 0:
-                raise AssertionError(f"Tensor {tensor_id} has invalid row size {row_size}.")
-            if start % row_size != 0:
-                raise AssertionError(
-                    f"Tensor {tensor_id} offset {start} is not aligned to row size {row_size}."
-                )
-
-            end = start + shape.numel()
-            if end > self.size:
-                raise AssertionError(
-                    f"Tensor {tensor_id} range [{start}, {end}) exceeds "
-                    f"layout size {self.size}."
-                )
-            tensor_ranges.append(TensorRange(start, end, tensor_id))
-
-        previous_range: TensorRange | None = None
-        for current_range in sorted(tensor_ranges, key=lambda tensor_range: tensor_range.start):
-            if previous_range is not None and current_range.start < previous_range.end:
-                raise AssertionError(
-                    "Global layout tensors overlap: "
-                    f"tensor {previous_range.tensor_id} "
-                    f"[{previous_range.start}, {previous_range.end}) and "
-                    f"tensor {current_range.tensor_id} "
-                    f"[{current_range.start}, {current_range.end})."
-                )
-            previous_range = current_range
-
-    def get_local_range(self, mesh: DeviceMesh, placements: Iterable[Placement]) -> tuple[int, int]:
-        """Return this rank's local element offset and length for ``placements``."""
-        offset = 0
-        numel = self.size
-        for axis, placement in reversed(tuple(enumerate(placements))):
-            if not isinstance(placement, Flat):
-                continue
-            axis_size = mesh.size(axis)
-            if numel % axis_size != 0:
-                raise ValueError(
-                    f"Local range size {numel} is not divisible by Flat axis size {axis_size}."
-                )
-            shard_size = numel // axis_size
-            offset += mesh.get_local_rank(axis) * shard_size
-            numel = shard_size
-        return offset, numel
-
-
-def _non_leading_numel(shape: torch.Size) -> int:
-    return shape[1:].numel() if len(shape) > 1 else 1
-
-
-def _pad_to_multiple(value: int, multiple: int) -> int:
-    return ((value + multiple - 1) // multiple) * multiple
-
-
 def _validate_mesh_axis(mesh: DeviceMesh, axis: int) -> None:
     if not isinstance(axis, int) or isinstance(axis, bool):
         raise TypeError(f"Mesh axis must be an int, got {type(axis).__name__}.")
     if axis < 0 or axis >= mesh.ndim:
         raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
-
-
-def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
-    """Compute global tensor element offsets and padded size.
-
-    This is a DBuffer-specific reimplementation of
-    ``param_and_grad_buffer.build_data_parallel_buffer_index``. It keeps only
-    the global offset construction and final padding so each rank-local shard
-    size is a multiple of ``chunk_size``; DBuffer derives rank-local slices
-    later through DTensor placements.
-
-    The computed layout is compatible with Flat, TensorAtomic, and BlockAtomic,
-    even though the latter two are not implemented.
-
-    ``chunk_size`` is the least common multiple of each tensor's row size
-    (``shape[1:].numel()``). For example, with shapes P0=(2, 6), P1=(4, 4),
-    P2=(4, 4), P3=(1, 2), P4=(1, 6), ``chunk_size = LCM(6, 4, 4, 2, 6) = 12``
-    and a 5-rank DP layout has equal-size rank shards:
-
-    ```
-    rank 0 [ 0, 12): | P0 row 0              | P0 row 1               |
-    rank 1 [12, 24): | P1 row 0      | P1 row 1      | P1 row 2       |
-    rank 2 [24, 36): | P1 row 3      | P3    | gap   | P2 row 0       |
-    rank 3 [36, 48): | P2 row 1      | P2 row 2      | P2 row 3       |
-    rank 4 [48, 60): | P4                    | pad                    |
-    ```
-
-    The diagram uses four character columns per element; segment widths are
-    proportional. Every chunk boundary is aligned to each tensor's row size,
-    so each DP shard owns full rows even when fragments fill regular-tensor
-    padding gaps.
-
-    Args:
-        shapes: Logical tensor shapes in tensor-id order.
-        dp_size: Data-parallel shard count for this global layout.
-
-    Returns:
-        Global layout with row-aligned tensor offsets and a total size padded
-        to a multiple of ``chunk_size * dp_size``, so every rank-local shard
-        length is a multiple of ``chunk_size``.
-    """
-    if dp_size <= 0:
-        raise ValueError(f"DP size must be positive, got {dp_size}.")
-
-    tensor_shapes = tuple(torch.Size(shape) for shape in shapes)
-    chunk_size = 1
-    for shape in tensor_shapes:
-        non_leading_numel = _non_leading_numel(shape)
-        if non_leading_numel <= 0:
-            raise ValueError(f"Cannot compute a layout for zero-sized non-leading dims: {shape}.")
-        chunk_size = math.lcm(chunk_size, non_leading_numel)
-
-    # chunk_size is the packing unit. Since every tensor row size divides it,
-    # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
-    UNASSIGNED_OFFSET = -1
-    tensor_to_offset: list[int] = [UNASSIGNED_OFFSET] * len(tensor_shapes)
-    fragment_items = []
-    regular_items = []
-    for tensor_id, shape in enumerate(tensor_shapes):
-        if shape.numel() < chunk_size:
-            fragment_items.append((tensor_id, shape))
-        else:
-            regular_items.append((tensor_id, shape))
-
-    # Regular tensors anchor the layout. Fragments are held back to fill padding
-    # gaps left by regular tensors whose sizes are not exact multiples of chunk_size.
-    fragment_items.sort(key=lambda id_shape: id_shape[1].numel(), reverse=True)
-
-    next_offset = 0
-    while regular_items:
-        tensor_id, shape = regular_items.pop(0)
-        tensor_numel = shape.numel()
-        tensor_to_offset[tensor_id] = next_offset
-
-        if tensor_numel % chunk_size == 0:
-            next_offset += tensor_numel
-            continue
-
-        gap_offset = next_offset + tensor_numel
-        next_offset += _pad_to_multiple(tensor_numel, chunk_size)
-        fragment_gap_end = next_offset
-        remainder = tensor_numel % chunk_size
-
-        # Try to pair this non-divisible regular tensor with a conjugate regular
-        # tensor whose remainder fits in the same chunk_size interval. The
-        # conjugate starts in the gap and then continues with full chunk_size
-        # intervals after this one.
-        conjugate_item = None
-        for candidate_item in regular_items[:]:
-            _, candidate_shape = candidate_item
-            candidate_numel = candidate_shape.numel()
-            candidate_remainder = candidate_numel % chunk_size
-            if candidate_remainder == 0:
-                continue
-            if remainder + candidate_remainder <= chunk_size:
-                conjugate_item = candidate_item
-                regular_items.remove(candidate_item)
-                break
-
-        if conjugate_item is not None:
-            conjugate_id, conjugate_shape = conjugate_item
-            conjugate_numel = conjugate_shape.numel()
-            conjugate_remainder = conjugate_numel % chunk_size
-            conjugate_offset = next_offset - conjugate_remainder
-            tensor_to_offset[conjugate_id] = conjugate_offset
-            fragment_gap_end = conjugate_offset
-            next_offset += (conjugate_numel // chunk_size) * chunk_size
-
-        # Fill any remaining gap with fragments, keeping each fragment aligned to
-        # its own row size so dim-0 rows remain contiguous within DP shards.
-        for fragment in fragment_items[:]:
-            frag_id, frag_shape = fragment
-            frag_numel = frag_shape.numel()
-            aligned_gap_offset = _pad_to_multiple(gap_offset, _non_leading_numel(frag_shape))
-            if aligned_gap_offset + frag_numel > fragment_gap_end:
-                continue
-            tensor_to_offset[frag_id] = aligned_gap_offset
-            gap_offset = aligned_gap_offset + frag_numel
-            fragment_items.remove(fragment)
-
-    # Fragments that did not fit into regular-tensor gaps are appended at the tail.
-    for frag_id, frag_shape in fragment_items:
-        next_offset = _pad_to_multiple(next_offset, _non_leading_numel(frag_shape))
-        tensor_to_offset[frag_id] = next_offset
-        next_offset += frag_shape.numel()
-
-    return GlobalLayout(
-        tensor_shapes=tensor_shapes,
-        tensor_to_offset=tuple(tensor_to_offset),
-        size=_pad_to_multiple(next_offset, chunk_size * dp_size),
-    )
 
 
 class DBuffer:
@@ -307,7 +87,7 @@ class DBuffer:
         self.placements = placements
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        self.layout = _compute_layout(tensor_shapes, dp_size=self.mesh.size())
+        self.layout = GlobalLayout.build(tensor_shapes, dp_size=self.mesh.size())
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
@@ -373,7 +153,7 @@ class DBuffer:
             raise ValueError("local_buffer must be contiguous for collective operations.")
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        layout = _compute_layout(tensor_shapes, dp_size=mesh.size())
+        layout = GlobalLayout.build(tensor_shapes, dp_size=mesh.size())
         offset, local_numel = layout.get_local_range(mesh, placements)
         if local_buffer.numel() != local_numel:
             raise ValueError(
@@ -619,7 +399,7 @@ class DBuffer:
         shape = self.layout.tensor_shapes[index]
         owned_range = self._get_owned_range(index)
 
-        row_size = _non_leading_numel(shape)
+        row_size = non_leading_numel(shape)
         if owned_range is None:
             empty_shape = torch.Size((0, *shape[1:]))
             return torch.empty(empty_shape, dtype=self.dtype, device=self.device)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -16,7 +16,7 @@
 
 import dataclasses
 import math
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 import torch
 import torch.distributed as dist
@@ -56,7 +56,7 @@ class GlobalLayout:
     tensor_to_offset: tuple[int, ...]
     size: int
 
-    def get_local_range(self, mesh: DeviceMesh, placements: Sequence[Placement]) -> tuple[int, int]:
+    def get_local_range(self, mesh: DeviceMesh, placements: Iterable[Placement]) -> tuple[int, int]:
         """Return this rank's local element offset and length for ``placements``."""
         offset = 0
         numel = self.size
@@ -101,7 +101,7 @@ def _validate_placement(placement: Placement) -> None:
         raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
 
 
-def _validate_placements(placements: Sequence[Placement]) -> None:
+def _validate_placements(placements: Iterable[Placement]) -> None:
     seen_flat = False
     for placement in placements:
         _validate_placement(placement)
@@ -114,7 +114,7 @@ def _validate_placements(placements: Sequence[Placement]) -> None:
             )
 
 
-def _compute_layout(shapes: Sequence[torch.Size], dp_size: int) -> GlobalLayout:
+def _compute_layout(shapes: Iterable[torch.Size], dp_size: int) -> GlobalLayout:
     """Compute flat-buffer element offsets and globally padded size.
 
     Args:
@@ -227,8 +227,8 @@ class DBuffer:
     def __init__(
         self,
         mesh: DeviceMesh,
-        placements: Sequence[Placement],
-        tensor_shapes: Sequence[torch.Size],
+        placements: Iterable[Placement],
+        tensor_shapes: Iterable[torch.Size],
         dtype: torch.dtype,
         device: torch.device | str,
     ) -> None:
@@ -257,9 +257,59 @@ class DBuffer:
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
 
+    @property
+    def dtype(self) -> torch.dtype:
+        """Dtype of the local flat buffer."""
+        return self.local_buffer.dtype
+
+    @classmethod
+    def from_local(
+        cls,
+        local_buffer: torch.Tensor,
+        mesh: DeviceMesh,
+        placements: Iterable[Placement],
+        tensor_shapes: Iterable[torch.Size],
+    ) -> "DBuffer":
+        """Create a DBuffer from an existing local flat buffer.
+
+        Args:
+            local_buffer: Local flat tensor storage for this rank.
+            mesh: Device mesh whose dimensions correspond to ``placements``.
+            placements: Per-mesh-axis DBuffer placements.
+            tensor_shapes: Global shapes for each logical tensor in this buffer.
+
+        Returns:
+            A DBuffer that reuses ``local_buffer`` without allocating storage.
+        """
+        placements = tuple(placements)
+        if len(placements) != mesh.ndim:
+            raise ValueError(
+                f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
+            )
+        _validate_placements(placements)
+        if local_buffer.dim() != 1:
+            raise ValueError("local_buffer must be a flat 1D tensor.")
+
+        tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
+        layout = _compute_layout(tensor_shapes, dp_size=mesh.size())
+        offset, local_numel = layout.get_local_range(mesh, placements)
+        if local_buffer.numel() != local_numel:
+            raise ValueError(
+                f"Expected local_buffer with {local_numel} elements, got "
+                f"{local_buffer.numel()}."
+            )
+
+        buffer = cls.__new__(cls)
+        buffer.mesh = mesh
+        buffer.placements = placements
+        buffer.layout = layout
+        buffer.offset = offset
+        buffer.local_buffer = local_buffer
+        return buffer
+
     @classmethod
     def distribute_tensors(
-        cls, tensors: Iterable[torch.Tensor], mesh: DeviceMesh, placements: Sequence[Placement]
+        cls, tensors: Iterable[torch.Tensor], mesh: DeviceMesh, placements: Iterable[Placement]
     ) -> "DBuffer":
         """Distribute full local tensor values into a DBuffer.
 
@@ -317,10 +367,37 @@ class DBuffer:
             )
         return buffer
 
-    def redistribute(self, new_placements: Sequence[Placement]) -> "DBuffer":
+    def _create_or_validate_out(
+        self, placements: Iterable[Placement], out: "DBuffer | None"
+    ) -> "DBuffer":
+        placements = tuple(placements)
+        if out is None:
+            return DBuffer(
+                mesh=self.mesh,
+                placements=placements,
+                tensor_shapes=self.layout.tensor_shapes,
+                dtype=self.dtype,
+                device=self.local_buffer.device,
+            )
+
+        if out.mesh != self.mesh:
+            raise ValueError("out must use the same mesh.")
+        if out.placements != placements:
+            raise ValueError(f"Expected out placements {placements}, got {out.placements}.")
+        if out.layout != self.layout:
+            raise ValueError("out layout must match the source layout.")
+        if out.dtype != self.dtype:
+            raise ValueError("out dtype must match the source dtype.")
+        if out.local_buffer.device != self.local_buffer.device:
+            raise ValueError("out device must match the source device.")
+        return out
+
+    def redistribute(
+        self, new_placements: Iterable[Placement], *, out: "DBuffer | None" = None
+    ) -> "DBuffer":
         """Redistribute this buffer to ``new_placements``.
 
-        This dispatcher composes the supported one-axis transitions:
+        This dispatcher supports the one-axis transitions:
         Flat -> Replicate, Partial -> Replicate, Partial -> Flat, and
         Replicate -> Flat. Other placement changes are intentionally unsupported.
         """
@@ -332,32 +409,43 @@ class DBuffer:
             )
         _validate_placements(new_placements)
 
-        buffer = self
-        for axis, new_placement in enumerate(new_placements):
-            old_placement = buffer.placements[axis]
+        changed_axis: int | None = None
+        for axis, (old_placement, new_placement) in enumerate(
+            zip(self.placements, new_placements, strict=True)
+        ):
             if old_placement == new_placement:
                 continue
-            if isinstance(old_placement, Flat) and isinstance(new_placement, Replicate):
-                buffer = buffer.allgather(axis)
-            elif isinstance(old_placement, Partial) and isinstance(new_placement, Replicate):
-                buffer = buffer.allreduce(axis)
-            elif isinstance(old_placement, Partial) and isinstance(new_placement, Flat):
-                buffer = buffer.reduce_scatter(axis, new_placement)
-            elif isinstance(old_placement, Replicate) and isinstance(new_placement, Flat):
-                buffer = buffer.scatter(axis, new_placement)
-            else:
+            if changed_axis is not None:
                 raise NotImplementedError(
-                    "Unsupported DBuffer placement transition on axis "
-                    f"{axis}: {old_placement!r} -> {new_placement!r}."
+                    "redistribute() currently supports one placement change, "
+                    f"got changed axes {changed_axis} and {axis}."
                 )
+            changed_axis = axis
 
-        if buffer.placements != new_placements:
-            raise AssertionError(
-                f"Redistribute produced placements {buffer.placements}, expected {new_placements}."
-            )
-        return buffer
+        if changed_axis is None:
+            if out is None:
+                return self
+            destination = self._create_or_validate_out(new_placements, out)
+            destination.local_buffer.copy_(self.local_buffer)
+            return destination
 
-    def allgather(self, mesh_axis: MeshAxis) -> "DBuffer":
+        axis = changed_axis
+        old_placement = self.placements[axis]
+        new_placement = new_placements[axis]
+        if isinstance(old_placement, Flat) and isinstance(new_placement, Replicate):
+            return self.allgather(axis, out=out)
+        if isinstance(old_placement, Partial) and isinstance(new_placement, Replicate):
+            return self.allreduce(axis, out=out)
+        if isinstance(old_placement, Partial) and isinstance(new_placement, Flat):
+            return self.reduce_scatter(axis, new_placement, out=out)
+        if isinstance(old_placement, Replicate) and isinstance(new_placement, Flat):
+            return self.scatter(axis, new_placement, out=out)
+        raise NotImplementedError(
+            "Unsupported DBuffer placement transition on axis "
+            f"{axis}: {old_placement!r} -> {new_placement!r}."
+        )
+
+    def allgather(self, mesh_axis: MeshAxis, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-gather a Flat axis into Replicate placement."""
         axis = _axis_index(self.mesh, mesh_axis)
         if not isinstance(self.placements[axis], Flat):
@@ -366,21 +454,15 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = Replicate()
         _validate_placements(placements)
-        buffer = DBuffer(
-            mesh=self.mesh,
-            placements=placements,
-            tensor_shapes=self.layout.tensor_shapes,
-            dtype=self.local_buffer.dtype,
-            device=self.local_buffer.device,
-        )
+        destination = self._create_or_validate_out(placements, out)
         dist.all_gather_into_tensor(
-            output_tensor=buffer.local_buffer,
+            output_tensor=destination.local_buffer,
             input_tensor=self.local_buffer,
             group=self.mesh.get_group(axis),
         )
-        return buffer
+        return destination
 
-    def allreduce(self, mesh_axis: MeshAxis) -> "DBuffer":
+    def allreduce(self, mesh_axis: MeshAxis, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-reduce a Partial axis into Replicate placement."""
         axis = _axis_index(self.mesh, mesh_axis)
         partial_placement = self.placements[axis]
@@ -389,22 +471,18 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = Replicate()
-        buffer = DBuffer(
-            mesh=self.mesh,
-            placements=placements,
-            tensor_shapes=self.layout.tensor_shapes,
-            dtype=self.local_buffer.dtype,
-            device=self.local_buffer.device,
-        )
-        buffer.local_buffer.copy_(self.local_buffer)
+        destination = self._create_or_validate_out(placements, out)
+        destination.local_buffer.copy_(self.local_buffer)
         dist.all_reduce(
-            buffer.local_buffer,
+            destination.local_buffer,
             op=partial_placement.reduce_op,
             group=self.mesh.get_group(axis),
         )
-        return buffer
+        return destination
 
-    def reduce_scatter(self, mesh_axis: MeshAxis, new_placement: Placement) -> "DBuffer":
+    def reduce_scatter(
+        self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
+    ) -> "DBuffer":
         """Reduce-scatter a Partial axis into ``new_placement``."""
         axis = _axis_index(self.mesh, mesh_axis)
         if not isinstance(new_placement, Flat):
@@ -416,22 +494,18 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = new_placement
         _validate_placements(placements)
-        buffer = DBuffer(
-            mesh=self.mesh,
-            placements=placements,
-            tensor_shapes=self.layout.tensor_shapes,
-            dtype=self.local_buffer.dtype,
-            device=self.local_buffer.device,
-        )
+        destination = self._create_or_validate_out(placements, out)
         dist.reduce_scatter_tensor(
-            output=buffer.local_buffer,
+            output=destination.local_buffer,
             input=self.local_buffer,
             op=partial_placement.reduce_op,
             group=self.mesh.get_group(axis),
         )
-        return buffer
+        return destination
 
-    def scatter(self, mesh_axis: MeshAxis, new_placement: Placement) -> "DBuffer":
+    def scatter(
+        self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
+    ) -> "DBuffer":
         """Locally chunk a Replicate axis into ``new_placement``."""
         axis = _axis_index(self.mesh, mesh_axis)
         if not isinstance(new_placement, Flat):
@@ -442,23 +516,30 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = new_placement
         _validate_placements(placements)
-        buffer = DBuffer(
-            mesh=self.mesh,
-            placements=placements,
-            tensor_shapes=self.layout.tensor_shapes,
-            dtype=self.local_buffer.dtype,
-            device=self.local_buffer.device,
-        )
-        local_buffer_offset = buffer.offset - self.offset
+
+        if out is None:
+            destination_offset, destination_numel = self.layout.get_local_range(
+                self.mesh, placements
+            )
+        else:
+            destination = self._create_or_validate_out(placements, out)
+            destination_offset = destination.offset
+            destination_numel = destination.local_buffer.numel()
+
+        local_buffer_offset = destination_offset - self.offset
         if (
             local_buffer_offset < 0
-            or local_buffer_offset + buffer.local_buffer.numel() > self.local_buffer.numel()
+            or local_buffer_offset + destination_numel > self.local_buffer.numel()
         ):
             raise RuntimeError("scatter() destination is not contained in the source local buffer.")
-        buffer.local_buffer.copy_(
-            self.local_buffer.narrow(0, local_buffer_offset, buffer.local_buffer.numel())
-        )
-        return buffer
+        local_slice = self.local_buffer.narrow(0, local_buffer_offset, destination_numel)
+        if out is None:
+            return DBuffer.from_local(
+                local_slice, self.mesh, placements, self.layout.tensor_shapes
+            )
+
+        destination.local_buffer.copy_(local_slice)
+        return destination
 
     def get_tensor(self, index: int) -> torch.Tensor:
         """Return this rank's local view for logical tensor ``index``.
@@ -479,7 +560,7 @@ class DBuffer:
         if overlap_end <= overlap_start:
             empty_shape = torch.Size((0, *shape[1:]))
             return torch.empty(
-                empty_shape, dtype=self.local_buffer.dtype, device=self.local_buffer.device
+                empty_shape, dtype=self.dtype, device=self.local_buffer.device
             )
 
         local_numel = overlap_end - overlap_start

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -31,6 +31,13 @@ Shape: TypeAlias = torch.Size | Iterable[int]
 
 
 @dataclasses.dataclass(frozen=True)
+class _OwnedRange:
+    numel: int
+    tensor_relative_offset: int
+    buffer_relative_offset: int
+
+
+@dataclasses.dataclass(frozen=True)
 class GlobalLayout:
     """Global tensor layout in element coordinates."""
 
@@ -248,6 +255,24 @@ class DBuffer:
         """Device of the local buffer."""
         return self.local_buffer.device
 
+    def _get_owned_range(self, tensor_index: int) -> _OwnedRange | None:
+        """Return this buffer's owned range for logical tensor ``tensor_index``."""
+        tensor_start = self.layout.tensor_to_offset[tensor_index]
+        tensor_end = tensor_start + self.layout.tensor_shapes[tensor_index].numel()
+        buffer_start = self.offset
+        buffer_end = self.offset + self.local_buffer.numel()
+
+        overlap_start = max(tensor_start, buffer_start)
+        overlap_end = min(tensor_end, buffer_end)
+        if overlap_start >= overlap_end:
+            return None
+
+        return _OwnedRange(
+            numel=overlap_end - overlap_start,
+            tensor_relative_offset=overlap_start - tensor_start,
+            buffer_relative_offset=overlap_start - buffer_start,
+        )
+
     @classmethod
     def from_local(
         cls,
@@ -328,24 +353,19 @@ class DBuffer:
             dtype=dtype,
             device=mesh.device_type,
         )
-        local_start = buffer.offset
-        local_end = local_start + buffer.local_buffer.numel()
         # Only logical tensor ranges are initialized. Padding and layout gaps are not
         # observable through get_local_tensor() and can remain unspecified.
-        for tensor, tensor_start in zip(tensors, buffer.layout.tensor_to_offset, strict=True):
-            tensor_end = tensor_start + tensor.numel()
-            overlap_start = max(local_start, tensor_start)
-            overlap_end = min(local_end, tensor_end)
-            if overlap_start >= overlap_end:
+        for index, tensor in enumerate(tensors):
+            owned_range = buffer._get_owned_range(index)
+            if owned_range is None:
                 continue
 
-            overlap_numel = overlap_end - overlap_start
-            source_offset = overlap_start - tensor_start
-            destination_offset = overlap_start - local_start
-            source_slice = tensor.view(-1).narrow(0, source_offset, overlap_numel)
-            buffer.local_buffer.narrow(0, destination_offset, overlap_numel).copy_(
-                source_slice.to(buffer.device)
+            source_slice = tensor.view(-1).narrow(
+                0, owned_range.tensor_relative_offset, owned_range.numel
             )
+            buffer.local_buffer.narrow(
+                0, owned_range.buffer_relative_offset, owned_range.numel
+            ).copy_(source_slice)
         return buffer
 
     def _create_or_validate_out(
@@ -530,27 +550,21 @@ class DBuffer:
         non-leading dimensions and only changes the leading dimension.
         """
         shape = self.layout.tensor_shapes[index]
-        offset = self.layout.tensor_to_offset[index]
-        numel = shape.numel()
-
-        tensor_start = offset
-        tensor_end = offset + numel
-        overlap_start = max(tensor_start, self.offset)
-        overlap_end = min(tensor_end, self.offset + self.local_buffer.numel())
+        owned_range = self._get_owned_range(index)
 
         row_size = _non_leading_numel(shape)
-        if overlap_end <= overlap_start:
+        if owned_range is None:
             empty_shape = torch.Size((0, *shape[1:]))
             return torch.empty(empty_shape, dtype=self.dtype, device=self.device)
 
-        local_numel = overlap_end - overlap_start
-        local_buffer_offset = overlap_start - self.offset
-        if (overlap_start - tensor_start) % row_size != 0 or local_numel % row_size != 0:
+        if owned_range.tensor_relative_offset % row_size != 0 or owned_range.numel % row_size != 0:
             raise RuntimeError(
                 f"Local tensor shard for tensor {index} does not preserve dim-0 boundaries."
             )
-        local_shape = torch.Size((local_numel // row_size, *shape[1:]))
-        return self.local_buffer.narrow(0, local_buffer_offset, local_numel).view(local_shape)
+        local_shape = torch.Size((owned_range.numel // row_size, *shape[1:]))
+        return self.local_buffer.narrow(
+            0, owned_range.buffer_relative_offset, owned_range.numel
+        ).view(local_shape)
 
     def get_dtensor(self, index: int) -> DTensor:
         """Return logical tensor ``index`` as a DTensor."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Distributed flat buffers for Megatron-FSDP."""
+"""Distributed tensor buffers for Megatron-FSDP."""
 
 import dataclasses
 import math
@@ -25,6 +25,7 @@ from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
 MeshAxis = int | str
+Shape = torch.Size | Iterable[int]
 
 
 class Placement:
@@ -50,7 +51,7 @@ class Flat(Placement):
 
 @dataclasses.dataclass(frozen=True)
 class GlobalLayout:
-    """Global flat-buffer layout in element coordinates."""
+    """Global tensor layout in element coordinates."""
 
     tensor_shapes: tuple[torch.Size, ...]
     tensor_to_offset: tuple[int, ...]
@@ -114,12 +115,15 @@ def _validate_placements(placements: Iterable[Placement]) -> None:
             )
 
 
-def _compute_layout(shapes: Iterable[torch.Size], dp_size: int) -> GlobalLayout:
-    """Compute flat-buffer element offsets and globally padded size.
+def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
+    """Compute global tensor element offsets and padded size.
+
+    The computed layout is compatible with Flat, TensorAtomic, and BlockAtomic,
+    even though the latter two are not implemented.
 
     Args:
         shapes: Logical tensor shapes in tensor-id order.
-        dp_size: Data-parallel shard count for this flat buffer layout.
+        dp_size: Data-parallel shard count for this global layout.
 
     Returns:
         Global layout with element offsets and size padded to a multiple of
@@ -211,13 +215,17 @@ def _compute_layout(shapes: Iterable[torch.Size], dp_size: int) -> GlobalLayout:
 
 
 class DBuffer:
-    """A flat distributed buffer holding a group of logical tensors.
+    """A distributed buffer holding a group of logical tensors.
 
-    DBuffer stores one flat local tensor and enough metadata to return per-tensor
+    DBuffer is analogous to DTensor, but manages a group of logical tensors in
+    one local storage tensor. It stores enough metadata to return per-tensor
     views, redistribute the buffer across mesh axes, and materialize per-tensor
     DTensors for optimizer state or distributed checkpointing.
     """
 
+    # DBuffer owns only the data-parallel sub-mesh. Higher-level callers, such as
+    # ParameterGroup, should extend returned DTensors with tensor-parallel mesh axes
+    # because TP sharding metadata lives on nn.Parameter in MCore/TransformerEngine.
     mesh: DeviceMesh
     placements: tuple[Placement, ...]
     layout: GlobalLayout
@@ -228,18 +236,18 @@ class DBuffer:
         self,
         mesh: DeviceMesh,
         placements: Iterable[Placement],
-        tensor_shapes: Iterable[torch.Size],
+        tensor_shapes: Iterable[Shape],
         dtype: torch.dtype,
         device: torch.device | str,
     ) -> None:
-        """Create a DBuffer and allocate its local flat buffer.
+        """Create a DBuffer and allocate its local buffer.
 
         Args:
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
             tensor_shapes: Global shapes for each logical tensor in this buffer.
-            dtype: Dtype for the local flat buffer.
-            device: Device for the local flat buffer.
+            dtype: Dtype for the local buffer.
+            device: Device for the local buffer.
         """
         placements = tuple(placements)
         if len(placements) != mesh.ndim:
@@ -259,7 +267,7 @@ class DBuffer:
 
     @property
     def dtype(self) -> torch.dtype:
-        """Dtype of the local flat buffer."""
+        """Dtype of the local buffer."""
         return self.local_buffer.dtype
 
     @classmethod
@@ -268,12 +276,12 @@ class DBuffer:
         local_buffer: torch.Tensor,
         mesh: DeviceMesh,
         placements: Iterable[Placement],
-        tensor_shapes: Iterable[torch.Size],
+        tensor_shapes: Iterable[Shape],
     ) -> "DBuffer":
-        """Create a DBuffer from an existing local flat buffer.
+        """Create a DBuffer from an existing local buffer.
 
         Args:
-            local_buffer: Local flat tensor storage for this rank.
+            local_buffer: Local tensor storage for this rank.
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
             tensor_shapes: Global shapes for each logical tensor in this buffer.
@@ -534,9 +542,7 @@ class DBuffer:
             raise RuntimeError("scatter() destination is not contained in the source local buffer.")
         local_slice = self.local_buffer.narrow(0, local_buffer_offset, destination_numel)
         if out is None:
-            return DBuffer.from_local(
-                local_slice, self.mesh, placements, self.layout.tensor_shapes
-            )
+            return DBuffer.from_local(local_slice, self.mesh, placements, self.layout.tensor_shapes)
 
         destination.local_buffer.copy_(local_slice)
         return destination
@@ -559,9 +565,7 @@ class DBuffer:
         row_size = _non_leading_numel(shape)
         if overlap_end <= overlap_start:
             empty_shape = torch.Size((0, *shape[1:]))
-            return torch.empty(
-                empty_shape, dtype=self.dtype, device=self.local_buffer.device
-            )
+            return torch.empty(empty_shape, dtype=self.dtype, device=self.local_buffer.device)
 
         local_numel = overlap_end - overlap_start
         local_buffer_offset = overlap_start - self.offset

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -268,6 +268,21 @@ class DBuffer:
             raise ValueError(f"Expected out device {self.device}, got {out.device}.")
         return out
 
+    def cast(self, dtype: torch.dtype) -> "DBuffer":
+        """Return this buffer with the same layout and placements in ``dtype``."""
+        if self.dtype == dtype:
+            return self
+
+        destination = DBuffer(
+            mesh=self.mesh,
+            placements=self.placements,
+            tensor_shapes=self.layout.tensor_shapes,
+            dtype=dtype,
+            device=self.device,
+        )
+        destination.local_buffer.copy_(self.local_buffer)
+        return destination
+
     def redistribute(
         self, new_placements: Iterable[Placement], *, out: "DBuffer | None" = None
     ) -> "DBuffer":

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -45,6 +45,58 @@ class GlobalLayout:
     tensor_to_offset: tuple[int, ...]
     size: int
 
+    def __post_init__(self) -> None:
+        """Validate tensor offsets are row-aligned, in bounds, and non-overlapping."""
+
+        @dataclasses.dataclass(frozen=True)
+        class TensorRange:
+            start: int
+            end: int
+            tensor_id: int
+
+        if self.size < 0:
+            raise AssertionError(f"Global layout size {self.size} is negative.")
+        if len(self.tensor_shapes) != len(self.tensor_to_offset):
+            raise AssertionError(
+                "Global layout has mismatched tensor shapes and offsets: "
+                f"{len(self.tensor_shapes)} shapes and {len(self.tensor_to_offset)} offsets."
+            )
+
+        tensor_ranges: list[TensorRange] = []
+        for tensor_id, (shape, start) in enumerate(
+            zip(self.tensor_shapes, self.tensor_to_offset, strict=True)
+        ):
+            if start < 0:
+                raise AssertionError(f"Tensor {tensor_id} offset {start} is negative.")
+
+            row_size = _non_leading_numel(shape)
+            if row_size <= 0:
+                raise AssertionError(f"Tensor {tensor_id} has invalid row size {row_size}.")
+            if start % row_size != 0:
+                raise AssertionError(
+                    f"Tensor {tensor_id} offset {start} is not aligned to row size {row_size}."
+                )
+
+            end = start + shape.numel()
+            if end > self.size:
+                raise AssertionError(
+                    f"Tensor {tensor_id} range [{start}, {end}) exceeds "
+                    f"layout size {self.size}."
+                )
+            tensor_ranges.append(TensorRange(start, end, tensor_id))
+
+        previous_range: TensorRange | None = None
+        for current_range in sorted(tensor_ranges, key=lambda tensor_range: tensor_range.start):
+            if previous_range is not None and current_range.start < previous_range.end:
+                raise AssertionError(
+                    "Global layout tensors overlap: "
+                    f"tensor {previous_range.tensor_id} "
+                    f"[{previous_range.start}, {previous_range.end}) and "
+                    f"tensor {current_range.tensor_id} "
+                    f"[{current_range.start}, {current_range.end})."
+                )
+            previous_range = current_range
+
     def get_local_range(self, mesh: DeviceMesh, placements: Iterable[Placement]) -> tuple[int, int]:
         """Return this rank's local element offset and length for ``placements``."""
         offset = 0
@@ -130,7 +182,8 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
 
     # chunk_size is the packing unit. Since every tensor row size divides it,
     # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
-    tensor_to_offset: list[int | None] = [None] * len(tensor_shapes)
+    UNASSIGNED_OFFSET = -1
+    tensor_to_offset: list[int] = [UNASSIGNED_OFFSET] * len(tensor_shapes)
     fragment_items = []
     regular_items = []
     for tensor_id, shape in enumerate(tensor_shapes):
@@ -201,17 +254,10 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         tensor_to_offset[frag_id] = next_offset
         next_offset += frag_shape.numel()
 
-    if any(offset is None for offset in tensor_to_offset):
-        raise AssertionError(f"Incomplete DBuffer layout for shapes {tensor_shapes}.")
-
-    resolved_tensor_to_offset = tuple(offset for offset in tensor_to_offset if offset is not None)
-    for shape, offset in zip(tensor_shapes, resolved_tensor_to_offset, strict=True):
-        row_size = _non_leading_numel(shape)
-        if offset % row_size != 0:
-            raise AssertionError(f"Tensor offset {offset} is not aligned to row size {row_size}.")
-    size = _pad_to_multiple(next_offset, chunk_size * dp_size)
     return GlobalLayout(
-        tensor_shapes=tensor_shapes, tensor_to_offset=resolved_tensor_to_offset, size=size
+        tensor_shapes=tensor_shapes,
+        tensor_to_offset=tuple(tensor_to_offset),
+        size=_pad_to_multiple(next_offset, chunk_size * dp_size),
     )
 
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -83,19 +83,39 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
 
     This is a DBuffer-specific reimplementation of
     ``param_and_grad_buffer.build_data_parallel_buffer_index``. It keeps only
-    the global offset construction and final DP-LCM padding; DBuffer derives
-    rank-local slices later through DTensor placements.
+    the global offset construction and final padding so each rank-local shard
+    size is a multiple of ``chunk_size``; DBuffer derives rank-local slices
+    later through DTensor placements.
 
     The computed layout is compatible with Flat, TensorAtomic, and BlockAtomic,
     even though the latter two are not implemented.
+
+    ``chunk_size`` is the least common multiple of each tensor's row size
+    (``shape[1:].numel()``). For example, with shapes P0=(2, 6), P1=(4, 4),
+    P2=(4, 4), P3=(1, 2), P4=(1, 6), ``chunk_size = LCM(6, 4, 4, 2, 6) = 12``
+    and a 5-rank DP layout has equal-size rank shards:
+
+    ```
+    rank 0 [ 0, 12): | P0 row 0              | P0 row 1               |
+    rank 1 [12, 24): | P1 row 0      | P1 row 1      | P1 row 2       |
+    rank 2 [24, 36): | P1 row 3      | P3    | gap   | P2 row 0       |
+    rank 3 [36, 48): | P2 row 1      | P2 row 2      | P2 row 3       |
+    rank 4 [48, 60): | P4                    | pad                    |
+    ```
+
+    The diagram uses four character columns per element; segment widths are
+    proportional. Every chunk boundary is aligned to each tensor's row size,
+    so each DP shard owns full rows even when fragments fill regular-tensor
+    padding gaps.
 
     Args:
         shapes: Logical tensor shapes in tensor-id order.
         dp_size: Data-parallel shard count for this global layout.
 
     Returns:
-        Global layout with element offsets and size padded to a multiple of
-        ``LCM(shape[1:].numel()) * dp_size``.
+        Global layout with row-aligned tensor offsets and a total size padded
+        to a multiple of ``chunk_size * dp_size``, so every rank-local shard
+        length is a multiple of ``chunk_size``.
     """
     if dp_size <= 0:
         raise ValueError(f"DP size must be positive, got {dp_size}.")
@@ -108,8 +128,8 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             raise ValueError(f"Cannot compute a layout for zero-sized non-leading dims: {shape}.")
         chunk_size = math.lcm(chunk_size, non_leading_numel)
 
-    # The LCM part is the packing grid. Since every row size divides this grid,
-    # DP shard boundaries that are multiples of the grid avoid splitting dim-0 rows.
+    # chunk_size is the packing unit. Since every tensor row size divides it,
+    # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
     tensor_to_offset: list[int | None] = [None] * len(tensor_shapes)
     fragment_items = []
     regular_items = []
@@ -120,7 +140,7 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
             regular_items.append((tensor_id, shape))
 
     # Regular tensors anchor the layout. Fragments are held back to fill padding
-    # gaps left by regular tensors whose sizes are not exact multiples of the grid.
+    # gaps left by regular tensors whose sizes are not exact multiples of chunk_size.
     fragment_items.sort(key=lambda id_shape: id_shape[1].numel(), reverse=True)
 
     next_offset = 0
@@ -139,8 +159,9 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         remainder = tensor_numel % chunk_size
 
         # Try to pair this non-divisible regular tensor with a conjugate regular
-        # tensor whose remainder fits in the same LCM part. The conjugate starts
-        # in the gap and then continues with full LCM parts after this one.
+        # tensor whose remainder fits in the same chunk_size interval. The
+        # conjugate starts in the gap and then continues with full chunk_size
+        # intervals after this one.
         conjugate_item = None
         for candidate_item in regular_items[:]:
             _, candidate_shape = candidate_item

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -411,9 +411,9 @@ class DBuffer:
         if changed_axis is None:
             if out is None:
                 return self
-            destination = self._create_or_validate_out(new_placements, out)
-            destination.local_buffer.copy_(self.local_buffer)
-            return destination
+            out = self._create_or_validate_out(new_placements, out)
+            out.local_buffer.copy_(self.local_buffer)
+            return out
 
         axis = changed_axis
         old_placement = self.placements[axis]
@@ -440,13 +440,13 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = Replicate()
         validate_placements(placements)
-        destination = self._create_or_validate_out(placements, out)
+        out = self._create_or_validate_out(placements, out)
         dist.all_gather_into_tensor(
-            output_tensor=destination.local_buffer,
+            output_tensor=out.local_buffer,
             input_tensor=self.local_buffer,
             group=self.mesh.get_group(axis),
         )
-        return destination
+        return out
 
     def allreduce(self, mesh_axis: MeshAxis, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-reduce a Partial axis into Replicate placement."""
@@ -457,14 +457,14 @@ class DBuffer:
 
         placements = list(self.placements)
         placements[axis] = Replicate()
-        destination = self._create_or_validate_out(placements, out)
-        destination.local_buffer.copy_(self.local_buffer)
+        out = self._create_or_validate_out(placements, out)
+        out.local_buffer.copy_(self.local_buffer)
         dist.all_reduce(
-            destination.local_buffer,
+            out.local_buffer,
             op=partial_placement.reduce_op,
             group=self.mesh.get_group(axis),
         )
-        return destination
+        return out
 
     def reduce_scatter(
         self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
@@ -480,14 +480,14 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = new_placement
         validate_placements(placements)
-        destination = self._create_or_validate_out(placements, out)
+        out = self._create_or_validate_out(placements, out)
         dist.reduce_scatter_tensor(
-            output=destination.local_buffer,
+            output=out.local_buffer,
             input=self.local_buffer,
             op=partial_placement.reduce_op,
             group=self.mesh.get_group(axis),
         )
-        return destination
+        return out
 
     def scatter(
         self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
@@ -508,9 +508,9 @@ class DBuffer:
                 self.mesh, placements
             )
         else:
-            destination = self._create_or_validate_out(placements, out)
-            destination_offset = destination.offset
-            destination_numel = destination.local_buffer.numel()
+            out = self._create_or_validate_out(placements, out)
+            destination_offset = out.offset
+            destination_numel = out.local_buffer.numel()
 
         local_buffer_offset = destination_offset - self.offset
         if (
@@ -522,8 +522,8 @@ class DBuffer:
         if out is None:
             return DBuffer.from_local(local_slice, self.mesh, placements, self.layout.tensor_shapes)
 
-        destination.local_buffer.copy_(local_slice)
-        return destination
+        out.local_buffer.copy_(local_slice)
+        return out
 
     def get_tensor(self, index: int) -> torch.Tensor:
         """Return this rank's local view for logical tensor ``index``.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -42,6 +42,7 @@ def _validate_mesh_axis(mesh: DeviceMesh, axis: int) -> None:
 
 
 def _validate_placements(placements: Iterable[Placement]) -> None:
+    """Validate DBuffer placements form a supported contiguous local layout."""
     seen_flat = False
     for placement in placements:
         if not isinstance(placement, (Replicate, Partial, Flat)):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -17,6 +17,7 @@
 import dataclasses
 import math
 from collections.abc import Iterable
+from typing import TypeAlias
 
 import torch
 import torch.distributed as dist
@@ -26,8 +27,7 @@ from torch.distributed.tensor import DTensor
 
 from .placement import Flat, Partial, Placement, Replicate, validate_placements
 
-MeshAxis = int | str
-Shape = torch.Size | Iterable[int]
+Shape: TypeAlias = torch.Size | Iterable[int]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -64,18 +64,11 @@ def _pad_to_multiple(value: int, multiple: int) -> int:
     return ((value + multiple - 1) // multiple) * multiple
 
 
-def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
-    if isinstance(axis, int):
-        if axis < 0:
-            axis += mesh.ndim
-        if axis < 0 or axis >= mesh.ndim:
-            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
-        return axis
-
-    dim_names = mesh.mesh_dim_names
-    if dim_names is None or axis not in dim_names:
-        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
-    return dim_names.index(axis)
+def _validate_mesh_axis(mesh: DeviceMesh, axis: int) -> None:
+    if not isinstance(axis, int) or isinstance(axis, bool):
+        raise TypeError(f"Mesh axis must be an int, got {type(axis).__name__}.")
+    if axis < 0 or axis >= mesh.ndim:
+        raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
 
 
 def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
@@ -100,9 +93,9 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
     if dp_size <= 0:
         raise ValueError(f"DP size must be positive, got {dp_size}.")
 
-    shapes = tuple(torch.Size(shape) for shape in shapes)
+    tensor_shapes = tuple(torch.Size(shape) for shape in shapes)
     chunk_size = 1
-    for shape in shapes:
+    for shape in tensor_shapes:
         non_leading_numel = _non_leading_numel(shape)
         if non_leading_numel <= 0:
             raise ValueError(f"Cannot compute a layout for zero-sized non-leading dims: {shape}.")
@@ -110,10 +103,10 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
 
     # The LCM part is the packing grid. Since every row size divides this grid,
     # DP shard boundaries that are multiples of the grid avoid splitting dim-0 rows.
-    tensor_to_offset: list[int | None] = [None] * len(shapes)
+    tensor_to_offset: list[int | None] = [None] * len(tensor_shapes)
     fragment_items = []
     regular_items = []
-    for tensor_id, shape in enumerate(shapes):
+    for tensor_id, shape in enumerate(tensor_shapes):
         if shape.numel() < chunk_size:
             fragment_items.append((tensor_id, shape))
         else:
@@ -181,15 +174,17 @@ def _compute_layout(shapes: Iterable[Shape], dp_size: int) -> GlobalLayout:
         next_offset += frag_shape.numel()
 
     if any(offset is None for offset in tensor_to_offset):
-        raise AssertionError(f"Incomplete DBuffer layout for shapes {shapes}.")
+        raise AssertionError(f"Incomplete DBuffer layout for shapes {tensor_shapes}.")
 
     resolved_tensor_to_offset = tuple(offset for offset in tensor_to_offset if offset is not None)
-    for shape, offset in zip(shapes, resolved_tensor_to_offset, strict=True):
+    for shape, offset in zip(tensor_shapes, resolved_tensor_to_offset, strict=True):
         row_size = _non_leading_numel(shape)
         if offset % row_size != 0:
             raise AssertionError(f"Tensor offset {offset} is not aligned to row size {row_size}.")
     size = _pad_to_multiple(next_offset, chunk_size * dp_size)
-    return GlobalLayout(tensor_shapes=shapes, tensor_to_offset=resolved_tensor_to_offset, size=size)
+    return GlobalLayout(
+        tensor_shapes=tensor_shapes, tensor_to_offset=resolved_tensor_to_offset, size=size
+    )
 
 
 class DBuffer:
@@ -433,9 +428,10 @@ class DBuffer:
             f"{axis}: {old_placement!r} -> {new_placement!r}."
         )
 
-    def allgather(self, mesh_axis: MeshAxis, *, out: "DBuffer | None" = None) -> "DBuffer":
+    def allgather(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-gather a Flat axis into Replicate placement."""
-        axis = _axis_index(self.mesh, mesh_axis)
+        _validate_mesh_axis(self.mesh, mesh_axis)
+        axis = mesh_axis
         if not isinstance(self.placements[axis], Flat):
             raise ValueError(f"allgather() requires Flat placement on axis {mesh_axis!r}.")
 
@@ -450,9 +446,10 @@ class DBuffer:
         )
         return out
 
-    def allreduce(self, mesh_axis: MeshAxis, *, out: "DBuffer | None" = None) -> "DBuffer":
+    def allreduce(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-reduce a Partial axis into Replicate placement."""
-        axis = _axis_index(self.mesh, mesh_axis)
+        _validate_mesh_axis(self.mesh, mesh_axis)
+        axis = mesh_axis
         partial_placement = self.placements[axis]
         if not isinstance(partial_placement, Partial):
             raise ValueError(f"allreduce() requires Partial placement on axis {mesh_axis!r}.")
@@ -462,17 +459,16 @@ class DBuffer:
         out = self._create_or_validate_out(placements, out)
         out.local_buffer.copy_(self.local_buffer)
         dist.all_reduce(
-            out.local_buffer,
-            op=partial_placement.reduce_op,
-            group=self.mesh.get_group(axis),
+            out.local_buffer, op=partial_placement.reduce_op, group=self.mesh.get_group(axis)
         )
         return out
 
     def reduce_scatter(
-        self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
+        self, mesh_axis: int, new_placement: Placement, *, out: "DBuffer | None" = None
     ) -> "DBuffer":
         """Reduce-scatter a Partial axis into ``new_placement``."""
-        axis = _axis_index(self.mesh, mesh_axis)
+        _validate_mesh_axis(self.mesh, mesh_axis)
+        axis = mesh_axis
         if not isinstance(new_placement, Flat):
             raise NotImplementedError("DBuffer currently supports reduce_scatter() to Flat only.")
         partial_placement = self.placements[axis]
@@ -492,10 +488,11 @@ class DBuffer:
         return out
 
     def scatter(
-        self, mesh_axis: MeshAxis, new_placement: Placement, *, out: "DBuffer | None" = None
+        self, mesh_axis: int, new_placement: Placement, *, out: "DBuffer | None" = None
     ) -> "DBuffer":
         """Locally chunk a Replicate axis into ``new_placement``."""
-        axis = _axis_index(self.mesh, mesh_axis)
+        _validate_mesh_axis(self.mesh, mesh_axis)
+        axis = mesh_axis
         if not isinstance(new_placement, Flat):
             raise NotImplementedError("DBuffer currently supports scatter() to Flat only.")
         if not isinstance(self.placements[axis], Replicate):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fsdp_module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fsdp_module.py
@@ -31,13 +31,13 @@ class FsdpModule:
 
     _parameter_groups: tuple[ParameterGroup, ...]
     _ready_grad_parameters: set[nn.Parameter]
-    num_training_parameters: int
+    _num_training_parameters: int
 
     def __init__(
         self, mesh: DeviceMesh, placements: Placements, mixed_precision_policy: MixedPrecisionPolicy
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
-        owned_parameters = _materialize_and_collect_owned_parameters(self, _mesh_device(mesh))
+        owned_parameters = _collect_owned_parameters(self)
         axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
         assert axis_indices == tuple(
             range(mesh.ndim)
@@ -54,7 +54,7 @@ class FsdpModule:
         ]
         self._parameter_groups = tuple(parameter_groups)
         self._ready_grad_parameters = set()
-        self.num_training_parameters = sum(
+        self._num_training_parameters = sum(
             len(group.sharded_parameters) for group in self._parameter_groups if group.requires_grad
         )
         self._register_hooks()
@@ -77,7 +77,7 @@ class FsdpModule:
     def _make_grad_hook(self, parameter: nn.Parameter) -> Callable[[nn.Parameter], None]:
         def grad_hook(_parameter: nn.Parameter) -> None:
             self._ready_grad_parameters.add(parameter)
-            if len(self._ready_grad_parameters) == self.num_training_parameters:
+            if len(self._ready_grad_parameters) == self._num_training_parameters:
                 self.post_backward()
 
         return grad_hook
@@ -86,6 +86,7 @@ class FsdpModule:
         """Prepare full parameters for forward compute."""
         self._ready_grad_parameters.clear()
         for group in self._parameter_groups:
+            group.sync_model_weight_from_main_weight()
             group.unshard_parameters()
 
     def post_forward(self) -> None:
@@ -126,39 +127,11 @@ def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
     return dim_names.index(axis)
 
 
-def _mesh_device(mesh: DeviceMesh) -> torch.device:
-    if mesh.device_type == "cuda":
-        return torch.device("cuda", torch.cuda.current_device())
-    return torch.device(mesh.device_type)
-
-
-def _materialize_and_collect_owned_parameters(
-    root_module: nn.Module, device: torch.device
-) -> dict[str, nn.Parameter]:
+def _collect_owned_parameters(root_module: nn.Module) -> dict[str, nn.Parameter]:
     parameters: dict[str, nn.Parameter] = {}
 
     def visit(submodule: nn.Module, submodule_fqn: str) -> None:
         direct_parameters = list(submodule.named_parameters(recurse=False))
-
-        if any(parameter.is_meta for _, parameter in direct_parameters):
-            if any(not parameter.is_meta for _, parameter in direct_parameters):
-                raise ValueError(
-                    f"Module {submodule_fqn!r} mixes meta and non-meta direct parameters. "
-                    "Initialize all direct parameters on meta or none of them."
-                )
-            submodule.to_empty(device=device, recurse=False)
-            with torch.no_grad():
-                if hasattr(submodule, "reset_parameters"):
-                    submodule.reset_parameters()
-                elif hasattr(submodule, "_reset_parameters"):
-                    submodule._reset_parameters()
-                else:
-                    raise ValueError(
-                        f"Module {submodule_fqn!r} does not have "
-                        "reset_parameters or _reset_parameters."
-                    )
-            # Module.to_empty may replace Parameters, so collect direct parameters again.
-            direct_parameters = list(submodule.named_parameters(recurse=False))
 
         for local_parameter_name, parameter in direct_parameters:
             parameter_fqn = (

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fsdp_module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fsdp_module.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module mixin for the minimal Megatron-FSDP path."""
+
+from collections.abc import Callable
+from typing import cast
+
+import torch
+from torch import nn
+from torch.distributed import DeviceMesh
+
+from ..mixed_precision import MixedPrecisionPolicy
+from .parameter_group import ParameterGroup, contained_in_parameter_group
+from .placement import MeshAxis, Placements
+
+
+class FsdpModule:
+    """Mixin attached to modules managed by the minimal FSDP path."""
+
+    _parameter_groups: tuple[ParameterGroup, ...]
+    _ready_grad_parameters: set[nn.Parameter]
+    num_training_parameters: int
+
+    def __init__(
+        self, mesh: DeviceMesh, placements: Placements, mixed_precision_policy: MixedPrecisionPolicy
+    ) -> None:
+        """Initialize FSDP runtime state on an already-constructed module."""
+        owned_parameters = _materialize_and_collect_owned_parameters(self, _mesh_device(mesh))
+        axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
+        assert axis_indices == tuple(
+            range(mesh.ndim)
+        ), "FSDP requires dp_axes to match every mesh axis in mesh order for now."
+        parameter_groups = [
+            ParameterGroup(
+                owning_module=self,
+                parameters=group_parameters,
+                mesh=mesh,
+                placements=placements,
+                mixed_precision_policy=mixed_precision_policy,
+            )
+            for group_parameters in _group_parameters(owned_parameters)
+        ]
+        self._parameter_groups = tuple(parameter_groups)
+        self._ready_grad_parameters = set()
+        self.num_training_parameters = sum(
+            len(group.sharded_parameters) for group in self._parameter_groups if group.requires_grad
+        )
+        self._register_hooks()
+
+    def _register_hooks(self) -> None:
+        module = cast(nn.Module, self)
+        module.register_forward_pre_hook(lambda _module, _args: self.pre_forward())
+        module.register_forward_hook(lambda _module, _args, _output: self.post_forward())
+        module.register_full_backward_pre_hook(lambda _module, _grad_output: self.pre_backward())
+        # Gradient reduction is parameter-completion based: once every owned
+        # Parameter has accumulated its grad, this FSDP unit can reduce and
+        # reshard. Module full-backward hooks can fire before that when module
+        # inputs do not require grad.
+        for group in self._parameter_groups:
+            if not group.requires_grad:
+                continue
+            for parameter in group.unsharded_parameters:
+                parameter.register_post_accumulate_grad_hook(self._make_grad_hook(parameter))
+
+    def _make_grad_hook(self, parameter: nn.Parameter) -> Callable[[nn.Parameter], None]:
+        def grad_hook(_parameter: nn.Parameter) -> None:
+            self._ready_grad_parameters.add(parameter)
+            if len(self._ready_grad_parameters) == self.num_training_parameters:
+                self.post_backward()
+
+        return grad_hook
+
+    def pre_forward(self) -> None:
+        """Prepare full parameters for forward compute."""
+        self._ready_grad_parameters.clear()
+        for group in self._parameter_groups:
+            group.unshard_parameters()
+
+    def post_forward(self) -> None:
+        """Return parameters to their sharded resting state after forward compute."""
+        for group in self._parameter_groups:
+            group.reshard_parameters()
+
+    def pre_backward(self) -> None:
+        """Prepare full parameters for backward compute."""
+        for group in self._parameter_groups:
+            group.unshard_parameters()
+
+    def post_backward(self) -> None:
+        """Reduce gradients and return parameters to their sharded resting state."""
+        for group in self._parameter_groups:
+            if group.requires_grad:
+                group.reduce_gradients()
+            group.reshard_parameters()
+        self._ready_grad_parameters.clear()
+
+    def parameter_groups(self) -> tuple[ParameterGroup, ...]:
+        """Return parameter groups owned by this FSDP unit."""
+        return self._parameter_groups
+
+
+def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
+    if isinstance(axis, int):
+        axis_index = axis
+        if axis_index < 0:
+            axis_index += mesh.ndim
+        if axis_index < 0 or axis_index >= mesh.ndim:
+            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
+        return axis_index
+
+    dim_names = mesh.mesh_dim_names
+    if dim_names is None or axis not in dim_names:
+        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
+    return dim_names.index(axis)
+
+
+def _mesh_device(mesh: DeviceMesh) -> torch.device:
+    if mesh.device_type == "cuda":
+        return torch.device("cuda", torch.cuda.current_device())
+    return torch.device(mesh.device_type)
+
+
+def _materialize_and_collect_owned_parameters(
+    root_module: nn.Module, device: torch.device
+) -> dict[str, nn.Parameter]:
+    parameters: dict[str, nn.Parameter] = {}
+
+    def visit(submodule: nn.Module, submodule_fqn: str) -> None:
+        direct_parameters = list(submodule.named_parameters(recurse=False))
+
+        if any(parameter.is_meta for _, parameter in direct_parameters):
+            if any(not parameter.is_meta for _, parameter in direct_parameters):
+                raise ValueError(
+                    f"Module {submodule_fqn!r} mixes meta and non-meta direct parameters. "
+                    "Initialize all direct parameters on meta or none of them."
+                )
+            submodule.to_empty(device=device, recurse=False)
+            with torch.no_grad():
+                if hasattr(submodule, "reset_parameters"):
+                    submodule.reset_parameters()
+                elif hasattr(submodule, "_reset_parameters"):
+                    submodule._reset_parameters()
+                else:
+                    raise ValueError(
+                        f"Module {submodule_fqn!r} does not have "
+                        "reset_parameters or _reset_parameters."
+                    )
+            # Module.to_empty may replace Parameters, so collect direct parameters again.
+            direct_parameters = list(submodule.named_parameters(recurse=False))
+
+        for local_parameter_name, parameter in direct_parameters:
+            parameter_fqn = (
+                f"{submodule_fqn}.{local_parameter_name}" if submodule_fqn else local_parameter_name
+            )
+            if contained_in_parameter_group(parameter):
+                raise ValueError(f"Parameter {parameter_fqn!r} is already owned by an FSDP unit.")
+            parameters[parameter_fqn] = parameter
+
+        for child_name, child_module in submodule.named_children():
+            if isinstance(child_module, FsdpModule):
+                continue
+            child_fqn = f"{submodule_fqn}.{child_name}" if submodule_fqn else child_name
+            visit(child_module, child_fqn)
+
+    visit(root_module, "")
+    if not parameters:
+        raise ValueError("fully_shard requires at least one unowned parameter.")
+    return parameters
+
+
+def _group_parameters(parameters: dict[str, nn.Parameter]) -> list[dict[str, nn.Parameter]]:
+    grouped: dict[tuple[torch.dtype, bool], dict[str, nn.Parameter]] = {}
+    for name, parameter in parameters.items():
+        key = (parameter.dtype, parameter.requires_grad)
+        grouped.setdefault(key, {})[name] = parameter
+    return [grouped[key] for key in grouped]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fsdp_module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fsdp_module.py
@@ -26,10 +26,17 @@ from .parameter_group import ParameterGroup, contained_in_parameter_group
 from .placement import MeshAxis, Placements
 
 
+class FsdpContext:
+    """Runtime state shared by one experimental FSDP subtree."""
+
+    is_first_microbatch: bool = True
+
+
 class FsdpModule:
     """Mixin attached to modules managed by the minimal FSDP path."""
 
     _parameter_groups: tuple[ParameterGroup, ...]
+    _context: FsdpContext | None
     _ready_grad_parameters: set[nn.Parameter]
     _num_training_parameters: int
 
@@ -37,6 +44,7 @@ class FsdpModule:
         self, mesh: DeviceMesh, placements: Placements, mixed_precision_policy: MixedPrecisionPolicy
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
+        self._context = None
         owned_parameters = _collect_owned_parameters(self)
         axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
         assert axis_indices == tuple(
@@ -58,6 +66,26 @@ class FsdpModule:
             len(group.sharded_parameters) for group in self._parameter_groups if group.requires_grad
         )
         self._register_hooks()
+
+    def _assign_context(self, context: FsdpContext) -> None:
+        self._context = context
+
+    def _lazy_init_context(self) -> FsdpContext:
+        """Initialize the shared runtime context for this FSDP root subtree."""
+        if self._context is not None:
+            return self._context
+
+        context = FsdpContext()
+        for submodule in cast(nn.Module, self).modules():
+            if not isinstance(submodule, FsdpModule):
+                continue
+            if submodule._context is not None:
+                raise RuntimeError(
+                    "FSDP context is already initialized for a descendant module. "
+                    "Run forward through the root FSDP module first."
+                )
+            submodule._assign_context(context)
+        return context
 
     def _register_hooks(self) -> None:
         module = cast(nn.Module, self)
@@ -84,9 +112,11 @@ class FsdpModule:
 
     def pre_forward(self) -> None:
         """Prepare full parameters for forward compute."""
+        context = self._lazy_init_context()
         self._ready_grad_parameters.clear()
         for group in self._parameter_groups:
-            group.sync_model_weight_from_main_weight()
+            if context.is_first_microbatch:
+                group.sync_model_weight_from_main_weight()
             group.unshard_parameters()
 
     def post_forward(self) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -24,9 +24,11 @@ from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
-from .dbuffer import DBuffer, MeshAxis, Partial, Placement, Replicate
+from .dbuffer import DBuffer
+from .placement import Partial, Placement, Replicate
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
+MeshAxis = int | str
 
 
 @dataclasses.dataclass(frozen=True)
@@ -179,7 +181,7 @@ class ParameterGroup:
         unsharded_parameters: list[nn.Parameter] = []
         main_grad_dtype = self.main_grad.local_buffer.dtype if self.main_grad is not None else None
         for index, parameter in enumerate(parameters.values()):
-            parameter.data = self._unsharded_model_weight.get_tensor(index)
+            parameter.data = self._unsharded_model_weight.get_local_tensor(index)
             parameter.grad = None
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
             unsharded_parameters.append(parameter)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -14,12 +14,17 @@
 
 """Minimal Megatron-FSDP fully_shard entrypoint."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
-from .fsdp_module import FsdpModule
+from .fsdp_module import FsdpContext, FsdpModule
 from .placement import Placements
+
+__all__ = ["FsdpContext", "FsdpModule", "fully_shard", "microbatch"]
 
 
 def fully_shard(
@@ -53,9 +58,42 @@ def fully_shard(
         raise
 
 
+@contextmanager
+def microbatch(module: nn.Module, is_first: bool) -> Iterator[None]:
+    """Scope experimental FSDP main-weight synchronization to one microbatch.
+
+    Args:
+        module: Module tree whose experimental FSDP roots should use this microbatch state.
+        is_first: Whether forwards in this scope are for the first microbatch.
+    """
+    contexts: list[FsdpContext] = []
+    _collect_fsdp_contexts(module, contexts)
+    previous_states = [(context, context.is_first_microbatch) for context in contexts]
+    for context in contexts:
+        context.is_first_microbatch = is_first
+
+    try:
+        yield
+    finally:
+        for context, is_first_microbatch in previous_states:
+            context.is_first_microbatch = is_first_microbatch
+
+
 def _attach_mixin(module: nn.Module) -> None:
     if isinstance(module, FsdpModule):
         return
     module_cls = module.__class__
     fsdp_cls = type(f"ExperimentalFsdp{module_cls.__name__}", (FsdpModule, module_cls), {})
     module.__class__ = fsdp_cls
+
+
+def _collect_fsdp_contexts(
+    module: nn.Module,
+    contexts: list[FsdpContext],
+) -> None:
+    if isinstance(module, FsdpModule):
+        contexts.append(module._lazy_init_context())
+        return
+
+    for child in module.children():
+        _collect_fsdp_contexts(child, contexts)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -15,7 +15,7 @@
 """Minimal per-module Megatron-FSDP implementation."""
 
 import dataclasses
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable
 
 import torch
 import torch.distributed as dist
@@ -104,11 +104,13 @@ class ParameterGroup:
         for name, parameter in parameters.items():
             if parameter.is_meta:
                 raise ValueError(
-                    f"Expected parameter {name!r} to be materialized before ParameterGroup construction."
+                    f"Expected parameter {name!r} to be materialized before "
+                    "ParameterGroup construction."
                 )
             if parameter.dtype != self.dtype:
                 raise ValueError(
-                    f"Expected parameter {name!r} to have dtype {self.dtype}, got {parameter.dtype}."
+                    f"Expected parameter {name!r} to have dtype {self.dtype}, "
+                    f"got {parameter.dtype}."
                 )
             if parameter.requires_grad != self.requires_grad:
                 raise ValueError(
@@ -117,31 +119,34 @@ class ParameterGroup:
                 )
 
         # ---------------------------------------------------------------------
-        # Initialize DBuffers from original parameter values
+        # Initialize persistent DBuffers
         # ---------------------------------------------------------------------
         # Python dicts preserve insertion order, so parameter_names and
         # parameters.values() define the same stable DBuffer tensor order.
-        self._unsharded_model_weight = DBuffer.distribute_tensors(
-            parameters.values(), mesh=self.mesh, placements=[Replicate()] * self.mesh.ndim
-        )
-        # Scratch initialization starts from model weights. Checkpoint loading will
-        # eventually initialize main weights first and derive model weights from them.
-        self.model_weight = self._unsharded_model_weight.redistribute(placements.parameter)
-        model_weight_storage = self.model_weight.local_buffer.untyped_storage()
-        unsharded_model_weight_storage = self._unsharded_model_weight.local_buffer.untyped_storage()
-        assert model_weight_storage.data_ptr() != unsharded_model_weight_storage.data_ptr(), (
-            "model_weight must not share storage with _unsharded_model_weight because "
-            "_unsharded_model_weight storage is resized and released after resharding."
+        tensor_shapes = tuple(parameter.shape for parameter in parameters.values())
+        main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
+        self.main_weight = DBuffer.distribute_tensors(
+            (parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()),
+            mesh=self.mesh,
+            placements=placements.optimizer,
         )
 
-        main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
+        self._unsharded_model_weight = DBuffer(
+            mesh=self.mesh,
+            placements=[Replicate()] * self.mesh.ndim,
+            tensor_shapes=tensor_shapes,
+            dtype=self.dtype,
+            device=self.main_weight.local_buffer.device,
+        )
         if main_weight_dtype == self.dtype and placements.optimizer == placements.parameter:
-            self.main_weight = self.model_weight
+            self.model_weight = self.main_weight
         else:
-            self.main_weight = DBuffer.distribute_tensors(
-                (parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()),
+            self.model_weight = DBuffer(
                 mesh=self.mesh,
-                placements=placements.optimizer,
+                placements=placements.parameter,
+                tensor_shapes=tensor_shapes,
+                dtype=self.dtype,
+                device=self.main_weight.local_buffer.device,
             )
 
         self.main_grad = None
@@ -154,25 +159,16 @@ class ParameterGroup:
                 dtype=grad_dtype,
                 device=self.main_weight.local_buffer.device,
             )
-            if self.main_grad.layout != self.main_weight.layout:
-                raise ValueError(
-                    "FSDP temporarily requires main_grad and main_weight to have the same "
-                    "layout until HSDP/HFSDP support is implemented."
-                )
+            assert self.main_grad.layout == self.main_weight.layout, (
+                "main_grad is built from main_weight tensor shapes on the same mesh, "
+                "and DBuffer layouts are deterministic from those shapes and mesh size."
+            )
             if self.main_grad.placements != self.main_weight.placements:
                 raise ValueError(
                     "FSDP temporarily requires main_grad and main_weight to have the same "
                     "placements until HSDP/HFSDP support is implemented. "
                     f"Got main_grad placements {self.main_grad.placements} and "
                     f"main_weight placements {self.main_weight.placements}."
-                )
-            if self.main_grad.local_buffer.dtype != self.main_weight.local_buffer.dtype:
-                raise ValueError(
-                    "FSDP temporarily requires main_grad and main_weight to have the same "
-                    "dtype until optimizer wrapping supports optimizer-visible gradient "
-                    "conversion. "
-                    f"Got main_grad dtype {self.main_grad.local_buffer.dtype} and "
-                    f"main_weight dtype {self.main_weight.local_buffer.dtype}."
                 )
 
         # ---------------------------------------------------------------------
@@ -216,8 +212,18 @@ class ParameterGroup:
     def _switch_to_unsharded_parameters(self) -> None:
         self._set_module_parameters(self.unsharded_parameters)
 
+    def sync_model_weight_from_main_weight(self) -> None:
+        """Refresh compute weights from optimizer weights."""
+        if self.main_weight is self.model_weight:
+            return
+
+        self.main_weight.cast(self.model_weight.local_buffer.dtype).redistribute(
+            self.model_weight.placements, out=self.model_weight
+        )
+
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""
+        self.sync_model_weight_from_main_weight()
         self._unsharded_model_weight.reallocate_storage()
         # This buffer backs unsharded Parameters whose views may be saved by autograd.
         # Materializing FSDP-managed storage should not look like a user mutation.
@@ -436,7 +442,7 @@ def _materialize_and_collect_owned_parameters(
                         f"Module {submodule_fqn!r} does not have "
                         "reset_parameters or _reset_parameters."
                     )
-            # Module.to_empty doesn't necessarily reuse Parameters so collects direct parameters again.
+            # Module.to_empty may replace Parameters, so collect direct parameters again.
             direct_parameters = list(submodule.named_parameters(recurse=False))
 
         for local_parameter_name, parameter in direct_parameters:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Minimal experimental per-module Megatron-FSDP implementation."""
+"""Minimal per-module Megatron-FSDP implementation."""
 
 import dataclasses
 from collections.abc import Callable, Sequence
@@ -51,53 +51,55 @@ class Placements:
 class ParameterGroup:
     """A dtype and requires-grad homogeneous group of FSDP-owned parameters."""
 
-    module: nn.Module
-    parameters: dict[str, nn.Parameter]
-    _unsharded_parameters: dict[str, nn.Parameter]
+    owning_module: nn.Module
+    sharded_parameters: dict[str, nn.Parameter]
+    unsharded_parameters: dict[str, nn.Parameter]
     mesh: DeviceMesh
+    dp_mesh: DeviceMesh
     dtype: torch.dtype
     requires_grad: bool
     main_weight: DBuffer
     model_weight: DBuffer
     main_grad: DBuffer | None
-    _full_weight: DBuffer | None
-    _full_weight_allocated: bool
+    _unsharded_model_weight: DBuffer
 
     def __init__(
         self,
-        module: nn.Module,
+        owning_module: nn.Module,
         parameters: dict[str, nn.Parameter],
         mesh: DeviceMesh,
-        model_weight_placements: Sequence[Placement],
-        main_grad_placements: Sequence[Placement],
-        main_weight_placements: Sequence[Placement],
+        placements: Placements,
         mixed_precision_policy: MixedPrecisionPolicy,
     ) -> None:
         """Create persistent sharded buffers for a group of parameters.
 
         Args:
-            module: Closest FSDP root module that owns this parameter group.
+            owning_module: Closest FSDP root module that owns this parameter group.
             parameters: Root-module-relative FQNs and their parameters.
-            mesh: Device mesh used by the buffers.
-            model_weight_placements: Placements for compute-weight storage.
-            main_grad_placements: Placements for persistent main gradients.
-            main_weight_placements: Placements for optimizer-owned main weights.
+            mesh: Full device mesh. DBuffer storage is built on the DP submesh.
+            placements: Parameter, gradient, and optimizer placements.
             mixed_precision_policy: Precision policy for main weights and gradients.
         """
         if not parameters:
             raise ValueError("ParameterGroup requires at least one parameter.")
 
+        dp_mesh = _dp_submesh(mesh, placements.dp_axes)
+
         # Python dicts preserve insertion order, so values() defines the stable
         # tensor order used by each DBuffer built from this group.
-        original_parameters = parameters
-        self.module = module
-        self.parameters = {}
-        self._unsharded_parameters = {}
+        self.owning_module = owning_module
+        self.sharded_parameters = {}
+        self.unsharded_parameters = {}
         self.mesh = mesh
-        first_parameter = next(iter(original_parameters.values()))
+        self.dp_mesh = dp_mesh
+        first_parameter = next(iter(parameters.values()))
         self.dtype = first_parameter.dtype
         self.requires_grad = first_parameter.requires_grad
-        for name, parameter in original_parameters.items():
+        for name, parameter in parameters.items():
+            if parameter.is_meta:
+                raise ValueError(
+                    f"Expected parameter {name!r} to be materialized before ParameterGroup construction."
+                )
             if parameter.dtype != self.dtype:
                 raise ValueError(
                     f"Expected parameter {name!r} to have dtype {self.dtype}, got {parameter.dtype}."
@@ -107,152 +109,87 @@ class ParameterGroup:
                     f"Expected parameter {name!r} to have requires_grad={self.requires_grad}, "
                     f"got {parameter.requires_grad}."
                 )
-        main_params_dtype = mixed_precision_policy.main_params_dtype
-        if main_params_dtype is None:
+        main_weight_dtype = mixed_precision_policy.main_params_dtype
+        if main_weight_dtype is None:
             raise ValueError(
-                "experimental FSDP requires main_params_dtype to be specified explicitly."
+                "FSDP requires a main weight dtype; set MixedPrecisionPolicy.main_params_dtype."
             )
-        main_grads_dtype = mixed_precision_policy.main_grads_dtype
-        if main_grads_dtype is None:
-            main_grads_dtype = self.dtype
-        self.main_weight = DBuffer(
-            mesh=self.mesh,
-            placements=main_weight_placements,
-            tensor_shapes=[parameter.shape for parameter in original_parameters.values()],
-            dtype=main_params_dtype,
-            device=_mesh_device(self.mesh),
+        main_grad_dtype = mixed_precision_policy.main_grads_dtype
+        if main_grad_dtype is None:
+            main_grad_dtype = self.dtype
+        # Scratch initialization starts from model weights. Checkpoint loading will
+        # eventually initialize main weights first and derive model weights from them.
+        self.model_weight = DBuffer.distribute_tensors(
+            [parameter.detach().contiguous() for parameter in parameters.values()],
+            mesh=self.dp_mesh,
+            placements=placements.parameter,
         )
-        for index, parameter in enumerate(original_parameters.values()):
-            if parameter.is_meta:
-                continue
-            self._copy_full_tensor_to_buffer(
-                self.main_weight,
-                index,
-                parameter.detach().to(
-                    dtype=main_params_dtype, device=self.main_weight.local_buffer.device
-                ),
-            )
-        self.model_weight = self._make_model_weight(tuple(model_weight_placements))
+        self.main_weight = DBuffer.distribute_tensors(
+            [
+                parameter.detach().to(dtype=main_weight_dtype).contiguous()
+                for parameter in parameters.values()
+            ],
+            mesh=self.dp_mesh,
+            placements=placements.optimizer,
+        )
         self.main_grad = (
             DBuffer(
-                mesh=self.mesh,
-                placements=main_grad_placements,
+                mesh=self.dp_mesh,
+                placements=placements.gradient,
                 tensor_shapes=self.main_weight.layout.tensor_shapes,
-                dtype=main_grads_dtype,
+                dtype=main_grad_dtype,
                 device=self.main_weight.local_buffer.device,
             )
             if self.requires_grad
             else None
         )
-        self._full_weight: DBuffer | None = None
-        self._full_weight_allocated = False
-
-        for index, (name, original_parameter) in enumerate(original_parameters.items()):
-            sharded_parameter = nn.Parameter(
-                self.main_weight.get_dtensor(index), requires_grad=original_parameter.requires_grad
-            )
-            setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
-            self.parameters[name] = sharded_parameter
-            self._set_module_parameter(name, sharded_parameter)
-
-    def _make_model_weight(self, placements: Sequence[Placement]) -> DBuffer:
-        model_weight = self.main_weight.redistribute(placements)
-        if model_weight.local_buffer.dtype != self.dtype:
-            converted = DBuffer(
-                mesh=model_weight.mesh,
-                placements=model_weight.placements,
-                tensor_shapes=model_weight.layout.tensor_shapes,
-                dtype=self.dtype,
-                device=model_weight.local_buffer.device,
-            )
-            converted.local_buffer.copy_(model_weight.local_buffer.to(dtype=self.dtype))
-            return converted
-        return model_weight
-
-    def _copy_full_tensor_to_buffer(
-        self, buffer: DBuffer, index: int, tensor: torch.Tensor
-    ) -> None:
-        """Copy this rank's overlapping slice from a full tensor into a DBuffer."""
-        tensor = tensor.contiguous().view(-1)
-        shape = buffer.layout.tensor_shapes[index]
-        tensor_start = buffer.layout.tensor_to_offset[index]
-        tensor_end = tensor_start + shape.numel()
-        buffer_start = buffer.offset
-        buffer_end = buffer.offset + buffer.local_buffer.numel()
-        overlap_start = max(tensor_start, buffer_start)
-        overlap_end = min(tensor_end, buffer_end)
-        if overlap_end <= overlap_start:
-            return
-        local_numel = overlap_end - overlap_start
-        buffer.local_buffer.narrow(0, overlap_start - buffer_start, local_numel).copy_(
-            tensor.narrow(0, overlap_start - tensor_start, local_numel)
+        self._unsharded_model_weight = DBuffer(
+            mesh=self.dp_mesh,
+            placements=[Replicate()] * self.dp_mesh.ndim,
+            tensor_shapes=self.model_weight.layout.tensor_shapes,
+            dtype=self.model_weight.local_buffer.dtype,
+            device=self.model_weight.local_buffer.device,
         )
 
-    def _set_module_parameter(self, name: str, parameter: nn.Parameter) -> None:
-        module, parameter_name = _get_parameter_owner(self.module, name)
-        module._parameters[parameter_name] = parameter
+        for index, (name, parameter) in enumerate(parameters.items()):
+            parameter.data = self._unsharded_model_weight.get_tensor(index)
+            parameter.grad = None
+            setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
+            self.unsharded_parameters[name] = parameter
+            sharded_parameter = nn.Parameter(
+                self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
+            )
+            setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
+            self.sharded_parameters[name] = sharded_parameter
+        self._switch_to_sharded_parameters()
+        self._unsharded_model_weight.release_storage()
 
-    def refresh_model_weight(self) -> None:
-        """Refresh compute-weight storage from the current main weights."""
-        self.model_weight = self._make_model_weight(self.model_weight.placements)
+    def _set_module_parameters(self, parameters: dict[str, nn.Parameter]) -> None:
+        for name, parameter in parameters.items():
+            module, parameter_name = _get_parameter_owner(self.owning_module, name)
+            module._parameters[parameter_name] = parameter
+
+    def _switch_to_sharded_parameters(self) -> None:
+        self._set_module_parameters(self.sharded_parameters)
+
+    def _switch_to_unsharded_parameters(self) -> None:
+        self._set_module_parameters(self.unsharded_parameters)
 
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""
-        self.refresh_model_weight()
-        self._allocate_full_weight()
-        assert self._full_weight is not None
-        self._ensure_unsharded_parameters()
-        for name, parameter in self._unsharded_parameters.items():
-            parameter.grad = None
-            self._set_module_parameter(name, parameter)
+        self._unsharded_model_weight.reallocate_storage()
+        # This buffer backs unsharded Parameters whose views may be saved by autograd.
+        # Materializing FSDP-managed storage should not look like a user mutation.
+        with torch.autograd._unsafe_preserve_version_counter(
+            self._unsharded_model_weight.local_buffer
+        ):
+            self.model_weight.fully_allgather_into(self._unsharded_model_weight)
+        self._switch_to_unsharded_parameters()
 
     def reshard_parameters(self) -> None:
         """Install sharded DTensor parameters on the owning modules."""
-        for name, parameter in self.parameters.items():
-            self._set_module_parameter(name, parameter)
-        self._release_full_weight_storage()
-
-    def _ensure_unsharded_parameters(self) -> None:
-        """Create stable full-size autograd leaf parameters."""
-        if self._unsharded_parameters:
-            return
-        assert self._full_weight is not None
-        for index, (name, sharded_parameter) in enumerate(self.parameters.items()):
-            self._unsharded_parameters[name] = nn.Parameter(
-                self._full_weight.get_tensor(index), requires_grad=sharded_parameter.requires_grad
-            )
-
-    def _allocate_full_weight(self) -> None:
-        """Ensure the stable full-weight storage is allocated and current."""
-        if self._full_weight is None:
-            self._full_weight = self.model_weight.redistribute([Replicate()] * self.mesh.ndim)
-            self._full_weight_allocated = True
-            return
-        if self._full_weight_allocated:
-            return
-
-        self._resize_full_weight_storage(self._full_weight.local_buffer.numel())
-        refreshed = self.model_weight.redistribute([Replicate()] * self.mesh.ndim)
-        with torch.autograd._unsafe_preserve_version_counter(self._full_weight.local_buffer):
-            self._full_weight.local_buffer.copy_(refreshed.local_buffer)
-        self._full_weight_allocated = True
-
-    def _release_full_weight_storage(self) -> None:
-        """Free full-weight storage without replacing the Storage object."""
-        if self._full_weight is None or not self._full_weight_allocated:
-            return
-        # Non-leaf parameter views saved by autograd keep their Storage object.
-        # Retaining that object and resizing it back before backward avoids
-        # stale-storage failures while still releasing the allocation.
-        self._resize_full_weight_storage(0)
-        self._full_weight_allocated = False
-
-    def _resize_full_weight_storage(self, numel: int) -> None:
-        assert self._full_weight is not None
-        with torch.autograd._unsafe_preserve_version_counter(self._full_weight.local_buffer):
-            self._full_weight.local_buffer.untyped_storage().resize_(
-                numel * self._full_weight.local_buffer.element_size()
-            )
+        self._switch_to_sharded_parameters()
+        self._unsharded_model_weight.release_storage()
 
     def reduce_gradients(self, average: bool = True) -> None:
         """Reduce full local gradients into the persistent sharded gradient buffer."""
@@ -262,7 +199,7 @@ class ParameterGroup:
 
         accumulate = self.has_sharded_grad()
         full_grads: list[torch.Tensor] = []
-        for name, parameter in self._unsharded_parameters.items():
+        for name, parameter in self.unsharded_parameters.items():
             if parameter.grad is None:
                 raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
             full_grads.append(
@@ -270,64 +207,60 @@ class ParameterGroup:
             )
 
         partial_grad = DBuffer.distribute_tensors(
-            full_grads, mesh=self.mesh, placements=[Partial()] * self.mesh.ndim
+            full_grads, mesh=self.dp_mesh, placements=[Partial()] * self.dp_mesh.ndim
         )
         reduced_grad = partial_grad.redistribute(self.main_grad.placements)
         if average:
-            reduced_grad.local_buffer.div_(self.mesh.size())
+            reduced_grad.local_buffer.div_(self.dp_mesh.size())
 
         if accumulate:
             self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
         else:
             self.main_grad.local_buffer.copy_(reduced_grad.local_buffer)
 
-        for parameter in self._unsharded_parameters.values():
+        for parameter in self.unsharded_parameters.values():
             parameter.grad = None
         self.install_sharded_gradients()
 
     def has_sharded_grad(self) -> bool:
         """Return whether persistent sharded gradients are currently materialized."""
-        return any(parameter.grad is not None for parameter in self.parameters.values())
+        return any(parameter.grad is not None for parameter in self.sharded_parameters.values())
 
     def install_sharded_gradients(self) -> None:
         """Install sharded DTensor gradients backed by main_grad."""
         if self.main_grad is None:
             return
-        for index, parameter in enumerate(self.parameters.values()):
+        for index, parameter in enumerate(self.sharded_parameters.values()):
             parameter.grad = self.main_grad.get_dtensor(index)
 
-    def zero_grad(self, set_to_none: bool = True) -> None:
-        """Clear persistent and parameter gradients."""
-        if self.main_grad is not None:
-            self.main_grad.local_buffer.zero_()
-        if set_to_none:
-            for parameter in self.parameters.values():
-                parameter.grad = None
-        else:
-            self.install_sharded_gradients()
-        for parameter in self._unsharded_parameters.values():
-            parameter.grad = None
-
-    def unsharded_parameters(self) -> tuple[nn.Parameter, ...]:
-        """Return temporary full-size parameters used for autograd."""
-        return tuple(self._unsharded_parameters.values())
-
-
 class FsdpModule:
-    """Mixin attached to modules managed by the minimal experimental FSDP path."""
+    """Mixin attached to modules managed by the minimal FSDP path."""
 
     _parameter_groups: tuple[ParameterGroup, ...]
     _ready_grad_params: set[nn.Parameter]
     _registered_grad_param_ids: set[int]
     _trainable_param_count: int
 
-    def __init__(self, parameter_groups: Sequence[ParameterGroup]) -> None:
-        """Initialize mixin runtime state on an already-constructed module."""
+    def __init__(
+        self, mesh: DeviceMesh, placements: Placements, mixed_precision_policy: MixedPrecisionPolicy
+    ) -> None:
+        """Initialize FSDP runtime state on an already-constructed module."""
+        owned_parameters = _materialize_and_collect_owned_parameters(self, _mesh_device(mesh))
+        parameter_groups = [
+            ParameterGroup(
+                owning_module=self,
+                parameters=group_parameters,
+                mesh=mesh,
+                placements=placements,
+                mixed_precision_policy=mixed_precision_policy,
+            )
+            for group_parameters in _group_parameters(owned_parameters)
+        ]
         self._parameter_groups = tuple(parameter_groups)
         self._ready_grad_params: set[nn.Parameter] = set()
         self._registered_grad_param_ids: set[int] = set()
         self._trainable_param_count = sum(
-            len(group.parameters) for group in self._parameter_groups if group.requires_grad
+            len(group.sharded_parameters) for group in self._parameter_groups if group.requires_grad
         )
         self._register_hooks()
 
@@ -341,7 +274,7 @@ class FsdpModule:
         for group in self._parameter_groups:
             if not group.requires_grad:
                 continue
-            for parameter in group.unsharded_parameters():
+            for parameter in group.unsharded_parameters.values():
                 parameter_id = id(parameter)
                 if parameter_id in self._registered_grad_param_ids:
                     continue
@@ -391,9 +324,8 @@ def fully_shard(
     mesh: DeviceMesh,
     placements: Placements,
     mixed_precision_policy: MixedPrecisionPolicy | None = None,
-    init_model_with_meta_device: bool = False,
 ) -> None:
-    """Shard one module as an experimental per-module FSDP unit.
+    """Shard one module as a per-module FSDP unit.
 
     Args:
         module: Module whose currently unowned parameters become this FSDP unit.
@@ -401,50 +333,21 @@ def fully_shard(
         placements: Parameter, gradient, and optimizer placements.
         mixed_precision_policy: Optional precision policy. Defaults to FP32 main weights
             and parameter-dtype main gradients.
-        init_model_with_meta_device: If true, initialize owned meta parameters by
-            calling their direct module's reset_parameters() or _reset_parameters().
     """
     if isinstance(module, FsdpModule):
-        raise ValueError("This module is already managed by experimental FSDP.")
+        raise ValueError("This module is already managed by FSDP.")
 
     mixed_precision_policy = mixed_precision_policy or MixedPrecisionPolicy()
-    model_weight_placements = _placements_in_mesh_order(
-        mesh, placements.dp_axes, placements.parameter
-    )
-    main_grad_placements = _placements_in_mesh_order(mesh, placements.dp_axes, placements.gradient)
-    main_weight_placements = _placements_in_mesh_order(
-        mesh, placements.dp_axes, placements.optimizer
-    )
-    owned_parameters = _collect_owned_parameters(module)
-    if (
-        any(parameter.is_meta for parameter in owned_parameters.values())
-        and not init_model_with_meta_device
-    ):
-        raise ValueError(
-            "experimental FSDP found meta parameters. Pass init_model_with_meta_device=True "
-            "to initialize them with reset_parameters()/_reset_parameters()."
-        )
-    grouped_parameters = _group_parameters(owned_parameters)
-    parameter_groups = [
-        ParameterGroup(
-            module,
-            group_parameters,
-            mesh=mesh,
-            model_weight_placements=model_weight_placements,
-            main_grad_placements=main_grad_placements,
-            main_weight_placements=main_weight_placements,
-            mixed_precision_policy=mixed_precision_policy,
-        )
-        for group_parameters in grouped_parameters
-    ]
-    if init_model_with_meta_device:
-        _reset_owned_meta_modules(module, owned_parameters)
-        for group in parameter_groups:
-            group.refresh_model_weight()
-
+    original_cls = module.__class__
     _attach_mixin(module)
-    assert isinstance(module, FsdpModule)
-    FsdpModule.__init__(module, parameter_groups=parameter_groups)
+    try:
+        assert isinstance(module, FsdpModule)
+        FsdpModule.__init__(
+            module, mesh=mesh, placements=placements, mixed_precision_policy=mixed_precision_policy
+        )
+    except Exception:
+        module.__class__ = original_cls
+        raise
 
 
 def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
@@ -461,23 +364,26 @@ def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
     return dim_names.index(axis)
 
 
-def _placements_in_mesh_order(
-    mesh: DeviceMesh, dp_axes: Sequence[MeshAxis], placements: Sequence[Placement]
-) -> tuple[Placement, ...]:
-    if len(dp_axes) != mesh.ndim:
+def _dp_submesh(mesh: DeviceMesh, dp_axes: Sequence[MeshAxis]) -> DeviceMesh:
+    if not dp_axes:
+        raise ValueError("FSDP requires at least one DP mesh axis.")
+
+    axis_indices = tuple(_axis_index(mesh, axis) for axis in dp_axes)
+    if len(set(axis_indices)) != len(axis_indices):
+        raise ValueError(f"Duplicate DP mesh axes are not allowed: {tuple(dp_axes)!r}.")
+
+    if axis_indices == tuple(range(mesh.ndim)):
+        return mesh
+
+    dim_names = mesh.mesh_dim_names
+    if dim_names is None:
         raise ValueError(
-            "experimental fully_shard currently requires placements for every mesh axis: "
-            f"mesh ndim is {mesh.ndim}, got {len(dp_axes)} axes."
+            "Slicing a DP submesh from a full mesh requires named mesh dimensions unless "
+            "dp_axes covers every mesh axis in mesh order."
         )
-    result: list[Placement | None] = [None] * mesh.ndim
-    for axis, placement in zip(dp_axes, placements, strict=True):
-        axis_index = _axis_index(mesh, axis)
-        if result[axis_index] is not None:
-            raise ValueError(f"Duplicate placement for mesh axis {axis!r}.")
-        result[axis_index] = placement
-    if any(placement is None for placement in result):
-        raise ValueError("Missing placement for at least one mesh axis.")
-    return tuple(placement for placement in result if placement is not None)
+
+    dp_axis_names = tuple(dim_names[index] for index in axis_indices)
+    return mesh[dp_axis_names[0] if len(dp_axis_names) == 1 else dp_axis_names]
 
 
 def _mesh_device(mesh: DeviceMesh) -> torch.device:
@@ -486,26 +392,49 @@ def _mesh_device(mesh: DeviceMesh) -> torch.device:
     return torch.device(mesh.device_type)
 
 
-def _collect_owned_parameters(module: nn.Module) -> dict[str, nn.Parameter]:
-    child_prefixes = [
-        f"{name}."
-        for name, child in module.named_modules()
-        if name and isinstance(child, FsdpModule)
-    ]
+def _materialize_and_collect_owned_parameters(
+    root_module: nn.Module, device: torch.device
+) -> dict[str, nn.Parameter]:
     parameters: dict[str, nn.Parameter] = {}
-    for module_name, child in module.named_modules():
-        prefix = f"{module_name}." if module_name else ""
-        if any(prefix.startswith(child_prefix) for child_prefix in child_prefixes):
-            continue
-        for parameter_name, parameter in child.named_parameters(recurse=False):
-            name = f"{prefix}{parameter_name}"
-            if hasattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR):
+
+    def visit(submodule: nn.Module, submodule_fqn: str) -> None:
+        direct_parameters = list(submodule.named_parameters(recurse=False))
+
+        if any(parameter.is_meta for _, parameter in direct_parameters):
+            if any(not parameter.is_meta for _, parameter in direct_parameters):
                 raise ValueError(
-                    f"Parameter {name!r} is already owned by an experimental FSDP unit."
+                    f"Module {submodule_fqn!r} mixes meta and non-meta direct parameters. "
+                    "Initialize all direct parameters on meta or none of them."
                 )
-            parameters[name] = parameter
+            submodule.to_empty(device=device, recurse=False)
+            with torch.no_grad():
+                if hasattr(submodule, "reset_parameters"):
+                    submodule.reset_parameters()
+                elif hasattr(submodule, "_reset_parameters"):
+                    submodule._reset_parameters()
+                else:
+                    raise ValueError(
+                        f"Module {submodule_fqn!r} does not have "
+                        "reset_parameters or _reset_parameters."
+                    )
+            # Module.to_empty doesn't necessarily reuse Parameters so collects direct parameters again.
+            direct_parameters = list(submodule.named_parameters(recurse=False))
+
+        for local_param_name, parameter in direct_parameters:
+            param_fqn = f"{submodule_fqn}.{local_param_name}" if submodule_fqn else local_param_name
+            if hasattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR):
+                raise ValueError(f"Parameter {param_fqn!r} is already owned by an FSDP unit.")
+            parameters[param_fqn] = parameter
+
+        for child_name, child_module in submodule.named_children():
+            if isinstance(child_module, FsdpModule):
+                continue
+            child_fqn = f"{submodule_fqn}.{child_name}" if submodule_fqn else child_name
+            visit(child_module, child_fqn)
+
+    visit(root_module, "")
     if not parameters:
-        raise ValueError("experimental fully_shard requires at least one unowned parameter.")
+        raise ValueError("fully_shard requires at least one unowned parameter.")
     return parameters
 
 
@@ -522,30 +451,6 @@ def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:
     module_name, separator, parameter_name = name.rpartition(".")
     owner = module.get_submodule(module_name) if separator else module
     return owner, parameter_name
-
-
-def _reset_owned_meta_modules(
-    module: nn.Module, original_parameters: dict[str, nn.Parameter]
-) -> None:
-    """Initialize modules that originally owned meta parameters."""
-    modules_to_reset: dict[int, tuple[str, nn.Module]] = {}
-    for name, parameter in original_parameters.items():
-        if not parameter.is_meta:
-            continue
-        owner_module, _ = _get_parameter_owner(module, name)
-        module_name = name.rsplit(".", 1)[0] if "." in name else ""
-        modules_to_reset.setdefault(id(owner_module), (module_name, owner_module))
-
-    for module_name, module in modules_to_reset.values():
-        if hasattr(module, "reset_parameters"):
-            module.reset_parameters()
-        elif hasattr(module, "_reset_parameters"):
-            module._reset_parameters()
-        else:
-            raise ValueError(
-                f"[init_model_with_meta_device=True] Module {module_name!r} does not have "
-                "reset_parameters or _reset_parameters."
-            )
 
 
 def _attach_mixin(module: nn.Module) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -16,6 +16,7 @@
 
 import dataclasses
 from collections.abc import Callable, Iterable
+from typing import cast
 
 import torch
 import torch.distributed as dist
@@ -176,20 +177,18 @@ class ParameterGroup:
         # ---------------------------------------------------------------------
         sharded_parameters: list[nn.Parameter] = []
         unsharded_parameters: list[nn.Parameter] = []
-        grad_dtype = self.main_grad.local_buffer.dtype if self.requires_grad else None
+        main_grad_dtype = self.main_grad.local_buffer.dtype if self.main_grad is not None else None
         for index, parameter in enumerate(parameters.values()):
             parameter.data = self._unsharded_model_weight.get_tensor(index)
             parameter.grad = None
-            if grad_dtype:
-                parameter.grad_dtype = grad_dtype
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
             unsharded_parameters.append(parameter)
 
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
             )
-            if grad_dtype:
-                sharded_parameter.grad_dtype = grad_dtype
+            if main_grad_dtype:
+                sharded_parameter.grad_dtype = main_grad_dtype
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
             sharded_parameters.append(sharded_parameter)
         self.sharded_parameters = tuple(sharded_parameters)
@@ -260,11 +259,6 @@ class ParameterGroup:
         for name, parameter in zip(self.parameter_names, self.unsharded_parameters, strict=True):
             if parameter.grad is None:
                 raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
-            assert parameter.grad.dtype == self.main_grad.local_buffer.dtype, (
-                "FSDP unsharded parameter grad dtype should be guaranteed by grad_dtype: "
-                f"parameter {name!r} has grad dtype {parameter.grad.dtype}, "
-                f"expected main_grad dtype {self.main_grad.local_buffer.dtype}."
-            )
             grads.append(parameter.grad)
 
         partial_grad = DBuffer.distribute_tensors(
@@ -274,11 +268,21 @@ class ParameterGroup:
         # zero_grad(set_to_none=True) clears sharded parameter grads, so the next
         # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
         # leaves sharded grads installed, so this backward accumulates into main_grad.
-        if has_grad(self.sharded_parameters):
-            reduced_grad = partial_grad.redistribute(self.main_grad.placements)
-            self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
-        else:
+        has_sharded_grads = has_grad(self.sharded_parameters)
+        can_reduce_into_main_grad = (
+            not has_sharded_grads
+            and partial_grad.local_buffer.dtype == self.main_grad.local_buffer.dtype
+        )
+        if can_reduce_into_main_grad:
             partial_grad.redistribute(self.main_grad.placements, out=self.main_grad)
+        else:
+            reduced_grad = partial_grad.redistribute(self.main_grad.placements)
+            if has_sharded_grads:
+                self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
+            else:
+                self.main_grad.local_buffer.copy_(reduced_grad.local_buffer)
+
+        if not has_sharded_grads:
             for index, parameter in enumerate(self.sharded_parameters):
                 parameter.grad = self.main_grad.get_dtensor(index)
 
@@ -316,9 +320,10 @@ class FsdpModule:
         self._register_hooks()
 
     def _register_hooks(self) -> None:
-        self.register_forward_pre_hook(lambda _module, _args: self.pre_forward())
-        self.register_forward_hook(lambda _module, _args, _output: self.post_forward())
-        self.register_full_backward_pre_hook(lambda _module, _grad_output: self.pre_backward())
+        module = cast(nn.Module, self)
+        module.register_forward_pre_hook(lambda _module, _args: self.pre_forward())
+        module.register_forward_hook(lambda _module, _args, _output: self.post_forward())
+        module.register_full_backward_pre_hook(lambda _module, _grad_output: self.pre_backward())
         # Gradient reduction is parameter-completion based: once every owned
         # Parameter has accumulated its grad, this FSDP unit can reduce and
         # reshard. Module full-backward hooks can fire before that when module
@@ -399,11 +404,12 @@ def fully_shard(
 
 def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
     if isinstance(axis, int):
-        if axis < 0:
-            axis += mesh.ndim
-        if axis < 0 or axis >= mesh.ndim:
+        axis_index = axis
+        if axis_index < 0:
+            axis_index += mesh.ndim
+        if axis_index < 0 or axis_index >= mesh.ndim:
             raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
-        return axis
+        return axis_index
 
     dim_names = mesh.mesh_dim_names
     if dim_names is None or axis not in dim_names:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -49,26 +49,13 @@ class Placements:
                 raise ValueError(f"Expected {axis_count} {name} placements, got {len(placements)}.")
 
 
-def has_grad(parameters: Iterable[nn.Parameter]) -> bool:
-    """Return whether parameters have gradients, requiring all-or-none state."""
-    has_any_grad = False
-    has_any_missing_grad = False
-    for parameter in parameters:
-        if parameter.grad is None:
-            has_any_missing_grad = True
-        else:
-            has_any_grad = True
-    if has_any_grad and has_any_missing_grad:
-        raise RuntimeError("FSDP sharded gradients must be either all set or all None.")
-    return has_any_grad
-
-
 class ParameterGroup:
     """A dtype and requires-grad homogeneous group of FSDP-owned parameters."""
 
     owning_module: nn.Module
-    sharded_parameters: dict[str, nn.Parameter]
-    unsharded_parameters: dict[str, nn.Parameter]
+    parameter_names: tuple[str, ...]
+    sharded_parameters: tuple[nn.Parameter, ...]
+    unsharded_parameters: tuple[nn.Parameter, ...]
     mesh: DeviceMesh
     dtype: torch.dtype
     requires_grad: bool
@@ -110,6 +97,7 @@ class ParameterGroup:
         # ---------------------------------------------------------------------
         self.owning_module = owning_module
         self.mesh = mesh
+        self.parameter_names = tuple(parameters)
         first_parameter = next(iter(parameters.values()))
         self.dtype = first_parameter.dtype
         self.requires_grad = first_parameter.requires_grad
@@ -131,8 +119,8 @@ class ParameterGroup:
         # ---------------------------------------------------------------------
         # Initialize DBuffers from original parameter values
         # ---------------------------------------------------------------------
-        # Python dicts preserve insertion order, so values() defines the stable
-        # tensor order used by each DBuffer built from this group.
+        # Python dicts preserve insertion order, so parameter_names and
+        # parameters.values() define the same stable DBuffer tensor order.
         self._unsharded_model_weight = DBuffer.distribute_tensors(
             parameters.values(),
             mesh=self.mesh,
@@ -150,7 +138,7 @@ class ParameterGroup:
 
         main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
         self.main_weight = DBuffer.distribute_tensors(
-            [parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()],
+            (parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()),
             mesh=self.mesh,
             placements=placements.optimizer,
         )
@@ -169,20 +157,28 @@ class ParameterGroup:
         )
 
         # ---------------------------------------------------------------------
-        # Build parameter maps for module swapping
+        # Build parameter tuples for module swapping
         # ---------------------------------------------------------------------
-        self.sharded_parameters = {}
-        self.unsharded_parameters = {}
-        for index, (name, parameter) in enumerate(parameters.items()):
+        sharded_parameters: list[nn.Parameter] = []
+        unsharded_parameters: list[nn.Parameter] = []
+        grad_dtype = self.main_grad.local_buffer.dtype if self.requires_grad else None
+        for index, parameter in enumerate(parameters.values()):
             parameter.data = self._unsharded_model_weight.get_tensor(index)
             parameter.grad = None
+            if grad_dtype:
+                parameter.grad_dtype = grad_dtype
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
-            self.unsharded_parameters[name] = parameter
+            unsharded_parameters.append(parameter)
+
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
             )
+            if grad_dtype:
+                sharded_parameter.grad_dtype = grad_dtype
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
-            self.sharded_parameters[name] = sharded_parameter
+            sharded_parameters.append(sharded_parameter)
+        self.sharded_parameters = tuple(sharded_parameters)
+        self.unsharded_parameters = tuple(unsharded_parameters)
 
         # ---------------------------------------------------------------------
         # Install resting sharded parameters
@@ -190,8 +186,8 @@ class ParameterGroup:
         self._switch_to_sharded_parameters()
         self._unsharded_model_weight.release_storage()
 
-    def _set_module_parameters(self, parameters: dict[str, nn.Parameter]) -> None:
-        for name, parameter in parameters.items():
+    def _set_module_parameters(self, parameters: tuple[nn.Parameter, ...]) -> None:
+        for name, parameter in zip(self.parameter_names, parameters, strict=True):
             module, parameter_name = _get_parameter_owner(self.owning_module, name)
             module._parameters[parameter_name] = parameter
 
@@ -223,28 +219,47 @@ class ParameterGroup:
         """Reduce full local gradients into sharded parameter gradients."""
         assert self.main_grad is not None
 
-        full_grads: list[torch.Tensor] = []
-        for name, parameter in self.unsharded_parameters.items():
+        def has_grad(parameters: Iterable[nn.Parameter]) -> bool:
+            has_any_grad = False
+            has_any_missing_grad = False
+            for parameter in parameters:
+                if parameter.grad is None:
+                    has_any_missing_grad = True
+                else:
+                    has_any_grad = True
+            if has_any_grad and has_any_missing_grad:
+                raise RuntimeError("FSDP sharded gradients must be either all set or all None.")
+            return has_any_grad
+
+        grads: list[torch.Tensor] = []
+        for name, parameter in zip(self.parameter_names, self.unsharded_parameters, strict=True):
             if parameter.grad is None:
                 raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
-            full_grads.append(parameter.grad.to(dtype=self.main_grad.local_buffer.dtype))
+            assert parameter.grad.dtype == self.main_grad.local_buffer.dtype, (
+                "FSDP unsharded parameter grad dtype should be guaranteed by grad_dtype: "
+                f"parameter {name!r} has grad dtype {parameter.grad.dtype}, "
+                f"expected main_grad dtype {self.main_grad.local_buffer.dtype}."
+            )
+            grads.append(parameter.grad)
 
         partial_grad = DBuffer.distribute_tensors(
-            full_grads,
+            grads,
             mesh=self.mesh,
             placements=[Partial(dist.ReduceOp.AVG)] * self.mesh.ndim,
         )
 
-        sharded_parameters = self.sharded_parameters.values()
-        if has_grad(sharded_parameters):
+        # zero_grad(set_to_none=True) clears sharded parameter grads, so the next
+        # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
+        # leaves sharded grads installed, so this backward accumulates into main_grad.
+        if has_grad(self.sharded_parameters):
             reduced_grad = partial_grad.redistribute(self.main_grad.placements)
             self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
         else:
             partial_grad.redistribute(self.main_grad.placements, out=self.main_grad)
-            for index, parameter in enumerate(sharded_parameters):
+            for index, parameter in enumerate(self.sharded_parameters):
                 parameter.grad = self.main_grad.get_dtensor(index)
 
-        for parameter in self.unsharded_parameters.values():
+        for parameter in self.unsharded_parameters:
             parameter.grad = None
 
 
@@ -252,9 +267,8 @@ class FsdpModule:
     """Mixin attached to modules managed by the minimal FSDP path."""
 
     _parameter_groups: tuple[ParameterGroup, ...]
-    _ready_grad_params: set[nn.Parameter]
-    _registered_grad_param_ids: set[int]
-    num_trainable_params: int
+    _ready_grad_parameters: set[nn.Parameter]
+    num_training_parameters: int
 
     def __init__(
         self, mesh: DeviceMesh, placements: Placements, mixed_precision_policy: MixedPrecisionPolicy
@@ -272,9 +286,8 @@ class FsdpModule:
             for group_parameters in _group_parameters(owned_parameters)
         ]
         self._parameter_groups = tuple(parameter_groups)
-        self._ready_grad_params: set[nn.Parameter] = set()
-        self._registered_grad_param_ids: set[int] = set()
-        self.num_trainable_params = sum(
+        self._ready_grad_parameters = set()
+        self.num_training_parameters = sum(
             len(group.sharded_parameters) for group in self._parameter_groups if group.requires_grad
         )
         self._register_hooks()
@@ -283,33 +296,29 @@ class FsdpModule:
         self.register_forward_pre_hook(lambda _module, _args: self.pre_forward())
         self.register_forward_hook(lambda _module, _args, _output: self.post_forward())
         self.register_full_backward_pre_hook(lambda _module, _grad_output: self.pre_backward())
-
-    def _register_grad_hooks(self) -> None:
-        """Register post-accumulate hooks on full-size autograd leaf parameters."""
+        # Gradient reduction is parameter-completion based: once every owned
+        # Parameter has accumulated its grad, this FSDP unit can reduce and
+        # reshard. Module full-backward hooks can fire before that when module
+        # inputs do not require grad.
         for group in self._parameter_groups:
             if not group.requires_grad:
                 continue
-            for parameter in group.unsharded_parameters.values():
-                parameter_id = id(parameter)
-                if parameter_id in self._registered_grad_param_ids:
-                    continue
+            for parameter in group.unsharded_parameters:
                 parameter.register_post_accumulate_grad_hook(self._make_grad_hook(parameter))
-                self._registered_grad_param_ids.add(parameter_id)
 
     def _make_grad_hook(self, parameter: nn.Parameter) -> Callable[[nn.Parameter], None]:
         def grad_hook(_parameter: nn.Parameter) -> None:
-            self._ready_grad_params.add(parameter)
-            if len(self._ready_grad_params) == self.num_trainable_params:
+            self._ready_grad_parameters.add(parameter)
+            if len(self._ready_grad_parameters) == self.num_training_parameters:
                 self.post_backward()
 
         return grad_hook
 
     def pre_forward(self) -> None:
         """Prepare full parameters for forward compute."""
-        self._ready_grad_params.clear()
+        self._ready_grad_parameters.clear()
         for group in self._parameter_groups:
             group.unshard_parameters()
-        self._register_grad_hooks()
 
     def post_forward(self) -> None:
         """Return parameters to their sharded resting state after forward compute."""
@@ -327,7 +336,7 @@ class FsdpModule:
             if group.requires_grad:
                 group.reduce_gradients()
             group.reshard_parameters()
-        self._ready_grad_params.clear()
+        self._ready_grad_parameters.clear()
 
     def parameter_groups(self) -> tuple[ParameterGroup, ...]:
         """Return parameter groups owned by this FSDP unit."""
@@ -413,11 +422,13 @@ def _materialize_and_collect_owned_parameters(
             # Module.to_empty doesn't necessarily reuse Parameters so collects direct parameters again.
             direct_parameters = list(submodule.named_parameters(recurse=False))
 
-        for local_param_name, parameter in direct_parameters:
-            param_fqn = f"{submodule_fqn}.{local_param_name}" if submodule_fqn else local_param_name
+        for local_parameter_name, parameter in direct_parameters:
+            parameter_fqn = (
+                f"{submodule_fqn}.{local_parameter_name}" if submodule_fqn else local_parameter_name
+            )
             if hasattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR):
-                raise ValueError(f"Parameter {param_fqn!r} is already owned by an FSDP unit.")
-            parameters[param_fqn] = parameter
+                raise ValueError(f"Parameter {parameter_fqn!r} is already owned by an FSDP unit.")
+            parameters[parameter_fqn] = parameter
 
         for child_name, child_module in submodule.named_children():
             if isinstance(child_module, FsdpModule):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -88,9 +88,9 @@ class ParameterGroup:
             raise ValueError("ParameterGroup requires at least one parameter.")
 
         axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
-        assert axis_indices == tuple(range(mesh.ndim)), (
-            "FSDP requires dp_axes to match every mesh axis in mesh order for now."
-        )
+        assert axis_indices == tuple(
+            range(mesh.ndim)
+        ), "FSDP requires dp_axes to match every mesh axis in mesh order for now."
 
         # ---------------------------------------------------------------------
         # Record shared metadata
@@ -122,9 +122,7 @@ class ParameterGroup:
         # Python dicts preserve insertion order, so parameter_names and
         # parameters.values() define the same stable DBuffer tensor order.
         self._unsharded_model_weight = DBuffer.distribute_tensors(
-            parameters.values(),
-            mesh=self.mesh,
-            placements=[Replicate()] * self.mesh.ndim,
+            parameters.values(), mesh=self.mesh, placements=[Replicate()] * self.mesh.ndim
         )
         # Scratch initialization starts from model weights. Checkpoint loading will
         # eventually initialize main weights first and derive model weights from them.
@@ -143,18 +141,36 @@ class ParameterGroup:
             placements=placements.optimizer,
         )
 
-        main_grad_dtype = mixed_precision_policy.main_grads_dtype or self.dtype
-        self.main_grad = (
-            DBuffer(
+        self.main_grad = None
+        if self.requires_grad:
+            main_grad_dtype = mixed_precision_policy.main_grads_dtype or self.dtype
+            self.main_grad = DBuffer(
                 mesh=self.mesh,
                 placements=placements.gradient,
                 tensor_shapes=self.main_weight.layout.tensor_shapes,
                 dtype=main_grad_dtype,
                 device=self.main_weight.local_buffer.device,
             )
-            if self.requires_grad
-            else None
-        )
+            if self.main_grad.layout != self.main_weight.layout:
+                raise ValueError(
+                    "FSDP temporarily requires main_grad and main_weight to have the same "
+                    "layout until HSDP/HFSDP support is implemented."
+                )
+            if self.main_grad.placements != self.main_weight.placements:
+                raise ValueError(
+                    "FSDP temporarily requires main_grad and main_weight to have the same "
+                    "placements until HSDP/HFSDP support is implemented. "
+                    f"Got main_grad placements {self.main_grad.placements} and "
+                    f"main_weight placements {self.main_weight.placements}."
+                )
+            if self.main_grad.local_buffer.dtype != self.main_weight.local_buffer.dtype:
+                raise ValueError(
+                    "FSDP temporarily requires main_grad and main_weight to have the same "
+                    "dtype until optimizer wrapping supports optimizer-visible gradient "
+                    "conversion. "
+                    f"Got main_grad dtype {self.main_grad.local_buffer.dtype} and "
+                    f"main_weight dtype {self.main_weight.local_buffer.dtype}."
+                )
 
         # ---------------------------------------------------------------------
         # Build parameter tuples for module swapping
@@ -243,9 +259,7 @@ class ParameterGroup:
             grads.append(parameter.grad)
 
         partial_grad = DBuffer.distribute_tensors(
-            grads,
-            mesh=self.mesh,
-            placements=[Partial(dist.ReduceOp.AVG)] * self.mesh.ndim,
+            grads, mesh=self.mesh, placements=[Partial(dist.ReduceOp.AVG)] * self.mesh.ndim
         )
 
         # zero_grad(set_to_none=True) clears sharded parameter grads, so the next

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -12,103 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Minimal per-module Megatron-FSDP implementation."""
+"""Minimal Megatron-FSDP fully_shard entrypoint."""
 
-from collections.abc import Callable
-from typing import cast
-
-import torch
 from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
-from .parameter_group import ParameterGroup, contained_in_parameter_group
-from .placement import MeshAxis, Placements
-
-
-class FsdpModule:
-    """Mixin attached to modules managed by the minimal FSDP path."""
-
-    _parameter_groups: tuple[ParameterGroup, ...]
-    _ready_grad_parameters: set[nn.Parameter]
-    num_training_parameters: int
-
-    def __init__(
-        self, mesh: DeviceMesh, placements: Placements, mixed_precision_policy: MixedPrecisionPolicy
-    ) -> None:
-        """Initialize FSDP runtime state on an already-constructed module."""
-        owned_parameters = _materialize_and_collect_owned_parameters(self, _mesh_device(mesh))
-        axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
-        assert axis_indices == tuple(
-            range(mesh.ndim)
-        ), "FSDP requires dp_axes to match every mesh axis in mesh order for now."
-        parameter_groups = [
-            ParameterGroup(
-                owning_module=self,
-                parameters=group_parameters,
-                mesh=mesh,
-                placements=placements,
-                mixed_precision_policy=mixed_precision_policy,
-            )
-            for group_parameters in _group_parameters(owned_parameters)
-        ]
-        self._parameter_groups = tuple(parameter_groups)
-        self._ready_grad_parameters = set()
-        self.num_training_parameters = sum(
-            len(group.sharded_parameters) for group in self._parameter_groups if group.requires_grad
-        )
-        self._register_hooks()
-
-    def _register_hooks(self) -> None:
-        module = cast(nn.Module, self)
-        module.register_forward_pre_hook(lambda _module, _args: self.pre_forward())
-        module.register_forward_hook(lambda _module, _args, _output: self.post_forward())
-        module.register_full_backward_pre_hook(lambda _module, _grad_output: self.pre_backward())
-        # Gradient reduction is parameter-completion based: once every owned
-        # Parameter has accumulated its grad, this FSDP unit can reduce and
-        # reshard. Module full-backward hooks can fire before that when module
-        # inputs do not require grad.
-        for group in self._parameter_groups:
-            if not group.requires_grad:
-                continue
-            for parameter in group.unsharded_parameters:
-                parameter.register_post_accumulate_grad_hook(self._make_grad_hook(parameter))
-
-    def _make_grad_hook(self, parameter: nn.Parameter) -> Callable[[nn.Parameter], None]:
-        def grad_hook(_parameter: nn.Parameter) -> None:
-            self._ready_grad_parameters.add(parameter)
-            if len(self._ready_grad_parameters) == self.num_training_parameters:
-                self.post_backward()
-
-        return grad_hook
-
-    def pre_forward(self) -> None:
-        """Prepare full parameters for forward compute."""
-        self._ready_grad_parameters.clear()
-        for group in self._parameter_groups:
-            group.unshard_parameters()
-
-    def post_forward(self) -> None:
-        """Return parameters to their sharded resting state after forward compute."""
-        for group in self._parameter_groups:
-            group.reshard_parameters()
-
-    def pre_backward(self) -> None:
-        """Prepare full parameters for backward compute."""
-        for group in self._parameter_groups:
-            group.unshard_parameters()
-
-    def post_backward(self) -> None:
-        """Reduce gradients and return parameters to their sharded resting state."""
-        for group in self._parameter_groups:
-            if group.requires_grad:
-                group.reduce_gradients()
-            group.reshard_parameters()
-        self._ready_grad_parameters.clear()
-
-    def parameter_groups(self) -> tuple[ParameterGroup, ...]:
-        """Return parameter groups owned by this FSDP unit."""
-        return self._parameter_groups
+from .fsdp_module import FsdpModule
+from .placement import Placements
 
 
 def fully_shard(
@@ -140,83 +51,6 @@ def fully_shard(
     except Exception:
         module.__class__ = original_cls
         raise
-
-
-def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
-    if isinstance(axis, int):
-        axis_index = axis
-        if axis_index < 0:
-            axis_index += mesh.ndim
-        if axis_index < 0 or axis_index >= mesh.ndim:
-            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
-        return axis_index
-
-    dim_names = mesh.mesh_dim_names
-    if dim_names is None or axis not in dim_names:
-        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
-    return dim_names.index(axis)
-
-
-def _mesh_device(mesh: DeviceMesh) -> torch.device:
-    if mesh.device_type == "cuda":
-        return torch.device("cuda", torch.cuda.current_device())
-    return torch.device(mesh.device_type)
-
-
-def _materialize_and_collect_owned_parameters(
-    root_module: nn.Module, device: torch.device
-) -> dict[str, nn.Parameter]:
-    parameters: dict[str, nn.Parameter] = {}
-
-    def visit(submodule: nn.Module, submodule_fqn: str) -> None:
-        direct_parameters = list(submodule.named_parameters(recurse=False))
-
-        if any(parameter.is_meta for _, parameter in direct_parameters):
-            if any(not parameter.is_meta for _, parameter in direct_parameters):
-                raise ValueError(
-                    f"Module {submodule_fqn!r} mixes meta and non-meta direct parameters. "
-                    "Initialize all direct parameters on meta or none of them."
-                )
-            submodule.to_empty(device=device, recurse=False)
-            with torch.no_grad():
-                if hasattr(submodule, "reset_parameters"):
-                    submodule.reset_parameters()
-                elif hasattr(submodule, "_reset_parameters"):
-                    submodule._reset_parameters()
-                else:
-                    raise ValueError(
-                        f"Module {submodule_fqn!r} does not have "
-                        "reset_parameters or _reset_parameters."
-                    )
-            # Module.to_empty may replace Parameters, so collect direct parameters again.
-            direct_parameters = list(submodule.named_parameters(recurse=False))
-
-        for local_parameter_name, parameter in direct_parameters:
-            parameter_fqn = (
-                f"{submodule_fqn}.{local_parameter_name}" if submodule_fqn else local_parameter_name
-            )
-            if contained_in_parameter_group(parameter):
-                raise ValueError(f"Parameter {parameter_fqn!r} is already owned by an FSDP unit.")
-            parameters[parameter_fqn] = parameter
-
-        for child_name, child_module in submodule.named_children():
-            if isinstance(child_module, FsdpModule):
-                continue
-            child_fqn = f"{submodule_fqn}.{child_name}" if submodule_fqn else child_name
-            visit(child_module, child_fqn)
-
-    visit(root_module, "")
-    if not parameters:
-        raise ValueError("fully_shard requires at least one unowned parameter.")
-    return parameters
-
-
-def _group_parameters(parameters: dict[str, nn.Parameter]) -> list[dict[str, nn.Parameter]]:
-    grouped: dict[tuple[torch.dtype, bool], dict[str, nn.Parameter]] = {}
-    for name, parameter in parameters.items():
-        key = (parameter.dtype, parameter.requires_grad)
-        grouped.setdefault(key, {})[name] = parameter
-    return [grouped[key] for key in grouped]
 
 
 def _attach_mixin(module: nn.Module) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -14,282 +14,16 @@
 
 """Minimal per-module Megatron-FSDP implementation."""
 
-import dataclasses
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from typing import cast
 
 import torch
-import torch.distributed as dist
 from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
-from .dbuffer import DBuffer
-from .placement import Partial, Placement, Replicate
-
-_CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
-MeshAxis = int | str
-
-
-@dataclasses.dataclass(frozen=True)
-class Placements:
-    """Per-mesh-axis placements for parameter, gradient, and optimizer buffers."""
-
-    dp_axes: list[MeshAxis]
-    parameter: list[Placement]
-    gradient: list[Placement]
-    optimizer: list[Placement]
-
-    def __post_init__(self) -> None:
-        """Validate placement list lengths."""
-        axis_count = len(self.dp_axes)
-        for name, placements in (
-            ("parameter", self.parameter),
-            ("gradient", self.gradient),
-            ("optimizer", self.optimizer),
-        ):
-            if len(placements) != axis_count:
-                raise ValueError(f"Expected {axis_count} {name} placements, got {len(placements)}.")
-
-
-class ParameterGroup:
-    """A dtype and requires-grad homogeneous group of FSDP-owned parameters."""
-
-    owning_module: nn.Module
-    parameter_names: tuple[str, ...]
-    sharded_parameters: tuple[nn.Parameter, ...]
-    unsharded_parameters: tuple[nn.Parameter, ...]
-    mesh: DeviceMesh
-    dtype: torch.dtype
-    requires_grad: bool
-    main_weight: DBuffer
-    model_weight: DBuffer
-    main_grad: DBuffer | None
-    _unsharded_model_weight: DBuffer
-
-    def __init__(
-        self,
-        owning_module: nn.Module,
-        parameters: dict[str, nn.Parameter],
-        mesh: DeviceMesh,
-        placements: Placements,
-        mixed_precision_policy: MixedPrecisionPolicy,
-    ) -> None:
-        """Create persistent sharded buffers for a group of parameters.
-
-        Args:
-            owning_module: Closest FSDP root module that owns this parameter group.
-            parameters: Root-module-relative FQNs and their parameters.
-            mesh: Device mesh used for all DBuffer storage in this version.
-            placements: Parameter, gradient, and optimizer placements.
-            mixed_precision_policy: Precision policy for main weights and gradients.
-        """
-        # ---------------------------------------------------------------------
-        # Validate group inputs and mesh contract
-        # ---------------------------------------------------------------------
-        if not parameters:
-            raise ValueError("ParameterGroup requires at least one parameter.")
-
-        axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
-        assert axis_indices == tuple(
-            range(mesh.ndim)
-        ), "FSDP requires dp_axes to match every mesh axis in mesh order for now."
-
-        # ---------------------------------------------------------------------
-        # Record shared metadata
-        # ---------------------------------------------------------------------
-        self.owning_module = owning_module
-        self.mesh = mesh
-        self.parameter_names = tuple(parameters)
-        first_parameter = next(iter(parameters.values()))
-        self.dtype = first_parameter.dtype
-        self.requires_grad = first_parameter.requires_grad
-        for name, parameter in parameters.items():
-            if parameter.is_meta:
-                raise ValueError(
-                    f"Expected parameter {name!r} to be materialized before "
-                    "ParameterGroup construction."
-                )
-            if parameter.dtype != self.dtype:
-                raise ValueError(
-                    f"Expected parameter {name!r} to have dtype {self.dtype}, "
-                    f"got {parameter.dtype}."
-                )
-            if parameter.requires_grad != self.requires_grad:
-                raise ValueError(
-                    f"Expected parameter {name!r} to have requires_grad={self.requires_grad}, "
-                    f"got {parameter.requires_grad}."
-                )
-
-        # ---------------------------------------------------------------------
-        # Initialize persistent DBuffers
-        # ---------------------------------------------------------------------
-        # Python dicts preserve insertion order, so parameter_names and
-        # parameters.values() define the same stable DBuffer tensor order.
-        tensor_shapes = tuple(parameter.shape for parameter in parameters.values())
-        main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
-        self.main_weight = DBuffer.distribute_tensors(
-            (parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()),
-            mesh=self.mesh,
-            placements=placements.optimizer,
-        )
-
-        self._unsharded_model_weight = DBuffer(
-            mesh=self.mesh,
-            placements=[Replicate()] * self.mesh.ndim,
-            tensor_shapes=tensor_shapes,
-            dtype=self.dtype,
-            device=self.main_weight.local_buffer.device,
-        )
-        if main_weight_dtype == self.dtype and placements.optimizer == placements.parameter:
-            self.model_weight = self.main_weight
-        else:
-            self.model_weight = DBuffer(
-                mesh=self.mesh,
-                placements=placements.parameter,
-                tensor_shapes=tensor_shapes,
-                dtype=self.dtype,
-                device=self.main_weight.local_buffer.device,
-            )
-
-        self.main_grad = None
-        if self.requires_grad:
-            grad_dtype = mixed_precision_policy.main_grads_dtype or self.dtype
-            self.main_grad = DBuffer(
-                mesh=self.mesh,
-                placements=placements.gradient,
-                tensor_shapes=self.main_weight.layout.tensor_shapes,
-                dtype=grad_dtype,
-                device=self.main_weight.local_buffer.device,
-            )
-            assert self.main_grad.layout == self.main_weight.layout, (
-                "main_grad is built from main_weight tensor shapes on the same mesh, "
-                "and DBuffer layouts are deterministic from those shapes and mesh size."
-            )
-            if self.main_grad.placements != self.main_weight.placements:
-                raise ValueError(
-                    "FSDP temporarily requires main_grad and main_weight to have the same "
-                    "placements until HSDP/HFSDP support is implemented. "
-                    f"Got main_grad placements {self.main_grad.placements} and "
-                    f"main_weight placements {self.main_weight.placements}."
-                )
-
-        # ---------------------------------------------------------------------
-        # Build parameter tuples for module swapping
-        # ---------------------------------------------------------------------
-        sharded_parameters: list[nn.Parameter] = []
-        unsharded_parameters: list[nn.Parameter] = []
-        main_grad_dtype = self.main_grad.local_buffer.dtype if self.main_grad is not None else None
-        for index, parameter in enumerate(parameters.values()):
-            parameter.data = self._unsharded_model_weight.get_local_tensor(index)
-            parameter.grad = None
-            setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
-            unsharded_parameters.append(parameter)
-
-            sharded_parameter = nn.Parameter(
-                self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
-            )
-            if main_grad_dtype:
-                sharded_parameter.grad_dtype = main_grad_dtype
-            setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
-            sharded_parameters.append(sharded_parameter)
-        self.sharded_parameters = tuple(sharded_parameters)
-        self.unsharded_parameters = tuple(unsharded_parameters)
-
-        # ---------------------------------------------------------------------
-        # Install resting sharded parameters
-        # ---------------------------------------------------------------------
-        self._switch_to_sharded_parameters()
-        self._unsharded_model_weight.release_storage()
-
-    def _set_module_parameters(self, parameters: tuple[nn.Parameter, ...]) -> None:
-        for name, parameter in zip(self.parameter_names, parameters, strict=True):
-            module, parameter_name = _get_parameter_owner(self.owning_module, name)
-            module._parameters[parameter_name] = parameter
-
-    def _switch_to_sharded_parameters(self) -> None:
-        self._set_module_parameters(self.sharded_parameters)
-
-    def _switch_to_unsharded_parameters(self) -> None:
-        self._set_module_parameters(self.unsharded_parameters)
-
-    def sync_model_weight_from_main_weight(self) -> None:
-        """Refresh compute weights from optimizer weights."""
-        if self.main_weight is self.model_weight:
-            return
-
-        self.main_weight.cast(self.model_weight.local_buffer.dtype).redistribute(
-            self.model_weight.placements, out=self.model_weight
-        )
-
-    def unshard_parameters(self) -> None:
-        """Install full parameters for local compute."""
-        self.sync_model_weight_from_main_weight()
-        self._unsharded_model_weight.reallocate_storage()
-        # This buffer backs unsharded Parameters whose views may be saved by autograd.
-        # Materializing FSDP-managed storage should not look like a user mutation.
-        with torch.autograd._unsafe_preserve_version_counter(
-            self._unsharded_model_weight.local_buffer
-        ):
-            self.model_weight.redistribute(
-                self._unsharded_model_weight.placements, out=self._unsharded_model_weight
-            )
-        self._switch_to_unsharded_parameters()
-
-    def reshard_parameters(self) -> None:
-        """Install sharded DTensor parameters on the owning modules."""
-        self._switch_to_sharded_parameters()
-        self._unsharded_model_weight.release_storage()
-
-    def reduce_gradients(self) -> None:
-        """Reduce full local gradients into sharded parameter gradients."""
-        assert self.main_grad is not None
-
-        def has_grad(parameters: Iterable[nn.Parameter]) -> bool:
-            has_any_grad = False
-            has_any_missing_grad = False
-            for parameter in parameters:
-                if parameter.grad is None:
-                    has_any_missing_grad = True
-                else:
-                    has_any_grad = True
-            if has_any_grad and has_any_missing_grad:
-                raise RuntimeError("FSDP sharded gradients must be either all set or all None.")
-            return has_any_grad
-
-        grads: list[torch.Tensor] = []
-        for name, parameter in zip(self.parameter_names, self.unsharded_parameters, strict=True):
-            if parameter.grad is None:
-                raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
-            grads.append(parameter.grad)
-
-        partial_grad = DBuffer.distribute_tensors(
-            grads, mesh=self.mesh, placements=[Partial(dist.ReduceOp.AVG)] * self.mesh.ndim
-        )
-
-        # zero_grad(set_to_none=True) clears sharded parameter grads, so the next
-        # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
-        # leaves sharded grads installed, so this backward accumulates into main_grad.
-        has_sharded_grads = has_grad(self.sharded_parameters)
-        can_reduce_into_main_grad = (
-            not has_sharded_grads
-            and partial_grad.local_buffer.dtype == self.main_grad.local_buffer.dtype
-        )
-        if can_reduce_into_main_grad:
-            partial_grad.redistribute(self.main_grad.placements, out=self.main_grad)
-        else:
-            reduced_grad = partial_grad.redistribute(self.main_grad.placements)
-            if has_sharded_grads:
-                self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
-            else:
-                self.main_grad.local_buffer.copy_(reduced_grad.local_buffer)
-
-        if not has_sharded_grads:
-            for index, parameter in enumerate(self.sharded_parameters):
-                parameter.grad = self.main_grad.get_dtensor(index)
-
-        for parameter in self.unsharded_parameters:
-            parameter.grad = None
+from .parameter_group import ParameterGroup, contained_in_parameter_group
+from .placement import MeshAxis, Placements
 
 
 class FsdpModule:
@@ -304,6 +38,10 @@ class FsdpModule:
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
         owned_parameters = _materialize_and_collect_owned_parameters(self, _mesh_device(mesh))
+        axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
+        assert axis_indices == tuple(
+            range(mesh.ndim)
+        ), "FSDP requires dp_axes to match every mesh axis in mesh order for now."
         parameter_groups = [
             ParameterGroup(
                 owning_module=self,
@@ -457,7 +195,7 @@ def _materialize_and_collect_owned_parameters(
             parameter_fqn = (
                 f"{submodule_fqn}.{local_parameter_name}" if submodule_fqn else local_parameter_name
             )
-            if hasattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR):
+            if contained_in_parameter_group(parameter):
                 raise ValueError(f"Parameter {parameter_fqn!r} is already owned by an FSDP unit.")
             parameters[parameter_fqn] = parameter
 
@@ -479,13 +217,6 @@ def _group_parameters(parameters: dict[str, nn.Parameter]) -> list[dict[str, nn.
         key = (parameter.dtype, parameter.requires_grad)
         grouped.setdefault(key, {})[name] = parameter
     return [grouped[key] for key in grouped]
-
-
-def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:
-    """Resolve a root-module-relative parameter FQN to its direct owner."""
-    module_name, separator, parameter_name = name.rpartition(".")
-    owner = module.get_submodule(module_name) if separator else module
-    return owner, parameter_name
 
 
 def _attach_mixin(module: nn.Module) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -135,20 +135,23 @@ class ParameterGroup:
         )
 
         main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
-        self.main_weight = DBuffer.distribute_tensors(
-            (parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()),
-            mesh=self.mesh,
-            placements=placements.optimizer,
-        )
+        if main_weight_dtype == self.dtype and placements.optimizer == placements.parameter:
+            self.main_weight = self.model_weight
+        else:
+            self.main_weight = DBuffer.distribute_tensors(
+                (parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()),
+                mesh=self.mesh,
+                placements=placements.optimizer,
+            )
 
         self.main_grad = None
         if self.requires_grad:
-            main_grad_dtype = mixed_precision_policy.main_grads_dtype or self.dtype
+            grad_dtype = mixed_precision_policy.main_grads_dtype or self.dtype
             self.main_grad = DBuffer(
                 mesh=self.mesh,
                 placements=placements.gradient,
                 tensor_shapes=self.main_weight.layout.tensor_shapes,
-                dtype=main_grad_dtype,
+                dtype=grad_dtype,
                 device=self.main_weight.local_buffer.device,
             )
             if self.main_grad.layout != self.main_weight.layout:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -15,9 +15,10 @@
 """Minimal per-module Megatron-FSDP implementation."""
 
 import dataclasses
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 
 import torch
+import torch.distributed as dist
 from torch import nn
 from torch.distributed import DeviceMesh
 
@@ -48,6 +49,20 @@ class Placements:
                 raise ValueError(f"Expected {axis_count} {name} placements, got {len(placements)}.")
 
 
+def has_grad(parameters: Iterable[nn.Parameter]) -> bool:
+    """Return whether parameters have gradients, requiring all-or-none state."""
+    has_any_grad = False
+    has_any_missing_grad = False
+    for parameter in parameters:
+        if parameter.grad is None:
+            has_any_missing_grad = True
+        else:
+            has_any_grad = True
+    if has_any_grad and has_any_missing_grad:
+        raise RuntimeError("FSDP sharded gradients must be either all set or all None.")
+    return has_any_grad
+
+
 class ParameterGroup:
     """A dtype and requires-grad homogeneous group of FSDP-owned parameters."""
 
@@ -55,7 +70,6 @@ class ParameterGroup:
     sharded_parameters: dict[str, nn.Parameter]
     unsharded_parameters: dict[str, nn.Parameter]
     mesh: DeviceMesh
-    dp_mesh: DeviceMesh
     dtype: torch.dtype
     requires_grad: bool
     main_weight: DBuffer
@@ -76,22 +90,26 @@ class ParameterGroup:
         Args:
             owning_module: Closest FSDP root module that owns this parameter group.
             parameters: Root-module-relative FQNs and their parameters.
-            mesh: Full device mesh. DBuffer storage is built on the DP submesh.
+            mesh: Device mesh used for all DBuffer storage in this version.
             placements: Parameter, gradient, and optimizer placements.
             mixed_precision_policy: Precision policy for main weights and gradients.
         """
+        # ---------------------------------------------------------------------
+        # Validate group inputs and mesh contract
+        # ---------------------------------------------------------------------
         if not parameters:
             raise ValueError("ParameterGroup requires at least one parameter.")
 
-        dp_mesh = _dp_submesh(mesh, placements.dp_axes)
+        axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
+        assert axis_indices == tuple(range(mesh.ndim)), (
+            "FSDP requires dp_axes to match every mesh axis in mesh order for now."
+        )
 
-        # Python dicts preserve insertion order, so values() defines the stable
-        # tensor order used by each DBuffer built from this group.
+        # ---------------------------------------------------------------------
+        # Record shared metadata
+        # ---------------------------------------------------------------------
         self.owning_module = owning_module
-        self.sharded_parameters = {}
-        self.unsharded_parameters = {}
         self.mesh = mesh
-        self.dp_mesh = dp_mesh
         first_parameter = next(iter(parameters.values()))
         self.dtype = first_parameter.dtype
         self.requires_grad = first_parameter.requires_grad
@@ -109,32 +127,38 @@ class ParameterGroup:
                     f"Expected parameter {name!r} to have requires_grad={self.requires_grad}, "
                     f"got {parameter.requires_grad}."
                 )
-        main_weight_dtype = mixed_precision_policy.main_params_dtype
-        if main_weight_dtype is None:
-            raise ValueError(
-                "FSDP requires a main weight dtype; set MixedPrecisionPolicy.main_params_dtype."
-            )
-        main_grad_dtype = mixed_precision_policy.main_grads_dtype
-        if main_grad_dtype is None:
-            main_grad_dtype = self.dtype
+
+        # ---------------------------------------------------------------------
+        # Initialize DBuffers from original parameter values
+        # ---------------------------------------------------------------------
+        # Python dicts preserve insertion order, so values() defines the stable
+        # tensor order used by each DBuffer built from this group.
+        self._unsharded_model_weight = DBuffer.distribute_tensors(
+            parameters.values(),
+            mesh=self.mesh,
+            placements=[Replicate()] * self.mesh.ndim,
+        )
         # Scratch initialization starts from model weights. Checkpoint loading will
         # eventually initialize main weights first and derive model weights from them.
-        self.model_weight = DBuffer.distribute_tensors(
-            [parameter.detach().contiguous() for parameter in parameters.values()],
-            mesh=self.dp_mesh,
-            placements=placements.parameter,
+        self.model_weight = self._unsharded_model_weight.redistribute(placements.parameter)
+        model_weight_storage = self.model_weight.local_buffer.untyped_storage()
+        unsharded_model_weight_storage = self._unsharded_model_weight.local_buffer.untyped_storage()
+        assert model_weight_storage.data_ptr() != unsharded_model_weight_storage.data_ptr(), (
+            "model_weight must not share storage with _unsharded_model_weight because "
+            "_unsharded_model_weight storage is resized and released after resharding."
         )
+
+        main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
         self.main_weight = DBuffer.distribute_tensors(
-            [
-                parameter.detach().to(dtype=main_weight_dtype).contiguous()
-                for parameter in parameters.values()
-            ],
-            mesh=self.dp_mesh,
+            [parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()],
+            mesh=self.mesh,
             placements=placements.optimizer,
         )
+
+        main_grad_dtype = mixed_precision_policy.main_grads_dtype or self.dtype
         self.main_grad = (
             DBuffer(
-                mesh=self.dp_mesh,
+                mesh=self.mesh,
                 placements=placements.gradient,
                 tensor_shapes=self.main_weight.layout.tensor_shapes,
                 dtype=main_grad_dtype,
@@ -143,14 +167,12 @@ class ParameterGroup:
             if self.requires_grad
             else None
         )
-        self._unsharded_model_weight = DBuffer(
-            mesh=self.dp_mesh,
-            placements=[Replicate()] * self.dp_mesh.ndim,
-            tensor_shapes=self.model_weight.layout.tensor_shapes,
-            dtype=self.model_weight.local_buffer.dtype,
-            device=self.model_weight.local_buffer.device,
-        )
 
+        # ---------------------------------------------------------------------
+        # Build parameter maps for module swapping
+        # ---------------------------------------------------------------------
+        self.sharded_parameters = {}
+        self.unsharded_parameters = {}
         for index, (name, parameter) in enumerate(parameters.items()):
             parameter.data = self._unsharded_model_weight.get_tensor(index)
             parameter.grad = None
@@ -161,6 +183,10 @@ class ParameterGroup:
             )
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
             self.sharded_parameters[name] = sharded_parameter
+
+        # ---------------------------------------------------------------------
+        # Install resting sharded parameters
+        # ---------------------------------------------------------------------
         self._switch_to_sharded_parameters()
         self._unsharded_model_weight.release_storage()
 
@@ -183,7 +209,9 @@ class ParameterGroup:
         with torch.autograd._unsafe_preserve_version_counter(
             self._unsharded_model_weight.local_buffer
         ):
-            self.model_weight.fully_allgather_into(self._unsharded_model_weight)
+            self.model_weight.redistribute(
+                self._unsharded_model_weight.placements, out=self._unsharded_model_weight
+            )
         self._switch_to_unsharded_parameters()
 
     def reshard_parameters(self) -> None:
@@ -191,47 +219,34 @@ class ParameterGroup:
         self._switch_to_sharded_parameters()
         self._unsharded_model_weight.release_storage()
 
-    def reduce_gradients(self, average: bool = True) -> None:
-        """Reduce full local gradients into the persistent sharded gradient buffer."""
-        if not self.requires_grad:
-            return
+    def reduce_gradients(self) -> None:
+        """Reduce full local gradients into sharded parameter gradients."""
         assert self.main_grad is not None
 
-        accumulate = self.has_sharded_grad()
         full_grads: list[torch.Tensor] = []
         for name, parameter in self.unsharded_parameters.items():
             if parameter.grad is None:
                 raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
-            full_grads.append(
-                parameter.grad.detach().to(dtype=self.main_grad.local_buffer.dtype).contiguous()
-            )
+            full_grads.append(parameter.grad.to(dtype=self.main_grad.local_buffer.dtype))
 
         partial_grad = DBuffer.distribute_tensors(
-            full_grads, mesh=self.dp_mesh, placements=[Partial()] * self.dp_mesh.ndim
+            full_grads,
+            mesh=self.mesh,
+            placements=[Partial(dist.ReduceOp.AVG)] * self.mesh.ndim,
         )
-        reduced_grad = partial_grad.redistribute(self.main_grad.placements)
-        if average:
-            reduced_grad.local_buffer.div_(self.dp_mesh.size())
 
-        if accumulate:
+        sharded_parameters = self.sharded_parameters.values()
+        if has_grad(sharded_parameters):
+            reduced_grad = partial_grad.redistribute(self.main_grad.placements)
             self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
         else:
-            self.main_grad.local_buffer.copy_(reduced_grad.local_buffer)
+            partial_grad.redistribute(self.main_grad.placements, out=self.main_grad)
+            for index, parameter in enumerate(sharded_parameters):
+                parameter.grad = self.main_grad.get_dtensor(index)
 
         for parameter in self.unsharded_parameters.values():
             parameter.grad = None
-        self.install_sharded_gradients()
 
-    def has_sharded_grad(self) -> bool:
-        """Return whether persistent sharded gradients are currently materialized."""
-        return any(parameter.grad is not None for parameter in self.sharded_parameters.values())
-
-    def install_sharded_gradients(self) -> None:
-        """Install sharded DTensor gradients backed by main_grad."""
-        if self.main_grad is None:
-            return
-        for index, parameter in enumerate(self.sharded_parameters.values()):
-            parameter.grad = self.main_grad.get_dtensor(index)
 
 class FsdpModule:
     """Mixin attached to modules managed by the minimal FSDP path."""
@@ -239,7 +254,7 @@ class FsdpModule:
     _parameter_groups: tuple[ParameterGroup, ...]
     _ready_grad_params: set[nn.Parameter]
     _registered_grad_param_ids: set[int]
-    _trainable_param_count: int
+    num_trainable_params: int
 
     def __init__(
         self, mesh: DeviceMesh, placements: Placements, mixed_precision_policy: MixedPrecisionPolicy
@@ -259,7 +274,7 @@ class FsdpModule:
         self._parameter_groups = tuple(parameter_groups)
         self._ready_grad_params: set[nn.Parameter] = set()
         self._registered_grad_param_ids: set[int] = set()
-        self._trainable_param_count = sum(
+        self.num_trainable_params = sum(
             len(group.sharded_parameters) for group in self._parameter_groups if group.requires_grad
         )
         self._register_hooks()
@@ -284,7 +299,7 @@ class FsdpModule:
     def _make_grad_hook(self, parameter: nn.Parameter) -> Callable[[nn.Parameter], None]:
         def grad_hook(_parameter: nn.Parameter) -> None:
             self._ready_grad_params.add(parameter)
-            if len(self._ready_grad_params) == self._trainable_param_count:
+            if len(self._ready_grad_params) == self.num_trainable_params:
                 self.post_backward()
 
         return grad_hook
@@ -309,9 +324,9 @@ class FsdpModule:
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""
         for group in self._parameter_groups:
-            group.reduce_gradients()
+            if group.requires_grad:
+                group.reduce_gradients()
             group.reshard_parameters()
-            group.install_sharded_gradients()
         self._ready_grad_params.clear()
 
     def parameter_groups(self) -> tuple[ParameterGroup, ...]:
@@ -362,28 +377,6 @@ def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
     if dim_names is None or axis not in dim_names:
         raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
     return dim_names.index(axis)
-
-
-def _dp_submesh(mesh: DeviceMesh, dp_axes: Sequence[MeshAxis]) -> DeviceMesh:
-    if not dp_axes:
-        raise ValueError("FSDP requires at least one DP mesh axis.")
-
-    axis_indices = tuple(_axis_index(mesh, axis) for axis in dp_axes)
-    if len(set(axis_indices)) != len(axis_indices):
-        raise ValueError(f"Duplicate DP mesh axes are not allowed: {tuple(dp_axes)!r}.")
-
-    if axis_indices == tuple(range(mesh.ndim)):
-        return mesh
-
-    dim_names = mesh.mesh_dim_names
-    if dim_names is None:
-        raise ValueError(
-            "Slicing a DP submesh from a full mesh requires named mesh dimensions unless "
-            "dp_axes covers every mesh axis in mesh order."
-        )
-
-    dp_axis_names = tuple(dim_names[index] for index in axis_indices)
-    return mesh[dp_axis_names[0] if len(dp_axis_names) == 1 else dp_axis_names]
 
 
 def _mesh_device(mesh: DeviceMesh) -> torch.device:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -1,0 +1,556 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal experimental per-module Megatron-FSDP implementation."""
+
+import dataclasses
+from collections.abc import Callable, Sequence
+
+import torch
+from torch import nn
+from torch.distributed import DeviceMesh
+
+from ..mixed_precision import MixedPrecisionPolicy
+from .dbuffer import DBuffer, MeshAxis, Partial, Placement, Replicate
+
+_CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
+
+
+@dataclasses.dataclass(frozen=True)
+class Placements:
+    """Per-mesh-axis placements for parameter, gradient, and optimizer buffers."""
+
+    dp_axes: list[MeshAxis]
+    parameter: list[Placement]
+    gradient: list[Placement]
+    optimizer: list[Placement]
+
+    def __post_init__(self) -> None:
+        """Validate placement list lengths."""
+        axis_count = len(self.dp_axes)
+        for name, placements in (
+            ("parameter", self.parameter),
+            ("gradient", self.gradient),
+            ("optimizer", self.optimizer),
+        ):
+            if len(placements) != axis_count:
+                raise ValueError(f"Expected {axis_count} {name} placements, got {len(placements)}.")
+
+
+class ParameterGroup:
+    """A dtype and requires-grad homogeneous group of FSDP-owned parameters."""
+
+    module: nn.Module
+    parameters: dict[str, nn.Parameter]
+    _unsharded_parameters: dict[str, nn.Parameter]
+    mesh: DeviceMesh
+    dtype: torch.dtype
+    requires_grad: bool
+    main_weight: DBuffer
+    model_weight: DBuffer
+    main_grad: DBuffer | None
+    _full_weight: DBuffer | None
+    _full_weight_allocated: bool
+
+    def __init__(
+        self,
+        module: nn.Module,
+        parameters: dict[str, nn.Parameter],
+        mesh: DeviceMesh,
+        model_weight_placements: Sequence[Placement],
+        main_grad_placements: Sequence[Placement],
+        main_weight_placements: Sequence[Placement],
+        mixed_precision_policy: MixedPrecisionPolicy,
+    ) -> None:
+        """Create persistent sharded buffers for a group of parameters.
+
+        Args:
+            module: Closest FSDP root module that owns this parameter group.
+            parameters: Root-module-relative FQNs and their parameters.
+            mesh: Device mesh used by the buffers.
+            model_weight_placements: Placements for compute-weight storage.
+            main_grad_placements: Placements for persistent main gradients.
+            main_weight_placements: Placements for optimizer-owned main weights.
+            mixed_precision_policy: Precision policy for main weights and gradients.
+        """
+        if not parameters:
+            raise ValueError("ParameterGroup requires at least one parameter.")
+
+        # Python dicts preserve insertion order, so values() defines the stable
+        # tensor order used by each DBuffer built from this group.
+        original_parameters = parameters
+        self.module = module
+        self.parameters = {}
+        self._unsharded_parameters = {}
+        self.mesh = mesh
+        first_parameter = next(iter(original_parameters.values()))
+        self.dtype = first_parameter.dtype
+        self.requires_grad = first_parameter.requires_grad
+        for name, parameter in original_parameters.items():
+            if parameter.dtype != self.dtype:
+                raise ValueError(
+                    f"Expected parameter {name!r} to have dtype {self.dtype}, got {parameter.dtype}."
+                )
+            if parameter.requires_grad != self.requires_grad:
+                raise ValueError(
+                    f"Expected parameter {name!r} to have requires_grad={self.requires_grad}, "
+                    f"got {parameter.requires_grad}."
+                )
+        main_params_dtype = mixed_precision_policy.main_params_dtype
+        if main_params_dtype is None:
+            raise ValueError(
+                "experimental FSDP requires main_params_dtype to be specified explicitly."
+            )
+        main_grads_dtype = mixed_precision_policy.main_grads_dtype
+        if main_grads_dtype is None:
+            main_grads_dtype = self.dtype
+        self.main_weight = DBuffer(
+            mesh=self.mesh,
+            placements=main_weight_placements,
+            tensor_shapes=[parameter.shape for parameter in original_parameters.values()],
+            dtype=main_params_dtype,
+            device=_mesh_device(self.mesh),
+        )
+        for index, parameter in enumerate(original_parameters.values()):
+            if parameter.is_meta:
+                continue
+            self._copy_full_tensor_to_buffer(
+                self.main_weight,
+                index,
+                parameter.detach().to(
+                    dtype=main_params_dtype, device=self.main_weight.local_buffer.device
+                ),
+            )
+        self.model_weight = self._make_model_weight(tuple(model_weight_placements))
+        self.main_grad = (
+            DBuffer(
+                mesh=self.mesh,
+                placements=main_grad_placements,
+                tensor_shapes=self.main_weight.layout.tensor_shapes,
+                dtype=main_grads_dtype,
+                device=self.main_weight.local_buffer.device,
+            )
+            if self.requires_grad
+            else None
+        )
+        self._full_weight: DBuffer | None = None
+        self._full_weight_allocated = False
+
+        for index, (name, original_parameter) in enumerate(original_parameters.items()):
+            sharded_parameter = nn.Parameter(
+                self.main_weight.get_dtensor(index), requires_grad=original_parameter.requires_grad
+            )
+            setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
+            self.parameters[name] = sharded_parameter
+            self._set_module_parameter(name, sharded_parameter)
+
+    def _make_model_weight(self, placements: Sequence[Placement]) -> DBuffer:
+        model_weight = self.main_weight.redistribute(placements)
+        if model_weight.local_buffer.dtype != self.dtype:
+            converted = DBuffer(
+                mesh=model_weight.mesh,
+                placements=model_weight.placements,
+                tensor_shapes=model_weight.layout.tensor_shapes,
+                dtype=self.dtype,
+                device=model_weight.local_buffer.device,
+            )
+            converted.local_buffer.copy_(model_weight.local_buffer.to(dtype=self.dtype))
+            return converted
+        return model_weight
+
+    def _copy_full_tensor_to_buffer(
+        self, buffer: DBuffer, index: int, tensor: torch.Tensor
+    ) -> None:
+        """Copy this rank's overlapping slice from a full tensor into a DBuffer."""
+        tensor = tensor.contiguous().view(-1)
+        shape = buffer.layout.tensor_shapes[index]
+        tensor_start = buffer.layout.tensor_to_offset[index]
+        tensor_end = tensor_start + shape.numel()
+        buffer_start = buffer.offset
+        buffer_end = buffer.offset + buffer.local_buffer.numel()
+        overlap_start = max(tensor_start, buffer_start)
+        overlap_end = min(tensor_end, buffer_end)
+        if overlap_end <= overlap_start:
+            return
+        local_numel = overlap_end - overlap_start
+        buffer.local_buffer.narrow(0, overlap_start - buffer_start, local_numel).copy_(
+            tensor.narrow(0, overlap_start - tensor_start, local_numel)
+        )
+
+    def _set_module_parameter(self, name: str, parameter: nn.Parameter) -> None:
+        module, parameter_name = _get_parameter_owner(self.module, name)
+        module._parameters[parameter_name] = parameter
+
+    def refresh_model_weight(self) -> None:
+        """Refresh compute-weight storage from the current main weights."""
+        self.model_weight = self._make_model_weight(self.model_weight.placements)
+
+    def unshard_parameters(self) -> None:
+        """Install full parameters for local compute."""
+        self.refresh_model_weight()
+        self._allocate_full_weight()
+        assert self._full_weight is not None
+        self._ensure_unsharded_parameters()
+        for name, parameter in self._unsharded_parameters.items():
+            parameter.grad = None
+            self._set_module_parameter(name, parameter)
+
+    def reshard_parameters(self) -> None:
+        """Install sharded DTensor parameters on the owning modules."""
+        for name, parameter in self.parameters.items():
+            self._set_module_parameter(name, parameter)
+        self._release_full_weight_storage()
+
+    def _ensure_unsharded_parameters(self) -> None:
+        """Create stable full-size autograd leaf parameters."""
+        if self._unsharded_parameters:
+            return
+        assert self._full_weight is not None
+        for index, (name, sharded_parameter) in enumerate(self.parameters.items()):
+            self._unsharded_parameters[name] = nn.Parameter(
+                self._full_weight.get_tensor(index), requires_grad=sharded_parameter.requires_grad
+            )
+
+    def _allocate_full_weight(self) -> None:
+        """Ensure the stable full-weight storage is allocated and current."""
+        if self._full_weight is None:
+            self._full_weight = self.model_weight.redistribute([Replicate()] * self.mesh.ndim)
+            self._full_weight_allocated = True
+            return
+        if self._full_weight_allocated:
+            return
+
+        self._resize_full_weight_storage(self._full_weight.local_buffer.numel())
+        refreshed = self.model_weight.redistribute([Replicate()] * self.mesh.ndim)
+        with torch.autograd._unsafe_preserve_version_counter(self._full_weight.local_buffer):
+            self._full_weight.local_buffer.copy_(refreshed.local_buffer)
+        self._full_weight_allocated = True
+
+    def _release_full_weight_storage(self) -> None:
+        """Free full-weight storage without replacing the Storage object."""
+        if self._full_weight is None or not self._full_weight_allocated:
+            return
+        # Non-leaf parameter views saved by autograd keep their Storage object.
+        # Retaining that object and resizing it back before backward avoids
+        # stale-storage failures while still releasing the allocation.
+        self._resize_full_weight_storage(0)
+        self._full_weight_allocated = False
+
+    def _resize_full_weight_storage(self, numel: int) -> None:
+        assert self._full_weight is not None
+        with torch.autograd._unsafe_preserve_version_counter(self._full_weight.local_buffer):
+            self._full_weight.local_buffer.untyped_storage().resize_(
+                numel * self._full_weight.local_buffer.element_size()
+            )
+
+    def reduce_gradients(self, average: bool = True) -> None:
+        """Reduce full local gradients into the persistent sharded gradient buffer."""
+        if not self.requires_grad:
+            return
+        assert self.main_grad is not None
+
+        accumulate = self.has_sharded_grad()
+        full_grads: list[torch.Tensor] = []
+        for name, parameter in self._unsharded_parameters.items():
+            if parameter.grad is None:
+                raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
+            full_grads.append(
+                parameter.grad.detach().to(dtype=self.main_grad.local_buffer.dtype).contiguous()
+            )
+
+        partial_grad = DBuffer.distribute_tensors(
+            full_grads, mesh=self.mesh, placements=[Partial()] * self.mesh.ndim
+        )
+        reduced_grad = partial_grad.redistribute(self.main_grad.placements)
+        if average:
+            reduced_grad.local_buffer.div_(self.mesh.size())
+
+        if accumulate:
+            self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
+        else:
+            self.main_grad.local_buffer.copy_(reduced_grad.local_buffer)
+
+        for parameter in self._unsharded_parameters.values():
+            parameter.grad = None
+        self.install_sharded_gradients()
+
+    def has_sharded_grad(self) -> bool:
+        """Return whether persistent sharded gradients are currently materialized."""
+        return any(parameter.grad is not None for parameter in self.parameters.values())
+
+    def install_sharded_gradients(self) -> None:
+        """Install sharded DTensor gradients backed by main_grad."""
+        if self.main_grad is None:
+            return
+        for index, parameter in enumerate(self.parameters.values()):
+            parameter.grad = self.main_grad.get_dtensor(index)
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        """Clear persistent and parameter gradients."""
+        if self.main_grad is not None:
+            self.main_grad.local_buffer.zero_()
+        if set_to_none:
+            for parameter in self.parameters.values():
+                parameter.grad = None
+        else:
+            self.install_sharded_gradients()
+        for parameter in self._unsharded_parameters.values():
+            parameter.grad = None
+
+    def unsharded_parameters(self) -> tuple[nn.Parameter, ...]:
+        """Return temporary full-size parameters used for autograd."""
+        return tuple(self._unsharded_parameters.values())
+
+
+class FsdpModule:
+    """Mixin attached to modules managed by the minimal experimental FSDP path."""
+
+    _parameter_groups: tuple[ParameterGroup, ...]
+    _ready_grad_params: set[nn.Parameter]
+    _registered_grad_param_ids: set[int]
+    _trainable_param_count: int
+
+    def __init__(self, parameter_groups: Sequence[ParameterGroup]) -> None:
+        """Initialize mixin runtime state on an already-constructed module."""
+        self._parameter_groups = tuple(parameter_groups)
+        self._ready_grad_params: set[nn.Parameter] = set()
+        self._registered_grad_param_ids: set[int] = set()
+        self._trainable_param_count = sum(
+            len(group.parameters) for group in self._parameter_groups if group.requires_grad
+        )
+        self._register_hooks()
+
+    def _register_hooks(self) -> None:
+        self.register_forward_pre_hook(lambda _module, _args: self.pre_forward())
+        self.register_forward_hook(lambda _module, _args, _output: self.post_forward())
+        self.register_full_backward_pre_hook(lambda _module, _grad_output: self.pre_backward())
+
+    def _register_grad_hooks(self) -> None:
+        """Register post-accumulate hooks on full-size autograd leaf parameters."""
+        for group in self._parameter_groups:
+            if not group.requires_grad:
+                continue
+            for parameter in group.unsharded_parameters():
+                parameter_id = id(parameter)
+                if parameter_id in self._registered_grad_param_ids:
+                    continue
+                parameter.register_post_accumulate_grad_hook(self._make_grad_hook(parameter))
+                self._registered_grad_param_ids.add(parameter_id)
+
+    def _make_grad_hook(self, parameter: nn.Parameter) -> Callable[[nn.Parameter], None]:
+        def grad_hook(_parameter: nn.Parameter) -> None:
+            self._ready_grad_params.add(parameter)
+            if len(self._ready_grad_params) == self._trainable_param_count:
+                self.post_backward()
+
+        return grad_hook
+
+    def pre_forward(self) -> None:
+        """Prepare full parameters for forward compute."""
+        self._ready_grad_params.clear()
+        for group in self._parameter_groups:
+            group.unshard_parameters()
+        self._register_grad_hooks()
+
+    def post_forward(self) -> None:
+        """Return parameters to their sharded resting state after forward compute."""
+        for group in self._parameter_groups:
+            group.reshard_parameters()
+
+    def pre_backward(self) -> None:
+        """Prepare full parameters for backward compute."""
+        for group in self._parameter_groups:
+            group.unshard_parameters()
+
+    def post_backward(self) -> None:
+        """Reduce gradients and return parameters to their sharded resting state."""
+        for group in self._parameter_groups:
+            group.reduce_gradients()
+            group.reshard_parameters()
+            group.install_sharded_gradients()
+        self._ready_grad_params.clear()
+
+    def parameter_groups(self) -> tuple[ParameterGroup, ...]:
+        """Return parameter groups owned by this FSDP unit."""
+        return self._parameter_groups
+
+
+def fully_shard(
+    module: nn.Module,
+    mesh: DeviceMesh,
+    placements: Placements,
+    mixed_precision_policy: MixedPrecisionPolicy | None = None,
+    init_model_with_meta_device: bool = False,
+) -> None:
+    """Shard one module as an experimental per-module FSDP unit.
+
+    Args:
+        module: Module whose currently unowned parameters become this FSDP unit.
+        mesh: Device mesh used for sharding.
+        placements: Parameter, gradient, and optimizer placements.
+        mixed_precision_policy: Optional precision policy. Defaults to FP32 main weights
+            and parameter-dtype main gradients.
+        init_model_with_meta_device: If true, initialize owned meta parameters by
+            calling their direct module's reset_parameters() or _reset_parameters().
+    """
+    if isinstance(module, FsdpModule):
+        raise ValueError("This module is already managed by experimental FSDP.")
+
+    mixed_precision_policy = mixed_precision_policy or MixedPrecisionPolicy()
+    model_weight_placements = _placements_in_mesh_order(
+        mesh, placements.dp_axes, placements.parameter
+    )
+    main_grad_placements = _placements_in_mesh_order(mesh, placements.dp_axes, placements.gradient)
+    main_weight_placements = _placements_in_mesh_order(
+        mesh, placements.dp_axes, placements.optimizer
+    )
+    owned_parameters = _collect_owned_parameters(module)
+    if (
+        any(parameter.is_meta for parameter in owned_parameters.values())
+        and not init_model_with_meta_device
+    ):
+        raise ValueError(
+            "experimental FSDP found meta parameters. Pass init_model_with_meta_device=True "
+            "to initialize them with reset_parameters()/_reset_parameters()."
+        )
+    grouped_parameters = _group_parameters(owned_parameters)
+    parameter_groups = [
+        ParameterGroup(
+            module,
+            group_parameters,
+            mesh=mesh,
+            model_weight_placements=model_weight_placements,
+            main_grad_placements=main_grad_placements,
+            main_weight_placements=main_weight_placements,
+            mixed_precision_policy=mixed_precision_policy,
+        )
+        for group_parameters in grouped_parameters
+    ]
+    if init_model_with_meta_device:
+        _reset_owned_meta_modules(module, owned_parameters)
+        for group in parameter_groups:
+            group.refresh_model_weight()
+
+    _attach_mixin(module)
+    assert isinstance(module, FsdpModule)
+    FsdpModule.__init__(module, parameter_groups=parameter_groups)
+
+
+def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
+    if isinstance(axis, int):
+        if axis < 0:
+            axis += mesh.ndim
+        if axis < 0 or axis >= mesh.ndim:
+            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
+        return axis
+
+    dim_names = mesh.mesh_dim_names
+    if dim_names is None or axis not in dim_names:
+        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
+    return dim_names.index(axis)
+
+
+def _placements_in_mesh_order(
+    mesh: DeviceMesh, dp_axes: Sequence[MeshAxis], placements: Sequence[Placement]
+) -> tuple[Placement, ...]:
+    if len(dp_axes) != mesh.ndim:
+        raise ValueError(
+            "experimental fully_shard currently requires placements for every mesh axis: "
+            f"mesh ndim is {mesh.ndim}, got {len(dp_axes)} axes."
+        )
+    result: list[Placement | None] = [None] * mesh.ndim
+    for axis, placement in zip(dp_axes, placements, strict=True):
+        axis_index = _axis_index(mesh, axis)
+        if result[axis_index] is not None:
+            raise ValueError(f"Duplicate placement for mesh axis {axis!r}.")
+        result[axis_index] = placement
+    if any(placement is None for placement in result):
+        raise ValueError("Missing placement for at least one mesh axis.")
+    return tuple(placement for placement in result if placement is not None)
+
+
+def _mesh_device(mesh: DeviceMesh) -> torch.device:
+    if mesh.device_type == "cuda":
+        return torch.device("cuda", torch.cuda.current_device())
+    return torch.device(mesh.device_type)
+
+
+def _collect_owned_parameters(module: nn.Module) -> dict[str, nn.Parameter]:
+    child_prefixes = [
+        f"{name}."
+        for name, child in module.named_modules()
+        if name and isinstance(child, FsdpModule)
+    ]
+    parameters: dict[str, nn.Parameter] = {}
+    for module_name, child in module.named_modules():
+        prefix = f"{module_name}." if module_name else ""
+        if any(prefix.startswith(child_prefix) for child_prefix in child_prefixes):
+            continue
+        for parameter_name, parameter in child.named_parameters(recurse=False):
+            name = f"{prefix}{parameter_name}"
+            if hasattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR):
+                raise ValueError(
+                    f"Parameter {name!r} is already owned by an experimental FSDP unit."
+                )
+            parameters[name] = parameter
+    if not parameters:
+        raise ValueError("experimental fully_shard requires at least one unowned parameter.")
+    return parameters
+
+
+def _group_parameters(parameters: dict[str, nn.Parameter]) -> list[dict[str, nn.Parameter]]:
+    grouped: dict[tuple[torch.dtype, bool], dict[str, nn.Parameter]] = {}
+    for name, parameter in parameters.items():
+        key = (parameter.dtype, parameter.requires_grad)
+        grouped.setdefault(key, {})[name] = parameter
+    return [grouped[key] for key in grouped]
+
+
+def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:
+    """Resolve a root-module-relative parameter FQN to its direct owner."""
+    module_name, separator, parameter_name = name.rpartition(".")
+    owner = module.get_submodule(module_name) if separator else module
+    return owner, parameter_name
+
+
+def _reset_owned_meta_modules(
+    module: nn.Module, original_parameters: dict[str, nn.Parameter]
+) -> None:
+    """Initialize modules that originally owned meta parameters."""
+    modules_to_reset: dict[int, tuple[str, nn.Module]] = {}
+    for name, parameter in original_parameters.items():
+        if not parameter.is_meta:
+            continue
+        owner_module, _ = _get_parameter_owner(module, name)
+        module_name = name.rsplit(".", 1)[0] if "." in name else ""
+        modules_to_reset.setdefault(id(owner_module), (module_name, owner_module))
+
+    for module_name, module in modules_to_reset.values():
+        if hasattr(module, "reset_parameters"):
+            module.reset_parameters()
+        elif hasattr(module, "_reset_parameters"):
+            module._reset_parameters()
+        else:
+            raise ValueError(
+                f"[init_model_with_meta_device=True] Module {module_name!r} does not have "
+                "reset_parameters or _reset_parameters."
+            )
+
+
+def _attach_mixin(module: nn.Module) -> None:
+    if isinstance(module, FsdpModule):
+        return
+    module_cls = module.__class__
+    fsdp_cls = type(f"ExperimentalFsdp{module_cls.__name__}", (FsdpModule, module_cls), {})
+    module.__class__ = fsdp_cls

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Global tensor layout metadata for DBuffer."""
+
+import dataclasses
+import math
+from collections.abc import Iterable
+from typing import TypeAlias
+
+import torch
+from torch.distributed import DeviceMesh
+
+from .placement import Flat, Placement
+
+Shape: TypeAlias = torch.Size | Iterable[int]
+
+
+@dataclasses.dataclass(frozen=True)
+class GlobalLayout:
+    """Global tensor layout in element coordinates."""
+
+    tensor_shapes: tuple[torch.Size, ...]
+    tensor_to_offset: tuple[int, ...]
+    size: int
+
+    @classmethod
+    def build(cls, shapes: Iterable[Shape], dp_size: int) -> "GlobalLayout":
+        """Compute global tensor element offsets and padded size.
+
+        This is a DBuffer-specific reimplementation of
+        ``param_and_grad_buffer.build_data_parallel_buffer_index``. It keeps only
+        the global offset construction and final padding so each rank-local shard
+        size is a multiple of ``chunk_size``; DBuffer derives rank-local slices
+        later through DTensor placements.
+
+        The computed layout is compatible with Flat, TensorAtomic, and BlockAtomic,
+        even though the latter two are not implemented.
+
+        ``chunk_size`` is the least common multiple of each tensor's row size
+        (``shape[1:].numel()``). For example, with shapes P0=(2, 6), P1=(4, 4),
+        P2=(4, 4), P3=(1, 2), P4=(1, 6), ``chunk_size = LCM(6, 4, 4, 2, 6) = 12``
+        and a 5-rank DP layout has equal-size rank shards:
+
+        ```
+        rank 0 [ 0, 12): | P0 row 0              | P0 row 1               |
+        rank 1 [12, 24): | P1 row 0      | P1 row 1      | P1 row 2       |
+        rank 2 [24, 36): | P1 row 3      | P3    | gap   | P2 row 0       |
+        rank 3 [36, 48): | P2 row 1      | P2 row 2      | P2 row 3       |
+        rank 4 [48, 60): | P4                    | pad                    |
+        ```
+
+        The diagram uses four character columns per element; segment widths are
+        proportional. Every chunk boundary is aligned to each tensor's row size,
+        so each DP shard owns full rows even when fragments fill regular-tensor
+        padding gaps.
+
+        Args:
+            shapes: Logical tensor shapes in tensor-id order.
+            dp_size: Data-parallel shard count for this global layout.
+
+        Returns:
+            Global layout with row-aligned tensor offsets and a total size padded
+            to a multiple of ``chunk_size * dp_size``, so every rank-local shard
+            length is a multiple of ``chunk_size``.
+        """
+        if dp_size <= 0:
+            raise ValueError(f"DP size must be positive, got {dp_size}.")
+
+        tensor_shapes = tuple(torch.Size(shape) for shape in shapes)
+        chunk_size = 1
+        for shape in tensor_shapes:
+            row_size = non_leading_numel(shape)
+            if row_size <= 0:
+                raise ValueError(
+                    f"Cannot compute a layout for zero-sized non-leading dims: {shape}."
+                )
+            chunk_size = math.lcm(chunk_size, row_size)
+
+        # chunk_size is the packing unit. Since every tensor row size divides it,
+        # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
+        UNASSIGNED_OFFSET = -1
+        tensor_to_offset: list[int] = [UNASSIGNED_OFFSET] * len(tensor_shapes)
+        fragment_items = []
+        regular_items = []
+        for tensor_id, shape in enumerate(tensor_shapes):
+            if shape.numel() < chunk_size:
+                fragment_items.append((tensor_id, shape))
+            else:
+                regular_items.append((tensor_id, shape))
+
+        # Regular tensors anchor the layout. Fragments are held back to fill padding
+        # gaps left by regular tensors whose sizes are not exact multiples of chunk_size.
+        fragment_items.sort(key=lambda id_shape: id_shape[1].numel(), reverse=True)
+
+        next_offset = 0
+        while regular_items:
+            tensor_id, shape = regular_items.pop(0)
+            tensor_numel = shape.numel()
+            tensor_to_offset[tensor_id] = next_offset
+
+            if tensor_numel % chunk_size == 0:
+                next_offset += tensor_numel
+                continue
+
+            gap_offset = next_offset + tensor_numel
+            next_offset += _pad_to_multiple(tensor_numel, chunk_size)
+            fragment_gap_end = next_offset
+            remainder = tensor_numel % chunk_size
+
+            # Try to pair this non-divisible regular tensor with a conjugate regular
+            # tensor whose remainder fits in the same chunk_size interval. The
+            # conjugate starts in the gap and then continues with full chunk_size
+            # intervals after this one.
+            conjugate_item = None
+            for candidate_item in regular_items[:]:
+                _, candidate_shape = candidate_item
+                candidate_numel = candidate_shape.numel()
+                candidate_remainder = candidate_numel % chunk_size
+                if candidate_remainder == 0:
+                    continue
+                if remainder + candidate_remainder <= chunk_size:
+                    conjugate_item = candidate_item
+                    regular_items.remove(candidate_item)
+                    break
+
+            if conjugate_item is not None:
+                conjugate_id, conjugate_shape = conjugate_item
+                conjugate_numel = conjugate_shape.numel()
+                conjugate_remainder = conjugate_numel % chunk_size
+                conjugate_offset = next_offset - conjugate_remainder
+                tensor_to_offset[conjugate_id] = conjugate_offset
+                fragment_gap_end = conjugate_offset
+                next_offset += (conjugate_numel // chunk_size) * chunk_size
+
+            # Fill any remaining gap with fragments, keeping each fragment aligned to
+            # its own row size so dim-0 rows remain contiguous within DP shards.
+            for fragment in fragment_items[:]:
+                frag_id, frag_shape = fragment
+                frag_numel = frag_shape.numel()
+                aligned_gap_offset = _pad_to_multiple(gap_offset, non_leading_numel(frag_shape))
+                if aligned_gap_offset + frag_numel > fragment_gap_end:
+                    continue
+                tensor_to_offset[frag_id] = aligned_gap_offset
+                gap_offset = aligned_gap_offset + frag_numel
+                fragment_items.remove(fragment)
+
+        # Fragments that did not fit into regular-tensor gaps are appended at the tail.
+        for frag_id, frag_shape in fragment_items:
+            next_offset = _pad_to_multiple(next_offset, non_leading_numel(frag_shape))
+            tensor_to_offset[frag_id] = next_offset
+            next_offset += frag_shape.numel()
+
+        return cls(
+            tensor_shapes=tensor_shapes,
+            tensor_to_offset=tuple(tensor_to_offset),
+            size=_pad_to_multiple(next_offset, chunk_size * dp_size),
+        )
+
+    def __post_init__(self) -> None:
+        """Validate tensor offsets are row-aligned, in bounds, and non-overlapping."""
+
+        @dataclasses.dataclass(frozen=True)
+        class TensorRange:
+            start: int
+            end: int
+            tensor_id: int
+
+        if self.size < 0:
+            raise AssertionError(f"Global layout size {self.size} is negative.")
+        if len(self.tensor_shapes) != len(self.tensor_to_offset):
+            raise AssertionError(
+                "Global layout has mismatched tensor shapes and offsets: "
+                f"{len(self.tensor_shapes)} shapes and {len(self.tensor_to_offset)} offsets."
+            )
+
+        tensor_ranges: list[TensorRange] = []
+        for tensor_id, (shape, start) in enumerate(
+            zip(self.tensor_shapes, self.tensor_to_offset, strict=True)
+        ):
+            if start < 0:
+                raise AssertionError(f"Tensor {tensor_id} offset {start} is negative.")
+
+            row_size = non_leading_numel(shape)
+            if row_size <= 0:
+                raise AssertionError(f"Tensor {tensor_id} has invalid row size {row_size}.")
+            if start % row_size != 0:
+                raise AssertionError(
+                    f"Tensor {tensor_id} offset {start} is not aligned to row size {row_size}."
+                )
+
+            end = start + shape.numel()
+            if end > self.size:
+                raise AssertionError(
+                    f"Tensor {tensor_id} range [{start}, {end}) exceeds "
+                    f"layout size {self.size}."
+                )
+            tensor_ranges.append(TensorRange(start, end, tensor_id))
+
+        previous_range: TensorRange | None = None
+        for current_range in sorted(tensor_ranges, key=lambda tensor_range: tensor_range.start):
+            if previous_range is not None and current_range.start < previous_range.end:
+                raise AssertionError(
+                    "Global layout tensors overlap: "
+                    f"tensor {previous_range.tensor_id} "
+                    f"[{previous_range.start}, {previous_range.end}) and "
+                    f"tensor {current_range.tensor_id} "
+                    f"[{current_range.start}, {current_range.end})."
+                )
+            previous_range = current_range
+
+    def get_local_range(self, mesh: DeviceMesh, placements: Iterable[Placement]) -> tuple[int, int]:
+        """Return this rank's local element offset and length for ``placements``."""
+        offset = 0
+        numel = self.size
+        for axis, placement in reversed(tuple(enumerate(placements))):
+            if not isinstance(placement, Flat):
+                continue
+            axis_size = mesh.size(axis)
+            if numel % axis_size != 0:
+                raise ValueError(
+                    f"Local range size {numel} is not divisible by Flat axis size {axis_size}."
+                )
+            shard_size = numel // axis_size
+            offset += mesh.get_local_rank(axis) * shard_size
+            numel = shard_size
+        return offset, numel
+
+
+def non_leading_numel(shape: torch.Size) -> int:
+    """Return the number of elements after dim 0 for a non-scalar shape."""
+    if len(shape) == 0:
+        raise ValueError(f"DBuffer layout does not support 0D tensor shapes: {shape}.")
+    return shape[1:].numel()
+
+
+def _pad_to_multiple(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -173,6 +173,8 @@ class GlobalLayout:
 
         @dataclasses.dataclass(frozen=True)
         class TensorRange:
+            """Contiguous global element range occupied by one logical tensor."""
+
             start: int
             end: int
             tensor_id: int

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -14,7 +14,8 @@
 
 """Parameter-group runtime state for the minimal Megatron-FSDP path."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 
 import torch
 import torch.distributed as dist
@@ -31,6 +32,19 @@ _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 def contained_in_parameter_group(parameter: nn.Parameter) -> bool:
     """Return whether a parameter is already owned by a ParameterGroup."""
     return hasattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR)
+
+
+@contextmanager
+def _nvtx_range(message: str) -> Iterator[None]:
+    if not torch.cuda.is_available():
+        yield
+        return
+
+    torch.cuda.nvtx.range_push(message)
+    try:
+        yield
+    finally:
+        torch.cuda.nvtx.range_pop()
 
 
 class ParameterGroup:
@@ -178,9 +192,10 @@ class ParameterGroup:
         if self.main_weight is self.model_weight:
             return
 
-        self.main_weight.cast(self.model_weight.dtype).redistribute(
-            self.model_weight.placements, out=self.model_weight
-        )
+        with _nvtx_range("sync_model_weight_from_main_weight"):
+            self.main_weight.cast(self.model_weight.dtype).redistribute(
+                self.model_weight.placements, out=self.model_weight
+            )
 
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parameter-group runtime state for the minimal Megatron-FSDP path."""
+
+from collections.abc import Iterable
+
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch.distributed import DeviceMesh
+
+from ..mixed_precision import MixedPrecisionPolicy
+from .dbuffer import DBuffer
+from .placement import Partial, Placements, Replicate
+
+_CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
+
+
+def contained_in_parameter_group(parameter: nn.Parameter) -> bool:
+    """Return whether a parameter is already owned by a ParameterGroup."""
+    return hasattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR)
+
+
+class ParameterGroup:
+    """A dtype and requires-grad homogeneous group of FSDP-owned parameters."""
+
+    owning_module: nn.Module
+    parameter_names: tuple[str, ...]
+    sharded_parameters: tuple[nn.Parameter, ...]
+    unsharded_parameters: tuple[nn.Parameter, ...]
+    mesh: DeviceMesh
+    dtype: torch.dtype
+    requires_grad: bool
+    main_weight: DBuffer
+    model_weight: DBuffer
+    main_grad: DBuffer | None
+    _unsharded_model_weight: DBuffer
+
+    def __init__(
+        self,
+        owning_module: nn.Module,
+        parameters: dict[str, nn.Parameter],
+        mesh: DeviceMesh,
+        placements: Placements,
+        mixed_precision_policy: MixedPrecisionPolicy,
+    ) -> None:
+        """Create persistent sharded buffers for a group of parameters.
+
+        Args:
+            owning_module: Closest FSDP root module that owns this parameter group.
+            parameters: Root-module-relative FQNs and their parameters.
+            mesh: Device mesh used for all DBuffer storage in this version.
+            placements: Parameter, gradient, and optimizer placements.
+            mixed_precision_policy: Precision policy for main weights and gradients.
+        """
+        if not parameters:
+            raise ValueError("ParameterGroup requires at least one parameter.")
+
+        model_weight_placements = tuple(placements.parameter)
+        main_grad_placements = tuple(placements.gradient)
+        main_weight_placements = tuple(placements.optimizer)
+
+        # Python dicts preserve insertion order, so parameter_names and
+        # parameters.values() define the same stable DBuffer tensor order.
+        self.owning_module = owning_module
+        self.mesh = mesh
+        self.parameter_names = tuple(parameters)
+        first_parameter = next(iter(parameters.values()))
+        self.dtype = first_parameter.dtype
+        self.requires_grad = first_parameter.requires_grad
+        for name, parameter in parameters.items():
+            if parameter.is_meta:
+                raise ValueError(
+                    f"Expected parameter {name!r} to be materialized before "
+                    "ParameterGroup construction."
+                )
+            if parameter.dtype != self.dtype:
+                raise ValueError(
+                    f"Expected parameter {name!r} to have dtype {self.dtype}, "
+                    f"got {parameter.dtype}."
+                )
+            if parameter.requires_grad != self.requires_grad:
+                raise ValueError(
+                    f"Expected parameter {name!r} to have requires_grad={self.requires_grad}, "
+                    f"got {parameter.requires_grad}."
+                )
+
+        tensor_shapes = tuple(parameter.shape for parameter in parameters.values())
+        main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
+        self.main_weight = DBuffer.distribute_tensors(
+            (parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()),
+            mesh=self.mesh,
+            placements=main_weight_placements,
+        )
+
+        self._unsharded_model_weight = DBuffer(
+            mesh=self.mesh,
+            placements=[Replicate()] * self.mesh.ndim,
+            tensor_shapes=tensor_shapes,
+            dtype=self.dtype,
+            device=self.main_weight.local_buffer.device,
+        )
+        if main_weight_dtype == self.dtype and main_weight_placements == model_weight_placements:
+            self.model_weight = self.main_weight
+        else:
+            self.model_weight = DBuffer(
+                mesh=self.mesh,
+                placements=model_weight_placements,
+                tensor_shapes=tensor_shapes,
+                dtype=self.dtype,
+                device=self.main_weight.local_buffer.device,
+            )
+
+        self.main_grad = None
+        if self.requires_grad:
+            grad_dtype = mixed_precision_policy.main_grads_dtype or self.dtype
+            self.main_grad = DBuffer(
+                mesh=self.mesh,
+                placements=main_grad_placements,
+                tensor_shapes=self.main_weight.layout.tensor_shapes,
+                dtype=grad_dtype,
+                device=self.main_weight.local_buffer.device,
+            )
+            assert self.main_grad.layout == self.main_weight.layout, (
+                "main_grad is built from main_weight tensor shapes on the same mesh, "
+                "and DBuffer layouts are deterministic from those shapes and mesh size."
+            )
+            if self.main_grad.placements != self.main_weight.placements:
+                raise ValueError(
+                    "FSDP temporarily requires main_grad and main_weight to have the same "
+                    "placements until HSDP/HFSDP support is implemented. "
+                    f"Got main_grad placements {self.main_grad.placements} and "
+                    f"main_weight placements {self.main_weight.placements}."
+                )
+
+        sharded_parameters: list[nn.Parameter] = []
+        unsharded_parameters: list[nn.Parameter] = []
+        main_grad_dtype = self.main_grad.local_buffer.dtype if self.main_grad is not None else None
+        for index, parameter in enumerate(parameters.values()):
+            parameter.data = self._unsharded_model_weight.get_local_tensor(index)
+            parameter.grad = None
+            setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
+            unsharded_parameters.append(parameter)
+
+            sharded_parameter = nn.Parameter(
+                self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
+            )
+            if main_grad_dtype:
+                sharded_parameter.grad_dtype = main_grad_dtype
+            setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
+            sharded_parameters.append(sharded_parameter)
+        self.sharded_parameters = tuple(sharded_parameters)
+        self.unsharded_parameters = tuple(unsharded_parameters)
+
+        self._switch_to_sharded_parameters()
+        self._unsharded_model_weight.release_storage()
+
+    def _set_module_parameters(self, parameters: tuple[nn.Parameter, ...]) -> None:
+        for name, parameter in zip(self.parameter_names, parameters, strict=True):
+            module, parameter_name = _get_parameter_owner(self.owning_module, name)
+            module._parameters[parameter_name] = parameter
+
+    def _switch_to_sharded_parameters(self) -> None:
+        self._set_module_parameters(self.sharded_parameters)
+
+    def _switch_to_unsharded_parameters(self) -> None:
+        self._set_module_parameters(self.unsharded_parameters)
+
+    def sync_model_weight_from_main_weight(self) -> None:
+        """Refresh compute weights from optimizer weights."""
+        if self.main_weight is self.model_weight:
+            return
+
+        self.main_weight.cast(self.model_weight.local_buffer.dtype).redistribute(
+            self.model_weight.placements, out=self.model_weight
+        )
+
+    def unshard_parameters(self) -> None:
+        """Install full parameters for local compute."""
+        self.sync_model_weight_from_main_weight()
+        self._unsharded_model_weight.reallocate_storage()
+        # This buffer backs unsharded Parameters whose views may be saved by autograd.
+        # Materializing FSDP-managed storage should not look like a user mutation.
+        with torch.autograd._unsafe_preserve_version_counter(
+            self._unsharded_model_weight.local_buffer
+        ):
+            self.model_weight.redistribute(
+                self._unsharded_model_weight.placements, out=self._unsharded_model_weight
+            )
+        self._switch_to_unsharded_parameters()
+
+    def reshard_parameters(self) -> None:
+        """Install sharded DTensor parameters on the owning modules."""
+        self._switch_to_sharded_parameters()
+        self._unsharded_model_weight.release_storage()
+
+    def reduce_gradients(self) -> None:
+        """Reduce full local gradients into sharded parameter gradients."""
+        assert self.main_grad is not None
+
+        def has_grad(parameters: Iterable[nn.Parameter]) -> bool:
+            has_any_grad = False
+            has_any_missing_grad = False
+            for parameter in parameters:
+                if parameter.grad is None:
+                    has_any_missing_grad = True
+                else:
+                    has_any_grad = True
+            if has_any_grad and has_any_missing_grad:
+                raise RuntimeError("FSDP sharded gradients must be either all set or all None.")
+            return has_any_grad
+
+        grads: list[torch.Tensor] = []
+        for name, parameter in zip(self.parameter_names, self.unsharded_parameters, strict=True):
+            if parameter.grad is None:
+                raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
+            grads.append(parameter.grad)
+
+        partial_grad = DBuffer.distribute_tensors(
+            grads, mesh=self.mesh, placements=[Partial(dist.ReduceOp.AVG)] * self.mesh.ndim
+        )
+
+        # zero_grad(set_to_none=True) clears sharded parameter grads, so the next
+        # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
+        # leaves sharded grads installed, so this backward accumulates into main_grad.
+        has_sharded_grads = has_grad(self.sharded_parameters)
+        can_reduce_into_main_grad = (
+            not has_sharded_grads
+            and partial_grad.local_buffer.dtype == self.main_grad.local_buffer.dtype
+        )
+        if can_reduce_into_main_grad:
+            partial_grad.redistribute(self.main_grad.placements, out=self.main_grad)
+        else:
+            reduced_grad = partial_grad.redistribute(self.main_grad.placements)
+            if has_sharded_grads:
+                self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
+            else:
+                self.main_grad.local_buffer.copy_(reduced_grad.local_buffer)
+
+        if not has_sharded_grads:
+            for index, parameter in enumerate(self.sharded_parameters):
+                parameter.grad = self.main_grad.get_dtensor(index)
+
+        for parameter in self.unsharded_parameters:
+            parameter.grad = None
+
+
+def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:
+    """Resolve a root-module-relative parameter FQN to its direct owner."""
+    module_name, separator, parameter_name = name.rpartition(".")
+    owner = module.get_submodule(module_name) if separator else module
+    return owner, parameter_name

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -81,11 +81,6 @@ class ParameterGroup:
         self.dtype = first_parameter.dtype
         self.requires_grad = first_parameter.requires_grad
         for name, parameter in parameters.items():
-            if parameter.is_meta:
-                raise ValueError(
-                    f"Expected parameter {name!r} to be materialized before "
-                    "ParameterGroup construction."
-                )
             if parameter.dtype != self.dtype:
                 raise ValueError(
                     f"Expected parameter {name!r} to have dtype {self.dtype}, "
@@ -110,7 +105,7 @@ class ParameterGroup:
             placements=[Replicate()] * self.mesh.ndim,
             tensor_shapes=tensor_shapes,
             dtype=self.dtype,
-            device=self.main_weight.local_buffer.device,
+            device=self.main_weight.device,
         )
         if main_weight_dtype == self.dtype and main_weight_placements == model_weight_placements:
             self.model_weight = self.main_weight
@@ -120,7 +115,7 @@ class ParameterGroup:
                 placements=model_weight_placements,
                 tensor_shapes=tensor_shapes,
                 dtype=self.dtype,
-                device=self.main_weight.local_buffer.device,
+                device=self.main_weight.device,
             )
 
         self.main_grad = None
@@ -131,7 +126,7 @@ class ParameterGroup:
                 placements=main_grad_placements,
                 tensor_shapes=self.main_weight.layout.tensor_shapes,
                 dtype=grad_dtype,
-                device=self.main_weight.local_buffer.device,
+                device=self.main_weight.device,
             )
             assert self.main_grad.layout == self.main_weight.layout, (
                 "main_grad is built from main_weight tensor shapes on the same mesh, "
@@ -147,7 +142,7 @@ class ParameterGroup:
 
         sharded_parameters: list[nn.Parameter] = []
         unsharded_parameters: list[nn.Parameter] = []
-        main_grad_dtype = self.main_grad.local_buffer.dtype if self.main_grad is not None else None
+        main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
         for index, parameter in enumerate(parameters.values()):
             parameter.data = self._unsharded_model_weight.get_local_tensor(index)
             parameter.grad = None
@@ -183,13 +178,12 @@ class ParameterGroup:
         if self.main_weight is self.model_weight:
             return
 
-        self.main_weight.cast(self.model_weight.local_buffer.dtype).redistribute(
+        self.main_weight.cast(self.model_weight.dtype).redistribute(
             self.model_weight.placements, out=self.model_weight
         )
 
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""
-        self.sync_model_weight_from_main_weight()
         self._unsharded_model_weight.reallocate_storage()
         # This buffer backs unsharded Parameters whose views may be saved by autograd.
         # Materializing FSDP-managed storage should not look like a user mutation.
@@ -238,7 +232,7 @@ class ParameterGroup:
         has_sharded_grads = has_grad(self.sharded_parameters)
         can_reduce_into_main_grad = (
             not has_sharded_grads
-            and partial_grad.local_buffer.dtype == self.main_grad.local_buffer.dtype
+            and partial_grad.dtype == self.main_grad.dtype
         )
         if can_reduce_into_main_grad:
             partial_grad.redistribute(self.main_grad.placements, out=self.main_grad)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DBuffer placement definitions."""
+
+import dataclasses
+from collections.abc import Iterable
+
+import torch.distributed as dist
+
+
+class Placement:
+    """Base class for DBuffer placements."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Replicate(Placement):
+    """Replicated local buffer placement."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Partial(Placement):
+    """Unreduced replicated local buffer placement."""
+
+    reduce_op: dist.ReduceOp.RedOpType = dist.ReduceOp.SUM
+
+
+@dataclasses.dataclass(frozen=True)
+class Flat(Placement):
+    """Flat per-unit dim-0 sharded local buffer placement."""
+
+
+def _validate_placement(placement: Placement) -> None:
+    if not isinstance(placement, (Replicate, Partial, Flat)):
+        raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
+
+
+def validate_placements(placements: Iterable[Placement]) -> None:
+    """Validate DBuffer placements form a supported contiguous local layout."""
+    seen_flat = False
+    for placement in placements:
+        _validate_placement(placement)
+        if isinstance(placement, Flat):
+            seen_flat = True
+        elif seen_flat:
+            raise ValueError(
+                "Flat placements must be a suffix of the placement list so each "
+                "local buffer is a contiguous global-buffer range."
+            )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -30,7 +30,6 @@ sharded        ``Replicate``  ``allgather()``
 """
 
 import dataclasses
-from collections.abc import Iterable
 
 import torch.distributed as dist
 
@@ -54,22 +53,3 @@ class Partial(Placement):
 @dataclasses.dataclass(frozen=True)
 class Flat(Placement):
     """Flat per-unit dim-0 sharded local buffer placement."""
-
-
-def _validate_placement(placement: Placement) -> None:
-    if not isinstance(placement, (Replicate, Partial, Flat)):
-        raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
-
-
-def validate_placements(placements: Iterable[Placement]) -> None:
-    """Validate DBuffer placements form a supported contiguous local layout."""
-    seen_flat = False
-    for placement in placements:
-        _validate_placement(placement)
-        if isinstance(placement, Flat):
-            seen_flat = True
-        elif seen_flat:
-            raise ValueError(
-                "Flat placements must be a suffix of the placement list so each "
-                "local buffer is a contiguous global-buffer range."
-            )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -38,6 +38,9 @@ class Placement:
     """Base class for DBuffer placements."""
 
 
+MeshAxis = int | str
+
+
 @dataclasses.dataclass(frozen=True)
 class Replicate(Placement):
     """Replicated local buffer placement."""
@@ -53,3 +56,24 @@ class Partial(Placement):
 @dataclasses.dataclass(frozen=True)
 class Flat(Placement):
     """Flat per-unit dim-0 sharded local buffer placement."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Placements:
+    """Per-mesh-axis placements for parameter, gradient, and optimizer buffers."""
+
+    dp_axes: list[MeshAxis]
+    parameter: list[Placement]
+    gradient: list[Placement]
+    optimizer: list[Placement]
+
+    def __post_init__(self) -> None:
+        """Validate placement list lengths."""
+        axis_count = len(self.dp_axes)
+        for name, placements in (
+            ("parameter", self.parameter),
+            ("gradient", self.gradient),
+            ("optimizer", self.optimizer),
+        ):
+            if len(placements) != axis_count:
+                raise ValueError(f"Expected {axis_count} {name} placements, got {len(placements)}.")

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -12,7 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""DBuffer placement definitions."""
+"""DBuffer placement definitions.
+
+These placement concepts are borrowed from PyTorch DTensor placements:
+``Replicate`` and ``Partial`` mirror DTensor's placements. ``Flat`` is the
+only sharded DBuffer placement implemented so far; it stores dim-0 shards in a
+flattened local buffer.
+
+=============  =============  ====================
+Source         Destination    DBuffer operation
+=============  =============  ====================
+sharded        ``Replicate``  ``allgather()``
+``Partial``    sharded        ``reduce_scatter()``
+``Partial``    ``Replicate``  ``allreduce()``
+``Replicate``  sharded        ``scatter()`` (local)
+=============  =============  ====================
+"""
 
 import dataclasses
 from collections.abc import Iterable

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -61,7 +61,7 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
 
 def _assert_dbuffer_contains_tensors(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
-        torch.testing.assert_close(buffer.get_tensor(index), tensor)
+        torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
 
 
 @pytest.mark.distributed
@@ -147,7 +147,7 @@ def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
     assert layout.size == 60
     expected_local_shapes = expected_local_shapes_by_rank[mesh.get_local_rank(0)]
     for index, expected_shape in enumerate(expected_local_shapes):
-        assert buffer.get_tensor(index).shape == torch.Size(expected_shape)
+        assert buffer.get_local_tensor(index).shape == torch.Size(expected_shape)
         assert buffer.get_dtensor(index).shape == shapes[index]
 
 
@@ -207,7 +207,7 @@ def test_from_local_reuses_required_local_buffer(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_replicate_get_tensor_and_dtensor(setup: DistributedSetup):
+def test_replicate_get_local_tensor_and_dtensor(setup: DistributedSetup):
     """Replicated DBuffer returns full local tensors and replicated DTensors."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     tensors = _same_tensors_on_all_ranks(setup.device)
@@ -240,7 +240,7 @@ def test_sharded_allgather_round_trip(setup: DistributedSetup):
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
     layout = sharded_buffer.layout
     for index, tensor in enumerate(tensors):
-        local_tensor = sharded_buffer.get_tensor(index)
+        local_tensor = sharded_buffer.get_local_tensor(index)
         assert local_tensor.shape[1:] == tensor.shape[1:]
         assert local_tensor.is_contiguous()
 
@@ -449,7 +449,9 @@ def test_get_dtensor_from_sharded_buffer(setup: DistributedSetup):
 
     dtensor = sharded_buffer.get_dtensor(0)
 
-    torch.testing.assert_close(dtensor.to_local(), sharded_buffer.get_tensor(0), rtol=0, atol=0)
+    torch.testing.assert_close(
+        dtensor.to_local(), sharded_buffer.get_local_tensor(0), rtol=0, atol=0
+    )
     assert dtensor.shape == tensors[0].shape
 
 
@@ -514,7 +516,7 @@ def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
         fully_sharded_buffer.local_buffer.numel() == fully_sharded_buffer.layout.size // mesh.size()
     )
     for index, _ in enumerate(tensors):
-        assert fully_sharded_buffer.get_tensor(index).is_contiguous()
+        assert fully_sharded_buffer.get_local_tensor(index).is_contiguous()
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -48,7 +48,10 @@ def setup() -> Iterator[DistributedSetup]:
     yield DistributedSetup(rank=rank, world_size=world_size, device=device)
 
     if dist.is_initialized():
-        dist.destroy_process_group()
+        dist.barrier()
+        # Leave the default process group alive for later distributed tests;
+        # only clear DeviceMesh bookkeeping from this module.
+        _clear_device_mesh_resources()
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -62,6 +65,21 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
 def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
         torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
+
+
+def _clear_device_mesh_resources() -> None:
+    from torch.distributed.device_mesh import _mesh_resources
+
+    for resource_name in (
+        "child_to_root_mapping",
+        "root_to_flatten_mapping",
+        "mesh_stack",
+        "mesh_dim_group_options",
+        "flatten_name_to_root_dims",
+    ):
+        resource = getattr(_mesh_resources, resource_name, None)
+        if resource is not None:
+            resource.clear()
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -16,6 +16,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer impor
     Partial,
     Replicate,
 )
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.layout import GlobalLayout
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -29,6 +30,12 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
 def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
         torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
+
+
+def test_dbuffer_layout_rejects_0d_tensor_shapes():
+    """DBuffer layout does not silently reinterpret scalar tensors as dim-0 rows."""
+    with pytest.raises(ValueError, match="0D tensor shapes"):
+        GlobalLayout.build([torch.Size(())], dp_size=1)
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -316,10 +316,10 @@ def test_replicate_scatter_round_trip(setup: DistributedSetup):
     assert redistributed_sharded_buffer.placements == (Flat(),)
     expected_sharded_local_numel = replicated_buffer.layout.size // setup.world_size
     assert sharded_buffer.offset == setup.rank * expected_sharded_local_numel
-    source_slice = replicated_buffer.local_buffer.narrow(
-        0, sharded_buffer.offset - replicated_buffer.offset, sharded_buffer.local_buffer.numel()
+    assert (
+        sharded_buffer.local_buffer.untyped_storage()
+        is replicated_buffer.local_buffer.untyped_storage()
     )
-    assert sharded_buffer.local_buffer.data_ptr() == source_slice.data_ptr()
     torch.testing.assert_close(
         sharded_buffer.local_buffer, redistributed_sharded_buffer.local_buffer, rtol=0, atol=0
     )

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -59,7 +59,7 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
     ]
 
 
-def _assert_dbuffer_contains_tensors(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
+def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
         torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
 
@@ -203,7 +203,7 @@ def test_from_local_reuses_required_local_buffer(setup: DistributedSetup):
     assert sharded_buffer.layout == replicated_buffer.layout
     assert sharded_buffer.offset == offset
     assert sharded_buffer.local_buffer.data_ptr() == local_buffer.data_ptr()
-    _assert_dbuffer_contains_tensors(sharded_buffer.allgather(0), tensors)
+    _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
 
 @pytest.mark.distributed
@@ -214,7 +214,7 @@ def test_replicate_get_local_tensor_and_dtensor(setup: DistributedSetup):
 
     buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
 
-    _assert_dbuffer_contains_tensors(buffer, tensors)
+    _assert_dbuffer_local_tensors_close(buffer, tensors)
     dtensor = buffer.get_dtensor(0)
     torch.testing.assert_close(dtensor.to_local(), tensors[0], rtol=0, atol=0)
 
@@ -228,7 +228,7 @@ def test_distribute_tensors_moves_inputs_to_mesh_device(setup: DistributedSetup)
     buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
 
     assert buffer.local_buffer.device == setup.device
-    _assert_dbuffer_contains_tensors(buffer, [tensor.to(setup.device) for tensor in tensors])
+    _assert_dbuffer_local_tensors_close(buffer, [tensor.to(setup.device) for tensor in tensors])
 
 
 @pytest.mark.distributed
@@ -247,7 +247,7 @@ def test_sharded_allgather_round_trip(setup: DistributedSetup):
     replicated_buffer = sharded_buffer.allgather(0)
 
     assert replicated_buffer.layout == layout
-    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, tensors)
 
 
 @pytest.mark.distributed
@@ -269,7 +269,7 @@ def test_sharded_allgather_into_existing_buffer(setup: DistributedSetup):
 
     assert result is destination
     assert destination.local_buffer.data_ptr() == destination_data_ptr
-    _assert_dbuffer_contains_tensors(destination, tensors)
+    _assert_dbuffer_local_tensors_close(destination, tensors)
 
 
 @pytest.mark.distributed
@@ -323,7 +323,7 @@ def test_replicate_scatter_round_trip(setup: DistributedSetup):
     torch.testing.assert_close(
         sharded_buffer.local_buffer, redistributed_sharded_buffer.local_buffer, rtol=0, atol=0
     )
-    _assert_dbuffer_contains_tensors(sharded_buffer.allgather(0), tensors)
+    _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
 
 @pytest.mark.distributed
@@ -344,7 +344,7 @@ def test_partial_allreduce(setup: DistributedSetup):
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
@@ -375,7 +375,7 @@ def test_partial_allreduce_average(setup: DistributedSetup):
         torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
@@ -409,7 +409,7 @@ def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
@@ -437,7 +437,7 @@ def test_partial_reduce_scatter_to_flat_average(setup: DistributedSetup):
         torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
@@ -469,7 +469,7 @@ def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
     replicated_buffer = sharded_buffer.allgather(1)
 
-    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, tensors)
 
 
 @pytest.mark.distributed
@@ -556,7 +556,7 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetu
         torch.full((6, 2), outer_scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), outer_scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
@@ -586,4 +586,4 @@ def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
         fully_sharded_buffer.local_buffer.numel()
         == replicated_sharded_buffer.local_buffer.numel() // 2
     )
-    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, tensors)

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -5,6 +5,7 @@
 import dataclasses
 import os
 from collections.abc import Iterable, Iterator
+from typing import cast
 
 import pytest
 import torch
@@ -272,6 +273,26 @@ def test_sharded_allgather_into_existing_buffer(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
+def test_mesh_axis_must_be_non_negative_int(setup: DistributedSetup):
+    """DBuffer communication methods require explicit non-negative integer mesh axes."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    buffer = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=[torch.Size((4,))],
+        dtype=torch.float32,
+        device=setup.device,
+    )
+
+    with pytest.raises(TypeError, match="Mesh axis must be an int"):
+        buffer.allgather(cast(int, "dp"))
+    with pytest.raises(TypeError, match="Mesh axis must be an int"):
+        buffer.allgather(True)
+    with pytest.raises(ValueError, match="Mesh axis -1 is out of bounds"):
+        buffer.allgather(-1)
+
+
+@pytest.mark.distributed
 def test_replicate_scatter_round_trip(setup: DistributedSetup):
     """Replicated buffers locally chunk into sharded buffers and all-gather back."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
@@ -444,7 +465,7 @@ def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
     )
 
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
-    replicated_buffer = sharded_buffer.allgather("flat")
+    replicated_buffer = sharded_buffer.allgather(1)
 
     _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
 
@@ -485,8 +506,8 @@ def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
     expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
     expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
-        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
-        + mesh.get_local_rank("dp_outer") * expected_local_numel
+        mesh.get_local_rank(1) * expected_inner_axis_shard_numel
+        + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
     assert (
@@ -512,15 +533,15 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetu
     ]
 
     partial_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial(), Flat()])
-    fully_sharded_buffer = partial_sharded_buffer.reduce_scatter("dp_outer", Flat())
-    replicated_buffer = fully_sharded_buffer.allgather("dp_outer").allgather("dp_inner")
+    fully_sharded_buffer = partial_sharded_buffer.reduce_scatter(0, Flat())
+    replicated_buffer = fully_sharded_buffer.allgather(0).allgather(1)
 
     assert fully_sharded_buffer.placements == (Flat(), Flat())
     expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
     expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
-        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
-        + mesh.get_local_rank("dp_outer") * expected_local_numel
+        mesh.get_local_rank(1) * expected_inner_axis_shard_numel
+        + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
     assert (
@@ -548,15 +569,15 @@ def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
     )
 
     replicated_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
-    fully_sharded_buffer = replicated_sharded_buffer.scatter("dp_outer", Flat())
-    replicated_buffer = fully_sharded_buffer.allgather("dp_outer").allgather("dp_inner")
+    fully_sharded_buffer = replicated_sharded_buffer.scatter(0, Flat())
+    replicated_buffer = fully_sharded_buffer.allgather(0).allgather(1)
 
     assert fully_sharded_buffer.placements == (Flat(), Flat())
     expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
     expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
-        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
-        + mesh.get_local_rank("dp_outer") * expected_local_numel
+        mesh.get_local_rank(1) * expected_inner_axis_shard_numel
+        + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
     assert (

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -107,6 +107,50 @@ def test_dbuffer_layout_aligns_fragment_offsets_to_rows(setup: DistributedSetup)
 
 
 @pytest.mark.distributed
+def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
+    """LCM packing fills row-aligned padding gaps on a 5-rank flat-sharded mesh."""
+    if setup.world_size < 5:
+        pytest.skip("LCM padding-gap layout test requires at least 5 ranks.")
+
+    # P0-P4 are zero-based logical tensor names matching tensor indices.
+    shapes = [
+        torch.Size((2, 6)),  # P0
+        torch.Size((4, 4)),  # P1
+        torch.Size((4, 4)),  # P2
+        torch.Size((1, 2)),  # P3
+        torch.Size((1, 6)),  # P4
+    ]
+
+    mesh = init_device_mesh(setup.device.type, (5,))
+    if mesh.get_coordinate() is None:
+        pytest.skip("Rank is outside the 5-rank DBuffer mesh.")
+
+    buffer = DBuffer(
+        mesh=mesh,
+        placements=[Flat()],
+        tensor_shapes=shapes,
+        dtype=torch.float32,
+        device=setup.device,
+    )
+    layout = buffer.layout
+    expected_local_shapes_by_rank = [
+        [(2, 6), (0, 4), (0, 4), (0, 2), (0, 6)],
+        [(0, 6), (3, 4), (0, 4), (0, 2), (0, 6)],
+        [(0, 6), (1, 4), (1, 4), (1, 2), (0, 6)],
+        [(0, 6), (0, 4), (3, 4), (0, 2), (0, 6)],
+        [(0, 6), (0, 4), (0, 4), (0, 2), (1, 6)],
+    ]
+
+    assert layout.tensor_shapes == tuple(shapes)
+    assert layout.tensor_to_offset == (0, 12, 32, 28, 48)
+    assert layout.size == 60
+    expected_local_shapes = expected_local_shapes_by_rank[mesh.get_local_rank(0)]
+    for index, expected_shape in enumerate(expected_local_shapes):
+        assert buffer.get_tensor(index).shape == torch.Size(expected_shape)
+        assert buffer.get_dtensor(index).shape == shapes[index]
+
+
+@pytest.mark.distributed
 def test_constructor_allocates_local_buffer(setup: DistributedSetup):
     """DBuffer allocates local storage from shape, mesh, placement, dtype, and device."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -156,6 +156,35 @@ def test_constructor_allocates_local_buffer(distributed_setup):
 
 
 @pytest.mark.distributed
+def test_release_and_reallocate_storage_preserves_buffer_views(distributed_setup):
+    """DBuffer storage can be released and reallocated without replacing existing views."""
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    buffer = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=[torch.Size((4, 4))],
+        dtype=torch.float32,
+        device=distributed_setup.device,
+    )
+    tensor_view = buffer.get_local_tensor(0)
+    buffer_data_ptr = buffer.local_buffer.data_ptr()
+    tensor_view_data_ptr = tensor_view.data_ptr()
+
+    buffer.release_storage()
+    assert buffer.local_buffer.untyped_storage().nbytes() == 0
+
+    buffer.reallocate_storage()
+    assert (
+        buffer.local_buffer.untyped_storage().nbytes()
+        == buffer.local_buffer.numel() * buffer.local_buffer.element_size()
+    )
+    assert buffer.local_buffer.data_ptr() == buffer_data_ptr
+    assert tensor_view.data_ptr() == tensor_view_data_ptr
+    buffer.local_buffer.fill_(7.0)
+    torch.testing.assert_close(tensor_view, torch.full_like(tensor_view, 7.0))
+
+
+@pytest.mark.distributed
 def test_from_local_reuses_required_local_buffer(distributed_setup):
     """DBuffer.from_local reuses caller-provided local storage without allocation."""
     mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -233,6 +233,24 @@ def test_distribute_tensors_moves_inputs_to_mesh_device(distributed_setup):
 
 
 @pytest.mark.distributed
+def test_distribute_tensors_detaches_and_contiguizes_inputs(distributed_setup):
+    """distribute_tensors treats input tensors as detached contiguous values."""
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    parameter = torch.nn.Parameter(
+        torch.arange(12, dtype=torch.float32, device=distributed_setup.device).view(3, 4).t()
+    )
+
+    buffer = DBuffer.distribute_tensors([parameter], mesh, [Replicate()])
+
+    assert not parameter.is_contiguous()
+    assert buffer.get_local_tensor(0).is_contiguous()
+    assert not buffer.local_buffer.requires_grad
+    torch.testing.assert_close(
+        buffer.get_local_tensor(0), parameter.detach().contiguous(), rtol=0, atol=0
+    )
+
+
+@pytest.mark.distributed
 def test_sharded_allgather_round_trip(distributed_setup):
     """Sharded buffers round-trip through all-gather as contiguous tensor fragments."""
     mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -156,6 +156,36 @@ def test_constructor_allocates_local_buffer(distributed_setup):
 
 
 @pytest.mark.distributed
+def test_cast_to_same_dtype_returns_self(distributed_setup):
+    """DBuffer.cast returns self when the dtype already matches."""
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
+    buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+
+    assert buffer.cast(torch.float32) is buffer
+
+
+@pytest.mark.distributed
+def test_cast_preserves_layout_and_casts_values(distributed_setup):
+    """DBuffer.cast preserves layout metadata and casts local values."""
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
+    buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+
+    cast_buffer = buffer.cast(torch.bfloat16)
+
+    assert cast_buffer is not buffer
+    assert cast_buffer.mesh == buffer.mesh
+    assert cast_buffer.placements == buffer.placements
+    assert cast_buffer.layout == buffer.layout
+    assert cast_buffer.device == buffer.device
+    assert cast_buffer.dtype is torch.bfloat16
+    _assert_dbuffer_local_tensors_close(
+        cast_buffer, [tensor.to(dtype=torch.bfloat16) for tensor in tensors]
+    )
+
+
+@pytest.mark.distributed
 def test_release_and_reallocate_storage_preserves_buffer_views(distributed_setup):
     """DBuffer storage can be released and reallocated without replacing existing views."""
     mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -1,0 +1,417 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for Megatron-FSDP DBuffer."""
+
+import dataclasses
+import os
+from collections.abc import Iterator
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.dbuffer import (
+    DBuffer,
+    Flat,
+    Partial,
+    Replicate,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class DistributedSetup:
+    """Per-rank distributed test setup."""
+
+    rank: int
+    world_size: int
+    device: torch.device
+
+
+@pytest.fixture(scope="module")
+def setup() -> Iterator[DistributedSetup]:
+    """Read torchrun rank state and set up this rank's local device."""
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Not running under torchrun.")
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+
+    if torch.cuda.is_available():
+        torch.cuda.set_device(local_rank)
+        device = torch.device(f"cuda:{local_rank}")
+    else:
+        device = torch.device("cpu")
+
+    yield DistributedSetup(rank=rank, world_size=world_size, device=device)
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
+    return [
+        torch.arange(21, dtype=torch.float32, device=device).reshape(7, 3),
+        torch.arange(10, dtype=torch.float32, device=device).reshape(2, 5) + 100,
+        torch.arange(7, dtype=torch.float32, device=device) + 200,
+    ]
+
+
+def _assert_dbuffer_contains_tensors(
+    buffer: DBuffer, expected: list[torch.Tensor], *, exact: bool = True
+) -> None:
+    for index, tensor in enumerate(expected):
+        if exact:
+            torch.testing.assert_close(buffer.get_tensor(index), tensor, rtol=0, atol=0)
+        else:
+            torch.testing.assert_close(buffer.get_tensor(index), tensor)
+
+
+@pytest.mark.distributed
+def test_dbuffer_layout_pads_to_lcm_times_dp_size_and_fills_gaps(setup: DistributedSetup):
+    """DBuffer layout returns element offsets and pads to LCM * DP size."""
+    if setup.world_size < 2:
+        pytest.skip("DBuffer layout test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (2,))
+    shapes = [torch.Size((5, 4)), torch.Size((2, 6)), torch.Size((3,))]
+
+    buffer = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=shapes,
+        dtype=torch.float32,
+        device=setup.device,
+    )
+
+    assert buffer.layout.tensor_shapes == tuple(shapes)
+    assert buffer.layout.tensor_to_offset == (0, 24, 20)
+    assert buffer.layout.size == 48
+
+
+@pytest.mark.distributed
+def test_dbuffer_layout_aligns_fragment_offsets_to_rows(setup: DistributedSetup):
+    """DBuffer layout keeps small tensors aligned to their non-leading dimensions."""
+    if setup.world_size < 2:
+        pytest.skip("DBuffer layout test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (2,))
+    shapes = [torch.Size((4, 4)), torch.Size((1, 6))]
+
+    buffer = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=shapes,
+        dtype=torch.float32,
+        device=setup.device,
+    )
+
+    assert buffer.layout.tensor_to_offset == (0, 18)
+    assert buffer.layout.size == 24
+
+
+@pytest.mark.distributed
+def test_constructor_allocates_local_buffer(setup: DistributedSetup):
+    """DBuffer allocates local storage from shape, mesh, placement, dtype, and device."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensor_shapes = [torch.Size((7, 3)), torch.Size((2, 5)), torch.Size((7,))]
+    mesh_size = mesh.size()
+
+    replicated_buffer = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=tensor_shapes,
+        dtype=torch.float32,
+        device=setup.device,
+    )
+    flat_buffer = DBuffer(
+        mesh=mesh,
+        placements=[Flat()],
+        tensor_shapes=tensor_shapes,
+        dtype=torch.float32,
+        device=setup.device,
+    )
+
+    assert replicated_buffer.layout == flat_buffer.layout
+    assert replicated_buffer.layout.tensor_shapes == tuple(tensor_shapes)
+    assert replicated_buffer.offset == 0
+    expected_flat_local_numel = replicated_buffer.layout.size // setup.world_size
+    assert flat_buffer.offset == setup.rank * expected_flat_local_numel
+    assert replicated_buffer.local_buffer.numel() == replicated_buffer.layout.size
+    assert flat_buffer.local_buffer.numel() == replicated_buffer.layout.size // setup.world_size
+    assert flat_buffer.layout.size % (15 * mesh_size) == 0
+    assert replicated_buffer.local_buffer.dtype == torch.float32
+    assert flat_buffer.local_buffer.device == setup.device
+
+
+@pytest.mark.distributed
+def test_replicate_get_tensor_and_dtensor(setup: DistributedSetup):
+    """Replicated DBuffer returns full local tensors and replicated DTensors."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+
+    buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+
+    _assert_dbuffer_contains_tensors(buffer, tensors)
+    dtensor = buffer.get_dtensor(0)
+    torch.testing.assert_close(dtensor.to_local(), tensors[0], rtol=0, atol=0)
+
+
+@pytest.mark.distributed
+def test_distribute_tensors_moves_inputs_to_mesh_device(setup: DistributedSetup):
+    """distribute_tensors moves full input tensors to the mesh device type."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(torch.device("cpu"))
+
+    buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+
+    assert buffer.local_buffer.device == setup.device
+    _assert_dbuffer_contains_tensors(buffer, [tensor.to(setup.device) for tensor in tensors])
+
+
+@pytest.mark.distributed
+def test_flat_allgather_round_trip(setup: DistributedSetup):
+    """Flat buffers round-trip through all-gather as contiguous tensor fragments."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+
+    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
+    layout = flat_buffer.layout
+    for index, tensor in enumerate(tensors):
+        local_tensor = flat_buffer.get_tensor(index)
+        assert local_tensor.shape[1:] == tensor.shape[1:]
+        assert local_tensor.is_contiguous()
+
+    replicated_buffer = flat_buffer.allgather(0)
+
+    assert replicated_buffer.layout == layout
+    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+
+
+@pytest.mark.distributed
+def test_replicate_scatter_round_trip(setup: DistributedSetup):
+    """Replicated buffers locally chunk into Flat buffers and all-gather back."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+
+    replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+    flat_buffer = replicated_buffer.scatter(0, Flat())
+    redistributed_flat_buffer = replicated_buffer.redistribute([Flat()])
+
+    assert flat_buffer.placements == (Flat(),)
+    assert redistributed_flat_buffer.placements == (Flat(),)
+    expected_flat_local_numel = replicated_buffer.layout.size // setup.world_size
+    assert flat_buffer.offset == setup.rank * expected_flat_local_numel
+    torch.testing.assert_close(
+        flat_buffer.local_buffer, redistributed_flat_buffer.local_buffer, rtol=0, atol=0
+    )
+    _assert_dbuffer_contains_tensors(flat_buffer.allgather(0), tensors)
+
+
+@pytest.mark.distributed
+def test_partial_allreduce(setup: DistributedSetup):
+    """Partial buffers all-reduce into replicated buffers."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    rank_scale = float(setup.rank + 1)
+    tensors = [
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+    ]
+    partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
+
+    replicated_buffer = partial_buffer.allreduce(0)
+
+    scale_sum = float(setup.world_size * (setup.world_size + 1) // 2)
+    expected = [
+        torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
+        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
+    ]
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+
+
+@pytest.mark.distributed
+def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
+    """Partial buffers reduce-scatter into Flat buffers."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    rank_scale = float(setup.rank + 1)
+    tensors = [
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+    ]
+    partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
+    layout = partial_buffer.layout
+
+    flat_buffer = partial_buffer.reduce_scatter(0, Flat())
+    replicated_buffer = flat_buffer.allgather(0)
+
+    assert flat_buffer.placements == (Flat(),)
+    assert flat_buffer.layout == layout
+    assert replicated_buffer.layout == layout
+    scale_sum = float(setup.world_size * (setup.world_size + 1) // 2)
+    expected_tensors = [
+        torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
+        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
+    ]
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors, exact=False)
+
+
+@pytest.mark.distributed
+def test_get_dtensor_from_flat_buffer(setup: DistributedSetup):
+    """Flat DBuffer exposes per-tensor local shards as DTensors."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
+
+    dtensor = flat_buffer.get_dtensor(0)
+
+    torch.testing.assert_close(dtensor.to_local(), flat_buffer.get_tensor(0), rtol=0, atol=0)
+    assert dtensor.shape == tensors[0].shape
+
+
+@pytest.mark.distributed
+def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
+    """A 2D mesh can replicate on one axis and flat-shard on the other."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("replicate", "flat")
+    )
+
+    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
+    replicated_buffer = flat_buffer.allgather("flat")
+
+    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+
+
+@pytest.mark.distributed
+def test_2d_mesh_flat_before_replicate_is_rejected(setup: DistributedSetup):
+    """Flat axes must be a suffix to keep every local buffer contiguous."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("flat", "replicate")
+    )
+
+    with pytest.raises(ValueError, match="Flat placements must be a suffix"):
+        DBuffer(
+            mesh=mesh,
+            placements=[Flat(), Replicate()],
+            tensor_shapes=[torch.Size((6, 4))],
+            dtype=torch.float32,
+            device=setup.device,
+        )
+
+
+@pytest.mark.distributed
+def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
+    """Multiple Flat axes shard local storage by the product of their mesh sizes."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+    )
+    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
+
+    assert flat_buffer.layout.tensor_shapes == tuple(tensor.shape for tensor in tensors)
+    expected_local_numel = flat_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = flat_buffer.layout.size // mesh.size(1)
+    expected_offset = (
+        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
+        + mesh.get_local_rank("dp_outer") * expected_local_numel
+    )
+    assert flat_buffer.offset == expected_offset
+    assert flat_buffer.local_buffer.numel() == flat_buffer.layout.size // mesh.size()
+    for index, _ in enumerate(tensors):
+        assert flat_buffer.get_tensor(index).is_contiguous()
+
+
+@pytest.mark.distributed
+def test_2d_mesh_flat_flat_redistribute_to_replicate_replicate(setup: DistributedSetup):
+    """Redistribute composes all-gathers across both Flat axes."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+    )
+    flat_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
+    layout = flat_flat_buffer.layout
+
+    replicated_buffer = flat_flat_buffer.redistribute([Replicate(), Replicate()])
+
+    assert replicated_buffer.placements == (Replicate(), Replicate())
+    assert replicated_buffer.layout == layout
+    assert replicated_buffer.offset == 0
+    assert replicated_buffer.local_buffer.numel() == layout.size
+    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+
+
+@pytest.mark.distributed
+def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetup):
+    """Partial+Flat reduce-scatter reduces the existing Flat local shard."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+    )
+    outer_scale = float(mesh.get_local_rank(0) + 1)
+    tensors = [
+        torch.full((6, 2), outer_scale, dtype=torch.float32, device=setup.device),
+        torch.full((4,), outer_scale * 10, dtype=torch.float32, device=setup.device),
+    ]
+
+    partial_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial(), Flat()])
+    flat_flat_buffer = partial_flat_buffer.reduce_scatter("dp_outer", Flat())
+    replicated_buffer = flat_flat_buffer.allgather("dp_outer").allgather("dp_inner")
+
+    assert flat_flat_buffer.placements == (Flat(), Flat())
+    expected_local_numel = flat_flat_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = flat_flat_buffer.layout.size // mesh.size(1)
+    expected_offset = (
+        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
+        + mesh.get_local_rank("dp_outer") * expected_local_numel
+    )
+    assert flat_flat_buffer.offset == expected_offset
+    assert flat_flat_buffer.local_buffer.numel() == partial_flat_buffer.local_buffer.numel() // 2
+
+    outer_scale_sum = float(mesh.size(0) * (mesh.size(0) + 1) // 2)
+    expected = [
+        torch.full((6, 2), outer_scale_sum, dtype=torch.float32, device=setup.device),
+        torch.full((4,), outer_scale_sum * 10, dtype=torch.float32, device=setup.device),
+    ]
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+
+
+@pytest.mark.distributed
+def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
+    """Replicate+Flat scatter chunks the existing Flat local shard."""
+    if setup.world_size < 4 or setup.world_size % 2 != 0:
+        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
+
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(
+        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+    )
+
+    replicate_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
+    flat_flat_buffer = replicate_flat_buffer.scatter("dp_outer", Flat())
+    replicated_buffer = flat_flat_buffer.allgather("dp_outer").allgather("dp_inner")
+
+    assert flat_flat_buffer.placements == (Flat(), Flat())
+    expected_local_numel = flat_flat_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = flat_flat_buffer.layout.size // mesh.size(1)
+    expected_offset = (
+        mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
+        + mesh.get_local_rank("dp_outer") * expected_local_numel
+    )
+    assert flat_flat_buffer.offset == expected_offset
+    assert flat_flat_buffer.local_buffer.numel() == replicate_flat_buffer.local_buffer.numel() // 2
+    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -4,7 +4,7 @@
 
 import dataclasses
 import os
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 
 import pytest
 import torch
@@ -58,14 +58,9 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
     ]
 
 
-def _assert_dbuffer_contains_tensors(
-    buffer: DBuffer, expected: list[torch.Tensor], *, exact: bool = True
-) -> None:
+def _assert_dbuffer_contains_tensors(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
-        if exact:
-            torch.testing.assert_close(buffer.get_tensor(index), tensor, rtol=0, atol=0)
-        else:
-            torch.testing.assert_close(buffer.get_tensor(index), tensor)
+        torch.testing.assert_close(buffer.get_tensor(index), tensor)
 
 
 @pytest.mark.distributed
@@ -125,7 +120,7 @@ def test_constructor_allocates_local_buffer(setup: DistributedSetup):
         dtype=torch.float32,
         device=setup.device,
     )
-    flat_buffer = DBuffer(
+    sharded_buffer = DBuffer(
         mesh=mesh,
         placements=[Flat()],
         tensor_shapes=tensor_shapes,
@@ -133,16 +128,37 @@ def test_constructor_allocates_local_buffer(setup: DistributedSetup):
         device=setup.device,
     )
 
-    assert replicated_buffer.layout == flat_buffer.layout
+    assert replicated_buffer.layout == sharded_buffer.layout
     assert replicated_buffer.layout.tensor_shapes == tuple(tensor_shapes)
     assert replicated_buffer.offset == 0
-    expected_flat_local_numel = replicated_buffer.layout.size // setup.world_size
-    assert flat_buffer.offset == setup.rank * expected_flat_local_numel
+    expected_sharded_local_numel = replicated_buffer.layout.size // setup.world_size
+    assert sharded_buffer.offset == setup.rank * expected_sharded_local_numel
     assert replicated_buffer.local_buffer.numel() == replicated_buffer.layout.size
-    assert flat_buffer.local_buffer.numel() == replicated_buffer.layout.size // setup.world_size
-    assert flat_buffer.layout.size % (15 * mesh_size) == 0
-    assert replicated_buffer.local_buffer.dtype == torch.float32
-    assert flat_buffer.local_buffer.device == setup.device
+    assert sharded_buffer.local_buffer.numel() == replicated_buffer.layout.size // setup.world_size
+    assert sharded_buffer.layout.size % (15 * mesh_size) == 0
+    assert replicated_buffer.dtype == torch.float32
+    assert sharded_buffer.local_buffer.device == setup.device
+
+
+@pytest.mark.distributed
+def test_from_local_reuses_required_local_buffer(setup: DistributedSetup):
+    """DBuffer.from_local reuses caller-provided local storage without allocation."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+    local_numel = replicated_buffer.layout.size // setup.world_size
+    offset = setup.rank * local_numel
+    local_buffer = replicated_buffer.local_buffer.narrow(0, offset, local_numel)
+
+    sharded_buffer = DBuffer.from_local(
+        local_buffer, mesh, iter([Flat()]), replicated_buffer.layout.tensor_shapes
+    )
+
+    assert sharded_buffer.placements == (Flat(),)
+    assert sharded_buffer.layout == replicated_buffer.layout
+    assert sharded_buffer.offset == offset
+    assert sharded_buffer.local_buffer.data_ptr() == local_buffer.data_ptr()
+    _assert_dbuffer_contains_tensors(sharded_buffer.allgather(0), tensors)
 
 
 @pytest.mark.distributed
@@ -171,42 +187,78 @@ def test_distribute_tensors_moves_inputs_to_mesh_device(setup: DistributedSetup)
 
 
 @pytest.mark.distributed
-def test_flat_allgather_round_trip(setup: DistributedSetup):
-    """Flat buffers round-trip through all-gather as contiguous tensor fragments."""
+def test_sharded_allgather_round_trip(setup: DistributedSetup):
+    """Sharded buffers round-trip through all-gather as contiguous tensor fragments."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     tensors = _same_tensors_on_all_ranks(setup.device)
 
-    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
-    layout = flat_buffer.layout
+    sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
+    layout = sharded_buffer.layout
     for index, tensor in enumerate(tensors):
-        local_tensor = flat_buffer.get_tensor(index)
+        local_tensor = sharded_buffer.get_tensor(index)
         assert local_tensor.shape[1:] == tensor.shape[1:]
         assert local_tensor.is_contiguous()
 
-    replicated_buffer = flat_buffer.allgather(0)
+    replicated_buffer = sharded_buffer.allgather(0)
 
     assert replicated_buffer.layout == layout
     _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
 
 
 @pytest.mark.distributed
+def test_sharded_allgather_into_existing_buffer(setup: DistributedSetup):
+    """Sharded buffers can all-gather directly into a preallocated replicated buffer."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(setup.device)
+    sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
+    destination = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=sharded_buffer.layout.tensor_shapes,
+        dtype=sharded_buffer.dtype,
+        device=sharded_buffer.local_buffer.device,
+    )
+    destination_data_ptr = destination.local_buffer.data_ptr()
+
+    result = sharded_buffer.allgather(0, out=destination)
+
+    assert result is destination
+    assert destination.local_buffer.data_ptr() == destination_data_ptr
+    _assert_dbuffer_contains_tensors(destination, tensors)
+
+
+@pytest.mark.distributed
 def test_replicate_scatter_round_trip(setup: DistributedSetup):
-    """Replicated buffers locally chunk into Flat buffers and all-gather back."""
+    """Replicated buffers locally chunk into sharded buffers and all-gather back."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     tensors = _same_tensors_on_all_ranks(setup.device)
 
     replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
-    flat_buffer = replicated_buffer.scatter(0, Flat())
-    redistributed_flat_buffer = replicated_buffer.redistribute([Flat()])
-
-    assert flat_buffer.placements == (Flat(),)
-    assert redistributed_flat_buffer.placements == (Flat(),)
-    expected_flat_local_numel = replicated_buffer.layout.size // setup.world_size
-    assert flat_buffer.offset == setup.rank * expected_flat_local_numel
-    torch.testing.assert_close(
-        flat_buffer.local_buffer, redistributed_flat_buffer.local_buffer, rtol=0, atol=0
+    sharded_buffer = replicated_buffer.scatter(0, Flat())
+    redistribute_destination = DBuffer(
+        mesh=mesh,
+        placements=[Flat()],
+        tensor_shapes=replicated_buffer.layout.tensor_shapes,
+        dtype=replicated_buffer.dtype,
+        device=replicated_buffer.local_buffer.device,
     )
-    _assert_dbuffer_contains_tensors(flat_buffer.allgather(0), tensors)
+    redistributed_sharded_buffer = replicated_buffer.redistribute(
+        [Flat()], out=redistribute_destination
+    )
+
+    assert sharded_buffer.placements == (Flat(),)
+    assert redistributed_sharded_buffer is redistribute_destination
+    assert redistributed_sharded_buffer.placements == (Flat(),)
+    expected_sharded_local_numel = replicated_buffer.layout.size // setup.world_size
+    assert sharded_buffer.offset == setup.rank * expected_sharded_local_numel
+    source_slice = replicated_buffer.local_buffer.narrow(
+        0, sharded_buffer.offset - replicated_buffer.offset, sharded_buffer.local_buffer.numel()
+    )
+    assert sharded_buffer.local_buffer.data_ptr() == source_slice.data_ptr()
+    torch.testing.assert_close(
+        sharded_buffer.local_buffer, redistributed_sharded_buffer.local_buffer, rtol=0, atol=0
+    )
+    _assert_dbuffer_contains_tensors(sharded_buffer.allgather(0), tensors)
 
 
 @pytest.mark.distributed
@@ -227,7 +279,7 @@ def test_partial_allreduce(setup: DistributedSetup):
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
@@ -243,19 +295,27 @@ def test_partial_allreduce_average(setup: DistributedSetup):
         tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
     )
 
-    replicated_buffer = partial_buffer.allreduce(0)
+    destination = DBuffer(
+        mesh=mesh,
+        placements=[Replicate()],
+        tensor_shapes=partial_buffer.layout.tensor_shapes,
+        dtype=partial_buffer.dtype,
+        device=partial_buffer.local_buffer.device,
+    )
+    replicated_buffer = partial_buffer.allreduce(0, out=destination)
 
+    assert replicated_buffer is destination
     scale_average = float(setup.world_size + 1) / 2.0
     expected = [
         torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
 def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
-    """Partial buffers reduce-scatter into Flat buffers."""
+    """Partial buffers reduce-scatter into sharded buffers."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     rank_scale = float(setup.rank + 1)
     tensors = [
@@ -265,18 +325,26 @@ def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
     partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
     layout = partial_buffer.layout
 
-    flat_buffer = partial_buffer.reduce_scatter(0, Flat())
-    replicated_buffer = flat_buffer.allgather(0)
+    destination = DBuffer(
+        mesh=mesh,
+        placements=[Flat()],
+        tensor_shapes=partial_buffer.layout.tensor_shapes,
+        dtype=partial_buffer.dtype,
+        device=partial_buffer.local_buffer.device,
+    )
+    sharded_buffer = partial_buffer.reduce_scatter(0, Flat(), out=destination)
+    replicated_buffer = sharded_buffer.allgather(0)
 
-    assert flat_buffer.placements == (Flat(),)
-    assert flat_buffer.layout == layout
+    assert sharded_buffer is destination
+    assert sharded_buffer.placements == (Flat(),)
+    assert sharded_buffer.layout == layout
     assert replicated_buffer.layout == layout
     scale_sum = float(setup.world_size * (setup.world_size + 1) // 2)
     expected_tensors = [
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors, exact=False)
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
@@ -293,30 +361,30 @@ def test_partial_reduce_scatter_to_flat_average(setup: DistributedSetup):
     )
     layout = partial_buffer.layout
 
-    flat_buffer = partial_buffer.reduce_scatter(0, Flat())
-    replicated_buffer = flat_buffer.allgather(0)
+    sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
+    replicated_buffer = sharded_buffer.allgather(0)
 
-    assert flat_buffer.placements == (Flat(),)
-    assert flat_buffer.layout == layout
+    assert sharded_buffer.placements == (Flat(),)
+    assert sharded_buffer.layout == layout
     assert replicated_buffer.layout == layout
     scale_average = float(setup.world_size + 1) / 2.0
     expected_tensors = [
         torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors, exact=False)
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
-def test_get_dtensor_from_flat_buffer(setup: DistributedSetup):
-    """Flat DBuffer exposes per-tensor local shards as DTensors."""
+def test_get_dtensor_from_sharded_buffer(setup: DistributedSetup):
+    """Sharded DBuffer exposes per-tensor local shards as DTensors."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     tensors = _same_tensors_on_all_ranks(setup.device)
-    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
+    sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
 
-    dtensor = flat_buffer.get_dtensor(0)
+    dtensor = sharded_buffer.get_dtensor(0)
 
-    torch.testing.assert_close(dtensor.to_local(), flat_buffer.get_tensor(0), rtol=0, atol=0)
+    torch.testing.assert_close(dtensor.to_local(), sharded_buffer.get_tensor(0), rtol=0, atol=0)
     assert dtensor.shape == tensors[0].shape
 
 
@@ -331,8 +399,8 @@ def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
         setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("replicate", "flat")
     )
 
-    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
-    replicated_buffer = flat_buffer.allgather("flat")
+    sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
+    replicated_buffer = sharded_buffer.allgather("flat")
 
     _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
 
@@ -367,41 +435,19 @@ def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
     mesh = init_device_mesh(
         setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
     )
-    flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
+    fully_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
 
-    assert flat_buffer.layout.tensor_shapes == tuple(tensor.shape for tensor in tensors)
-    expected_local_numel = flat_buffer.layout.size // mesh.size()
-    expected_inner_axis_shard_numel = flat_buffer.layout.size // mesh.size(1)
+    assert fully_sharded_buffer.layout.tensor_shapes == tuple(tensor.shape for tensor in tensors)
+    expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
         mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
-    assert flat_buffer.offset == expected_offset
-    assert flat_buffer.local_buffer.numel() == flat_buffer.layout.size // mesh.size()
+    assert fully_sharded_buffer.offset == expected_offset
+    assert fully_sharded_buffer.local_buffer.numel() == fully_sharded_buffer.layout.size // mesh.size()
     for index, _ in enumerate(tensors):
-        assert flat_buffer.get_tensor(index).is_contiguous()
-
-
-@pytest.mark.distributed
-def test_2d_mesh_flat_flat_redistribute_to_replicate_replicate(setup: DistributedSetup):
-    """Redistribute composes all-gathers across both Flat axes."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
-        pytest.skip("2D DBuffer test requires an even world size of at least 4.")
-
-    tensors = _same_tensors_on_all_ranks(setup.device)
-    mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
-    )
-    flat_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
-    layout = flat_flat_buffer.layout
-
-    replicated_buffer = flat_flat_buffer.redistribute([Replicate(), Replicate()])
-
-    assert replicated_buffer.placements == (Replicate(), Replicate())
-    assert replicated_buffer.layout == layout
-    assert replicated_buffer.offset == 0
-    assert replicated_buffer.local_buffer.numel() == layout.size
-    _assert_dbuffer_contains_tensors(replicated_buffer, tensors)
+        assert fully_sharded_buffer.get_tensor(index).is_contiguous()
 
 
 @pytest.mark.distributed
@@ -419,26 +465,26 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetu
         torch.full((4,), outer_scale * 10, dtype=torch.float32, device=setup.device),
     ]
 
-    partial_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial(), Flat()])
-    flat_flat_buffer = partial_flat_buffer.reduce_scatter("dp_outer", Flat())
-    replicated_buffer = flat_flat_buffer.allgather("dp_outer").allgather("dp_inner")
+    partial_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial(), Flat()])
+    fully_sharded_buffer = partial_sharded_buffer.reduce_scatter("dp_outer", Flat())
+    replicated_buffer = fully_sharded_buffer.allgather("dp_outer").allgather("dp_inner")
 
-    assert flat_flat_buffer.placements == (Flat(), Flat())
-    expected_local_numel = flat_flat_buffer.layout.size // mesh.size()
-    expected_inner_axis_shard_numel = flat_flat_buffer.layout.size // mesh.size(1)
+    assert fully_sharded_buffer.placements == (Flat(), Flat())
+    expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
         mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
-    assert flat_flat_buffer.offset == expected_offset
-    assert flat_flat_buffer.local_buffer.numel() == partial_flat_buffer.local_buffer.numel() // 2
+    assert fully_sharded_buffer.offset == expected_offset
+    assert fully_sharded_buffer.local_buffer.numel() == partial_sharded_buffer.local_buffer.numel() // 2
 
     outer_scale_sum = float(mesh.size(0) * (mesh.size(0) + 1) // 2)
     expected = [
         torch.full((6, 2), outer_scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), outer_scale_sum * 10, dtype=torch.float32, device=setup.device),
     ]
-    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
@@ -452,17 +498,17 @@ def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
         setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
     )
 
-    replicate_flat_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
-    flat_flat_buffer = replicate_flat_buffer.scatter("dp_outer", Flat())
-    replicated_buffer = flat_flat_buffer.allgather("dp_outer").allgather("dp_inner")
+    replicated_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
+    fully_sharded_buffer = replicated_sharded_buffer.scatter("dp_outer", Flat())
+    replicated_buffer = fully_sharded_buffer.allgather("dp_outer").allgather("dp_inner")
 
-    assert flat_flat_buffer.placements == (Flat(), Flat())
-    expected_local_numel = flat_flat_buffer.layout.size // mesh.size()
-    expected_inner_axis_shard_numel = flat_flat_buffer.layout.size // mesh.size(1)
+    assert fully_sharded_buffer.placements == (Flat(), Flat())
+    expected_local_numel = fully_sharded_buffer.layout.size // mesh.size()
+    expected_inner_axis_shard_numel = fully_sharded_buffer.layout.size // mesh.size(1)
     expected_offset = (
         mesh.get_local_rank("dp_inner") * expected_inner_axis_shard_numel
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
-    assert flat_flat_buffer.offset == expected_offset
-    assert flat_flat_buffer.local_buffer.numel() == replicate_flat_buffer.local_buffer.numel() // 2
+    assert fully_sharded_buffer.offset == expected_offset
+    assert fully_sharded_buffer.local_buffer.numel() == replicated_sharded_buffer.local_buffer.numel() // 2
     _assert_dbuffer_contains_tensors(replicated_buffer, tensors)

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -16,7 +16,6 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer impor
     Partial,
     Replicate,
 )
-from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.layout import GlobalLayout
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -30,12 +29,6 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
 def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
         torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
-
-
-def test_dbuffer_layout_rejects_0d_tensor_shapes():
-    """DBuffer layout does not silently reinterpret scalar tensors as dim-0 rows."""
-    with pytest.raises(ValueError, match="0D tensor shapes"):
-        GlobalLayout.build([torch.Size(())], dp_size=1)
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -48,10 +48,8 @@ def setup() -> Iterator[DistributedSetup]:
     yield DistributedSetup(rank=rank, world_size=world_size, device=device)
 
     if dist.is_initialized():
+        # Leave the default process group alive for later distributed tests.
         dist.barrier()
-        # Leave the default process group alive for later distributed tests;
-        # only clear DeviceMesh bookkeeping from this module.
-        _clear_device_mesh_resources()
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -65,21 +63,6 @@ def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
 def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torch.Tensor]) -> None:
     for index, tensor in enumerate(expected):
         torch.testing.assert_close(buffer.get_local_tensor(index), tensor)
-
-
-def _clear_device_mesh_resources() -> None:
-    from torch.distributed.device_mesh import _mesh_resources
-
-    for resource_name in (
-        "child_to_root_mapping",
-        "root_to_flatten_mapping",
-        "mesh_stack",
-        "mesh_dim_group_options",
-        "flatten_name_to_root_dims",
-    ):
-        resource = getattr(_mesh_resources, resource_name, None)
-        if resource is not None:
-            resource.clear()
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -11,7 +11,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import init_device_mesh
 
-from megatron.core.distributed.fsdp.src.megatron_fsdp.dbuffer import (
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import (
     DBuffer,
     Flat,
     Partial,
@@ -231,6 +231,29 @@ def test_partial_allreduce(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
+def test_partial_allreduce_average(setup: DistributedSetup):
+    """Partial buffers can all-reduce with AVG."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    rank_scale = float(setup.rank + 1)
+    tensors = [
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+    ]
+    partial_buffer = DBuffer.distribute_tensors(
+        tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
+    )
+
+    replicated_buffer = partial_buffer.allreduce(0)
+
+    scale_average = float(setup.world_size + 1) / 2.0
+    expected = [
+        torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
+        torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
+    ]
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected, exact=False)
+
+
+@pytest.mark.distributed
 def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
     """Partial buffers reduce-scatter into Flat buffers."""
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
@@ -252,6 +275,34 @@ def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
     expected_tensors = [
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
+    ]
+    _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors, exact=False)
+
+
+@pytest.mark.distributed
+def test_partial_reduce_scatter_to_flat_average(setup: DistributedSetup):
+    """Partial buffers can reduce-scatter with AVG."""
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    rank_scale = float(setup.rank + 1)
+    tensors = [
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+    ]
+    partial_buffer = DBuffer.distribute_tensors(
+        tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
+    )
+    layout = partial_buffer.layout
+
+    flat_buffer = partial_buffer.reduce_scatter(0, Flat())
+    replicated_buffer = flat_buffer.allgather(0)
+
+    assert flat_buffer.placements == (Flat(),)
+    assert flat_buffer.layout == layout
+    assert replicated_buffer.layout == layout
+    scale_average = float(setup.world_size + 1) / 2.0
+    expected_tensors = [
+        torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
+        torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
     ]
     _assert_dbuffer_contains_tensors(replicated_buffer, expected_tensors, exact=False)
 

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -2,9 +2,7 @@
 
 """Unit tests for Megatron-FSDP DBuffer."""
 
-import dataclasses
-import os
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from typing import cast
 
 import pytest
@@ -18,38 +16,6 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer impor
     Partial,
     Replicate,
 )
-
-
-@dataclasses.dataclass(frozen=True)
-class DistributedSetup:
-    """Per-rank distributed test setup."""
-
-    rank: int
-    world_size: int
-    device: torch.device
-
-
-@pytest.fixture(scope="module")
-def setup() -> Iterator[DistributedSetup]:
-    """Read torchrun rank state and set up this rank's local device."""
-    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
-        pytest.skip("Not running under torchrun.")
-
-    rank = int(os.environ["RANK"])
-    world_size = int(os.environ["WORLD_SIZE"])
-    local_rank = int(os.environ.get("LOCAL_RANK", rank))
-
-    if torch.cuda.is_available():
-        torch.cuda.set_device(local_rank)
-        device = torch.device(f"cuda:{local_rank}")
-    else:
-        device = torch.device("cpu")
-
-    yield DistributedSetup(rank=rank, world_size=world_size, device=device)
-
-    if dist.is_initialized():
-        # Leave the default process group alive for later distributed tests.
-        dist.barrier()
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -66,12 +32,12 @@ def _assert_dbuffer_local_tensors_close(buffer: DBuffer, expected: Iterable[torc
 
 
 @pytest.mark.distributed
-def test_dbuffer_layout_pads_to_lcm_times_dp_size_and_fills_gaps(setup: DistributedSetup):
+def test_dbuffer_layout_pads_to_lcm_times_dp_size_and_fills_gaps(distributed_setup):
     """DBuffer layout returns element offsets and pads to LCM * DP size."""
-    if setup.world_size < 2:
+    if distributed_setup.world_size < 2:
         pytest.skip("DBuffer layout test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (2,))
+    mesh = init_device_mesh(distributed_setup.device.type, (2,))
     shapes = [torch.Size((5, 4)), torch.Size((2, 6)), torch.Size((3,))]
 
     buffer = DBuffer(
@@ -79,7 +45,7 @@ def test_dbuffer_layout_pads_to_lcm_times_dp_size_and_fills_gaps(setup: Distribu
         placements=[Replicate()],
         tensor_shapes=shapes,
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
 
     assert buffer.layout.tensor_shapes == tuple(shapes)
@@ -88,12 +54,12 @@ def test_dbuffer_layout_pads_to_lcm_times_dp_size_and_fills_gaps(setup: Distribu
 
 
 @pytest.mark.distributed
-def test_dbuffer_layout_aligns_fragment_offsets_to_rows(setup: DistributedSetup):
+def test_dbuffer_layout_aligns_fragment_offsets_to_rows(distributed_setup):
     """DBuffer layout keeps small tensors aligned to their non-leading dimensions."""
-    if setup.world_size < 2:
+    if distributed_setup.world_size < 2:
         pytest.skip("DBuffer layout test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (2,))
+    mesh = init_device_mesh(distributed_setup.device.type, (2,))
     shapes = [torch.Size((4, 4)), torch.Size((1, 6))]
 
     buffer = DBuffer(
@@ -101,7 +67,7 @@ def test_dbuffer_layout_aligns_fragment_offsets_to_rows(setup: DistributedSetup)
         placements=[Replicate()],
         tensor_shapes=shapes,
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
 
     assert buffer.layout.tensor_to_offset == (0, 18)
@@ -109,9 +75,9 @@ def test_dbuffer_layout_aligns_fragment_offsets_to_rows(setup: DistributedSetup)
 
 
 @pytest.mark.distributed
-def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
+def test_compute_layout_fills_lcm_padding_gaps(distributed_setup):
     """LCM packing fills row-aligned padding gaps on a 5-rank flat-sharded mesh."""
-    if setup.world_size < 5:
+    if distributed_setup.world_size < 5:
         pytest.skip("LCM padding-gap layout test requires at least 5 ranks.")
 
     # P0-P4 are zero-based logical tensor names matching tensor indices.
@@ -123,7 +89,7 @@ def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
         torch.Size((1, 6)),  # P4
     ]
 
-    mesh = init_device_mesh(setup.device.type, (5,))
+    mesh = init_device_mesh(distributed_setup.device.type, (5,))
     if mesh.get_coordinate() is None:
         pytest.skip("Rank is outside the 5-rank DBuffer mesh.")
 
@@ -132,7 +98,7 @@ def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
         placements=[Flat()],
         tensor_shapes=shapes,
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
     layout = buffer.layout
     expected_local_shapes_by_rank = [
@@ -153,9 +119,9 @@ def test_compute_layout_fills_lcm_padding_gaps(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_constructor_allocates_local_buffer(setup: DistributedSetup):
+def test_constructor_allocates_local_buffer(distributed_setup):
     """DBuffer allocates local storage from shape, mesh, placement, dtype, and device."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     tensor_shapes = [torch.Size((7, 3)), torch.Size((2, 5)), torch.Size((7,))]
     mesh_size = mesh.size()
 
@@ -164,36 +130,39 @@ def test_constructor_allocates_local_buffer(setup: DistributedSetup):
         placements=[Replicate()],
         tensor_shapes=tensor_shapes,
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
     sharded_buffer = DBuffer(
         mesh=mesh,
         placements=[Flat()],
         tensor_shapes=tensor_shapes,
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
 
     assert replicated_buffer.layout == sharded_buffer.layout
     assert replicated_buffer.layout.tensor_shapes == tuple(tensor_shapes)
     assert replicated_buffer.offset == 0
-    expected_sharded_local_numel = replicated_buffer.layout.size // setup.world_size
-    assert sharded_buffer.offset == setup.rank * expected_sharded_local_numel
+    expected_sharded_local_numel = replicated_buffer.layout.size // distributed_setup.world_size
+    assert sharded_buffer.offset == distributed_setup.rank * expected_sharded_local_numel
     assert replicated_buffer.local_buffer.numel() == replicated_buffer.layout.size
-    assert sharded_buffer.local_buffer.numel() == replicated_buffer.layout.size // setup.world_size
+    assert (
+        sharded_buffer.local_buffer.numel()
+        == replicated_buffer.layout.size // distributed_setup.world_size
+    )
     assert sharded_buffer.layout.size % (15 * mesh_size) == 0
     assert replicated_buffer.dtype == torch.float32
-    assert sharded_buffer.local_buffer.device == setup.device
+    assert sharded_buffer.local_buffer.device == distributed_setup.device
 
 
 @pytest.mark.distributed
-def test_from_local_reuses_required_local_buffer(setup: DistributedSetup):
+def test_from_local_reuses_required_local_buffer(distributed_setup):
     """DBuffer.from_local reuses caller-provided local storage without allocation."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
-    local_numel = replicated_buffer.layout.size // setup.world_size
-    offset = setup.rank * local_numel
+    local_numel = replicated_buffer.layout.size // distributed_setup.world_size
+    offset = distributed_setup.rank * local_numel
     local_buffer = replicated_buffer.local_buffer.narrow(0, offset, local_numel)
 
     sharded_buffer = DBuffer.from_local(
@@ -208,10 +177,10 @@ def test_from_local_reuses_required_local_buffer(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_replicate_get_local_tensor_and_dtensor(setup: DistributedSetup):
+def test_replicate_get_local_tensor_and_dtensor(distributed_setup):
     """Replicated DBuffer returns full local tensors and replicated DTensors."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
 
     buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
 
@@ -221,22 +190,24 @@ def test_replicate_get_local_tensor_and_dtensor(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_distribute_tensors_moves_inputs_to_mesh_device(setup: DistributedSetup):
+def test_distribute_tensors_moves_inputs_to_mesh_device(distributed_setup):
     """distribute_tensors moves full input tensors to the mesh device type."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     tensors = _same_tensors_on_all_ranks(torch.device("cpu"))
 
     buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
 
-    assert buffer.local_buffer.device == setup.device
-    _assert_dbuffer_local_tensors_close(buffer, [tensor.to(setup.device) for tensor in tensors])
+    assert buffer.local_buffer.device == distributed_setup.device
+    _assert_dbuffer_local_tensors_close(
+        buffer, [tensor.to(distributed_setup.device) for tensor in tensors]
+    )
 
 
 @pytest.mark.distributed
-def test_sharded_allgather_round_trip(setup: DistributedSetup):
+def test_sharded_allgather_round_trip(distributed_setup):
     """Sharded buffers round-trip through all-gather as contiguous tensor fragments."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
 
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
     layout = sharded_buffer.layout
@@ -252,10 +223,10 @@ def test_sharded_allgather_round_trip(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_sharded_allgather_into_existing_buffer(setup: DistributedSetup):
+def test_sharded_allgather_into_existing_buffer(distributed_setup):
     """Sharded buffers can all-gather directly into a preallocated replicated buffer."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
     destination = DBuffer(
         mesh=mesh,
@@ -274,15 +245,15 @@ def test_sharded_allgather_into_existing_buffer(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_mesh_axis_must_be_non_negative_int(setup: DistributedSetup):
+def test_mesh_axis_must_be_non_negative_int(distributed_setup):
     """DBuffer communication methods require explicit non-negative integer mesh axes."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     buffer = DBuffer(
         mesh=mesh,
         placements=[Replicate()],
         tensor_shapes=[torch.Size((4,))],
         dtype=torch.float32,
-        device=setup.device,
+        device=distributed_setup.device,
     )
 
     with pytest.raises(TypeError, match="Mesh axis must be an int"):
@@ -294,10 +265,10 @@ def test_mesh_axis_must_be_non_negative_int(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_replicate_scatter_round_trip(setup: DistributedSetup):
+def test_replicate_scatter_round_trip(distributed_setup):
     """Replicated buffers locally chunk into sharded buffers and all-gather back."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
 
     replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
     sharded_buffer = replicated_buffer.scatter(0, Flat())
@@ -315,8 +286,8 @@ def test_replicate_scatter_round_trip(setup: DistributedSetup):
     assert sharded_buffer.placements == (Flat(),)
     assert redistributed_sharded_buffer is redistribute_destination
     assert redistributed_sharded_buffer.placements == (Flat(),)
-    expected_sharded_local_numel = replicated_buffer.layout.size // setup.world_size
-    assert sharded_buffer.offset == setup.rank * expected_sharded_local_numel
+    expected_sharded_local_numel = replicated_buffer.layout.size // distributed_setup.world_size
+    assert sharded_buffer.offset == distributed_setup.rank * expected_sharded_local_numel
     assert (
         sharded_buffer.local_buffer.untyped_storage()
         is replicated_buffer.local_buffer.untyped_storage()
@@ -328,34 +299,34 @@ def test_replicate_scatter_round_trip(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_partial_allreduce(setup: DistributedSetup):
+def test_partial_allreduce(distributed_setup):
     """Partial buffers all-reduce into replicated buffers."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    rank_scale = float(setup.rank + 1)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    rank_scale = float(distributed_setup.rank + 1)
     tensors = [
-        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
-        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
 
     replicated_buffer = partial_buffer.allreduce(0)
 
-    scale_sum = float(setup.world_size * (setup.world_size + 1) // 2)
+    scale_sum = float(distributed_setup.world_size * (distributed_setup.world_size + 1) // 2)
     expected = [
-        torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
-        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), scale_sum, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
-def test_partial_allreduce_average(setup: DistributedSetup):
+def test_partial_allreduce_average(distributed_setup):
     """Partial buffers can all-reduce with AVG."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    rank_scale = float(setup.rank + 1)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    rank_scale = float(distributed_setup.rank + 1)
     tensors = [
-        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
-        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     partial_buffer = DBuffer.distribute_tensors(
         tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
@@ -371,22 +342,22 @@ def test_partial_allreduce_average(setup: DistributedSetup):
     replicated_buffer = partial_buffer.allreduce(0, out=destination)
 
     assert replicated_buffer is destination
-    scale_average = float(setup.world_size + 1) / 2.0
+    scale_average = float(distributed_setup.world_size + 1) / 2.0
     expected = [
-        torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
-        torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), scale_average, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), scale_average * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
-def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
+def test_partial_reduce_scatter_to_flat(distributed_setup):
     """Partial buffers reduce-scatter into sharded buffers."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    rank_scale = float(setup.rank + 1)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    rank_scale = float(distributed_setup.rank + 1)
     tensors = [
-        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
-        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
     layout = partial_buffer.layout
@@ -405,22 +376,22 @@ def test_partial_reduce_scatter_to_flat(setup: DistributedSetup):
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == layout
     assert replicated_buffer.layout == layout
-    scale_sum = float(setup.world_size * (setup.world_size + 1) // 2)
+    scale_sum = float(distributed_setup.world_size * (distributed_setup.world_size + 1) // 2)
     expected_tensors = [
-        torch.full((5, 3), scale_sum, dtype=torch.float32, device=setup.device),
-        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), scale_sum, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
-def test_partial_reduce_scatter_to_flat_average(setup: DistributedSetup):
+def test_partial_reduce_scatter_to_flat_average(distributed_setup):
     """Partial buffers can reduce-scatter with AVG."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    rank_scale = float(setup.rank + 1)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    rank_scale = float(distributed_setup.rank + 1)
     tensors = [
-        torch.full((5, 3), rank_scale, dtype=torch.float32, device=setup.device),
-        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     partial_buffer = DBuffer.distribute_tensors(
         tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
@@ -433,19 +404,19 @@ def test_partial_reduce_scatter_to_flat_average(setup: DistributedSetup):
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == layout
     assert replicated_buffer.layout == layout
-    scale_average = float(setup.world_size + 1) / 2.0
+    scale_average = float(distributed_setup.world_size + 1) / 2.0
     expected_tensors = [
-        torch.full((5, 3), scale_average, dtype=torch.float32, device=setup.device),
-        torch.full((4,), scale_average * 10, dtype=torch.float32, device=setup.device),
+        torch.full((5, 3), scale_average, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), scale_average * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
 
 
 @pytest.mark.distributed
-def test_get_dtensor_from_sharded_buffer(setup: DistributedSetup):
+def test_get_dtensor_from_sharded_buffer(distributed_setup):
     """Sharded DBuffer exposes per-tensor local shards as DTensors."""
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat()])
 
     dtensor = sharded_buffer.get_dtensor(0)
@@ -457,14 +428,16 @@ def test_get_dtensor_from_sharded_buffer(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
+def test_2d_mesh_replicate_flat_round_trip(distributed_setup):
     """A 2D mesh can replicate on one axis and flat-shard on the other."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
+    if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("replicate", "flat")
+        distributed_setup.device.type,
+        (2, distributed_setup.world_size // 2),
+        mesh_dim_names=("replicate", "flat"),
     )
 
     sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
@@ -474,13 +447,15 @@ def test_2d_mesh_replicate_flat_round_trip(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_2d_mesh_flat_before_replicate_is_rejected(setup: DistributedSetup):
+def test_2d_mesh_flat_before_replicate_is_rejected(distributed_setup):
     """Flat axes must be a suffix to keep every local buffer contiguous."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
+    if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
     mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("flat", "replicate")
+        distributed_setup.device.type,
+        (2, distributed_setup.world_size // 2),
+        mesh_dim_names=("flat", "replicate"),
     )
 
     with pytest.raises(ValueError, match="Flat placements must be a suffix"):
@@ -489,19 +464,21 @@ def test_2d_mesh_flat_before_replicate_is_rejected(setup: DistributedSetup):
             placements=[Flat(), Replicate()],
             tensor_shapes=[torch.Size((6, 4))],
             dtype=torch.float32,
-            device=setup.device,
+            device=distributed_setup.device,
         )
 
 
 @pytest.mark.distributed
-def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
+def test_2d_mesh_shards_across_all_ranks(distributed_setup):
     """Multiple Flat axes shard local storage by the product of their mesh sizes."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
+    if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+        distributed_setup.device.type,
+        (2, distributed_setup.world_size // 2),
+        mesh_dim_names=("dp_outer", "dp_inner"),
     )
     fully_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Flat(), Flat()])
 
@@ -521,18 +498,20 @@ def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetup):
+def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(distributed_setup):
     """Partial+Flat reduce-scatter reduces the existing Flat local shard."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
+    if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
     mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+        distributed_setup.device.type,
+        (2, distributed_setup.world_size // 2),
+        mesh_dim_names=("dp_outer", "dp_inner"),
     )
     outer_scale = float(mesh.get_local_rank(0) + 1)
     tensors = [
-        torch.full((6, 2), outer_scale, dtype=torch.float32, device=setup.device),
-        torch.full((4,), outer_scale * 10, dtype=torch.float32, device=setup.device),
+        torch.full((6, 2), outer_scale, dtype=torch.float32, device=distributed_setup.device),
+        torch.full((4,), outer_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
 
     partial_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial(), Flat()])
@@ -554,21 +533,25 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetu
 
     outer_scale_sum = float(mesh.size(0) * (mesh.size(0) + 1) // 2)
     expected = [
-        torch.full((6, 2), outer_scale_sum, dtype=torch.float32, device=setup.device),
-        torch.full((4,), outer_scale_sum * 10, dtype=torch.float32, device=setup.device),
+        torch.full((6, 2), outer_scale_sum, dtype=torch.float32, device=distributed_setup.device),
+        torch.full(
+            (4,), outer_scale_sum * 10, dtype=torch.float32, device=distributed_setup.device
+        ),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
 @pytest.mark.distributed
-def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
+def test_2d_mesh_replicate_flat_scatter_to_flat_flat(distributed_setup):
     """Replicate+Flat scatter chunks the existing Flat local shard."""
-    if setup.world_size < 4 or setup.world_size % 2 != 0:
+    if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
-    tensors = _same_tensors_on_all_ranks(setup.device)
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     mesh = init_device_mesh(
-        setup.device.type, (2, setup.world_size // 2), mesh_dim_names=("dp_outer", "dp_inner")
+        distributed_setup.device.type,
+        (2, distributed_setup.world_size // 2),
+        mesh_dim_names=("dp_outer", "dp_inner"),
     )
 
     replicated_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])

--- a/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_dbuffer.py
@@ -445,7 +445,9 @@ def test_2d_mesh_shards_across_all_ranks(setup: DistributedSetup):
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert fully_sharded_buffer.local_buffer.numel() == fully_sharded_buffer.layout.size // mesh.size()
+    assert (
+        fully_sharded_buffer.local_buffer.numel() == fully_sharded_buffer.layout.size // mesh.size()
+    )
     for index, _ in enumerate(tensors):
         assert fully_sharded_buffer.get_tensor(index).is_contiguous()
 
@@ -477,7 +479,10 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(setup: DistributedSetu
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert fully_sharded_buffer.local_buffer.numel() == partial_sharded_buffer.local_buffer.numel() // 2
+    assert (
+        fully_sharded_buffer.local_buffer.numel()
+        == partial_sharded_buffer.local_buffer.numel() // 2
+    )
 
     outer_scale_sum = float(mesh.size(0) * (mesh.size(0) + 1) // 2)
     expected = [
@@ -510,5 +515,8 @@ def test_2d_mesh_replicate_flat_scatter_to_flat_flat(setup: DistributedSetup):
         + mesh.get_local_rank("dp_outer") * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert fully_sharded_buffer.local_buffer.numel() == replicated_sharded_buffer.local_buffer.numel() // 2
+    assert (
+        fully_sharded_buffer.local_buffer.numel()
+        == replicated_sharded_buffer.local_buffer.numel() // 2
+    )
     _assert_dbuffer_contains_tensors(replicated_buffer, tensors)

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -244,6 +244,42 @@ def test_backward_averages_across_dp_and_accumulates_across_calls(setup: Distrib
 
 
 @pytest.mark.distributed
+def test_next_forward_uses_optimizer_updated_weights(setup: DistributedSetup):
+    """The next forward should observe weights updated by the previous optimizer step."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    model = nn.Linear(1, setup.world_size, bias=False, dtype=torch.bfloat16).to(setup.device)
+    with torch.no_grad():
+        model.weight.fill_(1.0)
+
+    fully_shard(
+        model,
+        mesh=mesh,
+        placements=_flat_placements(),
+        mixed_precision_policy=MixedPrecisionPolicy(main_params_dtype=torch.float32),
+    )
+    # SGD's foreach/fused CUDA paths require matching parameter and gradient dtypes.
+    # Use the scalar path to exercise FP32 main weights with default BF16 main grads.
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.25, foreach=False)
+    x = torch.ones(1, 1, device=setup.device, dtype=torch.bfloat16)
+
+    def train_iteration() -> torch.Tensor:
+        optimizer.zero_grad(set_to_none=True)
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+        return loss.detach().float()
+
+    first_loss = train_iteration()
+    second_loss = train_iteration()
+
+    with pytest.raises(AssertionError):
+        torch.testing.assert_close(second_loss, first_loss)
+
+
+@pytest.mark.distributed
 def test_meta_parameters_initialize_with_reset_parameters(setup: DistributedSetup):
     """Meta parameters should be replaced by sharded DTensors and initialized in place."""
     if setup.world_size < 2:

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -3,13 +3,9 @@
 """Unit tests for the minimal Megatron-FSDP path."""
 
 import logging
-import os
-from collections.abc import Iterator
-from dataclasses import dataclass
 
 import pytest
 import torch
-import torch.distributed as dist
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DTensor
@@ -22,37 +18,6 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class DistributedSetup:
-    """Per-rank distributed test setup."""
-
-    rank: int
-    world_size: int
-    device: torch.device
-
-
-@pytest.fixture(scope="module")
-def setup() -> Iterator[DistributedSetup]:
-    """Read torchrun rank state and set up this rank's local device."""
-    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
-        pytest.skip("Not running under torchrun.")
-
-    rank = int(os.environ["RANK"])
-    world_size = int(os.environ["WORLD_SIZE"])
-    local_rank = int(os.environ.get("LOCAL_RANK", rank))
-
-    if torch.cuda.is_available():
-        torch.cuda.set_device(local_rank)
-        device = torch.device(f"cuda:{local_rank}")
-    else:
-        device = torch.device("cpu")
-
-    yield DistributedSetup(rank=rank, world_size=world_size, device=device)
-
-    if dist.is_initialized():
-        dist.destroy_process_group()
 
 
 class TinyModel(nn.Module):
@@ -113,18 +78,6 @@ class NonLeafViewModel(nn.Module):
         return SaveNonLeafWeightView.apply(x, weight_view)
 
 
-class ConstantMetaModel(nn.Module):
-    """Model whose meta parameter is initialized by reset_parameters()."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.weight = nn.Parameter(torch.empty(4, 4, device="meta"))
-
-    def reset_parameters(self) -> None:
-        """Initialize the weight to a deterministic value."""
-        self.weight.fill_(3.0)
-
-
 def _flat_placements() -> Placements:
     return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
 
@@ -134,15 +87,18 @@ def _mb(num_bytes: int) -> str:
 
 
 @pytest.mark.distributed
-def test_fully_shard_losses_match_baseline(setup: DistributedSetup):
+def test_fully_shard_losses_match_baseline(distributed_setup):
     """Minimal per-module FSDP training should match single-rank SGD."""
-    if setup.world_size < 2:
+    rank = distributed_setup.rank
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    mesh = init_device_mesh(device.type, (world_size,))
     torch.manual_seed(1234)
-    baseline = TinyModel().to(setup.device)
-    model = TinyModel().to(setup.device)
+    baseline = TinyModel().to(device)
+    model = TinyModel().to(device)
     model.load_state_dict(baseline.state_dict())
 
     fully_shard(model.fc1, mesh=mesh, placements=_flat_placements())
@@ -150,8 +106,8 @@ def test_fully_shard_losses_match_baseline(setup: DistributedSetup):
     baseline_optimizer = torch.optim.SGD(baseline.parameters(), lr=0.05)
     optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
 
-    x = torch.randn(3, 8, device=setup.device)
-    target = torch.randn(3, 4, device=setup.device)
+    x = torch.randn(3, 8, device=device)
+    target = torch.randn(3, 4, device=device)
 
     for step in range(5):
         baseline_optimizer.zero_grad()
@@ -161,7 +117,7 @@ def test_fully_shard_losses_match_baseline(setup: DistributedSetup):
         loss = torch.nn.functional.mse_loss(model(x), target)
         logger.info(
             "FSDP train parity: rank=%s, step=%s, baseline_loss=%s, sharded_loss=%s",
-            setup.rank,
+            rank,
             step,
             baseline_loss.item(),
             loss.item(),
@@ -175,13 +131,15 @@ def test_fully_shard_losses_match_baseline(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_nested_fully_shard_excludes_child_owned_parameters(setup: DistributedSetup):
+def test_nested_fully_shard_excludes_child_owned_parameters(distributed_setup):
     """An outer FSDP unit owns direct parameters but not nested child-unit parameters."""
-    if setup.world_size < 2:
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = NestedModel().to(setup.device)
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = NestedModel().to(device)
 
     fully_shard(model.inner, mesh=mesh, placements=_flat_placements())
     fully_shard(model, mesh=mesh, placements=_flat_placements())
@@ -196,13 +154,15 @@ def test_nested_fully_shard_excludes_child_owned_parameters(setup: DistributedSe
 
 
 @pytest.mark.distributed
-def test_frozen_parameter_group_does_not_allocate_main_grad(setup: DistributedSetup):
+def test_frozen_parameter_group_does_not_allocate_main_grad(distributed_setup):
     """A non-trainable parameter group should not allocate persistent main gradients."""
-    if setup.world_size < 2:
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = nn.Linear(4, 4, bias=False).to(setup.device)
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = nn.Linear(4, 4, bias=False).to(device)
     model.weight.requires_grad_(False)
 
     fully_shard(model, mesh=mesh, placements=_flat_placements())
@@ -215,36 +175,41 @@ def test_frozen_parameter_group_does_not_allocate_main_grad(setup: DistributedSe
 pytest.mark.distributed
 
 
-def test_backward_averages_across_dp_and_accumulates_across_calls(setup: DistributedSetup):
+def test_backward_averages_across_dp_and_accumulates_across_calls(distributed_setup):
     """Each backward averages over DP ranks; repeated backwards accumulate by summing."""
-    if setup.world_size < 2:
+    rank = distributed_setup.rank
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = nn.Linear(1, setup.world_size, bias=False).to(setup.device)
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = nn.Linear(1, world_size, bias=False).to(device)
     with torch.no_grad():
         model.weight.fill_(1.0)
 
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    x = torch.full((1, 1), float(setup.rank + 1), device=setup.device)
+    x = torch.full((1, 1), float(rank + 1), device=device)
     model(x).sum().backward()
     model(x).sum().backward()
 
     assert isinstance(model.weight.grad, DTensor)
     local_grad = model.weight.grad.to_local()
-    expected = torch.full_like(local_grad, float(setup.world_size + 1))
+    expected = torch.full_like(local_grad, float(world_size + 1))
     torch.testing.assert_close(local_grad, expected, rtol=0, atol=0)
 
 
 @pytest.mark.distributed
-def test_next_forward_uses_optimizer_updated_weights(setup: DistributedSetup):
+def test_next_forward_uses_optimizer_updated_weights(distributed_setup):
     """The next forward should observe weights updated by the previous optimizer step."""
-    if setup.world_size < 2:
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = nn.Linear(1, setup.world_size, bias=False, dtype=torch.bfloat16).to(setup.device)
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = nn.Linear(1, world_size, bias=False, dtype=torch.bfloat16).to(device)
     with torch.no_grad():
         model.weight.fill_(1.0)
 
@@ -257,7 +222,7 @@ def test_next_forward_uses_optimizer_updated_weights(setup: DistributedSetup):
     # SGD's foreach/fused CUDA paths require matching parameter and gradient dtypes.
     # Use the scalar path to exercise FP32 main weights with default BF16 main grads.
     optimizer = torch.optim.SGD(model.parameters(), lr=0.25, foreach=False)
-    x = torch.ones(1, 1, device=setup.device, dtype=torch.bfloat16)
+    x = torch.ones(1, 1, device=device, dtype=torch.bfloat16)
 
     def train_iteration() -> torch.Tensor:
         optimizer.zero_grad(set_to_none=True)
@@ -274,34 +239,41 @@ def test_next_forward_uses_optimizer_updated_weights(setup: DistributedSetup):
 
 
 @pytest.mark.distributed
-def test_meta_parameters_initialize_with_reset_parameters(setup: DistributedSetup):
-    """Meta parameters should be replaced by sharded DTensors and initialized in place."""
-    if setup.world_size < 2:
+def test_cpu_initialized_parameters_shard_to_mesh_device(distributed_setup):
+    """CPU-initialized parameters should be sharded with their real values."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = ConstantMetaModel()
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = nn.Linear(4, 4, bias=False)
+    with torch.no_grad():
+        model.weight.fill_(3.0)
+    expected_weight = model.weight.detach().to(device)
 
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     (group,) = model.parameter_groups()
     full_weight = group.model_weight.allgather(0).get_local_tensor(0)
-    assert not full_weight.is_meta
-    torch.testing.assert_close(full_weight, torch.full_like(full_weight, 3.0))
+    assert full_weight.device.type == device.type
+    torch.testing.assert_close(full_weight, expected_weight)
 
 
 @pytest.mark.distributed
-def test_non_leaf_parameter_view_survives_storage_resize(setup: DistributedSetup):
+def test_non_leaf_parameter_view_survives_storage_resize(distributed_setup):
     """A non-leaf parameter view saved for backward should survive full-storage resize."""
-    if setup.world_size < 2:
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = NonLeafViewModel().to(setup.device)
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = NonLeafViewModel().to(device)
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     group = model.parameter_groups()[0]
-    x = torch.randn(8, device=setup.device, requires_grad=True)
+    x = torch.randn(8, device=device, requires_grad=True)
     loss = model(x).sum()
 
     assert group._unsharded_model_weight is not None
@@ -315,14 +287,17 @@ def test_non_leaf_parameter_view_survives_storage_resize(setup: DistributedSetup
 
 
 @pytest.mark.distributed
-def test_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
+def test_fully_shard_reduces_peak_training_memory(distributed_setup):
     """Per-layer FSDP should reduce peak CUDA memory during training."""
-    if setup.world_size < 2:
+    rank = distributed_setup.rank
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
-    if setup.device.type != "cuda":
+    if device.type != "cuda":
         pytest.skip("Peak memory verification requires CUDA.")
 
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    mesh = init_device_mesh(device.type, (world_size,))
     dim = 1024
     layers = 16
     batch = 8
@@ -337,14 +312,14 @@ def test_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
 
     torch.manual_seed(4321)
     baseline = nn.Sequential(*[nn.Linear(dim, dim, dtype=dtype) for _ in range(layers)]).to(
-        setup.device
+        device
     )
     baseline_optimizer = torch.optim.AdamW(baseline.parameters(), lr=0.01)
-    x = torch.randn(batch, dim, device=setup.device, dtype=dtype)
-    torch.cuda.reset_peak_memory_stats(setup.device)
+    x = torch.randn(batch, dim, device=device, dtype=dtype)
+    torch.cuda.reset_peak_memory_stats(device)
     train_steps(baseline, baseline_optimizer, x)
-    torch.cuda.synchronize(setup.device)
-    baseline_peak = torch.cuda.max_memory_allocated(setup.device)
+    torch.cuda.synchronize(device)
+    baseline_peak = torch.cuda.max_memory_allocated(device)
 
     del baseline_optimizer
     del baseline
@@ -353,7 +328,7 @@ def test_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
 
     torch.manual_seed(4321)
     model = nn.Sequential(*[nn.Linear(dim, dim, dtype=dtype) for _ in range(layers)]).to(
-        setup.device
+        device
     )
     for layer in model:
         fully_shard(
@@ -367,14 +342,14 @@ def test_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
     optimizer = torch.optim.AdamW(model.parameters(), lr=0.01)
     torch.cuda.empty_cache()
 
-    x = torch.randn(batch, dim, device=setup.device, dtype=dtype)
-    torch.cuda.reset_peak_memory_stats(setup.device)
+    x = torch.randn(batch, dim, device=device, dtype=dtype)
+    torch.cuda.reset_peak_memory_stats(device)
     train_steps(model, optimizer, x)
-    torch.cuda.synchronize(setup.device)
-    sharded_peak = torch.cuda.max_memory_allocated(setup.device)
+    torch.cuda.synchronize(device)
+    sharded_peak = torch.cuda.max_memory_allocated(device)
     logger.info(
         "FSDP peak memory: rank=%s, baseline=%s, sharded=%s",
-        setup.rank,
+        rank,
         _mb(baseline_peak),
         _mb(sharded_peak),
     )

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -2,7 +2,7 @@
 
 """Unit tests for the minimal Megatron-FSDP path."""
 
-import gc
+import logging
 import os
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -17,11 +17,12 @@ from torch.distributed.tensor import DTensor
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
     FsdpModule,
-    ParameterGroup,
     Placements,
     Replicate,
     fully_shard,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -107,7 +108,10 @@ class NonLeafViewModel(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run using a non-leaf view of the parameter."""
-        return SaveNonLeafWeightView.apply(x, self.weight.view_as(self.weight))
+        weight_view = self.weight.view_as(self.weight)
+        assert self.weight.is_leaf
+        assert not weight_view.is_leaf
+        return SaveNonLeafWeightView.apply(x, weight_view)
 
 
 class ConstantMetaModel(nn.Module):
@@ -122,46 +126,31 @@ class ConstantMetaModel(nn.Module):
         self.weight.fill_(3.0)
 
 
-class MixedMetaRealModel(nn.Module):
-    """Model with unsupported mixed meta and real direct parameters."""
-
-    def __init__(self, device: torch.device) -> None:
-        super().__init__()
-        self.weight = nn.Parameter(torch.empty(4, 4, device="meta"))
-        self.bias = nn.Parameter(torch.ones(4, device=device))
-
-    def reset_parameters(self) -> None:
-        """Initialize parameters."""
-        self.weight.fill_(1.0)
-        self.bias.zero_()
-
-
 def _flat_placements() -> Placements:
     return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
 
 
-def _full_named_parameters(module: nn.Module) -> dict[str, torch.Tensor]:
-    result = {}
-    for module_name, child in module.named_modules():
-        if not isinstance(child, FsdpModule):
-            continue
-        prefix = f"{module_name}." if module_name else ""
-        for group in child.parameter_groups():
-            full_weight = group.main_weight.redistribute([Flat()]).allgather(0)
-            for index, name in enumerate(group.sharded_parameters):
-                result[f"{prefix}{name}"] = full_weight.get_tensor(index).detach().clone()
-    return result
-
-
-def _full_model_weight(group: ParameterGroup) -> torch.Tensor:
-    return group.model_weight.redistribute([Flat()]).allgather(0).get_tensor(0)
+def _mb(num_bytes: int) -> str:
+    return f"{num_bytes / 1024**2:.2f} MB"
 
 
 @pytest.mark.distributed
-def test_experimental_fully_shard_train_step_matches_baseline(setup: DistributedSetup):
+def test_fully_shard_train_step_matches_baseline(setup: DistributedSetup):
     """A minimal per-module FSDP train step should match single-rank SGD."""
     if setup.world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
+
+    def full_named_parameters(module: nn.Module) -> dict[str, torch.Tensor]:
+        result = {}
+        for module_name, child in module.named_modules():
+            if not isinstance(child, FsdpModule):
+                continue
+            prefix = f"{module_name}." if module_name else ""
+            for group in child.parameter_groups():
+                full_weight = group.main_weight.allgather(0)
+                for index, name in enumerate(group.parameter_names):
+                    result[f"{prefix}{name}"] = full_weight.get_tensor(index).detach().clone()
+        return result
 
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     torch.manual_seed(1234)
@@ -186,9 +175,9 @@ def test_experimental_fully_shard_train_step_matches_baseline(setup: Distributed
     loss.backward()
     optimizer.step()
 
-    sharded_params = _full_named_parameters(model)
+    full_params = full_named_parameters(model)
     for name, expected in baseline.named_parameters():
-        torch.testing.assert_close(sharded_params[name], expected, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(full_params[name], expected, rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.distributed
@@ -203,10 +192,8 @@ def test_nested_fully_shard_excludes_child_owned_parameters(setup: DistributedSe
     fully_shard(model.inner, mesh=mesh, placements=_flat_placements())
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    inner_names = [
-        name for group in model.inner.parameter_groups() for name in group.sharded_parameters
-    ]
-    outer_names = [name for group in model.parameter_groups() for name in group.sharded_parameters]
+    inner_names = [name for group in model.inner.parameter_groups() for name in group.parameter_names]
+    outer_names = [name for group in model.parameter_groups() for name in group.parameter_names]
 
     assert inner_names == ["weight"]
     assert outer_names == ["bias"]
@@ -230,73 +217,34 @@ def test_frozen_parameter_group_does_not_allocate_main_grad(setup: DistributedSe
 
 
 @pytest.mark.distributed
-def test_default_main_buffer_dtypes_follow_policy_contract(setup: DistributedSetup):
-    """Default main weights are FP32 while default main gradients match parameter dtype."""
+def test_bfloat16_main_grads_follow_grad_dtype(setup: DistributedSetup):
+    """BF16 full grads should reduce into main_grad without casting before reduce-scatter."""
     if setup.world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = nn.Linear(4, 4, bias=False, dtype=torch.float64).to(setup.device)
-
+    model = nn.Linear(4, 4, bias=False, dtype=torch.bfloat16).to(setup.device)
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     (group,) = model.parameter_groups()
-    assert group.dtype is torch.float64
     assert group.main_weight.local_buffer.dtype is torch.float32
     assert group.main_grad is not None
-    assert group.main_grad.local_buffer.dtype is torch.float64
+    assert group.main_grad.local_buffer.dtype is torch.bfloat16
+    assert group.unsharded_parameters[0].grad_dtype is torch.bfloat16
+    assert group.sharded_parameters[0].dtype is group.main_weight.local_buffer.dtype
+    assert group.sharded_parameters[0].grad_dtype is group.main_grad.local_buffer.dtype
 
+    x = torch.randn(2, 4, device=setup.device, dtype=torch.bfloat16)
 
-@pytest.mark.distributed
-def test_full_mesh_is_used_for_dbuffers(setup: DistributedSetup):
-    """This version uses the full mesh for DBuffer storage."""
-    if setup.world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(setup.device.type, (1, setup.world_size), mesh_dim_names=("tp", "dp"))
-    placements = Placements(
-        dp_axes=["tp", "dp"],
-        parameter=[Replicate(), Flat()],
-        gradient=[Replicate(), Flat()],
-        optimizer=[Replicate(), Flat()],
-    )
-    model = nn.Linear(4, 4, bias=False).to(setup.device)
-
-    fully_shard(model, mesh=mesh, placements=placements)
-
-    (group,) = model.parameter_groups()
-    assert group.mesh is mesh
-    assert group.main_weight.mesh is mesh
-    assert group.model_weight.mesh is mesh
-    assert group.main_grad is not None
-    assert group.main_grad.mesh is mesh
+    model.zero_grad(set_to_none=True)
+    model(x).sum().backward()
     assert isinstance(model.weight, DTensor)
-    assert model.weight.device_mesh is mesh
-
-
-@pytest.mark.distributed
-def test_sharded_parameter_contract_uses_dtensors(setup: DistributedSetup):
-    """Resting sharded parameters and gradients should be DTensors."""
-    if setup.world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = nn.Linear(4, 4, bias=False).to(setup.device)
-    original_weight = model.weight
-
-    fully_shard(model, mesh=mesh, placements=_flat_placements())
-
-    (group,) = model.parameter_groups()
-    assert group.unsharded_parameters["weight"] is original_weight
-    assert isinstance(model.weight, DTensor)
-    assert isinstance(model.weight.data, DTensor)
-    model(torch.randn(2, 4, device=setup.device)).sum().backward()
-    assert isinstance(model.weight, DTensor)
+    assert model.weight.dtype is group.main_weight.local_buffer.dtype
     assert isinstance(model.weight.grad, DTensor)
-    assert original_weight.grad is None
+    assert model.weight.grad.dtype is group.main_grad.local_buffer.dtype
 
 
-@pytest.mark.distributed
+pytest.mark.distributed
 def test_backward_averages_across_dp_and_accumulates_across_calls(setup: DistributedSetup):
     """Each backward averages over DP ranks; repeated backwards accumulate by summing."""
     if setup.world_size < 2:
@@ -330,42 +278,10 @@ def test_meta_parameters_initialize_with_reset_parameters(setup: DistributedSetu
 
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    assert isinstance(model.weight, DTensor)
-    assert not model.weight.to_local().is_meta
     (group,) = model.parameter_groups()
-    assert not group.model_weight.local_buffer.is_meta
-    assert group.model_weight.local_buffer.numel() > 0
-    full_weight = _full_model_weight(group)
+    full_weight = group.model_weight.allgather(0).get_tensor(0)
+    assert not full_weight.is_meta
     torch.testing.assert_close(full_weight, torch.full_like(full_weight, 3.0))
-
-
-@pytest.mark.distributed
-def test_model_weight_alias_is_rejected(setup: DistributedSetup):
-    """Model weights cannot alias the unsharded parameter buffer."""
-    if setup.world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    placements = Placements(
-        dp_axes=[0], parameter=[Replicate()], gradient=[Flat()], optimizer=[Flat()]
-    )
-    model = nn.Linear(4, 4, bias=False).to(setup.device)
-
-    with pytest.raises(AssertionError, match="storage is resized and released"):
-        fully_shard(model, mesh=mesh, placements=placements)
-
-
-@pytest.mark.distributed
-def test_meta_parameters_reject_mixed_direct_parameters(setup: DistributedSetup):
-    """A module cannot mix meta and real direct parameters when reset is required."""
-    if setup.world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = MixedMetaRealModel(setup.device)
-
-    with pytest.raises(ValueError, match="mixes meta and non-meta direct parameters"):
-        fully_shard(model, mesh=mesh, placements=_flat_placements())
 
 
 @pytest.mark.distributed
@@ -373,8 +289,6 @@ def test_non_leaf_parameter_view_survives_storage_resize(setup: DistributedSetup
     """A non-leaf parameter view saved for backward should survive full-storage resize."""
     if setup.world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
-    if setup.device.type != "cuda":
-        pytest.skip("Storage resize verification requires CUDA.")
 
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     model = NonLeafViewModel().to(setup.device)
@@ -395,8 +309,8 @@ def test_non_leaf_parameter_view_survives_storage_resize(setup: DistributedSetup
 
 
 @pytest.mark.distributed
-def test_experimental_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
-    """Per-layer FSDP should reduce peak CUDA memory during a train step."""
+def test_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
+    """Per-layer FSDP should reduce peak CUDA memory during training."""
     if setup.world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
     if setup.device.type != "cuda":
@@ -406,35 +320,45 @@ def test_experimental_fully_shard_reduces_peak_training_memory(setup: Distribute
     dim = 1024
     layers = 16
     batch = 8
+    steps = 2
+
+    def train_steps(model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor) -> None:
+        for _ in range(steps):
+            optimizer.zero_grad(set_to_none=True)
+            model(x).sum().backward()
+            optimizer.step()
 
     torch.manual_seed(4321)
-    baseline = nn.Sequential(*[nn.Linear(dim, dim, bias=False) for _ in range(layers)]).to(
-        setup.device
-    )
+    baseline = nn.Sequential(*[nn.Linear(dim, dim) for _ in range(layers)]).to(setup.device)
+    baseline_optimizer = torch.optim.AdamW(baseline.parameters(), lr=0.01)
     x = torch.randn(batch, dim, device=setup.device)
     torch.cuda.reset_peak_memory_stats(setup.device)
-    baseline(x).sum().backward()
+    train_steps(baseline, baseline_optimizer, x)
     torch.cuda.synchronize(setup.device)
     baseline_peak = torch.cuda.max_memory_allocated(setup.device)
 
+    del baseline_optimizer
     del baseline
     del x
-    gc.collect()
     torch.cuda.empty_cache()
 
     torch.manual_seed(4321)
-    model = nn.Sequential(*[nn.Linear(dim, dim, bias=False) for _ in range(layers)]).to(
-        setup.device
-    )
+    model = nn.Sequential(*[nn.Linear(dim, dim) for _ in range(layers)]).to(setup.device)
     for layer in model:
         fully_shard(layer, mesh=mesh, placements=_flat_placements())
-    gc.collect()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=0.01)
     torch.cuda.empty_cache()
 
     x = torch.randn(batch, dim, device=setup.device)
     torch.cuda.reset_peak_memory_stats(setup.device)
-    model(x).sum().backward()
+    train_steps(model, optimizer, x)
     torch.cuda.synchronize(setup.device)
     sharded_peak = torch.cuda.max_memory_allocated(setup.device)
+    logger.info(
+        "FSDP peak memory: rank=%s, baseline=%s, sharded=%s",
+        setup.rank,
+        _mb(baseline_peak),
+        _mb(sharded_peak),
+    )
 
     assert sharded_peak < baseline_peak

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -19,6 +19,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     FsdpModule,
     ParameterGroup,
     Placements,
+    Replicate,
     fully_shard,
 )
 
@@ -247,14 +248,17 @@ def test_default_main_buffer_dtypes_follow_policy_contract(setup: DistributedSet
 
 
 @pytest.mark.distributed
-def test_full_mesh_is_distinct_from_dbuffer_dp_submesh(setup: DistributedSetup):
-    """ParameterGroup keeps the full mesh while DBuffers use only DP axes."""
+def test_full_mesh_is_used_for_dbuffers(setup: DistributedSetup):
+    """This version uses the full mesh for DBuffer storage."""
     if setup.world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
     mesh = init_device_mesh(setup.device.type, (1, setup.world_size), mesh_dim_names=("tp", "dp"))
     placements = Placements(
-        dp_axes=["dp"], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()]
+        dp_axes=["tp", "dp"],
+        parameter=[Replicate(), Flat()],
+        gradient=[Replicate(), Flat()],
+        optimizer=[Replicate(), Flat()],
     )
     model = nn.Linear(4, 4, bias=False).to(setup.device)
 
@@ -262,14 +266,12 @@ def test_full_mesh_is_distinct_from_dbuffer_dp_submesh(setup: DistributedSetup):
 
     (group,) = model.parameter_groups()
     assert group.mesh is mesh
-    assert group.dp_mesh.ndim == 1
-    assert group.dp_mesh.size() == setup.world_size
-    assert group.main_weight.mesh is group.dp_mesh
-    assert group.model_weight.mesh is group.dp_mesh
+    assert group.main_weight.mesh is mesh
+    assert group.model_weight.mesh is mesh
     assert group.main_grad is not None
-    assert group.main_grad.mesh is group.dp_mesh
+    assert group.main_grad.mesh is mesh
     assert isinstance(model.weight, DTensor)
-    assert model.weight.device_mesh is group.dp_mesh
+    assert model.weight.device_mesh is mesh
 
 
 @pytest.mark.distributed
@@ -291,6 +293,30 @@ def test_sharded_parameter_contract_uses_dtensors(setup: DistributedSetup):
     model(torch.randn(2, 4, device=setup.device)).sum().backward()
     assert isinstance(model.weight, DTensor)
     assert isinstance(model.weight.grad, DTensor)
+    assert original_weight.grad is None
+
+
+@pytest.mark.distributed
+def test_backward_averages_across_dp_and_accumulates_across_calls(setup: DistributedSetup):
+    """Each backward averages over DP ranks; repeated backwards accumulate by summing."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    model = nn.Linear(1, setup.world_size, bias=False).to(setup.device)
+    with torch.no_grad():
+        model.weight.fill_(1.0)
+
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    x = torch.full((1, 1), float(setup.rank + 1), device=setup.device)
+    model(x).sum().backward()
+    model(x).sum().backward()
+
+    assert isinstance(model.weight.grad, DTensor)
+    local_grad = model.weight.grad.to_local()
+    expected = torch.full_like(local_grad, float(setup.world_size + 1))
+    torch.testing.assert_close(local_grad, expected, rtol=0, atol=0)
 
 
 @pytest.mark.distributed
@@ -311,6 +337,22 @@ def test_meta_parameters_initialize_with_reset_parameters(setup: DistributedSetu
     assert group.model_weight.local_buffer.numel() > 0
     full_weight = _full_model_weight(group)
     torch.testing.assert_close(full_weight, torch.full_like(full_weight, 3.0))
+
+
+@pytest.mark.distributed
+def test_model_weight_alias_is_rejected(setup: DistributedSetup):
+    """Model weights cannot alias the unsharded parameter buffer."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    placements = Placements(
+        dp_axes=[0], parameter=[Replicate()], gradient=[Flat()], optimizer=[Flat()]
+    )
+    model = nn.Linear(4, 4, bias=False).to(setup.device)
+
+    with pytest.raises(AssertionError, match="storage is resized and released"):
+        fully_shard(model, mesh=mesh, placements=placements)
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -285,7 +285,7 @@ def test_meta_parameters_initialize_with_reset_parameters(setup: DistributedSetu
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     (group,) = model.parameter_groups()
-    full_weight = group.model_weight.allgather(0).get_tensor(0)
+    full_weight = group.model_weight.allgather(0).get_local_tensor(0)
     assert not full_weight.is_meta
     torch.testing.assert_close(full_weight, torch.full_like(full_weight, 3.0))
 

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Unit tests for the experimental minimal Megatron-FSDP path."""
+"""Unit tests for the minimal Megatron-FSDP path."""
 
 import gc
 import os
@@ -17,6 +17,7 @@ from torch.distributed.tensor import DTensor
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
     FsdpModule,
+    ParameterGroup,
     Placements,
     fully_shard,
 )
@@ -108,6 +109,32 @@ class NonLeafViewModel(nn.Module):
         return SaveNonLeafWeightView.apply(x, self.weight.view_as(self.weight))
 
 
+class ConstantMetaModel(nn.Module):
+    """Model whose meta parameter is initialized by reset_parameters()."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(4, 4, device="meta"))
+
+    def reset_parameters(self) -> None:
+        """Initialize the weight to a deterministic value."""
+        self.weight.fill_(3.0)
+
+
+class MixedMetaRealModel(nn.Module):
+    """Model with unsupported mixed meta and real direct parameters."""
+
+    def __init__(self, device: torch.device) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(4, 4, device="meta"))
+        self.bias = nn.Parameter(torch.ones(4, device=device))
+
+    def reset_parameters(self) -> None:
+        """Initialize parameters."""
+        self.weight.fill_(1.0)
+        self.bias.zero_()
+
+
 def _flat_placements() -> Placements:
     return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
 
@@ -120,9 +147,13 @@ def _full_named_parameters(module: nn.Module) -> dict[str, torch.Tensor]:
         prefix = f"{module_name}." if module_name else ""
         for group in child.parameter_groups():
             full_weight = group.main_weight.redistribute([Flat()]).allgather(0)
-            for index, name in enumerate(group.parameters):
+            for index, name in enumerate(group.sharded_parameters):
                 result[f"{prefix}{name}"] = full_weight.get_tensor(index).detach().clone()
     return result
+
+
+def _full_model_weight(group: ParameterGroup) -> torch.Tensor:
+    return group.model_weight.redistribute([Flat()]).allgather(0).get_tensor(0)
 
 
 @pytest.mark.distributed
@@ -171,8 +202,10 @@ def test_nested_fully_shard_excludes_child_owned_parameters(setup: DistributedSe
     fully_shard(model.inner, mesh=mesh, placements=_flat_placements())
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    inner_names = [name for group in model.inner.parameter_groups() for name in group.parameters]
-    outer_names = [name for group in model.parameter_groups() for name in group.parameters]
+    inner_names = [
+        name for group in model.inner.parameter_groups() for name in group.sharded_parameters
+    ]
+    outer_names = [name for group in model.parameter_groups() for name in group.sharded_parameters]
 
     assert inner_names == ["weight"]
     assert outer_names == ["bias"]
@@ -214,6 +247,32 @@ def test_default_main_buffer_dtypes_follow_policy_contract(setup: DistributedSet
 
 
 @pytest.mark.distributed
+def test_full_mesh_is_distinct_from_dbuffer_dp_submesh(setup: DistributedSetup):
+    """ParameterGroup keeps the full mesh while DBuffers use only DP axes."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (1, setup.world_size), mesh_dim_names=("tp", "dp"))
+    placements = Placements(
+        dp_axes=["dp"], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()]
+    )
+    model = nn.Linear(4, 4, bias=False).to(setup.device)
+
+    fully_shard(model, mesh=mesh, placements=placements)
+
+    (group,) = model.parameter_groups()
+    assert group.mesh is mesh
+    assert group.dp_mesh.ndim == 1
+    assert group.dp_mesh.size() == setup.world_size
+    assert group.main_weight.mesh is group.dp_mesh
+    assert group.model_weight.mesh is group.dp_mesh
+    assert group.main_grad is not None
+    assert group.main_grad.mesh is group.dp_mesh
+    assert isinstance(model.weight, DTensor)
+    assert model.weight.device_mesh is group.dp_mesh
+
+
+@pytest.mark.distributed
 def test_sharded_parameter_contract_uses_dtensors(setup: DistributedSetup):
     """Resting sharded parameters and gradients should be DTensors."""
     if setup.world_size < 2:
@@ -221,9 +280,12 @@ def test_sharded_parameter_contract_uses_dtensors(setup: DistributedSetup):
 
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     model = nn.Linear(4, 4, bias=False).to(setup.device)
+    original_weight = model.weight
 
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
+    (group,) = model.parameter_groups()
+    assert group.unsharded_parameters["weight"] is original_weight
     assert isinstance(model.weight, DTensor)
     assert isinstance(model.weight.data, DTensor)
     model(torch.randn(2, 4, device=setup.device)).sum().backward()
@@ -238,15 +300,30 @@ def test_meta_parameters_initialize_with_reset_parameters(setup: DistributedSetu
         pytest.skip("This test requires at least 2 ranks.")
 
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = nn.Linear(4, 4, bias=False, device="meta")
+    model = ConstantMetaModel()
 
-    fully_shard(model, mesh=mesh, placements=_flat_placements(), init_model_with_meta_device=True)
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     assert isinstance(model.weight, DTensor)
     assert not model.weight.to_local().is_meta
     (group,) = model.parameter_groups()
-    assert not group.main_weight.local_buffer.is_meta
-    assert group.main_weight.local_buffer.numel() > 0
+    assert not group.model_weight.local_buffer.is_meta
+    assert group.model_weight.local_buffer.numel() > 0
+    full_weight = _full_model_weight(group)
+    torch.testing.assert_close(full_weight, torch.full_like(full_weight, 3.0))
+
+
+@pytest.mark.distributed
+def test_meta_parameters_reject_mixed_direct_parameters(setup: DistributedSetup):
+    """A module cannot mix meta and real direct parameters when reset is required."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    model = MixedMetaRealModel(setup.device)
+
+    with pytest.raises(ValueError, match="mixes meta and non-meta direct parameters"):
+        fully_shard(model, mesh=mesh, placements=_flat_placements())
 
 
 @pytest.mark.distributed
@@ -265,19 +342,19 @@ def test_non_leaf_parameter_view_survives_storage_resize(setup: DistributedSetup
     x = torch.randn(8, device=setup.device, requires_grad=True)
     loss = model(x).sum()
 
-    assert group._full_weight is not None
-    assert group._full_weight.local_buffer.untyped_storage().nbytes() == 0
+    assert group._unsharded_model_weight is not None
+    assert group._unsharded_model_weight.local_buffer.untyped_storage().nbytes() == 0
 
     loss.backward()
 
     assert group.main_grad is not None
-    assert group._full_weight is not None
-    assert group._full_weight.local_buffer.untyped_storage().nbytes() == 0
+    assert group._unsharded_model_weight is not None
+    assert group._unsharded_model_weight.local_buffer.untyped_storage().nbytes() == 0
 
 
 @pytest.mark.distributed
 def test_experimental_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
-    """Per-layer experimental FSDP should reduce peak CUDA memory during a train step."""
+    """Per-layer FSDP should reduce peak CUDA memory during a train step."""
     if setup.world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
     if setup.device.type != "cuda":
@@ -285,7 +362,7 @@ def test_experimental_fully_shard_reduces_peak_training_memory(setup: Distribute
 
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     dim = 1024
-    layers = 8
+    layers = 16
     batch = 8
 
     torch.manual_seed(4321)
@@ -309,6 +386,8 @@ def test_experimental_fully_shard_reduces_peak_training_memory(setup: Distribute
     )
     for layer in model:
         fully_shard(layer, mesh=mesh, placements=_flat_placements())
+    gc.collect()
+    torch.cuda.empty_cache()
 
     x = torch.randn(batch, dim, device=setup.device)
     torch.cuda.reset_peak_memory_stats(setup.device)

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -16,7 +16,6 @@ from torch.distributed.tensor import DTensor
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
-    FsdpModule,
     Placements,
     fully_shard,
 )
@@ -135,22 +134,10 @@ def _mb(num_bytes: int) -> str:
 
 
 @pytest.mark.distributed
-def test_fully_shard_train_step_matches_baseline(setup: DistributedSetup):
-    """A minimal per-module FSDP train step should match single-rank SGD."""
+def test_fully_shard_losses_match_baseline(setup: DistributedSetup):
+    """Minimal per-module FSDP training should match single-rank SGD."""
     if setup.world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
-
-    def full_named_parameters(module: nn.Module) -> dict[str, torch.Tensor]:
-        result = {}
-        for module_name, child in module.named_modules():
-            if not isinstance(child, FsdpModule):
-                continue
-            prefix = f"{module_name}." if module_name else ""
-            for group in child.parameter_groups():
-                full_weight = group.main_weight.allgather(0)
-                for index, name in enumerate(group.parameter_names):
-                    result[f"{prefix}{name}"] = full_weight.get_tensor(index).detach().clone()
-        return result
 
     mesh = init_device_mesh(setup.device.type, (setup.world_size,))
     torch.manual_seed(1234)
@@ -160,24 +147,31 @@ def test_fully_shard_train_step_matches_baseline(setup: DistributedSetup):
 
     fully_shard(model.fc1, mesh=mesh, placements=_flat_placements())
     fully_shard(model.fc2, mesh=mesh, placements=_flat_placements())
+    baseline_optimizer = torch.optim.SGD(baseline.parameters(), lr=0.05)
     optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
 
     x = torch.randn(3, 8, device=setup.device)
     target = torch.randn(3, 4, device=setup.device)
 
-    baseline_loss = torch.nn.functional.mse_loss(baseline(x), target)
-    baseline_loss.backward()
-    with torch.no_grad():
-        for parameter in baseline.parameters():
-            parameter.add_(parameter.grad, alpha=-0.05)
+    for step in range(5):
+        baseline_optimizer.zero_grad()
+        optimizer.zero_grad()
 
-    loss = torch.nn.functional.mse_loss(model(x), target)
-    loss.backward()
-    optimizer.step()
+        baseline_loss = torch.nn.functional.mse_loss(baseline(x), target)
+        loss = torch.nn.functional.mse_loss(model(x), target)
+        logger.info(
+            "FSDP train parity: rank=%s, step=%s, baseline_loss=%s, sharded_loss=%s",
+            setup.rank,
+            step,
+            baseline_loss.item(),
+            loss.item(),
+        )
+        torch.testing.assert_close(loss, baseline_loss, msg=f"Loss mismatch at step {step}.")
 
-    full_params = full_named_parameters(model)
-    for name, expected in baseline.named_parameters():
-        torch.testing.assert_close(full_params[name], expected, rtol=1e-5, atol=1e-6)
+        baseline_loss.backward()
+        loss.backward()
+        baseline_optimizer.step()
+        optimizer.step()
 
 
 @pytest.mark.distributed

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -18,9 +18,9 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
     FsdpModule,
     Placements,
-    Replicate,
     fully_shard,
 )
+from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +192,9 @@ def test_nested_fully_shard_excludes_child_owned_parameters(setup: DistributedSe
     fully_shard(model.inner, mesh=mesh, placements=_flat_placements())
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    inner_names = [name for group in model.inner.parameter_groups() for name in group.parameter_names]
+    inner_names = [
+        name for group in model.inner.parameter_groups() for name in group.parameter_names
+    ]
     outer_names = [name for group in model.parameter_groups() for name in group.parameter_names]
 
     assert inner_names == ["weight"]
@@ -216,35 +218,9 @@ def test_frozen_parameter_group_does_not_allocate_main_grad(setup: DistributedSe
     assert group.main_grad is None
 
 
-@pytest.mark.distributed
-def test_bfloat16_main_grads_follow_grad_dtype(setup: DistributedSetup):
-    """BF16 full grads should reduce into main_grad without casting before reduce-scatter."""
-    if setup.world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
-    model = nn.Linear(4, 4, bias=False, dtype=torch.bfloat16).to(setup.device)
-    fully_shard(model, mesh=mesh, placements=_flat_placements())
-
-    (group,) = model.parameter_groups()
-    assert group.main_weight.local_buffer.dtype is torch.float32
-    assert group.main_grad is not None
-    assert group.main_grad.local_buffer.dtype is torch.bfloat16
-    assert group.unsharded_parameters[0].grad_dtype is torch.bfloat16
-    assert group.sharded_parameters[0].dtype is group.main_weight.local_buffer.dtype
-    assert group.sharded_parameters[0].grad_dtype is group.main_grad.local_buffer.dtype
-
-    x = torch.randn(2, 4, device=setup.device, dtype=torch.bfloat16)
-
-    model.zero_grad(set_to_none=True)
-    model(x).sum().backward()
-    assert isinstance(model.weight, DTensor)
-    assert model.weight.dtype is group.main_weight.local_buffer.dtype
-    assert isinstance(model.weight.grad, DTensor)
-    assert model.weight.grad.dtype is group.main_grad.local_buffer.dtype
-
-
 pytest.mark.distributed
+
+
 def test_backward_averages_across_dp_and_accumulates_across_calls(setup: DistributedSetup):
     """Each backward averages over DP ranks; repeated backwards accumulate by summing."""
     if setup.world_size < 2:
@@ -321,6 +297,7 @@ def test_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
     layers = 16
     batch = 8
     steps = 2
+    dtype = torch.bfloat16
 
     def train_steps(model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor) -> None:
         for _ in range(steps):
@@ -329,9 +306,11 @@ def test_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
             optimizer.step()
 
     torch.manual_seed(4321)
-    baseline = nn.Sequential(*[nn.Linear(dim, dim) for _ in range(layers)]).to(setup.device)
+    baseline = nn.Sequential(*[nn.Linear(dim, dim, dtype=dtype) for _ in range(layers)]).to(
+        setup.device
+    )
     baseline_optimizer = torch.optim.AdamW(baseline.parameters(), lr=0.01)
-    x = torch.randn(batch, dim, device=setup.device)
+    x = torch.randn(batch, dim, device=setup.device, dtype=dtype)
     torch.cuda.reset_peak_memory_stats(setup.device)
     train_steps(baseline, baseline_optimizer, x)
     torch.cuda.synchronize(setup.device)
@@ -343,13 +322,22 @@ def test_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
     torch.cuda.empty_cache()
 
     torch.manual_seed(4321)
-    model = nn.Sequential(*[nn.Linear(dim, dim) for _ in range(layers)]).to(setup.device)
+    model = nn.Sequential(*[nn.Linear(dim, dim, dtype=dtype) for _ in range(layers)]).to(
+        setup.device
+    )
     for layer in model:
-        fully_shard(layer, mesh=mesh, placements=_flat_placements())
+        fully_shard(
+            layer,
+            mesh=mesh,
+            placements=_flat_placements(),
+            mixed_precision_policy=MixedPrecisionPolicy(
+                main_params_dtype=dtype, main_grads_dtype=dtype
+            ),
+        )
     optimizer = torch.optim.AdamW(model.parameters(), lr=0.01)
     torch.cuda.empty_cache()
 
-    x = torch.randn(batch, dim, device=setup.device)
+    x = torch.randn(batch, dim, device=setup.device, dtype=dtype)
     torch.cuda.reset_peak_memory_stats(setup.device)
     train_steps(model, optimizer, x)
     torch.cuda.synchronize(setup.device)

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the experimental minimal Megatron-FSDP path."""
+
+import gc
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+    Flat,
+    FsdpModule,
+    Placements,
+    fully_shard,
+)
+
+
+@dataclass(frozen=True)
+class DistributedSetup:
+    """Per-rank distributed test setup."""
+
+    rank: int
+    world_size: int
+    device: torch.device
+
+
+@pytest.fixture(scope="module")
+def setup() -> Iterator[DistributedSetup]:
+    """Read torchrun rank state and set up this rank's local device."""
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Not running under torchrun.")
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+
+    if torch.cuda.is_available():
+        torch.cuda.set_device(local_rank)
+        device = torch.device(f"cuda:{local_rank}")
+    else:
+        device = torch.device("cpu")
+
+    yield DistributedSetup(rank=rank, world_size=world_size, device=device)
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+class TinyModel(nn.Module):
+    """Small model with two separately shardable units."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(8, 16)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(16, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the tiny model."""
+        return self.fc2(self.relu(self.fc1(x)))
+
+
+class NestedModel(nn.Module):
+    """Model with direct and child-owned parameters."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bias = nn.Parameter(torch.ones(4))
+        self.inner = nn.Linear(4, 4, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the nested model."""
+        return self.inner(x) + self.bias
+
+
+class SaveNonLeafWeightView(torch.autograd.Function):
+    """Autograd function that saves a non-leaf parameter view for backward."""
+
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, weight_view: torch.Tensor) -> torch.Tensor:
+        """Save the non-leaf weight view and run a simple elementwise op."""
+        ctx.save_for_backward(x, weight_view)
+        return x * weight_view
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Use the saved non-leaf weight view during backward."""
+        x, weight_view = ctx.saved_tensors
+        return grad_output * weight_view, grad_output * x
+
+
+class NonLeafViewModel(nn.Module):
+    """Model that saves a non-leaf parameter view across forward and backward."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(8))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run using a non-leaf view of the parameter."""
+        return SaveNonLeafWeightView.apply(x, self.weight.view_as(self.weight))
+
+
+def _flat_placements() -> Placements:
+    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+
+
+def _full_named_parameters(module: nn.Module) -> dict[str, torch.Tensor]:
+    result = {}
+    for module_name, child in module.named_modules():
+        if not isinstance(child, FsdpModule):
+            continue
+        prefix = f"{module_name}." if module_name else ""
+        for group in child.parameter_groups():
+            full_weight = group.main_weight.redistribute([Flat()]).allgather(0)
+            for index, name in enumerate(group.parameters):
+                result[f"{prefix}{name}"] = full_weight.get_tensor(index).detach().clone()
+    return result
+
+
+@pytest.mark.distributed
+def test_experimental_fully_shard_train_step_matches_baseline(setup: DistributedSetup):
+    """A minimal per-module FSDP train step should match single-rank SGD."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    torch.manual_seed(1234)
+    baseline = TinyModel().to(setup.device)
+    model = TinyModel().to(setup.device)
+    model.load_state_dict(baseline.state_dict())
+
+    fully_shard(model.fc1, mesh=mesh, placements=_flat_placements())
+    fully_shard(model.fc2, mesh=mesh, placements=_flat_placements())
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+
+    x = torch.randn(3, 8, device=setup.device)
+    target = torch.randn(3, 4, device=setup.device)
+
+    baseline_loss = torch.nn.functional.mse_loss(baseline(x), target)
+    baseline_loss.backward()
+    with torch.no_grad():
+        for parameter in baseline.parameters():
+            parameter.add_(parameter.grad, alpha=-0.05)
+
+    loss = torch.nn.functional.mse_loss(model(x), target)
+    loss.backward()
+    optimizer.step()
+
+    sharded_params = _full_named_parameters(model)
+    for name, expected in baseline.named_parameters():
+        torch.testing.assert_close(sharded_params[name], expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.distributed
+def test_nested_fully_shard_excludes_child_owned_parameters(setup: DistributedSetup):
+    """An outer FSDP unit owns direct parameters but not nested child-unit parameters."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    model = NestedModel().to(setup.device)
+
+    fully_shard(model.inner, mesh=mesh, placements=_flat_placements())
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    inner_names = [name for group in model.inner.parameter_groups() for name in group.parameters]
+    outer_names = [name for group in model.parameter_groups() for name in group.parameters]
+
+    assert inner_names == ["weight"]
+    assert outer_names == ["bias"]
+
+
+@pytest.mark.distributed
+def test_frozen_parameter_group_does_not_allocate_main_grad(setup: DistributedSetup):
+    """A non-trainable parameter group should not allocate persistent main gradients."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    model = nn.Linear(4, 4, bias=False).to(setup.device)
+    model.weight.requires_grad_(False)
+
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    (group,) = model.parameter_groups()
+    assert not group.requires_grad
+    assert group.main_grad is None
+
+
+@pytest.mark.distributed
+def test_default_main_buffer_dtypes_follow_policy_contract(setup: DistributedSetup):
+    """Default main weights are FP32 while default main gradients match parameter dtype."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    model = nn.Linear(4, 4, bias=False, dtype=torch.float64).to(setup.device)
+
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    (group,) = model.parameter_groups()
+    assert group.dtype is torch.float64
+    assert group.main_weight.local_buffer.dtype is torch.float32
+    assert group.main_grad is not None
+    assert group.main_grad.local_buffer.dtype is torch.float64
+
+
+@pytest.mark.distributed
+def test_sharded_parameter_contract_uses_dtensors(setup: DistributedSetup):
+    """Resting sharded parameters and gradients should be DTensors."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    model = nn.Linear(4, 4, bias=False).to(setup.device)
+
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    assert isinstance(model.weight, DTensor)
+    assert isinstance(model.weight.data, DTensor)
+    model(torch.randn(2, 4, device=setup.device)).sum().backward()
+    assert isinstance(model.weight, DTensor)
+    assert isinstance(model.weight.grad, DTensor)
+
+
+@pytest.mark.distributed
+def test_meta_parameters_initialize_with_reset_parameters(setup: DistributedSetup):
+    """Meta parameters should be replaced by sharded DTensors and initialized in place."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    model = nn.Linear(4, 4, bias=False, device="meta")
+
+    fully_shard(model, mesh=mesh, placements=_flat_placements(), init_model_with_meta_device=True)
+
+    assert isinstance(model.weight, DTensor)
+    assert not model.weight.to_local().is_meta
+    (group,) = model.parameter_groups()
+    assert not group.main_weight.local_buffer.is_meta
+    assert group.main_weight.local_buffer.numel() > 0
+
+
+@pytest.mark.distributed
+def test_non_leaf_parameter_view_survives_storage_resize(setup: DistributedSetup):
+    """A non-leaf parameter view saved for backward should survive full-storage resize."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+    if setup.device.type != "cuda":
+        pytest.skip("Storage resize verification requires CUDA.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    model = NonLeafViewModel().to(setup.device)
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    group = model.parameter_groups()[0]
+    x = torch.randn(8, device=setup.device, requires_grad=True)
+    loss = model(x).sum()
+
+    assert group._full_weight is not None
+    assert group._full_weight.local_buffer.untyped_storage().nbytes() == 0
+
+    loss.backward()
+
+    assert group.main_grad is not None
+    assert group._full_weight is not None
+    assert group._full_weight.local_buffer.untyped_storage().nbytes() == 0
+
+
+@pytest.mark.distributed
+def test_experimental_fully_shard_reduces_peak_training_memory(setup: DistributedSetup):
+    """Per-layer experimental FSDP should reduce peak CUDA memory during a train step."""
+    if setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+    if setup.device.type != "cuda":
+        pytest.skip("Peak memory verification requires CUDA.")
+
+    mesh = init_device_mesh(setup.device.type, (setup.world_size,))
+    dim = 1024
+    layers = 8
+    batch = 8
+
+    torch.manual_seed(4321)
+    baseline = nn.Sequential(*[nn.Linear(dim, dim, bias=False) for _ in range(layers)]).to(
+        setup.device
+    )
+    x = torch.randn(batch, dim, device=setup.device)
+    torch.cuda.reset_peak_memory_stats(setup.device)
+    baseline(x).sum().backward()
+    torch.cuda.synchronize(setup.device)
+    baseline_peak = torch.cuda.max_memory_allocated(setup.device)
+
+    del baseline
+    del x
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    torch.manual_seed(4321)
+    model = nn.Sequential(*[nn.Linear(dim, dim, bias=False) for _ in range(layers)]).to(
+        setup.device
+    )
+    for layer in model:
+        fully_shard(layer, mesh=mesh, placements=_flat_placements())
+
+    x = torch.randn(batch, dim, device=setup.device)
+    torch.cuda.reset_peak_memory_stats(setup.device)
+    model(x).sum().backward()
+    torch.cuda.synchronize(setup.device)
+    sharded_peak = torch.cuda.max_memory_allocated(setup.device)
+
+    assert sharded_peak < baseline_peak

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -14,6 +14,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
     Placements,
     fully_shard,
+    microbatch,
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 
@@ -86,7 +87,36 @@ def _mb(num_bytes: int) -> str:
     return f"{num_bytes / 1024**2:.2f} MB"
 
 
-@pytest.mark.distributed
+def _count_weight_syncs(nvtx_ranges: list[str]) -> int:
+    return sum(message == "sync_model_weight_from_main_weight" for message in nvtx_ranges)
+
+
+def _make_unwrapped_parent_microbatch_model(
+    device: torch.device, mesh
+) -> tuple[nn.Sequential, tuple]:
+    model = nn.Sequential(
+        nn.Linear(1, 1, bias=False, dtype=torch.bfloat16),
+        nn.Linear(1, 1, bias=False, dtype=torch.bfloat16),
+    ).to(device)
+    with torch.no_grad():
+        for layer in model:
+            layer.weight.fill_(1.0)
+
+    for layer in model:
+        fully_shard(
+            layer,
+            mesh=mesh,
+            placements=_flat_placements(),
+            mixed_precision_policy=MixedPrecisionPolicy(main_params_dtype=torch.float32),
+        )
+
+    assert not hasattr(model, "parameter_groups")
+    groups = tuple(layer.parameter_groups()[0] for layer in model)
+    for group in groups:
+        assert group.main_weight is not group.model_weight
+    return model, groups
+
+
 def test_fully_shard_losses_match_baseline(distributed_setup):
     """Minimal per-module FSDP training should match single-rank SGD."""
     rank = distributed_setup.rank
@@ -130,7 +160,6 @@ def test_fully_shard_losses_match_baseline(distributed_setup):
         optimizer.step()
 
 
-@pytest.mark.distributed
 def test_nested_fully_shard_excludes_child_owned_parameters(distributed_setup):
     """An outer FSDP unit owns direct parameters but not nested child-unit parameters."""
     world_size = distributed_setup.world_size
@@ -153,7 +182,6 @@ def test_nested_fully_shard_excludes_child_owned_parameters(distributed_setup):
     assert outer_names == ["bias"]
 
 
-@pytest.mark.distributed
 def test_frozen_parameter_group_does_not_allocate_main_grad(distributed_setup):
     """A non-trainable parameter group should not allocate persistent main gradients."""
     world_size = distributed_setup.world_size
@@ -170,9 +198,6 @@ def test_frozen_parameter_group_does_not_allocate_main_grad(distributed_setup):
     (group,) = model.parameter_groups()
     assert not group.requires_grad
     assert group.main_grad is None
-
-
-pytest.mark.distributed
 
 
 def test_backward_averages_across_dp_and_accumulates_across_calls(distributed_setup):
@@ -200,7 +225,6 @@ def test_backward_averages_across_dp_and_accumulates_across_calls(distributed_se
     torch.testing.assert_close(local_grad, expected, rtol=0, atol=0)
 
 
-@pytest.mark.distributed
 def test_next_forward_uses_optimizer_updated_weights(distributed_setup):
     """The next forward should observe weights updated by the previous optimizer step."""
     world_size = distributed_setup.world_size
@@ -238,7 +262,74 @@ def test_next_forward_uses_optimizer_updated_weights(distributed_setup):
         torch.testing.assert_close(second_loss, first_loss)
 
 
-@pytest.mark.distributed
+def test_microbatch_false_scopes_unwrapped_parent_child_contexts(distributed_setup):
+    """An unwrapped parent can set child FSDP contexts to a non-first microbatch."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    model, _groups = _make_unwrapped_parent_microbatch_model(device, mesh)
+
+    with microbatch(model, is_first=False):
+        contexts = tuple(layer._context for layer in model)
+        assert all(context is not None for context in contexts)
+        assert all(not context.is_first_microbatch for context in contexts)
+    assert tuple(layer._context for layer in model) == contexts
+    assert all(context.is_first_microbatch for context in contexts)
+
+
+def test_microbatch_training_syncs_once_per_minibatch(distributed_setup, monkeypatch):
+    """Training with microbatches syncs main weights once per FSDP unit per minibatch."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = nn.Sequential(
+        nn.Linear(1, 1, bias=False, dtype=torch.bfloat16),
+        nn.Linear(1, 1, bias=False, dtype=torch.bfloat16),
+    ).to(device)
+    with torch.no_grad():
+        for layer in model:
+            layer.weight.fill_(1.0)
+    fully_shard(
+        model,
+        mesh=mesh,
+        placements=_flat_placements(),
+        mixed_precision_policy=MixedPrecisionPolicy(main_params_dtype=torch.float32),
+    )
+    groups = model.parameter_groups()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.05, foreach=False)
+    x_microbatches = (
+        torch.ones(1, 1, device=device, dtype=torch.bfloat16),
+        torch.full((1, 1), 2.0, device=device, dtype=torch.bfloat16),
+    )
+    nvtx_ranges: list[str] = []
+
+    original_range_push = torch.cuda.nvtx.range_push
+
+    def range_push_spy(message: str) -> None:
+        nvtx_ranges.append(message)
+        original_range_push(message)
+
+    monkeypatch.setattr(torch.cuda.nvtx, "range_push", range_push_spy)
+
+    for _step in range(2):
+        optimizer.zero_grad(set_to_none=True)
+        nvtx_ranges.clear()
+        for microbatch_index, x in enumerate(x_microbatches):
+            with microbatch(model, is_first=microbatch_index == 0):
+                loss = model(x).float().sum() / len(x_microbatches)
+            assert _count_weight_syncs(nvtx_ranges) == len(groups), (
+                "main weights should sync once per FSDP group on the first microbatch, "
+                "and not again on later microbatches in the same minibatch"
+            )
+            loss.backward()
+        assert _count_weight_syncs(nvtx_ranges) == len(groups), (
+            "main weights should sync once per FSDP group over the full minibatch"
+        )
+        optimizer.step()
+
+
 def test_cpu_initialized_parameters_shard_to_mesh_device(distributed_setup):
     """CPU-initialized parameters should be sharded with their real values."""
     world_size = distributed_setup.world_size
@@ -260,7 +351,6 @@ def test_cpu_initialized_parameters_shard_to_mesh_device(distributed_setup):
     torch.testing.assert_close(full_weight, expected_weight)
 
 
-@pytest.mark.distributed
 def test_non_leaf_parameter_view_survives_storage_resize(distributed_setup):
     """A non-leaf parameter view saved for backward should survive full-storage resize."""
     world_size = distributed_setup.world_size
@@ -286,7 +376,6 @@ def test_non_leaf_parameter_view_survives_storage_resize(distributed_setup):
     assert group._unsharded_model_weight.local_buffer.untyped_storage().nbytes() == 0
 
 
-@pytest.mark.distributed
 def test_fully_shard_reduces_peak_training_memory(distributed_setup):
     """Per-layer FSDP should reduce peak CUDA memory during training."""
     rank = distributed_setup.rank


### PR DESCRIPTION
## Summary
- Add `FsdpContext` next to `FsdpModule`, with lazy root-subtree context creation following #5124's structure.
- Add `megatron_fsdp.experimental.microbatch(module, is_first)` alongside the experimental `fully_shard(...)` API in `fully_shard.py`.
- Implement `microbatch()` as a scoped DFS helper that lazy-inits discovered FSDP root contexts, sets `is_first_microbatch`, and restores prior values on exit.
- Keep default behavior correctness-first: forwards outside `microbatch()` still sync main weights before forward.
- Skip main-weight-to-model-weight sync after the first microbatch while still unsharding before every forward.
- Add a local Megatron-FSDP NVTX range around `sync_model_weight_from_main_weight()` without importing `megatron.core.utils`.
- Cover the unwrapped-parent case with child modules wrapped by `fully_shard()` in an isolated `is_first=False` context-state test.
- Cover sync cadence with a normal top-level FSDP model training loop that verifies weight sync runs once per FSDP group per minibatch, not once per microbatch.

## Stack
Stacked on #4976 with base `pull-request/4976`.

## Testing
- `uv run isort ...` could not run because uv attempted to modify `/opt/venv` and hit a permission error; reran as `uv run --no-sync isort ...` successfully.
- `git diff --check` passed.
- `uv run --no-sync python -m torch.distributed.run --nproc-per-node 1 -m pytest -q tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py::test_microbatch_false_scopes_unwrapped_parent_child_contexts tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py::test_microbatch_training_syncs_once_per_minibatch` passed: 2 passed.
- `uv run python -m torch.distributed.run --nproc-per-node 8 -m pytest -q tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py` could not run on this host: only 2 CUDA devices are visible, and rank 3 failed with `CUDA error: invalid device ordinal`.
- `uv run --no-sync python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py` passed: 10 passed.