### PR TITLE
build: install flash_mla from source in the CI image

### DIFF
--- a/docker/Dockerfile.ci.dev
+++ b/docker/Dockerfile.ci.dev
@@ -40,9 +40,18 @@ ENV NVTE_BUILD_NUM_PHILOX_ROUNDS=3
 RUN --mount=type=cache,target=/root/.cache/uv \
     bash -ex <<"EOF"
     export NVTE_CUDA_ARCHS="80;90;100"
+    # flash-mla (no_pypi_wheels group) has no PyPI wheel and is built from source by uv. Point the
+    # compilers at the CCCL/libcu++ headers (under cccl/ in this base image, not the default CUDA
+    # include path) and scope the build to the target archs. Skipped for the LTS image.
+    FLASH_MLA_GROUP=""
+    if [ "$IMAGE_TYPE" != "lts" ]; then
+        FLASH_MLA_GROUP="--group no_pypi_wheels"
+        export FLASH_MLA_DISABLE_SM90=1 NVCC_THREADS=16 \
+            CFLAGS="-I/usr/local/cuda/include/cccl" CXXFLAGS="-I/usr/local/cuda/include/cccl"
+    fi
     uv venv ${UV_PROJECT_ENVIRONMENT} --system-site-packages
     uv sync --only-group build
-    uv sync --extra ${IMAGE_TYPE} --extra mlm --extra ssm --extra te --link-mode copy --locked \
+    uv sync --extra ${IMAGE_TYPE} --extra mlm --extra ssm --extra te ${FLASH_MLA_GROUP} --link-mode copy --locked \
         --no-install-package torch \
         --no-install-package torchvision \
         --no-install-package triton \


### PR DESCRIPTION
## Background / motivation

* `flash_mla` (DeepSeek MLA kernels) is declared only in the `no_pypi_wheels` dependency group. The CI image build (`docker/Dockerfile.ci.dev`) installs deps via `uv sync --extra dev --extra mlm --extra ssm --extra te`, which does **not** pull that group — so `flash_mla` never lands in `/opt/venv`.
* It is a git-only dependency (no PyPI wheel); building it also needs the CCCL/libcu++ headers, which live under `cccl/` in this base image rather than the default CUDA include path.

## What changed

* Install `flash_mla` through the existing `uv sync` by adding the `no_pypi_wheels` group (built from source, no-build-isolation).

## Details

* In `docker/Dockerfile.ci.dev`, for non-LTS images: add `--group no_pypi_wheels` to the main `uv sync`, and export `FLASH_MLA_DISABLE_SM90=1`, `NVCC_THREADS=16`, and `CFLAGS`/`CXXFLAGS=-I/usr/local/cuda/include/cccl` beforehand so the build resolves `#include <cuda/std/utility>`.
* Skipped for `IMAGE_TYPE=lts` (same guard as DeepEP).

## Tested

* Pending CI. The same recipe is validated in the Megatron-Bridge image build (NVIDIA-NeMo/Megatron-Bridge#4466).

🤖 Generated with [Claude Code](https://claude.com/claude-code)