### PR TITLE
Fix merges_file kwarg name in HuggingFaceTokenizer

### DIFF
--- a/megatron/core/tokenizers/text/libraries/huggingface_tokenizer.py
+++ b/megatron/core/tokenizers/text/libraries/huggingface_tokenizer.py
@@ -83,7 +83,7 @@ class HuggingFaceTokenizer(MegatronTokenizerTextAbstract):
                 self.tokenizer = AutoTokenizer.from_pretrained(
                     pretrained_model_name_or_path=tokenizer_path,
                     vocab_file=vocab_file,
-                    merge_files=merges_file,
+                    merges_file=merges_file,
                     use_fast=use_fast,
                     trust_remote_code=trust_remote_code,
                 )


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Fixes a keyword-argument typo in `HuggingFaceTokenizer`. When both `vocab_file` and `merges_file` are supplied, the tokenizer called `AutoTokenizer.from_pretrained` with the misspelled keyword `merge_files` instead of `merges_file`. Slow HF tokenizers such as `GPT2Tokenizer` require the correctly spelled keyword, so this code path silently failed for any user who passed both files. The fix passes `merges_file=` as the transformers API actually expects.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR