### PR TITLE
[codex] Fix tensor-parallel label smoothing

### DIFF
--- a/megatron/core/tensor_parallel/cross_entropy.py
+++ b/megatron/core/tensor_parallel/cross_entropy.py
@@ -35,7 +35,15 @@ class VocabParallelCrossEntropy:
         logits_max: torch.Tensor,
         vocab_start_index: int,
         vocab_end_index: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        calculate_sum_logits: bool = False,
+    ) -> Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
         """Calculates predicted logits."""
 
         # In-place subtraction reduces memory pressure.
@@ -58,11 +66,19 @@ class VocabParallelCrossEntropy:
         predicted_logits = predicted_logits_1d.view_as(target)
         predicted_logits[target_mask] = 0.0
 
+        sum_logits = vocab_parallel_logits.sum(dim=-1) if calculate_sum_logits else None
         exp_logits = vocab_parallel_logits
         torch.exp(vocab_parallel_logits, out=exp_logits)
         sum_exp_logits = exp_logits.sum(dim=-1)
 
-        return target_mask, masked_target_1d, predicted_logits, sum_exp_logits, exp_logits
+        return (
+            target_mask,
+            masked_target_1d,
+            predicted_logits,
+            sum_exp_logits,
+            exp_logits,
+            sum_logits,
+        )
 
     @staticmethod
     def calculate_cross_entropy_loss(
@@ -136,10 +152,20 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
         world_size = get_pg_size(tp_group)
         vocab_start_index, vocab_end_index = get_vocab_range(partition_vocab_size, rank, world_size)
 
-        (target_mask, masked_target_1d, predicted_logits, sum_exp_logits, exp_logits) = (
-            VocabParallelCrossEntropy.calculate_predicted_logits(
-                vocab_parallel_logits, target, logits_max, vocab_start_index, vocab_end_index
-            )
+        (
+            target_mask,
+            masked_target_1d,
+            predicted_logits,
+            sum_exp_logits,
+            exp_logits,
+            sum_logits,
+        ) = VocabParallelCrossEntropy.calculate_predicted_logits(
+            vocab_parallel_logits,
+            target,
+            logits_max,
+            vocab_start_index,
+            vocab_end_index,
+            calculate_sum_logits=label_smoothing > 0,
         )
 
         # All reduce is needed to get the chunks from other GPUs.
@@ -155,7 +181,7 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
             exp_logits, predicted_logits, sum_exp_logits
         )
 
-        vocab_size = exp_logits.size(-1)
+        vocab_size = partition_vocab_size * world_size
         if label_smoothing > 0:
             r"""
             We'd like to assign 1 / (K - 1) probability mass to every index that is not the ground truth.
@@ -169,10 +195,11 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
             assert 1.0 > label_smoothing > 0.0
             smoothing = label_smoothing * vocab_size / (vocab_size - 1)
 
-            # Exp logits at this point are normalized probabilities.
-            # So we can just take the log to get log-probs.
-            log_probs = torch.log(exp_logits)
-            mean_log_probs = log_probs.mean(dim=-1)
+            assert sum_logits is not None
+            torch.distributed.all_reduce(
+                sum_logits, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+            mean_log_probs = sum_logits / vocab_size - torch.log(sum_exp_logits)
             loss = (1.0 - smoothing) * loss - smoothing * mean_log_probs
 
         ctx.label_smoothing, ctx.vocab_size = label_smoothing, vocab_size

--- a/tests/unit_tests/tensor_parallel/test_cross_entropy.py
+++ b/tests/unit_tests/tensor_parallel/test_cross_entropy.py
@@ -47,6 +47,69 @@ def test_vocab_parallel_cross_entropy_uses_explicit_tp_group(monkeypatch):
     assert all_reduce_groups == [tp_group, tp_group, tp_group]
 
 
+def test_vocab_parallel_cross_entropy_label_smoothing():
+    """Label smoothing should match dense cross entropy across TP ranks."""
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2)
+    try:
+        tp_group = cross_entropy_module.get_tensor_model_parallel_group()
+        tp_rank = tp_group.rank()
+        tp_size = tp_group.size()
+        assert tp_size == 2
+
+        full_logits = torch.tensor(
+            [
+                [3.0, -1.0, 0.5, 2.0, -4.0, 1.5, 0.0, 4.0],
+                [-2.0, 0.25, 5.0, -1.5, 3.5, -0.5, 1.0, 2.5],
+                [1.25, -3.0, 2.75, 0.5, -1.0, 0.75, 4.25, -2.5],
+                [120.0, -120.0, 80.0, -80.0, 60.0, -60.0, 40.0, -40.0],
+            ],
+            device='cuda',
+        )
+        target = torch.tensor([0, 5, 7, 6], device='cuda')
+        label_smoothing = 0.2
+
+        global_vocab_size = full_logits.size(-1)
+        partition_vocab_size = global_vocab_size // tp_size
+        partition_start = tp_rank * partition_vocab_size
+        partition_end = partition_start + partition_vocab_size
+
+        # Pass a non-leaf tensor because the implementation normalizes logits in-place.
+        local_logits_leaf = (
+            full_logits[:, partition_start:partition_end].clone().detach().requires_grad_(True)
+        )
+        actual_loss = vocab_parallel_cross_entropy(
+            local_logits_leaf + 0.0,
+            target,
+            label_smoothing=label_smoothing,
+            tp_group=tp_group,
+        )
+
+        # This API assigns alpha mass only to non-target classes, rather than
+        # using PyTorch's uniform-mixture interpretation of label_smoothing.
+        reference_logits = full_logits.clone().detach().requires_grad_(True)
+        target_distribution = torch.full_like(
+            reference_logits, label_smoothing / (global_vocab_size - 1)
+        )
+        target_distribution.scatter_(-1, target.unsqueeze(-1), 1.0 - label_smoothing)
+        reference_loss = -(
+            target_distribution * torch.log_softmax(reference_logits, dim=-1)
+        ).sum(dim=-1)
+
+        assert torch.isfinite(actual_loss).all()
+        actual_loss.sum().backward()
+        reference_loss.sum().backward()
+
+        torch.testing.assert_close(actual_loss, reference_loss, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(
+            local_logits_leaf.grad,
+            reference_logits.grad[:, partition_start:partition_end],
+            rtol=1e-5,
+            atol=1e-6,
+        )
+    finally:
+        Utils.destroy_model_parallel()
+
+
 def test_language_module_unfused_loss_passes_tp_group(monkeypatch):
     tp_group = _FakeTPGroup()
     captured = {}


### PR DESCRIPTION
## Summary

- compute label smoothing with the global tensor-parallel vocabulary size
- reduce the max-shifted logit sum across the explicit TP group so every rank uses the same mean log-probability
- keep the mean log-probability calculation finite when softmax probabilities underflow
- add a TP=2 forward/backward regression against the documented dense target distribution

## Root cause

The label-smoothing path treated each rank's vocabulary partition size as the full vocabulary size and averaged log-probabilities only within the local shard. That made losses rank-dependent and subtracted `alpha / (partition_vocab_size - 1)` from non-target gradients instead of `alpha / (global_vocab_size - 1)`.

The path also took `log()` after exponentiation and normalization. Large but finite logit gaps can underflow those probabilities to zero, producing an infinite smoothed loss.

## Impact

For `TP > 1` with `label_smoothing > 0`, every training step could use incorrect loss values and gradients. The default `label_smoothing=0` path does not perform the new sum or collective and is unchanged.

## Validation

Passed locally:

- `python3 -m py_compile megatron/core/tensor_parallel/cross_entropy.py tests/unit_tests/tensor_parallel/test_cross_entropy.py`
- `git diff --check`
- equation-level reproduction: the old TP=2 calculation produced rank losses differing by 1.0, a maximum loss error of 0.714286, and non-zero global gradient row sums; the corrected equations matched the dense loss and gradient to machine precision
- independent code review of the final diff found no actionable issues

Not run locally:

- `uv run python -m torch.distributed.run --nproc-per-node 8 -m pytest -q tests/unit_tests/tensor_parallel/test_cross_entropy.py::test_vocab_parallel_cross_entropy_label_smoothing`
  - this host has no PyTorch installation or working NVIDIA driver
- `tools/autoformat.sh`
  - the repository's CI container is unavailable and the host does not provide `black`

Fixes #737