### PR TITLE
ci: auto-retry test-data download in container-build job

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -581,8 +581,18 @@ jobs:
         shell: bash
         run: |
           echo "::group::Download test data"
-          pip install --no-cache-dir click requests
-          python tests/test_utils/python_scripts/download_unit_tests_dataset.py --assets-dir ./assets
+          for attempt in 1 2 3; do
+            if pip install --no-cache-dir click requests \
+              && python tests/test_utils/python_scripts/download_unit_tests_dataset.py --assets-dir ./assets; then
+              break
+            fi
+            echo "Download test data attempt ${attempt} failed, retrying..." >&2
+            if [ "${attempt}" -eq 3 ]; then
+              echo "Download test data failed after 3 attempts" >&2
+              exit 1
+            fi
+            sleep 10
+          done
           echo "::endgroup::"
 
       - name: Get last merged PR


### PR DESCRIPTION
## Background / motivation

- A merge-queue run of `cicd-container-build (gcp, …)` failed in the **"Download test data"** step.
- Root cause was a transient **SIGSEGV (exit 139)** inside `pip install --no-cache-dir click requests` on the arm64 GCP runner — pure infrastructure noise, unrelated to the changeset under test.
- The step had no retry, so a single transient crash failed the whole job (and blocked the merge queue). The adjacent "Install GH CLI" step already retries; this step did not.

  ```
  Segmentation fault (core dumped) pip install --no-cache-dir click requests
  ##[error]Process completed with exit code 139.
  ```

## What changed

- Wrapped the `pip install` + dataset download in a 3-attempt retry loop with a 10s backoff.

## Details

- `.github/workflows/cicd-main.yml`, `cicd-container-build` → "Download test data".
- Uses `if <cmds>; then break; fi` so the default `shell: bash` `set -e` does not abort on an intermediate attempt's failure.
- After the 3rd failed attempt the step `exit 1`s explicitly, so a genuine (non-transient) failure still fails the job rather than silently passing.

  ```bash
  for attempt in 1 2 3; do
    if pip install --no-cache-dir click requests \
      && python tests/test_utils/python_scripts/download_unit_tests_dataset.py --assets-dir ./assets; then
      break
    fi
    echo "Download test data attempt ${attempt} failed, retrying..." >&2
    if [ "${attempt}" -eq 3 ]; then
      echo "Download test data failed after 3 attempts" >&2
      exit 1
    fi
    sleep 10
  done
  ```

## Tested

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cicd-main.yml'))"` → parses.
- Retry/backoff and exhaustion (`exit 1`) logic verified by reading; full validation runs via this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
