### PR TITLE
Add Gefen optimizer option

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -47,6 +47,13 @@ HAVE_EMERGING_OPTIMIZERS = _eo_ver >= (0, 2)
 if HAVE_EMERGING_OPTIMIZERS:
     from emerging_optimizers.scalar_optimizers import Lion
 
+try:
+    from gefen import Gefen
+
+    HAVE_GEFEN = True
+except ImportError:
+    HAVE_GEFEN = False
+
 from megatron.core import parallel_state
 from megatron.core.optimizer.cpu_offloading.hybrid_optimizer import HybridDeviceOptimizer
 from megatron.core.optimizer_param_scheduler import (
@@ -486,7 +493,7 @@ def _get_megatron_optimizer_based_on_param_groups(
         Instance of MegatronOptimizer, or ``(optimizer, init_state_fn)`` when
         *skip_megatron_wrapping=True*.
     """
-    # All param_groups passed here must belong to the same optimizer type (adam / sgd).
+    # All param_groups passed here must belong to the same standard optimizer type.
     # Callers are responsible for splitting by optimizer type before calling this function.
 
     if skip_megatron_wrapping and config.use_precision_aware_optimizer:
@@ -595,6 +602,23 @@ def _get_megatron_optimizer_based_on_param_groups(
                                 opt.state[p]['exp_avg_sq'] = torch.zeros_like(p.data)
                             else:
                                 opt.initialize_state(p)
+
+        elif config.optimizer == 'gefen':
+            if not HAVE_GEFEN:
+                raise ImportError(
+                    "Gefen optimizer requires the gefen package to be importable. "
+                    "Install it or make sure the repository root is on PYTHONPATH."
+                )
+            optimizer = Gefen(
+                param_groups,
+                lr=config.lr,
+                fused=True,
+                betas=(config.adam_beta1, config.adam_beta2),
+                eps=config.adam_eps,
+                weight_decay=config.weight_decay,
+            )
+            # Gefen state depends on observed gradients and is initialized lazily on step().
+            init_state_fn = None
 
         elif config.optimizer == 'lion':
             if not HAVE_EMERGING_OPTIMIZERS:
@@ -1022,7 +1046,7 @@ def get_megatron_optimizer(
 
     # TODO: the standard and emerging optimizer paths handle pg_collection differently;
     # unify them so both use a single pg_collection-based flow.
-    if config.optimizer not in ('adam', 'sgd'):
+    if config.optimizer not in ('adam', 'sgd', 'gefen'):
         return _get_megatron_emerging_optimizer(
             config=config,
             model_chunks=model_chunks,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2594,7 +2594,16 @@ def _add_training_args(parser):
                        help='use FlashAttention implementation of attention. '
                        'https://arxiv.org/abs/2205.14135')
     group.add_argument('--optimizer', type=str, default='adam',
-                       choices=['adam', 'sgd', 'muon', 'dist_muon', 'lion', 'soap', 'adaptive_muon'],
+                       choices=[
+                           'adam',
+                           'sgd',
+                           'gefen',
+                           'muon',
+                           'dist_muon',
+                           'lion',
+                           'soap',
+                           'adaptive_muon',
+                       ],
                        help='Optimizer function. '
                             'Note: dist_muon is deprecated; use --optimizer muon '
                             'with --use-distributed-optimizer instead.')


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Adds Gefen as an optional optimizer choice in Megatron-LM.

## Issue tracking

Linked issue: Related to 5413

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

## Details

This PR adds `gefen` as a supported value for the `--optimizer` argument.

When `--optimizer gefen` is selected, Megatron-LM instantiates `Gefen` with the same optimizer arguments used by Adam-style optimizers:

- `lr`
- `betas`
- `eps`
- `weight_decay`
- `fused=True`

Gefen remains optional. If `--optimizer gefen` is used but the Gefen package is unavailable, Megatron-LM raises an explicit import error.

## Testing

Tested locally with a small GPT mock-data training run using:

```bash
torchrun --nproc_per_node=1 pretrain_gpt.py \
  --num-layers 2 \
  --hidden-size 128 \
  --num-attention-heads 4 \
  --seq-length 128 \
  --max-position-embeddings 128 \
  --micro-batch-size 1 \
  --global-batch-size 1 \
  --train-iters 2 \
  --lr 1e-4 \
  --min-lr 1e-5 \
  --eval-interval 1000 \
  --eval-iters 1 \
  --lr-decay-style cosine \
  --lr-warmup-iters 1 \
  --weight-decay 0.01 \
  --tensor-model-parallel-size 1 \
  --pipeline-model-parallel-size 1 \
  --transformer-impl transformer_engine \
  --bf16 \
  --fp8-format hybrid \
  --fp8-amax-compute-algo max \
  --fp8-amax-history-len 16 \
  --mock-data \
  --optimizer gefen



### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
