### PR TITLE
Add RADIO vision encoder wrapper for MIMO example

### DIFF
--- a/examples/mimo/model_providers/radio_encoder.py
+++ b/examples/mimo/model_providers/radio_encoder.py
@@ -27,6 +27,10 @@ from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.utils import sharded_state_dict_default
 
+# Canonical module name for the RADIO encoder. Single source of truth shared by
+# the provider (encoders-dict key) and the topology default encoder name.
+RADIO_ENCODER_MODULE_NAME = "radio_encoder"
+
 
 def add_radio_encoder_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Register the RADIO-encoder-specific CLI args (stock owns img/patch/hidden)."""

--- a/examples/mimo/model_providers/radio_encoder.py
+++ b/examples/mimo/model_providers/radio_encoder.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""RADIO vision encoder for hetero MIMO examples.
+
+Provides the RADIO encoder wrapper (class-token drop + pixel-shuffle adapter over
+core ``RADIOViTModel``), its vision ``TransformerConfig``, the encoder
+``ModuleSpec`` builder, and the RADIO-specific CLI args. Imported by the
+Nemotron6-MoE VLM provider.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import nullcontext
+from copy import deepcopy
+from typing import Optional
+
+import torch
+
+from megatron.core.activations import fast_gelu
+from megatron.core.models.multimodal.llava_model import pixel_shuffle
+from megatron.core.models.vision.radio import RADIOViTModel
+from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.transformer.utils import sharded_state_dict_default
+
+
+def add_radio_encoder_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Register the RADIO-encoder-specific CLI args (stock owns img/patch/hidden)."""
+    group = parser.add_argument_group("radio vision encoder")
+    group.add_argument("--class-token-len", type=int, default=8,
+                       help="Number of class tokens prepended by RADIO per tile.")
+    group.add_argument("--pixel-shuffle", action="store_true",
+                       help="Apply pixel shuffle to the RADIO features.")
+    group.add_argument("--disable-vision-class-token", action="store_true",
+                       help="Drop the RADIO class tokens from the emitted features.")
+    return parser
+
+
+def _dtype(args: argparse.Namespace):
+    """Resolve params/pipeline dtype: bf16 unless --fp32/--fp16."""
+    bf16 = not getattr(args, "fp32", False) and not getattr(args, "fp16", False)
+    return bf16, (torch.bfloat16 if bf16 else torch.float32)
+
+
+def _base_config(args: argparse.Namespace) -> TransformerConfig:
+    """Stock config from CLI args; the per-tower override helpers deepcopy this."""
+    from megatron.training.argument_utils import core_transformer_config_from_args
+
+    return core_transformer_config_from_args(args)
+
+
+def _make_dense_non_hybrid(config: TransformerConfig) -> None:
+    """Strip language-only MoE/Mamba/hybrid settings inherited from the base config."""
+    config.num_moe_experts = None
+    config.moe_ffn_hidden_size = None
+    config.moe_shared_expert_intermediate_size = None
+    config.moe_grouped_gemm = False
+    config.moe_router_fusion = False
+    config.moe_permute_fusion = False
+    config.moe_shared_expert_overlap = False
+    config.is_hybrid_model = False
+    config.use_fused_weighted_squared_relu = False
+
+
+def radio_vision_config(args: argparse.Namespace, tp_size: int, pp_size: int) -> TransformerConfig:
+    """RADIO vision config: stock from-args base + RADIO-specific overrides."""
+    config = deepcopy(_base_config(args))
+    bf16, dtype = _dtype(args)
+    config.num_layers = 32
+    config.hidden_size = 1280
+    config.num_attention_heads = 16
+    config.kv_channels = 80
+    config.num_query_groups = 16
+    config.ffn_hidden_size = 5120
+    config.gated_linear_unit = False
+    config.activation_func = fast_gelu
+    config.add_bias_linear = True
+    config.add_qkv_bias = True
+    config.normalization = "LayerNorm"
+    config.layernorm_epsilon = 1.0e-6
+    config.layernorm_zero_centered_gamma = False
+    config.apply_rope_fusion = False
+    config.qk_layernorm = False
+    config.bias_activation_fusion = False
+    config.bias_dropout_fusion = False
+    config.attention_softmax_in_fp32 = True
+    config.attention_dropout = 0.0
+    config.hidden_dropout = 0.0
+    config.mtp_num_layers = 0  # Trigger TransformerBlock's final_layernorm allocation.
+    config.use_cpu_initialization = True
+    _make_dense_non_hybrid(config)  # ViT inherits no MoE/Mamba/hybrid settings.
+    config.params_dtype = dtype
+    config.pipeline_dtype = dtype
+    config.bf16 = bf16
+    config.tensor_model_parallel_size = tp_size
+    config.pipeline_model_parallel_size = pp_size
+    config.sequence_parallel = False
+    return config
+
+
+def _pixel_shuffle_dynamic_res(x, imgs_sizes, patch_dim, scale_factor=0.5, version=2):
+    """Pixel shuffle for dynamic resolution (variable tile sizes).
+
+    Splits the packed sequence by per-tile lengths, applies pixel shuffle to each
+    tile, then re-concatenates. Element ordering intentionally differs from core
+    ``pixel_shuffle`` (e2e-validated); do not swap to match it.
+    """
+    seq_lens = torch.prod(imgs_sizes // patch_dim, dim=-1)
+    splits = torch.split(x, seq_lens.tolist(), dim=-2)
+
+    out = []
+    for i, sv in enumerate(splits):
+        h = imgs_sizes[i][0] // patch_dim
+        w = imgs_sizes[i][1] // patch_dim
+        sv = sv.reshape(sv.shape[0], h, w, -1)
+
+        n, h, w, c = sv.size()
+        sv = sv.view(n, h, int(w * scale_factor), int(c / scale_factor))
+        sv = sv.permute(0, 2, 1, 3).contiguous()
+        sv = sv.view(
+            n,
+            int(w * scale_factor),
+            int(h * scale_factor),
+            int(c / (scale_factor * scale_factor)),
+        )
+
+        if version == 2:
+            sv = sv.permute(0, 2, 1, 3).contiguous()
+
+        sv = sv.reshape(sv.shape[0], -1, sv.shape[-1])
+        out.append(sv)
+
+    return torch.cat(out, dim=-2)
+
+
+class RADIOEncoderWrapper(MegatronModule):
+    """RADIO encoder wrapper matching the Nemotron6-MoE VLM provider."""
+
+    def __init__(
+        self,
+        transformer_config: TransformerConfig,
+        transformer_layer_spec: ModuleSpec,
+        pg_collection: Optional[ProcessGroupCollection],
+        img_h: int,
+        img_w: int,
+        patch_dim: int,
+        class_token_len: int,
+        drop_class_token: bool = True,
+        apply_pixel_shuffle: bool = True,
+        force_eval_mode: bool = False,
+        dynamic_resolution: bool = False,
+    ) -> None:
+        super().__init__(config=transformer_config)
+        self.class_token_len = class_token_len
+        self.drop_class_token = drop_class_token
+        self.apply_pixel_shuffle = apply_pixel_shuffle
+        self.force_eval_mode = force_eval_mode
+        self.dynamic_resolution = dynamic_resolution
+        self.radio_model = RADIOViTModel(
+            transformer_config=transformer_config,
+            transformer_layer_spec=transformer_layer_spec,
+            patch_dim=patch_dim,
+            img_h=img_h,
+            img_w=img_w,
+            class_token_len=class_token_len,
+            add_class_token=True,
+            max_img_h=2048,
+            max_img_w=2048,
+            has_cpe=True,
+            embedder_bias=False,
+            dynamic_resolution=dynamic_resolution,
+            force_eval_mode=force_eval_mode,
+            pg_collection=pg_collection,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        imgs_sizes: Optional[torch.Tensor] = None,
+        packed_seq_params=None,
+    ) -> torch.Tensor:
+        """Run RADIO, drop class tokens, and apply pixel shuffle."""
+        context = torch.no_grad() if self.force_eval_mode else nullcontext()
+        with context:
+            x = x.to(dtype=self.radio_model.embedder.weight.dtype)
+            embeddings = self.radio_model(
+                x, imgs_sizes=imgs_sizes, packed_seq_params=packed_seq_params
+            )
+        if self.drop_class_token:
+            if self.dynamic_resolution and imgs_sizes is not None and self.class_token_len > 0:
+                # Class tokens are interleaved between tiles; build mask to remove them.
+                remove_mask = torch.full(
+                    (embeddings.shape[-2],), True, dtype=torch.bool, device=embeddings.device
+                )
+                patch_dim = self.radio_model.patch_dim
+                if torch.is_tensor(imgs_sizes):
+                    seq_lens = torch.prod(imgs_sizes // patch_dim, dim=-1)
+                else:
+                    seq_lens = torch.tensor(
+                        [(h // patch_dim) * (w // patch_dim) for h, w in imgs_sizes]
+                    )
+                current_length = 0
+                for sl in seq_lens:
+                    remove_mask[current_length : current_length + self.class_token_len] = False
+                    current_length += int(sl) + self.class_token_len
+                embeddings = embeddings[:, remove_mask, :]
+            else:
+                embeddings = embeddings[:, self.class_token_len :, :]
+        if self.apply_pixel_shuffle:
+            if self.dynamic_resolution and imgs_sizes is not None:
+                embeddings = _pixel_shuffle_dynamic_res(
+                    embeddings, imgs_sizes, self.radio_model.patch_dim
+                )
+            else:
+                embeddings = pixel_shuffle(embeddings, scale_factor=0.5)
+        return embeddings
+
+    def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
+        # Param-less wrapper: delegate straight to the child so checkpoint keys keep
+        # the ``radio_model.`` prefix without the base-class tp/dp_cp_group machinery.
+        sharded_sd = {}
+        for name, child in self.named_children():
+            sharded_sd.update(
+                sharded_state_dict_default(child, f"{prefix}{name}.", sharded_offsets, metadata)
+            )
+        return sharded_sd
+
+
+def radio_vision_encoder_spec(
+    args: argparse.Namespace,
+    vision_config: TransformerConfig,
+    pg_collection: Optional[ProcessGroupCollection],
+) -> ModuleSpec:
+    """Build the RADIO encoder ``ModuleSpec``, reading the RADIO knobs off ``args``."""
+    return ModuleSpec(
+        module=RADIOEncoderWrapper,
+        params={
+            "transformer_config": vision_config,
+            "transformer_layer_spec": get_vit_layer_with_transformer_engine_spec(),
+            "pg_collection": pg_collection,
+            "img_h": args.img_h,
+            "img_w": args.img_w,
+            "patch_dim": args.patch_dim,
+            "class_token_len": args.class_token_len,
+            "drop_class_token": args.disable_vision_class_token,
+            "apply_pixel_shuffle": args.pixel_shuffle,
+            "force_eval_mode": args.freeze_vit,
+            "dynamic_resolution": bool(getattr(args, "dynamic_resolution", False)),
+        },
+    )

--- a/examples/mimo/model_providers/radio_encoder.py
+++ b/examples/mimo/model_providers/radio_encoder.py
@@ -90,7 +90,6 @@ def radio_vision_config(args: argparse.Namespace, tp_size: int, pp_size: int) ->
     config.attention_dropout = 0.0
     config.hidden_dropout = 0.0
     config.mtp_num_layers = 0  # Trigger TransformerBlock's final_layernorm allocation.
-    config.use_cpu_initialization = True
     _make_dense_non_hybrid(config)  # ViT inherits no MoE/Mamba/hybrid settings.
     config.params_dtype = dtype
     config.pipeline_dtype = dtype

--- a/examples/mimo/model_providers/radio_encoder.py
+++ b/examples/mimo/model_providers/radio_encoder.py
@@ -1,12 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""RADIO vision encoder for hetero MIMO examples.
-
-Provides the RADIO encoder wrapper (class-token drop + pixel-shuffle adapter over
-core ``RADIOViTModel``), its vision ``TransformerConfig``, the encoder
-``ModuleSpec`` builder, and the RADIO-specific CLI args. Imported by the
-Nemotron6-MoE VLM provider.
-"""
+"""RADIO vision encoder for hetero MIMO examples: wrapper, vision config, encoder spec, and args."""
 
 from __future__ import annotations
 
@@ -27,8 +21,7 @@ from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.utils import sharded_state_dict_default
 
-# Canonical module name for the RADIO encoder. Single source of truth shared by
-# the provider (encoders-dict key) and the topology default encoder name.
+# Canonical RADIO encoder module name (shared by the provider key + topology default).
 RADIO_ENCODER_MODULE_NAME = "radio_encoder"
 
 
@@ -41,6 +34,8 @@ def add_radio_encoder_args(parser: argparse.ArgumentParser) -> argparse.Argument
                        help="Apply pixel shuffle to the RADIO features.")
     group.add_argument("--disable-vision-class-token", action="store_true",
                        help="Drop the RADIO class tokens from the emitted features.")
+    group.add_argument("--dynamic-resolution", action="store_true",
+                       help="Patchify each image at native aspect ratio with a token budget.")
     return parser
 
 

--- a/tests/unit_tests/models/mimo/test_radio_encoder.py
+++ b/tests/unit_tests/models/mimo/test_radio_encoder.py
@@ -46,7 +46,6 @@ def _build_wrapper(
         num_layers=2,
         hidden_size=HIDDEN,
         num_attention_heads=4,
-        use_cpu_initialization=True,
         params_dtype=params_dtype,
         bf16=params_dtype == torch.bfloat16,
         attention_backend=attention_backend,

--- a/tests/unit_tests/models/mimo/test_radio_encoder.py
+++ b/tests/unit_tests/models/mimo/test_radio_encoder.py
@@ -1,68 +1,123 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""CPU-only unit tests for the RADIO vision encoder helpers.
+"""GPU forward/backward test for the RADIO vision encoder wrapper.
 
-Covers the RADIO-specific arg registration and the encoder ``ModuleSpec`` builder
-mapping (the previously write-only ``--pixel-shuffle`` / ``--disable-vision-class-token``
-flags must now flow into the wrapper params). A real wrapper forward needs GPU/TE
-and is left to a functional (cog) check.
+Builds the real ``RADIOEncoderWrapper`` (RADIOViTModel + TE) via
+``radio_vision_encoder_spec`` and runs forward + backward on synthetic input,
+exercising the class-token-drop and pixel-shuffle flags (which change the output
+shape) plus the dynamic-resolution packed-tile path. Needs 1 GPU:
+
+    WORLD_SIZE=1 python -m torch.distributed.run --nproc_per_node=1 -m pytest \
+        tests/unit_tests/models/mimo/test_radio_encoder.py
 """
 
-import argparse
 from types import SimpleNamespace
+
+import pytest
+import torch
 
 from examples.mimo.model_providers.radio_encoder import (
     RADIOEncoderWrapper,
-    add_radio_encoder_args,
     radio_vision_encoder_spec,
 )
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+IMG = 224
+PATCH = 14
+CLASS_TOKENS = 8
+HIDDEN = 64
+PATCHES = (IMG // PATCH) ** 2  # 16 * 16 = 256
 
 
-def test_add_radio_encoder_args_registers_flags():
-    parser = argparse.ArgumentParser()
-    add_radio_encoder_args(parser)
-
-    defaults = parser.parse_args([])
-    assert defaults.class_token_len == 8
-    assert defaults.pixel_shuffle is False
-    assert defaults.disable_vision_class_token is False
-
-    enabled = parser.parse_args(
-        ["--class-token-len", "4", "--pixel-shuffle", "--disable-vision-class-token"]
-    )
-    assert enabled.class_token_len == 4
-    assert enabled.pixel_shuffle is True
-    assert enabled.disable_vision_class_token is True
-
-
-def test_radio_vision_encoder_spec_reads_args(monkeypatch):
-    # Avoid importing TransformerEngine on the CPU-only path.
-    monkeypatch.setattr(
-        "examples.mimo.model_providers.radio_encoder.get_vit_layer_with_transformer_engine_spec",
-        lambda: "layer-spec",
+def _build_wrapper(*, apply_pixel_shuffle, drop_class_token, dynamic_resolution):
+    """Build the wrapper through the production spec builder, then instantiate it."""
+    config = TransformerConfig(
+        num_layers=2, hidden_size=HIDDEN, num_attention_heads=4, use_cpu_initialization=True
     )
     args = SimpleNamespace(
-        img_h=512,
-        img_w=512,
-        patch_dim=16,
-        class_token_len=8,
-        pixel_shuffle=True,
-        disable_vision_class_token=True,
-        freeze_vit=True,
-        dynamic_resolution=False,
+        img_h=IMG,
+        img_w=IMG,
+        patch_dim=PATCH,
+        class_token_len=CLASS_TOKENS,
+        pixel_shuffle=apply_pixel_shuffle,
+        disable_vision_class_token=drop_class_token,
+        freeze_vit=False,
+        dynamic_resolution=dynamic_resolution,
     )
-    vision_config = object()
-
-    spec = radio_vision_encoder_spec(args, vision_config, pg_collection=None)
-
+    spec = radio_vision_encoder_spec(args, config, pg_collection=None)
     assert spec.module is RADIOEncoderWrapper
-    params = spec.params
-    assert params["transformer_config"] is vision_config
-    assert params["img_h"] == 512 and params["img_w"] == 512
-    assert params["patch_dim"] == 16
-    assert params["class_token_len"] == 8
-    # The previously write-only flags now drive the wrapper params.
-    assert params["apply_pixel_shuffle"] is True
-    assert params["drop_class_token"] is True
-    assert params["force_eval_mode"] is True
-    assert params["dynamic_resolution"] is False
+    return spec.module(**spec.params).cuda()
+
+
+def _has_finite_grad(module):
+    return any(
+        p.grad is not None and torch.isfinite(p.grad).all()
+        for p in module.parameters()
+        if p.requires_grad
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="RADIO encoder forward needs a GPU")
+class TestRADIOEncoderWrapper:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize(
+        "apply_pixel_shuffle,drop_class_token,expected_seq,expected_hidden",
+        [
+            # Raw RADIO output keeps the class tokens.
+            (False, False, PATCHES + CLASS_TOKENS, HIDDEN),
+            # Class-token drop removes class_token_len tokens.
+            (False, True, PATCHES, HIDDEN),
+            # Drop + 0.5x-per-axis pixel shuffle: seq /= 4, hidden *= 4.
+            (True, True, PATCHES // 4, HIDDEN * 4),
+        ],
+    )
+    def test_fixed_resolution_forward_backward(
+        self, apply_pixel_shuffle, drop_class_token, expected_seq, expected_hidden
+    ):
+        wrapper = _build_wrapper(
+            apply_pixel_shuffle=apply_pixel_shuffle,
+            drop_class_token=drop_class_token,
+            dynamic_resolution=False,
+        )
+        x = torch.randn(2, 3, IMG, IMG, device="cuda")
+
+        out = wrapper(x)
+        assert out.shape == torch.Size([2, expected_seq, expected_hidden])
+
+        out.sum().backward()
+        assert _has_finite_grad(wrapper)
+
+    def test_dynamic_resolution_forward_backward(self):
+        # Packed variable-tile path: one square tile of rows*cols patches, fed as
+        # pre-patchified features (matches the dynamic-resolution data builder).
+        wrapper = _build_wrapper(
+            apply_pixel_shuffle=True, drop_class_token=True, dynamic_resolution=True
+        )
+        rows = cols = 8
+        patches = rows * cols
+        feat_dim = 3 * PATCH * PATCH
+        x = torch.randn(1, patches, feat_dim, device="cuda")
+        imgs_sizes = torch.tensor([[rows * PATCH, cols * PATCH]], dtype=torch.int32)
+        cu_seqlens = torch.tensor([0, patches], dtype=torch.int32)
+        packed = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=torch.tensor(patches, dtype=torch.int32),
+            max_seqlen_kv=torch.tensor(patches, dtype=torch.int32),
+        )
+
+        out = wrapper(x, imgs_sizes=imgs_sizes, packed_seq_params=packed)
+        assert out.dim() == 3 and out.shape[0] == 1
+
+        out.sum().backward()
+        assert _has_finite_grad(wrapper)

--- a/tests/unit_tests/models/mimo/test_radio_encoder.py
+++ b/tests/unit_tests/models/mimo/test_radio_encoder.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""CPU-only unit tests for the RADIO vision encoder helpers.
+
+Covers the RADIO-specific arg registration and the encoder ``ModuleSpec`` builder
+mapping (the previously write-only ``--pixel-shuffle`` / ``--disable-vision-class-token``
+flags must now flow into the wrapper params). A real wrapper forward needs GPU/TE
+and is left to a functional (cog) check.
+"""
+
+import argparse
+from types import SimpleNamespace
+
+from examples.mimo.model_providers.radio_encoder import (
+    RADIOEncoderWrapper,
+    add_radio_encoder_args,
+    radio_vision_encoder_spec,
+)
+
+
+def test_add_radio_encoder_args_registers_flags():
+    parser = argparse.ArgumentParser()
+    add_radio_encoder_args(parser)
+
+    defaults = parser.parse_args([])
+    assert defaults.class_token_len == 8
+    assert defaults.pixel_shuffle is False
+    assert defaults.disable_vision_class_token is False
+
+    enabled = parser.parse_args(
+        ["--class-token-len", "4", "--pixel-shuffle", "--disable-vision-class-token"]
+    )
+    assert enabled.class_token_len == 4
+    assert enabled.pixel_shuffle is True
+    assert enabled.disable_vision_class_token is True
+
+
+def test_radio_vision_encoder_spec_reads_args(monkeypatch):
+    # Avoid importing TransformerEngine on the CPU-only path.
+    monkeypatch.setattr(
+        "examples.mimo.model_providers.radio_encoder.get_vit_layer_with_transformer_engine_spec",
+        lambda: "layer-spec",
+    )
+    args = SimpleNamespace(
+        img_h=512,
+        img_w=512,
+        patch_dim=16,
+        class_token_len=8,
+        pixel_shuffle=True,
+        disable_vision_class_token=True,
+        freeze_vit=True,
+        dynamic_resolution=False,
+    )
+    vision_config = object()
+
+    spec = radio_vision_encoder_spec(args, vision_config, pg_collection=None)
+
+    assert spec.module is RADIOEncoderWrapper
+    params = spec.params
+    assert params["transformer_config"] is vision_config
+    assert params["img_h"] == 512 and params["img_w"] == 512
+    assert params["patch_dim"] == 16
+    assert params["class_token_len"] == 8
+    # The previously write-only flags now drive the wrapper params.
+    assert params["apply_pixel_shuffle"] is True
+    assert params["drop_class_token"] is True
+    assert params["force_eval_mode"] is True
+    assert params["dynamic_resolution"] is False

--- a/tests/unit_tests/models/mimo/test_radio_encoder.py
+++ b/tests/unit_tests/models/mimo/test_radio_encoder.py
@@ -114,9 +114,12 @@ class TestRADIOEncoderWrapper:
         # Packed variable-tile path: one square tile of rows*cols patches, fed as
         # pre-patchified features (matches the dynamic-resolution data builder).
         # The packed (thd) attention path requires bf16 + a flash/fused backend
-        # (the fixed sbhd path tolerates fp32; this one does not). imgs_sizes /
-        # cu_seqlens / max_seqlen stay int32 on CPU, matching the data builder;
-        # RADIOViTModel itself adds class_token_len per tile to cu_seqlens.
+        # (the fixed sbhd path tolerates fp32; this one does not). TE fused attn
+        # needs cu_seqlens on CUDA (mirrors training/step.py::move_batch_to_cuda,
+        # which moves the PackedSeqParams index tensors to the device); max_seqlen
+        # is passed as plain ints; imgs_sizes stays on CPU since RADIOViTModel reads
+        # it via .tolist()/Python iteration. RADIOViTModel itself adds
+        # class_token_len per tile to cu_seqlens.
         wrapper = _build_wrapper(
             apply_pixel_shuffle=True,
             drop_class_token=True,
@@ -129,13 +132,13 @@ class TestRADIOEncoderWrapper:
         feat_dim = 3 * PATCH * PATCH
         x = torch.randn(1, patches, feat_dim, device="cuda", dtype=torch.bfloat16)
         imgs_sizes = torch.tensor([[rows * PATCH, cols * PATCH]], dtype=torch.int32)
-        cu_seqlens = torch.tensor([0, patches], dtype=torch.int32)
+        cu_seqlens = torch.tensor([0, patches], dtype=torch.int32, device="cuda")
         packed = PackedSeqParams(
             qkv_format="thd",
             cu_seqlens_q=cu_seqlens,
             cu_seqlens_kv=cu_seqlens,
-            max_seqlen_q=torch.tensor(patches, dtype=torch.int32),
-            max_seqlen_kv=torch.tensor(patches, dtype=torch.int32),
+            max_seqlen_q=patches,
+            max_seqlen_kv=patches,
         )
 
         out = wrapper(x, imgs_sizes=imgs_sizes, packed_seq_params=packed)

--- a/tests/unit_tests/models/mimo/test_radio_encoder.py
+++ b/tests/unit_tests/models/mimo/test_radio_encoder.py
@@ -22,6 +22,7 @@ from examples.mimo.model_providers.radio_encoder import (
 )
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
@@ -32,10 +33,23 @@ HIDDEN = 64
 PATCHES = (IMG // PATCH) ** 2  # 16 * 16 = 256
 
 
-def _build_wrapper(*, apply_pixel_shuffle, drop_class_token, dynamic_resolution):
+def _build_wrapper(
+    *,
+    apply_pixel_shuffle,
+    drop_class_token,
+    dynamic_resolution,
+    params_dtype=torch.float32,
+    attention_backend=AttnBackend.auto,
+):
     """Build the wrapper through the production spec builder, then instantiate it."""
     config = TransformerConfig(
-        num_layers=2, hidden_size=HIDDEN, num_attention_heads=4, use_cpu_initialization=True
+        num_layers=2,
+        hidden_size=HIDDEN,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        params_dtype=params_dtype,
+        bf16=params_dtype == torch.bfloat16,
+        attention_backend=attention_backend,
     )
     args = SimpleNamespace(
         img_h=IMG,
@@ -99,13 +113,21 @@ class TestRADIOEncoderWrapper:
     def test_dynamic_resolution_forward_backward(self):
         # Packed variable-tile path: one square tile of rows*cols patches, fed as
         # pre-patchified features (matches the dynamic-resolution data builder).
+        # The packed (thd) attention path requires bf16 + a flash/fused backend
+        # (the fixed sbhd path tolerates fp32; this one does not). imgs_sizes /
+        # cu_seqlens / max_seqlen stay int32 on CPU, matching the data builder;
+        # RADIOViTModel itself adds class_token_len per tile to cu_seqlens.
         wrapper = _build_wrapper(
-            apply_pixel_shuffle=True, drop_class_token=True, dynamic_resolution=True
+            apply_pixel_shuffle=True,
+            drop_class_token=True,
+            dynamic_resolution=True,
+            params_dtype=torch.bfloat16,
+            attention_backend=AttnBackend.flash,
         )
         rows = cols = 8
         patches = rows * cols
         feat_dim = 3 * PATCH * PATCH
-        x = torch.randn(1, patches, feat_dim, device="cuda")
+        x = torch.randn(1, patches, feat_dim, device="cuda", dtype=torch.bfloat16)
         imgs_sizes = torch.tensor([[rows * PATCH, cols * PATCH]], dtype=torch.int32)
         cu_seqlens = torch.tensor([0, patches], dtype=torch.int32)
         packed = PackedSeqParams(


### PR DESCRIPTION
Adds `examples/mimo/model_providers/radio_encoder.py`, a self-contained RADIO vision encoder module for the hetero MIMO examples:

- `RADIOEncoderWrapper` — class-token drop + pixel-shuffle adapter over core `RADIOViTModel`.
- `_pixel_shuffle_dynamic_res` — pixel shuffle for variable-size tiles (dynamic resolution).
- `radio_vision_config` — RADIO vision `TransformerConfig` overrides on the stock from-args base.
- `radio_vision_encoder_spec` — builds the encoder `ModuleSpec`, reading `--pixel-shuffle` / `--disable-vision-class-token` off args (these were previously write-only).
- `add_radio_encoder_args` — the small set of RADIO-specific CLI flags (`--class-token-len`, `--pixel-shuffle`, `--disable-vision-class-token`); image/patch/hidden sizes reuse stock `arguments.py`.

This is a leaf, merge-first dependency of the Nemotron6-MoE VLM provider PR.

Validation: `py_compile`, `ruff`, and `isort` clean on the new files; CPU-only unit test added under `tests/unit_tests/models/mimo/test_radio_encoder.py` (arg registration + spec arg-mapping). Wrapper forward needs GPU/TE and is deferred to a functional check.