### PR TITLE
test: mark ep_a2a_overlap activation-offloading test flaky_in_dev

### DIFF
--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -334,6 +334,7 @@ def test_gpt_fine_grained_activation_offloading_correctness_and_memory(
         Utils.destroy_model_parallel()
 
 
+@pytest.mark.flaky_in_dev
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offloading tests.")
 @pytest.mark.skipif(
     not is_te_min_version("1.9.0.dev0"),


### PR DESCRIPTION
## Background

`test_fine_grained_activation_offload_with_ep_a2a_overlap_compatibility` intermittently deadlocks on a NCCL `ALLREDUCE` collective in the EP A2A overlap path, then dies on the 600s watchdog timeout (SIGABRT). It surfaced as a CI hang on a DSv4 PR branch ([run](https://github.com/NVIDIA/Megatron-LM/actions/runs/28009627878/job/82901167835?pr=5011)).

`main` already quarantined this test in #5350 / #5368 (commit `ad5a93bcb`), but `dev` was missing the marker, so the test still runs and hangs.

## What changed

- Cherry-pick `ad5a93bcb` onto `dev`: add `@pytest.mark.flaky_in_dev` to `test_fine_grained_activation_offload_with_ep_a2a_overlap_compatibility`.

## Details

- 1-line change; applied via 3-way merge (the test file has drifted between `main` and `dev`).
- Verified the marker guards the correct test (not its neighbor).
- `flaky_in_dev` skips the test in the dev environment, matching `main`'s behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)