### PR TITLE
Fix invalid academic example script placeholders

### DIFF
--- a/examples/academic_paper_scripts/msdp/README.md
+++ b/examples/academic_paper_scripts/msdp/README.md
@@ -3,3 +3,4 @@
 
 This directory contains all the scripts of multi-stage prompting for knowledgeable dialogue generation that includes data preparation, and knowledge and response generations. More details are available on [`knowledgeable task directory`](../../tasks/msdp).
 
+The scripts expect input paths to be set as environment variables and fail with a clear message when a required value is missing.

--- a/examples/academic_paper_scripts/msdp/data_processing.sh
+++ b/examples/academic_paper_scripts/msdp/data_processing.sh
@@ -8,76 +8,75 @@
 DIR=`pwd`
 # Before running the preprocessing, please download 
 # the wizard of wikipedia and wizard datasets
-WOW_DATA_FOLDER=<PATH_OF_WIZARD_OF_WIKIPEDIA_DATA_FOLDER>
-WOI_DATA_FOLDER=<PATH_OF_WIZARD_OF_INTERNET_DATA_FOLDER>
+: "${WOW_DATA_FOLDER:?Set WOW_DATA_FOLDER, e.g. /path/to/wizard_of_wikipedia}"
+: "${WOI_DATA_FOLDER:?Set WOI_DATA_FOLDER, e.g. /path/to/wizard_of_internet}"
 
 # We provide examples for processing the raw data from Wizard of Wikipedia
 # Processing the train dataset (train.json)
 python ${DIR}/tasks/msdp/preprocessing.py \
         --func process_wow_dataset \
-        --raw_file ${WOW_DATA_FOLDER}/train.json \
-        --processed_file ${WOW_DATA_FOLDER}/train_processed.txt
+        --raw_file "${WOW_DATA_FOLDER}/train.json" \
+        --processed_file "${WOW_DATA_FOLDER}/train_processed.txt"
 
 # Processing test seen dataset (test_random_split.json)
 python ${DIR}/tasks/msdp/preprocessing.py \
         --func process_wow_dataset \
-        --raw_file ${WOW_DATA_FOLDER}/test_random_split.json \
-        --processed_file ${WOW_DATA_FOLDER}/testseen_processed.txt \
-        --knwl_ref_file ${WOW_DATA_FOLDER}/output_testseen_knowledge_reference.txt \
-        --resp_ref_file ${WOW_DATA_FOLDER}/output_testseen_response_reference.txt
+        --raw_file "${WOW_DATA_FOLDER}/test_random_split.json" \
+        --processed_file "${WOW_DATA_FOLDER}/testseen_processed.txt" \
+        --knwl_ref_file "${WOW_DATA_FOLDER}/output_testseen_knowledge_reference.txt" \
+        --resp_ref_file "${WOW_DATA_FOLDER}/output_testseen_response_reference.txt"
 
 # processing test unseen dataset (test_topic_split.json)
 python ${DIR}/tasks/msdp/preprocessing.py \
         --func process_wow_dataset \
-        --raw_file ${WOW_DATA_FOLDER}/test_topic_split.json \
-        --processed_file ${WOW_DATA_FOLDER}/testunseen_processed.txt \
-        --knwl_ref_file ${WOW_DATA_FOLDER}/output_testunseen_knowledge_reference.txt \
-        --resp_ref_file ${WOW_DATA_FOLDER}/output_testunseen_response_reference.txt
+        --raw_file "${WOW_DATA_FOLDER}/test_topic_split.json" \
+        --processed_file "${WOW_DATA_FOLDER}/testunseen_processed.txt" \
+        --knwl_ref_file "${WOW_DATA_FOLDER}/output_testunseen_knowledge_reference.txt" \
+        --resp_ref_file "${WOW_DATA_FOLDER}/output_testunseen_response_reference.txt"
 
 
 # We provide the following script to process the raw data from Wizard of Internet
 # Processing the test dataset (test.jsonl)
 python ${DIR}/tasks/msdp/preprocessing.py \
         --func process_woi_dataset \
-        --raw_file ${WOI_DATA_FOLDER}/test.jsonl \
-        --processed_file ${WOI_DATA_FOLDER}/test_processed.txt \
-        --knwl_ref_file ${WOI_DATA_FOLDER}/output_test_knowledge_reference.txt \
-        --resp_ref_file ${WOI_DATA_FOLDER}/output_test_response_reference.txt
+        --raw_file "${WOI_DATA_FOLDER}/test.jsonl" \
+        --processed_file "${WOI_DATA_FOLDER}/test_processed.txt" \
+        --knwl_ref_file "${WOI_DATA_FOLDER}/output_test_knowledge_reference.txt" \
+        --resp_ref_file "${WOI_DATA_FOLDER}/output_test_response_reference.txt"
 
 
 # Get the knowledge generation prompts for the each test dataset in WoW and WoI
-MODEL_FILE=<PATH_OF_THE_FINETUNED_DPR_MODEL> 
+: "${MODEL_FILE:?Set MODEL_FILE, e.g. /path/to/finetuned_dpr_model}"
 # WoW test seen
 python ${DIR}/tasks/msdp/preprocessing.py \
         --func get_knwl_gen_prompts \
-        --test_file ${WOW_DATA_FOLDER}/testseen_processed.txt \
-        --train_file ${WOW_DATA_FOLDER}/train_processed.txt \
-        --model_file ${MODEL_FILE} \
-        --processed_file ${WOW_DATA_FOLDER}/output_testseen_knowledge_prompts.json \
+        --test_file "${WOW_DATA_FOLDER}/testseen_processed.txt" \
+        --train_file "${WOW_DATA_FOLDER}/train_processed.txt" \
+        --model_file "${MODEL_FILE}" \
+        --processed_file "${WOW_DATA_FOLDER}/output_testseen_knowledge_prompts.json" \
         --data_type wow_seen
 
 # WoW test unseen
 python ${DIR}/tasks/msdp/preprocessing.py \
         --func get_knwl_gen_prompts \
-        --test_file ${WOW_DATA_FOLDER}/testunseen_processed.txt \
-        --train_file ${WOW_DATA_FOLDER}/train_processed.txt \
-        --model_file ${MODEL_FILE} \
-        --processed_file ${WOW_DATA_FOLDER}/output_testunseen_knowledge_prompts.json \
+        --test_file "${WOW_DATA_FOLDER}/testunseen_processed.txt" \
+        --train_file "${WOW_DATA_FOLDER}/train_processed.txt" \
+        --model_file "${MODEL_FILE}" \
+        --processed_file "${WOW_DATA_FOLDER}/output_testunseen_knowledge_prompts.json" \
         --data_type wow_unseen
 
 # WoI
 python ${DIR}/tasks/msdp/preprocessing.py \
         --func get_knwl_gen_prompts \
-        --test_file ${WOI_DATA_FOLDER}/test_processed.txt \
-        --train_file ${WOW_DATA_FOLDER}/train_processed.txt \
-        --model_file ${MODEL_FILE} \
-        --processed_file ${WOI_DATA_FOLDER}/output_test_knowledge_prompts.json \
+        --test_file "${WOI_DATA_FOLDER}/test_processed.txt" \
+        --train_file "${WOW_DATA_FOLDER}/train_processed.txt" \
+        --model_file "${MODEL_FILE}" \
+        --processed_file "${WOI_DATA_FOLDER}/output_test_knowledge_prompts.json" \
         --data_type woi
 
 
 # Get the response generation prompts (can be applied for all the test datasets)
 python ${DIR}/tasks/msdp/preprocessing.py \
         --func get_resp_gen_prompts \
-        --train_file ${WOW_DATA_FOLDER}/train_processed.txt \
-        --processed_file ${WOW_DATA_FOLDER}/output_response_prompts.txt
-
+        --train_file "${WOW_DATA_FOLDER}/train_processed.txt" \
+        --processed_file "${WOW_DATA_FOLDER}/output_response_prompts.txt"

--- a/examples/academic_paper_scripts/msdp/eval_knwl_generation.sh
+++ b/examples/academic_paper_scripts/msdp/eval_knwl_generation.sh
@@ -11,10 +11,9 @@ DISTRIBUTED_ARGS="--nproc_per_node $WORLD_SIZE \
                   --master_addr localhost \
                   --master_port 6000"
                   
-MODEL_GEN_PATH=<PATH_OF_THE_KNOWLEDGE_GENERATION> \ 
-        (e.g., /testseen_knowledge_generations.txt)
-GROUND_TRUTH_PATH=<PATH_OF_THE_GROUND_TRUTH_KNOWLEDGE> \ 
-        (e.g., /testseen_knowledge_reference.txt)
+# Required inputs. Set these in the environment before running this script.
+: "${MODEL_GEN_PATH:?Set MODEL_GEN_PATH, e.g. /path/to/testseen_knowledge_generations.txt}"
+: "${GROUND_TRUTH_PATH:?Set GROUND_TRUTH_PATH, e.g. /path/to/testseen_knowledge_reference.txt}"
 
 python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
         --num-layers 24 \
@@ -24,8 +23,8 @@ python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
         --max-position-embeddings 2048 \
         --micro-batch-size 4 \
         --task MSDP-EVAL-F1 \
-        --guess-file ${MODEL_GEN_PATH} \
-        --answer-file ${GROUND_TRUTH_PATH}
+        --guess-file "${MODEL_GEN_PATH}" \
+        --answer-file "${GROUND_TRUTH_PATH}"
 
 
 ############################################
@@ -39,5 +38,5 @@ python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
 # the nlg-eval github, and run the corresponding evaluation commands.
 
 nlg-eval \
-    --hypothesis=<PATH_OF_THE_KNOWLEDGE_GENERATION> \
-    --references=<PATH_OF_THE_GROUND_TRUTH_KNOWLEDGE>
+    --hypothesis="${MODEL_GEN_PATH}" \
+    --references="${GROUND_TRUTH_PATH}"

--- a/examples/academic_paper_scripts/msdp/eval_resp_generation.sh
+++ b/examples/academic_paper_scripts/msdp/eval_resp_generation.sh
@@ -11,10 +11,10 @@ DISTRIBUTED_ARGS="--nproc_per_node $WORLD_SIZE \
                   --master_addr localhost \
                   --master_port 6000"
                   
-MODEL_GEN_PATH=<PATH_OF_THE_RESPONSE_GENERATION> \ 
-        (e.g., /testseen_response_generations.txt)
-GROUND_TRUTH_PATH=<PATH_OF_THE_GROUND_TRUTH_RESPONSE> \ 
-        (e.g., /testseen_response_reference.txt)
+# Required inputs. Set these in the environment before running this script.
+: "${MODEL_GEN_PATH:?Set MODEL_GEN_PATH, e.g. /path/to/testseen_response_generations.txt}"
+: "${GROUND_TRUTH_RESPONSE_PATH:?Set GROUND_TRUTH_RESPONSE_PATH, e.g. /path/to/testseen_response_reference.txt}"
+: "${GROUND_TRUTH_KNOWLEDGE_PATH:?Set GROUND_TRUTH_KNOWLEDGE_PATH, e.g. /path/to/testseen_knowledge_reference.txt}"
 
 python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
         --num-layers 24 \
@@ -24,19 +24,14 @@ python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
         --max-position-embeddings 2048 \
         --micro-batch-size 4 \
         --task MSDP-EVAL-F1 \
-        --guess-file ${MODEL_GEN_PATH} \
-        --answer-file ${GROUND_TRUTH_PATH}
+        --guess-file "${MODEL_GEN_PATH}" \
+        --answer-file "${GROUND_TRUTH_RESPONSE_PATH}"
 
 
 ##########################
 # Evaluate the KF1 scores.
 ##########################
                   
-MODEL_GEN_PATH=<PATH_OF_THE_RESPONSE_GENERATION> \ 
-        (e.g., /testseen_response_generations.txt)
-GROUND_TRUTH_PATH=<PATH_OF_THE_GROUND_TRUTH_KNOWLEDGE> \ 
-        (e.g., /testseen_knowledge_reference.txt)
-
 python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
         --num-layers 24 \
         --hidden-size 1024 \
@@ -45,8 +40,8 @@ python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
         --max-position-embeddings 2048 \
         --micro-batch-size 4 \
         --task MSDP-EVAL-F1 \
-        --guess-file ${MODEL_GEN_PATH} \
-        --answer-file ${GROUND_TRUTH_PATH}
+        --guess-file "${MODEL_GEN_PATH}" \
+        --answer-file "${GROUND_TRUTH_KNOWLEDGE_PATH}"
 
 
 ############################################
@@ -60,5 +55,5 @@ python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
 # the nlg-eval github, and run the corresponding evaluation commands.
 
 nlg-eval \
-    --hypothesis=<PATH_OF_THE_RESPONSE_GENERATION> \
-    --references=<PATH_OF_THE_GROUND_TRUTH_RESPONSE>
+    --hypothesis="${MODEL_GEN_PATH}" \
+    --references="${GROUND_TRUTH_RESPONSE_PATH}"

--- a/examples/academic_paper_scripts/msdp/prep_resp_gen.sh
+++ b/examples/academic_paper_scripts/msdp/prep_resp_gen.sh
@@ -4,15 +4,13 @@
 
 DIR=`pwd`
 
-TEST_FILE=<PATH_OF_PROCESSED_TEST_DATA> \
-        (e.g., /testseen_processed.txt)
-KNOWLEDGE_FILE=<PATH_OF_GENERATED_KNOWLEDGE_DATA> \
-        (e.g., /testseen_knowledge_generations.txt)
-PROCESSED_FILE=<PATH_OF_INPUT_FILE_FOR_RESPONSE_GENERATION> \
-        (e.g., /testseen_processed_with_generated_knowledge.txt)
+# Required inputs. Set these in the environment before running this script.
+: "${TEST_FILE:?Set TEST_FILE, e.g. /path/to/testseen_processed.txt}"
+: "${KNOWLEDGE_FILE:?Set KNOWLEDGE_FILE, e.g. /path/to/testseen_knowledge_generations.txt}"
+: "${PROCESSED_FILE:?Set PROCESSED_FILE, e.g. /path/to/testseen_processed_with_generated_knowledge.txt}"
 
 python ${DIR}/tasks/msdp/preprocessing.py \
         --func prepare_input \
-        --test_file ${TEST_FILE} \
-        --knwl_gen_file ${KNOWLEDGE_FILE} \
-        --processed_file ${PROCESSED_FILE}
+        --test_file "${TEST_FILE}" \
+        --knwl_gen_file "${KNOWLEDGE_FILE}" \
+        --processed_file "${PROCESSED_FILE}"

--- a/examples/academic_paper_scripts/msdp/prompt_knwl_gen.sh
+++ b/examples/academic_paper_scripts/msdp/prompt_knwl_gen.sh
@@ -12,15 +12,13 @@ DISTRIBUTED_ARGS="--nproc_per_node $WORLD_SIZE \
                   --master_addr localhost \
                   --master_port 6000"
 
-CHECKPOINT_PATH=<PATH_OF_LANGUAGE_MODEL> (e.g., /357m)
-VOCAB_PATH=<PATH_OF_VOCAB_FILE> (e.g., /gpt2-vocab.json)
-MERGE_PATH=<PATH_OF_MERGE_FILE> (e.g., /gpt2-merges.txt)
-INPUT_PATH=<PATH_OF_PROCESSED_TEST_DATA_FILE> \ 
-        (e.g., /testseen_processed.txt)
-PROMPT_PATH=<PATH_OF_KNOWLEDGE_GENERATION_PROMPTS> \
-        (e.g., /testseen_knowledge_prompts.json)
-OUTPUT_PATH=<PATH_OF_OUTPUT_GENERATION_FILE> \
-        (e.g., /testseen_knowledge_generations.txt)
+# Required inputs. Set these in the environment before running this script.
+: "${CHECKPOINT_PATH:?Set CHECKPOINT_PATH, e.g. /path/to/357m}"
+: "${VOCAB_PATH:?Set VOCAB_PATH, e.g. /path/to/gpt2-vocab.json}"
+: "${MERGE_PATH:?Set MERGE_PATH, e.g. /path/to/gpt2-merges.txt}"
+: "${INPUT_PATH:?Set INPUT_PATH, e.g. /path/to/testseen_processed.txt}"
+: "${PROMPT_PATH:?Set PROMPT_PATH, e.g. /path/to/testseen_knowledge_prompts.json}"
+: "${OUTPUT_PATH:?Set OUTPUT_PATH, e.g. /path/to/testseen_knowledge_generations.txt}"
 
 python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
         --num-layers 24 \
@@ -29,15 +27,15 @@ python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
         --seq-length 2048 \
         --max-position-embeddings 2048 \
         --micro-batch-size 1 \
-        --vocab-file ${VOCAB_PATH} \
-        --merge-file ${MERGE_PATH} \
-        --load ${CHECKPOINT_PATH} \
+        --vocab-file "${VOCAB_PATH}" \
+        --merge-file "${MERGE_PATH}" \
+        --load "${CHECKPOINT_PATH}" \
         --fp16 \
         --DDP-impl torch \
         --tokenizer-type GPT2BPETokenizer \
-        --sample-input-file ${INPUT_PATH} \
-        --sample-output-file ${OUTPUT_PATH} \
-        --prompt-file ${PROMPT_PATH} \
+        --sample-input-file "${INPUT_PATH}" \
+        --sample-output-file "${OUTPUT_PATH}" \
+        --prompt-file "${PROMPT_PATH}" \
         --prompt-type knowledge \
         --num-prompt-examples 10 \
         --task MSDP-PROMPT 

--- a/examples/academic_paper_scripts/msdp/prompt_resp_gen.sh
+++ b/examples/academic_paper_scripts/msdp/prompt_resp_gen.sh
@@ -13,14 +13,13 @@ DISTRIBUTED_ARGS="--nproc_per_node $WORLD_SIZE \
                   --master_addr localhost \
                   --master_port 6000"
 
-CHECKPOINT_PATH=<PATH_OF_LANGUAGE_MODEL> (e.g., /357m)
-VOCAB_PATH=<PATH_OF_VOCAB_FILE> (e.g., /gpt2-vocab.json)
-MERGE_PATH=<PATH_OF_MERGE_FILE> (e.g., /gpt2-merges.txt)
-INPUT_PATH=<PATH_OF_INPUT_TEST_DATA_FILE> (e.g., /testseen_processed.txt)
-PROMPT_PATH=<PATH_OF_RESPONSE_GENERATION_PROMPTS> \
-        (e.g., /response_prompts.txt)
-OUTPUT_PATH=<PATH_OF_OUTPUT_GENERATION_FILE> \
-        (e.g., /output_testseen_response_generations.txt)
+# Required inputs. Set these in the environment before running this script.
+: "${CHECKPOINT_PATH:?Set CHECKPOINT_PATH, e.g. /path/to/357m}"
+: "${VOCAB_PATH:?Set VOCAB_PATH, e.g. /path/to/gpt2-vocab.json}"
+: "${MERGE_PATH:?Set MERGE_PATH, e.g. /path/to/gpt2-merges.txt}"
+: "${INPUT_PATH:?Set INPUT_PATH, e.g. /path/to/testseen_processed.txt}"
+: "${PROMPT_PATH:?Set PROMPT_PATH, e.g. /path/to/response_prompts.txt}"
+: "${OUTPUT_PATH:?Set OUTPUT_PATH, e.g. /path/to/output_testseen_response_generations.txt}"
 
 python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
         --num-layers 24 \
@@ -29,15 +28,15 @@ python -m torch.distributed.launch $DISTRIBUTED_ARGS ./tasks/msdp/main.py \
         --seq-length 2048 \
         --max-position-embeddings 2048 \
         --micro-batch-size 1 \
-        --vocab-file ${VOCAB_PATH} \
-        --merge-file ${MERGE_PATH} \
-        --load ${CHECKPOINT_PATH} \
+        --vocab-file "${VOCAB_PATH}" \
+        --merge-file "${MERGE_PATH}" \
+        --load "${CHECKPOINT_PATH}" \
         --fp16 \
         --DDP-impl torch \
         --tokenizer-type GPT2BPETokenizer \
-        --sample-input-file ${INPUT_PATH} \
-        --sample-output-file ${OUTPUT_PATH} \
-        --prompt-file ${PROMPT_PATH} \
+        --sample-input-file "${INPUT_PATH}" \
+        --sample-output-file "${OUTPUT_PATH}" \
+        --prompt-file "${PROMPT_PATH}" \
         --prompt-type response \
         --num-prompt-examples 20 \
         --task MSDP-PROMPT 

--- a/examples/academic_paper_scripts/sc21/CONFIG.sh
+++ b/examples/academic_paper_scripts/sc21/CONFIG.sh
@@ -2,25 +2,29 @@
 
 
 # SLURM options.
-export SLURM_PARTITION=<slurm partition, used to feed -p option in slurm>
-export SLURM_ACCOUNT=<slurm account, used to feed -A option in slurm>
+: "${SLURM_PARTITION:?Set SLURM_PARTITION, e.g. batch}"
+: "${SLURM_ACCOUNT:?Set SLURM_ACCOUNT, e.g. my-slurm-account}"
+export SLURM_PARTITION
+export SLURM_ACCOUNT
 
 
 # Source code.
-export MEGATRON_CODE_DIR=<megatron source code directory>
+: "${MEGATRON_CODE_DIR:?Set MEGATRON_CODE_DIR, e.g. /path/to/Megatron-LM}"
+export MEGATRON_CODE_DIR
 
 
 # This variable is used to mount the relevant part of the filesystem
 # inside the docker container. Note that the `MEGATRON_CODE_DIR` and the
 # launch directory already get mounted; this variable should be used to
 # mount the directories that contain the data and tokenizer files.
-export DOCKER_MOUNT_DIR=<megatron dataset and bpe tokenizer vocab path>
+: "${DOCKER_MOUNT_DIR:?Set DOCKER_MOUNT_DIR, e.g. /path/to/data-and-tokenizers}"
+export DOCKER_MOUNT_DIR
 
 
 # Data and tokenizer files.
-MEGATRON_DATA=<path to megatron processed data>
-BPE_VOCAB_FILE=<path to bpe vocab file>
-BPE_MERGE_FILE=<path to bpe merges file>
+: "${MEGATRON_DATA:?Set MEGATRON_DATA, e.g. /path/to/megatron_processed_data}"
+: "${BPE_VOCAB_FILE:?Set BPE_VOCAB_FILE, e.g. /path/to/gpt2-vocab.json}"
+: "${BPE_MERGE_FILE:?Set BPE_MERGE_FILE, e.g. /path/to/gpt2-merges.txt}"
 
 
 # Megatron input parameters.
@@ -53,5 +57,4 @@ export MEGATRON_PARAMS=" ${MEGATRON_EXTRA_PARAMS} \
         --clip-grad 1.0 \
         --fp16 \
 	--loss-scale 8192 "
-
 

--- a/examples/academic_paper_scripts/sc21/README.md
+++ b/examples/academic_paper_scripts/sc21/README.md
@@ -16,9 +16,9 @@ To replicate these results use Megatron-LM commit: 6985e58938d40ad91ac07b0fddcfa
 
 ## Setup
 
-All the cluster-dependent variables are in [`CONFIG.sh`](./CONFIG.sh). Please
-update the unspecified values (in angle brackets `<...>`) before launching any
-scripts.
+All the cluster-dependent variables are validated in [`CONFIG.sh`](./CONFIG.sh).
+Set the required values before launching any scripts; missing values fail with
+an explicit error.
 
 
 


### PR DESCRIPTION
## Summary
- replace invalid angle-bracket placeholder assignments in academic MSDP and SC21 shell scripts with required environment variable checks
- quote path arguments that use those required variables
- update the MSDP and SC21 READMEs to describe the new fail-fast setup behavior

## Root cause
Some archived example scripts used placeholder assignments such as `CHECKPOINT_PATH=<...> (e.g., ...)` and unquoted Slurm placeholders with spaces. Bash treats those as executable syntax, so the scripts fail parsing before users can fill in their local paths.

## Validation
- `find examples/academic_paper_scripts -name '*.sh' -print0 | xargs -0 -n1 bash -n`\n- `rg -n "<PATH_OF|<path to|<slurm|=<[^>]+>|--[A-Za-z0-9_-]+=<[^>]+>" examples/academic_paper_scripts --glob '*.sh'` returns no matches\n- `git diff HEAD~1..HEAD --check`