### PR TITLE
fix: restore fused group MLP offload in main2dev sync

### DIFF
--- a/docs/user-guide/features/fine_grained_activation_offloading.md
+++ b/docs/user-guide/features/fine_grained_activation_offloading.md
@@ -13,7 +13,7 @@ Contributed in collaboration with RedNote.
 
 Memory is often the limiting factor for very large sparse MoE models such as DeepSeek-V3 and Qwen3-235B. Fine-grained recomputation lowers activation memory at the cost of extra compute. Offloading can use host-device bandwidth so that reload overlaps compute and keeps overhead small in many setups. Fine-grained activation offloading moves activations at module granularity so you can tune how much activation memory leaves the device and adjust training throughput.
 
-Supported offloading modules are `"attn_norm"`, `"core_attn"`, `"attn_proj"`, `"mlp_norm"`, `"expert_fc1"`, and `"moe_act"`. They can be combined with fine-grained recomputation to free almost all activations for a transformer layer on the device.
+Supported offloading modules are `"attn_norm"`, `"qkv_linear"`, `"core_attn"`, `"attn_proj"`, `"mlp_norm"`, `"expert_fc1"`, `"moe_act"`, and `"fused_group_mlp"`. They can be combined with fine-grained recomputation to free almost all activations for a transformer layer on the device. `fused_group_mlp` requires `--use-transformer-engine-op-fuser` and offloads the whole fused grouped MLP, so it cannot be combined with `expert_fc1` or `moe_act`.
 
 ## Features
 
@@ -33,7 +33,7 @@ Supported offloading modules are `"attn_norm"`, `"core_attn"`, `"attn_proj"`, `"
 --fine-grained-activation-offloading
 
 # Modules whose inputs are offloaded (refer to your training script for list or delimiter syntax).
-# Choices: "attn_norm", "core_attn", "attn_proj", "mlp_norm", "expert_fc1", "moe_act".
+# Choices: "attn_norm", "qkv_linear", "core_attn", "attn_proj", "mlp_norm", "expert_fc1", "moe_act", "fused_group_mlp".
 --offload-modules expert_fc1
 ```
 

--- a/docs/user-guide/features/paged_stash.md
+++ b/docs/user-guide/features/paged_stash.md
@@ -21,7 +21,7 @@ Whenever `moe_expert_rank_capacity_factor` is set, a **runner** wraps forward-ba
 
 ## Prerequisites
 
-HybridEP + TE fused grouped experts are required whenever `moe_expert_rank_capacity_factor` is set. With `moe_paged_stash` enabled: capacity factor must be set; no `cpu_offloading`; `offload_modules` must not include `expert_fc1` or `moe_act`. The runner is active whenever capacity factor is set (even without `--moe-paged-stash`) for over-budget reruns; stash overflow is checked only when paged stashing is on.
+HybridEP + TE fused grouped experts are required whenever `moe_expert_rank_capacity_factor` is set. With `moe_paged_stash` enabled: capacity factor must be set; no `cpu_offloading`; `offload_modules` must not include `expert_fc1`, `moe_act`, or `fused_group_mlp`. The runner is active whenever capacity factor is set (even without `--moe-paged-stash`) for over-budget reruns; stash overflow is checked only when paged stashing is on.
 
 ## Configuration
 

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from collections import defaultdict, deque
 from contextlib import nullcontext
@@ -23,6 +23,22 @@ def debug_rank(message):
     assert torch.distributed.is_initialized()
     if torch.distributed.get_rank() == DEBUG_RANK:
         print(message)
+
+
+def _te_do_not_offload(tensor):
+    """Return whether TE marked a tensor-like object as non-offloadable."""
+    if getattr(tensor, "_TE_do_not_offload", False):
+        return True
+    if not hasattr(tensor, "get_data_tensors"):
+        return False
+    try:
+        data_tensors = tensor.get_data_tensors()
+    except Exception:  # pragma: no cover - best effort for third-party tensor wrappers
+        return False
+    return any(
+        data_tensor is not None and getattr(data_tensor, "_TE_do_not_offload", False)
+        for data_tensor in data_tensors
+    )
 
 
 def print_offload_summary_table(total_offload_bytes: Dict[str, int]):
@@ -344,9 +360,9 @@ class OffloadTensorGroup:
         self.total_offload_bytes = 0
         self.total_tensor_count = 0
         # Using memory pool is for the compatibility with cuda graph.
-        # Shapes of tensors for expert_fc1 and moe_act are not known in advance,
+        # Shapes of tensors for MoE activation offload groups are not known in advance,
         # so we do not use CPU pool for them.
-        if name == "expert_fc1" or name == "moe_act":
+        if name in ("expert_fc1", "moe_act", "fused_group_mlp"):
             self.use_cpu_pool = False
         else:
             self.use_cpu_pool = True
@@ -747,6 +763,7 @@ class PipelineOffloadManager:
         """Mark the current forward chunk as not offloadable."""
         if tensor is not None:
             tensor._do_not_offload = True
+            tensor.offloading_activation = False
 
     def __enter__(self):
         """Enter context manager to enable activation offloading hooks."""
@@ -790,7 +807,7 @@ class PipelineOffloadManager:
         Hook called when autograd retrieves a saved tensor during backward pass.
         Returns the actual tensor (potentially reloading from CPU).
         """
-        debug_rank(f"----on_get_saved_tensor {saved_state}")
+        debug_rank("----on_get_saved_tensor")
         return self.cur_backward_chunk().tensor_pop(saved_state)
 
 
@@ -913,8 +930,9 @@ class ChunkOffloadHandler:
         assert name is not None, "Name is required"
         return self.find_group_with_name(self.offload_groups, name, self._offloaded_group_index)
 
-    def tensor_push(self, tensor):
-        """Push tensor to the offload handler."""
+    @staticmethod
+    def _can_manage_tensor_for_offload(tensor):
+        """Return whether the tensor can be managed by activation offload hooks."""
         torch_stray_tensor = isinstance(
             tensor,
             (
@@ -922,7 +940,16 @@ class ChunkOffloadHandler:
                 torch._subclasses.functional_tensor.FunctionalTensor,
             ),
         )
-        assert not torch_stray_tensor, "Stray tensor should not be offloaded"
+        return (
+            not isinstance(tensor, torch.nn.Parameter)
+            and not torch_stray_tensor
+            and tensor.device.type == "cuda"
+        )
+
+    def tensor_push(self, tensor):
+        """Push tensor to the offload handler."""
+        if not self._can_manage_tensor_for_offload(tensor):
+            return tensor
 
         # Assign unique tag based on group index and position within group
         tensor_tag = (self._offloaded_group_index, self._tensor_count_current_group)
@@ -933,6 +960,9 @@ class ChunkOffloadHandler:
 
     def tensor_pop(self, tensor_tag):
         """Pop tensor from the offload handler."""
+        if isinstance(tensor_tag, torch.Tensor):
+            debug_rank(f"--------tensor_pop passthrough tensor {tensor_tag.shape}")
+            return tensor_tag
         debug_rank(f"--------tensor_pop {tensor_tag}")
         group_id, idx = tensor_tag
         tensor = self.offload_groups[group_id - 1].pop_tensor(tensor_tag)
@@ -944,13 +974,19 @@ class ChunkOffloadHandler:
 
     def tensor_need_offloading_checker(self, tensor):
         """Check if the tensor needs to be offloaded."""
-        debug_rank("tensor_need_offloading_checker")
+        debug_rank(
+            f"tensor_need_offloading_checker {getattr(tensor, 'offloading_activation', None)}"
+        )
+        if not self._can_manage_tensor_for_offload(tensor):
+            return False
+        if _te_do_not_offload(tensor):
+            return False
         if tensor.numel() < self.min_offloaded_tensor_size:
             return False
         # Respect tensor's offload preference if specified
-        if getattr(tensor, "_TE_do_not_offload", False) or getattr(
-            tensor, "_do_not_offload", False
-        ):
+        if hasattr(tensor, "offloading_activation") and not tensor.offloading_activation:
+            return False
+        if getattr(tensor, "_do_not_offload", False):
             return False
         return True
 

--- a/megatron/core/transformer/moe/README.md
+++ b/megatron/core/transformer/moe/README.md
@@ -386,7 +386,7 @@ Unlike recomputation (which trades compute for memory), offloading trades **GPU-
 **Usage**
 ```bash
 --fine-grained-activation-offloading
---offload-modules expert_fc1 moe_act # Choices: attn_norm, core_attn, attn_proj, mlp_norm, expert_fc1, moe_act
+--offload-modules expert_fc1 moe_act # Choices: attn_norm, qkv_linear, core_attn, attn_proj, mlp_norm, expert_fc1, moe_act, fused_group_mlp
 ```
 
 For more details, see `docs/user-guide/features/fine_grained_activation_offloading.md`

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -250,6 +250,11 @@ class TEGroupedMLP(MegatronModule):
             and "moe_act" in self.config.offload_modules
         )
 
+        self.offload_fused_group_mlp = (
+            self.config.fine_grained_activation_offloading
+            and "fused_group_mlp" in self.config.offload_modules
+        )
+
         self.activation_recompute = (
             self.config.recompute_granularity == 'selective'
             and "moe_act" in self.config.recompute_modules
@@ -655,14 +660,28 @@ class TEGroupedMLP(MegatronModule):
             )
         else:
             stash_context = nullcontext()
-        with stash_context:
-            # Call fused impl
-            output = ops(
-                permuted_local_hidden_states,
-                tokens_per_expert,  # FC1
-                permuted_probs,  # Scaled SwiGLU
-                tokens_per_expert,  # FC2
+        fine_grained_activation_offloading = getattr(self, "offload_fused_group_mlp", False)
+        offload_name = "fused_group_mlp"
+        fused_group_mlp_manager = off_interface(
+            fine_grained_activation_offloading, permuted_local_hidden_states, offload_name
+        )
+        with fused_group_mlp_manager as permuted_local_hidden_states:
+            forced_released_tensors = (
+                [permuted_local_hidden_states] if fine_grained_activation_offloading else []
             )
+            with stash_context:
+                # Call fused impl
+                output = ops(
+                    permuted_local_hidden_states,
+                    tokens_per_expert,  # FC1
+                    permuted_probs,  # Scaled activation
+                    tokens_per_expert,  # FC2
+                )
+        output = fused_group_mlp_manager.group_offload(
+            output,
+            forced_released_tensors=forced_released_tensors,
+            delay_offload=self.config.delay_offload_until_cuda_graph,
+        )
         # Remove padding if needed
         if unpadded_tokens_per_expert is not None:
             output = self.quantization_unpadding(output, unpadded_tokens_per_expert)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1298,7 +1298,7 @@ class TransformerConfig(ModelParallelConfig):
     offload_modules: Optional[list[str]] = field(default_factory=list)
     """The submodules to offload its input.
     choices: "attn_norm", "qkv_linear", "core_attn", "attn_proj",
-             "mlp_norm", "expert_fc1", "moe_act".
+             "mlp_norm", "expert_fc1", "moe_act", "fused_group_mlp".
     "attn_norm": offload the input of the normalization in the attention part.
     "qkv_linear": offload the input of the qkv linear part.
     "core_attn": offload the input of the core attention part.
@@ -2088,10 +2088,13 @@ class TransformerConfig(ModelParallelConfig):
                 "moe_paged_stash requires moe_expert_rank_capacity_factor to be set; "
                 "there is no need to use paged stashing without it."
             )
-            moe_offload_conflict = {"expert_fc1", "moe_act"} & set(self.offload_modules)
+            moe_offload_conflict = {"expert_fc1", "moe_act", "fused_group_mlp"} & set(
+                self.offload_modules
+            )
             assert not moe_offload_conflict, (
                 "When moe_paged_stash is enabled, offload_modules must not include "
-                f"expert_fc1 or moe_act (paged stash covers those activations). "
+                f"expert_fc1, moe_act, or fused_group_mlp "
+                f"(paged stash covers those activations). "
                 f"Remove: {moe_offload_conflict}"
             )
 
@@ -2799,9 +2802,22 @@ class TransformerConfig(ModelParallelConfig):
                         )
 
             if self.fine_grained_activation_offloading:
-                assert self.cuda_graph_impl in ("transformer_engine", "full_iteration"), (
+                offload_modules = set(self.offload_modules or [])
+                local_partial_moe_offload = (
+                    self.cuda_graph_impl == "local"
+                    and bool(offload_modules)
+                    and offload_modules <= {"expert_fc1", "moe_act", "fused_group_mlp"}
+                    and CudaGraphModule.moe not in self.cuda_graph_modules
+                )
+                assert (
+                    self.cuda_graph_impl in ("transformer_engine", "full_iteration")
+                    or local_partial_moe_offload
+                ), (
                     "fine-grained activation offloading is only supported with "
-                    "transformer_engine or full_iteration CUDA graph implementation."
+                    "transformer_engine CUDA graph implementation or local CUDA graph "
+                    "implementation with full_iteration scope. Local partial CUDA graphs "
+                    "are supported only for expert_fc1, moe_act, or fused_group_mlp "
+                    "offload when the full MoE module is not captured."
                 )
                 assert (
                     CudaGraphModule.moe not in self.cuda_graph_modules

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -10,6 +10,7 @@ import torch
 
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
 from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.pipeline_parallel.fine_grained_activation_offload import ChunkOffloadHandler
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
 )
@@ -31,6 +32,52 @@ def _reset_cuda_memory() -> None:
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
+
+
+def _make_chunk_handler_for_offload_checker(min_offloaded_tensor_size: int = 1):
+    handler = ChunkOffloadHandler.__new__(ChunkOffloadHandler)
+    handler.min_offloaded_tensor_size = min_offloaded_tensor_size
+    return handler
+
+
+def test_chunk_offload_handler_skips_non_offloadable_tensor_types():
+    handler = _make_chunk_handler_for_offload_checker()
+
+    cpu_tensor = torch.empty(1024)
+    assert not handler.tensor_need_offloading_checker(cpu_tensor)
+    assert handler.tensor_push(cpu_tensor) is cpu_tensor
+    assert handler.tensor_pop(cpu_tensor) is cpu_tensor
+
+    parameter = torch.nn.Parameter(torch.empty(1024))
+    assert not handler.tensor_need_offloading_checker(parameter)
+    assert handler.tensor_push(parameter) is parameter
+    assert handler.tensor_pop(parameter) is parameter
+
+    try:
+        from torch._subclasses.fake_tensor import FakeTensorMode
+    except ImportError:
+        pytest.skip("FakeTensorMode is not available in this PyTorch version.")
+
+    with FakeTensorMode():
+        fake_tensor = torch.empty(1024, device="cuda")
+    assert not handler.tensor_need_offloading_checker(fake_tensor)
+    assert handler.tensor_push(fake_tensor) is fake_tensor
+    assert handler.tensor_pop(fake_tensor) is fake_tensor
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offload check.")
+def test_chunk_offload_handler_respects_tensor_offloading_activation_opt_out():
+    handler = _make_chunk_handler_for_offload_checker()
+
+    tensor = torch.empty(1024, device="cuda")
+    assert handler.tensor_need_offloading_checker(tensor)
+
+    tensor._TE_do_not_offload = True
+    assert not handler.tensor_need_offloading_checker(tensor)
+
+    tensor = torch.empty(1024, device="cuda")
+    tensor.offloading_activation = False
+    assert not handler.tensor_need_offloading_checker(tensor)
 
 
 def _build_gpt_model(


### PR DESCRIPTION
## Summary
- Restores the #5082 fine-grained activation offloading changes that were dropped during the #5430 main-to-dev conflict resolution.
- Re-enables `fused_group_mlp` docs/config validation and TE fused GroupedMLP offload integration on top of the dev-side delayed-offload/CUDA graph API.
- Preserves TE opt-out handling for saved tensor wrappers and adds focused coverage for non-offloadable tensor handling.

## Test plan
- `uv run --project /home/scratch.hongbinl_sw/work/fsdp/agentic-mcore-dev --extra mcore-lint python -m py_compile megatron/core/pipeline_parallel/fine_grained_activation_offload.py megatron/core/transformer/moe/experts.py megatron/core/transformer/transformer_config.py tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py`
- `CHECK_ONLY=true BASE_REF=dev uv run --project /home/scratch.hongbinl_sw/work/fsdp/agentic-mcore-dev --extra mcore-lint -- bash tools/autoformat.sh`
- `CHECK_ONLY=true BASE_REF=main2dev/22_06_2026 uv run --project /home/scratch.hongbinl_sw/work/fsdp/agentic-mcore-dev --extra mcore-lint -- bash tools/autoformat.sh`
- `python tools/check_copyright.py` on the Python files changed relative to `main2dev/22_06_2026`

Note: targeted pytest collection is blocked in this local environment because `torch` is not installed. The autoformat script exits 0; its non-blocking mypy step still reports missing local torch/TE stubs.