### PR TITLE
test: restore G/G + lag=19 for gpt_grpo_tp4_pp1_dp2_8b throughput tests

### DIFF
--- a/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput/model_config.yaml
@@ -75,6 +75,16 @@ MODEL_ARGS:
   --rl-use-sequence-packing: true
   --rl-sequence-packing-algo: fifo
   --rl-offload-optimizer-during-inference: true
+  # Pre-generate all trainer batches upfront so iteration-time measures the
+  # training step alone, not the inference critical path. lag=19 sized so
+  # pgt = (lag+1) * grpo_prompts_per_step = 40 = exit_interval * prompts_per_step
+  # groups inflight; G/G yields groups as they complete instead of waiting on
+  # batch order.
+  # TODO: rebaseline iteration-time goldens against the lag=0 steady-state once
+  # post-rollout-refactor throughput targets are settled.
+  --rl-generation-lag: 19
+  --rl-submission-granularity: G
+  --rl-consumption-granularity: G
   --timing-log-level: 1
   --cuda-graph-impl: local
   --micro-batch-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_throughput/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_grpo_tp4_pp1_dp2_8b_throughput/model_config.yaml
@@ -75,6 +75,16 @@ MODEL_ARGS:
   --rl-use-sequence-packing: true
   --rl-sequence-packing-algo: fifo
   --rl-offload-optimizer-during-inference: true
+  # Pre-generate all trainer batches upfront so iteration-time measures the
+  # training step alone, not the inference critical path. lag=19 sized so
+  # pgt = (lag+1) * grpo_prompts_per_step = 40 = exit_interval * prompts_per_step
+  # groups inflight; G/G yields groups as they complete instead of waiting on
+  # batch order.
+  # TODO: rebaseline iteration-time goldens against the lag=0 steady-state once
+  # post-rollout-refactor throughput targets are settled.
+  --rl-generation-lag: 19
+  --rl-submission-granularity: G
+  --rl-consumption-granularity: G
   --timing-log-level: 1
   --cuda-graph-impl: local
   --micro-batch-size: 1


### PR DESCRIPTION
## Summary

Both `gpt_grpo_tp4_pp1_dp2_8b_throughput` and `gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput` were on the implicit pre-rollout-refactor defaults (~512 parallel generation tasks, G/G submission/consumption, no order enforcement). Their `iteration-time` goldens were calibrated against a deeply-pipelined regime where the inference engine was never on the per-step critical path.

The rollout refactor changed the effective defaults to `lag=0` with `B/B` submission/consumption granularity, which serializes one batch of inference into every training step. Measured iteration time jumped from ~13 ms (golden) to ~45 ms — a 3.6x regression that blows past the 15% golden tolerance.

This sets:

- `--rl-generation-lag: 19` → `pgt = (lag+1) * grpo_prompts_per_step = 40` groups inflight, which covers the full `exit_interval * prompts_per_step = 40` groups consumed across the 20-step test.
- `--rl-submission-granularity: G` + `--rl-consumption-granularity: G` → match the pre-refactor yield-as-ready semantics.

Goldens left unchanged. There's a `TODO` comment in both configs noting that we should rebaseline against the `lag=0` steady-state once post-refactor throughput targets are settled, rather than indefinitely pinning the pre-refactor regime.

PR #5306 made the analogous fix in the MoE GRPO config in the same diff (`--rl-num-parallel-generations: 2` → `--rl-generation-lag: 0`); these two GPT-8B tests were missed because they relied on the implicit default rather than setting the deprecated flag explicitly.

## Test plan

- [ ] Internal CI `gpt_grpo_tp4_pp1_dp2_8b_throughput` job passes (iteration-time within 15% of ~13 ms golden)
- [ ] Internal CI `gpt_grpo_tp4_pp1_dp2_8b_cudagraphs_throughput` job passes
- [ ] No unintended changes to other GRPO tests' behaviour