### PR TITLE
Add --functional-test-name to trigger_internal_ci

### DIFF
--- a/tools/trigger_internal_ci.md
+++ b/tools/trigger_internal_ci.md
@@ -40,6 +40,7 @@ python tools/trigger_internal_ci.py \
   [--functional-test-scope mr] \
   [--functional-test-repeat 5] \
   [--functional-test-cases all] \
+  [--functional-test-name release-testing/mcore-vX.Y.Z] \
   [--functional-test-time-limit 14400] \
   [--dry-run]
 ```
@@ -51,8 +52,13 @@ python tools/trigger_internal_ci.py \
 | `--functional-test-scope` | `mr` | `FUNCTIONAL_TEST_SCOPE` pipeline variable |
 | `--functional-test-repeat` | `5` | `FUNCTIONAL_TEST_REPEAT` pipeline variable |
 | `--functional-test-cases` | `all` | `FUNCTIONAL_TEST_CASES` pipeline variable |
+| `--functional-test-name` | commit SHA | `FUNCTIONAL_TEST_NAME` pipeline variable — names the run for `pre-release`/`release` scopes (used as the run name and W&B experiment). |
 | `--functional-test-time-limit` | *(scope-dependent)* | `FUNCTIONAL_TEST_TIME_LIMIT` pipeline variable, in seconds. Defaults to `14400` (4h) for the long-running `release` and `weekly` scopes; left unset otherwise. |
 | `--dry-run` | off | Print what would happen without pushing or triggering |
+
+> For release testing, set `--functional-test-scope release` and name the run
+> with the convention `release-testing/mcore-v<X.Y.Z>` (e.g.
+> `release-testing/mcore-v0.17.0`).
 
 ## Example
 
@@ -62,6 +68,12 @@ python tools/trigger_internal_ci.py --gitlab-origin gitlab --dry-run
 
 # Real run — uses token from environment
 python tools/trigger_internal_ci.py --gitlab-origin gitlab
+
+# Release testing — named run on the release scope
+python tools/trigger_internal_ci.py \
+  --gitlab-origin gitlab \
+  --functional-test-scope release \
+  --functional-test-name release-testing/mcore-v0.17.0
 ```
 
 ## Expected behavior

--- a/tools/trigger_internal_ci.py
+++ b/tools/trigger_internal_ci.py
@@ -165,6 +165,15 @@ def main():
         help="FUNCTIONAL_TEST_CASES pipeline variable (default: all)",
     )
     parser.add_argument(
+        "--functional-test-name",
+        default=None,
+        help=(
+            "FUNCTIONAL_TEST_NAME pipeline variable — names the run for "
+            "pre-release/release scopes (used as the run name and W&B experiment). "
+            "Defaults to the commit SHA when omitted."
+        ),
+    )
+    parser.add_argument(
         "--functional-test-time-limit",
         type=int,
         default=None,
@@ -217,6 +226,11 @@ def main():
         "FUNCTIONAL_TEST_REPEAT": str(args.functional_test_repeat),
         "FUNCTIONAL_TEST_CASES": args.functional_test_cases,
     }
+
+    # Only override FUNCTIONAL_TEST_NAME when explicitly provided; otherwise the
+    # pipeline default (the commit SHA) applies.
+    if args.functional_test_name is not None:
+        pipeline_vars["FUNCTIONAL_TEST_NAME"] = args.functional_test_name
 
     time_limit = resolve_time_limit(
         args.functional_test_scope, args.functional_test_time_limit


### PR DESCRIPTION
## Background

`trigger_internal_ci` triggers the internal CI pipeline. For `pre-release`/`release` scopes the pipeline supports a `FUNCTIONAL_TEST_NAME` variable (run name + W&B experiment), but the CLI had no way to set it, so release runs always fell back to the commit SHA — harder to find later.

## What changed

- Add `--functional-test-name` to `tools/trigger_internal_ci.py`, threaded into `pipeline_vars` as `FUNCTIONAL_TEST_NAME`.
- Document it in `tools/trigger_internal_ci.md`, with the `release-testing/mcore-v<X.Y.Z>` convention and a release example.

## Details

- Only set when explicitly provided, so the pipeline default (commit SHA) is preserved otherwise.
- Matches the existing "set-only-when-provided" pattern used for `--cluster-*` / `--functional-test-time-limit`.

Signed-off-by: oliver könig <okoenig@nvidia.com>