### PR TITLE
Add persistent first-iteration cache for fast warm restarts

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -92,6 +92,7 @@ def add_megatron_arguments(parser: argparse.ArgumentParser):
     parser = _add_sft_args(parser)
 
     parser = _add_fault_injector_args(parser)
+    parser = _add_persistent_cache_args(parser)
 
     return parser
 
@@ -3389,4 +3390,37 @@ def _add_sft_args(parser):
 def _add_fault_injector_args(parser):
     from megatron.training.config import FaultInjectorConfig
     ArgumentGroupFactory(FaultInjectorConfig).build_group(parser, "fault injector")
+    return parser
+
+
+def _add_persistent_cache_args(parser):
+    """Persistent cache for first-iteration acceleration across job restarts.
+
+    The bash bootstrap (tools/persistent_cache/bootstrap.sh) seeds node-local
+    storage from cache_read/<scope>.tar.zst before this Python process starts.
+    These flags only control the in-process validation, the save-hook writeback
+    throttle, and the atexit final flush. See tools/persistent_cache/README.md.
+    """
+    group = parser.add_argument_group(title='persistent cache')
+    group.add_argument(
+        '--persistent-cache-read-dir', type=str, default=None,
+        help='Shared-filesystem dir holding cache_read/<scope>.tar.zst tarballs for '
+             'warm-start seeding. Set up by tools/persistent_cache/bootstrap.sh before '
+             'Python starts.')
+    group.add_argument(
+        '--persistent-cache-write-dir', type=str, default=None,
+        help='Shared-filesystem dir for writeback of newly compiled artifacts. The '
+             'sidecar and save-hook rsync NODE_CACHE_BASE/<scope>/ -> <this>/<scope>/.')
+    group.add_argument(
+        '--persistent-cache-scopes', nargs='+',
+        default=['triton', 'inductor', 'cuda_ptx', 'hybrid_ep', 'cudnn_fe',
+                 'nccl_topo', 'megatron_fused_kernels', 'dataset_idx'],
+        help='Cache scopes to validate and write back.')
+    group.add_argument(
+        '--persistent-cache-writeback-every-n-saves', type=int, default=8,
+        help='Trigger a writeback every N successful checkpoint saves '
+             '(in addition to the bash sidecar and atexit). Set to 1 for every save.')
+    group.add_argument(
+        '--persistent-cache-skip-validation', action='store_true',
+        help='Skip post-bootstrap env-var validation. For tests.')
     return parser

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -82,6 +82,7 @@ def add_megatron_arguments(parser: argparse.ArgumentParser):
     parser = _add_varlen_dataset_args(parser)
 
     parser = _add_fault_injector_args(parser)
+    parser = _add_persistent_cache_args(parser)
 
     return parser
 
@@ -3978,4 +3979,37 @@ def _add_logits_distillation_args(parser):
 def _add_fault_injector_args(parser):
     from megatron.training.config import FaultInjectorConfig
     ArgumentGroupFactory(FaultInjectorConfig).build_group(parser, "fault injector")
+    return parser
+
+
+def _add_persistent_cache_args(parser):
+    """Persistent cache for first-iteration acceleration across job restarts.
+
+    The bash bootstrap (tools/persistent_cache/bootstrap.sh) seeds node-local
+    storage from cache_read/<scope>.tar.zst before this Python process starts.
+    These flags only control the in-process validation, the save-hook writeback
+    throttle, and the atexit final flush. See tools/persistent_cache/README.md.
+    """
+    group = parser.add_argument_group(title='persistent cache')
+    group.add_argument(
+        '--persistent-cache-read-dir', type=str, default=None,
+        help='Shared-filesystem dir holding cache_read/<scope>.tar.zst tarballs for '
+             'warm-start seeding. Set up by tools/persistent_cache/bootstrap.sh before '
+             'Python starts.')
+    group.add_argument(
+        '--persistent-cache-write-dir', type=str, default=None,
+        help='Shared-filesystem dir for writeback of newly compiled artifacts. The '
+             'sidecar and save-hook rsync NODE_CACHE_BASE/<scope>/ -> <this>/<scope>/.')
+    group.add_argument(
+        '--persistent-cache-scopes', nargs='+',
+        default=['triton', 'inductor', 'cuda_ptx', 'hybrid_ep', 'cudnn_fe',
+                 'nccl_topo', 'megatron_fused_kernels', 'dataset_idx'],
+        help='Cache scopes to validate and write back.')
+    group.add_argument(
+        '--persistent-cache-writeback-every-n-saves', type=int, default=8,
+        help='Trigger a writeback every N successful checkpoint saves '
+             '(in addition to the bash sidecar and atexit). Set to 1 for every save.')
+    group.add_argument(
+        '--persistent-cache-skip-validation', action='store_true',
+        help='Skip post-bootstrap env-var validation. For tests.')
     return parser

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -42,7 +42,7 @@ from megatron.core.rerun_state_machine import get_rerun_state_machine
 from megatron.core.utils import get_pg_rank, get_pg_size, unwrap_model
 
 from ..core.dist_checkpointing.utils import _clean_metadata_for_serialization
-from . import ft_integration, wandb_utils
+from . import ft_integration, persistent_cache, wandb_utils
 from .async_utils import get_save_and_finalize_callbacks, is_empty_async_queue, schedule_async_save
 from .global_vars import get_args
 from .one_logger_utils import on_save_checkpoint_start, on_save_checkpoint_success
@@ -881,6 +881,16 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
     logger.debug(f"rank: {rank}, takes {end_misc - start_misc} to finalize ckpt save ")
 
     ft_integration.on_checkpointing_end(is_async_finalization=False)
+
+    # Persistent cache: kick a throttled writeback of newly compiled artifacts after a
+    # successful save (no-op unless a persistent cache write dir is configured).
+    _pc_ctrl = persistent_cache.get()
+    if _pc_ctrl is not None:
+        try:
+            _pc_ctrl.maybe_kick_writeback(iteration)
+        except Exception as _pc_e:
+            logger.warning("persistent_cache writeback kick failed: %s", _pc_e)
+
 
 @_disable_gc()
 def _async_delete_checkpoint_impl(save_path, iteration_to_delete, log_progress=False, lower_priority=False,

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -55,7 +55,7 @@ from megatron.training.config import TokenizerConfig
 from megatron.training.global_vars import get_tokenizer
 
 from ..core.dist_checkpointing.utils import _clean_metadata_for_serialization
-from . import ft_integration, wandb_utils
+from . import ft_integration, persistent_cache, wandb_utils
 from .async_utils import get_save_and_finalize_callbacks, is_empty_async_queue, schedule_async_save
 from .global_vars import get_args
 from .one_logger_utils import on_save_checkpoint_start, on_save_checkpoint_success
@@ -1267,6 +1267,15 @@ def save_checkpoint(
             _maybe_compact_rollout_bank(iteration)
 
     ft_integration.on_checkpointing_end(is_async_finalization=False)
+
+    # Persistent cache: kick a throttled writeback of newly compiled artifacts after a
+    # successful save (no-op unless a persistent cache write dir is configured).
+    _pc_ctrl = persistent_cache.get()
+    if _pc_ctrl is not None:
+        try:
+            _pc_ctrl.maybe_kick_writeback(iteration)
+        except Exception as _pc_e:
+            logger.warning("persistent_cache writeback kick failed: %s", _pc_e)
 
 
 def save_tokenizer_assets(

--- a/megatron/training/persistent_cache.py
+++ b/megatron/training/persistent_cache.py
@@ -1,0 +1,217 @@
+"""Persistent cache hooks for Megatron-LM.
+
+Bootstrapping (seeding node-local storage from cache_read/<scope>.tar.zst,
+exporting env vars) is done by tools/persistent_cache/bootstrap.sh BEFORE this Python process
+starts. By the time Python runs, cache env vars have already been consumed by
+torch._inductor / triton / the CUDA driver. This module is responsible only
+for:
+
+  - validating that the bootstrap actually ran (warn if not),
+  - kicking the bash writeback from save_checkpoint(),
+  - registering atexit for a final writeback.
+
+See tools/persistent_cache/README.md for the architecture and bash side.
+"""
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# scope -> env var the scope's compiler/library reads.
+# 'dataset_idx' is CLI-driven (--data-cache-path), so it is intentionally absent.
+_SCOPE_ENV = {
+    'triton':                 'TRITON_CACHE_DIR',
+    'inductor':               'TORCHINDUCTOR_CACHE_DIR',
+    'cuda_ptx':               'CUDA_CACHE_PATH',
+    'hybrid_ep':              'HYBRID_EP_JIT_DIR',
+    'cudnn_fe':               'CUDNN_FRONTEND_CACHE_DIR',
+    'nccl_topo':              'NCCL_TOPO_DUMP_FILE',
+    'megatron_fused_kernels': 'TORCH_EXTENSIONS_DIR',
+}
+
+
+class PersistentCacheController:
+    """Thin coordinator for the bash cache pipeline.
+
+    Owns three responsibilities:
+      1. Validate at startup that the bash bootstrap left the env in a sane state.
+      2. Kick the bash writeback from save_checkpoint, throttled.
+      3. Register an atexit hook for final writeback on clean exit.
+    """
+
+    def __init__(self, args):
+        self.read_dir = getattr(args, 'persistent_cache_read_dir', None)
+        self.write_dir = getattr(args, 'persistent_cache_write_dir', None)
+        self.scopes = list(getattr(args, 'persistent_cache_scopes', []) or [])
+        self.writeback_every_n_saves = getattr(
+            args, 'persistent_cache_writeback_every_n_saves', 8)
+        self.skip_validation = getattr(
+            args, 'persistent_cache_skip_validation', False)
+        self.enabled = bool(self.read_dir or self.write_dir)
+        self._save_count = 0
+        self._writeback_in_flight: Optional[subprocess.Popen] = None
+        self._writeback_script = os.environ.get(
+            'MCORE_CACHE_WRITEBACK_SCRIPT',
+            self._default_script_path('writeback.sh'),
+        )
+
+    @staticmethod
+    def _default_script_path(name: str) -> str:
+        # Resolve <repo>/tools/persistent_cache/<name> relative to this file.
+        here = Path(__file__).resolve()
+        return str(here.parents[2] / 'tools' / 'persistent_cache' / name)
+
+    def validate(self) -> None:
+        """Sanity-check that the bash bootstrap populated the env. Never raises.
+
+        Local rank 0 only: the per-node bootstrap seed is identical for every rank
+        on a node, so one report per node catches per-node seed failures without
+        emitting the same lines from every rank at scale.
+        """
+        if not self.enabled or self.skip_validation:
+            return
+        if not _is_local_rank_zero():
+            return
+        for scope in self.scopes:
+            env_var = _SCOPE_ENV.get(scope)
+            if env_var is None:
+                continue  # CLI-driven scope (dataset_idx); not our concern here.
+            value = os.environ.get(env_var)
+            if not value:
+                logger.warning(
+                    "[persistent_cache] scope %r requested but %s is unset; "
+                    "did the launcher source tools/persistent_cache/bootstrap.sh?",
+                    scope, env_var)
+                continue
+            path = Path(value)
+            check_path = path.parent if env_var.endswith('_DUMP_FILE') else path
+            if not check_path.exists():
+                logger.warning(
+                    "[persistent_cache] scope %r %s=%s does not exist",
+                    scope, env_var, value)
+                continue
+            # If a read_dir was configured, the operator expected warm content.
+            # An empty seeded dir means the bash extract silently failed.
+            if self.read_dir and self._seed_looks_empty(env_var, path):
+                logger.warning(
+                    "[persistent_cache] scope %r %s=%s exists but is empty — "
+                    "bootstrap seed may have failed (will compile cold)",
+                    scope, env_var, value)
+                continue
+            logger.debug(
+                "[persistent_cache] scope %r ready (%s=%s, size=%s)",
+                scope, env_var, value, _du_sh(value))
+
+    @staticmethod
+    def _seed_looks_empty(env_var: str, path: Path) -> bool:
+        if env_var.endswith('_DUMP_FILE'):
+            return not (path.exists() and path.stat().st_size > 0)
+        try:
+            return path.is_dir() and not any(path.iterdir())
+        except OSError:
+            return False
+
+    def maybe_kick_writeback(self, iteration: int) -> None:
+        """Throttled writeback kick from save_checkpoint(). Local rank 0 only.
+
+        Non-blocking: spawns the bash writeback in a new session and returns
+        immediately. Save latency is unaffected.
+        """
+        if not self.enabled or not self.write_dir:
+            return
+        if not _is_local_rank_zero():
+            return
+        self._save_count += 1
+        if self._save_count % max(1, self.writeback_every_n_saves) != 0:
+            return
+        if self._writeback_in_flight is not None and self._writeback_in_flight.poll() is None:
+            logger.info(
+                "[persistent_cache] previous writeback still running, skipping kick at iter %d",
+                iteration)
+            return
+        try:
+            self._writeback_in_flight = subprocess.Popen(
+                ['bash', self._writeback_script],
+                start_new_session=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            logger.info(
+                "[persistent_cache] kicked writeback at iter %d (pid=%d)",
+                iteration, self._writeback_in_flight.pid)
+        except FileNotFoundError:
+            logger.warning(
+                "[persistent_cache] writeback script not found at %s",
+                self._writeback_script)
+
+    def register_atexit(self) -> None:
+        if not self.enabled or not self.write_dir:
+            return
+        if not _is_local_rank_zero():
+            return
+        atexit.register(self._final_writeback)
+
+    # Bounded so process exit isn't held hostage by a hung sidecar.
+    _IN_FLIGHT_WAIT_SECONDS = 60
+    _FINAL_WRITEBACK_TIMEOUT_SECONDS = 300
+
+    def _final_writeback(self) -> None:
+        # Wait for any in-flight writeback (bounded). If still hung, terminate it
+        # so container teardown isn't blocked.
+        if self._writeback_in_flight is not None:
+            try:
+                self._writeback_in_flight.wait(timeout=self._IN_FLIGHT_WAIT_SECONDS)
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    "[persistent_cache] in-flight writeback hung at exit (>%ds); terminating",
+                    self._IN_FLIGHT_WAIT_SECONDS)
+                self._writeback_in_flight.terminate()
+        try:
+            subprocess.run(
+                ['bash', self._writeback_script, '--final'],
+                timeout=self._FINAL_WRITEBACK_TIMEOUT_SECONDS, check=False,
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort
+            logger.warning("[persistent_cache] final writeback failed: %s", e)
+
+
+_singleton: Optional[PersistentCacheController] = None
+
+
+def init(args) -> Optional[PersistentCacheController]:
+    """Idempotent. Call once from training.py at startup."""
+    global _singleton
+    if _singleton is not None:
+        return _singleton
+    _singleton = PersistentCacheController(args)
+    _singleton.validate()
+    _singleton.register_atexit()
+    return _singleton
+
+
+def get() -> Optional[PersistentCacheController]:
+    return _singleton
+
+
+def _is_local_rank_zero() -> bool:
+    local_rank = (os.environ.get('SLURM_LOCALID')
+                  or os.environ.get('LOCAL_RANK')
+                  or '0')
+    try:
+        return int(local_rank) == 0
+    except ValueError:
+        return False
+
+
+def _du_sh(path: str) -> str:
+    try:
+        r = subprocess.run(
+            ['du', '-sh', path], capture_output=True, text=True, timeout=5)
+        return r.stdout.split()[0] if r.returncode == 0 else '?'
+    except Exception:  # noqa: BLE001
+        return '?'

--- a/megatron/training/persistent_cache.py
+++ b/megatron/training/persistent_cache.py
@@ -1,0 +1,227 @@
+"""Persistent cache hooks for Megatron-LM.
+
+Bootstrapping (seeding node-local storage from cache_read/<scope>.tar.zst,
+exporting env vars) is done by tools/persistent_cache/bootstrap.sh BEFORE this Python process
+starts. By the time Python runs, cache env vars have already been consumed by
+torch._inductor / triton / the CUDA driver. This module is responsible only
+for:
+
+  - validating that the bootstrap actually ran (warn if not),
+  - kicking the bash writeback from save_checkpoint(),
+  - registering atexit for a final writeback.
+
+See tools/persistent_cache/README.md for the architecture and bash side.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# scope -> env var the scope's compiler/library reads.
+# 'dataset_idx' is CLI-driven (--data-cache-path), so it is intentionally absent.
+_SCOPE_ENV = {
+    'triton': 'TRITON_CACHE_DIR',
+    'inductor': 'TORCHINDUCTOR_CACHE_DIR',
+    'cuda_ptx': 'CUDA_CACHE_PATH',
+    'hybrid_ep': 'HYBRID_EP_JIT_DIR',
+    'cudnn_fe': 'CUDNN_FRONTEND_CACHE_DIR',
+    'nccl_topo': 'NCCL_TOPO_DUMP_FILE',
+    'megatron_fused_kernels': 'TORCH_EXTENSIONS_DIR',
+}
+
+
+class PersistentCacheController:
+    """Thin coordinator for the bash cache pipeline.
+
+    Owns three responsibilities:
+      1. Validate at startup that the bash bootstrap left the env in a sane state.
+      2. Kick the bash writeback from save_checkpoint, throttled.
+      3. Register an atexit hook for final writeback on clean exit.
+    """
+
+    def __init__(self, args):
+        self.read_dir = getattr(args, 'persistent_cache_read_dir', None)
+        self.write_dir = getattr(args, 'persistent_cache_write_dir', None)
+        self.scopes = list(getattr(args, 'persistent_cache_scopes', []) or [])
+        self.writeback_every_n_saves = getattr(args, 'persistent_cache_writeback_every_n_saves', 8)
+        self.skip_validation = getattr(args, 'persistent_cache_skip_validation', False)
+        self.enabled = bool(self.read_dir or self.write_dir)
+        self._save_count = 0
+        self._writeback_in_flight: Optional[subprocess.Popen] = None
+        self._writeback_script = os.environ.get(
+            'MCORE_CACHE_WRITEBACK_SCRIPT', self._default_script_path('writeback.sh')
+        )
+
+    @staticmethod
+    def _default_script_path(name: str) -> str:
+        # Resolve <repo>/tools/persistent_cache/<name> relative to this file.
+        here = Path(__file__).resolve()
+        return str(here.parents[2] / 'tools' / 'persistent_cache' / name)
+
+    def validate(self) -> None:
+        """Sanity-check that the bash bootstrap populated the env. Never raises.
+
+        Local rank 0 only: the per-node bootstrap seed is identical for every rank
+        on a node, so one report per node catches per-node seed failures without
+        emitting the same lines from every rank at scale.
+        """
+        if not self.enabled or self.skip_validation:
+            return
+        if not _is_local_rank_zero():
+            return
+        for scope in self.scopes:
+            env_var = _SCOPE_ENV.get(scope)
+            if env_var is None:
+                continue  # CLI-driven scope (dataset_idx); not our concern here.
+            value = os.environ.get(env_var)
+            if not value:
+                logger.warning(
+                    "[persistent_cache] scope %r requested but %s is unset; "
+                    "did the launcher source tools/persistent_cache/bootstrap.sh?",
+                    scope,
+                    env_var,
+                )
+                continue
+            path = Path(value)
+            check_path = path.parent if env_var.endswith('_DUMP_FILE') else path
+            if not check_path.exists():
+                logger.warning(
+                    "[persistent_cache] scope %r %s=%s does not exist", scope, env_var, value
+                )
+                continue
+            # If a read_dir was configured, the operator expected warm content.
+            # An empty seeded dir means the bash extract silently failed.
+            if self.read_dir and self._seed_looks_empty(env_var, path):
+                logger.warning(
+                    "[persistent_cache] scope %r %s=%s exists but is empty — "
+                    "bootstrap seed may have failed (will compile cold)",
+                    scope,
+                    env_var,
+                    value,
+                )
+                continue
+            logger.debug(
+                "[persistent_cache] scope %r ready (%s=%s, size=%s)",
+                scope,
+                env_var,
+                value,
+                _du_sh(value),
+            )
+
+    @staticmethod
+    def _seed_looks_empty(env_var: str, path: Path) -> bool:
+        if env_var.endswith('_DUMP_FILE'):
+            return not (path.exists() and path.stat().st_size > 0)
+        try:
+            return path.is_dir() and not any(path.iterdir())
+        except OSError:
+            return False
+
+    def maybe_kick_writeback(self, iteration: int) -> None:
+        """Throttled writeback kick from save_checkpoint(). Local rank 0 only.
+
+        Non-blocking: spawns the bash writeback in a new session and returns
+        immediately. Save latency is unaffected.
+        """
+        if not self.enabled or not self.write_dir:
+            return
+        if not _is_local_rank_zero():
+            return
+        self._save_count += 1
+        if self._save_count % max(1, self.writeback_every_n_saves) != 0:
+            return
+        if self._writeback_in_flight is not None and self._writeback_in_flight.poll() is None:
+            logger.info(
+                "[persistent_cache] previous writeback still running, skipping kick at iter %d",
+                iteration,
+            )
+            return
+        try:
+            self._writeback_in_flight = subprocess.Popen(
+                ['bash', self._writeback_script],
+                start_new_session=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            logger.info(
+                "[persistent_cache] kicked writeback at iter %d (pid=%d)",
+                iteration,
+                self._writeback_in_flight.pid,
+            )
+        except FileNotFoundError:
+            logger.warning(
+                "[persistent_cache] writeback script not found at %s", self._writeback_script
+            )
+
+    def register_atexit(self) -> None:
+        if not self.enabled or not self.write_dir:
+            return
+        if not _is_local_rank_zero():
+            return
+        atexit.register(self._final_writeback)
+
+    # Bounded so process exit isn't held hostage by a hung sidecar.
+    _IN_FLIGHT_WAIT_SECONDS = 60
+    _FINAL_WRITEBACK_TIMEOUT_SECONDS = 300
+
+    def _final_writeback(self) -> None:
+        # Wait for any in-flight writeback (bounded). If still hung, terminate it
+        # so container teardown isn't blocked.
+        if self._writeback_in_flight is not None:
+            try:
+                self._writeback_in_flight.wait(timeout=self._IN_FLIGHT_WAIT_SECONDS)
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    "[persistent_cache] in-flight writeback hung at exit (>%ds); terminating",
+                    self._IN_FLIGHT_WAIT_SECONDS,
+                )
+                self._writeback_in_flight.terminate()
+        try:
+            subprocess.run(
+                ['bash', self._writeback_script, '--final'],
+                timeout=self._FINAL_WRITEBACK_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort
+            logger.warning("[persistent_cache] final writeback failed: %s", e)
+
+
+_singleton: Optional[PersistentCacheController] = None
+
+
+def init(args) -> Optional[PersistentCacheController]:
+    """Idempotent. Call once from training.py at startup."""
+    global _singleton
+    if _singleton is not None:
+        return _singleton
+    _singleton = PersistentCacheController(args)
+    _singleton.validate()
+    _singleton.register_atexit()
+    return _singleton
+
+
+def get() -> Optional[PersistentCacheController]:
+    return _singleton
+
+
+def _is_local_rank_zero() -> bool:
+    local_rank = os.environ.get('SLURM_LOCALID') or os.environ.get('LOCAL_RANK') or '0'
+    try:
+        return int(local_rank) == 0
+    except ValueError:
+        return False
+
+
+def _du_sh(path: str) -> str:
+    try:
+        r = subprocess.run(['du', '-sh', path], capture_output=True, text=True, timeout=5)
+        return r.stdout.split()[0] if r.returncode == 0 else '?'
+    except Exception:  # noqa: BLE001
+        return '?'

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -242,7 +242,7 @@ from megatron.core.num_microbatches_calculator import (
 )
 from megatron.core.pipeline_parallel import get_forward_backward_func
 
-from . import ft_integration, one_logger_utils
+from . import ft_integration, one_logger_utils, persistent_cache
 from .activation_logging import (
     disable_activation_logging,
     disable_tokens_per_expert_logging,
@@ -1107,6 +1107,11 @@ def pretrain(
 
     args = get_args()
     timers = get_timers()
+
+    # Persistent first-iteration cache: validate that the bash bootstrap populated
+    # the env, and register the atexit final writeback. No-op unless a persistent
+    # cache read/write dir is configured.
+    persistent_cache.init(args)
 
     if args.fine_grained_activation_offloading:
         from megatron.core.pipeline_parallel.utils import set_ideal_affinity_for_current_gpu

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -156,7 +156,7 @@ from megatron.training.initialize import (
 from megatron.training.utils import is_gtp_remat_active, is_hybrid_model
 
 # Local.
-from . import ft_integration, one_logger_utils
+from . import ft_integration, one_logger_utils, persistent_cache
 from .activation_logging import (
     disable_activation_logging,
     disable_tokens_per_expert_logging,
@@ -1610,6 +1610,11 @@ def pretrain(
 
     args = get_args()
     timers = get_timers()
+
+    # Persistent first-iteration cache: validate that the bash bootstrap populated
+    # the env, and register the atexit final writeback. No-op unless a persistent
+    # cache read/write dir is configured.
+    persistent_cache.init(args)
 
     # OTel span setup (_start_otel_job_spans) is deferred until after
     # set_jit_fusion_options() below, where program_start/main_entry/pretrain_entry

--- a/tools/persistent_cache/README.md
+++ b/tools/persistent_cache/README.md
@@ -1,0 +1,151 @@
+# Persistent Cache
+
+First-iteration acceleration across job restarts. Caches Triton autotune results,
+TorchInductor FX graphs, CUDA PTX→SASS, cuDNN frontend heuristics, NCCL topology,
+hybrid_ep NVCC JIT, and dataset index across job boundaries.
+
+On a warm restart the cold compile/autotune storm is paid once and reloaded, so
+first-iteration time drops substantially, with sub-second bootstrap extract overhead.
+
+## Architecture (three storage tiers)
+
+```
+${PERSISTENT_CACHE}/                         ◄── Lustre (durable)
+├── cache_read/<scope>.tar.zst                  read-only at job time
+└── cache_write/
+    ├── <scope>/<files>                         shared rsync sink, complete only
+    └── _nodes/<job>_<host>/<scope>/<files>     per-node cp fallback snapshots
+
+/tmp/mcore_cache_${SLURM_JOB_ID}/<scope>/    ◄── per-node, ephemeral
+                                                live working cache
+```
+
+**Read = tarball, write = directory tree.** Splitting them avoids Lustre MDT
+invalidation storms from concurrent reader/writer access on the same dir, and
+lets every job-start be one sequential tarball read instead of thousands of
+small-file opens.
+
+## Scripts
+
+| File                  | When                              | What                                              |
+| --------------------- | --------------------------------- | ------------------------------------------------- |
+| `lib.sh`              | sourced by all                    | shared functions + env defaults                   |
+| `bootstrap.sh`        | sourced per rank in rank entrypoint | per-node seed of `/tmp` + per-rank env export    |
+| `sidecar.sh`          | spawned `&` once per node         | long-running periodic writeback loop + EXIT trap |
+| `writeback.sh`        | invoked by sidecar / save-hook / atexit | one-shot writeback from `/tmp/<scope>/`; rsync writes shared scopes, cp fallback writes per-node snapshots |
+| `promote_tarballs.sh` | launcher's `srun -p cpu` between jobs | merge complete writeback sources, then tar to `cache_read/<scope>.tar.zst` |
+
+`writeback.sh` marks a scope dirty after a successful copy. This is intentional:
+`rsync -a` preserves cache file mtimes, so a newly copied artifact can otherwise
+look older than an existing tarball on Lustre and be missed by mtime-only
+promotion.
+
+Partial writebacks are fail-closed. Direct rsync creates
+`cache_write/<scope>/.mcore_cache_partial` before copying and removes it only
+after a clean `rsync` exit. If `rsync` is missing, the fallback copies into a
+job+node-private temp directory, publishes it under `cache_write/_nodes/` only
+after the copy succeeds, and leaves `<scope>.partial` on failure. Promotion skips
+any source with a partial marker and exits nonzero if only partial sources exist.
+
+## Required env
+
+Set by the launcher before sourcing `bootstrap.sh`:
+
+```bash
+export PERSISTENT_CACHE=/path/to/shared_fs/<user>/.cache/mcore_persistent
+# Derived (optional override):
+export CACHE_READ_DIR="${PERSISTENT_CACHE}/cache_read"
+export CACHE_WRITE_DIR="${PERSISTENT_CACHE}/cache_write"
+```
+
+Tunables (defaults shown):
+
+```bash
+export MCORE_CACHE_SYNC_DELAY_SECONDS=600     # don't rsync before compile is likely done
+export MCORE_CACHE_SYNC_FREQUENCY=300         # sidecar loop interval
+export MCORE_CACHE_SYNC_JITTER_SECONDS=120    # spread initial rsync across 16 nodes
+export MCORE_CACHE_MAX_PERIODIC_WRITEBACKS=0  # default 0 = end-of-job consolidated writeback only
+export MCORE_CACHE_SIDECAR_ENABLED=0          # default 0 = sidecar off; opt in with 1 for in-job snapshots
+export MCORE_CACHE_SCOPES="triton inductor cuda_ptx hybrid_ep cudnn_fe nccl_topo dataset_idx megatron_fused_kernels"
+```
+
+## How to use (launcher integration)
+
+```bash
+# 1. In sbatch wrapper, before srun:
+export PERSISTENT_CACHE=/path/to/shared_fs/<user>/.cache/mcore_persistent
+mkdir -p "${PERSISTENT_CACHE}/cache_read" "${PERSISTENT_CACHE}/cache_write"
+
+# 2. Refresh stale tarballs out-of-band on a CPU partition:
+srun -N1 -n1 -p cpu -q cpu-short -A "${SLURM_ACCOUNT}" -t 00:15:00 --quiet \
+    bash "${MEGATRON_LM_DIR}/tools/persistent_cache/promote_tarballs.sh" \
+    || echo "[CACHE] promote step failed (first job will compile cold)"
+
+# 3. Add the new CLI flags to your training command:
+OPTIONS+=" --persistent-cache-read-dir ${PERSISTENT_CACHE}/cache_read"
+OPTIONS+=" --persistent-cache-write-dir ${PERSISTENT_CACHE}/cache_write"
+
+# 4. In your rank entrypoint, source bootstrap and spawn sidecar:
+if [[ -n "${PERSISTENT_CACHE:-}" ]]; then
+    # shellcheck disable=SC1091
+    source "${MEGATRON_LM_DIR}/tools/persistent_cache/bootstrap.sh"
+    if [[ "${MCORE_CACHE_SIDECAR_ENABLED:-0}" == "1" ]]; then
+        bash "${MEGATRON_LM_DIR}/tools/persistent_cache/sidecar.sh" </dev/null &
+    fi
+fi
+
+# 5. Exec the training command — env vars from bootstrap stick:
+exec python pretrain_mamba.py …
+```
+
+## Cache scopes
+
+| Scope        | Env var                       | What's cached                                         |
+| ------------ | ----------------------------- | ----------------------------------------------------- |
+| `triton`     | `TRITON_CACHE_DIR`            | Triton compiled cubins + autotune choices             |
+| `inductor`   | `TORCHINDUCTOR_CACHE_DIR`     | torch._dynamo FX graphs + autograd cache              |
+| `cuda_ptx`   | `CUDA_CACHE_PATH`             | CUDA driver PTX→SASS                                  |
+| `hybrid_ep`  | `HYBRID_EP_JIT_DIR`           | NVCC-JIT compiled .so for DeepEP hybrid_ep dispatcher |
+| `cudnn_fe`   | `CUDNN_FRONTEND_CACHE_DIR`    | cuDNN heuristic results                               |
+| `nccl_topo`  | `NCCL_TOPO_DUMP_FILE`         | NCCL topology dump (informational; read-side reload unreliable at scale) |
+| `dataset_idx`| `--data-cache-path`           | Megatron dataset blend / index files                  |
+| `megatron_fused_kernels`| `TORCH_EXTENSIONS_DIR`| Megatron "compiling and loading fused kernels" `torch.utils.cpp_extension.load` build dir (saves 5-17 s/restart) |
+
+## Triton autotune `pre_hook` disk-cache patch
+
+Upstream Triton skips disk-cache lookup for any autotune `Config` carrying a
+`pre_hook`, so kernels that register a `pre_hook` (e.g. some Mamba backward
+kernels) re-autotune on every warm restart. Two files fix this without
+serializing the hook itself:
+
+| File | Role |
+|---|---|
+| `triton_autotune_disk_cache.py` | Monkey-patches `Autotuner.check_disk_cache` to key configs by a JSON-friendly dict (kwargs + `pre_hook.__qualname__`), persist `pre_hook` configs, and reconstruct + run the local hook on a cache hit. `arm()` registers a `MetaPathFinder` so the patch lands on the first `import triton.runtime.autotuner` regardless of import order; `install()` covers the already-imported case. |
+| `_triton_patch_shim/sitecustomize.py` | Auto-loaded by Python's `site` module when its directory is on `PYTHONPATH`; calls `arm()`+`install()`, then chains to the container's apport `sitecustomize.py`. |
+
+Wiring (in your rank entrypoint): prepend the shim dir to `PYTHONPATH` so it arms
+before Triton is imported:
+
+```bash
+export PYTHONPATH="${MEGATRON_LM_DIR}/tools/persistent_cache/_triton_patch_shim:${PYTHONPATH:-}"
+```
+
+Kill switch: `TRITON_AUTOTUNE_PREHOOK_PATCH_DISABLE=1`. Debug: `TRITON_AUTOTUNE_PATCH_DEBUG=1`.
+
+## Failure modes
+
+| Failure | What happens | Recovery |
+| ------- | ------------ | -------- |
+| Tarball missing | `[CACHE SEED] <scope>: no tarball` | Cold compile, sidecar populates `cache_write/`, next promote builds tarball |
+| Tarball corrupt | `tar --zstd -xf` fails non-fatally | Cold compile; bash logs warning |
+| `/dev/shm` noexec | exec-probe falls back to `/tmp` | Automatic |
+| `rsync` not in container image | sidecar uses per-node cp snapshot fallback | Automatic, logged once; promotion merges completed snapshots later |
+| Writeback fails midway | Partial marker is left beside the source | Promotion skips it and returns nonzero if no complete source exists |
+| Job crashes before writeback | `cache_write/` may be empty for this job | No corruption; next job compiles cold |
+| Sidecar hangs | atexit terminates it after 60 s wait | Bounded exit delay |
+| Lustre temporarily unreachable | Tar/rsync fails | Logged non-fatal; training unaffected |
+
+## How to opt out
+
+Don't pass `--persistent-cache-read-dir` or `--persistent-cache-write-dir`. The
+Python side becomes a no-op; the bash side never sources without `PERSISTENT_CACHE`.

--- a/tools/persistent_cache/_triton_patch_shim/sitecustomize.py
+++ b/tools/persistent_cache/_triton_patch_shim/sitecustomize.py
@@ -1,0 +1,43 @@
+"""sitecustomize.py loaded via PYTHONPATH prepend during cache bootstrap.
+
+Loaded automatically by Python's `site` module before user code runs. Two jobs:
+
+1. Install the Triton autotune-disk-cache `pre_hook` patch. See
+   `triton_autotune_disk_cache.py` in the parent directory for what it does.
+2. Re-execute the container's existing `/usr/lib/python3.12/sitecustomize.py`
+   so we don't drop the Ubuntu `apport_python_hook` handler. The container's
+   sitecustomize is small (6 lines) — apport handles uncaught exceptions, not
+   critical, but worth preserving so we don't silently change crash behavior.
+
+Disable with `TRITON_AUTOTUNE_PREHOOK_PATCH_DISABLE=1` (the patch's own kill
+switch). This file remains a no-op for the Triton install when set.
+"""
+
+import os
+import sys
+
+# (1) Arm + install our Triton autotune patch. `arm()` registers a
+# MetaPathFinder so the patch lands on the first `import triton.runtime.autotuner`
+# regardless of import order — this is the fix for the failure mode where
+# `install()` alone ran before Triton was importable and silently no-op'd.
+# `install()` covers the rare case where Triton was already pulled in.
+try:
+    _shim_dir = os.path.dirname(os.path.abspath(__file__))
+    _pc_dir = os.path.dirname(_shim_dir)
+    if _pc_dir not in sys.path:
+        sys.path.insert(0, _pc_dir)
+    import triton_autotune_disk_cache  # noqa: E402
+    triton_autotune_disk_cache.arm()
+    triton_autotune_disk_cache.install()
+except Exception:
+    pass
+
+# (2) Chain to the container's apport sitecustomize. Use runpy to execute the
+# file by path so it works whether or not the container changes Python version.
+try:
+    import runpy
+    _apport_path = "/usr/lib/python3.12/sitecustomize.py"
+    if os.path.exists(_apport_path):
+        runpy.run_path(_apport_path, run_name="__sitecustomize_chain__")
+except Exception:
+    pass

--- a/tools/persistent_cache/_triton_patch_shim/sitecustomize.py
+++ b/tools/persistent_cache/_triton_patch_shim/sitecustomize.py
@@ -1,0 +1,45 @@
+"""sitecustomize.py loaded via PYTHONPATH prepend during cache bootstrap.
+
+Loaded automatically by Python's `site` module before user code runs. Two jobs:
+
+1. Install the Triton autotune-disk-cache `pre_hook` patch. See
+   `triton_autotune_disk_cache.py` in the parent directory for what it does.
+2. Re-execute the container's existing `/usr/lib/python3.12/sitecustomize.py`
+   so we don't drop the Ubuntu `apport_python_hook` handler. The container's
+   sitecustomize is small (6 lines) — apport handles uncaught exceptions, not
+   critical, but worth preserving so we don't silently change crash behavior.
+
+Disable with `TRITON_AUTOTUNE_PREHOOK_PATCH_DISABLE=1` (the patch's own kill
+switch). This file remains a no-op for the Triton install when set.
+"""
+
+import os
+import sys
+
+# (1) Arm + install our Triton autotune patch. `arm()` registers a
+# MetaPathFinder so the patch lands on the first `import triton.runtime.autotuner`
+# regardless of import order — this is the fix for the failure mode where
+# `install()` alone ran before Triton was importable and silently no-op'd.
+# `install()` covers the rare case where Triton was already pulled in.
+try:
+    _shim_dir = os.path.dirname(os.path.abspath(__file__))
+    _pc_dir = os.path.dirname(_shim_dir)
+    if _pc_dir not in sys.path:
+        sys.path.insert(0, _pc_dir)
+    import triton_autotune_disk_cache  # noqa: E402
+
+    triton_autotune_disk_cache.arm()
+    triton_autotune_disk_cache.install()
+except Exception:
+    pass
+
+# (2) Chain to the container's apport sitecustomize. Use runpy to execute the
+# file by path so it works whether or not the container changes Python version.
+try:
+    import runpy
+
+    _apport_path = "/usr/lib/python3.12/sitecustomize.py"
+    if os.path.exists(_apport_path):
+        runpy.run_path(_apport_path, run_name="__sitecustomize_chain__")
+except Exception:
+    pass

--- a/tools/persistent_cache/bootstrap.sh
+++ b/tools/persistent_cache/bootstrap.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# tools/persistent_cache/bootstrap.sh — SOURCE me from rank_entrypoint.sh.
+#
+# Per node: seed NODE_CACHE_BASE/<scope>/ from CACHE_READ_DIR/<scope>.tar.zst.
+# Per rank: export the env vars Megatron-LM's child processes will read.
+#
+# Sourcing (not executing) is required so the env-var exports stick in the
+# caller's shell, where `python pretrain_*.py` will inherit them.
+
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# Sweep stale exec-probe files from crashed prior jobs (>1 day old).
+# Best-effort; failures are silent. Bounds disk leak from probe writes.
+find /tmp /dev/shm -maxdepth 1 -name '.pc_probe.*' -mtime +1 -delete 2>/dev/null || true
+
+# Probe candidate node-local dirs for write+exec. Some container runtimes mount
+# /dev/shm with noexec, which breaks Triton/Inductor (they dlopen compiled .so).
+# Probe order: /dev/shm (fastest) → /tmp → per-node lustre subdir (always works).
+_pc_can_write_exec() {
+  local dir="$1"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  local probe="${dir}/.pc_probe.$$"
+  printf '#!/bin/bash\nexit 0\n' > "$probe" 2>/dev/null || return 1
+  if ! chmod +x "$probe" 2>/dev/null; then rm -f "$probe"; return 1; fi
+  if ! "$probe" >/dev/null 2>&1;        then rm -f "$probe"; return 1; fi
+  rm -f "$probe"
+  return 0
+}
+
+_pc_select_base() {
+  # NODE_CACHE_BASE_OVERRIDE wins if set (for testing).
+  if [[ -n "${NODE_CACHE_BASE_OVERRIDE:-}" ]]; then
+    if _pc_can_write_exec "${NODE_CACHE_BASE_OVERRIDE}"; then
+      echo "${NODE_CACHE_BASE_OVERRIDE}" ; return 0
+    fi
+    echo "[CACHE BOOTSTRAP] override ${NODE_CACHE_BASE_OVERRIDE} is not write+exec; falling back" >&2
+  fi
+  local jid="${SLURM_JOB_ID:-manual}"
+  local host
+  host="$(hostname -s 2>/dev/null || hostname || echo unknown)"
+  local cands=(
+    "/dev/shm/mcore_cache_${jid}"
+    "/tmp/mcore_cache_${jid}"
+    "${PERSISTENT_CACHE:-/tmp}/_node/${host}_${jid}"
+  )
+  for c in "${cands[@]}"; do
+    if _pc_can_write_exec "$c"; then
+      echo "$c"; return 0
+    fi
+  done
+  return 1
+}
+
+NODE_CACHE_BASE="$(_pc_select_base)"
+export NODE_CACHE_BASE
+echo "[CACHE BOOTSTRAP] node=$(hostname) base=${NODE_CACHE_BASE} (write+exec verified)"
+if (( ! MCORE_CACHE_RSYNC_AVAILABLE )); then
+  echo "[CACHE BOOTSTRAP] rsync not in PATH; sidecar/writeback will use per-node cp snapshot fallback"
+fi
+
+_pc_lock_dir="$(dirname "${NODE_CACHE_BASE}")"
+mkdir -p "${_pc_lock_dir}"
+_pc_lock_file="${NODE_CACHE_BASE}.bootstrap.lock"
+_pc_sentinel="${NODE_CACHE_BASE}/.bootstrapped"
+
+# Per-scope extract (run in parallel for speed).
+_pc_extract_one() {
+  local scope="$1"
+  local local_dir tar_file t0 t1 dur
+  local_dir="$(scope_local_dir "${scope}")"
+  tar_file="$(scope_lustre_read_tar "${scope}")"
+  mkdir -p "${local_dir}"
+  if [[ -f "${tar_file}" ]]; then
+    t0=$(date +%s.%N)
+    # tar --zstd respects ZSTD_NBTHREADS=0 for multi-threaded decompress.
+    if tar --zstd -xf "${tar_file}" -C "${local_dir}" 2>/dev/null; then
+      t1=$(date +%s.%N)
+      dur=$(awk -v a="${t0}" -v b="${t1}" 'BEGIN{printf "%.2f", b-a}')
+      echo "[CACHE SEED] ${scope}: ok in ${dur}s ($(du -sh "${local_dir}" 2>/dev/null | cut -f1))"
+    else
+      echo "[CACHE SEED] ${scope}: extract failed (non-fatal, will compile cold)"
+    fi
+  else
+    echo "[CACHE SEED] ${scope}: no tarball at ${tar_file}"
+  fi
+}
+
+(
+  # Bounded flock: if some other rank dies holding the lock, fall through after 600s
+  # rather than block forever. Runs as cold seed (=== compile-from-scratch path).
+  if ! flock -x -w 600 9; then
+    echo "[CACHE BOOTSTRAP] flock timed out (600s); skipping seed (will compile cold)"
+    exit 0
+  fi
+  if [[ ! -f "${_pc_sentinel}" ]]; then
+    # Free-space pre-flight (informational only; probe already proved write).
+    _free_gb=$(df -BG "${NODE_CACHE_BASE}" 2>/dev/null | awk 'NR==2{gsub(/G/,"",$4); print $4}' || true)
+    echo "[CACHE BOOTSTRAP] ${NODE_CACHE_BASE}: ${_free_gb:-?}G free"
+
+    # Ensure zstd is available.
+    command -v zstd >/dev/null 2>&1 || {
+      apt-get update -qq && apt-get install -y -qq zstd 2>/dev/null || true
+    }
+
+    # Wipe stale cache from a prior failed job on this node.
+    rm -rf "${NODE_CACHE_BASE}"
+    mkdir -p "${NODE_CACHE_BASE}"
+
+    # Extract scopes in parallel. Each scope writes to its own dir, no conflicts.
+    _pc_total_t0=$(date +%s.%N)
+    for _scope in "${SCOPES[@]}"; do
+      _pc_extract_one "${_scope}" &
+    done
+    wait
+    _pc_total_t1=$(date +%s.%N)
+    _pc_total_dur=$(awk -v a="${_pc_total_t0}" -v b="${_pc_total_t1}" 'BEGIN{printf "%.2f", b-a}')
+    echo "[CACHE BOOTSTRAP] all scopes extracted in ${_pc_total_dur}s wall (parallel, ZSTD_NBTHREADS=${ZSTD_NBTHREADS})"
+
+    touch "${_pc_sentinel}"
+  fi
+) 9>"${_pc_lock_file}"
+
+# Every rank exports env vars now that the seed is done (or attempted).
+# These are read by torch._inductor / triton / CUDA driver / TE at first import.
+export TRITON_CACHE_DIR="$(scope_local_dir triton)"
+export TORCHINDUCTOR_CACHE_DIR="$(scope_local_dir inductor)"
+export CUDA_CACHE_PATH="$(scope_local_dir cuda_ptx)"
+export HYBRID_EP_JIT_DIR="$(scope_local_dir hybrid_ep)"
+export CUDNN_FRONTEND_CACHE_DIR="$(scope_local_dir cudnn_fe)"
+# Megatron's "compiling and loading fused kernels" step uses
+# torch.utils.cpp_extension.load, which checks TORCH_EXTENSIONS_DIR for an
+# existing build, saving several seconds on warm restart.
+export TORCH_EXTENSIONS_DIR="$(scope_local_dir megatron_fused_kernels)"
+mkdir -p "$(scope_local_dir nccl_topo)"
+# Dump-side: NCCL writes topology graph here at init. Useful for diagnostics.
+export NCCL_TOPO_DUMP_FILE="$(scope_local_dir nccl_topo)/topo.xml"
+export NCCL_GRAPH_DUMP_FILE="$(scope_local_dir nccl_topo)/graph.xml"
+# NOTE: NCCL_TOPO_FILE read-side is intentionally NOT set. Tried it in v2; the
+# dumped XML at 64-GPU scale exceeds NCCL 2.28's 256-node XML parser limit and
+# causes init to fail. The dump is informational only for now.
+
+echo "[CACHE BOOTSTRAP] rank=${SLURM_PROCID:-?} ready (NODE_CACHE_BASE=${NODE_CACHE_BASE})"

--- a/tools/persistent_cache/lib.sh
+++ b/tools/persistent_cache/lib.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# tools/persistent_cache/lib.sh — shared functions and config. Source me; don't run me.
+#
+# Required env (caller must set):
+#   PERSISTENT_CACHE  Lustre dir holding cache_read/ and cache_write/ subdirs.
+#
+# Derived (set by this lib if not already):
+#   CACHE_READ_DIR, CACHE_WRITE_DIR, NODE_CACHE_BASE,
+#   MCORE_CACHE_SYNC_DELAY_SECONDS, MCORE_CACHE_SYNC_FREQUENCY,
+#   MCORE_CACHE_SYNC_JITTER_SECONDS, MCORE_CACHE_SYNC_EXIT_JITTER_SECONDS,
+#   MCORE_CACHE_MAX_PERIODIC_WRITEBACKS, MCORE_JOB_START_EPOCH, SCOPES.
+
+: "${PERSISTENT_CACHE:?PERSISTENT_CACHE is unset (set in launcher before sourcing)}"
+: "${CACHE_READ_DIR:=${PERSISTENT_CACHE}/cache_read}"
+: "${CACHE_WRITE_DIR:=${PERSISTENT_CACHE}/cache_write}"
+: "${NODE_CACHE_BASE:=/dev/shm/mcore_cache_${SLURM_JOB_ID:-manual}}"
+
+: "${MCORE_CACHE_SYNC_DELAY_SECONDS:=600}"
+: "${MCORE_CACHE_SYNC_FREQUENCY:=300}"
+: "${MCORE_CACHE_SYNC_JITTER_SECONDS:=120}"
+: "${MCORE_CACHE_SYNC_EXIT_JITTER_SECONDS:=}"
+# Default 0 = no in-job periodic writebacks (doc comment #1 / Russell). Only
+# the staggered end-of-job consolidated writeback runs via sidecar EXIT trap.
+# Set ≥1 only at small scale where a mid-job crash leaving the cache stale is
+# more costly than the Lustre write storm. At ≥256 cards prefer the image-baked
+# path with MCORE_CACHE_WRITEBACK_DISABLED=1.
+: "${MCORE_CACHE_MAX_PERIODIC_WRITEBACKS:=0}"
+: "${MCORE_JOB_START_EPOCH:=$(date +%s)}"
+export MCORE_JOB_START_EPOCH
+
+# shellcheck disable=SC2206
+SCOPES=(${MCORE_CACHE_SCOPES:-triton inductor cuda_ptx hybrid_ep cudnn_fe nccl_topo dataset_idx megatron_fused_kernels})
+
+# Multi-threaded zstd by default (decompress 4-8x faster on multi-core nodes).
+# Can be overridden by user; tar --zstd reads ZSTD_NBTHREADS for both compress/decompress.
+: "${ZSTD_NBTHREADS:=0}"   # 0 = use all available cores
+export ZSTD_NBTHREADS
+
+# Probe rsync availability once per process. If absent, writeback uses a
+# per-node snapshot fallback instead of concurrent cp into the shared scope.
+if command -v rsync >/dev/null 2>&1; then
+  MCORE_CACHE_RSYNC_AVAILABLE=1
+else
+  MCORE_CACHE_RSYNC_AVAILABLE=0
+fi
+export MCORE_CACHE_RSYNC_AVAILABLE
+
+scope_local_dir()        { echo "${NODE_CACHE_BASE}/$1"; }
+scope_lustre_write_dir() { echo "${CACHE_WRITE_DIR}/$1"; }
+scope_lustre_read_tar()  { echo "${CACHE_READ_DIR}/$1.tar.zst"; }
+cache_node_id() {
+  local host
+  host="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo unknown)"
+  echo "${SLURM_JOB_ID:-manual}_${host}"
+}
+scope_node_write_dir() { echo "${CACHE_WRITE_DIR}/_nodes/$(cache_node_id)/$1"; }
+
+is_local_rank_zero() { [[ "${SLURM_LOCALID:-0}" == "0" ]]; }
+
+# Copy src/ into the persistent writeback area.
+#
+# With rsync, write directly to cache_write/<scope>/ and mark the scope dirty
+# only after a clean rc=0. Any nonzero rsync leaves .mcore_cache_partial, which
+# promote_tarballs.sh refuses to package.
+#
+# Without rsync, never cp concurrently into the shared scope. Copy into a
+# job+node-private staging dir, then atomically publish the complete snapshot
+# under cache_write/_nodes/<job>_<host>/<scope>. Promotion later merges completed
+# node snapshots on a CPU node.
+rsync_safe() {
+  local src="$1" dst="$2" name="$3"
+  [[ -d "$src" ]] || return 1
+  [[ -n "$(ls -A "$src" 2>/dev/null)" ]] || return 1
+  local _err _rc=0 partial
+  if command -v rsync >/dev/null 2>&1; then
+    mkdir -p "$dst"
+    partial="${dst}/.mcore_cache_partial"
+    touch "$partial" 2>/dev/null || true
+    _err=$(rsync -a --exclude='tmp*' --exclude='.tmp_*' --exclude='.*' \
+      "$src/" "$dst/" 2>&1) || _rc=$?
+    if (( _rc == 0 )); then
+      rm -f "$partial"
+      touch "$dst/.mcore_cache_dirty" 2>/dev/null || true
+      touch "$dst/.mcore_cache_writeback_stamp" 2>/dev/null || true
+      echo "[CACHE] ${name}: rsynced ($(du -sh "$dst" 2>/dev/null | cut -f1))"
+      return 0
+    fi
+    echo "[CACHE] ${name}: rsync failed, left partial marker at ${partial} (rc=${_rc}: ${_err})" >&2
+    return 1
+  fi
+
+  # Fallback: private per-node snapshot. The shared cache_write/<scope>/ is not
+  # touched, so a failed cp cannot leave truncated files in the promotable tree.
+  local node_dst tmp parent sibling_partial
+  node_dst="$(scope_node_write_dir "$name")"
+  parent="$(dirname "$node_dst")"
+  tmp="${node_dst}.tmp.$$"
+  sibling_partial="${node_dst}.partial"
+  mkdir -p "$parent"
+  rm -rf "$tmp"
+  touch "$sibling_partial" 2>/dev/null || true
+  mkdir -p "$tmp"
+  shopt -s nullglob dotglob 2>/dev/null
+  local entry _bn
+  for entry in "$src"/*; do
+    _bn="$(basename "$entry")"
+    case "$_bn" in
+      tmp*|.tmp_*|.*) continue ;;
+    esac
+    cp -a "$entry" "$tmp/" 2>/dev/null || _rc=$?
+  done
+  if (( _rc == 0 )); then
+    touch "$tmp/.mcore_cache_dirty" 2>/dev/null || true
+    touch "$tmp/.mcore_cache_writeback_stamp" 2>/dev/null || true
+    if rm -rf "$node_dst" && mv "$tmp" "$node_dst"; then
+      rm -f "$sibling_partial"
+      echo "[CACHE] ${name}: cp-snapshotted $(cache_node_id) ($(du -sh "$node_dst" 2>/dev/null | cut -f1))"
+      return 0
+    fi
+    _rc=$?
+  fi
+  rm -rf "$tmp"
+  echo "[CACHE] ${name}: cp snapshot failed, left partial marker at ${sibling_partial} (rc=${_rc})" >&2
+  return 1
+}
+
+has_partial_marker() {
+  local src="$1"
+  [[ -f "${src}.partial" || -f "${src}/.mcore_cache_partial" ]]
+}
+
+source_has_content() {
+  local src="$1"
+  [[ -d "$src" ]] && [[ -n "$(find "$src" -mindepth 1 \
+    ! -name '.mcore_cache_dirty' \
+    ! -name '.mcore_cache_writeback_stamp' \
+    ! -name '.mcore_cache_partial' \
+    ! -name 'tmp*' \
+    ! -name '.tmp_*' \
+    -print -quit 2>/dev/null)" ]]
+}
+
+source_is_dirty_or_newer() {
+  local src="$1" tarball="$2"
+  [[ -f "${src}/.mcore_cache_dirty" ]] && return 0
+  [[ ! -f "$tarball" ]] && return 0
+  find "$src" -type f \
+    ! -name '.mcore_cache_dirty' \
+    ! -name '.mcore_cache_writeback_stamp' \
+    ! -name '.mcore_cache_partial' \
+    -newer "$tarball" -print -quit 2>/dev/null | grep -q .
+}
+
+merge_cache_source() {
+  local src="$1" dst="$2" name="$3"
+  [[ -d "$src" ]] || return 0
+  mkdir -p "$dst"
+  local _err _rc=0
+  if command -v rsync >/dev/null 2>&1; then
+    _err=$(rsync -a --ignore-existing --exclude='tmp*' --exclude='.tmp_*' \
+      --exclude='.mcore_cache_*' "$src/" "$dst/" 2>&1) || _rc=$?
+    if (( _rc == 0 || _rc == 23 || _rc == 24 )); then
+      return 0
+    fi
+    echo "[CACHE PROMOTE] ${name}: merge rsync failed from ${src} (rc=${_rc}: ${_err})" >&2
+    return 1
+  fi
+
+  shopt -s nullglob dotglob 2>/dev/null
+  local entry _bn
+  for entry in "$src"/*; do
+    _bn="$(basename "$entry")"
+    case "$_bn" in
+      tmp*|.tmp_*|.mcore_cache_*) continue ;;
+    esac
+    cp -an "$entry" "$dst/" 2>/dev/null || _rc=$?
+  done
+  if (( _rc == 0 )); then
+    return 0
+  fi
+  echo "[CACHE PROMOTE] ${name}: merge cp failed from ${src} (rc=${_rc})" >&2
+  return 1
+}
+
+# Atomic tar+zstd. tmp+rename so readers never see a partial tarball.
+# NOTE: don't use --exclude='.*' — that matches the '.' source arg and emits an empty tar.
+tar_safe() {
+  local src="$1" tarball="$2" name="$3"
+  [[ -d "$src" ]] || return 1
+  [[ -n "$(ls -A "$src" 2>/dev/null)" ]] || return 1
+  local tmp="${tarball}.tmp.$$"
+  if tar --zstd -cf "$tmp" --blocking-factor=8192 \
+       -C "$src" --exclude='tmp*' --exclude='.tmp_*' \
+       --exclude='.mcore_cache_dirty' --exclude='.mcore_cache_writeback_stamp' . ; then
+    mv "$tmp" "$tarball"
+    echo "[CACHE] ${name}: tarball ($(du -sh "$tarball" 2>/dev/null | cut -f1))"
+    return 0
+  fi
+  rm -f "$tmp"
+  echo "[CACHE] ${name}: tar failed" >&2
+  return 1
+}

--- a/tools/persistent_cache/promote_tarballs.sh
+++ b/tools/persistent_cache/promote_tarballs.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# tools/persistent_cache/promote_tarballs.sh — refresh CACHE_READ_DIR/<scope>.tar.zst from
+# CACHE_WRITE_DIR/<scope>/. Called from sbatch wrapper as a separate
+# `srun -p cpu`, never from a GPU job. Heavy tar work belongs on a CPU node.
+#
+# Args: scope names to promote. Defaults to all SCOPES.
+
+set -euo pipefail
+# shellcheck disable=SC1091
+source "$(dirname "$0")/lib.sh"
+
+mkdir -p "${CACHE_READ_DIR}"
+
+# shellcheck disable=SC2206
+todo=("${@:-${SCOPES[@]}}")
+had_error=0
+
+for scope in "${todo[@]}"; do
+  tarball="$(scope_lustre_read_tar "$scope")"
+  sources=()
+  skipped_partial=0
+
+  src="$(scope_lustre_write_dir "$scope")"
+  if source_has_content "$src"; then
+    if has_partial_marker "$src"; then
+      echo "[CACHE PROMOTE] ${scope}: skip partial shared source ${src}" >&2
+      skipped_partial=1
+    else
+      sources+=("$src")
+    fi
+  fi
+
+  node_root="${CACHE_WRITE_DIR}/_nodes"
+  if [[ -d "$node_root" ]]; then
+    while IFS= read -r partial_marker; do
+      echo "[CACHE PROMOTE] ${scope}: skip orphan partial node marker ${partial_marker}" >&2
+      skipped_partial=1
+    done < <(find "$node_root" -mindepth 2 -maxdepth 2 -type f -name "${scope}.partial" 2>/dev/null | sort)
+
+    while IFS= read -r node_src; do
+      if has_partial_marker "$node_src"; then
+        echo "[CACHE PROMOTE] ${scope}: skip partial node source ${node_src}" >&2
+        skipped_partial=1
+        continue
+      fi
+      if source_has_content "$node_src"; then
+        sources+=("$node_src")
+      fi
+    done < <(find "$node_root" -mindepth 2 -maxdepth 2 -type d -name "$scope" 2>/dev/null | sort)
+  fi
+
+  if (( ${#sources[@]} == 0 )); then
+    if (( skipped_partial )); then
+      echo "[CACHE PROMOTE] ${scope}: no complete source to promote (partial sources present)" >&2
+      had_error=1
+    fi
+    continue
+  fi
+
+  needs=0
+  if [[ ! -f "$tarball" ]]; then
+    needs=1
+  else
+    for src in "${sources[@]}"; do
+      if source_is_dirty_or_newer "$src" "$tarball"; then
+        needs=1
+        break
+      fi
+    done
+  fi
+
+  if (( needs )); then
+    stage="${CACHE_WRITE_DIR}/.promote_${scope}.$$"
+    rm -rf "$stage"
+    mkdir -p "$stage"
+    merge_failed=0
+    for src in "${sources[@]}"; do
+      if ! merge_cache_source "$src" "$stage" "$scope"; then
+        merge_failed=1
+      fi
+    done
+    if (( merge_failed )); then
+      rm -rf "$stage"
+      had_error=1
+      continue
+    fi
+    if tar_safe "$stage" "$tarball" "$scope"; then
+      for src in "${sources[@]}"; do
+        rm -f "$src/.mcore_cache_dirty"
+      done
+      rm -rf "$stage"
+    else
+      rm -rf "$stage"
+      had_error=1
+    fi
+  else
+    echo "[CACHE PROMOTE] ${scope}: tarball up to date"
+  fi
+done
+
+exit "$had_error"

--- a/tools/persistent_cache/sidecar.sh
+++ b/tools/persistent_cache/sidecar.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# tools/persistent_cache/sidecar.sh — long-running per-node writeback loop.
+# Spawn from rank_entrypoint with `&`. One per node (gated by SLURM_LOCALID==0).
+
+set -euo pipefail
+# shellcheck disable=SC1091
+source "$(dirname "$0")/lib.sh"
+
+is_local_rank_zero || exit 0
+# Default OFF (doc comment #1): periodic in-job writebacks add Lustre fan-in
+# without measurable benefit beyond the staggered end-of-job consolidation.
+# Launchers needing in-job snapshotting must opt in with MCORE_CACHE_SIDECAR_ENABLED=1.
+[[ "${MCORE_CACHE_SIDECAR_ENABLED:-0}" == "1" ]] || exit 0
+
+WB="$(dirname "$0")/writeback.sh"
+
+cache_sleep() {
+  local seconds="${1:-0}"
+  [[ "$seconds" =~ ^[0-9]+$ ]] || seconds=0
+  if command -v python >/dev/null 2>&1; then
+    python - "$seconds" <<'PY'
+import sys
+import time
+
+time.sleep(int(sys.argv[1]))
+PY
+    return
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$seconds" <<'PY'
+import sys
+import time
+
+time.sleep(int(sys.argv[1]))
+PY
+    return
+  fi
+  sleep "$seconds"
+}
+
+_final() {
+  # Per-node exit jitter scaled by cluster size. Avoids N-node thundering herd
+  # at job teardown.
+  local nnodes=${SLURM_JOB_NUM_NODES:-1}
+  local window=${MCORE_CACHE_SYNC_EXIT_JITTER_SECONDS:-}
+  if [[ -z "$window" ]]; then
+    window=$(( nnodes / 20 ))
+    (( window < 15 )) && window=15
+    (( window > 45 )) && window=45
+  fi
+  cache_sleep "$(( RANDOM % (window > 0 ? window : 1) ))"
+  bash "$WB" --final || true
+}
+trap '_final' EXIT
+
+# Initial per-node jitter so 64 nodes don't first-rsync at the same wall clock.
+cache_sleep "$(( RANDOM % MCORE_CACHE_SYNC_JITTER_SECONDS ))"
+
+_periodic_count=0
+while cache_sleep "$MCORE_CACHE_SYNC_FREQUENCY"; do
+  if (( MCORE_CACHE_MAX_PERIODIC_WRITEBACKS >= 0 && _periodic_count >= MCORE_CACHE_MAX_PERIODIC_WRITEBACKS )); then
+    continue
+  fi
+  bash "$WB" || true
+  _periodic_count=$(( _periodic_count + 1 ))
+done

--- a/tools/persistent_cache/triton_autotune_disk_cache.py
+++ b/tools/persistent_cache/triton_autotune_disk_cache.py
@@ -1,0 +1,476 @@
+"""Monkey-patch Triton's `Autotuner.check_disk_cache` to keep cache hits
+even when some configs have `pre_hook`.
+
+Upstream Triton bails out of disk caching whenever *any* config in the
+autotune set has a `pre_hook`:
+
+    # We can't serialize prehooks, so just give up and run the benchmarks.
+    if not tuning_key or any(cfg.pre_hook for cfg in configs):
+        bench_fn()
+        return False
+
+Save side also drops pre_hook configs:
+
+    "configs_timings": [(config.__dict__, timings)
+                       for config, timings in self.configs_timings.items()
+                       if not config.pre_hook],
+
+Practical effect at scale: Triton autotuning lines on warm-cache cold
+restarts stay >0 for kernels (TE/hybrid_ep) that register a pre_hook on at
+least one Config. This patch:
+
+1. Identifies each Config by a JSON-friendly dict (kwargs + num_warps/...,
+   and `pre_hook.__qualname__` if any). Configs with unnamed pre_hooks
+   (lambdas/closures) are excluded — they would not round-trip.
+2. On load: matches cached entries against the live `configs` list by
+   structural equality. If every config has a hit, skip benching. Otherwise
+   fall back to upstream behavior (re-bench the whole set).
+3. On save: includes pre_hook configs (keyed by `__qualname__`) instead of
+   filtering them out.
+
+Forces `cache_results=True` at construction so the disk-cache path is always
+reached regardless of caller intent.
+
+Wiring (prefer `arm()` over `install()` so we win the import-order race):
+  * `arm()` registers a `MetaPathFinder` that intercepts the first
+    `import triton.runtime.autotuner` and applies the patch right after the
+    module body finishes executing. Survives `from triton...` and lazy imports.
+  * `install()` patches in place if `triton.runtime.autotuner` is already
+    loaded. Used as a follow-up after `arm()` for the case where Triton was
+    pulled in before our sitecustomize ran (rare but possible via pth files).
+  * Sitecustomize shim calls `arm()` then `install()` — `arm()` covers the
+    forward path, `install()` covers the already-loaded path.
+
+Env vars:
+  * `TRITON_AUTOTUNE_PREHOOK_PATCH_DISABLE=1` skips both arm and install
+    (kill switch).
+  * `TRITON_AUTOTUNE_PATCH_DEBUG=1` emits `[TRITON_PATCH] ...` lines to
+    stderr at each lifecycle point (arm, install, MetaPathFinder fire,
+    apply) and prints a counter summary at process exit
+    (full_hit / partial_hit / no_cache_file / no_key / unstable_prehook /
+    load_error). Use this to disambiguate a null result:
+    if `[TRITON_PATCH] patch applied` is missing, the patch never loaded;
+    if it's present but the summary shows full_hit=0 with high
+    no_cache_file, the cache is cold for these shapes (priming run needed).
+"""
+
+from __future__ import annotations
+
+import atexit
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+
+_INSTALLED = False
+_ARMED = False
+
+# Diagnostic counters for `check_disk_cache` outcomes. Without these the
+# ambiguity (autotune lines unchanged — patch loaded but ineffective, or patch
+# never loaded?) is unresolvable from logs. Counters
+# are reported once at process exit via atexit when TRITON_AUTOTUNE_PATCH_DEBUG=1.
+_DIAG_COUNTERS = {
+    "no_key": 0,         # tuning_key empty → fall through to bench
+    "unstable_prehook": 0,  # lambda/closure pre_hook → fall through
+    "upstream_fallthrough": 0,  # no config has pre_hook → delegate to upstream
+    "no_cache_file": 0,  # cache.get_file returned None → bench + save
+    "full_hit": 0,       # every live config hit the cache → skip bench
+    "partial_hit": 0,    # some hits, some misses → fall through (upstream-equiv)
+    "load_error": 0,     # cached file existed but unreadable → bench + save
+}
+
+# Per-kernel-name dedup for the verbose cache_key breakdown logs. At 64 ranks
+# × N kernels × multiple autotune cycles, naive logging would emit thousands of
+# duplicate lines. We log each kernel's full breakdown the first time it's
+# autotuned per process; subsequent invocations of the same kernel just bump
+# the counters. Set on rank 0 is sufficient; non-zero ranks log only the
+# kernels they actually hit (usually the same set).
+_LOGGED_KEY_BREAKDOWNS: set = set()
+_LOGGED_OUTCOMES: set = set()  # (kernel_name, outcome) — log first occurrence of each combo
+
+
+def _debug() -> bool:
+    return os.environ.get("TRITON_AUTOTUNE_PATCH_DEBUG", "0") == "1"
+
+
+def _log(msg: str) -> None:
+    r"""Emit a diagnostic line to stderr if TRITON_AUTOTUNE_PATCH_DEBUG=1.
+
+    Prefix is fixed so logs grep cleanly: `grep '\[TRITON_PATCH\]' run.log`.
+    """
+    if _debug():
+        sys.stderr.write(f"[TRITON_PATCH] {msg}\n")
+        sys.stderr.flush()
+
+
+def _report_at_exit() -> None:
+    if not _debug():
+        return
+    total = sum(_DIAG_COUNTERS.values())
+    _log(
+        f"check_disk_cache summary: total={total} "
+        + " ".join(f"{k}={v}" for k, v in _DIAG_COUNTERS.items())
+    )
+
+
+def _config_identity(cfg) -> dict:
+    """JSON-friendly stable identity for a Triton Config.
+
+    `pre_hook` is replaced by its `__qualname__` (or `"__unstable__"` for
+    lambdas/closures, which signals the caller to skip this entry).
+
+    `ir_override` is included as `None` when absent on the Config (older
+    Triton versions did not expose it). Upstream Triton's save side
+    serializes `config.__dict__` which includes `ir_override`, so a cached
+    entry from upstream will have the key with value `None`. Including it
+    in our identity ensures dict equality matches those entries.
+    """
+    d = {
+        "kwargs": dict(cfg.kwargs) if hasattr(cfg, "kwargs") else {},
+        "num_warps": getattr(cfg, "num_warps", None),
+        "num_stages": getattr(cfg, "num_stages", None),
+        "num_ctas": getattr(cfg, "num_ctas", None),
+        "maxnreg": getattr(cfg, "maxnreg", None),
+        "ir_override": getattr(cfg, "ir_override", None),
+    }
+    ph = getattr(cfg, "pre_hook", None)
+    if ph is not None:
+        qn = getattr(ph, "__qualname__", None)
+        d["pre_hook"] = qn if qn else "__unstable__"
+    else:
+        d["pre_hook"] = None
+    return d
+
+
+def _has_unstable_prehook(cfg) -> bool:
+    ph = getattr(cfg, "pre_hook", None)
+    return ph is not None and not getattr(ph, "__qualname__", None)
+
+
+def _apply_patch(Autotuner):
+    """Replace `Autotuner.check_disk_cache` and `__init__` on the given class.
+
+    Idempotent via module-level `_INSTALLED`. Called by both `install()` (when
+    Triton is already imported) and the MetaPathFinder loader wrapper (right
+    after the autotuner module body finishes executing).
+    """
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    import builtins as _builtins
+
+    # Save a reference to upstream's check_disk_cache so we can fall through
+    # for kernels upstream handles correctly. Without this, we'd lose access
+    # to the original method the moment we replace Autotuner.check_disk_cache.
+    _orig_check_disk_cache = Autotuner.check_disk_cache
+
+    def patched_check_disk_cache(self, tuning_key, configs, bench_fn):
+        if not tuning_key:
+            _DIAG_COUNTERS["no_key"] += 1
+            bench_fn()
+            return False
+
+        # Path C: for kernels with no pre_hook on any config, upstream Triton
+        # handles disk caching correctly — it falls through to the standard
+        # disk-cache path and uses cached timings for whichever cached config
+        # matches the live tuning_key. Upstream is more lenient than our
+        # strict structural-identity matching: it does not require every live
+        # config to appear in the cache; it just needs the cached "best"
+        # config to still be benchable. Our patch was designed for the case
+        # where upstream BAILS (`any(cfg.pre_hook ...)`), so call upstream
+        # for the non-pre_hook case rather than re-implement it ourselves.
+        # Empirically, the strict matching path
+        # caused 12/16 mamba kernels to fall through to re-bench on partial
+        # mismatches that upstream would have skipped. Falling through here
+        # restores upstream's win for mamba kernels while keeping our patch
+        # active for TE / hybrid_ep kernels that do have pre_hooks.
+        if not any(getattr(c, "pre_hook", None) for c in configs):
+            _DIAG_COUNTERS["upstream_fallthrough"] += 1
+            return _orig_check_disk_cache(self, tuning_key, configs, bench_fn)
+
+        # If any config has a lambda/closure pre_hook, we can't round-trip it.
+        # Fall back to upstream behavior for safety.
+        if any(_has_unstable_prehook(c) for c in configs):
+            _DIAG_COUNTERS["unstable_prehook"] += 1
+            bench_fn()
+            return False
+
+        import hashlib
+        from triton._C.libtriton import get_cache_invalidating_env_vars
+        from triton.compiler.compiler import make_backend, triton_key
+        from triton.runtime.cache import get_cache_manager
+        from triton.runtime.driver import driver
+        from triton.runtime.jit import JITFunction
+
+        fn = self.fn
+        while not isinstance(fn, JITFunction):
+            fn = fn.fn
+
+        env_vars = get_cache_invalidating_env_vars()
+        cache_key_parts = [
+            triton_key(),
+            make_backend(driver.active.get_current_target()).hash(),
+            fn.cache_key,
+            str(sorted(env_vars.items())),
+            str(tuning_key),
+        ] + [str(c) for c in configs]
+        cache_key = hashlib.sha256("-".join(cache_key_parts).encode("utf-8")).hexdigest()
+        cache = get_cache_manager(cache_key)
+        file_name = f"{fn.__name__[:150]}.autotune.json"
+        path = cache.get_file(file_name)
+
+        # Diagnostic: dump the 6 cache_key components once per unique kernel
+        # name when TRITON_AUTOTUNE_PATCH_DEBUG=1. Goal is to identify which
+        # component differs between cache-write context and runtime context,
+        # which causes a hash mismatch and re-autotune even when the cache
+        # tarball contains a matching autotune.json file. Each component
+        # gets a 16-char sha256 prefix so two runs' logs can be diffed
+        # field-by-field; the full env_vars list is also emitted (separate
+        # line) because that's the most volatile component empirically.
+        if _debug() and fn.__name__ not in _LOGGED_KEY_BREAKDOWNS:
+            _LOGGED_KEY_BREAKDOWNS.add(fn.__name__)
+            _h = lambda s: hashlib.sha256(s.encode("utf-8")).hexdigest()[:16]
+            _cdir = getattr(cache, "cache_dir", None) or getattr(cache, "_cache_dir", "?")
+            _log(
+                f"cache_key for {fn.__name__[:60]}: "
+                f"sha256={cache_key} "
+                f"triton={_h(cache_key_parts[0])} "
+                f"backend={_h(cache_key_parts[1])} "
+                f"fn_src={_h(cache_key_parts[2])} "
+                f"env={_h(cache_key_parts[3])} "
+                f"tk={_h(cache_key_parts[4])} "
+                f"cfgs={_h(''.join(cache_key_parts[5:]))} "
+                f"cache_dir={_cdir} "
+                f"file_name={file_name} "
+                f"path_found={path is not None}"
+            )
+            _log(f"env_vars for {fn.__name__[:60]}: {cache_key_parts[3]}")
+
+        if path:
+            try:
+                with open(path) as cached_file:
+                    payload = json.load(cached_file)
+                cached_entries = payload.get("configs_timings", [])
+            except (OSError, ValueError):
+                _DIAG_COUNTERS["load_error"] += 1
+                cached_entries = []
+
+            # Try to satisfy every live config from the cache.
+            hits = {}
+            for cfg in configs:
+                ident = _config_identity(cfg)
+                for entry_ident, timing in cached_entries:
+                    if entry_ident == ident:
+                        hits[cfg] = timing
+                        break
+            if len(hits) == len(configs):
+                _DIAG_COUNTERS["full_hit"] += 1
+                if _debug() and (fn.__name__, "full_hit") not in _LOGGED_OUTCOMES:
+                    _LOGGED_OUTCOMES.add((fn.__name__, "full_hit"))
+                    _log(f"full_hit: {fn.__name__[:60]} cache_key={cache_key[:16]}")
+                self.configs_timings = hits
+                self.cache[tuning_key] = _builtins.min(hits, key=hits.get)
+                full_nargs = {**self.nargs, **self.cache[tuning_key].all_kwargs()}
+                self.pre_hook(full_nargs, reset_only=True)
+                return True
+            # Partial hit — fall through to re-bench. Triton's bench_fn
+            # captures `pruned_configs` by closure, so we can't easily skip
+            # the cached ones. Upstream-equivalent.
+            _DIAG_COUNTERS["partial_hit"] += 1
+            if _debug() and (fn.__name__, "partial_hit") not in _LOGGED_OUTCOMES:
+                _LOGGED_OUTCOMES.add((fn.__name__, "partial_hit"))
+                # Log the first mismatched live config so we can see whether
+                # kwargs or pre_hook qualname is the differing field.
+                first_missing = None
+                for cfg in configs:
+                    if cfg not in hits:
+                        first_missing = _config_identity(cfg)
+                        break
+                _log(
+                    f"partial_hit: {fn.__name__[:60]} cache_key={cache_key[:16]} "
+                    f"live_configs={len(configs)} hits={len(hits)} "
+                    f"first_missing={first_missing}"
+                )
+        else:
+            _DIAG_COUNTERS["no_cache_file"] += 1
+            if _debug() and (fn.__name__, "no_cache_file") not in _LOGGED_OUTCOMES:
+                _LOGGED_OUTCOMES.add((fn.__name__, "no_cache_file"))
+                _cdir = getattr(cache, "cache_dir", None) or getattr(cache, "_cache_dir", "?")
+                _log(
+                    f"no_cache_file: {fn.__name__[:60]} cache_key={cache_key[:16]} "
+                    f"looked_in={_cdir}"
+                )
+
+        bench_fn()
+        serializable = []
+        for cfg, t in self.configs_timings.items():
+            ident = _config_identity(cfg)
+            if ident.get("pre_hook") == "__unstable__":
+                continue
+            serializable.append((ident, t))
+        try:
+            cache.put(
+                json.dumps({"key": tuning_key, "configs_timings": serializable}),
+                file_name,
+                binary=False,
+            )
+        except (OSError, ValueError):
+            pass
+        return False
+
+    _orig_init = Autotuner.__init__
+
+    def patched_init(self, *args, **kwargs):
+        # Path E: only force cache_results=True for Autotuner instances that
+        # actually need our shim — i.e. those where upstream Triton bails on
+        # disk caching (any config has a pre_hook). For the common case (all
+        # pre_hook=None configs, e.g. mamba kernels), keep upstream's default
+        # cache_results=False — that avoids per-autotune-cycle disk I/O that
+        # cost significant init wall time at scale (Path C).
+        # Sniff configs before calling _orig_init (so we have them regardless
+        # of where upstream stores them on `self`). Autotuner signature is
+        # __init__(self, fn, arg_names, configs, key, ...) — configs is the
+        # third positional arg.
+        _configs = kwargs.get("configs")
+        if _configs is None and len(args) >= 3:
+            _configs = args[2]
+        _orig_init(self, *args, **kwargs)
+        if _configs and any(getattr(c, "pre_hook", None) for c in _configs):
+            self.cache_results = True
+
+    Autotuner.check_disk_cache = patched_check_disk_cache
+    Autotuner.__init__ = patched_init
+
+    # Retrofit existing Autotuner instances. Triton's `Autotuner.run`
+    # gates the `check_disk_cache` call on `self.cache_results`, which is set
+    # at __init__ time. Class-level __init__ patch only affects FUTURE
+    # instances. When this shim runs, the worker rank has already inherited
+    # Autotuner instances from the torch.distributed.run parent process (those
+    # were created when mamba_ssm / torch / TE were imported and decorated
+    # their @triton.autotune kernels) — those instances have
+    # `cache_results=False` baked in. Without this retrofit, our
+    # `patched_check_disk_cache` never fires (verified empirically:
+    # total=0, full_hit=0, every counter zero).
+    import gc
+    _retrofitted = 0
+    for _obj in gc.get_objects():
+        try:
+            if isinstance(_obj, Autotuner) and not getattr(_obj, "cache_results", True):
+                _obj.cache_results = True
+                _retrofitted += 1
+        except (ReferenceError, AttributeError):
+            pass
+    _log(
+        f"retrofitted cache_results=True on {_retrofitted} existing Autotuner "
+        f"instances (gc.get_objects walk)"
+    )
+
+    _INSTALLED = True
+    _log(f"patch applied to {Autotuner.__module__}.{Autotuner.__name__}")
+    atexit.register(_report_at_exit)
+
+
+def install():
+    """In-place install if `triton.runtime.autotuner` is already importable.
+
+    Idempotent. No-op if kill switch set or Triton not available.
+    """
+    if _INSTALLED:
+        _log("install: already installed (no-op)")
+        return
+    if os.environ.get("TRITON_AUTOTUNE_PREHOOK_PATCH_DISABLE", "0") == "1":
+        _log("install: skipped (TRITON_AUTOTUNE_PREHOOK_PATCH_DISABLE=1)")
+        return
+    try:
+        from triton.runtime.autotuner import Autotuner
+    except ImportError:
+        _log("install: skipped (triton.runtime.autotuner not importable)")
+        return
+    _log("install: triton.runtime.autotuner already loaded — patching directly")
+    _apply_patch(Autotuner)
+
+
+class _AutotunerFinder(importlib.abc.MetaPathFinder):
+    """Intercept the first `import triton.runtime.autotuner` and patch after exec.
+
+    The trainer pulls Triton in lazily via the kernel registration path. By the
+    time the launcher's sitecustomize runs, Triton itself may not yet be
+    importable cleanly (depends on torch init order on some images). Registering
+    a MetaPathFinder lets us patch deterministically at the moment Triton's
+    autotuner module finishes loading — independent of whether site-init or the
+    trainer wins the race.
+    """
+
+    TARGET = "triton.runtime.autotuner"
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname != self.TARGET:
+            return None
+        for finder in sys.meta_path:
+            if finder is self:
+                continue
+            find = getattr(finder, "find_spec", None)
+            if find is None:
+                continue
+            try:
+                spec = find(fullname, path, target)
+            except Exception:
+                continue
+            if spec is None or spec.loader is None:
+                continue
+            orig_loader = spec.loader
+
+            class _WrapLoader(importlib.abc.Loader):
+                def create_module(self_inner, spec):  # noqa: N805
+                    cm = getattr(orig_loader, "create_module", None)
+                    return cm(spec) if cm else None
+
+                def exec_module(self_inner, module):  # noqa: N805
+                    orig_loader.exec_module(module)
+                    _log(
+                        "_AutotunerFinder: intercepted triton.runtime.autotuner "
+                        "exec — applying patch"
+                    )
+                    try:
+                        _apply_patch(module.Autotuner)
+                    except Exception as e:  # noqa: BLE001 — diagnostic-only
+                        _log(f"_AutotunerFinder: _apply_patch raised: {e}")
+
+            spec.loader = _WrapLoader()
+            return spec
+        return None
+
+
+def arm():
+    """Register `_AutotunerFinder` so the patch lands on first Triton import.
+
+    Falls back to in-place `install()` if Triton's autotuner module is already
+    in `sys.modules` (rare but possible).
+    """
+    global _ARMED
+    if _ARMED:
+        _log("arm: already armed (no-op)")
+        return
+    if os.environ.get("TRITON_AUTOTUNE_PREHOOK_PATCH_DISABLE", "0") == "1":
+        _log("arm: skipped (TRITON_AUTOTUNE_PREHOOK_PATCH_DISABLE=1)")
+        return
+    if _AutotunerFinder.TARGET in sys.modules:
+        _log("arm: triton.runtime.autotuner already loaded — installing directly")
+        install()
+    else:
+        sys.meta_path.insert(0, _AutotunerFinder())
+        _log("arm: registered _AutotunerFinder at head of sys.meta_path")
+    _ARMED = True
+
+
+if __name__ == "__main__":
+    arm()
+    install()
+    print(
+        "triton_autotune_disk_cache: armed="
+        + str(_ARMED)
+        + " installed="
+        + str(_INSTALLED)
+    )

--- a/tools/persistent_cache/triton_autotune_disk_cache.py
+++ b/tools/persistent_cache/triton_autotune_disk_cache.py
@@ -198,8 +198,7 @@ def _apply_patch(Autotuner):
             return False
 
         import hashlib
-        from triton._C.libtriton import get_cache_invalidating_env_vars
-        from triton.compiler.compiler import make_backend, triton_key
+        import importlib
         from triton.runtime.cache import get_cache_manager
         from triton.runtime.driver import driver
         from triton.runtime.jit import JITFunction
@@ -208,10 +207,50 @@ def _apply_patch(Autotuner):
         while not isinstance(fn, JITFunction):
             fn = fn.fn
 
-        env_vars = get_cache_invalidating_env_vars()
+        # Version-robust key components. triton_key() / make_backend /
+        # get_cache_invalidating_env_vars all moved (or were removed) across
+        # Triton releases (this patch was authored on 3.4.0; 3.6+ relocates
+        # triton_key out of triton.compiler.compiler). Resolve each defensively
+        # and fall back to triton.__version__, which is still version-specific
+        # -- all the cache key needs is to be deterministic within a run and to
+        # change when Triton changes. Never hard-crash on an unfamiliar layout.
+        _tk = None
+        for _mod, _name in (
+            ("triton.compiler.compiler", "triton_key"),
+            ("triton.runtime.jit", "triton_key"),
+            ("triton._utils", "triton_key"),
+            ("triton.runtime.cache", "triton_key"),
+        ):
+            try:
+                _f = getattr(importlib.import_module(_mod), _name, None)
+                if _f is not None:
+                    _tk = _f()
+                    break
+            except Exception:
+                pass
+        if _tk is None:
+            import triton
+
+            _tk = f"triton-{getattr(triton, '__version__', 'unknown')}"
+        try:
+            from triton.compiler.compiler import make_backend
+
+            _backend = make_backend(driver.active.get_current_target()).hash()
+        except Exception:
+            try:
+                _backend = str(driver.active.get_current_target())
+            except Exception:
+                _backend = "backend-unknown"
+        try:
+            from triton._C.libtriton import get_cache_invalidating_env_vars
+
+            env_vars = get_cache_invalidating_env_vars()
+        except Exception:
+            env_vars = {}
+
         cache_key_parts = [
-            triton_key(),
-            make_backend(driver.active.get_current_target()).hash(),
+            _tk,
+            _backend,
             fn.cache_key,
             str(sorted(env_vars.items())),
             str(tuning_key),

--- a/tools/persistent_cache/triton_autotune_disk_cache.py
+++ b/tools/persistent_cache/triton_autotune_disk_cache.py
@@ -72,13 +72,13 @@ _ARMED = False
 # never loaded?) is unresolvable from logs. Counters
 # are reported once at process exit via atexit when TRITON_AUTOTUNE_PATCH_DEBUG=1.
 _DIAG_COUNTERS = {
-    "no_key": 0,         # tuning_key empty → fall through to bench
+    "no_key": 0,  # tuning_key empty → fall through to bench
     "unstable_prehook": 0,  # lambda/closure pre_hook → fall through
     "upstream_fallthrough": 0,  # no config has pre_hook → delegate to upstream
     "no_cache_file": 0,  # cache.get_file returned None → bench + save
-    "full_hit": 0,       # every live config hit the cache → skip bench
-    "partial_hit": 0,    # some hits, some misses → fall through (upstream-equiv)
-    "load_error": 0,     # cached file existed but unreadable → bench + save
+    "full_hit": 0,  # every live config hit the cache → skip bench
+    "partial_hit": 0,  # some hits, some misses → fall through (upstream-equiv)
+    "load_error": 0,  # cached file existed but unreadable → bench + save
 }
 
 # Per-kernel-name dedup for the verbose cache_key breakdown logs. At 64 ranks
@@ -198,8 +198,8 @@ def _apply_patch(Autotuner):
             return False
 
         import hashlib
-        from triton._C.libtriton import get_cache_invalidating_env_vars
-        from triton.compiler.compiler import make_backend, triton_key
+        import importlib
+
         from triton.runtime.cache import get_cache_manager
         from triton.runtime.driver import driver
         from triton.runtime.jit import JITFunction
@@ -208,10 +208,50 @@ def _apply_patch(Autotuner):
         while not isinstance(fn, JITFunction):
             fn = fn.fn
 
-        env_vars = get_cache_invalidating_env_vars()
+        # Version-robust key components. triton_key() / make_backend /
+        # get_cache_invalidating_env_vars all moved (or were removed) across
+        # Triton releases (this patch was authored on 3.4.0; 3.6+ relocates
+        # triton_key out of triton.compiler.compiler). Resolve each defensively
+        # and fall back to triton.__version__, which is still version-specific
+        # -- all the cache key needs is to be deterministic within a run and to
+        # change when Triton changes. Never hard-crash on an unfamiliar layout.
+        _tk = None
+        for _mod, _name in (
+            ("triton.compiler.compiler", "triton_key"),
+            ("triton.runtime.jit", "triton_key"),
+            ("triton._utils", "triton_key"),
+            ("triton.runtime.cache", "triton_key"),
+        ):
+            try:
+                _f = getattr(importlib.import_module(_mod), _name, None)
+                if _f is not None:
+                    _tk = _f()
+                    break
+            except Exception:
+                pass
+        if _tk is None:
+            import triton
+
+            _tk = f"triton-{getattr(triton, '__version__', 'unknown')}"
+        try:
+            from triton.compiler.compiler import make_backend
+
+            _backend = make_backend(driver.active.get_current_target()).hash()
+        except Exception:
+            try:
+                _backend = str(driver.active.get_current_target())
+            except Exception:
+                _backend = "backend-unknown"
+        try:
+            from triton._C.libtriton import get_cache_invalidating_env_vars
+
+            env_vars = get_cache_invalidating_env_vars()
+        except Exception:
+            env_vars = {}
+
         cache_key_parts = [
-            triton_key(),
-            make_backend(driver.active.get_current_target()).hash(),
+            _tk,
+            _backend,
             fn.cache_key,
             str(sorted(env_vars.items())),
             str(tuning_key),
@@ -354,6 +394,7 @@ def _apply_patch(Autotuner):
     # `patched_check_disk_cache` never fires (verified empirically:
     # total=0, full_hit=0, every counter zero).
     import gc
+
     _retrofitted = 0
     for _obj in gc.get_objects():
         try:
@@ -468,9 +509,4 @@ def arm():
 if __name__ == "__main__":
     arm()
     install()
-    print(
-        "triton_autotune_disk_cache: armed="
-        + str(_ARMED)
-        + " installed="
-        + str(_INSTALLED)
-    )
+    print("triton_autotune_disk_cache: armed=" + str(_ARMED) + " installed=" + str(_INSTALLED))

--- a/tools/persistent_cache/writeback.sh
+++ b/tools/persistent_cache/writeback.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# tools/persistent_cache/writeback.sh — one-shot writeback from NODE_CACHE_BASE/
+# to CACHE_WRITE_DIR/. Uses rsync when available; otherwise writes per-node
+# snapshots that promotion merges later.
+# Args: --final  bypass delay/recency guards (used by EXIT trap and atexit).
+
+set -euo pipefail
+# shellcheck disable=SC1091
+source "$(dirname "$0")/lib.sh"
+
+is_local_rank_zero || exit 0
+
+force=0
+[[ "${1:-}" == "--final" ]] && force=1
+
+now=$(date +%s)
+elapsed=$(( now - MCORE_JOB_START_EPOCH ))
+had_error=0
+
+for scope in "${SCOPES[@]}"; do
+  src="$(scope_local_dir "$scope")"
+  dst="$(scope_lustre_write_dir "$scope")"
+  [[ -d "$src" ]] || continue
+  [[ -n "$(ls -A "$src" 2>/dev/null)" ]] || continue
+
+  if (( ! force )); then
+    # Guard 1: delay since job start. Compile is in flight before this.
+    if (( elapsed < MCORE_CACHE_SYNC_DELAY_SECONDS )); then
+      echo "[CACHE WB] ${scope}: skip (${elapsed}s < ${MCORE_CACHE_SYNC_DELAY_SECONDS}s)"
+      continue
+    fi
+    # Guard 2: file recency — anything modified in last 5m means compile in progress.
+    if find "$src" -type f -mmin -5 -print -quit 2>/dev/null | grep -q .; then
+      echo "[CACHE WB] ${scope}: skip (compile in flight)"
+      continue
+    fi
+  fi
+
+  if ! rsync_safe "$src" "$dst" "$scope"; then
+    had_error=1
+  fi
+done
+
+exit "$had_error"

--- a/tools/persistent_cache/writeback_tarball.sh
+++ b/tools/persistent_cache/writeback_tarball.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# writeback_tarball.sh — simplified single-writer tarball writeback for PRETRAINING.
+#
+# Pretraining is single-role: the Triton/Inductor compile cache is ~identical
+# across ranks (high overlap), so we don't need a per-role cache_write directory
+# stage, rsync, or union accumulation.
+#
+# ONE designated writer (global rank 0) tars its node-local cache per scope and
+# writes ONE <scope>.tar.zst straight to cache_read/ (atomic tmp+rename via
+# tar_safe). Result: a handful of large sequential writes by a single rank ->
+# NO per-node dirs, NO millions of small-file creates, NO Lustre MDT storm.
+# The read path (bootstrap.sh) already extracts cache_read/*.tar.zst into /tmp.
+#
+# Compression is large (inductor-dominated), so the single write per scope is
+# cheap and storm-free.
+#
+# Kill switch: MCORE_CACHE_WRITEBACK_DISABLED=1 (use image-baked at >=256 cards).
+# Override the writer rank with MCORE_CACHE_WRITER_GLOBAL_RANK (default 0).
+
+set -euo pipefail
+# shellcheck disable=SC1091
+source "$(dirname "$0")/lib.sh"
+
+[[ "${MCORE_CACHE_WRITEBACK_DISABLED:-0}" == "1" ]] && { echo "[CACHE WB] disabled (MCORE_CACHE_WRITEBACK_DISABLED=1)"; exit 0; }
+
+# Exactly one writer for the whole job — the union is ~one node's cache anyway.
+writer_rank="${MCORE_CACHE_WRITER_GLOBAL_RANK:-0}"
+if [[ "${SLURM_PROCID:-0}" != "${writer_rank}" ]]; then
+  exit 0
+fi
+
+# Optional stagger so that, if this is ever run by >1 writer, they don't collide.
+if [[ -n "${MCORE_CACHE_SYNC_EXIT_JITTER_SECONDS:-}" ]]; then
+  sleep "$(( RANDOM % (MCORE_CACHE_SYNC_EXIT_JITTER_SECONDS + 1) ))" || true
+fi
+
+mkdir -p "${CACHE_READ_DIR}"
+had_error=0
+for scope in "${SCOPES[@]}"; do
+  src="$(scope_local_dir "$scope")"
+  [[ -d "$src" ]] || continue
+  [[ -n "$(ls -A "$src" 2>/dev/null)" ]] || continue
+  # tar_safe: atomic tar --zstd to <tmp> then rename, so readers never see a partial tarball.
+  if ! tar_safe "$src" "$(scope_lustre_read_tar "$scope")" "$scope"; then
+    had_error=1
+  fi
+done
+
+if (( had_error )); then
+  echo "[CACHE WB] one or more scopes failed to tar (rank ${writer_rank})" >&2
+fi
+exit "$had_error"


### PR DESCRIPTION
## What

Adds an **opt-in persistent first-iteration cache** that persists the cold first-iteration compile artifacts (Triton autotune, TorchInductor FX graphs, CUDA PTX→SASS, cuDNN frontend heuristics, NCCL topology, fused-kernel JIT builds, ...) to a shared filesystem and reloads them on subsequent job restarts — so the cold compile/autotune storm is paid once instead of every restart.

## How

- **`tools/persistent_cache/`** — bash machinery:
  - `bootstrap.sh` seeds node-local storage from `cache_read/<scope>.tar.zst` and exports the env vars each compiler reads (`TRITON_CACHE_DIR`, `TORCHINDUCTOR_CACHE_DIR`, `CUDA_CACHE_PATH`, `TORCH_EXTENSIONS_DIR`, `NCCL_TOPO_DUMP_FILE`, ...) **before Python starts**.
  - `writeback.sh` / `writeback_tarball.sh` push newly compiled artifacts back (single-writer tarball or per-node), `promote_tarballs.sh` merges into the read tarballs, `sidecar.sh` periodically flushes, plus a Triton autotune disk-cache shim that keeps cache hits for configs carrying a `pre_hook`.
- **`megatron/training/persistent_cache.py`** — `PersistentCacheController`: validates the bootstrap env (local rank 0), kicks a throttled writeback from `save_checkpoint`, and registers an `atexit` final flush.
- **Integration**: `--persistent-cache-*` args (`arguments.py`), `persistent_cache.init(args)` in `pretrain()` (`training.py`), and a throttled writeback kick after `save_checkpoint` (`checkpointing.py`).

## Safety / compatibility

Fully **opt-in and inert by default** — every code path no-ops unless `--persistent-cache-read-dir` / `--persistent-cache-write-dir` is set, so existing runs are unaffected. See `tools/persistent_cache/README.md` for usage. Best-effort throughout: a missing/corrupt tarball, missing `rsync`, or unreachable filesystem falls back to a cold compile and logs a non-fatal warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)