### PR TITLE
ci: cache-from a single coherent buildcache donor

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -568,15 +568,6 @@ jobs:
         with:
           python-version: 3.12
 
-      - name: Install GH CLI
-        shell: bash -x -e -u -o pipefail {0}
-        run: |
-          for i in 1 2 3; do
-            apt-get update && apt-get install -y gh && break
-            echo "apt attempt $i failed, retrying..."
-            sleep 10
-          done
-
       - name: Download test data
         shell: bash
         run: |
@@ -595,27 +586,27 @@ jobs:
           done
           echo "::endgroup::"
 
-      - name: Get last merged PR
-        id: cache_from
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Compute cache config
+        id: cache_keys
+        shell: bash
         run: |
-          LAST_PRS=$(gh api graphql -f query='
-            query {
-              repository(owner: "NVIDIA", name: "Megatron-LM") {
-                pullRequests(states: MERGED, first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
-                  nodes {
-                    number
-                  }
-                }
-              }
-            }' | jq -r '.data.repository.pullRequests.nodes[].number' | while read -r number; do
-              echo "type=registry,ref=${{ matrix.registry }}/megatron-lm:$number-buildcache,mode=max"
-            done)
+          KEY="${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').number || 0 }}"
 
-          echo "LAST_PRS<<EOF" | tee -a $GITHUB_OUTPUT
-          echo "$LAST_PRS" | tee -a $GITHUB_OUTPUT
-          echo "EOF" | tee -a $GITHUB_OUTPUT
+          # Single coherent cache donor. Dockerfile.ci builds non-reproducible
+          # from-source layers: the same BuildKit cache key yields a different
+          # result digest on every cold build. Listing more than one cache-from
+          # donor lets BuildKit chain from a conflicting copy of such a layer and
+          # miss every layer downstream — a long cold rebuild even when a warm
+          # cache exists. So read EXACTLY ONE donor.
+          #
+          # Key 0 is the no-PR build cache: it is written by the daily schedule
+          # (from main HEAD), the merge queue, and deploy-release builds, so it is
+          # the integration baseline. PR builds seed from it and write their own
+          # ${KEY}-buildcache; baseline builds (KEY=0) seed from and write 0.
+          SEED="0"
+
+          echo "key=$KEY" | tee -a "$GITHUB_OUTPUT"
+          echo "seed=$SEED" | tee -a "$GITHUB_OUTPUT"
 
       - name: Parse baseimage
         shell: bash
@@ -648,15 +639,11 @@ jobs:
           build-args: |
             FROM_IMAGE_NAME=${{ steps.base-image.outputs.version }}
             IMAGE_TYPE=${{ steps.base-image.outputs.image_type }}
-          cache-from: |
-            type=registry,ref=${{ matrix.registry }}/megatron-lm:${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').number || 0 }}-buildcache,mode=max
-            type=registry,ref=${{ matrix.registry }}/megatron-lm:main-buildcache,mode=max
-            ${{ steps.cache_from.outputs.LAST_PRS }}
-          cache-to: |
-            type=registry,ref=${{ matrix.registry }}/megatron-lm:${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').number || 0 }}-buildcache,mode=max
+          cache-from: type=registry,ref=${{ matrix.registry }}/megatron-lm:${{ steps.cache_keys.outputs.seed }}-buildcache,mode=max
+          cache-to: type=registry,ref=${{ matrix.registry }}/megatron-lm:${{ steps.cache_keys.outputs.key }}-buildcache,mode=max
           no-cache: false
           tags: |
-            ${{ matrix.registry }}/megatron-lm:${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').number || 0 }}
+            ${{ matrix.registry }}/megatron-lm:${{ steps.cache_keys.outputs.key }}
             ${{ matrix.registry }}/megatron-lm:${{ needs.configure.outputs.sha }}
           secrets: |
             GH_TOKEN=${{ secrets.PAT }}


### PR DESCRIPTION
## Background / motivation

* `cicd-container-build` cold-rebuilds the CI image on nearly every run.
* `Dockerfile.ci.{dev,lts}` builds **non-reproducible from-source layers**. Such a layer gets the **same** BuildKit cache key but a **different** result digest on every cold build.
* The `cache-from` block offered up to **~102 donors**: this PR's cache, a `main-buildcache`, **and the last 100 merged PRs** (the `Get last merged PR` step). With multiple donors carrying conflicting copies of that layer, BuildKit can chain from the wrong copy and **miss every layer downstream** — a cold rebuild even when a warm cache exists.
* Same root cause + fix as `dl/joc/nemo-ci!2575` (the equivalent GitLab build) and the Megatron-Bridge port. Decisive A/B there, same SHA: single-source `cache-from` = **WARM (~170 s)** vs multi-source = **COLD (2300 s+)**. More donors made it *worse*.

## What changed

* `cache-from` now reads **exactly one coherent donor** instead of ~102.
* Removed the `Get last merged PR` step (the 100-PR fan-out) and the now-dead `Install GH CLI` step it depended on.
* Dropped the `main-buildcache` donor — **it is never written** by any workflow or the internal GitLab build, so it could only ever miss or go stale.

## Details

* New `Compute cache config` step emits `key` and `seed`:
  * `key` = `<PR number || 0>` (unchanged cache-to target / tag).
  * `seed` = **`0`** — key `0` is the no-PR build cache, written by the daily `schedule` (from main HEAD), the `merge_group` queue, and `deploy-release` builds. It is the de-facto **integration baseline** in this repo (the workflow doesn't push on `main`, so there is no `main-buildcache`).
* PR builds seed from `0-buildcache` and write their own `<PR>-buildcache`; baseline builds (`key=0`) seed from and write `0`. This is the exact analog of "seed from the integration branch, write your own" used in the GitLab fix.
* **Net warmth gain:** PR builds previously seeded from their own + `main-buildcache`(dead) + 100 PRs, so they never warmed from the main baseline at all. They now do.
* Single donor can only ever **hit or miss**, never poison — so even if a `deploy-release` build last wrote `0`, the worst case is one cold build that self-corrects on the next daily refresh.
* No `resource_group` analog needed: `concurrency` with `cancel-in-progress` already serializes same-ref builds, and per-PR `cache-to` isolates PR writes.

```yaml
# before — up to ~102 donors, poisons the from-source layer
cache-from: |
  type=registry,ref=.../megatron-lm:${PR||0}-buildcache,mode=max
  type=registry,ref=.../megatron-lm:main-buildcache,mode=max   # never written
  ${{ steps.cache_from.outputs.LAST_PRS }}                      # last 100 merged PRs

# after — one coherent donor (the main-state baseline, key 0)
cache-from: type=registry,ref=.../megatron-lm:0-buildcache,mode=max
cache-to:   type=registry,ref=.../megatron-lm:${PR||0}-buildcache,mode=max
```

```mermaid
flowchart TD
    A[Build and push] --> B{PR build?}
    B -->|yes| C["key = PR number"]
    B -->|"no (schedule / merge_group / deploy-release)"| D["key = 0"]
    C --> E["seed = 0<br/>(main-state baseline)"]
    D --> E
    E --> F["cache-from: ONE donor (0-buildcache)"]
    F --> G["cache-to: key-buildcache"]
    subgraph old [removed]
        H[Install GH CLI] --> I["Get last merged PR<br/>(100-PR fan-out)"]
        J["main-buildcache donor<br/>(never written)"]
    end
```

## Tested

* YAML validated (`yaml.safe_load`).
* Cache behavior validated empirically by `dl/joc/nemo-ci!2575` on the identical non-reproducible from-source layer; CI on this PR is the on-platform confirmation.
* Safe rollback: `cache-to` / tag refs are unchanged, so reverting restores the old donor list without orphaning any cache ref.
