### PR TITLE
test: mark gated_delta_net selective-recompute test flaky_in_dev

### DIFF
--- a/tests/unit_tests/ssm/test_gated_delta_net.py
+++ b/tests/unit_tests/ssm/test_gated_delta_net.py
@@ -166,6 +166,7 @@ class TestGatedDeltaNet:
             output.dtype == hidden_states.dtype
         ), f"Output dtype {output.dtype=} mismatch with {hidden_states.dtype=}"
 
+    @pytest.mark.flaky_in_dev  # Issue #5473
     def test_selective_recompute_gdn(self):
         """Whole-module 'gdn' recompute must match the non-recompute forward and gradients.
 


### PR DESCRIPTION
## Background / motivation

- `tests/unit_tests/ssm/test_gated_delta_net.py::TestGatedDeltaNet::test_selective_recompute_gdn` intermittently hangs in CI and aborts a rank with `SIGABRT`.
- Tracked in #5473.
- The hang is in **distributed setup**, not the test body: `setup_method` → `Utils.initialize_model_parallel` → `parallel_state.create_group` → `torch.distributed.new_group` → `_new_process_group_helper` (NCCL communicator creation). Suspected GPU-node / NCCL-init flake, not a code regression.

## What changed

- Mark `test_selective_recompute_gdn` with `@pytest.mark.flaky_in_dev` so it is skipped by the `not flaky_in_dev` marker filter in the DEV environment, unblocking CI.

## Details

- `tests/unit_tests/ssm/test_gated_delta_net.py` — single decorator added above `test_selective_recompute_gdn` (+ `# Issue #5473`). No other changes.

## Tested

- Observed failure: [PR #5011 run 28032794934, job 82991762768](https://github.com/NVIDIA/Megatron-LM/actions/runs/28032794934/job/82991762768) — `test_selective_recompute_gdn[2-True-1]` hung ~17 min, `rank 4` exited `-6 (SIGABRT)`, launcher `SIGTERM`'d the remaining ranks.
- `python -m py_compile` passes; marker matches existing repo convention (`pyproject.toml` registers `flaky_in_dev`).

Closes #5473
