### PR TITLE
[codex] Preserve real and padded THD sequence lengths

### DIFF
--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -18,8 +18,10 @@ from megatron.core.datasets.data_schedule_utils import (
 )
 from megatron.core.packed_seq_params import (
     PackedSeqParams,
+    extend_thd_padding_before_cp_slice,
     get_thd_padding_kwargs,
     pad_sequence_for_thd,
+    resolve_thd_tail_padding_policy,
 )
 from megatron.core.pipeline_parallel.hybrid_cp_schedule import BalancedCPScheduler
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -29,7 +31,11 @@ from megatron.core.transformer.multi_token_prediction import mtp_on_this_rank
 def _build_thd_padding_mask(
     cu_seqlens: torch.Tensor, cu_seqlens_padded: torch.Tensor
 ) -> torch.Tensor:
-    """Build a 1D THD padding mask from scheduler sequence metadata."""
+    """Build a 1D THD padding mask from packed-sequence metadata.
+
+    True marks physical slots that carry no valid tokens, covering both
+    inter-sequence gaps and the padding tail of the final sequence.
+    """
     assert cu_seqlens.dim() == 1
     assert cu_seqlens_padded.dim() == 1
     assert cu_seqlens.numel() == cu_seqlens_padded.numel()
@@ -467,8 +473,9 @@ def _get_scheduler_max_real_num_seqs(config) -> Optional[int]:
     if max_num_seqs < 1:
         raise ValueError(f"thd_max_packed_sequences must be >= 1, got {max_num_seqs}.")
 
-    if getattr(config, 'pad_packed_seq_alignment', None) is not None and getattr(
-        config, 'pad_packed_seq_by_appending_dummy_seq', True
+    if (
+        getattr(config, 'pad_packed_seq_alignment', None) is not None
+        and resolve_thd_tail_padding_policy(config) == 'append_dummy_seq'
     ):
         if max_num_seqs < 2:
             raise ValueError(
@@ -631,7 +638,9 @@ def get_batch_on_this_rank_for_sequence_packing(
         )
 
     cp_partition_mode = getattr(config, "cp_partition_mode", "zigzag")
+    tail_padding_policy = resolve_thd_tail_padding_policy(config)
     contiguous_cp_local_target_len = None
+    non_dummy_global_target_len = None
     pad_alignment = (
         getattr(config, 'pad_packed_seq_alignment', None) if config is not None else None
     )
@@ -666,17 +675,35 @@ def get_batch_on_this_rank_for_sequence_packing(
         )
         _sanitize_thd_padding_values(batch, batch['padding_mask'])
 
+        # In extend_last mode, the padding tail belongs to the final real
+        # sequence. Extend its global physical endpoint before CP slicing so
+        # both zigzag indices and contiguous rank origins see the padded layout.
+        if pad_alignment is not None and tail_padding_policy == 'extend_last':
+            batch['cu_seqlens_padded'], batch['max_seqlen'], non_dummy_global_target_len = (
+                extend_thd_padding_before_cp_slice(
+                    batch['cu_seqlens_padded'],
+                    batch['max_seqlen'],
+                    alignment=alignment,
+                    target_len=(
+                        target_len if target_len is not None else contiguous_cp_local_target_len
+                    ),
+                    cp_size=cp_group.size(),
+                    cp_partition_mode=cp_partition_mode,
+                )
+            )
+
     # Partition sequence tensors for context parallelism. Padding mask is needed
     # on every PP stage, while data tensors are only needed on first/last/MTP stages.
     if is_tp_rank_0:
         cp_slice_keys = ['padding_mask']
         if is_first_or_last_stage or mtp_on_this_rank:
             cp_slice_keys.extend(['tokens', 'position_ids', 'labels', 'loss_mask'])
-        partition_total_tokens = (
-            contiguous_cp_local_target_len * cp_group.size()
-            if contiguous_cp_local_target_len is not None
-            else None
-        )
+        if non_dummy_global_target_len is not None:
+            partition_total_tokens = non_dummy_global_target_len
+        elif contiguous_cp_local_target_len is not None:
+            partition_total_tokens = contiguous_cp_local_target_len * cp_group.size()
+        else:
+            partition_total_tokens = None
         get_cp_slice_for_thd(
             batch,
             cp_group,
@@ -823,12 +850,14 @@ def get_batch_on_this_rank_for_sequence_packing(
         local_cp_size=local_cp_size,
         cp_group=cp_group,
         cp_partition_mode=cp_partition_mode,
-        pad_between_seqs=False,
+        pad_between_seqs=True,
     )
 
-    # Pad the already-packed THD tensors at the end when requested. A configured
-    # thd_max_packed_sequences also pads cu_seqlens to a fixed capacity in eager or graph mode.
-    if pad_alignment is not None and packed_seq_params is not None:
+    # Dummy metadata is appended after CP slicing as an ordinary sequence.
+    # Non-dummy tensors and their final padded endpoint were extended before
+    # slicing; this call is then a no-op except for fixed-capacity cu_seqlens
+    # entries in eager or graph mode.
+    if pad_alignment is not None:
         tokens, labels, loss_mask, position_ids, packed_seq_params, padding_mask = (
             pad_sequence_for_thd(
                 tokens,
@@ -839,9 +868,7 @@ def get_batch_on_this_rank_for_sequence_packing(
                 alignment=alignment,
                 target_len=target_len,
                 max_num_seqs=max_num_seqs,
-                pad_by_appending_dummy_seq=getattr(
-                    config, 'pad_packed_seq_by_appending_dummy_seq', True
-                ),
+                tail_padding_policy=tail_padding_policy,
                 padding_mask=padding_mask,
                 cp_group=cp_group,
             )

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -34,7 +34,7 @@ def get_cp_slice_for_thd(
             before slicing. Existing cu_seqlens metadata is left unchanged.
     """
     cp_size = cp_group.size()
-    if cp_size <= 1:
+    if cp_size <= 1 and partition_total_tokens is None:
         return
     cp_rank = cp_group.rank()
     # Partition with padded cumulative lengths so CP slices match the THD
@@ -63,6 +63,8 @@ def get_cp_slice_for_thd(
             if pad_len > 0:
                 pad_value = True if key == 'padding_mask' else 0
                 batch[key] = torch.cat([batch[key], batch[key].new_full((pad_len,), pad_value)])
+    if cp_size <= 1:
+        return
     if cp_partition_mode == "contiguous":
         if total_tokens % cp_size != 0:
             raise RuntimeError(

--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -118,13 +118,21 @@ class ModelParallelConfig:
     tensors are padded to a multiple of N.
     """
 
-    pad_packed_seq_by_appending_dummy_seq: bool = True
-    """Represent a THD packed-sequence padding tail by appending a dummy sequence.
+    thd_tail_padding_policy: Optional[Literal["append_dummy_seq", "extend_last"]] = None
+    """Policy for representing the THD packed-sequence padding tail.
 
-    When disabled, token-like tensors are still padded according to
-    pad_packed_seq_alignment, but cu_seqlens sequence boundaries are not extended
-    for the padding tail. When thd_max_packed_sequences is set, static-input
-    padding may still pad cu_seqlens tensors to that value + 1 entries.
+    - append_dummy_seq: cover the post-pack padding tail with an ordinary
+      dummy sequence appended to the cu_seqlens metadata. Existing
+      valid/physical gaps between real sequences are preserved. This is the
+      default behavior.
+    - extend_last: keep valid cu_seqlens boundaries unchanged and extend the
+      final padded boundary so the tail is physical padding of the last
+      sequence. With context parallelism the extension is applied to the
+      global metadata before CP slicing.
+    - None (default): treated as append_dummy_seq.
+
+    When thd_max_packed_sequences is set, cu_seqlens tensors are padded to
+    that value + 1 entries in both eager and CUDA Graph modes.
     """
 
     expert_model_parallel_size: int = 1
@@ -513,6 +521,12 @@ class ModelParallelConfig:
                     f"min_dynamic_context_parallel_size must be >= 1, "
                     f"got {self.min_dynamic_context_parallel_size}"
                 )
+
+        if self.thd_tail_padding_policy not in (None, "append_dummy_seq", "extend_last"):
+            raise ValueError(
+                "thd_tail_padding_policy must be 'append_dummy_seq', 'extend_last', or None, "
+                f"got {self.thd_tail_padding_policy!r}."
+            )
 
         if self.pad_packed_seq_alignment is not None:
             self.pad_packed_seq_alignment = _parse_pad_packed_seq_alignment(

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -169,7 +169,9 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
             cu_seqlens_kv_padded=kwargs.pop('cu_seqlens_kv_padded'),
             max_seqlen_q=max_seqlen,
             max_seqlen_kv=max_seqlen,
-            pad_between_seqs=False,
+            # This Python flag is baked into the captured graph and cannot vary
+            # between replay batches. Use the conservative THD-safe branch.
+            pad_between_seqs=True,
         )
         kwargs['packed_seq_params'] = packed_seq_params
 

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -149,16 +149,44 @@ def _pad_cu_seqlens(cu_seqlens: Optional[Tensor], target_entries: int) -> Option
 def _append_dummy_seq(cu_seqlens: Optional[Tensor], dummy_end: int) -> Optional[Tensor]:
     """Append a dummy sequence boundary to a cu_seqlens tensor.
 
-    ``dummy_end`` is the padded target length. Appending it to both
-    ``cu_seqlens_*`` and ``cu_seqlens_*_padded`` represents the post-pack
-    alignment tail as an ordinary dummy sequence. That keeps every token row
-    covered by THD metadata without enabling TE's pad-between-sequences mode.
+    ``dummy_end`` is the endpoint in this tensor's coordinate space. Padded
+    metadata uses the physical target; compact valid-token metadata uses its
+    previous endpoint plus the dummy tail length when earlier gaps exist.
     """
     if cu_seqlens is None:
         return None
 
     dummy = torch.full((1,), int(dummy_end), dtype=cu_seqlens.dtype, device=cu_seqlens.device)
     return torch.cat((cu_seqlens, dummy), dim=0)
+
+
+def _extend_last_padded_sequence(
+    cu_seqlens_padded: Optional[Tensor], padded_end: int
+) -> Optional[Tensor]:
+    """Extend the final padded sequence to ``padded_end`` without adding a boundary."""
+    if cu_seqlens_padded is None:
+        return None
+
+    assert (
+        cu_seqlens_padded.numel() >= 2
+    ), "Non-dummy THD tail padding requires at least one real sequence."
+    current_end = int(cu_seqlens_padded[-1].item())
+    assert (
+        current_end <= padded_end
+    ), f"THD padded endpoint ({current_end}) exceeds padding target ({padded_end})."
+    if current_end == padded_end:
+        return cu_seqlens_padded
+
+    extended = cu_seqlens_padded.clone()
+    extended[-1] = padded_end
+    return extended
+
+
+def _last_padded_sequence_length(cu_seqlens_padded: Optional[Tensor]) -> int:
+    """Return the physical length of the final sequence, or zero when unavailable."""
+    if cu_seqlens_padded is None or cu_seqlens_padded.numel() < 2:
+        return 0
+    return int((cu_seqlens_padded[-1] - cu_seqlens_padded[-2]).item())
 
 
 def _round_up_to_alignment(value: int, alignment: int) -> int:
@@ -190,6 +218,79 @@ def get_thd_padding_kwargs(
         return None, int(max_seqlen_per_dp_cp_rank), thd_max_packed_sequences
 
     return int(pad_packed_seq_alignment), None, thd_max_packed_sequences
+
+
+def resolve_thd_tail_padding_policy(config) -> Literal["append_dummy_seq", "extend_last"]:
+    """Resolve the THD tail-padding policy from the training config.
+
+    Defaults to ``append_dummy_seq`` when ``thd_tail_padding_policy`` is unset.
+    """
+    policy = getattr(config, 'thd_tail_padding_policy', None) or "append_dummy_seq"
+    assert policy in (
+        "append_dummy_seq",
+        "extend_last",
+    ), f"Unsupported thd_tail_padding_policy: {policy}"
+    return policy
+
+
+def extend_thd_padding_before_cp_slice(
+    cu_seqlens_padded: Tensor,
+    max_seqlen: Union[int, Tensor],
+    *,
+    alignment: Optional[int],
+    target_len: Optional[int],
+    cp_size: int,
+    cp_partition_mode: str,
+) -> Tuple[Tensor, Union[int, Tensor], int]:
+    """Extend the global THD physical endpoint for non-dummy tail padding.
+
+    Non-dummy padding attaches the alignment tail to the final real sequence.
+    With context parallelism this must happen on the global metadata before CP
+    slicing so partition indices and rank origins see the padded layout.
+
+    Args:
+        cu_seqlens_padded: Global physical sequence boundaries (1D).
+        max_seqlen: Longest sequence length, as an int or a tensor.
+        alignment: Round the CP-local length up to this multiple when
+            ``target_len`` is not given.
+        target_len: CP-local padding target.
+        cp_size: Context-parallel world size.
+        cp_partition_mode: ``zigzag`` or ``contiguous``.
+
+    Returns:
+        The (possibly extended) ``cu_seqlens_padded``, the updated
+        ``max_seqlen``, and the global padding target length.
+    """
+    assert cu_seqlens_padded.dim() == 1
+    global_actual_len = int(cu_seqlens_padded[-1].item())
+    if target_len is not None:
+        local_target_len = int(target_len)
+    else:
+        assert alignment is not None
+        local_rows = (global_actual_len + cp_size - 1) // cp_size
+        local_target_len = _round_up_to_alignment(local_rows, alignment)
+
+    global_target_len = local_target_len * cp_size
+    assert global_actual_len <= global_target_len, (
+        f"Packed THD length ({global_actual_len}) exceeds global padding target "
+        f"({global_target_len})."
+    )
+    if cp_size > 1 and cp_partition_mode == "zigzag":
+        assert global_target_len % (2 * cp_size) == 0, (
+            f"Zigzag THD padding target ({global_target_len}) must be "
+            f"divisible by 2 * context_parallel_size ({2 * cp_size})."
+        )
+
+    if global_actual_len < global_target_len:
+        cu_seqlens_padded = _extend_last_padded_sequence(cu_seqlens_padded, global_target_len)
+        last_padded_seqlen = _last_padded_sequence_length(cu_seqlens_padded)
+        if isinstance(max_seqlen, Tensor):
+            new_max_value = max(int(max_seqlen.max().item()), last_padded_seqlen)
+            max_seqlen = torch.full_like(max_seqlen, new_max_value)
+        else:
+            max_seqlen = max(int(max_seqlen), last_padded_seqlen)
+
+    return cu_seqlens_padded, max_seqlen, global_target_len
 
 
 def _resolve_thd_padding_lengths(
@@ -228,9 +329,14 @@ def _resolve_thd_padding_lengths(
             mask_device = candidate.device
             break
 
-    # Prefer THD metadata for the global packed length when it is available.
+    # The padded endpoint describes tensor storage. The unpadded endpoint is
+    # only the compact valid-token count when gaps exist between sequences.
     has_local_tensor = local_tensor_T is not None
-    if packed_seq_params.cu_seqlens_q is not None:
+    if packed_seq_params.cu_seqlens_q_padded is not None:
+        global_actual_T = int(packed_seq_params.cu_seqlens_q_padded[-1].item())
+        if mask_device is None:
+            mask_device = packed_seq_params.cu_seqlens_q_padded.device
+    elif packed_seq_params.cu_seqlens_q is not None:
         global_actual_T = int(packed_seq_params.cu_seqlens_q[-1].item())
         if mask_device is None:
             mask_device = packed_seq_params.cu_seqlens_q.device
@@ -338,7 +444,7 @@ def pad_sequence_for_thd(
     alignment: Optional[int] = None,
     target_len: Optional[int] = None,
     max_num_seqs: Optional[int] = None,
-    pad_by_appending_dummy_seq: bool = True,
+    tail_padding_policy: Literal["append_dummy_seq", "extend_last"] = "append_dummy_seq",
     padding_mask: Optional[Tensor] = None,
     cp_group: Optional[dist.ProcessGroup] = None,
     cp_size: Optional[int] = None,
@@ -373,8 +479,11 @@ def pad_sequence_for_thd(
             Exactly one of ``alignment`` and ``target_len`` must be provided.
         max_num_seqs: If set, pad cu_seqlens tensors to
             ``max_num_seqs + 1`` entries for static eager or CUDA Graph inputs.
-        pad_by_appending_dummy_seq: If true, represent the post-pack padding
-            tail as an extra dummy sequence in cu_seqlens metadata.
+        tail_padding_policy: How to represent the post-pack padding tail.
+            ``"append_dummy_seq"`` adds an extra dummy sequence to the
+            cu_seqlens metadata. ``"extend_last"`` keeps valid boundaries
+            unchanged and extends the final padded sequence boundary to cover
+            the tail.
         padding_mask: Existing bool padding mask for already-packed tokens,
             with True marking padding positions.
         cp_group: Context-parallel process group for resolving local/global
@@ -388,11 +497,24 @@ def pad_sequence_for_thd(
         - On stages without token-like tensors, an already CP-sliced padding
           mask supplies the local physical row count. Legacy callers without a
           padding mask ask TE which packed rows this CP rank would receive.
-        - When ``pad_by_appending_dummy_seq`` is true, the padding tail is also
-          represented as an ordinary dummy sequence in cu_seqlens metadata.
+        - With ``"append_dummy_seq"``, the padding tail is represented as an
+          ordinary dummy sequence in cu_seqlens metadata. Existing
+          valid/physical gaps remain intact.
+        - With ``"extend_last"``, valid cu_seqlens remain unchanged while the
+          final padded endpoint is extended, treating the tail as padding of the
+          last sequence. With CP, callers must do this on the global tensors
+          before slicing.
+        - With zigzag context parallelism, a dummy tail must be divisible by
+          twice the effective CP size, matching TE's THD partitioning requirement.
         - ``max_num_seqs`` pads all four cu_seqlens tensors. CUDA Graph replay
           requires this because those tensors are graph inputs; eager mode can
           opt into the same static metadata contract.
+          ``pad_between_seqs`` is a capture-time Python branch rather than a
+          graph input, so it is fixed to the conservative ``True``: correct
+          for any replay batch regardless of its gap layout, at the cost of
+          restricting TE backend selection for THD to cuDNN fused attention
+          (FlashAttention is not eligible when padding may exist between
+          sequences).
 
     Returns:
         Padded (tokens, labels, loss_mask, position_ids, packed_seq_params, padding_mask)
@@ -441,16 +563,76 @@ def pad_sequence_for_thd(
     cu_seqlens_q_padded = packed_seq_params.cu_seqlens_q_padded
     cu_seqlens_kv_padded = packed_seq_params.cu_seqlens_kv_padded
 
-    # Represent post-pack padding as a dummy sequence when requested.
+    # Represent post-pack padding either as a dummy sequence or as physical
+    # padding attached to the final real sequence.
+    has_padding_tail = global_target_len > global_actual_T
     target_cu_entries = None if max_num_seqs is None else max_num_seqs + 1
-    has_dummy_padding_seq = pad_by_appending_dummy_seq and global_target_len > global_actual_T
+    has_dummy_padding_seq = tail_padding_policy == "append_dummy_seq" and has_padding_tail
+    has_non_dummy_padding_tail = tail_padding_policy == "extend_last" and has_padding_tail
     dummy_seq_len = global_target_len - global_actual_T if has_dummy_padding_seq else 0
+    last_padded_q_len = 0
+    last_padded_kv_len = 0
+
+    # Existing valid/padded differences describe physical gaps between real
+    # sequences. Preserve that contract while adding an ordinary dummy sequence:
+    # its valid and physical lengths are both exactly the new tail length.
+    has_inter_sequence_padding = packed_seq_params.pad_between_seqs is True
+    if has_dummy_padding_seq and packed_seq_params.pad_between_seqs is None:
+        has_inter_sequence_padding = any(
+            valid is not None and padded is not None and not torch.equal(valid, padded)
+            for valid, padded in (
+                (cu_seqlens_q, cu_seqlens_q_padded),
+                (cu_seqlens_kv, cu_seqlens_kv_padded),
+            )
+        )
 
     if has_dummy_padding_seq:
-        cu_seqlens_q = _append_dummy_seq(cu_seqlens_q, global_target_len)
-        cu_seqlens_kv = _append_dummy_seq(cu_seqlens_kv, global_target_len)
+        cp_size, _ = _resolve_thd_cp_geometry(
+            packed_seq_params, cp_group=cp_group, cp_size=cp_size, cp_rank=cp_rank
+        )
+        if cp_size > 1 and packed_seq_params.cp_partition_mode == "zigzag":
+            assert dummy_seq_len % (2 * cp_size) == 0, (
+                f"THD dummy padding length ({dummy_seq_len}) must be divisible by "
+                f"2 * context_parallel_size ({2 * cp_size}) for zigzag partitioning. "
+                "Choose an even CP-local padding target/alignment."
+            )
+
+        if has_inter_sequence_padding:
+            if cu_seqlens_q is not None:
+                cu_seqlens_q = _append_dummy_seq(
+                    cu_seqlens_q, int(cu_seqlens_q[-1].item()) + dummy_seq_len
+                )
+            if cu_seqlens_kv is not None:
+                cu_seqlens_kv = _append_dummy_seq(
+                    cu_seqlens_kv, int(cu_seqlens_kv[-1].item()) + dummy_seq_len
+                )
+        else:
+            # Legacy equal-boundary case: retain the original dummy behavior.
+            cu_seqlens_q = _append_dummy_seq(cu_seqlens_q, global_target_len)
+            cu_seqlens_kv = _append_dummy_seq(cu_seqlens_kv, global_target_len)
         cu_seqlens_q_padded = _append_dummy_seq(cu_seqlens_q_padded, global_target_len)
         cu_seqlens_kv_padded = _append_dummy_seq(cu_seqlens_kv_padded, global_target_len)
+    elif has_non_dummy_padding_tail:
+        # Keep compact valid-token coordinates unchanged. Only physical
+        # metadata grows, so the tail belongs to the final real sequence.
+        non_dummy_cp_size, _ = _resolve_thd_cp_geometry(
+            packed_seq_params, cp_group=cp_group, cp_size=cp_size, cp_rank=cp_rank
+        )
+        assert non_dummy_cp_size == 1, (
+            "Non-dummy THD tail padding with context parallelism must be applied "
+            "to global tensors before CP slicing."
+        )
+        if cu_seqlens_q_padded is None:
+            cu_seqlens_q_padded = cu_seqlens_q
+        if cu_seqlens_kv_padded is None:
+            cu_seqlens_kv_padded = cu_seqlens_kv
+        assert (
+            cu_seqlens_q_padded is not None or cu_seqlens_kv_padded is not None
+        ), "Non-dummy THD tail padding requires metadata for at least one real sequence."
+        cu_seqlens_q_padded = _extend_last_padded_sequence(cu_seqlens_q_padded, global_target_len)
+        cu_seqlens_kv_padded = _extend_last_padded_sequence(cu_seqlens_kv_padded, global_target_len)
+        last_padded_q_len = _last_padded_sequence_length(cu_seqlens_q_padded)
+        last_padded_kv_len = _last_padded_sequence_length(cu_seqlens_kv_padded)
 
     # Pad cu_seqlens entry counts when a static sequence capacity is configured.
     if target_cu_entries is not None:
@@ -469,18 +651,37 @@ def pad_sequence_for_thd(
         max_seqlen_q=(
             global_target_len
             if target_cu_entries is not None
-            else max(packed_seq_params.max_seqlen_q, dummy_seq_len)
+            else max(
+                packed_seq_params.max_seqlen_q,
+                dummy_seq_len,
+                last_padded_q_len if has_non_dummy_padding_tail else 0,
+            )
         ),
         max_seqlen_kv=(
             global_target_len
             if target_cu_entries is not None
-            else max(packed_seq_params.max_seqlen_kv, dummy_seq_len)
+            else max(
+                packed_seq_params.max_seqlen_kv,
+                dummy_seq_len,
+                last_padded_kv_len if has_non_dummy_padding_tail else 0,
+            )
         ),
         local_cp_size=packed_seq_params.local_cp_size,
         cp_group=packed_seq_params.cp_group,
         cp_partition_mode=packed_seq_params.cp_partition_mode,
         total_tokens=local_target_len if target_cu_entries is None else None,
-        pad_between_seqs=False if has_dummy_padding_seq else packed_seq_params.pad_between_seqs,
+        pad_between_seqs=(
+            # CUDA Graph capture bakes this Python branch into the captured
+            # kernels, so static inputs use the conservative batch-independent
+            # True (see Notes in the docstring).
+            True
+            if target_cu_entries is not None
+            else (
+                has_inter_sequence_padding
+                if has_dummy_padding_seq
+                else (True if has_non_dummy_padding_tail else packed_seq_params.pad_between_seqs)
+            )
+        ),
     )
 
     # True marks padded local token slots for routing/loss paths.

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -22,6 +22,7 @@ from torch.utils._pytree import tree_map as tree_map_pyt
 
 from megatron.core import parallel_state
 from megatron.core.num_microbatches_calculator import get_num_microbatches
+from megatron.core.packed_seq_params import resolve_thd_tail_padding_policy
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import (
     CudaRNGStatesTracker,
@@ -2254,8 +2255,9 @@ class TECudaGraphHelper:
         max_num_seqs = getattr(self.config, 'thd_max_packed_sequences', None)
         if max_num_seqs is not None:
             max_num_seqs = int(max_num_seqs)
-            if getattr(self.config, 'pad_packed_seq_alignment', None) is not None and getattr(
-                self.config, 'pad_packed_seq_by_appending_dummy_seq', True
+            if (
+                getattr(self.config, 'pad_packed_seq_alignment', None) is not None
+                and resolve_thd_tail_padding_policy(self.config) == 'append_dummy_seq'
             ):
                 max_num_seqs -= 1
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1614,9 +1614,10 @@ class TransformerConfig(ModelParallelConfig):
 
             if self.experimental_attention_variant == "gated_delta_net":
                 if self.pad_packed_seq_alignment is not None:
-                    assert self.pad_packed_seq_by_appending_dummy_seq, (
+                    tail_policy = self.thd_tail_padding_policy or 'append_dummy_seq'
+                    assert tail_policy == 'append_dummy_seq', (
                         "gated_delta_net with pad_packed_seq_alignment requires "
-                        "pad_packed_seq_by_appending_dummy_seq."
+                        "thd_tail_padding_policy='append_dummy_seq'."
                     )
 
                 # Check required parameters
@@ -3397,6 +3398,21 @@ class TransformerConfig(ModelParallelConfig):
                 "THD CUDA Graph requires --pad-packed-seq-alignment='max' "
                 "or --pad-packed-seq-alignment equal to max_seqlen_per_dp_cp_rank "
                 f"({self.max_seqlen_per_dp_cp_rank}), got {self.pad_packed_seq_alignment}."
+            )
+
+        # 'extend_last' THD tail padding with context parallelism requires the
+        # global metadata to be extended before CP slicing, which only the
+        # sequence-packing scheduler path performs. Restrict this combination.
+        if (
+            self.sequence_packing_scheduler is None
+            and self.pad_packed_seq_alignment is not None
+            and (self.thd_tail_padding_policy or 'append_dummy_seq') == 'extend_last'
+            and (self.context_parallel_size > 1 or self.dynamic_context_parallel)
+        ):
+            raise ValueError(
+                "thd_tail_padding_policy='extend_last' with context parallelism is only "
+                "supported together with a sequence_packing_scheduler. Either enable a "
+                "sequence_packing_scheduler, or use thd_tail_padding_policy='append_dummy_seq'."
             )
 
         if self.sequence_packing_scheduler is not None:

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1371,6 +1371,8 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         individual cu_seqlens tensor kwargs. This method reassembles them into a
         PackedSeqParams. max_seqlen_q/kv are taken from config since they are always
         the padded static value and cannot be read from CUDA tensors during graph capture.
+        pad_between_seqs is conservatively enabled because its Python value is not a
+        graph input and inferring it from CUDA tensors would synchronize during capture.
         """
         if 'cu_seqlens_q' not in kwargs:
             return
@@ -1384,7 +1386,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             cu_seqlens_kv_padded=kwargs.pop('cu_seqlens_kv_padded'),
             max_seqlen_q=max_seqlen,
             max_seqlen_kv=max_seqlen,
-            pad_between_seqs=False,
+            # CUDA graph inputs do not carry this Python bool. Sequence-packing
+            # metadata may contain valid/physical gaps, so use the conservative
+            # graph-static value instead of asking TE to infer it with a CUDA
+            # tensor comparison during capture. This restricts TE backend
+            # selection for THD to cuDNN fused attention.
+            pad_between_seqs=True,
         )
         kwargs['packed_seq_params'] = packed_seq_params
 

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -34,6 +34,7 @@ from megatron.core.packed_seq_params import (
     PackedSeqParams,
     get_thd_padding_kwargs,
     pad_sequence_for_thd,
+    resolve_thd_tail_padding_policy,
 )
 from megatron.core.rerun_state_machine import get_rerun_state_machine
 from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer
@@ -186,6 +187,7 @@ def get_batch(data_iterator, vp_stage: Optional[int] = None):
             None,
         )
 
+    thd_tail_padding_policy = resolve_thd_tail_padding_policy(config)
     if cu_seqlens is None:
         # slice batch along sequence dimension for context parallelism
         batch = get_batch_on_this_cp_rank(batch)  # The implementation of this function is in MCore
@@ -197,7 +199,7 @@ def get_batch(data_iterator, vp_stage: Optional[int] = None):
 
     # Pad the already-packed THD tensors at the end when requested. A configured
     # thd_max_packed_sequences also pads cu_seqlens to a fixed capacity in eager or graph mode.
-    padding_mask = None
+    padding_mask = batch.pop('padding_mask', None)
     if config.pad_packed_seq_alignment is not None and packed_seq_params is not None:
         tokens = batch.get('tokens', None)
         labels = batch.get('labels', None)
@@ -219,7 +221,8 @@ def get_batch(data_iterator, vp_stage: Optional[int] = None):
                 alignment=alignment,
                 target_len=target_len,
                 max_num_seqs=max_num_seqs,
-                pad_by_appending_dummy_seq=config.pad_packed_seq_by_appending_dummy_seq,
+                tail_padding_policy=thd_tail_padding_policy,
+                padding_mask=padding_mask,
             )
         )
         if 'tokens' in batch:
@@ -443,6 +446,7 @@ def core_gpt_dataset_config_from_args(args: Any) -> GPTDatasetConfig:
         "data_parallel_size": args.data_parallel_size,
         "sequence_parallel_size": args.tensor_model_parallel_size * args.sequence_parallel,
         "dynamic_context_parallel": args.dynamic_context_parallel,
+        "sft_mock_dataset_config_json": args.sft_mock_dataset_config_json,
         "varlen_mock_dataset_config_json": args.varlen_mock_dataset_config_json,
         "varlen_sbhd_validation": args.varlen_sbhd_validation,
     }

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_cp4_dcp/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_cp4_dcp/model_config.yaml
@@ -56,6 +56,6 @@ MODEL_ARGS:
   --dist-ckpt-strictness: log_all
   --data-cache-path: ${DATA_CACHE_PATH}
   --bf16: true
-  --attention-backend: flash
+  --attention-backend: fused
   --log-memory-to-tensorboard: true
 TEST_TYPE: ckpt-resume

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_dsv4_hybrid_mhc_mtp/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_dsv4_hybrid_mhc_mtp/model_config.yaml
@@ -54,7 +54,7 @@ MODEL_ARGS:
   --sequence-packing-scheduler: dp_balanced
   --max-seqlen-per-dp-cp-rank: 512
   --pad-packed-seq-alignment: max
-  --no-pad-packed-seq-by-appending-dummy-seq: true
+  --thd-tail-padding-policy: extend_last
   --calculate-per-token-loss: true
   --thd-max-packed-sequences: 8
   --cp-partition-mode: contiguous

--- a/tests/unit_tests/data/test_pretrain_gpt_dataset_config.py
+++ b/tests/unit_tests/data/test_pretrain_gpt_dataset_config.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import sys
+from types import SimpleNamespace
+
+from megatron.training.arguments import parse_args
+
+
+def test_core_gpt_dataset_config_forwards_sft_mock_dataset_config(monkeypatch):
+    import pretrain_gpt
+
+    config_json = (
+        '{"mode":"distribution","type":"lognormal","format":"thd",'
+        '"min_seq_len":128,"max_seq_len":2048,"mean_seq_len":512,'
+        '"lognormal_sigma":1.2}'
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["pretrain_gpt.py", "--seq-length", "2048", "--sft-mock-dataset-config-json", config_json],
+    )
+    args = parse_args()
+    args.data_parallel_size = args.world_size // (
+        args.tensor_model_parallel_size
+        * args.pipeline_model_parallel_size
+        * args.context_parallel_size
+    )
+    monkeypatch.setattr(pretrain_gpt, "build_tokenizer", lambda _: SimpleNamespace(vocab_size=2048))
+    monkeypatch.setattr(pretrain_gpt, "get_blend_and_blend_per_split", lambda _: (None, None))
+
+    config = pretrain_gpt.core_gpt_dataset_config_from_args(args)
+
+    assert config.sft_mock_dataset_config_json == config_json

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -371,7 +371,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
 # Fields to ignore entirely (ephemeral, environment-specific, very large).
 SKIP_FIELDS = set()
 # Fields that are allowed to appear in the live config even if not yet in the golden.
-ALLOW_ADDED_FIELDS = {"pad_packed_seq_alignment", "pad_packed_seq_by_appending_dummy_seq"}
+ALLOW_ADDED_FIELDS = {"pad_packed_seq_alignment", "thd_tail_padding_policy"}
 
 
 def serialize_config(cfg: Any) -> Dict[str, Any]:

--- a/tests/unit_tests/test_model_parallel_config.py
+++ b/tests/unit_tests/test_model_parallel_config.py
@@ -23,6 +23,11 @@ def test_native_cross_entropy_loss_fusion_is_allowed():
     assert config.cross_entropy_fusion_impl == 'native'
 
 
+def test_invalid_thd_tail_padding_policy_is_rejected_during_config_initialization():
+    with pytest.raises(ValueError, match="thd_tail_padding_policy must be"):
+        ModelParallelConfig(thd_tail_padding_policy="bogus")
+
+
 def test_te_cross_entropy_loss_fusion_is_disabled_by_training_args(monkeypatch):
     monkeypatch.setattr(sys, 'argv', ['test_model_parallel_config.py'])
     args = parse_args()

--- a/tests/unit_tests/test_sequence_packing.py
+++ b/tests/unit_tests/test_sequence_packing.py
@@ -27,16 +27,16 @@ def test_scheduler_max_real_num_seqs_reserves_dummy_sequence():
     config = SimpleNamespace(
         thd_max_packed_sequences=32,
         pad_packed_seq_alignment="max",
-        pad_packed_seq_by_appending_dummy_seq=True,
+        thd_tail_padding_policy="append_dummy_seq",
     )
 
     assert _get_scheduler_max_real_num_seqs(config) == 31
 
-    config.pad_packed_seq_by_appending_dummy_seq = False
+    config.thd_tail_padding_policy = "extend_last"
     assert _get_scheduler_max_real_num_seqs(config) == 32
 
     config.pad_packed_seq_alignment = None
-    config.pad_packed_seq_by_appending_dummy_seq = True
+    config.thd_tail_padding_policy = "append_dummy_seq"
     assert _get_scheduler_max_real_num_seqs(config) == 32
 
 
@@ -44,7 +44,7 @@ def test_scheduler_max_real_num_seqs_rejects_dummy_without_capacity():
     config = SimpleNamespace(
         thd_max_packed_sequences=1,
         pad_packed_seq_alignment="max",
-        pad_packed_seq_by_appending_dummy_seq=True,
+        thd_tail_padding_policy="append_dummy_seq",
     )
 
     with pytest.raises(ValueError, match="includes that dummy sequence"):
@@ -91,6 +91,7 @@ class MockVariableLengthSequencePackingDataIterator:
         self,
         total_seq_length: int,
         sequence_lengths: list,
+        padded_sequence_lengths: list = None,
         local_cp_size: int = None,
         device: str = "cuda",
         seed: int = 42,
@@ -100,17 +101,25 @@ class MockVariableLengthSequencePackingDataIterator:
             total_seq_length: Total length of packed sequences
             sequence_lengths: List of individual sequence lengths (variable-length).
                               If None, generates random variable lengths.
+            padded_sequence_lengths: Physical storage length for each sequence.
             device: Device to create tensors on
             seed: Random seed for reproducibility
         """
         self.total_seq_length = total_seq_length
         self.sequence_lengths = sequence_lengths
+        self.padded_sequence_lengths = padded_sequence_lengths or sequence_lengths
         self.local_cp_size = local_cp_size
         self.device = device
         self.seed = seed
-        assert (
-            sum(self.sequence_lengths) == total_seq_length
-        ), f"Sequence lengths sum {sum(self.sequence_lengths)} != total {total_seq_length}"
+        assert len(self.sequence_lengths) == len(self.padded_sequence_lengths)
+        assert all(
+            real <= padded
+            for real, padded in zip(self.sequence_lengths, self.padded_sequence_lengths)
+        )
+        assert sum(self.padded_sequence_lengths) == total_seq_length, (
+            f"Padded sequence lengths sum {sum(self.padded_sequence_lengths)} "
+            f"!= total {total_seq_length}"
+        )
 
     def __iter__(self):
         """Interface for the data iterator."""
@@ -126,24 +135,34 @@ class MockVariableLengthSequencePackingDataIterator:
 
         # Create position_ids that reset for each sequence (THD format)
         position_ids = []
-        for seq_len in self.sequence_lengths:
+        for seq_len, padded_seq_len in zip(self.sequence_lengths, self.padded_sequence_lengths):
             position_ids.extend(range(seq_len))
+            position_ids.extend([0] * (padded_seq_len - seq_len))
         position_ids = torch.tensor(position_ids, dtype=torch.int64, device=dev)
 
         # Labels are tokens shifted by 1 for easy verification
         labels = tokens + 1
 
-        # Loss mask: 1.0 for all positions except padding (none here)
-        loss_mask = torch.ones(self.total_seq_length, dtype=torch.float32, device=dev)
+        # Loss mask: 1.0 for valid tokens and 0.0 for physical padding.
+        loss_mask = []
+        for seq_len, padded_seq_len in zip(self.sequence_lengths, self.padded_sequence_lengths):
+            loss_mask.extend([1.0] * seq_len)
+            loss_mask.extend([0.0] * (padded_seq_len - seq_len))
+        loss_mask = torch.tensor(loss_mask, dtype=torch.float32, device=dev)
 
         # Create cu_seqlens for variable-length packed sequences
         cu_seqlens = [0]
         for seq_len in self.sequence_lengths:
             cu_seqlens.append(cu_seqlens[-1] + seq_len)
         cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=dev)
-        cu_seqlens_padded = cu_seqlens.clone()
+        cu_seqlens_padded = [0]
+        for seq_len in self.padded_sequence_lengths:
+            cu_seqlens_padded.append(cu_seqlens_padded[-1] + seq_len)
+        cu_seqlens_padded = torch.tensor(cu_seqlens_padded, dtype=torch.int32, device=dev)
 
-        max_seqlen = torch.tensor([max(self.sequence_lengths)], dtype=torch.int32, device=dev)
+        max_seqlen = torch.tensor(
+            [max(self.padded_sequence_lengths)], dtype=torch.int32, device=dev
+        )
 
         batch = {
             "tokens": tokens,
@@ -213,11 +232,30 @@ def test_dsv4_thd_cp_slice_uses_static_partition_total():
 
 
 @pytest.mark.parametrize(
-    ("alignment", "cuda_graph_impl", "local_cp_size", "total_tokens", "local_target"),
-    [(4, "none", 2, 10, 8), (8, "transformer_engine", 2, 10, 8)],
+    (
+        "alignment",
+        "cuda_graph_impl",
+        "local_cp_size",
+        "total_tokens",
+        "local_target",
+        "tail_padding_policy",
+    ),
+    [
+        (4, "none", 1, 3, 4, "extend_last"),
+        (4, "none", 2, 10, 8, "extend_last"),
+        (8, "transformer_engine", 2, 10, 8, "extend_last"),
+        (4, "none", 2, 10, 8, "append_dummy_seq"),
+        (8, "transformer_engine", 2, 10, 8, "append_dummy_seq"),
+    ],
 )
 def test_dsv4_thd_dynamic_cp_pads_before_slicing(
-    monkeypatch, alignment, cuda_graph_impl, local_cp_size, total_tokens, local_target
+    monkeypatch,
+    alignment,
+    cuda_graph_impl,
+    local_cp_size,
+    total_tokens,
+    local_target,
+    tail_padding_policy,
 ):
     """DSv4 padding must not change rank-local row origins after CP slicing."""
     cp_rank = local_cp_size - 1
@@ -233,7 +271,7 @@ def test_dsv4_thd_dynamic_cp_pads_before_slicing(
         max_seqlen_per_dp_cp_rank=8,
         thd_max_packed_sequences=None,
         cuda_graph_impl=cuda_graph_impl,
-        pad_packed_seq_by_appending_dummy_seq=True,
+        thd_tail_padding_policy=tail_padding_policy,
     )
     tokens = torch.arange(1, total_tokens + 1, dtype=torch.int64)
     batch = {
@@ -247,7 +285,9 @@ def test_dsv4_thd_dynamic_cp_pads_before_slicing(
         "local_cp_size": torch.tensor([local_cp_size], dtype=torch.int32),
     }
     pad_input_lengths = []
+    slice_metadata = []
     real_pad_sequence_for_thd = data_schedule.pad_sequence_for_thd
+    real_get_cp_slice_for_thd = data_schedule.get_cp_slice_for_thd
 
     def record_padding(
         tokens, labels, loss_mask, position_ids, packed_seq_params, *, padding_mask, **_
@@ -268,6 +308,16 @@ def test_dsv4_thd_dynamic_cp_pads_before_slicing(
         assert result[-1].shape[-1] == local_target
         return result
 
+    def record_slice(batch, cp_group, **kwargs):
+        slice_metadata.append(
+            (
+                batch['cu_seqlens'].clone(),
+                batch['cu_seqlens_padded'].clone(),
+                kwargs.get('partition_total_tokens'),
+            )
+        )
+        return real_get_cp_slice_for_thd(batch, cp_group, **kwargs)
+
     monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
     monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda _: [0])
     monkeypatch.setattr(
@@ -280,6 +330,7 @@ def test_dsv4_thd_dynamic_cp_pads_before_slicing(
     )
     monkeypatch.setattr(data_schedule, "broadcast_tensor", lambda *_: None)
     monkeypatch.setattr(data_schedule, "pad_sequence_for_thd", record_padding)
+    monkeypatch.setattr(data_schedule, "get_cp_slice_for_thd", record_slice)
     monkeypatch.setattr(
         parallel_state,
         "get_dynamic_data_context_parallel_groups",
@@ -306,7 +357,112 @@ def test_dsv4_thd_dynamic_cp_pads_before_slicing(
     )
     assert packed_seq_params.local_cp_size == local_cp_size
     assert packed_seq_params.cp_partition_mode == "contiguous"
+    global_target = local_target * local_cp_size
+    if tail_padding_policy == "append_dummy_seq":
+        expected_final_cu = torch.tensor([0, total_tokens, global_target], dtype=torch.int32)
+        assert torch.equal(packed_seq_params.cu_seqlens_q, expected_final_cu)
+        assert torch.equal(packed_seq_params.cu_seqlens_q_padded, expected_final_cu)
+        assert packed_seq_params.max_seqlen_q == max(total_tokens, global_target - total_tokens)
+        assert packed_seq_params.pad_between_seqs is True
+    else:
+        assert torch.equal(
+            packed_seq_params.cu_seqlens_q, torch.tensor([0, total_tokens], dtype=torch.int32)
+        )
+        assert torch.equal(
+            packed_seq_params.cu_seqlens_q_padded,
+            torch.tensor([0, global_target], dtype=torch.int32),
+        )
+        assert packed_seq_params.max_seqlen_q == global_target
+        assert packed_seq_params.pad_between_seqs is True
     assert pad_input_lengths == [local_target]
+    assert len(slice_metadata) == 1
+    slice_valid, slice_padded, partition_total = slice_metadata[0]
+    assert torch.equal(slice_valid, torch.tensor([0, total_tokens], dtype=torch.int32))
+    expected_slice_padded_end = (
+        total_tokens if tail_padding_policy == "append_dummy_seq" else global_target
+    )
+    assert torch.equal(
+        slice_padded, torch.tensor([0, expected_slice_padded_end], dtype=torch.int32)
+    )
+    assert partition_total == global_target
+
+
+def test_non_dummy_zigzag_padding_updates_metadata_before_cp_slice(monkeypatch):
+    """Zigzag CP indices must be generated from the globally padded layout."""
+    from megatron.core.datasets import data_schedule_utils
+
+    cp_size = 2
+    cp_rank = 0
+    total_tokens = 12
+    local_target = 8
+    dynamic_cp_group = _MockCPGroup(size=cp_size, rank=cp_rank)
+    pg_collection = SimpleNamespace(
+        tp=_MockCPGroup(size=1, rank=0),
+        pp=_MockCPGroup(size=1, rank=0),
+        cp=_MockCPGroup(size=cp_size, rank=cp_rank),
+    )
+    config = SimpleNamespace(
+        cp_partition_mode="zigzag",
+        pad_packed_seq_alignment=4,
+        max_seqlen_per_dp_cp_rank=local_target,
+        thd_max_packed_sequences=None,
+        cuda_graph_impl="none",
+        thd_tail_padding_policy="extend_last",
+    )
+    tokens = torch.arange(1, total_tokens + 1, dtype=torch.int64)
+    batch = {
+        "tokens": tokens.clone(),
+        "position_ids": torch.arange(total_tokens, dtype=torch.int64),
+        "labels": tokens + 100,
+        "loss_mask": torch.ones(total_tokens, dtype=torch.float32),
+        "cu_seqlens": torch.tensor([0, 4, total_tokens], dtype=torch.int32),
+        "cu_seqlens_padded": torch.tensor([0, 4, total_tokens], dtype=torch.int32),
+        "max_seqlen": torch.tensor([8], dtype=torch.int32),
+        "local_cp_size": torch.tensor([cp_size], dtype=torch.int32),
+    }
+
+    def get_padded_zigzag_indices(cu_seqlens, total, world_size, rank):
+        assert torch.equal(cu_seqlens, torch.tensor([0, 4, 16], dtype=torch.int32))
+        assert (total, world_size, rank) == (16, cp_size, cp_rank)
+        return torch.tensor([0, 3, 4, 5, 6, 13, 14, 15], dtype=torch.int64)
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda _: [0])
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_world_size",
+        lambda group=None: group.size() if group is not None else 1,
+    )
+    monkeypatch.setattr(
+        torch.distributed, "get_rank", lambda group=None: group.rank() if group is not None else 0
+    )
+    monkeypatch.setattr(data_schedule, "broadcast_tensor", lambda *_: None)
+    monkeypatch.setattr(
+        parallel_state,
+        "get_dynamic_data_context_parallel_groups",
+        lambda group_size: dynamic_cp_group,
+    )
+    monkeypatch.setattr(
+        data_schedule_utils, "get_thd_partitioned_indices", get_padded_zigzag_indices
+    )
+
+    result = get_batch_on_this_rank_for_sequence_packing(
+        data_iterator=iter([batch]), dynamic_cp=True, pg_collection=pg_collection, config=config
+    )
+
+    local_tokens, _, _, _, _, packed_seq_params, padding_mask = result
+    assert torch.equal(
+        local_tokens.squeeze(0), torch.tensor([1, 4, 5, 6, 7, 0, 0, 0], dtype=torch.int64)
+    )
+    assert torch.equal(
+        padding_mask.squeeze(0), torch.tensor([False, False, False, False, False, True, True, True])
+    )
+    assert torch.equal(packed_seq_params.cu_seqlens_q, torch.tensor([0, 4, 12], dtype=torch.int32))
+    assert torch.equal(
+        packed_seq_params.cu_seqlens_q_padded, torch.tensor([0, 4, 16], dtype=torch.int32)
+    )
+    assert packed_seq_params.max_seqlen_q == 12
+    assert packed_seq_params.pad_between_seqs is True
 
 
 def test_next_hdp_group_packing_aware_can_use_larger_cp_group_for_short_sequences():
@@ -421,14 +577,14 @@ def test_get_batch_on_this_rank_for_sequence_packing(tp, pp, cp, dynamic_cp, loc
         if tp_rank == 0:
             # Use deterministic seed based on DP rank so same data within TP/PP/CP group
             dp_rank = parallel_state.get_data_parallel_rank()
-            sequence_lengths = [1024, 2048, 512, 1536, 3072]
-            assert (
-                sum(sequence_lengths) == args.seq_length
-            ), f"Sequence lengths sum {sum(sequence_lengths)} != total {args.seq_length}"
+            sequence_lengths = [1000, 2040, 500, 1500, 3000]
+            padded_sequence_lengths = [1024, 2048, 512, 1536, 3072]
+            assert sum(padded_sequence_lengths) == args.seq_length
             data_iterator = iter(
                 MockVariableLengthSequencePackingDataIterator(
                     total_seq_length=args.seq_length,
                     sequence_lengths=sequence_lengths,
+                    padded_sequence_lengths=padded_sequence_lengths,
                     local_cp_size=local_cp_size,
                     seed=42 + dp_rank,
                 )
@@ -451,7 +607,17 @@ def test_get_batch_on_this_rank_for_sequence_packing(tp, pp, cp, dynamic_cp, loc
         assert padding_mask is not None
         assert padding_mask.dtype == torch.bool
         assert padding_mask.dim() == 2
-        assert not padding_mask.any(), "Mock data has no per-sequence padding."
+        assert packed_seq_params is not None
+        has_padding = padding_mask.any().to(torch.int32)
+        effective_cp_group = (
+            packed_seq_params.cp_group
+            if packed_seq_params.cp_group is not None
+            else parallel_state.get_context_parallel_group()
+        )
+        torch.distributed.all_reduce(
+            has_padding, op=torch.distributed.ReduceOp.MAX, group=effective_cp_group
+        )
+        assert has_padding.item(), "Mock data intentionally has padding in each CP group."
 
         # Get parallel state info
         tp_rank = parallel_state.get_tensor_model_parallel_rank()
@@ -488,8 +654,12 @@ def test_get_batch_on_this_rank_for_sequence_packing(tp, pp, cp, dynamic_cp, loc
         # =====================================================================
         # TEST 2: Verify packed_seq_params consistency
         # =====================================================================
-        assert packed_seq_params is not None
         assert packed_seq_params.qkv_format == "thd"
+        assert packed_seq_params.pad_between_seqs is True
+        assert not torch.equal(
+            packed_seq_params.cu_seqlens_q, packed_seq_params.cu_seqlens_q_padded
+        )
+        assert packed_seq_params.cu_seqlens_q[-1] < packed_seq_params.cu_seqlens_q_padded[-1]
 
         test_keys = [
             "cu_seqlens_q",

--- a/tests/unit_tests/transformer/test_thd_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_cuda_graph.py
@@ -30,11 +30,14 @@ from pathlib import Path
 import pytest
 import torch
 
+from megatron.core.datasets.data_schedule import _build_thd_padding_mask
 from megatron.core.packed_seq_params import (
     PackedSeqParams,
     _resolve_thd_padding_lengths,
+    extend_thd_padding_before_cp_slice,
     get_thd_padding_kwargs,
     pad_sequence_for_thd,
+    resolve_thd_tail_padding_policy,
 )
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -121,6 +124,25 @@ def test_pad_to_max_resolves_padding_kwargs(cuda_graph_static, expected_max_num_
     assert max_num_seqs == expected_max_num_seqs
 
 
+@pytest.mark.internal
+def test_resolve_thd_tail_padding_policy():
+    from types import SimpleNamespace
+
+    # Default (unset): append an ordinary dummy sequence.
+    assert resolve_thd_tail_padding_policy(SimpleNamespace()) == "append_dummy_seq"
+    assert (
+        resolve_thd_tail_padding_policy(SimpleNamespace(thd_tail_padding_policy=None))
+        == "append_dummy_seq"
+    )
+    # Explicit policies are returned as-is.
+    assert (
+        resolve_thd_tail_padding_policy(SimpleNamespace(thd_tail_padding_policy="extend_last"))
+        == "extend_last"
+    )
+    with pytest.raises(AssertionError, match="Unsupported thd_tail_padding_policy"):
+        resolve_thd_tail_padding_policy(SimpleNamespace(thd_tail_padding_policy="bogus"))
+
+
 class TestResolveThdPaddingLengths:
 
     def setup_method(self):
@@ -173,6 +195,23 @@ class TestResolveThdPaddingLengths:
             _resolve_thd_padding_lengths(
                 None, None, None, None, psp, target_len=128, alignment=None
             )
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_metadata_only_uses_physical_padded_endpoint(self):
+        """Physical storage, not compact valid-token count, determines padding length."""
+        cu_valid = torch.tensor([0, 3, 5], dtype=torch.int32, device="cuda")
+        cu_padded = torch.tensor([0, 4, 8], dtype=torch.int32, device="cuda")
+        psp = PackedSeqParams(
+            qkv_format="thd", cu_seqlens_q=cu_valid, cu_seqlens_q_padded=cu_padded
+        )
+
+        resolved = _resolve_thd_padding_lengths(
+            None, None, None, None, psp, target_len=None, alignment=6
+        )
+
+        assert resolved[:4] == (8, 8, 12, 12)
+        assert resolved[4] == cu_padded.device
 
     @pytest.mark.internal
     @_REQUIRES_TWO_RANKS
@@ -268,7 +307,7 @@ class TestPadSequenceForThd:
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_generic_alignment_appends_dummy_padding_sequence(self):
-        """Generic THD padding covers tail slots with an independent dummy sequence."""
+        """Default THD padding covers tail slots with an ordinary dummy sequence."""
         seqlens, total_T = [50, 30], 80
         psp = _make_psp(seqlens)
         # Use the non-default mode so losing it during rebuild cannot silently pass as zigzag.
@@ -285,6 +324,54 @@ class TestPadSequenceForThd:
         assert p.cp_partition_mode == "contiguous"
         assert mask.shape == (1, 128)
         assert not mask[0, :total_T].any() and mask[0, total_T:].all()
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_default_dummy_preserves_existing_valid_and_physical_gaps(self):
+        """The legacy ordinary dummy adds only the tail length to compact metadata."""
+        cu_valid = torch.tensor([0, 3, 5], dtype=torch.int32, device="cuda")
+        cu_padded = torch.tensor([0, 4, 8], dtype=torch.int32, device="cuda")
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_valid,
+            cu_seqlens_kv=cu_valid.clone(),
+            cu_seqlens_q_padded=cu_padded,
+            cu_seqlens_kv_padded=cu_padded.clone(),
+            max_seqlen_q=4,
+            max_seqlen_kv=4,
+        )
+        initial_padding_mask = torch.tensor(
+            [[False, False, False, True, False, False, True, True]], dtype=torch.bool, device="cuda"
+        )
+
+        p_tok, _, _, _, padded, mask = pad_sequence_for_thd(
+            torch.ones(1, 8, device="cuda"),
+            None,
+            None,
+            None,
+            psp,
+            target_len=12,
+            padding_mask=initial_padding_mask,
+        )
+
+        expected_valid = torch.tensor([0, 3, 5, 9], dtype=torch.int32, device="cuda")
+        expected_padded = torch.tensor([0, 4, 8, 12], dtype=torch.int32, device="cuda")
+        assert p_tok.shape == (1, 12)
+        assert torch.equal(padded.cu_seqlens_q, expected_valid)
+        assert torch.equal(padded.cu_seqlens_kv, expected_valid)
+        assert torch.equal(padded.cu_seqlens_q_padded, expected_padded)
+        assert torch.equal(padded.cu_seqlens_kv_padded, expected_padded)
+        assert padded.pad_between_seqs is True
+        assert padded.max_seqlen_q == 4
+        assert padded.max_seqlen_kv == 4
+        assert torch.equal(
+            mask,
+            torch.tensor(
+                [[False, False, False, True, False, False, True, True, True, True, True, True]],
+                dtype=torch.bool,
+                device="cuda",
+            ),
+        )
 
     @pytest.mark.internal
     @_REQUIRES_TWO_RANKS
@@ -323,35 +410,250 @@ class TestPadSequenceForThd:
         assert p_tok.shape[-1] == 1664
         assert p.cu_seqlens_q[-1].item() == 3328
         assert p.cu_seqlens_q_padded[-1].item() == 3328
+        assert p.max_seqlen_q == 1600
+        assert p.max_seqlen_kv == 1600
         assert mask.shape[-1] == p_tok.shape[-1]
         assert not mask[0, :local_T].any()
         assert mask[0, local_T:].all()
 
     @pytest.mark.internal
+    @_REQUIRES_TWO_RANKS
+    def test_cp_dummy_rejects_tail_that_cannot_be_partitioned(self):
+        """An ordinary dummy sequence must satisfy TE's 2*CP divisibility rule."""
+        Utils.destroy_model_parallel()
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+
+        with pytest.raises(AssertionError, match="must be divisible"):
+            pad_sequence_for_thd(
+                torch.ones(1, 2, device="cuda"), None, None, None, _make_psp([4]), target_len=3
+            )
+
+    @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    def test_padding_without_dummy_sequence_preserves_metadata(self):
-        """Disabling dummy sequence padding only pads token-like tensors."""
-        seqlens, total_T = [50, 30], 80
-        psp = _make_psp(seqlens)
-        psp.pad_between_seqs = False
-        orig = psp.cu_seqlens_q.clone()
+    def test_cp_non_dummy_padding_rejects_slice_first_call(self):
+        """Non-dummy metadata must be extended before CP partitions the tensors."""
+        with pytest.raises(AssertionError, match="before CP slicing"):
+            pad_sequence_for_thd(
+                torch.ones(1, 2, device="cuda"),
+                None,
+                None,
+                None,
+                _make_psp([4]),
+                target_len=3,
+                tail_padding_policy="extend_last",
+                cp_size=2,
+                cp_rank=0,
+            )
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_padding_without_dummy_extends_last_padded_sequence(self):
+        """Non-dummy tail padding belongs to the final real sequence."""
+        cu_valid = torch.tensor([0, 3, 5], dtype=torch.int32, device="cuda")
+        cu_padded = torch.tensor([0, 4, 8], dtype=torch.int32, device="cuda")
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_valid,
+            cu_seqlens_kv=cu_valid.clone(),
+            cu_seqlens_q_padded=cu_padded,
+            cu_seqlens_kv_padded=cu_padded.clone(),
+            max_seqlen_q=4,
+            max_seqlen_kv=4,
+            pad_between_seqs=True,
+        )
+        original = {
+            "cu_seqlens_q": psp.cu_seqlens_q.clone(),
+            "cu_seqlens_kv": psp.cu_seqlens_kv.clone(),
+            "cu_seqlens_q_padded": psp.cu_seqlens_q_padded.clone(),
+            "cu_seqlens_kv_padded": psp.cu_seqlens_kv_padded.clone(),
+        }
+        initial_padding_mask = torch.tensor(
+            [[False, False, False, True, False, False, True, True]], dtype=torch.bool, device="cuda"
+        )
         p_tok, _, _, _, p, mask = pad_sequence_for_thd(
-            torch.ones(1, total_T, device="cuda"),
+            torch.ones(1, 8, device="cuda"),
             None,
             None,
             None,
             psp,
-            alignment=64,
-            pad_by_appending_dummy_seq=False,
+            target_len=10,
+            tail_padding_policy="extend_last",
+            padding_mask=initial_padding_mask,
         )
-        assert p_tok.shape == (1, 128)
-        assert torch.equal(p.cu_seqlens_q, orig)
-        assert torch.equal(p.cu_seqlens_q_padded, orig)
-        assert p.max_seqlen_q == max(seqlens)
-        assert p.max_seqlen_kv == max(seqlens)
-        assert p.pad_between_seqs is False
-        assert mask.shape == (1, 128)
-        assert not mask[0, :total_T].any() and mask[0, total_T:].all()
+        expected_padded = torch.tensor([0, 4, 10], dtype=torch.int32, device="cuda")
+        assert p_tok.shape == (1, 10)
+        assert torch.equal(p.cu_seqlens_q, cu_valid)
+        assert torch.equal(p.cu_seqlens_kv, cu_valid)
+        assert torch.equal(p.cu_seqlens_q_padded, expected_padded)
+        assert torch.equal(p.cu_seqlens_kv_padded, expected_padded)
+        assert p.max_seqlen_q == 6
+        assert p.max_seqlen_kv == 6
+        assert p.pad_between_seqs is True
+        assert torch.equal(
+            p.seq_idx,
+            torch.tensor([[0, 0, 0, 0, 1, 1, 1, 1, 1, 1]], dtype=torch.int32, device="cuda"),
+        )
+        for name, value in original.items():
+            assert torch.equal(getattr(psp, name), value)
+        assert torch.equal(
+            mask,
+            torch.tensor(
+                [[False, False, False, True, False, False, True, True, True, True]],
+                dtype=torch.bool,
+                device="cuda",
+            ),
+        )
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_cp_non_dummy_padding_extends_globally_before_slice(self):
+        """The supported slice-then-pad recipe for the non-scheduler SFT path.
+
+        With CP > 1 the caller extends the global physical endpoint and pads
+        tensors before CP slicing; the post-slice pad_sequence_for_thd call is
+        then a metadata no-op instead of tripping the slice-first assertion.
+        """
+        cp_size = 2
+        cu_valid = torch.tensor([0, 4, 12], dtype=torch.int32, device="cuda")
+        cu_padded = cu_valid.clone()
+        max_seqlen = torch.tensor([8], dtype=torch.int32, device="cuda")
+
+        cu_padded, max_seqlen, global_target_len = extend_thd_padding_before_cp_slice(
+            cu_padded,
+            max_seqlen,
+            alignment=4,
+            target_len=None,
+            cp_size=cp_size,
+            cp_partition_mode="zigzag",
+        )
+        assert global_target_len == 16
+        assert torch.equal(cu_padded, torch.tensor([0, 4, 16], dtype=torch.int32, device="cuda"))
+        assert int(max_seqlen.item()) == 12
+
+        padding_mask = _build_thd_padding_mask(cu_valid, cu_padded)
+        assert padding_mask.tolist() == [False] * 12 + [True] * 4
+
+        tokens = torch.arange(1, global_target_len + 1, device="cuda").unsqueeze(0)
+        tokens[0, 12:] = 0
+        expected_local_rows = {
+            0: [0, 3, 4, 5, 6, 13, 14, 15],  # zigzag chunks 0 and 3 of each sequence
+            1: [1, 2, 7, 8, 9, 10, 11, 12],  # zigzag chunks 1 and 2 of each sequence
+        }
+        for cp_rank, rows in expected_local_rows.items():
+            index = torch.tensor(rows, dtype=torch.int64, device="cuda")
+            local_tokens = tokens.index_select(1, index)
+            local_mask = padding_mask.unsqueeze(0).index_select(1, index)
+            psp = PackedSeqParams(
+                qkv_format="thd",
+                cu_seqlens_q=cu_valid,
+                cu_seqlens_kv=cu_valid.clone(),
+                cu_seqlens_q_padded=cu_padded,
+                cu_seqlens_kv_padded=cu_padded.clone(),
+                max_seqlen_q=int(max_seqlen.item()),
+                max_seqlen_kv=int(max_seqlen.item()),
+            )
+            p_tok, _, _, _, p, mask = pad_sequence_for_thd(
+                local_tokens,
+                None,
+                None,
+                None,
+                psp,
+                alignment=4,
+                tail_padding_policy="extend_last",
+                padding_mask=local_mask,
+                cp_size=cp_size,
+                cp_rank=cp_rank,
+            )
+            assert torch.equal(p_tok, local_tokens)
+            assert torch.equal(p.cu_seqlens_q, cu_valid)
+            assert torch.equal(p.cu_seqlens_q_padded, cu_padded)
+            assert p.max_seqlen_q == 12
+            assert torch.equal(mask, local_mask)
+
+    @pytest.mark.internal
+    @_REQUIRES_TWO_RANKS
+    def test_cp_non_dummy_pretrain_gpt_flow_does_not_assert(self):
+        """Regression for the non-scheduler SFT path with CP > 1.
+
+        pretrain_gpt passes no explicit CP geometry, so pad_sequence_for_thd
+        resolves it from parallel_state. After the global pre-slice extension
+        the call must succeed on every rank instead of raising the slice-first
+        assertion.
+        """
+        from megatron.core import parallel_state
+
+        Utils.destroy_model_parallel()
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+        cp_size = parallel_state.get_context_parallel_world_size()
+        cp_rank = parallel_state.get_context_parallel_rank()
+
+        cu_valid = torch.tensor([0, 4, 12], dtype=torch.int32, device="cuda")
+        cu_padded, max_seqlen, global_target_len = extend_thd_padding_before_cp_slice(
+            cu_valid.clone(),
+            torch.tensor([8], dtype=torch.int32, device="cuda"),
+            alignment=4,
+            target_len=None,
+            cp_size=cp_size,
+            cp_partition_mode="zigzag",
+        )
+        padding_mask = _build_thd_padding_mask(cu_valid, cu_padded).unsqueeze(0)
+
+        local_rows = [0, 3, 4, 5, 6, 13, 14, 15] if cp_rank == 0 else [1, 2, 7, 8, 9, 10, 11, 12]
+        index = torch.tensor(local_rows, dtype=torch.int64, device="cuda")
+        local_tokens = torch.ones(1, global_target_len, device="cuda").index_select(1, index)
+        local_mask = padding_mask.index_select(1, index)
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_valid,
+            cu_seqlens_kv=cu_valid.clone(),
+            cu_seqlens_q_padded=cu_padded,
+            cu_seqlens_kv_padded=cu_padded.clone(),
+            max_seqlen_q=int(max_seqlen.item()),
+            max_seqlen_kv=int(max_seqlen.item()),
+        )
+        p_tok, _, _, _, p, mask = pad_sequence_for_thd(
+            local_tokens,
+            None,
+            None,
+            None,
+            psp,
+            alignment=4,
+            tail_padding_policy="extend_last",
+            padding_mask=local_mask,
+        )
+        assert torch.equal(p_tok, local_tokens)
+        assert torch.equal(p.cu_seqlens_q, cu_valid)
+        assert torch.equal(p.cu_seqlens_q_padded, cu_padded)
+        assert p.max_seqlen_q == 12
+        assert torch.equal(mask, local_mask)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_padding_without_dummy_creates_padded_metadata(self):
+        """Equal input boundaries diverge when the last sequence absorbs the tail."""
+        psp = _make_psp([5, 3])
+
+        _, _, _, _, padded, mask = pad_sequence_for_thd(
+            torch.ones(1, 8, device="cuda"),
+            None,
+            None,
+            None,
+            psp,
+            target_len=12,
+            tail_padding_policy="extend_last",
+        )
+
+        expected_valid = torch.tensor([0, 5, 8], dtype=torch.int32, device="cuda")
+        expected_padded = torch.tensor([0, 5, 12], dtype=torch.int32, device="cuda")
+        assert torch.equal(padded.cu_seqlens_q, expected_valid)
+        assert torch.equal(padded.cu_seqlens_kv, expected_valid)
+        assert torch.equal(padded.cu_seqlens_q_padded, expected_padded)
+        assert torch.equal(padded.cu_seqlens_kv_padded, expected_padded)
+        assert padded.max_seqlen_q == 7
+        assert padded.max_seqlen_kv == 7
+        assert padded.pad_between_seqs is True
+        assert not mask[0, :8].any()
+        assert mask[0, 8:].all()
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -387,15 +689,15 @@ class TestPadSequenceForThd:
         assert torch.equal(p_params.cu_seqlens_kv_padded, expected_cu)
         assert p_params.max_seqlen_q == max_seqlen
         assert p_params.max_seqlen_kv == max_seqlen
-        assert p_params.pad_between_seqs is False
+        assert p_params.pad_between_seqs is True
         assert p_mask.shape == (1, max_seqlen) and p_mask.dtype == torch.bool
         assert torch.equal(p_tok[0, :total_T], tokens[0])
         assert (p_tok[0, total_T:] == 0).all()
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    def test_eager_pad_to_max_adds_dummy_padding_sequence(self):
-        """Eager pad-to-max represents the tail as an independent dummy sequence."""
+    def test_eager_pad_to_max_appends_dummy_padding_sequence(self):
+        """Default eager pad-to-max covers the tail with a dummy sequence."""
         seqlens, total_T, target_len = [50, 30], 80, 8192
         psp = _make_psp(seqlens)
         orig_cu = psp.cu_seqlens_q.clone()
@@ -508,13 +810,13 @@ class TestPadSequenceForThd:
         )
 
         assert torch.equal(padded_mask, padding_mask)
-        assert padded_params.cu_seqlens_q.tolist() == [0, 15, 16]
-        assert padded_params.cu_seqlens_q_padded.tolist() == [0, 16, 16]
+        assert padded_params.cu_seqlens_q.tolist() == [0, 15]
+        assert padded_params.cu_seqlens_q_padded.tolist() == [0, 16]
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_cu_seqlens_fill_value(self):
-        """Static cu padding repeats dummy valid/padded cumulative values."""
+        """Static cu padding repeats the dummy endpoint."""
         seqlens, total_T = [50, 30], 80
         _, _, _, _, p, _ = pad_sequence_for_thd(
             torch.ones(1, total_T, device="cuda"),
@@ -529,7 +831,49 @@ class TestPadSequenceForThd:
         assert (p.cu_seqlens_q[3:] == 128).all()
         assert p.cu_seqlens_q_padded[0] == 0 and p.cu_seqlens_q_padded[2] == 80
         assert (p.cu_seqlens_q_padded[3:] == 128).all()
-        assert p.pad_between_seqs is False
+        assert p.pad_between_seqs is True
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_non_dummy_tail_padding_extends_static_padded_endpoint(self):
+        """Static entry padding repeats the extended final padded endpoint."""
+        cu_valid = torch.tensor([0, 18, 44, 52, 96, 118], dtype=torch.int32, device="cuda")
+        cu_padded = torch.tensor([0, 24, 56, 64, 112, 144], dtype=torch.int32, device="cuda")
+        psp = PackedSeqParams(
+            qkv_format='thd',
+            cu_seqlens_q=cu_valid,
+            cu_seqlens_kv=cu_valid.clone(),
+            cu_seqlens_q_padded=cu_padded,
+            cu_seqlens_kv_padded=cu_padded.clone(),
+            max_seqlen_q=48,
+            max_seqlen_kv=48,
+            pad_between_seqs=True,
+        )
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 144, device="cuda"),
+            None,
+            None,
+            None,
+            psp,
+            target_len=160,
+            max_num_seqs=8,
+            tail_padding_policy="extend_last",
+        )
+
+        expected_valid = torch.tensor(
+            [0, 18, 44, 52, 96, 118, 118, 118, 118], dtype=torch.int32, device="cuda"
+        )
+        expected_padded = torch.tensor(
+            [0, 24, 56, 64, 112, 160, 160, 160, 160], dtype=torch.int32, device="cuda"
+        )
+        assert torch.equal(padded.cu_seqlens_q, expected_valid)
+        assert torch.equal(padded.cu_seqlens_kv, expected_valid)
+        assert torch.equal(padded.cu_seqlens_q_padded, expected_padded)
+        assert torch.equal(padded.cu_seqlens_kv_padded, expected_padded)
+        assert padded.max_seqlen_q == 160
+        assert padded.max_seqlen_kv == 160
+        assert padded.pad_between_seqs is True
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -558,8 +902,8 @@ class TestDecomposeReconstruct:
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    def test_round_trip(self):
-        """Decompose then reconstruct preserves cu_seqlens values."""
+    def test_reconstruct_preserves_cu_tensors_and_uses_conservative_padding_flag(self):
+        """Reconstruction preserves cu tensors and uses a graph-static padding flag."""
         psp = _make_psp([100, 50, 30])
         orig = {
             k: getattr(psp, k).clone()
@@ -579,10 +923,36 @@ class TestDecomposeReconstruct:
         layer._reconstruct_packed_seq_params_from_kwargs(kw)
         r = kw['packed_seq_params']
         assert r.qkv_format == 'thd' and r.max_seqlen_q == 128
-        assert r.pad_between_seqs is False
+        assert r.pad_between_seqs is True
         assert r.cp_partition_mode == "contiguous"
         for k, v in orig.items():
             assert torch.equal(getattr(r, k), v)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_reconstruct_preserves_inter_sequence_padding_semantics(self):
+        """CUDA graph reconstruction conservatively enables valid/physical gaps."""
+        cu_valid = torch.tensor([0, 3, 5], dtype=torch.int32, device="cuda")
+        cu_padded = torch.tensor([0, 4, 8], dtype=torch.int32, device="cuda")
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_valid,
+            cu_seqlens_kv=cu_valid.clone(),
+            cu_seqlens_q_padded=cu_padded,
+            cu_seqlens_kv_padded=cu_padded.clone(),
+            max_seqlen_q=4,
+            max_seqlen_kv=4,
+            pad_between_seqs=True,
+        )
+        layer = _build_layer(256, 4, 4, 1024, 128, 8)
+        kw = {'packed_seq_params': psp}
+
+        TransformerLayer._decompose_packed_seq_params_to_kwargs(kw)
+        layer._reconstruct_packed_seq_params_from_kwargs(kw)
+
+        reconstructed = kw['packed_seq_params']
+        assert reconstructed.pad_between_seqs is True
+        assert not torch.equal(reconstructed.cu_seqlens_q, reconstructed.cu_seqlens_q_padded)
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -771,7 +1141,8 @@ _COMMON_ARGS = [
     "4096",
     "--pad-packed-seq-alignment",
     "max",
-    "--no-pad-packed-seq-by-appending-dummy-seq",
+    "--thd-tail-padding-policy",
+    "extend_last",
     "--calculate-per-token-loss",
     "--transformer-impl",
     "transformer_engine",


### PR DESCRIPTION
# What does this PR do?

This PR fixes THD tail-padding metadata in two cases:

1. **Dummy sequence padding:** preserves existing gaps between valid and padded sequence boundaries when appending the dummy sequence.
2. **Non-dummy padding:** keeps `cu_seqlens` unchanged and extends `cu_seqlens_padded[-1]` to the actual padded tensor size.

For non-dummy padding, tensors are padded before context-parallel slicing to ensure the correct token distribution.

The default dummy-sequence behavior remains unchanged.


## Why?

Using physical padded boundaries as valid-token boundaries makes padding appear to be real data and prevents Transformer Engine from inferring gaps between sequences correctly.

## Impact

THD attention still receives physical storage boundaries, while routing and loss paths retain the real token boundaries. The default dummy-sequence behavior remains unchanged. The `extend_last` policy is opt-in.

The sequence-packing test now validates deterministic metadata locally on every rank and checks padding presence across the CP group. This avoids incorrectly comparing independent DP replicas or requiring every CP slice to contain padding.

## Validation

- `BASE_REF=dev CHECK_ONLY=true SKIP_DOCS=true bash tools/autoformat.sh`
- `tests/unit_tests/test_sequence_packing.py`: 29 passed
- `tests/unit_tests/transformer/test_thd_cuda_graph.py`: 28 passed, 2 skipped pending the required TE change
- `tests/unit_tests/transformer/moe/test_token_dispatcher.py`: 19 passed, 92 skipped by configuration

