### PR TITLE
[Fix] Fix MoE router z-loss compatibility with TE CUDA Graph capture.

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -643,11 +643,13 @@ class TopKRouter(Router):
                 valid_mask = ~padding_mask
                 z_loss_values = z_loss_values * valid_mask
                 num_local_tokens = valid_mask.sum()
+                z_loss_sum = z_loss_values.sum()
+                z_loss_mean = z_loss_sum / torch.clamp(num_local_tokens, min=1)
             else:
-                num_local_tokens = torch.tensor(logits.shape[0], device=logits.device)
-
-            z_loss_sum = z_loss_values.sum()
-            z_loss_mean = z_loss_sum / torch.clamp(num_local_tokens, min=1)
+                z_loss_sum = z_loss_values.sum()
+                # Keep the token count as a Python scalar so CUDA graph capture does not
+                # record a CPU-to-CUDA tensor creation.
+                z_loss_mean = z_loss_sum / max(logits.shape[0], 1)
 
             mtp_loss_scale = 1
             if (


### PR DESCRIPTION
Fix MoE router z-loss CUDA graph capture failure

When MoE router z-loss is enabled together with TE CUDA Graph capture
for moe_router, training can fail during graph creation if padding_mask is
None.

The previous implementation created a CUDA tensor from logits.shape[0]:

   ` torch.tensor(logits.shape[0], device=logits.device)`

During CUDA graph capture this records a CPU-to-CUDA copy, which PyTorch
rejects unless the CPU tensor is pinned.

This change keeps the no-padding token count as a Python scalar and uses
it directly as the divisor for z_loss_mean. The padding-mask path still
uses the tensor count from valid_mask.sum(), preserving existing behavior
for padded inputs.

This keeps router z-loss compatible with TE CUDA Graph while preserving
per-token loss scaling, MTP scaling, and z-loss metric logging.