### PR TITLE
Add NCCL symmetric-memory staging to experimental FSDP

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -19,12 +19,13 @@ from collections.abc import Iterable
 
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 import torch.distributed.tensor as dist_tensor
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
 from .layout import GlobalLayout, Shape, non_leading_numel
-from .placement import Flat, Partial, Placement, Replicate
+from .placement import Flat, Partial, Placement, Replicate, changed_mesh_axis
 
 
 @dataclasses.dataclass(frozen=True)
@@ -120,6 +121,11 @@ class DBuffer:
         # existing Storage releases the allocation while preserving those aliases
         # for a later reallocate_storage().
         self._resize_storage(0)
+
+    def rendezvous(self, mesh_axis: int) -> None:
+        """Rendezvous this local buffer for symmetric-memory collectives."""
+        group = self.mesh.get_group(mesh_axis)
+        symm_mem.rendezvous(self.local_buffer, group=group.group_name)
 
     def _resize_storage(self, numel: int) -> None:
         self.local_buffer.untyped_storage().resize_(numel * self.local_buffer.element_size())
@@ -294,19 +300,7 @@ class DBuffer:
             )
         _validate_placements(new_placements)
 
-        changed_axis: int | None = None
-        for axis, (old_placement, new_placement) in enumerate(
-            zip(self.placements, new_placements, strict=True)
-        ):
-            if old_placement == new_placement:
-                continue
-            if changed_axis is not None:
-                raise NotImplementedError(
-                    "redistribute() currently supports one placement change, "
-                    f"got changed axes {changed_axis} and {axis}."
-                )
-            changed_axis = axis
-
+        changed_axis = changed_mesh_axis(self.placements, new_placements)
         if changed_axis is None:
             if out is None:
                 return self

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -27,6 +27,7 @@ def fully_shard(
     mesh: DeviceMesh,
     placements: Placements,
     mixed_precision_policy: MixedPrecisionPolicy | None = None,
+    use_symm_mem: bool = False,
 ) -> None:
     """Shard one module as a per-module FSDP unit.
 
@@ -39,6 +40,8 @@ def fully_shard(
         placements: Parameter, gradient, and optimizer placements.
         mixed_precision_policy: Optional precision policy. Defaults to FP32 main weights
             and parameter-dtype main gradients.
+        use_symm_mem: Allocate all-gather and reduce-scatter staging buffers from
+            PyTorch's NCCL symmetric-memory pool.
     """
     if isinstance(module, FsdpModule):
         raise ValueError("This module is already managed by FSDP.")
@@ -49,7 +52,11 @@ def fully_shard(
     try:
         assert isinstance(module, FsdpModule)
         FsdpModule.__init__(
-            module, mesh=mesh, placements=placements, mixed_precision_policy=mixed_precision_policy
+            module,
+            mesh=mesh,
+            placements=placements,
+            mixed_precision_policy=mixed_precision_policy,
+            use_symm_mem=use_symm_mem,
         )
     except Exception:
         module.__class__ = original_cls

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -34,7 +34,11 @@ class FsdpModule:
     _num_training_parameters: int
 
     def __init__(
-        self, mesh: DeviceMesh, placements: Placements, mixed_precision_policy: MixedPrecisionPolicy
+        self,
+        mesh: DeviceMesh,
+        placements: Placements,
+        mixed_precision_policy: MixedPrecisionPolicy,
+        use_symm_mem: bool = False,
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
         owned_parameters = _collect_owned_parameters(self)
@@ -49,6 +53,7 @@ class FsdpModule:
                 mesh=mesh,
                 placements=placements,
                 mixed_precision_policy=mixed_precision_policy,
+                use_symm_mem=use_symm_mem,
             )
             for group_parameters in _group_parameters(owned_parameters)
         ]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -15,15 +15,17 @@
 """Parameter-group runtime state for the minimal Megatron-FSDP path."""
 
 from collections.abc import Iterable
+from contextlib import nullcontext
 
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
-from .placement import Partial, Placements, Replicate
+from .placement import Partial, Placements, Replicate, changed_mesh_axis
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -47,6 +49,7 @@ class FsdpParameterGroup:
     model_weight: DBuffer
     main_grad: DBuffer | None
     _unsharded_model_weight: DBuffer
+    _symm_mem_pool: torch.cuda.MemPool | None
 
     def __init__(
         self,
@@ -55,6 +58,7 @@ class FsdpParameterGroup:
         mesh: DeviceMesh,
         placements: Placements,
         mixed_precision_policy: MixedPrecisionPolicy,
+        use_symm_mem: bool = False,
     ) -> None:
         """Create persistent sharded buffers for a group of parameters.
 
@@ -64,6 +68,8 @@ class FsdpParameterGroup:
             mesh: Device mesh used for all DBuffer storage in this version.
             placements: Parameter, gradient, and optimizer placements.
             mixed_precision_policy: Precision policy for main weights and gradients.
+            use_symm_mem: Allocate communication staging buffers from PyTorch's
+                NCCL symmetric-memory pool.
         """
         if not parameters:
             raise ValueError("FsdpParameterGroup requires at least one parameter.")
@@ -100,13 +106,21 @@ class FsdpParameterGroup:
             placements=main_weight_placements,
         )
 
-        self._unsharded_model_weight = DBuffer(
-            mesh=self.mesh,
-            placements=[Replicate()] * self.mesh.ndim,
-            tensor_shapes=tensor_shapes,
-            dtype=self.dtype,
-            device=self.main_weight.device,
-        )
+        if use_symm_mem:
+            # PyTorch caches this in C++ and returns early when the backend is already NCCL.
+            symm_mem.set_backend("NCCL")
+            self._symm_mem_pool = symm_mem.get_mem_pool(self.main_weight.device)
+        else:
+            self._symm_mem_pool = None
+
+        with self._symmetric_memory_context():
+            self._unsharded_model_weight = DBuffer(
+                mesh=self.mesh,
+                placements=[Replicate()] * self.mesh.ndim,
+                tensor_shapes=tensor_shapes,
+                dtype=self.dtype,
+                device=self.main_weight.device,
+            )
         if main_weight_dtype == self.dtype and main_weight_placements == model_weight_placements:
             self.model_weight = self.main_weight
         else:
@@ -144,7 +158,6 @@ class FsdpParameterGroup:
                     f"Got main_grad placements {self.main_grad.placements} and "
                     f"main_weight placements {self.main_weight.placements}."
                 )
-
         sharded_parameters: list[nn.Parameter] = []
         unsharded_parameters: list[nn.Parameter] = []
         main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
@@ -166,6 +179,11 @@ class FsdpParameterGroup:
 
         self._switch_to_sharded_parameters()
         self._unsharded_model_weight.release_storage()
+
+    def _symmetric_memory_context(self):
+        if self._symm_mem_pool is None:
+            return nullcontext()
+        return torch.cuda.use_mem_pool(self._symm_mem_pool)
 
     def _set_module_parameters(self, parameters: tuple[nn.Parameter, ...]) -> None:
         for name, parameter in zip(self.parameter_names, parameters, strict=True):
@@ -189,15 +207,21 @@ class FsdpParameterGroup:
 
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""
-        self._unsharded_model_weight.reallocate_storage()
+        with self._symmetric_memory_context():
+            self._unsharded_model_weight.reallocate_storage()
         # This buffer backs unsharded Parameters whose views may be saved by autograd.
         # Autograd records a tensor's version counter when saving it for backward, and
         # in-place writes like the out= redistribution below increment that counter even
         # under no_grad. Without preserving it, backward can fail with "modified by an
         # inplace operation" even though FSDP only materialized internal storage.
+        gather_axis = changed_mesh_axis(
+            self.model_weight.placements, self._unsharded_model_weight.placements
+        )
         with torch.autograd._unsafe_preserve_version_counter(
             self._unsharded_model_weight.local_buffer
         ):
+            if self._symm_mem_pool is not None and gather_axis is not None:
+                self._unsharded_model_weight.rendezvous(gather_axis)
             self.model_weight.redistribute(
                 self._unsharded_model_weight.placements, out=self._unsharded_model_weight
             )
@@ -236,9 +260,13 @@ class FsdpParameterGroup:
                 raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
             grads.append(parameter.grad)
 
-        partial_grad = DBuffer.distribute_tensors(
-            grads, mesh=self.mesh, placements=[Partial(dist.ReduceOp.AVG)] * self.mesh.ndim
-        )
+        # NCCL symmetric-memory reduce-scatter only selects the symmetric kernel for SUM today.
+        # Preserve AVG semantics by reducing SUM and scaling the output below.
+        partial_op = dist.ReduceOp.AVG if self._symm_mem_pool is None else dist.ReduceOp.SUM
+        with self._symmetric_memory_context():
+            partial_grad = DBuffer.distribute_tensors(
+                grads, mesh=self.mesh, placements=[Partial(partial_op)] * self.mesh.ndim
+            )
 
         # zero_grad(set_to_none=True) clears sharded parameter grads, so the next
         # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
@@ -247,10 +275,20 @@ class FsdpParameterGroup:
         can_reduce_into_main_grad = (
             not has_sharded_grads and partial_grad.dtype == self.main_grad.dtype
         )
+        reduce_axis = changed_mesh_axis(partial_grad.placements, self.main_grad.placements)
+        if reduce_axis is None:
+            raise RuntimeError("FSDP gradient reduction requires a changed placement axis.")
+        grad_divisor = self.mesh.size(reduce_axis) if partial_op == dist.ReduceOp.SUM else 1
+        if self._symm_mem_pool is not None:
+            partial_grad.rendezvous(reduce_axis)
         if can_reduce_into_main_grad:
             partial_grad.redistribute(self.main_grad.placements, out=self.main_grad)
+            if grad_divisor != 1:
+                self.main_grad.local_buffer.div_(grad_divisor)
         else:
             reduced_grad = partial_grad.redistribute(self.main_grad.placements)
+            if grad_divisor != 1:
+                reduced_grad.local_buffer.div_(grad_divisor)
             if has_sharded_grads:
                 self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
             else:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -217,10 +217,12 @@ class FsdpParameterGroup:
         gather_axis = changed_mesh_axis(
             self.model_weight.placements, self._unsharded_model_weight.placements
         )
+        if gather_axis is None:
+            raise RuntimeError("FSDP parameter unshard requires a changed placement axis.")
         with torch.autograd._unsafe_preserve_version_counter(
             self._unsharded_model_weight.local_buffer
         ):
-            if self._symm_mem_pool is not None and gather_axis is not None:
+            if self._symm_mem_pool is not None:
                 self._unsharded_model_weight.rendezvous(gather_axis)
             self.model_weight.redistribute(
                 self._unsharded_model_weight.placements, out=self._unsharded_model_weight

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -30,6 +30,7 @@ sharded        ``Replicate``  ``allgather()``
 """
 
 import dataclasses
+from collections.abc import Iterable
 
 import torch.distributed as dist
 
@@ -56,6 +57,25 @@ class Partial(Placement):
 @dataclasses.dataclass(frozen=True)
 class Flat(Placement):
     """Flat per-unit dim-0 sharded local buffer placement."""
+
+
+def changed_mesh_axis(
+    old_placements: Iterable[Placement], new_placements: Iterable[Placement]
+) -> int | None:
+    """Return the changed mesh axis, requiring at most one placement change."""
+    changed_axis = None
+    for axis, (old_placement, new_placement) in enumerate(
+        zip(old_placements, new_placements, strict=True)
+    ):
+        if old_placement == new_placement:
+            continue
+        if changed_axis is not None:
+            raise NotImplementedError(
+                "Expected at most one changed placement axis, "
+                f"got changed axes {changed_axis} and {axis}."
+            )
+        changed_axis = axis
+    return changed_axis
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for experimental FSDP symmetric-memory staging."""
+
+import pytest
+import torch
+from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.profiler import ProfilerActivity, profile
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+    Flat,
+    Placements,
+    fully_shard,
+)
+
+
+class TinyModel(nn.Module):
+    """Small model with two separately shardable units."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(8, 16)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(16, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the tiny model."""
+        return self.fc2(self.relu(self.fc1(x)))
+
+
+def _flat_placements() -> Placements:
+    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+
+
+def _kernels(prof: torch.profiler.profile) -> list[str]:
+    return [event.name for event in prof.events()]
+
+
+def _is_symmetric_kernel(kernel: str) -> bool:
+    return "ncclSymk" in kernel
+
+
+def _count_symmetric_kernels(kernels: list[str], subname: str) -> int:
+    return sum(
+        1
+        for kernel in kernels
+        if _is_symmetric_kernel(kernel) and subname in kernel
+    )
+
+
+@pytest.mark.parametrize("num_microbatches", [1, 3])
+def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
+    distributed_setup, num_microbatches
+):
+    """NCCL symmetric-memory staging should preserve training parity and hit symmetric kernels."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    num_sharded_modules = 2
+    num_training_steps = 5
+
+    def train(use_symm_mem: bool) -> list[torch.Tensor]:
+        torch.manual_seed(1234)
+        model = TinyModel().to(device)
+        fully_shard(
+            model.fc1, mesh=mesh, placements=_flat_placements(), use_symm_mem=use_symm_mem
+        )
+        fully_shard(
+            model.fc2, mesh=mesh, placements=_flat_placements(), use_symm_mem=use_symm_mem
+        )
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+
+        micro_batch_size = 2
+        x = torch.randn(num_microbatches, micro_batch_size, 8, device=device)
+        target = torch.randn(num_microbatches, micro_batch_size, 4, device=device)
+        microbatches = tuple(zip(x.unbind(), target.unbind()))
+
+        losses = []
+        for _ in range(num_training_steps):
+            optimizer.zero_grad()
+            for microbatch_x, microbatch_target in microbatches:
+                loss = torch.nn.functional.mse_loss(model(microbatch_x), microbatch_target)
+                losses.append(loss.detach())
+                (loss / num_microbatches).backward()
+            optimizer.step()
+
+        return losses
+
+    with profile(activities=[ProfilerActivity.CUDA]) as prof_without_symm_mem:
+        losses_without_symm_mem = train(use_symm_mem=False)
+        torch.cuda.synchronize()
+
+    with profile(activities=[ProfilerActivity.CUDA]) as prof_with_symm_mem:
+        losses_with_symm_mem = train(use_symm_mem=True)
+        torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        torch.stack(losses_with_symm_mem),
+        torch.stack(losses_without_symm_mem),
+        msg="Symmetric-memory FSDP losses did not match default FSDP losses.",
+    )
+
+    kernels_without_symm_mem = _kernels(prof_without_symm_mem)
+    assert _count_symmetric_kernels(kernels_without_symm_mem, "AllGather") == 0
+    assert _count_symmetric_kernels(kernels_without_symm_mem, "ReduceScatter") == 0
+
+    kernels_with_symm_mem = _kernels(prof_with_symm_mem)
+    expected_reduce_scatter_kernel_count = num_training_steps * num_microbatches * num_sharded_modules
+    nccl_kernels_with_symm_mem = [
+        kernel for kernel in kernels_with_symm_mem if "nccl" in kernel.lower()
+    ]
+    assert (
+        _count_symmetric_kernels(kernels_with_symm_mem, "ReduceScatter")
+        == expected_reduce_scatter_kernel_count
+    ), (
+        "Unexpected NCCL symmetric-memory reduce-scatter kernel count. "
+        f"Observed NCCL kernels: {nccl_kernels_with_symm_mem[:20]}"
+    )
+
+    expected_all_gather_kernel_count = 2 * expected_reduce_scatter_kernel_count
+    assert (
+        _count_symmetric_kernels(kernels_with_symm_mem, "AllGather")
+        == expected_all_gather_kernel_count
+    ), (
+        "Unexpected NCCL symmetric-memory all-gather kernel count. "
+        f"Observed NCCL kernels: {nccl_kernels_with_symm_mem[:20]}"
+    )

--- a/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
@@ -43,11 +43,7 @@ def _is_symmetric_kernel(kernel: str) -> bool:
 
 
 def _count_symmetric_kernels(kernels: list[str], subname: str) -> int:
-    return sum(
-        1
-        for kernel in kernels
-        if _is_symmetric_kernel(kernel) and subname in kernel
-    )
+    return sum(1 for kernel in kernels if _is_symmetric_kernel(kernel) and subname in kernel)
 
 
 @pytest.mark.parametrize("num_microbatches", [1, 3])
@@ -61,7 +57,6 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
         pytest.skip("This test requires at least 2 ranks.")
 
     mesh = init_device_mesh(device.type, (world_size,))
-    num_sharded_modules = 2
     num_training_steps = 5
 
     def train(use_symm_mem: bool) -> list[torch.Tensor]:
@@ -85,9 +80,7 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
         optimizer = torch.optim.SGD(model.parameters(), lr=0.05, foreach=False)
 
         micro_batch_size = 2
-        x = torch.randn(
-            num_microbatches, micro_batch_size, 8, device=device, dtype=torch.bfloat16
-        )
+        x = torch.randn(num_microbatches, micro_batch_size, 8, device=device, dtype=torch.bfloat16)
         target = torch.randn(
             num_microbatches, micro_batch_size, 4, device=device, dtype=torch.bfloat16
         )
@@ -123,7 +116,8 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
     assert _count_symmetric_kernels(kernels_without_symm_mem, "ReduceScatter") == 0
 
     kernels_with_symm_mem = _kernels(prof_with_symm_mem)
-    expected_reduce_scatter_kernel_count = num_training_steps * num_microbatches * num_sharded_modules
+    # 2 sharded modules (fc1, fc2), one reduce-scatter each per microbatch step.
+    expected_reduce_scatter_kernel_count = num_training_steps * num_microbatches * 2
     nccl_kernels_with_symm_mem = [
         kernel for kernel in kernels_with_symm_mem if "nccl" in kernel.lower()
     ]

--- a/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
@@ -15,18 +15,25 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     fully_shard,
 )
 
+# Each sharded Linear's collective must be large enough that NCCL selects its
+# symmetric-memory (ncclSymk*) kernels over ring. Sub-KB collectives fall back to
+# ring on some platforms (e.g. CI with NCCL_NVLS_ENABLE=0), which would make the
+# symmetric-kernel assertions below fail; 1024-wide units (a few-MiB bf16 weight)
+# reliably engage the symmetric kernels.
+_HIDDEN = 1024
+
 
 class TinyModel(nn.Module):
-    """Small model with two separately shardable units."""
+    """Two separately shardable units, sized so NCCL selects symmetric-memory kernels."""
 
     def __init__(self) -> None:
         super().__init__()
-        self.fc1 = nn.Linear(8, 16)
+        self.fc1 = nn.Linear(_HIDDEN, _HIDDEN)
         self.relu = nn.ReLU()
-        self.fc2 = nn.Linear(16, 4)
+        self.fc2 = nn.Linear(_HIDDEN, _HIDDEN)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the tiny model."""
+        """Run the model."""
         return self.fc2(self.relu(self.fc1(x)))
 
 
@@ -80,9 +87,11 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
         optimizer = torch.optim.SGD(model.parameters(), lr=0.05, foreach=False)
 
         micro_batch_size = 2
-        x = torch.randn(num_microbatches, micro_batch_size, 8, device=device, dtype=torch.bfloat16)
+        x = torch.randn(
+            num_microbatches, micro_batch_size, _HIDDEN, device=device, dtype=torch.bfloat16
+        )
         target = torch.randn(
-            num_microbatches, micro_batch_size, 4, device=device, dtype=torch.bfloat16
+            num_microbatches, micro_batch_size, _HIDDEN, device=device, dtype=torch.bfloat16
         )
         microbatches = tuple(zip(x.unbind(), target.unbind()))
 

--- a/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
@@ -8,6 +8,7 @@ from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.profiler import ProfilerActivity, profile
 
+from megatron.core.distributed.fsdp.src.megatron_fsdp import MixedPrecisionPolicy
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
     Placements,
@@ -65,18 +66,31 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
 
     def train(use_symm_mem: bool) -> list[torch.Tensor]:
         torch.manual_seed(1234)
-        model = TinyModel().to(device)
+        model = TinyModel().to(device=device, dtype=torch.bfloat16)
+        mixed_precision_policy = MixedPrecisionPolicy(main_params_dtype=torch.float32)
         fully_shard(
-            model.fc1, mesh=mesh, placements=_flat_placements(), use_symm_mem=use_symm_mem
+            model.fc1,
+            mesh=mesh,
+            placements=_flat_placements(),
+            mixed_precision_policy=mixed_precision_policy,
+            use_symm_mem=use_symm_mem,
         )
         fully_shard(
-            model.fc2, mesh=mesh, placements=_flat_placements(), use_symm_mem=use_symm_mem
+            model.fc2,
+            mesh=mesh,
+            placements=_flat_placements(),
+            mixed_precision_policy=mixed_precision_policy,
+            use_symm_mem=use_symm_mem,
         )
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.05, foreach=False)
 
         micro_batch_size = 2
-        x = torch.randn(num_microbatches, micro_batch_size, 8, device=device)
-        target = torch.randn(num_microbatches, micro_batch_size, 4, device=device)
+        x = torch.randn(
+            num_microbatches, micro_batch_size, 8, device=device, dtype=torch.bfloat16
+        )
+        target = torch.randn(
+            num_microbatches, micro_batch_size, 4, device=device, dtype=torch.bfloat16
+        )
         microbatches = tuple(zip(x.unbind(), target.unbind()))
 
         losses = []


### PR DESCRIPTION
## Summary

This adds an opt-in `use_symm_mem=True` path for experimental Megatron-FSDP staging buffers. The full-parameter all-gather buffer and full-gradient reduce-scatter buffer are allocated from PyTorch's NCCL symmetric-memory pool, rendezvoused before collectives, and verified through profiler activity.

> **Note:** the communication-time benchmark (and its `pytest-benchmark`/`uv.lock` changes) was split out to #5596 to keep this PR focused on the core staging feature.

## Details

- Threads `use_symm_mem` through `fully_shard`, `FsdpModule`, and `FsdpParameterGroup`.
- Adds DBuffer rendezvous support and a shared placement-axis helper used by redistribution and symmetric-memory call sites.
- Allocates unsharded parameter and partial-gradient staging buffers under `torch.cuda.use_mem_pool` while leaving the `DBuffer` allocation API unchanged.
- Uses SUM reduce-scatter for the symmetric-memory path and scales locally to preserve AVG gradient semantics.
- `unshard_parameters` raises on a `None` gather axis and rendezvous unconditionally under symmetric memory, mirroring `reduce_gradients`.
- Adds distributed CUDA/NCCL coverage in `test_symmetric_memory.py` that checks loss parity and requires observed `ncclSymk` all-gather and reduce-scatter kernels.

## Validation

- `python -m isort megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py`
- `python -m torch.distributed.run --nproc-per-node 2 --standalone -m pytest -q tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py`
