### PR TITLE
Merge cu_seqlens across micro-batch for THD attention

### DIFF
--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -2280,9 +2280,9 @@ def _get_batch_on_this_cp_rank_per_document_balancing(
     cp_rank = torch.distributed.get_rank(cp_group)
 
     if cp_size > 1:
-        # cu_seqlens / cu_seqlens_padded carry the dataloader's batch dim (1, n).
-        # tex.thd_get_partitioned_indices expects a 1-D tensor, so squeeze the
-        # batch dim inline without mutating the batch dict.
+        # cu_seqlens / cu_seqlens_padded carry a leading batch dim (1, n).
+        # tex.thd_get_partitioned_indices expects a 1-D tensor, so squeeze
+        # the batch dim inline without mutating the batch dict.
         cu_seqlens_for_te = (
             batch["cu_seqlens_padded"]
             if batch["cu_seqlens_padded"] is not None
@@ -2360,6 +2360,101 @@ def _get_batch_on_this_cp_rank_per_sequence_balancing(
             val = val.index_select(seq_dim, index)
             val = val.view(*val.shape[0:seq_dim], -1, *val.shape[(seq_dim + 2) :])
             batch[key] = val
+
+    return batch
+
+
+def _merge_cu_seqlens_across_micro_batch(cu_seqlens: torch.Tensor, seq_length: int) -> torch.Tensor:
+    """Merge per-sample cu_seqlens into one 1-D tensor for THD attention.
+
+    When micro_batch_size > 1, the dataloader produces cu_seqlens with shape
+    (micro_batch_size, padded_length).  THD / FlashAttention expects a
+    single 1-D cu_seqlens covering all tokens.  This function strips
+    per-row padding (trailing copies of ``seq_length`` beyond the first),
+    offsets each sample's cu_seqlens by ``sample_index * seq_length``, and
+    concatenates them, dropping the leading zero of every sample after the
+    first.
+
+    When micro_batch_size == 1, returns the unpadded ``cu_seqlens[0]``.
+
+    Args:
+        cu_seqlens: int32 tensor of shape ``(micro_batch_size, padded_length)``
+            where each row starts at 0, ends at ``seq_length``, and may be
+            right-padded with extra copies of ``seq_length``.
+        seq_length: per-sample sequence length used to compute offsets and
+            to detect padding.
+
+    Returns:
+        1-D int32 tensor of merged cumulative sequence lengths.
+    """
+
+    def _strip_padding(row):
+        """Return the valid prefix of a padded cu_seqlens row.
+
+        Valid entries run from 0 up to and including the first occurrence
+        of ``seq_length``.  Any trailing copies of ``seq_length`` (padding
+        inserted by the dataset for uniform collation) are dropped.
+        """
+        hits = (row == seq_length).nonzero(as_tuple=True)[0]
+        if hits.numel() > 0:
+            return row[: hits[0].item() + 1]
+        return row
+
+    micro_batch_size = cu_seqlens.shape[0]
+    if micro_batch_size == 1:
+        return _strip_padding(cu_seqlens[0])
+
+    parts = [_strip_padding(cu_seqlens[0])]
+    for i in range(1, micro_batch_size):
+        offset = i * seq_length
+        valid = _strip_padding(cu_seqlens[i])
+        parts.append(valid[1:] + offset)
+    return torch.cat(parts)
+
+
+def flatten_batch_for_packed_sequences(batch: Dict[str, Any]) -> Dict[str, Any]:
+    """Flatten a multi-sample batch into a single packed sequence for THD attention.
+
+    When ``micro_batch_size > 1`` and ``cu_seqlens`` is present, THD /
+    FlashAttention still expects one flat token stream with a single 1-D
+    ``cu_seqlens``.  This function merges ``cu_seqlens`` (and
+    ``cu_seqlens_padded`` if present) across samples, reshapes
+    sequence-dimension tensors from ``(mbs, seq_len)`` to
+    ``(1, mbs * seq_len)``, and reduces ``max_seqlen`` to its maximum.
+
+    When ``cu_seqlens`` is absent or ``micro_batch_size == 1``, the batch
+    is returned with only the batch dimension squeezed from ``cu_seqlens``
+    (and ``cu_seqlens_padded``).
+
+    Args:
+        batch: Batch dict produced by ``get_batch_on_this_tp_rank``.
+
+    Returns:
+        The batch dict with packed-sequence tensors flattened.
+    """
+    cu_seqlens = batch.get('cu_seqlens')
+    if cu_seqlens is None:
+        return batch
+
+    seq_length = None
+    for key in ('tokens', 'labels', 'loss_mask', 'position_ids'):
+        if batch.get(key) is not None:
+            seq_length = batch[key].shape[1]
+            break
+    if seq_length is None:
+        seq_length = cu_seqlens[0, -1].item()
+
+    batch['cu_seqlens'] = _merge_cu_seqlens_across_micro_batch(cu_seqlens, seq_length).unsqueeze(0)
+    if batch.get('cu_seqlens_padded') is not None:
+        batch['cu_seqlens_padded'] = _merge_cu_seqlens_across_micro_batch(
+            batch['cu_seqlens_padded'], seq_length
+        ).unsqueeze(0)
+    if batch.get('max_seqlen') is not None:
+        batch['max_seqlen'] = batch['max_seqlen'].max().unsqueeze(0)
+
+    for key in ('tokens', 'labels', 'loss_mask', 'position_ids'):
+        if batch.get(key) is not None:
+            batch[key] = batch[key].reshape(1, -1)
 
     return batch
 

--- a/megatron/elastification/pretrain_hybrid_flex.py
+++ b/megatron/elastification/pretrain_hybrid_flex.py
@@ -35,6 +35,7 @@ from megatron.core.transformer.multi_token_prediction import (
 from megatron.core.transformer.spec_utils import import_module
 from megatron.core.utils import (
     StragglerDetector,
+    flatten_batch_for_packed_sequences,
     get_batch_on_this_cp_rank,
     get_batch_on_this_tp_rank,
 )
@@ -215,6 +216,8 @@ def get_batch(data_iterator, vp_stage=None):
         is_pipeline_last_stage=mpu.is_pipeline_last_stage(),
     )
 
+    batch = flatten_batch_for_packed_sequences(batch)
+
     # Intermediate PP stage under SFT only needs THD metadata (matches the
     # pretrain_hybrid.py PP-SFT shortcut, collapsed to the flex 7-tuple shape).
     if not is_first_or_last_pipeline_stage(vp_stage) and not mtp_on_this_rank:
@@ -228,15 +231,10 @@ def get_batch(data_iterator, vp_stage=None):
         hybrid_cp_group_func=get_hybrid_data_context_parallel_groups,
     )
 
-    # cu_seqlens / max_seqlen arrive with the dataloader's batch dim (shape (1, n)
-    # and (1,) respectively when micro_batch_size==1). Squeeze to match the historical
-    # 1-D / scalar shape the flextron forward path was built around.
     cu_seqlens = batch.get('cu_seqlens')
     max_seqlen = batch.get('max_seqlen')
-    if cu_seqlens is not None:
-        cu_seqlens = cu_seqlens[0]
     if max_seqlen is not None:
-        max_seqlen = int(max_seqlen.item()) if max_seqlen.dim() == 0 else int(max_seqlen[0].item())
+        max_seqlen = int(max_seqlen.item())
 
     return (
         batch.get('tokens'),

--- a/megatron/training/datasets/sft_dataset.py
+++ b/megatron/training/datasets/sft_dataset.py
@@ -181,12 +181,21 @@ class SFTDataset(MegatronDataset):
         adjacent_diffs = cu_seqlens[1:] - cu_seqlens[:-1]
         max_seqlen = adjacent_diffs.max()  # max_seqlen is a 0-D tensor
 
+        # Pad cu_seqlens to a fixed length so that default_collate can
+        # stack samples with different numbers of documents.  Trailing
+        # entries are filled with pack_length; the merge helper strips
+        # them later.
+        padded_cu_seqlens = torch.full(
+            (pack_length + 1,), pack_length, dtype=torch.int32,
+        )
+        padded_cu_seqlens[:cu_seqlens.numel()] = cu_seqlens
+
         return {
             'tokens': input_ids,
             'labels': labels,
             # 'attention_mask': attention_mask,  # PyTorch collate cannot handle NoneType
             'loss_mask': loss_mask,
             'position_ids': position_ids,
-            'cu_seqlens': cu_seqlens,
+            'cu_seqlens': padded_cu_seqlens,
             'max_seqlen': max_seqlen,
         }

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -42,6 +42,7 @@ from megatron.core.transformer.multi_token_prediction import (
 )
 from megatron.core.utils import (
     StragglerDetector,
+    flatten_batch_for_packed_sequences,
     get_attr_wrapped_model,
     get_batch_on_this_cp_rank,
     get_batch_on_this_tp_rank,
@@ -135,6 +136,8 @@ def get_batch(data_iterator, vp_stage: Optional[int] = None):
         is_pipeline_first_stage=mpu.is_pipeline_first_stage(),
         is_pipeline_last_stage=mpu.is_pipeline_last_stage(),
     )
+
+    batch = flatten_batch_for_packed_sequences(batch)
 
     if not is_first_or_last_pipeline_stage(vp_stage) and not mtp_on_this_rank:
         assert is_sft
@@ -295,11 +298,11 @@ def forward_step(data_iterator, model: GPTModel, return_schedule_plan: bool = Fa
 
     packed_seq_params = None
     if cu_seqlens is not None:
-        # cu_seqlens / cu_seqlens_padded carry the dataloader's batch dim (1, n).
-        # PackedSeqParams (and TE attention) expect 1-D, so squeeze before use.
-        cu_seqlens = cu_seqlens[0]
+        # Squeeze the batch dim: the batch dict keeps cu_seqlens as (1, N)
+        # for consistency, but PackedSeqParams and TE expect 1-D.
+        cu_seqlens = cu_seqlens.squeeze(0)
         if cu_seqlens_padded is not None:
-            cu_seqlens_padded = cu_seqlens_padded[0]
+            cu_seqlens_padded = cu_seqlens_padded.squeeze(0)
         # Use real (unpadded) cu_seqlens to feed the FLOPs accounting: varlen
         # attention only computes work for real tokens within each chunk.
         update_seqlen_stats_from_cu_seqlens(cu_seqlens)

--- a/pretrain_hybrid.py
+++ b/pretrain_hybrid.py
@@ -40,6 +40,7 @@ from megatron.core.transformer.multi_token_prediction import (
 )
 from megatron.core.utils import (
     StragglerDetector,
+    flatten_batch_for_packed_sequences,
     get_attr_wrapped_model,
     get_batch_on_this_cp_rank,
     get_batch_on_this_tp_rank,
@@ -135,6 +136,8 @@ def get_batch(data_iterator, vp_stage=None):
         is_pipeline_first_stage=mpu.is_pipeline_first_stage(),
         is_pipeline_last_stage=mpu.is_pipeline_last_stage(),
     )
+
+    batch = flatten_batch_for_packed_sequences(batch)
 
     if not is_first_or_last_pipeline_stage(vp_stage) and not mtp_on_this_rank:
         assert is_sft
@@ -292,11 +295,11 @@ def forward_step(data_iterator, model: HybridModel):
 
     packed_seq_params = None
     if cu_seqlens is not None:
-        # cu_seqlens / cu_seqlens_padded carry the dataloader's batch dim (1, n).
-        # PackedSeqParams (and TE attention) expect 1-D, so squeeze before use.
-        cu_seqlens = cu_seqlens[0]
+        # Squeeze the batch dim: the batch dict keeps cu_seqlens as (1, N)
+        # for consistency, but PackedSeqParams and TE expect 1-D.
+        cu_seqlens = cu_seqlens.squeeze(0)
         if cu_seqlens_padded is not None:
-            cu_seqlens_padded = cu_seqlens_padded[0]
+            cu_seqlens_padded = cu_seqlens_padded.squeeze(0)
         # Use real (unpadded) cu_seqlens to feed the FLOPs accounting: varlen
         # attention only computes work for real tokens within each chunk.
         update_seqlen_stats_from_cu_seqlens(cu_seqlens)

--- a/tests/unit_tests/data/test_get_batch.py
+++ b/tests/unit_tests/data/test_get_batch.py
@@ -8,6 +8,7 @@ import torch
 
 from megatron.core import mpu
 from megatron.core.num_microbatches_calculator import destroy_num_microbatches_calculator
+from megatron.core.utils import flatten_batch_for_packed_sequences
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.global_vars import destroy_global_vars, set_global_variables
 from pretrain_hybrid import get_batch
@@ -339,6 +340,176 @@ def test_sft_batch(tp_size, pp_size, cp_size, seq_length):
         assert 0 < max_seqlen.item() <= seq_length
 
     Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("micro_batch_size", [1, 2, 4])
+@pytest.mark.parametrize("seq_length", [16, 1024])
+def test_flatten_batch_for_packed_sequences(micro_batch_size, seq_length):
+    """Verify that flatten_batch_for_packed_sequences correctly merges
+    cu_seqlens across samples and flattens sequence-dimension tensors.
+    """
+    # Each sample: tokens = range(seq_length), two documents per sample.
+    tokens = (
+        torch.arange(seq_length, dtype=torch.int64)
+        .unsqueeze(0)
+        .expand(micro_batch_size, -1)
+        .clone()
+    )
+    labels = tokens.clone()
+    loss_mask = torch.ones(micro_batch_size, seq_length, dtype=torch.float32)
+    position_ids = (
+        torch.arange(seq_length, dtype=torch.int64)
+        .unsqueeze(0)
+        .expand(micro_batch_size, -1)
+        .clone()
+    )
+    half = seq_length // 2
+    cu_seqlens = torch.tensor([[0, half, seq_length]] * micro_batch_size, dtype=torch.int32)
+    max_seqlen = torch.tensor([half] * micro_batch_size, dtype=torch.int32)
+
+    batch = {
+        'tokens': tokens,
+        'labels': labels,
+        'loss_mask': loss_mask,
+        'position_ids': position_ids,
+        'cu_seqlens': cu_seqlens,
+        'max_seqlen': max_seqlen,
+    }
+    result = flatten_batch_for_packed_sequences(batch)
+
+    total_tokens = micro_batch_size * seq_length
+
+    # Sequence-dimension tensors are flattened to (1, mbs * seq_length).
+    assert result['tokens'].shape == (1, total_tokens)
+    assert result['labels'].shape == (1, total_tokens)
+    assert result['loss_mask'].shape == (1, total_tokens)
+    assert result['position_ids'].shape == (1, total_tokens)
+
+    # cu_seqlens is 2-D (1, N), starts at 0, ends at total_tokens.
+    assert result['cu_seqlens'].dim() == 2
+    assert result['cu_seqlens'].shape[0] == 1
+    assert result['cu_seqlens'][0, 0].item() == 0
+    assert result['cu_seqlens'][0, -1].item() == total_tokens
+
+    # Each sample contributes 3 cu_seqlens entries; the first sample's
+    # leading zero is kept while subsequent samples' leading zeros are
+    # dropped, so total entries = 3 + (mbs - 1) * 2.
+    expected_entries = 3 + (micro_batch_size - 1) * 2
+    assert result['cu_seqlens'].shape[1] == expected_entries
+
+    # Verify offsets: sample i's boundaries are offset by i * seq_length.
+    for i in range(micro_batch_size):
+        offset = i * seq_length
+        if i == 0:
+            assert result['cu_seqlens'][0, 0].item() == 0
+            assert result['cu_seqlens'][0, 1].item() == half
+            assert result['cu_seqlens'][0, 2].item() == seq_length
+        else:
+            base = 3 + (i - 1) * 2
+            assert result['cu_seqlens'][0, base].item() == offset + half
+            assert result['cu_seqlens'][0, base + 1].item() == offset + seq_length
+
+    # max_seqlen is reduced to a single value.
+    assert result['max_seqlen'].numel() == 1
+    assert result['max_seqlen'].item() == half
+
+
+@pytest.mark.parametrize("micro_batch_size", [1, 2, 4])
+@pytest.mark.parametrize("seq_length", [16, 1024])
+def test_flatten_batch_for_packed_sequences_intermediate_pp_stage(micro_batch_size, seq_length):
+    """On intermediate PP stages, tokens/labels/loss_mask/position_ids are None.
+    seq_length should be inferred from cu_seqlens[0, -1].
+    """
+    half = seq_length // 2
+    cu_seqlens = torch.tensor([[0, half, seq_length]] * micro_batch_size, dtype=torch.int32)
+    max_seqlen = torch.tensor([half] * micro_batch_size, dtype=torch.int32)
+
+    batch = {
+        'tokens': None,
+        'labels': None,
+        'loss_mask': None,
+        'position_ids': None,
+        'cu_seqlens': cu_seqlens,
+        'max_seqlen': max_seqlen,
+    }
+    result = flatten_batch_for_packed_sequences(batch)
+
+    total_tokens = micro_batch_size * seq_length
+
+    # cu_seqlens is 2-D (1, N), starts at 0, ends at total_tokens.
+    assert result['cu_seqlens'].dim() == 2
+    assert result['cu_seqlens'].shape[0] == 1
+    assert result['cu_seqlens'][0, 0].item() == 0
+    assert result['cu_seqlens'][0, -1].item() == total_tokens
+
+    expected_entries = 3 + (micro_batch_size - 1) * 2
+    assert result['cu_seqlens'].shape[1] == expected_entries
+
+    # max_seqlen is reduced to a single value.
+    assert result['max_seqlen'].numel() == 1
+    assert result['max_seqlen'].item() == half
+
+    # Sequence-dimension tensors remain None.
+    assert result['tokens'] is None
+    assert result['labels'] is None
+    assert result['loss_mask'] is None
+    assert result['position_ids'] is None
+
+
+@pytest.mark.parametrize("micro_batch_size", [1, 2, 4])
+@pytest.mark.parametrize("seq_length", [16, 1024])
+def test_flatten_batch_for_packed_sequences_padded_cu_seqlens(micro_batch_size, seq_length):
+    """Verify that _strip_padding correctly removes trailing padding from
+    cu_seqlens before merging. This matches the collation padding added by
+    GPTDataset and SFTDataset.
+    """
+    half = seq_length // 2
+    # Padded cu_seqlens: valid entries [0, half, seq_length] followed by
+    # trailing copies of seq_length (matching dataset collation).
+    padded_len = seq_length + 1
+    cu_seqlens = torch.full((micro_batch_size, padded_len), seq_length, dtype=torch.int32)
+    for i in range(micro_batch_size):
+        cu_seqlens[i, 0] = 0
+        cu_seqlens[i, 1] = half
+        cu_seqlens[i, 2] = seq_length
+
+    tokens = (
+        torch.arange(seq_length, dtype=torch.int64)
+        .unsqueeze(0)
+        .expand(micro_batch_size, -1)
+        .clone()
+    )
+    labels = tokens.clone()
+    loss_mask = torch.ones(micro_batch_size, seq_length, dtype=torch.float32)
+    position_ids = (
+        torch.arange(seq_length, dtype=torch.int64)
+        .unsqueeze(0)
+        .expand(micro_batch_size, -1)
+        .clone()
+    )
+    max_seqlen = torch.tensor([half] * micro_batch_size, dtype=torch.int32)
+
+    batch = {
+        'tokens': tokens,
+        'labels': labels,
+        'loss_mask': loss_mask,
+        'position_ids': position_ids,
+        'cu_seqlens': cu_seqlens,
+        'max_seqlen': max_seqlen,
+    }
+    result = flatten_batch_for_packed_sequences(batch)
+
+    total_tokens = micro_batch_size * seq_length
+
+    # After stripping padding and merging, result should be identical to the
+    # unpadded case: 2-D (1, N) with correct offsets.
+    assert result['cu_seqlens'].dim() == 2
+    assert result['cu_seqlens'].shape[0] == 1
+    assert result['cu_seqlens'][0, 0].item() == 0
+    assert result['cu_seqlens'][0, -1].item() == total_tokens
+
+    expected_entries = 3 + (micro_batch_size - 1) * 2
+    assert result['cu_seqlens'].shape[1] == expected_entries
 
 
 def create_pretrain_data_iterator(
@@ -692,7 +863,7 @@ def test_hybrid_cp_batch(tp_size, cp_size, seq_length, create_attention_mask):
     # Loss mask is all-ones (no masking in the HybridCP pretrain dataloader)
     assert loss_mask.sum().item() == seq_len_per_rank
 
-    # cu_seqlens: 2D int32 (1, n_seqs + 1), [0, seq_len_each, 2*seq_len_each, ..., total_seq_len]
+    # cu_seqlens: 2-D int32 (1, n_seqs + 1) after flatten_batch_for_packed_sequences.
     assert cu_seqlens.shape == (
         1,
         n_seqs + 1,


### PR DESCRIPTION
## Summary
- When `micro_batch_size > 1` with packed sequences (SFT or inter-document masking), each sample has its own `cu_seqlens`. THD / FlashAttention expects a single 1-D `cu_seqlens`, but the previous code silently took only the first sample's boundaries via `cu_seqlens[0]`.
- Add `flatten_batch_for_packed_sequences()` in `megatron/core/utils.py` that merges `cu_seqlens` (and `cu_seqlens_padded`) across samples with proper offsets, reshapes sequence-dimension tensors from `(mbs, seq_len)` to `(1, mbs * seq_len)`, and reduces `max_seqlen` to its maximum.
- Called from each `get_batch()` right after the TP broadcast, replacing duplicated `cu_seqlens[0]` squeeze logic in all three entry points.

## Test plan
- [x] Verify existing SFT unit tests pass with `micro_batch_size=1` (no behavioral change)
- [x] Test with `micro_batch_size > 1` and `--sft` or `--dataloader-inter-document-masking` on cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)