### PR TITLE
Thread process groups through training checkpoint paths

### DIFF
--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -180,8 +180,6 @@ class MimoOptimizer(MegatronOptimizer):
                     _extract_param_state_sharding_type(sub_sd, name, suffix, replica_id)
                     _extract_grad_scaler(sub_sd, name, suffix, replica_id)
 
-                # Namespace every internal ShardedBase key with the submodule name
-                # so disjoint grids don't collide on shared distributed-optimizer keys.
                 add_prefix_for_sharding(module_sd, f'mimo.{name}.')
                 sharded_state[name] = module_sd
             else:

--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -52,6 +52,7 @@ class MimoOptimizer(MegatronOptimizer):
 
     @torch.no_grad()
     def prepare_grads(self) -> bool:
+        """Prepare gradients for all active module optimizers."""
         found_inf = False
         for opt in self._active_optimizers:
             found_inf |= opt.prepare_grads()
@@ -73,6 +74,7 @@ class MimoOptimizer(MegatronOptimizer):
 
     @torch.no_grad()
     def step(self) -> Tuple[bool, Optional[float], Optional[int]]:
+        """Run one optimizer step across all active module optimizers."""
         found_inf = self.prepare_grads()
         # Synchronize found_inf across all ranks to prevent deadlock:
         # if encoder ranks detect inf but LLM ranks don't, the early return
@@ -105,21 +107,25 @@ class MimoOptimizer(MegatronOptimizer):
 
     @torch.no_grad()
     def step_with_ready_grads(self) -> bool:
+        """Step active optimizers after gradients have been prepared."""
         success = True
         for opt in self._active_optimizers:
             success &= opt.step_with_ready_grads()
         return success
 
     def zero_grad(self, set_to_none: bool = True):
+        """Clear gradients on all active module optimizers."""
         for opt in self._active_optimizers:
             opt.zero_grad(set_to_none)
 
     def get_loss_scale(self) -> torch.Tensor:
+        """Return the loss scale tensor from the first active optimizer."""
         if self._active_optimizers:
             return self._active_optimizers[0].get_loss_scale()
         return torch.tensor([1.0], dtype=torch.float32, device="cuda")
 
     def count_zeros(self) -> int:
+        """Count zero gradients across all active module optimizers."""
         return sum(opt.count_zeros() for opt in self._active_optimizers)
 
     @property
@@ -133,6 +139,7 @@ class MimoOptimizer(MegatronOptimizer):
     # Checkpointing
 
     def state_dict(self):
+        """Return per-module optimizer state dicts."""
         return {
             name: info.optimizer.state_dict() if info.is_active and info.optimizer else None
             for name, info in self.module_infos.items()
@@ -187,6 +194,7 @@ class MimoOptimizer(MegatronOptimizer):
         return sharded_state
 
     def reload_model_params(self, state_dict=None):
+        """Reload model parameters in all active module optimizers."""
         for opt in self._active_optimizers:
             opt.reload_model_params(state_dict)
 

--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 import torch
 
 from megatron.core.dist_checkpointing.mapping import ShardedObject
+from megatron.core.dist_checkpointing.utils import add_prefix_for_sharding
 from megatron.core.optimizer.clip_grads import clip_grad_by_total_norm_fp32
 from megatron.core.optimizer.optimizer import MegatronOptimizer
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
@@ -179,6 +180,9 @@ class MimoOptimizer(MegatronOptimizer):
                     _extract_param_state_sharding_type(sub_sd, name, suffix, replica_id)
                     _extract_grad_scaler(sub_sd, name, suffix, replica_id)
 
+                # Namespace every internal ShardedBase key with the submodule name
+                # so disjoint grids don't collide on shared distributed-optimizer keys.
+                add_prefix_for_sharding(module_sd, f'mimo.{name}.')
                 sharded_state[name] = module_sd
             else:
                 sharded_state[name] = {}

--- a/megatron/core/models/vision/radio.py
+++ b/megatron/core/models/vision/radio.py
@@ -17,6 +17,7 @@ from megatron.core.transformer.enums import ModelType
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.utils import get_tensor_model_parallel_group_if_none
 
 # RADIO reference code: https://github.com/NVlabs/RADIO
 
@@ -211,7 +212,9 @@ class RADIOViTModel(VisionModule):
         self.ln_pre = None
         self.ln_post = None
         self.pg_collection = pg_collection
-        self.tp_group = pg_collection.tp if pg_collection is not None else None
+        self.tp_group = get_tensor_model_parallel_group_if_none(
+            pg_collection.tp if pg_collection is not None else None
+        )
         self.vp_stage = vp_stage
         if ln_pre_impl is not None:
             self.ln_pre = build_module(

--- a/megatron/core/models/vision/radio.py
+++ b/megatron/core/models/vision/radio.py
@@ -211,6 +211,7 @@ class RADIOViTModel(VisionModule):
         self.ln_pre = None
         self.ln_post = None
         self.pg_collection = pg_collection
+        self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.vp_stage = vp_stage
         if ln_pre_impl is not None:
             self.ln_pre = build_module(

--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -121,6 +121,7 @@ class GatedDeltaNet(MegatronModule):
         self.use_qk_l2norm = use_qk_l2norm
         assert pg_collection is not None, "pg_collection must be provided for GatedDeltaNet"
         self.pg_collection = pg_collection
+        self.tp_group = pg_collection.tp
         self.cp_size = self.pg_collection.cp.size()
         self.tp_size = self.pg_collection.tp.size()
         self.sp_size = self.tp_size if config.sequence_parallel else 1

--- a/megatron/core/ssm/mamba_layer.py
+++ b/megatron/core/ssm/mamba_layer.py
@@ -81,6 +81,7 @@ class MambaLayer(GraphableMegatronModule):
         """
         super().__init__(config)
         assert pg_collection is not None, "pg_collection must be provided for MambaLayer"
+        self.tp_group = pg_collection.tp
 
         self.config = config
         self.submodules_config = submodules

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -415,6 +415,7 @@ class MambaMixer(MegatronModule):
             )
             setattr(self.norm.weight, "tensor_model_parallel", True)
             setattr(self.norm.weight, "partition_dim", 0)
+            self.norm.tp_group = self.pg_collection.tp
         # Assume sequence parallelism: input is partitioned along d_inner and
         # output is partitioned along the sequence dimension
         self.out_proj = build_module(
@@ -1335,6 +1336,8 @@ class MambaMixer(MegatronModule):
                 "conv1d_bias": 0,
             },
             sharded_offsets=sharded_offsets,
+            tp_group=self.tp_group,
+            dp_cp_group=metadata["dp_cp_group"],
         )
         # Submodules
         for name, module in self.named_children():

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -622,6 +622,15 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
             raise NotImplementedError(f'Async checkpoint save not implemented for {args.ckpt_format} distributed checkpoint format')
 
     rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    dp_rank = 0
+    expt_dp_rank = 0
+    if torch.distributed.is_initialized():
+        dp_rank = get_pg_rank(dp_group) if dp_group is not None else mpu.get_data_parallel_rank()
+        expt_dp_rank = (
+            get_pg_rank(expt_dp_group)
+            if expt_dp_group is not None
+            else mpu.get_expert_data_parallel_rank()
+        )
 
     # Collect args, model, RNG.
     # For LEGACY checkpoints, every unique (tp_rank, ep_rank) shard must be written by
@@ -630,8 +639,8 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
     # does, with at most one rank per (tp_rank, ep_rank) inside any DP group.
     if not torch.distributed.is_initialized() \
             or ckpt_type != CheckpointType.LEGACY \
-            or mpu.get_data_parallel_rank() == 0 \
-            or mpu.get_expert_data_parallel_rank() == 0:
+            or dp_rank == 0 \
+            or expt_dp_rank == 0:
         if ckpt_type != CheckpointType.LEGACY:
             sharded_sd_metadata = _build_sharded_state_dict_metadata(args, dp_cp_group=dp_cp_group)
             if args.use_distributed_optimizer:

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -373,11 +373,13 @@ def get_rng_state(
     tp_group: torch.distributed.ProcessGroup,
     pp_group: torch.distributed.ProcessGroup,
     dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    dp_group: Optional[torch.distributed.ProcessGroup] = None,
     key_prefix: str = '',
 ) -> Union[List[Dict[str, Any]], ShardedObject]:
     """Collect rng state across data parallel ranks.
 
-    dp_cp_group threads the data-parallel (with context-parallel) group; None falls back to the mpu API.
+    dp_group threads the data-parallel group used for RNG gather/indexing.
+    dp_cp_group threads the data-parallel (with context-parallel) group used for checkpoint replica id.
     key_prefix namespaces the rng ShardedObject key so disjoint grids avoid a key collision (default '').
     """
     args = get_args()
@@ -388,24 +390,16 @@ def get_rng_state(
         'cuda_rng_state': torch.cuda.get_rng_state(),
         'rng_tracker_states': tensor_parallel.get_cuda_rng_tracker().get_states()}
 
-    dp_cp_world_size = (
-        get_pg_size(dp_cp_group)
-        if dp_cp_group is not None
-        else mpu.get_data_parallel_world_size(with_context_parallel=True)
-    )
+    dp_world_size = get_pg_size(dp_group) if dp_group is not None else mpu.get_data_parallel_world_size()
     rng_state_list = None
     if args.data_parallel_random_init and torch.distributed.is_initialized() and \
-            dp_cp_world_size > 1:
+            dp_world_size > 1:
         rng_state_list = \
-            [None for i in range(dp_cp_world_size)]
+            [None for i in range(dp_world_size)]
         torch.distributed.all_gather_object(
             rng_state_list,
             rng_state,
-            group=(
-                dp_cp_group
-                if dp_cp_group is not None
-                else mpu.get_data_parallel_group(with_context_parallel=True)
-            ),
+            group=dp_group if dp_group is not None else mpu.get_data_parallel_group(),
         )
     else:
         rng_state_list = [rng_state]
@@ -515,7 +509,7 @@ def save_grads(save_dir, state_dict, iteration, grad_label):
 
 def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floating_point_operations_so_far,
                     checkpointing_context=None, pipeline_rank=None, expert_rank=None, tensor_rank=None, pipeline_parallel=None, expert_parallel=None, non_persistent_ckpt=False,
-                    train_data_iterator=None, preprocess_common_state_dict_fn = None, release=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None, expt_dp_group: Optional[torch.distributed.ProcessGroup] = None, rng_state_key_prefix: str = ''):
+                    train_data_iterator=None, preprocess_common_state_dict_fn = None, release=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None, dp_group: Optional[torch.distributed.ProcessGroup] = None, expt_dp_group: Optional[torch.distributed.ProcessGroup] = None, rng_state_key_prefix: str = ''):
     """Save a model, optimizer and optionally dataloader checkpoint.
 
     Checkpointing context is used to persist some checkpointing state
@@ -532,6 +526,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
 
     Args:
         dp_cp_group: Data parallel + context parallel group (default: None, falls back to mpu API)
+        dp_group: Data parallel group (default: None, falls back to mpu API)
         expt_dp_group: Expert data parallel group (default: None, falls back to mpu API)
     """
     start_ckpt = time()
@@ -581,6 +576,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
         pp_group = mpu.get_pipeline_model_parallel_group()
     rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
                               dp_cp_group=dp_cp_group,
+                              dp_group=dp_group,
                               key_prefix=rng_state_key_prefix)
 
     # Collect rerun state across all ranks
@@ -1655,7 +1651,7 @@ def load_args_from_checkpoint(
 
 
 def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', strict=True,
-                    checkpointing_context=None, skip_load_to_model_and_opt=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None, rng_state_key_prefix: str = ''):
+                    checkpointing_context=None, skip_load_to_model_and_opt=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None, dp_group: Optional[torch.distributed.ProcessGroup] = None, rng_state_key_prefix: str = ''):
     """Load a model checkpoint and return the iteration.
     strict (bool): whether to strictly enforce that the keys in
         :attr:`state_dict` of the checkpoint match the names of
@@ -1664,6 +1660,7 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
         for :attr:`model` and :attr:`optimizer`. In case of running FSDP2 with mcore distributed
         checkpointing, the tensors are already loaded in-place by `_load_base_checkpoint`.
     dp_cp_group: Data parallel + context parallel group (default: None, falls back to mpu API)
+    dp_group: Data parallel group (default: None, falls back to mpu API)
     """
     args = get_args()
     load_dir = getattr(args, load_arg)
@@ -1742,6 +1739,7 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                 pp_group = mpu.get_pipeline_model_parallel_group()
             gen_sd_rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
                                              dp_cp_group=dp_cp_group,
+                                             dp_group=dp_group,
                                              key_prefix=rng_state_key_prefix)  # we can load the rng state
         else:
             ignore_rng_state = True
@@ -1846,7 +1844,9 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
             "optimizer": optimizer_sd,
             "args": None,
             "iteration": 1,
-            "rng_state": get_rng_state(args.ckpt_format, tp_group, pp_group, dp_cp_group=dp_cp_group),
+            "rng_state": get_rng_state(
+                args.ckpt_format, tp_group, pp_group, dp_cp_group=dp_cp_group, dp_group=dp_group
+            ),
             "checkpoint_version": None,
             "opt_param_scheduler": opt_param_scheduler.state_dict(),
             "num_floating_point_operations_so_far": 0,
@@ -1870,7 +1870,7 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                 )
             if not args.no_load_rng:
                 gen_sd_rng_state = get_rng_state(
-                    args.ckpt_format, tp_group, pp_group, dp_cp_group=dp_cp_group
+                    args.ckpt_format, tp_group, pp_group, dp_cp_group=dp_cp_group, dp_group=dp_group
                 )
             if not args.no_load_optim:
                 gen_sd_optim = optimizer
@@ -2064,12 +2064,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
 
                 # access rng_state for data parallel rank
                 if args.data_parallel_random_init:
-                    dp_cp_rank = (
-                        get_pg_rank(dp_cp_group)
-                        if dp_cp_group is not None
-                        else mpu.get_data_parallel_rank(with_context_parallel=True)
-                    )
-                    rng_state = rng_state[dp_cp_rank]
+                    dp_rank = get_pg_rank(dp_group) if dp_group is not None else mpu.get_data_parallel_rank()
+                    rng_state = rng_state[dp_rank]
                 else:
                     rng_state = rng_state[0]
                 random.setstate(rng_state['random_rng_state'])

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -372,10 +372,12 @@ def get_rng_state(
     ckpt_format: str,
     tp_group: torch.distributed.ProcessGroup,
     pp_group: torch.distributed.ProcessGroup,
+    key_prefix: str = '',
     dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
 ) -> Union[List[Dict[str, Any]], ShardedObject]:
     """Collect rng state across data parallel ranks.
 
+    key_prefix namespaces the rng ShardedObject key so disjoint grids avoid a key collision (default '').
     dp_cp_group threads the data-parallel (with context-parallel) group; None falls back to the mpu API.
     """
     args = get_args()
@@ -405,7 +407,7 @@ def get_rng_state(
         pp_size = get_pg_size(pp_group)
         tp_rank = get_pg_rank(tp_group)
         tp_size = get_pg_size(tp_group)
-        rng_state_list = ShardedObject('rng_state', rng_state_list, (pp_size, tp_size), (pp_rank, tp_rank),
+        rng_state_list = ShardedObject(f'{key_prefix}rng_state', rng_state_list, (pp_size, tp_size), (pp_rank, tp_rank),
                                        replica_id=dp_cp_rank)
     elif ckpt_format == "fsdp_dtensor":
         pp_rank = get_pg_rank(pp_group)
@@ -504,7 +506,7 @@ def save_grads(save_dir, state_dict, iteration, grad_label):
 
 def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floating_point_operations_so_far,
                     checkpointing_context=None, pipeline_rank=None, expert_rank=None, tensor_rank=None, pipeline_parallel=None, expert_parallel=None, non_persistent_ckpt=False,
-                    train_data_iterator=None, preprocess_common_state_dict_fn = None, release=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None):
+                    train_data_iterator=None, preprocess_common_state_dict_fn = None, release=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None, rng_state_key_prefix: str = ''):
     """Save a model, optimizer and optionally dataloader checkpoint.
 
     Checkpointing context is used to persist some checkpointing state
@@ -567,7 +569,9 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
     if tp_group is None and pp_group is None:
         tp_group = mpu.get_tensor_model_parallel_group()
         pp_group = mpu.get_pipeline_model_parallel_group()
-    rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group, dp_cp_group=dp_cp_group)
+    rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
+                              key_prefix=rng_state_key_prefix,
+                              dp_cp_group=dp_cp_group)
 
     # Collect rerun state across all ranks
     rerun_state_machine = get_rerun_state_machine()
@@ -1642,7 +1646,7 @@ def load_args_from_checkpoint(
 
 
 def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', strict=True,
-                    checkpointing_context=None, skip_load_to_model_and_opt=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None):
+                    checkpointing_context=None, skip_load_to_model_and_opt=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None, rng_state_key_prefix: str = ''):
     """Load a model checkpoint and return the iteration.
     strict (bool): whether to strictly enforce that the keys in
         :attr:`state_dict` of the checkpoint match the names of
@@ -1727,9 +1731,9 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
             if tp_group is None and pp_group is None:
                 tp_group = mpu.get_tensor_model_parallel_group()
                 pp_group = mpu.get_pipeline_model_parallel_group()
-            gen_sd_rng_state = get_rng_state(
-                args.ckpt_format, tp_group, pp_group, dp_cp_group=dp_cp_group
-            )  # we can load the rng state
+            gen_sd_rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
+                                             key_prefix=rng_state_key_prefix,
+                                             dp_cp_group=dp_cp_group)  # we can load the rng state
         else:
             ignore_rng_state = True
             gen_sd_rng_state = None

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -388,16 +388,25 @@ def get_rng_state(
         'cuda_rng_state': torch.cuda.get_rng_state(),
         'rng_tracker_states': tensor_parallel.get_cuda_rng_tracker().get_states()}
 
-    dp_world_size = get_pg_size(dp_cp_group) if dp_cp_group is not None else mpu.get_data_parallel_world_size()
+    dp_cp_world_size = (
+        get_pg_size(dp_cp_group)
+        if dp_cp_group is not None
+        else mpu.get_data_parallel_world_size(with_context_parallel=True)
+    )
     rng_state_list = None
     if args.data_parallel_random_init and torch.distributed.is_initialized() and \
-            dp_world_size > 1:
+            dp_cp_world_size > 1:
         rng_state_list = \
-            [None for i in range(dp_world_size)]
+            [None for i in range(dp_cp_world_size)]
         torch.distributed.all_gather_object(
             rng_state_list,
             rng_state,
-            group=dp_cp_group if dp_cp_group is not None else mpu.get_data_parallel_group())
+            group=(
+                dp_cp_group
+                if dp_cp_group is not None
+                else mpu.get_data_parallel_group(with_context_parallel=True)
+            ),
+        )
     else:
         rng_state_list = [rng_state]
 
@@ -2055,7 +2064,11 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
 
                 # access rng_state for data parallel rank
                 if args.data_parallel_random_init:
-                    dp_cp_rank = get_pg_rank(dp_cp_group) if dp_cp_group is not None else mpu.get_data_parallel_rank()
+                    dp_cp_rank = (
+                        get_pg_rank(dp_cp_group)
+                        if dp_cp_group is not None
+                        else mpu.get_data_parallel_rank(with_context_parallel=True)
+                    )
                     rng_state = rng_state[dp_cp_rank]
                 else:
                     rng_state = rng_state[0]

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -515,7 +515,7 @@ def save_grads(save_dir, state_dict, iteration, grad_label):
 
 def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floating_point_operations_so_far,
                     checkpointing_context=None, pipeline_rank=None, expert_rank=None, tensor_rank=None, pipeline_parallel=None, expert_parallel=None, non_persistent_ckpt=False,
-                    train_data_iterator=None, preprocess_common_state_dict_fn = None, release=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None, rng_state_key_prefix: str = ''):
+                    train_data_iterator=None, preprocess_common_state_dict_fn = None, release=False, tp_group: Optional[torch.distributed.ProcessGroup] = None, pp_group: Optional[torch.distributed.ProcessGroup] = None, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None, expt_dp_group: Optional[torch.distributed.ProcessGroup] = None, rng_state_key_prefix: str = ''):
     """Save a model, optimizer and optionally dataloader checkpoint.
 
     Checkpointing context is used to persist some checkpointing state
@@ -532,6 +532,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
 
     Args:
         dp_cp_group: Data parallel + context parallel group (default: None, falls back to mpu API)
+        expt_dp_group: Expert data parallel group (default: None, falls back to mpu API)
     """
     start_ckpt = time()
     args = get_args()
@@ -689,8 +690,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
                     if args.ckpt_fully_parallel_save_process_group == 'dp':
                         process_group = dp_cp_group if dp_cp_group is not None else mpu.get_data_parallel_group(with_context_parallel=True)
                     elif args.ckpt_fully_parallel_save_process_group == 'ep_dp':
-                        # NOTE: expert-DP save group not threaded yet; falls back to mpu (not on the disjoint-grid path).
-                        process_group = mpu.get_expert_data_parallel_group()
+                        process_group = expt_dp_group if expt_dp_group is not None else mpu.get_expert_data_parallel_group()
                     save_strategy = FullyParallelSaveStrategyWrapper(save_strategy, process_group,
                                                                      args.ckpt_assume_constant_structure)
             # Store save strategy for future checkpoint saves

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -372,13 +372,13 @@ def get_rng_state(
     ckpt_format: str,
     tp_group: torch.distributed.ProcessGroup,
     pp_group: torch.distributed.ProcessGroup,
-    key_prefix: str = '',
     dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    key_prefix: str = '',
 ) -> Union[List[Dict[str, Any]], ShardedObject]:
     """Collect rng state across data parallel ranks.
 
-    key_prefix namespaces the rng ShardedObject key so disjoint grids avoid a key collision (default '').
     dp_cp_group threads the data-parallel (with context-parallel) group; None falls back to the mpu API.
+    key_prefix namespaces the rng ShardedObject key so disjoint grids avoid a key collision (default '').
     """
     args = get_args()
     rng_state = {
@@ -570,8 +570,8 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
         tp_group = mpu.get_tensor_model_parallel_group()
         pp_group = mpu.get_pipeline_model_parallel_group()
     rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
-                              key_prefix=rng_state_key_prefix,
-                              dp_cp_group=dp_cp_group)
+                              dp_cp_group=dp_cp_group,
+                              key_prefix=rng_state_key_prefix)
 
     # Collect rerun state across all ranks
     rerun_state_machine = get_rerun_state_machine()
@@ -1732,8 +1732,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                 tp_group = mpu.get_tensor_model_parallel_group()
                 pp_group = mpu.get_pipeline_model_parallel_group()
             gen_sd_rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group,
-                                             key_prefix=rng_state_key_prefix,
-                                             dp_cp_group=dp_cp_group)  # we can load the rng state
+                                             dp_cp_group=dp_cp_group,
+                                             key_prefix=rng_state_key_prefix)  # we can load the rng state
         else:
             ignore_rng_state = True
             gen_sd_rng_state = None

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -368,8 +368,16 @@ def read_metadata(tracker_filename):
     return max_iter, release
 
 
-def get_rng_state(ckpt_format: str, tp_group: torch.distributed.ProcessGroup, pp_group: torch.distributed.ProcessGroup) -> Union[List[Dict[str, Any]], ShardedObject]:
-    """Collect rng state across data parallel ranks."""
+def get_rng_state(
+    ckpt_format: str,
+    tp_group: torch.distributed.ProcessGroup,
+    pp_group: torch.distributed.ProcessGroup,
+    dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> Union[List[Dict[str, Any]], ShardedObject]:
+    """Collect rng state across data parallel ranks.
+
+    dp_cp_group threads the data-parallel (with context-parallel) group; None falls back to the mpu API.
+    """
     args = get_args()
     rng_state = {
         'random_rng_state': random.getstate(),
@@ -378,28 +386,30 @@ def get_rng_state(ckpt_format: str, tp_group: torch.distributed.ProcessGroup, pp
         'cuda_rng_state': torch.cuda.get_rng_state(),
         'rng_tracker_states': tensor_parallel.get_cuda_rng_tracker().get_states()}
 
+    dp_world_size = get_pg_size(dp_cp_group) if dp_cp_group is not None else mpu.get_data_parallel_world_size()
     rng_state_list = None
     if args.data_parallel_random_init and torch.distributed.is_initialized() and \
-            mpu.get_data_parallel_world_size() > 1:
+            dp_world_size > 1:
         rng_state_list = \
-            [None for i in range(mpu.get_data_parallel_world_size())]
+            [None for i in range(dp_world_size)]
         torch.distributed.all_gather_object(
             rng_state_list,
             rng_state,
-            group=mpu.get_data_parallel_group())
+            group=dp_cp_group if dp_cp_group is not None else mpu.get_data_parallel_group())
     else:
         rng_state_list = [rng_state]
 
+    dp_cp_rank = get_pg_rank(dp_cp_group) if dp_cp_group is not None else mpu.get_data_parallel_rank(with_context_parallel=True)
     if ckpt_format == "torch_dist":
         pp_rank = get_pg_rank(pp_group)
         pp_size = get_pg_size(pp_group)
         tp_rank = get_pg_rank(tp_group)
         tp_size = get_pg_size(tp_group)
         rng_state_list = ShardedObject('rng_state', rng_state_list, (pp_size, tp_size), (pp_rank, tp_rank),
-                                       replica_id=mpu.get_data_parallel_rank(with_context_parallel=True))
+                                       replica_id=dp_cp_rank)
     elif ckpt_format == "fsdp_dtensor":
-        pp_rank = mpu.get_pipeline_model_parallel_rank()
-        tp_rank = mpu.get_tensor_model_parallel_rank()
+        pp_rank = get_pg_rank(pp_group)
+        tp_rank = get_pg_rank(tp_group)
         rng_state_list = {
             f"({pp_rank}, {tp_rank})": rng_state_list
         }
@@ -557,7 +567,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
     if tp_group is None and pp_group is None:
         tp_group = mpu.get_tensor_model_parallel_group()
         pp_group = mpu.get_pipeline_model_parallel_group()
-    rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group)
+    rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group, dp_cp_group=dp_cp_group)
 
     # Collect rerun state across all ranks
     rerun_state_machine = get_rerun_state_machine()
@@ -609,9 +619,9 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
     # the dense and expert parallelism layouts disagree (e.g. TP > EP*ETP); the union
     # does, with at most one rank per (tp_rank, ep_rank) inside any DP group.
     if not torch.distributed.is_initialized() \
+            or ckpt_type != CheckpointType.LEGACY \
             or mpu.get_data_parallel_rank() == 0 \
-            or mpu.get_expert_data_parallel_rank() == 0 \
-            or ckpt_type != CheckpointType.LEGACY:
+            or mpu.get_expert_data_parallel_rank() == 0:
         if ckpt_type != CheckpointType.LEGACY:
             sharded_sd_metadata = _build_sharded_state_dict_metadata(args, dp_cp_group=dp_cp_group)
             if args.use_distributed_optimizer:
@@ -664,8 +674,9 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
 
                 if args.ckpt_fully_parallel_save:
                     if args.ckpt_fully_parallel_save_process_group == 'dp':
-                        process_group = mpu.get_data_parallel_group(with_context_parallel=True)
+                        process_group = dp_cp_group if dp_cp_group is not None else mpu.get_data_parallel_group(with_context_parallel=True)
                     elif args.ckpt_fully_parallel_save_process_group == 'ep_dp':
+                        # NOTE: expert-DP save group not threaded yet; falls back to mpu (not on the disjoint-grid path).
                         process_group = mpu.get_expert_data_parallel_group()
                     save_strategy = FullyParallelSaveStrategyWrapper(save_strategy, process_group,
                                                                      args.ckpt_assume_constant_structure)
@@ -1716,7 +1727,9 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
             if tp_group is None and pp_group is None:
                 tp_group = mpu.get_tensor_model_parallel_group()
                 pp_group = mpu.get_pipeline_model_parallel_group()
-            gen_sd_rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group)  # we can load the rng state
+            gen_sd_rng_state = get_rng_state(
+                args.ckpt_format, tp_group, pp_group, dp_cp_group=dp_cp_group
+            )  # we can load the rng state
         else:
             ignore_rng_state = True
             gen_sd_rng_state = None
@@ -1724,7 +1737,7 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                 print_rank_0("{}: RNG state will be ignored".format(mismatch_msg))
 
         if ckpt_type == CheckpointType.LOCAL:
-            sharded_sd_metadata = _build_sharded_state_dict_metadata(args)
+            sharded_sd_metadata = _build_sharded_state_dict_metadata(args, dp_cp_group=dp_cp_group)
         else:
             sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
         print_rank_0(f'sharded_state_dict metadata loaded from the checkpoint: {sharded_sd_metadata}')
@@ -1820,7 +1833,7 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
             "optimizer": optimizer_sd,
             "args": None,
             "iteration": 1,
-            "rng_state": get_rng_state(args.ckpt_format, tp_group, pp_group),
+            "rng_state": get_rng_state(args.ckpt_format, tp_group, pp_group, dp_cp_group=dp_cp_group),
             "checkpoint_version": None,
             "opt_param_scheduler": opt_param_scheduler.state_dict(),
             "num_floating_point_operations_so_far": 0,
@@ -1843,12 +1856,17 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
                     data_iterator=None, ckpt_format=ckpt_format, force=True,
                 )
             if not args.no_load_rng:
-                gen_sd_rng_state = get_rng_state(args.ckpt_format, tp_group, pp_group)
+                gen_sd_rng_state = get_rng_state(
+                    args.ckpt_format, tp_group, pp_group, dp_cp_group=dp_cp_group
+                )
             if not args.no_load_optim:
                 gen_sd_optim = optimizer
                 gen_sd_opt_param_scheduler = opt_param_scheduler
 
-        optim_sd_kwargs = dict(metadata=_build_sharded_state_dict_metadata(args), is_loading=True)
+        optim_sd_kwargs = dict(
+            metadata=_build_sharded_state_dict_metadata(args, dp_cp_group=dp_cp_group),
+            is_loading=True,
+        )
 
         state_dict = generate_state_dict(
             args,
@@ -2021,8 +2039,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
             if 'rng_state' in state_dict:
                 if args.ckpt_format == "fsdp_dtensor":
                     # FSDP DTensor checkpoints store rng_state in a different format.
-                    tp_rank = mpu.get_tensor_model_parallel_rank()
-                    pp_rank = mpu.get_pipeline_model_parallel_rank()
+                    tp_rank = get_pg_rank(tp_group) if tp_group is not None else mpu.get_tensor_model_parallel_rank()
+                    pp_rank = get_pg_rank(pp_group) if pp_group is not None else mpu.get_pipeline_model_parallel_rank()
                     if f"({pp_rank}, {tp_rank})" in state_dict['rng_state']:
                         rng_state = state_dict['rng_state'][f"({pp_rank}, {tp_rank})"]
                     else:
@@ -2033,7 +2051,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
 
                 # access rng_state for data parallel rank
                 if args.data_parallel_random_init:
-                    rng_state = rng_state[mpu.get_data_parallel_rank()]
+                    dp_cp_rank = get_pg_rank(dp_cp_group) if dp_cp_group is not None else mpu.get_data_parallel_rank()
+                    rng_state = rng_state[dp_cp_rank]
                 else:
                     rng_state = rng_state[0]
                 random.setstate(rng_state['random_rng_state'])
@@ -2071,9 +2090,13 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
 
+    _tp_r = get_pg_rank(tp_group) if tp_group is not None else mpu.get_tensor_model_parallel_rank()
+    _tp_w = get_pg_size(tp_group) if tp_group is not None else mpu.get_tensor_model_parallel_world_size()
+    _pp_r = get_pg_rank(pp_group) if pp_group is not None else mpu.get_pipeline_model_parallel_rank()
+    _pp_w = get_pg_size(pp_group) if pp_group is not None else mpu.get_pipeline_model_parallel_world_size()
     print_rank_0(f'  successfully loaded checkpoint from {load_dir} '
-                 f'[ t {mpu.get_tensor_model_parallel_rank() + 1}/{mpu.get_tensor_model_parallel_world_size()}, '
-                 f'p {mpu.get_pipeline_model_parallel_rank() + 1}/{mpu.get_pipeline_model_parallel_world_size()} ] '
+                 f'[ t {_tp_r + 1}/{_tp_w}, '
+                 f'p {_pp_r + 1}/{_pp_w} ] '
                  f'at iteration {iteration}')
 
     # Additional callback for wandb (last rank)

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -46,6 +46,11 @@ def initialize_megatron(
     get_position_embedding_ranks=None,
     store=None,
     skip_model_parallel_init=False,
+    seed_pp_group=None,
+    seed_dp_group=None,
+    seed_tp_group=None,
+    seed_ep_group=None,
+    seed_etp_group=None,
 ):
     """Set global variables, initialize distributed, and
     set autoresume and random seeds.
@@ -102,16 +107,20 @@ def initialize_megatron(
             skip_model_parallel_init=skip_model_parallel_init,
         )
 
-        # Random seeds (skipped when caller owns seeding -- reads mpu ranks).
-        if not skip_model_parallel_init:
-            print_rank_0("> setting random seeds to {} ...".format(args.seed))
-            _set_random_seed(
-                args.seed,
-                args.data_parallel_random_init,
-                args.te_rng_tracker,
-                args.inference_rng_tracker,
-                use_cudagraphable_rng=args.cuda_graph_impl != "none",
-            )
+        # Random seeds for reproducibility.
+        print_rank_0("> setting random seeds to {} ...".format(args.seed))
+        _set_random_seed(
+            args.seed,
+            args.data_parallel_random_init,
+            args.te_rng_tracker,
+            args.inference_rng_tracker,
+            use_cudagraphable_rng=args.cuda_graph_impl != "none",
+            pp_group=seed_pp_group,
+            dp_group=seed_dp_group,
+            tp_group=seed_tp_group,
+            ep_group=seed_ep_group,
+            etp_group=seed_etp_group,
+        )
 
         # Setup MoE aux loss scale value.
         if args.num_experts is not None:

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -7,6 +7,7 @@ import random
 import time
 import warnings
 from datetime import timedelta
+from typing import Optional
 
 import numpy as np
 import torch
@@ -25,7 +26,7 @@ from megatron.core.rerun_state_machine import (
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
     enable_batch_invariant_mode,
 )
-from megatron.core.utils import get_te_version, is_te_min_version, is_torch_min_version
+from megatron.core.utils import get_pg_rank, get_te_version, is_te_min_version, is_torch_min_version
 from megatron.training import (
     get_adlr_autoresume,
     get_args,
@@ -393,20 +394,41 @@ def _set_random_seed(
     te_rng_tracker: bool = False,
     inference_rng_tracker: bool = False,
     use_cudagraphable_rng: bool = False,
+    pp_group: Optional[torch.distributed.ProcessGroup] = None,
+    dp_group: Optional[torch.distributed.ProcessGroup] = None,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    ep_group: Optional[torch.distributed.ProcessGroup] = None,
+    etp_group: Optional[torch.distributed.ProcessGroup] = None,
 ):
-    """Set random seed for reproducability."""
+    """Set random seed for reproducability.
+
+    The optional pp/dp/tp/ep/etp groups let a caller without an initialized mpu
+    (e.g. a disjoint-grid run) supply the parallel ranks explicitly; each falls
+    back to the mpu group when None.
+    """
     if seed_ is not None and seed_ > 0:
         # Ensure that different pipeline MP stages get different seeds.
-        seed = seed_ + (100 * mpu.get_pipeline_model_parallel_rank())
+        pp_rank = get_pg_rank(pp_group) if pp_group is not None else mpu.get_pipeline_model_parallel_rank()
+        seed = seed_ + (100 * pp_rank)
         # Ensure different data parallel ranks get different seeds
         if data_parallel_random_init:
-            seed = seed + (10 * mpu.get_data_parallel_rank())
+            dp_rank = get_pg_rank(dp_group) if dp_group is not None else mpu.get_data_parallel_rank()
+            seed = seed + (10 * dp_rank)
         random.seed(seed)
         np.random.seed(seed)
         torch.manual_seed(seed)
         if torch.cuda.device_count() > 0:
+            tp_rank = get_pg_rank(tp_group) if tp_group is not None else None
+            ep_rank = get_pg_rank(ep_group) if ep_group is not None else None
+            etp_rank = get_pg_rank(etp_group) if etp_group is not None else None
             tensor_parallel.model_parallel_cuda_manual_seed(
-                seed, te_rng_tracker, inference_rng_tracker, use_cudagraphable_rng
+                seed,
+                te_rng_tracker,
+                inference_rng_tracker,
+                use_cudagraphable_rng,
+                tp_rank=tp_rank,
+                ep_rank=ep_rank,
+                etp_rank=etp_rank,
             )
     else:
         raise ValueError("Seed ({}) should be a positive integer.".format(seed_))

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -44,6 +44,7 @@ def initialize_megatron(
     get_embedding_ranks=None,
     get_position_embedding_ranks=None,
     store=None,
+    skip_model_parallel_init=False,
 ):
     """Set global variables, initialize distributed, and
     set autoresume and random seeds.
@@ -93,17 +94,23 @@ def initialize_megatron(
     def finish_mpu_init():
         args = get_args()
         # Pytorch distributed.
-        _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, store)
-
-        # Random seeds for reproducibility.
-        print_rank_0("> setting random seeds to {} ...".format(args.seed))
-        _set_random_seed(
-            args.seed,
-            args.data_parallel_random_init,
-            args.te_rng_tracker,
-            args.inference_rng_tracker,
-            use_cudagraphable_rng=args.cuda_graph_impl != "none",
+        _initialize_distributed(
+            get_embedding_ranks,
+            get_position_embedding_ranks,
+            store,
+            skip_model_parallel_init=skip_model_parallel_init,
         )
+
+        # Random seeds (skipped when caller owns seeding -- reads mpu ranks).
+        if not skip_model_parallel_init:
+            print_rank_0("> setting random seeds to {} ...".format(args.seed))
+            _set_random_seed(
+                args.seed,
+                args.data_parallel_random_init,
+                args.te_rng_tracker,
+                args.inference_rng_tracker,
+                use_cudagraphable_rng=args.cuda_graph_impl != "none",
+            )
 
         # Setup MoE aux loss scale value.
         if args.num_experts is not None:
@@ -243,7 +250,8 @@ def _initialize_tp_communicators():
         )
 
 
-def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, store):
+def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, store,
+                            skip_model_parallel_init=False):
     """Initialize torch.distributed and core model parallel."""
     args = get_args()
 
@@ -334,7 +342,8 @@ def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, s
 
     # Set the tensor model-parallel, pipeline model-parallel, and
     # data-parallel communicators.
-    if device_count > 0:
+    # (skipped when caller owns model-parallel setup)
+    if device_count > 0 and not skip_model_parallel_init:
         if mpu.model_parallel_is_initialized():
             print("model parallel is already initialized")
         else:
@@ -412,7 +421,7 @@ def write_args_to_tensorboard():
             writer.add_text(arg, str(getattr(args, arg)), global_step=args.iteration)
 
 
-def set_jit_fusion_options():
+def set_jit_fusion_options(tp_size=None):
     """Set PyTorch JIT layer fusion options."""
     # flags required to enable jit fusion kernels
     if is_torch_min_version("2.2.0a0"):
@@ -433,10 +442,10 @@ def set_jit_fusion_options():
         torch._C._jit_override_can_fuse_on_cpu(True)
         torch._C._jit_override_can_fuse_on_gpu(True)
 
-    _warmup_jit_function()
+    _warmup_jit_function(tp_size=tp_size)
 
 
-def _warmup_jit_function():
+def _warmup_jit_function(tp_size=None):
     """Compilie JIT functions before the main training steps"""
     args = get_args()
     if args.bf16:
@@ -472,7 +481,8 @@ def _warmup_jit_function():
 
     # Warmup fused bias+dropout+add
     if args.sequence_parallel:
-        seq_length = args.seq_length // mpu.get_tensor_model_parallel_world_size()
+        # tp_size threaded by the caller (hetero MIMO language PGC); None -> mpu.
+        seq_length = args.seq_length // (tp_size or mpu.get_tensor_model_parallel_world_size())
     else:
         seq_length = args.seq_length
     input = torch.rand(

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2901,6 +2901,8 @@ def save_checkpoint_and_time(
     tp_group = getattr(ckpt_pgc, "tp", None) if ckpt_pgc is not None else None
     pp_group = getattr(ckpt_pgc, "pp", None) if ckpt_pgc is not None else None
     dp_cp_group = getattr(ckpt_pgc, "dp_cp", None) if ckpt_pgc is not None else None
+    # Per-grid rng key namespace set by a multi-grid model; '' for stock single-grid.
+    rng_state_key_prefix = getattr(unwrap_model(model)[0], "rng_state_key_prefix", "")
 
     # Save checkpoint.
     save_checkpoint(
@@ -2916,6 +2918,7 @@ def save_checkpoint_and_time(
         tp_group=tp_group,
         pp_group=pp_group,
         dp_cp_group=dp_cp_group,
+        rng_state_key_prefix=rng_state_key_prefix,
     )
 
     # Stop timer and compute time elapsed to save checkpoint. Stop timer before timers.log() call as it resets the timer.

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1059,12 +1059,25 @@ def pretrain(
     ft_integration.setup()
     timestamp_after_in_job_setup = time.time()
 
+    init_pg_collection = None
+    if schedule_pg_collection is not None:
+        init_pg_collection = (
+            schedule_pg_collection.get_language_model_collection()
+            if schedule_pg_collection.has_language_model()
+            else next(iter(schedule_pg_collection.module_pgs.values()))
+        )
+
     # Initalize and get arguments, timers, and Tensorboard writer.
     initialize_megatron(
         get_embedding_ranks=get_embedding_ranks,
         get_position_embedding_ranks=get_position_embedding_ranks,
         store=store,
         skip_model_parallel_init=skip_model_parallel_init,
+        seed_pp_group=getattr(init_pg_collection, "pp", None),
+        seed_dp_group=getattr(init_pg_collection, "dp", None),
+        seed_tp_group=getattr(init_pg_collection, "tp", None),
+        seed_ep_group=getattr(init_pg_collection, "ep", None),
+        seed_etp_group=getattr(init_pg_collection, "expt_tp", None),
     )
 
     timestamp_after_initialize_megatron = time.time()
@@ -1080,14 +1093,7 @@ def pretrain(
     if cfg_container.logger.log_progress:
         append_to_progress_log(args.save, "Starting job")
 
-    jit_pg_collection = None
-    if schedule_pg_collection is not None:
-        jit_pg_collection = (
-            schedule_pg_collection.get_language_model_collection()
-            if schedule_pg_collection.has_language_model()
-            else next(iter(schedule_pg_collection.module_pgs.values()))
-        )
-    _jit_tp_size = get_pg_size(jit_pg_collection.tp) if jit_pg_collection is not None else None
+    _jit_tp_size = get_pg_size(init_pg_collection.tp) if init_pg_collection is not None else None
     set_jit_fusion_options(tp_size=_jit_tp_size)
 
     timestamp_after_set_jit_fusion_options = time.time()

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1080,11 +1080,14 @@ def pretrain(
     if cfg_container.logger.log_progress:
         append_to_progress_log(args.save, "Starting job")
 
-    _jit_tp_size = (
-        get_pg_size(schedule_pg_collection.get_language_model_collection().tp)
-        if schedule_pg_collection is not None and schedule_pg_collection.has_language_model()
-        else None
-    )
+    jit_pg_collection = None
+    if schedule_pg_collection is not None:
+        jit_pg_collection = (
+            schedule_pg_collection.get_language_model_collection()
+            if schedule_pg_collection.has_language_model()
+            else next(iter(schedule_pg_collection.module_pgs.values()))
+        )
+    _jit_tp_size = get_pg_size(jit_pg_collection.tp) if jit_pg_collection is not None else None
     set_jit_fusion_options(tp_size=_jit_tp_size)
 
     timestamp_after_set_jit_fusion_options = time.time()
@@ -1194,6 +1197,7 @@ def pretrain(
     else:
         checkpointing_context = {}
 
+    # Model, optimizer, and learning rate.
     timers('model-and-optimizer-setup', log_level=0).start(barrier=True)
     model, optimizer, opt_param_scheduler = setup_model_and_optimizer(
         model_provider, model_type, checkpointing_context=checkpointing_context

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3265,9 +3265,6 @@ def train(
 
             args.no_load_optim = no_load_optim
 
-    # Resolve the language-model process groups when a hetero MultiModule collection
-    # is passed; None for stock single-module runs, which fall back to the global
-    # mpu groups below (byte-identical behavior).
     lang_pgc = (
         schedule_pg_collection.get_language_model_collection()
         if schedule_pg_collection is not None and schedule_pg_collection.has_language_model()

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -998,6 +998,9 @@ def pretrain(
     non_loss_data_func=None,
     store=None,
     inprocess_call_wrapper: Optional[Any] = None,
+    p2p_communicator: Optional[P2PCommunicator] = None,
+    schedule_pg_collection: Optional[MultiModuleProcessGroupCollection] = None,
+    skip_model_parallel_init=False,
 ):
     """Main training program.
 
@@ -1061,6 +1064,7 @@ def pretrain(
         get_embedding_ranks=get_embedding_ranks,
         get_position_embedding_ranks=get_position_embedding_ranks,
         store=store,
+        skip_model_parallel_init=skip_model_parallel_init,
     )
 
     timestamp_after_initialize_megatron = time.time()
@@ -1076,8 +1080,12 @@ def pretrain(
     if cfg_container.logger.log_progress:
         append_to_progress_log(args.save, "Starting job")
 
-    # Set pytorch JIT layer fusion options and warmup JIT functions.
-    set_jit_fusion_options()
+    _jit_tp_size = (
+        get_pg_size(schedule_pg_collection.get_language_model_collection().tp)
+        if schedule_pg_collection is not None and schedule_pg_collection.has_language_model()
+        else None
+    )
+    set_jit_fusion_options(tp_size=_jit_tp_size)
 
     timestamp_after_set_jit_fusion_options = time.time()
 
@@ -1186,7 +1194,6 @@ def pretrain(
     else:
         checkpointing_context = {}
 
-    # Model, optimizer, and learning rate.
     timers('model-and-optimizer-setup', log_level=0).start(barrier=True)
     model, optimizer, opt_param_scheduler = setup_model_and_optimizer(
         model_provider, model_type, checkpointing_context=checkpointing_context
@@ -1378,6 +1385,8 @@ def pretrain(
                 checkpointing_context,
                 non_loss_data_func,
                 inference_model,
+                p2p_communicator=p2p_communicator,
+                schedule_pg_collection=schedule_pg_collection,
             )
 
         print_datetime('after training is done')
@@ -2508,7 +2517,10 @@ def training_log(
     total_iterations = total_loss_dict[advanced_iters_key] + total_loss_dict[skipped_iters_key]
 
     # learning rate will be None on ranks without trainable params, so we must gather across mp ranks
-    learning_rate: float | None = reduce_max_stat_across_model_parallel_group(learning_rate)
+    _lr_mp_group = pg_collection.mp if pg_collection is not None else None
+    learning_rate: float | None = reduce_max_stat_across_model_parallel_group(
+        learning_rate, group=_lr_mp_group
+    )
     if learning_rate is None and args.freeze_all_layers:
         learning_rate = 0.0
     # Tensorboard values.
@@ -2663,9 +2675,7 @@ def training_log(
             batch_size,
             seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
             total_real_tokens_in_batch=total_real_tokens_in_batch,
-        ) / (
-            elapsed_time_per_iteration * 10**12 * args.world_size
-        )
+        ) / (elapsed_time_per_iteration * 10**12 * args.world_size)
 
         one_logger_utils.track_e2e_metrics(args.log_throughput, throughput)
 
@@ -2749,7 +2759,10 @@ def training_log(
             if torch.distributed.get_rank() == 0:
                 num_microbatches = get_num_microbatches()
                 report_theoretical_memory(args, num_microbatches=num_microbatches, verbose=True)
-            report_memory(f'(after {iteration} iterations)')
+            report_memory(
+                f'(after {iteration} iterations)',
+                group=pg_collection.dp if pg_collection is not None else None,
+            )
             reported_memory_in_this_iteration = True
             loaded_iteration = max(get_loaded_iteration() or 0, 0)
             if iteration > (loaded_iteration + 1):
@@ -2757,7 +2770,10 @@ def training_log(
                 report_memory_flag = False
         if args.log_memory_interval is not None and iteration % args.log_memory_interval == 0 and \
             not reported_memory_in_this_iteration:
-            report_memory(f'(after {iteration} iterations)')
+            report_memory(
+                f'(after {iteration} iterations)',
+                group=pg_collection.dp if pg_collection is not None else None,
+            )
         # Log RL profiling data if enabled (must be before timers.log which resets timers).
         # Token throughput metrics are read from RLRuntimeState automatically.
         if args.rl_profile:
@@ -2878,6 +2894,14 @@ def save_checkpoint_and_time(
     if should_report_memory:
         # Track memory before checkpoint save.
         report_memory(f"(before save_checkpoint for iteration {iteration})")
+
+    # Resolve checkpoint groups from this rank's module PGC; None for stock runs
+    # falls back to the mpu groups inside save_checkpoint (byte-identical).
+    ckpt_pgc = getattr(unwrap_model(model)[0], "pg_collection", None)
+    tp_group = getattr(ckpt_pgc, "tp", None) if ckpt_pgc is not None else None
+    pp_group = getattr(ckpt_pgc, "pp", None) if ckpt_pgc is not None else None
+    dp_cp_group = getattr(ckpt_pgc, "dp_cp", None) if ckpt_pgc is not None else None
+
     # Save checkpoint.
     save_checkpoint(
         iteration,
@@ -2889,6 +2913,9 @@ def save_checkpoint_and_time(
         non_persistent_ckpt=non_persistent_ckpt,
         train_data_iterator=train_data_iterator,
         preprocess_common_state_dict_fn=preprocess_common_state_dict,
+        tp_group=tp_group,
+        pp_group=pp_group,
+        dp_cp_group=dp_cp_group,
     )
 
     # Stop timer and compute time elapsed to save checkpoint. Stop timer before timers.log() call as it resets the timer.
@@ -3221,6 +3248,22 @@ def train(
 
             args.no_load_optim = no_load_optim
 
+    # Resolve the language-model process groups when a hetero MultiModule collection
+    # is passed; None for stock single-module runs, which fall back to the global
+    # mpu groups below (byte-identical behavior).
+    lang_pgc = (
+        schedule_pg_collection.get_language_model_collection()
+        if schedule_pg_collection is not None and schedule_pg_collection.has_language_model()
+        else None
+    )
+
+    def _dp_world_size():
+        if lang_pgc is not None:
+            return lang_pgc.dp.size()
+        if mpu.model_parallel_is_initialized():
+            return mpu.get_data_parallel_world_size()
+        return args.data_parallel_size
+
     # IMPORTANT FIX: For RL training, reinitialize the microbatch calculator with the correct configuration
     if args.perform_rl_step:
         print_rank_0("> Reinitializing microbatch calculator for GRPO training...")
@@ -3236,7 +3279,7 @@ def train(
             rank=args.rank,
             global_batch_size=args.global_batch_size,
             micro_batch_size=args.micro_batch_size,
-            data_parallel_size=mpu.get_data_parallel_world_size(),
+            data_parallel_size=_dp_world_size(),
             decrease_batch_size_if_needed=args.decrease_batch_size_if_needed,
             step_batch_size_schedule=args.step_batch_size_schedule,
             seq_length=args.seq_length,
@@ -3554,7 +3597,7 @@ def train(
                 start_iteration = iteration + 1
             iteration += 1
             batch_size = (
-                mpu.get_data_parallel_world_size() * args.micro_batch_size * get_num_microbatches()
+                _dp_world_size() * args.micro_batch_size * get_num_microbatches()
             )
             args.consumed_train_samples += batch_size
             args.skipped_train_samples += batch_size
@@ -3681,12 +3724,12 @@ def train(
             iteration_sequences = rl_utils.get_iteration_sequence_count(args)
             # Track bins separately for packed mode
             bin_count = (
-                mpu.get_data_parallel_world_size() * args.micro_batch_size * get_num_microbatches()
+                _dp_world_size() * args.micro_batch_size * get_num_microbatches()
             )
             args.consumed_train_bins += bin_count
         else:
             batch_size = (
-                mpu.get_data_parallel_world_size() * args.micro_batch_size * get_num_microbatches()
+                _dp_world_size() * args.micro_batch_size * get_num_microbatches()
             )
             iteration_sequences = batch_size
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2761,7 +2761,7 @@ def training_log(
                 report_theoretical_memory(args, num_microbatches=num_microbatches, verbose=True)
             report_memory(
                 f'(after {iteration} iterations)',
-                group=pg_collection.dp if pg_collection is not None else None,
+                process_group=pg_collection.dp if pg_collection is not None else None,
             )
             reported_memory_in_this_iteration = True
             loaded_iteration = max(get_loaded_iteration() or 0, 0)
@@ -2772,7 +2772,7 @@ def training_log(
             not reported_memory_in_this_iteration:
             report_memory(
                 f'(after {iteration} iterations)',
-                group=pg_collection.dp if pg_collection is not None else None,
+                process_group=pg_collection.dp if pg_collection is not None else None,
             )
         # Log RL profiling data if enabled (must be before timers.log which resets timers).
         # Token throughput metrics are read from RLRuntimeState automatically.

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2905,6 +2905,7 @@ def save_checkpoint_and_time(
     tp_group = getattr(ckpt_pgc, "tp", None) if ckpt_pgc is not None else None
     pp_group = getattr(ckpt_pgc, "pp", None) if ckpt_pgc is not None else None
     dp_cp_group = getattr(ckpt_pgc, "dp_cp", None) if ckpt_pgc is not None else None
+    expt_dp_group = getattr(ckpt_pgc, "expt_dp", None) if ckpt_pgc is not None else None
     # Per-grid rng key namespace set by a multi-grid model; '' for stock single-grid.
     rng_state_key_prefix = getattr(unwrap_model(model)[0], "rng_state_key_prefix", "")
 
@@ -2922,6 +2923,7 @@ def save_checkpoint_and_time(
         tp_group=tp_group,
         pp_group=pp_group,
         dp_cp_group=dp_cp_group,
+        expt_dp_group=expt_dp_group,
         rng_state_key_prefix=rng_state_key_prefix,
     )
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2904,6 +2904,7 @@ def save_checkpoint_and_time(
     ckpt_pgc = getattr(unwrap_model(model)[0], "pg_collection", None)
     tp_group = getattr(ckpt_pgc, "tp", None) if ckpt_pgc is not None else None
     pp_group = getattr(ckpt_pgc, "pp", None) if ckpt_pgc is not None else None
+    dp_group = getattr(ckpt_pgc, "dp", None) if ckpt_pgc is not None else None
     dp_cp_group = getattr(ckpt_pgc, "dp_cp", None) if ckpt_pgc is not None else None
     expt_dp_group = getattr(ckpt_pgc, "expt_dp", None) if ckpt_pgc is not None else None
     # Per-grid rng key namespace set by a multi-grid model; '' for stock single-grid.
@@ -2923,6 +2924,7 @@ def save_checkpoint_and_time(
         tp_group=tp_group,
         pp_group=pp_group,
         dp_cp_group=dp_cp_group,
+        dp_group=dp_group,
         expt_dp_group=expt_dp_group,
         rng_state_key_prefix=rng_state_key_prefix,
     )

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -294,10 +294,10 @@ def logical_and_across_model_parallel_group(
     return bool(input.item())
 
 
-def report_memory(name, group=None):
+def report_memory(name, process_group=None):
     """Simple GPU memory report.
 
-    group: optional data-parallel group to gate the rank-0 print on; None falls back
+    process_group: optional data-parallel group to gate the rank-0 print on; None falls back
         to ``mpu.get_data_parallel_rank()`` (byte-identical for callers passing nothing).
     """
     args = get_args()
@@ -309,7 +309,11 @@ def report_memory(name, group=None):
     string += f" | max reserved: {torch.cuda.max_memory_reserved() / mega_bytes:.2f}"
     if args.log_device_memory_used:
         string += f" | total device memory used: {torch.cuda.device_memory_used() / mega_bytes:.2f}"
-    is_dp_rank_0 = get_pg_rank(group) == 0 if group is not None else mpu.get_data_parallel_rank() == 0
+    is_dp_rank_0 = (
+        get_pg_rank(process_group) == 0
+        if process_group is not None
+        else mpu.get_data_parallel_rank() == 0
+    )
     if is_dp_rank_0:
         print("[Rank {}] {}".format(torch.distributed.get_rank(), string), flush=True)
 

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -5,18 +5,17 @@ import json
 import os
 import sys
 import warnings
+from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
-from collections import defaultdict
 from typing import Optional
 
 import torch
 
-from megatron.core.msc_utils import open_file
 from megatron.core._rank_utils import safe_get_rank as _safe_get_rank
-from megatron.core.dist_checkpointing.strategies.nvrx import has_nvrx_async_support
-
 from megatron.core._slurm_utils import resolve_slurm_local_rank
+from megatron.core.dist_checkpointing.strategies.nvrx import has_nvrx_async_support
+from megatron.core.msc_utils import open_file
 
 try:
     from transformer_engine.pytorch.optimizers import multi_tensor_applier, multi_tensor_l2norm
@@ -36,17 +35,17 @@ except ImportError:
             local_multi_tensor_applier as multi_tensor_applier,
         )
 
-from megatron.training import get_args, get_timers, get_adlr_autoresume
 from megatron.core import mpu
 from megatron.core.datasets.utils import get_blend_from_list
 from megatron.core.tensor_parallel import param_is_not_tensor_parallel_duplicate
+from megatron.core.transformer.module import param_is_not_shared
 from megatron.core.utils import (
     get_data_parallel_group_if_dtensor,
+    get_pg_rank,
     to_local_if_dtensor,
     unwrap_model,
 )
-
-from megatron.core.transformer.module import param_is_not_shared
+from megatron.training import get_adlr_autoresume, get_args, get_timers
 
 
 def calc_params_l2_norm(model, force_create_fp32_copy=False):
@@ -295,8 +294,12 @@ def logical_and_across_model_parallel_group(
     return bool(input.item())
 
 
-def report_memory(name):
-    """Simple GPU memory report."""
+def report_memory(name, group=None):
+    """Simple GPU memory report.
+
+    group: optional data-parallel group to gate the rank-0 print on; None falls back
+        to ``mpu.get_data_parallel_rank()`` (byte-identical for callers passing nothing).
+    """
     args = get_args()
     mega_bytes = 1024.0 * 1024.0
     string = name + ' memory (MB)'
@@ -306,7 +309,8 @@ def report_memory(name):
     string += f" | max reserved: {torch.cuda.max_memory_reserved() / mega_bytes:.2f}"
     if args.log_device_memory_used:
         string += f" | total device memory used: {torch.cuda.device_memory_used() / mega_bytes:.2f}"
-    if mpu.get_data_parallel_rank() == 0:
+    is_dp_rank_0 = get_pg_rank(group) == 0 if group is not None else mpu.get_data_parallel_rank() == 0
+    if is_dp_rank_0:
         print("[Rank {}] {}".format(torch.distributed.get_rank(), string), flush=True)
 
 


### PR DESCRIPTION
## What
Split from WIP integration PR #5377. This PR carries only the Megatron process-group threading slice needed before the larger hetero MIMO entrypoint work:

- Thread explicit process groups through training reductions, schedule selection, memory logging, and checkpoint save/load metadata.
- Let checkpointing use model-local tp/pp/dp_cp groups when a model exposes a `pg_collection`, while preserving MPU fallback behavior for stock runs.
- Store module-local TP groups on RADIO and SSM modules so sharded checkpointing does not fall back to global tensor-parallel groups.
- Namespace MIMO optimizer sharded keys to avoid per-module distributed-optimizer key collisions.

Intentionally excluded from this split:

- Example entrypoint/bootstrap/data changes.
- RNG key-prefix namespacing from #5377.
- Broader custom setup hooks and throughput-normalization changes from the WIP branch.

## Validation
- `git diff --cached --check`
- `uv run isort megatron/core/models/mimo/optimizer.py megatron/training/utils/common_utils.py`
- `uv run isort --check-only megatron/core/models/mimo/optimizer.py megatron/training/utils/common_utils.py`
- `python3 -m py_compile megatron/core/models/mimo/optimizer.py megatron/core/models/vision/radio.py megatron/core/ssm/gated_delta_net.py megatron/core/ssm/mamba_layer.py megatron/core/ssm/mamba_mixer.py megatron/training/checkpointing.py megatron/training/initialize.py megatron/training/training.py megatron/training/utils/common_utils.py`