### PR TITLE
chore: bump megatron-core to v0.18.2

### DIFF
--- a/megatron/core/package_info.py
+++ b/megatron/core/package_info.py
@@ -4,7 +4,7 @@
 
 MAJOR = 0
 MINOR = 18
-PATCH = 1
+PATCH = 2
 PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)


### PR DESCRIPTION
## Background

* `core_r0.18.0` release branch is currently pinned at `megatron-core` `0.18.1`.
* Cutting the next `0.18.x` patch requires bumping the package version.

## What changed

* `megatron/core/package_info.py`: `PATCH` `1` → `2`, so `__version__` resolves to `0.18.2`.

## Details

* Single-line change on the `core_r0.18.0` release branch — `main` stays on the `0.19.x` line, unaffected.

## Tested

* `python -c "from megatron.core.package_info import __version__; print(__version__)"` → `0.18.2`.
