### PR TITLE
cp: `build: bump transformer-engine to release_v2.16.post` into `core_r0.18.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,7 @@ requires-dist = ["torch", "packaging", "ninja"]
 flash_mla = [
     { git = "https://github.com/deepseek-ai/FlashMLA", rev = "nv_dev" },
 ]
-transformer-engine = { git = "https://github.com/NVIDIA/TransformerEngine.git", rev = "4220403e831d29e93868f7793693ea83f6b8b05b" }
+transformer-engine = { git = "https://github.com/NVIDIA/TransformerEngine.git", rev = "b9d690e042b1c4e455214e7dab65d6d3512c05d6" }
 nemo-run = { git = "https://github.com/NVIDIA-NeMo/Run.git", rev = "17ae86b64d7f75653351664f5d8c9e466faede00" }
 emerging_optimizers = { git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git", rev = "v0.2.0" }
 fast-hadamard-transform = { git = "https://github.com/Dao-AILab/fast-hadamard-transform.git", rev = "f134af63deb2df17e1171a9ec1ea4a7d8604d5ca" }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -2319,7 +2319,7 @@ requires-dist = [
     { name = "tiktoken", marker = "extra == 'training'" },
     { name = "torch", specifier = ">=2.6.0" },
     { name = "tqdm", marker = "extra == 'dev'" },
-    { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "extra == 'te'", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=4220403e831d29e93868f7793693ea83f6b8b05b" },
+    { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "extra == 'te'", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=b9d690e042b1c4e455214e7dab65d6d3512c05d6" },
     { name = "transformers", marker = "extra == 'mlm'" },
     { name = "transformers", marker = "extra == 'training'" },
     { name = "wandb", marker = "extra == 'mlm'" },
@@ -5213,8 +5213,8 @@ wheels = [
 
 [[package]]
 name = "transformer-engine"
-version = "2.16.0+4220403e"
-source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=4220403e831d29e93868f7793693ea83f6b8b05b#4220403e831d29e93868f7793693ea83f6b8b05b" }
+version = "2.16.0+b9d690e0"
+source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=b9d690e042b1c4e455214e7dab65d6d3512c05d6#b9d690e042b1c4e455214e7dab65d6d3512c05d6" }
 dependencies = [
     { name = "einops" },
     { name = "importlib-metadata" },


### PR DESCRIPTION
## What

- Bump `transformer-engine` pin to the head of upstream `release_v2.16.post` (`b9d690e`) on `core_r0.18.0`.
- Regenerate `uv.lock` (TE entry only).

## Details

- `pyproject.toml` — `transformer-engine` rev `4220403e` → `b9d690e042b1c4e455214e7dab65d6d3512c05d6`.
- `uv.lock` — `transformer-engine` `2.16.0+4220403e` → `2.16.0+b9d690e0`; relocked with the CI uv (`0.7.2`).

## Tested

- `uv lock` clean: `Resolved 291 packages`, only the TE references change.
- `/ok to test` to follow.

Release-branch counterpart of the `main` bump #5517. Companion bumps: Megatron-Bridge `main` + `r0.5.0`.
