### PR TITLE
Add DSA/DSv4 Indexer Replay for RL training stability

### DIFF
--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -49,6 +49,7 @@ from .attention_context.mamba_metadata import MambaMetadata
 from .attention_context.mha_metadata import GraphedMHAMetadata, NonGraphedMHAMetadata
 from .base_context import BaseInferenceContext
 from .gpu_view import ContextGPUView
+from .indexer_metadata import IndexerMetadata
 from .kv_block_allocator import KVBlockAllocator
 from .mamba_slot_allocator import MAX_INTERMEDIATE_OFFSETS_PER_REQUEST, MambaSlotAllocator
 from .routing_metadata import RoutingMetadata
@@ -115,9 +116,13 @@ class ContextOverflowError(Exception):
     """
 
     def __init__(
-        self, request_id: Optional[int], message: Optional[str] = None, *, is_transient: bool = True
+        self,
+        request_id: Optional[int],
+        message: Optional[str] = None,
+        *,
+        is_transient: bool = True,
     ):
-        request_str = '--' if request_id is None else str(request_id)
+        request_str = "--" if request_id is None else str(request_id)
         _message = "" if message is None else f" | {message}"
         super().__init__(f"request {request_str}{_message}")
         self.request_id = request_id
@@ -151,8 +156,8 @@ class BlockOverflowError(ContextOverflowError):
 
 
 class ActiveRequestCountOverflowError(ContextOverflowError):
-    '''Used when `initialize_attention_state()` is called with
-    `num_warmup_requests > max_requests.'''
+    """Used when `initialize_attention_state()` is called with
+    `num_warmup_requests > max_requests."""
 
     def __init__(self, max_request_count, active_request_count):
         assert active_request_count > max_request_count
@@ -258,16 +263,24 @@ class DynamicInferenceContext(BaseInferenceContext):
             "Only pass `model_config` and `inference_config`"
         ),
     )
-    def __init__(self, model_config: TransformerConfig, inference_config: InferenceConfig):
+    def __init__(
+        self, model_config: TransformerConfig, inference_config: InferenceConfig
+    ):
         super().__init__(inference_config=inference_config)
 
         # Prefix caching configuration
         self.enable_prefix_caching = inference_config.enable_prefix_caching
-        self.prefix_caching_eviction_policy = inference_config.prefix_caching_eviction_policy
-        self.prefix_caching_coordinator_policy = inference_config.prefix_caching_coordinator_policy
+        self.prefix_caching_eviction_policy = (
+            inference_config.prefix_caching_eviction_policy
+        )
+        self.prefix_caching_coordinator_policy = (
+            inference_config.prefix_caching_coordinator_policy
+        )
 
         # Hyperparameter for choosing to prioritize prefix hit matches vs minimizing idle load
-        self.prefix_caching_routing_alpha = inference_config.prefix_caching_routing_alpha
+        self.prefix_caching_routing_alpha = (
+            inference_config.prefix_caching_routing_alpha
+        )
 
         # Monotonic clock for prefix caching LRU eviction ordering.
         # Incremented each engine step but kept independent so the engine step
@@ -282,15 +295,18 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.step_count = 0
 
         self.cache_mla_latent = (
-            isinstance(model_config, MLATransformerConfig) and model_config.cache_mla_latents
+            isinstance(model_config, MLATransformerConfig)
+            and model_config.cache_mla_latents
         )
         if self.cache_mla_latent:
-            assert (
-                inference_config.block_size_tokens == 64
-            ), "Flash MLA requires a block size of 64. Set --inference-dynamic-batching-block-size 64 to fix this assert"
+            assert inference_config.block_size_tokens == 64, (
+                "Flash MLA requires a block size of 64. Set --inference-dynamic-batching-block-size 64 to fix this assert"
+            )
 
         # Per partition num heads and hidden size.
-        num_attention_heads = model_config.num_query_groups or model_config.num_attention_heads
+        num_attention_heads = (
+            model_config.num_query_groups or model_config.num_attention_heads
+        )
         projection_size = model_config.kv_channels * num_attention_heads
         pg_collection = inference_config.pg_collection
         if pg_collection is not None:
@@ -299,9 +315,13 @@ class DynamicInferenceContext(BaseInferenceContext):
         else:
             tp_size = model_config.tensor_model_parallel_size
             pp_size = model_config.pipeline_model_parallel_size
-        self.hidden_size_per_attention_head = core_divide(projection_size, num_attention_heads)
+        self.hidden_size_per_attention_head = core_divide(
+            projection_size, num_attention_heads
+        )
         if num_attention_heads >= tp_size:
-            self.num_attention_heads_per_partition = core_divide(num_attention_heads, tp_size)
+            self.num_attention_heads_per_partition = core_divide(
+                num_attention_heads, tp_size
+            )
         else:
             self.num_attention_heads_per_partition = 1
 
@@ -319,14 +339,18 @@ class DynamicInferenceContext(BaseInferenceContext):
         if pg_collection is not None and get_pg_size(pg_collection.pp) > 1:
             self.pipeline_parallel_group = pg_collection.pp
         elif pp_size > 1:
-            self.pipeline_parallel_group = parallel_state.get_pipeline_model_parallel_group()
+            self.pipeline_parallel_group = (
+                parallel_state.get_pipeline_model_parallel_group()
+            )
         else:
             self.pipeline_parallel_group = None
 
         if pg_collection is not None:
             self.expert_model_parallel_group = pg_collection.ep
         elif parallel_state.get_expert_model_parallel_world_size() > 1:
-            self.expert_model_parallel_group = parallel_state.get_expert_model_parallel_group()
+            self.expert_model_parallel_group = (
+                parallel_state.get_expert_model_parallel_group()
+            )
         else:
             self.expert_model_parallel_group = None
 
@@ -340,9 +364,13 @@ class DynamicInferenceContext(BaseInferenceContext):
         mamba_inference_state_config = inference_config.mamba_inference_state_config
         self.is_hybrid_model = mamba_inference_state_config is not None
         if self.is_hybrid_model:
-            self.mamba_conv_states_shape = mamba_inference_state_config.conv_states_shape
+            self.mamba_conv_states_shape = (
+                mamba_inference_state_config.conv_states_shape
+            )
             self.mamba_ssm_states_shape = mamba_inference_state_config.ssm_states_shape
-            self.mamba_conv_states_dtype = mamba_inference_state_config.conv_states_dtype
+            self.mamba_conv_states_dtype = (
+                mamba_inference_state_config.conv_states_dtype
+            )
             self.mamba_ssm_states_dtype = mamba_inference_state_config.ssm_states_dtype
             self.mamba_chunk_size = mamba_inference_state_config.mamba_chunk_size
 
@@ -352,7 +380,11 @@ class DynamicInferenceContext(BaseInferenceContext):
             attention_layer_map, dsa_layer_map, gdn_layer_map, mamba_layer_map = (
                 operator.itemgetter(
                     Symbols.ATTENTION, Symbols.DS_ATTENTION, Symbols.GDN, Symbols.MAMBA
-                )(get_layer_maps_from_layer_type_list(mamba_inference_state_config.layer_type_list))
+                )(
+                    get_layer_maps_from_layer_type_list(
+                        mamba_inference_state_config.layer_type_list
+                    )
+                )
             )
 
             if len(gdn_layer_map) > 0:
@@ -396,7 +428,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.block_size_tokens = inference_config.block_size_tokens
         if self.cache_mla_latent:
             #   one vector  c_t  (rank)  +  optional RoPE phase slice
-            self.kv_reduced_dim = model_config.kv_lora_rank + model_config.qk_pos_emb_head_dim
+            self.kv_reduced_dim = (
+                model_config.kv_lora_rank + model_config.qk_pos_emb_head_dim
+            )
             self.block_size_bytes = (
                 kv_dtype_size_bytes
                 * self.num_attention_layers
@@ -417,17 +451,21 @@ class DynamicInferenceContext(BaseInferenceContext):
         mamba_states_memory_per_request = 0
         if self.is_hybrid_model:
             mamba_states_memory_per_request += (
-                math.prod(self.mamba_conv_states_shape) * self.mamba_conv_states_dtype.itemsize
+                math.prod(self.mamba_conv_states_shape)
+                * self.mamba_conv_states_dtype.itemsize
             )
             mamba_states_memory_per_request += (
-                math.prod(self.mamba_ssm_states_shape) * self.mamba_ssm_states_dtype.itemsize
+                math.prod(self.mamba_ssm_states_shape)
+                * self.mamba_ssm_states_dtype.itemsize
             )
             mamba_states_memory_per_request *= self.num_mamba_layers
             if self.num_speculative_tokens > 0:
                 # Add memory for intermediate conv and SSM states
                 intermediate_memory_per_request = (
-                    math.prod(self.mamba_conv_states_shape) * self.mamba_conv_states_dtype.itemsize
-                    + math.prod(self.mamba_ssm_states_shape) * self.mamba_ssm_states_dtype.itemsize
+                    math.prod(self.mamba_conv_states_shape)
+                    * self.mamba_conv_states_dtype.itemsize
+                    + math.prod(self.mamba_ssm_states_shape)
+                    * self.mamba_ssm_states_dtype.itemsize
                 )
                 intermediate_memory_per_request *= self.num_mamba_layers
                 intermediate_memory_per_request *= self.num_speculative_tokens + 1
@@ -473,7 +511,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             else int(inference_config.paused_buffer_size_gb * 1024**3)
         )
 
-        mamba_max_requests = float('inf')
+        mamba_max_requests = float("inf")
 
         if (mamba_memory_ratio := inference_config.mamba_memory_ratio) is not None:
             assert self.is_hybrid_model
@@ -482,11 +520,15 @@ class DynamicInferenceContext(BaseInferenceContext):
             # Calculate total memory before partition
             total_memory = buffer_size_bytes + paused_buffer_size_bytes
             mamba_memory_bytes = total_memory * mamba_memory_ratio
-            mamba_max_requests = int(mamba_memory_bytes // mamba_states_memory_per_request)
+            mamba_max_requests = int(
+                mamba_memory_bytes // mamba_states_memory_per_request
+            )
 
             # Reduce buffer sizes for KV cache
             buffer_size_bytes = int(buffer_size_bytes * (1.0 - mamba_memory_ratio))
-            paused_buffer_size_bytes = int(paused_buffer_size_bytes * (1.0 - mamba_memory_ratio))
+            paused_buffer_size_bytes = int(
+                paused_buffer_size_bytes * (1.0 - mamba_memory_ratio)
+            )
 
             block_count = buffer_size_bytes // self.block_size_bytes
             block_count = max(2, block_count)  # need >= 1 active block + 1 dummy block
@@ -495,7 +537,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             # Auto-derive mamba/KV split from max_requests. Allocate exactly enough
             # mamba memory for max_requests, and give the rest to KV cache blocks.
             total_memory = buffer_size_bytes + paused_buffer_size_bytes
-            mamba_memory_needed = inference_config.max_requests * mamba_states_memory_per_request
+            mamba_memory_needed = (
+                inference_config.max_requests * mamba_states_memory_per_request
+            )
             assert mamba_memory_needed < total_memory, (
                 f"Not enough memory for {inference_config.max_requests} mamba requests. "
                 f"Need {mamba_memory_needed / 1024**3:.2f} GB for mamba states, "
@@ -506,7 +550,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             # Subtract mamba memory proportionally from active and paused buffers.
             mamba_memory_ratio = mamba_memory_needed / total_memory
             buffer_size_bytes = int(buffer_size_bytes * (1.0 - mamba_memory_ratio))
-            paused_buffer_size_bytes = int(paused_buffer_size_bytes * (1.0 - mamba_memory_ratio))
+            paused_buffer_size_bytes = int(
+                paused_buffer_size_bytes * (1.0 - mamba_memory_ratio)
+            )
 
             block_count = buffer_size_bytes // self.block_size_bytes
             block_count = max(2, block_count)  # need >= 1 active block + 1 dummy block
@@ -541,7 +587,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.kv_block_allocator = KVBlockAllocator(
             context=self,
             total_count=(
-                block_count if self.unified_memory_level == 0 else block_count + paused_block_count
+                block_count
+                if self.unified_memory_level == 0
+                else block_count + paused_block_count
             ),
             paused_count=paused_block_count,
             enable_prefix_caching=self.enable_prefix_caching,
@@ -563,28 +611,34 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Block ids. With speculative decoding, blocks are pre-allocated when the
         # last block offset >= block_size - 1 - num_speculative_tokens, so we may
         # need one extra block beyond what max_sequence_length alone requires.
-        self.max_kv_block_count = math.ceil(self.max_sequence_length / self.block_size_tokens)
+        self.max_kv_block_count = math.ceil(
+            self.max_sequence_length / self.block_size_tokens
+        )
         if self.num_speculative_tokens > 0:
             self.max_kv_block_count += 1
 
         # Set max_requests, max_tokens.
         if inference_config.max_requests is None:
             # Maximize compute utilization by defaulting to 1 block per request.
-            self.max_requests = self.kv_block_allocator.total_count - 1  # -1 for dummy block
+            self.max_requests = (
+                self.kv_block_allocator.total_count - 1
+            )  # -1 for dummy block
 
             # Adjust max_requests for Mamba memory constraints if necessary
             if self.is_hybrid_model and mamba_max_requests < self.max_requests:
                 self.max_requests = int(mamba_max_requests)
 
             self.max_requests = self.max_requests // tp_size * tp_size
-            self.max_requests = self.max_requests // self.REQUEST_ROUNDER * self.REQUEST_ROUNDER
+            self.max_requests = (
+                self.max_requests // self.REQUEST_ROUNDER * self.REQUEST_ROUNDER
+            )
         else:
             # User can control request overflow via max_requests.
             self.max_requests = inference_config.max_requests
 
-        assert (
-            self.max_requests % tp_size == 0
-        ), f"max_requests must be divisible by tp_size ({tp_size}), but got {self.max_requests}"
+        assert self.max_requests % tp_size == 0, (
+            f"max_requests must be divisible by tp_size ({tp_size}), but got {self.max_requests}"
+        )
 
         self.max_tokens = inference_config.max_tokens or self.DEFAULT_MAX_TOKENS
 
@@ -617,15 +671,26 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         self.moe_enable_routing_replay = model_config.moe_enable_routing_replay
         if self.moe_enable_routing_replay:
-            assert (
-                model_config.num_moe_experts is not None
-            ), "Router recording/replay requested but no MoE experts specified!"
-            self.moe_routing_metadata = RoutingMetadata(self, model_config.moe_router_topk)
+            assert model_config.num_moe_experts is not None, (
+                "Router recording/replay requested but no MoE experts specified!"
+            )
+            self.moe_routing_metadata = RoutingMetadata(
+                self, model_config.moe_router_topk
+            )
+
+        self.dsa_enable_indexer_replay = model_config.dsa_enable_indexer_replay
+        if self.dsa_enable_indexer_replay:
+            assert model_config.dsa_indexer_topk is not None, (
+                "Indexer recording/replay requested but no DSA indexer topk specified!"
+            )
+            self.dsa_indexer_metadata = IndexerMetadata(
+                self, model_config.dsa_indexer_topk
+            )
 
         # are we using the inference_optimized nccl ep dispatcher for MoEs?
         self._nccl_ep_dispatcher = (
             get_pg_size(self.expert_model_parallel_group) > 1
-            and model_config.inference_moe_token_dispatcher_type == 'nccl'
+            and model_config.inference_moe_token_dispatcher_type == "nccl"
         )
 
         # are we using the training a2a dispatcher for MoEs?
@@ -674,13 +739,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         # triggers an allocation inside a captured CUDA graph.
         # Both dispatchers need _valid_tokens_tensor initialized even at EP=1:
         # mcore_fused_moe's Triton kernel reads it as a pointer regardless of EP size.
-        if model_config.inference_moe_token_dispatcher_type == 'nccl':
+        if model_config.inference_moe_token_dispatcher_type == "nccl":
             NCCLAllGatherDispatcher.allocate_buffers()
         elif get_pg_size(self.expert_model_parallel_group) > 1:
             # Use moe_latent_size if set, else hidden_size.
             moe_hidden_size = model_config.moe_latent_size or model_config.hidden_size
             NVLSAllGatherVDispatcher.allocate_buffers(
-                per_rank_worst_case_token_count=self.round_up_tokens(self.max_tokens) // tp_size,
+                per_rank_worst_case_token_count=self.round_up_tokens(self.max_tokens)
+                // tp_size,
                 topk=model_config.moe_router_topk,
                 hidden_size=moe_hidden_size,
                 ep_group=self.expert_model_parallel_group,
@@ -699,7 +765,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         elif inference_config.use_flashinfer_fused_rope is None:
             inference_config.use_flashinfer_fused_rope = HAVE_FLASHINFER
         self.use_flashinfer_fused_rope = inference_config.use_flashinfer_fused_rope
-        self.inference_grouped_gemm_backend = model_config.inference_grouped_gemm_backend
+        self.inference_grouped_gemm_backend = (
+            model_config.inference_grouped_gemm_backend
+        )
 
         # Placeholder for the MTP decoder hidden-states buffer; allocated inside
         # initialize_all_tensors() when num_speculative_tokens > 0.
@@ -778,7 +846,9 @@ class DynamicInferenceContext(BaseInferenceContext):
                 # per-slot footprint of both.
                 scratch_slots = MAX_INTERMEDIATE_OFFSETS_PER_REQUEST * self.max_requests
                 scratch_bytes = scratch_slots * mamba_bytes_per_req
-                durable_slots = (prefix_cache_bytes - scratch_bytes) // mamba_bytes_per_req
+                durable_slots = (
+                    prefix_cache_bytes - scratch_bytes
+                ) // mamba_bytes_per_req
                 durable_slots = max(durable_slots, 0)
                 log_lines += [
                     f"  Mamba prefix cache:",
@@ -856,12 +926,14 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
             self.mamba_metadata.bind_gpu_buffers(self.gpu_view)
             self.mamba_conv_states = torch.empty(
-                (self.num_mamba_layers, self.max_requests) + self.mamba_conv_states_shape,
+                (self.num_mamba_layers, self.max_requests)
+                + self.mamba_conv_states_shape,
                 dtype=self.mamba_conv_states_dtype,
                 device=torch.cuda.current_device(),
             )
             self.mamba_ssm_states = torch.empty(
-                (self.num_mamba_layers, self.max_requests) + self.mamba_ssm_states_shape,
+                (self.num_mamba_layers, self.max_requests)
+                + self.mamba_ssm_states_shape,
                 dtype=self.mamba_ssm_states_dtype,
                 device=torch.cuda.current_device(),
             )
@@ -932,39 +1004,39 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # Per-request state (CPU, pinned memory for fast H2D transfer).
         self.request_ids = torch.full(
-            (self.max_requests,), -1, dtype=torch.int32, device='cpu', pin_memory=True
+            (self.max_requests,), -1, dtype=torch.int32, device="cpu", pin_memory=True
         )
         # request_query_lengths is the input prompt tokens length during prefill phase (1st step) and then 1 for the decode phase (i.e During generation)
         self.request_query_lengths = torch.empty(
-            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True
+            self.max_requests, dtype=torch.int32, device="cpu", pin_memory=True
         )
         # True only for a new request , then after a forward pass it is set to False
         self.request_in_prefill_status_tensor = torch.empty(
-            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True
+            self.max_requests, dtype=torch.int32, device="cpu", pin_memory=True
         )
         # request_output_lengths is len(input_prompt_tokens) + num_tokens_to_generate
         self.request_output_lengths = torch.empty(
-            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True
+            self.max_requests, dtype=torch.int32, device="cpu", pin_memory=True
         )
         # request_kv_length_offsets is the same as query length during prefill phase (1st step) and then 1 for the decode phase (i.e During generation)
         self.request_kv_length_offsets = torch.empty(
-            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True
+            self.max_requests, dtype=torch.int32, device="cpu", pin_memory=True
         )
         self.request_kv_block_counts = torch.empty(
-            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True
+            self.max_requests, dtype=torch.int32, device="cpu", pin_memory=True
         )
         self.request_last_kv_block_id = torch.empty(
-            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True
+            self.max_requests, dtype=torch.int32, device="cpu", pin_memory=True
         )
         # request_last_kv_block_offset represents number of tokens in the last kv block
         self.request_last_kv_block_offset = torch.empty(
-            self.max_requests, dtype=torch.int32, device='cpu', pin_memory=True
+            self.max_requests, dtype=torch.int32, device="cpu", pin_memory=True
         )
         self.request_to_kv_block_ids = torch.full(
             (self.max_requests, self.max_kv_block_count),
             -1,
             dtype=torch.int,
-            device='cpu',
+            device="cpu",
             pin_memory=True,
         )
 
@@ -972,7 +1044,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         # CPU-resident; GPU consumers read from the active-slice mirror in
         # `active_request_metadata` (also CPU pinned, refreshed each step).
         self.request_metadata = {
-            label: torch.empty((self.max_requests,), dtype=dtype, device='cpu', pin_memory=True)
+            label: torch.empty(
+                (self.max_requests,), dtype=dtype, device="cpu", pin_memory=True
+            )
             for label, dtype in self.request_metadata_types
         }
 
@@ -1037,7 +1111,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.is_hybrid_model:
             # mamba_batch_indices_decode is int64; pad to 8-byte alignment.
             _mamba_align_pad = (8 - _pre_mamba_bytes % 8) % 8
-            self._max_mamba_chunks = self.max_tokens // self.mamba_chunk_size + self.max_requests
+            self._max_mamba_chunks = (
+                self.max_tokens // self.mamba_chunk_size + self.max_requests
+            )
             _mamba_batch_indices_decode_bytes = self.max_requests * 8
             _mamba_batch_indices_prefill_bytes = self.max_requests * 4
             _mamba_seq_idx_bytes = self.max_tokens * 4
@@ -1073,7 +1149,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             + _mamba_conv_seq_start_bytes
         )
         self._cpu_bookkeeping_buf = torch.empty(
-            _total_bytes, dtype=torch.uint8, device='cpu', pin_memory=True
+            _total_bytes, dtype=torch.uint8, device="cpu", pin_memory=True
         )
         # token_to_input_ids and token_to_pos_ids were previously torch.full(0);
         # zero the whole buffer so their views start at 0 too, and so the
@@ -1084,17 +1160,17 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Per-token state (source-of-truth lives in the coalesced buffer since
         # the CPU-side bookkeeping and the GPU forward pass use the same
         # `[:n_tok]` slice).
-        self.token_to_input_ids = self._cpu_bookkeeping_buf[_off : _off + _tok_int64_bytes].view(
-            torch.long
-        )
+        self.token_to_input_ids = self._cpu_bookkeeping_buf[
+            _off : _off + _tok_int64_bytes
+        ].view(torch.long)
         _off += _tok_int64_bytes
-        self.token_to_pos_ids = self._cpu_bookkeeping_buf[_off : _off + _tok_int64_bytes].view(
-            torch.long
-        )
+        self.token_to_pos_ids = self._cpu_bookkeeping_buf[
+            _off : _off + _tok_int64_bytes
+        ].view(torch.long)
         _off += _tok_int64_bytes
-        self.token_to_block_idx = self._cpu_bookkeeping_buf[_off : _off + _tok_int64_bytes].view(
-            torch.int64
-        )
+        self.token_to_block_idx = self._cpu_bookkeeping_buf[
+            _off : _off + _tok_int64_bytes
+        ].view(torch.int64)
         _off += _tok_int64_bytes
         # i.e For a set of tokens A B C D E F ..  and block_size 4:
         # token_to_position_in_request is  [0, 1, 2, 3, 4, 5]
@@ -1103,9 +1179,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             _off : _off + _tok_int32_bytes
         ].view(torch.int32)
         _off += _tok_int32_bytes
-        self.token_to_request_idx = self._cpu_bookkeeping_buf[_off : _off + _tok_int32_bytes].view(
-            torch.int32
-        )
+        self.token_to_request_idx = self._cpu_bookkeeping_buf[
+            _off : _off + _tok_int32_bytes
+        ].view(torch.int32)
         _off += _tok_int32_bytes
         self.token_to_position_in_request = self._cpu_bookkeeping_buf[
             _off : _off + _tok_int32_bytes
@@ -1131,17 +1207,17 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Sampling-parameter staging slots, refreshed from `active_request_metadata`
         # in transfer_bookkeeping_to_gpu(). FlashInfer reads these via
         # `gpu_view.{temperature, top_k, top_p}`.
-        self._staging_temperature = self._cpu_bookkeeping_buf[_off : _off + _req_4byte_bytes].view(
-            torch.float32
-        )
+        self._staging_temperature = self._cpu_bookkeeping_buf[
+            _off : _off + _req_4byte_bytes
+        ].view(torch.float32)
         _off += _req_4byte_bytes
-        self._staging_top_k = self._cpu_bookkeeping_buf[_off : _off + _req_4byte_bytes].view(
-            torch.int32
-        )
+        self._staging_top_k = self._cpu_bookkeeping_buf[
+            _off : _off + _req_4byte_bytes
+        ].view(torch.int32)
         _off += _req_4byte_bytes
-        self._staging_top_p = self._cpu_bookkeeping_buf[_off : _off + _req_4byte_bytes].view(
-            torch.float32
-        )
+        self._staging_top_p = self._cpu_bookkeeping_buf[
+            _off : _off + _req_4byte_bytes
+        ].view(torch.float32)
         _off += _req_4byte_bytes
 
         # Per-request last-token row indices. Aliased with the matching gpu_view slot:
@@ -1272,7 +1348,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         elif HAVE_TORCH_MEMORY_SAVER and need_static_addr:
             ctx_manager = torch_memory_saver.region(
                 tag=self.TMS_TAG,
-                enable_cpu_backup=(self.kv_cache_management_mode == KVCacheManagementMode.OFFLOAD),
+                enable_cpu_backup=(
+                    self.kv_cache_management_mode == KVCacheManagementMode.OFFLOAD
+                ),
             )
             self._uses_torch_memory_saver = True
         with ctx_manager:
@@ -1344,19 +1422,25 @@ class DynamicInferenceContext(BaseInferenceContext):
                 tag = self.TMS_TAG
                 if torch.distributed.get_rank() == 0:
                     logging.info(
-                        "torch_memory_saver: resuming %s, before: %s", tag, device_memory_summary()
+                        "torch_memory_saver: resuming %s, before: %s",
+                        tag,
+                        device_memory_summary(),
                     )
                 torch_memory_saver.resume(tag)
                 if torch.distributed.get_rank() == 0:
                     logging.info(
-                        "torch_memory_saver: resumed  %s, after:  %s", tag, device_memory_summary()
+                        "torch_memory_saver: resumed  %s, after:  %s",
+                        tag,
+                        device_memory_summary(),
                     )
             if self.kv_cache_management_mode == KVCacheManagementMode.RECOMPUTE:
                 self.reset_metadata()
             return
 
         if self.kv_cache_management_mode == KVCacheManagementMode.OFFLOAD:
-            for name, tensor in ((n, getattr(self, n)) for n in self._offloadable_tensor_names):
+            for name, tensor in (
+                (n, getattr(self, n)) for n in self._offloadable_tensor_names
+            ):
                 tensor.storage().resize_(self._offloadable_storage_sizes[name])
                 tensor.copy_(self._offloadable_cpu_backups[name], non_blocking=True)
         elif self.kv_cache_management_mode == KVCacheManagementMode.RECOMPUTE:
@@ -1382,17 +1466,23 @@ class DynamicInferenceContext(BaseInferenceContext):
             tag = self.TMS_TAG
             if torch.distributed.get_rank() == 0:
                 logging.info(
-                    "torch_memory_saver: pausing %s, before: %s", tag, device_memory_summary()
+                    "torch_memory_saver: pausing %s, before: %s",
+                    tag,
+                    device_memory_summary(),
                 )
             torch_memory_saver.pause(tag)
             if torch.distributed.get_rank() == 0:
                 logging.info(
-                    "torch_memory_saver: paused  %s, after:  %s", tag, device_memory_summary()
+                    "torch_memory_saver: paused  %s, after:  %s",
+                    tag,
+                    device_memory_summary(),
                 )
             return
 
         if self.kv_cache_management_mode == KVCacheManagementMode.OFFLOAD:
-            for name, tensor in ((n, getattr(self, n)) for n in self._offloadable_tensor_names):
+            for name, tensor in (
+                (n, getattr(self, n)) for n in self._offloadable_tensor_names
+            ):
                 self._offloadable_storage_sizes[name] = tensor.storage().size()
                 self._offloadable_cpu_backups[name].copy_(tensor, non_blocking=True)
                 tensor.storage().resize_(0)
@@ -1460,7 +1550,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         """Cumulative query sequence lengths."""
         assert self.active_attn_metadata is not None
         return (
-            self.active_attn_metadata["mha_metadata"].state_data["cu_query_seq_lengths"],
+            self.active_attn_metadata["mha_metadata"].state_data[
+                "cu_query_seq_lengths"
+            ],
             self.active_attn_metadata["mha_metadata"].state_data["max_seqlen_q"],
         )
 
@@ -1481,7 +1573,9 @@ class DynamicInferenceContext(BaseInferenceContext):
 
     def get_max_sequence_lengths(self) -> Tensor:
         """Maximum sequence length for active requests."""
-        return self.request_output_lengths[self.paused_request_count : self.total_request_count]
+        return self.request_output_lengths[
+            self.paused_request_count : self.total_request_count
+        ]
 
     def get_active_request_count(self):
         """Returns the current number of active requests."""
@@ -1492,7 +1586,9 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         If the context is reordered to active -> paused -> finished, this can be graphed.
         """
-        padded_slice = slice(self.paused_request_count, self.paused_request_count + batch_size)
+        padded_slice = slice(
+            self.paused_request_count, self.paused_request_count + batch_size
+        )
 
         # Request metadata all needs to be sliced.
         for label in self.request_metadata:
@@ -1512,7 +1608,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         active_request_count = self.total_request_count - self.paused_request_count
         active_decode_count = self.num_decode_requests
         active_prefill_count = active_request_count - active_decode_count
-        active_decode_token_count = active_decode_count * (self.num_speculative_tokens + 1)
+        active_decode_token_count = active_decode_count * (
+            self.num_speculative_tokens + 1
+        )
 
         # Decode prefix: positions [0, 1, ..., active_decode_token_count - 1].
         self.active_logit_idxs[:active_decode_token_count].copy_(
@@ -1525,15 +1623,21 @@ class DynamicInferenceContext(BaseInferenceContext):
             active_decode_token_count : active_decode_token_count + active_prefill_count
         ]
         prefill_idxs = self.paused_request_count + active_decode_count
-        prefill_lengths = self.request_query_lengths[prefill_idxs : self.total_request_count]
+        prefill_lengths = self.request_query_lengths[
+            prefill_idxs : self.total_request_count
+        ]
         if active_prefill_count > 0:
             prefill_cumsum = torch.cumsum(prefill_lengths, dim=0, dtype=torch.int32)
             prefill_cumsum.add_(active_decode_token_count - 1)
             prefill_dst.copy_(prefill_cumsum, non_blocking=True)
 
-        self.active_logit_idxs[active_decode_token_count + active_prefill_count :].zero_()
+        self.active_logit_idxs[
+            active_decode_token_count + active_prefill_count :
+        ].zero_()
 
-        padding_request_slice = slice(active_request_count, self.padded_active_request_count)
+        padding_request_slice = slice(
+            active_request_count, self.padded_active_request_count
+        )
 
         # Sampling metadata: pad with neutral defaults, so that the kernel early-exits.
         self.active_request_metadata["temperature"][padding_request_slice].fill_(1.0)
@@ -1542,7 +1646,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Padded gather indices fan in to row 0 harmlessly when used by FlashInfer.
         self.active_request_last_token_idxs[padding_request_slice].fill_(0)
 
-    def append_key_value_cache(self, layer_number: int, key: Tensor, value: Tensor) -> None:
+    def append_key_value_cache(
+        self, layer_number: int, key: Tensor, value: Tensor
+    ) -> None:
         """Append to KV cache.
 
         Args:
@@ -1580,18 +1686,20 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.cache_mla_latent:
             # We pass the kv_concat as the key in cache_mla_latent
             kv_concat = key
-            self.memory_buffer[attention_layer_number, block_idx, local_kv_seq_idx] = kv_concat[
-                : self.padded_active_token_count
-            ]
+            self.memory_buffer[attention_layer_number, block_idx, local_kv_seq_idx] = (
+                kv_concat[: self.padded_active_token_count]
+            )
         else:
-            self.memory_buffer[0, attention_layer_number, block_idx, local_kv_seq_idx] = key[
-                : self.padded_active_token_count
-            ]
-            self.memory_buffer[1, attention_layer_number, block_idx, local_kv_seq_idx] = value[
-                : self.padded_active_token_count
-            ]
+            self.memory_buffer[
+                0, attention_layer_number, block_idx, local_kv_seq_idx
+            ] = key[: self.padded_active_token_count]
+            self.memory_buffer[
+                1, attention_layer_number, block_idx, local_kv_seq_idx
+            ] = value[: self.padded_active_token_count]
 
-    def key_value_cache(self, layer_number: int) -> Tuple[Tensor, Optional[Tensor], Tensor]:
+    def key_value_cache(
+        self, layer_number: int
+    ) -> Tuple[Tensor, Optional[Tensor], Tensor]:
         """Read from KV cache.
 
         Args:
@@ -1646,8 +1754,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         import math as _math
 
-        conv_size = _math.prod(self.mamba_conv_states_shape) * self.mamba_conv_states_dtype.itemsize
-        ssm_size = _math.prod(self.mamba_ssm_states_shape) * self.mamba_ssm_states_dtype.itemsize
+        conv_size = (
+            _math.prod(self.mamba_conv_states_shape)
+            * self.mamba_conv_states_dtype.itemsize
+        )
+        ssm_size = (
+            _math.prod(self.mamba_ssm_states_shape)
+            * self.mamba_ssm_states_dtype.itemsize
+        )
         per_slot_bytes = self.num_mamba_layers * (conv_size + ssm_size)
         total_bytes = int(mamba_gb * 1024**3)
 
@@ -1852,7 +1966,10 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_metadata.reset()
 
     def add_dummy_requests_parallel(
-        self, requests: Sequence[DynamicInferenceRequest], *, count_as_prefill: bool = True
+        self,
+        requests: Sequence[DynamicInferenceRequest],
+        *,
+        count_as_prefill: bool = True,
     ) -> None:
         """Fast path to add dummy requests without allocating real KV blocks."""
 
@@ -1870,22 +1987,27 @@ class DynamicInferenceContext(BaseInferenceContext):
         metadata_cols: List[List] = [[] for _ in self.request_metadata_types]
 
         for req in requests:
-            assert isinstance(
-                req, DynamicInferenceRequest
-            ), "add_dummy_requests_parallel expects DynamicInferenceRequest objects"
-            assert (
-                req.finished_chunk_token_count == 0
-            ), "chunked requests are not supported in add_dummy_requests_parallel"
-            assert req.remaining_prompt_tokens is not None, "request missing prompt tokens"
+            assert isinstance(req, DynamicInferenceRequest), (
+                "add_dummy_requests_parallel expects DynamicInferenceRequest objects"
+            )
+            assert req.finished_chunk_token_count == 0, (
+                "chunked requests are not supported in add_dummy_requests_parallel"
+            )
+            assert req.remaining_prompt_tokens is not None, (
+                "request missing prompt tokens"
+            )
             assert req.sampling_params is not None, "request missing sampling params"
             prefill_chunk_length = req.remaining_prompt_length
-            assert prefill_chunk_length > 0, "request without prompt tokens is not supported"
+            assert prefill_chunk_length > 0, (
+                "request without prompt tokens is not supported"
+            )
             lengths.append(prefill_chunk_length)
             num_tokens_to_generate.append(req.sampling_params.num_tokens_to_generate)
             request_ids.append(req.request_id)
             prompt_tokens.append(
                 req.remaining_prompt_tokens.to(
-                    device=self.token_to_input_ids.device, dtype=self.token_to_input_ids.dtype
+                    device=self.token_to_input_ids.device,
+                    dtype=self.token_to_input_ids.dtype,
                 )
             )
             for i, m in enumerate(req.tracked_metadata):
@@ -1900,9 +2022,13 @@ class DynamicInferenceContext(BaseInferenceContext):
             lengths, dtype=self.request_query_lengths.dtype, device=device
         )
         tokens_to_generate_tensor = torch.tensor(
-            num_tokens_to_generate, dtype=self.request_query_lengths.dtype, device=device
+            num_tokens_to_generate,
+            dtype=self.request_query_lengths.dtype,
+            device=device,
         )
-        request_ids_tensor = torch.tensor(request_ids, dtype=self.request_ids.dtype, device=device)
+        request_ids_tensor = torch.tensor(
+            request_ids, dtype=self.request_ids.dtype, device=device
+        )
 
         block_counts = torch.div(
             lengths_tensor + (self.block_size_tokens - 1),
@@ -1917,12 +2043,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_ids[request_slice] = request_ids_tensor
         self.request_query_lengths[request_slice] = lengths_tensor
         self.request_in_prefill_status_tensor[request_slice] = 1
-        self.request_output_lengths[request_slice] = lengths_tensor + tokens_to_generate_tensor
+        self.request_output_lengths[request_slice] = (
+            lengths_tensor + tokens_to_generate_tensor
+        )
         self.request_kv_length_offsets[request_slice] = 0
         self.request_kv_block_counts[request_slice] = block_counts
         for i, (label, dtype) in enumerate(self.request_metadata_types):
             self.request_metadata[label][request_slice] = torch.tensor(
-                metadata_cols[i], dtype=dtype, device='cpu'
+                metadata_cols[i], dtype=dtype, device="cpu"
             )
 
         dummy_block_idx = self.kv_block_allocator.dummy_block_idx
@@ -1975,7 +2103,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.token_to_block_idx[token_slice] = dummy_block_idx
 
         if self.is_hybrid_model:
-            for logical_idx, request_idx in enumerate(range(start_request_idx, end_request_idx)):
+            for logical_idx, request_idx in enumerate(
+                range(start_request_idx, end_request_idx)
+            ):
                 mamba_idx = self.mamba_metadata.allocate_slot()
                 if mamba_idx is None:
                     raise ContextOverflowError(
@@ -2001,9 +2131,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
 
         # Pre-construct shared objects (safe due to deep copy in DynamicInferenceRequest.__post_init__)
-        shared_sampling_params = SamplingParams(num_tokens_to_generate=1, termination_id=-1)
+        shared_sampling_params = SamplingParams(
+            num_tokens_to_generate=1, termination_id=-1
+        )
         shared_decode_tokens = torch.zeros(
-            self.num_speculative_tokens + 1, dtype=torch.long, device='cpu'
+            self.num_speculative_tokens + 1, dtype=torch.long, device="cpu"
         )
 
         decode_requests = [
@@ -2033,7 +2165,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         assert per_prefill_tokens > 0
         # Create a single large tensor and slice from it for each prefill request
         max_prefill_tokens = per_prefill_tokens + (1 if rem_prefill_tokens > 0 else 0)
-        shared_prefill_tokens = torch.zeros(max_prefill_tokens, dtype=torch.long, device='cpu')
+        shared_prefill_tokens = torch.zeros(
+            max_prefill_tokens, dtype=torch.long, device="cpu"
+        )
 
         prefill_requests = [
             DynamicInferenceRequest(
@@ -2051,7 +2185,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         Returns the number of decode requests.
         """
-        return self.total_request_count - self.paused_request_count - self.num_prefill_requests
+        return (
+            self.total_request_count
+            - self.paused_request_count
+            - self.num_prefill_requests
+        )
 
     def add_dummy_requests_for_expert_parallel_step(
         self, graph_dimensions: InferenceBatchDimensions
@@ -2088,7 +2226,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             rem_prefill_tokens = prefill_tokens % N_prefill
             self.request_query_lengths[N_decode:N].fill_(per_prefill_tokens)
             if rem_prefill_tokens > 0:
-                self.request_query_lengths[N_decode : N_decode + rem_prefill_tokens] += 1
+                self.request_query_lengths[
+                    N_decode : N_decode + rem_prefill_tokens
+                ] += 1
 
         self.request_kv_length_offsets[0:N].fill_(0)
         self.request_to_kv_block_ids[0:N, 0] = dummy_block_idx
@@ -2173,7 +2313,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.cuda_graph_batch_dimensions_list,
             strict=self.is_hybrid_model,
             ep_group=self.expert_model_parallel_group,
-            match_ep_token_counts=self._nccl_ep_dispatcher or self._training_ep_dispatcher,
+            match_ep_token_counts=self._nccl_ep_dispatcher
+            or self._training_ep_dispatcher,
             ep_zmq_communicator=self._ep_zmq_communicator,
         )
         self._using_cuda_graph_this_step = best_graph is not None
@@ -2187,9 +2328,12 @@ class DynamicInferenceContext(BaseInferenceContext):
             if self.is_decode_only():
                 if self.num_speculative_tokens > 0:
                     padded_decode_req_count = min(
-                        self.max_requests, self.round_up_requests(self.num_decode_requests)
+                        self.max_requests,
+                        self.round_up_requests(self.num_decode_requests),
                     )
-                    padded_token_count = padded_decode_req_count * (self.num_speculative_tokens + 1)
+                    padded_token_count = padded_decode_req_count * (
+                        self.num_speculative_tokens + 1
+                    )
                 else:
                     padded_token_count = min(
                         self.max_tokens,
@@ -2202,10 +2346,14 @@ class DynamicInferenceContext(BaseInferenceContext):
                 padded_token_count = self.round_up_tokens(self.active_token_count)
                 target_padding_req_count = min(
                     self.max_requests,
-                    self.round_up_requests(self.total_request_count - self.paused_request_count),
+                    self.round_up_requests(
+                        self.total_request_count - self.paused_request_count
+                    ),
                 )
                 padded_decode_req_count = self.num_decode_requests
-                padded_prefill_req_count = target_padding_req_count - padded_decode_req_count
+                padded_prefill_req_count = (
+                    target_padding_req_count - padded_decode_req_count
+                )
             self.padded_batch_dimensions = InferenceBatchDimensions(
                 token_count=padded_token_count,
                 prefill_req_count=padded_prefill_req_count,
@@ -2213,17 +2361,22 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
         self.padded_active_token_count = self.padded_batch_dimensions.token_count
         self.padded_active_request_count = self.padded_batch_dimensions.req_count
-        self.padding_slice = slice(self.active_token_count, self.padded_active_token_count)
+        self.padding_slice = slice(
+            self.active_token_count, self.padded_active_token_count
+        )
 
         self.build_active_slices(
-            min(self.padded_active_request_count, self.max_requests - self.paused_request_count)
+            min(
+                self.padded_active_request_count,
+                self.max_requests - self.paused_request_count,
+            )
         )
         self.pad_active_slices()
 
         # Update token position indexes.
-        self.token_to_block_idx[self.active_token_count : self.padded_active_token_count] = (
-            self.kv_block_allocator.dummy_block_idx
-        )
+        self.token_to_block_idx[
+            self.active_token_count : self.padded_active_token_count
+        ] = self.kv_block_allocator.dummy_block_idx
         self.token_to_local_position_within_kv_block[
             self.active_token_count : self.padded_active_token_count
         ] = 0
@@ -2246,9 +2399,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         attn_dimensions = batch_dimensions
         if self.using_cuda_graph_this_step():
             # Treat some decode requests as prefill requests to fit the cuda graph batch dimension.
-            if batch_dimensions.decode_req_count > self.padded_batch_dimensions.decode_req_count:
+            if (
+                batch_dimensions.decode_req_count
+                > self.padded_batch_dimensions.decode_req_count
+            ):
                 total_req = batch_dimensions.req_count
-                adjusted_decode_req_count = self.padded_batch_dimensions.decode_req_count
+                adjusted_decode_req_count = (
+                    self.padded_batch_dimensions.decode_req_count
+                )
                 adjusted_prefill_req_count = total_req - adjusted_decode_req_count
                 attn_dimensions = InferenceBatchDimensions(
                     token_count=batch_dimensions.token_count,
@@ -2346,8 +2504,12 @@ class DynamicInferenceContext(BaseInferenceContext):
                     self.mamba_slot_allocator.get_intermediate_cpu_data()
                 )
             self._pending_mamba_transfer = self.mamba_metadata.compute_cpu_metadata(
-                active_mamba_indices=self.mamba_metadata.request_to_mamba_state_idx[active_slice],
-                token_to_request_idx=self.token_to_request_idx[: self.active_token_count],
+                active_mamba_indices=self.mamba_metadata.request_to_mamba_state_idx[
+                    active_slice
+                ],
+                token_to_request_idx=self.token_to_request_idx[
+                    : self.active_token_count
+                ],
                 cpu_cu_query=self._cpu_mha_cu_query_seq_lengths,
                 batch_dimensions=attn_dimensions,
                 padded_batch_dimensions=self.padded_batch_dimensions,
@@ -2362,10 +2524,18 @@ class DynamicInferenceContext(BaseInferenceContext):
             else:
                 self.moe_routing_metadata.disable_static_buffer_recording()
 
+        if self.dsa_enable_indexer_replay:
+            if self.using_cuda_graph_this_step():
+                self.dsa_indexer_metadata.enable_static_buffer_recording()
+            else:
+                self.dsa_indexer_metadata.disable_static_buffer_recording()
+
         # Flip NCCLAllGather dispatcher's path selector to not use allgathers.
         # _nccl_ep_dispatcher already implies ep_size > 1, so no extra EP guard.
         if self._nccl_ep_dispatcher:
-            NCCLAllGatherDispatcher._use_allgather_v = not self.using_cuda_graph_this_step()
+            NCCLAllGatherDispatcher._use_allgather_v = (
+                not self.using_cuda_graph_this_step()
+            )
 
         # Flush any Mamba ops queued by add_dummy_requests_for_cudagraph_capture
         # (warmup) or add_dummy_requests_for_expert_parallel_step (EP dummy step).
@@ -2400,7 +2570,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Batch-zero newly allocated Mamba slots.
         if self._pending_mamba_zeros:
             device = self.mamba_conv_states.device
-            indices = torch.tensor(self._pending_mamba_zeros, dtype=torch.long, device=device)
+            indices = torch.tensor(
+                self._pending_mamba_zeros, dtype=torch.long, device=device
+            )
             self.mamba_conv_states[:, indices] = 0.0
             self.mamba_ssm_states[:, indices] = 0.0
             self._pending_mamba_zeros.clear()
@@ -2426,21 +2598,27 @@ class DynamicInferenceContext(BaseInferenceContext):
         # CPU-to-CPU slice assignment on pinned memory (~15 KB total for 6
         # 4-byte fields at max_requests=624). Negligible vs. the launch overhead
         # we save by merging the H2D memcpys into 1.
-        self._staging_request_in_prefill_status[:n_active] = self.request_in_prefill_status_tensor[
+        self._staging_request_in_prefill_status[:n_active] = (
+            self.request_in_prefill_status_tensor[active_slice]
+        )
+        self._staging_request_query_lengths[:n_active] = self.request_query_lengths[
             active_slice
         ]
-        self._staging_request_query_lengths[:n_active] = self.request_query_lengths[active_slice]
-        self._staging_request_kv_length_offsets[:n_active] = self.request_kv_length_offsets[
-            active_slice
-        ]
+        self._staging_request_kv_length_offsets[:n_active] = (
+            self.request_kv_length_offsets[active_slice]
+        )
         # Sampling-parameter staging slots: read from `active_request_metadata`,
         # which `build_active_slices` + `pad_active_slices` already populated for
         # `[:padded_active]` (active values + neutral padding defaults).
-        self._staging_temperature[:padded_active] = self.active_request_metadata["temperature"][
+        self._staging_temperature[:padded_active] = self.active_request_metadata[
+            "temperature"
+        ][:padded_active]
+        self._staging_top_k[:padded_active] = self.active_request_metadata["top_k"][
             :padded_active
         ]
-        self._staging_top_k[:padded_active] = self.active_request_metadata["top_k"][:padded_active]
-        self._staging_top_p[:padded_active] = self.active_request_metadata["top_p"][:padded_active]
+        self._staging_top_p[:padded_active] = self.active_request_metadata["top_p"][
+            :padded_active
+        ]
 
         # Full-iteration CUDA graphs may have captured GPU consumers with the
         # padded graph request count. Keep those padded staging rows bounded so
@@ -2461,7 +2639,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         # bytes. Nothing else to do here for MHA.
 
         # Mamba metadata: copy pre-computed CPU tensors to GPU buffers.
-        if hasattr(self, '_pending_mamba_transfer') and self._pending_mamba_transfer is not None:
+        if (
+            hasattr(self, "_pending_mamba_transfer")
+            and self._pending_mamba_transfer is not None
+        ):
             self.mamba_metadata.load_from_cpu(self._pending_mamba_transfer)
             self._pending_mamba_transfer = None
 
@@ -2638,7 +2819,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             f"logits.size(1) ({tuple(logits.shape)}) != "
             f"padded_active_token_count ({self.padded_active_token_count})."
         )
-        return logits.squeeze(0)[self.active_logit_idxs[: self.num_last_token_logits], :]
+        return logits.squeeze(0)[
+            self.active_logit_idxs[: self.num_last_token_logits], :
+        ]
 
     def _compute_prefix_match(
         self, req: DynamicInferenceRequest, prefill_chunk_length: int
@@ -2653,14 +2836,18 @@ class DynamicInferenceContext(BaseInferenceContext):
                       prefix_skip_tokens, effective_prefill_chunk_length).
         """
         finished = req.finished_chunk_token_count
-        already_allocated_blocks = (finished + self.block_size_tokens - 1) // self.block_size_tokens
+        already_allocated_blocks = (
+            finished + self.block_size_tokens - 1
+        ) // self.block_size_tokens
         overall_required_blocks = (
             finished + prefill_chunk_length + self.block_size_tokens - 1
         ) // self.block_size_tokens
 
         # Fast path: skip all prefix matching when disabled.
         if not self.enable_prefix_caching:
-            num_blocks_from_pool = max(0, overall_required_blocks - already_allocated_blocks)
+            num_blocks_from_pool = max(
+                0, overall_required_blocks - already_allocated_blocks
+            )
             return (
                 [],
                 num_blocks_from_pool,
@@ -2677,18 +2864,24 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         block_aligned = finished % self.block_size_tokens == 0
         if num_matched > 0 and block_aligned:
-            prefix_skip_tokens = min(num_matched * self.block_size_tokens, prefill_chunk_length - 1)
+            prefix_skip_tokens = min(
+                num_matched * self.block_size_tokens, prefill_chunk_length - 1
+            )
         else:
             prefix_skip_tokens = 0
 
         # Hybrid models with Mamba caching: skip based on Mamba match count.
         # Only applies to the first chunk (finished == 0); continuation chunks
         # already had Mamba state restored during the first chunk.
-        if self.is_hybrid_model and self.mamba_slot_allocator is not None and finished == 0:
-            num_mamba_matched = getattr(req, '_mamba_num_matched_blocks', 0)
-            assert (
-                num_mamba_matched <= num_matched
-            ), f"Mamba match ({num_mamba_matched}) > KV match ({num_matched})"
+        if (
+            self.is_hybrid_model
+            and self.mamba_slot_allocator is not None
+            and finished == 0
+        ):
+            num_mamba_matched = getattr(req, "_mamba_num_matched_blocks", 0)
+            assert num_mamba_matched <= num_matched, (
+                f"Mamba match ({num_mamba_matched}) > KV match ({num_matched})"
+            )
             if num_mamba_matched > 0 and block_aligned:
                 raw_skip = num_mamba_matched * self.block_size_tokens
                 if raw_skip >= prefill_chunk_length:
@@ -2713,7 +2906,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Round down to a block boundary to keep block-table indexing consistent.
         if prefill_chunk_length - prefix_skip_tokens < 2 and prefill_chunk_length >= 2:
             max_skip = prefill_chunk_length - 2
-            prefix_skip_tokens = (max_skip // self.block_size_tokens) * self.block_size_tokens
+            prefix_skip_tokens = (
+                max_skip // self.block_size_tokens
+            ) * self.block_size_tokens
 
         effective_prefill_chunk_length = prefill_chunk_length - prefix_skip_tokens
         num_blocks_from_pool = max(
@@ -2729,14 +2924,17 @@ class DynamicInferenceContext(BaseInferenceContext):
             effective_prefill_chunk_length,
         )
 
-    def check_availability(self, req: DynamicInferenceRequest) -> Tuple[bool, bool, bool]:
+    def check_availability(
+        self, req: DynamicInferenceRequest
+    ) -> Tuple[bool, bool, bool]:
         """
         Check if the request can be added to the context.
         """
         # Note that for hybrid models checking the total request count is sufficient
         # because we allocate a single set of Mamba state tensors for each request
         request_can_be_added = (
-            self.total_request_count < self.max_requests and self.paused_request_count == 0
+            self.total_request_count < self.max_requests
+            and self.paused_request_count == 0
         )
 
         (_, num_blocks_from_pool, _, _, _, effective_prefill_chunk_length) = (
@@ -2746,7 +2944,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         request_tokens_can_be_added = (
             self.active_token_count + effective_prefill_chunk_length <= self.max_tokens
         )
-        kv_cache_available = self.kv_block_allocator.is_memory_available(num_blocks_from_pool)
+        kv_cache_available = self.kv_block_allocator.is_memory_available(
+            num_blocks_from_pool
+        )
         return request_can_be_added, request_tokens_can_be_added, kv_cache_available
 
     def _find_kv_match_count(
@@ -2790,7 +2990,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         for i in range(len(hashes) - 1, -1, -1):
             if hashes[i] in kv_hash_to_block:
                 num_matched = i + 1
-                matched_blocks = [kv_hash_to_block[hashes[j]] for j in range(num_matched)]
+                matched_blocks = [
+                    kv_hash_to_block[hashes[j]] for j in range(num_matched)
+                ]
                 parent_hash = hashes[num_matched - 1]
                 return matched_blocks, parent_hash
 
@@ -2817,9 +3019,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             prefill_chunk_length = req.remaining_prompt_length
 
         assert prefill_chunk_length > 0, "Chunk length is 0"
-        assert (
-            prefill_chunk_length <= req.remaining_prompt_length
-        ), "Prefill chunk length is greater than remaining prompt length"
+        assert prefill_chunk_length <= req.remaining_prompt_length, (
+            "Prefill chunk length is greater than remaining prompt length"
+        )
 
         # =========================================================================
         # Block allocation + prefix matching + prefill skipping
@@ -2841,17 +3043,23 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.prefix_cache_blocks_matched += num_matched_blocks
 
         # Slice tokens to skip matched prefix
-        this_round_tokens = req.remaining_prompt_tokens[prefix_skip_tokens:prefill_chunk_length]
+        this_round_tokens = req.remaining_prompt_tokens[
+            prefix_skip_tokens:prefill_chunk_length
+        ]
 
         new_block_ids = None
         if num_blocks_from_pool > 0:
-            new_block_ids = self.kv_block_allocator.allocate_memory_blocks(num_blocks_from_pool)
+            new_block_ids = self.kv_block_allocator.allocate_memory_blocks(
+                num_blocks_from_pool
+            )
             if new_block_ids is None or len(new_block_ids) != num_blocks_from_pool:
                 raise BlockOverflowError(req.request_id)
 
         # Increment ref counts and update timestamps for matched (shared) blocks
         if num_matched_blocks > 0:
-            matched_tensor = torch.tensor(matched_block_ids, dtype=torch.int32, device='cpu')
+            matched_tensor = torch.tensor(
+                matched_block_ids, dtype=torch.int32, device="cpu"
+            )
             self.kv_block_allocator.block_ref_counts[matched_tensor] += 1
             if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
                 self.kv_block_allocator.update_timestamps(matched_tensor)
@@ -2870,9 +3078,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.request_ids[current_id] = req.request_id
 
         # Handle request metadata.
-        assert (
-            req.get_metadata_types() == self.request_metadata_types
-        ), "Request added to context with invalid metadata types"
+        assert req.get_metadata_types() == self.request_metadata_types, (
+            "Request added to context with invalid metadata types"
+        )
         metadata = req.tracked_metadata
         metadata_types = req.get_metadata_types()
         for m, m_type in zip(metadata, metadata_types):
@@ -2910,9 +3118,9 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         self.request_kv_length_offsets[current_id] = effective_kv_offset
         self.request_kv_block_counts[current_id] = overall_required_blocks
-        self.request_last_kv_block_id[current_id] = self.request_to_kv_block_ids[current_id][
-            overall_required_blocks - 1
-        ]
+        self.request_last_kv_block_id[current_id] = self.request_to_kv_block_ids[
+            current_id
+        ][overall_required_blocks - 1]
         self.request_last_kv_block_offset[current_id] = (
             prefill_chunk_length + req.finished_chunk_token_count - 1
         ) % self.block_size_tokens
@@ -2923,23 +3131,31 @@ class DynamicInferenceContext(BaseInferenceContext):
             device=self.token_to_pos_ids.device,
         )
         self.token_to_pos_ids[
-            self.active_token_count : self.active_token_count + effective_prefill_chunk_length
+            self.active_token_count : self.active_token_count
+            + effective_prefill_chunk_length
         ] = token_offset_range
         self.token_to_input_ids[
-            self.active_token_count : self.active_token_count + effective_prefill_chunk_length
+            self.active_token_count : self.active_token_count
+            + effective_prefill_chunk_length
         ] = this_round_tokens
         self.token_to_request_idx[
-            self.active_token_count : self.active_token_count + effective_prefill_chunk_length
+            self.active_token_count : self.active_token_count
+            + effective_prefill_chunk_length
         ] = current_id
         self.token_to_position_in_request[
-            self.active_token_count : self.active_token_count + effective_prefill_chunk_length
+            self.active_token_count : self.active_token_count
+            + effective_prefill_chunk_length
         ] = token_offset_range
         self.token_to_block_idx[
-            self.active_token_count : self.active_token_count + effective_prefill_chunk_length
-        ] = self.request_to_kv_block_ids[current_id][token_offset_range // self.block_size_tokens]
+            self.active_token_count : self.active_token_count
+            + effective_prefill_chunk_length
+        ] = self.request_to_kv_block_ids[current_id][
+            token_offset_range // self.block_size_tokens
+        ]
         self.token_to_local_position_within_kv_block[
-            self.active_token_count : self.active_token_count + effective_prefill_chunk_length
-        ] = (token_offset_range % self.block_size_tokens)
+            self.active_token_count : self.active_token_count
+            + effective_prefill_chunk_length
+        ] = token_offset_range % self.block_size_tokens
 
         # Register hashes for completely filled blocks (skip matched blocks).
         # Two disjoint ranges may need registration:
@@ -2950,28 +3166,38 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.enable_prefix_caching and req.precomputed_block_hashes:
             total_tokens_after = req.finished_chunk_token_count + prefill_chunk_length
             num_complete_blocks = total_tokens_after // self.block_size_tokens
-            previously_complete = req.finished_chunk_token_count // self.block_size_tokens
+            previously_complete = (
+                req.finished_chunk_token_count // self.block_size_tokens
+            )
 
             def _register_range(start: int, end: int):
                 if start >= end:
                     return
-                block_ids_to_hash = self.request_to_kv_block_ids[current_id][start:end].tolist()
+                block_ids_to_hash = self.request_to_kv_block_ids[current_id][
+                    start:end
+                ].tolist()
                 block_hashes_slice = req.precomputed_block_hashes[start:end]
                 self.kv_block_allocator.register_kv_block_hashes(
                     block_ids_to_hash, block_hashes_slice
                 )
 
             # Range 1: prior-chunk partial block that this chunk just completed
-            _register_range(previously_complete, min(already_allocated_blocks, num_complete_blocks))
+            _register_range(
+                previously_complete, min(already_allocated_blocks, num_complete_blocks)
+            )
             # Range 2: newly allocated (non-matched) blocks that are now complete
-            _register_range(already_allocated_blocks + num_matched_blocks, num_complete_blocks)
+            _register_range(
+                already_allocated_blocks + num_matched_blocks, num_complete_blocks
+            )
 
         if self.is_hybrid_model and req.finished_chunk_token_count == 0:
             # Allocate a slot for Mamba states
             mamba_idx = self.mamba_metadata.allocate_slot()
             if mamba_idx is None:
                 raise ContextOverflowError(req.request_id, "No Mamba slots available")
-            self.mamba_metadata.request_to_mamba_state_idx[self.total_request_count] = mamba_idx
+            self.mamba_metadata.request_to_mamba_state_idx[self.total_request_count] = (
+                mamba_idx
+            )
 
             # Restore Mamba state from the block corresponding to prefix_skip_tokens
             restore_block_count = prefix_skip_tokens // self.block_size_tokens
@@ -3009,10 +3235,12 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         Move all the relevent booking tensors with src idxs to dst idxs
         """
-        self.request_kv_length_offsets[dst_idxs] = self.request_kv_length_offsets[src_idxs]
-        self.request_in_prefill_status_tensor[dst_idxs] = self.request_in_prefill_status_tensor[
+        self.request_kv_length_offsets[dst_idxs] = self.request_kv_length_offsets[
             src_idxs
         ]
+        self.request_in_prefill_status_tensor[dst_idxs] = (
+            self.request_in_prefill_status_tensor[src_idxs]
+        )
         self.request_query_lengths[dst_idxs] = self.request_query_lengths[src_idxs]
         self.request_output_lengths[dst_idxs] = self.request_output_lengths[src_idxs]
         self.request_ids[dst_idxs] = self.request_ids[src_idxs]
@@ -3021,8 +3249,12 @@ class DynamicInferenceContext(BaseInferenceContext):
             new_speculative_tokens[:, dst_idxs] = new_speculative_tokens[:, src_idxs]
         self.request_to_kv_block_ids[dst_idxs] = self.request_to_kv_block_ids[src_idxs]
         self.request_kv_block_counts[dst_idxs] = self.request_kv_block_counts[src_idxs]
-        self.request_last_kv_block_id[dst_idxs] = self.request_last_kv_block_id[src_idxs]
-        self.request_last_kv_block_offset[dst_idxs] = self.request_last_kv_block_offset[src_idxs]
+        self.request_last_kv_block_id[dst_idxs] = self.request_last_kv_block_id[
+            src_idxs
+        ]
+        self.request_last_kv_block_offset[dst_idxs] = self.request_last_kv_block_offset[
+            src_idxs
+        ]
 
         for metadata_tensor in self.request_metadata.values():
             metadata_tensor[dst_idxs] = metadata_tensor[src_idxs]
@@ -3060,7 +3292,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             tensor_swap(metadata_tensor, src_idxs, dst_idxs)
 
         if self.is_hybrid_model:
-            tensor_swap(self.mamba_metadata.request_to_mamba_state_idx, src_idxs, dst_idxs)
+            tensor_swap(
+                self.mamba_metadata.request_to_mamba_state_idx, src_idxs, dst_idxs
+            )
 
     def get_index_of_chunked_prefill_request(self, safe: bool = True) -> int:
         """
@@ -3138,7 +3372,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.paused_request_count > 0:
             active_block_count_avail = self.kv_block_allocator.get_active_avail()
             # Clone not needed: flip() makes a copy.
-            paused_block_counts = self.request_kv_block_counts[: self.paused_request_count]
+            paused_block_counts = self.request_kv_block_counts[
+                : self.paused_request_count
+            ]
             # Flip counts before cumsum, since paused requests are resumed from
             # the right-most index, so we must count resumed blocks starting from
             # the right side.
@@ -3155,7 +3391,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             paused_block_counts += needs_new_block
             paused_block_counts_cumsum = paused_block_counts.cumsum(dim=0)
             resume_request_count = min(
-                torch.nonzero(paused_block_counts_cumsum <= active_block_count_avail).numel(),
+                torch.nonzero(
+                    paused_block_counts_cumsum <= active_block_count_avail
+                ).numel(),
                 self.kv_block_allocator.total_avail,
             )
 
@@ -3176,12 +3414,16 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             # Check which resumed requests actually need a new block
             offsets = self.request_last_kv_block_offset[resume_start:resume_end]
-            needs_new_block = offsets >= (self.block_size_tokens - 1 - self.num_speculative_tokens)
+            needs_new_block = offsets >= (
+                self.block_size_tokens - 1 - self.num_speculative_tokens
+            )
             num_new_blocks = needs_new_block.sum().item()
 
             if num_new_blocks > 0:
                 assert num_new_blocks <= self.kv_block_allocator.total_avail
-                block_ids = self.kv_block_allocator.allocate_memory_blocks(num_new_blocks)
+                block_ids = self.kv_block_allocator.allocate_memory_blocks(
+                    num_new_blocks
+                )
 
                 # Apply updates only to the requests that required a new block
                 relative_row_idx = torch.nonzero(needs_new_block).squeeze(1)
@@ -3220,7 +3462,8 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # Overflow paused block count.
         overflow_paused_block_count = (
-            self.kv_block_allocator.get_paused_used() - self.kv_block_allocator.paused_count
+            self.kv_block_allocator.get_paused_used()
+            - self.kv_block_allocator.paused_count
         )
 
         # Nothing to evict?
@@ -3233,7 +3476,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         valid_paused_request_count = torch.nonzero(
             paused_block_counts_cumsum <= self.kv_block_allocator.paused_count
         ).numel()
-        overflow_paused_request_count = self.paused_request_count - valid_paused_request_count
+        overflow_paused_request_count = (
+            self.paused_request_count - valid_paused_request_count
+        )
 
         # Nothing to evict? (Similar to checking overflow_paused_block_count
         # above, but here we allow up to one paused request to overflow into the
@@ -3243,14 +3488,16 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # Evict request count. (Flip paused_block_counts because evictions are
         # counted from the right-most paused requests.
-        paused_block_counts = paused_block_counts[-overflow_paused_request_count:].flip(dims=[0])
+        paused_block_counts = paused_block_counts[-overflow_paused_request_count:].flip(
+            dims=[0]
+        )
         paused_block_counts_cumsum = paused_block_counts.cumsum(dim=0)
         remaining_paused_request_counts = torch.arange(
             overflow_paused_request_count - 1,
             -1,
             -1,
             dtype=paused_block_counts_cumsum.dtype,
-            device='cpu',
+            device="cpu",
         )
         net_block_counts = paused_block_counts_cumsum - remaining_paused_request_counts
         evict_request_count = torch.nonzero(net_block_counts >= 0)[0].item() + 1
@@ -3258,7 +3505,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Eviction index range.
         evict_start_idx = self.paused_request_count - evict_request_count
         evict_end_idx = self.paused_request_count
-        evict_request_idxs = torch.arange(evict_start_idx, evict_end_idx, device='cpu')
+        evict_request_idxs = torch.arange(evict_start_idx, evict_end_idx, device="cpu")
         # Clone needed: subsequent release_memory_blocks_from_request_indexes and
         # _swap_book_keeping_tensors calls mutate self.request_ids in place.
         evict_request_ids = self.request_ids[evict_start_idx:evict_end_idx].clone()
@@ -3273,24 +3520,24 @@ class DynamicInferenceContext(BaseInferenceContext):
             src_idxs = torch.arange(
                 self.paused_request_count - evict_request_count,
                 self.paused_request_count,
-                device='cpu',
+                device="cpu",
             )
             dst_idxs = torch.arange(
                 self.total_request_count - evict_request_count,
                 self.total_request_count,
-                device='cpu',
+                device="cpu",
             )
         else:
             # Swap all active requests with left-most evicted requests.
             src_idxs = torch.arange(
                 self.paused_request_count - evict_request_count,
                 self.paused_request_count - evict_request_count + active_request_count,
-                device='cpu',
+                device="cpu",
             )
             dst_idxs = torch.arange(
                 self.paused_request_count,
                 self.paused_request_count + active_request_count,
-                device='cpu',
+                device="cpu",
             )
 
         # Swap evicted and active requests.
@@ -3378,10 +3625,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         # All request that were in prefill become decode requests.
         # For the chunked prefill request we will overwrite this the next time add_request
         # is called on that request.
-        self.request_in_prefill_status_tensor[self.request_in_prefill_status_tensor == 1] = 0
+        self.request_in_prefill_status_tensor[
+            self.request_in_prefill_status_tensor == 1
+        ] = 0
 
         if (
-            chunked_prefill_request_idx := self.get_index_of_chunked_prefill_request(safe=True)
+            chunked_prefill_request_idx := self.get_index_of_chunked_prefill_request(
+                safe=True
+            )
         ) != -1:
             # Chunked prefill request was active this step.
             # We must keep it active so that the next iteration will add a new chunk to it.
@@ -3426,7 +3677,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.paused_request_count != 0:
             assert self.paused_tokens is not None
             next_tokens = torch.cat((self.paused_tokens, new_tokens))
-            if new_speculative_tokens is not None and self.paused_speculative_tokens is not None:
+            if (
+                new_speculative_tokens is not None
+                and self.paused_speculative_tokens is not None
+            ):
                 new_speculative_tokens = torch.cat(
                     (self.paused_speculative_tokens, new_speculative_tokens), dim=1
                 )
@@ -3445,13 +3699,15 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             if active_request_count > 0:
                 finished_idxs_on_left = (
-                    torch.nonzero(active_requests_mask[:active_request_count] == 0, as_tuple=True)[
-                        0
-                    ]
+                    torch.nonzero(
+                        active_requests_mask[:active_request_count] == 0, as_tuple=True
+                    )[0]
                     + self.paused_request_count
                 )
                 active_idxs_on_right = (
-                    torch.nonzero(active_requests_mask[active_request_count:], as_tuple=True)[0]
+                    torch.nonzero(
+                        active_requests_mask[active_request_count:], as_tuple=True
+                    )[0]
                     + active_request_count
                     + self.paused_request_count
                 )
@@ -3466,7 +3722,9 @@ class DynamicInferenceContext(BaseInferenceContext):
                 # Reset chunk ids for recently moved requests.
                 self.request_to_kv_block_ids[active_idxs_on_right] = -1
                 if self.is_hybrid_model:
-                    self.mamba_metadata.request_to_mamba_state_idx[active_idxs_on_right] = -1
+                    self.mamba_metadata.request_to_mamba_state_idx[
+                        active_idxs_on_right
+                    ] = -1
 
         # 5. We identify requests that require a new block and add them to the paused requests (i.e move them left) :-
         #       a) Put requests that have filled their current block and  require a new one in a pause state temporarily
@@ -3475,22 +3733,27 @@ class DynamicInferenceContext(BaseInferenceContext):
         newly_paused_request_ids = None
         if active_request_count > 0:
             num_tokens_in_last_block = self.request_last_kv_block_offset[
-                self.paused_request_count : (active_request_count + self.paused_request_count)
+                self.paused_request_count : (
+                    active_request_count + self.paused_request_count
+                )
             ]
             active_requests_requiring_new_block = (
-                num_tokens_in_last_block >= self.block_size_tokens - 1 - self.num_speculative_tokens
+                num_tokens_in_last_block
+                >= self.block_size_tokens - 1 - self.num_speculative_tokens
             ).byte()
 
             # Find the id in request_ids that is the chunked_prefill_request_id. Only one request should be chunked.
             if (
-                chunked_prefill_request_idx := self.get_index_of_chunked_prefill_request(safe=True)
+                chunked_prefill_request_idx
+                := self.get_index_of_chunked_prefill_request(safe=True)
             ) != -1:
                 active_requests_requiring_new_block[
                     chunked_prefill_request_idx - self.paused_request_count
                 ] = 0  # chunked prefill should not be paused
             else:
                 max_allowed_active = min(
-                    self.max_requests, self.max_tokens // (self.num_speculative_tokens + 1)
+                    self.max_requests,
+                    self.max_tokens // (self.num_speculative_tokens + 1),
                 )
                 if active_request_count > max_allowed_active:
                     # Force-pause excess requests in a decode-only batch
@@ -3502,7 +3765,8 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             if active_requests_requiring_new_block_count > 0:
                 newly_paused_request_ids = self.request_ids[
-                    torch.nonzero(active_requests_requiring_new_block) + self.paused_request_count
+                    torch.nonzero(active_requests_requiring_new_block)
+                    + self.paused_request_count
                 ]
 
             # Swap unfinished active requests on the left side with paused requests on the right side
@@ -3532,8 +3796,12 @@ class DynamicInferenceContext(BaseInferenceContext):
                     + active_requests_requiring_new_block_count
                     + self.paused_request_count
                 )
-                dst_idxs = torch.cat((active_request_ids_on_left, paused_requests_idxs_on_right))
-                src_idxs = torch.cat((paused_requests_idxs_on_right, active_request_ids_on_left))
+                dst_idxs = torch.cat(
+                    (active_request_ids_on_left, paused_requests_idxs_on_right)
+                )
+                src_idxs = torch.cat(
+                    (paused_requests_idxs_on_right, active_request_ids_on_left)
+                )
                 self._move_book_keeping_tensors(
                     src_idxs=src_idxs,
                     dst_idxs=dst_idxs,
@@ -3574,13 +3842,16 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
 
         assert active_request_count > 0 or self.chunked_prefill_request_id != -1, (
-            "active_request_count == %d with no hidden chunked prefill." % active_request_count
+            "active_request_count == %d with no hidden chunked prefill."
+            % active_request_count
         )
 
         # 6.d. Swap the chunked prefill request to the end of the active requests
         # to obey the invariance.
         if (
-            chunked_prefill_request_idx := self.get_index_of_chunked_prefill_request(safe=False)
+            chunked_prefill_request_idx := self.get_index_of_chunked_prefill_request(
+                safe=False
+            )
         ) != -1:
             if chunked_prefill_request_idx < self.total_request_count:
                 # Chunked prefill request was active this step.
@@ -3607,7 +3878,8 @@ class DynamicInferenceContext(BaseInferenceContext):
                 if chunked_prefill_request_idx != self.total_request_count:
                     self._swap_book_keeping_tensors(
                         src_idxs=torch.tensor(
-                            [chunked_prefill_request_idx], device=self.request_ids.device
+                            [chunked_prefill_request_idx],
+                            device=self.request_ids.device,
                         ),
                         dst_idxs=torch.tensor(
                             [self.total_request_count], device=self.request_ids.device
@@ -3617,7 +3889,9 @@ class DynamicInferenceContext(BaseInferenceContext):
                     )
 
         # 7. We make changes to the request book keeping tesnsors and setup the tokens for next iteration
-        assert self.total_request_count == active_request_count + self.paused_request_count
+        assert (
+            self.total_request_count == active_request_count + self.paused_request_count
+        )
 
         if self.paused_request_count > 0:
             # Clone needed: next_tokens is a shared buffer that will be overwritten in
@@ -3632,14 +3906,18 @@ class DynamicInferenceContext(BaseInferenceContext):
         # add_ and fill_ calls seems to work as intended with sliced indexing
         # (i.e. x[3:5].add(...) or x[3:5].fill_) but when another tensor is used
         # for indexing, it does not work as expected (i.e. x[y] if x and y are torch tensors)
-        self.request_kv_length_offsets[self.paused_request_count : self.total_request_count].add_(
-            self.request_query_lengths[self.paused_request_count : self.total_request_count]
+        self.request_kv_length_offsets[
+            self.paused_request_count : self.total_request_count
+        ].add_(
+            self.request_query_lengths[
+                self.paused_request_count : self.total_request_count
+            ]
         )
 
         num_generated_tokens = 1 + self.num_speculative_tokens
-        self.request_query_lengths[self.paused_request_count : self.total_request_count].fill_(
-            num_generated_tokens
-        )
+        self.request_query_lengths[
+            self.paused_request_count : self.total_request_count
+        ].fill_(num_generated_tokens)
 
         # Clone needed: old_offsets is reused later to compute raw_positions
         # for block-boundary detection. The write-back on the next line overwrites the
@@ -3649,12 +3927,14 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.paused_request_count : self.total_request_count
         ].clone()
 
-        self.request_last_kv_block_offset[self.paused_request_count : self.total_request_count] = (
-            old_offsets + num_generated_tokens
-        ) % self.block_size_tokens
+        self.request_last_kv_block_offset[
+            self.paused_request_count : self.total_request_count
+        ] = (old_offsets + num_generated_tokens) % self.block_size_tokens
 
         self.active_token_count = active_request_count * num_generated_tokens
-        sampled_tokens = next_tokens[self.paused_request_count : self.total_request_count]
+        sampled_tokens = next_tokens[
+            self.paused_request_count : self.total_request_count
+        ]
 
         if self.num_speculative_tokens > 0:
             # new_speculative_tokens has shape [num_spec_tokens, num_requests],
@@ -3675,22 +3955,23 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # Req kv length offsets : [0, 5, 10 ... ]
         # For num spec tokens = 2 , this will become [0, 1, 2, 5, 6, 7 10, 11, 12 ...]
-        self.token_to_pos_ids[: self.active_token_count] = self.request_kv_length_offsets[
-            self.paused_request_count : self.total_request_count
-        ].repeat_interleave(num_generated_tokens) + torch.arange(
-            num_generated_tokens, device='cpu'
-        ).repeat(
-            active_request_count
+        self.token_to_pos_ids[: self.active_token_count] = (
+            self.request_kv_length_offsets[
+                self.paused_request_count : self.total_request_count
+            ].repeat_interleave(num_generated_tokens)
+            + torch.arange(num_generated_tokens, device="cpu").repeat(
+                active_request_count
+            )
         )
         #
         # Token to request idx : [0, 0, 0, 1, 1, 1, 2, 2, 2 ...]
         self.token_to_request_idx[: self.active_token_count] = torch.arange(
-            self.paused_request_count, self.total_request_count, device='cpu'
+            self.paused_request_count, self.total_request_count, device="cpu"
         ).repeat_interleave(num_generated_tokens)
 
-        self.token_to_position_in_request[: self.active_token_count] = self.token_to_pos_ids[
-            : self.active_token_count
-        ]
+        self.token_to_position_in_request[: self.active_token_count] = (
+            self.token_to_pos_ids[: self.active_token_count]
+        )
 
         self.token_to_local_position_within_kv_block[: self.active_token_count] = (
             self.token_to_pos_ids[: self.active_token_count] % self.block_size_tokens
@@ -3707,7 +3988,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         raw_positions = (
             old_offsets[:, None]
             + 1  # Offset by 1 because old_offsets points to the LAST token
-            + torch.arange(num_generated_tokens, device='cpu')[None, :]
+            + torch.arange(num_generated_tokens, device="cpu")[None, :]
         )
         #
         # A token crosses to the next block if its raw_position >= block_size
@@ -3715,11 +3996,12 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         if not crosses_boundary.any() or self.num_speculative_tokens == 0:
             # Fast path: no tokens cross block boundary, all use current block
-            self.token_to_block_idx[: self.active_token_count] = self.request_last_kv_block_id[
-                self.paused_request_count : self.total_request_count
-            ].repeat_interleave(num_generated_tokens)
+            self.token_to_block_idx[: self.active_token_count] = (
+                self.request_last_kv_block_id[
+                    self.paused_request_count : self.total_request_count
+                ].repeat_interleave(num_generated_tokens)
+            )
         else:
-
             # Some tokens cross to the next block (this happens for resumed requests)
             #
             # When a request is paused and resumed:
@@ -3758,10 +4040,14 @@ class DynamicInferenceContext(BaseInferenceContext):
             # For requests that have crossing, tokens BEFORE boundary use prev block
             # crosses_boundary is False for tokens before boundary
             # So: where request_has_crossing AND NOT crosses_boundary, use prev_block
-            use_prev_block = request_has_crossing[:, None] & ~crosses_boundary  # [active_count, N]
+            use_prev_block = (
+                request_has_crossing[:, None] & ~crosses_boundary
+            )  # [active_count, N]
 
             # Apply previous block IDs where needed
-            prev_block_ids_expanded = prev_block_ids[:, None].expand(-1, num_generated_tokens)
+            prev_block_ids_expanded = prev_block_ids[:, None].expand(
+                -1, num_generated_tokens
+            )
             block_idx = torch.where(use_prev_block, prev_block_ids_expanded, block_idx)
 
             # Convert back to 1d tensor
@@ -3773,7 +4059,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         }
 
     def calculate_log_probs(
-        self, logits: Tensor, new_tokens: Tensor, only_last_token_logits: Optional[bool] = False
+        self,
+        logits: Tensor,
+        new_tokens: Tensor,
+        only_last_token_logits: Optional[bool] = False,
     ) -> Tuple[List[List[float]], Tensor]:
         """Calculate log probs for all active requests and return them.
 
@@ -3794,7 +4083,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         logits_squeezed = logits.squeeze(0).float()
 
         if only_last_token_logits or self.is_decode_only():
-            seq_idx = torch.arange(len(new_tokens), dtype=torch.int32, device=logits.device)
+            seq_idx = torch.arange(
+                len(new_tokens), dtype=torch.int32, device=logits.device
+            )
             log_probs = F.log_softmax(logits_squeezed[seq_idx], dim=-1)
             selected_log_probs = log_probs[seq_idx, new_tokens]
             return [[lp] for lp in selected_log_probs.tolist()], log_probs
@@ -3824,7 +4115,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         #   active_token_ids[new_token_idx] = new_tokens
         #                       : [ 52 | 12 | 16  3 | 12 72 24 88 86 ]
         n_active = self.total_request_count - self.paused_request_count
-        active_token_ids = self.gpu_view.token_to_input_ids[: self.active_token_count].roll(-1, 0)
+        active_token_ids = self.gpu_view.token_to_input_ids[
+            : self.active_token_count
+        ].roll(-1, 0)
         active_query_lengths = self.gpu_view.request_query_lengths[:n_active]
 
         new_token_idx = active_query_lengths.cumsum(0) - 1
@@ -3891,15 +4184,15 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Diagnostic helpers
         total_request_count = int(self.total_request_count)
         return {
-            'total_blocks': int(total_blocks),
-            'allocated_blocks': int(allocated_blocks),
-            'active_unique_blocks': int(active_unique_blocks),
-            'allocated_utilization': allocated_utilization,
-            'active_utilization': active_utilization,
-            'active_request_count': int(self.get_active_request_count()),
-            'paused_request_count': int(self.paused_request_count),
-            'block_count_avail': int(block_count_avail),
-            'active_token_count': int(self.active_token_count),
-            'total_request_count': int(total_request_count),
-            'max_requests': int(self.max_requests),
+            "total_blocks": int(total_blocks),
+            "allocated_blocks": int(allocated_blocks),
+            "active_unique_blocks": int(active_unique_blocks),
+            "allocated_utilization": allocated_utilization,
+            "active_utilization": active_utilization,
+            "active_request_count": int(self.get_active_request_count()),
+            "paused_request_count": int(self.paused_request_count),
+            "block_count_avail": int(block_count_avail),
+            "active_token_count": int(self.active_token_count),
+            "total_request_count": int(total_request_count),
+            "max_requests": int(self.max_requests),
         }

--- a/megatron/core/inference/contexts/indexer_metadata.py
+++ b/megatron/core/inference/contexts/indexer_metadata.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+if TYPE_CHECKING:
+    from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
+
+from megatron.core.transformer.experimental_attention_variant.indexer_replay import IndexerReplay
+
+
+class IndexerMetadata:
+    """Manages indexer topk indices metadata for DSA attention layers during inference.
+
+    This class provides static buffers for CUDA graph compatibility when
+    recording indexer top-k decisions. It holds a reference to the inference context
+    to automatically determine whether to use static buffers based on CUDA graph state.
+
+    Args:
+        context (DynamicInferenceContext): The inference context.
+        dsa_indexer_topk (int): Number of top-k tokens selected per query by the DSA indexer.
+    """
+
+    def __init__(self, context: "DynamicInferenceContext", dsa_indexer_topk: int):
+        self.context = context
+        self.max_tokens = context.max_tokens
+        self.dsa_indexer_topk = dsa_indexer_topk
+        self.device = torch.cuda.current_device()
+
+        self.indexer_indices_buffer: Optional[torch.Tensor] = None
+        self.num_dsa_layers: Optional[int] = None
+
+    def _ensure_buffer_allocated(self) -> None:
+        if self.indexer_indices_buffer is not None:
+            return
+
+        self.num_dsa_layers = len(IndexerReplay.global_indexer_replay_instances)
+
+        if self.num_dsa_layers == 0:
+            return
+
+        self.indexer_indices_buffer = torch.empty(
+            (self.max_tokens, self.num_dsa_layers, self.dsa_indexer_topk),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+    def get_indexer_indices(self) -> Optional[torch.Tensor]:
+        if self.context.using_cuda_graph_this_step():
+            if self.indexer_indices_buffer is None:
+                return None
+            return self.indexer_indices_buffer[: self.context.active_token_count]
+        else:
+            recorded_data = IndexerReplay.get_recorded_data()
+            if recorded_data is None or len(recorded_data) == 0:
+                return None
+            if recorded_data[0] is None:
+                return None
+            return torch.stack(recorded_data, dim=1)
+
+    def enable_static_buffer_recording(self) -> None:
+        self._ensure_buffer_allocated()
+        if self.indexer_indices_buffer is not None:
+            IndexerReplay.set_global_static_buffers(self.indexer_indices_buffer)
+
+    def disable_static_buffer_recording(self) -> None:
+        IndexerReplay.clear_global_static_buffers()

--- a/megatron/core/inference/contexts/kv_block_allocator.py
+++ b/megatron/core/inference/contexts/kv_block_allocator.py
@@ -35,7 +35,6 @@ class KVBlockAllocator:
             PrefixCachingEvictionPolicy.REF_ZERO
         ),
     ):
-
         self.context = context
         self.enable_prefix_caching = enable_prefix_caching
         self.prefix_caching_eviction_policy = prefix_caching_eviction_policy
@@ -49,29 +48,34 @@ class KVBlockAllocator:
         self.dummy_block_idx = self.total_count - 1
 
         # Initialize block pool as a "stack" data structure (CPU for bookkeeping).
-        self.block_bag = torch.arange(self.total_count, dtype=torch.int32, device='cpu')
+        self.block_bag = torch.arange(self.total_count, dtype=torch.int32, device="cpu")
 
         if self.enable_prefix_caching:
             # Block hash tracking for prefix caching: -1 = uncomputed, positive = valid hash
-            self.block_hashes = torch.full((self.total_count,), -1, dtype=torch.int64, device='cpu')
+            self.block_hashes = torch.full(
+                (self.total_count,), -1, dtype=torch.int64, device="cpu"
+            )
 
             # Hash-to-block mapping for O(1) prefix lookup
             self.kv_hash_to_block_id: Dict[int, int] = {}
 
             # Reference count per block: 0 = cached (evictable), >0 = actively used
             self.block_ref_counts = torch.zeros(
-                (self.total_count,), dtype=torch.int32, device='cpu'
+                (self.total_count,), dtype=torch.int32, device="cpu"
             )
 
             # LRU timestamps for eviction ordering (higher = more recently used)
             # Only needed in LRU mode; RZ mode evicts immediately on ref_count==0
             if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
                 self.block_timestamps = torch.zeros(
-                    (self.total_count,), dtype=torch.int64, device='cpu'
+                    (self.total_count,), dtype=torch.int64, device="cpu"
                 )
 
         # Per-block MoE routing storage (populated when routing replay is enabled)
         self.block_routing: Dict[int, np.ndarray] = {}
+
+        # Per-block DSA indexer indices storage (populated when indexer replay is enabled)
+        self.block_indexer_indices: Dict[int, np.ndarray] = {}
 
     def __str__(self):
         return (
@@ -108,13 +112,17 @@ class KVBlockAllocator:
         """Compute number of paused blocks used."""
         if not self.enable_prefix_caching:
             return (
-                self.context.request_kv_block_counts[: self.context.paused_request_count]
+                self.context.request_kv_block_counts[
+                    : self.context.paused_request_count
+                ]
                 .sum()
                 .item()
             )
 
         if self.context.paused_request_count > 0:
-            paused_rows = self.context.request_to_kv_block_ids[: self.context.paused_request_count]
+            paused_rows = self.context.request_to_kv_block_ids[
+                : self.context.paused_request_count
+            ]
             valid_ids = paused_rows[paused_rows >= 0]
             if valid_ids.numel() > 0:
                 return int(torch.unique(valid_ids).numel())
@@ -165,7 +173,8 @@ class KVBlockAllocator:
         if self.total_avail < num_blocks:
             if (
                 not self.enable_prefix_caching
-                or self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.REF_ZERO
+                or self.prefix_caching_eviction_policy
+                == PrefixCachingEvictionPolicy.REF_ZERO
             ):
                 return None  # RZ: no eviction path; disabled: no cached blocks
             blocks_needed_from_eviction = num_blocks - self.total_avail
@@ -206,7 +215,10 @@ class KVBlockAllocator:
 
         if self.enable_prefix_caching:
             self.block_ref_counts[blocks] -= 1
-            if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.REF_ZERO:
+            if (
+                self.prefix_caching_eviction_policy
+                == PrefixCachingEvictionPolicy.REF_ZERO
+            ):
                 zero_mask = self.block_ref_counts[blocks] == 0
                 if zero_mask.any():
                     self._deregister_blocks(blocks[zero_mask])
@@ -221,7 +233,9 @@ class KVBlockAllocator:
                 if unreg_mask.any():
                     unreg_blocks = blocks[unreg_mask]
                     num_unreg = unreg_blocks.numel()
-                    self.block_bag[self.total_avail : self.total_avail + num_unreg] = unreg_blocks
+                    self.block_bag[self.total_avail : self.total_avail + num_unreg] = (
+                        unreg_blocks
+                    )
                     self.total_avail += num_unreg
         else:
             num_blocks = blocks.numel()
@@ -243,7 +257,7 @@ class KVBlockAllocator:
         # Without resetting the block bag, context request memory will clash and
         # requests will point to each other's memory blocks, resulting in faulty
         # generations.
-        self.block_bag = torch.arange(self.total_count, dtype=torch.int32, device='cpu')
+        self.block_bag = torch.arange(self.total_count, dtype=torch.int32, device="cpu")
 
         self.total_avail = self.total_count - 1
 
@@ -264,7 +278,9 @@ class KVBlockAllocator:
     # Prefix caching methods
     # =========================================================================
 
-    def register_kv_block_hashes(self, block_ids: list[int], block_hashes: list[int]) -> None:
+    def register_kv_block_hashes(
+        self, block_ids: list[int], block_hashes: list[int]
+    ) -> None:
         """Register blocks in the hash-to-block mapping for discovery (batch).
 
         Args:
@@ -273,8 +289,12 @@ class KVBlockAllocator:
         """
         if not block_ids:
             return
-        id_tensor = torch.tensor(block_ids, dtype=torch.int64, device=self.block_hashes.device)
-        hash_tensor = torch.tensor(block_hashes, dtype=torch.int64, device=self.block_hashes.device)
+        id_tensor = torch.tensor(
+            block_ids, dtype=torch.int64, device=self.block_hashes.device
+        )
+        hash_tensor = torch.tensor(
+            block_hashes, dtype=torch.int64, device=self.block_hashes.device
+        )
         self.block_hashes[id_tensor] = hash_tensor
         self.kv_hash_to_block_id.update(zip(block_hashes, block_ids))
 
@@ -297,7 +317,10 @@ class KVBlockAllocator:
         # Remove from kv_hash_to_block_id dict (set ops + C-level map, no Python loop)
         keys_to_delete = set(hashes) - {-1}
         deque(
-            map(self.kv_hash_to_block_id.pop, keys_to_delete & self.kv_hash_to_block_id.keys()),
+            map(
+                self.kv_hash_to_block_id.pop,
+                keys_to_delete & self.kv_hash_to_block_id.keys(),
+            ),
             maxlen=0,
         )
 
@@ -388,13 +411,15 @@ class KVBlockAllocator:
         if token_count == 0:
             return
 
-        assert (
-            flat_routing.shape[0] == token_count
-        ), f"Routing token count {flat_routing.shape[0]} != active token count {token_count}"
+        assert flat_routing.shape[0] == token_count, (
+            f"Routing token count {flat_routing.shape[0]} != active token count {token_count}"
+        )
 
         # Token-to-block mapping for all active tokens
         block_ids_np = context.token_to_block_idx[:token_count].cpu().numpy()
-        positions_np = context.token_to_local_position_within_kv_block[:token_count].cpu().numpy()
+        positions_np = (
+            context.token_to_local_position_within_kv_block[:token_count].cpu().numpy()
+        )
 
         dummy = self.dummy_block_idx
 
@@ -402,7 +427,7 @@ class KVBlockAllocator:
         unique_blocks, inverse, counts = np.unique(
             block_ids_np, return_inverse=True, return_counts=True
         )
-        sorted_indices = np.argsort(inverse, kind='stable')
+        sorted_indices = np.argsort(inverse, kind="stable")
         sorted_positions = positions_np[sorted_indices]
         sorted_routing = flat_routing[sorted_indices]
 
@@ -483,3 +508,117 @@ class KVBlockAllocator:
             ndarray [block_size_tokens, num_layers, topk] or None if not stored.
         """
         return self.block_routing.get(block_id)
+
+    def store_indexer_per_block(self, flat_indices: Optional[np.ndarray]) -> None:
+        """Scatter flat indexer indices into per-block storage.
+
+        Uses the context's token-to-block mapping to distribute each token's
+        indexer data into the appropriate block.
+
+        Args:
+            flat_indices: ndarray of shape [active_token_count, num_dsa_layers, index_topk]
+                aligned with the context's active-token layout, or None.
+        """
+        if flat_indices is None:
+            return
+
+        context = self.context
+        token_count = context.active_token_count
+        if token_count == 0:
+            return
+
+        assert flat_indices.shape[0] == token_count, (
+            f"Indexer token count {flat_indices.shape[0]} != active token count {token_count}"
+        )
+
+        block_ids_np = context.token_to_block_idx[:token_count].cpu().numpy()
+        positions_np = (
+            context.token_to_local_position_within_kv_block[:token_count].cpu().numpy()
+        )
+
+        dummy = self.dummy_block_idx
+
+        unique_blocks, inverse, counts = np.unique(
+            block_ids_np, return_inverse=True, return_counts=True
+        )
+        sorted_indices = np.argsort(inverse, kind="stable")
+        sorted_positions = positions_np[sorted_indices]
+        sorted_flat_indices = flat_indices[sorted_indices]
+
+        offset = 0
+        for bid, count in zip(unique_blocks, counts):
+            bid = int(bid)
+            count = int(count)
+            if bid == dummy:
+                offset += count
+                continue
+            block_pos = sorted_positions[offset : offset + count]
+            block_indices = sorted_flat_indices[offset : offset + count]
+            self.store_block_indexer_indices(bid, block_pos, block_indices)
+            offset += count
+
+    def reconstruct_indexer_from_blocks(
+        self, block_ids: list[int], total_indexer_tokens: int
+    ) -> Optional[np.ndarray]:
+        """Reconstruct indexer indices from per-block storage.
+
+        Concatenates per-block indexer ndarrays in block order, trimming the
+        last block to exactly ``total_indexer_tokens`` entries.
+
+        Args:
+            block_ids: Ordered list of block IDs for the request.
+            total_indexer_tokens: Expected number of indexer tokens
+                (total_tokens - 1, since the last generated token has no
+                forward-pass indexer).
+
+        Returns:
+            ndarray [total_indexer_tokens, num_dsa_layers, index_topk] or None if any
+            block is missing indexer data.
+        """
+        block_size = self.context.block_size_tokens
+        indexer_parts = []
+        tokens_collected = 0
+
+        for bid in block_ids:
+            indices = self.get_block_indexer_indices(bid)
+            if indices is None:
+                return None
+            remaining = total_indexer_tokens - tokens_collected
+            if remaining <= 0:
+                break
+            take = min(block_size, remaining)
+            indexer_parts.append(indices[:take])
+            tokens_collected += take
+
+        if not indexer_parts or tokens_collected != total_indexer_tokens:
+            return None
+
+        return np.concatenate(indexer_parts, axis=0)
+
+    def store_block_indexer_indices(
+        self, block_id: int, positions: np.ndarray, indices: np.ndarray
+    ) -> None:
+        """Store indexer indices for specific token positions in a block.
+
+        Args:
+            block_id: The block ID.
+            positions: ndarray of token positions within the block (1D, int).
+            indices: ndarray of indexer data [num_positions, num_dsa_layers, index_topk].
+        """
+        if block_id not in self.block_indexer_indices:
+            self.block_indexer_indices[block_id] = np.zeros(
+                (self.context.block_size_tokens, indices.shape[-2], indices.shape[-1]),
+                dtype=indices.dtype,
+            )
+        self.block_indexer_indices[block_id][positions] = indices
+
+    def get_block_indexer_indices(self, block_id: int) -> Optional[np.ndarray]:
+        """Get indexer indices for a block.
+
+        Args:
+            block_id: The block ID.
+
+        Returns:
+            ndarray [block_size_tokens, num_dsa_layers, index_topk] or None if not stored.
+        """
+        return self.block_indexer_indices.get(block_id)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -50,6 +50,10 @@ from megatron.core.inference.utils import Counter, InferenceMode, await_process_
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.cuda_graphs import CudaGraphManager, delete_cuda_graphs
 from megatron.core.transformer.enums import InferenceCudaGraphScope
+from megatron.core.transformer.experimental_attention_variant.indexer_replay import (
+    IndexerReplay,
+    IndexerReplayAction,
+)
 from megatron.core.transformer.moe.router_replay import RouterReplay, RouterReplayAction
 from megatron.core.utils import (
     deprecate_args,
@@ -214,14 +218,15 @@ class DynamicInferenceEngine(AbstractEngine):
         *DEPRECATED_ARGS,
         message="Argument `{name}` has been deprecated. Only pass `controller` and `context`",
     )
-    def __init__(self, controller: TextGenerationController, context: DynamicInferenceContext):
-
-        assert isinstance(
-            controller, TextGenerationController
-        ), f"controller must be a TextGenerationController, got {type(controller)}"
-        assert isinstance(
-            context, DynamicInferenceContext
-        ), f"context must be a DynamicInferenceContext, got {type(context)}"
+    def __init__(
+        self, controller: TextGenerationController, context: DynamicInferenceContext
+    ):
+        assert isinstance(controller, TextGenerationController), (
+            f"controller must be a TextGenerationController, got {type(controller)}"
+        )
+        assert isinstance(context, DynamicInferenceContext), (
+            f"context must be a DynamicInferenceContext, got {type(context)}"
+        )
 
         model_config = controller.inference_wrapped_model.model.config
         inference_config = context.config
@@ -240,21 +245,29 @@ class DynamicInferenceEngine(AbstractEngine):
             inference_config.materialize_only_last_token_logits
         )
 
-        assert self.num_speculative_tokens >= 0, "Number of speculative tokens must be non-negative"
+        assert self.num_speculative_tokens >= 0, (
+            "Number of speculative tokens must be non-negative"
+        )
 
         if self.num_speculative_tokens > 0:
             assert (
                 model_config.mtp_use_repeated_layer
                 or self.num_speculative_tokens <= model_config.mtp_num_layers
-            ), f"Number of speculative tokens {self.num_speculative_tokens} must be less than or equal to number of MTP layers {model_config.mtp_num_layers}"
+            ), (
+                f"Number of speculative tokens {self.num_speculative_tokens} must be less than or equal to number of MTP layers {model_config.mtp_num_layers}"
+            )
         self.track_paused_request_events = inference_config.track_paused_request_events
-        self.track_generated_token_events = inference_config.track_generated_token_events
+        self.track_generated_token_events = (
+            inference_config.track_generated_token_events
+        )
         self.enable_chunked_prefill = inference_config.enable_chunked_prefill
         self.cuda_graph_all_prefills = inference_config.cuda_graph_all_prefills
         self.metrics_writer = inference_config.metrics_writer
         self.logging_step_interval = inference_config.logging_step_interval
         self.unified_memory_level = inference_config.unified_memory_level
-        self.use_synchronous_zmq_collectives = inference_config.use_synchronous_zmq_collectives
+        self.use_synchronous_zmq_collectives = (
+            inference_config.use_synchronous_zmq_collectives
+        )
         self.disable_ep_consensus = inference_config.disable_ep_consensus
         self.ep_consensus_interval = inference_config.ep_consensus_interval
         self.cuda_graph_impl = model_config.cuda_graph_impl
@@ -410,13 +423,15 @@ class DynamicInferenceEngine(AbstractEngine):
         mtp_warmup_enabled = (
             controller.num_mtp_depths > 0
             and (controller.num_speculative_tokens or 0) > 0
-            and hasattr(unwrapped, 'mtp')
+            and hasattr(unwrapped, "mtp")
         )
         if mtp_warmup_enabled:
             tp_size = get_pg_size(controller.inference_wrapped_model.tp_group)
             sp_enabled = model_config.sequence_parallel and tp_size > 1
             mtp_pass_depth = not unwrapped.mtp.mtp_use_repeated_layer
-            mtp_warmup_depths = range(controller.num_mtp_depths) if mtp_pass_depth else [None]
+            mtp_warmup_depths = (
+                range(controller.num_mtp_depths) if mtp_pass_depth else [None]
+            )
             mtp_seen_batch_sizes = set()
 
         tbar = enumerate(context.cuda_graph_batch_dimensions_list)
@@ -439,6 +454,10 @@ class DynamicInferenceEngine(AbstractEngine):
             # This ensures the record_indices copy operation is captured in the CUDA graph.
             if model_config.moe_enable_routing_replay:
                 RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+            if model_config.dsa_enable_indexer_replay:
+                IndexerReplay.set_global_indexer_replay_action(
+                    IndexerReplayAction.RECORD
+                )
 
             # Forward pass -> logits.
             with torch.inference_mode():
@@ -446,7 +465,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
                 if controller._sampling_backend == "flashinfer":
                     if controller.num_speculative_tokens > 0:
-                        controller._dynamic_step_sample_logits_and_verify_tokens(input_ids)
+                        controller._dynamic_step_sample_logits_and_verify_tokens(
+                            input_ids
+                        )
                     else:
                         controller._dynamic_step_sample_logits()
 
@@ -469,8 +490,12 @@ class DynamicInferenceEngine(AbstractEngine):
                                     device=device,
                                     dtype=model_config.params_dtype,
                                 ),
-                                next_token_ids=torch.zeros((1, n), device=device, dtype=torch.long),
-                                position_ids=torch.zeros((1, n), device=device, dtype=torch.int64),
+                                next_token_ids=torch.zeros(
+                                    (1, n), device=device, dtype=torch.long
+                                ),
+                                position_ids=torch.zeros(
+                                    (1, n), device=device, dtype=torch.int64
+                                ),
                                 depth=depth,
                                 cache_key=("mtp", n, depth),
                             )
@@ -482,7 +507,8 @@ class DynamicInferenceEngine(AbstractEngine):
             # NCCL workspaces, etc.) that pollutes `torch.cuda.memory_stats()`.
             pool_reserved, pool_alloc = _cuda_graph_mempool_bytes()
             logging.info(
-                "  [graph %d/%d] %s | pool reserved=%s (Δiter=%s) " "pool allocated=%s (Δiter=%s)",
+                "  [graph %d/%d] %s | pool reserved=%s (Δiter=%s) "
+                "pool allocated=%s (Δiter=%s)",
                 tbar_idx + 1,
                 len(context.cuda_graph_batch_dimensions_list),
                 cuda_graph_batch_dimension,
@@ -494,7 +520,9 @@ class DynamicInferenceEngine(AbstractEngine):
             prev_pool_reserved, prev_pool_alloc = pool_reserved, pool_alloc
 
         if mtp_warmup_enabled and mtp_seen_batch_sizes:
-            logging.info("> MTP CUDA graph warmup: %d batch size(s)", len(mtp_seen_batch_sizes))
+            logging.info(
+                "> MTP CUDA graph warmup: %d batch size(s)", len(mtp_seen_batch_sizes)
+            )
 
         # Memory usage.
         time_end = time.time()
@@ -502,8 +530,12 @@ class DynamicInferenceEngine(AbstractEngine):
         final_pool_reserved, final_pool_alloc = _cuda_graph_mempool_bytes()
         capture_stats = {
             "time": time_end - time_start,
-            "allocated_bytes": (mem_stats_end["allocated_bytes.all.current"] - start_proc_alloc),
-            "reserved_bytes": (mem_stats_end["reserved_bytes.all.current"] - start_proc_reserved),
+            "allocated_bytes": (
+                mem_stats_end["allocated_bytes.all.current"] - start_proc_alloc
+            ),
+            "reserved_bytes": (
+                mem_stats_end["reserved_bytes.all.current"] - start_proc_reserved
+            ),
             "pool_reserved_bytes": final_pool_reserved,
             "pool_allocated_bytes": final_pool_alloc,
         }
@@ -575,7 +607,8 @@ class DynamicInferenceEngine(AbstractEngine):
         """
 
         assert HAVE_ZMQ, (
-            "please install the pyzmq library to use InferenceCoordinator\n" "pip install pyzmq"
+            "please install the pyzmq library to use InferenceCoordinator\n"
+            "pip install pyzmq"
         )
         assert HAVE_MSGPACK, (
             "please install the messagepack library to use InferenceCoordinator\n"
@@ -603,7 +636,7 @@ class DynamicInferenceEngine(AbstractEngine):
 
         # Spawn a DP coordinator process and get the connection info.
         if launch_inference_coordinator and self.is_dp_coordinator:
-            spawn_context = multiprocessing.get_context('spawn')
+            spawn_context = multiprocessing.get_context("spawn")
             deterministic_mode = torch.are_deterministic_algorithms_enabled()
             dp_pipe, dp_process_pipe = spawn_context.Pipe()
             coordinator_ready_event = spawn_context.Event()
@@ -632,7 +665,10 @@ class DynamicInferenceEngine(AbstractEngine):
 
             # Check if the port number is not inference_coordinator_port
             actual_port = int(dp_addr.rsplit(":", 1)[-1])
-            if inference_coordinator_port != None and actual_port != inference_coordinator_port:
+            if (
+                inference_coordinator_port != None
+                and actual_port != inference_coordinator_port
+            ):
                 logging.warning(
                     f"Requested InferenceCoordinator port {inference_coordinator_port} "
                     f"but got port {actual_port} instead. This happens if the request port "
@@ -660,13 +696,15 @@ class DynamicInferenceEngine(AbstractEngine):
         torch.distributed.broadcast_object_list(bcast, src=mp_src, group=mp_group)
         [mp_req_addr] = bcast
 
-        identity = f'mp-coord-{dp_rank}'
+        identity = f"mp-coord-{dp_rank}"
         if self.is_mp_coordinator:
             # 1. Create dealer sockets where tp_rank = 0 and pp_rank = 0
             #    These will receive requests from an InferenceCoordinator.
             self.socket_for_receiving_requests = self.zmq_context.socket(zmq.DEALER)
 
-            self.socket_for_receiving_requests.setsockopt(zmq.IDENTITY, identity.encode('utf-8'))
+            self.socket_for_receiving_requests.setsockopt(
+                zmq.IDENTITY, identity.encode("utf-8")
+            )
             self.socket_for_receiving_requests.connect(dp_addr)
 
             # send empty string. this is used to register with the coordinator.
@@ -700,7 +738,9 @@ class DynamicInferenceEngine(AbstractEngine):
             # Give the context a CPU-side MAX-reduction primitive so
             # match_graph_config() can avoid a per-step NCCL AllReduce kernel.
             if hasattr(self.context, "set_ep_zmq_communicator"):
-                self.context.set_ep_zmq_communicator(self.expert_parallel_zmq_communicator)
+                self.context.set_ep_zmq_communicator(
+                    self.expert_parallel_zmq_communicator
+                )
 
         # initialize zmq-based world communicator for consensus barriers
         total_world_size = torch.distributed.get_world_size()
@@ -718,7 +758,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
         # Finally run the engine infinite loop.
         loop = get_asyncio_loop(loop)
-        self.engine_loop_task = loop.create_task(self.run_engine_with_coordinator(loop=loop))
+        self.engine_loop_task = loop.create_task(
+            self.run_engine_with_coordinator(loop=loop)
+        )
 
         return dp_addr
 
@@ -739,7 +781,6 @@ class DynamicInferenceEngine(AbstractEngine):
         """
 
         try:
-
             start_mem = torch.cuda.memory_stats()
             start_time = time.time()
             nvtx_range_push(f"{key}-inference-context")
@@ -748,7 +789,6 @@ class DynamicInferenceEngine(AbstractEngine):
             yield
 
         finally:
-
             nvtx_range_pop(f"{key}-inference-context")
             end_time = time.time()
 
@@ -759,9 +799,13 @@ class DynamicInferenceEngine(AbstractEngine):
             end_mem_res = end_mem["reserved_bytes.all.current"]
 
             rank_str = torch.distributed.get_rank()
-            dir_str = "deallocating" if end_mem_alloc <= start_mem_alloc else "allocating"
+            dir_str = (
+                "deallocating" if end_mem_alloc <= start_mem_alloc else "allocating"
+            )
             relative_time_str = f"{end_time - start_time:.3f} sec"
-            relative_mem_str = f"{abs(start_mem_alloc - end_mem_alloc) / 1024**3:.1f} gb"
+            relative_mem_str = (
+                f"{abs(start_mem_alloc - end_mem_alloc) / 1024**3:.1f} gb"
+            )
 
             if HAVE_PSUTIL:
                 process = psutil.Process()
@@ -849,7 +893,6 @@ class DynamicInferenceEngine(AbstractEngine):
         with self.__class__.suspend_resume_ctx(
             "resumed", unified_memory_level=self.unified_memory_level
         ):
-
             # Allocate context tensors.
             alloc_time = time.time()
             torch.cuda.synchronize()
@@ -874,8 +917,12 @@ class DynamicInferenceEngine(AbstractEngine):
             # Ensure chunked prefill request remains at the head of the waiting queue
             if self.context.chunked_prefill_request_id != -1:
                 if self.context.chunked_prefill_request_id in self.waiting_request_ids:
-                    self.waiting_request_ids.remove(self.context.chunked_prefill_request_id)
-                    self.waiting_request_ids.appendleft(self.context.chunked_prefill_request_id)
+                    self.waiting_request_ids.remove(
+                        self.context.chunked_prefill_request_id
+                    )
+                    self.waiting_request_ids.appendleft(
+                        self.context.chunked_prefill_request_id
+                    )
 
             torch.cuda.synchronize()
             add_time = time.time() - add_time
@@ -925,7 +972,9 @@ class DynamicInferenceEngine(AbstractEngine):
                 )
             ]
             errors_str = (
-                "; ".join(f"{type(e).__name__}: {e}" for e in errors) if errors else "unknown error"
+                "; ".join(f"{type(e).__name__}: {e}" for e in errors)
+                if errors
+                else "unknown error"
             )
             warnings.warn(
                 f"Request {request_id} failed to be added to the engine ({errors_str}). "
@@ -942,7 +991,10 @@ class DynamicInferenceEngine(AbstractEngine):
         # Send the reply immediately, because it may never get a chance to be sent again.
         if self.use_coordinator and self.is_mp_coordinator:
             payload = msgpack.packb(
-                [Headers.ENGINE_REPLY.value, [request_entry.record.merge().serialize()]],
+                [
+                    Headers.ENGINE_REPLY.value,
+                    [request_entry.record.merge().serialize()],
+                ],
                 use_bin_type=True,
             )
             self.socket_for_receiving_requests.send(payload)
@@ -961,7 +1013,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
     def has_unfinished_requests(self) -> bool:
         """Test if context contains unfinished requests."""
-        return self.context.has_unfinished_requests() or len(self.waiting_request_ids) > 0
+        return (
+            self.context.has_unfinished_requests() or len(self.waiting_request_ids) > 0
+        )
 
     def get_request(self, request_id: int) -> DynamicInferenceRequest:
         """Get most recent request from a request record.
@@ -977,7 +1031,6 @@ class DynamicInferenceEngine(AbstractEngine):
     def _add_request(
         self, request: DynamicInferenceRequest
     ) -> asyncio.Future[DynamicInferenceRequest]:
-
         request_id = request.request_id
 
         # Add request to self.requests. If the engine has previously been
@@ -1003,9 +1056,9 @@ class DynamicInferenceEngine(AbstractEngine):
             or request.sampling_params.num_tokens_total is None
         )
         if request.sampling_params.top_n_logprobs > 0:
-            assert (
-                request.sampling_params.return_log_probs
-            ), "top_n_logprobs requires sampling_params.return_log_probs to be True"
+            assert request.sampling_params.return_log_probs, (
+                "top_n_logprobs requires sampling_params.return_log_probs to be True"
+            )
         if (
             request.sampling_params.return_log_probs
             and not request.sampling_params.skip_prompt_log_probs
@@ -1022,8 +1075,8 @@ class DynamicInferenceEngine(AbstractEngine):
             )
             request.sampling_params.num_tokens_total = None
         if request.sampling_params.num_tokens_to_generate is None:
-            request.sampling_params.num_tokens_to_generate = self.context.max_sequence_length - len(
-                request.prompt_tokens
+            request.sampling_params.num_tokens_to_generate = (
+                self.context.max_sequence_length - len(request.prompt_tokens)
             )
         if request.sampling_params.termination_id is None:
             try:
@@ -1042,7 +1095,9 @@ class DynamicInferenceEngine(AbstractEngine):
         remaining_tokens = self.context.max_sequence_length - len(request.prompt_tokens)
         if request.sampling_params.num_tokens_to_generate < 0 or remaining_tokens < 0:
             request.status = Status.FAILED
-            request.add_event_error_nontransient(MaxSequenceLengthOverflowError(request_id))
+            request.add_event_error_nontransient(
+                MaxSequenceLengthOverflowError(request_id)
+            )
         elif request.sampling_params.num_tokens_to_generate > remaining_tokens:
             requested_tokens = request.sampling_params.num_tokens_to_generate
             request.sampling_params.num_tokens_to_generate = remaining_tokens
@@ -1053,7 +1108,10 @@ class DynamicInferenceEngine(AbstractEngine):
                     f"Clamping num_tokens_to_generate to {remaining_tokens}."
                 )
 
-        if len(request.prompt_tokens) > self.context.max_tokens and not self.enable_chunked_prefill:
+        if (
+            len(request.prompt_tokens) > self.context.max_tokens
+            and not self.enable_chunked_prefill
+        ):
             request.status = Status.FAILED
             request.add_event_error_nontransient(TokenOverflowError(request_id))
 
@@ -1061,8 +1119,12 @@ class DynamicInferenceEngine(AbstractEngine):
         max_request_tokens = (
             len(request.prompt_tokens) + request.sampling_params.num_tokens_to_generate
         )
-        request_block_count = math.ceil(max_request_tokens / self.context.block_size_tokens)
-        total_blocks = self.context.kv_block_allocator.total_count - 1  # -1 for dummy block
+        request_block_count = math.ceil(
+            max_request_tokens / self.context.block_size_tokens
+        )
+        total_blocks = (
+            self.context.kv_block_allocator.total_count - 1
+        )  # -1 for dummy block
         if request_block_count > total_blocks:
             request.status = Status.FAILED
             request.add_event_error_nontransient(BlockOverflowError(request_id))
@@ -1070,7 +1132,9 @@ class DynamicInferenceEngine(AbstractEngine):
         # Tokenize stop words if provided
         if request.sampling_params.stop_words:
             stop_word_ids = [
-                self.controller.tokenize_prompt(self.controller.tokenizer, stop_word, add_BOS=False)
+                self.controller.tokenize_prompt(
+                    self.controller.tokenizer, stop_word, add_BOS=False
+                )
                 for stop_word in request.sampling_params.stop_words
             ]
             request.stop_word_ids = stop_word_ids
@@ -1116,7 +1180,9 @@ class DynamicInferenceEngine(AbstractEngine):
             )
         elif isinstance(prompt, list):
             # Convert List[int] -> Tensor.
-            tokens = torch.tensor(prompt, dtype=torch.int64, device=torch.cuda.current_device())
+            tokens = torch.tensor(
+                prompt, dtype=torch.int64, device=torch.cuda.current_device()
+            )
         elif isinstance(prompt, torch.Tensor):
             # Prompt already tokenized.
             assert prompt.dtype == torch.int64, prompt.dtype
@@ -1150,7 +1216,9 @@ class DynamicInferenceEngine(AbstractEngine):
         sample: torch.Tensor,
         accepted_tokens: torch.Tensor,
         log_probs: torch.Tensor,
-        top_n_logprobs: Optional[Dict[int, List[Tuple[torch.Tensor, torch.Tensor]]]] = None,
+        top_n_logprobs: Optional[
+            Dict[int, List[Tuple[torch.Tensor, torch.Tensor]]]
+        ] = None,
         pre_fwd_active_token_count: Optional[int] = None,
         pre_fwd_step_count: Optional[int] = None,
         finished_routing_block_ids: Optional[Dict[int, list[int]]] = None,
@@ -1189,7 +1257,9 @@ class DynamicInferenceEngine(AbstractEngine):
         if self.track_generated_token_events:
             blocks_allocated = block_allocator.total_count - block_allocator.total_avail
             if block_allocator.enable_prefix_caching:
-                blocks_hashed_active = int((block_allocator.block_ref_counts > 0).sum().item())
+                blocks_hashed_active = int(
+                    (block_allocator.block_ref_counts > 0).sum().item()
+                )
                 blocks_ref_count = block_allocator.block_ref_counts.sum().item()
             else:
                 blocks_hashed_active = blocks_allocated
@@ -1197,15 +1267,26 @@ class DynamicInferenceEngine(AbstractEngine):
 
         # When accepted_tokens is None (no speculative decoding), use repeat([]) to provide
         # empty lists for each request, so the zip produces the correct number of iterations
-        accepted_tokens_iter = repeat([]) if accepted_tokens is None else accepted_tokens.tolist()
+        accepted_tokens_iter = (
+            repeat([]) if accepted_tokens is None else accepted_tokens.tolist()
+        )
 
         if self.num_speculative_tokens > 0 and accepted_tokens is not None:
             self._spec_steps += 1
 
-        for req_idx, (request_id, tokens, accepted_tokens_list, request_log_probs) in enumerate(
-            zip(request_ids.tolist(), sample.tolist(), accepted_tokens_iter, log_probs_iter)
+        for req_idx, (
+            request_id,
+            tokens,
+            accepted_tokens_list,
+            request_log_probs,
+        ) in enumerate(
+            zip(
+                request_ids.tolist(),
+                sample.tolist(),
+                accepted_tokens_iter,
+                log_probs_iter,
+            )
         ):
-
             # Ensure tokens is always a list for consistent handling
             if not isinstance(tokens, list):
                 tokens = [tokens]
@@ -1213,7 +1294,9 @@ class DynamicInferenceEngine(AbstractEngine):
             request: DynamicInferenceRequest = self.get_request(request_id)
 
             if self.num_speculative_tokens > 0:
-                accepted_tokens = list(filter(lambda tok: tok != -1, accepted_tokens_list))
+                accepted_tokens = list(
+                    filter(lambda tok: tok != -1, accepted_tokens_list)
+                )
 
                 # The order `accepted_tokens + tokens` is correct here.
                 # `accepted_tokens` contains the sequence of
@@ -1249,7 +1332,9 @@ class DynamicInferenceEngine(AbstractEngine):
                         if request_log_probs is not None:
                             request_log_probs = request_log_probs[:-num_dropped]
                         if top_n_logprobs is not None and req_idx in top_n_logprobs:
-                            top_n_logprobs[req_idx] = top_n_logprobs[req_idx][:-num_dropped]
+                            top_n_logprobs[req_idx] = top_n_logprobs[req_idx][
+                                :-num_dropped
+                            ]
                 if request_id not in self.stop_word_being_finished_ids:
                     is_first_token = len(request.generated_tokens) == 0
                     request.generated_tokens += tokens
@@ -1284,7 +1369,8 @@ class DynamicInferenceEngine(AbstractEngine):
                                 payload={"token_id": tokens[0]},
                             )
                         request.ttft = (
-                            first_token_event.timestamp - request.event_add_engine.timestamp
+                            first_token_event.timestamp
+                            - request.event_add_engine.timestamp
                         )
                     # TPOT is observability-only. step_time is 0.0 on
                     # non-logging steps (async_forward skips the event sync),
@@ -1299,8 +1385,8 @@ class DynamicInferenceEngine(AbstractEngine):
                 # appended token. The check truncates generated_tokens in-place and
                 # returns how many trailing tokens were removed so we can also trim
                 # the corresponding log probs below.
-                stop_word_hit, num_stop_word_trim = self._check_stop_words_for_request_post_append(
-                    request
+                stop_word_hit, num_stop_word_trim = (
+                    self._check_stop_words_for_request_post_append(request)
                 )
 
                 # Track per-position acceptance statistics for logging.
@@ -1312,7 +1398,9 @@ class DynamicInferenceEngine(AbstractEngine):
                     and len(request.generated_tokens) > 0
                     and self.num_speculative_tokens > 0
                 ):
-                    actual_proposed = max(0, self.num_speculative_tokens - num_stop_word_trim)
+                    actual_proposed = max(
+                        0, self.num_speculative_tokens - num_stop_word_trim
+                    )
                     self._spec_tokens_proposed_per_pos[:actual_proposed] += 1
                     accepted_t = torch.tensor(accepted_tokens_list[:actual_proposed])
                     self._spec_tokens_accepted_per_pos[:actual_proposed] += (
@@ -1327,12 +1415,17 @@ class DynamicInferenceEngine(AbstractEngine):
                         and len(self.requests[request_id].record.requests) == 1
                     ):
                         block_ids = finished_routing_block_ids[request_id]
-                        total_tokens = len(request.prompt_tokens) + len(request.generated_tokens)
-                        request.routing_indices = (
-                            self.context.kv_block_allocator.reconstruct_routing_from_blocks(
+                        total_tokens = len(request.prompt_tokens) + len(
+                            request.generated_tokens
+                        )
+                        request.routing_indices = self.context.kv_block_allocator.reconstruct_routing_from_blocks(
+                            block_ids, total_tokens - 1
+                        )
+                        # Reconstruct indexer indices from the same per-block storage.
+                        if self.model_config.dsa_enable_indexer_replay:
+                            request.indexer_indices = self.context.kv_block_allocator.reconstruct_indexer_from_blocks(
                                 block_ids, total_tokens - 1
                             )
-                        )
 
                     # Request finished by normal means (termination_id, max_length, or stop word from previous step)
                     request.generated_length = len(request.generated_tokens)
@@ -1340,7 +1433,9 @@ class DynamicInferenceEngine(AbstractEngine):
                     request.add_event_finish()
                     finished_entry = self.requests.pop(request_id)
                     finished_request = finished_entry.record[-1]
-                    finished_request.generated_length = len(finished_request.generated_tokens)
+                    finished_request.generated_length = len(
+                        finished_request.generated_tokens
+                    )
                     finished_request_records.append(finished_entry.record)
                     finished_entry.future.set_result(finished_entry.record)
                 elif stop_word_hit:
@@ -1362,7 +1457,9 @@ class DynamicInferenceEngine(AbstractEngine):
                 if request_log_probs is not None:
                     request_log_probs = request_log_probs[:-num_stop_word_trim]
                 if top_n_logprobs is not None and req_idx in top_n_logprobs:
-                    top_n_logprobs[req_idx] = top_n_logprobs[req_idx][:-num_stop_word_trim]
+                    top_n_logprobs[req_idx] = top_n_logprobs[req_idx][
+                        :-num_stop_word_trim
+                    ]
 
             # Process log_probs if available (unified for both regular and chunked prefill)
             # Skip for requests being finished due to stop words — tokens are not
@@ -1378,7 +1475,9 @@ class DynamicInferenceEngine(AbstractEngine):
                 if not request.generated_log_probs:
                     request.generated_log_probs = []
 
-                is_chunked_prefill = request_id == self.context.chunked_prefill_request_id
+                is_chunked_prefill = (
+                    request_id == self.context.chunked_prefill_request_id
+                )
                 is_prefill = len(request.generated_log_probs) == 0
 
                 if request.sampling_params.skip_prompt_log_probs:
@@ -1395,13 +1494,17 @@ class DynamicInferenceEngine(AbstractEngine):
                     total_accumulated = len(request.prompt_log_probs) + len(
                         request.generated_log_probs
                     )
-                    remaining_prompt_slots = max(0, prompt_length - 1 - total_accumulated)
+                    remaining_prompt_slots = max(
+                        0, prompt_length - 1 - total_accumulated
+                    )
                     split_idx = min(remaining_prompt_slots, len(request_log_probs))
 
                     if split_idx > 0:
                         request.prompt_log_probs.extend(request_log_probs[:split_idx])
                     if split_idx < len(request_log_probs):
-                        request.generated_log_probs.extend(request_log_probs[split_idx:])
+                        request.generated_log_probs.extend(
+                            request_log_probs[split_idx:]
+                        )
 
             # Process top_n_logprobs if available (unified for both regular and chunked prefill)
             # Same stop-word guard as log probs above.
@@ -1445,7 +1548,6 @@ class DynamicInferenceEngine(AbstractEngine):
 
         # Handle evicted requests.
         if evict_request_ids is not None and evict_request_ids.numel() > 0:
-
             evict_request_ids = evict_request_ids.tolist()
 
             # Insert into waiting_request_ids after any chunk prefill request.
@@ -1465,7 +1567,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
         return active_request_ids, finished_request_records
 
-    def _get_and_clear_stop_word_finished_ids(self, active_request_ids: list[int]) -> set[int]:
+    def _get_and_clear_stop_word_finished_ids(
+        self, active_request_ids: list[int]
+    ) -> set[int]:
         """Get and clear the set of request IDs that should be finished due to stop words.
 
         This callback is called from the controller during bookkeeping to get request IDs
@@ -1529,7 +1633,9 @@ class DynamicInferenceEngine(AbstractEngine):
                     end_idx = -i if i > 0 else None
                     if list(generated_tokens[-stop_len - i : end_idx]) == stop_word_ids:
                         trim = (
-                            i if request.sampling_params.detokenize_stop_sequence else i + stop_len
+                            i
+                            if request.sampling_params.detokenize_stop_sequence
+                            else i + stop_len
                         )
                         if trim > 0:
                             request.generated_tokens = request.generated_tokens[:-trim]
@@ -1612,14 +1718,19 @@ class DynamicInferenceEngine(AbstractEngine):
             request_can_be_added, request_tokens_can_be_added, kv_cache_available = (
                 self.context.check_availability(req)
             )
-            if request_can_be_added and request_tokens_can_be_added and kv_cache_available:
+            if (
+                request_can_be_added
+                and request_tokens_can_be_added
+                and kv_cache_available
+            ):
                 # CUDA graph-aware admission gating: defer if the resulting batch shape lacks a
                 # matching captured CG. Non-chunked admit takes the request whole, so the
                 # candidate token_count is active + remaining_prompt_tokens.
                 if self._cg_admission_gating_active():
                     candidate = InferenceBatchDimensions(
                         token_count=(
-                            self.context.active_token_count + len(req.remaining_prompt_tokens)
+                            self.context.active_token_count
+                            + len(req.remaining_prompt_tokens)
                         ),
                         prefill_req_count=self.context.num_prefill_requests + 1,
                         decode_req_count=self.context.num_decode_requests,
@@ -1630,7 +1741,10 @@ class DynamicInferenceEngine(AbstractEngine):
                 # Add these hashes to pending.
                 if prefix_caching_enabled:
                     for block_hash in req.precomputed_block_hashes:
-                        if block_hash not in self.context.kv_block_allocator.kv_hash_to_block_id:
+                        if (
+                            block_hash
+                            not in self.context.kv_block_allocator.kv_hash_to_block_id
+                        ):
                             pending_block_hashes.add(block_hash)
                 self.context.add_request(req)
                 self._loop.call_soon_threadsafe(
@@ -1784,22 +1898,35 @@ class DynamicInferenceEngine(AbstractEngine):
 
             # Use remaining prompt tokens for scheduling decisions
             remaining_len = len(req.remaining_prompt_tokens)
-            token_partially_can_be_added = self.context.active_token_count < self.context.max_tokens
-            request_can_be_added, _, kv_cache_available = self.context.check_availability(req)
+            token_partially_can_be_added = (
+                self.context.active_token_count < self.context.max_tokens
+            )
+            request_can_be_added, _, kv_cache_available = (
+                self.context.check_availability(req)
+            )
             request_can_be_added = is_continuing_chunked_prefill or request_can_be_added
 
-            if request_can_be_added and kv_cache_available and token_partially_can_be_added:
+            if (
+                request_can_be_added
+                and kv_cache_available
+                and token_partially_can_be_added
+            ):
                 # How many tokens we can admit this step.
                 token_budget = self.context.max_tokens - self.context.active_token_count
                 max_chunk = min(remaining_len, token_budget)
 
                 # Skip CG gating for the continuation of an in-flight chunked prefill:
                 # the request is already mid-flight, deferring it would deadlock progress.
-                if self._cg_admission_gating_active() and not is_continuing_chunked_prefill:
+                if (
+                    self._cg_admission_gating_active()
+                    and not is_continuing_chunked_prefill
+                ):
                     # Snap chunk size to the largest captured-CG boundary within budget.
                     # Fall back to eager (max_chunk) if no CG shape covers the budget.
                     snapped_chunk = self._find_cg_chunk_size(max_chunk)
-                    prefill_chunk_length = snapped_chunk if snapped_chunk is not None else max_chunk
+                    prefill_chunk_length = (
+                        snapped_chunk if snapped_chunk is not None else max_chunk
+                    )
                     req.cg_wait_iters = 0
                 else:
                     prefill_chunk_length = max_chunk
@@ -1819,7 +1946,10 @@ class DynamicInferenceEngine(AbstractEngine):
                 # Add hashes to pending set (prefix-caching bookkeeping).
                 if prefix_caching_enabled:
                     for block_hash in req.precomputed_block_hashes:
-                        if block_hash not in self.context.kv_block_allocator.kv_hash_to_block_id:
+                        if (
+                            block_hash
+                            not in self.context.kv_block_allocator.kv_hash_to_block_id
+                        ):
                             pending_block_hashes.add(block_hash)
 
                 if prefill_chunk_length >= remaining_len:
@@ -1828,18 +1958,24 @@ class DynamicInferenceEngine(AbstractEngine):
                     self._loop.call_soon_threadsafe(
                         self._loop.create_task, self._notify_cond_for_new_request()
                     )
-                    req.remaining_prompt_tokens = req.remaining_prompt_tokens.new_empty(0)
+                    req.remaining_prompt_tokens = req.remaining_prompt_tokens.new_empty(
+                        0
+                    )
                     req.add_event_add_context()
                     self.waiting_request_ids.popleft()
                     can_schedule = True
                 else:
                     # Partial admit: schedule this chunk and keep the request at the queue head.
-                    self.context.add_request(req, prefill_chunk_length=prefill_chunk_length)
+                    self.context.add_request(
+                        req, prefill_chunk_length=prefill_chunk_length
+                    )
                     self._loop.call_soon_threadsafe(
                         self._loop.create_task, self._notify_cond_for_new_request()
                     )
                     self.context.chunked_prefill_request_id = req.request_id
-                    req.remaining_prompt_tokens = req.remaining_prompt_tokens[prefill_chunk_length:]
+                    req.remaining_prompt_tokens = req.remaining_prompt_tokens[
+                        prefill_chunk_length:
+                    ]
                     req.finished_chunk_token_count += prefill_chunk_length
 
         # Prepend pending request ids to waiting queue.
@@ -1972,13 +2108,21 @@ class DynamicInferenceEngine(AbstractEngine):
             accepted_tokens = step_result["accepted_tokens"]
             log_probs = step_result["log_probs"]
             top_n_logprobs = step_result.get("top_n_logprobs", None)
-            finished_routing_block_ids = step_result.get("finished_routing_block_ids", None)
+            finished_routing_block_ids = step_result.get(
+                "finished_routing_block_ids", None
+            )
             cuda_graph_request_count = step_result["cuda_graph_request_count"]
 
             # Add paused events.
-            if newly_paused_request_ids is not None and self.track_paused_request_events:
+            if (
+                newly_paused_request_ids is not None
+                and self.track_paused_request_events
+            ):
                 newly_paused_request_ids = newly_paused_request_ids.tolist()
-                [self.get_request(i).add_event_pause() for i in newly_paused_request_ids]
+                [
+                    self.get_request(i).add_event_pause()
+                    for i in newly_paused_request_ids
+                ]
 
             # Process finished requests (adds FINISH events and returns records).
             (active_request_ids, finished_request_records) = self.post_process_requests(
@@ -2004,9 +2148,9 @@ class DynamicInferenceEngine(AbstractEngine):
         for failed_request_id in self.failed_request_ids:
             failed_entry = self.requests.pop(failed_request_id)
             finished_request_records.append(failed_entry.record)
-            assert (
-                failed_entry.future.done()
-            ), f"Failed request {failed_request_id} future has not been properly resolved."
+            assert failed_entry.future.done(), (
+                f"Failed request {failed_request_id} future has not been properly resolved."
+            )
         self.failed_request_ids.clear()
 
         nvtx_range_pop("bookkeeping")
@@ -2036,12 +2180,17 @@ class DynamicInferenceEngine(AbstractEngine):
         # so only send completed records here.
         if self.use_coordinator and self.is_mp_coordinator:
             records_to_send = [
-                r for r in finished_request_records if r.requests[-1].status != Status.FAILED
+                r
+                for r in finished_request_records
+                if r.requests[-1].status != Status.FAILED
             ]
             if records_to_send:
                 nvtx_range_push("coordinator_communication")
                 payload = msgpack.packb(
-                    [Headers.ENGINE_REPLY.value, [r.merge().serialize() for r in records_to_send]],
+                    [
+                        Headers.ENGINE_REPLY.value,
+                        [r.merge().serialize() for r in records_to_send],
+                    ],
                     use_bin_type=True,
                 )
                 self.socket_for_receiving_requests.send(payload)
@@ -2050,7 +2199,9 @@ class DynamicInferenceEngine(AbstractEngine):
         # Drain prefix cache hit counters from context into engine accumulators.
         if self.context.enable_prefix_caching:
             self._prefix_cache_hits += self.context.prefix_cache_hits
-            self._prefix_cache_blocks_matched += self.context.prefix_cache_blocks_matched
+            self._prefix_cache_blocks_matched += (
+                self.context.prefix_cache_blocks_matched
+            )
             self.context.prefix_cache_hits = 0
             self.context.prefix_cache_blocks_matched = 0
 
@@ -2060,52 +2211,56 @@ class DynamicInferenceEngine(AbstractEngine):
             # Prepare metrics dictionary with all stats
             # Use 'inference/' prefix for all metrics to separate from training metrics
             metrics = {
-                'inference/inference_step': int(
+                "inference/inference_step": int(
                     self.inference_step_offset + int(self.context.step_count)
                 ),
-                'inference/step_time_s': float(step_time),
-                'inference/waiting_queue_len': int(len(self.waiting_request_ids)),
-                'inference/total_requests_dict_size': int(len(self.requests)),
+                "inference/step_time_s": float(step_time),
+                "inference/waiting_queue_len": int(len(self.waiting_request_ids)),
+                "inference/total_requests_dict_size": int(len(self.requests)),
             }
             # Add KV stats with inference/ prefix
             # Convert utilization metrics from 0-1 range to 0-100 percentage range for better visualization
             for key, value in context_state["kv_stats"].items():
-                if 'utilization' in key:
+                if "utilization" in key:
                     # Convert to percentage (0-100) and group under kvcache_utilization
-                    metrics[f'inference/{key}'] = float(value * 100.0)
+                    metrics[f"inference/{key}"] = float(value * 100.0)
                 else:
-                    metrics[f'inference/{key}'] = value
+                    metrics[f"inference/{key}"] = value
 
             # Add speculative decoding acceptance metrics (aggregate + per-position).
             total_proposed = sum(self._spec_tokens_proposed_per_pos)
             total_accepted = sum(self._spec_tokens_accepted_per_pos)
             if self.num_speculative_tokens > 0 and total_proposed > 0:
                 acceptance_rate = total_accepted / total_proposed
-                metrics['inference/spec_decode_acceptance_rate'] = float(acceptance_rate * 100.0)
-                metrics['inference/spec_decode_tokens_proposed'] = int(total_proposed)
-                metrics['inference/spec_decode_tokens_accepted'] = int(total_accepted)
-                metrics['inference/spec_decode_num_steps'] = int(self._spec_steps)
+                metrics["inference/spec_decode_acceptance_rate"] = float(
+                    acceptance_rate * 100.0
+                )
+                metrics["inference/spec_decode_tokens_proposed"] = int(total_proposed)
+                metrics["inference/spec_decode_tokens_accepted"] = int(total_accepted)
+                metrics["inference/spec_decode_num_steps"] = int(self._spec_steps)
                 for pos in range(self.num_speculative_tokens):
                     if self._spec_tokens_proposed_per_pos[pos] > 0:
                         pos_rate = (
                             self._spec_tokens_accepted_per_pos[pos]
                             / self._spec_tokens_proposed_per_pos[pos]
                         )
-                        metrics[f'inference/spec_decode_acceptance_rate_pos{pos + 1}'] = float(
-                            pos_rate * 100.0
-                        )
+                        metrics[
+                            f"inference/spec_decode_acceptance_rate_pos{pos + 1}"
+                        ] = float(pos_rate * 100.0)
 
             # Add prefix caching metrics.
             if self.context.enable_prefix_caching and self._prefix_cache_hits > 0:
-                metrics['inference/prefix_cache_hits'] = int(self._prefix_cache_hits)
-                metrics['inference/prefix_cache_blocks_matched'] = int(
+                metrics["inference/prefix_cache_hits"] = int(self._prefix_cache_hits)
+                metrics["inference/prefix_cache_blocks_matched"] = int(
                     self._prefix_cache_blocks_matched
                 )
 
             if HAVE_WANDB and self.metrics_writer.__name__ == "wandb":
                 self.metrics_writer.log(metrics, commit=True)
             else:
-                raise ValueError(f"Unsupported metrics writer type: {type(self.metrics_writer)}")
+                raise ValueError(
+                    f"Unsupported metrics writer type: {type(self.metrics_writer)}"
+                )
         nvtx_range_pop("wandb_logging")
 
         # Print context state.
@@ -2140,7 +2295,8 @@ class DynamicInferenceEngine(AbstractEngine):
                             ),
                         )
                     ),
-                    context_state["total_request_count"] - context_state["paused_request_count"],
+                    context_state["total_request_count"]
+                    - context_state["paused_request_count"],
                     context_state["max_requests"],
                     context_state["paused_request_count"],
                     context_state["waiting_request_count"],
@@ -2168,17 +2324,23 @@ class DynamicInferenceEngine(AbstractEngine):
                             * 100.0
                         )
                         per_pos_rates.append("t%d=%.1f%%" % (pos + 1, pos_rate))
-                output_str += " ... spec (cumul): accept %.1f%% (%d/%d in %d steps) [%s]" % (
-                    spec_rate,
-                    total_accepted,
-                    total_proposed,
-                    self._spec_steps,
-                    ", ".join(per_pos_rates),
+                output_str += (
+                    " ... spec (cumul): accept %.1f%% (%d/%d in %d steps) [%s]"
+                    % (
+                        spec_rate,
+                        total_accepted,
+                        total_proposed,
+                        self._spec_steps,
+                        ", ".join(per_pos_rates),
+                    )
                 )
             if self.context.enable_prefix_caching and self._prefix_cache_hits > 0:
-                output_str += " ... prefix cache (cumul): %d hits, %d blocks matched" % (
-                    self._prefix_cache_hits,
-                    self._prefix_cache_blocks_matched,
+                output_str += (
+                    " ... prefix cache (cumul): %d hits, %d blocks matched"
+                    % (
+                        self._prefix_cache_hits,
+                        self._prefix_cache_blocks_matched,
+                    )
                 )
             if context_state["is_decode_only"]:
                 output_str = f"\033[94m{output_str}\033[0m"
@@ -2255,7 +2417,9 @@ class DynamicInferenceEngine(AbstractEngine):
     step = step_legacy
 
     def generate(
-        self, prompts: List[str], sampling_params: Optional[SamplingParams] = SamplingParams()
+        self,
+        prompts: List[str],
+        sampling_params: Optional[SamplingParams] = SamplingParams(),
     ) -> List[DynamicInferenceRequest]:
         """Generates completions for a static list of prompts."""
 
@@ -2310,7 +2474,9 @@ class DynamicInferenceEngine(AbstractEngine):
             while True:
                 try:
                     # Receive messages in a non-blocking way.
-                    all_messages.append(self.socket_for_receiving_requests.recv(flags=zmq.NOBLOCK))
+                    all_messages.append(
+                        self.socket_for_receiving_requests.recv(flags=zmq.NOBLOCK)
+                    )
                 except zmq.Again:
                     # This exception is hit as soon as the socket is empty.
                     break
@@ -2373,17 +2539,23 @@ class DynamicInferenceEngine(AbstractEngine):
                 # Any other state can safely ignore PAUSE.
 
             elif header == Headers.UNPAUSE:
-                assert self.state == EngineState.PAUSED, f"Received UNPAUSE in state {self.state}"
+                assert self.state == EngineState.PAUSED, (
+                    f"Received UNPAUSE in state {self.state}"
+                )
                 self.state = EngineState.UNPAUSING
 
             elif header == Headers.SUSPEND:
-                assert self.state == EngineState.PAUSED, f"Received SUSPEND in state {self.state}"
+                assert self.state == EngineState.PAUSED, (
+                    f"Received SUSPEND in state {self.state}"
+                )
                 self._state_events[EngineState.RESUMED].clear()
                 self.suspend()
                 self.state = EngineState.SUSPENDING
 
             elif header == Headers.RESUME:
-                assert self.state == EngineState.SUSPENDED, f"Received RESUME in state {self.state}"
+                assert self.state == EngineState.SUSPENDED, (
+                    f"Received RESUME in state {self.state}"
+                )
                 self._state_events[EngineState.SUSPENDED].clear()
                 self.resume()
                 self.state = EngineState.RESUMING
@@ -2415,15 +2587,15 @@ class DynamicInferenceEngine(AbstractEngine):
                 entry.future.cancel()
 
         # ZMQ cleanup; designed to be idempotent.
-        sock = getattr(self, 'socket_for_receiving_requests', None)
+        sock = getattr(self, "socket_for_receiving_requests", None)
         if sock is not None and not sock.closed:
             try:
                 sock.send(msgpack.packb([Headers.DISCONNECT.value], use_bin_type=True))
             except Exception:
                 pass
-        for socket in getattr(self, 'zmq_sockets', []):
+        for socket in getattr(self, "zmq_sockets", []):
             socket.close(linger=0)
-        if hasattr(self, 'zmq_sockets'):
+        if hasattr(self, "zmq_sockets"):
             self.zmq_sockets.clear()
         if hasattr(self, "expert_parallel_zmq_communicator"):
             self.expert_parallel_zmq_communicator.close()
@@ -2446,7 +2618,8 @@ class DynamicInferenceEngine(AbstractEngine):
                 async with self._cond:
                     await self._cond.wait_for(
                         lambda: (
-                            self.state not in (EngineState.SUSPENDED, EngineState.SUSPENDING)
+                            self.state
+                            not in (EngineState.SUSPENDED, EngineState.SUSPENDING)
                             and (
                                 self.context.get_active_request_count() > 0
                                 or self.waiting_request_ids
@@ -2495,10 +2668,13 @@ class DynamicInferenceEngine(AbstractEngine):
             # The user may have other tasks running in the event loop that need to be serviced.
             # Do not using a torch.distributed blocking all-reduce here using nccl/gloo.
             # We have tried that and it blocks the event loop in megatron-rl.
-            global_work, global_consensus = (
-                await self.expert_parallel_zmq_communicator.all_reduce_max(
-                    local_work, consensus_val, async_op=(not self.use_synchronous_zmq_collectives)
-                )
+            (
+                global_work,
+                global_consensus,
+            ) = await self.expert_parallel_zmq_communicator.all_reduce_max(
+                local_work,
+                consensus_val,
+                async_op=(not self.use_synchronous_zmq_collectives),
             )
         else:
             global_work, global_consensus = local_work, consensus_val
@@ -2516,7 +2692,7 @@ class DynamicInferenceEngine(AbstractEngine):
         No-op when world_size == 1 (communicator is not created).
         """
         nvtx_range_push("world_barrier")
-        if hasattr(self, 'world_zmq_communicator'):
+        if hasattr(self, "world_zmq_communicator"):
             await self.world_zmq_communicator.all_reduce_max(
                 1, async_op=(not self.use_synchronous_zmq_collectives)
             )
@@ -2576,7 +2752,8 @@ class DynamicInferenceEngine(AbstractEngine):
                     global_work_from_last_consensus, _ = self._last_ep_consensus
                     if (
                         global_work_from_last_consensus == 0
-                        or self._ep_consensus_loop_counter % self.ep_consensus_interval == 0
+                        or self._ep_consensus_loop_counter % self.ep_consensus_interval
+                        == 0
                     ):
                         # selectively enter ep_establish_consensus if
                         # 1. there is no global work -> engine is idle. At any step in the future
@@ -2586,7 +2763,8 @@ class DynamicInferenceEngine(AbstractEngine):
                         # In the worst case, this delays pausing by 20 steps which is around
                         # 200-400 milliseconds.
                         self._last_ep_consensus = await self._ep_establish_consensus(
-                            local_pending, signal_consensus=(self.state == EngineState.PAUSING)
+                            local_pending,
+                            signal_consensus=(self.state == EngineState.PAUSING),
                         )
                     global_work, all_pausing = self._last_ep_consensus
                     self._ep_consensus_loop_counter += 1

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -67,7 +67,9 @@ def unwrap_serialized_tensors(serialized_request: dict) -> dict:
         dict: A shallow copy with tensor wrapper tuples replaced by their inner lists.
     """
     return {
-        k: v[1] if isinstance(v, (list, tuple)) and len(v) == 2 and v[0] == "tensor" else v
+        k: v[1]
+        if isinstance(v, (list, tuple)) and len(v) == 2 and v[0] == "tensor"
+        else v
         for k, v in serialized_request.items()
     }
 
@@ -88,7 +90,9 @@ class Status(Enum):
 # =========================================================================
 
 
-def compute_block_hashes_batched(prompt_tokens: torch.Tensor, block_size: int) -> List[int]:
+def compute_block_hashes_batched(
+    prompt_tokens: torch.Tensor, block_size: int
+) -> List[int]:
     """Compute SHA-256 based hashes for all complete blocks in a prompt.
 
     Each block hash is computed as SHA-256(parent_digest || block_bytes), where
@@ -113,14 +117,14 @@ def compute_block_hashes_batched(prompt_tokens: torch.Tensor, block_size: int) -
     block_byte_size = block_size * tokens_cpu.element_size()  # 8 bytes per int64
 
     hashes = []
-    parent_digest = b'\x00' * 32  # SHA-256 digest size
+    parent_digest = b"\x00" * 32  # SHA-256 digest size
 
     for i in range(num_complete_blocks):
         block_bytes = tokens_bytes[i * block_byte_size : (i + 1) * block_byte_size]
         digest = hashlib.sha256(parent_digest + block_bytes).digest()
 
         # Map to positive int64 range [1, 2^63-1], avoiding sentinels -1 and 0
-        raw = int.from_bytes(digest[:8], byteorder='little', signed=False)
+        raw = int.from_bytes(digest[:8], byteorder="little", signed=False)
         hash_val = (raw % (2**63 - 1)) + 1
 
         hashes.append(hash_val)
@@ -177,7 +181,9 @@ class InferenceRequest:
         # and if there are tensors, it will try to deepcopy them
         obj = self.__dict__.copy()  # shallow dict copy
         obj["status"] = self.status.name if self.status else None
-        obj["sampling_params"] = self.sampling_params.serialize() if self.sampling_params else None
+        obj["sampling_params"] = (
+            self.sampling_params.serialize() if self.sampling_params else None
+        )
         obj["inference_parameters"] = (
             self.inference_parameters.serialize() if self.inference_parameters else None
         )
@@ -187,7 +193,9 @@ class InferenceRequest:
             k: (
                 ("tensor", serialize_tensor(v))
                 if isinstance(v, torch.Tensor)
-                else ("ndarray", serialize_ndarray(v)) if isinstance(v, np.ndarray) else v
+                else ("ndarray", serialize_ndarray(v))
+                if isinstance(v, np.ndarray)
+                else v
             )
             for k, v in obj.items()
         }
@@ -240,7 +248,9 @@ class DynamicInferenceEventType(Enum):
 
     ADD_ENGINE = auto()  # When request is added to engine via _add_request()
     ADD_CONTEXT = auto()  # When request is added to context (scheduled for prefill)
-    GENERATED_TOKEN = auto()  # When an output token is generated (payload = {"token_id": int})
+    GENERATED_TOKEN = (
+        auto()
+    )  # When an output token is generated (payload = {"token_id": int})
     PAUSE = auto()
     EVICT = auto()
     FINISH = auto()
@@ -269,7 +279,6 @@ class DynamicInferenceEvent:
     payload: Optional[Any] = None
 
     def __post_init__(self):
-
         # Timestamp.
         if self.timestamp is None:
             self.timestamp = time.time()
@@ -371,8 +380,12 @@ class DynamicInferenceRequest(InferenceRequest):
     latency: Optional[float] = None
     # routing_indices is reconstructed from per-block storage when a request finishes.
     routing_indices: Optional[np.ndarray] = None
+    # indexer_indices is reconstructed from per-block storage when a request finishes.
+    indexer_indices: Optional[np.ndarray] = None
     finished_chunk_token_count: int = 0
-    stop_word_ids: Optional[List[List[int]]] = None  # Tokenized stop words (populated internally)
+    stop_word_ids: Optional[List[List[int]]] = (
+        None  # Tokenized stop words (populated internally)
+    )
     # Consecutive steps this request has been deferred by CG-aware admission gating.
     # Reset to 0 on successful admission. Used only for starvation logging.
     cg_wait_iters: int = 0
@@ -451,7 +464,7 @@ class DynamicInferenceRequest(InferenceRequest):
             # hence we expect routing indices for total_tokens - 1
             assert self.routing_indices.shape[0] == total_tokens - 1, (
                 f"routing_indices first dimension {self.routing_indices.shape[0]} does not match "
-                f"total tokens {total_tokens-1}."
+                f"total tokens {total_tokens - 1}."
             )
 
         nvtx_range_pop("DynamicInferenceRequest.serialize")
@@ -459,7 +472,9 @@ class DynamicInferenceRequest(InferenceRequest):
 
     def _post_deserialize(self, obj):
         super()._post_deserialize(obj)
-        self.events = [DynamicInferenceEvent.deserialize(e) for e in obj.get("events", [])]
+        self.events = [
+            DynamicInferenceEvent.deserialize(e) for e in obj.get("events", [])
+        ]
 
     @property
     def tracked_metadata(self) -> List[Any]:
@@ -473,7 +488,10 @@ class DynamicInferenceRequest(InferenceRequest):
         """
         sp = self.sampling_params
         if sp.termination_id is None:
-            if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+            if (
+                not torch.distributed.is_initialized()
+                or torch.distributed.get_rank() == 0
+            ):
                 warnings.warn(
                     f"DynamicInferenceRequest {self.request_id} has no termination_id set "
                     "in its sampling_params. Defaulting to -1."
@@ -595,7 +613,9 @@ class DynamicInferenceRequestRecord:
     latency: Optional[float] = None
 
     @classmethod
-    def from_request(cls, request: DynamicInferenceRequest) -> "DynamicInferenceRequestRecord":
+    def from_request(
+        cls, request: DynamicInferenceRequest
+    ) -> "DynamicInferenceRequestRecord":
         """Initialize record from a single request.
 
         Args:
@@ -685,7 +705,9 @@ class DynamicInferenceRequestRecord:
             new_request.add_event_add_engine()
         self.requests.append(new_request)
 
-    def merge(self, tokenizer: MegatronTokenizer | None = None) -> DynamicInferenceRequest:
+    def merge(
+        self, tokenizer: MegatronTokenizer | None = None
+    ) -> DynamicInferenceRequest:
         """Merge requests into a single checkpoint-agnostic request object.
 
         Args:
@@ -704,9 +726,17 @@ class DynamicInferenceRequestRecord:
         prompt_tokens = self.requests[0].prompt_tokens
         prompt_text = self.requests[0].prompt
         routing_indices = None
-        routing_parts = [r.routing_indices for r in self.requests if r.routing_indices is not None]
+        routing_parts = [
+            r.routing_indices for r in self.requests if r.routing_indices is not None
+        ]
         if routing_parts:
             routing_indices = np.concatenate(routing_parts)
+        indexer_indices = None
+        indexer_parts = [
+            r.indexer_indices for r in self.requests if r.indexer_indices is not None
+        ]
+        if indexer_parts:
+            indexer_indices = np.concatenate(indexer_parts)
         generated_tokens = merge_lists("generated_tokens")
         try:
             generated_text = "".join(r.generated_text for r in self.requests)
@@ -737,6 +767,7 @@ class DynamicInferenceRequestRecord:
             latency=self.latency,
             events=merge_lists("events"),
             routing_indices=routing_indices,
+            indexer_indices=indexer_indices,
             block_size_tokens=self.requests[0].block_size_tokens,
             enable_prefix_caching=self.requests[0].enable_prefix_caching,
             precomputed_block_hashes=self.requests[0].precomputed_block_hashes,
@@ -768,7 +799,9 @@ class DynamicInferenceRequestRecord:
             (DynamicInferenceRequestRecord) Deserialized record.
         """
         request = cls(**obj)
-        request.requests = [DynamicInferenceRequest.deserialize(r) for r in obj["requests"]]
+        request.requests = [
+            DynamicInferenceRequest.deserialize(r) for r in obj["requests"]
+        ]
         return request
 
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -37,6 +37,10 @@ from megatron.core.tensor_parallel.mappings import (
     scatter_to_sequence_parallel_region,
 )
 from megatron.core.transformer.enums import InferenceCudaGraphScope
+from megatron.core.transformer.experimental_attention_variant.indexer_replay import (
+    IndexerReplay,
+    IndexerReplayAction,
+)
 from megatron.core.transformer.moe.moe_layer import BaseMoELayer
 from megatron.core.transformer.moe.router_replay import RouterReplay, RouterReplayAction
 from megatron.core.transformer.utils import set_model_to_sequence_parallel
@@ -81,7 +85,9 @@ class TextGenerationController:
         tokenizer (_type_): Tokenizer used for tokenizing and detokenizing the prompts
     """
 
-    def __init__(self, inference_wrapped_model: AbstractModelInferenceWrapper, tokenizer):
+    def __init__(
+        self, inference_wrapped_model: AbstractModelInferenceWrapper, tokenizer
+    ):
         self.inference_wrapped_model = inference_wrapped_model
         self.model_config = self.inference_wrapped_model.model.config
         inference_config = self.inference_wrapped_model.inference_context.config
@@ -94,7 +100,9 @@ class TextGenerationController:
         else:
             self.pp_group = parallel_state.get_pipeline_model_parallel_group()
 
-        self.model_is_pipeline_parallel = self.model_config.pipeline_model_parallel_size > 1
+        self.model_is_pipeline_parallel = (
+            self.model_config.pipeline_model_parallel_size > 1
+        )
 
         # Use padded vocab size because tokenizer vocab size might pad to nearest power of 2.
         # TODO(ksanthanam): Consider deprecating this check if LLaVAModel is no longer used
@@ -111,7 +119,8 @@ class TextGenerationController:
             self.num_mtp_depths = 0
         else:
             assert (
-                self.model_config.mtp_num_layers and self.model_config.mtp_num_layers >= 1
+                self.model_config.mtp_num_layers
+                and self.model_config.mtp_num_layers >= 1
             ), "mtp_num_layers must be >= 1 when num_speculative_tokens > 0"
             if self.model_config.mtp_use_repeated_layer:
                 self.num_mtp_depths = self.num_speculative_tokens
@@ -211,13 +220,19 @@ class TextGenerationController:
         context = self.inference_wrapped_model.inference_context
         max_requests = context.max_requests
         device = torch.cuda.current_device()
-        self._sampled_tokens_cuda = torch.empty(max_requests, dtype=torch.int64, device=device)
+        self._sampled_tokens_cuda = torch.empty(
+            max_requests, dtype=torch.int64, device=device
+        )
         self._sampled_mtp_tokens_cuda = torch.empty(
-            [self.num_speculative_tokens, max_requests], dtype=torch.int64, device=device
+            [self.num_speculative_tokens, max_requests],
+            dtype=torch.int64,
+            device=device,
         )
         self._accepted_tokens_per_request = (
             torch.ones(
-                [max_requests, self.num_speculative_tokens], dtype=torch.int64, device=device
+                [max_requests, self.num_speculative_tokens],
+                dtype=torch.int64,
+                device=device,
             )
             * -1
         )
@@ -228,7 +243,9 @@ class TextGenerationController:
             max_requests, dtype=torch.int64, device=device
         )
         self._last_accepted_seq_indices = None
-        self._mtp_token_ids_buf = torch.empty([1, max_requests], dtype=torch.int64, device=device)
+        self._mtp_token_ids_buf = torch.empty(
+            [1, max_requests], dtype=torch.int64, device=device
+        )
         self._mtp_position_ids_buf = torch.empty(
             [1, max_requests], dtype=torch.int64, device=device
         )
@@ -261,7 +278,10 @@ class TextGenerationController:
 
     @staticmethod
     def detokenize(
-        tokenizer, tokens: List[int], remove_EOD: bool = True, skip_special_tokens: bool = True
+        tokenizer,
+        tokens: List[int],
+        remove_EOD: bool = True,
+        skip_special_tokens: bool = True,
     ) -> str:
         """
         Detokenize a sequence of token IDs, optionally removing trailing EOD
@@ -315,7 +335,9 @@ class TextGenerationController:
         if not detokenize_segments:
             tokens = tokens_gpu_tensor.tolist()
             return (
-                self.detokenize(self.tokenizer, tokens, skip_special_tokens=skip_special_tokens),
+                self.detokenize(
+                    self.tokenizer, tokens, skip_special_tokens=skip_special_tokens
+                ),
                 None,
             )
 
@@ -331,12 +353,15 @@ class TextGenerationController:
             prompts_plus_generations.append(detok_str)
             offsets = self.tokenizer.offsets(sequence_tokens, detok_str)
             words = [
-                detok_str[start:end] for start, end in zip(offsets, offsets[1:] + [len(detok_str)])
+                detok_str[start:end]
+                for start, end in zip(offsets, offsets[1:] + [len(detok_str)])
             ]
 
             prompts_plus_generations_segments.append(words)
 
-        text = self.detokenize(self.tokenizer, tokens[0], skip_special_tokens=skip_special_tokens)
+        text = self.detokenize(
+            self.tokenizer, tokens[0], skip_special_tokens=skip_special_tokens
+        )
 
         return text, prompts_plus_generations_segments
 
@@ -381,7 +406,9 @@ class TextGenerationController:
             assert generation_started is not None
             if logits is None:
                 batch_size = last_token_logits.shape[0]
-                last_token_log_probs = F.log_softmax(last_token_logits, dim=1).to(torch.float32)
+                last_token_log_probs = F.log_softmax(last_token_logits, dim=1).to(
+                    torch.float32
+                )
                 top_n_logits_this_step = torch.topk(
                     last_token_log_probs, k=sampling_params.top_n_logprobs
                 )
@@ -396,7 +423,10 @@ class TextGenerationController:
                     mask = torch.ones(batch_size, dtype=torch.bool)
 
                 self._update_top_n_logprobs_dict(
-                    top_n_logprobs_this_step, top_n_logprobs_indices, mask, top_n_logprobs_dict
+                    top_n_logprobs_this_step,
+                    top_n_logprobs_indices,
+                    mask,
+                    top_n_logprobs_dict,
                 )
             else:
                 assert not sampling_params.skip_prompt_log_probs
@@ -404,12 +434,18 @@ class TextGenerationController:
                 # Compute the prompt logprobs
                 batch_size, seq_length, _ = logits.shape
                 log_probs = F.log_softmax(logits, dim=2).to(torch.float32)
-                top_n_logits_this_step = torch.topk(log_probs, k=sampling_params.top_n_logprobs)
+                top_n_logits_this_step = torch.topk(
+                    log_probs, k=sampling_params.top_n_logprobs
+                )
 
                 # Move the token dimension to the front and then add each token logprobs
                 # individually for every request in the batch
-                top_n_logprobs_this_step = top_n_logits_this_step.values.permute(1, 0, 2).cpu()
-                top_n_logprobs_indices = top_n_logits_this_step.indices.permute(1, 0, 2).cpu()
+                top_n_logprobs_this_step = top_n_logits_this_step.values.permute(
+                    1, 0, 2
+                ).cpu()
+                top_n_logprobs_indices = top_n_logits_this_step.indices.permute(
+                    1, 0, 2
+                ).cpu()
 
                 # We append to the logprobs dict for every prompt token
                 mask = torch.ones(batch_size, dtype=torch.bool)
@@ -510,10 +546,13 @@ class TextGenerationController:
         padded_prompt_tokens_list = batch_prompt_tokens_list
         num_padded_requests = padded_batch_size - len(batch_prompt_tokens_list)
         padded_prompt_tokens_list += [
-            [self.tokenizer.eod] * padded_sequence_length for _ in range(num_padded_requests)
+            [self.tokenizer.eod] * padded_sequence_length
+            for _ in range(num_padded_requests)
         ]
 
-        tokens = torch.tensor(padded_prompt_tokens_list, device=torch.cuda.current_device())
+        tokens = torch.tensor(
+            padded_prompt_tokens_list, device=torch.cuda.current_device()
+        )
 
         return tokens
 
@@ -585,7 +624,9 @@ class TextGenerationController:
         moe_pad_experts_for_cuda_graph_inference = (
             self.model_config.moe_pad_experts_for_cuda_graph_inference
         )
-        is_inference_optimized = self.model_config.transformer_impl == "inference_optimized"
+        is_inference_optimized = (
+            self.model_config.transformer_impl == "inference_optimized"
+        )
         if is_inference_optimized:
             assert not moe_pad_experts_for_cuda_graph_inference, (
                 "moe_pad_experts_for_cuda_graph_inference cannot be True when "
@@ -593,8 +634,12 @@ class TextGenerationController:
             )
         if moe_pad_experts_for_cuda_graph_inference:
             if context.using_cuda_graph_this_step():
-                capacity_factor = model_config.num_moe_experts / model_config.moe_router_topk
-                set_decode_expert_padding(unwrapped_model, True, capacity_factor=capacity_factor)
+                capacity_factor = (
+                    model_config.num_moe_experts / model_config.moe_router_topk
+                )
+                set_decode_expert_padding(
+                    unwrapped_model, True, capacity_factor=capacity_factor
+                )
             else:
                 set_decode_expert_padding(unwrapped_model, False)
 
@@ -633,7 +678,11 @@ class TextGenerationController:
 
         with torch.inference_mode():
             logits = self.inference_wrapped_model.run_one_forward_step(
-                {"tokens": input_ids, "position_ids": position_ids, "attention_mask": None}
+                {
+                    "tokens": input_ids,
+                    "position_ids": position_ids,
+                    "attention_mask": None,
+                }
             )
             # logits shape: [1, seq_len, vocab_size]
 
@@ -664,7 +713,9 @@ class TextGenerationController:
 
         # Copy logits to contiguous buffer.
         if self._enable_cuda_graph:
-            self._all_logits_cuda[:, :logits_seq_len, :].copy_(logits[:, :logits_seq_len, :])
+            self._all_logits_cuda[:, :logits_seq_len, :].copy_(
+                logits[:, :logits_seq_len, :]
+            )
         else:
             self._all_logits_cuda = logits
 
@@ -681,8 +732,12 @@ class TextGenerationController:
         back to the allocator outside the compiled graph.
         """
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
-        active_request_slice = slice(context.paused_request_count, context.total_request_count)
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
+        active_request_slice = slice(
+            context.paused_request_count, context.total_request_count
+        )
 
         # accepted_counts is the only GPU input; D2H a small slice so the
         # CPU rewind can read its values via .tolist() inside a Python loop.
@@ -692,8 +747,12 @@ class TextGenerationController:
 
         blocks_to_release, remove_mask = rewind_kv_cache(
             accepted_counts=accepted_tokens_per_request_cpu,
-            prefill_status=context.request_in_prefill_status_tensor[active_request_slice],
-            last_kv_block_offset=context.request_last_kv_block_offset[active_request_slice],
+            prefill_status=context.request_in_prefill_status_tensor[
+                active_request_slice
+            ],
+            last_kv_block_offset=context.request_last_kv_block_offset[
+                active_request_slice
+            ],
             kv_length_offsets=context.request_kv_length_offsets[active_request_slice],
             kv_block_counts=context.request_kv_block_counts[active_request_slice],
             last_kv_block_id=context.request_last_kv_block_id[active_request_slice],
@@ -710,8 +769,12 @@ class TextGenerationController:
             # gpu_view.request_in_prefill_status was uploaded by this step's
             # coalesced H2D and mirrors the active-slice CPU values, so we
             # don't need to re-upload prefill_status for the Mamba kernels.
-            prefill_status_gpu = context.gpu_view.request_in_prefill_status[:active_request_count]
-            accepted_counts_gpu = self._accepted_token_counts_per_request[:active_request_count]
+            prefill_status_gpu = context.gpu_view.request_in_prefill_status[
+                :active_request_count
+            ]
+            accepted_counts_gpu = self._accepted_token_counts_per_request[
+                :active_request_count
+            ]
             mamba_state_idx = context.mamba_metadata.request_to_mamba_state_idx[
                 active_request_slice
             ].to(cuda_device, non_blocking=True)
@@ -764,13 +827,17 @@ class TextGenerationController:
         """
         nvtx_range_push("mtp-spec-decoding/serial-mtp-init")
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
         active_slice = slice(context.paused_request_count, context.total_request_count)
 
         unwrapped_model = self._unwrapped_model
 
         # On non-last pipeline stages, the model won't have decoder hidden states.
-        has_mtp = self._is_last_pp_stage and context.mtp_decoder_hidden_states is not None
+        has_mtp = (
+            self._is_last_pp_stage and context.mtp_decoder_hidden_states is not None
+        )
 
         if has_mtp:
             # Get decoder hidden states at last accepted positions.
@@ -807,7 +874,7 @@ class TextGenerationController:
         current_hidden = last_accepted_hidden if has_mtp else None
 
         # Compute padding needed to make batch compatible with SP and CUDA graphs.
-        if getattr(self, '_mtp_resolved_padded_count', None) is not None:
+        if getattr(self, "_mtp_resolved_padded_count", None) is not None:
             # CUDA-graph path: use the EP-synced padded count.
             padded_count = self._mtp_resolved_padded_count
             assert not self._sp_enabled or padded_count % self._tp_size == 0
@@ -845,7 +912,9 @@ class TextGenerationController:
             mtp_logits_2d = None
             if has_mtp:
                 nvtx_range_push(f"mtp-spec-decoding/depth-{depth}/forward")
-                mtp_depth = None if unwrapped_model.mtp.mtp_use_repeated_layer else depth
+                mtp_depth = (
+                    None if unwrapped_model.mtp.mtp_use_repeated_layer else depth
+                )
                 current_hidden, mtp_logits = unwrapped_model.compute_mtp_single_step(
                     hidden_states=current_hidden,
                     next_token_ids=token_ids_buf,
@@ -865,7 +934,9 @@ class TextGenerationController:
                 mtp_logits = mtp_logits[:active_request_count]
 
                 # mtp_logits: [active_request_count, 1, vocab_size]
-                mtp_logits_2d = mtp_logits.squeeze(1)  # [active_request_count, vocab_size]
+                mtp_logits_2d = mtp_logits.squeeze(
+                    1
+                )  # [active_request_count, vocab_size]
 
             # Broadcast MTP logits across pipeline stages.
             if self.model_is_pipeline_parallel:
@@ -892,7 +963,10 @@ class TextGenerationController:
         # the context attribute; release it so the tensor can be garbage
         # collected. In block-scope CUDA graph mode the attribute is a
         # pre-allocated fixed buffer that must persist across replays.
-        if has_mtp and context.inference_cuda_graph_scope != InferenceCudaGraphScope.block:
+        if (
+            has_mtp
+            and context.inference_cuda_graph_scope != InferenceCudaGraphScope.block
+        ):
             context.mtp_decoder_hidden_states = None
 
     def _verify_speculative_tokens(
@@ -917,7 +991,9 @@ class TextGenerationController:
         Sample tokens from logits for dynamic batching with speculative tokens and verify the tokens.
         """
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
 
         # Sampling-side request counts: padded when running a captured graph.
         # Verify uses the actual counts so the Triton kernels operate on the real workload.
@@ -1035,7 +1111,9 @@ class TextGenerationController:
             num_speculative_tokens=self.num_speculative_tokens,
         )
         # Expose the active slice so downstream code sees the right length.
-        self._last_accepted_seq_indices = self._last_accepted_seq_indices_buf[:active_request_count]
+        self._last_accepted_seq_indices = self._last_accepted_seq_indices_buf[
+            :active_request_count
+        ]
 
     def _dynamic_step_sample_logits(self):
         """Sample tokens from logits for dynamic batching."""
@@ -1043,7 +1121,9 @@ class TextGenerationController:
         # and then broadcast the sampled tokens rather than broadcasting the raw logits.
 
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
         use_graph = (
             self._sampling_backend == "flashinfer"
             and self._enable_cuda_graph
@@ -1075,11 +1155,20 @@ class TextGenerationController:
             return_log_probs (bool): Whether to return the sampled log_probs.
         """
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
 
         return (
-            (context.active_request_metadata["return_log_probs"][:active_request_count]).any(),
-            (context.active_request_metadata["top_n_logprobs"][:active_request_count] > 0).any(),
+            (
+                context.active_request_metadata["return_log_probs"][
+                    :active_request_count
+                ]
+            ).any(),
+            (
+                context.active_request_metadata["top_n_logprobs"][:active_request_count]
+                > 0
+            ).any(),
         )
 
     def _router_record_bookkeeping(self) -> Optional[np.ndarray]:
@@ -1120,7 +1209,10 @@ class TextGenerationController:
         tp_size = get_pg_size(tp_group)
 
         # All-gather across TP group if using sequence parallelism (tp_size > 1)
-        if tp_size > 1 and get_model_config(self.inference_wrapped_model.model).sequence_parallel:
+        if (
+            tp_size > 1
+            and get_model_config(self.inference_wrapped_model.model).sequence_parallel
+        ):
             # With SP, the model processes padded_active_token_count tokens total,
             # scattered evenly across TP ranks. Each rank routes
             # padded_active_token_count // tp_size tokens through MoE layers.
@@ -1135,16 +1227,63 @@ class TextGenerationController:
             stacked_routing = stacked_routing[:local_token_count]
             # gather_from_sequence_parallel_region gathers along dim 0
             # [local_token_count, num_layers, topk] -> [padded_token_count, num_layers, topk]
-            stacked_routing = gather_from_sequence_parallel_region(stacked_routing, group=tp_group)
+            stacked_routing = gather_from_sequence_parallel_region(
+                stacked_routing, group=tp_group
+            )
 
         # Slice to real tokens (remove CUDA padding), move to CPU as numpy with target dtype
         _ri_dtype = np.int16 if (config.num_moe_experts or 0) <= 32768 else np.int32
         return stacked_routing[:active_token_count].cpu().numpy().astype(_ri_dtype)
 
+    def _indexer_record_bookkeeping(self) -> Optional[np.ndarray]:
+        """Collect flat indexer topk indices for DSA indexer recording.
+
+        Retrieves recorded indexer decisions via the context's indexer_metadata
+        (which handles CUDA graph static buffers), performs the TP all-gather
+        when sequence parallelism is active, strips CUDA padding, and returns
+        a flat CPU numpy array aligned with the context's active-token layout.
+
+        Returns:
+            Optional[np.ndarray]: Flat indexer array of shape
+                [active_token_count, num_layers, index_topk], or None if indexer
+                replay is disabled or no indexer data was recorded.
+        """
+        config = self.inference_wrapped_model.model.config
+        if not config.dsa_enable_indexer_replay:
+            return None
+
+        context = self.inference_wrapped_model.inference_context
+        if context.dsa_indexer_metadata is None:
+            return None
+
+        stacked_indices = context.dsa_indexer_metadata.get_indexer_indices()
+
+        if stacked_indices is None:
+            return None
+
+        active_token_count = context.active_token_count
+
+        tp_group = self.inference_wrapped_model.tp_group
+        tp_size = get_pg_size(tp_group)
+
+        if (
+            tp_size > 1
+            and get_model_config(self.inference_wrapped_model.model).sequence_parallel
+        ):
+            local_token_count = context.padded_active_token_count // tp_size
+            stacked_indices = stacked_indices[:local_token_count]
+            stacked_indices = gather_from_sequence_parallel_region(
+                stacked_indices, group=tp_group
+            )
+
+        return stacked_indices[:active_token_count].cpu().numpy().astype(np.int32)
+
     def _dynamic_step_calculate_log_probs(self) -> Optional[Tensor]:
         """Calculate log probs from logits."""
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
         # This code cannot be reached when we are using speculative decode.
         assert self.num_speculative_tokens == 0
         logits_seq_len = (
@@ -1159,7 +1298,9 @@ class TextGenerationController:
             only_last_token_logits=context.config.materialize_only_last_token_logits,
         )
 
-    def _dynamic_step_calculate_log_probs_speculative(self) -> Tuple[List[List[float]], Tensor]:
+    def _dynamic_step_calculate_log_probs_speculative(
+        self,
+    ) -> Tuple[List[List[float]], Tensor]:
         """Calculate log probs from logits for speculative decoding.
 
         For decode requests, computes log probs for each accepted speculative token
@@ -1177,13 +1318,17 @@ class TextGenerationController:
                 log_probs_tensor: Full log_softmax tensor for top-n computation.
         """
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
 
         # Use gpu_view for data consumed by GPU log-probs operations.
         request_in_prefill_status_tensor = context.gpu_view.request_in_prefill_status[
             :active_request_count
         ]
-        request_query_lengths = context.gpu_view.request_query_lengths[:active_request_count]
+        request_query_lengths = context.gpu_view.request_query_lengths[
+            :active_request_count
+        ]
 
         num_prefill_requests = request_in_prefill_status_tensor.sum().item()
         num_decode_requests = active_request_count - num_prefill_requests
@@ -1195,7 +1340,9 @@ class TextGenerationController:
         if only_last:
             log_probs_tensor = F.log_softmax(logits_squeezed, dim=-1)
         else:
-            log_probs_tensor = F.log_softmax(logits_squeezed[: context.active_token_count], dim=-1)
+            log_probs_tensor = F.log_softmax(
+                logits_squeezed[: context.active_token_count], dim=-1
+            )
 
         log_probs_list_decode = []
 
@@ -1204,7 +1351,9 @@ class TextGenerationController:
             decode_log_probs = log_probs_tensor[:decode_len].reshape(
                 num_decode_requests, self.num_speculative_tokens + 1, -1
             )
-            accepted_counts = self._accepted_token_counts_per_request[:num_decode_requests]
+            accepted_counts = self._accepted_token_counts_per_request[
+                :num_decode_requests
+            ]
 
             # Build a [num_decode, num_spec+1] token ID matrix for gathering.
             # Columns 0..num_spec-1 hold accepted speculative tokens (clamped to 0
@@ -1216,15 +1365,17 @@ class TextGenerationController:
                 device=logits.device,
                 dtype=torch.long,
             )
-            gather_tokens[:, : self.num_speculative_tokens] = self._accepted_tokens_per_request[
-                :num_decode_requests
-            ].clamp(min=0)
+            gather_tokens[:, : self.num_speculative_tokens] = (
+                self._accepted_tokens_per_request[:num_decode_requests].clamp(min=0)
+            )
             gather_tokens[
                 torch.arange(num_decode_requests, device=logits.device), accepted_counts
             ] = self._sampled_tokens_cuda[:num_decode_requests]
 
             # Gather: [num_decode, num_spec+1]
-            gathered_log_probs = decode_log_probs.gather(2, gather_tokens.unsqueeze(-1)).squeeze(-1)
+            gathered_log_probs = decode_log_probs.gather(
+                2, gather_tokens.unsqueeze(-1)
+            ).squeeze(-1)
 
             log_probs_list_decode = [
                 gathered_log_probs[i, : accepted_counts[i].item() + 1].tolist()
@@ -1242,14 +1393,17 @@ class TextGenerationController:
                     num_decode_requests:active_request_count
                 ]
                 selected_log_probs = prefill_log_probs[
-                    torch.arange(num_prefill_requests, device=logits.device), prefill_new_tokens
+                    torch.arange(num_prefill_requests, device=logits.device),
+                    prefill_new_tokens,
                 ]
                 log_probs_list_prefill = [[lp.item()] for lp in selected_log_probs]
             else:
                 prefill_token_ids = context.gpu_view.token_to_input_ids[
                     decode_len : context.active_token_count
                 ].roll(-1, 0)
-                prefill_query_lengths = request_query_lengths[request_in_prefill_status_tensor == 1]
+                prefill_query_lengths = request_query_lengths[
+                    request_in_prefill_status_tensor == 1
+                ]
                 new_token_idx = prefill_query_lengths.cumsum(0) - 1
                 prefill_new_tokens = self._sampled_tokens_cuda[
                     num_decode_requests:active_request_count
@@ -1287,13 +1441,17 @@ class TextGenerationController:
             tuples, one per emitted token position.
         """
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
 
         # Use gpu_view for data consumed by GPU top-n operations.
         request_in_prefill_status_tensor = context.gpu_view.request_in_prefill_status[
             :active_request_count
         ]
-        request_query_lengths = context.gpu_view.request_query_lengths[:active_request_count]
+        request_query_lengths = context.gpu_view.request_query_lengths[
+            :active_request_count
+        ]
 
         num_prefill_requests = request_in_prefill_status_tensor.sum().item()
         num_decode_requests = active_request_count - num_prefill_requests
@@ -1305,14 +1463,15 @@ class TextGenerationController:
             decode_log_probs = log_probs_tensor[:decode_len].reshape(
                 num_decode_requests, self.num_speculative_tokens + 1, -1
             )
-            accepted_counts = self._accepted_token_counts_per_request[:num_decode_requests]
+            accepted_counts = self._accepted_token_counts_per_request[
+                :num_decode_requests
+            ]
             top_n_per_request = context.active_request_metadata["top_n_logprobs"][
                 :num_decode_requests
             ]
             max_top_n = int(top_n_per_request.max().item())
 
             if max_top_n > 0:
-
                 # Single batched topk on GPU: [num_decode, num_spec+1, max_top_n]
                 topk_results = torch.topk(decode_log_probs, k=max_top_n, dim=-1)
 
@@ -1325,7 +1484,10 @@ class TextGenerationController:
                     if top_n > 0:
                         num_valid = accepted_counts[i].item() + 1
                         top_n_results[i] = [
-                            (topk_values_cpu[i, j, :top_n], topk_indices_cpu[i, j, :top_n])
+                            (
+                                topk_values_cpu[i, j, :top_n],
+                                topk_indices_cpu[i, j, :top_n],
+                            )
                             for j in range(num_valid)
                         ]
 
@@ -1363,9 +1525,9 @@ class TextGenerationController:
                     prefill_log_probs_per_request = prefill_log_probs.split(
                         prefill_query_lengths.tolist(), dim=0
                     )
-                    prefill_skip_prompt = context.active_request_metadata["skip_prompt_log_probs"][
-                        num_decode_requests:active_request_count
-                    ].tolist()
+                    prefill_skip_prompt = context.active_request_metadata[
+                        "skip_prompt_log_probs"
+                    ][num_decode_requests:active_request_count].tolist()
 
                     for i in range(num_prefill_requests):
                         top_n = int(prefill_top_n[i])
@@ -1377,7 +1539,10 @@ class TextGenerationController:
                             if skip_prompt and request_lp.size(0) > 1:
                                 top_n_logits = torch.topk(request_lp[-1], k=top_n)
                                 top_n_results[req_idx] = [
-                                    (top_n_logits.values.cpu(), top_n_logits.indices.cpu())
+                                    (
+                                        top_n_logits.values.cpu(),
+                                        top_n_logits.indices.cpu(),
+                                    )
                                 ]
                             else:
                                 top_n_logits = torch.topk(request_lp, k=top_n, dim=-1)
@@ -1410,18 +1575,27 @@ class TextGenerationController:
         )
 
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
-        active_request_slice = slice(context.paused_request_count, context.total_request_count)
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
+        active_request_slice = slice(
+            context.paused_request_count, context.total_request_count
+        )
 
         # Handle decode-only mode (only last token)
-        if context.config.materialize_only_last_token_logits or context.is_decode_only():
+        if (
+            context.config.materialize_only_last_token_logits
+            or context.is_decode_only()
+        ):
             # In decode mode or when only last token logits are materialized,
             # logits already represent only the last tokens
             log_probs = log_probs_tensor[:active_request_count]
 
             top_n_results = {}
             for req_idx in range(active_request_count):
-                top_n = int(context.active_request_metadata["top_n_logprobs"][req_idx].item())
+                top_n = int(
+                    context.active_request_metadata["top_n_logprobs"][req_idx].item()
+                )
                 if top_n > 0:
                     # Get top-n logprobs and indices for this request (single token)
                     top_n_logits = torch.topk(log_probs[req_idx], k=top_n)
@@ -1443,13 +1617,17 @@ class TextGenerationController:
 
         top_n_results = {}
         for req_idx in range(active_request_count):
-            top_n = int(context.active_request_metadata["top_n_logprobs"][req_idx].item())
+            top_n = int(
+                context.active_request_metadata["top_n_logprobs"][req_idx].item()
+            )
             if top_n > 0:
                 request_log_probs = log_probs_per_request[
                     req_idx
                 ]  # [num_tokens_for_request, vocab_size]
                 skip_prompt = bool(
-                    context.active_request_metadata["skip_prompt_log_probs"][req_idx].item()
+                    context.active_request_metadata["skip_prompt_log_probs"][
+                        req_idx
+                    ].item()
                 )
 
                 # If skip_prompt_log_probs is True, only compute for last token
@@ -1520,7 +1698,9 @@ class TextGenerationController:
             return
 
         context = self.inference_wrapped_model.inference_context
-        has_mtp = self._is_last_pp_stage and context.mtp_decoder_hidden_states is not None
+        has_mtp = (
+            self._is_last_pp_stage and context.mtp_decoder_hidden_states is not None
+        )
         if not has_mtp and not self.model_is_pipeline_parallel:
             # No MTP on this rank and no PP broadcast to participate in.
             return
@@ -1532,7 +1712,7 @@ class TextGenerationController:
 
         # Use precomputed MTP CUDA graph batch size when available;
         # otherwise use minimal SP-compatible size.
-        if getattr(self, '_mtp_resolved_padded_count', None) is not None:
+        if getattr(self, "_mtp_resolved_padded_count", None) is not None:
             padded_count = self._mtp_resolved_padded_count
             assert not self._sp_enabled or padded_count % self._tp_size == 0
         elif has_mtp:
@@ -1543,13 +1723,19 @@ class TextGenerationController:
         if has_mtp:
             # Minimal dummy tensors to drive the MTP layer forward
             # so that the MoE all-to-all collectives are issued.
-            dummy_hidden = torch.zeros((padded_count, 1, hidden_size), device=device, dtype=dtype)
+            dummy_hidden = torch.zeros(
+                (padded_count, 1, hidden_size), device=device, dtype=dtype
+            )
             if self._sp_enabled:
                 dummy_hidden = scatter_to_sequence_parallel_region(
                     dummy_hidden, group=self.inference_wrapped_model.tp_group
                 )
-            dummy_token_ids = torch.zeros((1, padded_count), device=device, dtype=torch.long)
-            dummy_position_ids = torch.zeros((1, padded_count), device=device, dtype=torch.long)
+            dummy_token_ids = torch.zeros(
+                (1, padded_count), device=device, dtype=torch.long
+            )
+            dummy_position_ids = torch.zeros(
+                (1, padded_count), device=device, dtype=torch.long
+            )
 
         context = self.inference_wrapped_model.inference_context
 
@@ -1557,7 +1743,9 @@ class TextGenerationController:
             nvtx_range_push(f"mtp-spec-decoding/dummy-depth-{depth}")
             mtp_logits_2d = None
             if has_mtp:
-                mtp_depth = None if unwrapped_model.mtp.mtp_use_repeated_layer else depth
+                mtp_depth = (
+                    None if unwrapped_model.mtp.mtp_use_repeated_layer else depth
+                )
                 dummy_hidden, mtp_logits = unwrapped_model.compute_mtp_single_step(
                     hidden_states=dummy_hidden,
                     next_token_ids=dummy_token_ids,
@@ -1595,7 +1783,9 @@ class TextGenerationController:
         """
         sampled_tokens_cpu = self._sampled_tokens_cuda[:active_request_count].cpu()
         if self.num_speculative_tokens > 0:
-            sampled_mtp_tokens_cpu = self._sampled_mtp_tokens_cuda[:, :active_request_count].cpu()
+            sampled_mtp_tokens_cpu = self._sampled_mtp_tokens_cuda[
+                :, :active_request_count
+            ].cpu()
         else:
             sampled_mtp_tokens_cpu = None
         return sampled_tokens_cpu, sampled_mtp_tokens_cpu
@@ -1616,8 +1806,12 @@ class TextGenerationController:
                 finished_request_ids (Tensor): Finished request IDs.
         """
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
-        active_request_slice = slice(context.paused_request_count, context.total_request_count)
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
+        active_request_slice = slice(
+            context.paused_request_count, context.total_request_count
+        )
 
         # Batch GPU-to-CPU transfer of all sampled tokens.
         range_push("transfer_samples_to_cpu")
@@ -1650,14 +1844,17 @@ class TextGenerationController:
         # (detected in previous step's post_process_requests)
         if self._get_stop_word_finished_ids_callback is not None:
             request_ids_list = active_request_ids.tolist()
-            stop_word_finished_ids = self._get_stop_word_finished_ids_callback(request_ids_list)
+            stop_word_finished_ids = self._get_stop_word_finished_ids_callback(
+                request_ids_list
+            )
             if stop_word_finished_ids:
                 for idx, request_id in enumerate(request_ids_list):
                     if request_id in stop_word_finished_ids:
                         active_request_mask[idx] = 0
 
         finished_idxs = (
-            torch.nonzero(active_request_mask == 0, as_tuple=True)[0] + context.paused_request_count
+            torch.nonzero(active_request_mask == 0, as_tuple=True)[0]
+            + context.paused_request_count
         )
         finished_request_ids = context.request_ids[finished_idxs]
 
@@ -1713,7 +1910,9 @@ class TextGenerationController:
                 cuda_graph_request_count (Optional[int]): Size of cuda graph used for this step.
         """
         context = self.inference_wrapped_model.inference_context
-        active_request_count = context.total_request_count - context.paused_request_count
+        active_request_count = (
+            context.total_request_count - context.paused_request_count
+        )
 
         # No tokens and no active requests?
         if context.active_token_count == 0 and active_request_count == 0:
@@ -1728,10 +1927,14 @@ class TextGenerationController:
                 else None
             )
 
-            # Enable routing recording before forward pass if routing replay is enabled
+            # Enable routing/indexer recording before forward pass if replay is enabled
             config = self.inference_wrapped_model.model.config
             if config.moe_enable_routing_replay:
                 RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+            if config.dsa_enable_indexer_replay:
+                IndexerReplay.set_global_indexer_replay_action(
+                    IndexerReplayAction.RECORD
+                )
 
             # Forward pass produces only base logits. When speculative decoding is
             # active, MTP logits are computed serially after verification.
@@ -1748,7 +1951,13 @@ class TextGenerationController:
             # Collect flat routing indices and scatter them into per-block storage.
             # Must be done before update_requests while token-to-block mappings are valid.
             # Reconstruction happens from blocks at request completion.
-            context.kv_block_allocator.store_routing_per_block(self._router_record_bookkeeping())
+            context.kv_block_allocator.store_routing_per_block(
+                self._router_record_bookkeeping()
+            )
+            # Collect flat indexer indices and scatter them into per-block storage.
+            context.kv_block_allocator.store_indexer_per_block(
+                self._indexer_record_bookkeeping()
+            )
             range_pop()
 
         # This is the best place to yield control back to event loop.
@@ -1762,7 +1971,9 @@ class TextGenerationController:
 
         with torch.inference_mode():
             range_push("sampling")
-            return_log_probs, return_top_n_logprobs = self._dynamic_step_log_probs_bookkeeping()
+            return_log_probs, return_top_n_logprobs = (
+                self._dynamic_step_log_probs_bookkeeping()
+            )
 
             if self.num_speculative_tokens > 0:
                 # Phase 1: Verify speculative tokens using base logits only.
@@ -1787,7 +1998,9 @@ class TextGenerationController:
 
                 # Phase 4: Release freed blocks. Deferred from Phase 2 so the
                 # data-dependent boolean-mask sync overlaps with MTP GPU work.
-                context.kv_block_allocator.release_memory_blocks(blocks_to_release[remove_mask])
+                context.kv_block_allocator.release_memory_blocks(
+                    blocks_to_release[remove_mask]
+                )
             else:
                 self._dynamic_step_sample_logits()
 
@@ -1799,11 +2012,15 @@ class TextGenerationController:
                         self._dynamic_step_calculate_log_probs_speculative()
                     )
                     if return_top_n_logprobs:
-                        top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs_speculative(
-                            log_probs_tensor
+                        top_n_logprobs = (
+                            self._dynamic_step_calculate_top_n_logprobs_speculative(
+                                log_probs_tensor
+                            )
                         )
                 else:
-                    log_probs, log_probs_tensor = self._dynamic_step_calculate_log_probs()
+                    log_probs, log_probs_tensor = (
+                        self._dynamic_step_calculate_log_probs()
+                    )
                     if return_top_n_logprobs:
                         top_n_logprobs = self._dynamic_step_calculate_top_n_logprobs(
                             log_probs_tensor
@@ -1816,7 +2033,10 @@ class TextGenerationController:
             num_decode_requests = context.num_decode_requests
             if self.num_speculative_tokens > 0:
                 # Prefill-only batches must not have any accepted speculative tokens.
-                assert num_decode_requests > 0 or (self._accepted_tokens_per_request == -1).all()
+                assert (
+                    num_decode_requests > 0
+                    or (self._accepted_tokens_per_request == -1).all()
+                )
 
             if skip_bookkeeping:
                 # _transfer_samples_to_cpu wasn't invoked on this path, so do
@@ -1853,7 +2073,9 @@ class TextGenerationController:
     ) -> Optional[Dict]:
         """Synchronous wrapper for `self.async_generate_output_tokens_dynamic_batch."""
         loop = get_asyncio_loop(loop)
-        return loop.run_until_complete(self.async_generate_output_tokens_dynamic_batch())
+        return loop.run_until_complete(
+            self.async_generate_output_tokens_dynamic_batch()
+        )
 
     def _update_top_n_logprobs_dict(
         self,
@@ -1904,7 +2126,9 @@ class TextGenerationController:
         Returns:
             OrderedDict[int, InferenceRequest]: The result for each of the incoming requests
         """
-        assert all(request.prompt_tokens is not None for request in active_requests.values())
+        assert all(
+            request.prompt_tokens is not None for request in active_requests.values()
+        )
 
         # Perform a deep copy so that the request prompt tokens do not get modified.
         batch_prompt_tokens_list: List[List[int]] = list(
@@ -1921,7 +2145,9 @@ class TextGenerationController:
         min_prompt_length_in_batch = min(prompt_lengths_in_batch)
 
         # For batch inference the sampling params are the same for all request
-        sampling_params: SamplingParams = list(active_requests.values())[0].sampling_params
+        sampling_params: SamplingParams = list(active_requests.values())[
+            0
+        ].sampling_params
 
         # Remove Float16Module wrapper if it exists
         unwrapped_model = unwrap_model(self.inference_wrapped_model.model)
@@ -1939,12 +2165,16 @@ class TextGenerationController:
 
         # Pad batch tokens if necessary
         batch_size = len(active_requests)
-        max_sequence_length = max_prompt_length_in_batch + sampling_params.num_tokens_to_generate
+        max_sequence_length = (
+            max_prompt_length_in_batch + sampling_params.num_tokens_to_generate
+        )
         context = self.inference_wrapped_model.inference_context
         assert isinstance(context, StaticInferenceContext)
         inference_max_batch_size = context.max_batch_size
         inference_max_sequence_length = context.max_sequence_length
-        padded_batch_size = inference_max_batch_size if enable_cuda_graph else batch_size
+        padded_batch_size = (
+            inference_max_batch_size if enable_cuda_graph else batch_size
+        )
         if padded_batch_size > inference_max_batch_size:
             raise ValueError(
                 f"Padded batch size {padded_batch_size} > max batch size {inference_max_batch_size}"
@@ -2101,7 +2331,10 @@ class TextGenerationController:
                 # Only materialize prompt log probs if the user requests log probs
                 materialize_only_last_token_logits = (
                     self.inference_wrapped_model.inference_context.is_decode_only()
-                    or not (sampling_params.return_log_probs or sampling_params.top_n_logprobs > 0)
+                    or not (
+                        sampling_params.return_log_probs
+                        or sampling_params.top_n_logprobs > 0
+                    )
                 )
                 inference_context = self.inference_wrapped_model.inference_context
                 inference_context.config.materialize_only_last_token_logits = (
@@ -2118,16 +2351,23 @@ class TextGenerationController:
                 batch_prompt_tokens = self.unpad_input_prompt_tokens(
                     padded_batch_prompt_tokens, batch_size
                 )
-                assert batch_prompt_tokens.shape[0] == batch_size, batch_prompt_tokens.shape[0]
+                assert batch_prompt_tokens.shape[0] == batch_size, (
+                    batch_prompt_tokens.shape[0]
+                )
                 if is_pipeline_last_stage(self.pp_group):
                     logits = logits[:batch_size]
 
                 if self.model_is_pipeline_parallel:
                     context_length = context_end_position - context_start_position
-                    logits_seq_len = 1 if materialize_only_last_token_logits else context_length
+                    logits_seq_len = (
+                        1 if materialize_only_last_token_logits else context_length
+                    )
                     logits_shape = [batch_size, logits_seq_len, self.vocab_size]
                     if is_pipeline_last_stage(self.pp_group):
-                        assert logits is not None and torch.Size(logits_shape) == logits.shape
+                        assert (
+                            logits is not None
+                            and torch.Size(logits_shape) == logits.shape
+                        )
                     # TODO(ksanthanam): Evaluate whether it makes more sense to sample on 1 rank
                     # and then broadcast the sampled tokens rather than broadcasting the raw logits.
                     logits = broadcast_from_last_pipeline_stage(
@@ -2155,7 +2395,8 @@ class TextGenerationController:
 
                 logits_for_top_n_prompt_logprobs = (
                     logits
-                    if context_start_position == 0 and not sampling_params.skip_prompt_log_probs
+                    if context_start_position == 0
+                    and not sampling_params.skip_prompt_log_probs
                     else None
                 )
                 sampled_logits = self.sample_from_logits(
@@ -2170,9 +2411,9 @@ class TextGenerationController:
                 if sampling_params.num_tokens_to_generate > 0:
                     # Substitute the sampled logits only for the prompts that
                     # have started generating tokens
-                    batch_prompt_tokens[generation_started, context_end_position] = sampled_logits[
-                        generation_started
-                    ]
+                    batch_prompt_tokens[generation_started, context_end_position] = (
+                        sampled_logits[generation_started]
+                    )
 
                 # Compute log probs
                 if sampling_params.return_log_probs:
@@ -2186,9 +2427,9 @@ class TextGenerationController:
                     )
                     # Get the log probabilities for only the prompt tokens
                     assert output_log_probs is not None
-                    output_log_probs[:, context_start_position:context_end_position] = torch.gather(
-                        log_probs, 2, indices
-                    ).squeeze(2)
+                    output_log_probs[:, context_start_position:context_end_position] = (
+                        torch.gather(log_probs, 2, indices).squeeze(2)
+                    )
 
                 context_start_position = context_end_position
 
@@ -2281,14 +2522,22 @@ class TextGenerationController:
             input_prompt_length = int(prompt_lengths_in_batch[idx])
             # Shorter prompts might have generated more than required tokens. So we trim them down
             required_sequence_length = int(
-                min(generated_sequence_lengths[idx], sampling_params.num_tokens_to_generate)
+                min(
+                    generated_sequence_lengths[idx],
+                    sampling_params.num_tokens_to_generate,
+                )
             )
             # Extract only the generated tokens
             required_result_tokens = batch_prompt_tokens_with_generations[
-                idx, input_prompt_length : (input_prompt_length + required_sequence_length)
+                idx,
+                input_prompt_length : (input_prompt_length + required_sequence_length),
             ]
-            generated_sequence_lengths = generated_sequence_lengths.to(dtype=torch.int32)
-            request.generated_sequence_lengths = generated_sequence_lengths.to(dtype=torch.int32)
+            generated_sequence_lengths = generated_sequence_lengths.to(
+                dtype=torch.int32
+            )
+            request.generated_sequence_lengths = generated_sequence_lengths.to(
+                dtype=torch.int32
+            )
             request.generated_length = required_sequence_length
             request.generated_tokens = required_result_tokens
 
@@ -2299,7 +2548,9 @@ class TextGenerationController:
             spill_length = input_prompt_length - min_prompt_length_in_batch
             if spill_length > 0:
                 spill_latency = request_tpot[:spill_length].sum()
-                request_tpot = torch.cat((spill_latency.unsqueeze(0), request_tpot[spill_length:]))
+                request_tpot = torch.cat(
+                    (spill_latency.unsqueeze(0), request_tpot[spill_length:])
+                )
 
             # Remove the extraneous latencies if the
             # request sequence length < maximum sequence length
@@ -2307,10 +2558,14 @@ class TextGenerationController:
             request.tpot = request_tpot.tolist()
 
             if output_log_probs is not None:
-                request.prompt_log_probs = output_log_probs[idx, : input_prompt_length - 1].tolist()
+                request.prompt_log_probs = output_log_probs[
+                    idx, : input_prompt_length - 1
+                ].tolist()
                 request.generated_log_probs = output_log_probs[
                     idx,
-                    input_prompt_length - 1 : (input_prompt_length + required_sequence_length - 1),
+                    input_prompt_length - 1 : (
+                        input_prompt_length + required_sequence_length - 1
+                    ),
                 ].tolist()
             if sampling_params.top_n_logprobs > 0:
                 if not sampling_params.skip_prompt_log_probs:
@@ -2325,8 +2580,9 @@ class TextGenerationController:
                         : input_prompt_length - 1
                     ]
                     request.generated_top_n_logprobs = top_n_logprobs_dict[idx][
-                        input_prompt_length
-                        - 1 : (input_prompt_length + required_sequence_length - 1)
+                        input_prompt_length - 1 : (
+                            input_prompt_length + required_sequence_length - 1
+                        )
                     ]
                 else:
                     assert len(top_n_logprobs_dict[idx]) >= required_sequence_length, (
@@ -2346,7 +2602,9 @@ class TextGenerationController:
                 input_prompt_length + generated_sequence_lengths,
                 sampling_params.return_segments,
             )
-            request.text = text  # Inference server returns prompts & generations together
+            request.text = (
+                text  # Inference server returns prompts & generations together
+            )
             if sampling_params.return_segments:
                 request.segments = segments[0]
             request.generated_text = text[len(request.prompt) :]
@@ -2369,12 +2627,16 @@ class TextGenerationController:
         Returns:
             A dict of the inference input for the current batch.
         """
-        inference_input = self.inference_wrapped_model.prep_inference_input(prompts_tokens)
+        inference_input = self.inference_wrapped_model.prep_inference_input(
+            prompts_tokens
+        )
 
         if use_attention_mask and (
             attention_mask := inference_input.get("attention_mask", None) is None
         ):
-            inference_input["attention_mask"] = get_attention_mask(prompts_tokens.size(1))
+            inference_input["attention_mask"] = get_attention_mask(
+                prompts_tokens.size(1)
+            )
 
         return inference_input
 
@@ -2465,7 +2727,10 @@ class TextGenerationController:
                 )
             )
 
-            if is_generation_done or generated_length == sampling_params.num_tokens_to_generate:
+            if (
+                is_generation_done
+                or generated_length == sampling_params.num_tokens_to_generate
+            ):
                 stream.finish()
 
         ret = map(

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -17,6 +17,10 @@ from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.mappings import gather_from_sequence_parallel_region
 from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.experimental_attention_variant.indexer_replay import (
+    IndexerReplay,
+    IndexerReplayAction,
+)
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -38,9 +42,9 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
     Returns:
         Rotated tensor.
     """
-    assert (
-        x.dtype == torch.bfloat16
-    ), f"rotate_activation only support bf16 input, but got {x.dtype}"
+    assert x.dtype == torch.bfloat16, (
+        f"rotate_activation only support bf16 input, but got {x.dtype}"
+    )
     assert hadamard_transform is not None, "fast_hadamard_transform is not installed."
     hidden_size = x.size(-1)
     return hadamard_transform(x, scale=hidden_size**-0.5)
@@ -74,7 +78,9 @@ class DSAIndexerLossLoggingHelper:
 
         tracker = DSAIndexerLossLoggingHelper.tracker
         if "values" not in tracker:
-            tracker["values"] = torch.zeros(num_layers, device=torch.cuda.current_device())
+            tracker["values"] = torch.zeros(
+                num_layers, device=torch.cuda.current_device()
+            )
         tracker["values"][layer_number - 1] += loss.detach()
         tracker["reduce_group"] = reduce_group
         tracker["avg_group"] = avg_group
@@ -100,11 +106,11 @@ class DSAIndexerLossLoggingHelper:
             values, group=parallel_state.get_pipeline_model_parallel_group()
         )
         # Reduce indexer losses across ranks.
-        if tracker.get('reduce_group') is not None:
-            torch.distributed.all_reduce(values, group=tracker.get('reduce_group'))
-        if tracker.get('avg_group') is not None:
+        if tracker.get("reduce_group") is not None:
+            torch.distributed.all_reduce(values, group=tracker.get("reduce_group"))
+        if tracker.get("avg_group") is not None:
             torch.distributed.all_reduce(
-                values, group=tracker['avg_group'], op=torch.distributed.ReduceOp.AVG
+                values, group=tracker["avg_group"], op=torch.distributed.ReduceOp.AVG
             )
         torch.distributed.all_reduce(
             values,
@@ -205,7 +211,9 @@ def compute_dsa_indexer_loss(
 
     # causal_mask [sq, sk]
     causal_mask = torch.triu(
-        torch.full((sq, sk), float('-inf'), dtype=torch.float32, device=attention_scores.device),
+        torch.full(
+            (sq, sk), float("-inf"), dtype=torch.float32, device=attention_scores.device
+        ),
         diagonal=1,
     )
     # index_mask [b, sq, sk]
@@ -222,16 +230,22 @@ def compute_dsa_indexer_loss(
         index_scores += index_mask
 
     # [b, np, sq, sk] -> [b, np, sq, sk]
-    attention_scores = torch.nn.functional.softmax(attention_scores, dim=-1, dtype=torch.float32)
+    attention_scores = torch.nn.functional.softmax(
+        attention_scores, dim=-1, dtype=torch.float32
+    )
     # [b, sq, sk] -> [b, sq, sk]
-    index_scores = torch.nn.functional.softmax(index_scores, dim=-1, dtype=torch.float32)
+    index_scores = torch.nn.functional.softmax(
+        index_scores, dim=-1, dtype=torch.float32
+    )
 
     # Sum attention scores across heads.
     # [batch, heads, seqlen_q, seqlen_k] -> [batch, seqlen_q, seqlen_k]
     attention_scores = attention_scores.sum(dim=1)
     if pg_collection.tp.size() > 1:
         # attention scores are scattered to TP ranks in head dimension.
-        torch.distributed.all_reduce(attention_scores.contiguous(), group=pg_collection.tp)
+        torch.distributed.all_reduce(
+            attention_scores.contiguous(), group=pg_collection.tp
+        )
     # L1 normalize target on the last dimension. Doesn't use abs() because attention_scores are
     # obtained from softmax so they are already non-negative.
     attention_scores = attention_scores / attention_scores.sum(dim=-1, keepdim=True)
@@ -252,7 +266,9 @@ def compute_dsa_indexer_loss(
     return indexer_loss
 
 
-def _compute_index_scores(q: torch.Tensor, weights: torch.Tensor, k: torch.Tensor) -> torch.Tensor:
+def _compute_index_scores(
+    q: torch.Tensor, weights: torch.Tensor, k: torch.Tensor
+) -> torch.Tensor:
     """
     Perform index score using BF16 precision.
 
@@ -275,7 +291,7 @@ def _compute_index_scores(q: torch.Tensor, weights: torch.Tensor, k: torch.Tenso
     # Compute attention scores: q @ k^T
     # [seqlen_q, batch, index_n_heads, index_head_dim] @ [seqlen_k, batch, index_head_dim]^T
     #   -> [seqlen_q, batch, index_n_heads, seqlen_k]
-    index_scores = torch.einsum('sbhd,tbd->sbht', q.float(), k.float())
+    index_scores = torch.einsum("sbhd,tbd->sbht", q.float(), k.float())
 
     # Apply ReLU activation.
     index_scores = torch.relu(index_scores)
@@ -310,7 +326,9 @@ def fused_qk_topk_naive(
     # [batch, seqlen, seqlen]
     index_scores = _compute_index_scores(q, weights, k)
     if mask is not None:
-        assert mask.dtype == index_scores.dtype, "Mask dtype must match index scores dtype"
+        assert mask.dtype == index_scores.dtype, (
+            "Mask dtype must match index scores dtype"
+        )
         index_scores = index_scores + mask
 
     # =========================================
@@ -324,7 +342,17 @@ def fused_qk_topk_naive(
 
 
 def fwd_fused_indexer_loss_naive(
-    q, weights, k, query, key, topk, softmax_scale, loss_coeff, mask, sparse_loss, pg_collection
+    q,
+    weights,
+    k,
+    query,
+    key,
+    topk,
+    softmax_scale,
+    loss_coeff,
+    mask,
+    sparse_loss,
+    pg_collection,
 ):
     """Naive implementation of forward pass for indexer loss."""
     index_scores, topk_indices = fused_qk_topk_naive(q, k, weights, topk, mask)
@@ -367,7 +395,9 @@ def bwd_fused_indexer_loss_naive(
     # [sk, b, np, hn] -> [b, np, hn, sk] -> [b * np, hn, sk]
     key_reshaped = key.permute(1, 2, 3, 0).reshape(b * np, hn, sk)
     # Compute attention scores [b * np, sq, sk]
-    attention_scores = torch.bmm(query_reshaped.float(), key_reshaped.float()) * softmax_scale
+    attention_scores = (
+        torch.bmm(query_reshaped.float(), key_reshaped.float()) * softmax_scale
+    )
     # Free reshaped tensors - no longer needed after bmm
     del query_reshaped, key_reshaped
 
@@ -376,7 +406,9 @@ def bwd_fused_indexer_loss_naive(
 
     # causal_mask [sq, sk]
     causal_mask = torch.triu(
-        torch.full((sq, sk), float('-inf'), dtype=torch.float32, device=attention_scores.device),
+        torch.full(
+            (sq, sk), float("-inf"), dtype=torch.float32, device=attention_scores.device
+        ),
         diagonal=1,
     )
     # index_mask [b, sq, sk]
@@ -405,7 +437,9 @@ def bwd_fused_indexer_loss_naive(
     # Free attention_scores immediately
     del attention_scores
 
-    index_scores_softmax = torch.nn.functional.softmax(index_scores, dim=-1, dtype=torch.float32)
+    index_scores_softmax = torch.nn.functional.softmax(
+        index_scores, dim=-1, dtype=torch.float32
+    )
     # Free index_scores - no longer needed after softmax
     del index_scores
 
@@ -416,7 +450,9 @@ def bwd_fused_indexer_loss_naive(
 
     if pg_collection.tp.size() > 1:
         # attention scores are scattered to TP ranks in head dimension.
-        torch.distributed.all_reduce(attention_scores_sum.contiguous(), group=pg_collection.tp)
+        torch.distributed.all_reduce(
+            attention_scores_sum.contiguous(), group=pg_collection.tp
+        )
 
     # L1 normalize
     attention_scores_normalized = attention_scores_sum / attention_scores_sum.sum(
@@ -439,14 +475,20 @@ def bwd_fused_indexer_loss_naive(
     # Backward through kl_per_element = target * (log(target) - log(index))
     # ∂kl/∂index_softmax = -target / index_softmax
     grad_index_scores_softmax = (
-        -attention_scores_normalized / (index_scores_softmax + 1e-10) * grad_kl_per_element
+        -attention_scores_normalized
+        / (index_scores_softmax + 1e-10)
+        * grad_kl_per_element
     )
     # Free attention_scores_normalized - no longer needed
     del attention_scores_normalized
 
     # Backward through softmax: ∂L/∂x = softmax * (∂L/∂softmax - sum(∂L/∂softmax * softmax))
-    sum_grad = (grad_index_scores_softmax * index_scores_softmax).sum(dim=-1, keepdim=True)
-    grad_index_scores_logits = index_scores_softmax * (grad_index_scores_softmax - sum_grad)
+    sum_grad = (grad_index_scores_softmax * index_scores_softmax).sum(
+        dim=-1, keepdim=True
+    )
+    grad_index_scores_logits = index_scores_softmax * (
+        grad_index_scores_softmax - sum_grad
+    )
     # Free intermediate tensors
     del index_scores_softmax, grad_index_scores_softmax, sum_grad
 
@@ -479,7 +521,7 @@ def bwd_fused_indexer_loss_naive(
     del grad_index_scores
 
     # Compute forward values needed for backward
-    scores = torch.einsum('sbhd,tbd->sbht', q.float(), k.float())  # [sq, b, h, sk]
+    scores = torch.einsum("sbhd,tbd->sbht", q.float(), k.float())  # [sq, b, h, sk]
     # Compute relu_mask before relu (saves memory vs keeping both scores and relu output)
     relu_mask = scores > 0
     scores_after_relu = torch.relu(scores)
@@ -490,7 +532,9 @@ def bwd_fused_indexer_loss_naive(
     grad_weights = (grad_weighted_scores * scores_after_relu).sum(dim=-1)  # [sq, b, h]
 
     # ∂L/∂relu_scores = grad * weights
-    grad_scores_after_relu = grad_weighted_scores * weights.unsqueeze(-1)  # [sq, b, h, sk]
+    grad_scores_after_relu = grad_weighted_scores * weights.unsqueeze(
+        -1
+    )  # [sq, b, h, sk]
     del grad_weighted_scores, scores_after_relu
 
     # Backward through ReLU
@@ -499,9 +543,9 @@ def bwd_fused_indexer_loss_naive(
 
     # Backward through einsum 'sbhd,tbd->sbht'
     # ∂L/∂q = einsum('sbht,tbd->sbhd', grad_scores, k)
-    grad_q = torch.einsum('sbht,tbd->sbhd', grad_scores, k.float())  # [sq, b, h, d]
+    grad_q = torch.einsum("sbht,tbd->sbhd", grad_scores, k.float())  # [sq, b, h, d]
     # ∂L/∂k = einsum('sbht,sbhd->tbd', grad_scores, q)
-    grad_k = torch.einsum('sbht,sbhd->tbd', grad_scores, q.float())  # [sk, b, d]
+    grad_k = torch.einsum("sbht,sbhd->tbd", grad_scores, q.float())  # [sk, b, d]
     del grad_scores
 
     return grad_q.to(q.dtype), grad_weights.to(weights.dtype), grad_k.to(k.dtype)
@@ -524,23 +568,44 @@ class FusedDSAIndexerLoss(torch.autograd.Function):
         mask,
         sparse_loss,
         pg_collection,
+        replay_topk_indices=None,
     ):
         """
         Fused forward: index_scores never materialized in full.
+
+        Args:
+            replay_topk_indices: If provided, skip top-k computation and use these
+                pre-computed indices instead (used during replay mode).
         """
-        topk_indices, loss = fwd_fused_indexer_loss_naive(
-            q,
-            weights,
-            k,
-            query,
-            key,
-            topk,
-            softmax_scale,
-            loss_coeff,
-            mask,
-            sparse_loss,
-            pg_collection,
-        )
+        if replay_topk_indices is not None:
+            index_scores = _compute_index_scores(q, weights, k)
+            if mask is not None:
+                index_scores = index_scores + mask
+            topk_indices = replay_topk_indices
+            loss = compute_dsa_indexer_loss(
+                index_scores,
+                topk_indices,
+                query,
+                key,
+                softmax_scale,
+                loss_coeff,
+                sparse_loss,
+                pg_collection,
+            )
+        else:
+            topk_indices, loss = fwd_fused_indexer_loss_naive(
+                q,
+                weights,
+                k,
+                query,
+                key,
+                topk,
+                softmax_scale,
+                loss_coeff,
+                mask,
+                sparse_loss,
+                pg_collection,
+            )
 
         # Save for backward (recomputation strategy)
         ctx.save_for_backward(q, weights, k, query, key, topk_indices)
@@ -573,7 +638,20 @@ class FusedDSAIndexerLoss(torch.autograd.Function):
         )
 
         # query and key are detached in forward, so return None for their gradients
-        return grad_q, grad_weights, grad_k, None, None, None, None, None, None, None, None
+        return (
+            grad_q,
+            grad_weights,
+            grad_k,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 class DSAIndexerLossAutoScaler(torch.autograd.Function):
@@ -616,7 +694,9 @@ class DSAIndexerLossAutoScaler(torch.autograd.Function):
                 1.0, device=indexer_loss.device
             )
         indexer_loss_backward_scale = DSAIndexerLossAutoScaler.main_loss_backward_scale
-        scaled_indexer_loss_grad = torch.ones_like(indexer_loss) * indexer_loss_backward_scale
+        scaled_indexer_loss_grad = (
+            torch.ones_like(indexer_loss) * indexer_loss_backward_scale
+        )
         return grad_output, scaled_indexer_loss_grad
 
     @staticmethod
@@ -702,18 +782,20 @@ class DSAIndexer(MegatronModule):
         self.softmax_scale: float = self.index_head_dim**-0.5
 
         if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=["tp", "cp"]
+            )
         self.pg_collection = pg_collection
 
         # Initialize Position Embedding.
-        if self.config.rope_type == 'rope':
+        if self.config.rope_type == "rope":
             self.rotary_pos_emb = RotaryEmbedding(
                 self.qk_pos_emb_head_dim,
                 rotary_percent=self.config.rotary_percent,
                 rotary_base=self.config.rotary_base,
                 cp_group=self.pg_collection.cp,
             )
-        elif self.config.rope_type == 'yarn':
+        elif self.config.rope_type == "yarn":
             self.rotary_pos_emb = YarnRotaryEmbedding(
                 self.qk_pos_emb_head_dim,
                 rotary_base=self.config.rotary_base,
@@ -776,6 +858,10 @@ class DSAIndexer(MegatronModule):
             parallel_mode="duplicated",
         )
 
+        self.indexer_replay = None
+        if self.config.dsa_enable_indexer_replay:
+            self.indexer_replay = IndexerReplay()
+
     def _apply_rope(self, x: torch.Tensor, rotary_pos_emb: torch.Tensor, mscale: float):
         """Apply RoPE to the input tensor."""
         # x_pe   [seqlen, batch, *, qk_pos_emb_head_dim]
@@ -783,7 +869,9 @@ class DSAIndexer(MegatronModule):
         # To align with DeepSeek's implementation,
         # x_pe is placed at the front, and x_nope is placed at the back.
         x_pe, x_nope = torch.split(
-            x, [self.qk_pos_emb_head_dim, self.index_head_dim - self.qk_pos_emb_head_dim], dim=-1
+            x,
+            [self.qk_pos_emb_head_dim, self.index_head_dim - self.qk_pos_emb_head_dim],
+            dim=-1,
         )
         x_pe = apply_rotary_pos_emb(
             x_pe,
@@ -801,7 +889,10 @@ class DSAIndexer(MegatronModule):
         return x
 
     def forward_before_topk(
-        self, x: torch.Tensor, qr: torch.Tensor, packed_seq_params: Optional[PackedSeqParams] = None
+        self,
+        x: torch.Tensor,
+        qr: torch.Tensor,
+        packed_seq_params: Optional[PackedSeqParams] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """All computations before topk."""
         # =========================================
@@ -814,7 +905,9 @@ class DSAIndexer(MegatronModule):
             rotary_pos_emb = self.rotary_pos_emb(rotary_seq_len, packed_seq=False)
             mscale = 1.0
         else:
-            rotary_pos_emb, mscale = self.rotary_pos_emb(rotary_seq_len, packed_seq=False)
+            rotary_pos_emb, mscale = self.rotary_pos_emb(
+                rotary_seq_len, packed_seq=False
+            )
 
         # =========================================
         # Gather inputs if sp is enabled
@@ -887,7 +980,9 @@ class DSAIndexer(MegatronModule):
             index_scores: Index scores [batch, seqlen, seqlen].
             topk_indices: Top-k indices [batch, seqlen, index_topk].
         """
-        assert packed_seq_params is None, "Packed sequence is not supported for DSAttention"
+        assert packed_seq_params is None, (
+            "Packed sequence is not supported for DSAttention"
+        )
 
         # [seqlen, batch, index_n_heads * index_head_dim]
         # [seqlen, batch, index_head_dim]
@@ -895,7 +990,9 @@ class DSAIndexer(MegatronModule):
         q, k, weights = self.forward_before_topk(x, qr, packed_seq_params)
 
         # [batch, seqlen, seqlen], [batch, seqlen, index_topk]
-        index_scores, topk_indices = fused_qk_topk_naive(q, k, weights, self.index_topk, mask)
+        index_scores, topk_indices = fused_qk_topk_naive(
+            q, k, weights, self.index_topk, mask
+        )
 
         return index_scores, topk_indices
 
@@ -950,14 +1047,18 @@ def unfused_dsa_fn(query, key, value, topk_indices, softmax_scale):
     index_mask.scatter_(-1, topk_indices, 0)
     # causal_mask [sq, skv]
     causal_mask = torch.triu(
-        torch.full((sq, skv), float('-inf'), dtype=torch.float32, device=index_mask.device),
+        torch.full(
+            (sq, skv), float("-inf"), dtype=torch.float32, device=index_mask.device
+        ),
         diagonal=1,
     )
     # [b, sq, skv] + [1, sq, skv] -> [b, sq, skv]
     index_mask += causal_mask.view(1, sq, skv)
     # [b, np, sq, skv] + [b, 1, sq, skv] -> [b, np, sq, skv]
     attention_scores += index_mask.unsqueeze(1)
-    attention_scores = torch.nn.functional.softmax(attention_scores, dim=-1, dtype=torch.float32)
+    attention_scores = torch.nn.functional.softmax(
+        attention_scores, dim=-1, dtype=torch.float32
+    )
 
     # ===================================
     # Output
@@ -1051,21 +1152,27 @@ class DSAttention(MegatronModule):
 
         # Get a FP32 mask with -inf for masked positions.
         if attn_mask_type is not None:
-            assert attn_mask_type == AttnMaskType.causal, 'Only causal mask is supported for now'
+            assert attn_mask_type == AttnMaskType.causal, (
+                "Only causal mask is supported for now"
+            )
             # Generate upper triangular mask with -inf above diagonal, 0 elsewhere
             # torch.triu with diagonal=1 creates upper triangular matrix (excluding main diagonal)
             # float_mask [sq, skv]
             float_mask = torch.triu(
-                torch.full((sq, skv), float('-inf'), dtype=torch.float32, device=x.device),
+                torch.full(
+                    (sq, skv), float("-inf"), dtype=torch.float32, device=x.device
+                ),
                 diagonal=1,
             )
         else:
-            assert attention_mask.shape == (b, 1, sq, skv), 'attention_mask shape mismatch'
+            assert attention_mask.shape == (b, 1, sq, skv), (
+                "attention_mask shape mismatch"
+            )
             # [b, 1, sq, skv] -> [b, sq, skv]
             mask = attention_mask.squeeze()
             # float_mask [b, sq, skv]
             float_mask = torch.zeros_like(mask, dtype=torch.float32).masked_fill(
-                mask, float('-inf')
+                mask, float("-inf")
             )
 
         if self.training and torch.is_grad_enabled():
@@ -1073,25 +1180,83 @@ class DSAttention(MegatronModule):
             # Prepare inputs for indexer loss
             # ===================================
             q, k, weights = self.indexer.forward_before_topk(x, qr, packed_seq_params)
-            indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0)
+            indexer_loss_coeff = getattr(self.config, "dsa_indexer_loss_coeff", 0.0)
 
             # ===================================
-            # Attach indexer topk and loss
+            # Handle indexer replay
             # ===================================
-            # Compute KL divergence loss between indexer scores and true attention scores
-            topk_indices, indexer_loss = FusedDSAIndexerLoss.apply(
-                q,
-                weights,
-                k,
-                query.detach(),
-                key.detach(),
-                self.softmax_scale,
-                self.indexer.index_topk,
-                indexer_loss_coeff,
-                float_mask,
-                getattr(self.config, "dsa_indexer_use_sparse_loss", False),
-                self.indexer.pg_collection,
-            )
+            replay_topk = None
+            if self.indexer.indexer_replay is not None:
+                replay_action = self.indexer.indexer_replay.indexer_replay_action
+                if replay_action == IndexerReplayAction.RECORD:
+                    topk_indices, indexer_loss = FusedDSAIndexerLoss.apply(
+                        q,
+                        weights,
+                        k,
+                        query.detach(),
+                        key.detach(),
+                        self.softmax_scale,
+                        self.indexer.index_topk,
+                        indexer_loss_coeff,
+                        float_mask,
+                        getattr(self.config, "dsa_indexer_use_sparse_loss", False),
+                        self.indexer.pg_collection,
+                    )
+                    self.indexer.indexer_replay.record_indices(topk_indices)
+                elif replay_action in (
+                    IndexerReplayAction.REPLAY_FORWARD,
+                    IndexerReplayAction.REPLAY_BACKWARD,
+                ):
+                    if replay_action == IndexerReplayAction.REPLAY_FORWARD:
+                        replay_topk = self.indexer.indexer_replay.target_topk_idx
+                    else:
+                        replay_topk = (
+                            self.indexer.indexer_replay.replay_backward_list.pop(0)
+                        )
+                    replay_topk = replay_topk.to(q.device)
+                    topk_indices, indexer_loss = FusedDSAIndexerLoss.apply(
+                        q,
+                        weights,
+                        k,
+                        query.detach(),
+                        key.detach(),
+                        self.softmax_scale,
+                        self.indexer.index_topk,
+                        indexer_loss_coeff,
+                        float_mask,
+                        getattr(self.config, "dsa_indexer_use_sparse_loss", False),
+                        self.indexer.pg_collection,
+                        replay_topk,
+                    )
+                else:
+                    topk_indices, indexer_loss = FusedDSAIndexerLoss.apply(
+                        q,
+                        weights,
+                        k,
+                        query.detach(),
+                        key.detach(),
+                        self.softmax_scale,
+                        self.indexer.index_topk,
+                        indexer_loss_coeff,
+                        float_mask,
+                        getattr(self.config, "dsa_indexer_use_sparse_loss", False),
+                        self.indexer.pg_collection,
+                    )
+            else:
+                topk_indices, indexer_loss = FusedDSAIndexerLoss.apply(
+                    q,
+                    weights,
+                    k,
+                    query.detach(),
+                    key.detach(),
+                    self.softmax_scale,
+                    self.indexer.index_topk,
+                    indexer_loss_coeff,
+                    float_mask,
+                    getattr(self.config, "dsa_indexer_use_sparse_loss", False),
+                    self.indexer.pg_collection,
+                )
+
             # Save indexer loss for logging
             if indexer_loss_coeff > 0:
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(
@@ -1110,11 +1275,24 @@ class DSAttention(MegatronModule):
 
         else:
             # ===================================
-            # Get index scores and top-k indices
+            # Handle indexer replay in inference/eval mode
             # ===================================
-            _, topk_indices = self.indexer.forward_with_scores(
-                x, qr, mask=float_mask, packed_seq_params=packed_seq_params
-            )
+            if (
+                self.indexer.indexer_replay is not None
+                and self.indexer.indexer_replay.indexer_replay_action
+                == IndexerReplayAction.RECORD
+            ):
+                _, topk_indices = self.indexer.forward_with_scores(
+                    x, qr, mask=float_mask, packed_seq_params=packed_seq_params
+                )
+                self.indexer.indexer_replay.record_indices(topk_indices)
+            else:
+                # ===================================
+                # Get index scores and top-k indices
+                # ===================================
+                _, topk_indices = self.indexer.forward_with_scores(
+                    x, qr, mask=float_mask, packed_seq_params=packed_seq_params
+                )
 
             # ===================================
             # Run sparse attention kernel

--- a/megatron/core/transformer/experimental_attention_variant/indexer_replay.py
+++ b/megatron/core/transformer/experimental_attention_variant/indexer_replay.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from enum import Enum
+from typing import List, Optional, Tuple
+
+import torch
+
+
+class IndexerReplayAction(Enum):
+    RECORD = "record"
+    REPLAY_FORWARD = "replay_forward"
+    REPLAY_BACKWARD = "replay_backward"
+
+
+class IndexerReplay:
+    global_indexer_replay_instances: List["IndexerReplay"] = []
+
+    @staticmethod
+    def set_replay_data(all_layers_topk_indices: List[torch.Tensor]):
+        if len(all_layers_topk_indices) != len(
+            IndexerReplay.global_indexer_replay_instances
+        ):
+            raise ValueError(
+                f"The number of replay tensors ({len(all_layers_topk_indices)}) "
+                f"does not match instances ({len(IndexerReplay.global_indexer_replay_instances)})."
+            )
+        for i, instance in enumerate(IndexerReplay.global_indexer_replay_instances):
+            instance.set_target_indices(all_layers_topk_indices[i])
+
+    @staticmethod
+    def get_recorded_data() -> List[torch.Tensor]:
+        return [
+            instance.get_recorded_indices()
+            for instance in IndexerReplay.global_indexer_replay_instances
+        ]
+
+    @staticmethod
+    def clear_global_indices():
+        for instance in IndexerReplay.global_indexer_replay_instances:
+            instance.clear_indices()
+
+    @staticmethod
+    def set_global_indexer_replay_action(action: IndexerReplayAction):
+        for instance in IndexerReplay.global_indexer_replay_instances:
+            instance.set_indexer_replay_action(action)
+
+    @staticmethod
+    def clear_global_indexer_replay_action():
+        for instance in IndexerReplay.global_indexer_replay_instances:
+            instance.clear_indexer_replay_action()
+
+    @staticmethod
+    def clear_global_indexer_replay_instances():
+        IndexerReplay.global_indexer_replay_instances.clear()
+
+    @staticmethod
+    def set_global_static_buffers(static_buffer: torch.Tensor):
+        num_layers = len(IndexerReplay.global_indexer_replay_instances)
+        assert static_buffer.shape[1] == num_layers, (
+            f"Buffer has {static_buffer.shape[1]} layers but there are "
+            f"{num_layers} IndexerReplay instances."
+        )
+        for layer_idx, instance in enumerate(
+            IndexerReplay.global_indexer_replay_instances
+        ):
+            instance.set_static_buffer(static_buffer[:, layer_idx, :])
+
+    @staticmethod
+    def clear_global_static_buffers():
+        for instance in IndexerReplay.global_indexer_replay_instances:
+            instance.clear_static_buffer()
+
+    def __init__(self):
+        self.target_topk_idx: Optional[torch.Tensor] = None
+        self.recorded_topk_idx: Optional[torch.Tensor] = None
+        self.indexer_replay_action: Optional[IndexerReplayAction] = None
+        self.replay_backward_list: List[torch.Tensor] = []
+        self.static_buffer: Optional[torch.Tensor] = None
+        IndexerReplay.global_indexer_replay_instances.append(self)
+
+    def set_target_indices(self, topk_indices: torch.Tensor):
+        self.target_topk_idx = topk_indices
+        self.replay_backward_list.append(topk_indices)
+
+    def get_recorded_indices(self) -> Optional[torch.Tensor]:
+        return self.recorded_topk_idx
+
+    def clear_indices(self):
+        self.recorded_topk_idx = None
+        self.target_topk_idx = None
+        self.replay_backward_list = []
+
+    def set_indexer_replay_action(self, action: IndexerReplayAction):
+        self.indexer_replay_action = action
+
+    def clear_indexer_replay_action(self):
+        self.indexer_replay_action = None
+
+    def get_replay_topk_indices(
+        self, default_compute_topk_indices
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+        if self.indexer_replay_action == IndexerReplayAction.RECORD:
+            topk_indices = default_compute_topk_indices()
+            self.record_indices(topk_indices)
+            return topk_indices, None
+        elif self.indexer_replay_action == IndexerReplayAction.REPLAY_FORWARD:
+            topk_indices = self.target_topk_idx
+            return topk_indices, topk_indices
+        elif self.indexer_replay_action == IndexerReplayAction.REPLAY_BACKWARD:
+            topk_indices = self.replay_backward_list.pop(0)
+            return topk_indices, topk_indices
+        else:
+            return None, None
+
+    def set_static_buffer(self, buffer: torch.Tensor):
+        self.static_buffer = buffer
+
+    def clear_static_buffer(self):
+        self.static_buffer = None
+
+    def record_indices(self, topk_indices: torch.Tensor):
+        if self.static_buffer is not None:
+            num_tokens = topk_indices.shape[0]
+            self.static_buffer[:num_tokens].copy_(topk_indices)
+            self.recorded_topk_idx = self.static_buffer[:num_tokens]
+        else:
+            self.recorded_topk_idx = topk_indices

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -100,7 +100,9 @@ class TransformerConfig(ModelParallelConfig):
     """Number of transformer layers on last pipeline stage.
     None implies equal layer division across PP ranks."""
 
-    pipeline_model_parallel_layout: Optional[Union[str, list, PipelineParallelLayerLayout]] = None
+    pipeline_model_parallel_layout: Optional[
+        Union[str, list, PipelineParallelLayerLayout]
+    ] = None
     """Custom definition of the pipeline parallel partitioning.
     Support type:
     - str: e.g., 'Et*3|(tt|)*29,m|L'. Stages are split by '|', replicated stages or layers
@@ -137,7 +139,9 @@ class TransformerConfig(ModelParallelConfig):
     hidden_size: int = field(default=0, metadata={"argparse_meta": {"default": None}})
     """Transformer hidden size."""
 
-    num_attention_heads: int = field(default=0, metadata={"argparse_meta": {"default": None}})
+    num_attention_heads: int = field(
+        default=0, metadata={"argparse_meta": {"default": None}}
+    )
     """Number of transformer attention heads."""
 
     attention_backend: AttnBackend = AttnBackend.auto
@@ -149,7 +153,7 @@ class TransformerConfig(ModelParallelConfig):
     softmax_scale: Optional[float] = None
     """Softmax scale for attention scaling."""
 
-    softmax_type: Literal['vanilla', 'off-by-one', 'learnable'] = 'vanilla'
+    softmax_type: Literal["vanilla", "off-by-one", "learnable"] = "vanilla"
     """Applies modified softmax from https://www.evanmiller.org/attention-is-off-by-one.html. 
        Supports both TE FusedAttention and local unfused attention. Supports both a fixed offset and 
        and learnable offset."""
@@ -186,13 +190,15 @@ class TransformerConfig(ModelParallelConfig):
     """Epsilon value for any LayerNorm/RMSNorm operations."""
 
     layernorm_zero_centered_gamma: bool = field(
-        default=False, metadata={"argparse_meta": {"arg_names": ["--apply-layernorm-1p"]}}
+        default=False,
+        metadata={"argparse_meta": {"arg_names": ["--apply-layernorm-1p"]}},
     )
     """If set to True, the LayerNorm is adjusted to center the gamma values around 0. This improves
     numerical stability."""
 
     add_bias_linear: bool = field(
-        default=True, metadata={"argparse_meta": {"arg_names": ["--disable-bias-linear"]}}
+        default=True,
+        metadata={"argparse_meta": {"arg_names": ["--disable-bias-linear"]}},
     )
     """Include/exclude a bias term in all linear layers (QKV projections, after core attention,
     and two in MLP layer)."""
@@ -235,7 +241,7 @@ class TransformerConfig(ModelParallelConfig):
     - An integer N: Represents a (N-1):1 ratio, one full attention layer after (N-1) SWA layers.
     - A list that defines a custom pattern, e.g.: [1,1,1,1,0,0,0,0], where 1 represents SWA. """
 
-    normalization: Literal['LayerNorm', 'RMSNorm'] = "LayerNorm"
+    normalization: Literal["LayerNorm", "RMSNorm"] = "LayerNorm"
     """Which norm to use for normalization layers, valid options are `LayerNorm` and `RMSNorm`."""
 
     qk_layernorm: bool = False
@@ -280,7 +286,7 @@ class TransformerConfig(ModelParallelConfig):
     ####################
     # attention variant
     ####################
-    experimental_attention_variant: Optional[Literal['gated_delta_net', 'dsa']] = None
+    experimental_attention_variant: Optional[Literal["gated_delta_net", "dsa"]] = None
     """Type of attention variant to use. Currently support gated_delta_net and dsa."""
 
     ####################
@@ -301,6 +307,11 @@ class TransformerConfig(ModelParallelConfig):
     dsa_indexer_use_sparse_loss: bool = False
     """Whether to use sparse DSA indexer loss. If True, the indexer loss will be computed using the
     top-k indices."""
+
+    dsa_enable_indexer_replay: bool = False
+    """If True, enable the indexer replay feature for DSA attention layers. This records top-k
+    indexer decisions during inference and replays them during training to ensure train/rollout
+    consistency in RL training, analogous to MoE router replay."""
 
     ####################
     # linear attention
@@ -474,7 +485,7 @@ class TransformerConfig(ModelParallelConfig):
     ####################
     # activation recomputation
     ####################
-    recompute_granularity: Optional[Literal['full', 'selective']] = None
+    recompute_granularity: Optional[Literal["full", "selective"]] = None
     """Determines which type of activation recompute to use.  Megatron-core supports 'selective'
     activation checkpointing where the submodules set in --recompute-modules is checkpointed.
     The default is "core_attn" which is the memory intensive part of attention.
@@ -485,7 +496,7 @@ class TransformerConfig(ModelParallelConfig):
     If set, must be 'selective' or 'full'. 'selective' always uses all layers.
     """
 
-    recompute_method: Optional[Literal['uniform', 'block']] = None
+    recompute_method: Optional[Literal["uniform", "block"]] = None
     """Determines which transformer layers will be recomputed. uniform will uniformly divide the
     total number of transformer layers in a transformer block and recompute the input activation of
     each divided chunk at the specified granularity.  block will recompute the input activations for
@@ -522,16 +533,16 @@ class TransformerConfig(ModelParallelConfig):
     ####################
     # fp8 related
     ####################
-    fp8: Optional[Literal['e4m3', 'hybrid']] = field(
+    fp8: Optional[Literal["e4m3", "hybrid"]] = field(
         default=None, metadata={"argparse_meta": {"arg_names": ["--fp8-format"]}}
     )
     """If set, enables the use of FP8 precision through Transformer Engine. There are 2 predefined
     choices (1) 'e4m3' uniformly uses e4m3 for all FP8 tensors, (2) 'hybrid' uses e4m3 for all FP8
     activation and weight tensors and e5m2 for all FP8 output activation gradient tensors."""
 
-    fp8_recipe: Optional[Literal['tensorwise', 'delayed', 'mxfp8', 'blockwise', 'custom']] = (
-        "delayed"
-    )
+    fp8_recipe: Optional[
+        Literal["tensorwise", "delayed", "mxfp8", "blockwise", "custom"]
+    ] = "delayed"
     """If set, enables the use of FP8 precision through Transformer Engine. There are 5 predefined
     choices (1) 'tensorwise' uses per tensor current scaling recipe, (2) 'delayed'
     uses delayed scaling recipe, 3) 'mxfp8' for Blackwell architecture only,
@@ -559,7 +570,7 @@ class TransformerConfig(ModelParallelConfig):
     fp8_amax_history_len: int = 1
     """The length of the amax history window used for scaling factor computation."""
 
-    fp8_amax_compute_algo: Literal['most_recent', 'max'] = "most_recent"
+    fp8_amax_compute_algo: Literal["most_recent", "max"] = "most_recent"
     """Algorithm used for choosing the `amax` value for the scaling factor computation. There are 2
     predefined choices: `max` chooses the largest `amax` in the history window, while `most_recent`
     always chooses the most recently seen value.
@@ -608,13 +619,13 @@ class TransformerConfig(ModelParallelConfig):
     ####################
     # fp4 related
     ####################
-    fp4: Optional[Literal['e2m1']] = field(
+    fp4: Optional[Literal["e2m1"]] = field(
         default=None, metadata={"argparse_meta": {"arg_names": ["--fp4-format"]}}
     )
     """If set, enables the use of FP4 precision through Transformer Engine. Currently only 
     supports 'nvfp4' which uses NVFP4BlockScaling recipe (requires TE >= 2.7.0.dev0)."""
 
-    fp4_recipe: Optional[Literal['nvfp4', 'custom']] = "nvfp4"
+    fp4_recipe: Optional[Literal["nvfp4", "custom"]] = "nvfp4"
     """If set, enables the use of FP4 precision through Transformer Engine. Currently only
     'nvfp4' is supported which uses NVFP4BlockScaling recipe for Blackwell+ architecture."""
 
@@ -728,10 +739,10 @@ class TransformerConfig(ModelParallelConfig):
     """Scaling factor for routing score in top-k selection, only works when moe_router_pre_softmax
     enabled. Defaults to None, which means no scaling."""
 
-    moe_router_score_function: Literal['softmax', 'sigmoid', 'sqrtsoftplus'] = "softmax"
+    moe_router_score_function: Literal["softmax", "sigmoid", "sqrtsoftplus"] = "softmax"
     """Score function for MoE routing. Can be "softmax", "sigmoid" or "sqrtsoftplus"."""
 
-    moe_router_dtype: Optional[Literal['fp32', 'fp64']] = None
+    moe_router_dtype: Optional[Literal["fp32", "fp64"]] = None
     """Data type for routing and expert output weighted averaging. Using fp32 or fp64 can
     improve stability especially when the number of experts is large (e.g. finegrained-moe).
     None means no changes for dtype."""
@@ -785,7 +796,9 @@ class TransformerConfig(ModelParallelConfig):
     If a list of load balancing types is provided for `moe_router_load_balancing_type`,
     a corresponding list of coefficients should be provided here."""
 
-    moe_z_loss_coeff: Optional[float] = None  # 1e-3 would be a good start value for z-loss
+    moe_z_loss_coeff: Optional[float] = (
+        None  # 1e-3 would be a good start value for z-loss
+    )
     """Scaling coefficient for the z-loss. A starting value of 1e-3 is recommended."""
 
     moe_input_jitter_eps: Optional[float] = None
@@ -796,14 +809,14 @@ class TransformerConfig(ModelParallelConfig):
     specified capacity, similar to GShard, Switch-Transformer, and DeepSpeed-MoE. Note that this is
     currently unsupported so should remain False."""
 
-    moe_token_dispatcher_type: Literal['allgather', 'alltoall', 'flex'] = "allgather"
+    moe_token_dispatcher_type: Literal["allgather", "alltoall", "flex"] = "allgather"
     """The type of token dispatcher to use. The default is 'allgather'.
     Options are 'allgather','alltoall' and 'flex'."""
 
     moe_enable_deepep: bool = False
     """[Experimental] Enable DeepEP for efficient token dispatching and combine in MoE models."""
 
-    moe_flex_dispatcher_backend: Literal['deepep', 'hybridep'] = "deepep"
+    moe_flex_dispatcher_backend: Literal["deepep", "hybridep"] = "deepep"
     """[Experimental] The backend to use for flex token dispatcher. The default is "deepep".
     Options are "deepep" and "hybridep". Currently only "hybridep" backend supports 
     the MNNVL case."""
@@ -829,7 +842,7 @@ class TransformerConfig(ModelParallelConfig):
     max that an expert could see during inference so no tokens are actually dropped. The default
     setting is False."""
 
-    moe_token_drop_policy: Literal['probs', 'position'] = "probs"
+    moe_token_drop_policy: Literal["probs", "position"] = "probs"
     """The policy to drop tokens. Can be either "probs" or "position". If "probs", the tokens with
     the lowest probabilities will be dropped. If "position", tokens at the end of each batch will
     be dropped.
@@ -931,7 +944,9 @@ class TransformerConfig(ModelParallelConfig):
     """DEPRECATED and replaced by cuda_graph_impl.
     When set to true, TransformerLayer layers are swapped with user provided CUDA graphs."""
 
-    cuda_graph_impl: Literal['none', 'local', 'transformer_engine', 'full_iteration'] = "none"
+    cuda_graph_impl: Literal[
+        "none", "local", "transformer_engine", "full_iteration"
+    ] = "none"
     """Determines the CUDA graph capture implementation.
     "none": no CUDA graph.
     "local": MCore CUDA graph implementation. During training, graphable modules own per-layer
@@ -946,7 +961,9 @@ class TransformerConfig(ModelParallelConfig):
     cuda_graph_modules has no effect when cuda_graph_impl="none" and must be empty when
     cuda_graph_impl="full_iteration"."""
 
-    cuda_graph_modules: Union[str, CudaGraphModule, List[str], List[CudaGraphModule]] = "full"
+    cuda_graph_modules: Union[
+        str, CudaGraphModule, List[str], List[CudaGraphModule]
+    ] = "full"
     """Selects training capture coverage within per-layer CUDA graphs (local and
     transformer_engine implementations).
     Valid values are "attn", "mlp", "moe", "moe_router", "moe_preprocess", and "mamba":
@@ -987,7 +1004,10 @@ class TransformerConfig(ModelParallelConfig):
 
     cuda_graph_scope: Optional[
         Union[
-            str, CudaGraphModule, CudaGraphScope, List[Union[str, CudaGraphModule, CudaGraphScope]]
+            str,
+            CudaGraphModule,
+            CudaGraphScope,
+            List[Union[str, CudaGraphModule, CudaGraphScope]],
         ]
     ] = None
     """Deprecated: renamed to cuda_graph_modules. Accepted for backward compatibility and
@@ -1030,7 +1050,9 @@ class TransformerConfig(ModelParallelConfig):
     inference_sampling_seed: int = 42
     """ Random seed to use for sampling during inference. """
 
-    symmetric_ar_type: Optional[Literal['two_shot', "one_shot", "multimem_all_reduce"]] = None
+    symmetric_ar_type: Optional[
+        Literal["two_shot", "one_shot", "multimem_all_reduce"]
+    ] = None
     """What type of symmetric all reduce to use. The default is None
     which is no use of symmetric memory.
     """
@@ -1047,7 +1069,7 @@ class TransformerConfig(ModelParallelConfig):
     inference_disable_triton_nvls_kernels: bool = False
     """ If true, disables the use of Triton NVLS kernels during inference. """
 
-    inference_grouped_gemm_backend: Literal['flashinfer', 'torch', 'vllm'] = "vllm"
+    inference_grouped_gemm_backend: Literal["flashinfer", "torch", "vllm"] = "vllm"
     """Specifies the backend to use for grouped GEMM operations during inference.
     Options:
     - 'flashinfer': Uses FlashInfer cutlass_fused_moe. Not compatible with MXFP8.
@@ -1063,7 +1085,7 @@ class TransformerConfig(ModelParallelConfig):
     fp8_recipe='mxfp8'. Set to True to disable fusion and use separate kernel
     launches (useful for debugging)."""
 
-    inference_moe_token_dispatcher_type: Literal['nccl', 'nvls'] = 'nvls'
+    inference_moe_token_dispatcher_type: Literal["nccl", "nvls"] = "nvls"
     """Token dispatcher to use for MoE expert parallelism during inference.
     - 'nccl': AllGather/ReduceScatter via NCCL. Fixed token counts per rank; requires
       decode-only CUDA graphs (forced automatically).
@@ -1092,7 +1114,8 @@ class TransformerConfig(ModelParallelConfig):
     If None, the number of heads will be hidden_size * expand // mamba_head_dim."""
 
     use_mamba_mem_eff_path: bool = field(
-        default=True, metadata={"argparse_meta": {"arg_names": ["--disable-mamba-mem-eff-path"]}}
+        default=True,
+        metadata={"argparse_meta": {"arg_names": ["--disable-mamba-mem-eff-path"]}},
     )
     """Controls usage of the memory efficient path for Mamba layers."""
 
@@ -1115,7 +1138,7 @@ class TransformerConfig(ModelParallelConfig):
     quant_recipe: Optional[RecipeConfig] = None
     """Configuration of any per-module quantization settings to be applied to the model"""
 
-    transformer_impl: Literal['local', 'transformer_engine', 'inference_optimized'] = (
+    transformer_impl: Literal["local", "transformer_engine", "inference_optimized"] = (
         "transformer_engine"
     )
     """Transformer implementation to use.
@@ -1224,26 +1247,26 @@ class TransformerConfig(ModelParallelConfig):
             )
 
         if self.experimental_attention_variant == "gated_delta_net":
-            assert (
-                self.linear_attention_freq is not None
-            ), f"linear_attention_freq must be set for linear gated_delta_net."
+            assert self.linear_attention_freq is not None, (
+                f"linear_attention_freq must be set for linear gated_delta_net."
+            )
 
             # Check required parameters
-            assert (
-                self.linear_conv_kernel_dim is not None
-            ), "linear_conv_kernel_dim must be set for gated delta net."
-            assert (
-                self.linear_key_head_dim is not None
-            ), "linear_key_head_dim must be set for gated delta net."
-            assert (
-                self.linear_value_head_dim is not None
-            ), "linear_value_head_dim must be set for gated delta net."
-            assert (
-                self.linear_num_key_heads is not None
-            ), "linear_num_key_heads must be set for gated delta net."
-            assert (
-                self.linear_num_value_heads is not None
-            ), "linear_num_value_heads must be set for gated delta net."
+            assert self.linear_conv_kernel_dim is not None, (
+                "linear_conv_kernel_dim must be set for gated delta net."
+            )
+            assert self.linear_key_head_dim is not None, (
+                "linear_key_head_dim must be set for gated delta net."
+            )
+            assert self.linear_value_head_dim is not None, (
+                "linear_value_head_dim must be set for gated delta net."
+            )
+            assert self.linear_num_key_heads is not None, (
+                "linear_num_key_heads must be set for gated delta net."
+            )
+            assert self.linear_num_value_heads is not None, (
+                "linear_num_value_heads must be set for gated delta net."
+            )
             assert self.linear_num_value_heads % self.linear_num_key_heads == 0, (
                 f"linear_num_value_heads ({self.linear_num_value_heads}) must be a multiple of "
                 f"linear_num_key_heads ({self.linear_num_key_heads})."
@@ -1265,7 +1288,9 @@ class TransformerConfig(ModelParallelConfig):
         if self.fp8:
             # cannot support first last layer bf16 with delayed scaling
             if self.first_last_layers_bf16 and self.fp8_recipe == Fp8Recipe.delayed:
-                raise ValueError("Delayed scaling does not support first / last layer in BF16.")
+                raise ValueError(
+                    "Delayed scaling does not support first / last layer in BF16."
+                )
 
             # max bf16 layers per pipeline stage
             max_bf16_layers_per_pipeline_stage = (
@@ -1276,7 +1301,8 @@ class TransformerConfig(ModelParallelConfig):
             if self.first_last_layers_bf16:
                 if (
                     self.num_layers_at_start_in_bf16 < 0
-                    or self.num_layers_at_start_in_bf16 > max_bf16_layers_per_pipeline_stage
+                    or self.num_layers_at_start_in_bf16
+                    > max_bf16_layers_per_pipeline_stage
                 ):
                     raise ValueError(
                         f"num_layers_at_start_in_bf16 ({self.num_layers_at_start_in_bf16}) must be "
@@ -1285,7 +1311,8 @@ class TransformerConfig(ModelParallelConfig):
                     )
                 if (
                     self.num_layers_at_end_in_bf16 < 0
-                    or self.num_layers_at_end_in_bf16 > max_bf16_layers_per_pipeline_stage
+                    or self.num_layers_at_end_in_bf16
+                    > max_bf16_layers_per_pipeline_stage
                 ):
                     raise ValueError(
                         f"num_layers_at_end_in_bf16 ({self.num_layers_at_end_in_bf16}) must be "
@@ -1309,7 +1336,8 @@ class TransformerConfig(ModelParallelConfig):
                 raise ValueError("fp8_output_proj must be used together with fp8 mode.")
             if self.fp8_recipe != Fp8Recipe.mxfp8:
                 raise ValueError(
-                    f"fp8_output_proj requires fp8_recipe='mxfp8', got " f"'{self.fp8_recipe}'."
+                    f"fp8_output_proj requires fp8_recipe='mxfp8', got "
+                    f"'{self.fp8_recipe}'."
                 )
 
         # FP4 validation
@@ -1317,7 +1345,9 @@ class TransformerConfig(ModelParallelConfig):
             raise ValueError("fp4_param must be used together with fp4 mode.")
 
         if self.fp4 and self.fp8:
-            raise ValueError("fp4 and fp8 cannot be used simultaneously. Please choose one.")
+            raise ValueError(
+                "fp4 and fp8 cannot be used simultaneously. Please choose one."
+            )
 
         if self.fp4 and self.fp4_recipe == Fp4Recipe.custom:
             if not self.fp4_quantizer_factory:
@@ -1333,13 +1363,18 @@ class TransformerConfig(ModelParallelConfig):
         if self.expert_model_parallel_size > 1 and self.num_moe_experts is None:
             raise ValueError("num_moe_experts must be non None to use expert-parallel.")
 
-        if self.transformer_impl == "inference_optimized" and self.num_moe_experts is not None:
+        if (
+            self.transformer_impl == "inference_optimized"
+            and self.num_moe_experts is not None
+        ):
             if self.expert_tensor_parallel_size > 1:
                 raise ValueError(
                     "Inference-optimized MoE layers does not support expert tensor parallelism."
                 )
             if self.moe_expert_capacity_factor is not None:
-                raise ValueError("Inference-optimized MoE layers only support dropless MoE ")
+                raise ValueError(
+                    "Inference-optimized MoE layers only support dropless MoE "
+                )
             if self.moe_router_padding_for_quantization:
                 raise ValueError(
                     "Inference-optimized MoE layers do not support padded "
@@ -1376,7 +1411,8 @@ class TransformerConfig(ModelParallelConfig):
                 )
 
             if (
-                self.inference_grouped_gemm_backend == InferenceGroupedGemmBackend.FLASHINFER
+                self.inference_grouped_gemm_backend
+                == InferenceGroupedGemmBackend.FLASHINFER
                 and self.fp8 == "mxfp8"
             ):
                 raise ValueError(
@@ -1398,7 +1434,9 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.num_moe_experts is not None and self.moe_ffn_hidden_size is None:
             self.moe_ffn_hidden_size = self.ffn_hidden_size
-            warnings.warn("moe_ffn_hidden_size is not set, using ffn_hidden_size instead.")
+            warnings.warn(
+                "moe_ffn_hidden_size is not set, using ffn_hidden_size instead."
+            )
 
         if self.num_moe_experts is None and self.moe_ffn_hidden_size is not None:
             is_mixed_model = (
@@ -1446,9 +1484,13 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.moe_enable_deepep:
             if self.moe_token_dispatcher_type != "flex":
-                raise ValueError("DeepEP backend is only supported with flex token dispatcher.")
+                raise ValueError(
+                    "DeepEP backend is only supported with flex token dispatcher."
+                )
             if self.moe_flex_dispatcher_backend == "hybridep":
-                raise ValueError("Only one backend is supported for flex token dispatcher.")
+                raise ValueError(
+                    "Only one backend is supported for flex token dispatcher."
+                )
             self.moe_flex_dispatcher_backend = "deepep"
             warnings.warn(
                 "moe_enable_deepep is deprecated."
@@ -1471,10 +1513,14 @@ class TransformerConfig(ModelParallelConfig):
                     f"num_shared_experts * ffn_size_of_each_shared_expert, "
                     f"but got {self.moe_shared_expert_intermediate_size}"
                 )
-            if self.moe_shared_expert_overlap and self.moe_token_dispatcher_type not in [
-                "alltoall",
-                "flex",
-            ]:
+            if (
+                self.moe_shared_expert_overlap
+                and self.moe_token_dispatcher_type
+                not in [
+                    "alltoall",
+                    "flex",
+                ]
+            ):
                 raise ValueError(
                     f"moe_shared_expert_overlap only works with alltoall or flex token dispatcher."
                 )
@@ -1532,7 +1578,8 @@ class TransformerConfig(ModelParallelConfig):
                 )
 
         if self.cpu_offloading and (
-            self.cpu_offloading_num_layers < 0 or self.cpu_offloading_num_layers >= self.num_layers
+            self.cpu_offloading_num_layers < 0
+            or self.cpu_offloading_num_layers >= self.num_layers
         ):
             raise ValueError(
                 f"CPU offloading can be done only for layers less than {self.num_layers}"
@@ -1566,7 +1613,10 @@ class TransformerConfig(ModelParallelConfig):
                     'recompute_method must be "block" or "uniform"'
                 )
 
-            if self.recompute_granularity != "selective" and self.recompute_num_layers is None:
+            if (
+                self.recompute_granularity != "selective"
+                and self.recompute_num_layers is None
+            ):
                 raise ValueError(
                     f"When using recompute_granularity: {self.recompute_granularity} "
                     "recompute_num_layers must be between "
@@ -1574,7 +1624,8 @@ class TransformerConfig(ModelParallelConfig):
                     f"{self.num_layers // self.pipeline_model_parallel_size}"
                 )
             elif (
-                self.recompute_granularity == "selective" and self.recompute_num_layers is not None
+                self.recompute_granularity == "selective"
+                and self.recompute_num_layers is not None
             ):
                 raise ValueError(
                     f"When using recompute_granularity: {self.recompute_granularity} "
@@ -1613,7 +1664,10 @@ class TransformerConfig(ModelParallelConfig):
                     "moe_act in recompute_modules is only supported with moe_grouped_gemm."
                 )
 
-            if "mla_up_proj" in self.recompute_modules and not self.multi_latent_attention:
+            if (
+                "mla_up_proj" in self.recompute_modules
+                and not self.multi_latent_attention
+            ):
                 raise ValueError(
                     "mla_up_proj in recompute_modules is only supported with "
                     "multi_latent_attention."
@@ -1646,8 +1700,11 @@ class TransformerConfig(ModelParallelConfig):
                     )
 
             if self.fp8:
-                if "moe_act" in self.recompute_modules or "layernorm" in self.recompute_modules:
-                    if self.fp8_recipe == 'delayed':
+                if (
+                    "moe_act" in self.recompute_modules
+                    or "layernorm" in self.recompute_modules
+                ):
+                    if self.fp8_recipe == "delayed":
                         raise ValueError(
                             "Delayed scaling does not support moe_act and layernorm recompute "
                             "for fp8."
@@ -1673,9 +1730,9 @@ class TransformerConfig(ModelParallelConfig):
                 self.recompute_modules.append("moe")
 
         if self.fine_grained_activation_offloading:
-            assert (
-                not self.cpu_offloading
-            ), "fine_grained_activation_offloading cannot be enabled with cpu_offloading."
+            assert not self.cpu_offloading, (
+                "fine_grained_activation_offloading cannot be enabled with cpu_offloading."
+            )
             assert self.offload_modules is not None and len(self.offload_modules) > 0
             allowed_modules = {
                 "core_attn",
@@ -1688,10 +1745,13 @@ class TransformerConfig(ModelParallelConfig):
             }
             invalid_modules = set(self.offload_modules) - allowed_modules
             assert not invalid_modules, (
-                f'Invalid choices for offload_modules: {invalid_modules}. '
-                f'Allowed modules are: {allowed_modules}'
+                f"Invalid choices for offload_modules: {invalid_modules}. "
+                f"Allowed modules are: {allowed_modules}"
             )
-            if "attn_proj" in self.offload_modules and "core_attn" not in self.offload_modules:
+            if (
+                "attn_proj" in self.offload_modules
+                and "core_attn" not in self.offload_modules
+            ):
                 raise ValueError(
                     "attn_proj cannot be set to offload_modules alone without core_attn "
                     "because the input of attn_proj is the output of core_attn, "
@@ -1699,7 +1759,9 @@ class TransformerConfig(ModelParallelConfig):
                 )
         if self.moe_paged_stash:
             if self.cpu_offloading:
-                raise ValueError("moe_paged_stash cannot be enabled with cpu_offloading.")
+                raise ValueError(
+                    "moe_paged_stash cannot be enabled with cpu_offloading."
+                )
             if self.moe_expert_rank_capacity_factor is None:
                 raise ValueError(
                     "moe_paged_stash requires moe_expert_rank_capacity_factor to be set; "
@@ -1717,7 +1779,8 @@ class TransformerConfig(ModelParallelConfig):
             self.num_layers_in_first_pipeline_stage is not None
             or self.num_layers_in_last_pipeline_stage is not None
         ) and (
-            self.account_for_embedding_in_pipeline_split or self.account_for_loss_in_pipeline_split
+            self.account_for_embedding_in_pipeline_split
+            or self.account_for_loss_in_pipeline_split
         ):
             raise ValueError(
                 "num_layers_in_first_pipeline_stage and num_layers_in_last_pipeline_stage cannot be"
@@ -1748,9 +1811,11 @@ class TransformerConfig(ModelParallelConfig):
             # Transfer pipeline_model_parallel_layout from str or list to
             # PipelineParallelLayerLayout
             if isinstance(self.pipeline_model_parallel_layout, str):
-                self.pipeline_model_parallel_layout = PipelineParallelLayerLayout.from_str(
-                    layout=self.pipeline_model_parallel_layout,
-                    pipeline_model_parallel_size=self.pipeline_model_parallel_size,
+                self.pipeline_model_parallel_layout = (
+                    PipelineParallelLayerLayout.from_str(
+                        layout=self.pipeline_model_parallel_layout,
+                        pipeline_model_parallel_size=self.pipeline_model_parallel_size,
+                    )
                 )
             elif isinstance(self.pipeline_model_parallel_layout, list):
                 # Since list is not hashable, the initialization will not be cached.
@@ -1774,8 +1839,10 @@ class TransformerConfig(ModelParallelConfig):
                 self.virtual_pipeline_model_parallel_size = detected_vpp_size
 
             # Check whether the layout is valid.
-            self.mtp_standalone = self.pipeline_model_parallel_layout.validate_layer_layout(
-                num_layers=self.num_layers, mtp_num_layers=self.mtp_num_layers
+            self.mtp_standalone = (
+                self.pipeline_model_parallel_layout.validate_layer_layout(
+                    num_layers=self.num_layers, mtp_num_layers=self.mtp_num_layers
+                )
             )
 
         # Uneven PP
@@ -1788,7 +1855,9 @@ class TransformerConfig(ModelParallelConfig):
 
             if self.num_layers_in_first_pipeline_stage is not None:
                 if self.num_layers_in_first_pipeline_stage <= 0:
-                    raise ValueError("num_layers_in_first_pipeline_stage must be larger than 0")
+                    raise ValueError(
+                        "num_layers_in_first_pipeline_stage must be larger than 0"
+                    )
 
                 if self.virtual_pipeline_model_parallel_size is not None:
                     if (
@@ -1807,7 +1876,9 @@ class TransformerConfig(ModelParallelConfig):
 
             if self.num_layers_in_last_pipeline_stage is not None:
                 if self.num_layers_in_last_pipeline_stage <= 0:
-                    raise ValueError("num_layers_in_last_pipeline_stage must be larger than 0")
+                    raise ValueError(
+                        "num_layers_in_last_pipeline_stage must be larger than 0"
+                    )
 
                 if self.virtual_pipeline_model_parallel_size is not None:
                     if (
@@ -1841,8 +1912,13 @@ class TransformerConfig(ModelParallelConfig):
 
             # If there are middle PP stages, check number of layers
             # on each middle PP rank is divisible by VPP size.
-            if pipeline_parallel_size and self.virtual_pipeline_model_parallel_size is not None:
-                num_layers_per_middle_pipeline_rank = num_layers // pipeline_parallel_size
+            if (
+                pipeline_parallel_size
+                and self.virtual_pipeline_model_parallel_size is not None
+            ):
+                num_layers_per_middle_pipeline_rank = (
+                    num_layers // pipeline_parallel_size
+                )
                 if (
                     not num_layers_per_middle_pipeline_rank
                     % self.virtual_pipeline_model_parallel_size
@@ -1855,7 +1931,8 @@ class TransformerConfig(ModelParallelConfig):
                     )
 
         elif (
-            self.account_for_embedding_in_pipeline_split or self.account_for_loss_in_pipeline_split
+            self.account_for_embedding_in_pipeline_split
+            or self.account_for_loss_in_pipeline_split
         ):
             if self.virtual_pipeline_model_parallel_size is None:
                 num_layers = self.num_layers
@@ -1888,9 +1965,12 @@ class TransformerConfig(ModelParallelConfig):
                         f"{self.pipeline_model_parallel_size}"
                     )
 
-                num_layers_per_pipeline_rank = num_layers // self.pipeline_model_parallel_size
+                num_layers_per_pipeline_rank = (
+                    num_layers // self.pipeline_model_parallel_size
+                )
                 if (
-                    not num_layers_per_pipeline_rank % self.virtual_pipeline_model_parallel_size
+                    not num_layers_per_pipeline_rank
+                    % self.virtual_pipeline_model_parallel_size
                     == 0
                 ):
                     raise ValueError(
@@ -1953,7 +2033,9 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.activation_func_fp8_input_store:
             if self.activation_func != F.silu or not self.gated_linear_unit:
-                raise ValueError("Storing activation input in FP8 is supported only for SwiGLU.")
+                raise ValueError(
+                    "Storing activation input in FP8 is supported only for SwiGLU."
+                )
 
         if self.apply_rope_fusion:
             if self.multi_latent_attention:
@@ -1974,33 +2056,46 @@ class TransformerConfig(ModelParallelConfig):
                     fused_apply_rotary_pos_emb_thd,
                 )
 
-                if fused_apply_rotary_pos_emb is None and fused_apply_rotary_pos_emb_thd is None:
+                if (
+                    fused_apply_rotary_pos_emb is None
+                    and fused_apply_rotary_pos_emb_thd is None
+                ):
                     raise ValueError(
                         "apply_rope_fusion is not available. Please install TE >= 1.4."
                     )
 
         if self.fused_single_qkv_rope:
             if self.attention_output_gate:
-                raise ValueError("fused_single_qkv_rope does not support gated attention for now.")
+                raise ValueError(
+                    "fused_single_qkv_rope does not support gated attention for now."
+                )
 
         if self.multi_latent_attention and self.rotary_interleaved:
-            raise ValueError("rotary_interleaved does not work with multi_latent_attention.")
+            raise ValueError(
+                "rotary_interleaved does not work with multi_latent_attention."
+            )
 
         # MuP (Maximal Update Parameterization) configuration
         if self.use_mup:
             # Default base_hidden_size to hidden_size (base model case, width_mult=1.0)
             if self.mup_base_hidden_size is None:
                 self.mup_base_hidden_size = self.hidden_size
-            assert self.mup_base_hidden_size > 0, "--mup-base-hidden-size must be positive."
+            assert self.mup_base_hidden_size > 0, (
+                "--mup-base-hidden-size must be positive."
+            )
             # Compute width multiplier
             self.mup_width_mult = self.hidden_size / self.mup_base_hidden_size
 
             # MuP attention scaling: 1/d_head instead of 1/sqrt(d_head).
             if self.softmax_scale is None:
                 base_head_scale = (
-                    1.0 if self.mup_base_head_dim is None else self.mup_base_head_dim**0.5
+                    1.0
+                    if self.mup_base_head_dim is None
+                    else self.mup_base_head_dim**0.5
                 )
-                self.softmax_scale = base_head_scale / (self.kv_channels**self.mup_attn_scale_power)
+                self.softmax_scale = base_head_scale / (
+                    self.kv_channels**self.mup_attn_scale_power
+                )
 
             # MuP output scaling: scale logits by 1/width_mult to keep outputs O(1).
             # Only auto-set if user hasn't explicitly configured it.
@@ -2033,10 +2128,14 @@ class TransformerConfig(ModelParallelConfig):
             self.embedding_init_method_std = self.init_method_std
 
         if self.embedding_init_method is None:
-            if self.init_method is None or (self.embedding_init_method_std != self.init_method_std):
+            if self.init_method is None or (
+                self.embedding_init_method_std != self.init_method_std
+            ):
                 # In this case, we set both the init method and the embedding init method to
                 #  whatever std value requested (or defaulted) for the embedding_init_layer
-                self.embedding_init_method = init_method_normal(self.embedding_init_method_std)
+                self.embedding_init_method = init_method_normal(
+                    self.embedding_init_method_std
+                )
             else:
                 # Replicate the current behavior where if you are not changing the std of the
                 #  embedding init differently and the init method is set, we fallback to the
@@ -2070,13 +2169,17 @@ class TransformerConfig(ModelParallelConfig):
                 )
 
         if self.num_moe_experts is not None and self.add_bias_linear:
-            assert (
-                self.expert_tensor_parallel_size == 1
-            ), "Bias in Moe is only supported when ETP==1"
+            assert self.expert_tensor_parallel_size == 1, (
+                "Bias in Moe is only supported when ETP==1"
+            )
 
-        if self.moe_router_enable_expert_bias and self.moe_router_score_function not in (
-            "sigmoid",
-            "sqrtsoftplus",
+        if (
+            self.moe_router_enable_expert_bias
+            and self.moe_router_score_function
+            not in (
+                "sigmoid",
+                "sqrtsoftplus",
+            )
         ):
             raise ValueError(
                 "Expert bias for aux-loss-free routing only supports 'sigmoid' and 'sqrtsoftplus' "
@@ -2156,20 +2259,22 @@ class TransformerConfig(ModelParallelConfig):
             self.moe_router_num_groups = self.expert_model_parallel_size
 
         if self.enable_cuda_graph or self.external_cuda_graph:
-            assert (
-                self.cuda_graph_impl == "none"
-            ), "Do not use enable_cuda_graph or external_cuda_graph with cuda_graph_impl."
-            assert (
-                not self.enable_cuda_graph or not self.external_cuda_graph
-            ), "enable_cuda_graph and external_cuda_graph cannot be enabled at the same time."
+            assert self.cuda_graph_impl == "none", (
+                "Do not use enable_cuda_graph or external_cuda_graph with cuda_graph_impl."
+            )
+            assert not self.enable_cuda_graph or not self.external_cuda_graph, (
+                "enable_cuda_graph and external_cuda_graph cannot be enabled at the same time."
+            )
 
             if self.enable_cuda_graph:
-                warnings.warn('enable_cuda_graph is deprecated, use cuda_graph_impl=local instead.')
+                warnings.warn(
+                    "enable_cuda_graph is deprecated, use cuda_graph_impl=local instead."
+                )
                 self.cuda_graph_impl = "local"
             if self.external_cuda_graph:
                 warnings.warn(
-                    'external_cuda_graph is deprecated, '
-                    'use cuda_graph_impl=transformer_engine instead.'
+                    "external_cuda_graph is deprecated, "
+                    "use cuda_graph_impl=transformer_engine instead."
                 )
                 self.cuda_graph_impl = "transformer_engine"
 
@@ -2198,8 +2303,8 @@ class TransformerConfig(ModelParallelConfig):
                 self.cuda_graph_modules = _scope_to_str(scope)
             self.cuda_graph_scope = None
 
-        normalized_scopes, deprecated_scopes, used_full_scope = normalize_cuda_graph_modules(
-            self.cuda_graph_modules
+        normalized_scopes, deprecated_scopes, used_full_scope = (
+            normalize_cuda_graph_modules(self.cuda_graph_modules)
         )
         validate_deprecated_cuda_graph_modules_migration_inputs(
             deprecated_scopes, self.cuda_graph_impl, self.inference_cuda_graph_scope
@@ -2233,7 +2338,9 @@ class TransformerConfig(ModelParallelConfig):
         self.cuda_graph_modules = normalized_scopes
         assert all(
             isinstance(scope, CudaGraphModule) for scope in self.cuda_graph_modules
-        ), f"cuda_graph_modules must be a list of CudaGraphModule, got {self.cuda_graph_modules}."
+        ), (
+            f"cuda_graph_modules must be a list of CudaGraphModule, got {self.cuda_graph_modules}."
+        )
 
         assert self.cuda_graph_impl in [
             "none",
@@ -2246,7 +2353,10 @@ class TransformerConfig(ModelParallelConfig):
             self.inference_cuda_graph_scope, self.cuda_graph_impl
         )
 
-        assert self.inference_cuda_graph_scope in ALLOWED_INFERENCE_SCOPES[self.cuda_graph_impl], (
+        assert (
+            self.inference_cuda_graph_scope
+            in ALLOWED_INFERENCE_SCOPES[self.cuda_graph_impl]
+        ), (
             "Invalid inference CUDA graph scope "
             f"{self.inference_cuda_graph_scope.name!r} for cuda_graph_impl="
             f"{self.cuda_graph_impl!r}."
@@ -2256,7 +2366,6 @@ class TransformerConfig(ModelParallelConfig):
         ), 'cuda_graph_modules must be empty when cuda_graph_impl="full_iteration".'
 
         if self.cuda_graph_impl != "none":
-
             if self.cpu_offloading and self.cuda_graph_impl != "full_iteration":
                 raise ValueError("CUDA graphs not supported with CPU offloading.")
 
@@ -2271,51 +2380,60 @@ class TransformerConfig(ModelParallelConfig):
                     ):
                         if CudaGraphModule.moe_router not in self.cuda_graph_modules:
                             self.cuda_graph_modules.append(CudaGraphModule.moe_router)
-                        if CudaGraphModule.moe_preprocess not in self.cuda_graph_modules:
-                            self.cuda_graph_modules.append(CudaGraphModule.moe_preprocess)
+                        if (
+                            CudaGraphModule.moe_preprocess
+                            not in self.cuda_graph_modules
+                        ):
+                            self.cuda_graph_modules.append(
+                                CudaGraphModule.moe_preprocess
+                            )
 
                 assert (
                     CudaGraphModule.moe not in self.cuda_graph_modules
                     or CudaGraphModule.moe_router not in self.cuda_graph_modules
-                ), 'cuda_graph_modules must not contain both moe and moe_router.'
+                ), "cuda_graph_modules must not contain both moe and moe_router."
                 if CudaGraphModule.moe_preprocess in self.cuda_graph_modules:
-                    assert (
-                        CudaGraphModule.moe_router in self.cuda_graph_modules
-                    ), 'moe_preprocess cuda graph is only supported with moe_router cuda graph.'
+                    assert CudaGraphModule.moe_router in self.cuda_graph_modules, (
+                        "moe_preprocess cuda graph is only supported with moe_router cuda graph."
+                    )
                 if self.num_moe_experts is None or self.num_moe_experts <= 1:
                     assert (
                         CudaGraphModule.moe not in self.cuda_graph_modules
                         and CudaGraphModule.moe_router not in self.cuda_graph_modules
-                    ), 'moe cuda graph is only supported for MoE.'
+                    ), "moe cuda graph is only supported for MoE."
                 else:
                     if self.moe_layer_freq == 1 or (
-                        isinstance(self.moe_layer_freq, list) and 0 not in self.moe_layer_freq
+                        isinstance(self.moe_layer_freq, list)
+                        and 0 not in self.moe_layer_freq
                     ):
                         assert CudaGraphModule.mlp not in self.cuda_graph_modules, (
-                            'mlp cuda graph is only supported for dense layers, '
-                            'but not found in the model.'
+                            "mlp cuda graph is only supported for dense layers, "
+                            "but not found in the model."
                         )
                     if (
                         self.moe_expert_capacity_factor is None
                         or not self.moe_pad_expert_input_to_capacity
                     ):
-                        assert (
-                            CudaGraphModule.moe not in self.cuda_graph_modules
-                        ), 'moe cuda graph is only supported with drop-padding MoE.'
-                        if self.moe_token_dispatcher_type == 'alltoall' and (
+                        assert CudaGraphModule.moe not in self.cuda_graph_modules, (
+                            "moe cuda graph is only supported with drop-padding MoE."
+                        )
+                        if self.moe_token_dispatcher_type == "alltoall" and (
                             self.moe_expert_capacity_factor is not None
                             or self.moe_router_padding_for_fp8
                         ):
-                            assert CudaGraphModule.moe_preprocess not in self.cuda_graph_modules, (
-                                'moe_preprocess cuda graph is not supported when there are '
-                                'DtoH copies and synchronizations in the preprocess step.'
+                            assert (
+                                CudaGraphModule.moe_preprocess
+                                not in self.cuda_graph_modules
+                            ), (
+                                "moe_preprocess cuda graph is not supported when there are "
+                                "DtoH copies and synchronizations in the preprocess step."
                             )
 
             if self.recompute_granularity:
                 if self.recompute_granularity != "selective":
-                    assert (
-                        self.cuda_graph_impl == "full_iteration"
-                    ), "full recompute is only supported with full iteration CUDA graph."
+                    assert self.cuda_graph_impl == "full_iteration", (
+                        "full recompute is only supported with full iteration CUDA graph."
+                    )
                 else:
                     # The recompute module should be inside or outside of the graph scope.
                     # Recompute module coverring graph scope is not allowed.
@@ -2325,13 +2443,18 @@ class TransformerConfig(ModelParallelConfig):
                     ):
                         assert (
                             CudaGraphModule.moe_router not in self.cuda_graph_modules
-                        ), "moe recompute is not supported with moe_router CUDA graph with: "
+                        ), (
+                            "moe recompute is not supported with moe_router CUDA graph with: "
+                        )
                         "--cuda-graph-impl transformer_engine."
 
                     # Graphed recompute module doesn't accept random number.
                     # full_cudagraph means either full_iteration impl or an empty per-layer scope
                     # (which captures the whole layer).
-                    if self.cuda_graph_impl == "full_iteration" or not self.cuda_graph_modules:
+                    if (
+                        self.cuda_graph_impl == "full_iteration"
+                        or not self.cuda_graph_modules
+                    ):
                         full_cudagraph = True
                     else:
                         full_cudagraph = False
@@ -2356,7 +2479,9 @@ class TransformerConfig(ModelParallelConfig):
                                 and CudaGraphModule.moe not in self.cuda_graph_modules
                             )
                             or "moe" not in self.recompute_modules
-                        ), "hidden dropout is not supported with graphed MLP/MoE recomputation."
+                        ), (
+                            "hidden dropout is not supported with graphed MLP/MoE recomputation."
+                        )
                     if self.moe_input_jitter_eps is not None:
                         assert (
                             not full_cudagraph
@@ -2366,14 +2491,17 @@ class TransformerConfig(ModelParallelConfig):
                         )
 
             if self.fine_grained_activation_offloading:
-                assert self.cuda_graph_impl in ("transformer_engine", "full_iteration"), (
+                assert self.cuda_graph_impl in (
+                    "transformer_engine",
+                    "full_iteration",
+                ), (
                     "fine-grained activation offloading is only supported with "
                     "transformer_engine CUDA graph implementation or local CUDA graph "
                     "implementation with full_iteration scope."
                 )
-                assert (
-                    CudaGraphModule.moe not in self.cuda_graph_modules
-                ), "Token-drop MoE is temporarily not supported with activation offloading."
+                assert CudaGraphModule.moe not in self.cuda_graph_modules, (
+                    "Token-drop MoE is temporarily not supported with activation offloading."
+                )
                 assert self.cuda_graph_warmup_steps > 0, (
                     "cuda_graph_warmup_steps must be greater than 0 when enabling "
                     "fine-grained activation offloading."
@@ -2411,51 +2539,55 @@ class TransformerConfig(ModelParallelConfig):
                 or fused_sort_chunks_by_index_with_probs is None
                 or fused_unpermute is None
             ):
-                raise ValueError("fused permutation is not available. Please install TE >= 2.1.0.")
+                raise ValueError(
+                    "fused permutation is not available. Please install TE >= 2.1.0."
+                )
 
         if self.overlap_moe_expert_parallel_comm:
             # TODO: remove this after we fix the hang issue with torch version < 2.6.0
-            assert is_torch_min_version(
-                "2.6.0"
-            ), "A2A Overlap encounters hang issue with torch version < 2.6.0"
+            assert is_torch_min_version("2.6.0"), (
+                "A2A Overlap encounters hang issue with torch version < 2.6.0"
+            )
             if self.pipeline_model_parallel_size > 1:
                 assert self.virtual_pipeline_model_parallel_size is not None, (
                     "If enabling EP A2A overlap, virtual_pipeline_model_parallel_size "
                     "must be specified when pipeline_model_parallel_size > 1"
                 )
             # Expert model parallelism requirements
-            assert (
-                self.expert_model_parallel_size > 1
-            ), 'overlap_moe_expert_parallel_comm is only supported with expert model parallelism'
+            assert self.expert_model_parallel_size > 1, (
+                "overlap_moe_expert_parallel_comm is only supported with expert model parallelism"
+            )
             assert self.moe_token_dispatcher_type in [
-                'alltoall',
-                'flex',
-            ], 'overlap_moe_expert_parallel_comm is supported with alltoall/flex token dispatcher'
+                "alltoall",
+                "flex",
+            ], (
+                "overlap_moe_expert_parallel_comm is supported with alltoall/flex token dispatcher"
+            )
 
-            assert (
-                self.recompute_granularity != 'full'
-            ), 'disable full recomputation when enabling overlap_moe_expert_parallel_comm'
-            assert (
-                self.recompute_method is None
-            ), 'disable recomputation method when enabling overlap_moe_expert_parallel_comm'
-            assert (
-                self.recompute_num_layers is None
-            ), 'recompute_num_layers must be None when enabling overlap_moe_expert_parallel_comm'
-            assert (
-                "moe" not in self.recompute_modules
-            ), 'disable moe in recompute_modules when enabling overlap_moe_expert_parallel_comm'
+            assert self.recompute_granularity != "full", (
+                "disable full recomputation when enabling overlap_moe_expert_parallel_comm"
+            )
+            assert self.recompute_method is None, (
+                "disable recomputation method when enabling overlap_moe_expert_parallel_comm"
+            )
+            assert self.recompute_num_layers is None, (
+                "recompute_num_layers must be None when enabling overlap_moe_expert_parallel_comm"
+            )
+            assert "moe" not in self.recompute_modules, (
+                "disable moe in recompute_modules when enabling overlap_moe_expert_parallel_comm"
+            )
 
             # Check if bf16 or fp16 is used
-            assert (
-                self.bf16 or self.fp16
-            ), 'overlap_moe_expert_parallel_comm is only supported with bf16 or fp16 model'
+            assert self.bf16 or self.fp16, (
+                "overlap_moe_expert_parallel_comm is only supported with bf16 or fp16 model"
+            )
 
-            assert (
-                not self.moe_shared_expert_overlap
-            ), 'disable moe_shared_expert_overlap when enabling overlap_moe_expert_parallel_comm'
-            assert (
-                self.mtp_num_layers is None or self.mtp_num_layers == 1
-            ), 'MTP layernum only supports 1 when enabling overlap_moe_expert_parallel_comm.'
+            assert not self.moe_shared_expert_overlap, (
+                "disable moe_shared_expert_overlap when enabling overlap_moe_expert_parallel_comm"
+            )
+            assert self.mtp_num_layers is None or self.mtp_num_layers == 1, (
+                "MTP layernum only supports 1 when enabling overlap_moe_expert_parallel_comm."
+            )
 
             if self.cuda_graph_impl != "none":
                 if self.cuda_graph_impl == "transformer_engine":
@@ -2463,38 +2595,38 @@ class TransformerConfig(ModelParallelConfig):
                         CudaGraphModule.moe not in self.cuda_graph_modules
                         and CudaGraphModule.mlp not in self.cuda_graph_modules
                     ), (
-                        'CUDA graph scope on moe and mlp is not '
-                        'supported with overlap_moe_expert_parallel_comm'
+                        "CUDA graph scope on moe and mlp is not "
+                        "supported with overlap_moe_expert_parallel_comm"
                     )
 
         # Check delay_wgrad_compute compatibility
         if self.delay_wgrad_compute:
-            assert (
-                self.overlap_moe_expert_parallel_comm
-            ), 'overlap_moe_expert_parallel_comm must be enabled when enabling delay_wgrad_compute'
+            assert self.overlap_moe_expert_parallel_comm, (
+                "overlap_moe_expert_parallel_comm must be enabled when enabling delay_wgrad_compute"
+            )
             if self.cuda_graph_impl == "transformer_engine":
                 assert is_te_min_version("2.10.0"), (
-                    'TE version >= 2.10.0 is required for delay_wgrad_compute with '
-                    'partial cuda graph'
+                    "TE version >= 2.10.0 is required for delay_wgrad_compute with "
+                    "partial cuda graph"
                 )
 
         if self.overlap_dispatch_backward_with_experts_wgrad:
             assert not self.overlap_moe_expert_parallel_comm, (
-                'overlap_moe_expert_parallel_comm must be disabled when enabling '
-                'overlap_dispatch_backward_with_experts_wgrad.'
+                "overlap_moe_expert_parallel_comm must be disabled when enabling "
+                "overlap_dispatch_backward_with_experts_wgrad."
             )
-            assert is_te_min_version(
-                "2.3.0"
-            ), 'TE version >= 2.3.0 is required for overlap_dispatch_backward_with_experts_wgrad'
+            assert is_te_min_version("2.3.0"), (
+                "TE version >= 2.3.0 is required for overlap_dispatch_backward_with_experts_wgrad"
+            )
             assert not self.delay_wgrad_compute, (
-                'delay_wgrad_compute and overlap_dispatch_backward_with_experts_wgrad '
-                'are mutually exclusive; use only one'
+                "delay_wgrad_compute and overlap_dispatch_backward_with_experts_wgrad "
+                "are mutually exclusive; use only one"
             )
 
         if self.ep_overlap_early_attn_memory_release:
             assert self.overlap_moe_expert_parallel_comm, (
-                'overlap_moe_expert_parallel_comm must be enabled when enabling '
-                'ep_overlap_early_attn_memory_release'
+                "overlap_moe_expert_parallel_comm must be enabled when enabling "
+                "ep_overlap_early_attn_memory_release"
             )
 
         if self.context_parallel_size > 1 and self.cp_comm_type is not None:
@@ -2504,14 +2636,14 @@ class TransformerConfig(ModelParallelConfig):
                     f"the total number of transformer layers ({self.num_layers})!"
                 )
             else:
-                assert isinstance(
-                    self.cp_comm_type, str
-                ), "Unsupported communication type for context parallelism!"
+                assert isinstance(self.cp_comm_type, str), (
+                    "Unsupported communication type for context parallelism!"
+                )
 
-        assert (
-            self.pipeline_model_parallel_size > 0
-        ), f"Pipeline model parallel size must be larger than 0 \
+        assert self.pipeline_model_parallel_size > 0, (
+            f"Pipeline model parallel size must be larger than 0 \
             when enable --standalone-embedding-stage and --standalone-loss-stage"
+        )
 
         if (
             self.num_moe_experts is not None
@@ -2527,10 +2659,14 @@ class TransformerConfig(ModelParallelConfig):
                 raise ImportError(
                     "packaging is not installed. Please install it with `pip install packaging`."
                 )
-            assert is_torch_min_version("2.7.0a0"), "Must have at least torch version 2.7 or higher"
+            assert is_torch_min_version("2.7.0a0"), (
+                "Must have at least torch version 2.7 or higher"
+            )
             assert is_te_min_version("2.3.0") or get_te_version() == PkgVersion(
                 "2.3.0.dev0+39c0e70"
-            ), "Must have at least TE version 2.3 or higher to use symmetric memory all reduce"
+            ), (
+                "Must have at least TE version 2.3 or higher to use symmetric memory all reduce"
+            )
 
         if self.no_rope_freq:
             assert not self.flash_decode, "flash_decode cannot be used with no_rope."
@@ -2557,19 +2693,21 @@ class TransformerConfig(ModelParallelConfig):
             assert not self.use_kitchen
 
         if self.experimental_attention_variant == "dsa":
-            assert (
-                self.context_parallel_size == 1
-            ), "Currently context parallelism is not supported by DSAttention!"
-            assert not self.apply_rope_fusion, "RoPE fusion is not supported for DSAttention"
+            assert self.context_parallel_size == 1, (
+                "Currently context parallelism is not supported by DSAttention!"
+            )
+            assert not self.apply_rope_fusion, (
+                "RoPE fusion is not supported for DSAttention"
+            )
 
         if self.inference_fuse_tp_communication:
             assert self.transformer_impl == "inference_optimized", (
                 "inference_fuse_tp_communication is only supported "
                 "for inference_optimized transformer implementation."
             )
-            assert (
-                self.num_moe_experts is None
-            ), "--inference-fuse-tp-communication is not supported for MoE models."
+            assert self.num_moe_experts is None, (
+                "--inference-fuse-tp-communication is not supported for MoE models."
+            )
 
         if self.inference_disable_triton_nvls_kernels:
             assert self.transformer_impl == "inference_optimized", (
@@ -2578,9 +2716,9 @@ class TransformerConfig(ModelParallelConfig):
             )
 
         if self.batch_invariant_mode:
-            assert (
-                self.attention_backend == AttnBackend.flash
-            ), "Batch invariant mode only supports FlashAttention"
+            assert self.attention_backend == AttnBackend.flash, (
+                "Batch invariant mode only supports FlashAttention"
+            )
 
 
 @dataclass
@@ -2651,13 +2789,17 @@ class MLATransformerConfig(TransformerConfig):
 
     def __post_init__(self):
         super().__post_init__()
-        if self.multi_latent_attention and self.apply_rope_fusion and self.rope_type != "yarn":
+        if (
+            self.multi_latent_attention
+            and self.apply_rope_fusion
+            and self.rope_type != "yarn"
+        ):
             raise ValueError("apply_rope_fusion for MLA only works with YARN RoPE.")
 
         if self.attention_output_gate:
             raise NotImplementedError("Output gate is not supported for MLA yet.")
 
         if self.cache_mla_latents:
-            assert (
-                self.apply_rope_fusion is False
-            ), "Rope Fusion is not compatible with caching latents"
+            assert self.apply_rope_fusion is False, (
+                "Rope Fusion is not compatible with caching latents"
+            )

--- a/tests/unit_tests/inference/contexts/test_indexer_metadata.py
+++ b/tests/unit_tests/inference/contexts/test_indexer_metadata.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from megatron.core.inference.contexts.indexer_metadata import IndexerMetadata
+
+MAX_TOKENS = 32
+TOPK = 4
+NUM_DSA_LAYERS = 3
+
+
+def _make_context(active_token_count=10, using_cuda_graph=False):
+    ctx = MagicMock()
+    ctx.max_tokens = MAX_TOKENS
+    ctx.active_token_count = active_token_count
+    ctx.using_cuda_graph_this_step.return_value = using_cuda_graph
+    return ctx
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="IndexerMetadata uses cuda.current_device"
+)
+class TestIndexerMetadata:
+    def test_lazy_buffer_allocation_and_recording_lifecycle(self):
+        """IndexerMetadata lazily allocates the [max_tokens, num_dsa_layers, topk]
+        buffer on first use (skipping when no DSA layers are registered), and
+        enable/disable recording forwards to IndexerReplay only when there's a
+        buffer to record into."""
+        with patch(
+            "megatron.core.inference.contexts.indexer_metadata.IndexerReplay"
+        ) as fake_replay:
+            # No DSA layers -> no buffer allocated, no recording enabled.
+            fake_replay.global_indexer_replay_instances = []
+            im = IndexerMetadata(_make_context(), dsa_indexer_topk=TOPK)
+            im._ensure_buffer_allocated()
+            assert im.indexer_indices_buffer is None
+            assert im.num_dsa_layers == 0
+            im.enable_static_buffer_recording()
+            fake_replay.set_global_static_buffers.assert_not_called()
+
+            # Re-binding global instances and allocating produces the expected shape.
+            fake_replay.global_indexer_replay_instances = [object()] * NUM_DSA_LAYERS
+            im2 = IndexerMetadata(_make_context(), dsa_indexer_topk=TOPK)
+            im2._ensure_buffer_allocated()
+            assert im2.indexer_indices_buffer.shape == (
+                MAX_TOKENS,
+                NUM_DSA_LAYERS,
+                TOPK,
+            )
+            assert im2.indexer_indices_buffer.dtype == torch.int32
+
+            # Repeat call is a no-op (preserves the existing buffer identity).
+            sentinel = im2.indexer_indices_buffer
+            im2._ensure_buffer_allocated()
+            assert im2.indexer_indices_buffer is sentinel
+
+            # enable/disable_static_buffer_recording forward to IndexerReplay.
+            fake_replay.reset_mock()
+            im2.enable_static_buffer_recording()
+            fake_replay.set_global_static_buffers.assert_called_once_with(
+                im2.indexer_indices_buffer
+            )
+            im2.disable_static_buffer_recording()
+            fake_replay.clear_global_static_buffers.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "using_cuda_graph,buffer_allocated,recorded_data,expected_shape",
+        [
+            (True, False, None, None),
+            (True, True, None, (10, NUM_DSA_LAYERS, TOPK)),
+            (False, False, None, None),
+            (False, False, [], None),
+            (False, False, [None], None),
+            (False, False, "valid", (7, 2, TOPK)),
+        ],
+    )
+    def test_get_indexer_indices(
+        self, using_cuda_graph, buffer_allocated, recorded_data, expected_shape
+    ):
+        """get_indexer_indices either slices the static buffer (CUDA-graph mode)
+        or stacks per-layer IndexerReplay tensors (eager mode); returns None when
+        no data is available."""
+        ctx = _make_context(active_token_count=10, using_cuda_graph=using_cuda_graph)
+        im = IndexerMetadata(ctx, dsa_indexer_topk=TOPK)
+        if buffer_allocated:
+            im.indexer_indices_buffer = torch.zeros(
+                MAX_TOKENS, NUM_DSA_LAYERS, TOPK, dtype=torch.int32, device="cuda"
+            )
+        with patch(
+            "megatron.core.inference.contexts.indexer_metadata.IndexerReplay"
+        ) as fake_replay:
+            if recorded_data == "valid":
+                fake_replay.get_recorded_data.return_value = [
+                    torch.zeros(7, TOPK, dtype=torch.int32, device="cuda"),
+                    torch.zeros(7, TOPK, dtype=torch.int32, device="cuda"),
+                ]
+            else:
+                fake_replay.get_recorded_data.return_value = recorded_data
+            out = im.get_indexer_indices()
+        if expected_shape is None:
+            assert out is None
+        else:
+            assert out.shape == expected_shape

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -27,6 +27,10 @@ from megatron.core.transformer.experimental_attention_variant.dsa import (
     fused_qk_topk_naive,
     rotate_activation,
 )
+from megatron.core.transformer.experimental_attention_variant.indexer_replay import (
+    IndexerReplay,
+    IndexerReplayAction,
+)
 from megatron.core.transformer.multi_latent_attention import MLASelfAttention
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from tests.unit_tests.test_utilities import Utils
@@ -53,7 +57,7 @@ def patch_hadamard_if_needed():
     """Automatically patch hadamard_transform in dsa module if not installed."""
     if not HAVE_HADAMARD:
         with patch(
-            'megatron.core.transformer.experimental_attention_variant.dsa.hadamard_transform',
+            "megatron.core.transformer.experimental_attention_variant.dsa.hadamard_transform",
             mock_hadamard_transform,
         ):
             yield
@@ -64,7 +68,7 @@ def patch_hadamard_if_needed():
 class TestRotateActivation:
     """Test rotate_activation function."""
 
-    @pytest.fixture(scope='class', autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def setup_method(self):
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=1, pipeline_model_parallel_size=1
@@ -96,13 +100,13 @@ class TestRotateActivation:
 class TestComputeDSAIndexerLoss:
     """Test compute_dsa_indexer_loss function."""
 
-    @pytest.fixture(scope='class', autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def setup_method(self, request):
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=1, pipeline_model_parallel_size=1
         )
         request.cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-            required_pgs=['tp']
+            required_pgs=["tp"]
         )
         yield
         Utils.destroy_model_parallel()
@@ -117,12 +121,17 @@ class TestComputeDSAIndexerLoss:
         index_topk = seqlen_and_topk[1]
 
         # Create dummy index scores
-        index_scores = torch.randn(batch_size, seqlen, seqlen, dtype=torch.float32).cuda()
+        index_scores = torch.randn(
+            batch_size, seqlen, seqlen, dtype=torch.float32
+        ).cuda()
 
         # Apply causal mask to index_scores before computing topk
         causal_mask = torch.triu(
             torch.full(
-                (seqlen, seqlen), float('-inf'), dtype=torch.float32, device=index_scores.device
+                (seqlen, seqlen),
+                float("-inf"),
+                dtype=torch.float32,
+                device=index_scores.device,
             ),
             diagonal=1,
         )
@@ -133,8 +142,12 @@ class TestComputeDSAIndexerLoss:
         topk_k = min(index_topk, seqlen)
         topk_indices = masked_index_scores.topk(topk_k, dim=-1)[1]
 
-        query = torch.randn(seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16).cuda()
-        key = torch.randn(seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16).cuda()
+        query = torch.randn(
+            seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+        ).cuda()
+        key = torch.randn(
+            seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+        ).cuda()
         softmax_scale = head_dim**-0.5
 
         loss = compute_dsa_indexer_loss(
@@ -162,12 +175,17 @@ class TestComputeDSAIndexerLoss:
         index_topk = seqlen_and_topk[1]
 
         # Create dummy index scores
-        index_scores = torch.randn(batch_size, seqlen, seqlen, dtype=torch.float32).cuda()
+        index_scores = torch.randn(
+            batch_size, seqlen, seqlen, dtype=torch.float32
+        ).cuda()
 
         # Apply causal mask to index_scores before computing topk
         causal_mask = torch.triu(
             torch.full(
-                (seqlen, seqlen), float('-inf'), dtype=torch.float32, device=index_scores.device
+                (seqlen, seqlen),
+                float("-inf"),
+                dtype=torch.float32,
+                device=index_scores.device,
             ),
             diagonal=1,
         )
@@ -178,8 +196,12 @@ class TestComputeDSAIndexerLoss:
         topk_k = min(index_topk, seqlen)
         topk_indices = masked_index_scores.topk(topk_k, dim=-1)[1]
 
-        query = torch.randn(seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16).cuda()
-        key = torch.randn(seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16).cuda()
+        query = torch.randn(
+            seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+        ).cuda()
+        key = torch.randn(
+            seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+        ).cuda()
         softmax_scale = head_dim**-0.5
 
         loss_sparse = compute_dsa_indexer_loss(
@@ -216,7 +238,7 @@ class TestComputeDSAIndexerLoss:
 class TestDSAIndexerLossAutoScaler:
     """Test DSAIndexerLossAutoScaler autograd function."""
 
-    @pytest.fixture(scope='class', autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def setup_method(self):
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=1, pipeline_model_parallel_size=1
@@ -272,19 +294,21 @@ class TestDSAIndexerLossAutoScaler:
             torch.full_like(dummy_input, expected_grad_per_element),
             rtol=0,
             atol=0,
-        ), f"Gradient should be scaled by loss scale, expected {expected_grad_per_element}, got {dummy_input.grad[0].item()}"
+        ), (
+            f"Gradient should be scaled by loss scale, expected {expected_grad_per_element}, got {dummy_input.grad[0].item()}"
+        )
 
 
 class TestFusedDSAIndexerLossGradient:
     """Test that FusedDSAIndexerLoss manual backward matches autograd backward."""
 
-    @pytest.fixture(scope='class', autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def setup_method(self, request):
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=1, pipeline_model_parallel_size=1
         )
         request.cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-            required_pgs=['tp']
+            required_pgs=["tp"]
         )
         yield
         Utils.destroy_model_parallel()
@@ -310,7 +334,11 @@ class TestFusedDSAIndexerLossGradient:
 
                 q_ref = (
                     torch.randn(
-                        seqlen, batch_size, index_n_heads, index_head_dim, dtype=torch.float32
+                        seqlen,
+                        batch_size,
+                        index_n_heads,
+                        index_head_dim,
+                        dtype=torch.float32,
                     )
                     .cuda()
                     .requires_grad_(True)
@@ -332,7 +360,9 @@ class TestFusedDSAIndexerLossGradient:
                     seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16
                 ).cuda()
                 mask = torch.triu(
-                    torch.full((seqlen, seqlen), float('-inf'), dtype=torch.float32).cuda(),
+                    torch.full(
+                        (seqlen, seqlen), float("-inf"), dtype=torch.float32
+                    ).cuda(),
                     diagonal=1,
                 )
 
@@ -383,25 +413,156 @@ class TestFusedDSAIndexerLossGradient:
                 grad_k_fused = k_fused.grad
 
                 # Compare
-                assert torch.allclose(
-                    loss_fused, loss_ref, rtol=1e-5, atol=1e-5
-                ), f"{tag} Loss mismatch: fused={loss_fused.item()}, ref={loss_ref.item()}"
+                assert torch.allclose(loss_fused, loss_ref, rtol=1e-5, atol=1e-5), (
+                    f"{tag} Loss mismatch: fused={loss_fused.item()}, ref={loss_ref.item()}"
+                )
 
-                assert torch.equal(
-                    topk_indices_fused, topk_indices
-                ), f"{tag} Top-k indices mismatch between fused and reference"
+                assert torch.equal(topk_indices_fused, topk_indices), (
+                    f"{tag} Top-k indices mismatch between fused and reference"
+                )
 
-                assert torch.allclose(
-                    grad_q_fused, grad_q_ref, rtol=1e-5, atol=1e-5
-                ), f"{tag} grad_q mismatch: max diff = {(grad_q_fused - grad_q_ref).abs().max().item()}"
+                assert torch.allclose(grad_q_fused, grad_q_ref, rtol=1e-5, atol=1e-5), (
+                    f"{tag} grad_q mismatch: max diff = {(grad_q_fused - grad_q_ref).abs().max().item()}"
+                )
 
                 assert torch.allclose(
                     grad_weights_fused, grad_weights_ref, rtol=1e-5, atol=1e-5
-                ), f"{tag} grad_weights mismatch: max diff = {(grad_weights_fused - grad_weights_ref).abs().max().item()}"
+                ), (
+                    f"{tag} grad_weights mismatch: max diff = {(grad_weights_fused - grad_weights_ref).abs().max().item()}"
+                )
+
+                assert torch.allclose(grad_k_fused, grad_k_ref, rtol=1e-5, atol=1e-5), (
+                    f"{tag} grad_k mismatch: max diff = {(grad_k_fused - grad_k_ref).abs().max().item()}"
+                )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_fused_indexer_loss_replay_gradient_matches_autograd(self):
+        """
+        Test that FusedDSAIndexerLoss with replay_topk_indices produces the same
+        gradients as the normal forward path (without replay).
+        """
+        batch_size = 2
+        num_heads = 4
+        head_dim = 64
+        index_n_heads = 8
+        index_head_dim = 64
+        softmax_scale = head_dim**-0.5
+        loss_coeff = 1.0
+
+        for seqlen, index_topk in [[16, 8], [32, 16]]:
+            for sparse_loss in [False, True]:
+                tag = f"[seqlen={seqlen}, topk={index_topk}, sparse={sparse_loss}]"
+                torch.manual_seed(42)
+
+                q = (
+                    torch.randn(
+                        seqlen,
+                        batch_size,
+                        index_n_heads,
+                        index_head_dim,
+                        dtype=torch.float32,
+                    )
+                    .cuda()
+                    .requires_grad_(True)
+                )
+                weights = (
+                    torch.randn(seqlen, batch_size, index_n_heads, dtype=torch.float32)
+                    .cuda()
+                    .requires_grad_(True)
+                )
+                k = (
+                    torch.randn(seqlen, batch_size, index_head_dim, dtype=torch.float32)
+                    .cuda()
+                    .requires_grad_(True)
+                )
+                query = torch.randn(
+                    seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+                ).cuda()
+                key = torch.randn(
+                    seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+                ).cuda()
+                mask = torch.triu(
+                    torch.full(
+                        (seqlen, seqlen), float("-inf"), dtype=torch.float32
+                    ).cuda(),
+                    diagonal=1,
+                )
+
+                # Get reference topk indices from normal forward
+                _, topk_indices = FusedDSAIndexerLoss.apply(
+                    q.detach().clone().requires_grad_(True),
+                    weights.detach().clone().requires_grad_(True),
+                    k.detach().clone().requires_grad_(True),
+                    query.detach(),
+                    key.detach(),
+                    softmax_scale,
+                    index_topk,
+                    loss_coeff,
+                    mask,
+                    sparse_loss,
+                    self.pg_collection,
+                )
+
+                # Normal forward with gradient
+                q_normal = q.detach().clone().requires_grad_(True)
+                weights_normal = weights.detach().clone().requires_grad_(True)
+                k_normal = k.detach().clone().requires_grad_(True)
+
+                _, loss_normal = FusedDSAIndexerLoss.apply(
+                    q_normal,
+                    weights_normal,
+                    k_normal,
+                    query.detach(),
+                    key.detach(),
+                    softmax_scale,
+                    index_topk,
+                    loss_coeff,
+                    mask,
+                    sparse_loss,
+                    self.pg_collection,
+                )
+                loss_normal.backward()
+
+                # Replay forward with pre-computed topk indices
+                q_replay = q.detach().clone().requires_grad_(True)
+                weights_replay = weights.detach().clone().requires_grad_(True)
+                k_replay = k.detach().clone().requires_grad_(True)
+
+                _, loss_replay = FusedDSAIndexerLoss.apply(
+                    q_replay,
+                    weights_replay,
+                    k_replay,
+                    query.detach(),
+                    key.detach(),
+                    softmax_scale,
+                    index_topk,
+                    loss_coeff,
+                    mask,
+                    sparse_loss,
+                    self.pg_collection,
+                    topk_indices,
+                )
+                loss_replay.backward()
+
+                # Losses should be close (may differ slightly since normal path
+                # selects topk independently but replay uses pre-computed indices)
+                assert torch.allclose(loss_normal, loss_replay, rtol=1e-3, atol=1e-3), (
+                    f"{tag} Loss mismatch between normal and replay: "
+                    f"normal={loss_normal.item()}, replay={loss_replay.item()}"
+                )
+
+                # Gradients should be close
+                assert torch.allclose(
+                    q_normal.grad, q_replay.grad, rtol=1e-3, atol=1e-3
+                ), f"{tag} grad_q mismatch between normal and replay"
 
                 assert torch.allclose(
-                    grad_k_fused, grad_k_ref, rtol=1e-5, atol=1e-5
-                ), f"{tag} grad_k mismatch: max diff = {(grad_k_fused - grad_k_ref).abs().max().item()}"
+                    weights_normal.grad, weights_replay.grad, rtol=1e-3, atol=1e-3
+                ), f"{tag} grad_weights mismatch between normal and replay"
+
+                assert torch.allclose(
+                    k_normal.grad, k_replay.grad, rtol=1e-3, atol=1e-3
+                ), f"{tag} grad_k mismatch between normal and replay"
 
 
 class TestFusedDSAIndexerLossGradientTP:
@@ -435,14 +596,20 @@ class TestFusedDSAIndexerLossGradientTP:
         torch.manual_seed(42)
         model_parallel_cuda_manual_seed(42)
 
-        pg_collection_tp1 = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp'])
+        pg_collection_tp1 = ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=["tp"]
+        )
 
         # Create inputs (shared across all variants)
         q_input = torch.randn(
             seqlen, batch_size, index_n_heads, index_head_dim, dtype=torch.float32
         ).cuda()
-        weights_input = torch.randn(seqlen, batch_size, index_n_heads, dtype=torch.float32).cuda()
-        k_input = torch.randn(seqlen, batch_size, index_head_dim, dtype=torch.float32).cuda()
+        weights_input = torch.randn(
+            seqlen, batch_size, index_n_heads, dtype=torch.float32
+        ).cuda()
+        k_input = torch.randn(
+            seqlen, batch_size, index_head_dim, dtype=torch.float32
+        ).cuda()
         query_input = torch.randn(
             seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16
         ).cuda()
@@ -450,7 +617,8 @@ class TestFusedDSAIndexerLossGradientTP:
             seqlen, batch_size, num_heads, head_dim, dtype=torch.bfloat16
         ).cuda()
         mask = torch.triu(
-            torch.full((seqlen, seqlen), float('-inf'), dtype=torch.float32).cuda(), diagonal=1
+            torch.full((seqlen, seqlen), float("-inf"), dtype=torch.float32).cuda(),
+            diagonal=1,
         )
 
         # {sparse_loss: (topk_indices, loss, grad_q, grad_weights, grad_k)}
@@ -496,7 +664,9 @@ class TestFusedDSAIndexerLossGradientTP:
             torch.manual_seed(42)
             model_parallel_cuda_manual_seed(42)
 
-            pg_collection_tpn = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp'])
+            pg_collection_tpn = ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=["tp"]
+            )
             tp_rank = parallel_state.get_tensor_model_parallel_rank()
 
             # query and key split along heads for TP
@@ -507,9 +677,13 @@ class TestFusedDSAIndexerLossGradientTP:
             key_tpn = key_input[:, :, start_head:end_head, :].clone()
 
             for sparse_loss in [False, True]:
-                topk_indices_tp1, loss_tp1_value, grad_q_tp1, grad_weights_tp1, grad_k_tp1 = (
-                    baselines[sparse_loss]
-                )
+                (
+                    topk_indices_tp1,
+                    loss_tp1_value,
+                    grad_q_tp1,
+                    grad_weights_tp1,
+                    grad_k_tp1,
+                ) = baselines[sparse_loss]
                 tag = f"[TP={tensor_model_parallel_size}, sparse_loss={sparse_loss}]"
 
                 q_tpn = q_input.clone().requires_grad_(True)
@@ -532,27 +706,29 @@ class TestFusedDSAIndexerLossGradientTP:
                 loss_tpn.backward()
 
                 # Loss should be the same
-                assert torch.allclose(
-                    loss_tpn, loss_tp1_value, rtol=1e-5, atol=1e-5
-                ), f"{tag} Loss mismatch: got {loss_tpn.item()}, TP=1 got {loss_tp1_value.item()}"
+                assert torch.allclose(loss_tpn, loss_tp1_value, rtol=1e-5, atol=1e-5), (
+                    f"{tag} Loss mismatch: got {loss_tpn.item()}, TP=1 got {loss_tp1_value.item()}"
+                )
 
                 # Top-k indices should be the same
-                assert torch.equal(
-                    topk_indices_tpn, topk_indices_tp1
-                ), f"{tag} Top-k indices mismatch between TP=1 and TP=N"
+                assert torch.equal(topk_indices_tpn, topk_indices_tp1), (
+                    f"{tag} Top-k indices mismatch between TP=1 and TP=N"
+                )
 
                 # Gradients should match (indexer params are duplicated across TP)
-                assert torch.allclose(
-                    q_tpn.grad, grad_q_tp1, rtol=1e-5, atol=1e-5
-                ), f"{tag} grad_q mismatch: max diff = {(q_tpn.grad - grad_q_tp1).abs().max().item()}"
+                assert torch.allclose(q_tpn.grad, grad_q_tp1, rtol=1e-5, atol=1e-5), (
+                    f"{tag} grad_q mismatch: max diff = {(q_tpn.grad - grad_q_tp1).abs().max().item()}"
+                )
 
                 assert torch.allclose(
                     weights_tpn.grad, grad_weights_tp1, rtol=1e-5, atol=1e-5
-                ), f"{tag} grad_weights mismatch: max diff = {(weights_tpn.grad - grad_weights_tp1).abs().max().item()}"
+                ), (
+                    f"{tag} grad_weights mismatch: max diff = {(weights_tpn.grad - grad_weights_tp1).abs().max().item()}"
+                )
 
-                assert torch.allclose(
-                    k_tpn.grad, grad_k_tp1, rtol=1e-5, atol=1e-5
-                ), f"{tag} grad_k mismatch: max diff = {(k_tpn.grad - grad_k_tp1).abs().max().item()}"
+                assert torch.allclose(k_tpn.grad, grad_k_tp1, rtol=1e-5, atol=1e-5), (
+                    f"{tag} grad_k mismatch: max diff = {(k_tpn.grad - grad_k_tp1).abs().max().item()}"
+                )
 
                 # Check gradients are identical across all TP ranks
                 tp_size = parallel_state.get_tensor_model_parallel_world_size()
@@ -562,7 +738,9 @@ class TestFusedDSAIndexerLossGradientTP:
                         (weights_tpn.grad, "grad_weights"),
                         (k_tpn.grad, "grad_k"),
                     ]:
-                        grad_list = [torch.zeros_like(grad_tensor) for _ in range(tp_size)]
+                        grad_list = [
+                            torch.zeros_like(grad_tensor) for _ in range(tp_size)
+                        ]
                         torch.distributed.all_gather(
                             grad_list, grad_tensor, group=pg_collection_tpn.tp
                         )
@@ -579,7 +757,7 @@ class TestFusedDSAIndexerLossGradientTP:
 class TestDSAIndexer:
     """Test DSA Indexer module basic functionality with TP=1."""
 
-    @pytest.fixture(scope='class', autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def setup_method(self, request):
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=1, pipeline_model_parallel_size=1
@@ -603,7 +781,7 @@ class TestDSAIndexer:
             qk_head_dim=64,
             qk_pos_emb_head_dim=32,
             v_head_dim=64,
-            rope_type='rope',
+            rope_type="rope",
             rotary_base=10000,
             rotary_percent=1.0,
             # Sparse attention specific configs
@@ -623,7 +801,9 @@ class TestDSAIndexer:
             linear_weights_proj=ModuleSpec(module=TELinear),
         )
 
-        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
+        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=["tp", "cp"]
+        )
         cls.indexer = DSAIndexer(cls.config, indexer_submodules, cls.pg_collection)
 
         yield
@@ -645,14 +825,22 @@ class TestDSAIndexer:
         self.indexer.cuda()
 
         # Create input tensors
-        x = torch.randn(seqlen, batch_size, self.config.hidden_size, dtype=torch.bfloat16).cuda()
-        qr = torch.randn(seqlen, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16).cuda()
+        x = torch.randn(
+            seqlen, batch_size, self.config.hidden_size, dtype=torch.bfloat16
+        ).cuda()
+        qr = torch.randn(
+            seqlen, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16
+        ).cuda()
 
         # Forward pass
         topk_indices = self.indexer(x, qr)
 
         # Check output shape
-        assert topk_indices.shape == (batch_size, seqlen, min(self.config.dsa_indexer_topk, seqlen))
+        assert topk_indices.shape == (
+            batch_size,
+            seqlen,
+            min(self.config.dsa_indexer_topk, seqlen),
+        )
         assert topk_indices.dtype == torch.long
         assert torch.all((topk_indices >= 0) & (topk_indices < seqlen))
         # Make sure no duplicate indices are selected
@@ -669,15 +857,23 @@ class TestDSAIndexer:
         self.indexer.cuda()
 
         # Create input tensors
-        x = torch.randn(seqlen, batch_size, self.config.hidden_size, dtype=torch.bfloat16).cuda()
-        qr = torch.randn(seqlen, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16).cuda()
+        x = torch.randn(
+            seqlen, batch_size, self.config.hidden_size, dtype=torch.bfloat16
+        ).cuda()
+        qr = torch.randn(
+            seqlen, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16
+        ).cuda()
 
         # Forward pass with scores
         index_scores, topk_indices = self.indexer.forward_with_scores(x, qr)
 
         # Check output shapes
         assert index_scores.shape == (batch_size, seqlen, seqlen)
-        assert topk_indices.shape == (batch_size, seqlen, min(self.config.dsa_indexer_topk, seqlen))
+        assert topk_indices.shape == (
+            batch_size,
+            seqlen,
+            min(self.config.dsa_indexer_topk, seqlen),
+        )
         assert index_scores.dtype == torch.float32
         assert topk_indices.dtype == torch.long
         assert torch.all((topk_indices >= 0) & (topk_indices < seqlen))
@@ -695,10 +891,16 @@ class TestDSAIndexer:
         self.indexer.cuda()
 
         # Create input tensors
-        x = torch.randn(seqlen, batch_size, self.config.hidden_size, dtype=torch.bfloat16).cuda()
-        qr = torch.randn(seqlen, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16).cuda()
+        x = torch.randn(
+            seqlen, batch_size, self.config.hidden_size, dtype=torch.bfloat16
+        ).cuda()
+        qr = torch.randn(
+            seqlen, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16
+        ).cuda()
         mask = torch.triu(
-            torch.full((batch_size, seqlen, seqlen), float('-inf'), dtype=torch.float32).cuda(),
+            torch.full(
+                (batch_size, seqlen, seqlen), float("-inf"), dtype=torch.float32
+            ).cuda(),
             diagonal=1,
         )
 
@@ -716,7 +918,7 @@ class TestDSAIndexer:
 class TestDSAttention:
     """Test DSAttention module basic functionality with TP=1."""
 
-    @pytest.fixture(scope='class', autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def setup_method(self, request):
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=1, pipeline_model_parallel_size=1
@@ -739,7 +941,7 @@ class TestDSAttention:
             qk_head_dim=64,
             qk_pos_emb_head_dim=32,
             v_head_dim=64,
-            rope_type='rope',
+            rope_type="rope",
             rotary_base=10000,
             rotary_percent=1.0,
             # Sparse attention specific configs
@@ -763,14 +965,16 @@ class TestDSAttention:
         indexer_spec = ModuleSpec(module=DSAIndexer, submodules=indexer_submodules)
         sparse_attention_submodules = DSAttentionSubmodules(indexer=indexer_spec)
 
-        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
+        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=["tp", "cp"]
+        )
 
         cls.sparse_attention = DSAttention(
             config=cls.config,
             submodules=sparse_attention_submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            attention_type='self',
+            attention_type="self",
             pg_collection=cls.pg_collection,
         )
 
@@ -780,7 +984,7 @@ class TestDSAttention:
     def test_dsa_constructor(self):
         """Test sparse attention initialization."""
         assert isinstance(self.sparse_attention, DSAttention)
-        assert hasattr(self.sparse_attention, 'indexer')
+        assert hasattr(self.sparse_attention, "indexer")
         assert isinstance(self.sparse_attention.indexer, DSAIndexer)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -811,11 +1015,17 @@ class TestDSAttention:
         )
 
         # Original hidden states and low-rank query
-        x = torch.randn(seq_len, batch_size, self.config.hidden_size, dtype=torch.bfloat16).cuda()
-        qr = torch.randn(seq_len, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16).cuda()
+        x = torch.randn(
+            seq_len, batch_size, self.config.hidden_size, dtype=torch.bfloat16
+        ).cuda()
+        qr = torch.randn(
+            seq_len, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16
+        ).cuda()
 
         # Create causal attention mask
-        attention_mask = torch.ones(batch_size, 1, seq_len, seq_len, dtype=torch.bool).cuda()
+        attention_mask = torch.ones(
+            batch_size, 1, seq_len, seq_len, dtype=torch.bool
+        ).cuda()
         attention_mask = torch.tril(attention_mask)
 
         # Forward pass
@@ -862,11 +1072,17 @@ class TestDSAttention:
         )
 
         # Original hidden states and low-rank query
-        x = torch.randn(seq_len, batch_size, self.config.hidden_size, dtype=torch.bfloat16).cuda()
-        qr = torch.randn(seq_len, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16).cuda()
+        x = torch.randn(
+            seq_len, batch_size, self.config.hidden_size, dtype=torch.bfloat16
+        ).cuda()
+        qr = torch.randn(
+            seq_len, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16
+        ).cuda()
 
         # Create causal attention mask
-        attention_mask = torch.ones(batch_size, 1, seq_len, seq_len, dtype=torch.bool).cuda()
+        attention_mask = torch.ones(
+            batch_size, 1, seq_len, seq_len, dtype=torch.bool
+        ).cuda()
         attention_mask = torch.tril(attention_mask)
 
         # Forward pass
@@ -892,7 +1108,9 @@ class TestDSAttention:
         # Check that indexer parameters have gradients
         for name, param in self.sparse_attention.indexer.named_parameters():
             if param.requires_grad:
-                assert param.grad is not None, f"Indexer parameter {name} has no gradient"
+                assert param.grad is not None, (
+                    f"Indexer parameter {name} has no gradient"
+                )
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_dsa_topk_selection(self):
@@ -906,16 +1124,28 @@ class TestDSAttention:
         self.sparse_attention.cuda()
 
         # Create input tensors
-        query = torch.randn(seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16).cuda()
-        key = torch.randn(seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16).cuda()
-        value = torch.randn(seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16).cuda()
+        query = torch.randn(
+            seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+        ).cuda()
+        key = torch.randn(
+            seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+        ).cuda()
+        value = torch.randn(
+            seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+        ).cuda()
 
         # Original hidden states and low-rank query
-        x = torch.randn(seq_len, batch_size, self.config.hidden_size, dtype=torch.bfloat16).cuda()
-        qr = torch.randn(seq_len, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16).cuda()
+        x = torch.randn(
+            seq_len, batch_size, self.config.hidden_size, dtype=torch.bfloat16
+        ).cuda()
+        qr = torch.randn(
+            seq_len, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16
+        ).cuda()
 
         # Create causal attention mask
-        attention_mask = torch.ones(batch_size, 1, seq_len, seq_len, dtype=torch.bool).cuda()
+        attention_mask = torch.ones(
+            batch_size, 1, seq_len, seq_len, dtype=torch.bool
+        ).cuda()
         attention_mask = torch.tril(attention_mask)
 
         with torch.no_grad():
@@ -953,7 +1183,9 @@ class TestIndexerTensorParallel:
     def _create_config(self, sequence_parallel=False):
         """Helper to create MLA config."""
         # Get TP size from parallel_state
-        tensor_model_parallel_size = parallel_state.get_tensor_model_parallel_world_size()
+        tensor_model_parallel_size = (
+            parallel_state.get_tensor_model_parallel_world_size()
+        )
 
         return MLATransformerConfig(
             num_layers=2,
@@ -970,7 +1202,7 @@ class TestIndexerTensorParallel:
             qk_head_dim=64,
             qk_pos_emb_head_dim=32,
             v_head_dim=64,
-            rope_type='rope',
+            rope_type="rope",
             rotary_base=10000,
             rotary_percent=1.0,
             # Sparse attention specific configs
@@ -1009,7 +1241,7 @@ class TestIndexerTensorParallel:
 
                 config = self._create_config(sequence_parallel=sequence_parallel)
                 pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                    required_pgs=['tp', 'cp']
+                    required_pgs=["tp", "cp"]
                 )
                 indexer = self._create_indexer(config, pg_collection).cuda()
                 tag = f"[TP={tensor_model_parallel_size}, SP={sequence_parallel}]"
@@ -1017,13 +1249,17 @@ class TestIndexerTensorParallel:
                 # Check that all weights are identical across ALL ranks
                 if world_size > 1:
                     for name, param in indexer.named_parameters():
-                        param_list = [torch.zeros_like(param.data) for _ in range(world_size)]
+                        param_list = [
+                            torch.zeros_like(param.data) for _ in range(world_size)
+                        ]
                         torch.distributed.all_gather(param_list, param.data)
 
                         for i in range(1, world_size):
                             assert torch.allclose(
                                 param_list[0], param_list[i], rtol=0, atol=0
-                            ), f"{tag} Parameter {name} differs between rank 0 and rank {i} (world)"
+                            ), (
+                                f"{tag} Parameter {name} differs between rank 0 and rank {i} (world)"
+                            )
 
             Utils.destroy_model_parallel()
 
@@ -1041,7 +1277,9 @@ class TestIndexerTensorParallel:
         model_parallel_cuda_manual_seed(123)
 
         config_tp1 = self._create_config(sequence_parallel=False)
-        pg_collection_tp1 = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
+        pg_collection_tp1 = ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=["tp", "cp"]
+        )
         indexer_tp1 = self._create_indexer(config_tp1, pg_collection_tp1).cuda()
 
         x_input = torch.randn(
@@ -1051,7 +1289,9 @@ class TestIndexerTensorParallel:
             seq_len, batch_size, config_tp1.q_lora_rank, dtype=torch.bfloat16
         ).cuda()
 
-        index_scores_tp1, topk_indices_tp1 = indexer_tp1.forward_with_scores(x_input, qr_input)
+        index_scores_tp1, topk_indices_tp1 = indexer_tp1.forward_with_scores(
+            x_input, qr_input
+        )
         loss_tp1 = index_scores_tp1.sum()
         loss_tp1.backward()
 
@@ -1076,7 +1316,7 @@ class TestIndexerTensorParallel:
 
                 config_tpn = self._create_config(sequence_parallel=sequence_parallel)
                 pg_collection_tpn = ProcessGroupCollection.use_mpu_process_groups(
-                    required_pgs=['tp', 'cp']
+                    required_pgs=["tp", "cp"]
                 )
                 indexer_tpn = self._create_indexer(config_tpn, pg_collection_tpn).cuda()
                 tag = f"[TP={tensor_model_parallel_size}, SP={sequence_parallel}]"
@@ -1092,7 +1332,9 @@ class TestIndexerTensorParallel:
                     x_tpn = x_input
                     qr_tpn = qr_input
 
-                index_scores_tpn, topk_indices_tpn = indexer_tpn.forward_with_scores(x_tpn, qr_tpn)
+                index_scores_tpn, topk_indices_tpn = indexer_tpn.forward_with_scores(
+                    x_tpn, qr_tpn
+                )
                 loss_tpn = index_scores_tpn.sum()
                 loss_tpn.backward()
 
@@ -1101,9 +1343,9 @@ class TestIndexerTensorParallel:
                 assert torch.allclose(
                     index_scores_tpn, index_scores_tp1, rtol=0, atol=0
                 ), f"{tag} Index scores mismatch vs TP=1"
-                assert torch.equal(
-                    topk_indices_tpn, topk_indices_tp1
-                ), f"{tag} Top-k indices mismatch vs TP=1"
+                assert torch.equal(topk_indices_tpn, topk_indices_tp1), (
+                    f"{tag} Top-k indices mismatch vs TP=1"
+                )
 
                 for name, param in indexer_tpn.named_parameters():
                     if param.grad is not None and name in indexer_tp1_grads:
@@ -1131,7 +1373,7 @@ class TestIndexerTensorParallel:
 
                 config = self._create_config(sequence_parallel=sequence_parallel)
                 pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                    required_pgs=['tp', 'cp']
+                    required_pgs=["tp", "cp"]
                 )
                 indexer = self._create_indexer(config, pg_collection).cuda()
                 tag = f"[TP={tensor_model_parallel_size}, SP={sequence_parallel}]"
@@ -1161,13 +1403,17 @@ class TestIndexerTensorParallel:
 
                 for name, param in indexer.named_parameters():
                     if param.requires_grad:
-                        assert param.grad is not None, f"{tag} Parameter {name} has no gradient"
+                        assert param.grad is not None, (
+                            f"{tag} Parameter {name} has no gradient"
+                        )
 
                 tp_size = parallel_state.get_tensor_model_parallel_world_size()
                 if tp_size > 1:
                     for name, param in indexer.named_parameters():
                         if param.requires_grad and param.grad is not None:
-                            grad_list = [torch.zeros_like(param.grad) for _ in range(tp_size)]
+                            grad_list = [
+                                torch.zeros_like(param.grad) for _ in range(tp_size)
+                            ]
                             torch.distributed.all_gather(
                                 grad_list, param.grad, group=pg_collection.tp
                             )
@@ -1175,7 +1421,9 @@ class TestIndexerTensorParallel:
                             for i in range(1, tp_size):
                                 assert torch.allclose(
                                     grad_list[0], grad_list[i], rtol=0, atol=0
-                                ), f"{tag} Gradient for {name} differs between TP rank 0 and rank {i}"
+                                ), (
+                                    f"{tag} Gradient for {name} differs between TP rank 0 and rank {i}"
+                                )
 
             Utils.destroy_model_parallel()
 
@@ -1190,7 +1438,9 @@ class TestDSAttentionTensorParallel:
     def _create_config(self, sequence_parallel=False, use_sparse_indexer_loss=False):
         """Helper to create MLA config."""
         # Get TP size from parallel_state
-        tensor_model_parallel_size = parallel_state.get_tensor_model_parallel_world_size()
+        tensor_model_parallel_size = (
+            parallel_state.get_tensor_model_parallel_world_size()
+        )
 
         return MLATransformerConfig(
             num_layers=2,
@@ -1207,7 +1457,7 @@ class TestDSAttentionTensorParallel:
             qk_head_dim=64,
             qk_pos_emb_head_dim=32,
             v_head_dim=64,
-            rope_type='rope',
+            rope_type="rope",
             rotary_base=10000,
             rotary_percent=1.0,
             # Sparse attention specific configs
@@ -1237,7 +1487,7 @@ class TestDSAttentionTensorParallel:
             submodules=sparse_attention_submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            attention_type='self',
+            attention_type="self",
             pg_collection=pg_collection,
         )
 
@@ -1261,14 +1511,18 @@ class TestDSAttentionTensorParallel:
                         use_sparse_indexer_loss=use_sparse_indexer_loss,
                     )
                     pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                        required_pgs=['tp', 'cp']
+                        required_pgs=["tp", "cp"]
                     )
-                    sparse_attention = self._create_sparse_attention(config, pg_collection).cuda()
+                    sparse_attention = self._create_sparse_attention(
+                        config, pg_collection
+                    ).cuda()
                     tag = f"[TP={tensor_model_parallel_size}, SP={sequence_parallel}, sparse={use_sparse_indexer_loss}]"
 
                     if world_size > 1:
                         for name, param in sparse_attention.indexer.named_parameters():
-                            param_list = [torch.zeros_like(param.data) for _ in range(world_size)]
+                            param_list = [
+                                torch.zeros_like(param.data) for _ in range(world_size)
+                            ]
                             torch.distributed.all_gather(param_list, param.data)
 
                             for i in range(1, world_size):
@@ -1300,7 +1554,7 @@ class TestDSAttentionTensorParallel:
                 sequence_parallel=False, use_sparse_indexer_loss=use_sparse_indexer_loss
             )
             pg_collection_tp1 = ProcessGroupCollection.use_mpu_process_groups(
-                required_pgs=['tp', 'cp']
+                required_pgs=["tp", "cp"]
             )
             sparse_attention_tp1 = self._create_sparse_attention(
                 config_tp1, pg_collection_tp1
@@ -1310,17 +1564,23 @@ class TestDSAttentionTensorParallel:
             head_dim = config_tp1.hidden_size // num_heads
 
             query_input = (
-                torch.randn(seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16)
+                torch.randn(
+                    seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+                )
                 .cuda()
                 .requires_grad_(True)
             )
             key_input = (
-                torch.randn(seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16)
+                torch.randn(
+                    seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+                )
                 .cuda()
                 .requires_grad_(True)
             )
             value_input = (
-                torch.randn(seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16)
+                torch.randn(
+                    seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+                )
                 .cuda()
                 .requires_grad_(True)
             )
@@ -1330,7 +1590,9 @@ class TestDSAttentionTensorParallel:
             qr_input = torch.randn(
                 seq_len, batch_size, config_tp1.q_lora_rank, dtype=torch.bfloat16
             ).cuda()
-            attention_mask = torch.ones(batch_size, 1, seq_len, seq_len, dtype=torch.bool).cuda()
+            attention_mask = torch.ones(
+                batch_size, 1, seq_len, seq_len, dtype=torch.bool
+            ).cuda()
             attention_mask = torch.tril(attention_mask)
 
             sparse_attention_tp1.train()
@@ -1390,7 +1652,7 @@ class TestDSAttentionTensorParallel:
                         use_sparse_indexer_loss=use_sparse_indexer_loss,
                     )
                     pg_collection_tpn = ProcessGroupCollection.use_mpu_process_groups(
-                        required_pgs=['tp', 'cp']
+                        required_pgs=["tp", "cp"]
                     )
                     sparse_attention_tpn = self._create_sparse_attention(
                         config_tpn, pg_collection_tpn
@@ -1407,10 +1669,16 @@ class TestDSAttentionTensorParallel:
                         seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16
                     ).cuda()
                     x_input_tpn = torch.randn(
-                        seq_len, batch_size, config_tpn.hidden_size, dtype=torch.bfloat16
+                        seq_len,
+                        batch_size,
+                        config_tpn.hidden_size,
+                        dtype=torch.bfloat16,
                     ).cuda()
                     qr_input_tpn = torch.randn(
-                        seq_len, batch_size, config_tpn.q_lora_rank, dtype=torch.bfloat16
+                        seq_len,
+                        batch_size,
+                        config_tpn.q_lora_rank,
+                        dtype=torch.bfloat16,
                     ).cuda()
                     attention_mask_tpn = torch.ones(
                         batch_size, 1, seq_len, seq_len, dtype=torch.bool
@@ -1432,13 +1700,19 @@ class TestDSAttentionTensorParallel:
                     start_head = tp_rank * head_per_rank
                     end_head = (tp_rank + 1) * head_per_rank
                     query_tpn = (
-                        query_input_tpn[:, :, start_head:end_head, :].clone().requires_grad_(True)
+                        query_input_tpn[:, :, start_head:end_head, :]
+                        .clone()
+                        .requires_grad_(True)
                     )
                     key_tpn = (
-                        key_input_tpn[:, :, start_head:end_head, :].clone().requires_grad_(True)
+                        key_input_tpn[:, :, start_head:end_head, :]
+                        .clone()
+                        .requires_grad_(True)
                     )
                     value_tpn = (
-                        value_input_tpn[:, :, start_head:end_head, :].clone().requires_grad_(True)
+                        value_input_tpn[:, :, start_head:end_head, :]
+                        .clone()
+                        .requires_grad_(True)
                     )
 
                     sparse_attention_tpn.train()
@@ -1466,18 +1740,23 @@ class TestDSAttentionTensorParallel:
                     for name, param in sparse_attention_tpn.indexer.named_parameters():
                         if param.grad is not None and name in indexer_tp1_grads:
                             torch.testing.assert_close(
-                                param.grad, indexer_tp1_grads[name], rtol=1e-5, atol=1e-5
+                                param.grad,
+                                indexer_tp1_grads[name],
+                                rtol=1e-5,
+                                atol=1e-5,
                             )
 
                     sq, b, nh, hd = query_tpn.grad.shape
                     query_grad_gathered = gather_from_tensor_model_parallel_region(
-                        query_tpn.grad.reshape(sq, b, nh * hd), group=pg_collection_tpn.tp
+                        query_tpn.grad.reshape(sq, b, nh * hd),
+                        group=pg_collection_tpn.tp,
                     ).reshape(sq, b, num_heads, hd)
                     key_grad_gathered = gather_from_tensor_model_parallel_region(
                         key_tpn.grad.reshape(sq, b, nh * hd), group=pg_collection_tpn.tp
                     ).reshape(sq, b, num_heads, hd)
                     value_grad_gathered = gather_from_tensor_model_parallel_region(
-                        value_tpn.grad.reshape(sq, b, nh * hd), group=pg_collection_tpn.tp
+                        value_tpn.grad.reshape(sq, b, nh * hd),
+                        group=pg_collection_tpn.tp,
                     ).reshape(sq, b, num_heads, hd)
 
                     assert torch.allclose(
@@ -1514,9 +1793,11 @@ class TestDSAttentionTensorParallel:
                         use_sparse_indexer_loss=use_sparse_indexer_loss,
                     )
                     pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                        required_pgs=['tp', 'cp']
+                        required_pgs=["tp", "cp"]
                     )
-                    sparse_attention = self._create_sparse_attention(config, pg_collection).cuda()
+                    sparse_attention = self._create_sparse_attention(
+                        config, pg_collection
+                    ).cuda()
                     sparse_attention.train()
                     tag = f"[TP={tensor_model_parallel_size}, SP={sequence_parallel}, sparse={use_sparse_indexer_loss}]"
 
@@ -1586,15 +1867,17 @@ class TestDSAttentionTensorParallel:
 
                     for name, param in sparse_attention.indexer.named_parameters():
                         if param.requires_grad:
-                            assert (
-                                param.grad is not None
-                            ), f"{tag} Indexer parameter {name} has no gradient"
+                            assert param.grad is not None, (
+                                f"{tag} Indexer parameter {name} has no gradient"
+                            )
 
                     tp_size = parallel_state.get_tensor_model_parallel_world_size()
                     if tp_size > 1:
                         for name, param in sparse_attention.indexer.named_parameters():
                             if param.requires_grad and param.grad is not None:
-                                grad_list = [torch.zeros_like(param.grad) for _ in range(tp_size)]
+                                grad_list = [
+                                    torch.zeros_like(param.grad) for _ in range(tp_size)
+                                ]
                                 torch.distributed.all_gather(
                                     grad_list, param.grad, group=pg_collection.tp
                                 )
@@ -1602,7 +1885,9 @@ class TestDSAttentionTensorParallel:
                                 for i in range(1, tp_size):
                                     assert torch.allclose(
                                         grad_list[0], grad_list[i], rtol=0, atol=0
-                                    ), f"{tag} Gradient for {name} differs between TP rank 0 and rank {i}"
+                                    ), (
+                                        f"{tag} Gradient for {name} differs between TP rank 0 and rank {i}"
+                                    )
 
             Utils.destroy_model_parallel()
 
@@ -1611,7 +1896,7 @@ class TestDSAttentionTensorParallel:
 class TestDSAModuleSpecDispatch:
     """Tests for get_dsa_module_spec_for_backend and get_experimental_attention_variant_module_spec."""
 
-    @pytest.fixture(scope='class', autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def setup_method(self):
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=1, pipeline_model_parallel_size=1
@@ -1632,7 +1917,7 @@ class TestDSAModuleSpecDispatch:
             qk_head_dim=64,
             qk_pos_emb_head_dim=32,
             v_head_dim=64,
-            rope_type='rope',
+            rope_type="rope",
             rotary_base=10000,
             rotary_percent=1.0,
             dsa_indexer_n_heads=8,
@@ -1664,7 +1949,9 @@ class TestDSAModuleSpecDispatch:
         """get_dsa_module_spec_for_backend rejects configs without MLA."""
         from megatron.core.transformer import TransformerConfig as _TransformerConfig
 
-        config = _TransformerConfig(num_layers=2, hidden_size=256, num_attention_heads=4)
+        config = _TransformerConfig(
+            num_layers=2, hidden_size=256, num_attention_heads=4
+        )
         with pytest.raises(AssertionError, match="only MLA supports sparse attention"):
             get_dsa_module_spec_for_backend(config, backend=None)
 
@@ -1673,3 +1960,396 @@ class TestDSAModuleSpecDispatch:
         config = self._make_dsa_config(qk_l2_norm=True)
         with pytest.raises(AssertionError, match="qk_l2_norm is not supported"):
             get_dsa_module_spec_for_backend(config, backend=None)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestDSAIndexerReplay:
+    """Tests for DSA indexer replay integration."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_method(self, request):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        torch.manual_seed(123)
+        model_parallel_cuda_manual_seed(123)
+
+        cls = request.cls
+        cls.index_topk = 32
+        cls.config = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=256,
+            num_attention_heads=16,
+            use_cpu_initialization=True,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            q_lora_rank=64,
+            kv_lora_rank=64,
+            qk_head_dim=64,
+            qk_pos_emb_head_dim=32,
+            v_head_dim=64,
+            rope_type="rope",
+            rotary_base=10000,
+            rotary_percent=1.0,
+            dsa_indexer_n_heads=8,
+            dsa_indexer_head_dim=64,
+            dsa_indexer_topk=cls.index_topk,
+            dsa_indexer_loss_coeff=1.0,
+            dsa_indexer_use_sparse_loss=False,
+            dsa_enable_indexer_replay=True,
+        )
+
+        from megatron.core.extensions.transformer_engine import TELinear, TENorm
+        from megatron.core.transformer.spec_utils import ModuleSpec
+
+        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=["tp", "cp"]
+        )
+
+        # Create indexer submodules spec
+        indexer_submodules = DSAIndexerSubmodules(
+            linear_wq_b=ModuleSpec(module=TELinear),
+            linear_wk=ModuleSpec(module=TELinear),
+            k_norm=ModuleSpec(module=TENorm),
+            linear_weights_proj=ModuleSpec(module=TELinear),
+        )
+        cls.indexer = DSAIndexer(cls.config, indexer_submodules, cls.pg_collection)
+
+        # Create attention module
+        indexer_spec = ModuleSpec(module=DSAIndexer, submodules=indexer_submodules)
+        sparse_attention_submodules = DSAttentionSubmodules(indexer=indexer_spec)
+        cls.sparse_attention = DSAttention(
+            config=cls.config,
+            submodules=sparse_attention_submodules,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            pg_collection=cls.pg_collection,
+        )
+
+        yield
+
+        IndexerReplay.clear_global_indexer_replay_instances()
+        Utils.destroy_model_parallel()
+
+    def _make_inputs(self, seq_len=16, batch_size=2):
+        num_heads = self.config.num_attention_heads
+        head_dim = self.config.hidden_size // num_heads
+
+        query = torch.randn(
+            seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+        ).cuda()
+        key = torch.randn(
+            seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+        ).cuda()
+        value = torch.randn(
+            seq_len, batch_size, num_heads, head_dim, dtype=torch.bfloat16
+        ).cuda()
+        x = torch.randn(
+            seq_len, batch_size, self.config.hidden_size, dtype=torch.bfloat16
+        ).cuda()
+        qr = torch.randn(
+            seq_len, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16
+        ).cuda()
+        attention_mask = torch.ones(
+            batch_size, 1, seq_len, seq_len, dtype=torch.bool
+        ).cuda()
+        attention_mask = torch.tril(attention_mask)
+        return query, key, value, x, qr, attention_mask
+
+    def test_indexer_creates_replay_instance(self):
+        assert self.indexer.indexer_replay is not None
+        assert isinstance(self.indexer.indexer_replay, IndexerReplay)
+
+    def test_fused_loss_with_replay_topk_indices(self):
+        seq_len = 16
+        batch_size = 2
+
+        self.indexer.cuda()
+        x = torch.randn(
+            seq_len, batch_size, self.config.hidden_size, dtype=torch.bfloat16
+        ).cuda()
+        qr = torch.randn(
+            seq_len, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16
+        ).cuda()
+
+        q, k, weights = self.indexer.forward_before_topk(x, qr)
+
+        query = torch.randn(
+            seq_len,
+            batch_size,
+            self.config.num_attention_heads,
+            self.config.hidden_size // self.config.num_attention_heads,
+            dtype=torch.bfloat16,
+        ).cuda()
+        key = torch.randn_like(query)
+        float_mask = torch.triu(
+            torch.full((seq_len, seq_len), float("-inf"), dtype=torch.float32).cuda(),
+            diagonal=1,
+        )
+
+        # First compute normally to get reference topk_indices
+        ref_indices, ref_loss = FusedDSAIndexerLoss.apply(
+            q,
+            weights,
+            k,
+            query.detach(),
+            key.detach(),
+            (self.config.dsa_indexer_head_dim**-0.5),
+            self.config.dsa_indexer_topk,
+            1.0,
+            float_mask,
+            False,
+            self.pg_collection,
+        )
+
+        # Now replay with those same indices — loss should match
+        replay_indices, replay_loss = FusedDSAIndexerLoss.apply(
+            q,
+            weights,
+            k,
+            query.detach(),
+            key.detach(),
+            (self.config.dsa_indexer_head_dim**-0.5),
+            self.config.dsa_indexer_topk,
+            1.0,
+            float_mask,
+            False,
+            self.pg_collection,
+            ref_indices,
+        )
+
+        assert torch.equal(ref_indices, replay_indices)
+        assert torch.allclose(ref_loss, replay_loss, rtol=1e-3, atol=1e-3)
+
+    def test_replay_loss_backward_with_replayed_indices(self):
+        seq_len = 16
+        batch_size = 2
+
+        self.indexer.cuda()
+        x = torch.randn(
+            seq_len, batch_size, self.config.hidden_size, dtype=torch.bfloat16
+        ).cuda()
+        qr = torch.randn(
+            seq_len, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16
+        ).cuda()
+
+        q, k, weights = self.indexer.forward_before_topk(x, qr)
+        query = (
+            torch.randn(
+                seq_len,
+                batch_size,
+                self.config.num_attention_heads,
+                self.config.hidden_size // self.config.num_attention_heads,
+                dtype=torch.bfloat16,
+            )
+            .cuda()
+            .requires_grad_(True)
+        )
+        key = torch.randn_like(query)
+        float_mask = torch.triu(
+            torch.full((seq_len, seq_len), float("-inf"), dtype=torch.float32).cuda(),
+            diagonal=1,
+        )
+
+        # Get reference indices
+        ref_indices, _ = FusedDSAIndexerLoss.apply(
+            q,
+            weights,
+            k,
+            query.detach(),
+            key.detach(),
+            (self.config.dsa_indexer_head_dim**-0.5),
+            self.config.dsa_indexer_topk,
+            1.0,
+            float_mask,
+            False,
+            self.pg_collection,
+        )
+
+        # Replay forward with saved indices, then backward
+        replay_indices, replay_loss = FusedDSAIndexerLoss.apply(
+            q,
+            weights,
+            k,
+            query.detach(),
+            key.detach(),
+            (self.config.dsa_indexer_head_dim**-0.5),
+            self.config.dsa_indexer_topk,
+            1.0,
+            float_mask,
+            False,
+            self.pg_collection,
+            ref_indices,
+        )
+
+        replay_loss.backward()
+
+        # Indexer parameters should have gradients from the loss
+        indexer_has_grad = False
+        for param in self.indexer.parameters():
+            if param.requires_grad and param.grad is not None:
+                indexer_has_grad = True
+                break
+        assert indexer_has_grad, (
+            "Indexer parameters should receive gradients through replay loss"
+        )
+
+    def test_inference_record_mode(self):
+        seq_len = 16
+        batch_size = 2
+
+        self.sparse_attention.eval()
+        self.sparse_attention.cuda()
+
+        query, key, value, x, qr, attention_mask = self._make_inputs(
+            seq_len, batch_size
+        )
+
+        # Set RECORD action
+        IndexerReplay.set_global_indexer_replay_action(IndexerReplayAction.RECORD)
+
+        with torch.no_grad():
+            output = self.sparse_attention(
+                query=query,
+                key=key,
+                value=value,
+                x=x,
+                qr=qr,
+                attention_mask=attention_mask,
+                attn_mask_type=AttnMaskType.causal,
+            )
+
+        assert output.shape == (seq_len, batch_size, self.config.hidden_size)
+
+        # IndexerReplay should have recorded indices
+        recorded = self.indexer.indexer_replay.get_recorded_indices()
+        assert recorded is not None
+        assert recorded.shape[-1] == min(self.config.dsa_indexer_topk, seq_len)
+        assert recorded.dtype == torch.long
+
+        IndexerReplay.clear_global_indexer_replay_action()
+
+    def test_training_replay_forward_mode(self):
+        seq_len = 16
+        batch_size = 2
+
+        self.sparse_attention.train()
+        self.sparse_attention.cuda()
+
+        query, key, value, x, qr, attention_mask = self._make_inputs(
+            seq_len, batch_size
+        )
+
+        # First run in eval mode to record the indices
+        self.sparse_attention.eval()
+        IndexerReplay.set_global_indexer_replay_action(IndexerReplayAction.RECORD)
+        with torch.no_grad():
+            _ = self.sparse_attention(
+                query=query,
+                key=key,
+                value=value,
+                x=x,
+                qr=qr,
+                attention_mask=attention_mask,
+                attn_mask_type=AttnMaskType.causal,
+            )
+        IndexerReplay.clear_global_indexer_replay_action()
+
+        # Retrieve recorded indices and set as replay data
+        recorded_indices = self.indexer.indexer_replay.get_recorded_indices()
+        assert recorded_indices is not None
+
+        IndexerReplay.set_replay_data([recorded_indices])
+        IndexerReplay.set_global_indexer_replay_action(
+            IndexerReplayAction.REPLAY_FORWARD
+        )
+
+        # Now run in training mode with replay
+        self.sparse_attention.train()
+        output = self.sparse_attention(
+            query=query.requires_grad_(True),
+            key=key,
+            value=value,
+            x=x,
+            qr=qr,
+            attention_mask=attention_mask,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+        assert output.shape == (seq_len, batch_size, self.config.hidden_size)
+        assert output.dtype == torch.bfloat16
+
+        # Backward should succeed
+        loss = output.sum()
+        loss.backward()
+
+        IndexerReplay.clear_global_indices()
+        IndexerReplay.clear_global_indexer_replay_action()
+
+    def test_end_to_end_record_replay_cycle(self):
+        seq_len = 16
+        batch_size = 2
+
+        self.sparse_attention.eval()
+        self.sparse_attention.cuda()
+
+        query, key, value, x, qr, attention_mask = self._make_inputs(
+            seq_len, batch_size
+        )
+
+        # PHASE 1: Record during inference (simulating rollout)
+        IndexerReplay.set_global_indexer_replay_action(IndexerReplayAction.RECORD)
+        with torch.no_grad():
+            ref_output = self.sparse_attention(
+                query=query,
+                key=key,
+                value=value,
+                x=x,
+                qr=qr,
+                attention_mask=attention_mask,
+                attn_mask_type=AttnMaskType.causal,
+            )
+        IndexerReplay.clear_global_indexer_replay_action()
+
+        # Get recorded indices
+        recorded = self.indexer.indexer_replay.get_recorded_indices()
+        recorded_copy = recorded.clone()
+
+        # PHASE 2: Replay during training
+        IndexerReplay.clear_global_indices()
+        IndexerReplay.set_replay_data([recorded_copy])
+        IndexerReplay.set_global_indexer_replay_action(
+            IndexerReplayAction.REPLAY_FORWARD
+        )
+
+        self.sparse_attention.train()
+        replay_output = self.sparse_attention(
+            query=query.requires_grad_(True),
+            key=key,
+            value=value,
+            x=x,
+            qr=qr,
+            attention_mask=attention_mask,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+        # Backward through replay
+        replay_loss = replay_output.sum()
+        replay_loss.backward()
+
+        # Verify replay worked: outputs should be close (same topk)
+        assert ref_output.shape == replay_output.shape
+
+        # Verify indexer parameters received gradients through replay
+        indexer_params_with_grad = sum(
+            1
+            for p in self.sparse_attention.indexer.parameters()
+            if p.requires_grad and p.grad is not None
+        )
+        assert indexer_params_with_grad > 0, (
+            "Indexer parameters must receive gradients during replay"
+        )
+
+        IndexerReplay.clear_global_indices()
+        IndexerReplay.clear_global_indexer_replay_action()

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_indexer_replay.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_indexer_replay.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+import pytest
+import torch
+
+from megatron.core.transformer.experimental_attention_variant.indexer_replay import (
+    IndexerReplay,
+    IndexerReplayAction,
+)
+
+
+def setup_function():
+    IndexerReplay.global_indexer_replay_instances.clear()
+
+
+def teardown_function():
+    IndexerReplay.global_indexer_replay_instances.clear()
+
+
+class TestIndexerReplayUnit:
+    """Unit tests for IndexerReplay class — no CUDA required."""
+
+    def test_constructor_and_registration(self):
+        ir = IndexerReplay()
+        assert ir.target_topk_idx is None
+        assert ir.recorded_topk_idx is None
+        assert ir.indexer_replay_action is None
+        assert ir.replay_backward_list == []
+        assert ir.static_buffer is None
+        assert len(IndexerReplay.global_indexer_replay_instances) == 1
+        assert IndexerReplay.global_indexer_replay_instances[0] is ir
+
+    def test_set_and_clear_action(self):
+        ir = IndexerReplay()
+        ir.set_indexer_replay_action(IndexerReplayAction.RECORD)
+        assert ir.indexer_replay_action == IndexerReplayAction.RECORD
+        ir.set_indexer_replay_action(IndexerReplayAction.REPLAY_FORWARD)
+        assert ir.indexer_replay_action == IndexerReplayAction.REPLAY_FORWARD
+        ir.set_indexer_replay_action(IndexerReplayAction.REPLAY_BACKWARD)
+        assert ir.indexer_replay_action == IndexerReplayAction.REPLAY_BACKWARD
+        ir.clear_indexer_replay_action()
+        assert ir.indexer_replay_action is None
+
+    def test_record_indices_eager(self):
+        ir = IndexerReplay()
+        indices = torch.tensor([[0, 1], [2, 3]], dtype=torch.long)
+        ir.record_indices(indices)
+        assert ir.recorded_topk_idx is indices
+
+    def test_record_indices_static_buffer(self):
+        ir = IndexerReplay()
+        buffer = torch.zeros(10, 2, dtype=torch.int32)
+        ir.set_static_buffer(buffer)
+        indices = torch.tensor([[5, 6], [7, 8], [9, 0]], dtype=torch.int32)
+        ir.record_indices(indices)
+        assert torch.equal(buffer[:3], indices)
+        assert ir.recorded_topk_idx is buffer[:3]
+
+    def test_set_target_indices(self):
+        ir = IndexerReplay()
+        indices = torch.tensor([[0, 1]], dtype=torch.long)
+        ir.set_target_indices(indices)
+        assert ir.target_topk_idx is indices
+        assert len(ir.replay_backward_list) == 1
+        assert ir.replay_backward_list[0] is indices
+
+    def test_clear_indices(self):
+        ir = IndexerReplay()
+        ir.record_indices(torch.tensor([[0, 1]], dtype=torch.long))
+        ir.set_target_indices(torch.tensor([[1, 0]], dtype=torch.long))
+        ir.clear_indices()
+        assert ir.recorded_topk_idx is None
+        assert ir.target_topk_idx is None
+        assert ir.replay_backward_list == []
+
+    def test_get_recorded_indices(self):
+        ir = IndexerReplay()
+        assert ir.get_recorded_indices() is None
+        indices = torch.tensor([[0, 1]], dtype=torch.long)
+        ir.record_indices(indices)
+        assert ir.get_recorded_indices() is indices
+
+    def test_get_replay_topk_indices_record(self):
+        ir = IndexerReplay()
+        ir.set_indexer_replay_action(IndexerReplayAction.RECORD)
+        computed = torch.tensor([[5, 6]], dtype=torch.long)
+
+        def compute():
+            return computed
+
+        result, replay = ir.get_replay_topk_indices(compute)
+        assert result is computed
+        assert replay is None
+        assert ir.recorded_topk_idx is computed
+
+    def test_get_replay_topk_indices_replay_forward(self):
+        ir = IndexerReplay()
+        target = torch.tensor([[0, 1], [2, 3]], dtype=torch.long)
+        ir.set_target_indices(target)
+        ir.set_indexer_replay_action(IndexerReplayAction.REPLAY_FORWARD)
+
+        result, replay = ir.get_replay_topk_indices(lambda: None)
+        assert result is target
+        assert replay is target
+
+    def test_get_replay_topk_indices_replay_backward(self):
+        ir = IndexerReplay()
+        target = torch.tensor([[4, 5]], dtype=torch.long)
+        ir.set_target_indices(target)
+        ir.set_indexer_replay_action(IndexerReplayAction.REPLAY_BACKWARD)
+
+        result, replay = ir.get_replay_topk_indices(lambda: None)
+        assert result is target
+        assert replay is target
+        # backward list should now be empty
+        assert ir.replay_backward_list == []
+
+    def test_get_replay_topk_indices_none_action(self):
+        ir = IndexerReplay()
+        result, replay = ir.get_replay_topk_indices(lambda: None)
+        assert result is None
+        assert replay is None
+
+
+class TestIndexerReplayGlobalOps:
+    """Tests for IndexerReplay static/global methods."""
+
+    def setup_method(self):
+        IndexerReplay.global_indexer_replay_instances.clear()
+
+    def teardown_method(self):
+        IndexerReplay.global_indexer_replay_instances.clear()
+
+    def test_global_action_set_and_clear(self):
+        i1 = IndexerReplay()
+        i2 = IndexerReplay()
+        IndexerReplay.set_global_indexer_replay_action(
+            IndexerReplayAction.REPLAY_FORWARD
+        )
+        assert i1.indexer_replay_action == IndexerReplayAction.REPLAY_FORWARD
+        assert i2.indexer_replay_action == IndexerReplayAction.REPLAY_FORWARD
+        IndexerReplay.clear_global_indexer_replay_action()
+        assert i1.indexer_replay_action is None
+        assert i2.indexer_replay_action is None
+
+    def test_global_set_replay_data(self):
+        i1 = IndexerReplay()
+        i2 = IndexerReplay()
+        t1 = torch.tensor([[0, 1], [2, 3]], dtype=torch.long)
+        t2 = torch.tensor([[3, 2], [1, 0]], dtype=torch.long)
+        IndexerReplay.set_replay_data([t1, t2])
+        assert torch.equal(i1.target_topk_idx, t1)
+        assert torch.equal(i2.target_topk_idx, t2)
+        assert len(i1.replay_backward_list) == 1
+        assert len(i2.replay_backward_list) == 1
+
+    def test_global_set_replay_data_length_mismatch(self):
+        _ = IndexerReplay()
+        with pytest.raises(ValueError, match="does not match"):
+            IndexerReplay.set_replay_data(
+                [
+                    torch.tensor([[0, 1]], dtype=torch.long),
+                    torch.tensor([[1, 0]], dtype=torch.long),
+                ]
+            )
+
+    def test_global_get_recorded_data(self):
+        i1 = IndexerReplay()
+        i2 = IndexerReplay()
+        t1 = torch.tensor([[0, 1]], dtype=torch.long)
+        t2 = torch.tensor([[1, 0]], dtype=torch.long)
+        i1.record_indices(t1)
+        i2.record_indices(t2)
+        data = IndexerReplay.get_recorded_data()
+        assert len(data) == 2
+        assert torch.equal(data[0], t1)
+        assert torch.equal(data[1], t2)
+
+    def test_global_clear_indices(self):
+        i1 = IndexerReplay()
+        i2 = IndexerReplay()
+        i1.set_target_indices(torch.tensor([[0, 1]], dtype=torch.long))
+        i2.set_target_indices(torch.tensor([[1, 0]], dtype=torch.long))
+        i1.record_indices(torch.tensor([[2, 3]], dtype=torch.long))
+        i2.record_indices(torch.tensor([[3, 2]], dtype=torch.long))
+        IndexerReplay.clear_global_indices()
+        assert i1.target_topk_idx is None
+        assert i2.target_topk_idx is None
+        assert i1.recorded_topk_idx is None
+        assert i2.recorded_topk_idx is None
+        assert i1.replay_backward_list == []
+        assert i2.replay_backward_list == []
+
+    def test_global_clear_instances(self):
+        _ = IndexerReplay()
+        _ = IndexerReplay()
+        assert len(IndexerReplay.global_indexer_replay_instances) == 2
+        IndexerReplay.clear_global_indexer_replay_instances()
+        assert len(IndexerReplay.global_indexer_replay_instances) == 0
+
+    def test_global_set_static_buffers(self):
+        i1 = IndexerReplay()
+        i2 = IndexerReplay()
+        buffer = torch.zeros(10, 2, 4, dtype=torch.int32)
+        IndexerReplay.set_global_static_buffers(buffer)
+        assert i1.static_buffer is buffer[:, 0, :]
+        assert i2.static_buffer is buffer[:, 1, :]
+
+    def test_global_clear_static_buffers(self):
+        i1 = IndexerReplay()
+        i2 = IndexerReplay()
+        buffer = torch.zeros(10, 2, 4, dtype=torch.int32)
+        IndexerReplay.set_global_static_buffers(buffer)
+        IndexerReplay.clear_global_static_buffers()
+        assert i1.static_buffer is None
+        assert i2.static_buffer is None


### PR DESCRIPTION
Fixes #5384

Adds an opt-in replay path (`dsa_enable_indexer_replay`) for DSA/DSv4 hybrid-attention indexer top-k decisions during RL training, analogous to the existing MoE `RouterReplay`.

### Key changes

- **indexer_replay.py** — `IndexerReplay` class and `IndexerReplayAction` enum, following the same singleton-registry architecture as `RouterReplay`.
- **dsa.py** — Integration into `DSAIndexer`, `FusedDSAIndexerLoss`, and `DSAttention.forward()`.
- **transformer_config.py** — Added `dsa_enable_indexer_replay: bool = False` config field.
- **Inference support** — `IndexerMetadata`, per-block indexer indices, `indexer_indices` field, recording and reconstruction paths.
- **Tests** — Unit tests for `IndexerReplay`, `IndexerMetadata`, and end-to-end gradient replay tests.