### PR TITLE
fix: set DATA_PATH for moe-dynamic-inference recipe

### DIFF
--- a/tests/test_utils/recipes/gb200/moe-dynamic-inference.yaml
+++ b/tests/test_utils/recipes/gb200/moe-dynamic-inference.yaml
@@ -42,7 +42,7 @@ spec:
     ARGUMENTS=(
         "CHECKPOINT_LOAD_PATH=/mnt/artifacts"
         "CHECKPOINT_SAVE_PATH=/tmp/checkpoints"
-        "DATA_PATH=null"
+        "DATA_PATH=/mnt/artifacts"
         "DATA_CACHE_PATH=/workspace/data/cache"
         "TRAINING_SCRIPT_PATH=examples/inference/advanced/gpt_dynamic_inference.py"
         "TRAINING_PARAMS_PATH=./tests/functional_tests/test_cases/{model}/{test_case}/model_config.yaml"

--- a/tests/test_utils/recipes/h100/moe-dynamic-inference.yaml
+++ b/tests/test_utils/recipes/h100/moe-dynamic-inference.yaml
@@ -41,7 +41,7 @@ spec:
     ARGUMENTS=(
         "CHECKPOINT_LOAD_PATH=/mnt/artifacts"
         "CHECKPOINT_SAVE_PATH=/tmp/checkpoints"
-        "DATA_PATH=null"
+        "DATA_PATH=/mnt/artifacts"
         "DATA_CACHE_PATH=/workspace/data/cache"
         "TRAINING_SCRIPT_PATH=examples/inference/advanced/gpt_dynamic_inference.py"
         "TRAINING_PARAMS_PATH=./tests/functional_tests/test_cases/{model}/{test_case}/model_config.yaml"


### PR DESCRIPTION
## Background
The `moe-dynamic-inference` recipes hardcoded `DATA_PATH=null` (the literal string). The test config `model_config.yaml` derives `HF_HOME: ${DATA_PATH}/hf_home`, so `envsubst` expanded it to `HF_HOME=null/hf_home`, pointing the HF cache at a relative `./null/hf_home` directory.

Observed in job `348681538` (`ADLR/megatron-lm`): `++ echo HF_HOME=null/hf_home`.

## What changed
- `tests/test_utils/recipes/h100/moe-dynamic-inference.yaml`: `DATA_PATH=null` → `DATA_PATH=/mnt/artifacts`
- `tests/test_utils/recipes/gb200/moe-dynamic-inference.yaml`: `DATA_PATH=null` → `DATA_PATH=/mnt/artifacts`

## Details
- Resolution chain: recipe `DATA_PATH=null` → `run_ci_test.sh` arg → `_run_training.sh` `envsubst` of `${DATA_PATH}/hf_home` → `HF_HOME=null/hf_home`.
- `/mnt/artifacts` matches `CHECKPOINT_LOAD_PATH` on the same recipes and the sibling dynamic-inference recipes (`gpt-dynamic-inference`, `moe-dynamic-inference-with-coordinator`).
- The `gpt_dynamic_inference_tp2_pp2_ep2_gptoss_20b_swa` case uses a HuggingFaceTokenizer (`unsloth/gpt-oss-20b-BF16`), so a valid `HF_HOME` matters. That GPT-OSS-20B SWA test runs on both H100 and GB200, hence the matching fix in both recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
