### PR TITLE
Overlap experimental FSDP communication

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -24,7 +24,8 @@ from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
-from .parameter_group import FsdpParameterGroup, contained_in_parameter_group
+from .dbuffer import DBuffer
+from .parameter_group import FsdpParameterGroup, PendingReduction, contained_in_parameter_group
 from .placement import MeshAxis, Placements
 
 
@@ -36,11 +37,21 @@ class DelayedRelease:
     module: "FsdpModule"
 
 
+@dataclasses.dataclass(frozen=True)
+class PreparedReduction:
+    """A packed partial gradient waiting for a reduce-scatter launch point."""
+
+    group: FsdpParameterGroup
+    partial_grad: DBuffer
+
+
 class FsdpContext:
     """Runtime state, stream, and release scheduler shared by one FSDP subtree."""
 
-    allgather_stream: torch.cuda.Stream
+    communication_stream: torch.cuda.Stream
     delayed_releases: deque[DelayedRelease]
+    prepared_reductions: deque[PreparedReduction]
+    pending_reductions: deque[PendingReduction]
     # HFSDP/HSDP need explicit last-microbatch state. First-microbatch state is
     # unnecessary because it can be detected when ``model_weight``, after syncing
     # from ``main_weight``, has placements different from ``Placements.optimizer``.
@@ -57,12 +68,15 @@ class FsdpContext:
         self.root_module = root_module
         self.is_last_microbatch = True
         self.delayed_releases = deque()
+        self.prepared_reductions = deque()
+        self.pending_reductions = deque()
+        self._post_backward_callback_queued = False
         with torch.cuda.device(device):
-            self.allgather_stream = torch.cuda.Stream()
+            self.communication_stream = torch.cuda.Stream()
 
     def enqueue_release(self, module: "FsdpModule") -> None:
         """Queue a module's unsharded storage for delayed release."""
-        consumer_event = torch.cuda.current_stream(self.allgather_stream.device).record_event()
+        consumer_event = torch.cuda.current_stream(self.communication_stream.device).record_event()
         self.delayed_releases.append(DelayedRelease(consumer_event=consumer_event, module=module))
 
     def drain_delayed_releases(self, target_length: int) -> None:
@@ -72,10 +86,64 @@ class FsdpContext:
 
         while len(self.delayed_releases) > target_length:
             delayed_release = self.delayed_releases.popleft()
-            with torch.cuda.stream(self.allgather_stream):
+            with torch.cuda.stream(self.communication_stream):
                 if delayed_release.consumer_event is not None:
-                    self.allgather_stream.wait_event(delayed_release.consumer_event)
+                    self.communication_stream.wait_event(delayed_release.consumer_event)
                 delayed_release.module.release_unsharded_storage()
+
+    def enqueue_pending_reduction(self, pending_reduction: PendingReduction) -> None:
+        """Retain a scheduled reduction's temporary buffers until finalization."""
+        self.pending_reductions.append(pending_reduction)
+
+    def enqueue_prepared_reduction(self, prepared_reduction: PreparedReduction) -> None:
+        """Queue a packed partial gradient for a later reduce-scatter launch."""
+        self.prepared_reductions.append(prepared_reduction)
+
+    def launch_prepared_reductions(self) -> None:
+        """Launch queued reduce-scatters after work already ordered on the current stream."""
+        if not self.prepared_reductions:
+            return
+
+        current_stream = torch.cuda.current_stream(self.communication_stream.device)
+        self.communication_stream.wait_stream(current_stream)
+        with torch.cuda.stream(self.communication_stream):
+            while self.prepared_reductions:
+                prepared_reduction = self.prepared_reductions.popleft()
+                self.enqueue_pending_reduction(
+                    prepared_reduction.group.reduce_partial_gradients(
+                        prepared_reduction.partial_grad
+                    )
+                )
+
+    def queue_post_backward_callback(self) -> None:
+        """Queue a final callback to order default-stream consumers after reduction."""
+        if self._post_backward_callback_queued:
+            return
+
+        self._post_backward_callback_queued = True
+        try:
+            torch.autograd.Variable._execution_engine.queue_callback(
+                self.finalize_pending_reductions
+            )
+        except RuntimeError as error:
+            self._post_backward_callback_queued = False
+            if str(error) != "Final callbacks can only be installed during backward pass.":
+                raise
+            self.finalize_pending_reductions()
+
+    def finalize_pending_reductions(self) -> None:
+        """Wait for scheduled reductions and release their temporary buffers."""
+        try:
+            self.launch_prepared_reductions()
+            if not self.pending_reductions:
+                return
+
+            current_stream = torch.cuda.current_stream(self.communication_stream.device)
+            current_stream.wait_stream(self.communication_stream)
+            with torch.cuda.stream(self.communication_stream):
+                self.pending_reductions.clear()
+        finally:
+            self._post_backward_callback_queued = False
 
 
 class FsdpModule:
@@ -206,25 +274,27 @@ class FsdpModule:
         torch.cuda.nvtx.range_push(self._nvtx_label("forward"))
         self._ready_grad_parameters.clear()
         if self.is_root():
-            allgather_stream = self.context.allgather_stream
-            allgather_stream.wait_stream(torch.cuda.current_stream(allgather_stream.device))
+            communication_stream = self.context.communication_stream
+            communication_stream.wait_stream(
+                torch.cuda.current_stream(communication_stream.device)
+            )
         self._unshard_parameter_groups(sync_model_weight=True)
 
     def _unshard_parameter_groups(self, *, sync_model_weight: bool) -> None:
         """Materialize full parameters for this FSDP unit."""
         self.context.drain_delayed_releases(target_length=1)
 
-        allgather_stream = self.context.allgather_stream
-        current_stream = torch.cuda.current_stream(allgather_stream.device)
+        communication_stream = self.context.communication_stream
+        current_stream = torch.cuda.current_stream(communication_stream.device)
 
-        with torch.cuda.stream(allgather_stream):
+        with torch.cuda.stream(communication_stream):
             for group in self._parameter_groups:
                 if sync_model_weight:
                     # TODO: After NVIDIA/Megatron-LM#5411 lands, move this sync to the
                     # optimizer post-step hook instead of running it every microbatch.
                     group.sync_model_weight_from_main_weight()
                 group.unshard_parameters()
-        current_stream.wait_stream(allgather_stream)
+        current_stream.wait_stream(communication_stream)
 
     def post_forward(self) -> None:
         """Return parameters to their sharded resting state after forward compute."""
@@ -242,18 +312,37 @@ class FsdpModule:
         """Prepare full parameters for backward compute."""
         torch.cuda.nvtx.range_push(self._nvtx_label("backward"))
         self._unshard_parameter_groups(sync_model_weight=False)
+        self.context.launch_prepared_reductions()
 
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""
-        for group in self._parameter_groups:
-            if group.requires_grad:
-                group.reduce_gradients()
+        self._reduce_gradient_groups()
         self._reshard_parameter_groups()
         self.context.enqueue_release(self)
         if self.is_root():
             self.context.drain_delayed_releases(target_length=0)
         self._ready_grad_parameters.clear()
         torch.cuda.nvtx.range_pop()
+
+    def _reduce_gradient_groups(self) -> None:
+        context = self.context
+        current_stream = torch.cuda.current_stream(context.communication_stream.device)
+        scheduled_reduction = False
+        for group in self._parameter_groups:
+            if group.requires_grad:
+                with torch.cuda.stream(context.communication_stream):
+                    partial_grad = group.allocate_partial_grad_buffer()
+
+                current_stream.wait_stream(context.communication_stream)
+                group.copy_gradients_to_partial_buffer(partial_grad)
+
+                context.enqueue_prepared_reduction(
+                    PreparedReduction(group=group, partial_grad=partial_grad)
+                )
+                scheduled_reduction = True
+
+        if scheduled_reduction:
+            context.queue_post_backward_callback()
 
     def release_unsharded_storage(self) -> None:
         """Release unsharded storage owned by this FSDP unit."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -25,7 +25,7 @@ from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
-from .parameter_group import FsdpParameterGroup, PendingReduction, contained_in_parameter_group
+from .parameter_group import FsdpParameterGroup, contained_in_parameter_group
 from .placement import MeshAxis, Placements
 
 
@@ -52,7 +52,6 @@ class FsdpContext:
     reduce_scatter_stream: torch.cuda.Stream
     delayed_releases: deque[DelayedRelease]
     prepared_reductions: deque[PreparedReduction]
-    pending_reductions: deque[PendingReduction]
     # HFSDP/HSDP need explicit last-microbatch state. First-microbatch state is
     # unnecessary because it can be detected when ``model_weight``, after syncing
     # from ``main_weight``, has placements different from ``Placements.optimizer``.
@@ -70,7 +69,6 @@ class FsdpContext:
         self.is_last_microbatch = True
         self.delayed_releases = deque()
         self.prepared_reductions = deque()
-        self.pending_reductions = deque()
         with torch.cuda.device(device):
             self.allgather_stream = torch.cuda.Stream()
             self.reduce_scatter_stream = torch.cuda.Stream()
@@ -92,10 +90,6 @@ class FsdpContext:
                     self.allgather_stream.wait_event(delayed_release.consumer_event)
                 delayed_release.module.release_unsharded_storage()
 
-    def enqueue_pending_reduction(self, pending_reduction: PendingReduction) -> None:
-        """Retain a scheduled reduction's temporary buffers until finalization."""
-        self.pending_reductions.append(pending_reduction)
-
     def enqueue_prepared_reduction(self, prepared_reduction: PreparedReduction) -> None:
         """Queue a packed partial gradient for a later reduce-scatter launch."""
         self.prepared_reductions.append(prepared_reduction)
@@ -110,10 +104,8 @@ class FsdpContext:
         with torch.cuda.stream(self.reduce_scatter_stream):
             while self.prepared_reductions:
                 prepared_reduction = self.prepared_reductions.popleft()
-                self.enqueue_pending_reduction(
-                    prepared_reduction.group.reduce_partial_gradients(
-                        prepared_reduction.partial_grad
-                    )
+                prepared_reduction.group.reduce_partial_gradients(
+                    prepared_reduction.partial_grad
                 )
 
     def register_post_backward_final_callback(self) -> None:
@@ -124,19 +116,15 @@ class FsdpContext:
         at autograd completion orders consumers after every descendant reduction.
         """
         torch.autograd.Variable._execution_engine.queue_callback(
-            self.finalize_pending_reductions
+            self.post_backward_final_callback
         )
 
-    def finalize_pending_reductions(self) -> None:
-        """Wait for scheduled reductions and release their temporary buffers."""
+    def post_backward_final_callback(self) -> None:
+        """Launch delayed reductions and order subsequent work after their stream."""
         self.launch_prepared_reductions()
-        if not self.pending_reductions:
-            return
 
         current_stream = torch.cuda.current_stream(self.reduce_scatter_stream.device)
         current_stream.wait_stream(self.reduce_scatter_stream)
-        with torch.cuda.stream(self.reduce_scatter_stream):
-            self.pending_reductions.clear()
 
 
 class FsdpModule:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -33,14 +33,16 @@ from .placement import MeshAxis, Placements
 class DelayedRelease:
     """A module whose unsharded storage can be released after its consumer event."""
 
-    consumer_event: torch.cuda.Event | None
+    consumer_event: torch.cuda.Event
     module: "FsdpModule"
 
 
 @dataclasses.dataclass(frozen=True)
-class PreparedReduction:
-    """A packed partial gradient waiting for a reduce-scatter launch point."""
+class DelayedReduction:
+    """A packed partial gradient whose reduce-scatter can be launched after its
+    packing consumer event completes, mirroring ``DelayedRelease``."""
 
+    consumer_event: torch.cuda.Event
     group: FsdpParameterGroup
     partial_grad: DBuffer
 
@@ -51,7 +53,7 @@ class FsdpContext:
     allgather_stream: torch.cuda.Stream
     reduce_scatter_stream: torch.cuda.Stream
     delayed_releases: deque[DelayedRelease]
-    prepared_reductions: deque[PreparedReduction]
+    delayed_reductions: deque[DelayedReduction]
     # HFSDP/HSDP need explicit last-microbatch state. First-microbatch state is
     # unnecessary because it can be detected when ``model_weight``, after syncing
     # from ``main_weight``, has placements different from ``Placements.optimizer``.
@@ -68,7 +70,7 @@ class FsdpContext:
         self.root_module = root_module
         self.is_last_microbatch = True
         self.delayed_releases = deque()
-        self.prepared_reductions = deque()
+        self.delayed_reductions = deque()
         with torch.cuda.device(device):
             self.allgather_stream = torch.cuda.Stream()
             self.reduce_scatter_stream = torch.cuda.Stream()
@@ -86,27 +88,31 @@ class FsdpContext:
         while len(self.delayed_releases) > target_length:
             delayed_release = self.delayed_releases.popleft()
             with torch.cuda.stream(self.allgather_stream):
-                if delayed_release.consumer_event is not None:
-                    self.allgather_stream.wait_event(delayed_release.consumer_event)
+                self.allgather_stream.wait_event(delayed_release.consumer_event)
                 delayed_release.module.release_unsharded_storage()
 
-    def enqueue_prepared_reduction(self, prepared_reduction: PreparedReduction) -> None:
-        """Queue a packed partial gradient for a later reduce-scatter launch."""
-        self.prepared_reductions.append(prepared_reduction)
+    def enqueue_reduction(self, group: "FsdpParameterGroup", partial_grad: DBuffer) -> None:
+        """Queue a packed partial gradient for a later reduce-scatter launch.
 
-    def launch_prepared_reductions(self) -> None:
-        """Launch queued reduce-scatters after work already ordered on the current stream."""
-        if not self.prepared_reductions:
-            return
+        Records a consumer event on the current (compute) stream where the
+        gradients were packed, so the reduce-scatter waits for only that packing
+        rather than all default-stream work -- mirroring ``enqueue_release``.
+        """
+        consumer_event = torch.cuda.current_stream(self.reduce_scatter_stream.device).record_event()
+        self.delayed_reductions.append(
+            DelayedReduction(consumer_event=consumer_event, group=group, partial_grad=partial_grad)
+        )
 
-        current_stream = torch.cuda.current_stream(self.reduce_scatter_stream.device)
-        self.reduce_scatter_stream.wait_stream(current_stream)
-        with torch.cuda.stream(self.reduce_scatter_stream):
-            while self.prepared_reductions:
-                prepared_reduction = self.prepared_reductions.popleft()
-                prepared_reduction.group.reduce_partial_gradients(
-                    prepared_reduction.partial_grad
-                )
+    def drain_delayed_reductions(self, target_length: int) -> None:
+        """Launch queued reduce-scatters FIFO until the queue reaches ``target_length``."""
+        if target_length < 0:
+            raise ValueError(f"target_length must be non-negative, got {target_length}.")
+
+        while len(self.delayed_reductions) > target_length:
+            delayed_reduction = self.delayed_reductions.popleft()
+            with torch.cuda.stream(self.reduce_scatter_stream):
+                self.reduce_scatter_stream.wait_event(delayed_reduction.consumer_event)
+                delayed_reduction.group.reduce_partial_gradients(delayed_reduction.partial_grad)
 
     def register_post_backward_final_callback(self) -> None:
         """Register this root context's final callback for the current backward.
@@ -115,13 +121,11 @@ class FsdpContext:
         accumulated gradients; it may run before descendant reductions. Waiting
         at autograd completion orders consumers after every descendant reduction.
         """
-        torch.autograd.Variable._execution_engine.queue_callback(
-            self.post_backward_final_callback
-        )
+        torch.autograd.Variable._execution_engine.queue_callback(self.post_backward_final_callback)
 
     def post_backward_final_callback(self) -> None:
-        """Launch delayed reductions and order subsequent work after their stream."""
-        self.launch_prepared_reductions()
+        """Launch remaining delayed reductions and order subsequent work after their stream."""
+        self.drain_delayed_reductions(target_length=0)
 
         current_stream = torch.cuda.current_stream(self.reduce_scatter_stream.device)
         current_stream.wait_stream(self.reduce_scatter_stream)
@@ -293,7 +297,7 @@ class FsdpModule:
         if self.is_root():
             self.context.register_post_backward_final_callback()
         self._unshard_parameter_groups(sync_model_weight=False)
-        self.context.launch_prepared_reductions()
+        self.context.drain_delayed_reductions(target_length=0)
 
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""
@@ -316,9 +320,7 @@ class FsdpModule:
                 current_stream.wait_stream(context.reduce_scatter_stream)
                 group.copy_gradients_to_partial_buffer(partial_grad)
 
-                context.enqueue_prepared_reduction(
-                    PreparedReduction(group=group, partial_grad=partial_grad)
-                )
+                context.enqueue_reduction(group, partial_grad)
 
     def release_unsharded_storage(self) -> None:
         """Release unsharded storage owned by this FSDP unit."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -71,7 +71,6 @@ class FsdpContext:
         self.delayed_releases = deque()
         self.prepared_reductions = deque()
         self.pending_reductions = deque()
-        self._post_backward_callback_queued = False
         with torch.cuda.device(device):
             self.allgather_stream = torch.cuda.Stream()
             self.reduce_scatter_stream = torch.cuda.Stream()
@@ -117,35 +116,27 @@ class FsdpContext:
                     )
                 )
 
-    def queue_post_backward_callback(self) -> None:
-        """Queue a final callback to order default-stream consumers after reduction."""
-        if self._post_backward_callback_queued:
-            return
+    def register_post_backward_final_callback(self) -> None:
+        """Register this root context's final callback for the current backward.
 
-        self._post_backward_callback_queued = True
-        try:
-            torch.autograd.Variable._execution_engine.queue_callback(
-                self.finalize_pending_reductions
-            )
-        except RuntimeError as error:
-            self._post_backward_callback_queued = False
-            if str(error) != "Final callbacks can only be installed during backward pass.":
-                raise
-            self.finalize_pending_reductions()
+        Root ``post_backward()`` means only that root-owned parameters have
+        accumulated gradients; it may run before descendant reductions. Waiting
+        at autograd completion orders consumers after every descendant reduction.
+        """
+        torch.autograd.Variable._execution_engine.queue_callback(
+            self.finalize_pending_reductions
+        )
 
     def finalize_pending_reductions(self) -> None:
         """Wait for scheduled reductions and release their temporary buffers."""
-        try:
-            self.launch_prepared_reductions()
-            if not self.pending_reductions:
-                return
+        self.launch_prepared_reductions()
+        if not self.pending_reductions:
+            return
 
-            current_stream = torch.cuda.current_stream(self.reduce_scatter_stream.device)
-            current_stream.wait_stream(self.reduce_scatter_stream)
-            with torch.cuda.stream(self.reduce_scatter_stream):
-                self.pending_reductions.clear()
-        finally:
-            self._post_backward_callback_queued = False
+        current_stream = torch.cuda.current_stream(self.reduce_scatter_stream.device)
+        current_stream.wait_stream(self.reduce_scatter_stream)
+        with torch.cuda.stream(self.reduce_scatter_stream):
+            self.pending_reductions.clear()
 
 
 class FsdpModule:
@@ -311,6 +302,8 @@ class FsdpModule:
     def pre_backward(self) -> None:
         """Prepare full parameters for backward compute."""
         torch.cuda.nvtx.range_push(self._nvtx_label("backward"))
+        if self.is_root():
+            self.context.register_post_backward_final_callback()
         self._unshard_parameter_groups(sync_model_weight=False)
         self.context.launch_prepared_reductions()
 
@@ -327,7 +320,6 @@ class FsdpModule:
     def _reduce_gradient_groups(self) -> None:
         context = self.context
         current_stream = torch.cuda.current_stream(context.reduce_scatter_stream.device)
-        scheduled_reduction = False
         for group in self._parameter_groups:
             if group.requires_grad:
                 with torch.cuda.stream(context.reduce_scatter_stream):
@@ -339,10 +331,6 @@ class FsdpModule:
                 context.enqueue_prepared_reduction(
                     PreparedReduction(group=group, partial_grad=partial_grad)
                 )
-                scheduled_reduction = True
-
-        if scheduled_reduction:
-            context.queue_post_backward_callback()
 
     def release_unsharded_storage(self) -> None:
         """Release unsharded storage owned by this FSDP unit."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -48,7 +48,8 @@ class PreparedReduction:
 class FsdpContext:
     """Runtime state, stream, and release scheduler shared by one FSDP subtree."""
 
-    communication_stream: torch.cuda.Stream
+    allgather_stream: torch.cuda.Stream
+    reduce_scatter_stream: torch.cuda.Stream
     delayed_releases: deque[DelayedRelease]
     prepared_reductions: deque[PreparedReduction]
     pending_reductions: deque[PendingReduction]
@@ -72,11 +73,12 @@ class FsdpContext:
         self.pending_reductions = deque()
         self._post_backward_callback_queued = False
         with torch.cuda.device(device):
-            self.communication_stream = torch.cuda.Stream()
+            self.allgather_stream = torch.cuda.Stream()
+            self.reduce_scatter_stream = torch.cuda.Stream()
 
     def enqueue_release(self, module: "FsdpModule") -> None:
         """Queue a module's unsharded storage for delayed release."""
-        consumer_event = torch.cuda.current_stream(self.communication_stream.device).record_event()
+        consumer_event = torch.cuda.current_stream(self.allgather_stream.device).record_event()
         self.delayed_releases.append(DelayedRelease(consumer_event=consumer_event, module=module))
 
     def drain_delayed_releases(self, target_length: int) -> None:
@@ -86,9 +88,9 @@ class FsdpContext:
 
         while len(self.delayed_releases) > target_length:
             delayed_release = self.delayed_releases.popleft()
-            with torch.cuda.stream(self.communication_stream):
+            with torch.cuda.stream(self.allgather_stream):
                 if delayed_release.consumer_event is not None:
-                    self.communication_stream.wait_event(delayed_release.consumer_event)
+                    self.allgather_stream.wait_event(delayed_release.consumer_event)
                 delayed_release.module.release_unsharded_storage()
 
     def enqueue_pending_reduction(self, pending_reduction: PendingReduction) -> None:
@@ -104,9 +106,9 @@ class FsdpContext:
         if not self.prepared_reductions:
             return
 
-        current_stream = torch.cuda.current_stream(self.communication_stream.device)
-        self.communication_stream.wait_stream(current_stream)
-        with torch.cuda.stream(self.communication_stream):
+        current_stream = torch.cuda.current_stream(self.reduce_scatter_stream.device)
+        self.reduce_scatter_stream.wait_stream(current_stream)
+        with torch.cuda.stream(self.reduce_scatter_stream):
             while self.prepared_reductions:
                 prepared_reduction = self.prepared_reductions.popleft()
                 self.enqueue_pending_reduction(
@@ -138,9 +140,9 @@ class FsdpContext:
             if not self.pending_reductions:
                 return
 
-            current_stream = torch.cuda.current_stream(self.communication_stream.device)
-            current_stream.wait_stream(self.communication_stream)
-            with torch.cuda.stream(self.communication_stream):
+            current_stream = torch.cuda.current_stream(self.reduce_scatter_stream.device)
+            current_stream.wait_stream(self.reduce_scatter_stream)
+            with torch.cuda.stream(self.reduce_scatter_stream):
                 self.pending_reductions.clear()
         finally:
             self._post_backward_callback_queued = False
@@ -274,27 +276,25 @@ class FsdpModule:
         torch.cuda.nvtx.range_push(self._nvtx_label("forward"))
         self._ready_grad_parameters.clear()
         if self.is_root():
-            communication_stream = self.context.communication_stream
-            communication_stream.wait_stream(
-                torch.cuda.current_stream(communication_stream.device)
-            )
+            allgather_stream = self.context.allgather_stream
+            allgather_stream.wait_stream(torch.cuda.current_stream(allgather_stream.device))
         self._unshard_parameter_groups(sync_model_weight=True)
 
     def _unshard_parameter_groups(self, *, sync_model_weight: bool) -> None:
         """Materialize full parameters for this FSDP unit."""
         self.context.drain_delayed_releases(target_length=1)
 
-        communication_stream = self.context.communication_stream
-        current_stream = torch.cuda.current_stream(communication_stream.device)
+        allgather_stream = self.context.allgather_stream
+        current_stream = torch.cuda.current_stream(allgather_stream.device)
 
-        with torch.cuda.stream(communication_stream):
+        with torch.cuda.stream(allgather_stream):
             for group in self._parameter_groups:
                 if sync_model_weight:
                     # TODO: After NVIDIA/Megatron-LM#5411 lands, move this sync to the
                     # optimizer post-step hook instead of running it every microbatch.
                     group.sync_model_weight_from_main_weight()
                 group.unshard_parameters()
-        current_stream.wait_stream(communication_stream)
+        current_stream.wait_stream(allgather_stream)
 
     def post_forward(self) -> None:
         """Return parameters to their sharded resting state after forward compute."""
@@ -326,14 +326,14 @@ class FsdpModule:
 
     def _reduce_gradient_groups(self) -> None:
         context = self.context
-        current_stream = torch.cuda.current_stream(context.communication_stream.device)
+        current_stream = torch.cuda.current_stream(context.reduce_scatter_stream.device)
         scheduled_reduction = False
         for group in self._parameter_groups:
             if group.requires_grad:
-                with torch.cuda.stream(context.communication_stream):
+                with torch.cuda.stream(context.reduce_scatter_stream):
                     partial_grad = group.allocate_partial_grad_buffer()
 
-                current_stream.wait_stream(context.communication_stream)
+                current_stream.wait_stream(context.reduce_scatter_stream)
                 group.copy_gradients_to_partial_buffer(partial_grad)
 
                 context.enqueue_prepared_reduction(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 """Parameter-group runtime state for the minimal Megatron-FSDP path."""
-
-import dataclasses
 from contextlib import nullcontext
 
 import torch
@@ -33,14 +31,6 @@ _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 def contained_in_parameter_group(parameter: nn.Parameter) -> bool:
     """Return whether a parameter is already owned by an FsdpParameterGroup."""
     return hasattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR)
-
-
-@dataclasses.dataclass(frozen=True)
-class PendingReduction:
-    """Reduce-scatter buffers retained until the post-backward stream wait."""
-
-    partial_grad: DBuffer
-    reduced_grad: DBuffer | None
 
 
 class FsdpParameterGroup:
@@ -285,7 +275,7 @@ class FsdpParameterGroup:
         for parameter in self.unsharded_parameters:
             parameter.grad = None
 
-    def reduce_partial_gradients(self, partial_grad: DBuffer) -> PendingReduction:
+    def reduce_partial_gradients(self, partial_grad: DBuffer) -> None:
         """Reduce a packed partial gradient buffer into sharded parameter gradients."""
         assert self.main_grad is not None
 
@@ -325,8 +315,6 @@ class FsdpParameterGroup:
         if not has_sharded_grads:
             for index, parameter in enumerate(self.sharded_parameters):
                 parameter.grad = self.main_grad.get_dtensor(index)
-
-        return PendingReduction(partial_grad=partial_grad, reduced_grad=reduced_grad)
 
     def _require_unsharded_grads(self) -> tuple[torch.Tensor, ...]:
         grads: list[torch.Tensor] = []

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -14,7 +14,7 @@
 
 """Parameter-group runtime state for the minimal Megatron-FSDP path."""
 
-from collections.abc import Iterable
+import dataclasses
 from contextlib import nullcontext
 
 import torch
@@ -33,6 +33,14 @@ _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 def contained_in_parameter_group(parameter: nn.Parameter) -> bool:
     """Return whether a parameter is already owned by an FsdpParameterGroup."""
     return hasattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR)
+
+
+@dataclasses.dataclass(frozen=True)
+class PendingReduction:
+    """Reduce-scatter buffers retained until the post-backward stream wait."""
+
+    partial_grad: DBuffer
+    reduced_grad: DBuffer | None
 
 
 class FsdpParameterGroup:
@@ -87,6 +95,11 @@ class FsdpParameterGroup:
         self.dtype = first_parameter.dtype
         self.requires_grad = first_parameter.requires_grad
         for name, parameter in parameters.items():
+            if parameter.is_meta:
+                raise ValueError(
+                    f"Expected parameter {name!r} to be materialized before "
+                    "FsdpParameterGroup construction."
+                )
             if parameter.dtype != self.dtype:
                 raise ValueError(
                     f"Expected parameter {name!r} to have dtype {self.dtype}, "
@@ -245,49 +258,57 @@ class FsdpParameterGroup:
         # so keep the shared storage-release path.
         self._unsharded_model_weight.release_storage()
 
-    def reduce_gradients(self) -> None:
-        """Reduce full local gradients into sharded parameter gradients."""
+    def allocate_partial_grad_buffer(self) -> DBuffer:
+        """Allocate the unreduced reduce-scatter input buffer."""
         assert self.main_grad is not None
-
-        def has_grad(parameters: Iterable[nn.Parameter]) -> bool:
-            has_any_grad = False
-            has_any_missing_grad = False
-            for parameter in parameters:
-                if parameter.grad is None:
-                    has_any_missing_grad = True
-                else:
-                    has_any_grad = True
-            if has_any_grad and has_any_missing_grad:
-                raise RuntimeError("FSDP sharded gradients must be either all set or all None.")
-            return has_any_grad
-
-        grads: list[torch.Tensor] = []
-        for name, parameter in zip(self.parameter_names, self.unsharded_parameters, strict=True):
-            if parameter.grad is None:
-                raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
-            grads.append(parameter.grad)
 
         # NCCL symmetric-memory reduce-scatter only selects the symmetric kernel for SUM today.
         # Preserve AVG semantics by reducing SUM and scaling the output below.
         partial_op = dist.ReduceOp.AVG if self._symm_mem_pool is None else dist.ReduceOp.SUM
+        grads = self._require_unsharded_grads()
         with self._symmetric_memory_context():
-            partial_grad = DBuffer.distribute_tensors(
-                grads, mesh=self.mesh, placements=[Partial(partial_op)] * self.mesh.ndim
+            return DBuffer(
+                mesh=self.mesh,
+                placements=[Partial(partial_op)] * self.mesh.ndim,
+                tensor_shapes=tuple(grad.shape for grad in grads),
+                dtype=grads[0].dtype,
+                device=grads[0].device,
             )
+
+    def copy_gradients_to_partial_buffer(self, partial_grad: DBuffer) -> None:
+        """Pack full local gradients into an existing reduce-scatter input buffer."""
+        grads = self._require_unsharded_grads()
+        # This packs per-parameter grads into the reduce-scatter input buffer. A future
+        # fused-wgrad path can avoid this copy by writing directly into those buffer views.
+        for index, grad in enumerate(grads):
+            partial_grad.get_local_tensor(index).copy_(grad)
+        for parameter in self.unsharded_parameters:
+            parameter.grad = None
+
+    def reduce_partial_gradients(self, partial_grad: DBuffer) -> PendingReduction:
+        """Reduce a packed partial gradient buffer into sharded parameter gradients."""
+        assert self.main_grad is not None
 
         # zero_grad(set_to_none=True) clears sharded parameter grads, so the next
         # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
         # leaves sharded grads installed, so this backward accumulates into main_grad.
-        has_sharded_grads = has_grad(self.sharded_parameters)
+        has_sharded_grads = self._sharded_parameters_have_grad()
         can_reduce_into_main_grad = (
             not has_sharded_grads and partial_grad.dtype == self.main_grad.dtype
         )
         reduce_axis = changed_mesh_axis(partial_grad.placements, self.main_grad.placements)
         if reduce_axis is None:
             raise RuntimeError("FSDP gradient reduction requires a changed placement axis.")
-        grad_divisor = self.mesh.size(reduce_axis) if partial_op == dist.ReduceOp.SUM else 1
+        partial_placement = partial_grad.placements[reduce_axis]
+        assert isinstance(partial_placement, Partial)
+        grad_divisor = (
+            self.mesh.size(reduce_axis)
+            if partial_placement.reduce_op == dist.ReduceOp.SUM
+            else 1
+        )
         if self._symm_mem_pool is not None:
             partial_grad.rendezvous(reduce_axis)
+        reduced_grad = None
         if can_reduce_into_main_grad:
             partial_grad.redistribute(self.main_grad.placements, out=self.main_grad)
             if grad_divisor != 1:
@@ -305,8 +326,27 @@ class FsdpParameterGroup:
             for index, parameter in enumerate(self.sharded_parameters):
                 parameter.grad = self.main_grad.get_dtensor(index)
 
-        for parameter in self.unsharded_parameters:
-            parameter.grad = None
+        return PendingReduction(partial_grad=partial_grad, reduced_grad=reduced_grad)
+
+    def _require_unsharded_grads(self) -> tuple[torch.Tensor, ...]:
+        grads: list[torch.Tensor] = []
+        for name, parameter in zip(self.parameter_names, self.unsharded_parameters, strict=True):
+            if parameter.grad is None:
+                raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
+            grads.append(parameter.grad)
+        return tuple(grads)
+
+    def _sharded_parameters_have_grad(self) -> bool:
+        has_any_grad = False
+        has_any_missing_grad = False
+        for parameter in self.sharded_parameters:
+            if parameter.grad is None:
+                has_any_missing_grad = True
+            else:
+                has_any_grad = True
+        if has_any_grad and has_any_missing_grad:
+            raise RuntimeError("FSDP sharded gradients must be either all set or all None.")
+        return has_any_grad
 
 
 def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -311,8 +311,8 @@ def test_root_backward_returns_to_resting_memory(distributed_setup):
     )
 
 
-def test_overlaps_all_gather_and_compute(distributed_setup):
-    """A shared root context should let child all-gathers overlap GEMM compute."""
+def test_overlaps_communication_and_compute(distributed_setup):
+    """A shared root context should let child collectives overlap GEMM compute."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
     if world_size < 2:
@@ -352,6 +352,12 @@ def test_overlaps_all_gather_and_compute(distributed_setup):
         for event in cuda_events
         if "nccl" in event.name.lower() and "allgather" in event.name.lower()
     ]
+    reduce_scatter_events = [
+        event
+        for event in cuda_events
+        if "nccl" in event.name.lower()
+        and ("reducescatter" in event.name.lower() or "reduce_scatter" in event.name.lower())
+    ]
     # GEMM device-kernel names vary across CUDA/cuBLAS versions and GPU archs
     # (e.g. "*gemm*", "cutlass*", "cublas*", and cuBLASLt's Hopper "nvjet_sm90_*").
     gemm_events = [
@@ -360,29 +366,27 @@ def test_overlaps_all_gather_and_compute(distributed_setup):
         if any(token in event.name.lower() for token in ("gemm", "cutlass", "cublas", "nvjet"))
     ]
     assert all_gather_events, [event.name for event in cuda_events]
+    assert reduce_scatter_events, [event.name for event in cuda_events]
     assert gemm_events, [event.name for event in cuda_events]
 
     all_gather_streams = {event.device_resource_id for event in all_gather_events}
+    reduce_scatter_streams = {event.device_resource_id for event in reduce_scatter_events}
     gemm_streams = {event.device_resource_id for event in gemm_events}
     assert len(all_gather_streams) == 1
+    assert len(reduce_scatter_streams) == 1
+    assert all_gather_streams == reduce_scatter_streams
     assert all_gather_streams.isdisjoint(gemm_streams)
+    assert reduce_scatter_streams.isdisjoint(gemm_streams)
 
-    overlap_count = sum(
-        any(_events_overlap(all_gather_event, gemm_event) for gemm_event in gemm_events)
+    assert any(
+        _events_overlap(all_gather_event, gemm_event)
         for all_gather_event in all_gather_events
+        for gemm_event in gemm_events
     )
-    # This profiles a full forward/backward iteration, so backward all-gathers are
-    # included in all_gather_events. The expected overlap count is from the forward
-    # child pipeline: each child after the first can all-gather while the previous
-    # child computes, giving num_children - 1 overlaps. Backward does not overlap
-    # in this all-gather-only path because gradient reduction is not delayed:
-    # each module synchronously reduces gradients in post_backward before autograd
-    # reaches the next module's pre_backward all-gather. The next PR addresses
-    # this by delaying gradient reduction.
-    expected_overlap_count = num_children - 1
-    assert overlap_count >= expected_overlap_count, (
-        f"Expected at least {expected_overlap_count} all-gather events to overlap compute, "
-        f"got {overlap_count}/{len(all_gather_events)}."
+    assert any(
+        _events_overlap(reduce_scatter_event, gemm_event)
+        for reduce_scatter_event in reduce_scatter_events
+        for gemm_event in gemm_events
     )
 
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -374,7 +374,7 @@ def test_overlaps_communication_and_compute(distributed_setup):
     gemm_streams = {event.device_resource_id for event in gemm_events}
     assert len(all_gather_streams) == 1
     assert len(reduce_scatter_streams) == 1
-    assert all_gather_streams == reduce_scatter_streams
+    assert all_gather_streams.isdisjoint(reduce_scatter_streams)
     assert all_gather_streams.isdisjoint(gemm_streams)
     assert reduce_scatter_streams.isdisjoint(gemm_streams)
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -378,15 +378,26 @@ def test_overlaps_communication_and_compute(distributed_setup):
     assert all_gather_streams.isdisjoint(gemm_streams)
     assert reduce_scatter_streams.isdisjoint(gemm_streams)
 
-    assert any(
-        _events_overlap(all_gather_event, gemm_event)
+    all_gather_overlap_count = sum(
+        any(_events_overlap(all_gather_event, gemm_event) for gemm_event in gemm_events)
         for all_gather_event in all_gather_events
-        for gemm_event in gemm_events
     )
-    assert any(
-        _events_overlap(reduce_scatter_event, gemm_event)
+    reduce_scatter_overlap_count = sum(
+        any(_events_overlap(reduce_scatter_event, gemm_event) for gemm_event in gemm_events)
         for reduce_scatter_event in reduce_scatter_events
-        for gemm_event in gemm_events
+    )
+    # Forward pipelines each child after the first across the previous child's
+    # GEMM. Backward pipelines each completed child's reduce-scatter across the
+    # preceding child's GEMM.
+    expected_all_gather_overlap_count = num_children - 1
+    expected_reduce_scatter_overlap_count = num_children - 1
+    assert all_gather_overlap_count >= expected_all_gather_overlap_count, (
+        f"Expected at least {expected_all_gather_overlap_count} all-gather events to overlap "
+        f"compute, got {all_gather_overlap_count}/{len(all_gather_events)}."
+    )
+    assert reduce_scatter_overlap_count >= expected_reduce_scatter_overlap_count, (
+        f"Expected at least {expected_reduce_scatter_overlap_count} reduce-scatter events to "
+        f"overlap compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
     )
 
 


### PR DESCRIPTION
## Summary

- Add a lazy `FsdpContext` shared by nested experimental FSDP units.
- Delay full-parameter storage release until stream-ordered consumers are done.
- Launch packed reduce-scatters asynchronously from backward and finalize their temporary buffers after communication completes.
- Use one CUDA communication stream for both all-gather and reduce-scatter work to keep AG/RS temporary buffers on one allocator stream.
- Add unconditional FSDP NVTX compute ranges such as `FSDP:layers.0:forward_compute` and `FSDP:layers.0:backward_compute` for nsys attribution.
- Expand experimental FSDP tests for context sharing, delayed release, AG/compute overlap, RS/compute overlap, shared AG/RS stream ownership, and NVTX range naming.

## Why

This brings the doublebuffer communication-overlap changes onto the experimental FSDP path now merged in `main`. The single communication stream intentionally serializes AG and RS relative to each other, but keeps temporary communication buffers owned by one PyTorch caching-allocator stream. The NVTX ranges make the resulting compute/communication overlap easier to inspect in nsys.

## Validation

- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh`
- `python -m py_compile megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py`
- `CUDA_VISIBLE_DEVICES=0,1 MASTER_PORT=29569 uv run --no-sync python -m torch.distributed.run --nproc-per-node 2 -m pytest -q --experimental tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py::test_fsdp_nvtx_ranges_use_named_module_paths tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py::test_fully_sharded_root_with_child_units_overlaps_all_gather_and_compute`
- `CUDA_VISIBLE_DEVICES=0,1 MASTER_PORT=29570 uv run --no-sync python -m torch.distributed.run --nproc-per-node 2 -m pytest -q --experimental tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py`
