### PR TITLE
build: bump transformer-engine to release_v2.16_post

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,7 +227,7 @@ requires-dist = ["torch", "packaging", "ninja"]
 flash_mla = [
     { git = "https://github.com/deepseek-ai/FlashMLA", rev = "nv_dev" },
 ]
-transformer-engine = { git = "https://github.com/NVIDIA/TransformerEngine.git", rev = "4220403e831d29e93868f7793693ea83f6b8b05b" }
+transformer-engine = { git = "https://github.com/NVIDIA/TransformerEngine.git", rev = "d64bc14dc87eb658ab98839e4b7687595ee53e2d" }
 nemo-run = { git = "https://github.com/NVIDIA-NeMo/Run.git", rev = "17ae86b64d7f75653351664f5d8c9e466faede00" }
 emerging_optimizers = { git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git", rev = "v0.2.0" }
 fast-hadamard-transform = { git = "https://github.com/Dao-AILab/fast-hadamard-transform.git", rev = "f134af63deb2df17e1171a9ec1ea4a7d8604d5ca" }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -2328,7 +2328,7 @@ requires-dist = [
     { name = "tiktoken", marker = "extra == 'training'" },
     { name = "torch", specifier = ">=2.6.0" },
     { name = "tqdm", marker = "extra == 'dev'" },
-    { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "extra == 'te'", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=4220403e831d29e93868f7793693ea83f6b8b05b" },
+    { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "extra == 'te'", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=d64bc14dc87eb658ab98839e4b7687595ee53e2d" },
     { name = "transformers", marker = "extra == 'mlm'" },
     { name = "transformers", marker = "extra == 'training'" },
     { name = "wandb", marker = "extra == 'mlm'" },
@@ -5224,7 +5224,7 @@ wheels = [
 [[package]]
 name = "transformer-engine"
 version = "2.16.0+4220403e"
-source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=4220403e831d29e93868f7793693ea83f6b8b05b#4220403e831d29e93868f7793693ea83f6b8b05b" }
+source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=d64bc14dc87eb658ab98839e4b7687595ee53e2d#d64bc14dc87eb658ab98839e4b7687595ee53e2d" }
 dependencies = [
     { name = "einops" },
     { name = "importlib-metadata" },


### PR DESCRIPTION
## Background

- Bump TransformerEngine to `release_v2.16_post` to pick up the latest fixes on the 2.16 line.

## What changed

- Bump `transformer-engine` git pin in `[tool.uv.sources]`.
- Regenerate `uv.lock`.

## Details

- `pyproject.toml`: `rev` `4220403e` → `d64bc14d` — the resolved HEAD of TE `release_v2.16_post`, pinned as a full SHA for reproducibility.
- `uv.lock`: only the TE `source`/`git` refs move to the new rev; no other resolution changes (2 files, 8 lines total).

## Tested

- `uv lock` regenerated cleanly inside the CI dev container (uv 0.7.2); diff limited to the TE rev.
- CI: `Run functional tests` + `container::lts` — a TE bump can shift training numerics, so exercise the golden-value compare on both image variants.

## Cherry-pick

- Labeled `core_r0.18.0` for auto-cherrypick to the release branch after merge.
