### PR TITLE
build: point flash_mla at the nv_dev branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,7 @@ requires-dist = ["torch", "packaging", "ninja"]
 [tool.uv.sources]
 
 flash_mla = [
-    { git = "https://github.com/deepseek-ai/FlashMLA", rev = "9edee0c022cd0938148a18e334203b0aab43aa19" },
+    { git = "https://github.com/deepseek-ai/FlashMLA", rev = "nv_dev" },
 ]
 transformer-engine = { git = "https://github.com/NVIDIA/TransformerEngine.git", rev = "4220403e831d29e93868f7793693ea83f6b8b05b" }
 nemo-run = { git = "https://github.com/NVIDIA-NeMo/Run.git", rev = "17ae86b64d7f75653351664f5d8c9e466faede00" }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1238,7 +1238,7 @@ wheels = [
 [[package]]
 name = "flash-mla"
 version = "1.0.0+9edee0c"
-source = { git = "https://github.com/deepseek-ai/FlashMLA?rev=9edee0c022cd0938148a18e334203b0aab43aa19#9edee0c022cd0938148a18e334203b0aab43aa19" }
+source = { git = "https://github.com/deepseek-ai/FlashMLA?rev=nv_dev#b7643bd54521f563b839b98289b5cd048c062ba2" }
 
 [[package]]
 name = "flashinfer-python"
@@ -2370,7 +2370,7 @@ linting = [
 ]
 no-pypi-wheels = [
     { name = "emerging-optimizers", git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git?rev=v0.2.0" },
-    { name = "flash-mla", git = "https://github.com/deepseek-ai/FlashMLA?rev=9edee0c022cd0938148a18e334203b0aab43aa19" },
+    { name = "flash-mla", git = "https://github.com/deepseek-ai/FlashMLA?rev=nv_dev" },
 ]
 test = [
     { name = "coverage" },
@@ -5156,14 +5156,14 @@ version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
+    { name = "filelock", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "fsspec", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jinja2", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "networkx", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "setuptools", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "sympy", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
     { name = "triton", marker = "sys_platform == 'never'" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Background

FlashMLA needs to track the `nv_dev` branch of `deepseek-ai/FlashMLA` rather than the fixed `9edee0c` commit.

## What changed

- `pyproject.toml`: `flash_mla` source `rev` `9edee0c…` → `nv_dev`.
- Regenerate `uv.lock` (run inside the CI container) — flash-mla now resolves to `nv_dev` tip `b7643bd`.

## Details

- Lock delta is scoped to the flash-mla source/rev plus the incidental `revision`/torch-marker normalization uv emits on re-resolution.
- Companion backport to `core_r0.18.0`: NVIDIA/Megatron-LM#5447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
