### PR TITLE
Preserve DSA output across fused inverse RoPE

### DIFF
--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -433,6 +433,40 @@ def fused_mla_rope_inplace(
     )
 
 
+def fused_mla_rope_out_of_place(
+    t: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    nope_dim: int,
+    emb_dim: int,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+    rotary_interleaved: bool = False,
+    inverse: bool = False,
+    remove_interleaving: bool = False,
+) -> torch.Tensor:
+    """Apply the fused RoPE kernel without modifying the input tensor.
+
+    Use this wrapper when an upstream autograd function may have retained its
+    output for backward. The underlying kernel remains in-place, so a private
+    copy is required to keep the retained tensor unchanged.
+    """
+    return fused_mla_rope_inplace(
+        t.clone(),
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        cu_seqlens_q=cu_seqlens_q,
+        cp_rank=cp_rank,
+        cp_size=cp_size,
+        rotary_interleaved=rotary_interleaved,
+        inverse=inverse,
+        remove_interleaving=remove_interleaving,
+    )
+
+
 @triton.autotune(
     configs=[
         triton.Config({"BLOCK_H": 1}),

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -26,9 +26,13 @@ from megatron.core.typed_torch import apply_module
 from megatron.core.utils import get_pg_size, is_te_min_version
 
 try:
-    from megatron.core.fusions.fused_mla_yarn_rope_apply import fused_mla_rope_inplace
+    from megatron.core.fusions.fused_mla_yarn_rope_apply import (
+        fused_mla_rope_inplace,
+        fused_mla_rope_out_of_place,
+    )
 except Exception:
     fused_mla_rope_inplace = None
+    fused_mla_rope_out_of_place = None
 
 
 if HAVE_TE:
@@ -357,7 +361,11 @@ class DSv4HybridAttention(Attention):
         if self.config.apply_rope_fusion:
             if packed_seq:
                 core_attn_out = core_attn_out.squeeze(1)
-            core_attn_out = fused_mla_rope_inplace(
+            # Fused DSA backward retains the raw attention output O. Applying
+            # inverse RoPE to its view in-place corrupts the retained O used by
+            # the softmax backward, so this call needs private storage.
+            assert fused_mla_rope_out_of_place is not None
+            core_attn_out = fused_mla_rope_out_of_place(
                 core_attn_out,
                 rotary_pos_cos,
                 rotary_pos_sin,

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -18,10 +18,12 @@ try:
     from megatron.core.fusions.fused_mla_yarn_rope_apply import (
         fused_mla_rope_inplace,
         fused_mla_rope_kv_split,
+        fused_mla_rope_out_of_place,
     )
 except Exception:
     fused_mla_rope_inplace = None
     fused_mla_rope_kv_split = None
+    fused_mla_rope_out_of_place = None
 
 
 def dtype_tols(dtype):
@@ -41,6 +43,21 @@ class FakeCPGroup:
 
     def rank(self):
         return 0
+
+
+class _SaveOutputForBackward(torch.autograd.Function):
+    """Minimal stand-in for a kernel whose backward consumes its output."""
+
+    @staticmethod
+    def forward(ctx, tensor):
+        output = tensor.clone()
+        ctx.save_for_backward(output)
+        return output
+
+    @staticmethod
+    def backward(ctx, _grad_output):
+        (saved_output,) = ctx.saved_tensors
+        return saved_output
 
 
 def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleaving=False):
@@ -283,6 +300,83 @@ class TestFusedApplyMLARope:
     @pytest.mark.parametrize("remove_interleaving", [False, True])
     def test_kv_split_forward_backward(self, input_format, remove_interleaving):
         _test_fused_mla_rope_kv_split(input_format, remove_interleaving=remove_interleaving)
+
+
+@pytest.mark.experimental
+@pytest.mark.internal
+@pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("input_format", ["sbhd", "thd"])
+def test_out_of_place_inverse_rope_preserves_upstream_saved_output(input_format):
+    """Post-attention inverse RoPE must not overwrite an output saved for backward."""
+    assert fused_mla_rope_out_of_place is not None
+    seqlen = 32
+    batch_size = 1
+    num_heads = 2
+    nope_dim = 16
+    emb_dim = 64
+    dtype = torch.bfloat16
+
+    yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+    freqs, mscale = yarn_rope(seqlen, 0)
+    cos = (torch.cos(freqs) * mscale).to(dtype)
+    sin = (torch.sin(freqs) * mscale).to(dtype)
+
+    if input_format == "sbhd":
+        shape = (seqlen, batch_size, num_heads, nope_dim + emb_dim)
+        cu_seqlens = None
+    else:
+        shape = (2 * seqlen, num_heads, nope_dim + emb_dim)
+        cu_seqlens = torch.tensor([0, seqlen, 2 * seqlen], dtype=torch.int32, device="cuda")
+
+    unsafe_source = torch.randn(shape, dtype=dtype, device="cuda", requires_grad=True)
+    unsafe_attention_output = _SaveOutputForBackward.apply(unsafe_source)
+    unsafe_reference = unsafe_attention_output.detach().clone()
+    unsafe_inverse_output = fused_mla_rope_inplace(
+        unsafe_attention_output,
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        cu_seqlens_q=cu_seqlens,
+        inverse=True,
+        remove_interleaving=True,
+    )
+
+    assert unsafe_inverse_output.data_ptr() == unsafe_attention_output.data_ptr()
+    assert not torch.equal(unsafe_attention_output, unsafe_reference)
+
+    source = torch.randn(shape, dtype=dtype, device="cuda", requires_grad=True)
+    attention_output = _SaveOutputForBackward.apply(source)
+    saved_reference = attention_output.detach().clone()
+
+    inverse_output = fused_mla_rope_out_of_place(
+        attention_output,
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        cu_seqlens_q=cu_seqlens,
+        inverse=True,
+        remove_interleaving=True,
+    )
+    expected_inverse_output = fused_mla_rope_inplace(
+        saved_reference.clone(),
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        cu_seqlens_q=cu_seqlens,
+        inverse=True,
+        remove_interleaving=True,
+    )
+
+    assert inverse_output.data_ptr() != attention_output.data_ptr()
+    torch.testing.assert_close(attention_output, saved_reference, rtol=0, atol=0)
+    torch.testing.assert_close(inverse_output, expected_inverse_output, rtol=0, atol=0)
+
+    inverse_output.backward(torch.randn_like(inverse_output).contiguous())
+    torch.testing.assert_close(source.grad, saved_reference, rtol=0, atol=0)
 
 
 class TestApplyRotaryPosEmbMlaFusionConflict:


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Fix a bug:

Fused DSA forward saves the raw attention output `O` for use during backward, while the value returned to the caller is only a reshape/view backed by the same storage. without creating independent storage.

Post-attention inverse RoPE then operates in-place on this returned view. The Triton kernel writes directly back through the input pointer (fused_mla_yarn_rope_apply.py). As a result, the original O saved for DSA backward is overwritten by the inverse-RoPE output before backward executes, causing the backward kernel to consume an incorrect attention output.

Bug reported by [5780122+shyoshyo@users.noreply.github.com](mailto:5780122+shyoshyo@users.noreply.github.com)

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
