### PR TITLE
Remove deprecated and unsafe type=bool usage on boolean CLI flags

### DIFF
--- a/examples/post_training/modelopt/convert_model.py
+++ b/examples/post_training/modelopt/convert_model.py
@@ -60,7 +60,7 @@ def add_convert_args(parser):
     )
     group.add_argument(
         "--mix-hidden-states",
-        type=bool,
+        action="store_true",
         default=False,
         help="Whether to mix hidden states from previous TTT step.",
     )

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2434,7 +2434,7 @@ def _add_rl_args(parser):
                             'persist: leave KV cache in GPU memory (default), '
                             'offload: offload KV cache to CPU during training, '
                             'recompute: deallocate KV cache and recompute from scratch each cycle')
-    group.add_argument('--rl-persist-cuda-graphs', action=argparse.BooleanOptionalAction, type=bool, default=False,
+    group.add_argument('--rl-persist-cuda-graphs', action=argparse.BooleanOptionalAction, default=False,
                        help='Persist CUDA graphs when the inference engine is suspended. '
                             'If False, CUDA graphs are deleted on suspend and re-captured on resume.')
     group.add_argument('--rl-partial-rollouts', action=argparse.BooleanOptionalAction, default=False,
@@ -2443,11 +2443,11 @@ def _add_rl_args(parser):
                             'be generated with a stale version of the policy. Use '
                             '--rl-num-parallel-generations or --rl-num-parallel-generation-batches '
                             'to control the degree of staleness.')
-    group.add_argument('--rl-inference-logprobs-is-correction', action=argparse.BooleanOptionalAction, type=bool, default=False,
+    group.add_argument('--rl-inference-logprobs-is-correction', action=argparse.BooleanOptionalAction, default=False,
                        help='If set, use inference logprobs in importance sampling correction of the loss.')
     group.add_argument('--rl-importance-sampling-truncation-coef', type=float, default=None,
                        help="If --inference-logprobs-is-correction is on and this coefficient is set, apply truncation for the IS correction at GRPO loss.")
-    group.add_argument('--rl-use-sequence-packing', action=argparse.BooleanOptionalAction, type=bool, default=False,
+    group.add_argument('--rl-use-sequence-packing', action=argparse.BooleanOptionalAction, default=False,
                        help='Enable sequence packing')
     group.add_argument('--rl-sequence-packing-max-sequences-per-bin', type=int, default=50,
                        help='Maximum number of sequences that can be packed into a single bin. ')
@@ -2456,7 +2456,7 @@ def _add_rl_args(parser):
                        help='Algorithm for distributing packed bins across ranks. '
                             'fifo: first-in-first-out sequential distribution, '
                             'round-robin: distribute bins cyclically across ranks for better load balancing')
-    group.add_argument('--rl-training-cuda-graphs', action=argparse.BooleanOptionalAction, type=bool,
+    group.add_argument('--rl-training-cuda-graphs', action=argparse.BooleanOptionalAction,
                        default=False,
                        help='If set, do not toggle CUDA graphs on/off between inference and training phases.')
     group.add_argument('--rl-inference-tensor-model-parallel-size', type=int, default=None,
@@ -2517,7 +2517,7 @@ def _add_rl_args(parser):
 
     group.add_argument('--rl-parallel-generation-tasks', type=int, default=None,
                        help='Deprecated: use --rl-num-parallel-generations instead.')
-    group.add_argument('--rl-skip-bos-token', action=argparse.BooleanOptionalAction, type=bool, default=False,
+    group.add_argument('--rl-skip-bos-token', action=argparse.BooleanOptionalAction, default=False,
                         help='Skip BOS token at the beginning of the sequences. Default is False.')
     group.add_argument('--rl-inference-parsers', nargs='*', default=[],
                        help='List of response parsers to enable for RL inference '

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2182,7 +2182,7 @@ def _add_network_size_args(parser):
                        help='Use gated linear units and SiLU activation instead of default gelu')
     group.add_argument('--quick-geglu', action='store_true',
                        help='Use quick geglu activation instead of default gelu')
-    group.add_argument('--onnx-safe', type=bool, required=False,
+    group.add_argument('--onnx-safe', action='store_true',
                        help='Use workarounds for known problems with '
                        'Torch ONNX exporter')
     group.add_argument('--bert-no-binary-head', action='store_false',

--- a/tests/functional_tests/python_test_utils/get_test_results_from_tensorboard_logs.py
+++ b/tests/functional_tests/python_test_utils/get_test_results_from_tensorboard_logs.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 @click.option("--output-path", required=False, type=str, help="Path to write golden values")
 @click.option(
     "--is-convergence-test/--is-normal-test",
-    type=bool,
     help="Use first or all tensorboard logs",
     default=False,
 )

--- a/tests/test_utils/python_scripts/generate_jet_trigger_job.py
+++ b/tests/test_utils/python_scripts/generate_jet_trigger_job.py
@@ -48,7 +48,6 @@ BASE_PATH = pathlib.Path(__file__).parent.resolve()
     is_flag=True,
     show_default=True,
     required=False,
-    type=bool,
     default=False,
     help="Run 2-step smoke tests instead of full training",
 )
@@ -57,7 +56,6 @@ BASE_PATH = pathlib.Path(__file__).parent.resolve()
     required=False,
     is_flag=True,
     default=True,
-    type=bool,
     help="Run one job as dependency to others as to warm up cache",
 )
 @click.option(

--- a/tests/test_utils/python_scripts/generate_local_jobs.py
+++ b/tests/test_utils/python_scripts/generate_local_jobs.py
@@ -50,7 +50,6 @@ def load_script(config_path: str) -> str:
     is_flag=True,
     show_default=True,
     required=False,
-    type=bool,
     default=False,
     help="Run 2-step smoke tests instead of full training",
 )
@@ -59,7 +58,6 @@ def load_script(config_path: str) -> str:
     is_flag=True,
     show_default=True,
     required=False,
-    type=bool,
     default=False,
     help="Save checkpoints, do not run pytest",
 )

--- a/tests/test_utils/python_scripts/launch_jet_workload.py
+++ b/tests/test_utils/python_scripts/launch_jet_workload.py
@@ -454,7 +454,6 @@ def is_flaky_failure(concat_allranks_logs: str) -> bool:
     is_flag=True,
     show_default=True,
     required=False,
-    type=bool,
     default=False,
     help="Wandb experiment (only relevant for release tests)",
 )

--- a/tests/test_utils/python_scripts/launch_nemo_run_workload.py
+++ b/tests/test_utils/python_scripts/launch_nemo_run_workload.py
@@ -103,7 +103,6 @@ def _collect_failure_logs(workdir: pathlib.Path) -> list[str]:
     is_flag=True,
     show_default=True,
     required=False,
-    type=bool,
     default=False,
     help="To enable lightweight mode",
 )

--- a/tests/unit_tests/test_argument_utils.py
+++ b/tests/unit_tests/test_argument_utils.py
@@ -919,6 +919,22 @@ class TestArgparseBooleanOptionalActionCompat:
 
     _INCOMPATIBLE_KWARGS = frozenset({"type", "choices", "metavar"})
 
+    @staticmethod
+    def _iter_megatron_sources():
+        """Yield ``(relative_path, source)`` for every .py file in the megatron package."""
+        import megatron
+
+        # ``megatron`` is a PEP 420 namespace package (no __init__.py), so __file__ is
+        # None; resolve the source root(s) via __path__ instead (it may list a dir twice).
+        roots = list(dict.fromkeys(pathlib.Path(p).resolve() for p in megatron.__path__))
+        seen: set[pathlib.Path] = set()
+        for root in roots:
+            for path in sorted(root.rglob("*.py")):
+                if path in seen:
+                    continue
+                seen.add(path)
+                yield path.relative_to(root.parent), path.read_text(encoding="utf-8")
+
     @classmethod
     def _find_violations(cls, source: str) -> list[tuple[int, list[str]]]:
         """Return ``(lineno, sorted_bad_kwargs)`` for every offending call in ``source``."""
@@ -939,28 +955,44 @@ class TestArgparseBooleanOptionalActionCompat:
 
     def test_no_incompatible_kwargs_on_boolean_optional_action(self):
         """No file under ``megatron/`` may pass type/choices/metavar to BooleanOptionalAction."""
-        import megatron
-
-        # ``megatron`` is a PEP 420 namespace package (no __init__.py), so __file__ is
-        # None; resolve the source root(s) via __path__ instead (it may list a dir twice).
-        roots = list(dict.fromkeys(pathlib.Path(p).resolve() for p in megatron.__path__))
         violations = []
-        scanned: set[pathlib.Path] = set()
-        for root in roots:
-            for path in sorted(root.rglob("*.py")):
-                if path in scanned:
-                    continue
-                scanned.add(path)
-                source = path.read_text(encoding="utf-8")
-                if "BooleanOptionalAction" not in source:  # cheap prefilter before parsing
-                    continue
-                for lineno, bad in self._find_violations(source):
-                    violations.append(f"{path.relative_to(root.parent)}:{lineno} -> {', '.join(bad)}")
+        for rel_path, source in self._iter_megatron_sources():
+            if "BooleanOptionalAction" not in source:  # cheap prefilter before parsing
+                continue
+            for lineno, bad in self._find_violations(source):
+                violations.append(f"{rel_path}:{lineno} -> {', '.join(bad)}")
 
         assert not violations, (
             "argparse.BooleanOptionalAction rejects type=/choices=/metavar= on Python >= 3.14 "
             "(they are silently-ignored no-ops on earlier versions). Remove them from:\n  "
             + "\n  ".join(violations)
+        )
+
+    def test_no_type_bool_on_argparse_add_argument(self):
+        """No argparse ``add_argument`` under ``megatron/`` may use ``type=bool``.
+
+        ``type=bool`` on a value-taking argument is a footgun: argparse feeds the raw
+        string to ``bool()``, and ``bool()`` of any non-empty string is ``True`` — so
+        ``--flag False`` silently *enables* the flag. Use ``action="store_true"`` /
+        ``"store_false"`` or ``BooleanOptionalAction`` for boolean flags instead.
+        """
+        violations = []
+        for rel_path, source in self._iter_megatron_sources():
+            if "add_argument" not in source or "type=bool" not in source:  # cheap prefilter
+                continue
+            for node in ast.walk(ast.parse(source)):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "add_argument"
+                    and any(kw.arg == "type" and ast.unparse(kw.value) == "bool" for kw in node.keywords)
+                ):
+                    violations.append(f"{rel_path}:{node.lineno}")
+
+        assert not violations, (
+            "argparse add_argument(type=bool) is a footgun: bool() of any non-empty string is "
+            "True, so '--flag False' silently enables it. Use action='store_true'/'store_false' "
+            "or BooleanOptionalAction. Found at:\n  " + "\n  ".join(violations)
         )
 
     def test_rl_boolean_flags_register_and_parse_as_bools(self):

--- a/tests/unit_tests/test_argument_utils.py
+++ b/tests/unit_tests/test_argument_utils.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
+import ast
+import pathlib
 import signal
 from argparse import ArgumentError, ArgumentParser, Namespace
 from dataclasses import dataclass, field
@@ -896,3 +898,90 @@ class TestTrainingConfigMapping:
         assert result.train.train_iters is None
         assert result.train.micro_batch_size is None
         assert result.train.global_batch_size is None
+
+
+# ---------------------------------------------------------------------------
+# Guard against argparse usage that is incompatible with Python >= 3.14
+# ---------------------------------------------------------------------------
+
+
+class TestArgparseBooleanOptionalActionCompat:
+    """Guard against re-introducing argparse usage that breaks on Python >= 3.14.
+
+    Python 3.14 removed support for the ``type``, ``choices``, and ``metavar``
+    keyword arguments on ``argparse.BooleanOptionalAction``. The action always
+    stores a literal ``True``/``False`` constant, so those kwargs were never
+    applied; passing any of them now raises ``TypeError`` at argument-registration
+    time (i.e. before ``parse_args()`` even runs). Interpreters before 3.14 — including
+    CI's 3.12 — silently accept and ignore them, so the only reliable guard is a
+    static scan of the source rather than a runtime ``parse_args()`` call.
+    """
+
+    _INCOMPATIBLE_KWARGS = frozenset({"type", "choices", "metavar"})
+
+    @classmethod
+    def _find_violations(cls, source: str) -> list[tuple[int, list[str]]]:
+        """Return ``(lineno, sorted_bad_kwargs)`` for every offending call in ``source``."""
+        violations = []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Call):
+                continue
+            uses_boa = any(
+                kw.arg == "action" and "BooleanOptionalAction" in ast.unparse(kw.value)
+                for kw in node.keywords
+            )
+            if not uses_boa:
+                continue
+            bad = sorted(kw.arg for kw in node.keywords if kw.arg in cls._INCOMPATIBLE_KWARGS)
+            if bad:
+                violations.append((node.lineno, bad))
+        return violations
+
+    def test_no_incompatible_kwargs_on_boolean_optional_action(self):
+        """No file under ``megatron/`` may pass type/choices/metavar to BooleanOptionalAction."""
+        import megatron
+
+        # ``megatron`` is a PEP 420 namespace package (no __init__.py), so __file__ is
+        # None; resolve the source root(s) via __path__ instead (it may list a dir twice).
+        roots = list(dict.fromkeys(pathlib.Path(p).resolve() for p in megatron.__path__))
+        violations = []
+        scanned: set[pathlib.Path] = set()
+        for root in roots:
+            for path in sorted(root.rglob("*.py")):
+                if path in scanned:
+                    continue
+                scanned.add(path)
+                source = path.read_text(encoding="utf-8")
+                if "BooleanOptionalAction" not in source:  # cheap prefilter before parsing
+                    continue
+                for lineno, bad in self._find_violations(source):
+                    violations.append(f"{path.relative_to(root.parent)}:{lineno} -> {', '.join(bad)}")
+
+        assert not violations, (
+            "argparse.BooleanOptionalAction rejects type=/choices=/metavar= on Python >= 3.14 "
+            "(they are silently-ignored no-ops on earlier versions). Remove them from:\n  "
+            + "\n  ".join(violations)
+        )
+
+    def test_rl_boolean_flags_register_and_parse_as_bools(self):
+        """The RL on/off flags must register cleanly and yield real bools (no behavior change)."""
+        from megatron.training.arguments import _add_rl_args
+
+        parser = ArgumentParser()
+        _add_rl_args(parser)
+
+        for dest in (
+            "rl_persist_cuda_graphs",
+            "rl_inference_logprobs_is_correction",
+            "rl_use_sequence_packing",
+            "rl_training_cuda_graphs",
+            "rl_skip_bos_token",
+        ):
+            flag = "--" + dest.replace("_", "-")
+            no_flag = "--no-" + dest.replace("_", "-")
+            default = getattr(parser.parse_args([]), dest)
+            enabled = getattr(parser.parse_args([flag]), dest)
+            disabled = getattr(parser.parse_args([no_flag]), dest)
+            assert default is False, dest
+            assert enabled is True and isinstance(enabled, bool), dest
+            assert disabled is False and isinstance(disabled, bool), dest


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Removes `type=bool` (and related) usage on boolean CLI options. Across the
codebase this usage is deprecated at best and dangerous at worst, and adds a
guard test so the unsafe cases cannot reappear.

- `argparse.BooleanOptionalAction` stores a literal bool, so `type`, `choices`,
  and `metavar` are never applied. Passing them is deprecated: older
  interpreters ignore them and newer ones reject them outright, which makes the
  parser fail to build. Removed `type=bool` from five RL flags in `_add_rl_args`.
- `type=bool` on a value-taking argparse argument is dangerous: argparse runs
  the raw string through `bool()`, and `bool()` of any non-empty string is
  `True`, so `--flag False` silently enables the flag. Converted `--onnx-safe`
  and `--mix-hidden-states` to `action='store_true'`.
- `type=bool` on a Click `is_flag` or `--x/--no-x` option is redundant: Click
  resolves these to its `BOOL` type regardless (verified on the pinned Click
  8.4.1, behavior identical). Removed it from seven options in the CI scripts.
- Added a static guard test that rejects both argparse patterns anywhere under
  `megatron/`, so they cannot be reintroduced.

## Issue tracking

Linked issue: N/A (small bug fix and cleanup)

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code
- [ ] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR