### PR TITLE
Fix fast-cache-load rank synchronization guard

### DIFF
--- a/megatron/core/datasets/blended_megatron_dataset_builder.py
+++ b/megatron/core/datasets/blended_megatron_dataset_builder.py
@@ -440,7 +440,7 @@ class BlendedMegatronDatasetBuilder(object):
             False
             if (
                 synchronize_ranks
-                and (isinstance(self.cls, GPTDatasetConfig) and self.config.fast_cache_load)
+                and (isinstance(self.config, GPTDatasetConfig) and self.config.fast_cache_load)
             )
             else synchronize_ranks
         )  # NOTE(asolergi-nv): Set synchronize_ranks to False if we are using --dataloader-fast-cache-load # pylint: disable=C0301

--- a/tests/unit_tests/data/test_builder.py
+++ b/tests/unit_tests/data/test_builder.py
@@ -330,6 +330,58 @@ def test_builder():
         ).build()
 
 
+def test_fast_cache_load_disables_rank_synchronization(monkeypatch, tmp_path):
+    tokenizer = build_tokenizer(
+        Namespace(
+            vocab_size=2048,
+            tokenizer_type="NullTokenizer",
+            rank=0,
+            make_vocab_size_divisible_by=128,
+            tensor_model_parallel_size=1,
+        )
+    )
+    config = GPTDatasetConfig(
+        random_seed=1234,
+        sequence_length=8,
+        blend=None,
+        blend_per_split=[(["dummy-prefix"], None), (["dummy-prefix"], None), None],
+        split=None,
+        path_to_cache=str(tmp_path),
+        tokenizer=tokenizer,
+        reset_position_ids=False,
+        reset_attention_mask=False,
+        eod_mask_loss=False,
+        create_attention_mask=False,
+        fast_cache_load=True,
+    )
+    builder = BlendedMegatronDatasetBuilder(GPTDataset, [10, 10, 0], lambda: True, config)
+
+    class DummyLowLevelDataset:
+        sequence_lengths = numpy.ones(16, dtype=numpy.int32)
+
+    synchronize_ranks_values = []
+
+    monkeypatch.setattr(
+        GPTDataset,
+        "build_low_level_dataset",
+        staticmethod(lambda dataset_path, config: DummyLowLevelDataset()),
+    )
+
+    def record_synchronize_ranks(cls, is_built_on_rank, synchronize_ranks, *args):
+        synchronize_ranks_values.append(synchronize_ranks)
+        return object()
+
+    monkeypatch.setattr(
+        BlendedMegatronDatasetBuilder,
+        "build_generic_dataset",
+        staticmethod(record_synchronize_ranks),
+    )
+
+    builder._build_megatron_dataset_splits("dummy-prefix", config.split_matrix, [10, 10, 0])
+
+    assert synchronize_ranks_values == [False, False]
+
+
 @pytest.mark.parametrize("use_split", [True, False])
 @pytest.mark.parametrize("add_weights", [True, False])
 @pytest.mark.parametrize("fast_cache_load", [True, False])


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
Fix the `--dataloader-fast-cache-load` rank synchronization guard in `BlendedMegatronDatasetBuilder`.

The existing check used the dataset class object when testing for `GPTDatasetConfig`, which means the guard could fail to disable rank synchronization in some builder paths. This updates the check to inspect `self.config`, which is the actual dataset config instance.

## Motivation

`--dataloader-fast-cache-load` is intended to skip the rank-0-first synchronization path when loading dataset indices from an existing cache. However, the inner `_build_megatron_dataset_splits()` guard checked:

```python
isinstance(self.cls, GPTDatasetConfig)
```
self.cls is the dataset class, such as GPTDataset, not the config object. As a result, this condition is false even when self.config.fast_cache_load is enabled.

Some multi-prefix fast-cache cases may still work because higher-level builder paths already bypass synchronization, but the inner guard remains incorrect and can affect single-prefix paths, direct calls, or future refactors.
Changes

Use self.config instead of self.cls when checking for GPTDatasetConfig. Ensure synchronize_ranks is forced to False when --dataloader-fast-cache-load is enabled for GPT datasets.